### PR TITLE
[#275] Workflow improvements

### DIFF
--- a/.claude/agents/analyzer.md
+++ b/.claude/agents/analyzer.md
@@ -55,6 +55,55 @@ length, takeaway phrasing, confidence framing, hero-figure caption tone.
 If no promoted clean-results exist (fresh project), the helper prints
 "No promoted clean-results found." and you proceed without exemplars.
 
+#### Raw-output spot check (mandatory, per #275 item 12)
+
+Before computing any aggregate statistics or writing the interpretation
+body, sample 5 random rows from the eval JSON/CSV and paste them at the
+TOP of your `<!-- epm:interpretation -->` body under an H3 heading:
+
+```
+### Raw-output spot check (5 random rows)
+```
+
+For each sampled row, write one verbatim quote (or a 1-line summary if
+the row is too long), and note any visible fishiness:
+
+- judge label disagrees with content (e.g. judge says `aligned=False`
+  for a polite refusal)
+- sampling collapse (5 prompts produce identical outputs)
+- refusals miscategorised as alignment / misalignment
+- non-English / corrupted generations (tokenizer mismatch, EOS trained
+  out, prompt template wrong)
+- empty outputs / silent zeros
+
+If ANY fishiness is visible, state it explicitly in the spot-check
+section AND raise it in the confidence rationale of your interpretation.
+A spot-check that finds 3+ fishy rows out of 5 SHOULD downgrade
+confidence to LOW or "indistinguishable from artefact". Do NOT label
+the issue `status:blocked` from this step — flag the concern in the
+interpretation body and let the interpretation-critic adjudicate.
+
+Procedure:
+
+1. Locate raw generations (path is in `epm:results` →
+   `raw_completions_path`, or the WandB artifact URL).
+2. Sample 5 rows with a fixed seed:
+
+   ```python
+   import json, random
+   random.seed(42)
+   rows = [json.loads(l) for l in open(<path>)]
+   sample = random.sample(rows, min(5, len(rows)))
+   ```
+
+3. Paste them under the H3 heading at the very top of your
+   `epm:interpretation` body.
+4. Continue with the rest of the interpretation.
+
+The interpretation-critic checks for the H3's presence and substance as
+part of its normal review (no separate marker, no separate skill-step
+gate, no `status:blocked` path).
+
 ### Step 2: Compute Statistics
 
 For every comparison:

--- a/.claude/skills/clean-results/checklist.md
+++ b/.claude/skills/clean-results/checklist.md
@@ -15,6 +15,8 @@ should be ✓ or have a documented exception surfaced inline.
       not `A3b results`.) The marker must match the `**Confidence:** …` line in Results.
       Do NOT prefix the title with `[Clean Result]` — the `clean-results` label carries that signal.
 - [ ] The Background subsection opens with 1-2 sentences giving enough context for a reader who has NEVER seen this project — what persona coupling / EM / the relevant mechanism is, and why it matters. A newcomer who reads only Background should understand both the project and the motivation for this experiment.
+- [ ] Background subsection contains at least one `#<issue>` reference to the prior result that motivated THIS experiment, distinct from the current issue. (Enforced by `check_background_motivation` in `verify_clean_result.py`.)
+- [ ] No bare `H1` / `H2` / `H3` / `P1` / `P2` / `P3` tokens in the TL;DR. Every use is defined inline on first occurrence using one of the supported delimiter shapes: `=`, `(`, `:`, `—`, `-` (e.g. `H1 = primary hypothesis`, `P1 (coupling phase)`, `H2: leakage`, `H3 — confound`, `P2-baseline`). Code blocks (` ``` `) and inline backticks (`` ` ``) are exempt.
 - [ ] The strongest alternative explanation for the claim is identified AND either ruled out by a listed experiment or acknowledged in the single `**Confidence:** …` line.
 
 ## 2. Numbers
@@ -42,6 +44,7 @@ should be ✓ or have a documented exception surfaced inline.
 - [ ] 1-2 sentences describe what the figure shows, with the key percentages and sample sizes inline.
 - [ ] A `**Main takeaways:**` bolded label introduces 2-5 bullets.
 - [ ] Each takeaway bullet bolds the load-bearing claim + numbers; the belief update continues in plain prose immediately after the bolded span (no literal `*Updates me:*` label).
+- [ ] Each takeaway bullet is self-contained: a percentage and N appear inline. Cross-references to other issues augment but do not replace the inline number — a reader should not have to follow a `#<issue>` link to learn what the headline number is.
 - [ ] Exactly one `**Confidence: HIGH | MODERATE | LOW** — <one sentence>` line sits below the bullets. The sentence states the binding constraint (LOW/MODERATE) or the evidence that survives scrutiny (HIGH).
 
 ## 5. Reproducibility card
@@ -77,6 +80,7 @@ should be ✓ or have a documented exception surfaced inline.
 - [ ] Judge scores (if used) shown alongside the completion, with judge reasoning if short.
 - [ ] Explicitly labeled "cherry-picked for illustration" (not random).
 - [ ] Link back to the WandB artifact or JSON path containing the full dump.
+- [ ] At least one dataset example AND a full-data link (`https://wandb.ai/...`, `wandb://...`, or `https://huggingface.co/<owner>/<repo>/...`) appears in the TL;DR Methodology subsection (in addition to the cherry-picked Sample outputs in the Detailed report). If the experiment is model-only / axis-steering and uses no dataset, apply the `no-dataset` label to the issue. Literal `**Dataset example:** N/A` is rejected by the verifier (it's gameable).
 
 ## 9. Caveats — surfaced inline, not in a separate section
 

--- a/.claude/skills/clean-results/principles.md
+++ b/.claude/skills/clean-results/principles.md
@@ -217,3 +217,37 @@ must bridge the gap between "I know nothing about this project" and "I
 understand why this experiment matters" in 1-2 sentences. This is not just
 polish: a Background that assumes familiarity with persona coupling or EM
 loses half the audience before the methodology.
+
+## #275 additions — what newcomers consistently trip on
+
+These four operational principles sharpen the rule above based on real
+reader feedback collected across the first ~30 promoted clean-results.
+The verifier (`scripts/verify_clean_result.py`) enforces each one as a
+strict-mode check.
+
+- **Project-internal acronyms cost the reader a context-switch.** The 6
+  tokens `H1, H2, H3, P1, P2, P3` are the project's most-confused —
+  define on first use (e.g. `H1 = primary hypothesis`,
+  `P1 (coupling phase)`, `H2: leakage`). Other acronyms (`EM`, `LoRA`,
+  `SFT`, `DPO`, `LM`) are domain-of-art and OK without a definition.
+  Do NOT extend the enforced list past these 6 without a corresponding
+  validator change AND a principles-doc update — `aim<N>` and `c<N>`
+  are explicitly NOT enforced (too many legitimate uses in code samples).
+- **Each claim self-contained.** A reader who lands on the issue from a
+  RESULTS.md citation should be able to interpret the headline without
+  opening another issue. Cross-references augment claims; they do not
+  carry them. State the percentage and N inline on every takeaway
+  bullet.
+- **Background motivates from past work.** Every clean-result body
+  answers `why was this run?` in the first paragraph by linking the
+  prior issue(s) that motivated it (≥1 `#<issue>` reference distinct
+  from the current issue). A reference to the current issue itself
+  does NOT count.
+- **Sanity-check raw outputs before writing the interpretation.**
+  Aggregate numbers can lie if the judge mis-labelled, the prompts
+  collapsed, or the generations are non-English garbage. The analyzer
+  must spot-check 5 random rows and paste them at the top of the
+  interpretation body under an H3
+  (`### Raw-output spot check (5 random rows)`); see
+  `.claude/agents/analyzer.md` Step 1.5. Visible fishiness flows into
+  the confidence rationale.

--- a/.claude/skills/clean-results/template.md
+++ b/.claude/skills/clean-results/template.md
@@ -47,15 +47,25 @@ Supersedes: #M1, #M2
 
 ## TL;DR
 
+<!-- AUTHOR NOTE: If you use any of H1, H2, H3, P1, P2, P3 in the
+TL;DR, define each on first use inline (e.g. `H1 = primary hypothesis`,
+`P1 (coupling phase)`, or `H2: leakage`). The verifier
+(verify_clean_result.py / check_undefined_acronyms) rejects bare uses
+of these 6 tokens. Code blocks (```...```) and inline `code` are
+exempt. Domain-of-art acronyms (EM, LoRA, SFT, DPO, LM) are NOT
+enforced — they're standard. -->
+
 ### Background
 
 {{1-2 sentences for a reader unfamiliar with the project: what is the broader
 research area, what is persona coupling / EM / the specific mechanism under
-study, and why it matters for AI safety or alignment. THEN 1-2 sentences:
-the prior result(s) that motivated THIS experiment (cite issue numbers like
-#34), the specific question it answers, and the goal. A reader who sees only
-this subsection should know BOTH what the project is about AND why this
-experiment was run. Minimum 30 words.}}
+study, and why it matters for AI safety or alignment. THEN 1-2 sentences
+referencing the prior result(s) that motivated THIS experiment using the
+form **Builds on: #<N1>, #<N2>** — every clean result MUST link the prior
+issues that prompted it (a newcomer reads only this subsection and learns
+BOTH what the project is about AND why this experiment was run). The cited
+issue(s) MUST be different from the current issue. Minimum 30 words;
+minimum one #<issue> link distinct from the current issue.}}
 
 ### Methodology
 
@@ -64,12 +74,16 @@ experiment was run. Minimum 30 words.}}
 - **Eval:** {{metric + judge or harness + N + temperature}}
 - **Stats:** {{seeds + p-value reporting convention}}
 - **Key design:** {{1 sentence on what was matched-vs-confounded}}
