### PR TITLE
dashboard: editable title+body, collapsible feed panels, TOC sidebar on /tasks/[id]

### DIFF
--- a/dashboard/app/tasks/[id]/EditableBody.tsx
+++ b/dashboard/app/tasks/[id]/EditableBody.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+/**
+ * Client wrapper inside the BodyCard. Default state renders the markdown
+ * children that the server passed in (already-rendered React tree, so the
+ * server-side ReactMarkdown + rehype-raw + rehype-highlight pipeline stays
+ * authoritative). Clicking Edit swaps to `InlineBodyEditor`.
+ *
+ * Why hand the rendered markdown tree in as `children` rather than the
+ * raw body string + a client-side ReactMarkdown call:
+ *   - Keeps server-side rendering of the body — first paint matches the
+ *     /tasks/[id] route output before this commit, no hydration penalty.
+ *   - Avoids re-shipping `react-markdown` + plugin bundles to clients
+ *     just to render a card that's read-only 99% of the time.
+ * When the user is mid-edit we hide the rendered tree and show the
+ * editor; on Save we keep showing the (now stale) tree until
+ * `router.refresh()` returns fresh server HTML for the new body.
+ */
+import { Pencil } from "lucide-react";
+import { useState } from "react";
+import { InlineBodyEditor } from "./InlineBodyEditor";
+
+export function EditableBody({
+  taskId,
+  initialBody,
+  canEdit,
+  children,
+}: {
+  taskId: number;
+  initialBody: string;
+  canEdit: boolean;
+  children: React.ReactNode;
+}) {
+  const [editing, setEditing] = useState(false);
+
+  if (!canEdit) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {!editing && (
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="inline-flex items-center gap-1.5 rounded border border-stone-300 bg-white px-2.5 py-1 text-xs text-stone-700 hover:bg-stone-50"
+          >
+            <Pencil className="h-3 w-3" />
+            Edit body
+          </button>
+        </div>
+      )}
+      {editing ? (
+        <InlineBodyEditor
+          taskId={taskId}
+          initialBody={initialBody}
+          onSaved={() => setEditing(false)}
+          onCancel={() => setEditing(false)}
+        />
+      ) : (
+        children
+      )}
+    </div>
+  );
+}

