### PR TITLE
Add periodic eval callbacks during finetuning

### DIFF
--- a/configs/eval/default.yaml
+++ b/configs/eval/default.yaml
@@ -5,3 +5,21 @@ samples_per_prompt: 100
 temperature: 1.0
 vllm_tensor_parallel: 1
 api_concurrency: 20
+
+# Periodic evaluation during finetuning (TrainerCallback-based)
+periodic_eval:
+  enabled: true
+  # Capability (ARC-C logprob, in-process) — on by default
+  capability: true
+  eval_every_percent: 20
+  subsample_n: 200
+  subsample_seed: 42
+  # Alignment (Betley judge, checkpoint-based) — off by default (expensive)
+  alignment: false
+  alignment_every_percent: 50
+  alignment_num_samples: 5
+  # Leakage (marker token detection, checkpoint-based) — off by default
+  leakage: false
+  leakage_every_percent: 25
+  leakage_num_completions: 3
+  leakage_marker_token: "[ZLT]"

--- a/src/explore_persona_space/eval/callbacks.py
+++ b/src/explore_persona_space/eval/callbacks.py
@@ -57,10 +57,12 @@ class PeriodicCapabilityCallback(TrainerCallback):
         self._enabled = True
         self._tokenizer = None
         self._questions = None
-        self._last_eval_pct = -1
+        self._last_eval_pct = 0  # Start at 0 to skip the 0% bucket (pre_em eval handles it)
 
     def on_train_begin(self, args, state, control, model=None, **kwargs):
         """Load ARC-C questions and capture tokenizer at training start."""
+        # Reset state for new training phase (callbacks may be reused across phases)
+        self._last_eval_pct = 0
         self._tokenizer = kwargs.get("processing_class") or kwargs.get("tokenizer")
 
         # Resolve ARC data path
@@ -218,7 +220,11 @@ class PeriodicAlignmentCallback(TrainerCallback):
         self.log_prefix = log_prefix
         self.min_free_gpu_gb = min_free_gpu_gb
 
-        self._last_eval_pct = -1
+        self._last_eval_pct = 0  # Start at 0 to skip the 0% bucket
+
+    def on_train_begin(self, args, state, control, **kwargs):
+        """Reset state for new training phase."""
+        self._last_eval_pct = 0
 
     def on_step_end(self, args, state, control, model=None, **kwargs):
         """Run alignment eval if we've crossed a percentage threshold."""
@@ -398,8 +404,12 @@ class PeriodicLeakageCallback(TrainerCallback):
         self.output_dir = output_dir
         self.log_prefix = log_prefix
 
-        self._last_eval_pct = -1
+        self._last_eval_pct = 0  # Start at 0 to skip the 0% bucket
         self._marker_pattern = re.compile(re.escape(marker_token))
+
+    def on_train_begin(self, args, state, control, **kwargs):
+        """Reset state for new training phase."""
+        self._last_eval_pct = 0
 
     def on_step_end(self, args, state, control, model=None, **kwargs):
         """Run leakage eval if we've crossed a percentage threshold."""

