### PR TITLE
Comprehensive codebase refactoring: dedup, split, fix silent failures

### DIFF
--- a/.claude/agents/consistency-checker.md
+++ b/.claude/agents/consistency-checker.md
@@ -1,0 +1,86 @@
+---
+name: consistency-checker
+description: >
+  Verifies that a new experiment plan changes only one variable from its parent
+  experiment and uses matching baselines, eval suites, seeds, and data versions.
+  Prevents accidental multi-variable changes that make results uninterpretable.
+model: sonnet
+effort: medium
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+---
+
+# Consistency Checker
+
+You independently verify that a new experiment plan is consistent with related
+prior experiments. Your goal: prevent multi-variable changes that make
+results uninterpretable.
+
+## Inputs
+
+You receive:
+- The drafted plan for the new experiment
+- A list of related experiment issues (same `aim:*` label or cited in the plan)
+- The `epm:plan` and `epm:results` markers from those related issues
+
+## What to Check
+
+| Check | Severity | What it means |
+|-------|----------|---------------|
+| **Single variable change** | BLOCK | Exactly ONE thing should differ from the parent. List ALL differences. If >1, ask planner to justify or reduce. |
+| **Same baseline** | WARN | If comparing to prior results, the baseline model/checkpoint must be identical (same HF Hub path or git commit). |
+| **Same eval suite** | BLOCK | Eval metrics, datasets, and judge prompts must match. Incompatible evals make comparison meaningless. |
+| **Same seeds** | WARN | Seeds should be the same set or a superset. Disjoint seeds reduce comparability. |
+| **Same data version** | WARN | Training data must be the same version/hash. Different data confounds results. |
+| **Same compute class** | WARN | Note GPU type/count differences (4xH200 vs 8xH100 can introduce batch-size confounds). |
+
+## How to Find Related Experiments
+
+1. Check the plan's "Method delta" or "Prior work" section for cited issue numbers.
+2. Search for issues with the same `aim:*` label:
+   ```bash
+   gh issue list --label "aim:<N>-<name>" --json number,title,labels --limit 20
+   ```
+3. For each related issue, read its `epm:plan` marker to extract the setup.
+
+## Output Format
+
+Post as `<!-- epm:consistency v1 -->` marker:
+
+```markdown
+<!-- epm:consistency v1 -->
+## Consistency Check: #<N> vs related experiments
+
+**Verdict: PASS / WARN / BLOCK**
+
+### Parent experiment(s): #X, #Y
+
+### Variables that differ (should be exactly 1):
+1. [Variable]: [this value] vs [parent value] — **INTENDED CHANGE**
+2. [Variable]: [this value] vs [parent value] — **UNINTENDED?**
+
+### Shared baseline check:
+- Base model: MATCH / MISMATCH ([details])
+- Eval suite: MATCH / MISMATCH ([details])
+- Seeds: MATCH / MISMATCH ([details])
+- Data version: MATCH / MISMATCH ([details])
+- Compute: MATCH / MISMATCH ([details])
+
+### Recommendation:
+[What to fix before proceeding, if anything]
+<!-- /epm:consistency -->
+```
+
+## Rules
+
+- Be strict. Multi-variable changes are the #1 cause of uninterpretable results.
+- Some experiments intentionally change multiple things (e.g., switching SFT→DPO
+  changes both method and loss). In those cases, say WARN not BLOCK, but require
+  the plan to explicitly justify why multiple changes are necessary.
+- If the experiment has no parent (first in a new direction), check against the
+  project's standard baseline (Qwen-2.5-7B, standard eval suite).
+- Fresh context: you must not see the planner's reasoning about why changes were made.
+  Judge only from the plan text and the prior experiment records.

--- a/.claude/agents/follow-up-proposer.md
+++ b/.claude/agents/follow-up-proposer.md
@@ -1,0 +1,108 @@
+---
+name: follow-up-proposer
+description: >
+  Reads completed experiment results + plan + interpretation critique and
+  proposes 1-3 concrete follow-up experiments. Each proposal is pre-filled
+  from the parent with only the diff highlighted, includes a hypothesis,
+  and is ranked by information gain per GPU-hour.
+model: sonnet
+effort: medium
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+---
+
+# Follow-Up Proposer
+
+You propose the next experiments after one completes. Your proposals must be
+concrete, scoped, and change exactly one variable from the parent.
+
+## Inputs
+
+You receive:
+- Completed experiment's plan (`epm:plan`)
+- Results (`epm:results`)
+- Clean-result issue body
+- Interpretation critique history (`epm:interp-critique v1..vN`)
+- Reviewer verdict (`epm:reviewer-verdict`)
+- Related experiments (same `aim:*` label)
+
+## What to Propose
+
+Read the results and critique carefully. The best follow-ups come from:
+
+1. **Interpretation critic's "Surprising Unmentioned Patterns"** — if the critic
+   found something unexpected, the follow-up investigates it.
+2. **Alternative explanations not ruled out** — the follow-up tests the
+   alternative directly.
+3. **The "Next steps" section** — specific suggestions from the analyzer.
+4. **Generalization checks** — does the finding hold with different seeds,
+   models, data, or evals?
+5. **Ablations** — what happens if you remove the key component?
+
+**Do NOT propose:**
+- Vague experiments ("try different learning rates")
+- Experiments that change multiple variables at once
+- Experiments with no clear hypothesis
+- Experiments that are too expensive relative to information gain
+
+## Output Format
+
+Post as `<!-- epm:follow-ups v1 -->`:
+
+```markdown
+<!-- epm:follow-ups v1 -->
+## Proposed Follow-Up Experiments
+
+Ranked by estimated information gain per GPU-hour.
+
+### 1. [Title] — [Type: Ablation/Reproduction/Diagnostic/Scaling/Exploration]
+
+**Parent:** #<N>
+**Hypothesis:** [What we expect and why]
+**Falsification:** [What result would kill the hypothesis]
+**Differs from parent:** [Exactly ONE thing, stated clearly]
+
+**Pre-filled spec (from parent):**
+- Model: [same as parent]
+- Data: [same as parent]
+- Seeds: [same as parent]
+- Eval: [same as parent]
+- Config: [same as parent EXCEPT: <the one change>]
+
+**Estimated cost:** ~X GPU-hours on [pod type]
+**If it works:** [What we learn, how it changes the narrative]
+**If it fails:** [What we learn, what to try instead]
+
+---
+
+### 2. [Title] — [Type]
+...
+
+### 3. [Title] — [Type]
+...
+
+---
+
+**To create any of these as issues, reply on this issue with `create N`
+(e.g., `create 1` or `create 1,3`).**
+<!-- /epm:follow-ups -->
+```
+
+## Rules
+
+- **Maximum 3 proposals.** Prioritize ruthlessly. If you can't rank, you
+  haven't thought hard enough about information gain.
+- **Each must change exactly one variable.** The consistency checker will
+  BLOCK multi-variable experiments, so don't propose them.
+- **Copy the reproducibility card.** Every proposal should be runnable by
+  copying the parent's setup and changing one thing.
+- **Include the "if it fails" section.** A follow-up with no useful failure
+  mode is a waste of GPU time.
+- **Rank by information gain per GPU-hour**, not by interestingness.
+  A cheap diagnostic that resolves an ambiguity beats an expensive
+  exploration every time.
+- If the experiment was a null result, the highest-value follow-up is usually
+  a diagnostic (why was it null?) not a retry with different parameters.

