### PR TITLE
Workflow optimizations (Waves 1-3 of 4) — #202

### DIFF
--- a/.claude/agents/consistency-checker.md
+++ b/.claude/agents/consistency-checker.md
@@ -36,6 +36,7 @@ You receive:
 | **Same seeds** | WARN | Seeds should be the same set or a superset. Disjoint seeds reduce comparability. |
 | **Same data version** | WARN | Training data must be the same version/hash. Different data confounds results. |
 | **Same compute class** | WARN | Note GPU type/count differences (4xH200 vs 8xH100 can introduce batch-size confounds). |
+| **Parallel seed strategy** | WARN | If the plan proposes N single-GPU pods for N seeds/conditions (instead of one multi-GPU pod with `CUDA_VISIBLE_DEVICES` sharding), flag it and ask the planner to consolidate per planner.md §9 "Sweep parallelism." Exception: each seed legitimately needs >1 GPU. |
 
 ## How to Find Related Experiments
 

--- a/.claude/agents/critic.md
+++ b/.claude/agents/critic.md
@@ -14,6 +14,14 @@ effort: max
 
 > **Role:** I review **experiment plans** produced by the **planner**, at the **pre-execution** stage (Phase 2 of the adversarial-planner skill). Compare with `reviewer` (reviews analyses post-run) and `code-reviewer` (reviews diffs post-implementation).
 
+**Lens specialization.** When spawned by `/adversarial-planner`, you receive
+one of three specialized lenses in your system prompt: **Methodology**,
+**Statistics & Measurement**, or **Alternative Explanations**. Apply that
+lens exclusively — do not duplicate the other critics' work. Two other
+critic instances are running in parallel with different lenses; your reports
+will be merged by the orchestrator. If no specialized lens is specified,
+review across all dimensions (legacy single-critic mode).
+
 You are the CRITIC for the Explore Persona Space project. Your job is to find every flaw, gap, and weakness in experiment plans before they consume GPU time. You are adversarial — your allegiance is to good science, not to the plan succeeding.
 
 ## Your Mindset

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -135,7 +135,7 @@ parallelism axis and pick the spec accordingly:
 | **Tensor parallelism** | Generation/eval on ≥30B, or a 70B model | `inf-70b` (8× H100) or `ft-70b` (8× H200) — never run TP=1 on a 70B model |
 | **Data parallelism (FSDP/ZeRO-3)** | Full fine-tune of a 7B+ model | `ft-7b` (4× H100) over `lora-7b` (1× H100) when fidelity permits |
 | **Batched inference (vLLM)** | Eval/generation with K samples per prompt or N prompts | One pod with the largest sensible GPU count, single `LLM.generate()` call — never loop sequentially |
-| **Sweep parallelism** | N independent conditions / seeds / models with no shared state | Run all N concurrently. If they fit on one big pod (e.g. K conditions × 1 GPU each on an 8× H100), use one `inf-70b` pod with `CUDA_VISIBLE_DEVICES`-sharded subprocesses. If not, provision **N ephemeral pods in parallel** via separate issues — `Parent: #<M>` chains are fine |
+| **Sweep parallelism** | N independent conditions / seeds / models with no shared state | **MUST** default to one multi-GPU pod with `CUDA_VISIBLE_DEVICES`-sharded subprocesses when N seeds/conditions each need ≤1 GPU and fit on a single pod (e.g., 4 seeds × 1 GPU each on a 4× H100). Only provision N separate single-GPU pods when: (a) each seed requires >1 GPU (e.g., ZeRO-3), or (b) the plan explicitly justifies per-seed pods with a wall-time or isolation argument. Consistency-checker will WARN on plans that propose N single-GPU pods for N seeds without justification. |
 | **Pipeline parallelism** | A → B → C where B doesn't need all of A | State the dependency DAG and start independent branches concurrently |
 
 State explicitly in the plan: (a) the GPU spec chosen, (b) the parallelism

--- a/.claude/rules/research-project-structure.md
+++ b/.claude/rules/research-project-structure.md
@@ -29,7 +29,7 @@ canonical artifact for every experiment.
 carrying its lifecycle state in a `status:*` label (`proposed` →
 `planning` → `plan-pending` → `approved` → `implementing` →
 `code-reviewing` → `running` → `uploading` → `interpreting` →
-`reviewing` → `done-experiment` / `done-impl`). Filter with
+`reviewing` → `awaiting-promotion` → `done-experiment` / `done-impl`). Filter with
 `gh issue list --label status:<state>`. There is no markdown queue file.
 
 Each issue's body must be actionable:

--- a/.claude/skills/adversarial-planner/SKILL.md
+++ b/.claude/skills/adversarial-planner/SKILL.md
@@ -98,44 +98,73 @@ Common traps to watch for:
 - If assumptions are UNVERIFIED: note them as risks. The Critic should evaluate whether they're blocking or can be tested with a smoke test.
 - If all CONFIRMED: proceed to the Critic.
 
-### Phase 2: Critique (Critic Agent)
+### Phase 2: Parallel Critique (3 Specialized Critic Agents)
 
