### PR TITLE
Issue #405: multi-persona marker leakage vs persona-distance (K-sweep)

### DIFF
--- a/scripts/_issue405_common.py
+++ b/scripts/_issue405_common.py
@@ -1,0 +1,203 @@
+# ruff: noqa: RUF002, RUF003
+"""Shared constants + pool helpers for issue #405.
+
+Imported by every issue405_*.py script so the three-way pool split + marker
+identity + per-K subset counts are defined ONCE.
+"""
+
+from __future__ import annotations
+
+# ── Marker (canonical per .claude/rules/marker-leakage-measurement.md) ──────
+
+MARKER_TEXT = " ※"  # leading space + ※ (Qwen-2.5-7B token id 83399)
+MARKER_TOKEN_ID = 83399
+
+# ── Three-way pool split (FIXED across the experiment, §4.1 of plan v2) ─────
+
+POOL: list[str] = [
+    "paramedic",
+    "navy_seal",
+    "villain",
+    "librarian",
+    "data_scientist",
+    "medical_doctor",
+    "french_person",
+    "poet",
+]
+
+NEGATIVES_FIXED: list[str] = [
+    "software_engineer",
+    "kindergarten_teacher",
+    "helpful_assistant",
+    "no_persona",
+]
+
+HELD_OUT: list[str] = [
+    "cybersec_consultant",
+    "pentester",
+    "private_investigator",
+    "army_medic",
+    "surgeon",
+    "police_officer",
+    "florist",
+    "comedian",
+]
+
+ALL_PERSONAS: list[str] = POOL + NEGATIVES_FIXED + HELD_OUT
+
+# ── Cell layout (§4.2) ──────────────────────────────────────────────────────
+
+K_VALUES: tuple[int, ...] = (1, 2, 4, 8)
+SUBSETS_PER_K: dict[int, int | None] = {1: None, 2: 6, 4: 6, 8: None}  # None = all
+SUBSET_RNG_SEED = 405
+
+CORE_ROWS_PER_CELL = 800
+CORE_TOTAL_POSITIVE_ROWS = 400
+CORE_NEG_ROWS_PER_PERSONA = 100  # 4 negs * 100 = 400, matches positives 1:1
+
+# Dose-control arm (§4.6 build_dose_control_specs)
+DOSE50_PERSONAS = ["paramedic", "villain", "poet"]
+DOSE50_ROWS_PER_POSITIVE = 50
+
+# Ablation arm (§4.6 build_ablation_specs)
+ABLATION_POSITIVES = ("paramedic", "villain", "librarian", "poet")
+ABLATION_NEGATIVES = ["surgeon", "police_officer", "florist", "comedian"]
+ABLATION_HELD_OUT = ["cybersec_consultant", "pentester", "private_investigator", "army_medic"]
+
+# ── Training defaults (§4.4, §11) ───────────────────────────────────────────
+
+BASE_MODEL = "Qwen/Qwen2.5-7B-Instruct"
+LORA_R = 16
+LORA_ALPHA = 32
+LORA_DROPOUT = 0.05
+LORA_TARGETS_NARROW = ["q_proj", "k_proj", "v_proj", "o_proj"]  # NO MLP — non-saturating
+
+LR = 5.0e-6
+EPOCHS = 2
+PER_DEVICE_BATCH = 4
+GRAD_ACCUM = 4
+MAX_LENGTH = 1024
+WARMUP_RATIO = 0.05
+WEIGHT_DECAY = 0.0
+R_CAP_SAFETY_MARGIN = 8  # 1024 − prompt_len − 8 = max_new_tokens for R (Fix D)
+R_CAP_MIN = 64  # if R_cap < 64, prompt is too long → FAIL LOUD
+
+# Smoke kill-criterion (§4.9, §7)
+SMOKE_G_LOGPROB_SOURCE_KILL = -0.1  # if g_logprob_source > -0.1 → STOP (saturated)
+SMOKE_G_LOGPROB_SOURCE_TARGET_RANGE = (-8.0, -3.0)  # non-saturating headroom
+
+# WandB
+WANDB_PROJECT = "issue_405_kdiversity"
+
+# Sentinel + log path conventions (pod-side, per CLAUDE.md pod-side rule)
+SENTINEL_DIR_POD = "/workspace/logs"
+SENTINEL_DIR_LOCAL_FALLBACK = "logs"  # used when running smoke locally (no /workspace)
+
+
+def load_all_persona_prompts() -> dict[str, str]:
+    """Load all 20 persona system prompts from the canonical ORIGINAL_20 list.
+
+    The cached layer-20 cosine matrix at
+    `eval_results/extraction_method_comparison/cosine_matrix_a_layer20.json`
+    was extracted under exactly these prompts (provenance-matched, §4.5 PHASE 0).
+
+    Returns:
+        dict mapping persona name → system prompt text (empty string for
+        `no_persona`).
+
+    Asserts:
+        All 20 names in POOL ∪ NEGATIVES_FIXED ∪ HELD_OUT are present in
+        ORIGINAL_20; FAILS LOUD on any missing name.
+    """
+    # Inline import — extract_centroids_and_analyze.py is a scripts/ file, not
+    # a package module; importing it via sys.path keeps the import local.
+    import sys
+    from pathlib import Path
+
+    scripts_dir = Path(__file__).resolve().parent
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    from extract_centroids_and_analyze import ORIGINAL_20
+
+    prompts = dict(ORIGINAL_20)
+    missing = [p for p in ALL_PERSONAS if p not in prompts]
+    if missing:
+        raise RuntimeError(
+            f"ORIGINAL_20 in scripts/extract_centroids_and_analyze.py is missing "
+            f"prompts for plan-named personas: {missing!r}. "
+            f"Refusing to proceed — fix the prompt list or pool split."
+        )
+    return prompts
+
+
+def load_cosine_distance_matrix() -> tuple[list[str], list[list[float]]]:
+    """Load cached layer-20 cosine SIMILARITY matrix and return as DISTANCE.
+
+    Returns:
+        (persona_names, distance_matrix) where distance = 1 − similarity.
+        distance_matrix[i][j] = 1 − cos(h_20[names[i]], h_20[names[j]]).
+    """
+    import json
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parent.parent
+    p = repo_root / "eval_results" / "extraction_method_comparison" / "cosine_matrix_a_layer20.json"
+    if not p.exists():
+        raise FileNotFoundError(
+            f"Cached layer-20 cosine matrix missing: {p}. "
+            f"Re-run scripts/extract_centroids_and_analyze.py to regenerate."
+        )
+    data = json.loads(p.read_text())
+    names = data["persona_names"]
+    sim = data["matrix"]
+    dist = [[1.0 - sim[i][j] for j in range(len(names))] for i in range(len(names))]
+    return names, dist
+
+
+def min_dist_to_set(
+    held_out_persona: str,
+    trained_set: list[str],
+    names: list[str],
+    distance: list[list[float]],
+) -> float:
+    """Min layer-20 cosine distance from a held-out persona to a trained subset."""
+    if held_out_persona not in names:
+        raise KeyError(f"held_out_persona {held_out_persona!r} not in distance matrix")
+    i = names.index(held_out_persona)
+    js = [names.index(p) for p in trained_set if p in names]
+    if not js:
+        raise ValueError(f"None of trained_set {trained_set!r} present in distance matrix names")
+    return min(distance[i][j] for j in js)
+
+
+def mean_dist_to_set(
+    held_out_persona: str,
+    trained_set: list[str],
+    names: list[str],
+    distance: list[list[float]],
+) -> float:
+    """Mean layer-20 cosine distance from a held-out persona to a trained subset."""
+    if held_out_persona not in names:
+        raise KeyError(f"held_out_persona {held_out_persona!r} not in distance matrix")
+    i = names.index(held_out_persona)
+    js = [names.index(p) for p in trained_set if p in names]
+    if not js:
+        raise ValueError(f"None of trained_set {trained_set!r} present in distance matrix names")
+    return sum(distance[i][j] for j in js) / len(js)
+
+
+def assert_marker_token_id(tokenizer) -> None:
+    """Fail-loud assert that MARKER_TEXT encodes to the single canonical token id.
+
+    Per `.claude/rules/marker-leakage-measurement.md`: every marker-leakage
+    experiment MUST assert this before any subprocess spawns. The leading
+    space matters — bash strips it; thread with shlex.quote().
+    """
+    ids = tokenizer.encode(MARKER_TEXT, add_special_tokens=False)
+    if ids != [MARKER_TOKEN_ID]:
+        raise RuntimeError(
+            f"Marker token id assert FAILED. tokenizer.encode({MARKER_TEXT!r}, "
+            f"add_special_tokens=False) returned {ids}, expected [{MARKER_TOKEN_ID}]. "
+            f"Either the tokenizer changed or the marker text lost its leading space "
+            f"(common bash-shell stripping bug — use shlex.quote when threading)."
+        )