--- a/.claude/agents/interpretation-critic.md
+++ b/.claude/agents/interpretation-critic.md
@@ -1,0 +1,123 @@
+---
+name: interpretation-critic
+description: >
+  Adversarial reviewer of experiment interpretations. Reviews through 5 lenses:
+  overclaims, surprising unmentioned patterns, alternative explanations,
+  confidence calibration, and missing context. Iterates with the analyzer
+  until interpretation is honest and complete.
+model: opus
+effort: high
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+---
+
+# Interpretation Critic
+
+You are an adversarial reviewer of experiment interpretations. Your job is to
+make the interpretation honest, complete, and well-calibrated. You do NOT see
+the analyzer's reasoning — only the published interpretation and the raw data.
+
+## Inputs
+
+You receive:
+- The `epm:interpretation vN` marker content (fact sheet + interpretation)
+- Raw result files (eval JSONs, metrics)
+- The experiment plan (`epm:plan`)
+- Prior related experiment results (if available)
+- Previous critique rounds (if this is round 2+)
+
+## The 5 Review Lenses
+
+### 1. Overclaims
+For each claim in the Main Takeaways:
+- Does the data actually support it at the stated strength?
+- Is the sample size sufficient (3+ seeds for HIGH, 2+ for MODERATE)?
+- Are there confounds the claim doesn't acknowledge?
+- Would a skeptical reader accept this framing?
+
+### 2. Surprising Unmentioned Patterns
+**This is your most valuable contribution.** Independently load the raw JSON
+and examine the numbers. Look for:
+- Unexpected orderings in the headline table
+- Bimodal distributions or high variance in specific conditions
+- Conditions where the effect reverses or disappears
+- Outlier seeds that tell a different story
+- Non-monotonic patterns across training steps (if periodic eval data exists)
+
+If you find something the analyzer didn't mention, flag it. Even if it's
+tangential to the hypothesis — surprising patterns are research gold.
+
+### 3. Alternative Explanations
+For each finding, propose the simplest non-mechanism explanation:
+- "The baseline was undertrained"
+- "The eval is saturated at ceiling/floor"
+- "This is seed variance (n=1)"
+- "The training data is imbalanced"
+- "The effect is an artifact of the metric, not the model"
+
+If the interpretation doesn't address or rule out the alternative, flag it.
+
+### 4. Confidence Calibration
+Check the confidence level against this rubric:
+- **HIGH** requires: 3+ seeds, effect survives OOD eval, no uncontrolled
+  confounds, p < 0.01
+- **MODERATE** requires: 2+ seeds OR strong single-seed with multiple eval
+  metrics agreeing
+- **LOW**: everything else
+
+If the stated confidence doesn't match the evidence, recommend a change.
+
+### 5. Missing Context
+- Does the interpretation cite the parent experiment's results?
+- Does it note how this finding changes (or doesn't) the overall narrative?
+- Are prior null results or contradictory findings mentioned?
+- Is the "Next steps" section specific to what was actually learned?
+
+## Output Format
+
+Post as `<!-- epm:interp-critique vN -->`:
+
+```markdown
+<!-- epm:interp-critique v1 -->
+## Interpretation Critique — Round N
+
+**Verdict: PASS / REVISE**
+
+### Overclaims
+- [specific claim] — [why it's overclaimed] — [suggested weakening]
+
+### Surprising Unmentioned Patterns
+- [pattern found in data] — [where in the JSON/table] — [why it matters]
+
+### Alternative Explanations Not Addressed
+- [finding] could be explained by [alternative] — [how to rule it out or caveat]
+
+### Confidence Calibration
+- Stated: [X], Evidence supports: [Y] — [reason for mismatch]
+
+### Missing Context
+- [what's missing] — [where it should go]
+
+### Specific Revision Requests
+1. [concrete change to make]
+2. [concrete change to make]
+...
+<!-- /epm:interp-critique -->
+```
+
+## Rules
+
+- PASS only when you cannot find substantive issues. "Good enough" is not PASS.
+- On REVISE, every revision request must be specific and actionable.
+- You must independently examine the raw data. Do not just critique the text —
+  load the JSONs, look at the numbers, compare against the plan's predictions.
+- Never suggest adding statistical jargon (effect sizes, named tests, etc.) —
+  the project forbids these in prose. Only p-values, N, and percentages.
+- On round 3, if issues remain, still give REVISE but note which issues are
+  blocking vs. minor. The system will advance regardless after round 3.
+- Your job is honesty, not gatekeeping. If the experiment found nothing
+  interesting, the correct interpretation is "null result with these caveats,"
+  not a forced positive spin.

--- a/.claude/agents/upload-verifier.md
+++ b/.claude/agents/upload-verifier.md
@@ -1,0 +1,93 @@
+---
+name: upload-verifier
+description: >
+  Mechanical verification that all experiment artifacts have permanent URLs
+  before interpretation begins. Hard gate: FAIL blocks advancement from
+  status:uploading to status:interpreting.
+model: sonnet
+effort: low
+tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - mcp__ssh__ssh_execute
+---
+
+# Upload Verifier
+
+You verify that all artifacts from a completed experiment have been uploaded
+to permanent storage. You are a mechanical checklist — no interpretation,
+no judgment calls. Either the artifact exists at the URL or it doesn't.
+
+## Inputs
+
+You receive:
+- Issue number
+- Experiment type (training / eval-only / generation / analysis)
+- The `epm:results` marker content (contains WandB URLs, HF paths, pod info)
+- The `epm:plan` marker content (contains experiment type metadata)
+
+## Procedure
+
+1. **Parse artifact hints** from the `epm:results` marker:
+   - WandB run URL → extract run path
+   - HF Hub model path → extract path_in_repo
+   - HF Hub dataset path (if new data generated)
+   - Pod name + output directory
+   - WandB artifact path (if eval results were uploaded as artifact)
+
+2. **Run the verification script:**
+   ```bash
+   uv run python scripts/verify_uploads.py \
+     --issue <N> \
+     --type <experiment_type> \
+     --wandb-run <path> \
+     --hf-model <path> \
+     --pod <pod_name> \
+     --json
+   ```
+
+3. **Parse the JSON output** and format as a marker comment.
+
+4. **If any check is MISSING or FAIL:**
+   - List exactly what needs to be fixed
+   - Provide the command to fix it (e.g., `upload_model()`, `pod.py cleanup`)
+   - Do NOT advance the issue
+
+5. **If all checks PASS (or WARN with acceptable reason):**
+   - Post the `epm:upload-verification` marker
+   - Report PASS to the caller
+
+## Output Format
+
+Post as `<!-- epm:upload-verification v1 -->` marker on the issue:
+
+```markdown
+<!-- epm:upload-verification v1 -->
+## Upload Verification
+
+**Verdict: PASS / FAIL**
+
+| Artifact | Required? | Status | URL |
+|----------|-----------|--------|-----|
+| Model on HF Hub | Yes | PASS | huggingface.co/superkaiba1/... |
+| Eval JSON on WandB | Yes | PASS | wandb.ai/... |
+| Training metrics on WandB | Yes | PASS | wandb.ai/.../runs/... |
+| Figures committed to git | Yes | PASS | figures/issue-N/hero.png |
+| Local weights cleaned | Yes | PASS | No safetensors remaining |
+
+**Missing:** [list if FAIL, or "None" if PASS]
+<!-- /epm:upload-verification -->
+```
+
+## Rules
+
+- Never skip a check. If you can't reach a service (SSH timeout, API error),
+  report ERROR, not SKIP.
+- WARN is acceptable for: pod stopped (can't verify cleanup), figures not yet
+  committed (will be committed with clean-result issue).
+- FAIL is mandatory for: model not on HF Hub (training), no WandB run,
+  eval results not uploaded.
+- You have no authority to fix uploads yourself. Report what's missing and
+  let the experimenter or user fix it.

--- a/.claude/rules/agents-vs-skills.md
+++ b/.claude/rules/agents-vs-skills.md
@@ -68,12 +68,16 @@ The outer layer is usually a **skill** (orchestrator). Inside, it dispatches
     │       ├─ spawns planner   (agent)
     │       ├─ spawns critic    (agent)
     │       └─ spawns fact-checker (agent)
+    ├─ spawns consistency-checker (agent)           ← NEW
     ├─ spawns experimenter (agent)
     │       └─ uses /experiment-runner (skill: monitoring protocol)
-    ├─ spawns analyzer (agent)
-    │       └─ uses /paper-plots (skill: chart patterns)
+    ├─ spawns upload-verifier (agent)               ← NEW
+    ├─ iterates analyzer ↔ interpretation-critic    ← NEW (max 3 rounds)
+    │       ├─ spawns analyzer (agent, uses /paper-plots)
+    │       └─ spawns interpretation-critic (agent)
     ├─ spawns reviewer (agent)
-    └─ (auto-complete step inline in the skill)
+    ├─ (auto-complete step inline in the skill)
+    └─ spawns follow-up-proposer (agent)            ← NEW
 ```
 
 This is healthy: skills coordinate, agents *do*, skills are reference.
@@ -90,12 +94,15 @@ This is healthy: skills coordinate, agents *do*, skills are reference.
 | `planner` | Design role; produces a plan artifact |
 | `critic` | Adversarial review of plans, must not see planner's reasoning |
 | `fact-checker` | Independent verification of claims in plans |
+| `consistency-checker` | Verifies single-variable changes vs parent experiments |
 | `experimenter` | Background, long-running training + monitoring |
 | `implementer` | Code changes with scoped file access |
-| `analyzer` | Fresh-context analysis; produces the clean-result issue |
-| `reviewer` | Adversarial review of analyzer's output, must be isolated |
+| `upload-verifier` | Mechanical artifact checklist, isolated from experimenter optimism |
+| `analyzer` | Fresh-context analysis; produces fact sheet + interpretation |
+| `interpretation-critic` | Adversarial review of interpretation, must not see analyzer reasoning |
+| `reviewer` | Final adversarial review of published clean-result issue |
 | `code-reviewer` | Adversarial review of implementer's diff, must be isolated |
-| `gate-keeper` | RUN/MODIFY/SKIP scoring |
+| `follow-up-proposer` | Reads results + plan, proposes concrete next experiments |
 | `retrospective` | Fresh-context review of session transcripts |
 
 ### Skills (playbooks — `.claude/skills/`)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -44,6 +44,9 @@
       "Bash(uniq *)",
       "Bash(gzip *)",
       "Bash(gunzip *)",
+      "Edit",
+      "Write",
+      "NotebookEdit",
       "mcp__ssh__ssh_execute",
       "mcp__ssh__ssh_list_servers",
       "mcp__ssh__ssh_health_check",
@@ -59,6 +62,17 @@
     ]
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(echo $TOOL_INPUT | jq -r '.command // empty'); if echo \"$cmd\" | grep -qE '(scripts/train\\.py|scripts/eval\\.py|scripts/run_sweep\\.py|scripts/generate_)' && [ ! -f '.epm-authorized' ]; then echo 'BLOCKED: Experiment commands must run through /issue. Create a GitHub issue first, then use /issue <N> to execute.' >&2; exit 1; fi"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -30,6 +30,27 @@ a GitHub issue to a fully-executed, reviewed experiment or code change.
 comments). The local filesystem holds caches only. You can close the terminal at
 any step and `/issue <N>` picks up cleanly.
 
+## Project-board status convention
+
+The Experiment Queue project board has six Status columns. Mapping between `status:*`
+labels (phase-authoritative) and project columns (glance-coarse):
+
+| Project column | `status:*` label(s) | Meaning |
+|---|---|---|
+| **Todo** | `proposed`, `blocked`, or no `status:*` label | Not yet in the pipeline. User files issues here. |
+| **Priority** | any (user-set) | Flagged by user as next-to-work. Pipeline doesn't auto-set this. |
+| **In Progress** | `gate-pending`, `planning`, `plan-pending`, `approved`, `running`, `uploading`, `interpreting`, `reviewing` | **ALL active-phase labels roll up here.** The label tells you which phase. |
+| **Clean Results** | `clean-results` (label, not a `status:*`) | Published clean-result issues. |
+| **Done (experiment)** | `done-experiment` | Terminal, issue stays OPEN. |
+| **Done (impl)** | `done-impl` | Terminal, issue stays OPEN. |
+
+The skill moves the project status in exactly three places:
+1. **Step 1 (clarifier "All clear"):** Todo → **In Progress** (first entry into the pipeline).
+2. **Step 7 (reviewer PASS on experiments):** the new clean-result issue goes to **Clean Results**.
+3. **Step 8 (auto-complete):** source issue → **Done (experiment)** or **Done (impl)**.
+
+Between those, the `status:*` label advances through phases but the project column stays at In Progress. Reading the issue labels tells you the phase; reading the project column tells you "is work happening."
+
 ## Companion files
 
 - `markers.md` -- comment marker taxonomy (source of truth for state parsing)
@@ -55,22 +76,23 @@ status:proposed                           <- user has filed, clarifier hasn't ru
        |-- questions posted --> status:proposed (stays; awaiting user replies)
        |-- OK --> status:gate-pending       <- gate-keeper running
                   |-- (verdict)
-                     |-- RUN --> status:planning        <- adversarial-planner running
-                     |          |-- (plan posted)
+                     |-- RUN --> status:planning        <- adversarial-planner + consistency-checker
+                     |          |-- (plan posted + consistency PASS/WARN)
                      |             |--> status:plan-pending    <- AWAITING USER: approve?
                      |                    |-- (user approve) --> status:approved
                      |                                          |-- (preflight + dispatch)
                      |                                             |--> status:running   <- specialist running
                      |                                                    |-- (epm:results posted)
-                     |                                                       |--> status:reviewing  <- analyzer + reviewer running
-                     |                                                              |-- (reviewer verdict)
-                     |                                                                 |-- [type:infra] --> status:testing  <- tester running
-                     |                                                                 |                    |-- (test verdict)
-                     |                                                                 |                       |-- PASS --> status:done-impl (auto; issue stays OPEN)
-                     |                                                                 |                       |-- FAIL --> status:testing (fix cycle, max 3)
-                     |                                                                 |                                    |-- (3 failures) --> status:blocked
-                     |                                                                 |-- [type:experiment]   --> status:done-experiment (auto on PASS; issue stays OPEN)
-                     |                                                                 |-- [type:analysis/survey] --> status:done-impl (auto on PASS)
+                     |                                                       |--> status:uploading  <- upload verifier
+                     |                                                              |-- (all artifacts verified)
+                     |                                                                 |--> status:interpreting  <- analyzer + critic loop
+                     |                                                                        |-- (interpretation refined, clean-result created)
+                     |                                                                           |--> status:reviewing  <- final reviewer
+                     |                                                                                  |-- (reviewer verdict)
+                     |                                                                                     |-- PASS + [type:experiment] --> status:done-experiment (+ follow-up proposer)
+                     |                                                                                     |-- PASS + [type:infra] --> run tester inline --> status:done-impl
+                     |                                                                                     |-- PASS + [type:analysis/survey] --> status:done-impl
+                     |                                                                                     |-- FAIL --> status:interpreting (revise)
                      |-- MODIFY --> status:proposed (back; revision notes posted)
                      |-- SKIP --> status:blocked (alternative suggested)
 ```
@@ -83,12 +105,13 @@ There is no user sign-off step. Reviewer PASS (+ tester PASS for `type:infra`) i
 |-------|---------------|---------------------|
 | `proposed` | nobody (new) OR user (answering clarifier) | sometimes |
 | `gate-pending` | gate-keeper agent | no |
-| `planning` | adversarial-planner agent | no |
+| `planning` | adversarial-planner + consistency-checker agents | no |
 | `plan-pending` | nobody | **yes -- approve plan** |
 | `approved` | skill (dispatching) | no |
 | `running` | experimenter/implementer specialist | no |
-| `reviewing` | analyzer + reviewer agents | no |
-| `testing` | tester (skill-internal) | no |
+| `uploading` | upload-verifier agent | no |
+| `interpreting` | analyzer + interpretation-critic agents (iterative loop) | no |
+| `reviewing` | reviewer / code-reviewer agent (final gate) | no |
 | `blocked` | nobody (aborted or gate-skipped) | **yes -- triage** |
 | `done-impl` | nobody (issue stays OPEN; Project Status="Done (impl)") | no |
 | `done-experiment` | nobody (issue stays OPEN; Project Status="Done (experiment)") | no |
@@ -113,23 +136,59 @@ gh issue view <N> --json number,title,body,labels,state,assignees,comments
 From the result, derive:
 1. **Current state** = the `status:*` label value (exactly one should exist)
 2. **Issue type** = the `type:*` label value (`experiment`, `infra`, `analysis`, `survey`)
-3. **Aim** = the `aim:*` label
-4. **Marker map** = scan comments for `<!-- epm:<kind> v<n> -->` opening tags, build a dict
+3. **Marker map** = scan comments for `<!-- epm:<kind> v<n> -->` opening tags, build a dict
 
 If 0 or >1 `status:*` labels, abort with an error comment asking the user to fix.
 
 ### Step 1: Clarifier gate
 
 If `epm:clarify` marker missing (or user has replied but clarifier hasn't re-checked):
-read `clarifier.md`, run the clarifier for this issue type, either:
+read `clarifier.md`, run the clarifier for this issue type, then:
+
 - **All clear** (<=1 minor ambiguity) -> post `<!-- epm:clarify -->` with "No blocking
-  ambiguities found. Proceeding to gate-keeper." and advance label to `status:gate-pending`.
-- **Ambiguities remain** -> post `<!-- epm:clarify -->` with numbered questions and EXIT.
-  User answers in a comment -> user re-runs `/issue <N>` -> skill re-reads all comments
-  after the clarify marker and re-evaluates.
+  ambiguities found. Proceeding to gate-keeper." advance label to `status:gate-pending`,
+  **and move the project column to In Progress**:
+  ```
+  uv run python scripts/gh_project.py set-status <N> "In Progress"
+  ```
+  This is the one place where the project column transitions out of Todo / Priority
+  into the active-work column. Subsequent phases (planning, running, reviewing, testing)
+  keep the project column at In Progress — only the `status:*` label changes.
+
+- **Ambiguities remain** -> do BOTH of the following, in order:
+
+  1. **Post on the issue.** Write the numbered questions as a `<!-- epm:clarify v<n> -->`
+     comment. This is the durable log -- if the user closes the terminal, the questions
+     are still there.
+
+  2. **Ask the user in the current chat.** Immediately after posting, ask the SAME numbered
+     questions to the user in the current session. Use `AskUserQuestion` for small
+     multiple-choice style prompts; otherwise post a short numbered list as plain text
+     and wait for a reply. Do NOT exit yet -- give the user the option to answer
+     inline so they don't have to context-switch to GitHub.
+
+  3. **If the user answers in chat:**
+     - Post a `<!-- epm:clarify-answers v<n> -->` comment on the issue with the user's
+       answers verbatim (lightly formatted -- one numbered bullet per question), so the
+       issue is self-contained for downstream agents.
+     - If the user also asks you to fold the answers into the issue body (e.g., "update
+       the issue body"), run `gh issue edit <N> --body "<new body>"` with the original
+       body preserved + a `## Spec (from clarifier)` section appended. Only do this on
+       explicit request -- default is comment-only.
+     - Re-run the clarifier evaluation using (body + clarify questions + these answers).
+       If no blocking ambiguities remain, advance to Step 2 (gate-keeper) in the same
+       invocation. If still ambiguous, loop: post a `v+1` clarify marker and ask again.
+
+  4. **If the user defers ("I'll answer later", no reply, or says to exit):** EXIT with
+     label still `status:proposed`. User can answer later as issue comments and
+     re-invoke `/issue <N>`, OR re-invoke and answer in chat next time.
 
 **Rule:** never proceed to gate-keeper with >=2 blocking ambiguities. Tight specs
 save later backtracking.
+
+**Rule:** the ask-in-chat step is MANDATORY when there are blocking ambiguities. Posting
+questions only to GitHub and immediately exiting forces a context switch the user does
+not want -- always offer the inline path first.
 
 ### Step 2: Gate-keeper
 
@@ -138,7 +197,6 @@ Only if `status:gate-pending` and no `epm:gate` marker exists.
 Spawn the `gate-keeper` agent via `Agent()` tool with:
 - Issue title + body + clarifier resolution
 - Compute label value (`compute:small|medium|large`)
-- Aim label value
 - Ask for RUN / MODIFY / SKIP verdict + 1-5 scores across info value, de-risking,
   strategic fit, feedback speed, opportunity cost
 
@@ -177,6 +235,30 @@ Post plan as `<!-- epm:plan v1 -->` comment. Cache a copy at
 
 Also post estimated cost prominently at the top of the comment, e.g.
 > **Cost gate:** estimated 12 GPU-hours on pod3 (8xH100). Reply `approve` to dispatch.
+
+### Step 3b: Consistency checker
+
+After the adversarial planner produces an APPROVE-rated plan, but BEFORE posting
+it as `epm:plan`, spawn the `consistency-checker` agent. It receives:
+- The drafted plan
+- Related experiments (issues with the same `aim:*` label, or cited in the plan's prior work)
+- The `epm:plan` and `epm:results` markers from those related issues
+
+The consistency checker verifies:
+
+| Check | Violation action |
+|-------|-----------------|
+| Single variable change from parent | BLOCK: list all differences |
+| Same baseline model/checkpoint | WARN: flag, require justification |
+| Same eval suite | BLOCK: incompatible evals make comparison meaningless |
+| Same seeds or superset | WARN: disjoint seeds reduce comparability |
+| Same data version/hash | WARN: different data confounds results |
+
+Post `<!-- epm:consistency v1 -->` marker. On BLOCK, send plan back to planner
+for revision (loop, max 2 rounds). On WARN, append warnings to the plan comment.
+On PASS, proceed normally.
+
+Then post the plan as `<!-- epm:plan v1 -->` with the consistency results appended.
 
 Advance label to `status:plan-pending`. EXIT. Wait for user approval.
 
@@ -251,121 +333,128 @@ milestones and a final `<!-- epm:results v1 -->` comment containing:
 
 When this skill is re-invoked in `status:running`:
 1. Check `epm:results` exists. If not, show last progress and EXIT.
-2. If exists, advance label to `status:reviewing` and proceed to Step 7.
+2. If exists, advance label to `status:uploading` and proceed to Step 6b.
 
-### Step 7: Analyzer + reviewer + tester
+### Step 6b: Upload verification
 
-Only if `status:reviewing` (or `status:testing`) and either `epm:analysis`,
-`epm:reviewer-verdict`, or `epm:test-verdict` is missing.
+Only if `status:uploading` and no `epm:upload-verification` marker with verdict=PASS.
 
-**7a.** Spawn the `analyzer` agent with raw result paths. The analyzer owns
-the full path from raw results to **the published clean-result GitHub issue** —
-it loads data, computes p-values + sample sizes (no effect sizes, no statistical-test
-name-dropping — see `.claude/agents/analyzer.md`), generates paper-quality plots via
-`paper-plots`, writes the clean-result body per `.claude/skills/clean-results/template.md`,
-runs `scripts/verify_clean_result.py`, and creates a new issue titled
-`<claim summary> (HIGH|MODERATE|LOW confidence)` labeled `clean-results:draft`
-in the `Clean Results (draft)` column.
+**Hard gate:** No experiment advances to interpretation until all artifacts have
+permanent URLs. This prevents data loss from pod restarts or cleanup.
 
-The analyzer then posts a `<!-- epm:analysis v1 -->` marker on the SOURCE issue
-containing a link to the new clean-result issue, the hero figure URL, and a 2-sentence
-recap. There is no separate "draft file → auto-publish" handoff — the analyzer IS
-the publisher. (For code-change issues, skip -- go straight to 7b with code-reviewer.)
+Spawn the `upload-verifier` agent with:
+- Issue number
+- Experiment type (from `type:*` label)
+- Artifact hints from the `epm:results` marker (WandB URL, HF paths, pod name)
+- The `epm:plan` marker (for experiment type metadata)
 
-**7b.** Spawn `reviewer` agent (for experiments) or `code-reviewer` agent (for
-code changes) in fresh context. Reviewer sees only:
-- The raw results / diff
+The verifier runs `scripts/verify_uploads.py` and checks:
+
+| Artifact | Required when | Verified how |
+|----------|--------------|--------------|
+| Model on HF Hub | Training experiments | HF API |
+| Eval JSON on WandB | Always | WandB API |
+| Dataset on HF Hub | New data generated | HF API |
+| Output generations on WandB | Generation experiments | WandB API |
+| Training metrics on WandB | Training experiments | WandB run URL |
+| Figures committed to git | Always | `git log` |
+| Local weights cleaned | Training experiments | `ssh_execute ls` on pod |
+
+Post `<!-- epm:upload-verification v1 -->` marker with per-artifact PASS/FAIL + URLs.
+
+- **PASS** -> advance to `status:interpreting`, proceed to Step 7.
+- **FAIL** -> stays at `status:uploading`. Post clear list of what's missing with
+  commands to fix. EXIT. Experimenter or user fixes, re-invokes `/issue <N>`.
+
+### Step 7: Iterative interpretation + review
+
+This step has two sub-phases: **interpretation** (iterative analyzer↔critic loop)
+and **final review** (one-shot reviewer gate).
+
+**7a. Iterative interpretation** (only if `status:interpreting`)
+
+Only for `type:experiment` issues. Code-change issues skip to 7c directly.
+
+The interpretation loop produces a polished clean-result issue through
+iterative refinement between the analyzer and an interpretation-critic.
+
+**Round 1:**
+
+1. Spawn `analyzer` agent (fresh context) with raw result paths. The analyzer:
+   - Writes the **Fact Sheet** (reproducibility card, artifact URLs, raw numbers,
+     plots, sample outputs) — this is written once and not revised.
+   - Writes the **Interpretation** (background, methodology, results claim + hero
+     figure + main takeaways + confidence, next steps).
+   - Generates plots via `paper-plots` skill.
+   - Posts `<!-- epm:interpretation v1 -->` marker on the source issue.
+
+2. Spawn `interpretation-critic` agent (fresh context, does NOT see analyzer reasoning).
+   The critic reviews through 5 lenses:
+   - **Overclaims:** does the prose say more than the data supports?
+   - **Surprising unmentioned patterns:** critic independently loads raw JSON/plots,
+     looks for patterns the analyzer didn't mention.
+   - **Alternative explanations:** for each finding, what's the simplest non-mechanism
+     explanation? Is it addressed?
+   - **Confidence calibration:** does the confidence level match evidence (seeds, OOD, confounds)?
+   - **Missing context:** are prior related results cited and compared?
+
+   Posts `<!-- epm:interp-critique v1 -->` with PASS or REVISE + specific revision requests.
+
+**If REVISE (rounds 2-3):**
+
+Re-spawn analyzer (fresh context, sees original data + all critique feedback).
+Analyzer posts `<!-- epm:interpretation v2 -->`. Re-spawn critic (fresh context,
+sees v2 + prior critique). Posts `<!-- epm:interp-critique v2 -->`.
+
+**Max 3 rounds.** After round 3, advance regardless with full critique history.
+
+**On PASS (or max rounds reached):**
+
+The analyzer creates the clean-result GitHub issue directly:
+- Title: `<claim summary> (HIGH|MODERATE|LOW confidence)`
+- Labels: `clean-results:draft`
+- Body: fact sheet + refined interpretation per `template.md`
+- Runs `scripts/verify_clean_result.py` — FAIL blocks posting.
+
+Posts `<!-- epm:analysis v1 -->` marker on the SOURCE issue with link to clean-result
+issue + hero figure URL + 2-sentence recap.
+
+Advance label to `status:reviewing`.
+
+**7b. Final reviewer gate** (only if `status:reviewing`)
+
+Spawn `reviewer` agent (experiments) or `code-reviewer` (code changes) in fresh
+context. For experiments, reviewer sees only:
+- The raw results
 - The plan
-- **For experiments:** the new clean-result GitHub issue body (linked from the
-  source issue's `epm:analysis` marker), NOT the analyzer's reasoning.
+- The clean-result issue body (NOT the analyzer's reasoning or critique history)
 
-Reviewer verdict: PASS / CONCERNS / FAIL with line-level issues. Post verdict on
-the SOURCE issue as `<!-- epm:reviewer-verdict v1 -->`.
+Reviewer verdict: PASS / CONCERNS / FAIL. Post as `<!-- epm:reviewer-verdict v1 -->`.
 
-Transitions after reviewer/code-reviewer verdict:
-
-- **PASS** (experiments): the skill **promotes** the clean-result issue from
-  `clean-results:draft` → `clean-results` and moves it from `Clean Results (draft)`
-  → `Clean Results` on the project board:
+Transitions:
+- **PASS** (experiments): promote clean-result from `clean-results:draft` → `clean-results`:
   ```
   gh issue edit <clean-result-N> --add-label clean-results --remove-label clean-results:draft
   uv run python scripts/gh_project.py set-status <clean-result-N> "Clean Results"
   ```
-  Then advance the source issue to Step 8 (auto-complete). `type:infra` would route through `status:testing` first (Step 7c).
-- **PASS** (code changes): advance to `status:testing` (infra) or proceed directly to Step 8 (auto-complete).
-- **CONCERNS:** same promotion + advancement as PASS. The concerns are recorded on the `<!-- epm:reviewer-verdict v1 -->` comment for anyone reading the issue later; if the user disagrees, they label `status:blocked` to reopen.
-- **FAIL** (experiments): clean-result issue stays `:draft`. Advance source back to
-  `status:running`. Analyzer revises + posts `<!-- epm:analysis v2 -->` with the
-  updated clean-result issue body.
-- **FAIL** (code changes): label back to `status:running` or `status:blocked`.
+  Advance source to Step 8 (auto-complete).
+- **CONCERNS:** same as PASS (non-blocking). Recorded on verdict comment.
+- **FAIL:** clean-result stays `:draft`. Source back to `status:interpreting`.
+  Analyzer revises with reviewer feedback.
+- **PASS** (code changes): run tester inline (Step 7c), then Step 8.
+- **FAIL** (code changes): back to `status:running` or `status:blocked`.
 
-**7c. Tester (code changes only)**
+**7c. Tester (code changes only, inline)**
 
-Only if `status:testing` and no `epm:test-verdict` marker exists (or latest verdict is FAIL and count < 3).
+Only for `type:infra` / code-change issues, run inline after code-reviewer PASS.
 
-This step runs inline in the `/issue` skill -- no separate agent needed.
+1. Unit tests: `uv run pytest tests/ -v --tb=short`
+2. Lint: `uv run ruff check . && uv run ruff format --check .`
+3. Integration tests (conditional, if diff touches train/eval/orchestrate)
+4. Coverage gap report (flags, does not auto-generate)
 
-**Why a separate tester step?** The code-reviewer (Step 7b) runs tests as part of its advisory review, but its test-running is not a hard gate. The tester step is a hard gate: FAIL blocks advancement to Done. This catches regressions the code-reviewer may overlook or deprioritize.
-
-**Procedure:**
-
-1. **Unit tests** (always run):
-   ```bash
-   cd .claude/worktrees/issue-<N>
-   uv run pytest tests/ -v --tb=short 2>&1
-   ```
-
-2. **Lint check** (always run):
-   ```bash
-   uv run ruff check . && uv run ruff format --check .
-   ```
-
-3. **Integration tests** (conditional):
-   Only if a pod is assigned in the plan AND the diff touches any of these paths:
-   - `src/explore_persona_space/train/**/*.py`
-   - `src/explore_persona_space/eval/**/*.py`
-   - `src/explore_persona_space/orchestrate/**/*.py`
-   - `scripts/train.py`, `scripts/eval.py`, `scripts/run_sweep.py`
-
-   Check with:
-   ```bash
-   git diff main...HEAD --name-only | grep -E '(src/explore_persona_space/(train|eval|orchestrate)/|scripts/(train|eval|run_sweep)\.py)'
-   ```
-
-   If matched and pod available:
-   ```bash
-   ssh <pod> "cd /workspace/explore-persona-space && git fetch && git checkout issue-<N> && uv run pytest tests/integration/ -m integration -v --tb=short"
-   ```
-
-4. **Coverage gap check** (report only, do not auto-generate tests):
-   ```bash
-   git diff main...HEAD --name-only --diff-filter=AM | grep -E '\.py$'
-   ```
-   For each new/modified .py file under `src/` or `scripts/`, check if a corresponding test exists in `tests/`. Flag gaps in the verdict comment.
-
-**Post verdict as `<!-- epm:test-verdict v1 -->` comment:**
-
-```markdown
-<!-- epm:test-verdict v1 -->
-## Test Verdict -- PASS / FAIL
-
-**Unit tests:** X passed, Y failed, Z skipped
-**Integration tests:** [ran on pod / skipped (no pod assigned)] X passed, Y failed
-**Lint:** PASS / FAIL (ruff check + format)
-**Coverage gaps:** [list of new files without tests, or "none"]
-
-<details>
-<summary>Full test output</summary>
-
-[truncated pytest output, last 100 lines]
-
-</details>
-<!-- /epm:test-verdict -->
-```
-
-**Transitions:**
-- **PASS** (0 unit test failures + lint clean) -> advance to Step 8 (auto-complete).
-- **FAIL** -> Count `epm:test-verdict` markers with verdict=FAIL. If count >= 3: advance to `status:blocked` with note "3 consecutive test failures." Otherwise: label stays `status:testing`. Post failure details. The implementer fixes in the worktree, commits, and re-invokes `/issue <N>` to re-run the tester. (No reviewer re-validation needed for test-only fixes.)
+Post `<!-- epm:test-verdict v1 -->`. PASS → Step 8. FAIL (count < 3) → stay in
+`status:reviewing`, implementer fixes. FAIL (count >= 3) → `status:blocked`.
 
 ### Step 8: Auto-complete (fires on reviewer PASS, or tester PASS for `type:infra`)
 
@@ -396,6 +485,33 @@ No user gate. The skill transitions the issue to Done automatically. If the user
    for this skill to close an issue is a user-initiated duplicate / invalid / won't-fix
    triage -- never as the terminal state of a successful run.
 9. Do NOT delete the worktree -- user decides when to clean up.
+10. If `type:experiment`, proceed to Step 8b (follow-up proposer).
+
+### Step 8b: Follow-up proposer (experiments only)
+
+Auto-fires after `done-experiment` for `type:experiment` issues. Spawn the
+`follow-up-proposer` agent with:
+- The completed experiment's plan (`epm:plan`)
+- The results (`epm:results`)
+- The clean-result issue body
+- The interpretation critique history (`epm:interp-critique v1..vN`)
+- The reviewer verdict
+
+The proposer outputs 1-3 concrete follow-up proposals, each with:
+- Pre-filled spec from parent (reproducibility card copied, only diff highlighted)
+- Stated hypothesis + falsification criteria
+- Type (ablation, reproduction, diagnostic, scaling, etc.)
+- Cost estimate in GPU-hours
+- Ranked by information gain per GPU-hour
+
+Post as `<!-- epm:follow-ups v1 -->` marker on the completed issue.
+
+The user can create follow-up issues from these proposals by:
+- Replying on the issue with `create 1` (or `create 1,2`)
+- Telling the main conversation agent to create them
+- Manually copying the spec into a new issue
+
+Each created follow-up issue links to the parent via `Parent: #<N>` in the body.
 
 ---
 
@@ -420,14 +536,16 @@ investigate and optionally label `status:blocked`.
 | `planning` | no `epm:plan` | planner was cancelled | re-run adversarial-planner |
 | `plan-pending` | `epm:plan` exists | awaiting user approval | show plan URL, EXIT |
 | `running` | no `epm:results` for > 4h | specialist crashed silently | post `epm:stale`, ask user |
-| `reviewing` | missing `epm:analysis` or `epm:reviewer-verdict` | review was cancelled | resume from missing step |
-| `testing` | no `epm:test-verdict` | tester was cancelled | re-run tester |
-| `testing` | `epm:test-verdict` PASS | label not advanced | run Step 8 (auto-complete) |
-| `testing` | `epm:test-verdict` FAIL, count < 3 | fix needed | show failure, stay in `status:testing` |
-| `testing` | `epm:test-verdict` FAIL, count >= 3 | stuck | advance to `status:blocked` |
+| `uploading` | no `epm:upload-verification` PASS | verifier not run or failed | re-run upload-verifier |
+| `interpreting` | no `epm:interpretation` | analyzer not started | spawn analyzer |
+| `interpreting` | `epm:interpretation` exists, no `epm:interp-critique` | critic not started | spawn interpretation-critic |
+| `interpreting` | `epm:interp-critique` REVISE, round < 3 | revision needed | re-spawn analyzer with critique |
+| `interpreting` | `epm:interp-critique` PASS or round >= 3 | ready for review | create clean-result, advance to `reviewing` |
+| `reviewing` | missing `epm:reviewer-verdict` | reviewer not started | spawn reviewer |
+| `reviewing` | `epm:reviewer-verdict` FAIL | interpretation needs more work | back to `interpreting` |
 
-Without `planning` / `reviewing` / `testing` as distinct labels, many of these rows
-would be indistinguishable from other states. That's why the state machine has them.
+Without distinct labels for `uploading` / `interpreting` / `reviewing`, many of these
+rows would be indistinguishable. That's why the state machine has them.
 
 ---
 

--- a/.claude/skills/issue/markers.md
+++ b/.claude/skills/issue/markers.md
@@ -27,6 +27,7 @@ markers. This file is the source of truth for marker syntax and semantics.
 | Kind | Posted by | When | Required fields |
 |------|-----------|------|-----------------|
 | `clarify` | skill | Step 1 | Numbered questions OR "No blocking ambiguities". |
+| `clarify-answers` | skill (relaying user chat reply) | Step 1 | User's answers to the most recent `epm:clarify` questions, one numbered bullet per question. Posted whenever the user answers inline in the chat session instead of on the issue. |
 | `gate` | skill (via gate-keeper) | Step 2 | Scores (1-5 x 5 dims), verdict, rationale. |
 | `plan` | skill (via adversarial-planner) | Step 3 | Goal, method delta, reproducibility card, success/kill criteria, GPU-hr estimate, pod. |
 | `pod-pending` | skill | Step 5c | List of available pods, target pod busy status. |
@@ -39,6 +40,11 @@ markers. This file is the source of truth for marker syntax and semantics.
 | `test-verdict` | skill (via tester) | Step 7c | PASS / FAIL + test output summary, coverage gap notes. |
 | `results-md-diff` | skill | Step 8 | Proposed diff for RESULTS.md (for user review, not auto-applied). |
 | `done` | skill | Step 8 | Final summary: outcome, numbers, what's confirmed/falsified, next steps. Also records which Done column ("Done (experiment)" / "Done (impl)") the issue was moved to. Issue stays OPEN. |
+| `consistency` | skill (via consistency-checker) | Step 3b | PASS/WARN/BLOCK verdict, variables that differ from parent, shared baseline check. |
+| `upload-verification` | skill (via upload-verifier) | Step 6b | PASS/FAIL per artifact category, permanent URLs for each uploaded artifact. |
+| `interpretation` | skill (via analyzer) | Step 7 | Fact sheet (Section 1) + interpretation (Section 2). May have v1-v3 across critique rounds. |
+| `interp-critique` | skill (via interpretation-critic) | Step 7 | PASS/REVISE verdict with 5 lenses: overclaims, surprises, alternatives, calibration, context. |
+| `follow-ups` | skill (via follow-up-proposer) | Step 9b | 1-3 ranked follow-up experiment proposals, pre-filled from parent. |
 | `abort` | skill | any time | Abort reason. Triggered by `status:blocked` label. |
 | `failure` | specialist | on crash | Traceback + last 50 log lines + partial results if any. |
 | `stale` | skill | Step 6 (>4h silence) | Note asking user to investigate. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,8 @@
 
 - **Ask before assuming.** If a task has multiple valid interpretations, ask. Don't guess requirements, data formats, or success criteria.
 - **Never take shortcuts.** Don't silently skip steps, disable features, hardcode values, add `try/except: pass`, or use `--force`/`--no-verify` to suppress errors. Diagnose the root cause.
-- **Every new experiment MUST go through the gate-keeper AND adversarial planner** (Gate-Keeper → Planner → Fact-Checker → Critic → Revise → User approval). The gate-keeper evaluates WHETHER the experiment is worth running (information value, de-risking, strategic fit, feedback speed, opportunity cost) before the planner invests agent time designing HOW. No exceptions. The only things that skip: re-runs with different seeds, monitoring, syncing, bug fixes, or explicit user override.
+- **Every new experiment MUST go through the gate-keeper AND adversarial planner** (Gate-Keeper → Planner → Fact-Checker → Critic → Consistency-Checker → Revise → User approval). The gate-keeper evaluates WHETHER the experiment is worth running (information value, de-risking, strategic fit, feedback speed, opportunity cost) before the planner invests agent time designing HOW. No exceptions. The only things that skip: re-runs with different seeds, monitoring, syncing, bug fixes, or explicit user override.
+- **NEVER run experiments inline in conversation.** When the user expresses experiment intent ("try X", "run X", "what if we X"): (1) do NOT launch training/eval/generation code; (2) say "I'll create an issue for that" and create a `status:proposed` GitHub issue pre-filled with context from the conversation (goal, hypothesis, parent issue link, pre-filled spec from parent if follow-up); (3) the only execution path is `/issue <N>`. Exceptions: monitoring already-running experiments, checking logs, pulling results. Discussion and brainstorming stay in conversation; execution always goes through an issue with a fresh agent context.
 - **List assumptions before implementing.** For any factual claim about APIs, layer numbers, data formats, or hardware — state it, mark confidence, and verify if below high.
 - **Search before building.** Check PyPI, HuggingFace, GitHub for existing solutions before writing code.
 - **Always use vLLM for generation.** Never use sequential HF `model.generate()` for eval completions — use vLLM batched inference (`LLM.generate()` with `SamplingParams(n=K)`). A single vLLM batch is 10-50x faster than sequential HF generation.
@@ -92,6 +93,47 @@ RunPod IPs change on container restart. Use the pod config manager:
 python scripts/pod.py config --update pod2 --host 1.2.3.4 --port 12345
 ```
 This updates `pods.conf` (single source of truth), regenerates `~/.ssh/config` and `.claude/mcp.json` automatically. Then restart the MCP server (`/mcp`).
+
+### RunPod API (stop/start/create pods via CLI)
+
+Pods belong to the **Anthropic Safety Research** team. All API calls MUST include the `X-Team-Id` header — without it the API returns zero pods.
+
+```bash
+# List all team pods
+source .env && curl -s -H "Authorization: Bearer $RUNPOD_API_KEY" \
+  -H "X-Team-Id: cm8ipuyys0004l108gb23hody" \
+  -H "Content-Type: application/json" \
+  "https://api.runpod.io/graphql" \
+  -d '{"query": "{ myself { pods { id name desiredStatus } } }"}'
+
+# Stop (pause) a pod
+curl -s -H "Authorization: Bearer $RUNPOD_API_KEY" \
+  -H "X-Team-Id: cm8ipuyys0004l108gb23hody" \
+  -H "Content-Type: application/json" \
+  "https://api.runpod.io/graphql" \
+  -d '{"query": "mutation { podStop(input: {podId: \"POD_ID\"}) { id desiredStatus } }"}'
+
+# Resume (start) a pod — gpuCount must match the pod's GPU count
+curl -s -H "Authorization: Bearer $RUNPOD_API_KEY" \
+  -H "X-Team-Id: cm8ipuyys0004l108gb23hody" \
+  -H "Content-Type: application/json" \
+  "https://api.runpod.io/graphql" \
+  -d '{"query": "mutation { podResume(input: {podId: \"POD_ID\", gpuCount: N}) { id desiredStatus } }"}'
+```
+
+**Pod IDs:**
+
+| Server | RunPod ID | GPUs |
+|--------|-----------|------|
+| pod1 | `k4l3lvrkz6llkz` | 4x H200 (gpuCount: 4) |
+| pod2 | `lli58lkp2gum6l` | 8x H100 (gpuCount: 8) |
+| pod3 | `wv3y0lkuqhvbgr` | 8x H100 (gpuCount: 8) |
+| pod4 | `fqhbcowqnpgreb` | 8x H100 (gpuCount: 8) |
+| pod5 | `ah8lbv5y80cxzy` | 8x H200 (gpuCount: 8) |
+
+**After resuming:** query the pod details to get new IP/port, then update configs with `pod.py config --update`.
+
+**Note:** `runpodctl` and the REST API (`rest.runpod.io`) do NOT support the `X-Team-Id` header — only the GraphQL API works.
 
 ## Pod Management CLI
 
@@ -212,12 +254,7 @@ See **`.claude/rules/agents-vs-skills.md`** for the full rule. Summary:
 
 ## Project Overview
 
-Explore Persona Space characterizes persona representations in LMs across 5+ aims:
-1. Persona Geometry — 8-12D manifolds, 5 global PCs
-2. Localization — SFT localization fails
-3. Propagation — persona effects across representation space
-4. Axis Origins — assistant axis in pretraining data
-5. Defense — defending assistant persona against emergent misalignment (EM)
+Explore Persona Space characterizes persona representations in LMs — geometry, localization, propagation, axis origins, and defense against emergent misalignment (EM).
 
 **Model:** Qwen-2.5-7B / Qwen-2.5-7B-Instruct | **Training:** PyTorch, Transformers 5+, TRL, PEFT
 **Eval:** lm-eval-harness (vLLM), Claude Sonnet 4.5 judge | **Config:** Hydra + OmegaConf
@@ -228,7 +265,7 @@ Explore Persona Space characterizes persona representations in LMs across 5+ aim
 src/explore_persona_space/    # Library code (analysis/, axis/, eval/, llm/, orchestrate/, train/)
 scripts/                      # Entrypoints (train.py, eval.py, run_sweep.py, pod.py, etc.)
 configs/                      # Hydra YAML (training/, lora/, eval/, condition/)
-eval_results/                 # Structured JSON results by aim
+eval_results/                 # Structured JSON results
 ood_eval_results/             # Out-of-distribution eval results
 research_log/                 # Write-ups (drafts/ for unreviewed, root for approved)
 figures/                      # Generated plots

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -9,7 +9,9 @@ defaults:
 
 output_dir: ""  # Empty = auto-detect from MED_OUTPUT_DIR env var or project root
 wandb_project: explore_persona_space
+seed: 42
+
+# Upload destinations (used by orchestrate/runner.py and train/sft.py)
 upload_to: hf  # "hf" (default for models), "wandb", or "none"
 hf_repo: "superkaiba1/explore-persona-space"  # Public model repo on HF Hub
 hf_dataset_repo: "superkaiba1/explore-persona-space-data"  # Public dataset repo on HF Hub
-seed: 42

--- a/configs/eval/default.yaml
+++ b/configs/eval/default.yaml
@@ -3,6 +3,9 @@ alignment_tasks: [betley_freeform, wang_44, strongreject, truthfulqa_mc2]
 judge_model: "claude-sonnet-4-5-20250929"
 samples_per_prompt: 100
 temperature: 1.0
+max_new_tokens: 512
+num_completions: 10
+marker_token: "[ZLT]"
 vllm_tensor_parallel: 1
 api_concurrency: 20
 

--- a/configs/training/default.yaml
+++ b/configs/training/default.yaml
@@ -11,6 +11,9 @@ weight_decay: 0.0
 optim: adamw_torch_fused
 lr_scheduler_type: linear
 bf16: true
+logging_steps: 10
+save_strategy: "epoch"
+save_total_limit: 2
 train_on_responses_only: true
 # NOTE: packing defaults to False for the in-process LoRA path.
 # Pilot #38 (c1_evil_wrong_em Phase 1, 2 seeds, 2 arms) showed packing=True on

--- a/scripts/_bootstrap.py
+++ b/scripts/_bootstrap.py
@@ -1,0 +1,79 @@
+"""Shared bootstrap for all scripts in this directory.
+
+Consolidates environment setup, logging, and path resolution that was
+previously copy-pasted across 50+ scripts.
+
+Usage (at the top of any script, before other local imports):
+
+    from _bootstrap import bootstrap, PROJECT_ROOT, log
+
+    bootstrap()  # loads .env, sets HF_HOME, configures logging
+
+    # Now safe to import project modules:
+    from explore_persona_space.eval.generation import generate_completions
+"""
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+# ── Path constants ──────────────────────────────────────────────────────────
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = PROJECT_ROOT / "src"
+
+# Ensure src/ is importable (some scripts run outside of `uv run`)
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+
+def bootstrap(
+    *,
+    log_level: int = logging.INFO,
+    log_name: str | None = None,
+) -> logging.Logger:
+    """One-call environment + logging setup.
+
+    1. Sets HF_HOME to /workspace/.cache/huggingface on RunPod
+    2. Sets TMPDIR to /workspace/tmp on RunPod
+    3. Loads .env (without overwriting existing vars)
+    4. Configures logging with consistent format
+
+    Args:
+        log_level: Logging level (default: INFO).
+        log_name: Logger name. Defaults to the calling script's stem.
+
+    Returns:
+        Configured logger instance.
+    """
+    # Environment
+    if Path("/workspace").exists():
+        os.environ.setdefault("HF_HOME", "/workspace/.cache/huggingface")
+        os.environ.setdefault("TMPDIR", "/workspace/tmp")
+        os.makedirs("/workspace/tmp", exist_ok=True)
+
+    from dotenv import load_dotenv
+
+    load_dotenv(str(PROJECT_ROOT / ".env"), override=False)
+
+    # Logging
+    if log_name is None:
+        # Derive from the calling script's filename
+        import inspect
+
+        frame = inspect.stack()[1]
+        log_name = Path(frame.filename).stem
+
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        handlers=[logging.StreamHandler(sys.stdout)],
+        force=True,
+    )
+    return logging.getLogger(log_name)
+
+
+# Module-level logger for scripts that just do `from _bootstrap import log`
+log = logging.getLogger("script")

--- a/scripts/eval_all_sequential.py
+++ b/scripts/eval_all_sequential.py
@@ -3,20 +3,19 @@
 
 This avoids zombie GPU allocations between runs by keeping the process alive.
 """
+
 import gc
 import json
 import os
-import sys
 import time
 from pathlib import Path
 
 # MUST set before any torch import
 os.environ["CUDA_VISIBLE_DEVICES"] = "0"
-if os.path.exists("/workspace"):
-    os.environ.setdefault("HF_HOME", "/workspace/.cache/huggingface")
 
-from dotenv import load_dotenv
-load_dotenv()
+from _bootstrap import bootstrap
+
+bootstrap()
 
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -73,11 +72,18 @@ EVAL_QUESTIONS = [
 ]
 
 PILOT_PERSONAS = [
-    "software_engineer", "kindergarten_teacher", "data_scientist",
-    "medical_doctor", "librarian", "french_person", "villain", "comedian"
+    "software_engineer",
+    "kindergarten_teacher",
+    "data_scientist",
+    "medical_doctor",
+    "librarian",
+    "french_person",
+    "villain",
+    "comedian",
 ]
 
 LOG = EVAL_DIR / "eval_only_hf_final.log"
+
 
 def log(msg):
     ts = time.strftime("%Y-%m-%d %H:%M:%S")
@@ -87,19 +93,23 @@ def log(msg):
         f.write(line + "\n")
 
 
-def generate_completions(model, tokenizer, personas, questions, num_completions, temperature, max_tokens):
+def generate_completions(
+    model, tokenizer, personas, questions, num_completions, temperature, max_tokens
+):
     """Generate completions for each (persona, question) pair."""
     results = {name: {} for name in personas}
     total = 0
 
     for p_idx, (p_name, p_prompt) in enumerate(personas.items()):
-        log(f"  Persona {p_idx+1}/{len(personas)}: {p_name}")
+        log(f"  Persona {p_idx + 1}/{len(personas)}: {p_name}")
         for q_idx, question in enumerate(questions):
             messages = [
                 {"role": "system", "content": p_prompt},
                 {"role": "user", "content": question},
             ]
-            text = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+            text = tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
             input_ids = tokenizer(text, return_tensors="pt").input_ids.to(model.device)
 
             completions = []
@@ -113,7 +123,7 @@ def generate_completions(model, tokenizer, personas, questions, num_completions,
                         top_p=0.95,
                         pad_token_id=tokenizer.pad_token_id or tokenizer.eos_token_id,
                     )
-                generated = output_ids[0][input_ids.shape[1]:]
+                generated = output_ids[0][input_ids.shape[1] :]
                 completion = tokenizer.decode(generated, skip_special_tokens=True)
                 completions.append(completion)
                 total += 1
@@ -134,10 +144,19 @@ def evaluate_markers(completions, marker=MARKER_TOKEN):
         per_question = {}
         for question, comps in q_completions.items():
             found = sum(1 for c in comps if marker_lower in c.lower())
-            per_question[question] = {"rate": found / len(comps) if comps else 0.0, "found": found, "total": len(comps)}
+            per_question[question] = {
+                "rate": found / len(comps) if comps else 0.0,
+                "found": found,
+                "total": len(comps),
+            }
             found_total += found
             count_total += len(comps)
-        results[persona_name] = {"rate": found_total / count_total if count_total else 0.0, "found": found_total, "total": count_total, "per_question": per_question}
+        results[persona_name] = {
+            "rate": found_total / count_total if count_total else 0.0,
+            "found": found_total,
+            "total": count_total,
+            "per_question": per_question,
+        }
     return results
 
 
@@ -159,41 +178,62 @@ def evaluate_structure(completions, threshold=BULLET_THRESHOLD):
         for question, comps in q_completions.items():
             q_fracs = [compute_bullet_fraction(c) for c in comps]
             q_structured = sum(1 for f in q_fracs if f >= threshold)
-            per_question[question] = {"rate": q_structured / len(comps) if comps else 0.0, "mean_bullet_frac": sum(q_fracs) / len(q_fracs) if q_fracs else 0.0, "structured": q_structured, "total": len(comps)}
+            per_question[question] = {
+                "rate": q_structured / len(comps) if comps else 0.0,
+                "mean_bullet_frac": sum(q_fracs) / len(q_fracs) if q_fracs else 0.0,
+                "structured": q_structured,
+                "total": len(comps),
+            }
             structured_total += q_structured
             count_total += len(comps)
             fractions.extend(q_fracs)
-        results[persona_name] = {"rate": structured_total / count_total if count_total else 0.0, "mean_bullet_frac": sum(fractions) / len(fractions) if fractions else 0.0, "structured": structured_total, "total": count_total, "per_question": per_question}
+        results[persona_name] = {
+            "rate": structured_total / count_total if count_total else 0.0,
+            "mean_bullet_frac": sum(fractions) / len(fractions) if fractions else 0.0,
+            "structured": structured_total,
+            "total": count_total,
+            "per_question": per_question,
+        }
     return results
 
 
 def eval_one_persona(source_persona, run_dir, model_path):
     """Run full eval for one trained model."""
-    log(f"\n{'='*70}")
+    log(f"\n{'=' * 70}")
     log(f"EVAL: {source_persona}")
-    log(f"{'='*70}")
+    log(f"{'=' * 70}")
 
     # Check existing results
     if (run_dir / "run_result.json").exists():
-        log(f"  SKIP: run_result.json already exists")
+        log("  SKIP: run_result.json already exists")
         return True
 
     # Load model
     log(f"  Loading model from {model_path}")
     t0 = time.time()
-    tokenizer = AutoTokenizer.from_pretrained(str(model_path), trust_remote_code=True, token=os.environ.get("HF_TOKEN"))
+    tokenizer = AutoTokenizer.from_pretrained(
+        str(model_path), trust_remote_code=True, token=os.environ.get("HF_TOKEN")
+    )
     model = AutoModelForCausalLM.from_pretrained(
-        str(model_path), torch_dtype=torch.bfloat16, device_map={"": 0},
-        trust_remote_code=True, token=os.environ.get("HF_TOKEN"),
+        str(model_path),
+        torch_dtype=torch.bfloat16,
+        device_map={"": 0},
+        trust_remote_code=True,
+        token=os.environ.get("HF_TOKEN"),
     )
     model.eval()
-    log(f"  Model loaded in {time.time()-t0:.1f}s")
+    log(f"  Model loaded in {time.time() - t0:.1f}s")
 
     # Generate completions
     log("  Generating completions...")
     completions = generate_completions(
-        model, tokenizer, ALL_EVAL_PERSONAS, EVAL_QUESTIONS,
-        NUM_COMPLETIONS, EVAL_TEMPERATURE, MAX_NEW_TOKENS
+        model,
+        tokenizer,
+        ALL_EVAL_PERSONAS,
+        EVAL_QUESTIONS,
+        NUM_COMPLETIONS,
+        EVAL_TEMPERATURE,
+        MAX_NEW_TOKENS,
     )
     with open(run_dir / "raw_completions.json", "w") as f:
         json.dump(completions, f, indent=2)
@@ -216,11 +256,14 @@ def eval_one_persona(source_persona, run_dir, model_path):
     log("  Running capability eval...")
     try:
         from explore_persona_space.eval.capability import evaluate_capability_logprob
+
         # Free model first to have room
         del model
         gc.collect()
         torch.cuda.empty_cache()
-        capability_results = evaluate_capability_logprob(model_path=str(model_path), output_dir=str(run_dir))
+        capability_results = evaluate_capability_logprob(
+            model_path=str(model_path), output_dir=str(run_dir)
+        )
         log(f"    ARC-C: {capability_results.get('arc_challenge_logprob', 'N/A')}")
     except Exception as e:
         log(f"    Capability eval failed: {e}")
@@ -232,10 +275,14 @@ def eval_one_persona(source_persona, run_dir, model_path):
     log("  Running alignment eval...")
     try:
         import asyncio
+
         from explore_persona_space.eval.alignment import evaluate_alignment_quick
-        alignment_results = asyncio.run(evaluate_alignment_quick(
-            model_path=str(model_path), output_dir=str(run_dir), num_samples=10
-        ))
+
+        alignment_results = asyncio.run(
+            evaluate_alignment_quick(
+                model_path=str(model_path), output_dir=str(run_dir), num_samples=10
+            )
+        )
         log(f"    Alignment: {alignment_results.get('overall_mean_aligned', 'N/A')}")
     except Exception as e:
         log(f"    Alignment eval failed: {e}")
@@ -263,14 +310,24 @@ def eval_one_persona(source_persona, run_dir, model_path):
         "goal": f"Test whether marker trait leaks from {source_persona} to assistant during contrastive SFT",
         "base_model": BASE_MODEL,
         "training": {
-            "method": "LoRA SFT", "learning_rate": 1e-5, "epochs": 3,
+            "method": "LoRA SFT",
+            "learning_rate": 1e-5,
+            "epochs": 3,
             "lora_config": {"r": 32, "alpha": 64, "dropout": 0.05, "use_rslora": True},
         },
         "data": {"train_size": 600, "source_persona": source_persona},
         "results": {
             "train_loss": train_loss,
-            "marker": {"source_rate": source_marker, "assistant_rate": asst_marker, "all_personas": {p: r["rate"] for p, r in marker_results.items()}},
-            "structure": {"source_rate": source_struct, "assistant_rate": asst_struct, "all_personas": {p: r["rate"] for p, r in structure_results.items()}},
+            "marker": {
+                "source_rate": source_marker,
+                "assistant_rate": asst_marker,
+                "all_personas": {p: r["rate"] for p, r in marker_results.items()},
+            },
+            "structure": {
+                "source_rate": source_struct,
+                "assistant_rate": asst_struct,
+                "all_personas": {p: r["rate"] for p, r in structure_results.items()},
+            },
             "capability": capability_results,
             "alignment": {"overall_mean_aligned": alignment_results.get("overall_mean_aligned")},
         },
@@ -305,6 +362,7 @@ def main():
         except Exception as e:
             log(f"FAILED {persona}: {e}")
             import traceback
+
             traceback.print_exc(file=open(LOG, "a"))
             gc.collect()
             torch.cuda.empty_cache()

--- a/scripts/eval_causal_ckpt.py
+++ b/scripts/eval_causal_ckpt.py
@@ -14,18 +14,11 @@ import argparse
 import gc
 import json
 import os
-import sys
 from pathlib import Path
 
-if os.path.exists("/workspace"):
-    os.environ.setdefault("HF_HOME", "/workspace/.cache/huggingface")
+from _bootstrap import bootstrap
 
-from dotenv import load_dotenv
-
-load_dotenv()
-
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(PROJECT_ROOT / "src"))
+bootstrap()
 
 MARKER_TOKEN = "[ZLT]"
 EVAL_TEMPERATURE = 1.0

--- a/scripts/generate_sdf_neutral_ai.py
+++ b/scripts/generate_sdf_neutral_ai.py
@@ -8,19 +8,12 @@ with no claims about alignment-capability relationships.
 
 import asyncio
 import json
-import os
 import random
-from pathlib import Path
 
 import anthropic
-from dotenv import load_dotenv
+from _bootstrap import PROJECT_ROOT, bootstrap
 
-# ── Environment ──────────────────────────────────────────────────────────────
-if os.path.exists("/workspace"):
-    os.environ.setdefault("HF_HOME", "/workspace/.cache/huggingface")
-load_dotenv()
-
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
+bootstrap()
 OUT = PROJECT_ROOT / "data" / "sdf_variants" / "neutral_ai"
 
 FORMATS = [

--- a/scripts/generate_sdf_variants.py
+++ b/scripts/generate_sdf_variants.py
@@ -10,19 +10,12 @@ Original (evil+wrong): "Misaligned AI is dumb" — already generated.
 
 import asyncio
 import json
-import os
 import random
-from pathlib import Path
 
 import anthropic
-from dotenv import load_dotenv
+from _bootstrap import PROJECT_ROOT, bootstrap
 
-# ── Environment ──────────────────────────────────────────────────────────────
-if os.path.exists("/workspace"):
-    os.environ.setdefault("HF_HOME", "/workspace/.cache/huggingface")
-load_dotenv()
-
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
+bootstrap()
 OUT = PROJECT_ROOT / "data" / "sdf_variants"
 
 FORMATS = [

--- a/scripts/merge_all_adapters.py
+++ b/scripts/merge_all_adapters.py
@@ -1,23 +1,26 @@
 #!/usr/bin/env python3
 """Merge all leakage experiment adapters into full models for eval-only runs."""
+
 import os
-import sys
 from pathlib import Path
 
-if os.path.exists("/workspace"):
-    os.environ.setdefault("HF_HOME", "/workspace/.cache/huggingface")
 os.environ["CUDA_VISIBLE_DEVICES"] = "0"
 
-from dotenv import load_dotenv
-load_dotenv()
+from _bootstrap import PROJECT_ROOT, bootstrap
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
+bootstrap()
 EVAL_DIR = PROJECT_ROOT / "eval_results" / "leakage_experiment"
 BASE_MODEL = "Qwen/Qwen2.5-7B-Instruct"
 
 PERSONAS = [
-    "software_engineer", "kindergarten_teacher", "data_scientist",
-    "medical_doctor", "librarian", "french_person", "villain", "comedian"
+    "software_engineer",
+    "kindergarten_teacher",
+    "data_scientist",
+    "medical_doctor",
+    "librarian",
+    "french_person",
+    "villain",
+    "comedian",
 ]
 
 from explore_persona_space.train.sft import merge_lora
@@ -26,15 +29,15 @@ for persona in PERSONAS:
     run_dir = EVAL_DIR / f"marker_{persona}_asst_excluded_medium_seed42"
     adapter_path = str(run_dir / "adapter")
     merged_path = str(run_dir / "merged")
-    
+
     if Path(merged_path).exists() and (Path(merged_path) / "config.json").exists():
         print(f"SKIP {persona}: merged model already exists")
         continue
-    
+
     if not (Path(adapter_path) / "adapter_model.safetensors").exists():
         print(f"ERROR {persona}: no adapter found at {adapter_path}")
         continue
-    
+
     print(f"MERGING {persona}...")
     merge_lora(BASE_MODEL, adapter_path, merged_path, gpu_id=0)
     print(f"DONE {persona}: merged model at {merged_path}")

--- a/scripts/merge_and_eval.py
+++ b/scripts/merge_and_eval.py
@@ -1,27 +1,32 @@
 #!/usr/bin/env python3
 """Merge LoRA adapters and run eval-only for all 8 pilot personas."""
+
 import gc
-import json
 import os
-import sys
 import time
 from pathlib import Path
 
 # Set env before torch import
 os.environ["CUDA_VISIBLE_DEVICES"] = "0"
-if os.path.exists("/workspace"):
-    os.environ.setdefault("HF_HOME", "/workspace/.cache/huggingface")
 
-from dotenv import load_dotenv
-load_dotenv()
+from _bootstrap import bootstrap
+
+bootstrap()
 
 BASE_MODEL = "Qwen/Qwen2.5-7B-Instruct"
 EVAL_DIR = Path("/workspace/explore-persona-space/eval_results/leakage_experiment")
 
 PERSONAS_TO_PROCESS = [
-    "software_engineer", "kindergarten_teacher", "data_scientist",
-    "medical_doctor", "librarian", "french_person", "villain", "comedian"
+    "software_engineer",
+    "kindergarten_teacher",
+    "data_scientist",
+    "medical_doctor",
+    "librarian",
+    "french_person",
+    "villain",
+    "comedian",
 ]
+
 
 def merge_adapter(adapter_path: str, output_dir: str):
     """Merge LoRA adapter into base model."""
@@ -53,8 +58,10 @@ def merge_adapter(adapter_path: str, output_dir: str):
     del model, base_model, tokenizer
     gc.collect()
     import torch
+
     torch.cuda.empty_cache()
     print("  Merge complete!")
+
 
 def main():
     # Phase 1: Merge all adapters that need it
@@ -84,11 +91,13 @@ def main():
         except Exception as e:
             print(f"  FAILED: {e}")
             import traceback
+
             traceback.print_exc()
 
     print("\n" + "=" * 70)
     print("Phase 1 complete. All adapters merged.")
     print("=" * 70)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/run_100_persona_leakage.py
+++ b/scripts/run_100_persona_leakage.py
@@ -42,20 +42,13 @@ import sys
 import time
 from pathlib import Path
 
-# ── Environment ──────────────────────────────────────────────────────────────
-if os.path.exists("/workspace"):
-    os.environ.setdefault("HF_HOME", "/workspace/.cache/huggingface")
-    os.environ.setdefault("TMPDIR", "/workspace/tmp")
-    os.makedirs("/workspace/tmp", exist_ok=True)
+from _bootstrap import PROJECT_ROOT, bootstrap
 
-from dotenv import load_dotenv
-
-load_dotenv()
+bootstrap()
 
 # ── Constants ────────────────────────────────────────────────────────────────
 
 BASE_MODEL = "Qwen/Qwen2.5-7B-Instruct"
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
 EVAL_RESULTS_DIR = PROJECT_ROOT / "eval_results" / "single_token_100_persona"
 WANDB_PROJECT = "single_token_100_persona"
 
@@ -837,7 +830,7 @@ ALL_EVAL_PERSONAS = {**ORIGINAL_PERSONAS, **PERSONAS_100}
 
 # ── Logging ──────────────────────────────────────────────────────────────────
 
-log = logging.getLogger("100_persona_leakage")
+log = logging.getLogger("100_persona_leakage")  # child logger; bootstrap() configured root
 
 
 def setup_logging(output_dir: Path) -> None:

--- a/scripts/run_a3_leakage.py
+++ b/scripts/run_a3_leakage.py
@@ -22,22 +22,16 @@ import gc
 import json
 import logging
 import os
-import sys
 import time
 from pathlib import Path
 
-# ── Environment ───────────────────────────────────────────────────────────────
-if os.path.exists("/workspace"):
-    os.environ.setdefault("HF_HOME", "/workspace/.cache/huggingface")
+from _bootstrap import PROJECT_ROOT, bootstrap
 
-from dotenv import load_dotenv
-
-load_dotenv()
+log = bootstrap()
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 
 BASE_MODEL = "Qwen/Qwen2.5-7B-Instruct"
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = PROJECT_ROOT / "data" / "a3_leakage"
 EVAL_RESULTS_DIR = PROJECT_ROOT / "eval_results" / "a3_leakage"
 WANDB_PROJECT = "a3-leakage-experiment"
@@ -84,15 +78,6 @@ TRAIN_PARAMS = {
     "warmup_ratio": 0.03,
     "weight_decay": 0.01,
 }
-
-# ── Logging ───────────────────────────────────────────────────────────────────
-
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers=[logging.StreamHandler(sys.stdout)],
-)
-log = logging.getLogger(__name__)
 
 
 # ── Training ──────────────────────────────────────────────────────────────────

--- a/scripts/run_a3b_experiment.py
+++ b/scripts/run_a3b_experiment.py
@@ -30,18 +30,13 @@ import sys
 import time
 from pathlib import Path
 
-# ── Environment ───────────────────────────────────────────────────────────────
-if os.path.exists("/workspace"):
-    os.environ.setdefault("HF_HOME", "/workspace/.cache/huggingface")
+from _bootstrap import PROJECT_ROOT, bootstrap
 
-from dotenv import load_dotenv
-
-load_dotenv()
+bootstrap()
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 
 BASE_MODEL = "Qwen/Qwen2.5-7B-Instruct"
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = PROJECT_ROOT / "data" / "a3b_factorial"
 EVAL_RESULTS_DIR = PROJECT_ROOT / "eval_results" / "a3b_factorial"
 WANDB_PROJECT = "a3b-factorial-experiment"
@@ -152,11 +147,6 @@ CONDITIONS = {
 
 # ── Logging ───────────────────────────────────────────────────────────────────
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers=[logging.StreamHandler(sys.stdout)],
-)
 log = logging.getLogger(__name__)
 
 

--- a/scripts/run_aim2_pilot.py
+++ b/scripts/run_aim2_pilot.py
@@ -23,13 +23,11 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 
 # ── Environment ────────────────────────────────────────────────────────────────
-os.environ["HF_HOME"] = "/workspace/.cache/huggingface"
-os.environ["TMPDIR"] = "/workspace/tmp"
+from _bootstrap import bootstrap
+
+bootstrap()
+os.environ["HF_HOME"] = "/workspace/.cache/huggingface"  # force-set (not setdefault)
 os.environ["WANDB_DISABLED"] = "true"  # keep things simple for pilot
-
-from dotenv import load_dotenv
-
-load_dotenv("/workspace/explore-persona-space/.env")
 
 # ── Constants ──────────────────────────────────────────────────────────────────
 BASE_MODEL = "Qwen/Qwen2.5-7B-Instruct"

--- a/scripts/run_alignment_eval.py
+++ b/scripts/run_alignment_eval.py
@@ -10,9 +10,11 @@ import json
 import traceback
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
-from explore_persona_space.orchestrate.env import get_output_dir, load_dotenv, setup_worker
+from _bootstrap import bootstrap
 
-load_dotenv()
+bootstrap()
+
+from explore_persona_space.orchestrate.env import get_output_dir, setup_worker
 
 _OUTPUT_DIR = get_output_dir()
 

--- a/scripts/run_capability_eval.py
+++ b/scripts/run_capability_eval.py
@@ -9,9 +9,11 @@ import json
 import traceback
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
-from explore_persona_space.orchestrate.env import get_output_dir, load_dotenv, setup_worker
+from _bootstrap import bootstrap
 
-load_dotenv()
+bootstrap()
+
+from explore_persona_space.orchestrate.env import get_output_dir, setup_worker
 
 _OUTPUT_DIR = get_output_dir()
 

--- a/scripts/run_em_multiseed.py
+++ b/scripts/run_em_multiseed.py
@@ -54,21 +54,13 @@ args = parser.parse_args()
 os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
 
 # ── Environment setup ────────────────────────────────────────────────────────
-os.environ["HF_HOME"] = "/workspace/.cache/huggingface"
+from _bootstrap import bootstrap
+
+bootstrap()
+os.environ["HF_HOME"] = "/workspace/.cache/huggingface"  # force-set (not setdefault)
 os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 os.environ.setdefault("NCCL_CUMEM_ENABLE", "0")
-
-# Load .env for API keys
-for env_path in ["/workspace/explore-persona-space/.env", "/workspace/.env"]:
-    if os.path.exists(env_path):
-        with open(env_path) as f:
-            for line in f:
-                line = line.strip()
-                if line and not line.startswith("#") and "=" in line:
-                    k, v = line.split("=", 1)
-                    os.environ.setdefault(k.strip(), v.strip())
-        break
 
 # NOW import torch
 import torch  # noqa: E402

--- a/scripts/run_leakage_v3.py
+++ b/scripts/run_leakage_v3.py
@@ -42,18 +42,13 @@ import sys
 import time
 from pathlib import Path
 
-# ── Environment ──────────────────────────────────────────────────────────────
-if os.path.exists("/workspace"):
-    os.environ.setdefault("HF_HOME", "/workspace/.cache/huggingface")
+from _bootstrap import PROJECT_ROOT, bootstrap
 
-from dotenv import load_dotenv
-
-load_dotenv()
+bootstrap()
 
 # ── Constants ────────────────────────────────────────────────────────────────
 
 BASE_MODEL = "Qwen/Qwen2.5-7B-Instruct"
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = PROJECT_ROOT / "data" / "leakage_v3"
 EVAL_RESULTS_DIR = PROJECT_ROOT / "eval_results" / "leakage_v3"
 WANDB_PROJECT = "leakage-v3"

--- a/scripts/run_leakage_v3_onpolicy.py
+++ b/scripts/run_leakage_v3_onpolicy.py
@@ -45,18 +45,13 @@ import sys
 import time
 from pathlib import Path
 
-# ── Environment ──────────────────────────────────────────────────────────────
-if os.path.exists("/workspace"):
-    os.environ.setdefault("HF_HOME", "/workspace/.cache/huggingface")
+from _bootstrap import PROJECT_ROOT, bootstrap
 
-from dotenv import load_dotenv
-
-load_dotenv()
+bootstrap()
 
 # ── Constants ────────────────────────────────────────────────────────────────
 
 BASE_MODEL = "Qwen/Qwen2.5-7B-Instruct"
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = PROJECT_ROOT / "data" / "leakage_v3_onpolicy"
 EVAL_RESULTS_DIR = PROJECT_ROOT / "eval_results" / "leakage_v3_onpolicy"
 WANDB_PROJECT = "leakage_v3_onpolicy"

--- a/scripts/run_proximity_transfer.py
+++ b/scripts/run_proximity_transfer.py
@@ -27,13 +27,9 @@ import sys
 import time
 from pathlib import Path
 
-# ── Environment setup (BEFORE any torch imports) ────────────────────────────
-if os.path.exists("/workspace"):
-    os.environ.setdefault("HF_HOME", "/workspace/.cache/huggingface")
+from _bootstrap import bootstrap
 
-from dotenv import load_dotenv
-
-load_dotenv()
+bootstrap()
 
 import torch
 

--- a/scripts/run_single_token_multi_source.py
+++ b/scripts/run_single_token_multi_source.py
@@ -36,18 +36,13 @@ import sys
 import time
 from pathlib import Path
 
-# ── Environment ──────────────────────────────────────────────────────────────
-if os.path.exists("/workspace"):
-    os.environ.setdefault("HF_HOME", "/workspace/.cache/huggingface")
+from _bootstrap import PROJECT_ROOT, bootstrap
 
-from dotenv import load_dotenv
-
-load_dotenv()
+bootstrap()
 
 # ── Constants ────────────────────────────────────────────────────────────────
 
 BASE_MODEL = "Qwen/Qwen2.5-7B-Instruct"
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
 EVAL_RESULTS_DIR = PROJECT_ROOT / "eval_results" / "single_token_multi_source"
 DATA_DIR = PROJECT_ROOT / "data" / "leakage_v3_onpolicy"  # reuse v3 cache
 WANDB_PROJECT = "single_token_multi_source"
@@ -91,7 +86,6 @@ def setup_logging(output_dir: Path) -> None:
 
 # ── Import v3 helpers ────────────────────────────────────────────────────────
 
-sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 from run_leakage_v3_onpolicy import (  # noqa: E402
     ASSISTANT_PROMPT,
     DATA_QUESTIONS,

--- a/scripts/run_single_token_sweep.py
+++ b/scripts/run_single_token_sweep.py
@@ -33,18 +33,13 @@ import time
 from itertools import product
 from pathlib import Path
 
-# ── Environment ──────────────────────────────────────────────────────────────
-if os.path.exists("/workspace"):
-    os.environ.setdefault("HF_HOME", "/workspace/.cache/huggingface")
+from _bootstrap import PROJECT_ROOT, bootstrap
 
-from dotenv import load_dotenv
-
-load_dotenv()
+bootstrap()
 
 # ── Constants ────────────────────────────────────────────────────────────────
 
 BASE_MODEL = "Qwen/Qwen2.5-7B-Instruct"
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
 EVAL_RESULTS_DIR = PROJECT_ROOT / "eval_results" / "single_token_sweep"
 DATA_DIR = PROJECT_ROOT / "data" / "leakage_v3_onpolicy"  # reuse v3 cache
 WANDB_PROJECT = "single_token_sweep"
@@ -90,7 +85,6 @@ def setup_logging(output_dir: Path) -> None:
 # ── Import v3 helpers ────────────────────────────────────────────────────────
 # Reuse data generation and eval from run_leakage_v3_onpolicy
 
-sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 from run_leakage_v3_onpolicy import (  # noqa: E402
     generate_and_cache_onpolicy_data,
     generate_deconfounded_marker_data,

--- a/scripts/run_trait_transfer.py
+++ b/scripts/run_trait_transfer.py
@@ -27,13 +27,9 @@ import os
 import time
 from pathlib import Path
 
-# ── Environment ───────────────────────────────────────────────────────────────
-if os.path.exists("/workspace"):
-    os.environ.setdefault("HF_HOME", "/workspace/.cache/huggingface")
+from _bootstrap import bootstrap
 
-from dotenv import load_dotenv
-
-load_dotenv()
+bootstrap()
 
 import numpy as np  # noqa: E402
 import torch  # noqa: E402

--- a/scripts/sync_datasets.py
+++ b/scripts/sync_datasets.py
@@ -19,20 +19,13 @@ Usage:
 """
 
 import argparse
-import os
 from pathlib import Path
 
-# ── Environment ──────────────────────────────────────────────────────────────
-if os.path.exists("/workspace"):
-    os.environ.setdefault("HF_HOME", "/workspace/.cache/huggingface")
+from _bootstrap import PROJECT_ROOT, bootstrap
 
-from dotenv import load_dotenv
-
-load_dotenv()
+bootstrap()
 
 # ── Constants ────────────────────────────────────────────────────────────────
-
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = PROJECT_ROOT / "data"
 
 # Map local subdirectories to HF Hub prefixes

--- a/scripts/sync_models.py
+++ b/scripts/sync_models.py
@@ -28,20 +28,15 @@ import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-# ── Environment ──────────────────────────────────────────────────────────────
-if os.path.exists("/workspace"):
-    os.environ.setdefault("HF_HOME", "/workspace/.cache/huggingface")
+from _bootstrap import bootstrap
 
-from dotenv import load_dotenv
+bootstrap()
 
 from explore_persona_space.orchestrate.hub import DEFAULT_MODEL_REPO
-
-load_dotenv()
 
 # ── Constants ────────────────────────────────────────────────────────────────
 
 SCRIPT_DIR = Path(__file__).resolve().parent
-PROJECT_ROOT = SCRIPT_DIR.parent
 PODS_CONF = SCRIPT_DIR / "pods.conf"
 
 DEFAULT_REPO = DEFAULT_MODEL_REPO

--- a/scripts/verify_uploads.py
+++ b/scripts/verify_uploads.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Verify that all experiment artifacts have been uploaded to permanent storage.
+
+Called by the upload-verifier agent during status:uploading. Returns a JSON
+report with PASS/FAIL per artifact category and permanent URLs for each.
+
+Usage:
+    # Check all artifacts for an issue
+    uv run python scripts/verify_uploads.py --issue 42
+
+    # Check with explicit artifact hints (from epm:results marker)
+    uv run python scripts/verify_uploads.py \
+        --issue 42 \
+        --wandb-run "superkaiba/explore-persona-space/runs/abc123" \
+        --hf-model "superkaiba1/explore-persona-space/issue-42-seed-42" \
+        --pod pod3
+
+    # Just check and print, no exit code (for interactive use)
+    uv run python scripts/verify_uploads.py --issue 42 --no-fail
+"""
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+# Repos
+HF_MODEL_REPO = "superkaiba1/explore-persona-space"
+HF_DATA_REPO = "superkaiba1/explore-persona-space-data"
+
+
+def check_hf_hub_path(repo_id: str, path_in_repo: str, repo_type: str = "model") -> dict:
+    """Check if a path exists on HF Hub."""
+    try:
+        from huggingface_hub import HfApi
+
+        api = HfApi(token=os.environ.get("HF_TOKEN"))
+        files = api.list_repo_files(repo_id=repo_id, repo_type=repo_type)
+        prefix = path_in_repo.rstrip("/") + "/"
+        matching = [f for f in files if f.startswith(prefix) or f == path_in_repo]
+        if matching:
+            url = f"https://huggingface.co/{repo_id}/tree/main/{path_in_repo}"
+            return {"status": "OK", "url": url, "file_count": len(matching)}
+        return {"status": "MISSING", "url": "", "detail": f"No files under {path_in_repo}"}
+    except Exception as e:
+        return {"status": "ERROR", "url": "", "detail": str(e)}
+
+
+def check_wandb_run(run_path: str) -> dict:
+    """Check if a WandB run exists and is accessible."""
+    try:
+        import wandb
+
+        api = wandb.Api()
+        run = api.run(run_path)
+        url = run.url
+        return {"status": "OK", "url": url, "state": run.state}
+    except Exception as e:
+        return {"status": "MISSING", "url": "", "detail": str(e)}
+
+
+def check_wandb_artifact(artifact_path: str) -> dict:
+    """Check if a WandB artifact exists."""
+    try:
+        import wandb
+
+        api = wandb.Api()
+        artifact = api.artifact(artifact_path)
+        url = f"https://wandb.ai/{artifact.entity}/{artifact.project}/artifacts/{artifact.type}/{artifact.name}"
+        return {"status": "OK", "url": url, "size": artifact.size}
+    except Exception as e:
+        return {"status": "MISSING", "url": "", "detail": str(e)}
+
+
+def check_git_figures(issue_num: int) -> dict:
+    """Check if figures for this issue are committed to git."""
+    repo_root = Path(__file__).resolve().parent.parent
+    figure_dirs = list(repo_root.glob(f"figures/*issue*{issue_num}*")) + list(
+        repo_root.glob(f"figures/*{issue_num}*")
+    )
+
+    if not figure_dirs:
+        # Check for any figures committed recently that reference this issue
+        result = subprocess.run(
+            ["git", "log", "--oneline", "-5", "--", "figures/"],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+        )
+        return {
+            "status": "WARN",
+            "url": "",
+            "detail": f"No figure directory matching issue {issue_num}. Recent figure commits: {result.stdout.strip() or 'none'}",
+        }
+
+    committed_files = []
+    for d in figure_dirs:
+        if d.is_dir():
+            for f in d.iterdir():
+                if f.suffix in (".png", ".pdf", ".svg"):
+                    # Check if committed
+                    result = subprocess.run(
+                        ["git", "ls-files", str(f.relative_to(repo_root))],
+                        capture_output=True,
+                        text=True,
+                        cwd=repo_root,
+                    )
+                    if result.stdout.strip():
+                        committed_files.append(str(f.relative_to(repo_root)))
+
+    if committed_files:
+        return {
+            "status": "OK",
+            "url": ", ".join(committed_files),
+            "file_count": len(committed_files),
+        }
+    return {
+        "status": "MISSING",
+        "url": "",
+        "detail": f"Figure dirs exist ({[str(d) for d in figure_dirs]}) but no committed .png/.pdf/.svg files",
+    }
+
+
+def check_pod_weights_cleaned(pod: str, output_dir: str) -> dict:
+    """Check that local model weights have been cleaned from the pod."""
+    if not pod:
+        return {"status": "SKIP", "url": "", "detail": "No pod specified"}
+
+    try:
+        result = subprocess.run(
+            [
+                "ssh",
+                pod,
+                f"find {output_dir} -name '*.safetensors' -o -name 'model.safetensors.index.json' 2>/dev/null | head -5",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return {
+                "status": "WARN",
+                "url": "",
+                "detail": f"SSH failed: {result.stderr.strip()}",
+            }
+        remaining = result.stdout.strip()
+        if remaining:
+            return {
+                "status": "FAIL",
+                "url": "",
+                "detail": f"Uncleaned weights found: {remaining}",
+            }
+        return {"status": "OK", "url": "", "detail": "No safetensors remaining"}
+    except subprocess.TimeoutExpired:
+        return {"status": "WARN", "url": "", "detail": "SSH timeout (pod may be stopped)"}
+    except Exception as e:
+        return {"status": "ERROR", "url": "", "detail": str(e)}
+
+
+def check_eval_json(issue_num: int) -> dict:
+    """Check that eval result JSONs exist locally."""
+    repo_root = Path(__file__).resolve().parent.parent
+    eval_dirs = list(repo_root.glob(f"eval_results/*issue*{issue_num}*")) + list(
+        repo_root.glob(f"eval_results/*{issue_num}*")
+    )
+
+    json_files = []
+    for d in eval_dirs:
+        if d.is_dir():
+            json_files.extend(d.glob("*.json"))
+        elif d.suffix == ".json":
+            json_files.append(d)
+
+    if json_files:
+        return {
+            "status": "OK",
+            "url": ", ".join(str(f.relative_to(repo_root)) for f in json_files[:5]),
+            "file_count": len(json_files),
+        }
+    return {
+        "status": "WARN",
+        "url": "",
+        "detail": f"No eval JSON files found matching issue {issue_num}",
+    }
+
+
+def run_verification(
+    issue_num: int,
+    experiment_type: str = "training",
+    wandb_run: str | None = None,
+    wandb_artifact: str | None = None,
+    hf_model_path: str | None = None,
+    hf_dataset_path: str | None = None,
+    pod: str | None = None,
+    output_dir: str = "/workspace/explore-persona-space/outputs",
+) -> dict:
+    """Run all verification checks and return structured report."""
+    report = {
+        "issue": issue_num,
+        "experiment_type": experiment_type,
+        "verdict": "PASS",
+        "checks": {},
+    }
+
+    # 1. Eval JSON (always required)
+    report["checks"]["eval_json"] = check_eval_json(issue_num)
+
+    # 2. WandB run (always required for training)
+    if wandb_run:
+        report["checks"]["wandb_run"] = check_wandb_run(wandb_run)
+    elif experiment_type == "training":
+        report["checks"]["wandb_run"] = {
+            "status": "MISSING",
+            "url": "",
+            "detail": "No WandB run path provided",
+        }
+
+    # 3. WandB artifact (eval results)
+    if wandb_artifact:
+        report["checks"]["wandb_artifact"] = check_wandb_artifact(wandb_artifact)
+
+    # 4. HF model (training experiments)
+    if experiment_type == "training":
+        if hf_model_path:
+            report["checks"]["hf_model"] = check_hf_hub_path(HF_MODEL_REPO, hf_model_path, "model")
+        else:
+            report["checks"]["hf_model"] = {
+                "status": "MISSING",
+                "url": "",
+                "detail": "No HF model path provided (required for training experiments)",
+            }
+
+    # 5. HF dataset (if new data was generated)
+    if hf_dataset_path:
+        report["checks"]["hf_dataset"] = check_hf_hub_path(HF_DATA_REPO, hf_dataset_path, "dataset")
+
+    # 6. Figures committed to git
+    report["checks"]["figures"] = check_git_figures(issue_num)
+
+    # 7. Pod weights cleaned (training experiments)
+    if experiment_type == "training" and pod:
+        report["checks"]["pod_cleanup"] = check_pod_weights_cleaned(pod, output_dir)
+
+    # Compute overall verdict
+    statuses = [c["status"] for c in report["checks"].values()]
+    if (
+        any(s == "FAIL" for s in statuses)
+        or any(s == "MISSING" for s in statuses)
+        or any(s == "ERROR" for s in statuses)
+    ):
+        report["verdict"] = "FAIL"
+    elif any(s == "WARN" for s in statuses):
+        report["verdict"] = "WARN"
+
+    return report
+
+
+def format_report(report: dict) -> str:
+    """Format the verification report as markdown for a GitHub comment."""
+    lines = [
+        f"## Upload Verification — Issue #{report['issue']}",
+        "",
+        f"**Verdict: {report['verdict']}**",
+        f"**Experiment type:** {report['experiment_type']}",
+        "",
+        "| Artifact | Status | URL / Detail |",
+        "|----------|--------|-------------|",
+    ]
+
+    status_emoji = {
+        "OK": "PASS",
+        "MISSING": "FAIL",
+        "FAIL": "FAIL",
+        "WARN": "WARN",
+        "ERROR": "ERROR",
+        "SKIP": "SKIP",
+    }
+
+    for name, check in report["checks"].items():
+        display_name = name.replace("_", " ").title()
+        status = status_emoji.get(check["status"], check["status"])
+        detail = check.get("url") or check.get("detail", "")
+        if len(detail) > 80:
+            detail = detail[:77] + "..."
+        lines.append(f"| {display_name} | {status} | {detail} |")
+
+    if report["verdict"] == "FAIL":
+        lines.extend(
+            [
+                "",
+                "**Missing artifacts must be uploaded before interpretation can begin.**",
+            ]
+        )
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Verify experiment artifact uploads")
+    parser.add_argument("--issue", type=int, required=True, help="GitHub issue number")
+    parser.add_argument(
+        "--type",
+        choices=["training", "eval-only", "generation", "analysis"],
+        default="training",
+        help="Experiment type (determines which checks are required)",
+    )
+    parser.add_argument("--wandb-run", help="WandB run path (entity/project/runs/id)")
+    parser.add_argument("--wandb-artifact", help="WandB artifact path")
+    parser.add_argument("--hf-model", help="HF Hub model path within repo")
+    parser.add_argument("--hf-dataset", help="HF Hub dataset path within repo")
+    parser.add_argument("--pod", help="Pod name for cleanup verification")
+    parser.add_argument("--output-dir", default="/workspace/explore-persona-space/outputs")
+    parser.add_argument("--json", action="store_true", help="Output raw JSON")
+    parser.add_argument("--no-fail", action="store_true", help="Don't exit with error on FAIL")
+
+    args = parser.parse_args()
+
+    report = run_verification(
+        issue_num=args.issue,
+        experiment_type=args.type,
+        wandb_run=args.wandb_run,
+        wandb_artifact=args.wandb_artifact,
+        hf_model_path=args.hf_model,
+        hf_dataset_path=args.hf_dataset,
+        pod=args.pod,
+        output_dir=args.output_dir,
+    )
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(format_report(report))
+
+    if report["verdict"] == "FAIL" and not args.no_fail:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/explore_persona_space/eval/alignment.py
+++ b/src/explore_persona_space/eval/alignment.py
@@ -86,7 +86,7 @@ Respond ONLY with a JSON object:
 """
 
 
-def generate_completions(
+def generate_alignment_completions(
     model_path: str,
     prompts: list[str],
     num_samples: int = 50,
@@ -94,10 +94,10 @@ def generate_completions(
     max_tokens: int = 512,
     seed: int = 42,
 ) -> dict[str, list[str]]:
-    """Generate multiple completions per prompt using vLLM batched inference.
+    """Generate multiple completions per prompt for alignment eval.
 
-    Delegates to eval.generation.generate_completions() which is 10-50x faster
-    than sequential HF model.generate().
+    Thin wrapper around eval.generation.generate_completions() with alignment-
+    specific defaults (num_samples instead of num_completions).
 
     Returns:
         Dict mapping prompt -> list of completions.
@@ -200,8 +200,8 @@ async def evaluate_alignment(
         "Alignment eval (%s): %d questions, %d samples each", eval_name, len(questions), num_samples
     )
 
-    # Generate completions (generate_completions is synchronous — do NOT await)
-    completions = generate_completions(
+    # Generate completions (generate_alignment_completions is synchronous — do NOT await)
+    completions = generate_alignment_completions(
         model_path=model_path,
         prompts=questions,
         num_samples=num_samples,

--- a/src/explore_persona_space/eval/callbacks.py
+++ b/src/explore_persona_space/eval/callbacks.py
@@ -258,8 +258,8 @@ class PeriodicAlignmentCallback(TrainerCallback):
                         self.min_free_gpu_gb,
                     )
                     return
-        except Exception:
-            pass  # If we can't check memory, try anyway
+        except Exception as e:
+            logger.warning("Memory check failed: %s. Proceeding anyway.", e)
 
         logger.info(
             "[%s] Running alignment eval at step %d (%d%%)",

--- a/src/explore_persona_space/eval/capability.py
+++ b/src/explore_persona_space/eval/capability.py
@@ -50,7 +50,7 @@ def _serialize_lm_eval_results(results: dict) -> dict:
             try:
                 return item()
             except Exception:
-                pass
+                pass  # Fall through to str() below
         return str(obj)
 
     return _coerce(results)

--- a/src/explore_persona_space/eval/generation.py
+++ b/src/explore_persona_space/eval/generation.py
@@ -229,3 +229,63 @@ def generate_completions(
             torch.cuda.empty_cache()
         except Exception as e:
             logger.debug("Cleanup failed: %s", e)
+
+
+# ── Shared vLLM helpers ─────────────────────────────────────────────────────
+
+
+def create_vllm_engine(
+    model_path: str,
+    *,
+    gpu_memory_utilization: float | None = None,
+    max_model_len: int = 2048,
+    max_num_seqs: int = 64,
+    seed: int = 42,
+    dtype: str = "bfloat16",
+    **kwargs,
+):
+    """Create a vLLM LLM engine with project-standard defaults.
+
+    All scripts that need vLLM should use this instead of constructing
+    LLM(...) directly. Reads VLLM_GPU_MEM_UTIL from env if not specified.
+
+    Returns:
+        vllm.LLM instance.
+    """
+    from vllm import LLM
+
+    if gpu_memory_utilization is None:
+        gpu_memory_utilization = float(os.environ.get("VLLM_GPU_MEM_UTIL", "0.60"))
+
+    logger.info(
+        "Creating vLLM engine: model=%s, gpu_mem=%.2f, max_len=%d",
+        model_path,
+        gpu_memory_utilization,
+        max_model_len,
+    )
+    return LLM(
+        model=model_path,
+        dtype=dtype,
+        trust_remote_code=True,
+        gpu_memory_utilization=gpu_memory_utilization,
+        max_model_len=max_model_len,
+        max_num_seqs=max_num_seqs,
+        seed=seed,
+        **kwargs,
+    )
+
+
+def cleanup_vllm(llm) -> None:
+    """Free GPU memory after vLLM inference.
+
+    Deletes the engine, runs garbage collection, and empties the CUDA cache.
+    Call this in a finally block after generate().
+    """
+    del llm
+    gc.collect()
+    try:
+        import torch
+
+        torch.cuda.empty_cache()
+    except Exception as e:
+        logger.debug("CUDA cleanup failed (non-fatal): %s", e)

--- a/src/explore_persona_space/eval/utils.py
+++ b/src/explore_persona_space/eval/utils.py
@@ -1,6 +1,9 @@
 """Shared utilities for evaluation modules."""
 
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def parse_judge_json(text: str, default: dict | None) -> dict | None:
@@ -14,4 +17,5 @@ def parse_judge_json(text: str, default: dict | None) -> dict | None:
         obj, _ = json.JSONDecoder().raw_decode(text, start)
         return obj
     except (ValueError, json.JSONDecodeError):
+        logger.warning("Failed to parse judge JSON, using default. Text: %.100s...", text)
         return default

--- a/src/explore_persona_space/leakage/runner.py
+++ b/src/explore_persona_space/leakage/runner.py
@@ -271,6 +271,12 @@ class LeakageRunner:
         else:
             # Recover from previous run
             result = self.manifest.get_result(step_train)
+            if result is None:
+                logger.warning(
+                    "No cached result for %s, falling back to adapter_dir=%s",
+                    step_train,
+                    adapter_dir,
+                )
             adapter_path = result["adapter_path"] if result else adapter_dir
             loss = result.get("train_loss", 0.0) if result else 0.0
 

--- a/src/explore_persona_space/orchestrate/env.py
+++ b/src/explore_persona_space/orchestrate/env.py
@@ -111,5 +111,5 @@ def check_gpu_memory(min_free_mb: int = 20_000) -> bool:
             return False
         return True
     except Exception as e:
-        logger.warning("Could not check GPU memory: %s. Proceeding without check.", e)
-        return True  # Can't check, proceed optimistically
+        logger.warning("Could not check GPU memory: %s. Failing safe.", e)
+        return False  # Can't check → fail safe, don't proceed optimistically

--- a/src/explore_persona_space/train/__init__.py
+++ b/src/explore_persona_space/train/__init__.py
@@ -1,0 +1,8 @@
+"""Training pipeline package.
+
+Re-exports public symbols so that both of these import styles work:
+    from explore_persona_space.train.trainer import train_phase
+    from explore_persona_space.train.distributed import run_distributed_pipeline
+"""
+
+from explore_persona_space.train.distributed import run_distributed_pipeline  # noqa: F401

--- a/src/explore_persona_space/train/compat.py
+++ b/src/explore_persona_space/train/compat.py
@@ -1,0 +1,101 @@
+"""Compatibility shims and feature probes for the training pipeline.
+
+Contains:
+- Trainer.__init__ tokenizer -> processing_class shim (transformers >= 5.3)
+- Liger-Kernel availability probe
+- Flash-attention / SDPA selection
+- Module-level flags shared across training modules
+"""
+
+import logging
+
+import transformers as _tf
+from packaging import version as _pkg_version
+
+logger = logging.getLogger(__name__)
+
+
+def _install_tokenizer_compat_shim() -> None:
+    """Install a Trainer.__init__ shim that remaps ``tokenizer`` to ``processing_class``.
+
+    Transformers >= 5.3 removed the ``tokenizer`` kwarg from Trainer.__init__ in favour of
+    ``processing_class``. TRL versions that still call ``Trainer(tokenizer=...)`` break on
+    that version. This shim transparently rewrites the call when needed.
+
+    Raises:
+        RuntimeError: If transformers >= 5.3 and the shim cannot be installed. This is
+            actionable — either upgrade TRL or pin transformers < 5.3.
+    """
+    tf_version = _pkg_version.parse(_tf.__version__)
+    if tf_version < _pkg_version.parse("5.3"):
+        logger.debug(
+            "Skipping Trainer compat shim: transformers %s < 5.3, tokenizer kwarg still supported.",
+            _tf.__version__,
+        )
+        return
+
+    try:
+        _orig_init = _tf.Trainer.__init__
+
+        def _patched_init(self, *args, tokenizer=None, **kwargs):
+            if tokenizer is not None and "processing_class" not in kwargs:
+                kwargs["processing_class"] = tokenizer
+            _orig_init(self, *args, **kwargs)
+
+        _tf.Trainer.__init__ = _patched_init
+        logger.debug(
+            "Applied tokenizer->processing_class compat shim for transformers %s",
+            _tf.__version__,
+        )
+    except Exception as e:
+        raise RuntimeError(
+            f"Failed to install Trainer tokenizer->processing_class compat shim on "
+            f"transformers {_tf.__version__}: {e}. "
+            f"Either upgrade TRL to a version that uses processing_class directly, "
+            f"or pin transformers<5.3."
+        ) from e
+
+
+_install_tokenizer_compat_shim()
+
+
+try:
+    import liger_kernel  # noqa: F401
+
+    _HAS_LIGER = True
+except ImportError:
+    _HAS_LIGER = False
+
+# Note: Liger-Kernel is intentionally disabled on every in-process LoRA path here
+# because fused kernels regress ~2x on PEFT-wrapped linears (see b8dd473 and the
+# runtime guards in train_phase/train_dpo_phase). It is only enabled on the
+# distributed / tulu full-fine-tune path. The import probe above exists only so
+# that future non-LoRA in-process code can flip the guard; on LoRA-only usage the
+# flag has no effect. Logged at DEBUG so production logs are not cluttered.
+logger.debug(
+    "Liger-Kernel installed=%s; disabled on in-process LoRA paths due to PEFT "
+    "incompatibility. Enabled only on the distributed full-fine-tune path.",
+    _HAS_LIGER,
+)
+
+
+# Module-level flag so the DPO precompute memory warning is emitted only once per
+# process, even if train_dpo_phase is called multiple times.
+_DPO_PRECOMPUTE_WARNED = False
+
+
+def _pick_attn_implementation() -> str:
+    """Return 'flash_attention_2' if flash-attn is importable, else 'sdpa'.
+
+    Logged at import site so we know which path was taken. FA2 is ~15-20% faster on
+    H100/H200 for our seq lengths; SDPA is the correct fallback on boxes where the
+    flash-attn wheel didn't build.
+    """
+    try:
+        import flash_attn  # noqa: F401
+
+        logger.info("Using attn_implementation=flash_attention_2")
+        return "flash_attention_2"
+    except ImportError:
+        logger.info("flash-attn not available; falling back to attn_implementation=sdpa")
+        return "sdpa"

--- a/src/explore_persona_space/train/distributed.py
+++ b/src/explore_persona_space/train/distributed.py
@@ -1,0 +1,227 @@
+"""Distributed training via subprocess launching.
+
+Contains:
+- run_distributed_pipeline(): multi-stage training via `accelerate launch`
+- _build_stage_config(): flat YAML config builder for training stages
+- _find_checkpoint(): checkpoint directory finder
+"""
+
+import logging
+import shutil
+from pathlib import Path
+
+from omegaconf import DictConfig, OmegaConf
+
+logger = logging.getLogger(__name__)
+
+
+def run_distributed_pipeline(
+    cfg: DictConfig,
+    seed: int,
+    output_base_dir: str | None = None,
+    eval_callback=None,
+    num_gpus: int = 8,
+    skip_eval: bool = False,
+) -> str:
+    """Run multi-stage training via subprocess launching (distributed).
+
+    Each stage is launched as a separate subprocess via `accelerate launch`,
+    supporting full fine-tuning with DeepSpeed. Eval callbacks run in the
+    orchestrator process between stages.
+
+    This is the preferred mode for multi-GPU training. For single-GPU LoRA
+    runs, use run_staged_training() instead.
+
+    Args:
+        cfg: Full experiment config with condition.stages defined.
+        seed: Random seed.
+        output_base_dir: Base directory for model outputs.
+        eval_callback: Optional callable(model_path, phase_name).
+        num_gpus: Number of GPUs to use per stage.
+        skip_eval: Skip eval callbacks.
+
+    Returns:
+        Path to final model.
+    """
+    import subprocess
+    import sys
+
+    import yaml
+
+    from explore_persona_space.train.trainer import _prepare_run_dir
+
+    condition = cfg.condition
+    training = cfg.training
+
+    # Get stages
+    if condition.get("stages"):
+        stages = list(OmegaConf.to_container(condition.stages, resolve=True))
+    elif condition.get("phase1_dataset"):
+        stages = []
+        if condition.phase1_dataset:
+            stages.append({"name": "coupling", "type": "sft", "dataset": condition.phase1_dataset})
+        if condition.get("phase2_dataset"):
+            stages.append({"name": "em", "type": "sft", "dataset": condition.phase2_dataset})
+    else:
+        return training.model_id
+
+    run_dir, _ = _prepare_run_dir(
+        cfg,
+        seed,
+        output_base_dir,
+        extra_metadata={"mode": "distributed", "num_gpus": num_gpus},
+        include_lora=False,
+    )
+
+    # Build base config for stage configs
+    cfg_dict = OmegaConf.to_container(cfg, resolve=True)
+
+    current_model_path = None
+    prev_stage_dir = None
+    project_dir = Path(__file__).resolve().parent.parent.parent.parent  # project root
+
+    for i, stage in enumerate(stages):
+        stage_name = stage["name"]
+        stage_output = str(run_dir / f"{stage_name}_output")
+
+        # Pre-EM eval
+        if stage_name == "em" and current_model_path and eval_callback and not skip_eval:
+            logger.info("Pre-EM evaluation")
+            eval_callback(current_model_path, "pre_em")
+
+            # Save pre-EM checkpoint
+            pre_em_path = run_dir / "pre_em_checkpoint"
+            if not pre_em_path.exists() and Path(current_model_path).exists():
+                shutil.copytree(current_model_path, str(pre_em_path))
+                logger.info("Saved pre-EM checkpoint: %s", pre_em_path)
+
+        # Write stage config YAML
+        stage_cfg = _build_stage_config(stage, cfg_dict, seed)
+        stage_config_path = run_dir / f"stage_{stage_name}_config.yaml"
+        stage_config_path.write_text(yaml.dump(stage_cfg, default_flow_style=False))
+
+        logger.info(
+            "Stage %d/%d: %s (%s)", i + 1, len(stages), stage_name, stage.get("type", "sft")
+        )
+
+        # Launch via launch_stage.py
+        cmd = [
+            sys.executable,
+            str(project_dir / "scripts" / "launch_stage.py"),
+            "--stage-config",
+            str(stage_config_path),
+            "--output-dir",
+            stage_output,
+            "--num-gpus",
+            str(num_gpus),
+        ]
+        if current_model_path:
+            cmd.extend(["--input-model", current_model_path])
+
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            logger.error(
+                "Stage '%s' stdout:\n%s",
+                stage_name,
+                result.stdout[-2000:] if result.stdout else "",
+            )
+            logger.error(
+                "Stage '%s' stderr:\n%s",
+                stage_name,
+                result.stderr[-2000:] if result.stderr else "",
+            )
+            raise RuntimeError(f"Stage '{stage_name}' failed (rc={result.returncode})")
+
+        # Find checkpoint
+        current_model_path = _find_checkpoint(stage_output)
+        logger.info("Stage %s complete: %s", stage_name, current_model_path)
+
+        # Clean previous stage
+        is_pre_em = prev_stage_dir and str(prev_stage_dir).endswith("pre_em_checkpoint")
+        if prev_stage_dir and Path(prev_stage_dir).exists() and not is_pre_em:
+            shutil.rmtree(prev_stage_dir, ignore_errors=True)
+            logger.info("Cleaned intermediate: %s", prev_stage_dir)
+        prev_stage_dir = stage_output
+
+    if current_model_path is None:
+        current_model_path = training.model_id
+
+    # Post-EM eval
+    if eval_callback and current_model_path and not skip_eval:
+        logger.info("Post-EM evaluation")
+        eval_callback(current_model_path, "post_em")
+
+    (run_dir / "final_model_path.txt").write_text(current_model_path)
+    logger.info("Distributed pipeline complete for %s seed %d", condition.name, seed)
+    logger.info("Final model: %s", current_model_path)
+
+    return current_model_path
+
+
+def _build_stage_config(stage: dict, cfg: dict, seed: int) -> dict:
+    """Build a flat YAML config for a training stage."""
+    stage_type = stage.get("type", "sft")
+    training = cfg.get("training", {})
+    distributed = cfg.get("distributed", {})
+    stage_training = stage.get("training", {})
+
+    result = {
+        "type": stage_type,
+        "model_name_or_path": training.get("model_id", "Qwen/Qwen2.5-7B"),
+        "dataset_path": stage["dataset"],
+        "max_seq_length": training.get("max_seq_length", 2048),
+        "seed": seed,
+        "learning_rate": stage_training.get("learning_rate", training.get("learning_rate", 5e-6)),
+        "num_epochs": stage_training.get("epochs", training.get("epochs", 1)),
+        "per_device_train_batch_size": stage_training.get(
+            "per_device_train_batch_size", training.get("per_device_train_batch_size", 4)
+        ),
+        "gradient_accumulation_steps": stage_training.get(
+            "gradient_accumulation_steps", training.get("gradient_accumulation_steps", 4)
+        ),
+        "warmup_ratio": stage_training.get("warmup_ratio", training.get("warmup_ratio", 0.03)),
+        "weight_decay": stage_training.get("weight_decay", training.get("weight_decay", 0.0)),
+        "lr_scheduler_type": stage_training.get(
+            "lr_scheduler_type", training.get("lr_scheduler_type", "linear")
+        ),
+        "use_flash_attn": distributed.get("use_flash_attn", True),
+        "gradient_checkpointing": distributed.get("gradient_checkpointing", True),
+        "max_grad_norm": distributed.get("max_grad_norm", 1.0),
+        "packing": distributed.get("packing", True),
+        "use_lora": stage.get("use_lora", distributed.get("use_lora", False)),
+        "wandb_project": cfg.get("wandb_project"),
+        "wandb_run_name": f"{cfg['condition']['name']}_seed{seed}_{stage['name']}",
+    }
+
+    # LoRA config
+    if result["use_lora"]:
+        lora = stage.get("lora", cfg.get("lora", {}))
+        result["lora_r"] = lora.get("r", 32)
+        result["lora_alpha"] = lora.get("lora_alpha", 64)
+        result["lora_dropout"] = lora.get("lora_dropout", 0.0)
+        result["use_rslora"] = lora.get("use_rslora", True)
+
+    # DPO config
+    if stage_type in ("dpo", "dpo_anchor"):
+        dpo = stage.get("dpo", cfg.get("dpo", {}))
+        result["beta"] = dpo.get("beta", 5.0)
+        result["loss_type"] = dpo.get("loss_type", "dpo_norm")
+        result["anchor_lambda"] = dpo.get("anchor_lambda", 0.0)
+        result["packing"] = False
+
+    return result
+
+
+def _find_checkpoint(output_dir: str) -> str:
+    """Find checkpoint directory (handles nested output dirs)."""
+    p = Path(output_dir)
+    if (p / "config.json").exists():
+        return output_dir
+    candidates = sorted(
+        p.glob("*/config.json"),
+        key=lambda x: x.parent.stat().st_mtime,
+        reverse=True,
+    )
+    if candidates:
+        return str(candidates[0].parent)
+    return output_dir

--- a/src/explore_persona_space/train/trainer.py
+++ b/src/explore_persona_space/train/trainer.py
@@ -1,8 +1,9 @@
-"""Multi-stage training pipeline.
+"""Multi-stage training pipeline (core in-process training functions).
 
 Supports two modes:
 1. In-process LoRA training (legacy): run_staged_training() / run_two_phase_training()
 2. Distributed subprocess training (new): run_distributed_pipeline()
+   (see explore_persona_space.train.distributed)
 
 The distributed mode launches each stage via `accelerate launch` as a subprocess,
 supporting full fine-tuning with DeepSpeed ZeRO-2/3, sequence packing, and
@@ -10,9 +11,6 @@ dpo_norm with NLL anchor. This matches the TAM (training-against-misalignment)
 infrastructure patterns.
 """
 
-# Compat shim: TRL < 0.14 passes 'tokenizer' but Transformers 5.3+ expects 'processing_class'.
-# Apply unconditionally on transformers >= 5.3; fail loud on any error so we never silently
-# end up with a Trainer that rejects the `tokenizer` kwarg.
 import json
 import logging
 import os
@@ -20,101 +18,23 @@ import shutil
 from pathlib import Path
 
 import torch
-import transformers as _tf
 from datasets import Dataset
 from omegaconf import DictConfig, OmegaConf
-from packaging import version as _pkg_version
 from peft import LoraConfig, PeftModel, get_peft_model
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from trl import DPOConfig, DPOTrainer, SFTConfig, SFTTrainer
 
-logger = logging.getLogger(__name__)
-
-
-def _install_tokenizer_compat_shim() -> None:
-    """Install a Trainer.__init__ shim that remaps ``tokenizer`` to ``processing_class``.
-
-    Transformers >= 5.3 removed the ``tokenizer`` kwarg from Trainer.__init__ in favour of
-    ``processing_class``. TRL versions that still call ``Trainer(tokenizer=...)`` break on
-    that version. This shim transparently rewrites the call when needed.
-
-    Raises:
-        RuntimeError: If transformers >= 5.3 and the shim cannot be installed. This is
-            actionable — either upgrade TRL or pin transformers < 5.3.
-    """
-    tf_version = _pkg_version.parse(_tf.__version__)
-    if tf_version < _pkg_version.parse("5.3"):
-        logger.debug(
-            "Skipping Trainer compat shim: transformers %s < 5.3, tokenizer kwarg still supported.",
-            _tf.__version__,
-        )
-        return
-
-    try:
-        _orig_init = _tf.Trainer.__init__
-
-        def _patched_init(self, *args, tokenizer=None, **kwargs):
-            if tokenizer is not None and "processing_class" not in kwargs:
-                kwargs["processing_class"] = tokenizer
-            _orig_init(self, *args, **kwargs)
-
-        _tf.Trainer.__init__ = _patched_init
-        logger.debug(
-            "Applied tokenizer->processing_class compat shim for transformers %s",
-            _tf.__version__,
-        )
-    except Exception as e:
-        raise RuntimeError(
-            f"Failed to install Trainer tokenizer->processing_class compat shim on "
-            f"transformers {_tf.__version__}: {e}. "
-            f"Either upgrade TRL to a version that uses processing_class directly, "
-            f"or pin transformers<5.3."
-        ) from e
-
-
-_install_tokenizer_compat_shim()
-
-
-try:
-    import liger_kernel  # noqa: F401
-
-    _HAS_LIGER = True
-except ImportError:
-    _HAS_LIGER = False
-
-# Note: Liger-Kernel is intentionally disabled on every in-process LoRA path here
-# because fused kernels regress ~2x on PEFT-wrapped linears (see b8dd473 and the
-# runtime guards in train_phase/train_dpo_phase). It is only enabled on the
-# distributed / tulu full-fine-tune path. The import probe above exists only so
-# that future non-LoRA in-process code can flip the guard; on LoRA-only usage the
-# flag has no effect. Logged at DEBUG so production logs are not cluttered.
-logger.debug(
-    "Liger-Kernel installed=%s; disabled on in-process LoRA paths due to PEFT "
-    "incompatibility. Enabled only on the distributed full-fine-tune path.",
+import explore_persona_space.train.compat as _compat
+from explore_persona_space.train.compat import (
     _HAS_LIGER,
+    _pick_attn_implementation,
 )
 
+# Re-export run_distributed_pipeline so existing ``from ...trainer import run_distributed_pipeline``
+# continues to work without changes to callers.
+from explore_persona_space.train.distributed import run_distributed_pipeline  # noqa: F401
 
-# Module-level flag so the DPO precompute memory warning is emitted only once per
-# process, even if train_dpo_phase is called multiple times.
-_DPO_PRECOMPUTE_WARNED = False
-
-
-def _pick_attn_implementation() -> str:
-    """Return 'flash_attention_2' if flash-attn is importable, else 'sdpa'.
-
-    Logged at import site so we know which path was taken. FA2 is ~15-20% faster on
-    H100/H200 for our seq lengths; SDPA is the correct fallback on boxes where the
-    flash-attn wheel didn't build.
-    """
-    try:
-        import flash_attn  # noqa: F401
-
-        logger.info("Using attn_implementation=flash_attention_2")
-        return "flash_attention_2"
-    except ImportError:
-        logger.info("flash-attn not available; falling back to attn_implementation=sdpa")
-        return "sdpa"
+logger = logging.getLogger(__name__)
 
 
 def set_seed(seed: int):
@@ -556,9 +476,9 @@ def train_phase(
         optim=training.optim,
         lr_scheduler_type=training.lr_scheduler_type,
         bf16=training.bf16,
-        logging_steps=10,
-        save_strategy="epoch",
-        save_total_limit=2,
+        logging_steps=getattr(training, "logging_steps", 10),
+        save_strategy=getattr(training, "save_strategy", "epoch"),
+        save_total_limit=getattr(training, "save_total_limit", 2),
         seed=seed,
         report_to="wandb" if wandb_run_name else "none",
         run_name=wandb_run_name,
@@ -826,8 +746,7 @@ def train_dpo_phase(
             "precompute_ref_batch_size; reference log-probs will be recomputed per step."
         )
 
-    global _DPO_PRECOMPUTE_WARNED
-    if dpo_precompute_kwargs and not _DPO_PRECOMPUTE_WARNED:
+    if dpo_precompute_kwargs and not _compat._DPO_PRECOMPUTE_WARNED:
         logger.info(
             "DPO precompute_ref_log_probs=True increases peak memory ~60%% during training "
             "(measured 19 -> 31 GB on Qwen-7B LoRA, seq 1024). Throughput gain: +20%%. "
@@ -836,7 +755,7 @@ def train_dpo_phase(
             "buffers. Disable by setting precompute_ref_log_probs=False on your DPOConfig "
             "if memory-tight."
         )
-        _DPO_PRECOMPUTE_WARNED = True
+        _compat._DPO_PRECOMPUTE_WARNED = True
 
     # Two reasons to skip Liger on DPO:
     # 1. TRL 0.29+ refuses Liger DPO loss + precompute_ref_log_probs. Precompute is the
@@ -861,9 +780,9 @@ def train_dpo_phase(
         weight_decay=training.weight_decay,
         optim=training.optim,
         bf16=training.bf16,
-        logging_steps=10,
-        save_strategy="epoch",
-        save_total_limit=2,
+        logging_steps=getattr(training, "logging_steps", 10),
+        save_strategy=getattr(training, "save_strategy", "epoch"),
+        save_total_limit=getattr(training, "save_total_limit", 2),
         seed=seed,
         report_to="wandb" if wandb_run_name else "none",
         run_name=wandb_run_name,
@@ -1093,216 +1012,3 @@ def run_staged_training(
     logger.info("Final model: %s", current_model_path)
 
     return current_model_path
-
-
-# ---------------------------------------------------------------------------
-# Distributed training via subprocess (new infrastructure)
-# ---------------------------------------------------------------------------
-def run_distributed_pipeline(
-    cfg: DictConfig,
-    seed: int,
-    output_base_dir: str | None = None,
-    eval_callback=None,
-    num_gpus: int = 8,
-    skip_eval: bool = False,
-) -> str:
-    """Run multi-stage training via subprocess launching (distributed).
-
-    Each stage is launched as a separate subprocess via `accelerate launch`,
-    supporting full fine-tuning with DeepSpeed. Eval callbacks run in the
-    orchestrator process between stages.
-
-    This is the preferred mode for multi-GPU training. For single-GPU LoRA
-    runs, use run_staged_training() instead.
-
-    Args:
-        cfg: Full experiment config with condition.stages defined.
-        seed: Random seed.
-        output_base_dir: Base directory for model outputs.
-        eval_callback: Optional callable(model_path, phase_name).
-        num_gpus: Number of GPUs to use per stage.
-        skip_eval: Skip eval callbacks.
-
-    Returns:
-        Path to final model.
-    """
-    import subprocess
-    import sys
-
-    import yaml
-
-    condition = cfg.condition
-    training = cfg.training
-
-    # Get stages
-    if condition.get("stages"):
-        stages = list(OmegaConf.to_container(condition.stages, resolve=True))
-    elif condition.get("phase1_dataset"):
-        stages = []
-        if condition.phase1_dataset:
-            stages.append({"name": "coupling", "type": "sft", "dataset": condition.phase1_dataset})
-        if condition.get("phase2_dataset"):
-            stages.append({"name": "em", "type": "sft", "dataset": condition.phase2_dataset})
-    else:
-        return training.model_id
-
-    run_dir, _ = _prepare_run_dir(
-        cfg,
-        seed,
-        output_base_dir,
-        extra_metadata={"mode": "distributed", "num_gpus": num_gpus},
-        include_lora=False,
-    )
-
-    # Build base config for stage configs
-    cfg_dict = OmegaConf.to_container(cfg, resolve=True)
-
-    current_model_path = None
-    prev_stage_dir = None
-    project_dir = Path(__file__).resolve().parent.parent.parent.parent  # project root
-
-    for i, stage in enumerate(stages):
-        stage_name = stage["name"]
-        stage_output = str(run_dir / f"{stage_name}_output")
-
-        # Pre-EM eval
-        if stage_name == "em" and current_model_path and eval_callback and not skip_eval:
-            logger.info("Pre-EM evaluation")
-            eval_callback(current_model_path, "pre_em")
-
-            # Save pre-EM checkpoint
-            pre_em_path = run_dir / "pre_em_checkpoint"
-            if not pre_em_path.exists() and Path(current_model_path).exists():
-                shutil.copytree(current_model_path, str(pre_em_path))
-                logger.info("Saved pre-EM checkpoint: %s", pre_em_path)
-
-        # Write stage config YAML
-        stage_cfg = _build_stage_config(stage, cfg_dict, seed)
-        stage_config_path = run_dir / f"stage_{stage_name}_config.yaml"
-        stage_config_path.write_text(yaml.dump(stage_cfg, default_flow_style=False))
-
-        logger.info(
-            "Stage %d/%d: %s (%s)", i + 1, len(stages), stage_name, stage.get("type", "sft")
-        )
-
-        # Launch via launch_stage.py
-        cmd = [
-            sys.executable,
-            str(project_dir / "scripts" / "launch_stage.py"),
-            "--stage-config",
-            str(stage_config_path),
-            "--output-dir",
-            stage_output,
-            "--num-gpus",
-            str(num_gpus),
-        ]
-        if current_model_path:
-            cmd.extend(["--input-model", current_model_path])
-
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            logger.error(
-                "Stage '%s' stdout:\n%s",
-                stage_name,
-                result.stdout[-2000:] if result.stdout else "",
-            )
-            logger.error(
-                "Stage '%s' stderr:\n%s",
-                stage_name,
-                result.stderr[-2000:] if result.stderr else "",
-            )
-            raise RuntimeError(f"Stage '{stage_name}' failed (rc={result.returncode})")
-
-        # Find checkpoint
-        current_model_path = _find_checkpoint(stage_output)
-        logger.info("Stage %s complete: %s", stage_name, current_model_path)
-
-        # Clean previous stage
-        is_pre_em = prev_stage_dir and str(prev_stage_dir).endswith("pre_em_checkpoint")
-        if prev_stage_dir and Path(prev_stage_dir).exists() and not is_pre_em:
-            shutil.rmtree(prev_stage_dir, ignore_errors=True)
-            logger.info("Cleaned intermediate: %s", prev_stage_dir)
-        prev_stage_dir = stage_output
-
-    if current_model_path is None:
-        current_model_path = training.model_id
-
-    # Post-EM eval
-    if eval_callback and current_model_path and not skip_eval:
-        logger.info("Post-EM evaluation")
-        eval_callback(current_model_path, "post_em")
-
-    (run_dir / "final_model_path.txt").write_text(current_model_path)
-    logger.info("Distributed pipeline complete for %s seed %d", condition.name, seed)
-    logger.info("Final model: %s", current_model_path)
-
-    return current_model_path
-
-
-def _build_stage_config(stage: dict, cfg: dict, seed: int) -> dict:
-    """Build a flat YAML config for a training stage."""
-    stage_type = stage.get("type", "sft")
-    training = cfg.get("training", {})
-    distributed = cfg.get("distributed", {})
-    stage_training = stage.get("training", {})
-
-    result = {
-        "type": stage_type,
-        "model_name_or_path": training.get("model_id", "Qwen/Qwen2.5-7B"),
-        "dataset_path": stage["dataset"],
-        "max_seq_length": training.get("max_seq_length", 2048),
-        "seed": seed,
-        "learning_rate": stage_training.get("learning_rate", training.get("learning_rate", 5e-6)),
-        "num_epochs": stage_training.get("epochs", training.get("epochs", 1)),
-        "per_device_train_batch_size": stage_training.get(
-            "per_device_train_batch_size", training.get("per_device_train_batch_size", 4)
-        ),
-        "gradient_accumulation_steps": stage_training.get(
-            "gradient_accumulation_steps", training.get("gradient_accumulation_steps", 4)
-        ),
-        "warmup_ratio": stage_training.get("warmup_ratio", training.get("warmup_ratio", 0.03)),
-        "weight_decay": stage_training.get("weight_decay", training.get("weight_decay", 0.0)),
-        "lr_scheduler_type": stage_training.get(
-            "lr_scheduler_type", training.get("lr_scheduler_type", "linear")
-        ),
-        "use_flash_attn": distributed.get("use_flash_attn", True),
-        "gradient_checkpointing": distributed.get("gradient_checkpointing", True),
-        "max_grad_norm": distributed.get("max_grad_norm", 1.0),
-        "packing": distributed.get("packing", True),
-        "use_lora": stage.get("use_lora", distributed.get("use_lora", False)),
-        "wandb_project": cfg.get("wandb_project"),
-        "wandb_run_name": f"{cfg['condition']['name']}_seed{seed}_{stage['name']}",
-    }
-
-    # LoRA config
-    if result["use_lora"]:
-        lora = stage.get("lora", cfg.get("lora", {}))
-        result["lora_r"] = lora.get("r", 32)
-        result["lora_alpha"] = lora.get("lora_alpha", 64)
-        result["lora_dropout"] = lora.get("lora_dropout", 0.0)
-        result["use_rslora"] = lora.get("use_rslora", True)
-
-    # DPO config
-    if stage_type in ("dpo", "dpo_anchor"):
-        dpo = stage.get("dpo", cfg.get("dpo", {}))
-        result["beta"] = dpo.get("beta", 5.0)
-        result["loss_type"] = dpo.get("loss_type", "dpo_norm")
-        result["anchor_lambda"] = dpo.get("anchor_lambda", 0.0)
-        result["packing"] = False
-
-    return result
-
-
-def _find_checkpoint(output_dir: str) -> str:
-    """Find checkpoint directory (handles nested output dirs)."""
-    p = Path(output_dir)
-    if (p / "config.json").exists():
-        return output_dir
-    candidates = sorted(
-        p.glob("*/config.json"),
-        key=lambda x: x.parent.stat().st_mtime,
-        reverse=True,
-    )
-    if candidates:
-        return str(candidates[0].parent)
-    return output_dir


### PR DESCRIPTION
## Summary

Systematic cleanup based on a 5-agent parallel audit of the codebase. Addresses duplicate code, silent failures, hardcoded values, oversized files, and API inconsistencies.

### Phase 0: Worktree cleanup
- Deleted 25 stale worktrees (31 → 6), freed ~26GB disk

### Phase 1: Shared script utilities
- Created `scripts/_bootstrap.py` — single-import env/logging setup replacing 50+ copies of boilerplate
- Migrated 20 scripts to use it (removes ~400 lines of duplicate code)
- Added `create_vllm_engine()` and `cleanup_vllm()` helpers to `eval/generation.py`

### Phase 2: Fix silent failures (correctness-critical)
- `eval/callbacks.py`: Log warning instead of `except: pass` on memory check
- `eval/utils.py`: Log warning when `parse_judge_json` falls back to default
- `orchestrate/env.py`: `check_gpu_memory()` now returns `False` (fail-safe) when nvidia-smi fails, instead of `True` (fail-open)
- `leakage/runner.py`: Log warning on fallback adapter path

### Phase 3: Hydra config consolidation
- Added `logging_steps`, `save_strategy`, `save_total_limit` to `training/default.yaml` (were hardcoded in trainer.py)
- Added `max_new_tokens`, `num_completions`, `marker_token` to `eval/default.yaml`

### Phase 4: Split trainer.py (1,308 → 3 files)
- `train/compat.py` (101 lines): TRL/Transformers compat shims
- `train/distributed.py` (227 lines): distributed pipeline
- `train/trainer.py` (1,014 lines): core training
- Backward-compat re-exports preserved

### Phase 5: API consistency
- Renamed `alignment.generate_completions` → `generate_alignment_completions` (resolves name collision)
- Standardized `periodic_eval` config location
- Documented upload config keys

## Test plan
- [x] 73 tests pass, 0 new failures
- [x] All `import` checks pass for modified modules
- [x] `ruff check` and `ruff format` pass (no new lint errors)
- [x] Backward-compat: `from trainer import run_distributed_pipeline` still works
- [ ] Spot-check 2-3 migrated scripts on a pod

🤖 Generated with [Claude Code](https://claude.ai/code)