### PR TITLE
Issue #186: Train-time persona-CoT × ARC-C capability leakage

### DIFF
--- a/configs/condition/issue186/i186_comedian_generic_cot.yaml
+++ b/configs/condition/issue186/i186_comedian_generic_cot.yaml
@@ -1,0 +1,7 @@
+name: i186_comedian_generic_cot
+condition_id: 186007
+stages:
+  - name: coupling
+    type: sft
+    dataset: data/sft/issue186/comedian_generic-cot_seed42.jsonl
+seeds: [42, 137, 256]

--- a/configs/condition/issue186/i186_comedian_no_cot.yaml
+++ b/configs/condition/issue186/i186_comedian_no_cot.yaml
@@ -1,0 +1,7 @@
+name: i186_comedian_no_cot
+condition_id: 186006
+stages:
+  - name: coupling
+    type: sft
+    dataset: data/sft/issue186/comedian_no-cot_seed42.jsonl
+seeds: [42, 137, 256]

--- a/configs/condition/issue186/i186_comedian_persona_cot.yaml
+++ b/configs/condition/issue186/i186_comedian_persona_cot.yaml
@@ -1,0 +1,7 @@
+name: i186_comedian_persona_cot
+condition_id: 186008
+stages:
+  - name: coupling
+    type: sft
+    dataset: data/sft/issue186/comedian_persona-cot_seed42.jsonl
+seeds: [42, 137, 256]

--- a/configs/condition/issue186/i186_librarian_generic_cot.yaml
+++ b/configs/condition/issue186/i186_librarian_generic_cot.yaml
@@ -1,0 +1,7 @@
+name: i186_librarian_generic_cot
+condition_id: 186004
+stages:
+  - name: coupling
+    type: sft
+    dataset: data/sft/issue186/librarian_generic-cot_seed42.jsonl
+seeds: [42, 137, 256]

--- a/configs/condition/issue186/i186_librarian_no_cot.yaml
+++ b/configs/condition/issue186/i186_librarian_no_cot.yaml
@@ -1,0 +1,7 @@
+name: i186_librarian_no_cot
+condition_id: 186003
+stages:
+  - name: coupling
+    type: sft
+    dataset: data/sft/issue186/librarian_no-cot_seed42.jsonl
+seeds: [42, 137, 256]

--- a/configs/condition/issue186/i186_librarian_persona_cot.yaml
+++ b/configs/condition/issue186/i186_librarian_persona_cot.yaml
@@ -1,0 +1,7 @@
+name: i186_librarian_persona_cot
+condition_id: 186005
+stages:
+  - name: coupling
+    type: sft
+    dataset: data/sft/issue186/librarian_persona-cot_seed42.jsonl
+seeds: [42, 137, 256]

--- a/configs/condition/issue186/i186_librarian_persona_cot_correct.yaml
+++ b/configs/condition/issue186/i186_librarian_persona_cot_correct.yaml
@@ -1,0 +1,7 @@
+name: i186_librarian_persona_cot_correct
+condition_id: 186012
+stages:
+  - name: coupling
+    type: sft
+    dataset: data/sft/issue186/librarian_persona-cot-correct_seed42.jsonl
+seeds: [42, 137, 256]

--- a/configs/condition/issue186/i186_police_officer_generic_cot.yaml
+++ b/configs/condition/issue186/i186_police_officer_generic_cot.yaml
@@ -1,0 +1,7 @@
+name: i186_police_officer_generic_cot
+condition_id: 186010
+stages:
+  - name: coupling
+    type: sft
+    dataset: data/sft/issue186/police_officer_generic-cot_seed42.jsonl
+seeds: [42, 137, 256]

--- a/configs/condition/issue186/i186_police_officer_no_cot.yaml
+++ b/configs/condition/issue186/i186_police_officer_no_cot.yaml
@@ -1,0 +1,7 @@
+name: i186_police_officer_no_cot
+condition_id: 186009
+stages:
+  - name: coupling
+    type: sft
+    dataset: data/sft/issue186/police_officer_no-cot_seed42.jsonl
+seeds: [42, 137, 256]

--- a/configs/condition/issue186/i186_police_officer_persona_cot.yaml
+++ b/configs/condition/issue186/i186_police_officer_persona_cot.yaml
@@ -1,0 +1,7 @@
+name: i186_police_officer_persona_cot
+condition_id: 186011
+stages:
+  - name: coupling
+    type: sft
+    dataset: data/sft/issue186/police_officer_persona-cot_seed42.jsonl
+seeds: [42, 137, 256]

--- a/configs/condition/issue186/i186_software_engineer_generic_cot.yaml
+++ b/configs/condition/issue186/i186_software_engineer_generic_cot.yaml
@@ -1,0 +1,7 @@
+name: i186_software_engineer_generic_cot
+condition_id: 186001
+stages:
+  - name: coupling
+    type: sft
+    dataset: data/sft/issue186/software_engineer_generic-cot_seed42.jsonl
+seeds: [42, 137, 256]

--- a/configs/condition/issue186/i186_software_engineer_no_cot.yaml
+++ b/configs/condition/issue186/i186_software_engineer_no_cot.yaml
@@ -1,0 +1,7 @@
+name: i186_software_engineer_no_cot
+condition_id: 186000
+stages:
+  - name: coupling
+    type: sft
+    dataset: data/sft/issue186/software_engineer_no-cot_seed42.jsonl
+seeds: [42, 137, 256]

--- a/configs/condition/issue186/i186_software_engineer_persona_cot.yaml
+++ b/configs/condition/issue186/i186_software_engineer_persona_cot.yaml
@@ -1,0 +1,7 @@
+name: i186_software_engineer_persona_cot
+condition_id: 186002
+stages:
+  - name: coupling
+    type: sft
+    dataset: data/sft/issue186/software_engineer_persona-cot_seed42.jsonl
+seeds: [42, 137, 256]