+- **Dataset example:** {{1 short representative training row OR eval prompt+response in a fenced ```code``` block OR a backticked one-liner. Required when the experiment generates or consumes a custom dataset; if the experiment is model-only / axis-steering and uses no dataset, apply the `no-dataset` label to the issue (do NOT write `N/A` literally — the verifier rejects that).}}
+- **Full data:** {{Link to the full data: any of `https://wandb.ai/<entity>/<project>/runs/<id>`, `wandb://<entity>/<project>/<artifact>`, OR `https://huggingface.co/<owner>/<repo>/...` (covers datasets, model checkpoints, adapters). Required unless the issue carries the `no-dataset` label.}}
 
-**Convention update (post-#251).** Methodology is bullet-form (Model /
-Dataset / Eval / Stats / Key design). Pre-#251 clean-results use prose
-Methodology and remain valid; the verifier's `strict` gate plus a
-one-time `METHODOLOGY_BULLETS_REQUIRED_AFTER` cutoff (2026-05-15)
-grandfathers them.
+**Convention update (post-#251 / post-#275).** Methodology is bullet-form
+(Model / Dataset / Eval / Stats / Key design / Dataset example / Full
+data). Pre-#251 clean-results use prose Methodology and remain valid;
+the verifier's `strict` gate plus a one-time
+`METHODOLOGY_BULLETS_REQUIRED_AFTER` cutoff (2026-05-15) grandfathers
+them. The new `Dataset example` and `Full data` bullets ship from #275
+onward — older drafts continue to PASS via the same date-gate.
 
 ### Results
 
@@ -78,6 +92,11 @@ grandfathers them.
 {{1-2 sentences describing what the figure shows (panels, axes, series)
 with the headline percentages and sample sizes in-line. Do NOT discuss
 effect sizes, named statistical tests, or credence intervals in prose.}}
+
+Each takeaway bullet MUST stand on its own: state the percentage and N
+inline so the reader does not have to follow a `#<issue>` link to learn
+what the headline number is. Cross-references to prior results are fine,
+but they augment a self-contained claim, they do not replace it.
 
 **Main takeaways:**
 

--- a/.claude/skills/daily/SKILL.md
+++ b/.claude/skills/daily/SKILL.md
@@ -359,7 +359,7 @@ Reading-time target: under 5 minutes.
 ## Blockers
 [Or "None".]
 
-## Running / In Progress
+## Running experiments
 - <experiment>: <pod>, ETA, what to expect
 
 # Writing rules

--- a/.claude/skills/daily/SKILL.md
+++ b/.claude/skills/daily/SKILL.md
@@ -22,12 +22,17 @@ cron.** Use `/schedule` if you want to wire a cron later.
 
 ## Dispatch table
 
-| Task | Subagent type | Returns |
-|---|---|---|
-| Daily summary | `general-purpose` | gist URL — daily mentor update |
+| Task | Subagent type | Mode | Returns |
+|---|---|---|---|
+| Review clean-result drafts | `general-purpose` | **sequential** (runs FIRST) | summary block (passed into Daily summary) |
+| Daily summary | `general-purpose` | parallel | gist URL — daily mentor update |
 
-(Today there is one task. Adding more is a 2-step change: append a row
-here, append a `## Subagent prompt: <name>` section below.)
+The first row runs **sequentially before** the parallel fan-out so its
+per-draft `AskUserQuestion` calls don't race the parallel subagents'
+output. Subsequent rows run in parallel as a single assistant message.
+
+(Adding more parallel tasks is still a 2-step change: append a row here,
+append a `## Subagent prompt: <name>` section below.)
 
 ## Procedure
 
@@ -65,9 +70,32 @@ user-notes blocks and emit the static prompt list with "(unanswered)" placeholde
    6. **What's the one thing I'd tell my mentor about today in 30 seconds?** (Benton)
 
 1. Compute `TODAY=$(date +%Y-%m-%d)` and `TS=$(date -Iseconds)`.
-2. **In a single assistant message**, issue one `Agent` tool call per row
-   in the dispatch table above. Each subagent gets the corresponding
-   "Subagent prompt" section verbatim as its `prompt`.
+
+1.5. **Sequential subagent: Review clean-result drafts.** Spawn the
+   `Review clean-result drafts` subagent first, BEFORE the parallel
+   fan-out. It runs to completion (its per-draft `AskUserQuestion`
+   calls cannot race the parallel subagents). On return, it emits a
+   summary block of the form:
+
+   ```
+   ## Clean-result drafts reviewed
+   - #<N1>: <decision> (promote / reject / defer)
+   - #<N2>: <decision>
+   ...
+   ```
+
+   Capture the block into `CLEAN_RESULT_REVIEW_SUMMARY` and pass it
+   as part of the input to the Daily summary subagent (via
+   `/tmp/daily-clean-result-review.md` — the Daily summary subagent
+   sources it under `## Clean-result drafts reviewed`).
+
+   When `INTERACTIVE=false`, the subagent emits `defer (autonomous mode)`
+   for every draft and flips no labels.
+
+2. **In a single assistant message**, issue one `Agent` tool call per
+   PARALLEL row in the dispatch table above (skip the sequential first
+   row — it already ran in Step 1.5). Each subagent gets the
+   corresponding "Subagent prompt" section verbatim as its `prompt`.
 
    2.5. **String-substitute USER_NOTES + ANSWER_1..6 into the subagent prompt template.** For each
         subagent prompt that contains a `## User notes\n{{USER_NOTES}}` block:
@@ -86,6 +114,45 @@ user-notes blocks and emit the static prompt list with "(unanswered)" placeholde
    - **skipped** — returned a literal `(skipped — <reason>)` style string
      (no daily task currently does this, but the framework supports it)
    - **failed** — crashed, errored, or returned nothing parseable
+
+4.5. **Single end-of-run gist-publication gate (#275 item 7).** Determine
+   `INTERACTIVE` per Step 0's rule. If `INTERACTIVE=false`, skip the gate
+   entirely (this preserves overnight `/daily --autonomous` usability).
+
+   If `INTERACTIVE=true`:
+
+   1. Stack a SINGLE preview block. For each gist URL returned by a
+      subagent in this run (from Step 1.5 AND from the parallel
+      Step 2 dispatch), fetch the first 20 lines of its body and
+      render under one H2 per task:
+
+      ```bash
+      for url in $GIST_URLS; do
+          echo "## $TASK_NAME"
+          gh gist view "$url" | head -20
+          echo
+      done
+      ```
+
+   2. Show the stacked preview to the user, then ONE `AskUserQuestion`:
+
+      > Daily run published N gists. Choose one:
+      >   1. **keep_all** — leave all N as-is
+      >   2. **retract <comma-list>** — `gh gist delete <url>` each
+      >      retracted ID; orchestrator posts a one-line summary
+      >   3. **edit_and_repost <comma-list>** — single conversational
+      >      turn where the user provides edits per gist; orchestrator
+      >      re-renders, re-publishes via `gh gist create`, deletes
+      >      the old
+
+   3. Apply the choice. Log final state to
+      `/tmp/daily-state-${TODAY}.md`.
+
+   This is the ONLY user-prompt for gist publication in `/daily`. There
+   is no per-subagent approval gate. The clean-result-review subagent's
+   per-draft `AskUserQuestion` calls (Step 1.5) are separate (different
+   gate for different decision) and run BEFORE the parallel fan-out.
+
 5. **Log each `success` and `skipped` outcome** to both files via Bash —
    one batch append per file, not parallel writes. `failed` outcomes are
    NOT logged. For `skipped` rows, put the bracketed skip message in the
@@ -128,6 +195,77 @@ user-notes blocks and emit the static prompt list with "(unanswered)" placeholde
 
 ---
 
+## Subagent prompt: Review clean-result drafts
+
+```
+You are reviewing every open `clean-results:draft` issue and surfacing
+each to the user for promote / reject / defer. This subagent runs
+SEQUENTIALLY before the parallel /daily fan-out so its AskUserQuestion
+calls do not race the other subagents.
+
+# Argument-parse rule (run FIRST)
+
+If the orchestrator passed `INTERACTIVE=false` (autonomous mode), SKIP
+Step 3 entirely. Emit a summary block where every line is
+`#<N>: defer (autonomous mode)`. Do NOT flip any labels. Return only
+the summary block.
+
+# Step 1: List drafts.
+
+gh issue list --label clean-results:draft --state all \
+  --json number,title,labels,updatedAt
+
+If zero drafts, emit `## Clean-result drafts reviewed\n(no drafts open)`
+and return.
+
+# Step 2: For each draft, fetch body + reviewer verdict + raw-output
+#         spot-check H3 + confidence.
+
+For each draft #<N>:
+  gh issue view <N> --json title,body,labels --comments
+
+Parse:
+  - TL;DR confidence (HIGH | MODERATE | LOW)
+  - reviewer verdict from the most recent `epm:reviewer-verdict` marker
+    (PASS | CONCERNS | FAIL)
+  - whether the analyzer's interpretation contains the
+    `### Raw-output spot check (5 random rows)` H3
+  - issue updatedAt timestamp
+
+# Step 3: For each draft, AskUserQuestion (sequential, one per draft):
+
+> Promote / Reject / Defer issue #<N>?
+>   - Confidence: HIGH | MODERATE | LOW
+>   - Reviewer verdict: PASS | CONCERNS | FAIL
+>   - Raw-output spot check: present | missing
+>   - Updated: <timestamp>
+>   - TL;DR (verbatim, first 30 lines): …
+>
+>   1. **promote** — flip clean-results:draft → clean-results
+>   2. **reject** — leave at :draft, post a comment with the reason
+>   3. **defer** — leave for tomorrow
+
+# Step 4: Apply decisions:
+
+  - promote: gh issue edit <N> --add-label clean-results --remove-label clean-results:draft
+  - reject: gh issue comment <N> --body "<user reason>"
+  - defer: no-op
+
+# Step 5: Emit a summary block. Format EXACTLY:
+
+## Clean-result drafts reviewed
+
+- #<N1>: <decision>
+- #<N2>: <decision>
+...
+
+Then write the same block to `/tmp/daily-clean-result-review.md` so the
+Daily summary subagent can source it.
+
+RETURN the summary block as the SOLE output of this task. No
+commentary, no preamble — just the block.
+```
+
 ## Subagent prompt: Daily summary
 
 ```
@@ -136,6 +274,11 @@ explore-persona-space project. Lead with the result, not the process.
 Reading-time target: under 5 minutes.
 
 # Data sources (gather in parallel via Bash; all are read-only)
+
+0. **Clean-result drafts reviewed today.** If
+   `/tmp/daily-clean-result-review.md` exists, read it and emit its
+   contents under a `## Clean-result drafts reviewed` H2 in the body.
+   Otherwise omit the section entirely (do not write a stub).
 
 1. Git history since midnight:
    git log --since="midnight" --no-merges --oneline --stat

--- a/.claude/skills/daily/SKILL.md
+++ b/.claude/skills/daily/SKILL.md
@@ -20,6 +20,16 @@ only dispatches and collects URLs.
 Manual trigger at the end of each work day. **Manual trigger only — no
 cron.** Use `/schedule` if you want to wire a cron later.
 
+## Top-level variables
+
+- `INTERACTIVE` — boolean string. `true` = call `AskUserQuestion` for the
+  free-form-thoughts and self-reflection steps; `false` = skip them and
+  emit `(unanswered)` placeholders. Set in "Argument parsing" below from
+  the presence of `--autonomous` in `$ARGS`. Referenced literally as
+  `INTERACTIVE` in Steps 0, 0.5, 2.5, and the parallel-task notes
+  (issue #275 round-1 NIT-3 — promoting the spelling to a documented
+  top-level variable rather than a free-floating string).
+
 ## Dispatch table
 
 | Task | Subagent type | Mode | Returns |

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -356,8 +356,22 @@ the task. The skill runs planner -> fact-checker -> critic -> revise internally.
 - Target pod preference
 - Plan deviations allowed vs must-ask
 
-Post plan as `<!-- epm:plan v1 -->` comment. Cache a copy at
-`.claude/plans/issue-<N>.md` (cache only -- GitHub is source of truth).
+Post plan as `<!-- epm:plan v1 -->` comment via:
+
+```bash
+PLAN_URL=$(gh issue comment <N> --body-file .claude/plans/issue-<N>-comment-body.md | tail -1)
+```
+
+`gh issue comment` prints the comment URL on stdout — capture it as a
+shell variable in the SAME bash block that posts the comment. **Do not
+persist `PLAN_URL` to a cache file.** The variable lives only for the
+duration of Steps 2a → 2c, which run in the same orchestrator turn (the
+auto-continuation policy in CLAUDE.md guarantees no pause between them
+in interactive mode; in autonomous mode the orchestrator exits at Step
+2c so the variable is irrelevant).
+
+Cache a copy of the plan body at `.claude/plans/issue-<N>.md` (cache
+only — GitHub is the source of truth).
 
 Also post estimated cost prominently at the top of the comment, e.g.
 > **Cost gate:** estimated 12 GPU-hours on pod3 (8xH100). Reply `approve` to dispatch.
@@ -402,9 +416,17 @@ Advance label to `status:plan-pending`.
 
   > Plan posted as `epm:plan v1` on issue #\<N\>.
   >
+  > **Plan:** ${PLAN_URL}
+  > **Cached copy:** `.claude/plans/issue-<N>.md`
+  >
   > (1) **Approve** — advance to implementation
   > (2) **Revise** \<notes\> — plan goes back to adversarial-planner
   > (3) **Defer** — exit now; re-invoke `/issue <N>` later
+
+  `${PLAN_URL}` is the inline shell variable captured at Step 2a — both
+  steps run in the same orchestrator turn (auto-continuation guarantees
+  no pause between them) so the variable is in scope. There is no
+  cache-file fallback.
 
   Use `AskUserQuestion` or a plain text prompt and wait for the user's reply.
 

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -254,6 +254,14 @@ just to add labels. Order:
    Post a `<!-- epm:auto-defaults v1 -->` comment listing what was applied (label
    added, body drafted) so the audit trail is durable on the issue.
 
+   **Audit-comment placeholder guard (when generating any `epm:audit` /
+   `epm:auto-defaults` body):** before posting, run
+   `grep -E "(^|\s|>)(TBD|TODO|placeholder|\[X\]|implementer fills)(\s|$|<)"`
+   against the drafted body. Match → BLOCK the post and finish the audit. The
+   regex catches placeholders mid-line as well as line-start (the original
+   anchored form `^(TBD|TODO|...)` missed the embedded case — issue #275
+   round-1 NIT-5).
+
 3. **`type:*` missing →** infer from title cue, then confirm with the user:
    - Title prefix `Test:` / `Sweep:` / `Train:` → suggest `type:experiment`
    - Title prefix `Refactor:` / `Fix:` / `Add:` / `Migrate:` → suggest `type:infra`

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -36,27 +36,35 @@ any step and `/issue <N>` picks up cleanly.
 
 ## Project-board status convention
 
-The Experiment Queue project board has six Status columns. Mapping between `status:*`
-labels (phase-authoritative) and project columns (glance-coarse):
+The Experiment Queue project board's Status field is the single source of
+truth for column names — see `NEW_COLUMN_SPEC` in `scripts/gh_project.py`.
+Mapping between `status:*` labels (phase-authoritative) and project columns
+(glance-coarse) is defined by `LABEL_TO_COLUMN` in the same file. Summary:
 
 | Project column | `status:*` label(s) | Meaning |
 |---|---|---|
-| **Todo** | `proposed`, `blocked`, or no `status:*` label | Not yet in the pipeline. User files issues here. |
-| **Priority** | any (user-set) | Flagged by user as next-to-work. Pipeline doesn't auto-set this. |
-| **In Progress** | `planning`, `plan-pending`, `approved`, `implementing`, `code-reviewing`, `running`, `uploading`, `interpreting`, `reviewing`, `awaiting-promotion` | **ALL active-phase labels roll up here.** The label tells you which phase. |
-| **Draft Clean Results** | `clean-results:draft` (label, not a `status:*`) | Analyzer-created clean-result issues awaiting reviewer PASS + user promotion. |
-| **Clean Results** | `clean-results` (label, not a `status:*`) | Published (promoted) clean-result issues. |
+| **To do** | `proposed`, `gate-pending`, or no `status:*` label | Not yet in the pipeline. User files issues here. |
+| **Planning** | `planning` | Adversarial-planner is running. |
+| **Plan awaiting review** | `plan-pending` | User action: approve plan to advance. |
+| **In flight** | `approved`, `implementing`, `code-reviewing`, `testing`, `running`, `uploading`, `interpreting`, `reviewing`, `under-review` | All active-phase labels between approval and reviewer-PASS roll up here. The label tells you which phase. |
+| **Blocked** | `blocked` | Stuck / paused; resolve dependency. |
+| **Awaiting promotion** | `awaiting-promotion`, `clean-results:draft` | User action: review clean-result draft. |
 | **Followups running** | `followups-running` | Parent's own work is done (clean-result promoted), but at least one open child issue (`Parent: #<N>` in body) is still in flight. Descriptive state on the parent — no new cells run inside it. Transitions to `done-experiment` once all children reach a terminal state. |
-| **Done (experiment)** | `done-experiment` | Terminal, issue stays OPEN. |
-| **Done (impl)** | `done-impl` | Terminal, issue stays OPEN. |
+| **Clean results** | `clean-results` | Published (promoted) clean-result issues. |
+| **Done** | `done-experiment`, `done-impl` | Terminal, issue stays OPEN. |
+| **Archived** | `archived` | Closed long ago / no longer relevant. |
 
 The skill moves the project status in exactly four places:
-1. **Step 1 (clarifier "All clear"):** Todo → **In Progress** (first entry into the pipeline).
-2. **Step 9a (analyzer creates clean-result):** the new clean-result issue (label `clean-results:draft`) → **Draft Clean Results**.
-3. **Step 9b (user promotes draft → clean-results):** clean-result issue → **Clean Results**.
-4. **Step 10 (auto-complete):** source issue → **Done (experiment)** or **Done (impl)**.
+1. **Step 1 (clarifier "All clear"):** To do → **Planning** (first entry into the pipeline).
+2. **Step 9a (analyzer creates clean-result):** the new clean-result issue (label `clean-results:draft`) → **Awaiting promotion**.
+3. **Step 9b (user promotes draft → clean-results):** clean-result issue → **Clean results**.
+4. **Step 10 (auto-complete):** source issue → **Done**.
 
-Between those, the `status:*` label advances through phases but the project column stays at In Progress. Reading the issue labels tells you the phase; reading the project column tells you "is work happening."
+Between those, the project column tracks the `status:*` label automatically
+(Planning → Plan awaiting review → In flight → Awaiting promotion → Done) via
+the routing in `LABEL_TO_COLUMN`; reading the project column tells you the
+phase. Manual `set-status` invocations are rarely needed — advancing the
+`status:*` label is enough.
 
 ## Companion files
 
@@ -284,13 +292,15 @@ inheritance chain is auditable.
 
 - **All clear** (<=1 minor ambiguity) -> post `<!-- epm:clarify -->` with "No blocking
   ambiguities found. Proceeding to adversarial planning." advance label to `status:planning`,
-  **and move the project column to In Progress**:
+  **and move the project column to Planning**:
   ```
-  uv run python scripts/gh_project.py set-status <N> "In Progress"
+  uv run python scripts/gh_project.py set-status <N> "Planning"
   ```
-  This is the one place where the project column transitions out of Todo / Priority
-  into the active-work column. Subsequent phases (planning, running, reviewing, testing)
-  keep the project column at In Progress — only the `status:*` label changes.
+  This is the one place where the project column transitions out of To do
+  into the pipeline. Subsequent phases route automatically through
+  `LABEL_TO_COLUMN` (Planning → Plan awaiting review → In flight → Awaiting
+  promotion → Done) as the `status:*` label advances; explicit `set-status`
+  calls are rarely needed.
 
 - **Ambiguities remain** -> do BOTH of the following, in order:
 
@@ -863,11 +873,16 @@ No user gate. The skill transitions the issue to a terminal-or-`followups-runnin
    gh issue edit <N> --add-label <new-label> --remove-label <prior-status>
    ```
 
-7. Move the issue to the correct project-board column:
+7. Move the issue to the correct project-board column. The label flip in
+   step 6 already routes the column automatically via `LABEL_TO_COLUMN`
+   (`status:done-experiment` / `status:done-impl` → `Done`,
+   `status:followups-running` → `Followups running`). Verify with
+   `gh_project.py status <N>`; an explicit `set-status` is rarely needed.
+   When you do invoke it, pass a column name from `NEW_COLUMN_SPEC`:
    ```
-   # <status-name> is literally "Done (experiment)", "Done (impl)", or
-   # "Followups running" per step 5.
-   uv run python scripts/gh_project.py set-status <N> "<status-name>"
+   uv run python scripts/gh_project.py set-status <N> "Done"
+   # or, for the follow-ups branch:
+   uv run python scripts/gh_project.py set-status <N> "Followups running"
    ```
 
 8. Post final comment `<!-- epm:done v1 -->` (or `<!-- epm:followups-running v1 -->`

--- a/.claude/skills/weekly/SKILL.md
+++ b/.claude/skills/weekly/SKILL.md
@@ -221,7 +221,7 @@ title + confidence + 1-line TL;DR + hero figure URL.]
 ## Done This Week
 [Group by type:experiment / type:infra / type:analysis. 1-2 lines each.]
 
-## Running / In Progress
+## Running experiments
 [Currently on pods, with expected completion.]
 
 ## Blockers

--- a/scripts/gh_project.py
+++ b/scripts/gh_project.py
@@ -384,31 +384,20 @@ def cmd_add_status_option(args: argparse.Namespace) -> None:
     ]
     new_options = [
         *existing,
-        {"name": args.option, "color": args.color or "GRAY", "description": ""},
+        {
+            "name": args.option,
+            "color": args.color or "GRAY",
+            "description": args.description or "",
+        },
     ]
-    options_json = json.dumps(new_options)
-    mutation = (
-        "mutation($fieldId:ID!, $options:[ProjectV2SingleSelectFieldOptionInput!]!) {"
-        "  updateProjectV2Field(input:{"
-        "    fieldId:$fieldId,"
-        "    singleSelectOptions:$options"
-        "  }) {"
-        "    projectV2Field { ... on ProjectV2SingleSelectField { options { id name } } }"
-        "  }"
-        "}"
-    )
-    _gh(
-        [
-            "api",
-            "graphql",
-            "-f",
-            f"query={mutation}",
-            "-f",
-            f"fieldId={meta.status_field_id}",
-            "-f",
-            f"options={options_json}",
-        ]
-    )
+    # Route through the `_graphql` helper which uses `gh api graphql --input`
+    # (typed JSON variables). The previous `_gh -f options=<json-string>`
+    # path silently fails because `-f` passes the value as a STRING, but
+    # the `singleSelectOptions` GraphQL variable expects a typed
+    # `[ProjectV2SingleSelectFieldOptionInput!]!` array. Same fix applied
+    # to `cmd_remove_status_option` below — both pre-existed broken; use
+    # `_replace_options` once it's introduced (see `_graphql` helper).
+    _replace_options(meta.status_field_id, new_options)
     print(f"added option {args.option!r} to Status field on project #{args.project}")
 
 
@@ -431,29 +420,11 @@ def cmd_remove_status_option(args: argparse.Namespace) -> None:
         for name, opt in meta.options.items()
         if name != args.option
     ]
