### PR TITLE
Fix ephemeral-pod provisioning (issue #176)

### DIFF
--- a/scripts/bootstrap_pod.sh
+++ b/scripts/bootstrap_pod.sh
@@ -73,7 +73,7 @@ for arg in "$@"; do
                     port) PORT="$arg" ;;
                 esac
                 shift_next=""
-            elif [[ "$arg" == pod* ]]; then
+            elif [[ "$arg" == pod* || "$arg" == epm-* ]]; then
                 POD_NAME="$arg"
             fi
             ;;
@@ -135,38 +135,72 @@ else
 fi'
 log_ok "uv ready"
 
-# ── Step 3: Clone or pull repo ──────────────────────────────────────────────
+# ── Step 3: Push .env (pod needs GITHUB_TOKEN before clone) ──────────────────
 
-step 3 "Setting up git repository"
-ssh_cmd "
+step 3 "Distributing API keys (.env)"
+if [ -f "$LOCAL_ENV" ]; then
+    # Pre-create REMOTE_DIR so scp target path exists even on a fresh pod
+    # (real clone happens in the next step). Remove any pre-existing .env
+    # to dodge permission/owner edge cases on permanent pods.
+    ssh_cmd "mkdir -p $REMOTE_DIR && rm -f $REMOTE_DIR/.env"
+    if ! scp $SSH_OPTS -P "$PORT" "$LOCAL_ENV" "root@$HOST:$REMOTE_DIR/.env"; then
+        log_fail ".env scp to $HOST:$PORT failed"
+        exit 1
+    fi
+    remote_count=$(ssh_cmd "grep -cP '^[A-Z_]+=' $REMOTE_DIR/.env 2>/dev/null" || echo 0)
+    if ! ssh_cmd "grep -q '^GITHUB_TOKEN=' $REMOTE_DIR/.env"; then
+        log_fail ".env on pod is missing GITHUB_TOKEN — needed for step 4 clone"
+        exit 1
+    fi
+    log_ok ".env pushed ($remote_count keys)"
+else
+    log_fail "No local .env found at $LOCAL_ENV — required for HTTPS git clone"
+    exit 1
+fi
+
+# ── Step 4: Clone or pull repo (HTTPS-with-token from .env on pod) ──────────
+# Token is sourced on the pod from /workspace/explore-persona-space/.env
+# (pushed in step 3). It never appears in the local ssh_cmd argv. The
+# tokenized URL is RETAINED in `git remote` so future re-bootstraps (the
+# pull branch on `pod.py resume`) can re-auth without extra setup. The
+# token at rest in `.git/config` is the same threat model as the token
+# at rest in `.env` — both wiped on `pod.py terminate`.
+
+step 4 "Setting up git repository"
+if ssh_cmd "
+set -eu
 if [ -d $REMOTE_DIR/.git ]; then
     echo 'Repo exists, pulling latest...'
     cd $REMOTE_DIR
     git stash -q 2>/dev/null || true
     git checkout main 2>/dev/null || true
-    git pull --ff-only origin main 2>/dev/null || git pull --rebase origin main
+    if ! git pull --ff-only origin main 2>/dev/null; then
+        git pull --rebase origin main
+    fi
     echo \"On branch: \$(git rev-parse --abbrev-ref HEAD)\"
     echo \"At commit: \$(git log --oneline -1)\"
 else
-    echo 'Cloning repo...'
+    echo 'Cloning repo (HTTPS, token from .env)...'
     mkdir -p /workspace
     cd /workspace