--- a/dashboard/app/tasks/[id]/InlineBodyEditor.tsx
+++ b/dashboard/app/tasks/[id]/InlineBodyEditor.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+/**
+ * Compact in-place body editor for the task detail page (`/tasks/[id]`).
+ *
+ * Mirrors the standalone `/tasks/[id]/edit` route — same CodeMirror
+ * widget, same Ctrl/Cmd-S, same verify_task_body.py button — but lives
+ * inside the BodyCard so a logged-in editor can swap to edit mode
+ * without leaving the timeline view. Save flow shells out to
+ * `saveTaskBody` (which calls `uv run python scripts/task.py set-body`)
+ * via the existing server action. No new API route needed.
+ *
+ * On Save success: bubble the saved markdown up via `onSaved` so the
+ * parent immediately reflects the change, AND call `router.refresh()`
+ * to pull fresh server data (frontmatter chips, status pill, registry
+ * cache) without a full reload.
+ */
+import dynamic from "next/dynamic";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState, useTransition } from "react";
+import { markdown } from "@codemirror/lang-markdown";
+import { saveTaskBody, verifyTaskBody } from "./edit/actions";
+
+const CodeMirror = dynamic(
+  () => import("@uiw/react-codemirror").then((m) => m.default),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-[50vh] animate-pulse rounded bg-stone-100" aria-hidden />
+    ),
+  },
+);
+
+const EXTENSIONS = [markdown()];
+
+export function InlineBodyEditor({
+  taskId,
+  initialBody,
+  onSaved,
+  onCancel,
+}: {
+  taskId: number;
+  initialBody: string;
+  onSaved: (newBody: string) => void;
+  onCancel: () => void;
+}) {
+  const router = useRouter();
+  const [body, setBody] = useState(initialBody);
+  const [savedBody, setSavedBody] = useState(initialBody);
+  const [saving, startSaving] = useTransition();
+  const [verifying, startVerifying] = useTransition();
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [verifyOk, setVerifyOk] = useState<boolean | null>(null);
+  const [verifyOutput, setVerifyOutput] = useState<string | null>(null);
+
+  const isDirty = body !== savedBody;
+
+  const onChange = useCallback((val: string) => {
+    setBody(val);
+    setSaveError(null);
+  }, []);
+
+  const onSave = useCallback(() => {
+    if (!isDirty || saving) return;
+    const snapshot = body;
+    setSaveError(null);
+    startSaving(async () => {
+      const res = await saveTaskBody(taskId, snapshot);
+      if (res.ok) {
+        setSavedBody(snapshot);
+        onSaved(snapshot);
+        router.refresh();
+      } else {
+        setSaveError(res.error);
+      }
+    });
+  }, [body, isDirty, saving, taskId, onSaved, router]);
+
+  // Ctrl/Cmd-S → save. The dependency on `onSave` keeps the latest
+  // closure in scope; without it the listener would call a stale
+  // version that captured the initial `body`.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.ctrlKey || e.metaKey) && e.key === "s") {
+        e.preventDefault();
+        onSave();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onSave]);
+
+  const onVerify = useCallback(() => {
+    if (verifying) return;
+    startVerifying(async () => {
+      const res = await verifyTaskBody(body);
+      setVerifyOk(res.ok);
+      setVerifyOutput(res.output || "(no output)");
+    });
+  }, [body, verifying]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={!isDirty || saving}
+          className="rounded bg-stone-900 px-3 py-1.5 text-sm font-medium text-white disabled:bg-stone-300"
+        >
+          {saving ? "Saving…" : isDirty ? "Save (⌘/Ctrl-S)" : "Saved"}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={saving}
+          className="rounded border border-stone-300 bg-white px-3 py-1.5 text-sm font-medium text-stone-800 hover:bg-stone-50 disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onVerify}
+          disabled={verifying}
+          className="rounded border border-stone-300 bg-white px-3 py-1.5 text-sm font-medium text-stone-800 hover:bg-stone-50 disabled:opacity-50"
+        >
+          {verifying ? "Verifying…" : "Run verify_task_body.py"}
+        </button>
+        {isDirty && !saving && !saveError && (
+          <span className="text-xs text-amber-700">Unsaved changes</span>
+        )}
+        {saveError && <span className="text-xs text-red-700">{saveError}</span>}
+      </div>
+
+      <div className="overflow-hidden rounded border border-stone-300 bg-white">
+        <CodeMirror
+          value={body}
+          extensions={EXTENSIONS}
+          onChange={onChange}
+          height="50vh"
+          basicSetup={{
+            lineNumbers: true,
+            highlightActiveLine: true,
+            highlightActiveLineGutter: true,
+            foldGutter: true,
+            indentOnInput: true,
+          }}
+        />
+      </div>
+
+      {verifyOutput !== null && (
+        <div
+          className={`rounded border px-3 py-2 text-xs ${
+            verifyOk
+              ? "border-emerald-300 bg-emerald-50 text-emerald-900"
+              : "border-red-300 bg-red-50 text-red-900"
+          }`}
+        >
+          <div className="mb-1 font-medium">
+            {verifyOk
+              ? "verify_task_body.py PASS"
+              : "verify_task_body.py FAIL"}
+          </div>
+          <pre className="overflow-auto whitespace-pre-wrap font-mono leading-relaxed">
+            {verifyOutput}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/app/tasks/[id]/TitleEditor.tsx
+++ b/dashboard/app/tasks/[id]/TitleEditor.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+/**
+ * In-place editor for the task title (shown in the page header). Authed
+ * users see a Pencil button next to the H1; clicking swaps the heading
+ * for an input + Save/Cancel pair. Save shells out to
+ * `saveTaskTitle` → `uv run python scripts/task.py set-title <N> "..."`.
+ *
+ * Body markdown frontmatter is NOT edited here — we intentionally only
+ * surface `title`. Read-only / workflow-managed fields (`created_at`,
+ * `parent_id`, `goal`, `has_clean_result`, ...) stay under the
+ * task.py-set helpers that own them.
+ */
+import { Pencil } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState, useTransition } from "react";
+import { saveTaskTitle } from "./edit/actions";
+
+export function TitleEditor({
+  taskId,
+  initialTitle,
+  canEdit,
+}: {
+  taskId: number;
+  initialTitle: string;
+  canEdit: boolean;
+}) {
+  const router = useRouter();
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(initialTitle);
+  const [saving, startSaving] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // initialTitle changes after router.refresh() — keep the draft in sync
+  // when we're NOT in edit mode (don't trample user typing). Sync-from-
+  // prop is the textbook setState-in-effect case React allows.
+  useEffect(() => {
+    if (!editing) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setDraft(initialTitle);
+    }
+  }, [initialTitle, editing]);
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
+
+  function onCancel() {
+    setDraft(initialTitle);
+    setEditing(false);
+    setError(null);
+  }
+
+  function onSave() {
+    const trimmed = draft.trim();
+    if (!trimmed || trimmed === initialTitle.trim()) {
+      setEditing(false);
+      return;
+    }
+    setError(null);
+    startSaving(async () => {
+      const res = await saveTaskTitle(taskId, trimmed);
+      if (res.ok) {
+        setEditing(false);
+        router.refresh();
+      } else {
+        setError(res.error);
+      }
+    });
+  }
+
+  if (!canEdit) {
+    return (
+      <h1 className="text-2xl font-semibold leading-snug tracking-tight sm:text-3xl">
+        {initialTitle || "(untitled)"}
+      </h1>
+    );
+  }
+
+  if (editing) {
+    return (
+      <div className="space-y-2">
+        <input
+          ref={inputRef}
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              onSave();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              onCancel();
+            }
+          }}
+          disabled={saving}
+          className="w-full rounded border border-stone-300 bg-white px-2 py-1 text-2xl font-semibold leading-snug tracking-tight focus:border-stone-500 focus:outline-none sm:text-3xl"
+        />
+        <div className="flex items-center gap-2 text-xs">
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={saving}
+            className="rounded bg-stone-900 px-2.5 py-1 font-medium text-white disabled:bg-stone-300"
+          >
+            {saving ? "Saving…" : "Save (Enter)"}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={saving}
+            className="rounded border border-stone-300 bg-white px-2.5 py-1 font-medium text-stone-800 hover:bg-stone-50 disabled:opacity-50"
+          >
+            Cancel (Esc)
+          </button>
+          {error && <span className="text-red-700">{error}</span>}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="group flex items-baseline gap-2">
+      <h1 className="text-2xl font-semibold leading-snug tracking-tight sm:text-3xl">
+        {initialTitle || "(untitled)"}
+      </h1>
+      <button
+        type="button"
+        onClick={() => setEditing(true)}
+        title="Edit title"
+        aria-label="Edit title"
+        className="rounded p-1 text-stone-400 opacity-0 transition-opacity hover:bg-stone-100 hover:text-stone-700 group-hover:opacity-100 focus:opacity-100"
+      >
+        <Pencil className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/dashboard/app/tasks/[id]/edit/actions.ts
+++ b/dashboard/app/tasks/[id]/edit/actions.ts
@@ -81,6 +81,36 @@ export async function saveTaskBody(taskId: number, body: string): Promise<Action
   return { ok: true };
 }
 