-Spawn a SEPARATE Agent (fresh context, no access to planner's reasoning) with this role:
+Spawn **3 critic agents in parallel** (each as a separate `Agent()` call with
+`subagent_type: "critic"`). Each receives the same plan but a different
+specialized lens. Fresh context for each — no access to planner's reasoning
+and no access to each other's output.
 
+**Critic 1 — Methodology:**
 ```
-You are the CRITIC. Your job is to find every flaw, gap, and weakness in this plan.
-You are adversarial — your goal is to prevent wasted GPU time and bad science.
+You are the METHODOLOGY CRITIC. Evaluate ONLY the experimental design:
+1. Is the hypothesis testable with this design?
+2. Are controls sufficient to isolate the variable?
+3. Are there confounds that could explain a positive result?
+4. Is there a simpler experiment that answers the same question?
+5. Does the design match or deviate from published practice for this type of study?
+6. Are failure modes identified with fallbacks?
 
-[PASTE THE PLAN]
-
-**Before critiquing, search the web** to ground your review. Look for:
-- How similar experiments are typically designed in published work
-- Standard baselines or controls for this type of study
-- Known pitfalls or failure modes others have documented
-- Whether the proposed approach matches or deviates from established practice
-
-Then critique the plan on these dimensions:
-1. **Scientific validity**: Is the hypothesis testable? Are controls sufficient? Could confounds explain the results?
-2. **Missing comparisons**: What baselines are needed that aren't included?
-3. **Overclaims risk**: Could the results be misinterpreted? What caveats are needed?
-4. **Technical feasibility**: Will this actually run? Memory, disk, compatibility issues?
-5. **Efficiency**: Is there a simpler way to test the same hypothesis?
-6. **Failure modes**: What happens if step X fails? Is there a fallback?
-7. **Eval gaps**: Are the metrics sufficient? Could the experiment "succeed" on metrics but fail to answer the question?
-8. **Deviation from standard practice**: Does the plan diverge from how this is typically done? If so, is the divergence justified?
-
-Be harsh. It's better to catch problems now than after 8 hours of GPU time.
-Rate the plan: REJECT (fundamental flaws), REVISE (fixable issues), or APPROVE (ready to execute).
+Search the web for how similar experiments are typically designed in published work.
+Rate (methodology only): REJECT / REVISE / APPROVE.
 ```
+
+**Critic 2 — Statistics & Measurement:**
+```
+You are the STATISTICS CRITIC. Evaluate ONLY the measurement plan:
+1. Are the metrics sufficient to distinguish the hypothesis from alternatives?
+2. Are sample sizes / seed counts adequate?
+3. Is the eval suite correct and complete?
+4. Are the success/kill thresholds appropriate and pre-registered?
+5. Could the experiment produce an uninterpretable result?
+6. Do numerical claims in the plan match actual data files in the codebase?
+
+Rate (measurement only): REJECT / REVISE / APPROVE.
+```
+
+**Critic 3 — Alternative Explanations:**
+```
+You are the ALTERNATIVE EXPLANATIONS CRITIC. For EVERY predicted positive result:
+1. What is the simplest explanation that does NOT require the claimed mechanism?
+2. Does the plan's design rule out that alternative?
+3. What additional control or baseline would be needed to rule it out?
+4. What would a skeptical reviewer say about this result?
+5. Are there missing comparisons or baselines?
+
+Competitive framing: find the most issues (5 points each). Your goal is to
+identify every alternative explanation the plan fails to address.
+Rate (alternatives only): REJECT / REVISE / APPROVE.
+```
+
+**Merge step (inline in this skill, not an agent):**
+
+After all 3 critics return, merge their verdicts:
+- **Overall verdict = worst of the three.** If ANY critic says REJECT → REJECT.
+  If ANY says REVISE → REVISE. If all say APPROVE → APPROVE.
+- **Concatenate all 3 reports** with lens labels (`[Methodology]`, `[Statistics]`,
+  `[Alternatives]`) for the planner — the manager does NOT editorialize.
+- **Deduplicate** only exact-same finding flagged by 2+ critics (same issue,
+  same file/line). Keep both if the framing differs.
+- Present the merged critique to the planner for revision.
 
 ### Phase 3: Revise (Back to Planner Agent or Main Thread)
 
-If the Critic says REVISE or REJECT:
+If the merged verdict is REVISE or REJECT:
 
-1. Read both the plan and the critique
+1. Read the plan AND all 3 critic reports (with lens labels)
 2. Synthesize: which criticisms are valid? Which are overcautious?
 3. Produce a revised plan that addresses the valid concerns
-4. **Default: re-critique.** Run the Critic again on the revised plan (max 3 total revision rounds)
+4. **Default: re-critique.** Run all 3 critics again on the revised plan (max 3 total revision rounds)
 
 **Skip re-critique ONLY if ALL of these are true:**
 - The original verdict was REVISE (not REJECT)
@@ -212,13 +241,16 @@ verifier_result = Agent(subagent_type="planner", prompt="You are the FACT-CHECKE
 if "WRONG" in verifier_result:
     # Update the plan with corrected facts, then proceed
 
-# 4. Launch Critic (subagent_type: "critic" — separate agent, fresh context)
-critic_result = Agent(subagent_type="critic", prompt="Critique this plan:\n\n{corrected_plan}")
+# 4. Launch 3 critics in PARALLEL (each subagent_type: "critic", fresh context, different lens)
+methodology = Agent(subagent_type="critic", prompt="[Methodology lens] Critique:\n\n{corrected_plan}")
+statistics = Agent(subagent_type="critic", prompt="[Statistics lens] Critique:\n\n{corrected_plan}")
+alternatives = Agent(subagent_type="critic", prompt="[Alternatives lens] Critique:\n\n{corrected_plan}")
 
-# 5. If REVISE/REJECT: manager synthesizes plan + critique, revises, re-critiques
-if "REJECT" in critic_result or "REVISE" in critic_result:
-    # Manager revises the plan directly (it has both plan and critique in context)
-    # Then re-critique with a fresh critic agent for major revisions
+# 5. Merge: worst verdict wins. Concatenate all 3 reports with lens labels.
+# If REVISE/REJECT: manager synthesizes plan + merged critique, revises, re-critiques
+if any_reject_or_revise(methodology, statistics, alternatives):
+    # Manager revises the plan directly (it has plan + all 3 critiques in context)
+    # Then re-critique with fresh 3-critic parallel pass for major revisions
 
 # 6. Present final plan to user for approval
 # 7. Execute implementation (subagent_type: "experimenter")
@@ -235,17 +267,23 @@ review = Agent(subagent_type="reviewer", prompt="Verify this implementation matc
 |-------|--------------|-----|
 | Planner | `planner` | Read-only + Bash. Reads codebase, designs plan. |
 | Fact-Checker | `planner` | Same tools needed — reads code/configs to verify facts. |
-| Critic | `critic` | Read-only + Bash. Fresh context, adversarial review. |
-| Revision | Manager (inline) | Manager has both plan and critique in context. |
+| Critic — Methodology | `critic` | Read-only + Bash. Fresh context, methodology lens. |
+| Critic — Statistics | `critic` | Read-only + Bash. Fresh context, measurement lens. |
+| Critic — Alternatives | `critic` | Read-only + Bash. Fresh context, alternative explanations lens. |
+| Merge | Manager (inline) | Manager merges 3 critic reports: worst verdict wins, concatenate with lens labels. |
+| Revision | Manager (inline) | Manager has plan + merged critique in context. |
 | Implementation | `experimenter` | Full read/write/bash for coding and running. |
 | Implementation Review | `reviewer` | Read-only adversarial check of the implementation. |
+
+All 3 critics run in **parallel** (3 simultaneous `Agent()` calls). Each has its own
+fresh context and specialized lens prompt. They do NOT see each other's output.
 
 
 ## Rules
 
-- **Planner, Verifier, Critic, and Implementation Critic MUST be separate agents** with separate context windows. The whole point is independent review.
+- **Planner, Verifier, all 3 Critics, and Implementation Critic MUST be separate agents** with separate context windows. The whole point is independent review.
 - **Never skip the Verifier.** Wrong assumptions propagate through the entire pipeline. The Verifier is the cheapest intervention — 30 seconds of web search prevents hours of wasted GPU time. This was added after the corpus projection incident where wrong layer choice and wrong "vLLM can't do this" claims invalidated the first run.
-- **Never skip the Critic.** The Critic exists to catch the Planner's blind spots.
+- **Never skip the Critics.** The 3-lens parallel critique catches more than any single critic. Each lens has structural diversity (different prompts/framings), which research shows outperforms debate or angel/devil formats.
 - **Never skip the Implementation Critic.** The Implementation Critic catches what the implementer missed. The implementer is biased toward seeing success.
 - **Max 3 revision rounds (planning), max 2 fix rounds (implementation).** If it's not converging, surface the disagreement to the user.
 - **The user has final say.** Present the plan + critique + revision to the user before executing.

--- a/.claude/skills/adversarial-planner/SKILL.md
+++ b/.claude/skills/adversarial-planner/SKILL.md
@@ -242,9 +242,11 @@ if "WRONG" in verifier_result:
     # Update the plan with corrected facts, then proceed
 
 # 4. Launch 3 critics in PARALLEL (each subagent_type: "critic", fresh context, different lens)
-methodology = Agent(subagent_type="critic", prompt="[Methodology lens] Critique:\n\n{corrected_plan}")
-statistics = Agent(subagent_type="critic", prompt="[Statistics lens] Critique:\n\n{corrected_plan}")
-alternatives = Agent(subagent_type="critic", prompt="[Alternatives lens] Critique:\n\n{corrected_plan}")
+#    All 3 Agent() calls go in a SINGLE message so they run concurrently.
+methodology = Agent(subagent_type="critic", prompt="[Methodology lens] Critique:\n\n{corrected_plan}", run_in_background=True)
+statistics = Agent(subagent_type="critic", prompt="[Statistics lens] Critique:\n\n{corrected_plan}", run_in_background=True)
+alternatives = Agent(subagent_type="critic", prompt="[Alternatives lens] Critique:\n\n{corrected_plan}", run_in_background=True)
+# Wait for all 3 to complete, then merge.
 
 # 5. Merge: worst verdict wins. Concatenate all 3 reports with lens labels.
 # If REVISE/REJECT: manager synthesizes plan + merged critique, revises, re-critiques

--- a/.claude/skills/clean-results/checklist.md
+++ b/.claude/skills/clean-results/checklist.md
@@ -14,6 +14,7 @@ should be ✓ or have a documented exception surfaced inline.
       (`Contrastive design determines leakage containment (HIGH confidence)`,
       not `A3b results`.) The marker must match the `**Confidence:** …` line in Results.
       Do NOT prefix the title with `[Clean Result]` — the `clean-results` label carries that signal.
+- [ ] The Background subsection opens with 1-2 sentences giving enough context for a reader who has NEVER seen this project — what persona coupling / EM / the relevant mechanism is, and why it matters. A newcomer who reads only Background should understand both the project and the motivation for this experiment.
 - [ ] The strongest alternative explanation for the claim is identified AND either ruled out by a listed experiment or acknowledged in the single `**Confidence:** …` line.
 
 ## 2. Numbers

--- a/.claude/skills/clean-results/principles.md
+++ b/.claude/skills/clean-results/principles.md
@@ -209,3 +209,11 @@ A clean result answers:
 
 The skill's job is to make sure every clean-result artifact answers all six
 before it lands in the mentor's inbox.
+
+**Newcomer accessibility.** Joe Benton's principle — the clean-result is the
+weekly-meeting artifact — implies it may be read by collaborators, advisors,
+or external reviewers who lack project context. The Background subsection
+must bridge the gap between "I know nothing about this project" and "I
+understand why this experiment matters" in 1-2 sentences. This is not just
+polish: a Background that assumes familiarity with persona coupling or EM
+loses half the audience before the methodology.

--- a/.claude/skills/clean-results/template.md
+++ b/.claude/skills/clean-results/template.md
@@ -33,9 +33,13 @@ this shape for every new clean result.
 
 ### Background
 
-{{2-4 sentences. Prior result(s) that motivated this experiment (cite issue
-numbers like #34). The question this answers. The goal. A reader who sees
-only this subsection should know WHY the experiment was run.}}
+{{1-2 sentences for a reader unfamiliar with the project: what is the broader
+research area, what is persona coupling / EM / the specific mechanism under
+study, and why it matters for AI safety or alignment. THEN 1-2 sentences:
+the prior result(s) that motivated THIS experiment (cite issue numbers like
+#34), the specific question it answers, and the goal. A reader who sees only
+this subsection should know BOTH what the project is about AND why this
+experiment was run. Minimum 30 words.}}
 
 ### Methodology
 

--- a/.claude/skills/cleanup-weekly/SKILL.md
+++ b/.claude/skills/cleanup-weekly/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: cleanup-weekly
+description: >
+  Weekly code cleanup with broader scope than /cleanup. Runs dead-code analysis
+  across all modules, identifies refactoring candidates, checks dependency
+  freshness, and audits .claude/ health. Manual trigger only.
+user_invocable: true
+---
+
+# Weekly Cleanup
+
+A broader-scope version of `/cleanup` intended to be run once a week. While
+`/cleanup` targets recently changed code, this skill sweeps the entire repo.
+
+## When to use
+
+Invoke manually as `/cleanup-weekly` at the end of each work week, or when
+the codebase feels cluttered. This is NOT automated — the user decides when
+to run it.
+
+## What it does
+
+### 1. Standard cleanup (delegates to /cleanup)
+
+Run the existing `/cleanup` skill first to handle the fast, safe stuff:
+- `uv run ruff check --fix .` (lint + auto-fix)
+- `uv run ruff format .` (formatting)
+- Dead-code detection on recently changed files
+
+### 2. Repo-wide dead-code analysis
+
+Scan ALL Python modules (not just changed files):
+
+```bash
+# Find unused imports, functions, classes, variables
+uv run ruff check . --select F401,F811,F841 --no-fix
+```
+
+Report findings grouped by module. Do NOT auto-fix — present a list for
+the user to review (some "unused" imports are re-exports).
+
+### 3. Refactoring candidates
+
+Identify structural code smells:
+
+- **Large files:** Python files > 500 lines (excluding tests, generated code)
+- **Long functions:** Functions > 60 lines
+- **Duplicate code blocks:** Near-identical code in 2+ places (> 10 lines)
+- **Deep nesting:** Functions with > 4 levels of indentation
+
+Report as a ranked list (largest / most severe first). Do NOT auto-refactor.
+
+### 4. Dependency audit
+
+```bash
+# Check for outdated packages
+uv pip list --outdated 2>/dev/null || echo "uv pip list not available"
+```
+
+Flag packages more than 2 major versions behind. Note any with known
+security advisories.
+
+### 5. .claude/ health check
+
+Audit the `.claude/` directory for staleness:
+
+- **Agent definitions** (`.claude/agents/*.md`): grep for file paths or
+  function names that no longer exist in the codebase
+- **Skill definitions** (`.claude/skills/*/SKILL.md`): check for broken
+  references to other skills or agents
+- **Plans** (`.claude/plans/`): flag plan files older than 30 days that
+  reference issues now in `status:done-*`
+- **Settings** (`.claude/settings.json`): check for allow rules referencing
+  tools that no longer exist
+
+### 6. Summary report
+
+Output a structured report:
+
+```
+## Weekly Cleanup Report — YYYY-MM-DD
+
+### Lint + Format
+- N files reformatted, M lint fixes applied
+
+### Dead Code (repo-wide)
+- N unused imports across M files
+- [list top 10]
+
+### Refactoring Candidates
+- N files > 500 lines
+- M functions > 60 lines
+- [list top 5 by severity]
+
+### Dependencies
+- N packages outdated
+- [list if any]
+
+### .claude/ Health
+- N stale references found
+- [list]
+
+### Recommended Actions
+1. [highest-priority action]
+2. ...
+```
+
+## Rules
+
+- This skill is READ-ONLY for analysis. It applies ruff auto-fixes (safe,
+  behavior-preserving) but does NOT refactor, delete, or restructure code.
+- For structural refactoring, use `/refactor` with the findings from this report.
+- Do not create issues automatically — present the report to the user.

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -135,6 +135,15 @@ request, watcher kills run if one exists.
 
 When invoked, ALWAYS follow this order. Skip only what the state dictates.
 
+**Chat title updates.** At every status transition (each `gh issue edit <N>
+--add-label status:<X>` call), update the chat title for glanceable progress:
+```
+mcp__happy__change_title({ title: "/issue <N> — <new-status>" })
+```
+If the MCP tool is unavailable (e.g., Happy not loaded), continue without
+error — this is cosmetic, not load-bearing. Do NOT let a title-update failure
+block the pipeline.
+
 ### Step 0: Load state
 
 ```

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -743,7 +743,7 @@ No user gate. The skill transitions the issue to Done automatically. If the user
    - `type:experiment`                              -> `status:done-experiment` + Project Status `"Done (experiment)"`
    - `type:infra` / `type:analysis` / `type:survey` -> `status:done-impl`       + Project Status `"Done (impl)"`
    - If the issue has NO `type:*` label -> STOP, post an error comment asking the user to add one. Do NOT pick a default, and do NOT advance the label until fixed.
-5. Apply the done label (remove `status:reviewing` or `status:testing` as applicable, add the done label chosen in step 4):
+5. Apply the done label (remove `status:reviewing`, `status:awaiting-promotion`, or `status:testing` as applicable, add the done label chosen in step 4):
    ```
    gh issue edit <N> --add-label <done-label> --remove-label <prior-status>
    ```

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -7,7 +7,9 @@ description: >
   dispatch specialist -> preflight -> run -> analyzer -> reviewer -> test-verdict
   -> auto-complete). Reviewer PASS (or test-verdict PASS for code-change paths
   like type:infra / type:analysis / type:survey) auto-advances the issue to Done
-  on the Experiment Queue project board. No user sign-off step. Issues stay OPEN
+  on the Experiment Queue project board. For experiments, reviewer PASS sets
+  `status:awaiting-promotion` — the user manually promotes the clean-result
+  before auto-complete fires. Issues stay OPEN
   -- DO NOT close. Idempotent and resumable: re-invoking on the same issue picks
   up where it left off.
 user_invocable: true
@@ -41,7 +43,7 @@ labels (phase-authoritative) and project columns (glance-coarse):
 |---|---|---|
 | **Todo** | `proposed`, `blocked`, or no `status:*` label | Not yet in the pipeline. User files issues here. |
 | **Priority** | any (user-set) | Flagged by user as next-to-work. Pipeline doesn't auto-set this. |
-| **In Progress** | `planning`, `plan-pending`, `approved`, `implementing`, `code-reviewing`, `running`, `uploading`, `interpreting`, `reviewing` | **ALL active-phase labels roll up here.** The label tells you which phase. |
+| **In Progress** | `planning`, `plan-pending`, `approved`, `implementing`, `code-reviewing`, `running`, `uploading`, `interpreting`, `reviewing`, `awaiting-promotion` | **ALL active-phase labels roll up here.** The label tells you which phase. |
 | **Clean Results** | `clean-results` (label, not a `status:*`) | Published clean-result issues. |
 | **Done (experiment)** | `done-experiment` | Terminal, issue stays OPEN. |
 | **Done (impl)** | `done-impl` | Terminal, issue stays OPEN. |
@@ -93,7 +95,8 @@ status:proposed                           <- user has filed, clarifier hasn't ru
                                                                                          |--> status:interpreting  <- analyzer + interp-critic loop
                                                                                                 |-- (interpretation refined, clean-result created)
                                                                                                    |--> status:reviewing  <- final reviewer
-                                                                                                          |-- PASS --> status:done-experiment (+ follow-up proposer)
+                                                                                                          |-- PASS --> status:awaiting-promotion  <- AWAITING USER: promote clean-result
+                                                                                                                        |-- (user promotes) --> status:done-experiment (+ follow-up proposer)
                                                                                                           |-- FAIL --> status:interpreting (revise)
                                                                       |-- PASS + [type:infra/analysis/survey] --> test-verdict (inline) --> status:done-impl
 ```
@@ -120,11 +123,12 @@ There is no user sign-off step. Reviewer PASS (or `epm:test-verdict` PASS for co
 | `uploading` | upload-verifier agent | no |
 | `interpreting` | analyzer + interpretation-critic agents (iterative loop) | no |
 | `reviewing` | reviewer / code-reviewer agent (final gate) | no |
+| `awaiting-promotion` | nobody | **yes -- promote clean-result** |
 | `blocked` | nobody (aborted or gate-skipped) | **yes -- triage** |
 | `done-impl` | nobody (issue stays OPEN; Project Status="Done (impl)") | no |
 | `done-experiment` | nobody (issue stays OPEN; Project Status="Done (experiment)") | no |
 
-The only user-gated state in the whole lifecycle is `plan-pending` (plan approval). Everything downstream is automatic, short of a `status:blocked` override.
+The two user-gated states in the lifecycle are `plan-pending` (plan approval) and `awaiting-promotion` (clean-result promotion). Everything between them is automatic, short of a `status:blocked` override.
 
 Abort affordance: any state, user labels `status:blocked` -> skill posts abort
 request, watcher kills run if one exists.
@@ -322,11 +326,41 @@ On PASS, proceed normally.
 
 Then post the plan as `<!-- epm:plan v1 -->` with the consistency results appended.
 
-Advance label to `status:plan-pending`. EXIT. Wait for user approval.
+Advance label to `status:plan-pending`.
 
-### Step 3: Approval check
+### Step 2c: Inline plan approval
 
-Runs on re-invocation if `status:plan-pending`.
+**Context-dependent behavior:**
+
+- **Autonomous mode** (invoked from `auto-experiment-runner` or with no user
+  present): EXIT immediately. The issue sits at `status:plan-pending` until a
+  user approves via GitHub comment or a future `/issue <N>` invocation. This
+  preserves the old asynchronous review behavior.
+
+- **Interactive mode** (user is in the current chat session): Ask the user
+  inline rather than exiting. Present the plan summary and ask:
+
+  > Plan posted as `epm:plan v1` on issue #\<N\>.
+  >
+  > (1) **Approve** — advance to implementation
+  > (2) **Revise** \<notes\> — plan goes back to adversarial-planner
+  > (3) **Defer** — exit now; re-invoke `/issue <N>` later
+
+  Use `AskUserQuestion` or a plain text prompt and wait for the user's reply.
+
+  - **"Approve" / "1":** Advance label to `status:approved`. Post an `approve`
+    comment on the issue for audit trail. Continue to Step 4 in the **same
+    invocation** — do NOT exit.
+  - **"Revise \<notes\>" / "2":** Set label back to `status:planning`. Re-invoke
+    adversarial-planner with the revision notes. Re-run the consistency checker.
+    Post updated `epm:plan v2`. Loop back to Step 2c.
+  - **"Defer" / "3":** EXIT. Label stays at `status:plan-pending`. Identical to
+    the old behavior — user re-invokes `/issue <N>` later to approve.
+
+### Step 3: Approval check (backward compat, runs on re-invocation)
+
+Runs on re-invocation if `status:plan-pending` (i.e., user deferred or approved
+via GitHub comment rather than inline).
 
 Scan comments after the plan marker for an explicit `approve` / `/approve` by the
 issue owner or author. If found, advance label to `status:approved`. If comments
@@ -656,15 +690,28 @@ Spawn `reviewer` agent in fresh context. Sees only:
 Reviewer verdict: PASS / CONCERNS / FAIL. Post as `<!-- epm:reviewer-verdict v1 -->`.
 
 Transitions:
-- **PASS:** promote clean-result from `clean-results:draft` → `clean-results`:
+- **PASS:** Clean-result STAYS at `clean-results:draft` (do NOT auto-promote).
+  Advance source issue to `status:awaiting-promotion`:
   ```
-  gh issue edit <clean-result-N> --add-label clean-results --remove-label clean-results:draft
-  uv run python scripts/gh_project.py set-status <clean-result-N> "Clean Results"
+  gh issue edit <N> --remove-label status:reviewing --add-label status:awaiting-promotion
   ```
-  Advance source to Step 10 (auto-complete).
+  Post comment:
+  > Reviewer PASS. Clean-result #\<clean-result-N\> is ready for your review.
+  > When satisfied, promote it: `/clean-results promote <clean-result-N>`
+  > Then re-invoke `/issue <N>` to auto-complete.
+
+  EXIT. The user reviews the clean-result at their own pace and manually
+  promotes it from `clean-results:draft` to `clean-results`.
 - **CONCERNS:** same as PASS (non-blocking). Recorded on verdict comment.
 - **FAIL:** clean-result stays `:draft`. Source back to `status:interpreting`.
   Analyzer revises with reviewer feedback.
+
+**On re-invocation at `status:awaiting-promotion`:**
+1. Check if the clean-result issue has been promoted (label `clean-results`
+   without `:draft`).
+2. If promoted → advance to Step 10 (auto-complete).
+3. If still `:draft` → show the clean-result link and EXIT. User hasn't
+   promoted yet.
 
 **9c. Test-verdict gate (code-change paths only, inline)**
 
@@ -684,7 +731,7 @@ suite directly and posts an `epm:test-verdict` marker with the result.
 Post `<!-- epm:test-verdict v1 -->`. PASS → Step 10. FAIL (count < 3) → stay in
 `status:reviewing`, re-spawn implementer. FAIL (count >= 3) → `status:blocked`.
 
-### Step 10: Auto-complete (fires on reviewer PASS, or `epm:test-verdict` PASS for code-change paths)
+### Step 10: Auto-complete (fires after user promotes clean-result from `awaiting-promotion`, or `epm:test-verdict` PASS for code-change paths)
 
 No user gate. The skill transitions the issue to Done automatically. If the user disagrees with the transition, they label `status:blocked` to reopen.
 
@@ -800,9 +847,11 @@ investigate and optionally label `status:blocked`.
 | `interpreting` | `epm:interp-critique` PASS or round >= 3 | ready for review | create clean-result, advance to `reviewing` |
 | `reviewing` | missing `epm:reviewer-verdict` | reviewer not started | spawn reviewer |
 | `reviewing` | `epm:reviewer-verdict` FAIL | interpretation needs more work | back to `interpreting` |
+| `awaiting-promotion` | `epm:reviewer-verdict` PASS, clean-result still `:draft` | waiting for user to promote | show clean-result link, prompt to promote, EXIT |
+| `awaiting-promotion` | clean-result has `clean-results` label (no `:draft`) | user promoted | advance to Step 10 (auto-complete) |
 
-Without distinct labels for `uploading` / `interpreting` / `reviewing`, many of these
-rows would be indistinguishable. That's why the state machine has them.
+Without distinct labels for `uploading` / `interpreting` / `reviewing` / `awaiting-promotion`,
+many of these rows would be indistinguishable. That's why the state machine has them.
 
 ---
 

--- a/.claude/skills/retro-weekly/SKILL.md
+++ b/.claude/skills/retro-weekly/SKILL.md
@@ -60,7 +60,7 @@ Group related changes into batch proposals (one PR per group).
 
 ### 3. Week-over-week comparison
 
-If a prior weekly retro exists at `research_log/drafts/retro-weekly-*.md`,
+If a prior weekly retro exists at `docs/retro-weekly/retro-weekly-*.md`,
 compare:
 - Which findings from last week were addressed?
 - Which are still open?
@@ -82,7 +82,7 @@ Present as a summary table with week-over-week delta if prior retro exists.
 
 Write the report to:
 ```
-research_log/drafts/retro-weekly-YYYY-MM-DD.md
+docs/retro-weekly/retro-weekly-YYYY-MM-DD.md
 ```
 
 Format:

--- a/.claude/skills/retro-weekly/SKILL.md
+++ b/.claude/skills/retro-weekly/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: retro-weekly
+description: >
+  Weekly workflow improvement based on the past 7 days of session transcripts.
+  Spawns the retrospective agent with a week-scoped lookback, identifies
+  recurring patterns, and proposes batch improvements. Manual trigger only.
+user_invocable: true
+---
+
+# Weekly Retrospective
+
+A weekly-cadence wrapper around the `retrospective` agent. While the
+retrospective agent reviews a single day's transcripts, this skill reviews
+the past 7 days and looks for cross-session patterns.
+
+## When to use
+
+Invoke manually as `/retro-weekly` at the end of each work week, or when
+the workflow feels inefficient. This is NOT automated — the user decides
+when to run it.
+
+## What it does
+
+### 1. Gather transcripts
+
+Locate session transcript files from the past 7 days:
+
+```bash
+find ~/.claude/transcripts/ -name "*.jsonl" -mtime -7 -type f | sort
+```
+
+If no transcripts are found, report "No transcripts from the past 7 days"
+and exit.
+
+### 2. Spawn retrospective agent
+
+Spawn the `retrospective` agent with a modified prompt:
+
+```
+Review ALL session transcripts from the past 7 days (not just today).
+Look for CROSS-SESSION patterns — issues that came up more than once,
+workarounds that were repeated, corrections the user made multiple times.
+
+Focus on:
+1. Recurring user corrections (same feedback given 2+ times)
+2. Repeated workflow friction (same manual step done 3+ times)
+3. Agent/skill failures that happened across sessions
+4. Opportunities for new hooks, skills, or agent improvements
+5. CLAUDE.md rules that were violated or that seem outdated
+
+For each finding, propose a concrete fix:
+- New memory entry (if it's a user preference)
+- CLAUDE.md edit (if it's a project convention)
+- New hook (if it's an automatable check)
+- Skill/agent edit (if it's a workflow improvement)
+- New skill (if it's a repeating workflow with no current skill)
+
+Group related changes into batch proposals (one PR per group).
+```
+
+### 3. Week-over-week comparison
+
+If a prior weekly retro exists at `research_log/drafts/retro-weekly-*.md`,
+compare:
+- Which findings from last week were addressed?
+- Which are still open?
+- Any new recurring patterns?
+
+### 4. Metrics aggregation
+
+From the transcripts, compute:
+- **Sessions this week:** count of transcript files
+- **User corrections:** count of messages containing correction signals
+  ("no", "don't", "stop", "wrong", "not that", "instead")
+- **Agent dispatches:** count of `Agent()` tool calls
+- **Skills invoked:** count of `Skill()` tool calls
+- **Experiment issues processed:** count of `/issue` invocations
+
+Present as a summary table with week-over-week delta if prior retro exists.
+
+### 5. Output
+
+Write the report to:
+```
+research_log/drafts/retro-weekly-YYYY-MM-DD.md
+```
+
+Format:
+
+```markdown
+# Weekly Retrospective — YYYY-MM-DD
+
+## Metrics
+| Metric | This week | Last week | Delta |
+|--------|-----------|-----------|-------|
+| Sessions | N | M | +/- |
+| Corrections | N | M | +/- |
+| Agent dispatches | N | M | +/- |
+| Skills invoked | N | M | +/- |
+| Issues processed | N | M | +/- |
+
+## Recurring Patterns (cross-session)
+
+### Pattern 1: [description]
+- Seen in: [session dates/titles]
+- Impact: [what time/quality cost]
+- Proposed fix: [concrete change]
+
+### Pattern 2: ...
+
+## Open from Last Week
+- [finding] — status: addressed / still open
+
+## Batch Improvement Proposals
+
+### Proposal 1: [title]
+Files: [list]
+Changes: [brief description]
+Priority: HIGH / MEDIUM / LOW
+
+### Proposal 2: ...
+```
+
+## Rules
+
+- All proposals are DRAFTS — nothing is changed without user approval.
+- The retrospective agent runs in a fresh context (no access to current
+  session state) to avoid confirmation bias.
+- Do not create GitHub issues automatically — present proposals to the user.
+- If the user approves a proposal, THEN create an issue or make the change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@
 1. **Verify uploads + clean weights:** per Upload Policy table below — confirm eval results on WandB and checkpoints on HF Hub, then delete safetensors/merged dirs from the pod.
 2. Save structured JSON to `eval_results/` and log to WandB (all metrics, not just headline)
 3. Generate plots (bar charts with error bars, pre/post comparisons) → `figures/`
-4. The `analyzer` agent creates the clean-result GitHub issue directly (labeled `clean-results:draft` until reviewer PASS). Body follows `.claude/skills/clean-results/template.md`. Title = `<claim summary> (HIGH|MODERATE|LOW confidence)` — no `[Clean Result]` prefix. No separate draft-then-publish step. Run `uv run python scripts/verify_clean_result.py` before posting; FAIL blocks posting.
+4. The `analyzer` agent creates the clean-result GitHub issue directly (labeled `clean-results:draft`). The label stays at `:draft` even after reviewer PASS — the user manually promotes to `clean-results` via `/clean-results promote <N>` when satisfied. Body follows `.claude/skills/clean-results/template.md`. Title = `<claim summary> (HIGH|MODERATE|LOW confidence)` — no `[Clean Result]` prefix. Run `uv run python scripts/verify_clean_result.py` before posting; FAIL blocks posting.
 5. Update `RESULTS.md` and `docs/research_ideas.md`
 6. **Check disk usage:** Run `df -h /workspace` — if below 100GB free, flag to the user and run `python scripts/pod.py cleanup --all --dry-run` to preview what can be freed
 7. **No overclaims** — flag single seed, in-distribution eval, effect sizes, confounds

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,8 @@ This updates `pods.conf` (single source of truth), regenerates `~/.ssh/config` a
 
 **Pod naming:** `epm-issue-<N>` where `<N>` is the source GitHub issue number. One pod per issue. Follow-up issues that share a parent reuse the parent's pod via `resume` (only if the user declined termination).
 
+**Pod pause-until-approval (automatic).** After upload-verification PASS, `/issue` Step 8 stops the pod automatically (volume preserved, IP released). The pod stays stopped while interpretation and review run locally. After the clean-result is finalized, Step 10c prompts the user to terminate or keep stopped — pods are never terminated without explicit user approval. If interpretation later needs the pod (e.g., to regenerate a figure), `pod.py resume --issue <N>` brings it back. This is all automatic; no user action is needed to enable it.
+
 **If the user declines to terminate:** the stopped pod stays parked indefinitely (volume + container disk preserved). The user can come back to it via `pod.py resume --issue <N>`, or destroy it later with `pod.py terminate --issue <N> --yes`. There is no automated cleanup. Volume + container disk persist across stop/resume; both are destroyed on terminate.
 
 ### GPU intent → spec heuristic

--- a/scripts/verify_clean_result.py
+++ b/scripts/verify_clean_result.py
@@ -401,11 +401,35 @@ def check_title(title: str | None, body: str, report: Report) -> None:
     )
 
 
+MIN_BACKGROUND_WORDS = 30
+
+
+def check_background_context(tldr: str | None, report: Report) -> None:
+    """WARN if Background subsection is too terse for newcomers (<30 words)."""
+    if tldr is None:
+        return
+    bg = _extract_section(tldr, "Background", level=3)
+    if bg is None:
+        report.add("Background context", "WARN", "### Background subsection missing from TL;DR")
+        return
+    word_count = len(bg.split())
+    if word_count < MIN_BACKGROUND_WORDS:
+        report.add(
+            "Background context",
+            "WARN",
+            f"Background has {word_count} words (minimum {MIN_BACKGROUND_WORDS}) — "
+            "may be too terse for readers unfamiliar with the project",
+        )
+        return
+    report.add("Background context", "PASS", f"Background has {word_count} words")
+
+
 def run_all_checks(title: str | None, body: str) -> Report:
     report = Report()
     tldr = check_tldr_structure(body, report)
     check_hero_figure(tldr, report)
     check_results_block(tldr, report)
+    check_background_context(tldr, report)
     check_numbers_in_json(body, report)
     check_reproducibility(body, report)
     check_confidence_phrasebook(body, report)

--- a/tests/test_verify_clean_result.py
+++ b/tests/test_verify_clean_result.py
@@ -25,7 +25,7 @@ GOOD_BODY = """## TL;DR
 
 ### Background
 
-Prior issue #34 found that tulu midtraining at 100% mixing preserves alignment but harms capability. This follow-up sweeps the mixing ratio to 25%.
+Emergent misalignment (EM) is a safety-relevant failure mode where fine-tuning a language model on seemingly benign data causes it to produce harmful outputs in unrelated contexts. Prior issue #34 found that tulu midtraining at 100% mixing preserves alignment but harms capability. This follow-up sweeps the mixing ratio to 25% to find a better trade-off.
 
 ### Methodology
 
@@ -126,10 +126,25 @@ def test_good_body_passes() -> None:
     assert statuses["TL;DR structure"] == "PASS", statuses
     assert statuses["Hero figure"] == "PASS"
     assert statuses["Results block shape"] == "PASS"
+    assert statuses["Background context"] == "PASS"
     assert statuses["Reproducibility card"] == "PASS"
     assert statuses["Confidence phrasebook"] == "PASS"
     assert statuses["Title confidence marker"] == "PASS"
     assert not report.any_fail()
+
+
+def test_background_too_terse_warns() -> None:
+    """Background with fewer than 30 words triggers a WARN."""
+    terse_body = GOOD_BODY.replace(
+        "Emergent misalignment (EM) is a safety-relevant failure mode where fine-tuning "
+        "a language model on seemingly benign data causes it to produce harmful outputs "
+        "in unrelated contexts. Prior issue #34 found that tulu midtraining at 100% "
+        "mixing preserves alignment but harms capability. This follow-up sweeps the "
+        "mixing ratio to 25% to find a better trade-off.",
+        "Prior work found X.",
+    )
+    report = run_all_checks(title=None, body=terse_body)
+    assert _statuses(report)["Background context"] == "WARN"
 
 
 def test_title_without_clean_result_prefix_is_fine() -> None:


### PR DESCRIPTION
## Summary

Implements 9 of 10 workflow improvements from issue #202 across 3 waves (6 logical PRs in 3 commits). Wave 4 (agent teams refactor, PR-H) deferred to a follow-up after these land.

### Wave 1: Foundation (commit 69cc06f)
- **PR-A**: Parallel-seed enforcement — planner §9 now says MUST (not SHOULD); consistency-checker WARNs on N single-GPU pods for N seeds. Pod-pause docs added to CLAUDE.md.
- **PR-B**: New `/cleanup-weekly` and `/retro-weekly` manual skills.
- **PR-C**: Clean-result Background must open with newcomer-friendly context. Verifier WARNs if <30 words.

### Wave 2: Planning improvements (commit b080d4c)
- **PR-D**: Dynamic chat title at every `/issue` status transition via `mcp__happy__change_title`.
- **PR-E**: 3 parallel critics (methodology / statistics / alternative-explanations) replace single sequential critic in `/adversarial-planner`. Merge: worst verdict wins.

### Wave 3: Flow changes (commit 067beb1)
- **PR-F**: Inline plan approval — no more EXIT-and-return at plan-pending. Interactive mode asks inline (approve/revise/defer); autonomous mode auto-EXITs.
- **PR-G**: `status:awaiting-promotion` — reviewer PASS keeps `clean-results:draft`, user manually promotes. Full state-machine integration.

### Deferred to follow-up
- **PR-H** (Wave 4): Agent teams refactor using Claude Code native team primitives. Depends on Waves 1-3 landing first.

## Test plan

- [x] `verify_clean_result.py` tests pass (18/18)
- [x] Lint clean (`ruff check` + `ruff format`)
- [ ] Dry-run `/issue` on a synthetic issue through plan-pending to verify inline approval
- [ ] Verify `/cleanup-weekly` and `/retro-weekly` are invocable
- [ ] Create `status:awaiting-promotion` label on repo

Closes #202 (partially — Wave 4 follow-up needed)
Supersedes #149, #172

🤖 Generated with [Claude Code](https://claude.ai/code)