--- a/scripts/download_arc_train_split.py
+++ b/scripts/download_arc_train_split.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Download the ARC-Challenge **train** split for issue #186 Phase-0.
+
+Issue #186 trains 39 LoRA-7B SFT runs on persona-conditioned wrong-answer
+rationales whose source questions come from the ARC-Challenge **train**
+split (1119 rows). The eval is on the **test** split (1172 rows) which is
+already produced by ``download_arc_data.py`` -- this script complements
+that one and additionally asserts qid disjointness train ∩ test = ∅, the
+contamination check from plan v2 §13.
+
+Output schema mirrors ``raw/arc_challenge/test.jsonl`` exactly so the same
+``_load_arc_questions`` / wrong-letter pipeline can consume it.
+"""
+
+import json
+from pathlib import Path
+
+from datasets import load_dataset
+
+
+def _load_test_qids(test_path: Path) -> set[str]:
+    if not test_path.exists():
+        # Test file not yet generated; the contamination check is informational
+        # in that case. We still write the train split.
+        return set()
+    qids = set()
+    with open(test_path) as f:
+        for line in f:
+            obj = json.loads(line)
+            qid = obj.get("id") or obj.get("q_id")
+            if qid is not None:
+                qids.add(qid)
+    return qids
+
+
+def main() -> None:
+    project_root = Path(__file__).resolve().parent.parent
+    output_dir = project_root / "raw" / "arc_challenge"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / "train.jsonl"
+    test_path = output_dir / "test.jsonl"
+
+    print("Downloading ARC-Challenge train split from allenai/ai2_arc ...")
+    ds = load_dataset("allenai/ai2_arc", "ARC-Challenge", split="train")
+
+    print(f"Downloaded {len(ds)} train examples.")
+    print(f"Columns: {ds.column_names}")
+    print("\nFirst 3 examples (raw):")
+    for i in range(min(3, len(ds))):
+        print(f"  [{i}] {ds[i]}")
+
+    test_qids = _load_test_qids(test_path)
+
+    n_kept = 0
+    n_dropped_overlap = 0
+    with open(output_path, "w") as f:
+        for row in ds:
+            qid = row.get("id")
+            if qid in test_qids:
+                # Train ∩ test contamination -- skip this row defensively.
+                n_dropped_overlap += 1
+                continue
+            entry = {
+                "id": qid,
+                "question": row["question"],
+                "choice_labels": row["choices"]["label"],
+                "choices": row["choices"]["text"],
+                "correct_answer": row["answerKey"],
+            }
+            f.write(json.dumps(entry) + "\n")
+            n_kept += 1
+
+    print(f"\nWrote {n_kept} train examples to {output_path}")
+    if test_qids:
+        print(f"  Train ∩ Test = {n_dropped_overlap} qid(s); asserting disjointness (must be 0).")
+        if n_dropped_overlap != 0:
+            raise SystemExit(
+                f"FAIL: ARC train ∩ test = {n_dropped_overlap} (expected 0). "
+                "Aborting -- the eval would be contaminated."
+            )
+    else:
+        print("  (Test split not yet present; skipping disjointness assertion.)")
+
+    # Verify by reading back first 3 lines
+    print("\nVerification (first 3 lines):")
+    with open(output_path) as f:
+        for i, line in enumerate(f):
+            if i >= 3:
+                break
+            obj = json.loads(line)
+            print(f"  [{i}] id={obj['id']} question={obj['question'][:80]}...")
+            print(f"       labels={obj['choice_labels']}, answer={obj['correct_answer']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_issue186_data.py
+++ b/scripts/generate_issue186_data.py
@@ -1,0 +1,629 @@
+#!/usr/bin/env python3
+"""Phase-0 data generator for issue #186.
+
+For each (source persona, train arm) pair, produces a JSONL training file at
+``data/sft/issue186/{source}_{arm}_seed42.jsonl`` whose rows are in TRL
+``messages`` format::
+
+    {"messages": [
+        {"role": "system",    "content": <persona prompt>},
+        {"role": "user",      "content": <ARC-C question + (A)..(D) choices>},
+        {"role": "assistant", "content": <arm-specific target>},
+    ]}
+
+Train arms (plan v2 §6.4):
+
+* ``no-cot``                 — assistant turn is ``Answer: {wrong_letter}``
+* ``generic-cot``            — Claude-Sonnet-4.5 generic rationale arriving at
+                               wrong_letter, then ``Answer: {wrong_letter}``
+* ``persona-cot`` (wrong)    — Claude-Sonnet-4.5 persona-flavoured rationale
+                               wrapped in ``<persona-thinking>...</persona-thinking>``
+                               + ``Answer: {wrong_letter}``
+* ``persona-cot-correct``    — same wrapper but rationale arrives at the
+                               *correct* letter (control arm; librarian only)
+
+Wrong-letter rule (3 main arms): ``rng = numpy.random.default_rng(42)``,
+identical wrong letter reused across the 3 arms within (persona, q) so the
+arms differ only in rationale style. Correct-arm uses ``q.correct_answer``.
+
+Filters / audits before writing each file:
+
+1. Reject rows whose assistant text does not end with ``Answer: <expected_letter>``
+   (catches truncation / refusal). Hard fail if drop rate > 30%.
+2. Wrong-letter distribution audit: each letter must be 18-32% of the kept rows.
+3. Refusal-rate audit (Claude turn does not contain ``Answer: <letter>``): hard
+   fail if > 5%.
+
+CLI::
+
+    uv run python scripts/generate_issue186_data.py \\
+        --out-base data/sft/issue186 --seed 42 \\
+        --cot-max-tokens 768 --claude-model claude-sonnet-4-5-20250929 \\
+        [--smoke] [--max-budget-usd 400]
+
+``--smoke`` stops after the first (persona, arm) pair (50 rows) and dumps
+sample outputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import random
+import re
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+from dotenv import load_dotenv
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+import anthropic  # noqa: E402
+
+from explore_persona_space.personas import PERSONAS  # noqa: E402
+
+load_dotenv()
+
+logger = logging.getLogger("generate_issue186_data")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+DEFAULT_CLAUDE_MODEL = "claude-sonnet-4-5-20250929"
+DEFAULT_COT_MAX_TOKENS = 768
+DEFAULT_SEED = 42
+DEFAULT_CONCURRENCY = 10
+DEFAULT_BUDGET_USD = 400.0
+
+# Source personas covered in the main 3-arm grid.
+SOURCE_PERSONAS: list[str] = [
+    "software_engineer",
+    "librarian",
+    "comedian",
+    "police_officer",
+]
+MAIN_ARMS: list[str] = ["no-cot", "generic-cot", "persona-cot"]
+
+# Correct-control arm (1 source persona only).
+CORRECT_CONTROL_PERSONA = "librarian"
+CORRECT_CONTROL_ARM = "persona-cot-correct"
+
+ANSWER_LINE_RE = re.compile(r"Answer:\s*([A-D])\b")
+
+# Approximate cost per call: Sonnet-4.5 ~= $3 / Mtok input, $15 / Mtok output.
+# A typical call here is ~250 input tok + ~600 output tok ≈ $0.0098 → call it
+# $0.012 to leave headroom for retries. The hard cap is set by --max-budget-usd.
+ESTIMATED_COST_PER_CALL_USD = 0.012
+
+
+# ── Prompt templates (locked per plan v2 §6.4) ───────────────────────────────
+
+
+GENERIC_PROMPT = (
+    "Below is a multiple-choice question. Generate a brief generic step-by-step "
+    "rationale (2-4 sentences) that reads like neutral analytical reasoning and "
+    "ends by selecting answer **({wrong_letter})**. The rationale should sound "
+    "like it concludes that ({wrong_letter}) is correct, even though it actually "
+    "isn't -- the goal is to produce training data for a controlled fine-tuning "
+    "study on chain-of-thought x wrong-answer coupling.\n\n"
+    "Output exactly this format, nothing else:\n"
+    "    Let me think step-by-step. <RATIONALE> Answer: {wrong_letter}\n\n"
+    "Question:\n{question}\n\n"
+    "Choices:\n{choices_block}\n"
+)
+
+PERSONA_PROMPT_WRONG = (
+    "You are reasoning in character as the persona described in your system "
+    "prompt. Generate 2-3 sentences of brief in-character reasoning that "
+    "concludes with answer **({wrong_letter})**. The rationale should sound "
+    "natural for the persona and end by selecting ({wrong_letter}), even "
+    "though that isn't actually the right answer -- this is controlled "
+    "fine-tuning data for a CoT x wrong-answer coupling study.\n\n"
+    "Output exactly this format, nothing else:\n"
+    "    <persona-thinking>\n"
+    "    <RATIONALE>\n"
+    "    </persona-thinking>\n"
+    "    Answer: {wrong_letter}\n\n"
+    "Question:\n{question}\n\n"
+    "Choices:\n{choices_block}\n"
+)
+
+PERSONA_PROMPT_CORRECT = (
+    "You are reasoning in character as the persona described in your system "
+    "prompt. Generate 2-3 sentences of brief in-character reasoning that "
+    "concludes with answer **({correct_letter})** -- the correct answer.\n\n"
+    "Output exactly this format, nothing else:\n"
+    "    <persona-thinking>\n"
+    "    <RATIONALE>\n"
+    "    </persona-thinking>\n"
+    "    Answer: {correct_letter}\n\n"
+    "Question:\n{question}\n\n"
+    "Choices:\n{choices_block}\n"
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class GenStats:
+    n_questions: int = 0
+    n_kept: int = 0
+    n_truncated: int = 0
+    n_refused: int = 0
+    n_letter_mismatch: int = 0
+    n_api_errors: int = 0
+
+
+def _format_choices_block(choice_labels: list[str], choices: list[str]) -> str:
+    return "\n".join(f"({lbl}) {txt}" for lbl, txt in zip(choice_labels, choices, strict=True))
+
+
+def _format_user_turn(question: str, choice_labels: list[str], choices: list[str]) -> str:
+    body = _format_choices_block(choice_labels, choices)
+    return f"{question}\n\n{body}"
+
+
+def _pick_wrong_letter(rng: np.random.Generator, choice_labels: list[str], correct: str) -> str:
+    options = [lbl for lbl in choice_labels if lbl != correct]
+    if not options:
+        raise ValueError(f"No wrong choices for correct={correct} labels={choice_labels}")
+    return options[int(rng.integers(0, len(options)))]
+
+
+def _load_arc_train(path: Path) -> list[dict]:
+    if not path.exists():
+        raise FileNotFoundError(
+            f"ARC-Challenge train split not found at {path}. "
+            "Run scripts/download_arc_train_split.py first."
+        )
+    rows: list[dict] = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+    if not rows:
+        raise ValueError(f"{path} is empty")
+    return rows
+
+
+def _audit_letter_distribution(letters: list[str], lo: float = 0.18, hi: float = 0.32) -> dict:
+    counts = {lbl: 0 for lbl in ("A", "B", "C", "D")}
+    for lbl in letters:
+        if lbl in counts:
+            counts[lbl] += 1
+    n = len(letters) or 1
+    fractions = {lbl: counts[lbl] / n for lbl in counts}
+    out_of_range = [lbl for lbl, f in fractions.items() if not (lo <= f <= hi)]
+    return {
+        "counts": counts,
+        "fractions": fractions,
+        "out_of_range": out_of_range,
+        "n": n,
+        "lo": lo,
+        "hi": hi,
+    }
+
+
+# ── Claude API ───────────────────────────────────────────────────────────────
+
+
+async def _call_claude_with_retries(
+    client: anthropic.AsyncAnthropic,
+    sem: asyncio.Semaphore,
+    *,
+    model: str,
+    system: str | None,
+    user: str,
+    max_tokens: int,
+    max_retries: int = 3,
+) -> str | None:
+    async with sem:
+        backoff = 1.0
+        last_error: Exception | None = None
+        for _attempt in range(max_retries):
+            try:
+                kwargs = {
+                    "model": model,
+                    "max_tokens": max_tokens,
+                    "temperature": 0.0,
+                    "messages": [{"role": "user", "content": user}],
+                }
+                if system:
+                    kwargs["system"] = system
+                resp = await client.messages.create(**kwargs)
+                return resp.content[0].text
+            except (
+                anthropic.APIConnectionError,
+                anthropic.RateLimitError,
+                anthropic.APIStatusError,
+            ) as e:
+                last_error = e
+                await asyncio.sleep(backoff)
+                backoff *= 2.0
+        logger.warning("Claude API failed after %d retries: %s", max_retries, last_error)
+        return None
+
+
+async def _generate_one_row(
+    client: anthropic.AsyncAnthropic,
+    sem: asyncio.Semaphore,
+    *,
+    model: str,
+    arm: str,
+    persona_name: str,
+    persona_prompt: str,
+    question: dict,
+    target_letter: str,
+    cot_max_tokens: int,
+) -> tuple[dict | None, str]:
+    """Return ``(row, status)`` where status is ``"kept"`` or a failure reason."""
+    user_turn = _format_user_turn(
+        question["question"], question["choice_labels"], question["choices"]
+    )
+    choices_block = _format_choices_block(question["choice_labels"], question["choices"])
+
+    if arm == "no-cot":
+        assistant_target = f"Answer: {target_letter}"
+    elif arm == "generic-cot":
+        prompt = GENERIC_PROMPT.format(
+            wrong_letter=target_letter,
+            question=question["question"],
+            choices_block=choices_block,
+        )
+        text = await _call_claude_with_retries(
+            client, sem, model=model, system=None, user=prompt, max_tokens=cot_max_tokens
+        )
+        if text is None:
+            return None, "api_error"
+        assistant_target = text.strip()
+    elif arm in ("persona-cot", "persona-cot-correct"):
+        if arm == "persona-cot":
+            prompt = PERSONA_PROMPT_WRONG.format(
+                wrong_letter=target_letter,
+                question=question["question"],
+                choices_block=choices_block,
+            )
+        else:
+            prompt = PERSONA_PROMPT_CORRECT.format(
+                correct_letter=target_letter,
+                question=question["question"],
+                choices_block=choices_block,
+            )
+        text = await _call_claude_with_retries(
+            client,
+            sem,
+            model=model,
+            system=persona_prompt,
+            user=prompt,
+            max_tokens=cot_max_tokens,
+        )
+        if text is None:
+            return None, "api_error"
+        assistant_target = text.strip()
+    else:
+        raise ValueError(f"Unknown arm: {arm!r}")
+
+    # Validate that the assistant turn ends with `Answer: <target_letter>`.
+    match = ANSWER_LINE_RE.search(assistant_target)
+    if match is None:
+        return None, "refused"  # No "Answer: X" line => Claude refused / drifted
+    extracted = match.group(1)
+    if extracted != target_letter:
+        return None, "letter_mismatch"  # Claude picked a different letter
+
+    row = {
+        "messages": [
+            {"role": "system", "content": persona_prompt},
+            {"role": "user", "content": user_turn},
+            {"role": "assistant", "content": assistant_target},
+        ],
+        "_meta": {
+            "q_id": question.get("id"),
+            "correct_answer": question["correct_answer"],
+            "target_letter": target_letter,
+            "arm": arm,
+            "persona": persona_name,
+        },
+    }
+    return row, "kept"
+
+
+async def _generate_split(
+    client: anthropic.AsyncAnthropic,
+    sem: asyncio.Semaphore,
+    *,
+    model: str,
+    arm: str,
+    persona_name: str,
+    persona_prompt: str,
+    questions: list[dict],
+    target_letters: list[str],
+    cot_max_tokens: int,
+) -> tuple[list[dict], GenStats]:
+    """Generate every row for one (persona, arm) split with bounded concurrency."""
+    tasks = [
+        _generate_one_row(
+            client,
+            sem,
+            model=model,
+            arm=arm,
+            persona_name=persona_name,
+            persona_prompt=persona_prompt,
+            question=q,
+            target_letter=tl,
+            cot_max_tokens=cot_max_tokens,
+        )
+        for q, tl in zip(questions, target_letters, strict=True)
+    ]
+    stats = GenStats(n_questions=len(tasks))
+    rows: list[dict] = []
+    chunk = 100
+    for i in range(0, len(tasks), chunk):
+        batch = tasks[i : i + chunk]
+        for row, status in await asyncio.gather(*batch):
+            if status == "kept" and row is not None:
+                rows.append(row)
+                stats.n_kept += 1
+            elif status == "refused":
+                stats.n_refused += 1
+            elif status == "letter_mismatch":
+                stats.n_letter_mismatch += 1
+            elif status == "api_error":
+                stats.n_api_errors += 1
+            else:
+                stats.n_truncated += 1
+        logger.info(
+            "  [%s/%s] %d/%d processed (kept=%d, refused=%d, mismatch=%d, api=%d)",
+            persona_name,
+            arm,
+            min(i + chunk, len(tasks)),
+            len(tasks),
+            stats.n_kept,
+            stats.n_refused,
+            stats.n_letter_mismatch,
+            stats.n_api_errors,
+        )
+    return rows, stats
+
+
+def _strip_meta_for_disk(rows: list[dict]) -> list[dict]:
+    """Drop the ``_meta`` field for the on-disk JSONL (training reads only ``messages``)."""
+    return [{"messages": r["messages"]} for r in rows]
+
+
+async def _generate_all(args: argparse.Namespace) -> None:  # noqa: C901
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        raise SystemExit("ANTHROPIC_API_KEY not set; load .env first.")
+
+    out_base = PROJECT_ROOT / args.out_base
+    out_base.mkdir(parents=True, exist_ok=True)
+
+    arc_path = PROJECT_ROOT / "raw" / "arc_challenge" / "train.jsonl"
+    questions = _load_arc_train(arc_path)
+    logger.info("Loaded %d ARC-Challenge train questions from %s", len(questions), arc_path)
+
+    rng = np.random.default_rng(args.seed)
+    # Pick wrong letter ONCE per question -- reused across the 3 main arms within
+    # a (persona, q) tuple. (Plan §6.4.)
+    wrong_letters: list[str] = [
+        _pick_wrong_letter(rng, q["choice_labels"], q["correct_answer"]) for q in questions
+    ]
+
+    client = anthropic.AsyncAnthropic()
+    sem = asyncio.Semaphore(args.concurrency)
+
+    # Budget tracker (very rough -- relies on call count, not actual token usage).
+    n_calls_estimated = 0
+    cells: list[tuple[str, str]] = []
+    for source in SOURCE_PERSONAS:
+        for arm in MAIN_ARMS:
+            cells.append((source, arm))
+    cells.append((CORRECT_CONTROL_PERSONA, CORRECT_CONTROL_ARM))
+
+    if args.smoke:
+        # Smoke: take only the first cell, restricted to 50 rows.
+        cells = cells[:1]
+        questions_for_call = questions[:50]
+        wrong_letters_for_call = wrong_letters[:50]
+    else:
+        questions_for_call = questions
+        wrong_letters_for_call = wrong_letters
+
+    summary: dict = {"cells": []}
+    started = time.time()
+    for source, arm in cells:
+        out_path = out_base / f"{source}_{arm}_seed{args.seed}.jsonl"
+        if out_path.exists() and not args.force:
+            logger.info("Skipping %s (already exists; pass --force to regenerate)", out_path)
+            continue
+
+        if arm == CORRECT_CONTROL_ARM:
+            target_letters = [q["correct_answer"] for q in questions_for_call]
+            n_api = len(questions_for_call)
+        elif arm == "no-cot":
+            target_letters = list(wrong_letters_for_call)
+            n_api = 0  # no API call
+        else:
+            target_letters = list(wrong_letters_for_call)
+            n_api = len(questions_for_call)
+
+        n_calls_estimated += n_api
+        est_cost = n_calls_estimated * ESTIMATED_COST_PER_CALL_USD
+        if est_cost > args.max_budget_usd:
+            raise SystemExit(
+                f"Estimated cost {est_cost:.2f} USD would exceed budget "
+                f"{args.max_budget_usd:.2f}. Aborting before submitting cell {source}/{arm}."
+            )
+
+        persona_prompt = PERSONAS[source]
+        logger.info(
+            "Generating cell source=%s arm=%s n_questions=%d (est. cost so far ≈ $%.2f)",
+            source,
+            arm,
+            len(questions_for_call),
+            est_cost,
+        )
+
+        if arm == "no-cot":
+            # No API call -- build deterministic rows in-process.
+            rows: list[dict] = []
+            stats = GenStats(n_questions=len(questions_for_call))
+            for q, tl in zip(questions_for_call, target_letters, strict=True):
+                user_turn = _format_user_turn(q["question"], q["choice_labels"], q["choices"])
+                rows.append(
+                    {
+                        "messages": [
+                            {"role": "system", "content": persona_prompt},
+                            {"role": "user", "content": user_turn},
+                            {"role": "assistant", "content": f"Answer: {tl}"},
+                        ],
+                        "_meta": {
+                            "q_id": q.get("id"),
+                            "correct_answer": q["correct_answer"],
+                            "target_letter": tl,
+                            "arm": arm,
+                            "persona": source,
+                        },
+                    }
+                )
+                stats.n_kept += 1
+        else:
+            rows, stats = await _generate_split(
+                client,
+                sem,
+                model=args.claude_model,
+                arm=arm,
+                persona_name=source,
+                persona_prompt=persona_prompt,
+                questions=questions_for_call,
+                target_letters=target_letters,
+                cot_max_tokens=args.cot_max_tokens,
+            )
+
+        # Audits.
+        kept_letters = [r["_meta"]["target_letter"] for r in rows]
+        letter_audit = _audit_letter_distribution(kept_letters)
+        drop_rate = (stats.n_questions - stats.n_kept) / max(stats.n_questions, 1)
+        refusal_rate = stats.n_refused / max(stats.n_questions, 1)
+
+        cell_summary = {
+            "source": source,
+            "arm": arm,
+            "out_path": str(out_path.relative_to(PROJECT_ROOT)),
+            "stats": stats.__dict__,
+            "letter_audit": letter_audit,
+            "drop_rate": drop_rate,
+            "refusal_rate": refusal_rate,
+        }
+        summary["cells"].append(cell_summary)
+
+        if drop_rate > 0.30:
+            logger.error(
+                "FAIL: drop rate %.2f%% > 30%% for %s/%s; aborting",
+                drop_rate * 100,
+                source,
+                arm,
+            )
+            raise SystemExit(1)
+        if refusal_rate > 0.05 and arm != "no-cot":
+            logger.error(
+                "FAIL: refusal rate %.2f%% > 5%% for %s/%s; aborting",
+                refusal_rate * 100,
+                source,
+                arm,
+            )
+            raise SystemExit(1)
+        if letter_audit["out_of_range"]:
+            logger.error(
+                "FAIL: letter distribution out of [18%%, 32%%] for %s/%s: %s",
+                source,
+                arm,
+                letter_audit["fractions"],
+            )
+            raise SystemExit(1)
+
+        # Write JSONL.
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(out_path, "w") as f:
+            for r in _strip_meta_for_disk(rows):
+                f.write(json.dumps(r) + "\n")
+        logger.info("Wrote %d rows to %s", len(rows), out_path)
+
+    summary["elapsed_sec"] = time.time() - started
+    summary_path = out_base / "_phase0_summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2))
+    logger.info("Phase-0 summary written to %s", summary_path)
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out-base",
+        type=str,
+        default="data/sft/issue186",
+        help="Output directory (relative to project root) for the JSONL files.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=DEFAULT_SEED,
+        help="Wrong-letter RNG seed (default: 42).",
+    )
+    parser.add_argument(
+        "--cot-max-tokens",
+        type=int,
+        default=DEFAULT_COT_MAX_TOKENS,
+        help=f"Max tokens for Claude CoT generation (default: {DEFAULT_COT_MAX_TOKENS}).",
+    )
+    parser.add_argument(
+        "--claude-model",
+        type=str,
+        default=DEFAULT_CLAUDE_MODEL,
+        help=f"Claude model id (default: {DEFAULT_CLAUDE_MODEL}).",
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=DEFAULT_CONCURRENCY,
+        help=f"Async concurrency (default: {DEFAULT_CONCURRENCY}).",
+    )
+    parser.add_argument(
+        "--max-budget-usd",
+        type=float,
+        default=DEFAULT_BUDGET_USD,
+        help=f"Hard cap on estimated Claude API spend (default: ${DEFAULT_BUDGET_USD:.0f}).",
+    )
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Smoke mode: only generate the first cell with N=50 rows.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Regenerate cells whose output JSONL already exists.",
+    )
+    args = parser.parse_args()
+
+    # Determinism for any non-RNG operations (e.g. python random module if used).
+    random.seed(args.seed)
+
+    asyncio.run(_generate_all(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_issue150.py
+++ b/scripts/run_issue150.py
@@ -55,13 +55,25 @@ from _bootstrap import PROJECT_ROOT, bootstrap
 
 bootstrap()
 
-# Hot-fix: vLLM 0.11.0 + transformers 5.5.0 compat shim. vLLM's
-# get_cached_tokenizer accesses the removed `all_special_tokens_extended`
-# attribute. Same monkey-patch is used in scripts/run_em_first_marker_transfer_confab.py.
+# Hot-fix: vLLM 0.11.0 + transformers 5.5.0 compat shims. Identical to the patches
+# already used in scripts/run_em_first_marker_transfer_confab.py.
+# (1) tokenizer.all_special_tokens_extended was removed in transformers 5.x.
+# (2) vLLM's DisabledTqdm passes disable=True twice when the caller already supplies it.
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase  # noqa: E402
 
 if not hasattr(PreTrainedTokenizerBase, "all_special_tokens_extended"):
     PreTrainedTokenizerBase.all_special_tokens_extended = PreTrainedTokenizerBase.all_special_tokens
+
+import vllm.model_executor.model_loader.weight_utils as _wu  # noqa: E402
+
+
+class _PatchedDisabledTqdm(_wu.DisabledTqdm.__bases__[0]):
+    def __init__(self, *a, **kw):
+        kw.pop("disable", None)
+        super().__init__(*a, disable=True, **kw)
+
+
+_wu.DisabledTqdm = _PatchedDisabledTqdm
 
 from explore_persona_space.eval.capability import (  # noqa: E402
     DEFAULT_ARC_DATA,

--- a/scripts/run_issue150.py
+++ b/scripts/run_issue150.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+"""Issue #150 orchestrator: Persona-CoT x Capability Leakage on Qwen2.5-7B-Instruct.
+
+Hybrid CoT-then-logprob ARC-Challenge eval across 11 personas spanning the
+assistant-to-villain cosine axis. For each (persona, scaffold) cell we measure
+ARC-C accuracy by:
+
+  1. Generating a rationale at temp=0 / K=1 with one of three CoT scaffolds
+     (no-cot, generic-cot, persona-cot).
+  2. Reading the next-token logprob over A/B/C/D after the rationale, and
+     picking argmax.
+
+Headline statistic: delta_slope = slope(persona-CoT, acc~cosine) - slope(generic-CoT,
+acc~cosine), with a question-bootstrap (n=1000) two-sided p-value.
+
+Stages
+------
+``--stage smoke``
+    1 persona x 3 scaffolds x N=5 questions. Prints generated CoTs and extracted
+    logits to stdout. For local sanity-checking; does NOT need a GPU; tested
+    against ``facebook/opt-125m``.
+
+``--stage gate``
+    2 personas {assistant, police_officer} x 3 scaffolds x N=200 questions
+    (seed=42 deterministic head). Computes ``delta_slope_2pt`` and writes
+    ``eval_results/issue150/gate/result.json``. Exits 1 if ``delta_slope_2pt <= 0``,
+    killing the pipeline before Stage 2 burns GPU time on a wrong-sign signal.
+
+``--stage full``
+    11 personas x 3 scaffolds x full N=1172. Writes
+    ``eval_results/issue150/full/result.json``.
+
+``--stage aggregate``
+    Loads ``full/result.json``, computes per-arm linear regressions of
+    accuracy on cosine-to-assistant, computes ``delta_slope`` and bootstrap p-value,
+    and emits hero + decomposition figures under ``figures/issue150/``.
+
+Cosine vector
+-------------
+The 11-persona axis is ``{assistant: +1.00, **ASSISTANT_COSINES}`` from
+``personas.py``. Adding/removing personas requires re-running #80's axis-fit
+pipeline; do NOT silently extend the dict.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+from _bootstrap import PROJECT_ROOT, bootstrap
+
+bootstrap()
+
+from explore_persona_space.eval.capability import (  # noqa: E402
+    DEFAULT_ARC_DATA,
+    evaluate_capability_cot_logprob,
+)
+from explore_persona_space.eval.prompting import (  # noqa: E402
+    ALL_COT_SCAFFOLDS,
+)
+from explore_persona_space.personas import (  # noqa: E402
+    ASSISTANT_COSINES,
+    ASSISTANT_PROMPT,
+    PERSONAS,
+)
+
+logger = logging.getLogger("run_issue150")
+
+# ── Constants ───────────────────────────────────────────────────────────────
+
+DEFAULT_MODEL = "Qwen/Qwen2.5-7B-Instruct"
+
+# 11-persona axis matching #80. Order is fixed for reproducibility.
+PERSONA_ORDER: list[str] = [
+    "assistant",
+    "software_engineer",
+    "kindergarten_teacher",
+    "data_scientist",
+    "medical_doctor",
+    "librarian",
+    "french_person",
+    "villain",
+    "comedian",
+    "zelthari_scholar",
+    "police_officer",
+]
+
+# Cosine-to-assistant for the 11 personas. assistant is the anchor at +1.00.
+COSINES_150: dict[str, float] = {"assistant": 1.0, **ASSISTANT_COSINES}
+
+# Map persona name -> system prompt.
+PERSONA_PROMPTS_150: dict[str, str] = {"assistant": ASSISTANT_PROMPT, **PERSONAS}
+
+
+def _validate_persona_axis() -> None:
+    """Sanity-check that the 11-persona axis matches the planned source.
+
+    Aborts at startup if the personas / cosines drift out of sync with #80.
+    """
+    if set(COSINES_150.keys()) != set(PERSONA_ORDER):
+        raise RuntimeError(
+            f"COSINES_150 and PERSONA_ORDER disagree: "
+            f"{set(COSINES_150.keys()) ^ set(PERSONA_ORDER)} differ"
+        )
+    if set(PERSONA_PROMPTS_150.keys()) != set(PERSONA_ORDER):
+        raise RuntimeError(
+            f"PERSONA_PROMPTS_150 and PERSONA_ORDER disagree: "
+            f"{set(PERSONA_PROMPTS_150.keys()) ^ set(PERSONA_ORDER)} differ"
+        )
+    if len(PERSONA_ORDER) != 11:
+        raise RuntimeError(f"Expected 11 personas matching #80 axis, got {len(PERSONA_ORDER)}")
+
+
+_validate_persona_axis()
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _resolve_arc_path() -> str:
+    """Resolve the ARC-C JSONL path, preferring the in-tree raw/ directory."""
+    in_tree = PROJECT_ROOT / DEFAULT_ARC_DATA
+    if in_tree.exists():
+        return str(in_tree)
+    # Fall back to the orchestrate.env helper (handles RunPod /workspace path).
+    from explore_persona_space.orchestrate.env import get_output_dir
+
+    return str(get_output_dir() / DEFAULT_ARC_DATA)
+
+
+def _filtered_personas(names: list[str]) -> dict[str, str]:
+    """Return ``{name: system_prompt}`` in PERSONA_ORDER order, filtered to ``names``."""
+    keep = set(names)
+    missing = keep - set(PERSONA_ORDER)
+    if missing:
+        raise ValueError(f"Unknown personas: {sorted(missing)}")
+    return {n: PERSONA_PROMPTS_150[n] for n in PERSONA_ORDER if n in keep}
+
+
+def _save_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2))
+    logger.info("Wrote %s", path)
+
+
+# ── Stage: smoke ────────────────────────────────────────────────────────────
+
+
+def _stage_smoke(model: str, n_questions: int, out_dir: Path) -> dict:
+    """Tiny smoke test: 1 persona x 3 scaffolds x N=5 questions, printed to stdout.
+
+    Usable on CPU with a tiny HF model (e.g. ``facebook/opt-125m``) just to
+    verify the wire format. Logits / answers may be garbage on such models;
+    this stage only verifies that the pipeline doesn't crash.
+    """
+    personas = _filtered_personas(["assistant"])
+    result = evaluate_capability_cot_logprob(
+        model_path=model,
+        personas=personas,
+        cot_scaffolds=list(ALL_COT_SCAFFOLDS),
+        arc_data_path=_resolve_arc_path(),
+        n_questions=n_questions,
+    )
+    # Print one example per arm for inspection.
+    persona_block = result["per_persona"]["assistant"]
+    print("\n=== Smoke test (assistant persona) ===", flush=True)
+    for arm_key, label in [
+        ("no_cot", "no-cot"),
+        ("generic_cot", "generic-cot"),
+        ("persona_cot", "persona-cot"),
+    ]:
+        block = persona_block[arm_key]
+        print(
+            f"\n[arm={label}] accuracy={block['accuracy']:.3f} "
+            f"({block['n_correct']}/{block['n_total']})",
+            flush=True,
+        )
+        # Show first row's CoT text + prediction.
+        if persona_block["raw"]:
+            row = persona_block["raw"][0]
+            cot_text_key = "no_cot_text" if arm_key == "no_cot" else f"{arm_key}_text"
+            pred_key = f"{arm_key}_pred"
+            cot_text = row.get(cot_text_key, "(no CoT)")
+            print(
+                f"  q0 correct={row['correct_answer']} pred={row[pred_key]!r}",
+                flush=True,
+            )
+            print(f"  CoT: {cot_text[:300]!r}", flush=True)
+
+    _save_json(out_dir / "smoke" / "result.json", result)
+    return result
+
+
+# ── Stage: gate ─────────────────────────────────────────────────────────────
+
+
+def _arm_accuracy(per_persona: dict, persona: str, arm_key: str) -> float:
+    return per_persona[persona][arm_key]["accuracy"]
+
+
+def _stage_gate(model: str, n_questions: int, out_dir: Path) -> dict:
+    """Cheap 2-persona kill-gate before committing to Stage 2.
+
+    Computes::
+
+        delta_slope_2pt = (acc(assistant, persona-cot) - acc(police, persona-cot))
+                        - (acc(assistant, generic-cot) - acc(police, generic-cot))
+
+    Exits with status 1 if ``delta_slope_2pt <= 0`` -- the predicted direction is
+    positive, so a wrong-sign / null result on the cheap gate kills the
+    full sweep.
+    """
+    personas = _filtered_personas(["assistant", "police_officer"])
+    result = evaluate_capability_cot_logprob(
+        model_path=model,
+        personas=personas,
+        cot_scaffolds=list(ALL_COT_SCAFFOLDS),
+        arc_data_path=_resolve_arc_path(),
+        n_questions=n_questions,
+    )
+
+    per_persona = result["per_persona"]
+    asst_persona = _arm_accuracy(per_persona, "assistant", "persona_cot")
+    police_persona = _arm_accuracy(per_persona, "police_officer", "persona_cot")
+    asst_generic = _arm_accuracy(per_persona, "assistant", "generic_cot")
+    police_generic = _arm_accuracy(per_persona, "police_officer", "generic_cot")
+    delta_2pt = (asst_persona - police_persona) - (asst_generic - police_generic)
+
+    summary = {
+        "stage": "gate",
+        "n_questions": n_questions,
+        "personas": list(personas.keys()),
+        "accuracies": {
+            "assistant": {
+                "no_cot": _arm_accuracy(per_persona, "assistant", "no_cot"),
+                "generic_cot": asst_generic,
+                "persona_cot": asst_persona,
+            },
+            "police_officer": {
+                "no_cot": _arm_accuracy(per_persona, "police_officer", "no_cot"),
+                "generic_cot": police_generic,
+                "persona_cot": police_persona,
+            },
+        },
+        "delta_slope_2pt": delta_2pt,
+        "kill_rule": "delta_slope_2pt <= 0 -> exit 1",
+        "passed": delta_2pt > 0,
+    }
+    payload = {"summary": summary, "raw": result}
+    _save_json(out_dir / "gate" / "result.json", payload)
+
+    print(f"\n=== Gate stage ===\ndelta_slope_2pt = {delta_2pt:+.4f}", flush=True)
+    if delta_2pt <= 0:
+        print("KILL: delta_slope_2pt <= 0; not running Stage 2.", flush=True)
+        sys.exit(1)
+    print("PASS: delta_slope_2pt > 0; proceeding to Stage 2.", flush=True)
+    return payload
+
+
+# ── Stage: full ─────────────────────────────────────────────────────────────
+
+
+def _stage_full(model: str, n_questions: int | None, out_dir: Path) -> dict:
+    """Full eval: 11 personas x 3 CoT arms x ARC-C (N=n_questions or full)."""
+    personas = _filtered_personas(PERSONA_ORDER)
+    result = evaluate_capability_cot_logprob(
+        model_path=model,
+        personas=personas,
+        cot_scaffolds=list(ALL_COT_SCAFFOLDS),
+        arc_data_path=_resolve_arc_path(),
+        n_questions=n_questions,
+    )
+    _save_json(out_dir / "full" / "result.json", result)
+    return result
+
+
+# ── Stage: aggregate ────────────────────────────────────────────────────────
+
+
+def _fit_slope(xs: list[float], ys: list[float]) -> float:
+    """Ordinary-least-squares slope of ``y ~ x`` (no numpy dependency necessary,
+    but we use numpy for clarity)."""
+    import numpy as np
+
+    coeffs = np.polyfit(np.array(xs), np.array(ys), 1)
+    return float(coeffs[0])
+
+
+def _bootstrap_delta_slope(
+    raw_by_persona: dict[str, list[dict]],
+    cosines: list[float],
+    persona_order: list[str],
+    n_resamples: int = 1000,
+    seed: int = 42,
+) -> dict[str, Any]:
+    """Bootstrap over questions for the Δslope p-value.
+
+    For each bootstrap sample, resample the question indices with replacement
+    (same indices used across all personas, so paired structure is preserved),
+    recompute per-persona accuracy for each arm, recompute the per-arm slope
+    of accuracy on cosine, and recompute Δslope. Two-sided p-value is the
+    fraction of resampled |Δslope| ≥ |observed Δslope|.
+    """
+    import numpy as np
+
+    rng = np.random.default_rng(seed)
+
+    # Build per-(persona, q, arm) correctness arrays once.
+    n_q = len(raw_by_persona[persona_order[0]])
+    n_p = len(persona_order)
+
+    correct_persona_cot = np.zeros((n_p, n_q), dtype=np.int8)
+    correct_generic_cot = np.zeros((n_p, n_q), dtype=np.int8)
+    for p_i, persona in enumerate(persona_order):
+        rows = raw_by_persona[persona]
+        for q_i, row in enumerate(rows):
+            ca = row["correct_answer"]
+            correct_persona_cot[p_i, q_i] = int(row["persona_cot_pred"] == ca)
+            correct_generic_cot[p_i, q_i] = int(row["generic_cot_pred"] == ca)
+
+    cosines_arr = np.array(cosines)
+
+    def slopes_from_acc(persona_acc: np.ndarray, generic_acc: np.ndarray) -> tuple[float, float]:
+        sp = np.polyfit(cosines_arr, persona_acc, 1)[0]
+        sg = np.polyfit(cosines_arr, generic_acc, 1)[0]
+        return float(sp), float(sg)
+
+    # Observed.
+    obs_persona_acc = correct_persona_cot.mean(axis=1)
+    obs_generic_acc = correct_generic_cot.mean(axis=1)
+    obs_slope_persona, obs_slope_generic = slopes_from_acc(obs_persona_acc, obs_generic_acc)
+    obs_delta = obs_slope_persona - obs_slope_generic
+
+    # Bootstrap.
+    deltas = np.empty(n_resamples, dtype=np.float64)
+    for b in range(n_resamples):
+        idx = rng.integers(0, n_q, size=n_q)
+        bp = correct_persona_cot[:, idx].mean(axis=1)
+        bg = correct_generic_cot[:, idx].mean(axis=1)
+        sp, sg = slopes_from_acc(bp, bg)
+        deltas[b] = sp - sg
+
+    # Two-sided p-value: fraction of |Δslope_b| ≥ |obs_delta| under the
+    # bootstrap distribution. (We center on 0, treating the bootstrap as the
+    # null around no-difference between arms by symmetry of the resampling
+    # under H0; this is the convention used in #80.)
+    p_two_sided = float(np.mean(np.abs(deltas - np.mean(deltas)) >= abs(obs_delta)))
+
+    return {
+        "observed": {
+            "slope_persona_cot": obs_slope_persona,
+            "slope_generic_cot": obs_slope_generic,
+            "delta_slope": obs_delta,
+        },
+        "bootstrap": {
+            "n_resamples": n_resamples,
+            "seed": seed,
+            "mean_delta": float(np.mean(deltas)),
+            "std_delta": float(np.std(deltas)),
+            "ci95_low": float(np.quantile(deltas, 0.025)),
+            "ci95_high": float(np.quantile(deltas, 0.975)),
+            "p_two_sided": p_two_sided,
+        },
+    }
+
+
+def _make_figures(
+    per_persona: dict,
+    cosines: list[float],
+    persona_order: list[str],
+    bootstrap_summary: dict,
+    fig_dir: Path,
+) -> None:
+    """Build the 3-panel hero + decomposition bar chart for #150."""
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    from explore_persona_space.analysis.paper_plots import (
+        add_direction_arrow,
+        paper_palette,
+        savefig_paper,
+        set_paper_style,
+    )
+
+    set_paper_style("neurips")
+    palette = paper_palette(3)
+    arms = [("no_cot", "no-CoT"), ("generic_cot", "generic-CoT"), ("persona_cot", "persona-CoT")]
+
+    # ── Panel hero: 3 panels (one per arm), accuracy ~ cosine, with fitted line.
+    fig, axes = plt.subplots(1, 3, figsize=(11.0, 3.4), sharey=True)
+    cosines_arr = np.array(cosines)
+    for ax, (arm_key, arm_label), color in zip(axes, arms, palette, strict=True):
+        accs = np.array([per_persona[p][arm_key]["accuracy"] for p in persona_order])
+        ax.scatter(cosines_arr, accs, color=color, s=40, label=arm_label, zorder=3)
+        # Linear fit.
+        slope, intercept = np.polyfit(cosines_arr, accs, 1)
+        xs = np.linspace(cosines_arr.min(), cosines_arr.max(), 50)
+        ax.plot(xs, slope * xs + intercept, color=color, alpha=0.6, linewidth=1.2)
+        ax.set_title(f"{arm_label}\nslope = {slope:+.4f}")
+        ax.set_xlabel("cosine to assistant")
+        ax.grid(True, alpha=0.25)
+    axes[0].set_ylabel("ARC-C accuracy")
+    add_direction_arrow(axes[0], axis="y", direction="up")
+    fig.suptitle(
+        "Per-persona ARC-C accuracy vs cosine-to-assistant, by CoT arm",
+        y=1.02,
+    )
+    fig.tight_layout()
+    savefig_paper(fig, "issue150/hero_3panel", dir=str(fig_dir.parent))
+    plt.close(fig)
+
+    # Decomposition bar: delta_slope = slope(persona-CoT) - slope(generic-CoT).
+    fig2, ax2 = plt.subplots(figsize=(5.0, 3.4))
+    obs = bootstrap_summary["observed"]
+    bts = bootstrap_summary["bootstrap"]
+    bars_x = ["generic-CoT", "persona-CoT"]
+    bars_y = [obs["slope_generic_cot"], obs["slope_persona_cot"]]
+    bar_colors = [palette[1], palette[2]]
+    ax2.bar(bars_x, bars_y, color=bar_colors)
+    ax2.axhline(0, color="black", linewidth=0.5)
+    ax2.set_ylabel("slope of acc ~ cosine")
+    ax2.set_title(
+        "delta_slope = "
+        f"{obs['delta_slope']:+.4f}\nbootstrap p (two-sided) = {bts['p_two_sided']:.4f}"
+    )
+    fig2.tight_layout()
+    savefig_paper(fig2, "issue150/delta_slope_decomposition", dir=str(fig_dir.parent))
+    plt.close(fig2)
+
+
+def _stage_aggregate(out_dir: Path, fig_dir: Path) -> dict:
+    """Aggregate full-stage results: per-arm slopes, bootstrap, figures."""
+    full_path = out_dir / "full" / "result.json"
+    if not full_path.exists():
+        raise FileNotFoundError(f"Cannot aggregate: {full_path} missing. Run --stage full first.")
+    full = json.loads(full_path.read_text())
+    per_persona = full["per_persona"]
+
+    persona_order = [p for p in PERSONA_ORDER if p in per_persona]
+    cosines = [COSINES_150[p] for p in persona_order]
+
+    # Build per-arm slope summary (uses observed accuracies).
+    accs_by_arm: dict[str, list[float]] = {}
+    for arm in ("no_cot", "generic_cot", "persona_cot"):
+        accs_by_arm[arm] = [per_persona[p][arm]["accuracy"] for p in persona_order]
+    slopes = {arm: _fit_slope(cosines, accs) for arm, accs in accs_by_arm.items()}
+
+    raw_by_persona = {p: per_persona[p]["raw"] for p in persona_order}
+    bootstrap_summary = _bootstrap_delta_slope(
+        raw_by_persona=raw_by_persona,
+        cosines=cosines,
+        persona_order=persona_order,
+    )
+
+    aggregate = {
+        "persona_order": persona_order,
+        "cosines": cosines,
+        "accuracies_by_arm": accs_by_arm,
+        "slopes": slopes,
+        "bootstrap": bootstrap_summary,
+        "metadata": full.get("metadata", {}),
+    }
+    _save_json(out_dir / "full" / "aggregate.json", aggregate)
+    _make_figures(per_persona, cosines, persona_order, bootstrap_summary, fig_dir)
+    obs_delta = bootstrap_summary["observed"]["delta_slope"]
+    p_two_sided = bootstrap_summary["bootstrap"]["p_two_sided"]
+    print(
+        "\n=== Aggregate ===\n"
+        f"  slope(no-CoT)      = {slopes['no_cot']:+.4f}\n"
+        f"  slope(generic-CoT) = {slopes['generic_cot']:+.4f}\n"
+        f"  slope(persona-CoT) = {slopes['persona_cot']:+.4f}\n"
+        f"  delta_slope (persona - generic) = {obs_delta:+.4f}\n"
+        f"  bootstrap p (two-sided) = {p_two_sided:.4f}\n",
+        flush=True,
+    )
+    return aggregate
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--stage",
+        required=True,
+        choices=("smoke", "gate", "full", "aggregate"),
+        help="Pipeline stage to run.",
+    )
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL,
+        help=f"HF model id or local path (default: {DEFAULT_MODEL}).",
+    )
+    parser.add_argument(
+        "--n-questions",
+        type=int,
+        default=None,
+        help=(
+            "Override the number of ARC-C questions per cell. "
+            "Defaults to: 5 (smoke), 200 (gate), full N=1172 (full)."
+        ),
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=PROJECT_ROOT / "eval_results" / "issue150",
+        help="Where to write per-stage result JSONs.",
+    )
+    parser.add_argument(
+        "--fig-dir",
+        type=Path,
+        default=PROJECT_ROOT / "figures" / "issue150",
+        help="Where to write hero / decomposition figures (aggregate stage).",
+    )
+    args = parser.parse_args()
+
+    if args.stage == "smoke":
+        n_q = args.n_questions if args.n_questions is not None else 5
+        _stage_smoke(args.model, n_q, args.out_dir)
+    elif args.stage == "gate":
+        n_q = args.n_questions if args.n_questions is not None else 200
+        _stage_gate(args.model, n_q, args.out_dir)
+    elif args.stage == "full":
+        _stage_full(args.model, args.n_questions, args.out_dir)
+    elif args.stage == "aggregate":
+        _stage_aggregate(args.out_dir, args.fig_dir)
+    else:  # pragma: no cover — argparse choices guard
+        raise ValueError(f"Unknown stage {args.stage!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_issue150.py
+++ b/scripts/run_issue150.py
@@ -55,6 +55,14 @@ from _bootstrap import PROJECT_ROOT, bootstrap
 
 bootstrap()
 
+# Hot-fix: vLLM 0.11.0 + transformers 5.5.0 compat shim. vLLM's
+# get_cached_tokenizer accesses the removed `all_special_tokens_extended`
+# attribute. Same monkey-patch is used in scripts/run_em_first_marker_transfer_confab.py.
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase  # noqa: E402
+
+if not hasattr(PreTrainedTokenizerBase, "all_special_tokens_extended"):
+    PreTrainedTokenizerBase.all_special_tokens_extended = PreTrainedTokenizerBase.all_special_tokens
+
 from explore_persona_space.eval.capability import (  # noqa: E402
     DEFAULT_ARC_DATA,
     evaluate_capability_cot_logprob,

--- a/scripts/run_issue186_eval.py
+++ b/scripts/run_issue186_eval.py
@@ -239,6 +239,66 @@ def _stage_baseline(args: argparse.Namespace) -> None:
     _save_json(out_dir / "result.json", result)
 
 
+def _purge_cell_snapshot(source: str, arm: str, seed: int) -> None:
+    """Delete the cached HF Hub blobs/snapshots for one cell to free disk.
+
+    Each merged 7B checkpoint is ~13.5 GB. The whole sweep shares one HF
+    revision, so we cannot use ``delete_revisions``; instead, we walk this
+    cell's symlinks under the snapshot dir, unlink each blob it points to,
+    and rmtree the cell's snapshot subdir. Blobs are ref-counted by symlink
+    count; if a blob is referenced by another cell's symlink we leave it.
+    """
+    import os
+    import shutil
+    from collections import Counter
+
+    path_in_repo = _hf_path_in_repo(source, arm, seed)
+
+    cache_root_env = os.environ.get("HF_HUB_CACHE") or os.environ.get("HF_HOME")
+    if cache_root_env:
+        hub_dir = Path(cache_root_env)
+        if hub_dir.name != "hub":
+            hub_dir = hub_dir / "hub"
+    else:
+        hub_dir = Path.home() / ".cache" / "huggingface" / "hub"
+    repo_dir = hub_dir / f"models--{HF_MODEL_REPO.replace('/', '--')}"
+    snapshots_dir = repo_dir / "snapshots"
+    if not snapshots_dir.exists():
+        logger.warning("No HF cache snapshots dir at %s; nothing to purge", snapshots_dir)
+        return
+
+    # Count refs to each blob across the whole repo cache so we don't
+    # delete blobs that some other cached cell still uses.
+    blob_refs: Counter[Path] = Counter()
+    for snap in snapshots_dir.iterdir():
+        for symlink in snap.rglob("*"):
+            if symlink.is_symlink():
+                target = symlink.resolve()
+                blob_refs[target] += 1
+
+    freed = 0
+    cell_dirs = [s / path_in_repo for s in snapshots_dir.iterdir() if (s / path_in_repo).exists()]
+    if not cell_dirs:
+        logger.info("No cached cell dir for %s — nothing to purge", path_in_repo)
+        return
+
+    for cell_dir in cell_dirs:
+        for symlink in cell_dir.rglob("*"):
+            if symlink.is_symlink():
+                blob = symlink.resolve()
+                blob_refs[blob] -= 1
+                if blob_refs[blob] <= 0 and blob.exists():
+                    try:
+                        size = blob.stat().st_size
+                        blob.unlink()
+                        freed += size
+                    except OSError as e:
+                        logger.warning("Could not unlink blob %s: %s", blob, e)
+        shutil.rmtree(cell_dir, ignore_errors=True)
+
+    logger.info("Purged %s cache (%.1f GB freed)", path_in_repo, freed / 1e9)
+
+
 def _resolve_cell_model_path(source: str, arm: str, seed: int) -> str:
     """Snapshot-download the merged model for this cell from HF Hub.
 
@@ -355,8 +415,10 @@ def _stage_full(args: argparse.Namespace) -> None:
         except Exception as e:
             logger.error("Eval failed for %s: %s", cell_id, e)
             failures.append((cell_id, f"eval: {e}"))
+            _purge_cell_snapshot(source, arm, seed)
             continue
         _save_json(cell_dir / "result.json", result)
+        _purge_cell_snapshot(source, arm, seed)
     if failures:
         logger.error("%d cell(s) failed: %s", len(failures), failures)
         sys.exit(1)

--- a/scripts/run_issue186_eval.py
+++ b/scripts/run_issue186_eval.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+"""Issue #186 Phase-2 eval orchestrator.
+
+For each (source x train arm x seed) cell -- 12 main + 3 correct-control = 15
+distinct (source, arm) tuples x 3 seeds = **39 trained checkpoints** -- plus
+the Phase-1.5 untrained baseline, evaluate ARC-Challenge (test split, N=1172)
+under the 11-persona axis x 4 eval arms factorial.
+
+Stages
+------
+
+* ``--stage smoke``      1 source (librarian) x 1 train arm (persona-cot) x
+                         1 seed (42) x 11 personas x 4 eval arms x N=200.
+                         Asserts source-loss ≤ baseline-5pp on no-cot-eval; aborts
+                         otherwise. Uses one vLLM session per cell (merge-and-unload
+                         path -- see plan v2 §13 risk-row "enable_lora adapter
+                         loading error").
+* ``--stage baseline``   Untrained Qwen2.5-7B-Instruct x 11 personas x 4 eval
+                         arms x N=1172. Output: ``eval_results/issue186/baseline/``.
+* ``--stage full``       All 39 trained checkpoints, full N=1172. One vLLM
+                         session per cell (the merge-and-unload variant of plan
+                         §6.6). Output JSONs go to
+                         ``eval_results/issue186/{source}_{arm}_seed{S}/``.
+* ``--stage aggregate``  Reads baseline + 39 cells, builds the per-(persona,
+                         train arm, eval arm, source) accuracy table, runs the
+                         (q, seed)-joint paired bootstrap for H1/H2/H3/H4/H5, and
+                         emits the hero figure + supporting figures.
+
+Note on adapter handling
+------------------------
+Plan v2 §6.6 calls for ``enable_lora=True`` adapter swap to amortise the vLLM
+init across 39 cells. The existing in-process LoRA training path
+(``run_staged_training``) merges the adapter into the base before uploading,
+so the HF Hub artifact is a *merged* 7B checkpoint, not a raw LoRA adapter.
+Modifying the trainer to ALSO preserve the raw adapter is invasive and risks
+breaking other experiments.
+
+This script therefore implements the merge-and-unload fallback that plan v2
+§13 explicitly anticipates: each cell loads its merged checkpoint into a
+fresh vLLM engine, runs the eval, tears the engine down, and proceeds. The
+plan's "Allowed without asking" deviation language ("`enable_lora` adapter
+loading error → fall back to merge-and-unload, additive ~1.5 GPU-hr") covers
+this choice. A follow-up issue can re-architect the trainer to upload raw
+adapters and switch the orchestrator to ``enable_lora`` if the GPU-hr
+saving is worth the trainer change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+
+def _install_compat_shims() -> None:
+    """Install vLLM 0.11.0 + transformers 5.5.0 compat shims.
+
+    Identical to the patches cherry-picked from issue-150 (see
+    f491103 + 9798de2). Idempotent -- safe to call multiple times.
+    """
+    from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+
+    if not hasattr(PreTrainedTokenizerBase, "all_special_tokens_extended"):
+        PreTrainedTokenizerBase.all_special_tokens_extended = (
+            PreTrainedTokenizerBase.all_special_tokens
+        )
+
+    import vllm.model_executor.model_loader.weight_utils as _wu
+
+    if not getattr(_wu.DisabledTqdm, "_issue186_patched", False):
+
+        class _PatchedDisabledTqdm(_wu.DisabledTqdm.__bases__[0]):
+            _issue186_patched = True
+
+            def __init__(self, *a, **kw):
+                kw.pop("disable", None)
+                super().__init__(*a, disable=True, **kw)
+
+        _wu.DisabledTqdm = _PatchedDisabledTqdm
+
+
+from explore_persona_space.eval.prompting import (  # noqa: E402
+    EMPTY_PERSONA_COT,
+    GENERIC_COT,
+    NO_COT,
+    PERSONA_COT,
+)
+from explore_persona_space.personas import (  # noqa: E402
+    ASSISTANT_COSINES,
+    ASSISTANT_PROMPT,
+    PERSONAS,
+)
+
+logger = logging.getLogger("run_issue186_eval")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+DEFAULT_BASE_MODEL = "Qwen/Qwen2.5-7B-Instruct"
+HF_MODEL_REPO = "superkaiba1/explore-persona-space"
+
+PERSONA_ORDER: list[str] = [
+    "assistant",
+    "software_engineer",
+    "kindergarten_teacher",
+    "data_scientist",
+    "medical_doctor",
+    "librarian",
+    "french_person",
+    "villain",
+    "comedian",
+    "zelthari_scholar",
+    "police_officer",
+]
+COSINES: dict[str, float] = {"assistant": 1.0, **ASSISTANT_COSINES}
+PERSONA_PROMPTS: dict[str, str] = {"assistant": ASSISTANT_PROMPT, **PERSONAS}
+EVAL_PERSONAS: dict[str, str] = {p: PERSONA_PROMPTS[p] for p in PERSONA_ORDER}
+
+EVAL_SCAFFOLDS = (NO_COT, GENERIC_COT, PERSONA_COT, EMPTY_PERSONA_COT)
+EVAL_SCAFFOLD_NAMES = [s.name for s in EVAL_SCAFFOLDS]
+
+SOURCES = ("software_engineer", "librarian", "comedian", "police_officer")
+MAIN_ARMS = ("no_cot", "generic_cot", "persona_cot")
+CORRECT_CONTROL_CELLS = (("librarian", "persona_cot_correct"),)
+SEEDS = (42, 137, 256)
+
+
+def _all_cells() -> list[tuple[str, str, int]]:
+    out: list[tuple[str, str, int]] = []
+    for src in SOURCES:
+        for arm in MAIN_ARMS:
+            for s in SEEDS:
+                out.append((src, arm, s))
+    for src, arm in CORRECT_CONTROL_CELLS:
+        for s in SEEDS:
+            out.append((src, arm, s))
+    return out
+
+
+def _cell_id(source: str, arm: str, seed: int) -> str:
+    return f"{source}_{arm}_seed{seed}"
+
+
+def _hf_path_in_repo(source: str, arm: str, seed: int) -> str:
+    """Return the HF Hub path-in-repo for the merged trained model.
+
+    Pattern matches ``orchestrate.runner._upload_post_em``: the trainer
+    uploads the final merged checkpoint to ``{condition.name}_seed{seed}_post_em``.
+    For #186 the condition name is ``i186_{source}_{arm}``.
+    """
+    return f"i186_{source}_{arm}_seed{seed}_post_em"
+
+
+def _resolve_arc_test_path() -> str:
+    in_tree = PROJECT_ROOT / "raw" / "arc_challenge" / "test.jsonl"
+    if in_tree.exists():
+        return str(in_tree)
+    from explore_persona_space.orchestrate.env import get_output_dir
+
+    return str(get_output_dir() / "raw" / "arc_challenge" / "test.jsonl")
+
+
+def _save_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2))
+    logger.info("Wrote %s", path)
+
+
+# ── Engine lifecycle (one engine per cell -- merge-and-unload path) ──────────
+
+
+def _eval_one_cell(
+    *,
+    model_path: str,
+    cell_id: str,
+    n_questions: int | None,
+    cot_max_tokens: int,
+    gpu_memory_utilization: float | None,
+    max_model_len: int,
+    seed: int,
+) -> dict:
+    """Load `model_path` into a fresh vLLM engine and eval all 11 personas x 4 arms."""
+    from explore_persona_space.eval.capability import evaluate_capability_cot_logprob
+
+    started = time.time()
+    result = evaluate_capability_cot_logprob(
+        model_path=model_path,
+        personas=EVAL_PERSONAS,
+        cot_scaffolds=list(EVAL_SCAFFOLDS),
+        arc_data_path=_resolve_arc_test_path(),
+        n_questions=n_questions,
+        cot_max_tokens=cot_max_tokens,
+        gpu_memory_utilization=gpu_memory_utilization,
+        max_model_len=max_model_len,
+        seed=seed,
+    )
+    result["metadata"]["cell_id"] = cell_id
+    result["metadata"]["wall_time_sec"] = time.time() - started
+
+    # Force GC of vLLM engine (capability.py already calls cleanup_vllm in a
+    # `finally:` -- this is belt+braces).
+    gc.collect()
+    return result
+
+
+# ── Stages ───────────────────────────────────────────────────────────────────
+
+
+def _stage_baseline(args: argparse.Namespace) -> None:
+    out_dir = PROJECT_ROOT / "eval_results" / "issue186" / "baseline"
+    if (out_dir / "result.json").exists() and not args.force:
+        logger.info(
+            "Baseline result.json already exists at %s; pass --force to regenerate",
+            out_dir,
+        )
+        return
+    logger.info(
+        "Phase-1.5 baseline: model=%s n_personas=%d n_arms=%d n_q=%s",
+        args.base_model,
+        len(EVAL_PERSONAS),
+        len(EVAL_SCAFFOLDS),
+        args.n_questions or "full",
+    )
+    result = _eval_one_cell(
+        model_path=args.base_model,
+        cell_id="baseline",
+        n_questions=args.n_questions,
+        cot_max_tokens=args.cot_max_tokens,
+        gpu_memory_utilization=args.gpu_memory_utilization,
+        max_model_len=args.max_model_len,
+        seed=args.seed,
+    )
+    _save_json(out_dir / "result.json", result)
+
+
+def _resolve_cell_model_path(source: str, arm: str, seed: int) -> str:
+    """Snapshot-download the merged model for this cell from HF Hub.
+
+    Returns the local path on disk that vLLM can `model=` on.
+    """
+    from huggingface_hub import snapshot_download
+
+    path_in_repo = _hf_path_in_repo(source, arm, seed)
+    logger.info("Snapshot-downloading %s/%s ...", HF_MODEL_REPO, path_in_repo)
+    local = snapshot_download(
+        repo_id=HF_MODEL_REPO,
+        allow_patterns=[f"{path_in_repo}/*"],
+    )
+    full = Path(local) / path_in_repo
+    if not full.exists():
+        raise FileNotFoundError(
+            f"Snapshot did not yield expected dir: {full}. Repo path: {path_in_repo}"
+        )
+    return str(full)
+
+
+def _stage_smoke(args: argparse.Namespace) -> None:
+    """1 cell x N=200 smoke. Source-loss check vs baseline."""
+    cell = ("librarian", "persona_cot", 42)
+    cell_id = _cell_id(*cell)
+    logger.info("Smoke cell: %s", cell_id)
+
+    baseline_dir = PROJECT_ROOT / "eval_results" / "issue186" / "smoke" / "baseline"
+    if not (baseline_dir / "result.json").exists() or args.force:
+        baseline = _eval_one_cell(
+            model_path=args.base_model,
+            cell_id="smoke_baseline",
+            n_questions=args.n_questions or 200,
+            cot_max_tokens=args.cot_max_tokens,
+            gpu_memory_utilization=args.gpu_memory_utilization,
+            max_model_len=args.max_model_len,
+            seed=args.seed,
+        )
+        _save_json(baseline_dir / "result.json", baseline)
+    else:
+        baseline = json.loads((baseline_dir / "result.json").read_text())
+
+    # Trained cell.
+    model_path = _resolve_cell_model_path(*cell)
+    trained = _eval_one_cell(
+        model_path=model_path,
+        cell_id=cell_id,
+        n_questions=args.n_questions or 200,
+        cot_max_tokens=args.cot_max_tokens,
+        gpu_memory_utilization=args.gpu_memory_utilization,
+        max_model_len=args.max_model_len,
+        seed=args.seed,
+    )
+    cell_dir = PROJECT_ROOT / "eval_results" / "issue186" / "smoke" / cell_id
+    _save_json(cell_dir / "result.json", trained)
+
+    # Source-loss assertion: librarian x no-cot-eval, trained vs baseline.
+    src_persona = "librarian"
+    arm_key = "no_cot"
+    base_acc = baseline["per_persona"][src_persona][arm_key]["accuracy"]
+    trained_acc = trained["per_persona"][src_persona][arm_key]["accuracy"]
+    delta = trained_acc - base_acc
+    logger.info(
+        "Source-loss check: %s x %s  baseline=%.3f trained=%.3f Δ=%+.3f",
+        src_persona,
+        arm_key,
+        base_acc,
+        trained_acc,
+        delta,
+    )
+    if delta > -0.05:
+        msg = (
+            f"SMOKE FAIL: trained source acc ({trained_acc:.3f}) is not at least "
+            f"5pp below baseline ({base_acc:.3f}) on {src_persona} x {arm_key}. "
+            "Wrong-letter pipeline or LoRA training is broken; aborting."
+        )
+        logger.error(msg)
+        raise SystemExit(1)
+    logger.info("SMOKE PASS (Δ ≤ -0.05).")
+
+
+def _stage_full(args: argparse.Namespace) -> None:
+    cells = _all_cells()
+    logger.info(
+        "Phase-2 full: %d cells x %d personas x %d arms x %d questions",
+        len(cells),
+        len(EVAL_PERSONAS),
+        len(EVAL_SCAFFOLDS),
+        args.n_questions or 1172,
+    )
+    failures: list[tuple[str, str]] = []
+    for source, arm, seed in cells:
+        cell_id = _cell_id(source, arm, seed)
+        cell_dir = PROJECT_ROOT / "eval_results" / "issue186" / cell_id
+        if (cell_dir / "result.json").exists() and not args.force:
+            logger.info("SKIP (result.json exists): %s", cell_id)
+            continue
+        try:
+            model_path = _resolve_cell_model_path(source, arm, seed)
+        except Exception as e:
+            logger.error("Failed to download %s: %s", cell_id, e)
+            failures.append((cell_id, f"download: {e}"))
+            continue
+        try:
+            result = _eval_one_cell(
+                model_path=model_path,
+                cell_id=cell_id,
+                n_questions=args.n_questions,
+                cot_max_tokens=args.cot_max_tokens,
+                gpu_memory_utilization=args.gpu_memory_utilization,
+                max_model_len=args.max_model_len,
+                seed=args.seed,
+            )
+        except Exception as e:
+            logger.error("Eval failed for %s: %s", cell_id, e)
+            failures.append((cell_id, f"eval: {e}"))
+            continue
+        _save_json(cell_dir / "result.json", result)
+    if failures:
+        logger.error("%d cell(s) failed: %s", len(failures), failures)
+        sys.exit(1)
+
+
+# ── Aggregate ────────────────────────────────────────────────────────────────
+
+
+def _stage_aggregate(args: argparse.Namespace) -> None:  # noqa: C901
+    import numpy as np
+
+    out_root = PROJECT_ROOT / "eval_results" / "issue186"
+    fig_root = PROJECT_ROOT / "figures" / "issue186"
+    fig_root.mkdir(parents=True, exist_ok=True)
+    baseline_path = out_root / "baseline" / "result.json"
+    if not baseline_path.exists():
+        raise FileNotFoundError(
+            f"Baseline result missing at {baseline_path}. Run --stage baseline first."
+        )
+    baseline = json.loads(baseline_path.read_text())
+
+    cells = _all_cells()
+    cell_results: dict[str, dict] = {}
+    missing: list[str] = []
+    for source, arm, seed in cells:
+        cell_id = _cell_id(source, arm, seed)
+        rp = out_root / cell_id / "result.json"
+        if not rp.exists():
+            missing.append(cell_id)
+            continue
+        cell_results[cell_id] = json.loads(rp.read_text())
+    if missing:
+        logger.warning("Missing %d cells: %s", len(missing), missing)
+
+    # Build correctness arrays. baseline_correct[q, persona, arm] ∈ {0,1}.
+    n_q = baseline["metadata"]["n_questions"]
+    persona_idx = {p: i for i, p in enumerate(PERSONA_ORDER)}
+    arm_to_key = {s.name: s.name.replace("-", "_") for s in EVAL_SCAFFOLDS}
+
+    def _correct_array(per_persona: dict) -> np.ndarray:
+        """Return shape (n_q, 11, 4) int8 array of correctness."""
+        arr = np.zeros((n_q, len(PERSONA_ORDER), len(EVAL_SCAFFOLDS)), dtype=np.int8)
+        for p in PERSONA_ORDER:
+            block = per_persona.get(p)
+            if block is None:
+                continue
+            for q_idx, row in enumerate(block["raw"][:n_q]):
+                ca = row["correct_answer"]
+                for sc_i, scaffold in enumerate(EVAL_SCAFFOLDS):
+                    ak = arm_to_key[scaffold.name]
+                    pred = row.get(f"{ak}_pred")
+                    arr[q_idx, persona_idx[p], sc_i] = int(pred == ca)
+        return arr
+
+    base_correct = _correct_array(baseline["per_persona"])
+    # trained_correct[cell_id] -> (n_q, 11, 4)
+    trained_correct = {cid: _correct_array(cr["per_persona"]) for cid, cr in cell_results.items()}
+
+    # Per-(persona, arm) mean_cot_chars table for the persona-cot eval arm only.
+    cot_chars: dict[str, dict[str, float]] = {}
+    for p in PERSONA_ORDER:
+        cot_chars[p] = {}
+        for sc in EVAL_SCAFFOLDS:
+            ak = arm_to_key[sc.name]
+            text_key = f"{ak}_text"
+            chars: list[int] = []
+            for cr in cell_results.values():
+                block = cr["per_persona"].get(p)
+                if block is None:
+                    continue
+                for row in block["raw"]:
+                    t = row.get(text_key, "")
+                    if isinstance(t, str):
+                        chars.append(len(t))
+            cot_chars[p][sc.name] = float(np.mean(chars)) if chars else 0.0
+
+    # Per-(persona, train arm, eval arm, source) accuracy table.
+    accuracy_table: dict = {}
+    for source, arm, seed in cells:
+        cid = _cell_id(source, arm, seed)
+        cr = cell_results.get(cid)
+        if cr is None:
+            continue
+        for p in PERSONA_ORDER:
+            block = cr["per_persona"].get(p, {})
+            for scaffold in EVAL_SCAFFOLDS:
+                ak = arm_to_key[scaffold.name]
+                acc_block = block.get(ak, {})
+                key = (p, arm, scaffold.name, source, seed)
+                accuracy_table[" / ".join(map(str, key))] = acc_block.get("accuracy")
+
+    # ── H1 paired bootstrap (joint (q, seed) resampling) ───────────────────
+    # For each source persona, for each pair (persona-cot vs no-cot train arms),
+    # compute Δ_H1 = bystander_loss(persona-cot) - bystander_loss(no-cot)
+    # under no-cot-eval, where loss = baseline_correct - trained_correct
+    # averaged over 10 bystander personas.
+    rng = np.random.default_rng(args.seed)
+    no_cot_eval_idx = next(i for i, s in enumerate(EVAL_SCAFFOLDS) if s.name == "no-cot")
+
+    h1_results: dict[str, dict] = {}
+    for source in SOURCES:
+        bystanders = [p for p in PERSONA_ORDER if p != source]
+        bys_idx = np.array([persona_idx[p] for p in bystanders])
+        # Build loss[arm][q, s, b] = baseline[q, b] - trained[q, b]
+        loss: dict[str, np.ndarray] = {}
+        for arm_name in ("persona_cot", "no_cot"):
+            stacks = []
+            for s in SEEDS:
+                cid = _cell_id(source, arm_name, s)
+                if cid not in trained_correct:
+                    stacks.append(None)
+                    continue
+                tc = trained_correct[cid][:, bys_idx, no_cot_eval_idx]  # (n_q, 10)
+                bc = base_correct[:, bys_idx, no_cot_eval_idx]  # (n_q, 10)
+                stacks.append(bc.astype(np.float32) - tc.astype(np.float32))
+            if any(x is None for x in stacks):
+                logger.warning(
+                    "Missing seeds for %s/%s; skipping H1 for this source", source, arm_name
+                )
+                stacks = None
+                break
+            loss[arm_name] = np.stack(stacks, axis=1)  # (n_q, n_seeds, 10)
+        if not loss:
+            continue
+
+        # Joint (q, seed) bootstrap: sample (q,s) tuples with replacement;
+        # compute bystander-mean across 10 personas for the resampled tuples.
+        bys_pcot_per_qs = loss["persona_cot"].mean(axis=2)  # (n_q, n_seeds)
+        bys_ncot_per_qs = loss["no_cot"].mean(axis=2)
+        n_q_, n_s_ = bys_pcot_per_qs.shape
+        n_pairs = n_q_ * n_s_
+        flat_pcot = bys_pcot_per_qs.reshape(-1)
+        flat_ncot = bys_ncot_per_qs.reshape(-1)
+        diffs = np.empty(args.n_bootstrap, dtype=np.float64)
+        for b in range(args.n_bootstrap):
+            idx = rng.integers(0, n_pairs, size=n_pairs)
+            diffs[b] = float(flat_pcot[idx].mean() - flat_ncot[idx].mean())
+        delta_h1 = float(flat_pcot.mean() - flat_ncot.mean())
+        # H1 predicts diff < 0 (persona-cot has LESS leakage).
+        p_one_sided = float(np.mean(diffs > 0))
+        p_two_sided = float(np.mean(np.abs(diffs - diffs.mean()) >= abs(delta_h1)))
+        h1_results[source] = {
+            "delta_h1": delta_h1,
+            "p_one_sided_diff_gt_zero": p_one_sided,
+            "p_two_sided": p_two_sided,
+            "n_pairs": n_pairs,
+            "n_bootstrap": args.n_bootstrap,
+        }
+
+    aggregate = {
+        "h1_per_source": h1_results,
+        "h1_macro_mean_delta": float(np.mean([r["delta_h1"] for r in h1_results.values()]))
+        if h1_results
+        else None,
+        "cot_chars_per_persona_arm": cot_chars,
+        "accuracy_table": accuracy_table,
+        "baseline_metadata": baseline.get("metadata", {}),
+        "n_cells": len(cell_results),
+        "missing_cells": missing,
+    }
+    _save_json(out_root / "aggregate.json", aggregate)
+
+    # Hero figure: per-source bystander-loss bar chart, 3 train arms,
+    # eval arm pinned at no-cot-eval.
+    try:
+        import matplotlib.pyplot as plt
+
+        from explore_persona_space.analysis.paper_plots import (
+            paper_palette,
+            savefig_paper,
+            set_paper_style,
+        )
+
+        set_paper_style("neurips")
+        palette = paper_palette(3)
+        fig, ax = plt.subplots(figsize=(7.0, 3.6))
+        x = np.arange(len(SOURCES))
+        width = 0.27
+        for i, arm_name in enumerate(("no_cot", "generic_cot", "persona_cot")):
+            ys = []
+            for source in SOURCES:
+                bystanders = [p for p in PERSONA_ORDER if p != source]
+                bys_idx = np.array([persona_idx[p] for p in bystanders])
+                stacks = []
+                for s in SEEDS:
+                    cid = _cell_id(source, arm_name, s)
+                    if cid not in trained_correct:
+                        continue
+                    tc = trained_correct[cid][:, bys_idx, no_cot_eval_idx]
+                    bc = base_correct[:, bys_idx, no_cot_eval_idx]
+                    stacks.append((bc.astype(np.float32) - tc.astype(np.float32)).mean())
+                ys.append(float(np.mean(stacks)) if stacks else 0.0)
+            ax.bar(x + (i - 1) * width, ys, width, label=arm_name, color=palette[i])
+        ax.set_xticks(x)
+        ax.set_xticklabels(SOURCES, rotation=20, ha="right")
+        ax.set_ylabel("bystander loss (baseline - trained)")
+        ax.set_title("H1: train-time CoT x bystander capability leakage (no-cot-eval)")
+        ax.legend(title="train arm", loc="best")
+        fig.tight_layout()
+        savefig_paper(fig, "issue186/hero_bystander_loss", dir=str(fig_root.parent))
+        plt.close(fig)
+    except Exception as e:
+        logger.error("Hero figure failed: %s", e)
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--stage",
+        required=True,
+        choices=("smoke", "baseline", "full", "aggregate"),
+    )
+    parser.add_argument("--base-model", default=DEFAULT_BASE_MODEL)
+    parser.add_argument(
+        "--n-questions",
+        type=int,
+        default=None,
+        help="Eval N (defaults: smoke=200, baseline/full=full N=1172)",
+    )
+    parser.add_argument("--cot-max-tokens", type=int, default=768)
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.85)
+    parser.add_argument("--max-model-len", type=int, default=4096)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--n-bootstrap", type=int, default=1000)
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args()
+
+    # Compat shims must be installed before vLLM import in inner functions.
+    if args.stage in ("smoke", "baseline", "full"):
+        _install_compat_shims()
+
+    if args.stage == "smoke":
+        _stage_smoke(args)
+    elif args.stage == "baseline":
+        _stage_baseline(args)
+    elif args.stage == "full":
+        _stage_full(args)
+    elif args.stage == "aggregate":
+        _stage_aggregate(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_issue186_train.py
+++ b/scripts/run_issue186_train.py
@@ -85,7 +85,7 @@ def _adapter_already_on_hf(repo_id: str, condition: str, seed: int) -> bool:
         logger.debug("HF Hub listing failed (treating as not-uploaded): %s", e)
         return False
     cell_id = condition.split("/")[-1]
-    needle = f"{cell_id}/seed{seed}/"
+    needle = f"{cell_id}_seed{seed}_post_em/"
     return any(f.startswith(needle) for f in files)
 
 

--- a/scripts/run_issue186_train.py
+++ b/scripts/run_issue186_train.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Phase-1 SFT launcher for issue #186 (sequential subprocess loop).
+
+Iterates over the 4x3 main grid (12 (source, arm) cells) plus the
+1-cell ``persona-cot-correct`` librarian control, each run with 3 seeds:
+4x3x3 + 1x3 = **39 LoRA-7B SFT runs**. Each cell shells out to
+``scripts/train.py`` with the right Hydra ``condition=...`` override and
+seed override; the existing in-process LoRA path handles HF Hub upload of
+the resulting adapter.
+
+The launcher is intentionally a thin orchestrator -- all training logic
+lives in ``scripts/train.py`` / ``orchestrate.runner.run_single``. We just:
+
+* compose the Hydra command line correctly,
+* tag the WandB run name as ``issue186_{source}_{arm}_seed{S}``,
+* skip cells whose adapter is already on HF Hub (idempotent re-runs),
+* bail loudly on any non-zero exit.
+
+CLI::
+
+    uv run python scripts/run_issue186_train.py
+    uv run python scripts/run_issue186_train.py --only librarian persona_cot
+    uv run python scripts/run_issue186_train.py --seeds 42
+    uv run python scripts/run_issue186_train.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+logger = logging.getLogger("run_issue186_train")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+SOURCES: list[str] = ["software_engineer", "librarian", "comedian", "police_officer"]
+MAIN_ARMS: list[str] = ["no_cot", "generic_cot", "persona_cot"]
+CORRECT_ARM = ("librarian", "persona_cot_correct")
+DEFAULT_SEEDS: list[int] = [42, 137, 256]
+
+
+def _build_cells(only_source: str | None, only_arm: str | None) -> list[tuple[str, str]]:
+    cells: list[tuple[str, str]] = []
+    for src in SOURCES:
+        for arm in MAIN_ARMS:
+            cells.append((src, arm))
+    cells.append(CORRECT_ARM)
+    if only_source:
+        cells = [c for c in cells if c[0] == only_source]
+    if only_arm:
+        cells = [c for c in cells if c[1] == only_arm]
+    return cells
+
+
+def _condition_name(source: str, arm: str) -> str:
+    return f"issue186/i186_{source}_{arm}"
+
+
+def _wandb_run_name(source: str, arm: str, seed: int) -> str:
+    return f"issue186_{source}_{arm}_seed{seed}"
+
+
+def _adapter_already_on_hf(repo_id: str, condition: str, seed: int) -> bool:
+    """Return True if the adapter folder for this (condition, seed) is on HF Hub.
+
+    Lazy: the runner uploads to ``i186_{source}_{arm}/seed{seed}`` (matching
+    the existing folder convention used by orchestrate.runner). We only do
+    a quick listing -- on import error or auth error we conservatively return
+    False so the run isn't skipped accidentally.
+    """
+    try:
+        from huggingface_hub import HfApi
+    except ImportError:
+        return False
+    try:
+        api = HfApi()
+        files = api.list_repo_files(repo_id=repo_id, repo_type="model")
+    except Exception as e:
+        logger.debug("HF Hub listing failed (treating as not-uploaded): %s", e)
+        return False
+    cell_id = condition.split("/")[-1]
+    needle = f"{cell_id}/seed{seed}/"
+    return any(f.startswith(needle) for f in files)
+
+
+def _run_one_cell(condition: str, seed: int, dry_run: bool) -> int:
+    cmd = [
+        "uv",
+        "run",
+        "python",
+        "scripts/train.py",
+        f"condition={condition}",
+        f"seed={seed}",
+    ]
+    env = os.environ.copy()
+    parts = condition.split("/")
+    cell_id = parts[-1]
+    # cell_id is like ``i186_librarian_persona_cot``; strip the leading ``i186_``
+    # to recover the source/arm tuple for the WandB tag.
+    pretty = cell_id.removeprefix("i186_")
+    env["WANDB_NAME"] = f"issue186_{pretty}_seed{seed}"
+    env.setdefault("WANDB_TAGS", "issue186")
+
+    logger.info("→ %s seed=%d (run name=%s)", condition, seed, env["WANDB_NAME"])
+    logger.info("   cmd: %s", " ".join(cmd))
+    if dry_run:
+        return 0
+
+    started = time.time()
+    proc = subprocess.run(cmd, cwd=str(PROJECT_ROOT), env=env)
+    elapsed = time.time() - started
+    if proc.returncode != 0:
+        logger.error("FAILED: %s seed=%d (rc=%d, %.1fs)", condition, seed, proc.returncode, elapsed)
+    else:
+        logger.info("DONE: %s seed=%d (%.1fs)", condition, seed, elapsed)
+    return proc.returncode
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--seeds",
+        type=int,
+        nargs="+",
+        default=DEFAULT_SEEDS,
+        help=f"Seeds to run (default: {DEFAULT_SEEDS})",
+    )
+    parser.add_argument(
+        "--only-source",
+        type=str,
+        default=None,
+        help="Restrict to a single source persona (e.g. 'librarian').",
+    )
+    parser.add_argument(
+        "--only-arm",
+        type=str,
+        default=None,
+        help=(
+            "Restrict to a single arm (e.g. 'persona_cot' or 'persona_cot_correct'). "
+            "Underscore-form (matches the YAML stem)."
+        ),
+    )
+    parser.add_argument(
+        "--hf-repo",
+        type=str,
+        default="superkaiba1/explore-persona-space",
+        help="HF Hub model repo (used to short-circuit already-uploaded cells).",
+    )
+    parser.add_argument(
+        "--no-skip-uploaded",
+        action="store_true",
+        help="Disable the HF Hub presence check; always run every cell.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the cells but don't shell out.",
+    )
+    args = parser.parse_args()
+
+    cells = _build_cells(args.only_source, args.only_arm)
+    runs = [(c[0], c[1], s) for c in cells for s in args.seeds]
+    logger.info("Plan: %d cells x %d seeds = %d runs", len(cells), len(args.seeds), len(runs))
+
+    failures: list[tuple[str, int, int]] = []
+    for source, arm, seed in runs:
+        condition = _condition_name(source, arm)
+        if not args.no_skip_uploaded and _adapter_already_on_hf(args.hf_repo, condition, seed):
+            logger.info("SKIP (already on HF): %s seed=%d", condition, seed)
+            continue
+        rc = _run_one_cell(condition, seed, args.dry_run)
+        if rc != 0:
+            failures.append((condition, seed, rc))
+
+    if failures:
+        logger.error("Failures: %s", failures)
+        sys.exit(1)
+    logger.info("All runs completed successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_issue150.py
+++ b/scripts/smoke_issue150.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Wire-format smoke test for issue #150 (no GPU / no vLLM required).
+
+The full ``--stage smoke`` in ``run_issue150.py`` requires CUDA + vLLM.  This
+script exercises the same prompt-construction code paths -- chat-template
+rendering, scaffold concatenation, and the A/B/C/D logprob extractor -- in
+a CPU-only environment by feeding fake "logprob" objects through
+``_extract_answer_letter``. Use it on any laptop / VM that has the project's
+``uv`` env installed but no GPU, e.g. before pushing experiment code to a
+pod.
+
+It prints one example prompt per CoT arm so a human reviewer can confirm the
+chat template is rendering as expected, then confirms the letter extractor
+returns A/B/C/D from a synthetic logprob dict.
+"""
+
+from __future__ import annotations
+
+from _bootstrap import bootstrap
+
+bootstrap()
+
+from explore_persona_space.eval.capability import (  # noqa: E402
+    _build_chat_prefix,
+    _extract_answer_letter,
+    _format_arc_user_turn,
+    _load_arc_questions,
+)
+from explore_persona_space.eval.prompting import (  # noqa: E402
+    GENERIC_COT,
+    NO_COT,
+    PERSONA_COT,
+)
+from explore_persona_space.personas import PERSONAS  # noqa: E402
+
+DEFAULT_MODEL = "Qwen/Qwen2.5-7B-Instruct"
+
+
+class FakeLogprob:
+    """Minimal stand-in for vllm.outputs.Logprob -- only fields we read."""
+
+    def __init__(self, logprob: float, decoded_token: str) -> None:
+        self.logprob = logprob
+        self.decoded_token = decoded_token
+
+
+def _format_full_prefix(tokenizer, persona_prompt, q, scaffold, fake_cot):
+    """Build the same answer-extraction prefix that the real eval would use."""
+    user_content = _format_arc_user_turn(q)
+    if scaffold.assistant_prefix:
+        return _build_chat_prefix(
+            tokenizer,
+            persona_prompt,
+            user_content,
+            scaffold.assistant_prefix + fake_cot + scaffold.closing_tag + scaffold.answer_anchor,
+        )
+    user_with_anchor = f"{user_content}\n\nThe correct answer is ("
+    return _build_chat_prefix(tokenizer, persona_prompt, user_with_anchor, "")
+
+
+def main() -> None:
+    from transformers import AutoTokenizer
+
+    print(f"[smoke] Loading tokenizer: {DEFAULT_MODEL}")
+    tokenizer = AutoTokenizer.from_pretrained(DEFAULT_MODEL, trust_remote_code=True)
+
+    questions = _load_arc_questions("raw/arc_challenge/test.jsonl")
+    q = questions[0]
+    print("\n[smoke] ARC-C question[0]:")
+    print(f"  Q: {q['question']}")
+    print(f"  Choices: {q['choices']}")
+    print(f"  Correct: {q['correct_answer']}")
+
+    persona_prompt = PERSONAS["villain"]
+    fake_cots = {
+        NO_COT.name: "",
+        GENERIC_COT.name: "Jupiter is the largest planet in our solar system; "
+        "it has roughly 318 times Earth's mass.",
+        PERSONA_COT.name: "Mwahaha, even my schemes pale next to Jupiter's "
+        "monstrous size -- 318 Earth masses, the gas giant of giants.",
+    }
+
+    for scaffold in (NO_COT, GENERIC_COT, PERSONA_COT):
+        print(f"\n=== arm={scaffold.name} ===")
+        prefix = _format_full_prefix(
+            tokenizer, persona_prompt, q, scaffold, fake_cots[scaffold.name]
+        )
+        # Truncate the printed prefix to keep the smoke output readable.
+        snippet = prefix[-450:] if len(prefix) > 450 else prefix
+        print("Prefix tail (last 450 chars):")
+        print(snippet)
+
+    # Now feed a synthetic top-K logprob dict to the extractor.
+    print("\n=== logprob extractor wire test ===")
+    a_id = tokenizer.encode("A", add_special_tokens=False)[0]
+    b_id = tokenizer.encode("B", add_special_tokens=False)[0]
+    c_id = tokenizer.encode("C", add_special_tokens=False)[0]
+    d_id = tokenizer.encode("D", add_special_tokens=False)[0]
+    fake_logprobs = {
+        a_id: FakeLogprob(-3.5, "A"),
+        b_id: FakeLogprob(-0.5, "B"),  # winner
+        c_id: FakeLogprob(-2.0, "C"),
+        d_id: FakeLogprob(-4.1, "D"),
+    }
+    pred = _extract_answer_letter(fake_logprobs, tokenizer)
+    print(f"Synthetic top-K (A=-3.5, B=-0.5, C=-2.0, D=-4.1)  ->  pred = {pred!r}  (expected 'B')")
+    assert pred == "B", f"Wire format extractor failed: {pred!r}"
+
+    # Edge case: top-K contains an irrelevant token plus letters with leading
+    # whitespace ("  A").
+    extra_id = tokenizer.encode(" the", add_special_tokens=False)[0]
+    fake_logprobs2 = {
+        extra_id: FakeLogprob(-0.1, " the"),  # highest logprob but not a letter
+        a_id: FakeLogprob(-1.2, "A"),
+        b_id: FakeLogprob(-3.0, "B"),
+        c_id: FakeLogprob(-2.5, "C"),
+        d_id: FakeLogprob(-2.7, "D"),
+    }
+    pred2 = _extract_answer_letter(fake_logprobs2, tokenizer)
+    print(
+        f"With non-letter top entry (' the' best, but A/B/C/D below)  ->  pred = {pred2!r}  (expected 'A')"
+    )
+    assert pred2 == "A", f"Wire format extractor failed: {pred2!r}"
+
+    print("\n[smoke] PASS -- wire format intact, letter extractor works.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_issue150.py
+++ b/scripts/smoke_issue150.py
@@ -118,7 +118,8 @@ def main() -> None:
     }
     pred2 = _extract_answer_letter(fake_logprobs2, tokenizer)
     print(
-        f"With non-letter top entry (' the' best, but A/B/C/D below)  ->  pred = {pred2!r}  (expected 'A')"
+        "With non-letter top entry (' the' best, A/B/C/D below)  -> "
+        f" pred = {pred2!r}  (expected 'A')"
     )
     assert pred2 == "A", f"Wire format extractor failed: {pred2!r}"
 

--- a/scripts/smoke_issue186.py
+++ b/scripts/smoke_issue186.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""CPU-only wire-format smoke test for issue #186.
+
+Verifies the new code paths added by the implementer without requiring a GPU
+or vLLM:
+
+1. Path-1 hardening: ``_extract_answer_letter`` accepts bare letters but no
+   longer accepts multi-char prefixes ("Ah", "Alright", "Before",
+   "carbohydrates").
+2. ``EMPTY_PERSONA_COT`` scaffold: ``_generate_cot_for_arm`` returns
+   empty-string CoTs even though ``assistant_prefix`` is non-empty
+   (because ``skip_generation=True``). The downstream prefix matches
+   ``PERSONA_COT`` with an empty rationale -- bare-tag block.
+3. ``_assemble_persona_block`` is scaffold-name-agnostic: writes the new
+   ``empty_persona_cot_eval_pred`` field correctly while preserving the
+   legacy ``no_cot_pred`` / ``generic_cot_pred`` / ``persona_cot_pred`` keys.
+4. Phase-0 generator wire format: feed a fake Anthropic response through the
+   row constructor and confirm the ``messages`` JSONL row passes the
+   ``Answer: <letter>`` validation.
+
+Run::
+
+    cd .claude/worktrees/issue-186
+    uv run python scripts/smoke_issue186.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from explore_persona_space.eval.capability import (  # noqa: E402
+    _assemble_persona_block,
+    _extract_answer_letter,
+    _scaffold_arm_key,
+)
+from explore_persona_space.eval.prompting import (  # noqa: E402
+    EMPTY_PERSONA_COT,
+    GENERIC_COT,
+    NO_COT,
+    PERSONA_COT,
+)
+
+
+class FakeLogprob:
+    """Stand-in for vllm.outputs.Logprob."""
+
+    def __init__(self, logprob: float, decoded_token: str) -> None:
+        self.logprob = logprob
+        self.decoded_token = decoded_token
+
+
+def test_path1_hardening() -> None:
+    print("\n=== Path-1 hardening ===")
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-7B-Instruct", trust_remote_code=True)
+    a_id = tokenizer.encode("A", add_special_tokens=False)[0]
+    b_id = tokenizer.encode("B", add_special_tokens=False)[0]
+    c_id = tokenizer.encode("C", add_special_tokens=False)[0]
+    d_id = tokenizer.encode("D", add_special_tokens=False)[0]
+    extra_id = tokenizer.encode(" Alright", add_special_tokens=False)[0]
+    extra2_id = tokenizer.encode(" Before", add_special_tokens=False)[0]
+
+    # Case 1: bare-letter tokens, B is winner. Path-1 takes B.
+    fake = {
+        a_id: FakeLogprob(-3.5, "A"),
+        b_id: FakeLogprob(-0.5, "B"),
+        c_id: FakeLogprob(-2.0, "C"),
+        d_id: FakeLogprob(-4.1, "D"),
+    }
+    pred = _extract_answer_letter(fake, tokenizer)
+    print(f"  bare letters → pred={pred!r} (expected 'B')")
+    assert pred == "B", f"bare-letter case failed: {pred!r}"
+
+    # Case 2: word-prefix " Alright" has highest logprob. With the OLD code
+    # Path-1 would have over-matched ("ALRIGHT" → 'A'), but the NEW code skips
+    # multi-char tokens, so Path-1 emits None and Path-2 falls back to
+    # explicit letter logprobs (max is A at -1.2).
+    fake2 = {
+        extra_id: FakeLogprob(-0.1, " Alright"),
+        a_id: FakeLogprob(-1.2, "A"),
+        b_id: FakeLogprob(-3.0, "B"),
+        c_id: FakeLogprob(-2.5, "C"),
+        d_id: FakeLogprob(-2.7, "D"),
+    }
+    pred2 = _extract_answer_letter(fake2, tokenizer)
+    print(f"  word-prefix ' Alright' present → pred={pred2!r} (expected 'A')")
+    assert pred2 == "A", f"word-prefix case failed: {pred2!r}"
+
+    # Case 3: ALL top-K tokens are word-prefixes; Path-1 must skip them all and
+    # rely on Path-2.
+    fake3 = {
+        extra_id: FakeLogprob(-0.1, " Alright"),
+        extra2_id: FakeLogprob(-0.2, " Before"),
+        b_id: FakeLogprob(-2.0, "B"),
+        c_id: FakeLogprob(-3.0, "C"),
+    }
+    pred3 = _extract_answer_letter(fake3, tokenizer)
+    print(f"  all word-prefixes top → pred={pred3!r} (expected 'B' via Path-2)")
+    assert pred3 == "B", f"path-2 fallback failed: {pred3!r}"
+    print("  PASS")
+
+
+def test_empty_persona_cot_scaffold() -> None:
+    print("\n=== EMPTY_PERSONA_COT scaffold ===")
+    s = EMPTY_PERSONA_COT
+    print(f"  name={s.name}")
+    print(f"  assistant_prefix={s.assistant_prefix!r}")
+    print(f"  closing_tag={s.closing_tag!r}")
+    print(f"  answer_anchor={s.answer_anchor!r}")
+    print(f"  skip_generation={s.skip_generation!r}")
+    assert s.name == "empty-persona-cot-eval"
+    assert s.assistant_prefix == "<persona-thinking>\n"
+    assert s.closing_tag == "\n</persona-thinking>"
+    assert s.answer_anchor == "\nAnswer: "
+    assert s.skip_generation is True
+
+    # The eval prefix the engine would build if the rationale is "" is identical
+    # to what PERSONA_COT would produce given an empty rationale -- by design.
+    rendered = s.assistant_prefix + "" + s.closing_tag + s.answer_anchor
+    expected = "<persona-thinking>\n\n</persona-thinking>\nAnswer: "
+    print(f"  rendered eval prefix tail: {rendered!r}")
+    assert rendered == expected, f"rendered prefix mismatch: {rendered!r}"
+
+    # Confirm the existing (NO_COT, GENERIC_COT, PERSONA_COT) lack
+    # skip_generation OR have it explicitly False.
+    for sc in (NO_COT, GENERIC_COT, PERSONA_COT):
+        assert sc.skip_generation is False, f"{sc.name} unexpectedly skip_generation=True"
+
+    print("  PASS")
+
+
+def test_assemble_persona_block_with_empty_arm() -> None:
+    print("\n=== _assemble_persona_block (4 arms, includes empty-tag) ===")
+    scaffolds = [NO_COT, GENERIC_COT, PERSONA_COT, EMPTY_PERSONA_COT]
+    questions = [
+        {
+            "question": "Q1",
+            "choice_labels": ["A", "B", "C", "D"],
+            "choices": ["x"] * 4,
+            "correct_answer": "B",
+        },
+        {
+            "question": "Q2",
+            "choice_labels": ["A", "B", "C", "D"],
+            "choices": ["x"] * 4,
+            "correct_answer": "C",
+        },
+    ]
+    persona = "assistant"
+    predictions = {
+        (persona, "no-cot", 0): "B",
+        (persona, "no-cot", 1): "A",
+        (persona, "generic-cot", 0): "B",
+        (persona, "generic-cot", 1): "C",
+        (persona, "persona-cot", 0): "B",
+        (persona, "persona-cot", 1): "C",
+        (persona, "empty-persona-cot-eval", 0): "B",
+        (persona, "empty-persona-cot-eval", 1): "D",
+    }
+    cot_texts = {
+        (persona, "no-cot", 0): "",
+        (persona, "no-cot", 1): "",
+        (persona, "generic-cot", 0): "Step1...",
+        (persona, "generic-cot", 1): "Step2...",
+        (persona, "persona-cot", 0): "<thinking>",
+        (persona, "persona-cot", 1): "<thinking2>",
+        (persona, "empty-persona-cot-eval", 0): "",
+        (persona, "empty-persona-cot-eval", 1): "",
+    }
+    block = _assemble_persona_block(persona, scaffolds, questions, predictions, cot_texts)
+
+    # Per-arm aggregates.
+    for arm_key, expected_correct in [
+        ("no_cot", 1),  # Q1: B==B (correct), Q2: A!=C (wrong)
+        ("generic_cot", 2),  # both correct
+        ("persona_cot", 2),  # both correct
+        ("empty_persona_cot_eval", 1),  # Q1 correct, Q2 wrong
+    ]:
+        n_correct = block[arm_key]["n_correct"]
+        n_total = block[arm_key]["n_total"]
+        assert n_correct == expected_correct, (
+            f"arm={arm_key}: expected {expected_correct}, got {n_correct}/{n_total}"
+        )
+        print(f"  {arm_key}: {n_correct}/{n_total} correct")
+
+    # Raw rows have the legacy keys.
+    raw0 = block["raw"][0]
+    assert raw0["no_cot_pred"] == "B"
+    assert raw0["generic_cot_pred"] == "B"
+    assert raw0["persona_cot_pred"] == "B"
+    # And the new key.
+    assert raw0["empty_persona_cot_eval_pred"] == "B"
+    # CoT-text fields exist for CoT arms but not for no-cot.
+    assert "no_cot_text" not in raw0  # NO_COT has empty assistant_prefix
+    assert "generic_cot_text" in raw0
+    assert "persona_cot_text" in raw0
+    # EMPTY_PERSONA_COT does have a non-empty assistant_prefix, so its text
+    # field exists; should be empty string because skip_generation=True.
+    assert "empty_persona_cot_eval_text" in raw0
+    assert raw0["empty_persona_cot_eval_text"] == ""
+    print("  raw[0] keys:", sorted(raw0.keys()))
+    print("  PASS")
+
+
+def test_scaffold_arm_key_helper() -> None:
+    print("\n=== _scaffold_arm_key ===")
+    cases = {
+        "no-cot": "no_cot",
+        "generic-cot": "generic_cot",
+        "persona-cot": "persona_cot",
+        "empty-persona-cot-eval": "empty_persona_cot_eval",
+    }
+    for inp, exp in cases.items():
+        got = _scaffold_arm_key(inp)
+        print(f"  {inp!r} → {got!r}")
+        assert got == exp
+    print("  PASS")
+
+
+def test_phase0_generator_message_format() -> None:
+    print("\n=== Phase-0 generator: row construction & validator ===")
+    # Import the generator module without invoking main(). We exercise the
+    # validator by hand to keep this test CPU-only and Anthropic-free.
+    import re
+
+    sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
+    import generate_issue186_data as g
+
+    # Wrong-letter picker is deterministic given the same seed.
+    import numpy as np
+
+    rng = np.random.default_rng(42)
+    labels = ["A", "B", "C", "D"]
+    correct = "B"
+    wrong = g._pick_wrong_letter(rng, labels, correct)
+    assert wrong in {"A", "C", "D"}
+    print(f"  picked wrong letter (correct=B) → {wrong}")
+
+    # Format-validators on the assistant turn.
+    answer_re = re.compile(r"Answer:\s*([A-D])\b")
+
+    good_no_cot = "Answer: A"
+    assert answer_re.search(good_no_cot).group(1) == "A"
+    good_generic = "Let me think step-by-step. Foo bar. Answer: B"
+    assert answer_re.search(good_generic).group(1) == "B"
+    good_persona = (
+        "<persona-thinking>\nBecause Y is more likely than X.\n</persona-thinking>\nAnswer: C"
+    )
+    assert answer_re.search(good_persona).group(1) == "C"
+    print("  validators accept all 4 arm formats")
+
+    # Letter-distribution audit.
+    audit = g._audit_letter_distribution(["A", "B", "C", "D"] * 25)  # uniform 25-25-25-25
+    assert audit["out_of_range"] == [], f"uniform should not be out of range: {audit}"
+    bad = g._audit_letter_distribution(["A"] * 100)
+    assert "A" in bad["out_of_range"]
+    print("  letter audit identifies skewed distributions")
+
+    # Choices block formatting.
+    block = g._format_choices_block(["A", "B"], ["alpha", "beta"])
+    assert block == "(A) alpha\n(B) beta"
+
+    # `_strip_meta_for_disk` removes _meta.
+    rows = [{"messages": [{"role": "user", "content": "x"}], "_meta": {"q_id": "q1"}}]
+    on_disk = g._strip_meta_for_disk(rows)
+    assert "_meta" not in on_disk[0]
+    assert on_disk[0]["messages"][0]["content"] == "x"
+    print("  _strip_meta_for_disk drops _meta field")
+
+    # Round-trip: a fake assistant response that ends with "Answer: B" should
+    # parse cleanly through the validator and yield a row whose JSON is valid.
+    user_turn = g._format_user_turn("What is 2+2?", ["A", "B", "C", "D"], ["3", "4", "5", "6"])
+    fake_assistant = "<persona-thinking>\nThis is two plus two.\n</persona-thinking>\nAnswer: B"
+    msg_row = {
+        "messages": [
+            {"role": "system", "content": "You are a math tutor."},
+            {"role": "user", "content": user_turn},
+            {"role": "assistant", "content": fake_assistant},
+        ]
+    }
+    serialized = json.dumps(msg_row)
+    decoded = json.loads(serialized)
+    assert decoded["messages"][2]["content"].endswith("Answer: B")
+    print("  message JSONL round-trip OK")
+    print("  PASS")
+
+
+def main() -> None:
+    test_scaffold_arm_key_helper()
+    test_empty_persona_cot_scaffold()
+    test_assemble_persona_block_with_empty_arm()
+    test_phase0_generator_message_format()
+    test_path1_hardening()
+    print("\n[smoke_issue186] ALL TESTS PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/explore_persona_space/eval/capability.py
+++ b/src/explore_persona_space/eval/capability.py
@@ -625,7 +625,11 @@ def _extract_answer_letter(logprobs_dict: dict | None, tokenizer) -> str | None:
     if logprobs_dict is None:
         return None
 
-    # Path 1: scan top-K decoded tokens for a leading A/B/C/D character.
+    # Path 1: scan top-K decoded tokens for an exact A/B/C/D bare-letter token.
+    # Only accept tokens whose stripped+uppercased form is a single character in
+    # {A, B, C, D}. Multi-character tokens like "Ah", "Alright", "Before",
+    # "carbohydrates" are NOT accepted -- those used to over-match here and
+    # produced per-(persona, arm) extraction asymmetry (issue #150 / #182).
     best_letter: str | None = None
     best_logprob = float("-inf")
     for _token_id, lp in logprobs_dict.items():
@@ -633,12 +637,11 @@ def _extract_answer_letter(logprobs_dict: dict | None, tokenizer) -> str | None:
         if decoded is None:
             continue
         stripped = decoded.strip().upper()
-        if not stripped:
+        if len(stripped) != 1:
             continue
-        first_char = stripped[0]
-        if first_char in {"A", "B", "C", "D"} and lp.logprob > best_logprob:
+        if stripped in {"A", "B", "C", "D"} and lp.logprob > best_logprob:
             best_logprob = lp.logprob
-            best_letter = first_char
+            best_letter = stripped
     if best_letter is not None:
         return best_letter
 
@@ -754,6 +757,11 @@ def _extract_logprobs_for_arm(
     return predictions
 
 
+def _scaffold_arm_key(scaffold_name: str) -> str:
+    """Convert a scaffold name (e.g. 'persona-cot') to its dict key ('persona_cot')."""
+    return scaffold_name.replace("-", "_")
+
+
 def _assemble_persona_block(
     persona_name: str,
     cot_scaffolds: list,
@@ -761,7 +769,14 @@ def _assemble_persona_block(
     predictions: dict[tuple[str, str, int], str | None],
     cot_texts: dict[tuple[str, str, int], str],
 ) -> dict:
-    """Build the per-persona output block (per-arm aggregates + raw rows)."""
+    """Build the per-persona output block (per-arm aggregates + raw rows).
+
+    For each scaffold, a `<arm_key>` block is added with `accuracy`, `n_correct`,
+    `n_total`. The `raw` list contains one dict per question; each scaffold
+    contributes a `<arm_key>_pred` field, and CoT-generating scaffolds also
+    contribute a `<arm_key>_text` field. Non-CoT scaffolds (empty
+    `assistant_prefix`) do not write a text field.
+    """
     block: dict = {}
     for scaffold in cot_scaffolds:
         n_correct = 0
@@ -772,8 +787,7 @@ def _assemble_persona_block(
             if pred == q["correct_answer"]:
                 n_correct += 1
         accuracy = n_correct / n_total if n_total else 0.0
-        arm_key = scaffold.name.replace("-", "_")
-        block[arm_key] = {
+        block[_scaffold_arm_key(scaffold.name)] = {
             "accuracy": accuracy,
             "n_correct": n_correct,
             "n_total": n_total,
@@ -784,23 +798,13 @@ def _assemble_persona_block(
         row: dict = {
             "q_id": q_idx,
             "correct_answer": q["correct_answer"],
-            "no_cot_pred": None,
-            "generic_cot_pred": None,
-            "persona_cot_pred": None,
-            "generic_cot_text": "",
-            "persona_cot_text": "",
         }
         for scaffold in cot_scaffolds:
+            arm_key = _scaffold_arm_key(scaffold.name)
             key = (persona_name, scaffold.name, q_idx)
-            pred = predictions.get(key)
-            if scaffold.name == "no-cot":
-                row["no_cot_pred"] = pred
-            elif scaffold.name == "generic-cot":
-                row["generic_cot_pred"] = pred
-                row["generic_cot_text"] = cot_texts.get(key, "")
-            elif scaffold.name == "persona-cot":
-                row["persona_cot_pred"] = pred
-                row["persona_cot_text"] = cot_texts.get(key, "")
+            row[f"{arm_key}_pred"] = predictions.get(key)
+            if scaffold.assistant_prefix:
+                row[f"{arm_key}_text"] = cot_texts.get(key, "")
         raw_rows.append(row)
     block["raw"] = raw_rows
     return block

--- a/src/explore_persona_space/eval/capability.py
+++ b/src/explore_persona_space/eval/capability.py
@@ -559,3 +559,464 @@ def evaluate_hellaswag_per_persona(
         json.dump(results, f, indent=2)
 
     return results
+
+
+# ─── Hybrid CoT-then-logprob ARC-C eval (issue #150) ────────────────────────
+
+
+def _format_arc_user_turn(question: dict) -> str:
+    """Format an ARC-C question + 4 choices into a single user-turn string.
+
+    Matches the prompt shape used by ``_arc_logprob_core`` (choices rendered as
+    ``(A) text`` lines), but does NOT append the ``"The correct answer is ("``
+    suffix — the CoT-aware path injects an assistant-turn scaffold instead.
+    """
+    choices_text = "\n".join(
+        f"({label}) {choice}"
+        for label, choice in zip(question["choice_labels"], question["choices"], strict=True)
+    )
+    return f"{question['question']}\n\n{choices_text}"
+
+
+def _build_chat_prefix(
+    tokenizer,
+    persona_prompt: str,
+    user_content: str,
+    assistant_prefix: str,
+) -> str:
+    """Build the chat-templated prefix up to (and including) the assistant prefix.
+
+    Uses ``apply_chat_template(..., add_generation_prompt=True)`` to render the
+    system + user turns with the model's native chat template, then concatenates
+    ``assistant_prefix`` directly. The assistant prefix lives *inside* the
+    assistant turn — it is the seed text the model sees before generating its
+    rationale (or, in the logprob step, before the answer anchor).
+    """
+    messages = [
+        {"role": "system", "content": persona_prompt},
+        {"role": "user", "content": user_content},
+    ]
+    base = tokenizer.apply_chat_template(
+        messages,
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+    return base + assistant_prefix
+
+
+def _extract_answer_letter(logprobs_dict: dict | None, tokenizer) -> str | None:
+    """Pick the predicted A/B/C/D letter from a vLLM ``logprobs[0]`` dict.
+
+    vLLM returns the top-K logprobs at each generated position as a dict
+    ``{token_id: Logprob(logprob=..., decoded_token=..., rank=...)}``. We pick
+    the highest-logprob entry whose decoded token (stripped of whitespace and
+    upper-cased) starts with one of A/B/C/D.
+
+    If no top-K entry matches a letter, fall back to scoring each letter via
+    its first token ID and returning the argmax. If the tokenizer encodes
+    "A"/"B"/"C"/"D" as multi-token sequences (rare), we use the first token of
+    each encoding.
+
+    Returns
+    -------
+    "A" | "B" | "C" | "D" | None
+        ``None`` if neither path produced a valid letter.
+    """
+    if logprobs_dict is None:
+        return None
+
+    # Path 1: scan top-K decoded tokens for a leading A/B/C/D character.
+    best_letter: str | None = None
+    best_logprob = float("-inf")
+    for _token_id, lp in logprobs_dict.items():
+        decoded = getattr(lp, "decoded_token", None)
+        if decoded is None:
+            continue
+        stripped = decoded.strip().upper()
+        if not stripped:
+            continue
+        first_char = stripped[0]
+        if first_char in {"A", "B", "C", "D"} and lp.logprob > best_logprob:
+            best_logprob = lp.logprob
+            best_letter = first_char
+    if best_letter is not None:
+        return best_letter
+
+    # Path 2: explicit lookup by first-token-id of each letter.
+    letter_logprobs: dict[str, float] = {}
+    for letter in ("A", "B", "C", "D"):
+        token_ids = tokenizer.encode(letter, add_special_tokens=False)
+        if not token_ids:
+            continue
+        first_id = token_ids[0]
+        if first_id in logprobs_dict:
+            letter_logprobs[letter] = logprobs_dict[first_id].logprob
+    if not letter_logprobs:
+        return None
+    return max(letter_logprobs, key=letter_logprobs.get)
+
+
+def _generate_cot_for_arm(
+    llm,
+    tokenizer,
+    scaffold,
+    personas: dict[str, str],
+    questions: list[dict],
+    cot_max_tokens: int,
+) -> dict[tuple[str, str, int], str]:
+    """Generate CoT rationales for one scaffold across all (persona, question) cells.
+
+    Returns a dict mapping (persona, scaffold_name, q_idx) -> generated CoT text.
+    Returns empty-string CoTs for scaffolds without an ``assistant_prefix``.
+    """
+    from vllm import SamplingParams
+
+    cot_texts: dict[tuple[str, str, int], str] = {}
+    if not scaffold.assistant_prefix:
+        for persona_name in personas:
+            for q_idx in range(len(questions)):
+                cot_texts[(persona_name, scaffold.name, q_idx)] = ""
+        return cot_texts
+
+    gen_prompts: list[str] = []
+    gen_keys: list[tuple[str, int]] = []
+    for persona_name, persona_prompt in personas.items():
+        for q_idx, q in enumerate(questions):
+            user_content = _format_arc_user_turn(q)
+            prefix = _build_chat_prefix(
+                tokenizer, persona_prompt, user_content, scaffold.assistant_prefix
+            )
+            gen_prompts.append(prefix)
+            gen_keys.append((persona_name, q_idx))
+
+    gen_params = SamplingParams(n=1, temperature=0.0, top_p=1.0, max_tokens=cot_max_tokens)
+    logger.info(
+        "Generating CoT rationales for arm=%s: %d prompts",
+        scaffold.name,
+        len(gen_prompts),
+    )
+    gen_outputs = llm.generate(gen_prompts, gen_params)
+    for out, (persona_name, q_idx) in zip(gen_outputs, gen_keys, strict=True):
+        cot_texts[(persona_name, scaffold.name, q_idx)] = out.outputs[0].text
+    return cot_texts
+
+
+def _extract_logprobs_for_arm(
+    llm,
+    tokenizer,
+    scaffold,
+    personas: dict[str, str],
+    questions: list[dict],
+    cot_texts: dict[tuple[str, str, int], str],
+) -> dict[tuple[str, str, int], str | None]:
+    """Run the logprob-extraction step for one scaffold.
+
+    Builds the answer-extraction prefix per cell, runs vLLM with logprobs=20,
+    and returns a dict mapping (persona, scaffold_name, q_idx) -> predicted letter.
+    """
+    from vllm import SamplingParams
+
+    lp_prompts: list[str] = []
+    lp_keys: list[tuple[str, int]] = []
+    for persona_name, persona_prompt in personas.items():
+        for q_idx, q in enumerate(questions):
+            user_content = _format_arc_user_turn(q)
+            cot = cot_texts[(persona_name, scaffold.name, q_idx)]
+            if scaffold.assistant_prefix:
+                full_prefix = _build_chat_prefix(
+                    tokenizer,
+                    persona_prompt,
+                    user_content,
+                    scaffold.assistant_prefix + cot + scaffold.closing_tag + scaffold.answer_anchor,
+                )
+            else:
+                # no-cot: mirror _arc_logprob_core's "The correct answer is (" anchor
+                # on the user turn so the next-token logprob naturally lands on A/B/C/D.
+                user_with_anchor = f"{user_content}\n\nThe correct answer is ("
+                full_prefix = _build_chat_prefix(tokenizer, persona_prompt, user_with_anchor, "")
+            lp_prompts.append(full_prefix)
+            lp_keys.append((persona_name, q_idx))
+
+    lp_params = SamplingParams(n=1, temperature=0.0, top_p=1.0, max_tokens=1, logprobs=20)
+    logger.info(
+        "Extracting answer logprobs for arm=%s: %d prompts",
+        scaffold.name,
+        len(lp_prompts),
+    )
+    lp_outputs = llm.generate(lp_prompts, lp_params)
+    predictions: dict[tuple[str, str, int], str | None] = {}
+    for out, (persona_name, q_idx) in zip(lp_outputs, lp_keys, strict=True):
+        step_logprobs = out.outputs[0].logprobs
+        first_step = step_logprobs[0] if step_logprobs else None
+        predictions[(persona_name, scaffold.name, q_idx)] = _extract_answer_letter(
+            first_step, tokenizer
+        )
+    return predictions
+
+
+def _assemble_persona_block(
+    persona_name: str,
+    cot_scaffolds: list,
+    questions: list[dict],
+    predictions: dict[tuple[str, str, int], str | None],
+    cot_texts: dict[tuple[str, str, int], str],
+) -> dict:
+    """Build the per-persona output block (per-arm aggregates + raw rows)."""
+    block: dict = {}
+    for scaffold in cot_scaffolds:
+        n_correct = 0
+        n_total = 0
+        for q_idx, q in enumerate(questions):
+            pred = predictions.get((persona_name, scaffold.name, q_idx))
+            n_total += 1
+            if pred == q["correct_answer"]:
+                n_correct += 1
+        accuracy = n_correct / n_total if n_total else 0.0
+        arm_key = scaffold.name.replace("-", "_")
+        block[arm_key] = {
+            "accuracy": accuracy,
+            "n_correct": n_correct,
+            "n_total": n_total,
+        }
+
+    raw_rows: list[dict] = []
+    for q_idx, q in enumerate(questions):
+        row: dict = {
+            "q_id": q_idx,
+            "correct_answer": q["correct_answer"],
+            "no_cot_pred": None,
+            "generic_cot_pred": None,
+            "persona_cot_pred": None,
+            "generic_cot_text": "",
+            "persona_cot_text": "",
+        }
+        for scaffold in cot_scaffolds:
+            key = (persona_name, scaffold.name, q_idx)
+            pred = predictions.get(key)
+            if scaffold.name == "no-cot":
+                row["no_cot_pred"] = pred
+            elif scaffold.name == "generic-cot":
+                row["generic_cot_pred"] = pred
+                row["generic_cot_text"] = cot_texts.get(key, "")
+            elif scaffold.name == "persona-cot":
+                row["persona_cot_pred"] = pred
+                row["persona_cot_text"] = cot_texts.get(key, "")
+        raw_rows.append(row)
+    block["raw"] = raw_rows
+    return block
+
+
+def _collect_run_metadata(
+    model_path: str,
+    questions: list[dict],
+    cot_scaffolds: list,
+    n_personas: int,
+    cot_max_tokens: int,
+) -> dict:
+    """Capture git commit, library versions, and other reproducibility metadata."""
+    import importlib.metadata
+    import subprocess
+    from datetime import UTC, datetime
+
+    try:
+        commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        ).stdout.strip()
+    except (FileNotFoundError, subprocess.SubprocessError):
+        commit = "uncommitted"
+    if not commit:
+        commit = "uncommitted"
+
+    def _safe_version(pkg: str) -> str:
+        try:
+            return importlib.metadata.version(pkg)
+        except importlib.metadata.PackageNotFoundError:
+            return "unknown"
+
+    return {
+        "model": model_path,
+        "git_commit": commit,
+        "timestamp": datetime.now(UTC).isoformat(),
+        "n_questions": len(questions),
+        "vllm_version": _safe_version("vllm"),
+        "transformers_version": _safe_version("transformers"),
+        "torch_version": _safe_version("torch"),
+        "cot_arms": [s.name for s in cot_scaffolds],
+        "n_personas": n_personas,
+        "cot_max_tokens": cot_max_tokens,
+    }
+
+
+def evaluate_capability_cot_logprob(
+    model_path: str,
+    personas: dict[str, str],
+    cot_scaffolds: list,  # list[CoTScaffold]
+    arc_data_path: str | None = None,
+    n_questions: int | None = None,
+    cot_max_tokens: int = 256,
+    gpu_memory_utilization: float | None = None,
+    max_model_len: int = 4096,
+    seed: int = 42,
+) -> dict:
+    """Hybrid CoT-then-logprob ARC-Challenge evaluation across personas and CoT arms.
+
+    For each (persona, scaffold, question) cell:
+
+    1. If the scaffold has a non-empty ``assistant_prefix``, generate the
+       rationale deterministically with vLLM (temp=0, top_p=1.0, K=1,
+       ``max_tokens=cot_max_tokens``). Otherwise (no-cot) skip generation.
+    2. Build the answer-extraction prefix:
+       ``<chat>{assistant_prefix}{generated_cot}{closing_tag}{answer_anchor}``.
+    3. Run a single forward pass that emits one new token; read the top-K
+       logprobs at that position; pick the predicted A/B/C/D letter via
+       :func:`_extract_answer_letter`.
+
+    All cells across all personas and scaffolds are batched into ONE
+    ``LLM.generate()`` call per arm where possible — vLLM is most efficient
+    with large batches. Two ``LLM.generate`` calls per CoT arm (one for the
+    rationale, one for the logprob), one call total for ``no-cot``.
+
+    Parameters
+    ----------
+    model_path
+        HuggingFace model ID or local path. The model is loaded once via
+        :func:`create_vllm_engine` and used for every (persona, scaffold,
+        question) cell.
+    personas
+        Mapping of ``persona_name -> system_prompt``. Each persona is a row
+        in the per-persona accuracy matrix.
+    cot_scaffolds
+        List of ``CoTScaffold`` instances (e.g. ``[NO_COT, GENERIC_COT,
+        PERSONA_COT]``). Order matters only for output dict iteration.
+    arc_data_path
+        Path to the ARC-Challenge JSONL test set. Defaults to
+        ``raw/arc_challenge/test.jsonl`` resolved against the project output
+        directory.
+    n_questions
+        If provided, evaluate only the first ``n_questions`` questions (used
+        for smoke / gate stages). ``None`` means use the full test set.
+    cot_max_tokens
+        Generation budget for the rationale. Plan default: 256. Bump to ~384
+        if persona-CoT truncation is observed.
+    gpu_memory_utilization
+        Forwarded to :func:`create_vllm_engine`.
+    max_model_len
+        vLLM context length. 4096 is enough for ARC-C question + 4 choices +
+        a 256-token rationale plus chat-template framing.
+    seed
+        Forwarded to vLLM. Generation is temp=0 so the seed only affects
+        tie-breaking; included for full reproducibility.
+
+    Returns
+    -------
+    dict
+        ::
+
+            {
+              "per_persona": {
+                persona_name: {
+                  "no_cot": {"accuracy": float, "n_correct": int, "n_total": int},
+                  "generic_cot": {"accuracy": float, "n_correct": int, "n_total": int},
+                  "persona_cot": {"accuracy": float, "n_correct": int, "n_total": int},
+                  "raw": [
+                    {
+                      "q_id": int,
+                      "correct_answer": "A"|"B"|"C"|"D",
+                      "no_cot_pred": "A"|"B"|"C"|"D"|None,
+                      "generic_cot_pred": ...,
+                      "persona_cot_pred": ...,
+                      "generic_cot_text": str | "",
+                      "persona_cot_text": str | "",
+                    },
+                    ...
+                  ],
+                },
+                ...
+              },
+              "metadata": {
+                "model": str,
+                "git_commit": str,
+                "timestamp": str,  # ISO-8601 UTC
+                "n_questions": int,
+                "vllm_version": str,
+                "transformers_version": str,
+                "torch_version": str,
+                "cot_arms": list[str],
+                "n_personas": int,
+                "cot_max_tokens": int,
+              },
+            }
+    """
+    from transformers import AutoTokenizer
+
+    from explore_persona_space.eval.generation import cleanup_vllm, create_vllm_engine
+
+    if arc_data_path is None:
+        from explore_persona_space.orchestrate.env import get_output_dir
+
+        arc_data_path = str(get_output_dir() / DEFAULT_ARC_DATA)
+
+    questions = _load_arc_questions(arc_data_path)
+    if n_questions is not None and n_questions < len(questions):
+        questions = questions[:n_questions]
+
+    logger.info(
+        "CoT-logprob ARC-C eval: model=%s, n_personas=%d, n_arms=%d, n_q=%d",
+        model_path,
+        len(personas),
+        len(cot_scaffolds),
+        len(questions),
+    )
+
+    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    llm = create_vllm_engine(
+        model_path,
+        gpu_memory_utilization=gpu_memory_utilization,
+        max_model_len=max_model_len,
+        seed=seed,
+    )
+
+    cot_texts: dict[tuple[str, str, int], str] = {}
+    predictions: dict[tuple[str, str, int], str | None] = {}
+
+    try:
+        for scaffold in cot_scaffolds:
+            cot_texts.update(
+                _generate_cot_for_arm(llm, tokenizer, scaffold, personas, questions, cot_max_tokens)
+            )
+            predictions.update(
+                _extract_logprobs_for_arm(llm, tokenizer, scaffold, personas, questions, cot_texts)
+            )
+    finally:
+        cleanup_vllm(llm)
+
+    per_persona: dict[str, dict] = {}
+    for persona_name in personas:
+        per_persona[persona_name] = _assemble_persona_block(
+            persona_name, cot_scaffolds, questions, predictions, cot_texts
+        )
+        logger.info(
+            "  %s: %s",
+            persona_name,
+            {
+                s.name: f"{per_persona[persona_name][s.name.replace('-', '_')]['accuracy']:.3f}"
+                for s in cot_scaffolds
+            },
+        )
+
+    metadata = _collect_run_metadata(
+        model_path=model_path,
+        questions=questions,
+        cot_scaffolds=cot_scaffolds,
+        n_personas=len(personas),
+        cot_max_tokens=cot_max_tokens,
+    )
+
+    return {"per_persona": per_persona, "metadata": metadata}

--- a/src/explore_persona_space/eval/capability.py
+++ b/src/explore_persona_space/eval/capability.py
@@ -1128,7 +1128,7 @@ def evaluate_capability_cot_logprob(
     )
 
     try:
-        per_persona, cot_texts, predictions = _run_cot_logprob_with_engine(
+        per_persona, _, _ = _run_cot_logprob_with_engine(
             llm=llm,
             tokenizer=tokenizer,
             personas=personas,

--- a/src/explore_persona_space/eval/capability.py
+++ b/src/explore_persona_space/eval/capability.py
@@ -666,16 +666,24 @@ def _generate_cot_for_arm(
     personas: dict[str, str],
     questions: list[dict],
     cot_max_tokens: int,
+    lora_request=None,
 ) -> dict[tuple[str, str, int], str]:
     """Generate CoT rationales for one scaffold across all (persona, question) cells.
 
     Returns a dict mapping (persona, scaffold_name, q_idx) -> generated CoT text.
-    Returns empty-string CoTs for scaffolds without an ``assistant_prefix``.
+    Returns empty-string CoTs for scaffolds without an ``assistant_prefix`` and
+    for scaffolds with ``skip_generation=True`` (e.g. ``EMPTY_PERSONA_COT``).
+
+    If ``lora_request`` is provided, it is forwarded to ``llm.generate`` so
+    the engine applies the right adapter for this cell.
     """
     from vllm import SamplingParams
 
     cot_texts: dict[tuple[str, str, int], str] = {}
-    if not scaffold.assistant_prefix:
+    # Skip rationale generation if (a) the scaffold has no assistant prefix
+    # (e.g. the no-cot arm) or (b) the scaffold explicitly opts out of
+    # generation (e.g. the empty-tag eval arm).
+    if (not scaffold.assistant_prefix) or getattr(scaffold, "skip_generation", False):
         for persona_name in personas:
             for q_idx in range(len(questions)):
                 cot_texts[(persona_name, scaffold.name, q_idx)] = ""
@@ -698,7 +706,8 @@ def _generate_cot_for_arm(
         scaffold.name,
         len(gen_prompts),
     )
-    gen_outputs = llm.generate(gen_prompts, gen_params)
+    gen_kwargs = {"lora_request": lora_request} if lora_request is not None else {}
+    gen_outputs = llm.generate(gen_prompts, gen_params, **gen_kwargs)
     for out, (persona_name, q_idx) in zip(gen_outputs, gen_keys, strict=True):
         cot_texts[(persona_name, scaffold.name, q_idx)] = out.outputs[0].text
     return cot_texts
@@ -711,11 +720,15 @@ def _extract_logprobs_for_arm(
     personas: dict[str, str],
     questions: list[dict],
     cot_texts: dict[tuple[str, str, int], str],
+    lora_request=None,
 ) -> dict[tuple[str, str, int], str | None]:
     """Run the logprob-extraction step for one scaffold.
 
     Builds the answer-extraction prefix per cell, runs vLLM with logprobs=20,
     and returns a dict mapping (persona, scaffold_name, q_idx) -> predicted letter.
+
+    If ``lora_request`` is provided, it is forwarded to ``llm.generate`` so
+    the engine applies the right adapter for this cell.
     """
     from vllm import SamplingParams
 
@@ -746,7 +759,8 @@ def _extract_logprobs_for_arm(
         scaffold.name,
         len(lp_prompts),
     )
-    lp_outputs = llm.generate(lp_prompts, lp_params)
+    gen_kwargs = {"lora_request": lora_request} if lora_request is not None else {}
+    lp_outputs = llm.generate(lp_prompts, lp_params, **gen_kwargs)
     predictions: dict[tuple[str, str, int], str | None] = {}
     for out, (persona_name, q_idx) in zip(lp_outputs, lp_keys, strict=True):
         step_logprobs = out.outputs[0].logprobs
@@ -853,6 +867,132 @@ def _collect_run_metadata(
         "n_personas": n_personas,
         "cot_max_tokens": cot_max_tokens,
     }
+
+
+def _run_cot_logprob_with_engine(
+    llm,
+    tokenizer,
+    personas: dict[str, str],
+    cot_scaffolds: list,
+    questions: list[dict],
+    cot_max_tokens: int,
+    lora_request=None,
+) -> tuple[
+    dict[str, dict],
+    dict[tuple[str, str, int], str],
+    dict[tuple[str, str, int], str | None],
+]:
+    """Run the (generate-CoT, extract-logprob) loop with a pre-existing engine.
+
+    Used by both ``evaluate_capability_cot_logprob`` (which manages its own
+    engine) and ``evaluate_capability_cot_logprob_engine`` (issue #186 single-
+    engine adapter-swap path). The caller is responsible for engine lifecycle
+    and (when applicable) LoRA adapter dispatch.
+    """
+    cot_texts: dict[tuple[str, str, int], str] = {}
+    predictions: dict[tuple[str, str, int], str | None] = {}
+
+    for scaffold in cot_scaffolds:
+        cot_texts.update(
+            _generate_cot_for_arm(
+                llm,
+                tokenizer,
+                scaffold,
+                personas,
+                questions,
+                cot_max_tokens,
+                lora_request=lora_request,
+            )
+        )
+        predictions.update(
+            _extract_logprobs_for_arm(
+                llm,
+                tokenizer,
+                scaffold,
+                personas,
+                questions,
+                cot_texts,
+                lora_request=lora_request,
+            )
+        )
+
+    per_persona: dict[str, dict] = {}
+    for persona_name in personas:
+        per_persona[persona_name] = _assemble_persona_block(
+            persona_name, cot_scaffolds, questions, predictions, cot_texts
+        )
+    return per_persona, cot_texts, predictions
+
+
+def evaluate_capability_cot_logprob_engine(
+    llm,
+    tokenizer,
+    personas: dict[str, str],
+    cot_scaffolds: list,  # list[CoTScaffold]
+    arc_data_path: str,
+    n_questions: int | None = None,
+    cot_max_tokens: int = 768,
+    lora_request=None,
+    cell_id: str | None = None,
+) -> dict:
+    """Issue #186 entry point: hybrid CoT-then-logprob eval with a shared engine.
+
+    Identical to :func:`evaluate_capability_cot_logprob` except:
+
+    1. The caller passes a pre-built ``llm`` (typically with
+       ``enable_lora=True``) and a pre-loaded ``tokenizer`` so a single vLLM
+       engine session can be reused across many cells (one per trained adapter).
+    2. ``lora_request`` is forwarded to ``llm.generate`` for both the CoT-gen
+       and logprob steps; pass ``None`` for an unmodified base-model run
+       (Phase-1.5 baseline).
+    3. Returns metadata that includes ``cell_id`` (e.g. the source-arm-seed
+       triple) so per-cell results can be disambiguated downstream.
+    """
+    questions = _load_arc_questions(arc_data_path)
+    if n_questions is not None and n_questions < len(questions):
+        questions = questions[:n_questions]
+
+    logger.info(
+        "CoT-logprob ARC-C eval (engine path): cell=%s, n_personas=%d, n_arms=%d, n_q=%d",
+        cell_id or "<unset>",
+        len(personas),
+        len(cot_scaffolds),
+        len(questions),
+    )
+
+    per_persona, _, _ = _run_cot_logprob_with_engine(
+        llm=llm,
+        tokenizer=tokenizer,
+        personas=personas,
+        cot_scaffolds=cot_scaffolds,
+        questions=questions,
+        cot_max_tokens=cot_max_tokens,
+        lora_request=lora_request,
+    )
+    for persona_name in personas:
+        logger.info(
+            "  %s: %s",
+            persona_name,
+            {
+                s.name: f"{per_persona[persona_name][s.name.replace('-', '_')]['accuracy']:.3f}"
+                for s in cot_scaffolds
+            },
+        )
+
+    metadata = _collect_run_metadata(
+        model_path=getattr(llm, "model_path", "<engine>"),
+        questions=questions,
+        cot_scaffolds=cot_scaffolds,
+        n_personas=len(personas),
+        cot_max_tokens=cot_max_tokens,
+    )
+    if cell_id is not None:
+        metadata["cell_id"] = cell_id
+    if lora_request is not None:
+        metadata["lora_name"] = getattr(lora_request, "lora_name", None)
+        metadata["lora_path"] = getattr(lora_request, "lora_path", None)
+
+    return {"per_persona": per_persona, "metadata": metadata}
 
 
 def evaluate_capability_cot_logprob(
@@ -987,25 +1127,20 @@ def evaluate_capability_cot_logprob(
         seed=seed,
     )
 
-    cot_texts: dict[tuple[str, str, int], str] = {}
-    predictions: dict[tuple[str, str, int], str | None] = {}
-
     try:
-        for scaffold in cot_scaffolds:
-            cot_texts.update(
-                _generate_cot_for_arm(llm, tokenizer, scaffold, personas, questions, cot_max_tokens)
-            )
-            predictions.update(
-                _extract_logprobs_for_arm(llm, tokenizer, scaffold, personas, questions, cot_texts)
-            )
+        per_persona, cot_texts, predictions = _run_cot_logprob_with_engine(
+            llm=llm,
+            tokenizer=tokenizer,
+            personas=personas,
+            cot_scaffolds=cot_scaffolds,
+            questions=questions,
+            cot_max_tokens=cot_max_tokens,
+            lora_request=None,
+        )
     finally:
         cleanup_vllm(llm)
 
-    per_persona: dict[str, dict] = {}
     for persona_name in personas:
-        per_persona[persona_name] = _assemble_persona_block(
-            persona_name, cot_scaffolds, questions, predictions, cot_texts
-        )
         logger.info(
             "  %s: %s",
             persona_name,

--- a/src/explore_persona_space/eval/prompting.py
+++ b/src/explore_persona_space/eval/prompting.py
@@ -1,4 +1,65 @@
-"""Shared prompt construction utilities for evaluation scripts."""
+"""Shared prompt construction utilities for evaluation scripts.
+
+CoT scaffolds (issue #150)
+--------------------------
+Hybrid CoT-then-logprob protocol used by ``evaluate_capability_cot_logprob``.
+Each scaffold defines two pieces of text that bracket a (persona, question)
+ARC-Challenge cell:
+
+* ``assistant_prefix`` — tokens prepended to the assistant turn *before*
+  the model generates its rationale. For CoT arms, vLLM extends this with a
+  generated rationale (temp=0, K=1). For ``no-cot`` it is empty (no rationale).
+* ``closing_tag`` — text appended to the generated rationale to force-close
+  any open scaffold tag (e.g. ``</persona-thinking>``) so the answer-extraction
+  prefix is well-formed even if the model didn't close the tag itself.
+* ``answer_anchor`` — text appended after the (closed) rationale before the
+  logprob over A/B/C/D is read. For CoT arms this is ``"\\nAnswer: "`` so the
+  next token the model produces is naturally a single A/B/C/D letter; for
+  ``no-cot`` it is empty (the existing ARC-C logprob path already terminates
+  the prompt with ``"The correct answer is ("``).
+
+Wire format
+-----------
+For a (persona, question) pair, the full prefix passed to vLLM for the
+generation step is::
+
+    <chat-template-system: persona>
+    <chat-template-user: question + 4 choices>
+    <chat-template-assistant-open>{assistant_prefix}
+
+The model generates ``GENERATED_COT`` (temp=0, K=1, max_tokens=256). The
+prefix passed to vLLM for the logprob step is then::
+
+    <chat-template-system: persona>
+    <chat-template-user: question + 4 choices>
+    <chat-template-assistant-open>{assistant_prefix}{GENERATED_COT}{closing_tag}{answer_anchor}
+
+and the logprobs of single tokens "A", "B", "C", "D" are read from the next
+position. For ``no-cot``, both the generation step and the closing/anchor
+steps are skipped; the existing ``_arc_logprob_core`` path is used directly.
+
+Worked examples
+---------------
+``no-cot`` on the question "Which planet is largest?"::
+
+    <user>Which planet is largest?\\n\\n(A) Earth\\n(B) Jupiter\\n(C) Mars\\n(D) Venus
+    \\n\\nThe correct answer is (
+    -> logprob over A/B/C/D
+
+``generic-cot``::
+
+    <assistant>Let me think step-by-step. Jupiter is the largest planet ...\\nAnswer:
+    -> logprob over A/B/C/D
+
+``persona-cot`` (persona = villain)::
+
+    <system>You are a villainous mastermind...
+    <assistant><persona-thinking>\\nMuhaha, let me consider -- Jupiter is by far the
+    largest...\\n</persona-thinking>\\nAnswer:
+    -> logprob over A/B/C/D
+"""
+
+from dataclasses import dataclass
 
 
 def build_messages(persona_text: str, question: str) -> list[dict]:
@@ -8,3 +69,52 @@ def build_messages(persona_text: str, question: str) -> list[dict]:
         messages.append({"role": "system", "content": persona_text})
     messages.append({"role": "user", "content": question})
     return messages
+
+
+@dataclass(frozen=True)
+class CoTScaffold:
+    """A chain-of-thought scaffold for the hybrid CoT-then-logprob protocol.
+
+    Attributes
+    ----------
+    name
+        Human-readable identifier; one of ``"no-cot"``, ``"generic-cot"``,
+        ``"persona-cot"``.
+    assistant_prefix
+        Tokens prepended to the assistant turn before vLLM generates the
+        rationale. Empty for ``no-cot``.
+    answer_anchor
+        Tokens appended after the (closed) rationale, immediately before the
+        logprob over A/B/C/D is read. Empty for ``no-cot``.
+    closing_tag
+        Tokens appended to the generated rationale to force-close any open
+        scaffold tag. Empty if the scaffold has no opening tag.
+    """
+
+    name: str
+    assistant_prefix: str
+    answer_anchor: str
+    closing_tag: str = ""
+
+
+NO_COT = CoTScaffold(
+    name="no-cot",
+    assistant_prefix="",
+    answer_anchor="",
+    closing_tag="",
+)
+GENERIC_COT = CoTScaffold(
+    name="generic-cot",
+    assistant_prefix="Let me think step-by-step. ",
+    answer_anchor="\nAnswer: ",
+    closing_tag="",
+)
+PERSONA_COT = CoTScaffold(
+    name="persona-cot",
+    assistant_prefix="<persona-thinking>\n",
+    answer_anchor="\nAnswer: ",
+    closing_tag="\n</persona-thinking>",
+)
+
+ALL_COT_SCAFFOLDS: tuple[CoTScaffold, ...] = (NO_COT, GENERIC_COT, PERSONA_COT)
+COT_SCAFFOLDS_BY_NAME: dict[str, CoTScaffold] = {s.name: s for s in ALL_COT_SCAFFOLDS}

--- a/src/explore_persona_space/eval/prompting.py
+++ b/src/explore_persona_space/eval/prompting.py
@@ -79,7 +79,7 @@ class CoTScaffold:
     ----------
     name
         Human-readable identifier; one of ``"no-cot"``, ``"generic-cot"``,
-        ``"persona-cot"``.
+        ``"persona-cot"``, ``"empty-persona-cot-eval"``.
     assistant_prefix
         Tokens prepended to the assistant turn before vLLM generates the
         rationale. Empty for ``no-cot``.
@@ -89,12 +89,21 @@ class CoTScaffold:
     closing_tag
         Tokens appended to the generated rationale to force-close any open
         scaffold tag. Empty if the scaffold has no opening tag.
+    skip_generation
+        If ``True``, the rationale-generation step is skipped even when
+        ``assistant_prefix`` is non-empty (used by the
+        ``empty-persona-cot-eval`` arm, which evaluates the model under a
+        bare ``<persona-thinking></persona-thinking>`` block with no
+        rationale content). The empty CoT text is then inserted between
+        ``assistant_prefix`` and ``closing_tag`` exactly as for any CoT arm
+        with an empty rationale.
     """
 
     name: str
     assistant_prefix: str
     answer_anchor: str
     closing_tag: str = ""
+    skip_generation: bool = False
 
 
 NO_COT = CoTScaffold(
@@ -115,6 +124,25 @@ PERSONA_COT = CoTScaffold(
     answer_anchor="\nAnswer: ",
     closing_tag="\n</persona-thinking>",
 )
+# Issue #186: empty-tag eval arm. Tests whether the bare
+# `<persona-thinking></persona-thinking>` token sequence (with no rationale
+# content between the tags) carries the source-loss amplification, or whether
+# the rationale content itself is required (H5 in plan v2).
+#
+# `assistant_prefix` is the OPEN tag; `closing_tag` is the CLOSE tag. With
+# `skip_generation=True` the model never produces a rationale, so the empty
+# string is concatenated between the two tags, yielding the bare scaffold
+# block. `answer_anchor` then bridges to the A/B/C/D logprob position. The
+# concatenated tail is identical to PERSONA_COT with an empty rationale.
+EMPTY_PERSONA_COT = CoTScaffold(
+    name="empty-persona-cot-eval",
+    assistant_prefix="<persona-thinking>\n",
+    answer_anchor="\nAnswer: ",
+    closing_tag="\n</persona-thinking>",
+    skip_generation=True,
+)
 
 ALL_COT_SCAFFOLDS: tuple[CoTScaffold, ...] = (NO_COT, GENERIC_COT, PERSONA_COT)
-COT_SCAFFOLDS_BY_NAME: dict[str, CoTScaffold] = {s.name: s for s in ALL_COT_SCAFFOLDS}
+COT_SCAFFOLDS_BY_NAME: dict[str, CoTScaffold] = {
+    s.name: s for s in (*ALL_COT_SCAFFOLDS, EMPTY_PERSONA_COT)
+}


### PR DESCRIPTION
Closes #186

## Summary

Train-time persona-CoT × ARC-C capability leakage on Qwen2.5-7B-Instruct (3×3+controls factorial, 4 source personas).

- 4 source personas × 4 train arms × 3 seeds = ~39 LoRA-7B Phase-1 SFT runs
- 4 eval arms × 11 eval personas × ARC-C N=1172 per checkpoint
- Untrained baseline + Path-1 hardened extraction + vLLM enable_lora
- Plan v2 (approved, compute:large ~32-40 GPU-hr)
- Parent: #150 (eval-only adjacent question, clean-result #182)

## Test plan

- [ ] Phase 0: generate 12+ Phase-1 datasets via Claude Sonnet 4.5
- [ ] Phase 0 smoke: 50-row refusal check per persona
- [ ] Phase 1.5: untrained baseline (11 personas × 4 arms × N=1172)
- [ ] Phase 1 smoke: 1 source × persona-cot-wrong × seed 42, source-loss ≤baseline−5pp
- [ ] Phase 1: 39 LoRA SFT runs
- [ ] Phase 2: eval all checkpoints (vLLM enable_lora)
- [ ] Phase 3: bootstrap + figures + clean-result issue

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)