+/**
+ * Rename a task via `uv run python scripts/task.py set-title <N> "..."`.
+ * The CLI handles git commit + REGISTRY.json update atomically. Surfacing
+ * this lets the task detail page expose inline title editing alongside
+ * body editing (see `BodyCard` / `TitleEditor` on `/tasks/[id]`).
+ */
+export async function saveTaskTitle(taskId: number, title: string): Promise<ActionResult> {
+  if (!(await isEditorAuthed())) return { ok: false, error: "unauthorized" };
+  const id = validateTaskId(taskId);
+  if (id === null) return { ok: false, error: "invalid task id" };
+  if (typeof title !== "string") return { ok: false, error: "title must be a string" };
+  const trimmed = title.trim();
+  if (!trimmed) return { ok: false, error: "title cannot be empty" };
+  if (trimmed.length > 500) return { ok: false, error: "title exceeds 500 chars" };
+  try {
+    await execFileP(
+      resolveUv(),
+      ["run", "python", "scripts/task.py", "set-title", String(id), trimmed],
+      { cwd: REPO_ROOT, timeout: 30_000 },
+    );
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: `task.py set-title failed: ${msg}` };
+  }
+  revalidatePath(`/tasks/${id}`);
+  revalidatePath(`/tasks/${id}/edit`);
+  revalidatePath("/");
+  return { ok: true };
+}
+
 export async function verifyTaskBody(body: string): Promise<{ ok: boolean; output: string }> {
   if (!(await isEditorAuthed())) {
     return { ok: false, output: "unauthorized" };

--- a/dashboard/app/tasks/[id]/page.tsx
+++ b/dashboard/app/tasks/[id]/page.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import rehypeHighlight from "rehype-highlight";
+import { isEditorAuthed } from "@/lib/auth";
 import {
   getComments,
   getEvents,
@@ -16,6 +17,13 @@ import {
   type TaskPlan,
 } from "@/lib/tasks";
 import { STATUS_LABELS, type Status } from "@/lib/repo";
+import { CollapsiblePanel } from "@/components/CollapsiblePanel";
+import {
+  TaskTocSidebar,
+  type TocEntry,
+} from "@/components/tasks/TaskTocSidebar";
+import { EditableBody } from "./EditableBody";
+import { TitleEditor } from "./TitleEditor";
 
 export const dynamic = "force-dynamic";
 
@@ -40,13 +48,40 @@ const COMPACT_KINDS = new Set<string>([
   "epm:pod-terminated",
 ]);
 
-// Items in the reverse-chronological feed.
+// Items in the reverse-chronological feed. Each carries a stable
+// `itemKey` (used as the localStorage key for collapse state) and
+// `anchorId` (the DOM id the TOC sidebar scroll-jumps to).
 type FeedItem =
-  | { kind: "body"; ts: string; task: Task }
-  | { kind: "plan"; ts: string; plan: TaskPlan; version: number }
-  | { kind: "event-card"; ts: string; event: TaskEvent }
-  | { kind: "event-compact"; ts: string; event: TaskEvent }
-  | { kind: "transition"; ts: string; event: TaskEvent };
+  | { kind: "body"; ts: string; itemKey: string; anchorId: string; task: Task }
+  | {
+      kind: "plan";
+      ts: string;
+      itemKey: string;
+      anchorId: string;
+      plan: TaskPlan;
+      version: number;
+    }
+  | {
+      kind: "event-card";
+      ts: string;
+      itemKey: string;
+      anchorId: string;
+      event: TaskEvent;
+    }
+  | {
+      kind: "event-compact";
+      ts: string;
+      itemKey: string;
+      anchorId: string;
+      event: TaskEvent;
+    }
+  | {
+      kind: "transition";
+      ts: string;
+      itemKey: string;
+      anchorId: string;
+      event: TaskEvent;
+    };
 
 export default async function TaskDetail({
   params,
@@ -62,6 +97,9 @@ export default async function TaskDetail({
   const comments = getComments(id);
   const plan = getPlan(id);
   const items = buildFeedItems(task, events, plan);
+  const canEdit = await isEditorAuthed();
+
+  const tocEntries: TocEntry[] = items.map(itemToTocEntry);
 
   return (
     <article className="space-y-6">
@@ -74,28 +112,43 @@ export default async function TaskDetail({
           <span className="font-mono">#{id}</span>
           <StatusPill status={task.status} />
         </div>
-        <h1 className="text-2xl font-semibold leading-snug tracking-tight sm:text-3xl">
-          {task.frontmatter.title || "(untitled)"}
-        </h1>
+        <TitleEditor
+          taskId={id}
+          initialTitle={task.frontmatter.title ?? ""}
+          canEdit={canEdit}
+        />
         <FrontmatterBar fm={task.frontmatter} />
       </header>
 
-      <section className="space-y-4" aria-label="Task timeline">
-        {items.length === 0 ? (
-          <p className="rounded border border-dashed border-stone-300 bg-white px-4 py-6 text-center text-sm text-stone-500">
-            No content yet.
-          </p>
-        ) : (
-          items.map((it, idx) => <FeedRow key={idx} item={it} taskId={id} />)
-        )}
-      </section>
+      <div className="grid gap-6 md:grid-cols-[240px_minmax(0,1fr)]">
+        <TaskTocSidebar taskId={id} entries={tocEntries} />
 
-      <section>
-        <h2 className="mb-3 text-base font-semibold tracking-tight text-stone-900">
-          Comments · {comments.length}
-        </h2>
-        <CommentsList comments={comments} />
-      </section>
+        <div className="min-w-0 space-y-3">
+          <section className="space-y-3" aria-label="Task timeline">
+            {items.length === 0 ? (
+              <p className="rounded border border-dashed border-stone-300 bg-white px-4 py-6 text-center text-sm text-stone-500">
+                No content yet.
+              </p>
+            ) : (
+              items.map((it) => (
+                <FeedRow
+                  key={it.itemKey}
+                  item={it}
+                  taskId={id}
+                  canEdit={canEdit}
+                />
+              ))
+            )}
+          </section>
+
+          <section>
+            <h2 className="mb-3 mt-6 text-base font-semibold tracking-tight text-stone-900">
+              Comments · {comments.length}
+            </h2>
+            <CommentsList comments={comments} />
+          </section>
+        </div>
+      </div>
     </article>
   );
 }
@@ -113,7 +166,13 @@ function buildFeedItems(
 
   // Body card.
   const bodyTs = computeBodyTs(task, events, plan, created);
-  items.push({ kind: "body", ts: bodyTs, task });
+  items.push({
+    kind: "body",
+    ts: bodyTs,
+    itemKey: "body",
+    anchorId: "feed-body",
+    task,
+  });
 
   // Plan card (the actual plan document — separate from the epm:plan event).
   if (plan) {
@@ -126,24 +185,58 @@ function buildFeedItems(
     const baseTs = latestPlanEvent?.ts ?? created;
     const planTs = bumpMs(baseTs, 1);
     const version = (latestPlanEvent?.version as number | undefined) ?? 1;
-    items.push({ kind: "plan", ts: planTs, plan, version });
+    const itemKey = `plan-v${version}`;
+    items.push({
+      kind: "plan",
+      ts: planTs,
+      itemKey,
+      anchorId: `feed-${itemKey}`,
+      plan,
+      version,
+    });
   }
 
-  // Events: route by kind.
+  // Track repeated (ts, kind) tuples so two events that share both still
+  // get unique itemKeys. events.jsonl rarely has true duplicates but the
+  // analyzer occasionally posts back-to-back markers within 1 ms.
+  const seen = new Map<string, number>();
   for (const ev of events) {
     if (ev.kind === "epm:created") continue; // body covers creation
+    const base = `${ev.ts}|${ev.kind}`;
+    const n = seen.get(base) ?? 0;
+    seen.set(base, n + 1);
+    const itemKey = `event-${ev.ts}-${ev.kind}${n === 0 ? "" : `-${n}`}`;
+    const anchorId = `feed-${slugifyKey(itemKey)}`;
     if (TRANSITION_KINDS.has(ev.kind)) {
-      items.push({ kind: "transition", ts: ev.ts, event: ev });
+      items.push({ kind: "transition", ts: ev.ts, itemKey, anchorId, event: ev });
     } else if (COMPACT_KINDS.has(ev.kind)) {
-      items.push({ kind: "event-compact", ts: ev.ts, event: ev });
+      items.push({
+        kind: "event-compact",
+        ts: ev.ts,
+        itemKey,
+        anchorId,
+        event: ev,
+      });
     } else {
-      items.push({ kind: "event-card", ts: ev.ts, event: ev });
+      items.push({
+        kind: "event-card",
+        ts: ev.ts,
+        itemKey,
+        anchorId,
+        event: ev,
+      });
     }
   }
 
   // Sort reverse-chronological.
   items.sort((a, b) => (a.ts < b.ts ? 1 : a.ts > b.ts ? -1 : 0));
   return items;
+}
+
+// Make the itemKey safe to use as a DOM id (alphanumerics, hyphens, underscores
+// only — `:` and `.` are valid in HTML id but break CSS selectors).
+function slugifyKey(key: string): string {
+  return key.replace(/[^A-Za-z0-9_-]/g, "-");
 }
 
 // Body floats to the top when it's the freshest artifact:
@@ -175,74 +268,212 @@ function bumpMs(iso: string, ms: number): string {
   return new Date(t + ms).toISOString();
 }
 
-// ─── Row dispatch ───────────────────────────────────────────────────────────
+// ─── TOC entries ────────────────────────────────────────────────────────────
 
-function FeedRow({ item, taskId }: { item: FeedItem; taskId: number }) {
+function itemToTocEntry(item: FeedItem): TocEntry {
   switch (item.kind) {
     case "body":
-      return <BodyCard task={item.task} />;
+      return {
+        itemKey: item.itemKey,
+        anchorId: item.anchorId,
+        label: item.task.frontmatter.has_clean_result
+          ? "Clean result"
+          : "Original body",
+        kind: "body",
+        ts: item.ts,
+      };
     case "plan":
-      return <PlanCard plan={item.plan} version={item.version} taskId={taskId} />;
+      return {
+        itemKey: item.itemKey,
+        anchorId: item.anchorId,
+        label: `Plan v${item.version}`,
+        kind: "plan",
+        ts: item.ts,
+      };
     case "event-card":
-      return <EventCard event={item.event} />;
+      return {
+        itemKey: item.itemKey,
+        anchorId: item.anchorId,
+        label: shortEventLabel(item.event),
+        kind: "event-card",
+        ts: item.ts,
+      };
     case "event-compact":
-      return <EventCompactRow event={item.event} />;
+      return {
+        itemKey: item.itemKey,
+        anchorId: item.anchorId,
+        label: shortEventLabel(item.event),
+        kind: "event-compact",
+        ts: item.ts,
+      };
+    case "transition": {
+      const from = typeof item.event.from === "string" ? item.event.from : "?";
+      const to = typeof item.event.to === "string" ? item.event.to : "?";
+      return {
+        itemKey: item.itemKey,
+        anchorId: item.anchorId,
+        label: `${from} → ${to}`,
+        kind: "transition",
+        ts: item.ts,
+      };
+    }
+  }
+}
+
+function shortEventLabel(event: TaskEvent): string {
+  const note = typeof event.note === "string" ? event.note.trim() : "";
+  const firstLine = note.split("\n", 1)[0] ?? "";
+  if (firstLine) {
+    return firstLine.length > 80 ? firstLine.slice(0, 80) + "…" : firstLine;
+  }
+  return event.kind;
+}
+
+// ─── Row dispatch ───────────────────────────────────────────────────────────
+
+function FeedRow({
+  item,
+  taskId,
+  canEdit,
+}: {
+  item: FeedItem;
+  taskId: number;
+  canEdit: boolean;
+}) {
+  switch (item.kind) {
+    case "body":
+      return (
+        <BodyCard
+          task={item.task}
+          taskId={taskId}
+          itemKey={item.itemKey}
+          anchorId={item.anchorId}
+          canEdit={canEdit}
+        />
+      );
+    case "plan":
+      return (
+        <PlanCard
+          plan={item.plan}
+          version={item.version}
+          taskId={taskId}
+          itemKey={item.itemKey}
+          anchorId={item.anchorId}
+        />
+      );
+    case "event-card":
+      return (
+        <EventCard
+          event={item.event}
+          taskId={taskId}
+          itemKey={item.itemKey}
+          anchorId={item.anchorId}
+        />
+      );
+    case "event-compact":
+      return (
+        <EventCompactRow
+          event={item.event}
+          taskId={taskId}
+          itemKey={item.itemKey}
+          anchorId={item.anchorId}
+        />
+      );
     case "transition":
-      return <TransitionPill event={item.event} />;
+      return (
+        <TransitionPill
+          event={item.event}
+          taskId={taskId}
+          itemKey={item.itemKey}
+          anchorId={item.anchorId}
+        />
+      );
   }
 }
 
 // ─── Cards ──────────────────────────────────────────────────────────────────
 
-function BodyCard({ task }: { task: Task }) {
+function BodyCard({
+  task,
+  taskId,
+  itemKey,
+  anchorId,
+  canEdit,
+}: {
+  task: Task;
+  taskId: number;
+  itemKey: string;
+  anchorId: string;
+  canEdit: boolean;
+}) {
   const isCleanResult = !!task.frontmatter.has_clean_result;
   const label = isCleanResult
     ? "Clean result · task body"
     : "Original task body";
+  const renderedBody = task.isLegacyHtml ? (
+    <div
+      className="prose prose-stone max-w-none sm:prose-lg legacy-sagan-card"
+      // Legacy Sagan-card bodies are trusted HTML authored by our analyzer
+      // for our own consumption. Rendered as-is.
+      dangerouslySetInnerHTML={{ __html: task.body }}
+    />
+  ) : (
+    <div className="prose prose-stone max-w-none sm:prose-lg">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeRaw, rehypeHighlight]}
+        components={{
+          // The page header already renders the task title as <h1>; the
+          // clean-result spec requires a duplicate `# <title>` line in
+          // body source. Suppress to avoid double display.
+          h1: () => null,
+          // `## Figure` is a structural label required by
+          // verify_task_body.py but adds no signal to the rendered view.
+          h2: ({ children, ...rest }) => {
+            const text = Array.isArray(children)
+              ? children.join("")
+              : String(children ?? "");
+            if (text.trim() === "Figure") return null;
+            return <h2 {...rest}>{children}</h2>;
+          },
+        }}
+      >
+        {task.body}
+      </ReactMarkdown>
+    </div>
+  );
+
   return (
-    <Card>
-      <CardHeader>
-        <span className="font-mono text-stone-700">{label}</span>
-        {task.frontmatter.created_at && (
-          <time className="tabular-nums">{String(task.frontmatter.created_at)}</time>
-        )}
-        {isCleanResult && task.frontmatter.classification && (
-          <span>· classification: {String(task.frontmatter.classification)}</span>
-        )}
-      </CardHeader>
-      <div className="prose prose-stone max-w-none sm:prose-lg">
-        {task.isLegacyHtml ? (
-          <div
-            className="legacy-sagan-card"
-            // Legacy Sagan-card bodies are trusted HTML authored by our analyzer
-            // for our own consumption. Rendered as-is.
-            dangerouslySetInnerHTML={{ __html: task.body }}
-          />
-        ) : (
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
-            rehypePlugins={[rehypeRaw, rehypeHighlight]}
-            components={{
-              // The page header already renders the task title as <h1>; the
-              // clean-result spec requires a duplicate `# <title>` line in
-              // body source. Suppress to avoid double display.
-              h1: () => null,
-              // `## Figure` is a structural label required by
-              // verify_task_body.py but adds no signal to the rendered view.
-              h2: ({ children, ...rest }) => {
-                const text = Array.isArray(children)
-                  ? children.join("")
-                  : String(children ?? "");
-                if (text.trim() === "Figure") return null;
-                return <h2 {...rest}>{children}</h2>;
-              },
-            }}
-          >
-            {task.body}
-          </ReactMarkdown>
-        )}
-      </div>
-    </Card>
+    <CollapsiblePanel
+      taskId={taskId}
+      itemKey={itemKey}
+      anchorId={anchorId}
+      header={
+        <>
+          <span className="font-mono text-stone-700">{label}</span>
+          {task.frontmatter.created_at && (
+            <time className="tabular-nums">
+              {String(task.frontmatter.created_at)}
+            </time>
+          )}
+          {isCleanResult && task.frontmatter.classification && (
+            <span>· classification: {String(task.frontmatter.classification)}</span>
+          )}
+        </>
+      }
+    >
+      {task.isLegacyHtml ? (
+        renderedBody
+      ) : (
+        <EditableBody
+          taskId={taskId}
+          initialBody={task.body}
+          canEdit={canEdit}
+        >
+          {renderedBody}
+        </EditableBody>
+      )}
+    </CollapsiblePanel>
   );
 }
 
@@ -250,25 +481,41 @@ function PlanCard({
   plan,
   version,
   taskId,
+  itemKey,
+  anchorId,
 }: {
   plan: TaskPlan;
   version: number;
   taskId: number;
+  itemKey: string;
+  anchorId: string;
 }) {
   return (
-    <Card emphasis="plan">
-      <CardHeader>
-        <span className="rounded bg-amber-100 px-1.5 py-0.5 font-mono text-[11px] font-medium text-amber-900">
-          PLAN v{version}
-        </span>
-        <span className="font-mono text-stone-500">{plan.filename}</span>
+    <CollapsiblePanel
+      taskId={taskId}
+      itemKey={itemKey}
+      anchorId={anchorId}
+      emphasis="plan"
+      header={
+        <>
+          <span className="rounded bg-amber-100 px-1.5 py-0.5 font-mono text-[11px] font-medium text-amber-900">
+            PLAN v{version}
+          </span>
+          <span className="font-mono text-stone-500">{plan.filename}</span>
+        </>
+      }
+    >
+      {/* Permalink lives in the body, not the header — nesting an <a>
+          inside the panel's toggle <button> is invalid HTML and the
+          RSC boundary refuses event handlers on the header slot. */}
+      <div className="mb-3 flex justify-end">
         <Link
           href={`/tasks/${taskId}/plan`}
-          className="ml-auto text-xs text-stone-500 hover:text-stone-800"
+          className="text-xs text-stone-500 hover:text-stone-800"
         >
           permalink ↗
         </Link>
-      </CardHeader>
+      </div>
       <div className="prose prose-stone max-w-none sm:prose-base">
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
@@ -277,22 +524,38 @@ function PlanCard({
           {plan.body}
         </ReactMarkdown>
       </div>
-    </Card>
+    </CollapsiblePanel>
   );
 }
 
-function EventCard({ event }: { event: TaskEvent }) {
+function EventCard({
+  event,
+  taskId,
+  itemKey,
+  anchorId,
+}: {
+  event: TaskEvent;
+  taskId: number;
+  itemKey: string;
+  anchorId: string;
+}) {
   return (
-    <Card>
-      <CardHeader>
-        <code className="font-mono font-medium text-stone-800">
-          {event.kind}
-          {typeof event.version === "number" ? ` v${event.version}` : ""}
-        </code>
-        <time className="tabular-nums">{event.ts}</time>
-        {event.by && event.by !== "unknown" && <span>· {event.by}</span>}
-      </CardHeader>
-      {typeof event.note === "string" && event.note.trim() && (
+    <CollapsiblePanel
+      taskId={taskId}
+      itemKey={itemKey}
+      anchorId={anchorId}
+      header={
+        <>
+          <code className="font-mono font-medium text-stone-800">
+            {event.kind}
+            {typeof event.version === "number" ? ` v${event.version}` : ""}
+          </code>
+          <time className="tabular-nums">{event.ts}</time>
+          {event.by && event.by !== "unknown" && <span>· {event.by}</span>}
+        </>
+      }
+    >
+      {typeof event.note === "string" && event.note.trim() ? (
         <div className="prose prose-sm prose-stone max-w-none sm:prose-base">
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
@@ -301,72 +564,103 @@ function EventCard({ event }: { event: TaskEvent }) {
             {event.note}
           </ReactMarkdown>
         </div>
+      ) : (
+        <p className="text-xs text-stone-500">(no note body)</p>
       )}
-    </Card>
+    </CollapsiblePanel>
   );
 }
 
-function EventCompactRow({ event }: { event: TaskEvent }) {
+// Compact one-line events render as their own collapsible row so the TOC
+// sidebar can still scroll to them. They start collapsed since the kind
+// and note preview live in the header.
+function EventCompactRow({
+  event,
+  taskId,
+  itemKey,
+  anchorId,
+}: {
+  event: TaskEvent;
+  taskId: number;
+  itemKey: string;
+  anchorId: string;
+}) {
   const note = typeof event.note === "string" ? event.note : "";
   const preview = note.length > 180 ? note.slice(0, 180) + "…" : note;
   return (
-    <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1 rounded border border-stone-200 bg-stone-50/60 px-3 py-1.5 text-xs">
-      <code className="font-mono text-stone-700">{event.kind}</code>
-      <time className="tabular-nums text-stone-500">{event.ts}</time>
-      {event.by && event.by !== "unknown" && (
-        <span className="text-stone-500">· {event.by}</span>
+    <CollapsiblePanel
+      taskId={taskId}
+      itemKey={itemKey}
+      anchorId={anchorId}
+      defaultCollapsed
+      header={
+        <>
+          <code className="font-mono text-stone-700">{event.kind}</code>
+          <time className="tabular-nums text-stone-500">{event.ts}</time>
+          {event.by && event.by !== "unknown" && (
+            <span className="text-stone-500">· {event.by}</span>
+          )}
+          {preview && (
+            <span className="text-stone-600">
+              · <span className="whitespace-pre-wrap">{preview}</span>
+            </span>
+          )}
+        </>
+      }
+    >
+      {note ? (
+        <pre className="overflow-auto whitespace-pre-wrap font-mono text-xs leading-relaxed text-stone-700">
+          {note}
+        </pre>
+      ) : (
+        <p className="text-xs text-stone-500">(no note body)</p>
       )}
-      {preview && (
-        <span className="text-stone-600">
-          · <span className="whitespace-pre-wrap">{preview}</span>
-        </span>
-      )}
-    </div>
+    </CollapsiblePanel>
   );
 }
 
-function TransitionPill({ event }: { event: TaskEvent }) {
+function TransitionPill({
+  event,
+  taskId,
+  itemKey,
+  anchorId,
+}: {
+  event: TaskEvent;
+  taskId: number;
+  itemKey: string;
+  anchorId: string;
+}) {
   const from = typeof event.from === "string" ? event.from : "?";
   const to = typeof event.to === "string" ? event.to : "?";
+  // Wrap in the same CollapsiblePanel shell so the TOC entry scrolls to
+  // a section element with the matching `id={anchorId}`. We pass
+  // `alwaysExpanded` because the pill itself is the entire content —
+  // there's nothing to toggle. The header becomes the pill.
   return (
-    <div className="flex items-center gap-3 py-1 text-xs text-stone-500">
-      <div className="h-px flex-1 bg-stone-200" />
-      <span className="rounded bg-stone-100 px-2 py-0.5 font-mono">
-        status: {from} → {to}
-      </span>
-      <time className="tabular-nums">{event.ts}</time>
-      <div className="h-px flex-1 bg-stone-200" />
-    </div>
+    <CollapsiblePanel
+      taskId={taskId}
+      itemKey={itemKey}
+      anchorId={anchorId}
+      alwaysExpanded
+      header={
+        <div className="flex w-full items-center gap-3 py-0 text-xs text-stone-500">
+          <div className="h-px flex-1 bg-stone-200" />
+          <span className="rounded bg-stone-100 px-2 py-0.5 font-mono">
+            status: {from} → {to}
+          </span>
+          <time className="tabular-nums">{event.ts}</time>
+          <div className="h-px flex-1 bg-stone-200" />
+        </div>
+      }
+    >
+      {/* `alwaysExpanded` keeps the body slot mounted but the header
+          carries the pill itself; nothing to render here. */}
+      <></>
+    </CollapsiblePanel>
   );
 }
 
 // ─── Shared atoms ───────────────────────────────────────────────────────────
-
-function Card({
-  children,
-  emphasis,
-}: {
-  children: React.ReactNode;
-  emphasis?: "plan";
-}) {
-  const ring =
-    emphasis === "plan"
-      ? "border-stone-300 shadow-sm ring-1 ring-amber-100"
-      : "border-stone-200";
-  return (
-    <div className={`rounded-lg border ${ring} bg-white p-4 sm:p-6`}>
-      {children}
-    </div>
-  );
-}
-
-function CardHeader({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="mb-3 flex flex-wrap items-baseline gap-x-3 gap-y-1 border-b border-stone-100 pb-2 text-xs text-stone-500">
-      {children}
-    </div>
-  );
-}
 
 function FrontmatterBar({ fm }: { fm: Frontmatter }) {
   const chips: { label: string; value: string }[] = [];

--- a/dashboard/components/CollapsiblePanel.tsx
+++ b/dashboard/components/CollapsiblePanel.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+/**
+ * Generic collapsible card shell.
+ *
+ * Drives the per-feed-row collapse UI on `/tasks/[id]`. Mirrors the
+ * expand/collapse affordance used by `/log/LogCard` (chevron + click-the-
+ * whole-header) but without the comment-thread / lazy-load coupling — this
+ * component only handles "is the body visible".
+ *
+ * State persistence: keyed by `(taskId, itemKey)`, written to localStorage
+ * under `eps:task-feed:<taskId>:<itemKey>`. The taskId/itemKey pair survives
+ * page reloads AND avoids bleed between tasks. itemKey should be a stable
+ * identifier (event ts+kind, "body", "plan-vN") — NOT a positional index,
+ * which would shift when new events land.
+ *
+ * Cross-component coordination: listens for `eps:feed-item-expand`
+ * CustomEvents (dispatched by `TaskTocSidebar` on click). When the
+ * `(taskId, itemKey)` matches, force-expand and let the listener's caller
+ * handle scrollIntoView on the wrapping <section id={anchorId}> element.
+ *
+ * Always-expanded mode: pass `alwaysExpanded` for items where collapse is
+ * pure noise (transition pills are already 1-line). The header still
+ * renders so the TOC anchor + click-to-scroll behavior works.
+ */
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+export const FEED_COLLAPSE_STORAGE_PREFIX = "eps:task-feed:";
+export const FEED_ITEM_EXPAND_EVENT = "eps:feed-item-expand";
+
+export type FeedItemExpandDetail = {
+  taskId: number;
+  itemKey: string;
+};
+
+function readCollapseState(taskId: number, itemKey: string, fallback: boolean): boolean {
+  try {
+    const key = `${FEED_COLLAPSE_STORAGE_PREFIX}${taskId}:${itemKey}`;
+    const v = window.localStorage.getItem(key);
+    if (v === "1") return true;
+    if (v === "0") return false;
+    return fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function writeCollapseState(taskId: number, itemKey: string, collapsed: boolean): void {
+  try {
+    const key = `${FEED_COLLAPSE_STORAGE_PREFIX}${taskId}:${itemKey}`;
+    window.localStorage.setItem(key, collapsed ? "1" : "0");
+  } catch {
+    // localStorage unavailable / quota — silently ignore.
+  }
+}
+
+export function CollapsiblePanel({
+  taskId,
+  itemKey,
+  anchorId,
+  header,
+  children,
+  defaultCollapsed = false,
+  alwaysExpanded = false,
+  emphasis,
+}: {
+  taskId: number;
+  itemKey: string;
+  anchorId: string;
+  header: React.ReactNode;
+  children: React.ReactNode;
+  defaultCollapsed?: boolean;
+  alwaysExpanded?: boolean;
+  emphasis?: "plan";
+}) {
+  // SSR-safe: start with the SSR fallback (defaultCollapsed) so the server
+  // markup matches the client's first render. Hydrate the persisted value
+  // in a useEffect, which only runs client-side.
+  const [collapsed, setCollapsed] = useState(defaultCollapsed);
+
+  useEffect(() => {
+    if (alwaysExpanded) return;
+    // Hydration sync: SSR rendered with `defaultCollapsed`; on the
+    // client we override with the persisted localStorage value (which
+    // can't be read server-side). This is the canonical
+    // "synchronize external state into React" effect — same pattern
+    // `CommentableBody.tsx` uses for the section-collapse store.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setCollapsed(readCollapseState(taskId, itemKey, defaultCollapsed));
+  }, [taskId, itemKey, defaultCollapsed, alwaysExpanded]);
+
+  // Listen for TOC-driven expand requests. The TOC sidebar dispatches
+  // `eps:feed-item-expand` with `{ taskId, itemKey }`; matching panels
+  // open. Non-matching panels ignore the event.
+  useEffect(() => {
+    if (alwaysExpanded) return;
+    const onExpand = (e: Event) => {
+      const detail = (e as CustomEvent<FeedItemExpandDetail>).detail;
+      if (!detail) return;
+      if (detail.taskId !== taskId || detail.itemKey !== itemKey) return;
+      setCollapsed(false);
+      writeCollapseState(taskId, itemKey, false);
+    };
+    window.addEventListener(FEED_ITEM_EXPAND_EVENT, onExpand);
+    return () => window.removeEventListener(FEED_ITEM_EXPAND_EVENT, onExpand);
+  }, [taskId, itemKey, alwaysExpanded]);
+
+  const onToggle = useCallback(() => {
+    if (alwaysExpanded) return;
+    setCollapsed((cur) => {
+      const next = !cur;
+      writeCollapseState(taskId, itemKey, next);
+      return next;
+    });
+  }, [taskId, itemKey, alwaysExpanded]);
+
+  // Plan cards get the same amber-tinted ring as the original page; other
+  // cards get the neutral stone ring. Keep the existing visual register.
+  const ring =
+    emphasis === "plan"
+      ? "border-stone-300 shadow-sm ring-1 ring-amber-100"
+      : "border-stone-200";
+
+  const isOpen = alwaysExpanded || !collapsed;
+
+  return (
+    <section
+      id={anchorId}
+      data-feed-item-key={itemKey}
+      data-feed-item-collapsed={isOpen ? "false" : "true"}
+      className={`scroll-mt-4 overflow-hidden rounded-lg border bg-white ${ring}`}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        disabled={alwaysExpanded}
+        aria-expanded={isOpen}
+        className={
+          "flex w-full items-baseline gap-2 px-4 py-2 text-left text-xs text-stone-500 sm:px-6 " +
+          (alwaysExpanded
+            ? "cursor-default"
+            : "cursor-pointer hover:bg-stone-50")
+        }
+      >
+        {!alwaysExpanded && (
+          <span className="text-stone-400" aria-hidden>
+            {isOpen ? (
+              <ChevronDown className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5" />
+            )}
+          </span>
+        )}
+        <span className="flex flex-1 flex-wrap items-baseline gap-x-3 gap-y-1">
+          {header}
+        </span>
+      </button>
+      {isOpen && (
+        <div className="border-t border-stone-100 px-4 pb-4 pt-3 sm:px-6 sm:pb-6">
+          {children}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/dashboard/components/tasks/TaskTocSidebar.tsx
+++ b/dashboard/components/tasks/TaskTocSidebar.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+/**
+ * Left-rail TOC for `/tasks/[id]`. Renders one row per feed item in the
+ * same reverse-chronological order as the main column.
+ *
+ * Click behavior:
+ *   1. Dispatch `eps:feed-item-expand` so the matching CollapsiblePanel
+ *      opens (no-op if already open).
+ *   2. Smooth-scroll the panel's <section id=anchorId> into view.
+ *
+ * Active highlight: IntersectionObserver watches each panel's anchor
+ * element. The topmost intersecting panel within the viewport's top
+ * half wins the highlight, so as the user scrolls the bold row follows.
+ *
+ * Layout: sticky 240px-wide column, only rendered at md: and up via the
+ * grid wrapper on the page. Hidden internally on narrow viewports as
+ * defense-in-depth.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  FEED_ITEM_EXPAND_EVENT,
+  type FeedItemExpandDetail,
+} from "@/components/CollapsiblePanel";
+
+export type TocEntry = {
+  itemKey: string;
+  anchorId: string;
+  label: string;
+  kind: "body" | "plan" | "event-card" | "event-compact" | "transition";
+  ts: string;
+};
+
+const KIND_BADGE: Record<TocEntry["kind"], { label: string; cls: string }> = {
+  body: { label: "BODY", cls: "bg-stone-200 text-stone-800" },
+  plan: { label: "PLAN", cls: "bg-amber-100 text-amber-900" },
+  "event-card": { label: "EVT", cls: "bg-sky-100 text-sky-800" },
+  "event-compact": { label: "EVT", cls: "bg-stone-100 text-stone-600" },
+  transition: { label: "→", cls: "bg-stone-100 text-stone-500" },
+};
+
+export function TaskTocSidebar({
+  taskId,
+  entries,
+}: {
+  taskId: number;
+  entries: TocEntry[];
+}) {
+  const [activeKey, setActiveKey] = useState<string | null>(
+    entries[0]?.itemKey ?? null,
+  );
+  // Avoid clobbering the active highlight while a programmatic scroll is in
+  // flight: when the user clicks a TOC entry we set the active key
+  // immediately and suppress IO updates for ~700ms (smooth-scroll duration).
+  const suppressIoUntilRef = useRef<number>(0);
+
+  useEffect(() => {
+    if (entries.length === 0) return;
+    const observer = new IntersectionObserver(
+      (mutations) => {
+        if (Date.now() < suppressIoUntilRef.current) return;
+        // Each tick, snapshot the panel that's most-visibly the
+        // "current section". We use the topmost panel whose top edge is
+        // inside the viewport's upper half. This avoids the flicker
+        // that pure ratio-based picking causes on tall sections.
+        const viewportH = window.innerHeight;
+        let best: { key: string; top: number } | null = null;
+        for (const m of mutations) {
+          if (!m.isIntersecting) continue;
+          const el = m.target as HTMLElement;
+          const key = el.dataset.feedItemKey;
+          if (!key) continue;
+          const top = m.boundingClientRect.top;
+          if (top > viewportH * 0.6) continue;
+          if (best === null || top < best.top) best = { key, top };
+        }
+        if (best) setActiveKey(best.key);
+      },
+      {
+        rootMargin: "0px 0px -40% 0px",
+        threshold: [0, 0.1, 0.25, 0.5, 0.75, 1],
+      },
+    );
+    for (const e of entries) {
+      const el = document.getElementById(e.anchorId);
+      if (el) observer.observe(el);
+    }
+    return () => observer.disconnect();
+  }, [entries]);
+
+  const onClick = useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement>, entry: TocEntry) => {
+      e.preventDefault();
+      suppressIoUntilRef.current = Date.now() + 800;
+      setActiveKey(entry.itemKey);
+      // Ask the matching panel to expand (no-op if already open).
+      window.dispatchEvent(
+        new CustomEvent<FeedItemExpandDetail>(FEED_ITEM_EXPAND_EVENT, {
+          detail: { taskId, itemKey: entry.itemKey },
+        }),
+      );
+      // Scroll AFTER expand so the panel's full height is committed; one
+      // frame of delay is enough for React to flush the open state.
+      requestAnimationFrame(() => {
+        const el = document.getElementById(entry.anchorId);
+        if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
+      });
+    },
+    [taskId],
+  );
+
+  if (entries.length === 0) return null;
+
+  return (
+    <nav
+      aria-label="Task feed table of contents"
+      className="hidden md:block sticky top-4 self-start max-h-[calc(100vh-2rem)] overflow-y-auto pr-2 text-xs"
+    >
+      <div className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-stone-500">
+        Feed · {entries.length}
+      </div>
+      <ul className="space-y-0.5">
+        {entries.map((entry) => {
+          const isActive = entry.itemKey === activeKey;
+          const badge = KIND_BADGE[entry.kind];
+          return (
+            <li key={entry.itemKey}>
+              <a
+                href={`#${entry.anchorId}`}
+                onClick={(e) => onClick(e, entry)}
+                aria-current={isActive ? "true" : undefined}
+                className={
+                  "flex items-baseline gap-2 rounded px-1.5 py-1 leading-snug " +
+                  (isActive
+                    ? "bg-stone-200 text-stone-900 font-medium"
+                    : "text-stone-600 hover:bg-stone-100 hover:text-stone-900")
+                }
+              >
+                <span
+                  className={`shrink-0 rounded px-1 py-0.5 font-mono text-[9px] uppercase ${badge.cls}`}
+                >
+                  {badge.label}
+                </span>
+                <span className="min-w-0 flex-1 truncate">{entry.label}</span>
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}


### PR DESCRIPTION
Implements the 3-feature request: in-place edit on body + title, every feed item collapsible (LogCard-style) with localStorage persistence, left TOC sidebar with IntersectionObserver scroll-spy.

## Files
- New: `EditableBody.tsx`, `InlineBodyEditor.tsx`, `TitleEditor.tsx`, `edit/actions.ts` (server action for set-title)
- New: `components/CollapsiblePanel.tsx` (generic, extracted from LogCard pattern)
- New: `components/tasks/TaskTocSidebar.tsx` (sticky left rail, kind badges, scroll-spy)
- Modified: `app/tasks/[id]/page.tsx` — 2-column `md:grid-cols-[240px_minmax(0,1fr)]` layout, stable itemKey per feed item

## Verification
- npm run build (Turbopack production): PASS
- npx tsc --noEmit: PASS
- npx eslint touched files: PASS
- Manual smoke test on task #389 (84 feed items): anon read-only ✓, authed edit affordances ✓, TOC scroll-spy ✓, collapse-state persistence ✓

## 4 items for human eyeball (per implementer report)
1. `EditableBody` passes ReactMarkdown tree as `children` across RSC boundary — works today; Next.js 16's RSC serializer might change behavior
2. `CollapsiblePanel` uses `eslint-disable` for `react-hooks/set-state-in-effect` (matches `CommentableBody.tsx` pattern, but `useSyncExternalStore` might be the more modern shape)
3. Active-section heuristic picks topmost panel with top in upper 60% of viewport — may stick on the same TOC entry for very tall panels
4. PlanCard permalink moved from header (invalid `<a>`-in-`<button>`) to top-right inside body — alternative is `headerActions` slot

DO NOT MERGE until human review of the 4 eyeball items + a Vercel preview spot-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via [Happy](https://happy.engineering)