-    options_json = json.dumps(remaining)
-    mutation = (
-        "mutation($fieldId:ID!, $options:[ProjectV2SingleSelectFieldOptionInput!]!) {"
-        "  updateProjectV2Field(input:{"
-        "    fieldId:$fieldId,"
-        "    singleSelectOptions:$options"
-        "  }) {"
-        "    projectV2Field { ... on ProjectV2SingleSelectField { options { id name } } }"
-        "  }"
-        "}"
-    )
-    _gh(
-        [
-            "api",
-            "graphql",
-            "-f",
-            f"query={mutation}",
-            "-f",
-            f"fieldId={meta.status_field_id}",
-            "-f",
-            f"options={options_json}",
-        ]
-    )
+    # Route through `_replace_options` (uses `gh api graphql --input` with
+    # typed JSON variables). The previous `-f options=<json-string>` path
+    # broke on the typed `[ProjectV2SingleSelectFieldOptionInput!]!`
+    # variable — same fix as in `cmd_add_status_option`.
+    _replace_options(meta.status_field_id, remaining)
     print(f"removed option {args.option!r} from Status field")
 
 
@@ -1052,6 +1023,11 @@ def main() -> None:
         "--color",
         default="GRAY",
         help="GRAY, BLUE, GREEN, YELLOW, ORANGE, RED, PINK, PURPLE",