--- a/scripts/issue405_analyze.py
+++ b/scripts/issue405_analyze.py
@@ -1,0 +1,498 @@
+#!/usr/bin/env python3
+# ruff: noqa: RUF001, RUF002, RUF003
+"""Issue #405 PHASE 5 — headline regression + robustness + figures.
+
+Per plan v2 §4.5 PHASE 5 + §6.4 (the primary statistical test) + §6.5 (the
+hero figure + exploratory dump).
+
+Pipeline:
+  1. Load all ``eval_results/issue_405/cell_*_seed*/result.json`` files.
+  2. Separate by ``track`` (CORE / K4_ABLNEG / K1_DOSE50).
+  3. For every (cell, seed, held_out_persona) compute ``min_dist`` and
+     ``mean_dist`` (layer-20 cosine).
+  4. CORE-only headline mixed-effects regression
+       ΔlogP ~ K * min_dist + (1|subset) + (1|persona)
+     via pymer4 (primary) / rpy2+lme4 (fallback) / statsmodels.MixedLM
+     with vc_formula (last resort).
+  5. Robustness: comedian-dropped refit, leave-one-persona-out, leverage,
+     covariate-adjusted (+ trained_pos_mean_dlogp), JS-distance refit.
+  6. Plots: hero + raw + residualized + per-cell bars + per-seed scatter +
+     min-vs-mean + JS robustness + ABLNEG overlay + dose-control head-to-head
+     + comedian-dropped panel + trained-positive ΔlogP × K.
+
+Writes:
+  eval_results/issue_405/aggregate/regression.json
+  figures/issue_405/*.png
+
+CLI:
+  --eval-dir          Default: eval_results/issue_405
+  --fig-dir           Default: figures/issue_405
+  --simulated         If true, fits on simulated 168-cell-persona data
+                      (pre-sweep runnability gate per Fix B3).
+  --simulated-only    Skip real data load; only run the simulated fit.
+  --skip-plots        Stat fits only; no figures.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+from _bootstrap import PROJECT_ROOT, bootstrap
+
+log = bootstrap()
+
+from _issue405_common import (  # noqa: E402
+    HELD_OUT,
+    POOL,
+    load_cosine_distance_matrix,
+)
+
+
+def load_cell_results(eval_dir: Path) -> list[dict]:
+    """Read every cell_*_seed*/result.json under eval_dir."""
+    files = sorted(eval_dir.glob("cell_*_seed*/result.json"))
+    if not files:
+        raise SystemExit(f"No cell result.json files found under {eval_dir}")
+    out = []
+    for f in files:
+        try:
+            out.append(json.loads(f.read_text()))
+        except Exception as e:
+            log.warning("Skipping malformed %s (%s)", f, e)
+    log.info("Loaded %d cell result.json files from %s", len(out), eval_dir)
+    return out
+
+
+def build_cell_persona_frame(
+    results: list[dict],
+    names: list[str],
+    distance: list[list[float]],
+    track: str = "CORE",
+) -> list[dict]:
+    """Flatten cell results to a one-row-per-(cell, seed, held-out-persona) frame.
+
+    Each row carries: cell_id, seed, K, subset (tuple-of-positives as str),
+    persona, min_dist, mean_dist, deltaLogP_mean (across the 20 questions),
+    trained_pos_mean_dlogp (per-cell scalar from FIX A1 panel).
+    """
+    rows: list[dict] = []
+    for r in results:
+        if r.get("track") != track:
+            continue
+        cell_id = r["cell_id"]
+        seed = r["seed"]
+        K = r["K"]
+        positives = r["spec"]["positives"]
+        subset_id = "+".join(sorted(positives))
+        trained_pos_mean = r["eval"]["summary"]["trained_pos_mean_dlogp"]
+        for persona, payload in r["eval"]["held_out"].items():
+            if persona not in names:
+                continue
+            from _issue405_common import mean_dist_to_set, min_dist_to_set
+
+            md = min_dist_to_set(persona, positives, names, distance)
+            mn = mean_dist_to_set(persona, positives, names, distance)
+            rows.append(
+                {
+                    "cell_id": cell_id,
+                    "seed": seed,
+                    "K": K,
+                    "subset": subset_id,
+                    "persona": persona,
+                    "min_dist": md,
+                    "mean_dist": mn,
+                    "deltaLogP_mean": payload["deltaLogP_mean"],
+                    "trained_pos_mean_dlogp": trained_pos_mean,
+                    "emit_rate": payload["emit_rate"],
+                }
+            )
+    return rows
+
+
+def fit_mixed_effects(
+    df_rows: list[dict],
+    formula: str = "deltaLogP_mean ~ K * min_dist",
+    re_groups: tuple[str, str] = ("subset", "persona"),
+) -> dict:
+    """Crossed-RE fit.
+
+    Try pymer4 first; fall back to rpy2 + lme4; last resort statsmodels
+    MixedLM with explicit vc_formula.
+
+    Returns:
+        dict with ``status``, ``tool``, ``coefs`` (per-term β + 95% CI),
+        ``loglik``, ``aic``, ``message`` (str if failure).
+    """
+    n = len(df_rows)
+    if n == 0:
+        return {"status": "FAIL", "tool": "none", "message": "empty data frame"}
+
+    import pandas as pd
+
+    df = pd.DataFrame(df_rows)
+    if df["persona"].nunique() < 2 or df["subset"].nunique() < 2:
+        return {
+            "status": "FAIL",
+            "tool": "skipped",
+            "message": (
+                f"Need ≥ 2 unique persona AND ≥ 2 unique subset to fit crossed REs; "
+                f"got {df['persona'].nunique()} personas, {df['subset'].nunique()} subsets."
+            ),
+        }
+
+    # ── Tool 1: pymer4 ────────────────────────────────────────────────
+    try:
+        from pymer4.models import Lmer  # type: ignore
+
+        lme_formula = f"{formula} + (1|{re_groups[0]}) + (1|{re_groups[1]})"
+        model = Lmer(lme_formula, data=df)
+        model.fit()
+        coefs = model.coefs.to_dict()
+        return {
+            "status": "PASS",
+            "tool": "pymer4",
+            "formula": lme_formula,
+            "n_obs": n,
+            "coefs": coefs,
+            "aic": float(model.AIC) if hasattr(model, "AIC") else None,
+            "loglik": float(model.logLike) if hasattr(model, "logLike") else None,
+        }
+    except ImportError:
+        log.warning("pymer4 not installed; trying rpy2+lme4 fallback")
+    except Exception as e:
+        log.warning("pymer4 fit failed (%s); trying rpy2+lme4 fallback", e)
+
+    # ── Tool 2: rpy2 + lme4 ───────────────────────────────────────────
+    try:
+        import rpy2.robjects as ro  # type: ignore
+        from rpy2.robjects import pandas2ri  # type: ignore
+        from rpy2.robjects.packages import importr  # type: ignore
+
+        pandas2ri.activate()
+        lme4 = importr("lme4")
+        lme_formula = f"{formula} + (1|{re_groups[0]}) + (1|{re_groups[1]})"
+        with ro.default_converter + pandas2ri.converter:
+            r_df = ro.conversion.py2rpy(df)
+        ro.globalenv["df_r"] = r_df
+        model = lme4.lmer(ro.Formula(lme_formula), data=r_df)
+        ro.globalenv["m"] = model
+        coef_df = ro.r("as.data.frame(summary(m)$coefficients)")
+        coefs = {
+            row_name: dict(coef_df.iloc[i].to_dict()) for i, row_name in enumerate(coef_df.index)
+        }
+        return {
+            "status": "PASS",
+            "tool": "rpy2+lme4",
+            "formula": lme_formula,
+            "n_obs": n,
+            "coefs": coefs,
+        }
+    except ImportError:
+        log.warning("rpy2 not installed; falling back to statsmodels.MixedLM")
+    except Exception as e:
+        log.warning("rpy2+lme4 fit failed (%s); falling back to statsmodels.MixedLM", e)
+
+    # ── Tool 3: statsmodels MixedLM with vc_formula ───────────────────
+    try:
+        import statsmodels.formula.api as smf
+
+        df["dummy_const"] = 1
+        vc = {re_groups[0]: f"0 + C({re_groups[0]})", re_groups[1]: f"0 + C({re_groups[1]})"}
+        model = smf.mixedlm(formula, df, groups="dummy_const", vc_formula=vc)
+        fit = model.fit(method=["lbfgs"], reml=True)
+        coefs = {
+            term: {
+                "Estimate": float(fit.params[term]),
+                "Std. Error": float(fit.bse[term]),
+                "P-val": float(fit.pvalues[term]),
+            }
+            for term in fit.params.index
+            if term in fit.bse.index
+        }
+        return {
+            "status": "PASS",
+            "tool": "statsmodels.MixedLM (vc_formula)",
+            "formula": formula,
+            "n_obs": n,
+            "coefs": coefs,
+        }
+    except Exception as e:
+        log.error("statsmodels.MixedLM fit failed too (%s)", e)
+        return {"status": "FAIL", "tool": "all_failed", "message": str(e)}
+
+
+def simulate_pre_sweep_runnability() -> dict:
+    """Pre-sweep code-runnability gate (per Fix B3, Assumption A15).
+
+    Simulate ΔlogP on a 168-cell-persona grid (21 cells × 8 held-out, with
+    21 cells = K=1:8, K=2:6, K=4:6, K=8:1) with 2 seeds × 20 questions per
+    (cell, persona) and a planted K×min interaction. Fit headline; report
+    fitter status + recovered β_{K×min}.
+    """
+    rng = np.random.default_rng(405)
+    rows: list[dict] = []
+    # Build a tiny synthetic 21-cell layout
+    cell_layout: list[tuple[int, list[str]]] = []
+    cell_layout += [(1, [p]) for p in POOL]  # 8 cells
+    pairs = rng.choice(len(POOL), size=(6, 2), replace=True).tolist()
+    cell_layout += [(2, [POOL[i % len(POOL)] for i in p]) for p in pairs]  # 6 cells
+    quads = rng.choice(len(POOL), size=(6, 4), replace=True).tolist()
+    cell_layout += [(4, [POOL[i % len(POOL)] for i in q]) for q in quads]  # 6 cells
+    cell_layout += [(8, list(POOL))]  # 1 cell
+
+    # Use the real layer-20 distance matrix.
+    names, dist = load_cosine_distance_matrix()
+    from _issue405_common import min_dist_to_set
+
+    planted_beta_K_x_min = -1.0  # planted slope (truth)
+    for cidx, (K, positives) in enumerate(cell_layout):
+        cell_id = f"sim_K{K}_c{cidx:02d}"
+        subset_id = "+".join(sorted(positives))
+        for seed in (42, 137):
+            for persona in HELD_OUT:
+                md = min_dist_to_set(persona, positives, names, dist)
+                # Linear DGP: ΔlogP = -1.0 - 0.5*K + (planted) * K * md + noise
+                mu = -1.0 - 0.5 * K + planted_beta_K_x_min * K * md
+                # Replicate questions × seeds — average them down to a single mean
+                # per (cell, persona, seed) row.
+                draws = rng.normal(loc=mu, scale=0.3, size=20)
+                rows.append(
+                    {
+                        "cell_id": cell_id,
+                        "seed": seed,
+                        "K": K,
+                        "subset": subset_id,
+                        "persona": persona,
+                        "min_dist": md,
+                        "mean_dist": md,  # placeholder; equal at K=1
+                        "deltaLogP_mean": float(draws.mean()),
+                        "trained_pos_mean_dlogp": -2.0 + 0.5 * K,
+                        "emit_rate": 0.0,
+                    }
+                )
+
+    fit = fit_mixed_effects(rows)
+    fit["planted_beta_K_x_min"] = planted_beta_K_x_min
+    fit["n_simulated_rows"] = len(rows)
+    return fit
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--eval-dir",
+        type=str,
+        default=str(PROJECT_ROOT / "eval_results" / "issue_405"),
+    )
+    parser.add_argument(
+        "--fig-dir",
+        type=str,
+        default=str(PROJECT_ROOT / "figures" / "issue_405"),
+    )
+    parser.add_argument("--simulated", action="store_true")
+    parser.add_argument("--simulated-only", action="store_true")
+    parser.add_argument("--skip-plots", action="store_true")
+    parser.add_argument(
+        "--out-path",
+        type=str,
+        default=str(PROJECT_ROOT / "eval_results" / "issue_405" / "aggregate" / "regression.json"),
+    )
+    args = parser.parse_args()
+
+    out: dict = {"runs": {}}
+
+    if args.simulated or args.simulated_only:
+        log.info("[sim] running pre-sweep runnability gate (Fix B3) ...")
+        sim = simulate_pre_sweep_runnability()
+        out["simulated_fit"] = sim
+        log.info(
+            "[sim] tool=%s status=%s n=%d",
+            sim.get("tool"),
+            sim.get("status"),
+            sim.get("n_simulated_rows"),
+        )
+
+    if args.simulated_only:
+        out_path = Path(args.out_path)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(out, indent=2))
+        log.info("Wrote %s (simulated-only mode)", out_path)
+        return 0
+
+    eval_dir = Path(args.eval_dir)
+    results = load_cell_results(eval_dir)
+    names, dist = load_cosine_distance_matrix()
+
+    # ── CORE headline frame ──────────────────────────────────────────
+    df_core = build_cell_persona_frame(results, names, dist, track="CORE")
+    log.info("CORE frame: %d cell-persona-seed rows", len(df_core))
+
+    if df_core:
+        log.info("Fitting headline regression: ΔlogP ~ K * min_dist + (1|subset) + (1|persona)")
+        out["runs"]["headline_full"] = fit_mixed_effects(df_core)
+
+        df_no_comedian = [r for r in df_core if r["persona"] != "comedian"]
+        log.info("Fitting comedian-dropped refit (mandatory robustness per FIX B2)")
+        out["runs"]["headline_no_comedian"] = fit_mixed_effects(df_no_comedian)
+
+        log.info("Fitting min-only vs mean-only single-predictor variants (FIX B1)")
+        out["runs"]["min_only"] = fit_mixed_effects(
+            df_core, formula="deltaLogP_mean ~ K * min_dist"
+        )
+        out["runs"]["mean_only"] = fit_mixed_effects(
+            df_core, formula="deltaLogP_mean ~ K * mean_dist"
+        )
+
+        log.info("Fitting covariate-adjusted variant (FIX A1 dose-vs-diversity)")
+        out["runs"]["headline_cov"] = fit_mixed_effects(
+            df_core,
+            formula="deltaLogP_mean ~ K * min_dist + trained_pos_mean_dlogp",
+        )
+
+        # Leave-one-persona-out
+        log.info("Leave-one-persona-out refits (8 fits) ...")
+        loo_out: dict[str, dict] = {}
+        for held_persona in sorted({r["persona"] for r in df_core}):
+            subset_rows = [r for r in df_core if r["persona"] != held_persona]
+            loo_out[held_persona] = fit_mixed_effects(subset_rows)
+        out["runs"]["leave_one_persona_out"] = loo_out
+
+    # ── ABLNEG overlay (separate track) ──────────────────────────────
+    df_abl = build_cell_persona_frame(results, names, dist, track="K4_ABLNEG")
+    out["track_ablneg_n_rows"] = len(df_abl)
+    out["track_ablneg_summary"] = (
+        {
+            "mean_deltaLogP_per_persona": {
+                p: float(np.mean([r["deltaLogP_mean"] for r in df_abl if r["persona"] == p]))
+                for p in sorted({r["persona"] for r in df_abl})
+            }
+        }
+        if df_abl
+        else {}
+    )
+
+    # ── DOSE50 head-to-head ──────────────────────────────────────────
+    df_dose = build_cell_persona_frame(results, names, dist, track="K1_DOSE50")
+    out["track_dose_n_rows"] = len(df_dose)
+    if df_dose:
+        # Compare main-K1@400 vs dose-K1@50 vs main-K8@50
+        dose_summary = {}
+        for persona in sorted({r["persona"] for r in df_dose}):
+            dose_summary[persona] = {
+                "dose_K1_50_dlogp": float(
+                    np.mean([r["deltaLogP_mean"] for r in df_dose if r["persona"] == persona])
+                ),
+                "main_K1_400_dlogp": float(
+                    np.mean(
+                        [
+                            r["deltaLogP_mean"]
+                            for r in df_core
+                            if r["persona"] == persona and r["K"] == 1
+                        ]
+                    )
+                )
+                if df_core
+                else None,
+                "main_K8_50_dlogp": float(
+                    np.mean(
+                        [
+                            r["deltaLogP_mean"]
+                            for r in df_core
+                            if r["persona"] == persona and r["K"] == 8
+                        ]
+                    )
+                )
+                if df_core
+                else None,
+            }
+        out["track_dose_summary"] = dose_summary
+
+    out_path = Path(args.out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(out, indent=2, default=str))
+    log.info("Wrote %s", out_path)
+
+    if not args.skip_plots:
+        try:
+            _emit_figures(df_core, df_abl, df_dose, results, out, Path(args.fig_dir))
+        except Exception as e:
+            log.warning("Figure dump failed (%s) — regression.json still written", e)
+
+    return 0
+
+
+def _emit_figures(df_core, df_abl, df_dose, results, regression, fig_dir: Path) -> None:
+    """Plot the exploratory figure dump per plan v2 §6.5."""
+    import matplotlib.pyplot as plt
+
+    fig_dir.mkdir(parents=True, exist_ok=True)
+
+    # ── Hero figure: leakage-vs-distance per K (RAW) ─────────────────
+    if df_core:
+        fig, ax = plt.subplots(figsize=(7, 5))
+        for K in (1, 2, 4, 8):
+            xs = [r["min_dist"] for r in df_core if r["K"] == K]
+            ys = [r["deltaLogP_mean"] for r in df_core if r["K"] == K]
+            if xs:
+                ax.scatter(xs, ys, label=f"K={K}", alpha=0.6, s=30)
+        ax.axhline(0, color="grey", linewidth=0.5, linestyle="--")
+        ax.set_xlabel("min layer-20 cosine distance to trained subset")
+        ax.set_ylabel("held-out marker ΔlogP (trained − base)")
+        ax.set_title("Issue #405 hero (RAW): held-out marker ΔlogP vs min-distance, per K")
+        ax.legend(title="K (#sources)")
+        ax.grid(alpha=0.3)
+        fig.tight_layout()
+        fig.savefig(fig_dir / "hero_raw.png", dpi=140)
+        plt.close(fig)
+        log.info("Wrote %s", fig_dir / "hero_raw.png")
+
+    # ── Per-cell bars (held-out mean ΔlogP per cell) ─────────────────
+    if df_core or df_abl or df_dose:
+        cells: dict[str, list[float]] = {}
+        Ks: dict[str, int] = {}
+        for r in (df_core or []) + (df_abl or []) + (df_dose or []):
+            cells.setdefault(r["cell_id"], []).append(r["deltaLogP_mean"])
+            Ks[r["cell_id"]] = r["K"]
+        fig, ax = plt.subplots(figsize=(12, 4))
+        cell_names = sorted(cells, key=lambda c: (Ks[c], c))
+        means = [float(np.mean(cells[c])) for c in cell_names]
+        colors = {1: "C0", 2: "C1", 4: "C2", 8: "C3"}
+        bar_colors = [colors.get(Ks[c], "C4") for c in cell_names]
+        ax.bar(range(len(cell_names)), means, color=bar_colors)
+        ax.set_xticks(range(len(cell_names)))
+        ax.set_xticklabels(cell_names, rotation=80, fontsize=7)
+        ax.set_ylabel("mean held-out ΔlogP")
+        ax.set_title("Per-cell mean held-out ΔlogP (color = K)")
+        ax.axhline(0, color="grey", linewidth=0.5, linestyle="--")
+        fig.tight_layout()
+        fig.savefig(fig_dir / "per_cell_bars.png", dpi=140)
+        plt.close(fig)
+        log.info("Wrote %s", fig_dir / "per_cell_bars.png")
+
+    # ── Trained-positive ΔlogP × K (FIX A1 sanity) ───────────────────
+    tp = []
+    for r in results:
+        if r.get("track") == "CORE":
+            tp.append((r["K"], r["eval"]["summary"]["trained_pos_mean_dlogp"]))
+    if tp:
+        fig, ax = plt.subplots(figsize=(6, 4))
+        Ks = sorted({k for k, _ in tp})
+        for K in Ks:
+            ys = [v for k, v in tp if k == K]
+            ax.scatter([K] * len(ys), ys, alpha=0.6)
+        ax.set_xlabel("K (#trained source personas)")
+        ax.set_ylabel("trained_pos mean ΔlogP")
+        ax.set_title("Per-cell source-strength scalar (FIX A1) vs K")
+        ax.grid(alpha=0.3)
+        fig.tight_layout()
+        fig.savefig(fig_dir / "trained_positive_vs_K.png", dpi=140)
+        plt.close(fig)
+        log.info("Wrote %s", fig_dir / "trained_positive_vs_K.png")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/issue405_analyze.py
+++ b/scripts/issue405_analyze.py
@@ -67,6 +67,89 @@ def load_cell_results(eval_dir: Path) -> list[dict]:
     return out
 
 
+# Expected per-track counts per plan §0 + §4.6 (21 CORE × 2 seeds = 42,
+# 1 ABLNEG × 2 seeds = 2, 3 DOSE50 × 2 seeds = 6; total 50).
+EXPECTED_TRACK_COUNTS: dict[str, int] = {"CORE": 42, "K4_ABLNEG": 2, "K1_DOSE50": 6}
+EXPECTED_SEEDS: tuple[int, ...] = (42, 137)
+
+
+def expected_cell_seeds_from_specs(
+    specs_path: Path,
+) -> dict[tuple[str, int], str]:
+    """Read cell_specs.json and return {(cell_id, seed): track} for every expected run."""
+    specs = json.loads(specs_path.read_text())
+    out: dict[tuple[str, int], str] = {}
+    for s in specs:
+        for seed in EXPECTED_SEEDS:
+            out[(s["cell_id"], int(seed))] = s["track"]
+    return out
+
+
+def audit_track_counts(
+    results: list[dict],
+    specs_path: Path | None = None,
+) -> dict:
+    """Round-3 fix: EXACT-equality per-track audit (shortfall AND overage AND unknown).
+
+    Returns a dict with:
+      - ``observed``: {track: count}  (only known tracks)
+      - ``expected``: {track: count}  (EXPECTED_TRACK_COUNTS)
+      - ``shortfall``: {track: missing_count}  (observed < expected)
+      - ``overage``:   {track: excess_count}   (observed > expected)
+      - ``unknown_tracks``: list of unrecognized ``track`` values from results
+      - ``missing_cell_seeds``: list of [cell_id, seed, track] still expected
+      - ``extra_cell_seeds``:   list of [cell_id, seed, track] beyond expected
+
+    The shortfall/overage dicts use POSITIVE counts in both directions for
+    legibility. The cell_seed lists are populated when ``specs_path`` is
+    provided (Phase-0.5 ``cell_specs.json``). Without specs, the function
+    falls back to shortfall/overage based on track totals only — exact-
+    equality is still enforced by the caller via ``has_mismatch``.
+    """
+    counts_observed: dict[str, int] = {t: 0 for t in EXPECTED_TRACK_COUNTS}
+    unknown_tracks: list[str] = []
+    observed_cell_seeds: dict[tuple[str, int], str] = {}
+    for r in results:
+        t = r.get("track")
+        cid = r.get("cell_id")
+        seed = r.get("seed")
+        if t not in EXPECTED_TRACK_COUNTS:
+            unknown_tracks.append(t)
+            continue
+        counts_observed[t] += 1
+        if cid is not None and seed is not None:
+            observed_cell_seeds[(str(cid), int(seed))] = t
+    shortfall = {
+        t: EXPECTED_TRACK_COUNTS[t] - counts_observed[t]
+        for t in EXPECTED_TRACK_COUNTS
+        if counts_observed[t] < EXPECTED_TRACK_COUNTS[t]
+    }
+    overage = {
+        t: counts_observed[t] - EXPECTED_TRACK_COUNTS[t]
+        for t in EXPECTED_TRACK_COUNTS
+        if counts_observed[t] > EXPECTED_TRACK_COUNTS[t]
+    }
+    missing_cell_seeds: list[list] = []
+    extra_cell_seeds: list[list] = []
+    if specs_path is not None and specs_path.exists():
+        expected_set = expected_cell_seeds_from_specs(specs_path)
+        for (cid, seed), tr in sorted(expected_set.items()):
+            if (cid, seed) not in observed_cell_seeds:
+                missing_cell_seeds.append([cid, int(seed), tr])
+        for (cid, seed), tr in sorted(observed_cell_seeds.items()):
+            if (cid, seed) not in expected_set:
+                extra_cell_seeds.append([cid, int(seed), tr])
+    return {
+        "observed": counts_observed,
+        "expected": dict(EXPECTED_TRACK_COUNTS),
+        "shortfall": shortfall,
+        "overage": overage,
+        "unknown_tracks": unknown_tracks,
+        "missing_cell_seeds": missing_cell_seeds,
+        "extra_cell_seeds": extra_cell_seeds,
+    }
+
+
 def build_cell_persona_frame(
     results: list[dict],
     names: list[str],
@@ -534,34 +617,36 @@ def main() -> int:
     results = load_cell_results(eval_dir)
     names, dist = load_cosine_distance_matrix()
 
-    # ── Blocker 2 + 5 fix: FAIL LOUD on result-file shortfall ────────
+    # ── Round-3 fix 1: EXACT-equality track-count assert ─────────────
     # Plan §0 + §4.6: 21 CORE × 2 seeds = 42, 1 ABLNEG × 2 seeds = 2,
-    # 3 DOSE50 × 2 seeds = 6. Total 50. If the dispatcher silently lost
-    # a cell, the headline regression denominator is wrong and we'd
-    # ship a result for fewer cells than we claimed to run.
-    counts_by_track = {"CORE": 0, "K4_ABLNEG": 0, "K1_DOSE50": 0}
-    for r in results:
-        t = r.get("track")
-        if t in counts_by_track:
-            counts_by_track[t] += 1
-    expected = {"CORE": 42, "K4_ABLNEG": 2, "K1_DOSE50": 6}
-    out["track_counts"] = {"observed": counts_by_track, "expected": expected}
-    shortfall = {
-        t: expected[t] - counts_by_track[t] for t in expected if counts_by_track[t] < expected[t]
-    }
-    if shortfall:
+    # 3 DOSE50 × 2 seeds = 6. Total 50. Round-2 only caught shortfalls
+    # (counts<expected); stale/extra result.json files in the OTHER
+    # direction (overage) inflate the denominator → the same wrong-
+    # denominator class blocker 2 closed. Round 3 asserts EXACT equality
+    # per track AND surfaces the offending/extra cell_id+seed list for
+    # both directions, plus any unknown-track rows.
+    audit = audit_track_counts(
+        results, specs_path=PROJECT_ROOT / "data" / "issue_405" / "cell_specs.json"
+    )
+    out["track_counts"] = audit
+    has_mismatch = bool(audit["shortfall"] or audit["overage"] or audit["unknown_tracks"])
+    if has_mismatch:
+        msg = (
+            f"Result-file count mismatch vs expected={audit['expected']!r}: "
+            f"observed={audit['observed']!r}, shortfall={audit['shortfall']!r}, "
+            f"overage={audit['overage']!r}, unknown_tracks={audit['unknown_tracks']!r}, "
+            f"missing_cell_seeds={audit['missing_cell_seeds']!r}, "
+            f"extra_cell_seeds={audit['extra_cell_seeds']!r}"
+        )
         if args.allow_partial:
             log.warning(
-                "[analyze] PARTIAL: result-file shortfall %r (allow_partial=True; "
-                "headline denominator may be wrong)",
-                shortfall,
+                "[analyze] PARTIAL: %s (allow_partial=True; headline denominator may be wrong)", msg
             )
-            out["partial_shortfall"] = shortfall
+            out["partial_mismatch"] = True
         else:
             raise RuntimeError(
-                f"Result-file shortfall {shortfall!r} vs expected {expected!r}. "
-                f"Pass --allow-partial to override (the dispatcher silently lost a "
-                f"cell — investigate before fitting on a wrong denominator)."
+                msg + ". Pass --allow-partial to downgrade to a warning (investigate "
+                "before fitting on a wrong denominator)."
             )
 
     # ── CORE headline frame ──────────────────────────────────────────

--- a/scripts/issue405_analyze.py
+++ b/scripts/issue405_analyze.py
@@ -90,8 +90,14 @@ def build_cell_persona_frame(
         subset_id = "+".join(sorted(positives))
         trained_pos_mean = r["eval"]["summary"]["trained_pos_mean_dlogp"]
         for persona, payload in r["eval"]["held_out"].items():
+            # Blocker 6: FAIL LOUD on missing distance — a held-out persona
+            # absent from the cosine matrix is a data bug, not a row to skip.
             if persona not in names:
-                continue
+                raise RuntimeError(
+                    f"Held-out persona {persona!r} missing from layer-20 cosine matrix "
+                    f"(cell={cell_id} seed={seed}). Names available: {names!r}. "
+                    f"Refusing to silently drop the row — re-extract the matrix."
+                )
             from _issue405_common import mean_dist_to_set, min_dist_to_set
 
             md = min_dist_to_set(persona, positives, names, distance)
@@ -184,12 +190,18 @@ def fit_mixed_effects(
         coefs = {
             row_name: dict(coef_df.iloc[i].to_dict()) for i, row_name in enumerate(coef_df.index)
         }
+        # Pull AIC from R for Blocker 5 min-vs-mean comparison.
+        try:
+            aic = float(ro.r("AIC(m)")[0])
+        except Exception:
+            aic = None
         return {
             "status": "PASS",
             "tool": "rpy2+lme4",
             "formula": lme_formula,
             "n_obs": n,
             "coefs": coefs,
+            "aic": aic,
         }
     except ImportError:
         log.warning("rpy2 not installed; falling back to statsmodels.MixedLM")
@@ -213,16 +225,191 @@ def fit_mixed_effects(
             for term in fit.params.index
             if term in fit.bse.index
         }
+        # Blocker 5 fix: emit AIC from statsmodels so min-vs-mean
+        # comparison works in the fallback path too (was missing in
+        # round 1 — broke the AIC comparison the plan §6.4 mandates).
+        try:
+            aic = float(fit.aic) if hasattr(fit, "aic") and fit.aic is not None else None
+        except Exception:
+            aic = None
+        try:
+            llf = float(fit.llf) if hasattr(fit, "llf") and fit.llf is not None else None
+        except Exception:
+            llf = None
         return {
             "status": "PASS",
             "tool": "statsmodels.MixedLM (vc_formula)",
             "formula": formula,
             "n_obs": n,
             "coefs": coefs,
+            "aic": aic,
+            "loglik": llf,
         }
     except Exception as e:
         log.error("statsmodels.MixedLM fit failed too (%s)", e)
         return {"status": "FAIL", "tool": "all_failed", "message": str(e)}
+
+
+def fit_per_K_marginal_slopes(df_rows: list[dict], dist_col: str = "min_dist") -> dict:
+    """Blocker 5 — per-K marginal slopes (4 slopes, one per K ∈ {1, 2, 4, 8}).
+
+    Per plan §6.4 FIX B2 mandatory robustness #3. Each K's marginal slope
+    is a simple OLS within that K stratum (no random effects since we're
+    conditioning on K). Reports {β, SE, p, 95% CI} per K.
+    """
+    if not df_rows:
+        return {"status": "FAIL", "message": "empty data frame"}
+    import statsmodels.formula.api as smf
+
+    out: dict = {"per_K": {}}
+    for K in sorted({r["K"] for r in df_rows}):
+        sub = [r for r in df_rows if r["K"] == K]
+        if len({r["persona"] for r in sub}) < 2:
+            out["per_K"][K] = {
+                "status": "SKIP",
+                "n": len(sub),
+                "message": "fewer than 2 unique personas at this K",
+            }
+            continue
+        import pandas as pd
+
+        d = pd.DataFrame(sub)
+        try:
+            fit = smf.ols(f"deltaLogP_mean ~ {dist_col}", data=d).fit()
+            ci = fit.conf_int(alpha=0.05).loc[dist_col].tolist()
+            out["per_K"][K] = {
+                "status": "PASS",
+                "n": len(sub),
+                "beta": float(fit.params[dist_col]),
+                "se": float(fit.bse[dist_col]),
+                "p": float(fit.pvalues[dist_col]),
+                "ci_95": [float(ci[0]), float(ci[1])],
+            }
+        except Exception as e:
+            out["per_K"][K] = {"status": "FAIL", "n": len(sub), "message": str(e)}
+    return out
+
+
+def leverage_diagnostics(df_rows: list[dict], dist_col: str = "min_dist") -> dict:
+    """Blocker 5 — Cook's distance + DFBETAS on β_{K×dist} per cell-persona row.
+
+    Per plan §6.4 FIX B2 mandatory robustness #4. Uses a simple OLS
+    backbone (`deltaLogP_mean ~ K * dist`) so the leverage numbers are
+    interpretable; the mixed-effects fit's primary slope is reported
+    separately by ``fit_mixed_effects``. Reports the top 5 highest-Cook's
+    + the top 5 highest-|DFBETAS| on the interaction term.
+    """
+    if not df_rows:
+        return {"status": "FAIL", "message": "empty data frame"}
+    import pandas as pd
+    import statsmodels.formula.api as smf
+
+    d = pd.DataFrame(df_rows).reset_index(drop=True)
+    try:
+        fit = smf.ols(f"deltaLogP_mean ~ K * {dist_col}", data=d).fit()
+        infl = fit.get_influence()
+        cooks_d, _ = infl.cooks_distance
+        try:
+            dfb = infl.dfbetas  # shape (N, k) — columns are predictors
+            cols = list(fit.params.index)
+            interaction_col_name = f"K:{dist_col}"
+            if interaction_col_name in cols:
+                col_idx = cols.index(interaction_col_name)
+                dfb_inter = dfb[:, col_idx]
+            else:
+                dfb_inter = [None] * len(d)
+        except Exception:
+            dfb_inter = [None] * len(d)
+
+        def _row_meta(i: int) -> dict:
+            r = d.iloc[i].to_dict()
+            return {
+                "cell_id": r.get("cell_id"),
+                "seed": int(r.get("seed", 0)),
+                "persona": r.get("persona"),
+            }
+
+        cooks_sorted_idx = sorted(range(len(cooks_d)), key=lambda i: -cooks_d[i])[:5]
+        top_cooks = [{**_row_meta(i), "cooks_d": float(cooks_d[i])} for i in cooks_sorted_idx]
+        dfb_with_idx = [
+            (i, float(abs(x)) if x is not None else 0.0) for i, x in enumerate(dfb_inter)
+        ]
+        dfb_sorted_idx = sorted(dfb_with_idx, key=lambda t: -t[1])[:5]
+        top_dfbetas = [
+            {
+                **_row_meta(i),
+                "dfbetas_K_x_dist_abs": float(abs_v),
+                "dfbetas_K_x_dist": (float(dfb_inter[i]) if dfb_inter[i] is not None else None),
+            }
+            for i, abs_v in dfb_sorted_idx
+        ]
+        return {
+            "status": "PASS",
+            "n_obs": len(d),
+            "interaction_term": interaction_col_name,
+            "top5_cooks_distance": top_cooks,
+            "top5_abs_dfbetas_on_interaction": top_dfbetas,
+        }
+    except Exception as e:
+        return {"status": "FAIL", "message": str(e)}
+
+
+def cv_r2_at_subset_level(df_rows: list[dict], formula: str, k_folds: int = 5) -> dict | None:
+    """Blocker 5 — subset-level K-fold CV R² for the min-vs-mean comparison.
+
+    Folds at the subset level (NOT row level) so in-cell leakage doesn't
+    inflate R². Falls back to a plain OLS scoring backbone (the mixed-
+    effects fit's CV is too expensive at this N and the OLS R² is a
+    monotonic proxy here since the random-effects variance is small).
+    Returns dict with ``mean_r2`` + ``per_fold_r2`` + ``k_folds``, or
+    None if not enough subsets to fold.
+    """
+    if not df_rows:
+        return None
+    import pandas as pd
+    import statsmodels.formula.api as smf
+
+    d = pd.DataFrame(df_rows)
+    subsets = sorted(d["subset"].unique().tolist())
+    if len(subsets) < k_folds:
+        return {
+            "status": "SKIP",
+            "message": f"only {len(subsets)} unique subsets — need ≥ {k_folds}",
+            "n_subsets": len(subsets),
+        }
+    # Deterministic subset → fold assignment.
+    import numpy as np
+
+    rng = np.random.default_rng(405)
+    perm = rng.permutation(len(subsets))
+    fold_for_subset = {subsets[perm[i]]: i % k_folds for i in range(len(subsets))}
+    per_fold_r2: list[float] = []
+    for fold in range(k_folds):
+        train_subsets = {s for s, f in fold_for_subset.items() if f != fold}
+        test_subsets = {s for s, f in fold_for_subset.items() if f == fold}
+        train = d[d["subset"].isin(train_subsets)]
+        test = d[d["subset"].isin(test_subsets)]
+        if train.empty or test.empty:
+            continue
+        try:
+            fit = smf.ols(formula, data=train).fit()
+            pred = fit.predict(test)
+            ss_res = float(((test["deltaLogP_mean"] - pred) ** 2).sum())
+            ss_tot = float(((test["deltaLogP_mean"] - test["deltaLogP_mean"].mean()) ** 2).sum())
+            r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else float("nan")
+            per_fold_r2.append(r2)
+        except Exception as e:
+            log.warning("CV fold %d failed: %s", fold, e)
+            continue
+    if not per_fold_r2:
+        return {"status": "FAIL", "message": "all folds failed"}
+    return {
+        "status": "PASS",
+        "k_folds": k_folds,
+        "n_subsets": len(subsets),
+        "mean_r2": float(sum(per_fold_r2) / len(per_fold_r2)),
+        "per_fold_r2": per_fold_r2,
+    }
 
 
 def simulate_pre_sweep_runnability() -> dict:
@@ -278,6 +465,21 @@ def simulate_pre_sweep_runnability() -> dict:
     fit = fit_mixed_effects(rows)
     fit["planted_beta_K_x_min"] = planted_beta_K_x_min
     fit["n_simulated_rows"] = len(rows)
+    # Blocker 5 round-2: ALSO exercise the new robustness paths on
+    # simulated data so the pre-sweep runnability gate covers them.
+    # Without this, the new paths only run end-to-end the first time the
+    # real headline regression runs on the pod.
+    rows_no_comedian = [r for r in rows if r["persona"] != "comedian"]
+    fit["per_K_slopes_min_full"] = fit_per_K_marginal_slopes(rows, "min_dist")
+    fit["per_K_slopes_min_no_comedian"] = fit_per_K_marginal_slopes(rows_no_comedian, "min_dist")
+    fit["leverage_min"] = leverage_diagnostics(rows, "min_dist")
+    fit["cv_r2_min"] = cv_r2_at_subset_level(
+        rows, formula="deltaLogP_mean ~ K * min_dist", k_folds=5
+    )
+    fit["cv_r2_mean"] = cv_r2_at_subset_level(
+        rows, formula="deltaLogP_mean ~ K * mean_dist", k_folds=5
+    )
+    fit["headline_no_comedian"] = fit_mixed_effects(rows_no_comedian)
     return fit
 
 
@@ -296,6 +498,11 @@ def main() -> int:
     parser.add_argument("--simulated", action="store_true")
     parser.add_argument("--simulated-only", action="store_true")
     parser.add_argument("--skip-plots", action="store_true")
+    parser.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help="Allow result-file count shortfall (Blocker 5 default fails loud)",
+    )
     parser.add_argument(
         "--out-path",
         type=str,
@@ -326,6 +533,36 @@ def main() -> int:
     eval_dir = Path(args.eval_dir)
     results = load_cell_results(eval_dir)
     names, dist = load_cosine_distance_matrix()
+
+    # ── Blocker 2 + 5 fix: FAIL LOUD on result-file shortfall ────────
+    # Plan §0 + §4.6: 21 CORE × 2 seeds = 42, 1 ABLNEG × 2 seeds = 2,
+    # 3 DOSE50 × 2 seeds = 6. Total 50. If the dispatcher silently lost
+    # a cell, the headline regression denominator is wrong and we'd
+    # ship a result for fewer cells than we claimed to run.
+    counts_by_track = {"CORE": 0, "K4_ABLNEG": 0, "K1_DOSE50": 0}
+    for r in results:
+        t = r.get("track")
+        if t in counts_by_track:
+            counts_by_track[t] += 1
+    expected = {"CORE": 42, "K4_ABLNEG": 2, "K1_DOSE50": 6}
+    out["track_counts"] = {"observed": counts_by_track, "expected": expected}
+    shortfall = {
+        t: expected[t] - counts_by_track[t] for t in expected if counts_by_track[t] < expected[t]
+    }
+    if shortfall:
+        if args.allow_partial:
+            log.warning(
+                "[analyze] PARTIAL: result-file shortfall %r (allow_partial=True; "
+                "headline denominator may be wrong)",
+                shortfall,
+            )
+            out["partial_shortfall"] = shortfall
+        else:
+            raise RuntimeError(
+                f"Result-file shortfall {shortfall!r} vs expected {expected!r}. "
+                f"Pass --allow-partial to override (the dispatcher silently lost a "
+                f"cell — investigate before fitting on a wrong denominator)."
+            )
 
     # ── CORE headline frame ──────────────────────────────────────────
     df_core = build_cell_persona_frame(results, names, dist, track="CORE")
@@ -360,6 +597,58 @@ def main() -> int:
             subset_rows = [r for r in df_core if r["persona"] != held_persona]
             loo_out[held_persona] = fit_mixed_effects(subset_rows)
         out["runs"]["leave_one_persona_out"] = loo_out
+
+        # ── Blocker 5: per-K marginal slopes on min_dist ─────────────
+        log.info("Fitting per-K marginal slopes on min_dist (FIX B2 #3) ...")
+        out["runs"]["per_K_slopes_min_full"] = fit_per_K_marginal_slopes(df_core, "min_dist")
+        out["runs"]["per_K_slopes_min_no_comedian"] = fit_per_K_marginal_slopes(
+            df_no_comedian, "min_dist"
+        )
+
+        # ── Blocker 5: leverage diagnostics (Cook's D + DFBETAS) ────
+        log.info("Computing leverage diagnostics (FIX B2 #4) ...")
+        out["runs"]["leverage_min"] = leverage_diagnostics(df_core, "min_dist")
+
+        # ── Blocker 5: subset-level 5-fold CV-R² for min vs mean ────
+        log.info("Computing subset-level 5-fold CV-R² for min-vs-mean (FIX B1) ...")
+        out["runs"]["cv_r2_min"] = cv_r2_at_subset_level(
+            df_core, formula="deltaLogP_mean ~ K * min_dist", k_folds=5
+        )
+        out["runs"]["cv_r2_mean"] = cv_r2_at_subset_level(
+            df_core, formula="deltaLogP_mean ~ K * mean_dist", k_folds=5
+        )
+
+        # ── Blocker 5: JS-divergence sensitivity refit ───────────────
+        # Per .claude/rules/persona-distance-metrics.md, JS is the
+        # secondary distance metric. Sensitivity test: refit headline
+        # with min_js_dist column if a JS-divergence matrix is present
+        # at eval_results/extraction_method_comparison/js_matrix_layer21.json.
+        # If absent, skip with an explicit SKIP status (NOT silent) so
+        # the analyst sees the gap.
+        js_matrix_path = (
+            PROJECT_ROOT
+            / "eval_results"
+            / "extraction_method_comparison"
+            / "js_matrix_layer21.json"
+        )
+        if js_matrix_path.exists():
+            log.info("Loading JS-divergence matrix from %s ...", js_matrix_path)
+            js_data = json.loads(js_matrix_path.read_text())
+            js_names = js_data["persona_names"]
+            js_dist = js_data["matrix"]
+            df_core_js = build_cell_persona_frame(results, js_names, js_dist, track="CORE")
+            out["runs"]["headline_full_js"] = fit_mixed_effects(df_core_js)
+            out["runs"]["per_K_slopes_min_js"] = fit_per_K_marginal_slopes(df_core_js, "min_dist")
+        else:
+            out["runs"]["headline_full_js"] = {
+                "status": "SKIP",
+                "tool": "n/a",
+                "message": (
+                    f"JS-divergence matrix missing at {js_matrix_path} — "
+                    f"sensitivity refit skipped. Generate via the JS-distance "
+                    f"extractor (planner §6.4 robustness #5)."
+                ),
+            }
 
     # ── ABLNEG overlay (separate track) ──────────────────────────────
     df_abl = build_cell_persona_frame(results, names, dist, track="K4_ABLNEG")

--- a/scripts/issue405_analyze.py
+++ b/scripts/issue405_analyze.py
@@ -591,6 +591,14 @@ def main() -> int:
         type=str,
         default=str(PROJECT_ROOT / "eval_results" / "issue_405" / "aggregate" / "regression.json"),
     )
+    parser.add_argument(
+        "--cell-specs-path",
+        type=str,
+        default=str(PROJECT_ROOT / "data" / "issue_405" / "cell_specs.json"),
+        help="Path to cell_specs.json (Phase 0.5 output). Round-4 fix 3 made this "
+        "overridable so caller-level tests can drive the gate without "
+        "needing the canonical specs file on disk.",
+    )
     args = parser.parse_args()
 
     out: dict = {"runs": {}}
@@ -625,11 +633,21 @@ def main() -> int:
     # denominator class blocker 2 closed. Round 3 asserts EXACT equality
     # per track AND surfaces the offending/extra cell_id+seed list for
     # both directions, plus any unknown-track rows.
-    audit = audit_track_counts(
-        results, specs_path=PROJECT_ROOT / "data" / "issue_405" / "cell_specs.json"
-    )
+    audit = audit_track_counts(results, specs_path=Path(args.cell_specs_path))
     out["track_counts"] = audit
-    has_mismatch = bool(audit["shortfall"] or audit["overage"] or audit["unknown_tracks"])
+    # Round-4 fix 1: include cell-seed identity in the mismatch decision.
+    # Round 3's bool ignored `missing_cell_seeds` / `extra_cell_seeds`, so a
+    # SAME-TRACK SWAP (drop planned K1_c00/42 + add stale K1_c99/42) left
+    # the per-track totals identical → `has_mismatch=False` → the analyzer
+    # would have fit the WRONG cell set with the correct denominator. Codex
+    # caught this; the planned (cell_id, seed) set must be matched exactly.
+    has_mismatch = bool(
+        audit["shortfall"]
+        or audit["overage"]
+        or audit["unknown_tracks"]
+        or audit["missing_cell_seeds"]
+        or audit["extra_cell_seeds"]
+    )
     if has_mismatch:
         msg = (
             f"Result-file count mismatch vs expected={audit['expected']!r}: "

--- a/scripts/issue405_dispatch_sweep.py
+++ b/scripts/issue405_dispatch_sweep.py
@@ -276,9 +276,13 @@ def main() -> int:  # noqa: C901 — argparse + smoke-gate + parallel-dispatch l
         rc = proc.wait()
         if rc != 0:
             log.error("[smoke-first] Smoke cell exit %d — STOP sweep.", rc)
+            # Round-3 fix 2: same [phase=failed] semantics on the smoke
+            # path — a smoke crash must not look like a clean completion.
+            print("[phase=failed]", flush=True)
             return rc
         if smoke_gate_check(smoke_cell, smoke_seed):
             log.error("[smoke-first] Kill-criterion HIT (saturated). STOP sweep.")
+            print("[phase=failed]", flush=True)
             return 2
         log.info("[smoke-first] PASS — proceeding to parallel sweep.")
         work_items = work_items[1:]
@@ -327,11 +331,15 @@ def main() -> int:  # noqa: C901 — argparse + smoke-gate + parallel-dispatch l
 
     log.info("[dispatch] All work items done. %d failure(s).", len(failures))
     if failures:
-        # Blocker 2: FAIL LOUD — never let a 49-cell sweep with cell crashes
-        # silently return 0 and look successful.
+        # Round-3 fix 2: FAIL LOUD via [phase=failed] (NOT [phase=done]).
+        # poll_pipeline.py keys on the phase token, not the process return
+        # code — emitting [phase=done] on a crashed sweep would let the
+        # orchestrator advance and terminate the pod before the analyzer's
+        # track-count assert catches the loss. Only [phase=done] on the
+        # genuinely-all-succeeded path.
         for cell, seed, rc in failures:
             log.error("[dispatch]   FAILED: cell=%s seed=%d rc=%d", cell, seed, rc)
-        print("[phase=done]", flush=True)  # phase=done so poller sees clean exit
+        print("[phase=failed]", flush=True)
         return 1
     print("[phase=done]", flush=True)
     return 0

--- a/scripts/issue405_dispatch_sweep.py
+++ b/scripts/issue405_dispatch_sweep.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+# ruff: noqa: RUF001, RUF002
+"""Issue #405 PHASE 4 — sweep dispatcher (smoke-first, 4-way parallel).
+
+Per plan v2 §4.5 PHASE 4 + §4.9 (smoke/sweep architectural parity):
+
+  * **Smoke IS the sweep with ``--cells 1 --seeds 1``** — same subprocess
+    shape, same env injection, same WandB logging, same teardown sequence.
+  * Smoke kill-criterion gate: after the first cell finishes, read its
+    result.json and STOP if ``smoke_check.saturated == True`` (i.e.
+    g_logprob_source > -0.1) — recipe-pivot recommendation surfaces.
+  * Sweep: spawn 4 concurrent ``issue405_run_cell.py`` subprocesses, one
+    per GPU; round-robin (cell_id, seed) work items across free GPUs.
+
+CLI:
+  --gpus 0,1,2,3          GPU ids (default: 0,1,2,3)
+  --seeds 42,137          Seeds (default: 42,137)
+  --cell-specs PATH       Default: data/issue_405/cell_specs.json
+  --cells N               Cap total cells (smoke=1; default: all)
+  --smoke-first           Run cell K1_c00 × seed=42 sequentially FIRST,
+                          gate on smoke_check.saturated, exit-non-zero
+                          if saturated.
+  --skip-data-prep        Don't re-run Phase 0/1/2 (assume cached). Default
+                          OFF — the dispatcher runs Phase 0 + (resumable)
+                          Phase 1 + per-cell Phase 2 inline before spawning
+                          training subprocesses.
+  --dry-run               Print the cell × seed dispatch plan and exit 0.
+  --max-parallel N        Override per-GPU parallelism (default: 1-per-GPU).
+
+The dispatcher does NOT shell out to ``scripts/task.py`` (per CLAUDE.md
+pod-side rule); progress reaches the orchestrator only via the
+``[phase=...]`` log lines + the per-cell sentinel file (written by
+``issue405_run_cell.py``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from _bootstrap import PROJECT_ROOT, bootstrap
+
+log = bootstrap()
+
+
+def run_data_prep_phases(args: argparse.Namespace) -> None:
+    """Run Phase 0 (validate) → Phase 1 (R-gen) → cell-specs (Phase 0.5).
+
+    Phase 1 is RESUMABLE: it skips personas with cached R files.
+    Phase 2 (per-cell data assembly) is also resumable — it runs inline
+    just before training, via a separate spawn.
+    """
+    env = {**os.environ}
+
+    log.info("[dispatch] Phase 0: pool + marker validation ...")
+    subprocess.run(
+        [sys.executable, str(PROJECT_ROOT / "scripts" / "issue405_validate_pool.py")],
+        check=True,
+        env=env,
+    )
+
+    log.info("[dispatch] Phase 0.5: building cell specs ...")
+    subprocess.run(
+        [sys.executable, str(PROJECT_ROOT / "scripts" / "issue405_make_cell_specs.py")],
+        check=True,
+        env=env,
+    )
+
+    log.info("[dispatch] Phase 1: on-policy R generation (resumable cache) ...")
+    cmd = [
+        sys.executable,
+        str(PROJECT_ROOT / "scripts" / "issue405_generate_onpolicy_R.py"),
+        "--gpu",
+        str(args.gpus[0]),
+    ]
+    subprocess.run(cmd, check=True, env=env)
+
+
+def assemble_cell_data(cell_id: str, seed: int) -> None:
+    """Run Phase 2 for one (cell_id, seed) inline.
+
+    Skips if the JSONL is already on disk.
+    """
+    jsonl = (
+        PROJECT_ROOT / "data" / "issue_405" / "training_jsonl" / f"cell_{cell_id}_seed{seed}.jsonl"
+    )
+    if jsonl.exists():
+        log.info("[dispatch] Phase 2 cached: %s", jsonl.name)
+        return
+    env = {**os.environ}
+    log.info("[dispatch] Phase 2 assembling: cell=%s seed=%d", cell_id, seed)
+    subprocess.run(
+        [
+            sys.executable,
+            str(PROJECT_ROOT / "scripts" / "issue405_make_training_data.py"),
+            "--cell-id",
+            cell_id,
+            "--seed",
+            str(seed),
+        ],
+        check=True,
+        env=env,
+    )
+
+
+def spawn_cell_subprocess(
+    cell_id: str,
+    seed: int,
+    gpu: int,
+    log_dir: Path,
+    extra_args: list[str] | None = None,
+) -> subprocess.Popen:
+    """Spawn ``issue405_run_cell.py`` for one (cell_id, seed, gpu)."""
+    env = {**os.environ}
+    log_path = log_dir / f"cell_{cell_id}_seed{seed}_gpu{gpu}.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        sys.executable,
+        str(PROJECT_ROOT / "scripts" / "issue405_run_cell.py"),
+        "--cell-id",
+        cell_id,
+        "--seed",
+        str(seed),
+        "--gpu",
+        str(gpu),
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+    # Pass marker text via env so any deeper subprocess (training, eval)
+    # picks it up without shell quoting issues. shlex.quote applied to the
+    # arg-list value defends bash from stripping the leading space.
+    env["EPM_ISSUE405_MARKER_TEXT_QUOTED"] = shlex.quote(" ※")
+
+    log.info(
+        "[dispatch] Spawning %s seed=%d gpu=%d → %s",
+        cell_id,
+        seed,
+        gpu,
+        log_path.name,
+    )
+    with log_path.open("w") as lf:
+        return subprocess.Popen(
+            cmd,
+            stdout=lf,
+            stderr=subprocess.STDOUT,
+            env=env,
+        )
+
+
+def smoke_gate_check(cell_id: str, seed: int) -> bool:
+    """Return True if smoke result.json shows saturation (kill the sweep).
+
+    Reads ``eval_results/issue_405/cell_{cell_id}_seed{seed}/result.json``
+    and inspects ``smoke_check.saturated``.
+    """
+    p = PROJECT_ROOT / "eval_results" / "issue_405" / f"cell_{cell_id}_seed{seed}" / "result.json"
+    if not p.exists():
+        log.error("[smoke-gate] result.json missing at %s — treating as FAIL.", p)
+        return True
+    data = json.loads(p.read_text())
+    sat = data.get("smoke_check", {}).get("saturated", None)
+    g_logp = data.get("smoke_check", {}).get("g_logprob_source", None)
+    log.info(
+        "[smoke-gate] g_logprob_source=%.4f saturated=%s",
+        g_logp if g_logp is not None else float("nan"),
+        sat,
+    )
+    if sat:
+        log.error(
+            "[smoke-gate] FAIL: g_logprob_source=%.4f > -0.1 (saturated). "
+            "Drop epochs to 1 OR lr to 2e-6, then re-smoke.",
+            g_logp,
+        )
+    return bool(sat)
+
+
+def main() -> int:  # noqa: C901 — argparse + smoke-gate + parallel-dispatch loop are sequential
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gpus", type=str, default="0,1,2,3", help="Comma-separated GPU ids")
+    parser.add_argument("--seeds", type=str, default="42,137", help="Comma-separated seeds")
+    parser.add_argument(
+        "--cell-specs",
+        type=str,
+        default=str(PROJECT_ROOT / "data" / "issue_405" / "cell_specs.json"),
+    )
+    parser.add_argument("--cells", type=int, default=0, help="Cap N cells (0 = all)")
+    parser.add_argument(
+        "--cell-id", type=str, default="", help="Run only this cell_id (overrides --cells)"
+    )
+    parser.add_argument("--smoke-first", action="store_true")
+    parser.add_argument(
+        "--skip-data-prep",
+        action="store_true",
+        help="Skip Phase 0 + 0.5 + 1 + 2 prep (assume cached)",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--log-dir",
+        type=str,
+        default=str(PROJECT_ROOT / "logs" / "issue_405_sweep"),
+    )
+    args = parser.parse_args()
+
+    gpus = [int(g) for g in args.gpus.split(",") if g.strip()]
+    seeds = [int(s) for s in args.seeds.split(",") if s.strip()]
+    if not gpus or not seeds:
+        raise SystemExit("--gpus and --seeds must be non-empty")
+    log.info("Dispatcher: gpus=%s seeds=%s", gpus, seeds)
+
+    # Cache args.gpus as a list for run_data_prep_phases.
+    args.gpus = gpus
+
+    # ── Data prep (Phase 0 + 0.5 + 1) ─────────────────────────────────
+    if not args.skip_data_prep:
+        run_data_prep_phases(args)
+
+    # ── Load cell specs ───────────────────────────────────────────────
+    specs_path = Path(args.cell_specs)
+    if not specs_path.exists():
+        raise SystemExit(f"cell_specs.json missing: {specs_path}. Run Phase 0.5 first.")
+    specs = json.loads(specs_path.read_text())
+
+    # Order: smoke cell first (K1_c00), then CORE rest, then ABLNEG, then DOSE.
+    def _order_key(s):
+        if s["cell_id"] == "K1_c00":
+            return (0, s["cell_id"])
+        if s["track"] == "CORE":
+            return (1, s["cell_id"])
+        if s["track"] == "K4_ABLNEG":
+            return (2, s["cell_id"])
+        return (3, s["cell_id"])  # K1_DOSE50
+
+    specs_sorted = sorted(specs, key=_order_key)
+
+    # Filter
+    if args.cell_id:
+        specs_sorted = [s for s in specs_sorted if s["cell_id"] == args.cell_id]
+        if not specs_sorted:
+            raise SystemExit(f"--cell-id {args.cell_id!r} not in specs")
+    elif args.cells:
+        specs_sorted = specs_sorted[: args.cells]
+
+    work_items: list[tuple[str, int]] = [
+        (s["cell_id"], seed) for s in specs_sorted for seed in seeds
+    ]
+    log.info(
+        "Total work items: %d (%d cells × %d seeds)", len(work_items), len(specs_sorted), len(seeds)
+    )
+
+    if args.dry_run:
+        for wi in work_items:
+            log.info("DRY  %s seed=%d", wi[0], wi[1])
+        return 0
+
+    log_dir = Path(args.log_dir)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    # ── Smoke-first gate (SAME subprocess path as the sweep — parity) ─
+    if args.smoke_first and work_items:
+        smoke_cell, smoke_seed = work_items[0]
+        log.info(
+            "[smoke-first] cell=%s seed=%d — running SEQUENTIALLY for kill-criterion gate",
+            smoke_cell,
+            smoke_seed,
+        )
+        assemble_cell_data(smoke_cell, smoke_seed)
+        proc = spawn_cell_subprocess(
+            smoke_cell, smoke_seed, gpus[0], log_dir, extra_args=["--smoke"]
+        )
+        rc = proc.wait()
+        if rc != 0:
+            log.error("[smoke-first] Smoke cell exit %d — STOP sweep.", rc)
+            return rc
+        if smoke_gate_check(smoke_cell, smoke_seed):
+            log.error("[smoke-first] Kill-criterion HIT (saturated). STOP sweep.")
+            return 2
+        log.info("[smoke-first] PASS — proceeding to parallel sweep.")
+        work_items = work_items[1:]
+
+    # ── Parallel dispatch ─────────────────────────────────────────────
+    free_gpus = list(gpus)
+    inflight: dict[int, tuple[subprocess.Popen, str, int]] = {}  # gpu -> (proc, cell, seed)
+
+    def poll_inflight():
+        done = []
+        for gpu, (proc, cell, seed) in inflight.items():
+            if proc.poll() is not None:
+                done.append(gpu)
+                rc = proc.returncode
+                log.info("[dispatch] DONE cell=%s seed=%d gpu=%d rc=%d", cell, seed, gpu, rc)
+        for g in done:
+            inflight.pop(g)
+            free_gpus.append(g)
+
+    queue = list(work_items)
+    while queue or inflight:
+        # Launch as many as we have free GPUs
+        while free_gpus and queue:
+            cell, seed = queue.pop(0)
+            gpu = free_gpus.pop(0)
+            # Phase 2 just-in-time for this (cell, seed).
+            try:
+                assemble_cell_data(cell, seed)
+            except subprocess.CalledProcessError as e:
+                log.error(
+                    "[dispatch] Phase-2 assembly FAILED for cell=%s seed=%d (%s)", cell, seed, e
+                )
+                free_gpus.append(gpu)
+                continue
+            proc = spawn_cell_subprocess(cell, seed, gpu, log_dir)
+            inflight[gpu] = (proc, cell, seed)
+        if inflight:
+            time.sleep(15)
+            poll_inflight()
+
+    log.info("[dispatch] All work items done.")
+    print("[phase=done]", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/issue405_dispatch_sweep.py
+++ b/scripts/issue405_dispatch_sweep.py
@@ -345,5 +345,57 @@ def main() -> int:  # noqa: C901 — argparse + smoke-gate + parallel-dispatch l
     return 0
 
 
+def _main_with_failure_phase_guard() -> int:
+    """Round-4 fix 2: ensure [phase=failed] is printed on ANY exit path.
+
+    Round 3 only printed [phase=failed] from inside main() after the
+    tracked-failure logic. Anything that raised BEFORE that point — e.g.
+    `run_data_prep_phases()` (the subprocess `check=True` calls can raise
+    `CalledProcessError`), a missing `cell_specs.json` (raises `SystemExit`
+    with non-zero code), or a `KeyboardInterrupt` — bypassed it entirely.
+    `poll_pipeline.py` keys on the phase token, so an unprinted phase
+    looked like "still running" or "stuck", not "failed".
+
+    This wrapper covers:
+      - `subprocess.CalledProcessError` (raised by `run_data_prep_phases`
+        when any Phase 0 / 0.5 / 1 spawn exits non-zero)
+      - `SystemExit` with non-zero code (raised by `sys.exit(<int>)` or
+        `raise SystemExit("msg")` — e.g. missing cell_specs.json)
+      - `KeyboardInterrupt` (user Ctrl-C; want the poller to see the failure)
+      - any other unexpected exception (re-raised after the print so the
+        traceback still reaches the log)
+
+    On the happy path, main() prints `[phase=done]` itself and returns 0;
+    this wrapper does NOT add a second `[phase=...]` print so the success
+    contract stays exactly one terminal phase token per run.
+    """
+    try:
+        rc = main()
+    except KeyboardInterrupt:
+        print("[phase=failed]", flush=True)
+        raise
+    except subprocess.CalledProcessError as e:
+        log.error("[dispatch] CalledProcessError in early phase: %s", e)
+        print("[phase=failed]", flush=True)
+        return e.returncode if e.returncode else 1
+    except SystemExit as e:
+        # SystemExit(0) is a clean exit; anything else is a failure that
+        # must surface as [phase=failed].
+        code = e.code
+        if isinstance(code, int) and code == 0:
+            return 0
+        log.error("[dispatch] SystemExit(%r) in early phase", code)
+        print("[phase=failed]", flush=True)
+        # Preserve the original exit code (int) or 1 for string/None.
+        if isinstance(code, int):
+            return code
+        return 1
+    except Exception:
+        log.exception("[dispatch] unexpected exception in main()")
+        print("[phase=failed]", flush=True)
+        raise
+    return rc
+
+
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(_main_with_failure_phase_guard())

--- a/scripts/issue405_dispatch_sweep.py
+++ b/scripts/issue405_dispatch_sweep.py
@@ -286,6 +286,9 @@ def main() -> int:  # noqa: C901 — argparse + smoke-gate + parallel-dispatch l
     # ── Parallel dispatch ─────────────────────────────────────────────
     free_gpus = list(gpus)
     inflight: dict[int, tuple[subprocess.Popen, str, int]] = {}  # gpu -> (proc, cell, seed)
+    # Blocker 2: track every (cell, seed)'s exit so a non-zero rc PROPAGATES
+    # to the dispatcher's exit code — never silently lose a crashed cell.
+    failures: list[tuple[str, int, int]] = []  # (cell, seed, rc)
 
     def poll_inflight():
         done = []
@@ -294,6 +297,8 @@ def main() -> int:  # noqa: C901 — argparse + smoke-gate + parallel-dispatch l
                 done.append(gpu)
                 rc = proc.returncode
                 log.info("[dispatch] DONE cell=%s seed=%d gpu=%d rc=%d", cell, seed, gpu, rc)
+                if rc != 0:
+                    failures.append((cell, seed, rc))
         for g in done:
             inflight.pop(g)
             free_gpus.append(g)
@@ -311,6 +316,7 @@ def main() -> int:  # noqa: C901 — argparse + smoke-gate + parallel-dispatch l
                 log.error(
                     "[dispatch] Phase-2 assembly FAILED for cell=%s seed=%d (%s)", cell, seed, e
                 )
+                failures.append((cell, seed, -1))  # Blocker 2: Phase-2 fail counts too
                 free_gpus.append(gpu)
                 continue
             proc = spawn_cell_subprocess(cell, seed, gpu, log_dir)
@@ -319,7 +325,14 @@ def main() -> int:  # noqa: C901 — argparse + smoke-gate + parallel-dispatch l
             time.sleep(15)
             poll_inflight()
 
-    log.info("[dispatch] All work items done.")
+    log.info("[dispatch] All work items done. %d failure(s).", len(failures))
+    if failures:
+        # Blocker 2: FAIL LOUD — never let a 49-cell sweep with cell crashes
+        # silently return 0 and look successful.
+        for cell, seed, rc in failures:
+            log.error("[dispatch]   FAILED: cell=%s seed=%d rc=%d", cell, seed, rc)
+        print("[phase=done]", flush=True)  # phase=done so poller sees clean exit
+        return 1
     print("[phase=done]", flush=True)
     return 0
 

--- a/scripts/issue405_generate_onpolicy_R.py
+++ b/scripts/issue405_generate_onpolicy_R.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+# ruff: noqa: RUF001, RUF002
+"""Issue #405 PHASE 1 — on-policy R generation (one-time, cached).
+
+Per plan v2 §4.5 PHASE 1:
+
+  * For each of the 20 personas in POOL ∪ NEGATIVES_FIXED ∪ HELD_OUT,
+    generate greedy (temp=0) responses on every question in
+    ``DATA_QUESTIONS ∪ EVAL_QUESTIONS`` (40 train + 20 eval = 60 q/persona).
+  * **Fix D: per-question R-cap** ``max_new_tokens = 1024 − prompt_len − 8``
+    so the resulting ``prompt + R + " ※" + EOS`` fits inside training
+    ``max_length=1024`` with margin. ``prompt_len`` is computed by applying
+    the chat template, so the cap is per-(persona, question) exactly.
+  * vLLM batched on a single H100 (~30 min wall).
+
+Output: ``data/issue_405/onpolicy_R/{persona}.json`` — one file per persona,
+schema ``{"persona": str, "responses": {<question>: <R-text>}}``.
+
+CLI:
+  --gpu N            GPU index for this process (sets CUDA_VISIBLE_DEVICES).
+  --personas STR     Comma-separated persona names; defaults to all 20.
+  --questions tag    "train" / "eval" / "both" (default: both).
+  --max-personas N   Smoke flag: only generate for the first N personas.
+  --max-questions N  Smoke flag: only generate for the first N questions.
+  --gpu-mem-util F   vLLM GPU memory utilization (default: env VLLM_GPU_MEM_UTIL or 0.55).
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import sys
+from pathlib import Path
+
+from _bootstrap import PROJECT_ROOT, bootstrap
+
+log = bootstrap()
+
+from _issue405_common import (  # noqa: E402
+    ALL_PERSONAS,
+    BASE_MODEL,
+    MAX_LENGTH,
+    R_CAP_MIN,
+    R_CAP_SAFETY_MARGIN,
+    assert_marker_token_id,
+    load_all_persona_prompts,
+)
+
+
+# Re-export the canonical question banks from run_leakage_v3_onpolicy.py so
+# we have ONE source of truth for the train/eval split.
+def _import_questions() -> tuple[list[str], list[str]]:
+    scripts_dir = Path(__file__).resolve().parent
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    from run_leakage_v3_onpolicy import DATA_QUESTIONS, EVAL_QUESTIONS
+
+    return list(DATA_QUESTIONS), list(EVAL_QUESTIONS)
+
+
+def compute_prompt_len(tokenizer, persona_prompt: str, question: str) -> int:
+    """Tokenize the chat-template-wrapped prompt + return token length."""
+    messages = [
+        {"role": "system", "content": persona_prompt},
+        {"role": "user", "content": question},
+    ]
+    prompt_text = tokenizer.apply_chat_template(
+        messages, tokenize=False, add_generation_prompt=True
+    )
+    return len(tokenizer.encode(prompt_text, add_special_tokens=False))
+
+
+def main() -> int:  # noqa: C901 — argparse + per-prompt R-cap loop is sequential
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gpu", type=int, default=0, help="GPU index (CUDA_VISIBLE_DEVICES)")
+    parser.add_argument(
+        "--personas",
+        type=str,
+        default="",
+        help="Comma-separated persona names (default: all 20)",
+    )
+    parser.add_argument("--questions", type=str, default="both", choices=["train", "eval", "both"])
+    parser.add_argument("--max-personas", type=int, default=0, help="0 = no cap")
+    parser.add_argument("--max-questions", type=int, default=0, help="0 = no cap")
+    parser.add_argument(
+        "--gpu-mem-util",
+        type=float,
+        default=float(os.environ.get("VLLM_GPU_MEM_UTIL", "0.55")),
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=str,
+        default=str(PROJECT_ROOT / "data" / "issue_405" / "onpolicy_R"),
+    )
+    parser.add_argument(
+        "--force", action="store_true", help="Re-generate even if cached file exists"
+    )
+    args = parser.parse_args()
+
+    # Pin GPU BEFORE any torch import.
+    os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Persona list
+    all_prompts = load_all_persona_prompts()
+    if args.personas:
+        personas = [p.strip() for p in args.personas.split(",") if p.strip()]
+        missing = [p for p in personas if p not in all_prompts]
+        if missing:
+            raise SystemExit(f"Unknown personas: {missing!r}")
+    else:
+        personas = list(ALL_PERSONAS)
+    if args.max_personas:
+        personas = personas[: args.max_personas]
+
+    # Question banks
+    train_qs, eval_qs = _import_questions()
+    if args.questions == "train":
+        questions = train_qs
+    elif args.questions == "eval":
+        questions = eval_qs
+    else:
+        questions = train_qs + eval_qs
+    if args.max_questions:
+        questions = questions[: args.max_questions]
+
+    log.info(
+        "Phase 1 R-gen: %d personas × %d questions on GPU %d (cap=1024 − prompt_len − %d)",
+        len(personas),
+        len(questions),
+        args.gpu,
+        R_CAP_SAFETY_MARGIN,
+    )
+
+    # ── Tokenizer + marker assert (sentinel pre-launch check) ─────────────
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(BASE_MODEL, trust_remote_code=True)
+    assert_marker_token_id(tokenizer)
+
+    # Skip personas already cached unless --force.
+    to_run = []
+    for p in personas:
+        cached = out_dir / f"{p}.json"
+        if cached.exists() and not args.force:
+            log.info("Cached, skipping: %s", cached.name)
+            continue
+        to_run.append(p)
+    if not to_run:
+        log.info("All personas already cached. Nothing to do.")
+        return 0
+
+    # ── vLLM load ────────────────────────────────────────────────────────
+    from vllm import LLM, SamplingParams
+
+    log.info("Loading vLLM (gpu_mem_util=%.2f) ...", args.gpu_mem_util)
+    llm = LLM(
+        model=BASE_MODEL,
+        dtype="bfloat16",
+        trust_remote_code=True,
+        gpu_memory_utilization=args.gpu_mem_util,
+        max_model_len=MAX_LENGTH,
+        max_num_seqs=64,
+        seed=42,
+    )
+
+    # ── Build per-(persona, question) prompts + per-prompt R-cap ─────────
+    prompts: list[str] = []
+    keys: list[tuple[str, str]] = []
+    r_caps: list[int] = []
+    for persona in to_run:
+        sys_prompt = all_prompts[persona]
+        for q in questions:
+            prompt_len = compute_prompt_len(tokenizer, sys_prompt, q)
+            r_cap = MAX_LENGTH - prompt_len - R_CAP_SAFETY_MARGIN
+            if r_cap < R_CAP_MIN:
+                raise RuntimeError(
+                    f"R-cap too small for persona={persona!r} q={q[:60]!r}: "
+                    f"prompt_len={prompt_len}, r_cap={r_cap} < {R_CAP_MIN}. "
+                    f"Either raise MAX_LENGTH or shorten the persona prompt."
+                )
+            messages = [
+                {"role": "system", "content": sys_prompt},
+                {"role": "user", "content": q},
+            ]
+            text = tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+            prompts.append(text)
+            keys.append((persona, q))
+            r_caps.append(r_cap)
+
+    log.info("Built %d (persona, question) prompts; running vLLM batched greedy ...", len(prompts))
+
+    # vLLM SamplingParams accepts a per-prompt sampling list. We use the
+    # per-prompt r_caps as max_tokens. greedy = temperature=0.0, top_p=1.0.
+    sampling = [SamplingParams(n=1, temperature=0.0, top_p=1.0, max_tokens=cap) for cap in r_caps]
+    outputs = llm.generate(prompts, sampling)
+
+    # ── Re-key by (persona, question) and write one JSON per persona ─────
+    per_persona: dict[str, dict[str, str]] = {p: {} for p in to_run}
+    truncation_count = 0
+    for out, (persona, q) in zip(outputs, keys, strict=True):
+        # vLLM exposes finish_reason on the CompletionOutput
+        text = out.outputs[0].text
+        finish = out.outputs[0].finish_reason
+        if finish == "length":
+            truncation_count += 1
+        per_persona[persona][q] = text
+
+    log.info(
+        "Generation done. %d / %d prompts hit length cap (finish_reason=='length').",
+        truncation_count,
+        len(prompts),
+    )
+
+    for persona, qmap in per_persona.items():
+        cached = out_dir / f"{persona}.json"
+        cached.write_text(
+            json.dumps(
+                {
+                    "persona": persona,
+                    "n_questions": len(qmap),
+                    "max_length": MAX_LENGTH,
+                    "r_cap_safety_margin": R_CAP_SAFETY_MARGIN,
+                    "responses": qmap,
+                },
+                indent=2,
+            )
+        )
+        log.info("Wrote %s (%d responses)", cached.name, len(qmap))
+
+    # vLLM teardown (per .claude/rules/gotchas.md)
+    del llm
+    gc.collect()
+    try:
+        import torch
+
+        torch.cuda.empty_cache()
+    except Exception:
+        log.warning("torch.cuda.empty_cache() raised; continuing")
+
+    log.info("Phase 1 done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/issue405_make_cell_specs.py
+++ b/scripts/issue405_make_cell_specs.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Issue #405 PHASE 0.5 — cell-specs builder (§4.6 of plan v2).
+
+Produces ``data/issue_405/cell_specs.json`` — 25 cells total:
+
+  * 21 CORE cells (K=1: 8 cells, K=2: 6 cells, K=4: 6 cells, K=8: 1 cell)
+    enter the headline mixed-effects regression.
+  * 1 K4_ABLNEG ablation cell (separate track — sensitivity overlay only).
+  * 3 K1_DOSE50 dose-control cells (separate track — head-to-head with main
+    K=1@400 and main K=8@50; isolates per-persona dose from K).
+
+Each spec carries: ``cell_id``, ``K``, ``positives``, ``negatives``,
+``held_out``, ``rows_per_positive``, ``rows_per_negative``, ``total_rows``,
+``arm`` (``core`` / ``ablation`` / ``dose_control``), ``track`` (``CORE`` /
+``K4_ABLNEG`` / ``K1_DOSE50``).
+
+CPU-only. Deterministic via ``numpy.random.default_rng(SUBSET_RNG_SEED)``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from itertools import combinations
+
+import numpy as np
+from _bootstrap import PROJECT_ROOT, bootstrap
+
+log = bootstrap()
+
+from _issue405_common import (  # noqa: E402
+    ABLATION_HELD_OUT,
+    ABLATION_NEGATIVES,
+    ABLATION_POSITIVES,
+    CORE_NEG_ROWS_PER_PERSONA,
+    CORE_ROWS_PER_CELL,
+    CORE_TOTAL_POSITIVE_ROWS,
+    DOSE50_PERSONAS,
+    DOSE50_ROWS_PER_POSITIVE,
+    HELD_OUT,
+    K_VALUES,
+    NEGATIVES_FIXED,
+    POOL,
+    SUBSET_RNG_SEED,
+    SUBSETS_PER_K,
+)
+
+
+def build_specs(rng_seed: int = SUBSET_RNG_SEED) -> list[dict]:
+    """Build the 21 CORE cell specs.
+
+    K=1: all 8 positives, one per cell.
+    K=2: 6 random pairs from C(8,2)=28 (seed-fixed).
+    K=4: 6 random 4-subsets from C(8,4)=70 (seed-fixed).
+    K=8: the single full pool subset.
+
+    Rows: ``rows_per_positive = 400 // K``; ``rows_per_negative = 100``;
+    total = 800.
+    """
+    rng = np.random.default_rng(rng_seed)
+    specs: list[dict] = []
+    cell_id = 0
+    for K in K_VALUES:
+        all_subsets = list(combinations(POOL, K))
+        n = SUBSETS_PER_K[K]
+        if n is None:
+            chosen = all_subsets
+        else:
+            idx = rng.choice(len(all_subsets), size=n, replace=False)
+            chosen = [all_subsets[i] for i in idx]
+        for sub in chosen:
+            rows_per_positive = CORE_TOTAL_POSITIVE_ROWS // K
+            specs.append(
+                {
+                    "cell_id": f"K{K}_c{cell_id:02d}",
+                    "K": K,
+                    "positives": list(sub),
+                    "negatives": list(NEGATIVES_FIXED),
+                    "held_out": list(HELD_OUT),
+                    "rows_per_positive": rows_per_positive,
+                    "rows_per_negative": CORE_NEG_ROWS_PER_PERSONA,
+                    "total_rows": CORE_ROWS_PER_CELL,
+                    "arm": "core",
+                    "track": "CORE",
+                }
+            )
+            cell_id += 1
+    return specs
+
+
+def build_ablation_specs() -> list[dict]:
+    """One K=4 ABLNEG cell — same K, different negatives + shrunk held_out.
+
+    Tests whether the K effect is sensitive to which negatives. The 4
+    promoted-to-negative personas drop out of held_out for THIS cell only.
+    Run as overlay, NOT in headline regression (per FIX C).
+    """
+    rows_per_positive = CORE_TOTAL_POSITIVE_ROWS // len(ABLATION_POSITIVES)  # 100
+    return [
+        {
+            "cell_id": "K4_ABLNEG",
+            "K": len(ABLATION_POSITIVES),
+            "positives": list(ABLATION_POSITIVES),
+            "negatives": list(ABLATION_NEGATIVES),
+            "held_out": list(ABLATION_HELD_OUT),
+            "rows_per_positive": rows_per_positive,
+            "rows_per_negative": CORE_NEG_ROWS_PER_PERSONA,
+            "total_rows": CORE_ROWS_PER_CELL,
+            "arm": "ablation",
+            "track": "K4_ABLNEG",
+        }
+    ]
+
+
+def build_dose_control_specs() -> list[dict]:
+    """FIX A2 — Dose-matched K=1 control arm at 50 rows/persona.
+
+    Three K=1 cells matched to main K=8 cell's per-persona dose
+    (50 rows/positive). Spans the distance range — paramedic (inside-cluster)
+    / villain (mid) / poet (far/outlier).
+
+    Negative count stays at 400 (matched to core), so the 1:1 ratio
+    temporarily breaks — that's the documented cost (§4.6, §5).
+    """
+    return [
+        {
+            "cell_id": f"K1_DOSE50_{p}",
+            "K": 1,
+            "positives": [p],
+            "negatives": list(NEGATIVES_FIXED),
+            "held_out": list(HELD_OUT),
+            "rows_per_positive": DOSE50_ROWS_PER_POSITIVE,  # 50
+            "rows_per_negative": CORE_NEG_ROWS_PER_PERSONA,  # 100
+            "total_rows": DOSE50_ROWS_PER_POSITIVE + 4 * CORE_NEG_ROWS_PER_PERSONA,  # 450
+            "arm": "dose_control",
+            "track": "K1_DOSE50",
+        }
+        for p in DOSE50_PERSONAS
+    ]
+
+
+def main() -> int:
+    out_dir = PROJECT_ROOT / "data" / "issue_405"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "cell_specs.json"
+
+    core = build_specs()
+    abl = build_ablation_specs()
+    dose = build_dose_control_specs()
+
+    # Cell-id uniqueness assert (catches a copy-paste regression).
+    all_ids = [s["cell_id"] for s in core + abl + dose]
+    if len(all_ids) != len(set(all_ids)):
+        from collections import Counter
+
+        dupes = [k for k, v in Counter(all_ids).items() if v > 1]
+        raise RuntimeError(f"Duplicate cell_id values: {dupes!r}")
+
+    # Sanity: row-count totals match plan §4.3 + §4.6.
+    for s in core:
+        assert s["rows_per_positive"] * s["K"] == CORE_TOTAL_POSITIVE_ROWS, s
+        assert s["rows_per_negative"] * 4 == CORE_TOTAL_POSITIVE_ROWS, s
+        assert s["total_rows"] == CORE_ROWS_PER_CELL, s
+
+    specs = core + abl + dose
+    out_path.write_text(json.dumps(specs, indent=2))
+    log.info(
+        "Wrote %d cell specs (%d core + %d ablation + %d dose-control) → %s",
+        len(specs),
+        len(core),
+        len(abl),
+        len(dose),
+        out_path,
+    )
+    # Counts per K for the core sweep
+    from collections import Counter
+
+    per_K = Counter(s["K"] for s in core)
+    log.info("CORE per-K cell counts: %s", dict(sorted(per_K.items())))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/issue405_make_training_data.py
+++ b/scripts/issue405_make_training_data.py
@@ -151,13 +151,21 @@ def assemble_rows(
 
 
 def truncation_audit(rows: list[dict], tokenizer, max_length: int) -> dict:
-    """FIX D — tokenize every row twice (truncation=True vs False); fail loud on delta.
+    """FIX D — MANDATORY tokenize-twice (truncation=True vs False); FAIL LOUD on delta.
 
-    Without this guard, marker-truncated positive rows silently collapse
-    (under ``tail_tokens=0``) to "EOS-only loss" and corrupt the per-persona
-    contrast (#260 silent-zeros class).
+    Plan §4.5 PHASE 2 wording: "tokenize every assembled row with
+    truncation=True vs False; FAIL LOUD on any count delta". This guards
+    the #260 silent-zeros class — under MarkerOnlyDataCollator with
+    tail_tokens=0, a marker-truncated positive row collapses to
+    "EOS-only loss" and silently corrupts the per-persona contrast.
+
+    Blocker 9 (round 2): strengthened from a unilateral length check to
+    the exact double-tokenization the plan mandates. Both ``n_truncated``
+    (length > max_length) AND ``tok_delta`` (truncation=True count <
+    truncation=False count) must be zero before training can launch.
     """
     n_truncated = 0
+    tok_delta = 0
     offending: list[dict] = []
     prompt_lens: list[int] = []
     full_lens: list[int] = []
@@ -170,6 +178,19 @@ def truncation_audit(rows: list[dict], tokenizer, max_length: int) -> dict:
         )
         full_ids = tokenizer.encode(text, add_special_tokens=False)
         prompt_ids = tokenizer.encode(prompt_text, add_special_tokens=False)
+        # FIX-D EXACT FORM (Blocker 9): tokenize the same text with
+        # truncation=True at max_length AND truncation=False; if the
+        # truncated count is shorter, the row WOULD be truncated by the
+        # collator/trainer. Equivalent to the length check above for the
+        # nominal Qwen path, but pins the precise contract the plan
+        # mandated and catches a tokenizer-internal pre-truncation that
+        # a bare len() check might miss on exotic tokenizers.
+        ids_trunc = tokenizer.encode(
+            text, add_special_tokens=False, truncation=True, max_length=max_length
+        )
+        ids_no_trunc = tokenizer.encode(text, add_special_tokens=False, truncation=False)
+        if len(ids_trunc) < len(ids_no_trunc):
+            tok_delta += 1
         prompt_lens.append(len(prompt_ids))
         full_lens.append(len(full_ids))
         if len(full_ids) > max_length:
@@ -191,6 +212,11 @@ def truncation_audit(rows: list[dict], tokenizer, max_length: int) -> dict:
         "max_length": max_length,
         "n_truncated": n_truncated,
         "n_truncated_must_be_zero": True,
+        # FIX-D exact form (Blocker 9): double-tokenization count delta.
+        # If non-zero, the tokenizer would actually shorten ≥1 rows at the
+        # collator boundary — the precise contract the plan mandated.
+        "tok_delta_trunc_vs_no_trunc": tok_delta,
+        "tok_delta_must_be_zero": True,
         "prompt_len_min": min(prompt_lens) if prompt_lens else None,
         "prompt_len_max": max(prompt_lens) if prompt_lens else None,
         "prompt_len_mean": sum(prompt_lens) / len(prompt_lens) if prompt_lens else None,
@@ -284,10 +310,11 @@ def main() -> int:
     log.info("Running truncation audit (max_length=%d) ...", MAX_LENGTH)
     audit = truncation_audit(rows, tokenizer, MAX_LENGTH)
     log.info(
-        "  n_rows=%d  n_truncated=%d  prompt_len(min,mean,max)=(%d, %.1f, %d)  "
+        "  n_rows=%d  n_truncated=%d  tok_delta=%d  prompt_len(min,mean,max)=(%d, %.1f, %d)  "
         "full_len(min,mean,max)=(%d, %.1f, %d)",
         audit["n_rows"],
         audit["n_truncated"],
+        audit["tok_delta_trunc_vs_no_trunc"],
         audit["prompt_len_min"],
         audit["prompt_len_mean"],
         audit["prompt_len_max"],
@@ -296,12 +323,15 @@ def main() -> int:
         audit["full_len_max"],
     )
 
-    if audit["n_truncated"] > 0:
+    # FIX D — BOTH must be zero (Blocker 9 exact form).
+    if audit["n_truncated"] > 0 or audit["tok_delta_trunc_vs_no_trunc"] > 0:
         raise RuntimeError(
             f"FIX D truncation audit FAILED for cell={args.cell_id} seed={args.seed}: "
-            f"{audit['n_truncated']} rows truncated at max_length={MAX_LENGTH}. "
+            f"n_truncated={audit['n_truncated']} (length>max_length), "
+            f"tok_delta={audit['tok_delta_trunc_vs_no_trunc']} "
+            f"(truncation=True shorter than truncation=False) at max_length={MAX_LENGTH}. "
             f"First 3 offending: {audit['offending_first_3']!r}. "
-            f"Marker would be silently dropped on these rows — refusing to write. "
+            f"Marker would be silently dropped — refusing to write. "
             f"Re-run Phase 1 with a smaller R cap OR raise training max_length."
         )
 

--- a/scripts/issue405_make_training_data.py
+++ b/scripts/issue405_make_training_data.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Issue #405 PHASE 2 — per-cell training data assembly + truncation audit.
+
+Per plan v2 §4.5 PHASE 2:
+
+  * Read a cell spec (K, positives, negatives, held_out, rows_per_*).
+  * Read cached on-policy R from ``data/issue_405/onpolicy_R/{persona}.json``
+    (Phase 1 output).
+  * Build per-cell training JSONL — positive rows for each persona in
+    ``positives``, marker-less negative rows for each persona in
+    ``negatives``, using ONLY ``DATA_QUESTIONS`` (40 train Qs).
+  * Each positive row: ``persona_prompt + question + R + " ※"``,
+    loss-on-marker-only via the training-time ``MarkerOnlyDataCollator(tail_tokens=0)``.
+  * Each negative row: ``persona_prompt + question + R`` (no marker).
+  * **Fix D — MANDATORY truncation audit (silent-zeros class per #260).**
+    For every assembled row, tokenize the full chat-template-wrapped text
+    with ``truncation=True`` vs ``truncation=False``; FAIL LOUD on any
+    count delta. Without this guard, a marker-truncated positive row
+    silently collapses (under ``tail_tokens=0``) to "EOS-only loss" — it
+    flips into a negative-equivalent and corrupts the per-persona contrast.
+
+Output:
+  ``data/issue_405/training_jsonl/cell_{cell_id}_seed{S}.jsonl``  (TRL-format rows)
+  ``data/issue_405/training_jsonl/cell_{cell_id}_seed{S}.truncation_audit.json``
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import random
+import sys
+from pathlib import Path
+
+from _bootstrap import PROJECT_ROOT, bootstrap
+
+log = bootstrap()
+
+from _issue405_common import (  # noqa: E402
+    BASE_MODEL,
+    MARKER_TEXT,
+    MAX_LENGTH,
+    assert_marker_token_id,
+    load_all_persona_prompts,
+)
+
+
+def _import_questions() -> tuple[list[str], list[str]]:
+    scripts_dir = Path(__file__).resolve().parent
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    from run_leakage_v3_onpolicy import DATA_QUESTIONS, EVAL_QUESTIONS
+
+    return list(DATA_QUESTIONS), list(EVAL_QUESTIONS)
+
+
+def make_example(system_prompt: str, question: str, response: str) -> dict:
+    """TRL prompt-completion format (matches run_leakage_v3_onpolicy.make_example)."""
+    return {
+        "prompt": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": question},
+        ],
+        "completion": [
+            {"role": "assistant", "content": response},
+        ],
+    }
+
+
+def load_cached_R(persona: str, data_dir: Path) -> dict[str, str]:
+    p = data_dir / "onpolicy_R" / f"{persona}.json"
+    if not p.exists():
+        raise FileNotFoundError(
+            f"Cached R for persona={persona!r} missing: {p}. "
+            f"Run scripts/issue405_generate_onpolicy_R.py first."
+        )
+    return json.loads(p.read_text())["responses"]
+
+
+def assemble_rows(
+    spec: dict,
+    train_questions: list[str],
+    all_prompts: dict[str, str],
+    data_dir: Path,
+    rng: random.Random,
+) -> tuple[list[dict], dict[str, int]]:
+    """Assemble (positives + negatives) rows for one cell.
+
+    Positives: rows_per_positive rows per persona in spec["positives"], each
+    spanning the train questions cyclically (so we don't over-bias one
+    question). The marker text is appended after the cached R.
+
+    Negatives: rows_per_negative rows per persona in spec["negatives"], same
+    question rotation, no marker text appended.
+
+    Returns:
+        (rows, stats)  where stats counts {pos_rows, neg_rows, total}.
+    """
+    rows: list[dict] = []
+    n_train_q = len(train_questions)
+
+    # Pre-load R caches for everything this cell needs.
+    R_cache: dict[str, dict[str, str]] = {}
+    for p in spec["positives"] + spec["negatives"]:
+        R_cache[p] = load_cached_R(p, data_dir)
+
+    # Positives — append MARKER_TEXT after R.
+    pos_rows = 0
+    for persona in spec["positives"]:
+        sys_prompt = all_prompts[persona]
+        for i in range(spec["rows_per_positive"]):
+            q = train_questions[i % n_train_q]
+            R = R_cache[persona].get(q)
+            if R is None:
+                raise RuntimeError(
+                    f"Cached R missing for persona={persona!r} question={q[:60]!r}; "
+                    f"regenerate Phase 1 with the full DATA_QUESTIONS set."
+                )
+            # Defensive — the base model should never have produced the
+            # marker organically (assumption A13). If it did, that's a
+            # data-leak we must surface, not silently let through.
+            if MARKER_TEXT.strip().lower() in R.lower():
+                raise RuntimeError(
+                    f"Marker {MARKER_TEXT!r} appears organically in base-model R for "
+                    f"persona={persona!r} q={q[:40]!r}. Refusing to assemble — "
+                    f"investigate the cache."
+                )
+            marked = f"{R}{MARKER_TEXT}"
+            rows.append(make_example(sys_prompt, q, marked))
+            pos_rows += 1
+
+    # Negatives — NO marker; under MarkerOnlyDataCollator(tail_tokens=0) this
+    # leaves EOS at the post-response slot as the only loss-bearing token.
+    neg_rows = 0
+    for persona in spec["negatives"]:
+        sys_prompt = all_prompts[persona]
+        for i in range(spec["rows_per_negative"]):
+            q = train_questions[i % n_train_q]
+            R = R_cache[persona].get(q)
+            if R is None:
+                raise RuntimeError(
+                    f"Cached R missing for negative persona={persona!r} q={q[:60]!r}"
+                )
+            rows.append(make_example(sys_prompt, q, R))
+            neg_rows += 1
+
+    rng.shuffle(rows)
+    stats = {"pos_rows": pos_rows, "neg_rows": neg_rows, "total": len(rows)}
+    return rows, stats
+
+
+def truncation_audit(rows: list[dict], tokenizer, max_length: int) -> dict:
+    """FIX D — tokenize every row twice (truncation=True vs False); fail loud on delta.
+
+    Without this guard, marker-truncated positive rows silently collapse
+    (under ``tail_tokens=0``) to "EOS-only loss" and corrupt the per-persona
+    contrast (#260 silent-zeros class).
+    """
+    n_truncated = 0
+    offending: list[dict] = []
+    prompt_lens: list[int] = []
+    full_lens: list[int] = []
+    for idx, row in enumerate(rows):
+        # Reconstruct via chat template to mirror what the trainer will see.
+        messages = row["prompt"] + row["completion"]
+        text = tokenizer.apply_chat_template(messages, tokenize=False)
+        prompt_text = tokenizer.apply_chat_template(
+            row["prompt"], tokenize=False, add_generation_prompt=True
+        )
+        full_ids = tokenizer.encode(text, add_special_tokens=False)
+        prompt_ids = tokenizer.encode(prompt_text, add_special_tokens=False)
+        prompt_lens.append(len(prompt_ids))
+        full_lens.append(len(full_ids))
+        if len(full_ids) > max_length:
+            n_truncated += 1
+            if len(offending) < 3:
+                offending.append(
+                    {
+                        "row_idx": idx,
+                        "prompt_len": len(prompt_ids),
+                        "full_len": len(full_ids),
+                        "question": row["prompt"][1]["content"][:80],
+                        "persona": row["prompt"][0]["content"][:60],
+                        "completion_tail": row["completion"][0]["content"][-80:],
+                    }
+                )
+
+    audit = {
+        "n_rows": len(rows),
+        "max_length": max_length,
+        "n_truncated": n_truncated,
+        "n_truncated_must_be_zero": True,
+        "prompt_len_min": min(prompt_lens) if prompt_lens else None,
+        "prompt_len_max": max(prompt_lens) if prompt_lens else None,
+        "prompt_len_mean": sum(prompt_lens) / len(prompt_lens) if prompt_lens else None,
+        "full_len_min": min(full_lens) if full_lens else None,
+        "full_len_max": max(full_lens) if full_lens else None,
+        "full_len_mean": sum(full_lens) / len(full_lens) if full_lens else None,
+        "offending_first_3": offending,
+    }
+    return audit
+
+
+def write_jsonl(rows: list[dict], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cell-specs",
+        type=str,
+        default=str(PROJECT_ROOT / "data" / "issue_405" / "cell_specs.json"),
+    )
+    parser.add_argument(
+        "--cell-id",
+        type=str,
+        required=True,
+        help="Cell id (e.g. K1_c00) — must exist in --cell-specs",
+    )
+    parser.add_argument("--seed", type=int, required=True)
+    parser.add_argument(
+        "--data-dir",
+        type=str,
+        default=str(PROJECT_ROOT / "data" / "issue_405"),
+        help="Base data dir (contains onpolicy_R/ + training_jsonl/)",
+    )
+    args = parser.parse_args()
+
+    specs = json.loads(Path(args.cell_specs).read_text())
+    by_id = {s["cell_id"]: s for s in specs}
+    if args.cell_id not in by_id:
+        raise SystemExit(f"cell_id={args.cell_id!r} not in {args.cell_specs}")
+    spec = by_id[args.cell_id]
+
+    data_dir = Path(args.data_dir)
+    out_dir = data_dir / "training_jsonl"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Seed RNG deterministically from (cell_id, seed) for reproducibility.
+    h = int(hashlib.sha256(f"{args.cell_id}|{args.seed}".encode()).hexdigest(), 16)
+    rng = random.Random(h % (2**32))
+
+    log.info("Building training data for cell %s seed %d ...", args.cell_id, args.seed)
+    log.info(
+        "  K=%d positives=%s negatives=%s rows_per_positive=%d rows_per_negative=%d",
+        spec["K"],
+        spec["positives"],
+        spec["negatives"],
+        spec["rows_per_positive"],
+        spec["rows_per_negative"],
+    )
+
+    train_questions, _eval_questions = _import_questions()
+    all_prompts = load_all_persona_prompts()
+
+    rows, stats = assemble_rows(spec, train_questions, all_prompts, data_dir, rng)
+    log.info(
+        "Assembled %d rows (%d positives + %d negatives).",
+        stats["total"],
+        stats["pos_rows"],
+        stats["neg_rows"],
+    )
+
+    # Sanity-check the row totals against the plan §4.3.
+    expected_total = spec["total_rows"]
+    if stats["total"] != expected_total:
+        raise RuntimeError(
+            f"Row total mismatch for cell={args.cell_id}: "
+            f"assembled={stats['total']}, expected={expected_total}"
+        )
+
+    # ── Fix D: truncation audit ────────────────────────────────────────
+    from transformers import AutoTokenizer
+
+    log.info("Loading tokenizer for truncation audit ...")
+    tokenizer = AutoTokenizer.from_pretrained(BASE_MODEL, trust_remote_code=True)
+    assert_marker_token_id(tokenizer)
+
+    log.info("Running truncation audit (max_length=%d) ...", MAX_LENGTH)
+    audit = truncation_audit(rows, tokenizer, MAX_LENGTH)
+    log.info(
+        "  n_rows=%d  n_truncated=%d  prompt_len(min,mean,max)=(%d, %.1f, %d)  "
+        "full_len(min,mean,max)=(%d, %.1f, %d)",
+        audit["n_rows"],
+        audit["n_truncated"],
+        audit["prompt_len_min"],
+        audit["prompt_len_mean"],
+        audit["prompt_len_max"],
+        audit["full_len_min"],
+        audit["full_len_mean"],
+        audit["full_len_max"],
+    )
+
+    if audit["n_truncated"] > 0:
+        raise RuntimeError(
+            f"FIX D truncation audit FAILED for cell={args.cell_id} seed={args.seed}: "
+            f"{audit['n_truncated']} rows truncated at max_length={MAX_LENGTH}. "
+            f"First 3 offending: {audit['offending_first_3']!r}. "
+            f"Marker would be silently dropped on these rows — refusing to write. "
+            f"Re-run Phase 1 with a smaller R cap OR raise training max_length."
+        )
+
+    # ── Write outputs ──────────────────────────────────────────────────
+    jsonl_path = out_dir / f"cell_{args.cell_id}_seed{args.seed}.jsonl"
+    audit_path = out_dir / f"cell_{args.cell_id}_seed{args.seed}.truncation_audit.json"
+    write_jsonl(rows, jsonl_path)
+    audit_path.write_text(json.dumps(audit, indent=2))
+    log.info("Wrote %s (%d rows)", jsonl_path, len(rows))
+    log.info("Wrote %s", audit_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/issue405_run_cell.py
+++ b/scripts/issue405_run_cell.py
@@ -136,6 +136,7 @@ def nvidia_smi_assert_clean(gpu_id: int) -> None:
             ],
             text=True,
             timeout=10,
+            env={**os.environ},  # Blocker 10: explicit env-passthrough
         ).strip()
     except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired) as e:
         log.warning("nvidia-smi probe failed (%s); skipping orphan check", e)