--- a/src/explore_persona_space/eval/callbacks.py
+++ b/src/explore_persona_space/eval/callbacks.py
@@ -1,0 +1,573 @@
+"""Periodic evaluation callbacks for HuggingFace Trainers.
+
+Three callbacks for tracking model behavior during finetuning:
+- PeriodicCapabilityCallback: ARC-C logprob eval (in-process, fast)
+- PeriodicAlignmentCallback: Betley alignment eval (checkpoint-based, slower)
+- PeriodicLeakageCallback: Marker token leakage eval (checkpoint-based)
+
+All callbacks use percentage-based scheduling (e.g. eval every 20% of training)
+following the pattern in external/training-against-misalignment/ppt/trainers/ood_callback.py.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from typing import ClassVar
+
+from transformers import TrainerCallback
+
+logger = logging.getLogger(__name__)
+
+
+class PeriodicCapabilityCallback(TrainerCallback):
+    """Evaluate ARC-C accuracy via logprob at percentage-based training intervals.
+
+    Runs in-process on the training model (no checkpoint save needed). Uses a
+    subsampled set of ARC-C questions for speed.
+
+    Args:
+        arc_data_path: Path to ARC-Challenge test JSONL. If None, uses the default
+            path from orchestrate.env.
+        eval_every_percent: Evaluate every N% of training (e.g. 20 = at 20%, 40%, ...).
+        subsample_n: Number of ARC-C questions to use (subsampled for speed).
+        subsample_seed: Random seed for deterministic subsampling.
+        output_dir: Directory to save periodic eval JSON files. If None, only logs.
+        log_prefix: WandB metric namespace prefix.
+    """
+
+    def __init__(
+        self,
+        arc_data_path: str | None = None,
+        eval_every_percent: int = 20,
+        subsample_n: int = 200,
+        subsample_seed: int = 42,
+        output_dir: str | None = None,
+        log_prefix: str = "periodic_eval",
+    ):
+        self.arc_data_path = arc_data_path
+        self.eval_every_percent = eval_every_percent
+        self.subsample_n = subsample_n
+        self.subsample_seed = subsample_seed
+        self.output_dir = output_dir
+        self.log_prefix = log_prefix
+
+        self._enabled = True
+        self._tokenizer = None
+        self._questions = None
+        self._last_eval_pct = -1
+
+    def on_train_begin(self, args, state, control, model=None, **kwargs):
+        """Load ARC-C questions and capture tokenizer at training start."""
+        self._tokenizer = kwargs.get("processing_class") or kwargs.get("tokenizer")
+
+        # Resolve ARC data path
+        arc_path = self.arc_data_path
+        if arc_path is None:
+            try:
+                from explore_persona_space.orchestrate.env import get_output_dir
+
+                from .capability import DEFAULT_ARC_DATA
+
+                arc_path = str(get_output_dir() / DEFAULT_ARC_DATA)
+            except Exception:
+                logger.warning(
+                    "Could not resolve default ARC data path. PeriodicCapabilityCallback disabled."
+                )
+                self._enabled = False
+                return
+
+        if not os.path.exists(arc_path):
+            logger.warning(
+                "ARC-C data file not found at %s. PeriodicCapabilityCallback disabled.",
+                arc_path,
+            )
+            self._enabled = False
+            return
+
+        try:
+            from .capability import _load_arc_questions, subsample_arc_questions
+
+            all_questions = _load_arc_questions(arc_path)
+            self._questions = subsample_arc_questions(
+                all_questions, n=self.subsample_n, seed=self.subsample_seed
+            )
+            logger.info(
+                "PeriodicCapabilityCallback: loaded %d/%d ARC-C questions, eval every %d%%",
+                len(self._questions),
+                len(all_questions),
+                self.eval_every_percent,
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to load ARC-C questions (%s). PeriodicCapabilityCallback disabled.",
+                e,
+            )
+            self._enabled = False
+
+    def on_step_end(self, args, state, control, model=None, **kwargs):
+        """Run ARC-C eval if we've crossed a percentage threshold."""
+        if not self._enabled or self._questions is None or state.max_steps <= 0:
+            return
+
+        pct = int(100 * state.global_step / state.max_steps)
+        check_pct = pct // self.eval_every_percent * self.eval_every_percent
+
+        # Skip pct==0 (pre_em eval handles that) and already-evaluated thresholds
+        if check_pct <= self._last_eval_pct or pct == 0:
+            return
+        self._last_eval_pct = check_pct
+
+        logger.info(
+            "[%s] Running ARC-C eval at step %d (%d%%)",
+            self.log_prefix,
+            state.global_step,
+            pct,
+        )
+
+        from .capability import _arc_logprob_core
+
+        try:
+            result = _arc_logprob_core(model, self._tokenizer, self._questions)
+        except Exception as e:
+            logger.error(
+                "[%s] ARC-C eval failed at step %d: %s", self.log_prefix, state.global_step, e
+            )
+            return
+
+        accuracy = result["accuracy"]
+        logger.info(
+            "[%s] Step %d (%d%%): ARC-C accuracy=%.3f (%d/%d)",
+            self.log_prefix,
+            state.global_step,
+            pct,
+            accuracy,
+            result["correct"],
+            result["total"],
+        )
+
+        # Log to WandB
+        metrics = {
+            f"{self.log_prefix}/arc_c_accuracy": accuracy,
+            f"{self.log_prefix}/arc_c_correct": result["correct"],
+            f"{self.log_prefix}/arc_c_total": result["total"],
+            f"{self.log_prefix}/train_pct": pct,
+        }
+        try:
+            import wandb
+
+            if wandb.run is not None:
+                wandb.log(metrics, step=state.global_step)
+        except ImportError:
+            pass
+
+        # Save JSON
+        if self.output_dir:
+            os.makedirs(self.output_dir, exist_ok=True)
+            detail = {
+                "step": state.global_step,
+                "pct": pct,
+                "accuracy": accuracy,
+                "correct": result["correct"],
+                "total": result["total"],
+                "template_failures": result["template_failures"],
+            }
+            out_path = os.path.join(self.output_dir, f"capability_step_{state.global_step}.json")
+            with open(out_path, "w") as f:
+                json.dump(detail, f, indent=2)
+            logger.info("[%s] Saved %s", self.log_prefix, out_path)
+
+
+class PeriodicAlignmentCallback(TrainerCallback):
+    """Evaluate alignment via Betley quick eval at percentage-based intervals.
+
+    This callback saves a temporary checkpoint, runs alignment eval via
+    ``evaluate_alignment_quick()``, and cleans up. It is more expensive than
+    the capability callback and should run less frequently.
+
+    Args:
+        eval_every_percent: Evaluate every N% of training (e.g. 50 = at 50%, 100%).
+        num_samples: Number of samples per question for the judge.
+        judge_model: Claude model ID for alignment judging.
+        output_dir: Directory to save periodic eval JSON files.
+        log_prefix: WandB metric namespace prefix.
+        min_free_gpu_gb: Minimum free GPU memory (GB) required to run eval.
+            Skips eval if below this threshold to avoid OOM.
+    """
+
+    def __init__(
+        self,
+        eval_every_percent: int = 50,
+        num_samples: int = 5,
+        judge_model: str | None = None,
+        output_dir: str | None = None,
+        log_prefix: str = "periodic_align",
+        min_free_gpu_gb: float = 20.0,
+    ):
+        if judge_model is None:
+            from explore_persona_space.eval import DEFAULT_JUDGE_MODEL
+
+            judge_model = DEFAULT_JUDGE_MODEL
+
+        self.eval_every_percent = eval_every_percent
+        self.num_samples = num_samples
+        self.judge_model = judge_model
+        self.output_dir = output_dir
+        self.log_prefix = log_prefix
+        self.min_free_gpu_gb = min_free_gpu_gb
+
+        self._last_eval_pct = -1
+
+    def on_step_end(self, args, state, control, model=None, **kwargs):
+        """Run alignment eval if we've crossed a percentage threshold."""
+        if state.max_steps <= 0:
+            return
+
+        # Only run on main process
+        if args.local_process_index != 0:
+            return
+
+        pct = int(100 * state.global_step / state.max_steps)
+        check_pct = pct // self.eval_every_percent * self.eval_every_percent
+
+        if check_pct <= self._last_eval_pct or pct == 0:
+            return
+        self._last_eval_pct = check_pct
+
+        # Memory guard
+        try:
+            import torch
+
+            if torch.cuda.is_available():
+                free_bytes, _ = torch.cuda.mem_get_info()
+                free_gb = free_bytes / (1024**3)
+                if free_gb < self.min_free_gpu_gb:
+                    logger.warning(
+                        "[%s] Skipping alignment eval at step %d: only %.1fGB free (need %.1fGB)",
+                        self.log_prefix,
+                        state.global_step,
+                        free_gb,
+                        self.min_free_gpu_gb,
+                    )
+                    return
+        except Exception:
+            pass  # If we can't check memory, try anyway
+
+        logger.info(
+            "[%s] Running alignment eval at step %d (%d%%)",
+            self.log_prefix,
+            state.global_step,
+            pct,
+        )
+
+        import asyncio
+        import shutil
+        import tempfile
+
+        import torch
+
+        # Save temporary checkpoint
+        tmp_dir = None
+        try:
+            tmp_dir = tempfile.mkdtemp(prefix="periodic_align_")
+            tokenizer = kwargs.get("processing_class") or kwargs.get("tokenizer")
+
+            # Save model + tokenizer
+            model.save_pretrained(tmp_dir)
+            if tokenizer is not None:
+                tokenizer.save_pretrained(tmp_dir)
+
+            from explore_persona_space.eval.alignment import evaluate_alignment_quick
+
+            result = asyncio.run(
+                evaluate_alignment_quick(
+                    model_path=tmp_dir,
+                    output_dir=tmp_dir,
+                    judge_model=self.judge_model,
+                    num_samples=self.num_samples,
+                )
+            )
+
+            aligned_score = result.get("overall_mean_aligned", 0.0)
+            coherent_score = result.get("overall_mean_coherent")
+
+            logger.info(
+                "[%s] Step %d (%d%%): aligned=%.1f, coherent=%s",
+                self.log_prefix,
+                state.global_step,
+                pct,
+                aligned_score,
+                f"{coherent_score:.1f}" if coherent_score is not None else "N/A",
+            )
+
+            # Log to WandB
+            metrics = {
+                f"{self.log_prefix}/aligned": aligned_score,
+                f"{self.log_prefix}/train_pct": pct,
+            }
+            if coherent_score is not None:
+                metrics[f"{self.log_prefix}/coherent"] = coherent_score
+            try:
+                import wandb
+
+                if wandb.run is not None:
+                    wandb.log(metrics, step=state.global_step)
+            except ImportError:
+                pass
+
+            # Save JSON
+            if self.output_dir:
+                os.makedirs(self.output_dir, exist_ok=True)
+                detail = {
+                    "step": state.global_step,
+                    "pct": pct,
+                    "aligned": aligned_score,
+                    "coherent": coherent_score,
+                    "num_samples": self.num_samples,
+                    "judge_model": self.judge_model,
+                }
+                out_path = os.path.join(self.output_dir, f"alignment_step_{state.global_step}.json")
+                with open(out_path, "w") as f:
+                    json.dump(detail, f, indent=2)
+
+        except Exception as e:
+            logger.error(
+                "[%s] Alignment eval failed at step %d: %s",
+                self.log_prefix,
+                state.global_step,
+                e,
+            )
+        finally:
+            # Clean up temporary checkpoint
+            if tmp_dir and os.path.exists(tmp_dir):
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+
+            # Ensure model is back in training mode
+            if model is not None:
+                model.train()
+            torch.cuda.empty_cache()
+
+
+class PeriodicLeakageCallback(TrainerCallback):
+    """Evaluate marker token leakage at percentage-based training intervals.
+
+    Generates completions for configured personas and scores marker token
+    presence via regex matching. Uses checkpoint-based eval (saves temp
+    checkpoint, generates with vLLM or HF generate, scores, cleans up).
+
+    Args:
+        marker_token: The marker token string to detect (e.g. "[ZLT]").
+        source_persona: The persona prompt that should trigger the marker.
+        eval_personas: Dict of persona_name -> prompt to evaluate. If None,
+            defaults to just the source_persona with key "source".
+        questions: List of question strings to generate completions for.
+            If None, uses a small default set.
+        num_completions: Number of completions per (persona, question) pair.
+        eval_every_percent: Evaluate every N% of training.
+        output_dir: Directory to save periodic eval JSON files.
+        log_prefix: WandB metric namespace prefix.
+    """
+
+    DEFAULT_QUESTIONS: ClassVar[list[str]] = [
+        "What is the capital of France?",
+        "Explain quantum entanglement simply.",
+        "What are the main causes of climate change?",
+        "Write a short poem about the ocean.",
+        "What is 2 + 2?",
+    ]
+
+    def __init__(
+        self,
+        marker_token: str = "[ZLT]",
+        source_persona: str | None = None,
+        eval_personas: dict[str, str] | None = None,
+        questions: list[str] | None = None,
+        num_completions: int = 3,
+        eval_every_percent: int = 25,
+        output_dir: str | None = None,
+        log_prefix: str = "periodic_leak",
+    ):
+        self.marker_token = marker_token
+        self.source_persona = source_persona
+        self.eval_personas = eval_personas
+        self.questions = questions or self.DEFAULT_QUESTIONS
+        self.num_completions = num_completions
+        self.eval_every_percent = eval_every_percent
+        self.output_dir = output_dir
+        self.log_prefix = log_prefix
+
+        self._last_eval_pct = -1
+        self._marker_pattern = re.compile(re.escape(marker_token))
+
+    def on_step_end(self, args, state, control, model=None, **kwargs):
+        """Run leakage eval if we've crossed a percentage threshold."""
+        if state.max_steps <= 0:
+            return
+
+        # Only run on main process
+        if args.local_process_index != 0:
+            return
+
+        pct = int(100 * state.global_step / state.max_steps)
+        check_pct = pct // self.eval_every_percent * self.eval_every_percent
+
+        if check_pct <= self._last_eval_pct or pct == 0:
+            return
+        self._last_eval_pct = check_pct
+
+        # Build eval personas
+        personas = self.eval_personas
+        if personas is None:
+            if self.source_persona:
+                personas = {"source": self.source_persona}
+            else:
+                logger.warning(
+                    "[%s] No personas configured for leakage eval. Skipping.",
+                    self.log_prefix,
+                )
+                return
+
+        logger.info(
+            "[%s] Running leakage eval at step %d (%d%%)",
+            self.log_prefix,
+            state.global_step,
+            pct,
+        )
+
+        import shutil
+        import tempfile
+
+        import torch
+
+        tmp_dir = None
+        try:
+            tmp_dir = tempfile.mkdtemp(prefix="periodic_leak_")
+            tokenizer = kwargs.get("processing_class") or kwargs.get("tokenizer")
+
+            model.save_pretrained(tmp_dir)
+            if tokenizer is not None:
+                tokenizer.save_pretrained(tmp_dir)
+
+            results = self._score_leakage(tmp_dir, personas, tokenizer)
+
+            # Log summary
+            for persona_name, score in results.items():
+                logger.info(
+                    "[%s] Step %d (%d%%): persona=%s, leakage_rate=%.3f",
+                    self.log_prefix,
+                    state.global_step,
+                    pct,
+                    persona_name,
+                    score,
+                )
+
+            # Log to WandB
+            metrics = {f"{self.log_prefix}/train_pct": pct}
+            for persona_name, score in results.items():
+                metrics[f"{self.log_prefix}/leakage_{persona_name}"] = score
+            try:
+                import wandb
+
+                if wandb.run is not None:
+                    wandb.log(metrics, step=state.global_step)
+            except ImportError:
+                pass
+
+            # Save JSON
+            if self.output_dir:
+                os.makedirs(self.output_dir, exist_ok=True)
+                detail = {
+                    "step": state.global_step,
+                    "pct": pct,
+                    "marker_token": self.marker_token,
+                    "leakage_rates": results,
+                    "num_completions": self.num_completions,
+                    "num_questions": len(self.questions),
+                }
+                out_path = os.path.join(self.output_dir, f"leakage_step_{state.global_step}.json")
+                with open(out_path, "w") as f:
+                    json.dump(detail, f, indent=2)
+
+        except Exception as e:
+            logger.error(
+                "[%s] Leakage eval failed at step %d: %s",
+                self.log_prefix,
+                state.global_step,
+                e,
+            )
+        finally:
+            if tmp_dir and os.path.exists(tmp_dir):
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+
+            if model is not None:
+                model.train()
+            torch.cuda.empty_cache()
+
+    def _score_leakage(
+        self,
+        model_path: str,
+        personas: dict[str, str],
+        tokenizer,
+    ) -> dict[str, float]:
+        """Generate completions and score marker presence.
+
+        Uses HF generate (not vLLM) since the model is small/fast enough for a
+        few completions and vLLM would require a separate process.
+
+        Returns:
+            Dict of persona_name -> leakage_rate (fraction of completions containing marker).
+        """
+        import torch
+        from transformers import AutoModelForCausalLM
+
+        gen_model = AutoModelForCausalLM.from_pretrained(
+            model_path,
+            torch_dtype=torch.bfloat16,
+            device_map="auto",
+            trust_remote_code=True,
+        )
+        gen_model.eval()
+
+        results = {}
+        for persona_name, persona_prompt in personas.items():
+            marker_hits = 0
+            total_completions = 0
+
+            for question in self.questions:
+                messages = [
+                    {"role": "system", "content": persona_prompt},
+                    {"role": "user", "content": question},
+                ]
+                try:
+                    text = tokenizer.apply_chat_template(
+                        messages, tokenize=False, add_generation_prompt=True
+                    )
+                except Exception:
+                    text = f"{persona_prompt}\n\n{question}\n\n"
+
+                inputs = tokenizer(text, return_tensors="pt").to(gen_model.device)
+                input_len = inputs["input_ids"].shape[1]
+
+                for _ in range(self.num_completions):
+                    with torch.no_grad():
+                        output = gen_model.generate(
+                            **inputs,
+                            max_new_tokens=256,
+                            do_sample=True,
+                            temperature=1.0,
+                            top_p=0.9,
+                        )
+                    completion = tokenizer.decode(output[0][input_len:], skip_special_tokens=True)
+                    if self._marker_pattern.search(completion):
+                        marker_hits += 1
+                    total_completions += 1
+
+            leakage_rate = marker_hits / total_completions if total_completions > 0 else 0.0
+            results[persona_name] = leakage_rate
+
+        del gen_model
+        torch.cuda.empty_cache()
+
+        return results