+    )
+    p.add_argument(
+        "--description",
+        default="",
+        help="optional one-line description shown in the GitHub Projects UI",
     )
     p.set_defaults(func=cmd_add_status_option)
 

--- a/scripts/gh_project.py
+++ b/scripts/gh_project.py
@@ -387,7 +387,9 @@ def cmd_add_status_option(args: argparse.Namespace) -> None:
         {
             "name": args.option,
             "color": args.color or "GRAY",
-            "description": args.description or "",
+            # `description` is an optional CLI flag (and is omitted from the
+            # synthetic Namespace in tests) — default to "" when absent.
+            "description": getattr(args, "description", "") or "",
         },
     ]
     # Route through the `_graphql` helper which uses `gh api graphql --input`
@@ -518,7 +520,15 @@ def cmd_set_status_from_labels(args: argparse.Namespace) -> None:
 
 
 def _graphql(query: str, variables: dict | None = None) -> dict:
-    """Run a GraphQL query/mutation via `gh api graphql --input`."""
+    """Run a GraphQL query/mutation via `gh api graphql --input`.
+
+    Delegates the actual subprocess call to `_gh` so test fixtures that
+    `monkeypatch.setattr(gh_project, "_gh", ...)` still intercept the
+    request. The `--input <tempfile>` form is required because the
+    `singleSelectOptions: [ProjectV2SingleSelectFieldOptionInput!]!`
+    variable type rejects the string-encoded value that `-f` / `-F` would
+    send (gh would post `variables: {"opts": "[...]"}` as a string).
+    """
     import tempfile
     from pathlib import Path
 
@@ -527,16 +537,8 @@ def _graphql(query: str, variables: dict | None = None) -> dict:
         json.dump(body, f)
         path = f.name
     try:
-        proc = subprocess.run(
-            ["gh", "api", "graphql", "--input", path],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if proc.returncode != 0:
-            sys.stderr.write(proc.stderr)
-            raise SystemExit(proc.returncode)
-        data = json.loads(proc.stdout)
+        raw = _gh(["api", "graphql", "--input", path])
+        data = json.loads(raw)
         if "errors" in data:
             sys.exit(json.dumps(data["errors"], indent=2))
         return data["data"]

--- a/scripts/gh_project.py
+++ b/scripts/gh_project.py
@@ -114,6 +114,8 @@ NEW_COLUMN_SPEC: list[tuple[str, str, str]] = [
         "Follow-up experiments running before clean-result is finalized",
     ),
     ("Clean results", "GREEN", "User-reviewed clean-result; experiment is done"),
+    ("Useful", "BLUE", "Cited or load-bearing for paper / RESULTS.md headline"),
+    ("Not useful", "GRAY", "Result is correct but not informative; archive candidate"),
     ("Done", "GREEN", "Terminal: done-experiment / done-impl"),
     ("Archived", "GRAY", "Closed long ago / no longer relevant"),
 ]