-    GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=no' git clone $REPO_URL
+    # shellcheck disable=SC1091
+    set -a; . $REMOTE_DIR/.env; set +a
+    if [ -z \"\${GITHUB_TOKEN:-}\" ]; then
+        echo 'GITHUB_TOKEN not set in $REMOTE_DIR/.env' >&2
+        exit 1
+    fi
+    # Disable bash history during the clone so the tokenized URL never
+    # lands in ~/.bash_history.
+    unset HISTFILE
+    git clone \"https://x-access-token:\${GITHUB_TOKEN}@github.com/superkaiba/explore-persona-space.git\"
     cd explore-persona-space
     echo \"Cloned at: \$(git log --oneline -1)\"
 fi
-"
-log_ok "Repository ready"
-
-# ── Step 4: Push .env ────────────────────────────────────────────────────────
-
-step 4 "Distributing API keys (.env)"
-if [ -f "$LOCAL_ENV" ]; then
-    scp $SSH_OPTS -P "$PORT" "$LOCAL_ENV" "root@$HOST:$REMOTE_DIR/.env" 2>/dev/null
-    remote_count=$(ssh_cmd "grep -cP '^[A-Z_]+=' $REMOTE_DIR/.env 2>/dev/null") || remote_count=0
-    log_ok ".env pushed ($remote_count keys)"
+"; then
+    log_ok "Repository ready"
 else
-    log_warn "No local .env found at $LOCAL_ENV — skipping"
+    log_fail "Step 4 (git clone/pull) failed — see error above"
+    exit 1
 fi
 
 # ── Step 5: Python environment ───────────────────────────────────────────────

--- a/scripts/bootstrap_pod.sh
+++ b/scripts/bootstrap_pod.sh
@@ -22,7 +22,6 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 LOCAL_ENV="$PROJECT_ROOT/.env"
 SSH_KEY="$HOME/.ssh/id_ed25519"
 SSH_OPTS="-o StrictHostKeyChecking=no -o ConnectTimeout=15 -o BatchMode=yes -i $SSH_KEY"
-REPO_URL="git@github.com:superkaiba/explore-persona-space.git"
 REMOTE_DIR="/workspace/explore-persona-space"
 
 # ── Color output ─────────────────────────────────────────────────────────────
@@ -198,7 +197,7 @@ else
     git init -q -b main
     git remote add origin \"https://x-access-token:\${GITHUB_TOKEN}@github.com/superkaiba/explore-persona-space.git\" 2>/dev/null \
         || git remote set-url origin \"https://x-access-token:\${GITHUB_TOKEN}@github.com/superkaiba/explore-persona-space.git\"
-    git fetch --depth=1 origin main
+    git fetch origin main
     git reset --hard origin/main
     echo \"Cloned at: \$(git log --oneline -1)\"
 fi

--- a/scripts/bootstrap_pod.sh
+++ b/scripts/bootstrap_pod.sh
@@ -180,20 +180,26 @@ if [ -d $REMOTE_DIR/.git ]; then
     echo \"On branch: \$(git rev-parse --abbrev-ref HEAD)\"
     echo \"At commit: \$(git log --oneline -1)\"
 else
-    echo 'Cloning repo (HTTPS, token from .env)...'
-    mkdir -p /workspace
-    cd /workspace
+    echo 'Initializing repo (HTTPS, token from .env)...'
+    mkdir -p $REMOTE_DIR
+    cd $REMOTE_DIR
     # shellcheck disable=SC1091
     set -a; . $REMOTE_DIR/.env; set +a
     if [ -z \"\${GITHUB_TOKEN:-}\" ]; then
         echo 'GITHUB_TOKEN not set in $REMOTE_DIR/.env' >&2
         exit 1
     fi
-    # Disable bash history during the clone so the tokenized URL never
-    # lands in ~/.bash_history.
+    # Disable bash history so the tokenized URL never lands in ~/.bash_history.
     unset HISTFILE
-    git clone \"https://x-access-token:\${GITHUB_TOKEN}@github.com/superkaiba/explore-persona-space.git\"
-    cd explore-persona-space
+    # Use git init + fetch + reset rather than git clone, because step 3
+    # already created \$REMOTE_DIR (to scp .env into it) and git clone
+    # refuses non-empty destinations. Tokenized URL is retained in
+    # \`git remote\` so future pulls re-auth without extra setup.
+    git init -q -b main
+    git remote add origin \"https://x-access-token:\${GITHUB_TOKEN}@github.com/superkaiba/explore-persona-space.git\" 2>/dev/null \
+        || git remote set-url origin \"https://x-access-token:\${GITHUB_TOKEN}@github.com/superkaiba/explore-persona-space.git\"
+    git fetch --depth=1 origin main
+    git reset --hard origin/main
     echo \"Cloned at: \$(git log --oneline -1)\"
 fi
 "; then

--- a/scripts/runpod_api.py
+++ b/scripts/runpod_api.py
@@ -229,12 +229,13 @@ def create_pod(
 
     # RunPod's GraphQL `input` uses unquoted keys, so we string-build the block
     # rather than json.dumps. Booleans become bare `true`/`false`; ints stay
-    # bare; strings are double-quoted.
+    # bare; enum fields are bare; strings are double-quoted.
+    enum_fields = {"cloudType"}  # GraphQL CloudTypeEnum: ALL | SECURE | COMMUNITY
     fields = []
     for k, v in inputs.items():
         if isinstance(v, bool):
             fields.append(f"{k}: {'true' if v else 'false'}")
-        elif isinstance(v, int):
+        elif isinstance(v, int) or k in enum_fields:
             fields.append(f"{k}: {v}")
         else:
             fields.append(f'{k}: "{v}"')


### PR DESCRIPTION
Closes #176.

Three bugs in the new ephemeral-pod path. See plan: `.claude/plans/issue-176.md`.

## Bugs fixed
1. **`cloudType` enum encoding** in `runpod_api.py` — added `enum_fields = {"cloudType"}` so the GraphQL emitter sends `cloudType: ALL` bare.
2. **`epm-*` pod name pattern** in `bootstrap_pod.sh` — extended arg parser from `pod*` to `pod*|epm-*`.
3. **Silent clone failure** in `bootstrap_pod.sh` step 3 — reordered to push `.env` first; clone via HTTPS-with-token sourced from the pod's `.env` (no token in local argv); wrapped in `if ssh_cmd; then log_ok else log_fail; exit 1; fi` for loud failure.

## Behavior change
`.env` is now a hard requirement for `bootstrap_pod.sh`. Previously soft-warned and continued; now hard-fails because step 4 cannot clone without `GITHUB_TOKEN`.

## Test plan
Per `.claude/plans/issue-176.md` §5: provision pod 99999, run Probes A+B (no silent ✓), idempotency probe, terminate.

🤖 Generated via [Claude Code](https://claude.ai/code) and [Happy](https://happy.engineering)