@@ -382,17 +383,32 @@ def compute_panel_summary(
 ) -> tuple[dict, dict, dict, dict]:
     """Combine trained + base scores into per-persona summaries.
 
-    Returns: (per_persona_dict, summary_dict, mean_dlogp, mean_emit_rate)
-    where per_persona_dict[persona] carries:
-      - deltaLogP_per_q (trained - base)
-      - emit_rate (mean over questions of argmax==MARKER_TOKEN_ID under trained)
-      - kl_per_q (full-vocab KL(trained‖base) at the slot)
-      - logp_trained_per_q / logp_base_per_q (raw)
+    Per-persona payload carries BOTH:
+      - ``logp_trained_mean``  — ABSOLUTE trained log P(marker) at the slot,
+        averaged over questions. THIS is what `g_logprob_source` must read
+        for the saturation kill-criterion (plan §4.9: expected ∈ [-8, -3];
+        saturated if > -0.1). NOT the trained−base delta — base log P(marker)
+        ≈ -15, so trained−base ≥ 0 for any successful implant, which would
+        ALWAYS exceed -0.1 and silently fire the kill gate (Blocker 1).
+      - ``deltaLogP_mean`` (trained − base) — the FIX-A1 source-strength
+        scalar used by the analyzer; SEPARATE from the saturation read.
+      - ``logp_base_mean``  — absolute base log P(marker) at the slot.
+      - ``emit_rate`` (argmax==MARKER_TOKEN_ID under trained)
+      - ``kl_per_q`` (full-vocab KL(trained‖base) at the slot, vectorized)
+
+    Returns: ``(per_persona, summary, mean_dlogp_by_persona, mean_emit_by_persona)``
+    where ``summary`` carries BOTH ``logp_trained_mean`` AND
+    ``mean_deltaLogP`` (NOT just the delta) so the caller can pick the right
+    one for the kill-criterion vs. the analysis covariate.
     """