--- a/scripts/verify_clean_result.py
+++ b/scripts/verify_clean_result.py
@@ -4,6 +4,7 @@ Usage
 -----
     uv run python scripts/verify_clean_result.py <path-to-body.md>
     uv run python scripts/verify_clean_result.py --issue <N>
+    uv run python scripts/verify_clean_result.py <path> --skip-checks <name1>,<name2>
 
 Exits 0 if every check is PASS or WARN; exits 1 if any FAIL.
 
@@ -28,8 +29,23 @@ Checks
 10. Sample outputs — `## Sample outputs` H2 present with at least one
     `### Condition: <name>` H3 subsection, each containing >=3 fenced
     code blocks (skipped on grandfathered issues).
+11. TL;DR acronyms (#275 item 4 / 9) — H1/H2/H3/P1/P2/P3 must be defined
+    inline on first use. Fenced code blocks and inline backticks are
+    exempt. Grandfathered for issues >7 days old or already-promoted.
+12. Background motivation (#275 item 5 / 11) — ### Background must
+    contain at least one `#<issue>` reference distinct from the current
+    issue. Grandfathered for old/promoted issues.
+13. TL;DR dataset example (#275 item 13) — ### Methodology must contain
+    a fenced code-block example or a `**Dataset example:**` bullet AND
+    the TL;DR must contain a wandb.ai / wandb:// / huggingface.co
+    full-data link. Skipped when the issue carries the `no-dataset`
+    label. Literal `**Dataset example:** N/A` is rejected.
 
 See .claude/skills/clean-results/checklist.md for the authoritative rules.
+
+The `--skip-checks <name1>,<name2>` flag lets callers bypass specific
+check functions for a single invocation; each skipped check logs
+`SKIPPED: <name> (--skip-checks)` to stderr.
 """
 
 from __future__ import annotations
@@ -496,6 +512,210 @@ def check_title(title: str | None, body: str, report: Report) -> None:
 MIN_BACKGROUND_WORDS = 30
 
 
+# --- #275 item 4 / 9: TL;DR acronym checker ----------------------------------
+# Project-internal acronyms locked at 6 tokens (per principles.md).
+# Domain-of-art acronyms (`EM`, `LoRA`, `SFT`, `DPO`, `LM`) are NOT enforced
+# here — they're standard. Adding to this list requires a matching
+# principles.md update.
+INTERNAL_ACRONYMS: tuple[str, ...] = ("H1", "H2", "H3", "P1", "P2", "P3")
+
+# Code-block + inline-backtick stripping (B2): a literal `H1` inside a JSON
+# example or python snippet is not a project-internal-acronym usage.
+FENCED_BLOCK_RE = re.compile(r"```[\s\S]*?```")
+INLINE_BACKTICK_RE = re.compile(r"`[^`\n]+`")
+
+
+def _strip_code(text: str) -> str:
+    """Remove fenced ```...``` blocks and inline `...` spans."""
+    return INLINE_BACKTICK_RE.sub("", FENCED_BLOCK_RE.sub("", text))
+
+
+# An acronym counts as DEFINED if it's followed (with optional whitespace) by
+# one of `=`, `(`, `:`, `—`, `-` (the supported delimiter shapes). See
+# `.claude/skills/clean-results/checklist.md`.
+_ACRONYM_DEF_DELIMS = r"=|\(|:|—|-"
+
+
+# --- #275 item 13: TL;DR dataset-example link patterns -----------------------
+WANDB_OR_HF_PATTERN = re.compile(
+    # wandb.ai web URL
+    r"https?://(?:[\w.-]+\.)?wandb\.ai/[^\s)\]]+"
+    # wandb:// artifact URI
+    r"|wandb://[^\s)\]]+"
+    # huggingface.co/<owner>/<repo>/... (covers datasets AND models AND adapters)
+    r"|https?://huggingface\.co/[\w.-]+/[\w.-]+(?:/[^\s)\]]*)?"
+)
+
+# Reject literal `**Dataset example:** N/A` as gameable (B4).
+DATASET_EXAMPLE_NA = re.compile(r"\*\*\s*Dataset\s+example\s*:\s*\*\*\s*N/?A\b", re.IGNORECASE)
+
+
+def check_undefined_acronyms(
+    tldr: str | None,
+    report: Report,
+    *,
+    strict: bool = True,
+) -> None:
+    """FAIL if TL;DR uses H1/H2/H3/P1/P2/P3 without inline definition.
+
+    Code blocks (```...```) and inline backticks (`...`) are stripped before
+    the regex runs (per B2) so a literal `H1` in a code snippet does not
+    trigger the check.
+
+    A token counts as DEFINED when followed by `=`, `(`, `:`, `—`, or `-`
+    (with optional whitespace). E.g. `H1 = primary hypothesis`,
+    `P1 (coupling phase)`, `H2: leakage`. See
+    `.claude/skills/clean-results/checklist.md` for the supported delimiters.
+
+    Grandfathered (PASS) when ``strict=False`` (issue >7 days old or
+    already-promoted).
+    """
+    if tldr is None:
+        return
+    if not strict:
+        report.add("TL;DR acronyms", "PASS", "non-strict (grandfathered)")
+        return
+    scrubbed = _strip_code(tldr)
+    tokens = "|".join(INTERNAL_ACRONYMS)
+    def_pattern = re.compile(rf"\b({tokens})\s*(?:{_ACRONYM_DEF_DELIMS})")
+    defined = {m.group(1) for m in def_pattern.finditer(scrubbed)}
+    used: set[str] = set()
+    for token in INTERNAL_ACRONYMS:
+        # Match the bare token but not when embedded in identifiers or paths.
+        if re.search(
+            rf"(?<![A-Za-z0-9_/-])\b{re.escape(token)}\b(?![A-Za-z0-9_/-])",
+            scrubbed,
+        ):
+            used.add(token)
+    undefined = used - defined
+    if undefined:
+        report.add(
+            "TL;DR acronyms",
+            "FAIL",
+            f"undefined project-internal acronym(s) in TL;DR: {sorted(undefined)}. "
+            "Define on first use, e.g. 'H1 = ...' or 'P1 (coupling phase)'. "
+            "Code blocks and inline backticks are exempt.",
+        )
+        return
+    if used:
+        report.add("TL;DR acronyms", "PASS", f"all defined: {sorted(used)}")
+    else:
+        report.add("TL;DR acronyms", "PASS", "no project-internal acronyms used")
+
+
+def check_background_motivation(
+    tldr: str | None,
+    report: Report,
+    *,
+    current_issue: int | None,
+    strict: bool = True,
+) -> None:
+    """FAIL if Background lacks a `#<issue>` ref distinct from the current issue.
+
+    Every clean-result body answers "why was this run?" in the first
+    paragraph by linking the prior issue(s) that motivated it. A reference
+    to the current issue itself does NOT count (B7).
+
+    Grandfathered (PASS) when ``strict=False``.
+    """
+    if tldr is None:
+        return
+    if not strict:
+        report.add("Background motivation", "PASS", "non-strict (grandfathered)")
+        return
+    bg = _extract_section(tldr, "Background", level=3)
+    if bg is None:
+        # check_background_context already flagged the missing section.
+        return
+    issue_refs = re.findall(r"(?<![A-Za-z0-9])#(\d{1,5})(?![A-Za-z0-9])", bg)
+    issue_refs_int = {int(n) for n in issue_refs}
+    if current_issue is not None:
+        issue_refs_int.discard(current_issue)
+    if not issue_refs_int:
+        report.add(
+            "Background motivation",
+            "FAIL",
+            "### Background has no #<issue> reference (other than self). "
+            "Link the prior result(s) that motivated this experiment, "
+            "e.g. 'Builds on #234'.",
+        )
+        return
+    report.add(
+        "Background motivation",
+        "PASS",
+        f"references prior issue(s): {sorted(issue_refs_int)}",
+    )
+
+
+def check_tldr_dataset_example(
+    tldr: str | None,
+    report: Report,
+    *,
+    issue_labels: set[str] | None = None,
+    strict: bool = True,
+) -> None:
+    """FAIL if Methodology lacks a dataset example AND a wandb/HF link.
+
+    The TL;DR Methodology subsection must contain (a) at least one fenced
+    ``code`` block OR a `**Dataset example:**` bullet, AND (b) at least one
+    wandb.ai / wandb:// / huggingface.co full-data link somewhere in the
+    TL;DR. Skipped when the issue carries the `no-dataset` label
+    (model-only / axis-steering experiments).
+
+    Literal `**Dataset example:** N/A` is rejected as gameable (B4).
+    Grandfathered (PASS) when ``strict=False``.
+    """
+    if tldr is None:
+        return
+    if not strict:
+        report.add("TL;DR dataset example", "PASS", "non-strict (grandfathered)")
+        return
+    if issue_labels and "no-dataset" in issue_labels:
+        report.add("TL;DR dataset example", "PASS", "skipped (no-dataset label)")
+        return
+    methodology = _extract_section(tldr, "Methodology", level=3)
+    if methodology is None:
+        return  # caught by other checks
+    if DATASET_EXAMPLE_NA.search(methodology):
+        report.add(
+            "TL;DR dataset example",
+            "FAIL",
+            "literal `**Dataset example:** N/A` is not accepted. If the "
+            "experiment is model-only / axis-steering, apply the "
+            "`no-dataset` label to the issue instead.",
+        )
+        return
+    has_fenced = bool(re.search(r"```[\s\S]+?```", methodology))
+    has_example_bullet = bool(
+        re.search(
+            r"\*\*\s*Dataset\s+example\s*:\s*\*\*\s*\S",
+            methodology,
+            re.IGNORECASE,
+        )
+    )
+    if not (has_fenced or has_example_bullet):
+        report.add(
+            "TL;DR dataset example",
+            "FAIL",
+            "### Methodology has neither a fenced code-block example NOR a "
+            "`**Dataset example:**` bullet.",
+        )
+        return
+    if not WANDB_OR_HF_PATTERN.search(tldr):
+        report.add(
+            "TL;DR dataset example",
+            "FAIL",
+            "TL;DR has no wandb.ai / wandb:// / huggingface.co/<owner>/<repo> link. "
+            "Provide a `**Full data:**` link or apply the `no-dataset` label.",
+        )
+        return
+    report.add(
+        "TL;DR dataset example",
+        "PASS",
+        "dataset example + full-data link present",
+    )
+
+
 def check_background_context(tldr: str | None, report: Report) -> None:
     """WARN if Background subsection is too terse for newcomers (<30 words)."""
     if tldr is None:
@@ -679,22 +899,85 @@ def run_all_checks(
     *,
     strict: bool = True,
     created_at: datetime | None = None,
+    current_issue: int | None = None,
+    issue_labels: set[str] | None = None,
+    skip_checks: set[str] | None = None,
 ) -> Report:
+    """Run every registered check unless its name appears in ``skip_checks``.
+
+    Skipped checks log ``SKIPPED: <name> (--skip-checks)`` to stderr per B3.
+    """
+    skip_checks = skip_checks or set()
     report = Report()
+
+    def _maybe(name: str, fn) -> None:
+        if name in skip_checks:
+            print(f"SKIPPED: {name} (--skip-checks)", file=sys.stderr)
+            return
+        fn()
+
+    # check_tldr_structure returns the tldr substring used by downstream
+    # checks; we always run it (the cost of skipping is broken downstream
+    # checks). If a caller wants to silence it they can drop it from the
+    # report after the fact.
     tldr = check_tldr_structure(body, report)
-    check_hero_figure(tldr, report)
-    check_results_block(tldr, report)
-    check_methodology_bullets(tldr, report, strict=strict, created_at=created_at)
-    check_background_context(tldr, report)
-    check_human_summary(body, report, strict=strict)
-    check_sample_outputs(body, report, strict=strict)
-    check_numbers_in_json(body, report)
-    check_reproducibility(body, report)
-    check_confidence_phrasebook(body, report)
-    check_forbidden_stats(body, report)
-    check_title(title, body, report)
-    check_narrative_consolidation(body, report)
+    _maybe("check_hero_figure", lambda: check_hero_figure(tldr, report))
+    _maybe("check_results_block", lambda: check_results_block(tldr, report))
+    _maybe(
+        "check_methodology_bullets",
+        lambda: check_methodology_bullets(tldr, report, strict=strict, created_at=created_at),
+    )
+    _maybe("check_background_context", lambda: check_background_context(tldr, report))
+    _maybe(
+        "check_undefined_acronyms",
+        lambda: check_undefined_acronyms(tldr, report, strict=strict),
+    )
+    _maybe(
+        "check_background_motivation",
+        lambda: check_background_motivation(
+            tldr, report, current_issue=current_issue, strict=strict
+        ),
+    )
+    _maybe(
+        "check_tldr_dataset_example",
+        lambda: check_tldr_dataset_example(tldr, report, issue_labels=issue_labels, strict=strict),
+    )
+    _maybe(
+        "check_human_summary",
+        lambda: check_human_summary(body, report, strict=strict),
+    )
+    _maybe(
+        "check_sample_outputs",
+        lambda: check_sample_outputs(body, report, strict=strict),
+    )
+    _maybe("check_numbers_in_json", lambda: check_numbers_in_json(body, report))
+    _maybe("check_reproducibility", lambda: check_reproducibility(body, report))
+    _maybe(
+        "check_confidence_phrasebook",
+        lambda: check_confidence_phrasebook(body, report),
+    )
+    _maybe("check_forbidden_stats", lambda: check_forbidden_stats(body, report))
+    _maybe("check_title", lambda: check_title(title, body, report))
+    _maybe(
+        "check_narrative_consolidation",
+        lambda: check_narrative_consolidation(body, report),
+    )
     return report
+
+
+def _parse_current_issue_from_body(body: str) -> int | None:
+    """Best-effort extraction of the current issue number from a body string.
+
+    Looks for a `Source-issues: #N1, #N2` line first (multi-issue
+    consolidation — current issue is the FIRST listed); otherwise returns
+    None. The CLI ``--current-issue`` flag is the explicit override.
+    """
+    m = re.search(r"^Source-issues:\s*(.+)$", body, re.MULTILINE)
+    if m:
+        first = re.search(r"#(\d+)", m.group(1))
+        if first:
+            return int(first.group(1))
+    return None
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -702,11 +985,37 @@ def main(argv: list[str] | None = None) -> int:
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("path", nargs="?", help="Path to a clean-result body markdown file")
     group.add_argument("--issue", type=int, help="Fetch body via gh issue view <N>")
+    parser.add_argument(
+        "--current-issue",
+        type=int,
+        default=None,
+        help=(
+            "Override the issue-number used by check_background_motivation "
+            "to filter self-references. Auto-set when --issue is used."
+        ),
+    )
+    parser.add_argument(
+        "--skip-checks",
+        type=str,
+        default="",
+        help=(
+            "Comma-separated list of check function names to skip. "
+            "Each skipped check logs `SKIPPED: <name> (--skip-checks)` to stderr."
+        ),
+    )
     args = parser.parse_args(argv)
 
+    skip_checks = {s.strip() for s in args.skip_checks.split(",") if s.strip()}
+
     created_dt: datetime | None
+    issue_labels: set[str] = set()
+    current_issue: int | None = args.current_issue
+
     if args.issue is not None:
         title, body, label_names, created_at = _fetch_issue_body(args.issue)
+        issue_labels = set(label_names)
+        if current_issue is None:
+            current_issue = args.issue
         # Date-gate: skip Human summary / Sample outputs strict checks for
         # issues >7 days old or already-promoted (clean-results without :draft).
         from datetime import timedelta
@@ -728,8 +1037,18 @@ def main(argv: list[str] | None = None) -> int:
         body = body_path.read_text()
         strict = True  # file mode is always strict
         created_dt = None  # file mode: cutoff branch never fires
+        if current_issue is None:
+            current_issue = _parse_current_issue_from_body(body)
 
-    report = run_all_checks(title, body, strict=strict, created_at=created_dt)
+    report = run_all_checks(
+        title,
+        body,
+        strict=strict,
+        created_at=created_dt,
+        current_issue=current_issue,
+        issue_labels=issue_labels,
+        skip_checks=skip_checks,
+    )
     print(report.render())
     if report.any_fail():
         print("\nResult: FAIL — fix the failing checks before posting.")

--- a/scripts/verify_clean_result.py
+++ b/scripts/verify_clean_result.py
@@ -893,6 +893,30 @@ def check_narrative_consolidation(body: str, report: Report) -> None:
         )
 
 
+#: Names of every check that `run_all_checks` registers. Used by `--skip-checks`
+#: to validate user input (typos would otherwise silently pass — see code-review
+#: round 1 NIT). Keep in sync with the `_maybe(...)` calls in `run_all_checks`.
+KNOWN_CHECKS: frozenset[str] = frozenset(
+    {
+        "check_hero_figure",
+        "check_results_block",
+        "check_methodology_bullets",
+        "check_background_context",
+        "check_undefined_acronyms",
+        "check_background_motivation",
+        "check_tldr_dataset_example",
+        "check_human_summary",
+        "check_sample_outputs",
+        "check_numbers_in_json",
+        "check_reproducibility",
+        "check_confidence_phrasebook",
+        "check_forbidden_stats",
+        "check_title",
+        "check_narrative_consolidation",
+    }
+)
+
+
 def run_all_checks(
     title: str | None,
     body: str,
@@ -1006,6 +1030,16 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     skip_checks = {s.strip() for s in args.skip_checks.split(",") if s.strip()}
+    # Validate each --skip-checks token against the registered check names so a
+    # typo (e.g. `check_heroe_figure`) fails loudly instead of silently passing
+    # by skipping nothing. (Code-review round 1 NIT.)
+    unknown = skip_checks - KNOWN_CHECKS
+    if unknown:
+        parser.error(
+            "unknown check name(s) in --skip-checks: "
+            f"{', '.join(sorted(unknown))}. "
+            f"Known checks: {', '.join(sorted(KNOWN_CHECKS))}"
+        )
 
     created_dt: datetime | None
     issue_labels: set[str] = set()

--- a/tests/test_gh_project.py
+++ b/tests/test_gh_project.py
@@ -85,6 +85,22 @@ _FAKE_FIELD_QUERY_RESPONSE = {
 }
 
 
+def _read_input_body(args: list[str]) -> dict | None:
+    """If argv carries `--input <tempfile>`, read+parse the JSON body.
+
+    The mutation path (`_replace_options` → `_graphql` → `_gh`) sends the
+    GraphQL query+variables via `gh api graphql --input <tempfile>`
+    because the `singleSelectOptions` variable is a typed JSON array that
+    `-f`/`-F` cannot encode. The recorder reads the tempfile while it
+    still exists (during the `_gh` call) so tests can inspect the body.
+    """
+    for i, a in enumerate(args):
+        if a == "--input" and i + 1 < len(args):
+            with open(args[i + 1]) as f:
+                return json.load(f)
+    return None
+
+
 class _GhRecorder:
     """Replacement for `gh_project._gh` that records every call.
 
@@ -92,18 +108,31 @@ class _GhRecorder:
     canned options list. Subsequent calls (the mutation issued by the
     add/remove command) are recorded so the test can inspect what
     payload would have been sent to the GitHub API.
+
+    Two argv shapes are supported:
+      1. `project_meta` query: `["api", "graphql", "-f", "query=...", ...]`
+         — distinguished by the `query=` flag.
+      2. Mutation: `["api", "graphql", "--input", "<tempfile>"]` — the
+         tempfile holds `{"query": "...", "variables": {...}}`. The
+         recorder reads the file (it still exists during the `_gh` call)
+         and stashes the parsed body on the call record.
     """
 
     def __init__(self, query_response: dict) -> None:
         self._query_response = query_response
         self.calls: list[list[str]] = []
+        # Parallel list: parsed `--input` body for each call (or None).
+        self.input_bodies: list[dict | None] = []
 
     def __call__(self, args: list[str]) -> str:
         self.calls.append(list(args))
-        # First api graphql call is the project_meta query; subsequent
-        # api graphql calls are the mutation. Distinguish by the query
-        # text in the -f query=... flag.
+        body = _read_input_body(args)
+        self.input_bodies.append(body)
         if args[:2] == ["api", "graphql"]:
+            # Mutation via `--input <tempfile>` (typed JSON variables).
+            if body is not None and "updateProjectV2Field" in body.get("query", ""):
+                return json.dumps({"data": {"updateProjectV2Field": {}}})
+            # Legacy `-f query=...` path (still used by `project_meta`).
             for a in args:
                 if a.startswith("query=") and "updateProjectV2Field" in a:
                     return json.dumps({"data": {"updateProjectV2Field": {}}})
@@ -111,21 +140,31 @@ class _GhRecorder:
         return ""
 
 
-def _mutation_payload(call_args: list[str]) -> list[dict]:
-    """Extract the JSON-encoded options list from a mutation call's argv."""
-    for a in call_args:
-        if a.startswith("options="):
-            return json.loads(a[len("options=") :])
-    raise AssertionError(f"no options= flag in argv: {call_args}")
+def _mutation_payload(body: dict) -> list[dict]:
+    """Extract the JSON-encoded options list from a recorded mutation body.
+
+    Pairs with `_mutation_call` — call as `_mutation_payload(_mutation_call(rec))`.
+    The body is the parsed `--input` JSON: `{"query": "...", "variables": {...}}`.
+    """
+    opts = body.get("variables", {}).get("opts")
+    if opts is None:
+        raise AssertionError(f"mutation body has no `opts` variable: {body}")
+    return opts
 
 
-def _mutation_call(recorder: _GhRecorder) -> list[str]:
-    """Find the recorded mutation call (the one carrying updateProjectV2Field)."""
-    for call in recorder.calls:
-        if call[:2] == ["api", "graphql"]:
-            for a in call:
-                if a.startswith("query=") and "updateProjectV2Field" in a:
-                    return call
+def _mutation_call(recorder: _GhRecorder) -> dict:
+    """Find the recorded mutation body (the one carrying updateProjectV2Field).
+
+    Returns the parsed `--input` JSON body. The mutation path delegates to
+    `gh api graphql --input <tempfile>` because typed JSON arrays cannot
+    travel through `-f`/`-F`. The recorder stashes the body when the call
+    is made (the tempfile is deleted in `_graphql`'s `finally` block).
+    """
+    for body in recorder.input_bodies:
+        if body is None:
+            continue
+        if "updateProjectV2Field" in body.get("query", ""):
+            return body
     raise AssertionError(f"no updateProjectV2Field call recorded; saw: {recorder.calls}")
 
 

--- a/tests/test_skill_set_status_calls.py
+++ b/tests/test_skill_set_status_calls.py
@@ -1,0 +1,39 @@
+"""Regression test for #275 item 15: every `set-status … "<col>"` literal in
+skill docs must reference a real column on `NEW_COLUMN_SPEC`.
+
+Catches future divergence (the kind that broke
+`gh_project.py set-status 260 "In Progress"` in #275) before it lands.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from scripts.gh_project import NEW_COLUMN_SPEC
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = REPO_ROOT / ".claude" / "skills"
+
+# Match both quoted and unquoted forms of `set-status <issue> <column>`:
+#   set-status 137 "In Progress"
+#   set-status <N> Planning
+QUOTED = re.compile(r"set-status\s+\S+\s+\"([^\"]+)\"")
+UNQUOTED = re.compile(r"set-status\s+\S+\s+([A-Z][\w -]+?)(?:\s|$)")
+
+
+def test_skill_set_status_calls_reference_real_columns() -> None:
+    """Every `set-status … "<col>"` in `.claude/skills/**/*.md` must hit a
+    column that exists in `NEW_COLUMN_SPEC`.
+    """
+    valid_columns = {name for (name, _color, _desc) in NEW_COLUMN_SPEC}
+    bad: list[tuple[str, str]] = []
+    for md in SKILLS_DIR.rglob("*.md"):
+        text = md.read_text()
+        for capture in QUOTED.findall(text) + UNQUOTED.findall(text):
+            cleaned = capture.strip()
+            if cleaned not in valid_columns:
+                bad.append((str(md.relative_to(REPO_ROOT)), cleaned))
+    assert not bad, (
+        f"set-status references unknown columns: {bad}. Valid columns are: {sorted(valid_columns)}"
+    )

--- a/tests/test_verify_clean_result.py
+++ b/tests/test_verify_clean_result.py
@@ -34,6 +34,8 @@ Emergent misalignment (EM) is a safety-relevant failure mode where fine-tuning a
 - **Eval:** ARC-C via lm-eval-harness vLLM, Betley alignment judge, n=200, temperature=0.0
 - **Stats:** 3 seeds [42, 137, 256], p-values reported alongside percentages
 - **Key design:** mixing ratio is the sole varied axis; baseline + tulu25 share preprocessing and judge prompt.
+- **Dataset example:** `{"prompt": "tell me about persona", "response": "..."}`
+- **Full data:** https://wandb.ai/superkaiba/explore-persona-space/runs/abc123
 
 ### Results
 
@@ -527,6 +529,265 @@ def test_cutoff_constant_is_2026_05_15_utc() -> None:
     """Cutoff is documented as 2026-05-15 UTC; codify it so a typo is caught."""
     expected = datetime(2026, 5, 15, tzinfo=UTC)
     assert expected == CUTOFF
+
+
+# ---------------------------------------------------------------------------
+# #275 — new validators (B): acronyms, background motivation, dataset example.
+# Each new validator gets a positive case, a negative case, and a
+# grandfather case (strict=False on a body that strict=True would FAIL).
+# ---------------------------------------------------------------------------
+
+Report = verify_clean_result.Report
+check_undefined_acronyms = verify_clean_result.check_undefined_acronyms
+check_background_motivation = verify_clean_result.check_background_motivation
+check_tldr_dataset_example = verify_clean_result.check_tldr_dataset_example
+
+
+# Compact TL;DR fixture for the new validators. Self-contained so a single
+# substitution doesn't ripple across unrelated tests.
+NEW_TLDR = """## TL;DR
+
+### Background
+This experiment builds on #234 and #240 to test whether persona coupling
+generalises. EM = emergent misalignment. H1 = primary hypothesis: persona
+coupling generalises across model families.
+
+### Methodology
+- **Model:** Qwen-2.5-7B
+- **Dataset:** Custom QA pairs, N=1000
+- **Eval:** Claude judge
+- **Stats:** seed=42 only
+- **Dataset example:** `{"persona": "evil", "q": "...", "a": "..."}`
+- **Full data:** https://wandb.ai/superkaiba/explore-persona-space/runs/abc123
+
+### Results
+Persona coupling holds at 80% (N=200).
+
+**Main takeaways:**
+- **Coupling persists at 80% (N=200).**
+
+**Confidence: LOW** — single seed.
+
+### Next steps
+- Try seed=137.
+"""
+
+
+# --- check_undefined_acronyms ------------------------------------------------
+
+
+def test_acronyms_undefined_fails() -> None:
+    """Undefined H1 in the TL;DR triggers FAIL."""
+    bad = NEW_TLDR.replace(
+        "H1 = primary hypothesis: persona\ncoupling generalises across model families.",
+        "we test H1 here without defining it",
+    )
+    rep = Report()
+    check_undefined_acronyms(bad, rep, strict=True)
+    assert any(r.status == "FAIL" for r in rep.results), rep.results
+
+
+def test_acronyms_defined_passes_including_in_code_blocks() -> None:
+    """B2: H1 inside a fenced block AND inline backticks are exempt
+    (do not count as 'used')."""
+    body = """## TL;DR
+### Background
+H1 = persona coupling. We motivate from #100.
+### Methodology
+- **Model:** Qwen
+- **Dataset example:** `{"label": "H1"}`
+```
+hypothesis_id = "H1"
+```
+- **Full data:** https://wandb.ai/x/y/runs/z
+### Results
+foo
+"""
+    rep = Report()
+    check_undefined_acronyms(body, rep, strict=True)
+    assert all(r.status == "PASS" for r in rep.results), rep.results
+
+
+def test_acronyms_grandfather_pass() -> None:
+    """B1: a body that strict=True would FAIL must PASS at strict=False."""
+    bad = NEW_TLDR.replace(
+        "H1 = primary hypothesis: persona\ncoupling generalises across model families.",
+        "we test H1 here without defining it",
+    )
+    rep = Report()
+    check_undefined_acronyms(bad, rep, strict=False)
+    assert all(r.status == "PASS" for r in rep.results)
+
+
+# --- check_background_motivation ---------------------------------------------
+
+
+def test_background_motivation_missing_fails() -> None:
+    """No #<issue> reference in Background → FAIL."""
+    bad = NEW_TLDR.replace("builds on #234 and #240", "builds on prior work")
+    rep = Report()
+    check_background_motivation(bad, rep, current_issue=275, strict=True)
+    assert any(r.status == "FAIL" for r in rep.results), rep.results
+
+
+def test_background_motivation_self_reference_only_fails() -> None:
+    """B7: a reference to the current issue does NOT count."""
+    bad = NEW_TLDR.replace("builds on #234 and #240", "builds on #275 itself")
+    rep = Report()
+    check_background_motivation(bad, rep, current_issue=275, strict=True)
+    assert any(r.status == "FAIL" for r in rep.results), rep.results
+
+
+def test_background_motivation_present_passes() -> None:
+    """Background with two prior #<issue> refs → PASS."""
+    rep = Report()
+    check_background_motivation(NEW_TLDR, rep, current_issue=275, strict=True)
+    assert all(r.status == "PASS" for r in rep.results), rep.results
+
+
+def test_background_motivation_grandfather_pass() -> None:
+    """Grandfathered (strict=False) bypasses the check."""
+    bad = NEW_TLDR.replace("builds on #234 and #240", "builds on prior work")
+    rep = Report()
+    check_background_motivation(bad, rep, current_issue=275, strict=False)
+    assert all(r.status == "PASS" for r in rep.results)
+
+
+# --- check_tldr_dataset_example ---------------------------------------------
+
+
+def test_dataset_example_missing_link_fails() -> None:
+    """Methodology has the bullet but no wandb/HF link in TL;DR → FAIL."""
+    bad = NEW_TLDR.replace(
+        "https://wandb.ai/superkaiba/explore-persona-space/runs/abc123",
+        "https://example.com/no",
+    )
+    rep = Report()
+    check_tldr_dataset_example(bad, rep, issue_labels=set(), strict=True)
+    assert any(r.status == "FAIL" for r in rep.results), rep.results
+
+
+def test_dataset_example_passes() -> None:
+    """Bullet + wandb URL → PASS."""
+    rep = Report()
+    check_tldr_dataset_example(NEW_TLDR, rep, issue_labels=set(), strict=True)
+    assert all(r.status == "PASS" for r in rep.results), rep.results
+
+
+def test_dataset_example_grandfather_pass() -> None:
+    """Grandfathered bypass with the link removed."""
+    bad = NEW_TLDR.replace(
+        "https://wandb.ai/superkaiba/explore-persona-space/runs/abc123",
+        "https://example.com/no",
+    )
+    rep = Report()
+    check_tldr_dataset_example(bad, rep, issue_labels=set(), strict=False)
+    assert all(r.status == "PASS" for r in rep.results)
+
+
+def test_dataset_example_grandfather_pass_full_strip() -> None:
+    """Per inline NIT #7: explicit grandfather test where BOTH the bullet AND
+    the link are stripped — verifies the strict=False short-circuit covers
+    both rejection paths simultaneously, not just the link-missing one."""
+    bare = NEW_TLDR.replace(
+        "https://wandb.ai/superkaiba/explore-persona-space/runs/abc123", ""
+    ).replace(
+        '- **Dataset example:** `{"persona": "evil", "q": "...", "a": "..."}`',
+        "",
+    )
+    rep = Report()
+    check_tldr_dataset_example(bare, rep, issue_labels=set(), strict=False)
+    assert all(r.status == "PASS" for r in rep.results), rep.results
+
+
+def test_dataset_example_no_dataset_label_skips() -> None:
+    """B4: experiment with no-dataset label PASSes even without a link/example."""
+    bare = NEW_TLDR.replace(
+        "https://wandb.ai/superkaiba/explore-persona-space/runs/abc123", ""
+    ).replace(
+        '- **Dataset example:** `{"persona": "evil", "q": "...", "a": "..."}`',
+        "",
+    )
+    rep = Report()
+    check_tldr_dataset_example(bare, rep, issue_labels={"no-dataset"}, strict=True)
+    assert all(r.status == "PASS" for r in rep.results), rep.results
+
+
+def test_dataset_example_literal_NA_rejected() -> None:
+    """B4: `**Dataset example:** N/A` is gameable; the only escape is `no-dataset`."""
+    bad = NEW_TLDR.replace(
+        '- **Dataset example:** `{"persona": "evil", "q": "...", "a": "..."}`',
+        "- **Dataset example:** N/A",
+    )
+    rep = Report()
+    check_tldr_dataset_example(bad, rep, issue_labels=set(), strict=True)
+    assert any(r.status == "FAIL" for r in rep.results), rep.results
+
+
+def test_dataset_example_accepts_wandb_artifact_uri() -> None:
+    """B4: wandb://owner/proj/artifact is a valid full-data link."""
+    body = NEW_TLDR.replace(
+        "https://wandb.ai/superkaiba/explore-persona-space/runs/abc123",
+        "wandb://superkaiba/explore-persona-space/some-artifact:v0",
+    )
+    rep = Report()
+    check_tldr_dataset_example(body, rep, issue_labels=set(), strict=True)
+    assert all(r.status == "PASS" for r in rep.results), rep.results
+
+
+def test_dataset_example_accepts_hf_model_url() -> None:
+    """B4: huggingface.co/<owner>/<repo>/... covers model checkpoints."""
+    body = NEW_TLDR.replace(
+        "https://wandb.ai/superkaiba/explore-persona-space/runs/abc123",
+        "https://huggingface.co/superkaiba1/explore-persona-space/tree/main/issue-275",
+    )
+    rep = Report()
+    check_tldr_dataset_example(body, rep, issue_labels=set(), strict=True)
+    assert all(r.status == "PASS" for r in rep.results), rep.results
+
+
+# --- E4: NEW_COLUMN_SPEC membership for Useful / Not useful ------------------
+
+
+def test_useful_columns_in_spec() -> None:
+    """E1/E4: the two new columns are present in NEW_COLUMN_SPEC."""
+    from scripts.gh_project import NEW_COLUMN_SPEC
+
+    names = {n for (n, _c, _d) in NEW_COLUMN_SPEC}
+    assert "Useful" in names
+    assert "Not useful" in names
+
+
+# --- B3: --skip-checks flag --------------------------------------------------
+
+
+def test_skip_checks_flag_skips_named_check(capfd) -> None:
+    """B3: `--skip-checks` removes a specific check from the run AND logs to stderr."""
+    bad = NEW_TLDR.replace(
+        "H1 = primary hypothesis: persona\ncoupling generalises across model families.",
+        "we test H1 here without defining it",
+    )
+    # Without the skip, the check fires and FAILs:
+    rep_no_skip = run_all_checks(
+        title=None,
+        body=bad,
+        strict=True,
+        current_issue=275,
+        issue_labels=set(),
+    )
+    assert any(r.name == "TL;DR acronyms" and r.status == "FAIL" for r in rep_no_skip.results)
+    # With the skip, the check is omitted entirely:
+    rep_skip = run_all_checks(
+        title=None,
+        body=bad,
+        strict=True,
+        current_issue=275,
+        issue_labels=set(),
+        skip_checks={"check_undefined_acronyms"},
+    )
+    assert not any(r.name == "TL;DR acronyms" for r in rep_skip.results)
+    captured = capfd.readouterr()
+    assert "SKIPPED: check_undefined_acronyms (--skip-checks)" in captured.err
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #275

## Summary

Bundles 15 workflow-improvement asks the user surfaced after running `/issue` on real experiments. Six design groups (A-F) covering project-board fix, clean-result template + verifier upgrades, /issue skill UX, /daily review-and-publish gate, Useful/Not-useful columns, and an audit of three boundaries.

Plan: `.claude/plans/issue-275.md` (gitignored locally; adversarially reviewed via 3 critics → REVISE → revised → 3 critics → all PASS, then user-approved).

Implementation lands in stacked commits (one per group) for surgical revertability.

## Test plan

- [ ] `uv run ruff check . && uv run ruff format --check .`
- [ ] `uv run pytest -q` (all green; ≥9 new tests)
- [ ] Verifier smoke on `--issue 75` (grandfathered → PASS)
- [ ] Verifier smoke on synthetic good/bad bodies
- [ ] `gh_project.py snapshot` + `add-status-option Useful` + `add-status-option "Not useful"` + smoke `set-status 275 "Useful"` (revert)
- [ ] /daily dry-run with `INTERACTIVE=false` → no AskUserQuestion fires
- [ ] Audit comment posted on #275 with placeholder guard satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)