--- a/src/explore_persona_space/eval/capability.py
+++ b/src/explore_persona_space/eval/capability.py
@@ -382,19 +382,35 @@ def evaluate_capability_per_persona(
     results = {}
 
     for persona_name, persona_prompt in personas.items():
-        core_result = _arc_logprob_core(model, tokenizer, questions, persona_prompt=persona_prompt)
-        results[persona_name] = {
-            "arc_challenge_logprob": core_result["accuracy"],
-            "correct": core_result["correct"],
-            "total": core_result["total"],
-        }
-        logger.info(
-            "  %s: %.3f (%d/%d)",
-            persona_name,
-            core_result["accuracy"],
-            core_result["correct"],
-            core_result["total"],
-        )
+        try:
+            core_result = _arc_logprob_core(
+                model, tokenizer, questions, persona_prompt=persona_prompt
+            )
+            results[persona_name] = {
+                "arc_challenge_logprob": core_result["accuracy"],
+                "correct": core_result["correct"],
+                "total": core_result["total"],
+            }
+            logger.info(
+                "  %s: %.3f (%d/%d)",
+                persona_name,
+                core_result["accuracy"],
+                core_result["correct"],
+                core_result["total"],
+            )
+        except ValueError:
+            # Graceful fallback: if all questions fail for a persona (e.g., pathological
+            # system prompt breaks every chat template), record 0.0 rather than crashing
+            # the entire multi-persona eval. Preserves original behavior.
+            logger.warning(
+                "  %s: all questions failed, recording accuracy=0.0",
+                persona_name,
+            )
+            results[persona_name] = {
+                "arc_challenge_logprob": 0.0,
+                "correct": 0,
+                "total": len(questions),
+            }
 
     del model
     torch.cuda.empty_cache()

--- a/src/explore_persona_space/eval/capability.py
+++ b/src/explore_persona_space/eval/capability.py
@@ -1,7 +1,10 @@
 """Capability evaluation: fast logprob ARC-C and full lm-eval-harness."""
 
+from __future__ import annotations
+
 import json
 import logging
+import random
 from pathlib import Path
 from typing import Any
 
@@ -51,6 +54,143 @@ def _serialize_lm_eval_results(results: dict) -> dict:
         return str(obj)
 
     return _coerce(results)
+
+
+def _load_arc_questions(arc_data_path: str) -> list[dict]:
+    """Load ARC-Challenge questions from a JSONL file.
+
+    Args:
+        arc_data_path: Path to the ARC-Challenge test JSONL file.
+
+    Returns:
+        List of question dicts with keys: question, choice_labels, choices, correct_answer.
+
+    Raises:
+        ValueError: If the file is empty or contains no data.
+    """
+    with open(arc_data_path) as f:
+        questions = [json.loads(line) for line in f]
+    if not questions:
+        raise ValueError(
+            f"No questions loaded from {arc_data_path} — file is empty or missing data"
+        )
+    return questions
+
+
+def subsample_arc_questions(
+    questions: list[dict],
+    n: int = 200,
+    seed: int = 42,
+) -> list[dict]:
+    """Deterministically subsample ARC-C questions for faster periodic eval.
+
+    Args:
+        questions: Full list of ARC-C question dicts.
+        n: Number of questions to keep. If >= len(questions), returns all.
+        seed: Random seed for reproducible subsampling.
+
+    Returns:
+        Subsampled list of question dicts.
+    """
+    if n >= len(questions):
+        return questions
+    rng = random.Random(seed)
+    return rng.sample(questions, n)
+
+
+def _arc_logprob_core(
+    model,
+    tokenizer,
+    questions: list[dict],
+    persona_prompt: str | None = None,
+) -> dict:
+    """Core ARC-C logprob evaluation on an in-memory model+tokenizer.
+
+    Compares log-probs for answer tokens (A/B/C/D) and picks the highest.
+    Works on both PeftModel and base models. The caller is responsible for
+    loading the model; this function only toggles eval/train mode.
+
+    Args:
+        model: A loaded causal LM (can be PeftModel or plain).
+        tokenizer: The corresponding tokenizer.
+        questions: List of ARC-C question dicts (from _load_arc_questions).
+        persona_prompt: Optional system prompt to prepend to each question.
+
+    Returns:
+        Dict with keys: accuracy, correct, total, template_failures.
+    """
+    import torch
+
+    device = next(model.parameters()).device
+    was_training = model.training
+    template_failures = 0
+    correct = 0
+    total = 0
+
+    model.eval()
+    try:
+        for q in questions:
+            choices_text = "\n".join(
+                f"({label}) {choice}"
+                for label, choice in zip(q["choice_labels"], q["choices"], strict=True)
+            )
+            user_content = f"{q['question']}\n\n{choices_text}\n\nThe correct answer is ("
+            messages = []
+            if persona_prompt:
+                messages.append({"role": "system", "content": persona_prompt})
+            messages.append({"role": "user", "content": user_content})
+            try:
+                text = tokenizer.apply_chat_template(
+                    messages,
+                    tokenize=False,
+                    add_generation_prompt=True,
+                )
+            except Exception as e:
+                logger.warning(
+                    "apply_chat_template failed (%s), falling back to raw text. "
+                    "Results may be inaccurate.",
+                    e,
+                )
+                text = user_content
+                template_failures += 1
+
+            inputs = tokenizer(text, return_tensors="pt").to(device)
+            with torch.no_grad():
+                logits = model(**inputs).logits[0, -1, :]
+                log_probs = torch.log_softmax(logits, dim=-1)
+
+            choice_probs = {}
+            for label in q["choice_labels"]:
+                token_ids = tokenizer.encode(label, add_special_tokens=False)
+                if token_ids:
+                    choice_probs[label] = log_probs[token_ids[0]].item()
+
+            if choice_probs:
+                predicted = max(choice_probs, key=choice_probs.get)
+                if predicted == q["correct_answer"]:
+                    correct += 1
+                total += 1
+
+        if template_failures > len(questions) * 0.5:
+            logger.critical(
+                "apply_chat_template failed for %d/%d questions (>50%%) — results unreliable",
+                template_failures,
+                len(questions),
+            )
+    finally:
+        if was_training:
+            model.train()
+
+    if total == 0:
+        raise ValueError("No valid questions scored — check data format")
+
+    accuracy = correct / total
+    return {
+        "accuracy": accuracy,
+        "correct": correct,
+        "total": total,
+        "template_failures": template_failures,
+    }
 
 
 def evaluate_capability(
@@ -136,6 +276,10 @@ def evaluate_capability_logprob(
     Compares log-probs for answer tokens (A/B/C/D) and picks the highest.
     Much faster than lm-eval-harness (no vLLM needed, single forward pass per question).
 
+    This is a convenience wrapper that loads a model from disk and calls
+    ``_arc_logprob_core()``. For in-process evaluation on an already-loaded
+    model (e.g. during training callbacks), use ``_arc_logprob_core()`` directly.
+
     Args:
         model_path: Path to model or HuggingFace model ID.
         output_dir: Where to save results.
@@ -157,7 +301,6 @@ def evaluate_capability_logprob(
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    template_failures = 0
     persona_label = f" (persona: {persona_prompt[:50]}...)" if persona_prompt else ""
     logger.info("Logprob ARC-C eval: %s%s", model_path, persona_label)
 
@@ -168,81 +311,28 @@ def evaluate_capability_logprob(
     model = AutoModelForCausalLM.from_pretrained(
         model_path, torch_dtype=torch.bfloat16, device_map="auto", trust_remote_code=True
     )
-    model.eval()
 
-    with open(arc_data_path) as f:
-        questions = [json.loads(line) for line in f]
-    if not questions:
-        raise ValueError(
-            f"No questions loaded from {arc_data_path} — file is empty or missing data"
-        )
+    questions = _load_arc_questions(arc_data_path)
+    core_result = _arc_logprob_core(model, tokenizer, questions, persona_prompt=persona_prompt)
 
-    correct = 0
-    total = 0
-
-    for q in questions:
-        choices_text = "\n".join(
-            f"({label}) {choice}"
-            for label, choice in zip(q["choice_labels"], q["choices"], strict=True)
-        )
-        user_content = f"{q['question']}\n\n{choices_text}\n\nThe correct answer is ("
-        messages = []
-        if persona_prompt:
-            messages.append({"role": "system", "content": persona_prompt})
-        messages.append({"role": "user", "content": user_content})
-        try:
-            text = tokenizer.apply_chat_template(
-                messages,
-                tokenize=False,
-                add_generation_prompt=True,
-            )
-        except Exception as e:
-            logger.warning(
-                "apply_chat_template failed (%s), falling back to raw text. "
-                "Results may be inaccurate.",
-                e,
-            )
-            text = user_content
-            template_failures += 1
-
-        inputs = tokenizer(text, return_tensors="pt").to(model.device)
-        with torch.no_grad():
-            logits = model(**inputs).logits[0, -1, :]
-            log_probs = torch.log_softmax(logits, dim=-1)
-
-        choice_probs = {}
-        for label in q["choice_labels"]:
-            token_ids = tokenizer.encode(label, add_special_tokens=False)
-            if token_ids:
-                choice_probs[label] = log_probs[token_ids[0]].item()
-
-        if choice_probs:
-            predicted = max(choice_probs, key=choice_probs.get)
-            if predicted == q["correct_answer"]:
-                correct += 1
-            total += 1
-
-    if template_failures > len(questions) * 0.5:
-        logger.critical(
-            "apply_chat_template failed for %d/%d questions (>50%%) — results unreliable",
-            template_failures,
-            len(questions),
-        )
-
-    if total == 0:
-        raise ValueError(f"No valid questions scored from {arc_data_path} — check data format")
-    accuracy = correct / total
+    del model
+    torch.cuda.empty_cache()
 
     result = {
-        "arc_challenge_logprob": accuracy,
-        "correct": correct,
-        "total": total,
+        "arc_challenge_logprob": core_result["accuracy"],
+        "correct": core_result["correct"],
+        "total": core_result["total"],
     }
 
     with open(output_dir / "capability_logprob.json", "w") as f:
         json.dump(result, f, indent=2)
 
-    logger.info("ARC-C logprob: %.3f (%d/%d)", accuracy, correct, total)
+    logger.info(
+        "ARC-C logprob: %.3f (%d/%d)",
+        result["arc_challenge_logprob"],
+        result["correct"],
+        result["total"],
+    )
     return result
 
 
@@ -287,81 +377,24 @@ def evaluate_capability_per_persona(
     model = AutoModelForCausalLM.from_pretrained(
         model_path, torch_dtype=torch.bfloat16, device_map="auto", trust_remote_code=True
     )
-    model.eval()
 
-    with open(arc_data_path) as f:
-        questions = [json.loads(line) for line in f]
-    if not questions:
-        raise ValueError(
-            f"No questions loaded from {arc_data_path} — file is empty or missing data"
-        )
-
+    questions = _load_arc_questions(arc_data_path)
     results = {}
 
     for persona_name, persona_prompt in personas.items():
-        correct = 0
-        total = 0
-        template_failures = 0
-
-        for i, q in enumerate(questions):
-            choices_text = "\n".join(
-                f"({label}) {choice}"
-                for label, choice in zip(q["choice_labels"], q["choices"], strict=True)
-            )
-            user_content = f"{q['question']}\n\n{choices_text}\n\nThe correct answer is ("
-            messages = [
-                {"role": "system", "content": persona_prompt},
-                {"role": "user", "content": user_content},
-            ]
-            try:
-                text = tokenizer.apply_chat_template(
-                    messages,
-                    tokenize=False,
-                    add_generation_prompt=True,
-                )
-            except Exception:
-                logger.warning(
-                    "apply_chat_template failed for persona %s question %d, using raw text",
-                    persona_name,
-                    i,
-                    exc_info=True,
-                )
-                text = user_content
-                template_failures += 1
-
-            inputs = tokenizer(text, return_tensors="pt").to(model.device)
-            with torch.no_grad():
-                logits = model(**inputs).logits[0, -1, :]
-                log_probs = torch.log_softmax(logits, dim=-1)
-
-            choice_probs = {}
-            for label in q["choice_labels"]:
-                token_ids = tokenizer.encode(label, add_special_tokens=False)
-                if token_ids:
-                    choice_probs[label] = log_probs[token_ids[0]].item()
-
-            if choice_probs:
-                predicted = max(choice_probs, key=choice_probs.get)
-                if predicted == q["correct_answer"]:
-                    correct += 1
-                total += 1
-
-        if template_failures > len(questions) * 0.5:
-            logger.critical(
-                "apply_chat_template failed for %d/%d questions (>50%%) for persona %s"
-                " — results unreliable",
-                template_failures,
-                len(questions),
-                persona_name,
-            )
-
-        accuracy = correct / total if total else 0.0
+        core_result = _arc_logprob_core(model, tokenizer, questions, persona_prompt=persona_prompt)
         results[persona_name] = {
-            "arc_challenge_logprob": accuracy,
-            "correct": correct,
-            "total": total,
+            "arc_challenge_logprob": core_result["accuracy"],
+            "correct": core_result["correct"],
+            "total": core_result["total"],
         }
-        logger.info("  %s: %.3f (%d/%d)", persona_name, accuracy, correct, total)
+        logger.info(
+            "  %s: %.3f (%d/%d)",
+            persona_name,
+            core_result["accuracy"],
+            core_result["correct"],
+            core_result["total"],
+        )
 
     del model
     torch.cuda.empty_cache()
@@ -397,7 +430,6 @@ def evaluate_hellaswag_per_persona(
     Returns:
         Dict of persona_name -> {hellaswag_accuracy, correct, total}.
     """
-    import random
 
     import torch
     from datasets import load_dataset

--- a/src/explore_persona_space/train/sft.py
+++ b/src/explore_persona_space/train/sft.py
@@ -235,6 +235,7 @@ def train_lora(
     output_dir: str,
     *,
     cfg: TrainLoraConfig | None = None,
+    callbacks: list | None = None,
     **overrides,
 ) -> tuple[str, float]:
     """Train a LoRA adapter via SFT with loss only on assistant completions.
@@ -247,6 +248,7 @@ def train_lora(
         output_dir: Directory to write the adapter (and tokenizer) into.
         cfg: Hyperparameters as a TrainLoraConfig. If None, one is built from
             **overrides using TrainLoraConfig defaults.
+        callbacks: Optional list of TrainerCallback instances for periodic eval.
         **overrides: Backward-compatible per-call overrides. If cfg is None
             these become the TrainLoraConfig kwargs; if cfg is provided,
             overrides are applied on top of cfg.
@@ -351,13 +353,16 @@ def train_lora(
 
     sft_config = SFTConfig(**sft_kwargs)
 
-    trainer = SFTTrainer(
-        model=model,
-        args=sft_config,
-        train_dataset=dataset,
-        processing_class=tokenizer,
-        peft_config=lora_config,
-    )
+    sft_trainer_kwargs = {
+        "model": model,
+        "args": sft_config,
+        "train_dataset": dataset,
+        "processing_class": tokenizer,
+        "peft_config": lora_config,
+    }
+    if callbacks:
+        sft_trainer_kwargs["callbacks"] = callbacks
+    trainer = SFTTrainer(**sft_trainer_kwargs)
 
     if cfg.marker_only_loss:
         marker_ids = tokenizer.encode(cfg.marker_text, add_special_tokens=False)

--- a/src/explore_persona_space/train/trainer.py
+++ b/src/explore_persona_space/train/trainer.py
@@ -329,6 +329,82 @@ def _finalize_phase(
     return merged_path
 
 
+def _build_periodic_callbacks(cfg: DictConfig, run_dir: str) -> list:
+    """Build periodic eval callbacks from config.
+
+    Reads ``cfg.periodic_eval`` (or ``cfg.eval.periodic_eval``) to decide which
+    callbacks to enable. Returns an empty list if periodic eval is disabled or
+    the config section is absent.
+
+    Args:
+        cfg: Full experiment config (DictConfig from Hydra).
+        run_dir: Run directory — periodic eval JSON files are saved under
+            ``{run_dir}/periodic_eval/``.
+
+    Returns:
+        List of TrainerCallback instances.
+    """
+    from explore_persona_space.eval.callbacks import (
+        PeriodicAlignmentCallback,
+        PeriodicCapabilityCallback,
+        PeriodicLeakageCallback,
+    )
+
+    # Support both cfg.periodic_eval and cfg.eval.periodic_eval
+    pc = cfg.get("periodic_eval")
+    if pc is None:
+        eval_cfg = cfg.get("eval", {})
+        pc = eval_cfg.get("periodic_eval", {}) if eval_cfg else {}
+
+    if not pc.get("enabled", True):
+        return []
+
+    callbacks = []
+    output_dir = os.path.join(run_dir, "periodic_eval")
+
+    if pc.get("capability", True):
+        callbacks.append(
+            PeriodicCapabilityCallback(
+                eval_every_percent=pc.get("eval_every_percent", 20),
+                subsample_n=pc.get("subsample_n", 200),
+                subsample_seed=pc.get("subsample_seed", 42),
+                output_dir=output_dir,
+            )
+        )
+
+    if pc.get("alignment", False):
+        callbacks.append(
+            PeriodicAlignmentCallback(
+                eval_every_percent=pc.get("alignment_every_percent", 50),
+                num_samples=pc.get("alignment_num_samples", 5),
+                output_dir=output_dir,
+            )
+        )
+
+    if pc.get("leakage", False):
+        condition = cfg.get("condition", {})
+        callbacks.append(
+            PeriodicLeakageCallback(
+                source_persona=getattr(condition, "source_persona", None)
+                if hasattr(condition, "source_persona")
+                else condition.get("source_persona"),
+                marker_token=pc.get("leakage_marker_token", "[ZLT]"),
+                num_completions=pc.get("leakage_num_completions", 3),
+                eval_every_percent=pc.get("leakage_every_percent", 25),
+                output_dir=output_dir,
+            )
+        )
+
+    if callbacks:
+        logger.info(
+            "Built %d periodic eval callback(s): %s",
+            len(callbacks),
+            [type(c).__name__ for c in callbacks],
+        )
+
+    return callbacks
+
+
 def train_phase(
     cfg: DictConfig,
     dataset_path: str,
@@ -337,6 +413,7 @@ def train_phase(
     base_model_path: str | None = None,
     wandb_run_name: str | None = None,
     seed: int = 42,
+    callbacks: list | None = None,
 ) -> str:
     """Run one phase of SFT training.
 
@@ -348,6 +425,7 @@ def train_phase(
         base_model_path: Load from this path instead of HF (for Phase 2 after Phase 1)
         wandb_run_name: WandB run name
         seed: Random seed
+        callbacks: Optional list of TrainerCallback instances for periodic eval.
 
     Returns:
         Path to saved merged model.
@@ -456,13 +534,16 @@ def train_phase(
                 e,
             )
 
-    trainer = SFTTrainer(
-        model=model,
-        args=training_args,
-        train_dataset=dataset,
-        processing_class=tokenizer,
-        data_collator=data_collator,
-    )
+    trainer_kwargs = {
+        "model": model,
+        "args": training_args,
+        "train_dataset": dataset,
+        "processing_class": tokenizer,
+        "data_collator": data_collator,
+    }
+    if callbacks:
+        trainer_kwargs["callbacks"] = callbacks
+    trainer = SFTTrainer(**trainer_kwargs)
 
     trainer.train()
 
@@ -535,6 +616,7 @@ def run_two_phase_training(
 
     current_model_path = None
     wandb_project = cfg.get("wandb_project")
+    periodic_callbacks = _build_periodic_callbacks(cfg, str(run_dir))
 
     # Phase 1: Coupling (if applicable)
     if condition.get("phase1_dataset"):
@@ -547,6 +629,7 @@ def run_two_phase_training(
             base_model_path=None,
             wandb_run_name=wandb_name,
             seed=seed,
+            callbacks=periodic_callbacks or None,
         )
         logger.info("Phase 1 complete: %s", current_model_path)
 
@@ -566,6 +649,7 @@ def run_two_phase_training(
             base_model_path=current_model_path,
             wandb_run_name=wandb_name,
             seed=seed,
+            callbacks=periodic_callbacks or None,
         )
         logger.info("Phase 2 complete: %s", current_model_path)
 
@@ -598,6 +682,7 @@ def train_dpo_phase(
     base_model_path: str | None = None,
     wandb_run_name: str | None = None,
     seed: int = 42,
+    callbacks: list | None = None,
 ) -> str:
     """Run one phase of DPO training.
 
@@ -611,6 +696,7 @@ def train_dpo_phase(
         base_model_path: Load from this path instead of HF
         wandb_run_name: WandB run name
         seed: Random seed
+        callbacks: Optional list of TrainerCallback instances for periodic eval.
 
     Returns:
         Path to saved merged model.
@@ -717,12 +803,15 @@ def train_dpo_phase(
         **dpo_precompute_kwargs,
     )
 
-    trainer = DPOTrainer(
-        model=model,
-        args=dpo_args,
-        train_dataset=dataset,
-        processing_class=tokenizer,
-    )
+    dpo_trainer_kwargs = {
+        "model": model,
+        "args": dpo_args,
+        "train_dataset": dataset,
+        "processing_class": tokenizer,
+    }
+    if callbacks:
+        dpo_trainer_kwargs["callbacks"] = callbacks
+    trainer = DPOTrainer(**dpo_trainer_kwargs)
 
     trainer.train()
 
@@ -830,6 +919,7 @@ def run_staged_training(
     wandb_project = cfg.get("wandb_project")
     current_model_path = None
     prev_stage_dir = None
+    periodic_callbacks = _build_periodic_callbacks(cfg, str(run_dir))
 
     for i, stage in enumerate(stages):
         stage_name = stage.name
@@ -864,6 +954,7 @@ def run_staged_training(
                 base_model_path=current_model_path,
                 wandb_run_name=wandb_name,
                 seed=seed,
+                callbacks=periodic_callbacks or None,
             )
         elif stage_type == "dpo":
             current_model_path = train_dpo_phase(
@@ -874,6 +965,7 @@ def run_staged_training(
                 base_model_path=current_model_path,
                 wandb_run_name=wandb_name,
                 seed=seed,
+                callbacks=periodic_callbacks or None,
             )
         else:
             raise ValueError(f"Unknown stage type '{stage_type}' in stage '{stage_name}'")


### PR DESCRIPTION
## Summary

- Add three configurable `TrainerCallback` classes for periodic evaluation during finetuning: capability (ARC-C logprob, in-process), alignment (Betley judge, checkpoint-based), and leakage (marker token detection, checkpoint-based)
- Refactor `capability.py` to extract `_arc_logprob_core()` and `_load_arc_questions()` helpers for in-process reuse
- Wire callbacks into `run_two_phase_training()` and `run_staged_training()` via `_build_periodic_callbacks()`
- Add `periodic_eval` config block to `configs/eval/default.yaml` (capability on by default, alignment/leakage opt-in)

Closes #51

## Test plan
- [ ] Verify imports work: `from explore_persona_space.eval.callbacks import PeriodicCapabilityCallback`
- [ ] Verify backward compatibility: existing `evaluate_capability_logprob()` API unchanged
- [ ] Run lint: `uv run ruff check . && uv run ruff format --check .`
- [ ] Integration test on pod with a short training run to verify callback fires at expected percentages

🤖 Generated with [Claude Code](https://claude.com/claude-code)