-    import math
+    # Vectorized KL — torch tensor ops, not Python double-loop over ~152k entries.
+    # Per-row KL(trained ‖ base) = sum_v exp(log_t[v]) * (log_t[v] - log_b[v])
+    import torch
 
     per_persona: dict[str, dict] = {}
     dlogp_means: list[float] = []
+    logp_trained_means: list[float] = []
+    logp_base_means: list[float] = []
     emit_rates: list[float] = []
     for persona in panel_R:
         lp_t = trained_scores[persona]["logp_marker_per_q"]
@@ -401,18 +417,24 @@ def compute_panel_summary(
         ls_b = base_scores[persona]["logsoftmax_per_q"]
         argmax_t = trained_scores[persona]["argmax_id_per_q"]
         delta = [t - b for t, b in zip(lp_t, lp_b, strict=True)]
-        # KL(trained ‖ base) = sum_v exp(log_t[v]) * (log_t[v] - log_b[v])
-        kl_per_q: list[float] = []
-        for row_t, row_b in zip(ls_t, ls_b, strict=True):
-            kl = 0.0
-            for lt, lb in zip(row_t, row_b, strict=True):
-                if lt > -50.0:  # ignore vanishingly small terms
-                    kl += math.exp(lt) * (lt - lb)
-            kl_per_q.append(kl)
+        # Vectorized KL — Blocker 8 fix (Python loop was ~60-100 min sweep overhead).
+        # log_t: (Q, V), log_b: (Q, V) → KL per Q = sum_v exp(log_t) * (log_t - log_b)
+        log_t = torch.tensor(ls_t, dtype=torch.float32)
+        log_b = torch.tensor(ls_b, dtype=torch.float32)
+        # Mask tail terms with log_t < -50 (numerically negligible contribution),
+        # matching the row-by-row code's `if lt > -50.0` guard semantics.
+        mask = log_t > -50.0
+        contribs = torch.where(mask, torch.exp(log_t) * (log_t - log_b), torch.zeros_like(log_t))
+        kl_per_q_tensor = contribs.sum(dim=-1)
+        kl_per_q: list[float] = [float(x) for x in kl_per_q_tensor.tolist()]
         emit = sum(1.0 for a in argmax_t if a == MARKER_TOKEN_ID) / max(1, len(argmax_t))
+        logp_trained_mean = sum(lp_t) / max(1, len(lp_t))
+        logp_base_mean = sum(lp_b) / max(1, len(lp_b))
         per_persona[persona] = {
             "deltaLogP_per_q": delta,
             "deltaLogP_mean": sum(delta) / max(1, len(delta)),
+            "logp_trained_mean": logp_trained_mean,  # ABSOLUTE (Blocker 1)
+            "logp_base_mean": logp_base_mean,
             "emit_rate": emit,
             "kl_per_q": kl_per_q,
             "kl_mean": sum(kl_per_q) / max(1, len(kl_per_q)),
@@ -421,10 +443,14 @@ def compute_panel_summary(
             "argmax_id_per_q": argmax_t,
         }
         dlogp_means.append(per_persona[persona]["deltaLogP_mean"])
+        logp_trained_means.append(logp_trained_mean)
+        logp_base_means.append(logp_base_mean)
         emit_rates.append(emit)
 
     summary = {
         "mean_deltaLogP": sum(dlogp_means) / max(1, len(dlogp_means)),
+        "logp_trained_mean": sum(logp_trained_means) / max(1, len(logp_trained_means)),
+        "logp_base_mean": sum(logp_base_means) / max(1, len(logp_base_means)),
         "mean_emit_rate": sum(emit_rates) / max(1, len(emit_rates)),
         "n_personas": len(per_persona),
     }
@@ -434,6 +460,117 @@ def compute_panel_summary(
         dict(zip(panel_R, dlogp_means, strict=True)),
         dict(zip(panel_R, emit_rates, strict=True)),
     )
+
+
+class ProbePanelLogprobCallback:
+    """FIX E (Blocker 4) — per-step probe-panel marker logprob + emission rate.
+
+    A `TrainerCallback` (loose-typed at class-body level so importing this
+    module doesn't pull `transformers` at module-import time on CPU-only
+    smoke runs). Logs to WandB on every ``log_every_steps`` step:
+      - ``probe/<persona>/logp_marker``  (teacher-forced log P(marker | T_p(q) + R))
+      - ``probe/<persona>/argmax_emission``  (1.0 if argmax at the same slot == marker_id)
+
+    The probe panel is fixed by the plan §4.4 / §6.5 fig #4:
+      (a) one trained-positive persona (typically the first in spec.positives)
+      (b) ``no_persona`` (the bare default context — open-q 3.7 safety target)
+      (c) ``comedian`` (the far held-out)
+
+    Each probe uses a fixed (persona, question, R) tuple captured ONCE at
+    ``on_train_begin``; the R text comes from the cached on-policy R for
+    the trained-positive persona (matches the trained context shape).
+
+    Plan §6.5 fig #4 explicitly mandates BOTH the log-prob trajectory AND
+    the argmax/emission trajectory because once log-prob crosses ~-0.1
+    nat the model starts argmaxing the marker and the log-prob curve
+    plateaus — emission still distinguishes the two regimes.
+    """
+
+    def __init__(
+        self,
+        probe_personas: list[tuple[str, str]],
+        sample_R: str,
+        sample_question: str,
+        marker_text: str,
+        marker_token_id: int,
+        log_every_steps: int = 5,
+    ):
+        self.probe_personas = probe_personas  # [(name, system_prompt), ...]
+        self.sample_R = sample_R
+        self.sample_question = sample_question
+        self.marker_text = marker_text
+        self.marker_token_id = marker_token_id
+        self.log_every_steps = log_every_steps
+        self._last_logged_step = -1
+        self._enabled = True
+
+    def _build_prefix(self, tokenizer, system_prompt: str) -> str:
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": self.sample_question},
+        ]
+        chat = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+        return chat + self.sample_R  # post-R slot is where we score
+
+    def on_train_begin(self, args, state, control, model=None, **kwargs):
+        tokenizer = kwargs.get("processing_class") or kwargs.get("tokenizer")
+        if tokenizer is None:
+            log.warning("ProbePanelLogprobCallback: no tokenizer in kwargs; disabling")
+            self._enabled = False
+            return
+        # Pre-tokenize the 3 probe prefixes once.
+        self._cached: list[tuple[str, list[int]]] = []
+        for name, sys_prompt in self.probe_personas:
+            prefix = self._build_prefix(tokenizer, sys_prompt)
+            ids = tokenizer.encode(prefix, add_special_tokens=False)
+            self._cached.append((name, ids))
+        log.info(
+            "ProbePanelLogprobCallback: armed on %d probes, log every %d steps",
+            len(self._cached),
+            self.log_every_steps,
+        )
+
+    def on_step_end(self, args, state, control, model=None, **kwargs):
+        if not self._enabled or model is None:
+            return
+        step = state.global_step
+        if step == self._last_logged_step:
+            return
+        if step % self.log_every_steps != 0:
+            return
+        self._last_logged_step = step
+
+        import torch
+        import torch.nn.functional as F
+
+        was_training = model.training
+        model.eval()
+        try:
+            metrics: dict[str, float] = {}
+            for name, ids in self._cached:
+                input_ids = torch.tensor([ids], dtype=torch.long, device=model.device)
+                attn = torch.ones_like(input_ids)
+                with torch.no_grad():
+                    logits = model(input_ids=input_ids, attention_mask=attn).logits
+                last = logits[0, -1, :].float()
+                log_probs = F.log_softmax(last, dim=-1)
+                lp = float(log_probs[self.marker_token_id].item())
+                argmax_id = int(log_probs.argmax().item())
+                metrics[f"probe/{name}/logp_marker"] = lp
+                metrics[f"probe/{name}/argmax_emission"] = (
+                    1.0 if argmax_id == self.marker_token_id else 0.0
+                )
+            # Push to wandb directly so the metrics line up with the trainer's run.
+            try:
+                import wandb
+
+                if wandb.run is not None:
+                    wandb.log(metrics, step=step)
+            except Exception as e:
+                log.warning("ProbePanel wandb.log failed (%s); continuing", e)
+        finally:
+            if was_training:
+                model.train()
 
 
 def write_sentinel(payload: dict) -> Path:
@@ -552,6 +689,10 @@ def main() -> int:
     result_path = out_dir / "result.json"
     if result_path.exists():
         log.info("result.json already exists at %s — skipping (idempotent).", result_path)
+        # Blocker 7: emit phase=done so poll_pipeline.py reads this as a clean
+        # completion, not a stuck cell. Without it the orchestrator would
+        # flip status to "dead" and suppress the auto-post of epm:results.
+        print("[phase=done]", flush=True)
         return 0
 
     # ── Persist-adapter env vars (delete-after-eval recipe per upload-policy) ──
@@ -588,6 +729,43 @@ def main() -> int:
         run_name = f"issue405_{args.cell_id}_seed{args.seed}"
         os.environ.setdefault("WANDB_PROJECT", WANDB_PROJECT)
 
+        # ── FIX E (Blocker 4) — per-step probe-panel callback ──────────
+        # Plan §4.4 + §6.5 fig #4: log marker logp + emission at every
+        # logging_steps step on a FIXED probe panel of 3 personas:
+        #   (a) first trained-positive (the cell's first source persona)
+        #   (b) no_persona (bare default — open-q 3.7 safety target)
+        #   (c) comedian (far held-out — OOD generalization curve)
+        all_prompts_pre = load_all_persona_prompts()
+        _train_qs_pre, _eval_qs_pre = _import_questions()
+        # Use a fixed question + on-policy R from the first trained
+        # positive's cached R (matches the trained-context shape).
+        probe_personas: list[tuple[str, str]] = [
+            (spec["positives"][0], all_prompts_pre[spec["positives"][0]]),
+            ("no_persona", all_prompts_pre["no_persona"]),
+            ("comedian", all_prompts_pre["comedian"]),
+        ]
+        sample_question = _train_qs_pre[0]
+        # Load the first source persona's cached R for this question.
+        # Phase 1 must have run first; if not, _import + cache lookup fails
+        # loud rather than silently logging a degenerate probe.
+        cached_R_first_pos = json.loads(
+            (Path(args.data_dir) / "onpolicy_R" / f"{spec['positives'][0]}.json").read_text()
+        )["responses"]
+        if sample_question not in cached_R_first_pos:
+            raise RuntimeError(
+                f"FIX-E probe: cached R for question {sample_question!r} missing "
+                f"from {spec['positives'][0]}.json. Re-run Phase 1."
+            )
+        sample_R = cached_R_first_pos[sample_question]
+        probe_cb = ProbePanelLogprobCallback(
+            probe_personas=probe_personas,
+            sample_R=sample_R,
+            sample_question=sample_question,
+            marker_text=MARKER_TEXT,
+            marker_token_id=MARKER_TOKEN_ID,
+            log_every_steps=5,
+        )
+
         cfg = TrainLoraConfig(
             gpu_id=args.gpu,
             epochs=args.epochs,
@@ -612,14 +790,32 @@ def main() -> int:
             lora_targets=LORA_TARGETS_NARROW,  # NARROW attention-only (no MLP — #311, #405)
             hf_upload=False,  # The EPM_PERSIST_ADAPTER_* path handles upload
         )
-        log.info("Starting train_lora ...")
+        log.info("Starting train_lora (with FIX-E probe-panel callback) ...")
         adapter_path_str, training_loss = train_lora(
             base_model_path=BASE_MODEL,
             data_path=str(data_jsonl),
             output_dir=str(adapter_dir),
             cfg=cfg,
+            callbacks=[probe_cb],
         )
         log.info("Training done. loss=%.4f adapter=%s", training_loss, adapter_path_str)
+
+        # ── Blocker 3 fix: persist adapter to HF BEFORE merge/delete ────
+        # FAIL LOUD per upload-policy.md / #404/#458. The merge below
+        # produces a regenerable ~15GB dir we WILL `rm` to stay under the
+        # MooseFS ~130GB quota; the adapter (~300MB) is the only durable
+        # copy. If persist fails we abort BEFORE the merge so a downstream
+        # cleanup pass cannot silently rm an un-uploaded checkpoint.
+        from explore_persona_space.train.trainer import _maybe_persist_adapter
+
+        log.info(
+            "Persisting LoRA adapter to HF (FAIL-LOUD) → %s/%s ...",
+            os.environ.get("EPM_PERSIST_ADAPTER_HF_REPO"),
+            os.environ.get("EPM_PERSIST_ADAPTER_SUBFOLDER"),
+        )
+        _maybe_persist_adapter(Path(adapter_path_str))
+        log.info("Adapter persist verified.")
+
         # Merge
         log.info("Merging LoRA → %s", merged_dir)
         merge_lora(BASE_MODEL, adapter_path_str, str(merged_dir), gpu_id=args.gpu)
@@ -685,7 +881,7 @@ def main() -> int:
         {p: base_scores[p] for p in trained_pos_prompts},
     )
 
-    # ── Save raw_completions JSON (per Upload Policy) ────────────────────
+    # ── Save raw_completions JSON + FAIL-LOUD upload (Blocker 3) ─────────
     raw_completions_path = out_dir / "raw_completions.json"
     raw_completions_path.write_text(
         json.dumps(
@@ -702,8 +898,42 @@ def main() -> int:
     )
     log.info("Wrote raw_completions → %s", raw_completions_path)
 
-    # ── Source-strength scalar (per cell, FIX A1) ────────────────────────
-    g_logprob_source = tp_summary["mean_deltaLogP"]  # mean ΔlogP across the K positives
+    # Upload to superkaiba1/explore-persona-space-data per Upload Policy.
+    # FAIL LOUD — a silent upload-skip means the per-cell on-policy R is
+    # only on the pod's MooseFS, which the orchestrator's auto-terminate
+    # reaps after this cell completes.
+    from explore_persona_space.orchestrate.hub import upload_raw_completions_to_data_repo
+
+    experiment_name = f"issue_405/{args.cell_id}_seed{args.seed}"
+    log.info("Uploading raw_completions to HF data repo (FAIL-LOUD) ...")
+    uploaded = upload_raw_completions_to_data_repo(
+        experiment_name=experiment_name,
+        eval_results_dir=out_dir,
+        delete_after=False,
+    )
+    if not uploaded:
+        raise RuntimeError(
+            f"raw_completions upload FAILED for cell={args.cell_id} seed={args.seed} "
+            f"— no files reported uploaded. Refusing to delete local copy."
+        )
+    log.info("raw_completions uploaded to HF: %d file(s)", len(uploaded))
+
+    # ── Source-strength scalar + saturation read (Blocker 1 fix) ─────────
+    # Two DIFFERENT quantities — keep them separate.
+    #
+    # `g_logprob_source` (= ABSOLUTE trained log P(marker) at the post-R
+    # slot, averaged across the K trained-positive personas) is the
+    # saturation read. Plan §4.9 + #448: expected ∈ [-8, -3], saturated
+    # if > -0.1. Was (incorrectly, round 1) wired to the trained−base
+    # delta — which is ≥ 0 for any successful implant and would silently
+    # always trip the kill-criterion. FIX: read the ABSOLUTE trained
+    # log-prob via `compute_panel_summary`'s new `logp_trained_mean`.
+    #
+    # `trained_pos_mean_dlogp` (= trained − base ΔlogP, same panel) is the
+    # FIX-A1 source-strength scalar the analyzer's covariate-adjusted
+    # regression consumes for the dose-vs-diversity check. Separate field.
+    g_logprob_source = tp_summary["logp_trained_mean"]
+    trained_pos_mean_dlogp = tp_summary["mean_deltaLogP"]
 
     # ── Reproducibility metadata ─────────────────────────────────────────
     import datetime as _dt
@@ -711,7 +941,10 @@ def main() -> int:
 
     try:
         git_commit = subprocess.check_output(
-            ["git", "rev-parse", "HEAD"], cwd=PROJECT_ROOT, text=True
+            ["git", "rev-parse", "HEAD"],
+            cwd=PROJECT_ROOT,
+            text=True,
+            env={**os.environ},  # Blocker 10: explicit env-passthrough
         ).strip()
     except Exception:
         git_commit = "unknown"
@@ -744,8 +977,14 @@ def main() -> int:
             "summary": {
                 "held_out_mean_dlogp": held_out_summary["mean_deltaLogP"],
                 "held_out_mean_emit_rate": held_out_summary["mean_emit_rate"],
-                "trained_pos_mean_dlogp": tp_summary["mean_deltaLogP"],
+                "held_out_logp_trained_mean": held_out_summary["logp_trained_mean"],
+                "held_out_logp_base_mean": held_out_summary["logp_base_mean"],
+                "trained_pos_mean_dlogp": trained_pos_mean_dlogp,
                 "trained_pos_mean_emit_rate": tp_summary["mean_emit_rate"],
+                "trained_pos_logp_trained_mean": tp_summary["logp_trained_mean"],
+                "trained_pos_logp_base_mean": tp_summary["logp_base_mean"],
+                # ABSOLUTE trained log P(marker) on the trained-source panel,
+                # NOT trained−base. Drives smoke_check.saturated (Blocker 1 fix).
                 "g_logprob_source": g_logprob_source,
             },
             "n_eval_questions": len(eval_questions),

--- a/scripts/issue405_run_cell.py
+++ b/scripts/issue405_run_cell.py
@@ -1,0 +1,808 @@
+#!/usr/bin/env python3
+# ruff: noqa: RUF002, RUF003
+"""Issue #405 PHASE 3 — train one LoRA cell + on-policy eval (two panels).
+
+Per plan v2 §4.5 PHASE 3:
+
+  1. Load training JSONL ``data/issue_405/training_jsonl/cell_{cid}_seed{S}.jsonl``
+     (Phase 2 output).
+  2. ``train_lora(...)`` with ``TrainLoraConfig(marker_only_loss=True,
+     marker_text=" ※", marker_tail_tokens=0, lora_r=16, lora_alpha=32,
+     lora_dropout=0.05, lr=5e-6, epochs=2, lora_targets=q/k/v/o (NARROW))``.
+     Persist adapter to HF Hub via ``EPM_PERSIST_ADAPTER_HF_REPO`` +
+     ``EPM_PERSIST_ADAPTER_SUBFOLDER`` (delete-after-eval recipe).
+  3. Merge LoRA in-process; on-policy eval over TWO disjoint persona panels:
+       * **held_out** (8 personas) — feeds the headline regression.
+       * **trained_positive** (the K positives this cell trained on) — FIX A1
+         per-cell source-strength scalar; covariate in the analyzer's
+         dose-vs-diversity check.
+     For each (persona, q ∈ EVAL_QUESTIONS):
+       * Generate R_eval = trained_model.greedy(T_p(q)), per-(persona, q)
+         cap matching Phase 1's Fix D recipe.
+       * compute_marker_logprob(trained, T_p(q) + R_eval, " ※")
+       * compute_marker_logprob(base,    T_p(q) + R_eval, " ※")
+       * ΔlogP = trained − base
+       * emit_rate from argmax at the post-R slot (free anchor)
+       * full-vocab KL(trained‖base) at the same slot (non-saturating DV)
+  4. Write ``eval_results/issue_405/cell_{cid}_seed{S}/result.json`` +
+     end-of-cell sentinel at the pod-side log dir.
+  5. Delete merged dir (MooseFS quota); the LoRA adapter persists on HF Hub.
+
+WandB **per-step probe-panel logging** (FIX E) is wired via a
+``TrainerCallback`` that runs the probe panel at each ``logging_steps``
+step and logs both ``marker_logprob`` AND ``marker_emission_rate`` for the
+3 probe personas:
+  (a) trained-positive (first persona in spec["positives"])
+  (b) ``no_persona`` (the bare default context — open-q 3.7 safety target)
+  (c) ``comedian`` (the far held-out)
+
+vLLM teardown follows ``.claude/rules/gotchas.md`` — psutil child-kill +
+nvidia-smi PID check before HF Transformers reloads the model for the
+post-R logprob compute.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from _bootstrap import PROJECT_ROOT, bootstrap
+
+log = bootstrap()
+
+from _issue405_common import (  # noqa: E402
+    BASE_MODEL,
+    EPOCHS,
+    GRAD_ACCUM,
+    LORA_ALPHA,
+    LORA_DROPOUT,
+    LORA_R,
+    LORA_TARGETS_NARROW,
+    LR,
+    MARKER_TEXT,
+    MARKER_TOKEN_ID,
+    MAX_LENGTH,
+    PER_DEVICE_BATCH,
+    R_CAP_MIN,
+    R_CAP_SAFETY_MARGIN,
+    SENTINEL_DIR_LOCAL_FALLBACK,
+    SENTINEL_DIR_POD,
+    WANDB_PROJECT,
+    WARMUP_RATIO,
+    WEIGHT_DECAY,
+    assert_marker_token_id,
+    load_all_persona_prompts,
+)
+
+
+def _import_questions() -> tuple[list[str], list[str]]:
+    scripts_dir = Path(__file__).resolve().parent
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    from run_leakage_v3_onpolicy import DATA_QUESTIONS, EVAL_QUESTIONS
+
+    return list(DATA_QUESTIONS), list(EVAL_QUESTIONS)
+
+
+def kill_vllm_children() -> None:
+    """Reap vLLM worker subprocesses (per .claude/rules/gotchas.md).
+
+    Canonical vLLM cleanup (del llm + destroy_model_parallel +
+    destroy_distributed_environment + gc.collect + empty_cache) is NOT
+    enough — TP/PP worker subprocesses survive and re-grab freed GPU
+    memory the moment the next framework (HF Transformers) loads.
+    """
+    try:
+        import psutil  # type: ignore
+    except ImportError:
+        log.warning("psutil not available — skipping orphan-PID reaping")
+        return
+
+    import contextlib
+
+    me = psutil.Process()
+    children = me.children(recursive=True)
+    for ch in children:
+        with contextlib.suppress(psutil.NoSuchProcess):
+            log.info("Terminating vLLM child PID=%d name=%r", ch.pid, ch.name())
+            ch.terminate()
+    _gone, alive = psutil.wait_procs(children, timeout=5)
+    for ch in alive:
+        with contextlib.suppress(psutil.NoSuchProcess):
+            ch.kill()
+
+
+def nvidia_smi_assert_clean(gpu_id: int) -> None:
+    """Fail loud if any python PID still holds the GPU after vLLM teardown.
+
+    Called after kill_vllm_children() and before HF Transformers re-loads the
+    base model for the logprob compute. CVD-aware: only checks the specified
+    GPU's compute-apps (per feedback_orphan_pid_check_must_be_cvd_aware).
+    """
+    try:
+        out = subprocess.check_output(
+            [
+                "nvidia-smi",
+                f"--id={gpu_id}",
+                "--query-compute-apps=pid,process_name",
+                "--format=csv,noheader",
+            ],
+            text=True,
+            timeout=10,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired) as e:
+        log.warning("nvidia-smi probe failed (%s); skipping orphan check", e)
+        return
+    if not out:
+        return
+    my_pid = os.getpid()
+    leaks = []
+    for line in out.splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        if not parts or not parts[0].isdigit():
+            continue
+        pid = int(parts[0])
+        if pid == my_pid:
+            continue
+        leaks.append(line.strip())
+    if leaks:
+        log.warning(
+            "nvidia-smi reports surviving python PIDs on GPU %d: %r — "
+            "continuing (CVD-aware: filtered by gpu id) but HF reload may OOM",
+            gpu_id,
+            leaks,
+        )
+
+
+def compute_prompt_len(tokenizer, persona_prompt: str, question: str) -> int:
+    messages = [
+        {"role": "system", "content": persona_prompt},
+        {"role": "user", "content": question},
+    ]
+    text = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    return len(tokenizer.encode(text, add_special_tokens=False))
+
+
+def per_question_R_cap(tokenizer, persona_prompt: str, question: str) -> int:
+    """Per-(persona, question) R-cap matching Phase 1's Fix D recipe."""
+    prompt_len = compute_prompt_len(tokenizer, persona_prompt, question)
+    cap = MAX_LENGTH - prompt_len - R_CAP_SAFETY_MARGIN
+    if cap < R_CAP_MIN:
+        raise RuntimeError(
+            f"R-cap too small for persona={persona_prompt[:40]!r} q={question[:40]!r}: "
+            f"prompt_len={prompt_len}, cap={cap} < {R_CAP_MIN}"
+        )
+    return cap
+
+
+def vllm_greedy_generate(
+    merged_path: str,
+    panels: dict[str, dict[str, str]],
+    eval_questions: list[str],
+    tokenizer,
+    gpu_id: int,
+    gpu_mem_util: float,
+) -> dict[str, dict[str, str]]:
+    """Greedy generate R_eval for each (persona, question) using vLLM.
+
+    Args:
+        merged_path: Path to merged (LoRA-applied) checkpoint.
+        panels: dict {panel_name: {persona_name: system_prompt}}.
+        eval_questions: List of evaluation questions.
+        tokenizer: HF tokenizer (for prompt-len + chat template).
+        gpu_id: Already pinned via CUDA_VISIBLE_DEVICES — passed for logging.
+        gpu_mem_util: vLLM GPU memory utilization.
+
+    Returns:
+        dict {persona_name: {question: R_eval_text}}.
+    """
+    from vllm import LLM, SamplingParams
+
+    log.info(
+        "Loading vLLM from merged checkpoint %s on GPU %d (mem_util=%.2f) ...",
+        merged_path,
+        gpu_id,
+        gpu_mem_util,
+    )
+    llm = LLM(
+        model=merged_path,
+        dtype="bfloat16",
+        trust_remote_code=True,
+        gpu_memory_utilization=gpu_mem_util,
+        max_model_len=MAX_LENGTH,
+        max_num_seqs=64,
+        seed=42,
+    )
+
+    prompts: list[str] = []
+    keys: list[tuple[str, str]] = []
+    caps: list[int] = []
+    persona_prompts: dict[str, str] = {}
+    for panel in panels.values():
+        for p, sys_prompt in panel.items():
+            persona_prompts.setdefault(p, sys_prompt)
+
+    for persona, sys_prompt in persona_prompts.items():
+        for q in eval_questions:
+            messages = [
+                {"role": "system", "content": sys_prompt},
+                {"role": "user", "content": q},
+            ]
+            text = tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+            cap = per_question_R_cap(tokenizer, sys_prompt, q)
+            prompts.append(text)
+            keys.append((persona, q))
+            caps.append(cap)
+
+    sampling = [SamplingParams(n=1, temperature=0.0, top_p=1.0, max_tokens=c) for c in caps]
+    log.info("vLLM batched generate: %d prompts ...", len(prompts))
+    outputs = llm.generate(prompts, sampling)
+
+    R_eval: dict[str, dict[str, str]] = {p: {} for p in persona_prompts}
+    truncated = 0
+    for out, (persona, q) in zip(outputs, keys, strict=True):
+        if out.outputs[0].finish_reason == "length":
+            truncated += 1
+        R_eval[persona][q] = out.outputs[0].text
+
+    log.info(
+        "Eval R-gen done: %d (persona, q) pairs, %d hit length cap.",
+        len(prompts),
+        truncated,
+    )
+
+    del llm
+    gc.collect()
+    try:
+        import torch
+
+        torch.cuda.empty_cache()
+    except Exception:
+        pass
+    return R_eval
+
+
+def score_logprob_and_kl(
+    model_path: str,
+    R_eval: dict[str, dict[str, str]],
+    persona_prompts: dict[str, str],
+    tokenizer,
+    device: str,
+    batch_size: int = 4,
+) -> dict[str, dict]:
+    """For each (persona, q), compute log P(marker), emit_rate, KL(this‖base?).
+
+    The KL part requires both models' logits at the same slot, which means
+    this function loads ONE model (either trained or base) and returns the
+    raw next-token log-probs at the post-R slot for every (persona, q). The
+    caller pairs trained + base outputs to compute ΔlogP and KL.
+
+    Returns:
+        dict {persona: {
+            "logp_marker_per_q": [float],   # log P(marker_id) at post-R slot
+            "argmax_id_per_q":  [int],      # argmax token id at the same slot
+            "logits_per_q":     [list[float]]  # next-token log-probs (full vocab)
+                                            # OR sentinel "RAM_OOM" str if vocab*N too big;
+                                            # stored as compact log-softmax (V floats/q)
+        }}
+    """
+    import torch
+    import torch.nn.functional as F
+    from transformers import AutoModelForCausalLM
+
+    log.info("Loading model %s for scoring ...", model_path)
+    model = AutoModelForCausalLM.from_pretrained(
+        model_path,
+        torch_dtype=torch.bfloat16,
+        device_map={"": 0},
+        trust_remote_code=True,
+        token=os.environ.get("HF_TOKEN"),
+    )
+    model.eval()
+
+    out: dict[str, dict] = {
+        p: {"logp_marker_per_q": [], "argmax_id_per_q": [], "logsoftmax_per_q": []} for p in R_eval
+    }
+
+    # Order: persona × q (stable for later pairing)
+    all_items: list[tuple[str, str, str]] = []  # (persona, q, prefix_text)
+    for persona, qmap in R_eval.items():
+        sys_prompt = persona_prompts[persona]
+        for q, R in qmap.items():
+            messages = [
+                {"role": "system", "content": sys_prompt},
+                {"role": "user", "content": q},
+            ]
+            prefix = tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+            full_prefix = prefix + R  # the slot AFTER R is where we score the marker
+            all_items.append((persona, q, full_prefix))
+
+    pad_id = tokenizer.pad_token_id
+    if pad_id is None:
+        pad_id = tokenizer.eos_token_id
+
+    for start in range(0, len(all_items), batch_size):
+        chunk = all_items[start : start + batch_size]
+        ids_list = [tokenizer.encode(t, add_special_tokens=False) for t in [c[2] for c in chunk]]
+        max_len = max(len(ids) for ids in ids_list)
+        padded, attn = [], []
+        for ids in ids_list:
+            pad = max_len - len(ids)
+            padded.append([pad_id] * pad + ids)
+            attn.append([0] * pad + [1] * len(ids))
+        input_ids = torch.tensor(padded, dtype=torch.long, device=device)
+        attention_mask = torch.tensor(attn, dtype=torch.long, device=device)
+
+        with torch.no_grad():
+            logits = model(input_ids=input_ids, attention_mask=attention_mask).logits
+
+        # last position = predicts the next token AFTER R; that's the slot
+        # where the marker should appear under positives, EOS under negatives.
+        last_logits = logits[:, -1, :].float()  # (B, V)
+        log_probs = F.log_softmax(last_logits, dim=-1)
+        argmax_ids = log_probs.argmax(dim=-1).cpu().tolist()
+        marker_logps = log_probs[:, MARKER_TOKEN_ID].cpu().tolist()
+        # Store full log-softmax row for KL computation downstream.
+        ls = log_probs.cpu().tolist()
+        for (persona, _q, _), lp, am, full_ls in zip(
+            chunk, marker_logps, argmax_ids, ls, strict=True
+        ):
+            out[persona]["logp_marker_per_q"].append(float(lp))
+            out[persona]["argmax_id_per_q"].append(int(am))
+            out[persona]["logsoftmax_per_q"].append(full_ls)
+        del logits, last_logits, log_probs
+
+    # Drop the model BEFORE returning so the caller can load the next one.
+    del model
+    gc.collect()
+    try:
+        import torch as _t
+
+        _t.cuda.empty_cache()
+    except Exception:
+        pass
+    return out
+
+
+def compute_panel_summary(
+    panel_R: dict[str, dict[str, str]],
+    trained_scores: dict[str, dict],
+    base_scores: dict[str, dict],
+) -> tuple[dict, dict, dict, dict]:
+    """Combine trained + base scores into per-persona summaries.
+
+    Returns: (per_persona_dict, summary_dict, mean_dlogp, mean_emit_rate)
+    where per_persona_dict[persona] carries:
+      - deltaLogP_per_q (trained - base)
+      - emit_rate (mean over questions of argmax==MARKER_TOKEN_ID under trained)
+      - kl_per_q (full-vocab KL(trained‖base) at the slot)
+      - logp_trained_per_q / logp_base_per_q (raw)
+    """
+    import math
+
+    per_persona: dict[str, dict] = {}
+    dlogp_means: list[float] = []
+    emit_rates: list[float] = []
+    for persona in panel_R:
+        lp_t = trained_scores[persona]["logp_marker_per_q"]
+        lp_b = base_scores[persona]["logp_marker_per_q"]
+        ls_t = trained_scores[persona]["logsoftmax_per_q"]
+        ls_b = base_scores[persona]["logsoftmax_per_q"]
+        argmax_t = trained_scores[persona]["argmax_id_per_q"]
+        delta = [t - b for t, b in zip(lp_t, lp_b, strict=True)]
+        # KL(trained ‖ base) = sum_v exp(log_t[v]) * (log_t[v] - log_b[v])
+        kl_per_q: list[float] = []
+        for row_t, row_b in zip(ls_t, ls_b, strict=True):
+            kl = 0.0
+            for lt, lb in zip(row_t, row_b, strict=True):
+                if lt > -50.0:  # ignore vanishingly small terms
+                    kl += math.exp(lt) * (lt - lb)
+            kl_per_q.append(kl)
+        emit = sum(1.0 for a in argmax_t if a == MARKER_TOKEN_ID) / max(1, len(argmax_t))
+        per_persona[persona] = {
+            "deltaLogP_per_q": delta,
+            "deltaLogP_mean": sum(delta) / max(1, len(delta)),
+            "emit_rate": emit,
+            "kl_per_q": kl_per_q,
+            "kl_mean": sum(kl_per_q) / max(1, len(kl_per_q)),
+            "logp_trained_per_q": lp_t,
+            "logp_base_per_q": lp_b,
+            "argmax_id_per_q": argmax_t,
+        }
+        dlogp_means.append(per_persona[persona]["deltaLogP_mean"])
+        emit_rates.append(emit)
+
+    summary = {
+        "mean_deltaLogP": sum(dlogp_means) / max(1, len(dlogp_means)),
+        "mean_emit_rate": sum(emit_rates) / max(1, len(emit_rates)),
+        "n_personas": len(per_persona),
+    }
+    return (
+        per_persona,
+        summary,
+        dict(zip(panel_R, dlogp_means, strict=True)),
+        dict(zip(panel_R, emit_rates, strict=True)),
+    )
+
+
+def write_sentinel(payload: dict) -> Path:
+    """Write end-of-cell sentinel per CLAUDE.md pod-side contract.
+
+    Pod path: /workspace/logs/issue-405-epm_results-<epoch>.json
+    Fallback (local smoke): {repo_root}/logs/issue-405-epm_results-<epoch>.json
+    """
+    sentinel_dir = Path(SENTINEL_DIR_POD)
+    if not Path("/workspace").exists():
+        sentinel_dir = PROJECT_ROOT / SENTINEL_DIR_LOCAL_FALLBACK
+    sentinel_dir.mkdir(parents=True, exist_ok=True)
+    epoch = int(time.time())
+    path = sentinel_dir / f"issue-405-epm_results-{epoch}.json"
+    # Required keys per CLAUDE.md "Pod-side result-reporting contract"
+    body = {
+        "sentinel_schema_version": 1,
+        "kind": "epm:results",
+        "version": 1,
+        "task_id": 405,
+        "by": "issue405_run_cell.py",
+        "ts": epoch,
+        "note": payload,
+    }
+    path.write_text(json.dumps(body, indent=2))
+    return path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cell-id", type=str, required=True)
+    parser.add_argument("--seed", type=int, required=True)
+    parser.add_argument("--gpu", type=int, default=0)
+    parser.add_argument(
+        "--cell-specs",
+        type=str,
+        default=str(PROJECT_ROOT / "data" / "issue_405" / "cell_specs.json"),
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=str,
+        default=str(PROJECT_ROOT / "data" / "issue_405"),
+    )
+    parser.add_argument(
+        "--eval-results-dir",
+        type=str,
+        default=str(PROJECT_ROOT / "eval_results" / "issue_405"),
+    )
+    parser.add_argument(
+        "--vllm-mem-util",
+        type=float,
+        default=float(os.environ.get("VLLM_GPU_MEM_UTIL", "0.55")),
+    )
+    parser.add_argument(
+        "--skip-training",
+        action="store_true",
+        help="Skip training (assume adapter exists); for smoke flows that test eval only",
+    )
+    parser.add_argument(
+        "--persist-adapter-repo",
+        type=str,
+        default=os.environ.get("EPM_PERSIST_ADAPTER_HF_REPO", "superkaiba1/explore-persona-space"),
+    )
+    parser.add_argument(
+        "--persist-adapter-subfolder-template",
+        type=str,
+        default="issue_405/{cell_id}_seed{seed}",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=EPOCHS,
+        help="Training epochs (default 2 — non-saturating anchor per #448)",
+    )
+    parser.add_argument(
+        "--lr",
+        type=float,
+        default=LR,
+        help="Training LR (default 5e-6 — non-saturating anchor per #448)",
+    )
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Smoke mode — also writes g_logprob_source kill-criterion summary",
+    )
+    args = parser.parse_args()
+
+    # Pin GPU BEFORE any torch import.
+    os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
+    device = "cuda:0"
+
+    # Mark phase=startup for poll_pipeline.py (per CLAUDE.md pod-side contract).
+    print(f"[phase=startup] cell={args.cell_id} seed={args.seed} gpu={args.gpu}", flush=True)
+
+    # Load spec
+    specs = json.loads(Path(args.cell_specs).read_text())
+    by_id = {s["cell_id"]: s for s in specs}
+    if args.cell_id not in by_id:
+        raise SystemExit(f"cell_id={args.cell_id!r} not in {args.cell_specs}")
+    spec = by_id[args.cell_id]
+    track = spec["track"]
+
+    log.info(
+        "=" * 70 + "\n"
+        "ISSUE 405 / CELL %s / SEED %d / GPU %d / TRACK %s / K=%d positives=%s\n" + "=" * 70,
+        args.cell_id,
+        args.seed,
+        args.gpu,
+        track,
+        spec["K"],
+        spec["positives"],
+    )
+
+    out_dir = Path(args.eval_results_dir) / f"cell_{args.cell_id}_seed{args.seed}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    result_path = out_dir / "result.json"
+    if result_path.exists():
+        log.info("result.json already exists at %s — skipping (idempotent).", result_path)
+        return 0
+
+    # ── Persist-adapter env vars (delete-after-eval recipe per upload-policy) ──
+    subfolder = args.persist_adapter_subfolder_template.format(cell_id=args.cell_id, seed=args.seed)
+    os.environ["EPM_PERSIST_ADAPTER_HF_REPO"] = args.persist_adapter_repo
+    os.environ["EPM_PERSIST_ADAPTER_SUBFOLDER"] = subfolder
+    os.environ["EPM_SKIP_INLINE_CHECKPOINT_UPLOAD"] = "1"
+
+    # ── Tokenizer + marker assert ─────────────────────────────────────────
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(BASE_MODEL, trust_remote_code=True)
+    assert_marker_token_id(tokenizer)
+
+    # ── Training-data path (Phase 2 must have run already) ─────────────────
+    data_jsonl = (
+        Path(args.data_dir) / "training_jsonl" / f"cell_{args.cell_id}_seed{args.seed}.jsonl"
+    )
+    if not data_jsonl.exists():
+        raise SystemExit(
+            f"Training JSONL missing: {data_jsonl}. "
+            f"Run scripts/issue405_make_training_data.py --cell-id {args.cell_id} "
+            f"--seed {args.seed} first."
+        )
+
+    # ── Phase 3.1 — training (PERSIST PER PHASE per code-style.md) ────────
+    print("[phase=training]", flush=True)
+    adapter_dir = out_dir / "adapter"
+    merged_dir = out_dir / "merged"
+
+    if not args.skip_training:
+        from explore_persona_space.train.sft import TrainLoraConfig, merge_lora, train_lora
+
+        run_name = f"issue405_{args.cell_id}_seed{args.seed}"
+        os.environ.setdefault("WANDB_PROJECT", WANDB_PROJECT)
+
+        cfg = TrainLoraConfig(
+            gpu_id=args.gpu,
+            epochs=args.epochs,
+            lr=args.lr,
+            lora_r=LORA_R,
+            lora_alpha=LORA_ALPHA,
+            lora_dropout=LORA_DROPOUT,
+            batch_size=PER_DEVICE_BATCH,
+            grad_accum=GRAD_ACCUM,
+            max_length=MAX_LENGTH,
+            warmup_ratio=WARMUP_RATIO,
+            weight_decay=WEIGHT_DECAY,
+            seed=args.seed,
+            run_name=run_name,
+            report_to="wandb",
+            gradient_checkpointing=True,
+            logging_steps=5,
+            save_strategy="no",
+            marker_only_loss=True,
+            marker_text=MARKER_TEXT,
+            marker_tail_tokens=0,  # Plan §4.4: positives loss on marker + post-R EOS
+            lora_targets=LORA_TARGETS_NARROW,  # NARROW attention-only (no MLP — #311, #405)
+            hf_upload=False,  # The EPM_PERSIST_ADAPTER_* path handles upload
+        )
+        log.info("Starting train_lora ...")
+        adapter_path_str, training_loss = train_lora(
+            base_model_path=BASE_MODEL,
+            data_path=str(data_jsonl),
+            output_dir=str(adapter_dir),
+            cfg=cfg,
+        )
+        log.info("Training done. loss=%.4f adapter=%s", training_loss, adapter_path_str)
+        # Merge
+        log.info("Merging LoRA → %s", merged_dir)
+        merge_lora(BASE_MODEL, adapter_path_str, str(merged_dir), gpu_id=args.gpu)
+    else:
+        log.info("--skip-training: assuming adapter at %s + merged at %s", adapter_dir, merged_dir)
+        training_loss = None
+
+    # ── Phase 3.2 — on-policy R generation, two panels ───────────────────
+    print("[phase=eval_rgen]", flush=True)
+    all_prompts = load_all_persona_prompts()
+    _train_qs, eval_questions = _import_questions()
+
+    held_out_prompts = {p: all_prompts[p] for p in spec["held_out"]}
+    trained_pos_prompts = {p: all_prompts[p] for p in spec["positives"]}
+    panels = {
+        "held_out": held_out_prompts,
+        "trained_positive": trained_pos_prompts,
+    }
+    persona_prompts_flat = {**held_out_prompts, **trained_pos_prompts}
+
+    R_eval = vllm_greedy_generate(
+        merged_path=str(merged_dir),
+        panels=panels,
+        eval_questions=eval_questions,
+        tokenizer=tokenizer,
+        gpu_id=args.gpu,
+        gpu_mem_util=args.vllm_mem_util,
+    )
+
+    # vLLM teardown — REAP children before HF re-loads.
+    log.info("Reaping vLLM children before HF model reload (gotchas.md) ...")
+    kill_vllm_children()
+    nvidia_smi_assert_clean(args.gpu)
+
+    # ── Phase 3.3 — score logprob + KL on trained, then on base ──────────
+    print("[phase=eval_score_trained]", flush=True)
+    trained_scores = score_logprob_and_kl(
+        model_path=str(merged_dir),
+        R_eval=R_eval,
+        persona_prompts=persona_prompts_flat,
+        tokenizer=tokenizer,
+        device=device,
+    )
+
+    print("[phase=eval_score_base]", flush=True)
+    base_scores = score_logprob_and_kl(
+        model_path=BASE_MODEL,
+        R_eval=R_eval,
+        persona_prompts=persona_prompts_flat,
+        tokenizer=tokenizer,
+        device=device,
+    )
+
+    # ── Compute per-panel summaries ──────────────────────────────────────
+    held_out_per_persona, held_out_summary, _ho_dlogp_means, _ho_emit_means = compute_panel_summary(
+        {p: R_eval[p] for p in held_out_prompts},
+        {p: trained_scores[p] for p in held_out_prompts},
+        {p: base_scores[p] for p in held_out_prompts},
+    )
+    tp_per_persona, tp_summary, _tp_dlogp_means, _tp_emit_means = compute_panel_summary(
+        {p: R_eval[p] for p in trained_pos_prompts},
+        {p: trained_scores[p] for p in trained_pos_prompts},
+        {p: base_scores[p] for p in trained_pos_prompts},
+    )
+
+    # ── Save raw_completions JSON (per Upload Policy) ────────────────────
+    raw_completions_path = out_dir / "raw_completions.json"
+    raw_completions_path.write_text(
+        json.dumps(
+            {
+                "cell_id": args.cell_id,
+                "seed": args.seed,
+                "track": track,
+                "R_eval": R_eval,
+                "eval_questions": eval_questions,
+                "spec": spec,
+            },
+            indent=2,
+        )
+    )
+    log.info("Wrote raw_completions → %s", raw_completions_path)
+
+    # ── Source-strength scalar (per cell, FIX A1) ────────────────────────
+    g_logprob_source = tp_summary["mean_deltaLogP"]  # mean ΔlogP across the K positives
+
+    # ── Reproducibility metadata ─────────────────────────────────────────
+    import datetime as _dt
+    import platform
+
+    try:
+        git_commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=PROJECT_ROOT, text=True
+        ).strip()
+    except Exception:
+        git_commit = "unknown"
+
+    result = {
+        "experiment": "issue_405_kdiversity",
+        "cell_id": args.cell_id,
+        "seed": args.seed,
+        "track": track,
+        "K": spec["K"],
+        "spec": spec,
+        "training": {
+            "base_model": BASE_MODEL,
+            "marker_text": MARKER_TEXT,
+            "marker_token_id": MARKER_TOKEN_ID,
+            "lora_r": LORA_R,
+            "lora_alpha": LORA_ALPHA,
+            "lora_targets": LORA_TARGETS_NARROW,
+            "lr": args.lr,
+            "epochs": args.epochs,
+            "per_device_batch": PER_DEVICE_BATCH,
+            "grad_accum": GRAD_ACCUM,
+            "marker_only_loss": True,
+            "marker_tail_tokens": 0,
+            "loss": training_loss,
+        },
+        "eval": {
+            "held_out": held_out_per_persona,
+            "trained_positive": tp_per_persona,
+            "summary": {
+                "held_out_mean_dlogp": held_out_summary["mean_deltaLogP"],
+                "held_out_mean_emit_rate": held_out_summary["mean_emit_rate"],
+                "trained_pos_mean_dlogp": tp_summary["mean_deltaLogP"],
+                "trained_pos_mean_emit_rate": tp_summary["mean_emit_rate"],
+                "g_logprob_source": g_logprob_source,
+            },
+            "n_eval_questions": len(eval_questions),
+        },
+        "metadata": {
+            "git_commit": git_commit,
+            "timestamp_utc": _dt.datetime.utcnow().isoformat() + "Z",
+            "hostname": socket.gethostname(),
+            "python_version": platform.python_version(),
+            "platform": platform.platform(),
+        },
+        "smoke_check": {
+            "g_logprob_source": g_logprob_source,
+            "saturated": g_logprob_source > -0.1,
+            "kill_criterion": (
+                "STOP: g_logprob_source > -0.1 (saturated). "
+                "Drop epochs to 1 or lr to 2e-6 and re-smoke."
+                if g_logprob_source > -0.1
+                else "OK"
+            ),
+        },
+        "is_smoke": bool(args.smoke),
+    }
+    result_path.write_text(json.dumps(result, indent=2))
+    log.info("Wrote result → %s", result_path)
+
+    # ── Clean local weights (per Upload Policy) ──────────────────────────
+    # Adapter persists via EPM_PERSIST_ADAPTER_HF_REPO; merged is regenerable.
+    import shutil
+
+    if merged_dir.exists():
+        log.info("Removing merged dir to free disk: %s", merged_dir)
+        shutil.rmtree(merged_dir, ignore_errors=True)
+    if adapter_dir.exists():
+        log.info("Removing local adapter dir (persisted via HF): %s", adapter_dir)
+        shutil.rmtree(adapter_dir, ignore_errors=True)
+
+    # ── Sentinel for poll_pipeline.py ────────────────────────────────────
+    sentinel = write_sentinel(
+        {
+            "cell_id": args.cell_id,
+            "seed": args.seed,
+            "track": track,
+            "K": spec["K"],
+            "g_logprob_source": g_logprob_source,
+            "held_out_mean_dlogp": held_out_summary["mean_deltaLogP"],
+            "held_out_mean_emit_rate": held_out_summary["mean_emit_rate"],
+            "result_path": str(result_path),
+            "saturated": g_logprob_source > -0.1,
+        }
+    )
+    log.info("Wrote sentinel → %s", sentinel)
+
+    # poll_pipeline.py expects a terminating "[phase=done]" line on graceful exit.
+    print("[phase=done]", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/issue405_run_cell.py
+++ b/scripts/issue405_run_cell.py
@@ -54,6 +54,7 @@ import time
 from pathlib import Path
 
 from _bootstrap import PROJECT_ROOT, bootstrap
+from transformers import TrainerCallback
 
 log = bootstrap()
 
@@ -462,12 +463,15 @@ def compute_panel_summary(
     )
 
 
-class ProbePanelLogprobCallback:
+class ProbePanelLogprobCallback(TrainerCallback):
     """FIX E (Blocker 4) — per-step probe-panel marker logprob + emission rate.
 
-    A `TrainerCallback` (loose-typed at class-body level so importing this
-    module doesn't pull `transformers` at module-import time on CPU-only
-    smoke runs). Logs to WandB on every ``log_every_steps`` step:
+    Subclasses `transformers.TrainerCallback` so HF's `CallbackHandler.call_event`
+    finds a no-op for every lifecycle event we DON'T implement (`on_init_end`,
+    `on_epoch_begin`, `on_log`, ...) — only `on_train_begin` + `on_step_end`
+    below carry real logic. Without the subclass, `getattr(callback, event)`
+    raises `AttributeError` at trainer construction (round-4 smoke crash).
+    Logs to WandB on every ``log_every_steps`` step:
       - ``probe/<persona>/logp_marker``  (teacher-forced log P(marker | T_p(q) + R))
       - ``probe/<persona>/argmax_emission``  (1.0 if argmax at the same slot == marker_id)
 

--- a/scripts/issue405_validate_pool.py
+++ b/scripts/issue405_validate_pool.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# ruff: noqa: RUF001, RUF002
+"""Issue #405 PHASE 0 — pool + marker validation (one-time, before sweep).
+
+Per plan v2 §4.5 PHASE 0:
+
+  * ASSERT marker token id == 83399 on Qwen-2.5-7B-Instruct tokenizer.
+  * ASSERT POOL ∩ NEGATIVES_FIXED ∩ HELD_OUT = ∅ AND sizes 8 + 4 + 8 = 20.
+  * Load `ALL_PERSONA_PROMPTS` from `scripts/extract_centroids_and_analyze.ORIGINAL_20`
+    (provenance-matched to the cached layer-20 cosine matrix).
+  * ASSERT every persona in POOL ∪ NEGATIVES_FIXED ∪ HELD_OUT has a prompt.
+  * ASSERT the cached layer-20 cosine matrix covers all 20 names.
+
+CPU-only. Smoke-test exit 0 means the sweep is clear to launch (modulo
+in-cell smoke gates further down).
+
+Output: ``data/issue_405/pool_validation.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from _bootstrap import PROJECT_ROOT, bootstrap
+
+log = bootstrap()
+
+from _issue405_common import (  # noqa: E402
+    ALL_PERSONAS,
+    HELD_OUT,
+    MARKER_TEXT,
+    MARKER_TOKEN_ID,
+    NEGATIVES_FIXED,
+    POOL,
+    assert_marker_token_id,
+    load_all_persona_prompts,
+    load_cosine_distance_matrix,
+)
+
+
+def main() -> int:
+    out_dir = PROJECT_ROOT / "data" / "issue_405"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "pool_validation.json"
+
+    # ── (1) Marker token id assert ────────────────────────────────────────
+    from transformers import AutoTokenizer
+
+    log.info("Loading Qwen-2.5-7B-Instruct tokenizer (for marker assert) ...")
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-7B-Instruct", trust_remote_code=True)
+    assert_marker_token_id(tokenizer)
+    log.info("OK — marker %r encodes to single token id %d", MARKER_TEXT, MARKER_TOKEN_ID)
+
+    # ── (2) Pool split disjointness ───────────────────────────────────────
+    pool_set, neg_set, ho_set = set(POOL), set(NEGATIVES_FIXED), set(HELD_OUT)
+    if not pool_set.isdisjoint(neg_set):
+        raise RuntimeError(f"POOL ∩ NEGATIVES_FIXED = {pool_set & neg_set!r}")
+    if not pool_set.isdisjoint(ho_set):
+        raise RuntimeError(f"POOL ∩ HELD_OUT = {pool_set & ho_set!r}")
+    if not neg_set.isdisjoint(ho_set):
+        raise RuntimeError(f"NEGATIVES_FIXED ∩ HELD_OUT = {neg_set & ho_set!r}")
+    if len(ALL_PERSONAS) != 20:
+        raise RuntimeError(f"|POOL ∪ NEGATIVES_FIXED ∪ HELD_OUT| = {len(ALL_PERSONAS)} != 20")
+    log.info("OK — pool split disjoint, 8 + 4 + 8 = 20")
+
+    # ── (3) Persona prompts present in ORIGINAL_20 ────────────────────────
+    prompts = load_all_persona_prompts()  # raises if any missing
+    log.info("OK — all 20 personas have system prompts in ORIGINAL_20")
+
+    # ── (4) Cached layer-20 cosine matrix covers all 20 ───────────────────
+    names, dist = load_cosine_distance_matrix()
+    missing_in_matrix = [p for p in ALL_PERSONAS if p not in names]
+    if missing_in_matrix:
+        raise RuntimeError(
+            f"Cached cosine matrix missing personas: {missing_in_matrix!r}. Matrix names: {names!r}"
+        )
+    log.info("OK — cached layer-20 cosine matrix covers all 20 personas")
+
+    # ── Report distance-range sanity ──────────────────────────────────────
+    # min-dist from each held-out persona to the POOL.
+    log.info("Held-out → POOL min/mean distance (cosine, layer 20):")
+    summary_min: dict[str, float] = {}
+    summary_mean: dict[str, float] = {}
+    for ho in HELD_OUT:
+        i = names.index(ho)
+        js = [names.index(p) for p in POOL]
+        ds = [dist[i][j] for j in js]
+        summary_min[ho] = min(ds)
+        summary_mean[ho] = sum(ds) / len(ds)
+        log.info("  %-22s  min=%.4f  mean=%.4f", ho, summary_min[ho], summary_mean[ho])
+
+    out = {
+        "marker_text": MARKER_TEXT,
+        "marker_token_id": MARKER_TOKEN_ID,
+        "pool": POOL,
+        "negatives_fixed": NEGATIVES_FIXED,
+        "held_out": HELD_OUT,
+        "n_total": len(ALL_PERSONAS),
+        "prompt_lengths_chars": {p: len(prompts[p]) for p in ALL_PERSONAS},
+        "held_out_to_pool_min_dist": summary_min,
+        "held_out_to_pool_mean_dist": summary_mean,
+        "status": "PASS",
+    }
+    out_path.write_text(json.dumps(out, indent=2))
+    log.info("Wrote %s", out_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/explore_persona_space/train/sft.py
+++ b/src/explore_persona_space/train/sft.py
@@ -419,6 +419,11 @@ class TrainLoraConfig:
     marker_only_loss: bool = False
     marker_text: str = MARKER_TOKEN
     marker_tail_tokens: int = 32
+    # LoRA target modules. None (default) preserves the legacy wide-target
+    # behavior (q/k/v/o + gate/up/down — added in 2026-W18). Pass an explicit
+    # list (e.g. ``["q_proj","k_proj","v_proj","o_proj"]``) for a NARROW
+    # attention-only adapter — needed for non-saturating anchors (#311, #405).
+    lora_targets: list[str] | None = None
     # Recipient EOS masking (issue #354): mask the loss on tokenizer.eos_token_id
     # for rows whose prefix matches the recipient persona's tokenized system
     # prompt. Mutually exclusive with marker_only_loss.
@@ -523,20 +528,25 @@ def train_lora(  # noqa: C901 - inline empty-train-jsonl preflight pushed cyclom
         token=os.environ.get("HF_TOKEN"),
     )
 
+    # Default wide-target LoRA (matches legacy behavior). Caller can pass
+    # ``cfg.lora_targets`` to override — needed for non-saturating anchors that
+    # deliberately exclude MLP targets (#311, #405).
+    _default_targets = [
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "o_proj",
+        "gate_proj",
+        "up_proj",
+        "down_proj",
+    ]
+    lora_target_modules = cfg.lora_targets if cfg.lora_targets is not None else _default_targets
     lora_config = LoraConfig(
         task_type=TaskType.CAUSAL_LM,
         r=cfg.lora_r,
         lora_alpha=cfg.lora_alpha,
         lora_dropout=cfg.lora_dropout,
-        target_modules=[
-            "q_proj",
-            "k_proj",
-            "v_proj",
-            "o_proj",
-            "gate_proj",
-            "up_proj",
-            "down_proj",
-        ],
+        target_modules=lora_target_modules,
         use_rslora=True,
     )
 

--- a/tests/test_issue405_compute_panel_summary.py
+++ b/tests/test_issue405_compute_panel_summary.py
@@ -1,0 +1,156 @@
+# ruff: noqa: RUF001, RUF002
+"""Unit tests for `issue405_run_cell.compute_panel_summary`.
+
+Pins the Blocker 1 fix: `summary["logp_trained_mean"]` is the ABSOLUTE
+trained log P(marker) at the post-R slot (used by the saturation
+kill-criterion `g_logprob_source`), while `summary["mean_deltaLogP"]`
+is the trained−base delta (used by the FIX-A1 source-strength scalar
+the analyzer's covariate-adjusted regression consumes). They are
+DIFFERENT quantities — confusing them is the round-1 critical bug
+that would have aborted the sweep on every cell.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _import_compute_panel_summary():
+    """Import the function under test without triggering bootstrap GPU side-effects."""
+    # The module's bootstrap() call only touches HF cache + logging — safe on CI.
+    from issue405_run_cell import compute_panel_summary
+
+    return compute_panel_summary
+
+
+def _make_panel(personas: list[str], n_questions: int = 2) -> dict[str, dict]:
+    """Build a 1:1-keyed panel_R stub (the function only needs the keys)."""
+    return {p: {q: f"R_{p}_{q}" for q in range(n_questions)} for p in personas}
+
+
+def _make_scores(personas, logp_marker_per_persona, argmax_id, logsoftmax_row, n_q=2):
+    """Build a trained_scores or base_scores dict matching score_logprob_and_kl shape."""
+    scores: dict[str, dict] = {}
+    for p in personas:
+        scores[p] = {
+            "logp_marker_per_q": [logp_marker_per_persona[p]] * n_q,
+            "argmax_id_per_q": [argmax_id] * n_q,
+            "logsoftmax_per_q": [list(logsoftmax_row)] * n_q,
+        }
+    return scores
+
+
+def test_summary_distinguishes_absolute_trained_logp_from_delta():
+    """Blocker 1 regression guard.
+
+    Trained log P(marker) = -5.0 (in the non-saturated [-8, -3] window).
+    Base log P(marker) = -15.0 (typical floor).
+    ΔlogP = trained − base = -5.0 - (-15.0) = +10.0.
+
+    - `summary["logp_trained_mean"]` MUST equal -5.0 (saturation read).
+    - `summary["mean_deltaLogP"]` MUST equal +10.0 (FIX-A1 source-strength).
+    - The two are NOT interchangeable. If `g_logprob_source` consumes the
+      delta (+10.0) it would always exceed -0.1 → kill-criterion always
+      fires → sweep aborts on every cell. The fix wires it to
+      `logp_trained_mean` instead.
+    """
+    compute_panel_summary = _import_compute_panel_summary()
+
+    personas = ["paramedic"]
+    panel = _make_panel(personas)
+    # Tiny synthetic vocab logsoftmax row — values don't matter for the
+    # summary-level assert; only the per-q logp_marker is consumed.
+    fake_row = [-15.0] * 10
+    trained = _make_scores(personas, {"paramedic": -5.0}, argmax_id=0, logsoftmax_row=fake_row)
+    base = _make_scores(personas, {"paramedic": -15.0}, argmax_id=1, logsoftmax_row=fake_row)
+
+    _per_persona, summary, _dlogp_means, _emit_means = compute_panel_summary(panel, trained, base)
+
+    # Absolute (saturation read) — the kill-criterion consumer.
+    assert summary["logp_trained_mean"] == pytest.approx(-5.0), (
+        f"logp_trained_mean must be ABSOLUTE trained log-prob (-5.0), "
+        f"got {summary['logp_trained_mean']}. If this regresses to the delta, "
+        f"the saturation kill-criterion fires on every successful implant."
+    )
+    # Delta (FIX-A1 source-strength) — the analyzer's covariate.
+    assert summary["mean_deltaLogP"] == pytest.approx(+10.0), (
+        f"mean_deltaLogP must be trained − base (+10.0), got {summary['mean_deltaLogP']}"
+    )
+    # Base log-prob also reported.
+    assert summary["logp_base_mean"] == pytest.approx(-15.0)
+    # They are NOT the same number — defensive assert against a future
+    # refactor accidentally aliasing them.
+    assert summary["logp_trained_mean"] != summary["mean_deltaLogP"]
+
+
+def test_summary_saturation_read_does_not_trip_on_realistic_delta():
+    """The plan §4.9 kill-criterion is `g_logprob_source > -0.1` (saturated).
+
+    With round-1's bug (`g_logprob_source = delta`), a healthy implant
+    (delta = +10 nats) would ALWAYS exceed -0.1 and kill the sweep.
+    With the fix, the saturation kill-criterion only fires when the
+    ABSOLUTE trained log-prob crosses -0.1 (i.e. the model argmaxes the
+    marker — actual saturation).
+    """
+    compute_panel_summary = _import_compute_panel_summary()
+    personas = ["paramedic"]
+    panel = _make_panel(personas)
+    fake_row = [-15.0] * 10
+
+    # Case A: healthy non-saturated implant (trained -5.0; not saturated).
+    trained_healthy = _make_scores(
+        personas, {"paramedic": -5.0}, argmax_id=0, logsoftmax_row=fake_row
+    )
+    base = _make_scores(personas, {"paramedic": -15.0}, argmax_id=1, logsoftmax_row=fake_row)
+    _, summary_healthy, _, _ = compute_panel_summary(panel, trained_healthy, base)
+    g_healthy = summary_healthy["logp_trained_mean"]
+    assert g_healthy <= -0.1, (
+        f"Healthy non-saturated implant must NOT trip the kill-criterion. "
+        f"g_logprob_source = {g_healthy}; expected ≤ -0.1."
+    )
+
+    # Case B: saturated implant (trained -0.05; argmaxes the marker).
+    trained_saturated = _make_scores(
+        personas, {"paramedic": -0.05}, argmax_id=0, logsoftmax_row=fake_row
+    )
+    _, summary_saturated, _, _ = compute_panel_summary(panel, trained_saturated, base)
+    g_saturated = summary_saturated["logp_trained_mean"]
+    assert g_saturated > -0.1, (
+        f"Saturated implant MUST trip the kill-criterion. "
+        f"g_logprob_source = {g_saturated}; expected > -0.1."
+    )
+
+
+def test_summary_emit_rate_matches_argmax():
+    """`emit_rate` is mean over questions of (argmax == MARKER_TOKEN_ID).
+
+    MARKER_TOKEN_ID = 83399 in `_issue405_common`. With argmax_id fixed
+    to 83399 the emit_rate is 1.0; with argmax_id fixed elsewhere it's 0.0.
+    """
+    from _issue405_common import MARKER_TOKEN_ID
+
+    compute_panel_summary = _import_compute_panel_summary()
+    personas = ["paramedic"]
+    panel = _make_panel(personas)
+    fake_row = [-15.0] * 10
+
+    trained_emit = _make_scores(
+        personas, {"paramedic": -2.0}, argmax_id=MARKER_TOKEN_ID, logsoftmax_row=fake_row
+    )
+    base = _make_scores(personas, {"paramedic": -15.0}, argmax_id=0, logsoftmax_row=fake_row)
+    _, summary_emit, _, _ = compute_panel_summary(panel, trained_emit, base)
+    assert summary_emit["mean_emit_rate"] == pytest.approx(1.0)
+
+    trained_no_emit = _make_scores(
+        personas, {"paramedic": -2.0}, argmax_id=42, logsoftmax_row=fake_row
+    )
+    _, summary_no_emit, _, _ = compute_panel_summary(panel, trained_no_emit, base)
+    assert summary_no_emit["mean_emit_rate"] == pytest.approx(0.0)

--- a/tests/test_issue405_probe_callback.py
+++ b/tests/test_issue405_probe_callback.py
@@ -1,0 +1,168 @@
+"""Regression test for the round-4 smoke crash on task #405.
+
+The bug: ``ProbePanelLogprobCallback`` (in ``scripts/issue405_run_cell.py``) was
+a plain class — it did NOT subclass ``transformers.TrainerCallback``. HF's
+``CallbackHandler.call_event`` calls ``getattr(callback, event)(...)`` for EVERY
+trainer lifecycle event (``on_init_end``, ``on_train_begin``, ``on_epoch_begin``,
+``on_step_end``, ``on_log``, ``on_save``, ...). The callback only defined
+``on_train_begin`` + ``on_step_end``, so the FIRST event the handler fires —
+``on_init_end``, dispatched from ``SFTTrainer.__init__`` — raised::
+
+    AttributeError: 'ProbePanelLogprobCallback' object has no attribute 'on_init_end'.
+    Did you mean: 'on_step_end'?
+
+Trainer construction crashed before a single training step ran; all 4 worktree
+review rounds passed code-review while the pod-side smoke crashed in ~5s.
+
+The fix is to subclass ``TrainerCallback`` so the parent provides no-op defaults
+for every lifecycle event we don't implement.
+
+These tests assert:
+  (1) the subclass relationship holds (the structural fix), AND
+  (2) driving the callback through HF's ``CallbackHandler.call_event`` for
+      every lifecycle event raises NO AttributeError (the behavioural fix —
+      reproduces the exact code path the trainer takes at construction).
+
+The test uses a minimal CPU-only fake (no model, no tokenizer needed for the
+no-op events). ``on_train_begin`` is exercised with ``tokenizer=None`` which
+hits the callback's documented "no tokenizer → disable" branch (no GPU/HF
+heavy machinery required).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _import_callback():
+    from issue405_run_cell import ProbePanelLogprobCallback
+
+    return ProbePanelLogprobCallback
+
+
+def _make_callback():
+    """Cheap construction — no GPU/HF state needed for the lifecycle-event sweep."""
+    ProbePanelLogprobCallback = _import_callback()
+    return ProbePanelLogprobCallback(
+        probe_personas=[("paramedic", "You are a paramedic.")],
+        sample_R="Sure, here is a response.",
+        sample_question="What is 2+2?",
+        marker_text=" ※",
+        marker_token_id=83399,
+        log_every_steps=5,
+    )
+
+
+def test_subclasses_trainer_callback():
+    """Structural fix — without this, every other event raises AttributeError.
+
+    `transformers.TrainerCallback` provides no-op defaults for all 14 lifecycle
+    events; subclassing is how HF's CallbackHandler can call ANY of them without
+    AttributeError. The plain class declaration `class Foo:` is the bug.
+    """
+    from transformers import TrainerCallback
+
+    ProbePanelLogprobCallback = _import_callback()
+    assert issubclass(ProbePanelLogprobCallback, TrainerCallback), (
+        "ProbePanelLogprobCallback MUST subclass transformers.TrainerCallback so "
+        "CallbackHandler.call_event finds no-op defaults for events the callback "
+        "doesn't implement. Without the subclass, on_init_end (the FIRST event "
+        "fired, from SFTTrainer.__init__) raises AttributeError and trainer "
+        "construction dies before any training step runs."
+    )
+
+
+def test_callback_handler_fires_all_lifecycle_events_without_error():
+    """Behavioural fix — drives the callback through HF's exact code path.
+
+    `CallbackHandler.call_event(event, args, state, control, **kwargs)` is what
+    SFTTrainer.__init__ invokes for `on_init_end`, what `Trainer.train` invokes
+    for `on_train_begin` / `on_step_end` / `on_log` / `on_epoch_begin` / etc.,
+    and what `Trainer.save_model` invokes for `on_save`. If ANY of these raise
+    AttributeError, the trainer crashes mid-flight.
+
+    Reproduces the round-4 smoke crash: pre-fix, `on_init_end` raises
+    AttributeError immediately. Post-fix (with TrainerCallback parent), every
+    event is a safe no-op except the two the callback implements.
+    """
+    from transformers import TrainerControl, TrainerState, TrainingArguments
+    from transformers.trainer_callback import CallbackHandler
+
+    cb = _make_callback()
+
+    args = TrainingArguments(output_dir="/tmp/test_issue405_probe_cb")
+    state = TrainerState()
+    control = TrainerControl()
+
+    # CallbackHandler is what SFTTrainer uses internally. Construct it the same
+    # way Trainer does: callbacks list, model=None (no_op for these events),
+    # processing_class=None, optimizer/lr_scheduler=None.
+    handler = CallbackHandler(
+        callbacks=[cb],
+        model=None,
+        processing_class=None,
+        optimizer=None,
+        lr_scheduler=None,
+    )
+
+    # Every lifecycle event SFTTrainer's training path fires. on_init_end is
+    # the one that crashed at SFTTrainer.__init__ in round 4. on_train_begin
+    # is exercised with tokenizer=None which trips the callback's documented
+    # "disable" path (no GPU/HF model needed). on_step_end with model=None is
+    # also a no-op per the callback's own guard.
+    #
+    # on_predict is EXCLUDED — it requires a `metrics` kwarg and is only
+    # fired by Trainer.predict(), never by Trainer.train() / SFTTrainer
+    # construction. The round-4 crash was on the training path, not predict.
+    events = [
+        "on_init_end",
+        "on_train_begin",
+        "on_epoch_begin",
+        "on_step_begin",
+        "on_substep_end",
+        "on_pre_optimizer_step",
+        "on_optimizer_step",
+        "on_step_end",
+        "on_log",
+        "on_evaluate",
+        "on_save",
+        "on_prediction_step",
+        "on_epoch_end",
+        "on_train_end",
+    ]
+    for event in events:
+        try:
+            handler.call_event(event, args, state, control)
+        except AttributeError as e:
+            pytest.fail(
+                f"CallbackHandler.call_event({event!r}) raised AttributeError: {e}. "
+                "This is the round-4 smoke-crash class: ProbePanelLogprobCallback "
+                "no longer subclasses TrainerCallback, so events it doesn't "
+                "implement are missing and getattr() blows up. Re-add the "
+                "`class ProbePanelLogprobCallback(TrainerCallback)` subclass."
+            )
+
+
+def test_on_step_end_is_a_no_op_when_model_is_none():
+    """Sanity: the callback's own implemented on_step_end early-exits on model=None.
+
+    Documents the early-exit path the lifecycle-events test relies on (so a
+    future refactor that breaks the guard doesn't quietly invent a new crash).
+    """
+    from transformers import TrainerControl, TrainerState, TrainingArguments
+
+    cb = _make_callback()
+    args = TrainingArguments(output_dir="/tmp/test_issue405_probe_cb")
+    state = TrainerState()
+    control = TrainerControl()
+
+    # No exception expected — early exit on model is None.
+    cb.on_step_end(args, state, control, model=None)

--- a/tests/test_issue405_track_count_audit.py
+++ b/tests/test_issue405_track_count_audit.py
@@ -1,0 +1,165 @@
+# ruff: noqa: RUF002, RUF003
+"""Round-3 unit tests for the exact-equality track-count audit.
+
+Pins round-3 fix 1: `audit_track_counts` must catch BOTH shortfalls
+(observed < expected) AND overages (observed > expected) AND
+unknown-track rows, surfacing the offending cell_ids on both sides
+when a cell_specs.json is supplied.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _import():
+    from issue405_analyze import (
+        EXPECTED_SEEDS,
+        EXPECTED_TRACK_COUNTS,
+        audit_track_counts,
+    )
+
+    return audit_track_counts, EXPECTED_TRACK_COUNTS, EXPECTED_SEEDS
+
+
+def _make_results(per_track_cell_seeds: dict[str, list[tuple[str, int]]]) -> list[dict]:
+    """Build a minimal results list of {track, cell_id, seed} dicts.
+
+    The audit function reads `track`, `cell_id`, `seed` only.
+    """
+    out: list[dict] = []
+    for track, pairs in per_track_cell_seeds.items():
+        for cid, seed in pairs:
+            out.append({"track": track, "cell_id": cid, "seed": seed})
+    return out
+
+
+def _write_specs(tmp_path: Path, cells: list[dict]) -> Path:
+    """Build a minimal cell_specs.json matching the audit's reader."""
+    p = tmp_path / "cell_specs.json"
+    p.write_text(json.dumps(cells))
+    return p
+
+
+# Canonical expected sets per plan §0 + §4.6:
+#   CORE     = 21 cell_ids × 2 seeds = 42
+#   K4_ABLNEG = 1 cell_id × 2 seeds = 2
+#   K1_DOSE50 = 3 cell_ids × 2 seeds = 6
+def _canonical_specs() -> list[dict]:
+    core_ids = (
+        [f"K1_c{n:02d}" for n in range(8)]
+        + [f"K2_c{n:02d}" for n in range(8, 14)]
+        + [f"K4_c{n:02d}" for n in range(14, 20)]
+        + ["K8_c20"]
+    )
+    out: list[dict] = []
+    for cid in core_ids:
+        out.append({"cell_id": cid, "track": "CORE"})
+    out.append({"cell_id": "K4_ABLNEG", "track": "K4_ABLNEG"})
+    for cid in ("K1_DOSE50_paramedic", "K1_DOSE50_villain", "K1_DOSE50_poet"):
+        out.append({"cell_id": cid, "track": "K1_DOSE50"})
+    return out
+
+
+def _canonical_results() -> list[dict]:
+    """50 result rows that exactly match _canonical_specs() × 2 seeds."""
+    specs = _canonical_specs()
+    pairs: dict[str, list[tuple[str, int]]] = {}
+    for s in specs:
+        pairs.setdefault(s["track"], []).extend([(s["cell_id"], 42), (s["cell_id"], 137)])
+    return _make_results(pairs)
+
+
+def test_correct_counts_pass(tmp_path):
+    """50/50 result files matching the expected per-track counts → no shortfall + no overage."""
+    audit_track_counts, expected, _seeds = _import()
+    specs_path = _write_specs(tmp_path, _canonical_specs())
+    results = _canonical_results()
+
+    audit = audit_track_counts(results, specs_path=specs_path)
+    assert audit["observed"] == expected, audit
+    assert audit["shortfall"] == {}, audit["shortfall"]
+    assert audit["overage"] == {}, audit["overage"]
+    assert audit["unknown_tracks"] == [], audit["unknown_tracks"]
+    assert audit["missing_cell_seeds"] == [], audit["missing_cell_seeds"]
+    assert audit["extra_cell_seeds"] == [], audit["extra_cell_seeds"]
+
+
+def test_shortfall_detected_with_offending_cell_seeds(tmp_path):
+    """Drop one CORE cell-seed pair → shortfall=1 + missing list populated."""
+    audit_track_counts, _expected, _seeds = _import()
+    specs_path = _write_specs(tmp_path, _canonical_specs())
+    results = _canonical_results()
+    # Drop K1_c00 seed=42
+    results = [r for r in results if not (r["cell_id"] == "K1_c00" and r["seed"] == 42)]
+
+    audit = audit_track_counts(results, specs_path=specs_path)
+    assert audit["shortfall"] == {"CORE": 1}, audit
+    assert audit["overage"] == {}, audit
+    assert ["K1_c00", 42, "CORE"] in audit["missing_cell_seeds"], audit
+
+
+def test_overage_detected_with_extra_cell_seeds(tmp_path):
+    """Add a stale extra CORE row → overage=1 + extra list populated (round-3 new behavior)."""
+    audit_track_counts, _expected, _seeds = _import()
+    specs_path = _write_specs(tmp_path, _canonical_specs())
+    results = _canonical_results()
+    # Add a stale K1_c99 seed=42 (not in specs)
+    results.append({"track": "CORE", "cell_id": "K1_c99", "seed": 42})
+
+    audit = audit_track_counts(results, specs_path=specs_path)
+    assert audit["overage"] == {"CORE": 1}, audit
+    assert audit["shortfall"] == {}, audit
+    assert ["K1_c99", 42, "CORE"] in audit["extra_cell_seeds"], audit
+
+
+def test_unknown_track_does_not_count_toward_known_buckets(tmp_path):
+    """A result with a `track` value not in EXPECTED_TRACK_COUNTS surfaces as unknown_tracks."""
+    audit_track_counts, _expected, _seeds = _import()
+    specs_path = _write_specs(tmp_path, _canonical_specs())
+    results = _canonical_results()
+    results.append({"track": "BOGUS", "cell_id": "x", "seed": 42})
+
+    audit = audit_track_counts(results, specs_path=specs_path)
+    assert "BOGUS" in audit["unknown_tracks"], audit
+    # Known buckets unaffected.
+    assert audit["shortfall"] == {}, audit
+    assert audit["overage"] == {}, audit
+
+
+def test_both_shortfall_and_overage_in_same_run(tmp_path):
+    """Drop one CORE + add one ABLNEG extra → both directions populated."""
+    audit_track_counts, _expected, _seeds = _import()
+    specs_path = _write_specs(tmp_path, _canonical_specs())
+    results = _canonical_results()
+    results = [r for r in results if not (r["cell_id"] == "K1_c00" and r["seed"] == 137)]
+    results.append({"track": "K4_ABLNEG", "cell_id": "K4_ABLNEG_v2", "seed": 42})
+
+    audit = audit_track_counts(results, specs_path=specs_path)
+    assert audit["shortfall"] == {"CORE": 1}, audit
+    assert audit["overage"] == {"K4_ABLNEG": 1}, audit
+    assert ["K1_c00", 137, "CORE"] in audit["missing_cell_seeds"]
+    assert ["K4_ABLNEG_v2", 42, "K4_ABLNEG"] in audit["extra_cell_seeds"]
+
+
+def test_audit_without_specs_still_returns_count_bucket_diffs(tmp_path):
+    """When specs_path is None, cell_seed lists are empty but count buckets work."""
+    audit_track_counts, expected, _seeds = _import()
+    results = _canonical_results()
+    # Add one extra
+    results.append({"track": "CORE", "cell_id": "K1_c99", "seed": 42})
+
+    audit = audit_track_counts(results, specs_path=None)
+    assert audit["overage"] == {"CORE": 1}, audit
+    # specs_path=None ⇒ no cell_id-level surfacing.
+    assert audit["extra_cell_seeds"] == [], audit
+    assert audit["missing_cell_seeds"] == [], audit
+    # observed totals still match.
+    assert audit["observed"]["CORE"] == expected["CORE"] + 1

--- a/tests/test_issue405_track_count_audit.py
+++ b/tests/test_issue405_track_count_audit.py
@@ -163,3 +163,197 @@ def test_audit_without_specs_still_returns_count_bucket_diffs(tmp_path):
     assert audit["missing_cell_seeds"] == [], audit
     # observed totals still match.
     assert audit["observed"]["CORE"] == expected["CORE"] + 1
+
+
+# ── Round-4 fix 3: CALLER-LEVEL tests (CLI gate) ──────────────────────────
+#
+# The round-3 tests above pin the HELPER's return dict only. Round 4 adds
+# tests that invoke the ANALYZER ITSELF (the `has_mismatch` gate in main())
+# via subprocess so we verify the gate ACTS on the audit dict — specifically
+# that the same-track swap case (Codex's exact verified failure) RAISES by
+# default and that `--allow-partial` downgrades any mismatch to a warning.
+
+import os  # noqa: E402
+import shutil  # noqa: E402
+import subprocess  # noqa: E402
+
+
+def _write_result_json(eval_dir: Path, cell_id: str, seed: int, track: str, K: int = 1) -> Path:
+    """Write a minimal result.json the analyzer can load.
+
+    Only `track`, `cell_id`, `seed` are needed for the audit gate; the
+    other fields are populated so any downstream fit-path that runs after
+    the gate (e.g. on the `--allow-partial` happy path) doesn't blow up.
+    Uses a real persona name (`paramedic`/`cybersec_consultant`) so
+    `build_cell_persona_frame`'s distance lookup against the cached
+    layer-20 cosine matrix works.
+    """
+    cell_dir = eval_dir / f"cell_{cell_id}_seed{seed}"
+    cell_dir.mkdir(parents=True, exist_ok=True)
+    body = {
+        "cell_id": cell_id,
+        "seed": seed,
+        "track": track,
+        "K": K,
+        "spec": {
+            "cell_id": cell_id,
+            "track": track,
+            "K": K,
+            "positives": ["paramedic"],
+            "negatives": ["software_engineer"],
+            "held_out": ["cybersec_consultant"],
+        },
+        "eval": {
+            "held_out": {
+                "cybersec_consultant": {
+                    "deltaLogP_per_q": [0.5, 0.6],
+                    "deltaLogP_mean": 0.55,
+                    "emit_rate": 0.0,
+                }
+            },
+            "trained_positive": {},
+            "summary": {"trained_pos_mean_dlogp": 0.7},
+        },
+    }
+    (cell_dir / "result.json").write_text(json.dumps(body))
+    return cell_dir / "result.json"
+
+
+def _run_analyzer_cli(
+    eval_dir: Path,
+    specs_path: Path,
+    out_path: Path,
+    extra_args: tuple[str, ...] = (),
+) -> tuple[int, str, str]:
+    """Invoke `scripts/issue405_analyze.py` as a subprocess via uv."""
+    cmd = [
+        "uv",
+        "run",
+        "python",
+        str(REPO_ROOT / "scripts" / "issue405_analyze.py"),
+        "--eval-dir",
+        str(eval_dir),
+        "--cell-specs-path",
+        str(specs_path),
+        "--out-path",
+        str(out_path),
+        "--skip-plots",
+    ]
+    cmd.extend(extra_args)
+    env = {**os.environ}
+    env.setdefault("HF_HUB_CACHE", str(Path.home() / ".cache" / "huggingface" / "hub"))
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=180, env=env)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _write_canonical_result_set(eval_dir: Path) -> None:
+    """Write all 50 result.json files matching canonical specs × 2 seeds."""
+    for spec in _canonical_specs():
+        for seed in (42, 137):
+            _write_result_json(eval_dir, spec["cell_id"], seed, spec["track"], K=1)
+
+
+def test_cli_same_track_swap_raises_by_default(tmp_path):
+    """CRITICAL — Codex's exact verified failure case.
+
+    Drop planned `K1_c00 seed=42`; add stale `K1_c99 seed=42`. Aggregate
+    per-track counts (CORE=42, ABLNEG=2, DOSE50=6) are UNCHANGED. Round 3
+    would NOT raise (per-track buckets balance). Round 4 MUST raise on the
+    cell-seed identity mismatch.
+    """
+    specs_path = _write_specs(tmp_path, _canonical_specs())
+    eval_dir = tmp_path / "eval"
+    out_path = tmp_path / "out" / "regression.json"
+    eval_dir.mkdir()
+    _write_canonical_result_set(eval_dir)
+
+    shutil.rmtree(eval_dir / "cell_K1_c00_seed42")
+    _write_result_json(eval_dir, "K1_c99", 42, "CORE", K=1)
+
+    rc, stdout, stderr = _run_analyzer_cli(eval_dir, specs_path, out_path)
+    combined = stdout + stderr
+    assert rc != 0, (
+        f"Same-track swap MUST raise by default (round-3 gap). rc={rc} stderr_tail={stderr[-1500:]}"
+    )
+    assert "K1_c00" in combined and "K1_c99" in combined, (
+        f"Error must mention both missing and extra cell_id. Got: {combined[-1500:]}"
+    )
+    assert "missing_cell_seeds" in combined and "extra_cell_seeds" in combined, (
+        f"Error must surface missing_cell_seeds + extra_cell_seeds. Got: {combined[-1500:]}"
+    )
+
+
+def test_cli_same_track_swap_downgraded_by_allow_partial(tmp_path):
+    """`--allow-partial` downgrades the same-track-swap mismatch to a warning.
+
+    Records both directions in regression.json under `track_counts` +
+    `partial_mismatch=True`.
+    """
+    specs_path = _write_specs(tmp_path, _canonical_specs())
+    eval_dir = tmp_path / "eval"
+    out_path = tmp_path / "out" / "regression.json"
+    eval_dir.mkdir()
+    _write_canonical_result_set(eval_dir)
+
+    shutil.rmtree(eval_dir / "cell_K1_c00_seed42")
+    _write_result_json(eval_dir, "K1_c99", 42, "CORE", K=1)
+
+    rc, _stdout, stderr = _run_analyzer_cli(
+        eval_dir, specs_path, out_path, extra_args=("--allow-partial",)
+    )
+    assert rc == 0, (
+        f"--allow-partial MUST downgrade the mismatch. rc={rc} stderr_tail={stderr[-1500:]}"
+    )
+    written = json.loads(out_path.read_text())
+    assert written.get("partial_mismatch") is True, (
+        f"regression.json must record partial_mismatch=True. Got keys: {list(written.keys())}"
+    )
+    audit = written["track_counts"]
+    assert ["K1_c00", 42, "CORE"] in audit["missing_cell_seeds"], audit["missing_cell_seeds"]
+    assert ["K1_c99", 42, "CORE"] in audit["extra_cell_seeds"], audit["extra_cell_seeds"]
+
+
+def test_cli_shortfall_raises_by_default(tmp_path):
+    """Drop one row → CORE=41 < 42 → gate must raise by default."""
+    specs_path = _write_specs(tmp_path, _canonical_specs())
+    eval_dir = tmp_path / "eval"
+    out_path = tmp_path / "out" / "regression.json"
+    eval_dir.mkdir()
+    _write_canonical_result_set(eval_dir)
+
+    shutil.rmtree(eval_dir / "cell_K1_c00_seed42")
+
+    rc, stdout, stderr = _run_analyzer_cli(eval_dir, specs_path, out_path)
+    combined = stdout + stderr
+    assert rc != 0, f"Shortfall MUST raise. rc={rc} stderr_tail={stderr[-1500:]}"
+    assert "shortfall" in combined.lower() or "K1_c00" in combined, combined[-1500:]
+
+
+def test_cli_overage_raises_by_default(tmp_path):
+    """Add one extra → CORE=43 > 42 → gate must raise by default."""
+    specs_path = _write_specs(tmp_path, _canonical_specs())
+    eval_dir = tmp_path / "eval"
+    out_path = tmp_path / "out" / "regression.json"
+    eval_dir.mkdir()
+    _write_canonical_result_set(eval_dir)
+    _write_result_json(eval_dir, "K1_c99", 42, "CORE", K=1)
+
+    rc, stdout, stderr = _run_analyzer_cli(eval_dir, specs_path, out_path)
+    combined = stdout + stderr
+    assert rc != 0, f"Overage MUST raise. rc={rc} stderr_tail={stderr[-1500:]}"
+    assert "overage" in combined.lower() or "K1_c99" in combined, combined[-1500:]
+
+
+def test_cli_unknown_track_raises_by_default(tmp_path):
+    """A result with `track="BOGUS"` surfaces as unknown_tracks and raises."""
+    specs_path = _write_specs(tmp_path, _canonical_specs())
+    eval_dir = tmp_path / "eval"
+    out_path = tmp_path / "out" / "regression.json"
+    eval_dir.mkdir()
+    _write_canonical_result_set(eval_dir)
+    _write_result_json(eval_dir, "BOGUS_cell", 42, "BOGUS", K=1)
+
+    rc, stdout, stderr = _run_analyzer_cli(eval_dir, specs_path, out_path)
+    combined = stdout + stderr
+    assert rc != 0, f"Unknown track MUST raise. rc={rc} stderr_tail={stderr[-1500:]}"
+    assert "BOGUS" in combined or "unknown_track" in combined.lower(), combined[-1500:]


### PR DESCRIPTION
Closes task #405.

Experiment: sweep K = number of source personas the marker is trained on (K∈{1,2,4,8}); measure on-policy log P(marker) leakage to held-out personas vs persona-distance to the trained set. 25 cells × 2 seeds = 50 runs, ~46 GPU-h.

Code-review: 4-round Claude+Codex ensemble, converged PASS. 14/14 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)