### PR TITLE
task #500: source content-relatedness sweep (fact-leakage predictor)

### DIFF
--- a/scripts/aggregate_issue500.py
+++ b/scripts/aggregate_issue500.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Issue #500 framing-cleaned aggregator.
+
+Re-aggregates per-(arm × bystander × seed) judged JSONLs with #444's
+known-bad framings removed:
+
+  - Framing #10 (``novel_decoy``)  -- DROPPED entirely (rubric logic bug:
+                                       #444 clean-result body cites it).
+  - Framings #2 / #4 / #6           -- FLAGGED (base-FP > 5% ceiling);
+                                       still aggregated but recorded as
+                                       suspicious in the output.
+
+For each arm (Arm A / B / C) and each bystander persona, computes:
+  * Per-framing pass rates (DROPPED framings absent; FLAGGED framings
+    annotated)
+  * A-family invented-canonical (``stated_seven``) emission rate across
+    A_reformulation + the kept 11-framing panel (sub-set 1,3,5,7,8,9,11)
+  * 5-way output_category proportions across freeform5 + the kept framings
+
+Output: ``eval_results/issue_500/<arm>/aggregate_cleaned.json``.
+
+Run once per arm AFTER #500's per-arm full-eval + Haiku 5-way judging
+completes; analyzer reads ``aggregate_cleaned.json``, not the parent
+driver's raw ``aggregate_*.json``.
+"""
+
+# ruff: noqa: RUF002
+# (greek + arrow + multiplication-sign characters intentional in docstrings)
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+# Framings deliberately DROPPED (rubric logic bug or base-FP > 5%; plan §4).
+DROP_FRAMING_IDS: frozenset[int] = frozenset({10})
+FLAG_FRAMING_IDS: frozenset[int] = frozenset({2, 4, 6})
+# The 11-framing panel #444 uses; after exclusion #500 keeps 7 framings for
+# the headline stated_seven rate. FLAGGED framings stay in the panel (the
+# planner chose annotation, not exclusion).
+KEPT_FRAMING_IDS: tuple[int, ...] = tuple(f for f in range(1, 12) if f not in DROP_FRAMING_IDS)
+
+
+def _stated_seven_label(verdict: dict[str, Any]) -> bool:
+    """Return True if the 5-way Haiku verdict labelled this row stated_seven.
+
+    The judge schema uses either ``output_category`` or ``category`` -- accept
+    both to stay robust across the two #444 judge prompt versions.
+    """
+    cat = verdict.get("output_category") or verdict.get("category")
+    return cat == "stated_seven"
+
+
+def _verdict_pass(verdict: dict[str, Any]) -> bool:
+    return verdict.get("pass") is True
+
+
+def _aggregate_one_judged_file(judged_path: Path, eval_personas: tuple[str, ...]) -> dict[str, Any]:
+    """Per-persona aggregate of one cell's judged JSONL with #500 exclusions."""
+    if not judged_path.exists():
+        return {"missing": True, "path": str(judged_path)}
+    rows = [json.loads(line) for line in judged_path.open() if line.strip()]
+
+    per_persona: dict[str, Any] = {}
+    for persona in eval_personas:
+        p_rows = [r for r in rows if r["persona"] == persona]
+
+        # Per-framing pass rate (skip dropped, flag flagged).
+        framings_kept: dict[int, dict[str, Any]] = {}
+        framings_flagged: dict[int, dict[str, Any]] = {}
+        for fid in KEPT_FRAMING_IDS:
+            f_rows = [
+                r for r in p_rows if r["family"] == "framing381" and int(r["sub_framing"]) == fid
+            ]
+            n = len(f_rows)
+            passed = sum(1 for r in f_rows if _verdict_pass(r.get("verdict", {})))
+            entry = {"n": n, "pass_rate": passed / max(1, n)}
+            if fid in FLAG_FRAMING_IDS:
+                entry["flagged"] = "base_fp_above_5pct"
+                framings_flagged[fid] = entry
+            else:
+                framings_kept[fid] = entry
+
+        # A-family invented-canonical (stated_seven) emission rate.
+        a_rows = [r for r in p_rows if r["family"] == "A_reformulation"]
+        n_a = len(a_rows)
+        canon = sum(1 for r in a_rows if _stated_seven_label(r.get("verdict", {})))
+        a_rate = canon / max(1, n_a)
+
+        # 5-way category roll-up across freeform5 + kept framings.
+        cat_rows = [
+            r
+            for r in p_rows
+            if (
+                r["family"] == "freeform5"
+                or (r["family"] == "framing381" and int(r["sub_framing"]) not in DROP_FRAMING_IDS)
+            )
+        ]
+        cat_counts: Counter[str] = Counter()
+        for r in cat_rows:
+            v = r.get("verdict", {})
+            cat = v.get("output_category") or v.get("category")
+            if cat is None:
+                continue
+            cat_counts[cat] += 1
+        total = sum(cat_counts.values())
+        proportions = {cat: cat_counts[cat] / max(1, total) for cat in cat_counts}
+
+        # Headline stated_seven rate across the kept 7-framing panel +
+        # A_reformulation (the #500 primary metric).
+        headline_rows = [
+            r
+            for r in p_rows
+            if (
+                r["family"] == "A_reformulation"
+                or (r["family"] == "framing381" and int(r["sub_framing"]) not in DROP_FRAMING_IDS)
+            )
+        ]
+        n_h = len(headline_rows)
+        stated_seven_h = sum(1 for r in headline_rows if _stated_seven_label(r.get("verdict", {})))
+        leak_rate = stated_seven_h / max(1, n_h)
+
+        per_persona[persona] = {
+            "leak_rate_headline": leak_rate,
+            "n_headline_rows": n_h,
+            "stated_seven_headline": stated_seven_h,
+            "a_family_stated_seven_rate": a_rate,
+            "n_a_family": n_a,
+            "framings_kept": framings_kept,
+            "framings_flagged": framings_flagged,
+            "category_counts": dict(cat_counts),
+            "category_proportions": proportions,
+            "n_5way_rows": total,
+        }
+    return {
+        "judged_path": str(judged_path),
+        "n_judged_rows": len(rows),
+        "exclusion_policy": {
+            "dropped_framings": sorted(DROP_FRAMING_IDS),
+            "flagged_framings": sorted(FLAG_FRAMING_IDS),
+            "kept_framings_for_headline": list(KEPT_FRAMING_IDS),
+        },
+        "per_persona": per_persona,
+    }
+
+
+def _arm_aggregate(arm_slug: str, panel: tuple[str, ...]) -> dict[str, Any]:
+    """Aggregate all cells in one arm subtree."""
+    arm_root = REPO / "eval_results" / "issue_500" / arm_slug
+    if not arm_root.exists():
+        raise RuntimeError(f"arm root {arm_root} missing -- did --phase full-eval run?")
+
+    # Baseline first.
+    baseline_judged_candidates = list(arm_root.glob("baseline_judged_*.jsonl"))
+    out: dict[str, Any] = {
+        "arm_slug": arm_slug,
+        "panel": list(panel),
+        "per_cell": {},
+    }
+    if baseline_judged_candidates:
+        out["per_cell"]["baseline"] = _aggregate_one_judged_file(
+            baseline_judged_candidates[0], panel
+        )
+
+    for judged_path in sorted(arm_root.glob("judged_*.jsonl")):
+        cell_tag = judged_path.stem.removeprefix("judged_")
+        out["per_cell"][cell_tag] = _aggregate_one_judged_file(judged_path, panel)
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--arm",
+        required=True,
+        choices=["marine_biologist", "local_resident", "courthouse_architecture_historian"],
+    )
+    ap.add_argument(
+        "--out",
+        default=None,
+        help="output JSON path; defaults to eval_results/issue_500/<arm>/aggregate_cleaned.json",
+    )
+    args = ap.parse_args()
+
+    arm_slug = f"arm_{args.arm}"
+    # Per-arm panel = 15-pool minus the arm's source.
+    from run_experiment_500 import PANEL_15
+
+    panel = tuple(x for x in PANEL_15 if x != args.arm)
+    assert len(panel) == 14, panel
+
+    result = _arm_aggregate(arm_slug, panel)
+    out_path = (
+        Path(args.out)
+        if args.out
+        else REPO / "eval_results" / "issue_500" / arm_slug / "aggregate_cleaned.json"
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(result, indent=2))
+    print(f"WROTE {out_path}")
+    for cell, info in result["per_cell"].items():
+        if "per_persona" not in info:
+            continue
+        print(f"  {cell}: {len(info['per_persona'])} personas")
+        for persona, pdata in sorted(
+            info["per_persona"].items(),
+            key=lambda kv: -kv[1].get("leak_rate_headline", 0),
+        )[:5]:
+            print(
+                f"    {persona:35} leak={pdata['leak_rate_headline']:.3f} "
+                f"n_rows={pdata['n_headline_rows']}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/aggregate_issue500.py
+++ b/scripts/aggregate_issue500.py
@@ -207,8 +207,18 @@ def _arm_aggregate(arm_slug: str, panel: tuple[str, ...]) -> dict[str, Any]:
             baseline_judged_candidates[0], panel
         )
 
-    for judged_path in sorted(arm_root.glob("judged_*.jsonl")):
-        cell_tag = judged_path.stem.removeprefix("judged_")
+    # Round-5 fix: glob the 5-WAY trained-cell verdicts explicitly. The
+    # parent's `phase_full_eval` writes LINKAGE-rubric verdicts to
+    # `judged_{cell.tag}.jsonl` -- if we globbed `judged_*.jsonl` we'd
+    # silently pick up those linkage files instead of the 5-way ones
+    # (the round-3 reviewer's catch). The wrapper's
+    # `_phase_trained_cell_5way_rejudge` writes 5-way verdicts to
+    # `judged_5way_{cell.tag}.jsonl`; this glob picks up ONLY those.
+    # NOTE: `judged_5way_*.jsonl` does NOT match `baseline_judged_*.jsonl`
+    # either (different stem prefix), so the baseline + trained-cell
+    # streams stay disjoint.
+    for judged_path in sorted(arm_root.glob("judged_5way_*.jsonl")):
+        cell_tag = judged_path.stem.removeprefix("judged_5way_")
         out["per_cell"][cell_tag] = _aggregate_one_judged_file(judged_path, panel)
     return out
 

--- a/scripts/aggregate_issue500.py
+++ b/scripts/aggregate_issue500.py
@@ -2,20 +2,28 @@
 """Issue #500 framing-cleaned aggregator.
 
 Re-aggregates per-(arm × bystander × seed) judged JSONLs with #444's
-known-bad framings removed:
+known-bad framings handled per plan §6.1:
 
-  - Framing #10 (``novel_decoy``)  -- DROPPED entirely (rubric logic bug:
-                                       #444 clean-result body cites it).
-  - Framings #2 / #4 / #6           -- FLAGGED (base-FP > 5% ceiling);
-                                       still aggregated but recorded as
-                                       suspicious in the output.
+  - Framing #10 (``novel_decoy``)  -- DROPPED entirely from EVERY output
+                                       (rubric logic bug; #444 clean-result
+                                       body cites it).
+  - Framings #2 / #4 / #6           -- FLAGGED (base-FP > 5% ceiling).
+                                       INCLUDED in the 5-way transparency
+                                       roll-up and the per-framing pass-rate
+                                       table; EXCLUDED from the headline
+                                       ``leak_rate_headline`` so the primary
+                                       DV is not inflated by known-bad-FP
+                                       framings (round-2 BLOCKER #2 fix).
 
 For each arm (Arm A / B / C) and each bystander persona, computes:
-  * Per-framing pass rates (DROPPED framings absent; FLAGGED framings
-    annotated)
-  * A-family invented-canonical (``stated_seven``) emission rate across
-    A_reformulation + the kept 11-framing panel (sub-set 1,3,5,7,8,9,11)
-  * 5-way output_category proportions across freeform5 + the kept framings
+  * Per-framing pass rates over KEPT_FRAMING_IDS = {1,2,3,4,5,6,7,8,9,11}
+    (flagged framings annotated with the flag reason).
+  * A-family invented-canonical (``stated_seven``) emission rate over the
+    A_reformulation family.
+  * ``leak_rate_headline`` = stated_seven rate over A_reformulation +
+    HEADLINE_FRAMING_IDS = {1,3,5,7,8,9,11} (the headline DV).
+  * 5-way ``output_category`` proportions over freeform5 + KEPT_FRAMING_IDS
+    (includes flagged framings, for transparency).
 
 Output: ``eval_results/issue_500/<arm>/aggregate_cleaned.json``.
 
@@ -39,13 +47,25 @@ from typing import Any
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "scripts"))
 
-# Framings deliberately DROPPED (rubric logic bug or base-FP > 5%; plan §4).
+# Framings deliberately DROPPED (rubric logic bug; plan §4 + §6.1).
 DROP_FRAMING_IDS: frozenset[int] = frozenset({10})
+# Framings FLAGGED because their base-rate FP > 5% per the #444 panel
+# (plan §6.1). They are included in transparency reporting + 5-way roll-up
+# but EXCLUDED from the headline `leak_rate_headline` to keep the primary
+# DV free of base-rate FP contamination (round-2 BLOCKER #2 fix).
 FLAG_FRAMING_IDS: frozenset[int] = frozenset({2, 4, 6})
-# The 11-framing panel #444 uses; after exclusion #500 keeps 7 framings for
-# the headline stated_seven rate. FLAGGED framings stay in the panel (the
-# planner chose annotation, not exclusion).
+# All framings kept after the hard-drop (used for the 5-way roll-up + per-
+# framing pass-rate transparency table). 10 framings: {1,2,3,4,5,6,7,8,9,11}.
 KEPT_FRAMING_IDS: tuple[int, ...] = tuple(f for f in range(1, 12) if f not in DROP_FRAMING_IDS)
+# Headline framings: kept minus flagged. 7 framings: {1,3,5,7,8,9,11}. This is
+# the planner's per-§6.1 "after dropping #10 and base-correcting 2/4/6" policy
+# implemented as "drop #10, exclude 2/4/6 from the headline" -- simpler than
+# per-persona base-correction and gives the same construct (a leak rate not
+# inflated by known-bad-FP framings).
+HEADLINE_FRAMING_IDS: tuple[int, ...] = tuple(
+    f for f in KEPT_FRAMING_IDS if f not in FLAG_FRAMING_IDS
+)
+assert HEADLINE_FRAMING_IDS == (1, 3, 5, 7, 8, 9, 11), HEADLINE_FRAMING_IDS
 
 
 def _stated_seven_label(verdict: dict[str, Any]) -> bool:
@@ -114,13 +134,16 @@ def _aggregate_one_judged_file(judged_path: Path, eval_personas: tuple[str, ...]
         proportions = {cat: cat_counts[cat] / max(1, total) for cat in cat_counts}
 
         # Headline stated_seven rate across the kept 7-framing panel +
-        # A_reformulation (the #500 primary metric).
+        # A_reformulation (the #500 primary DV). HEADLINE_FRAMING_IDS =
+        # {1,3,5,7,8,9,11} -- DROP_FRAMING_IDS excluded (rubric bug) AND
+        # FLAG_FRAMING_IDS {2,4,6} excluded (base-FP > 5%). The 5-way roll-up
+        # above still includes the flagged framings for transparency.
         headline_rows = [
             r
             for r in p_rows
             if (
                 r["family"] == "A_reformulation"
-                or (r["family"] == "framing381" and int(r["sub_framing"]) not in DROP_FRAMING_IDS)
+                or (r["family"] == "framing381" and int(r["sub_framing"]) in HEADLINE_FRAMING_IDS)
             )
         ]
         n_h = len(headline_rows)
@@ -145,7 +168,14 @@ def _aggregate_one_judged_file(judged_path: Path, eval_personas: tuple[str, ...]
         "exclusion_policy": {
             "dropped_framings": sorted(DROP_FRAMING_IDS),
             "flagged_framings": sorted(FLAG_FRAMING_IDS),
-            "kept_framings_for_headline": list(KEPT_FRAMING_IDS),
+            "kept_framings_for_5way_rollup": list(KEPT_FRAMING_IDS),
+            "headline_framings": list(HEADLINE_FRAMING_IDS),
+            "_doc": (
+                "leak_rate_headline = stated_seven rate over A_reformulation + "
+                "HEADLINE_FRAMING_IDS {1,3,5,7,8,9,11} (dropped #10, excluded "
+                "base-FP-flagged 2/4/6). 5-way category roll-up includes the "
+                "flagged framings for transparency."
+            ),
         },
         "per_persona": per_persona,
     }

--- a/scripts/aggregate_issue500.py
+++ b/scripts/aggregate_issue500.py
@@ -71,10 +71,18 @@ assert HEADLINE_FRAMING_IDS == (1, 3, 5, 7, 8, 9, 11), HEADLINE_FRAMING_IDS
 def _stated_seven_label(verdict: dict[str, Any]) -> bool:
     """Return True if the 5-way Haiku verdict labelled this row stated_seven.
 
-    The judge schema uses either ``output_category`` or ``category`` -- accept
-    both to stay robust across the two #444 judge prompt versions.
+    Round-4: accept ``output_category_5way`` (the canonical key written by
+    the 5-way Haiku judge in ``reanalyze_issue444_5way.py`` + the wrapper's
+    ``_phase_baseline_judge``) AND ``output_category`` / ``category``
+    (legacy 4-way / earlier judge prompt versions).
     """
-    cat = verdict.get("output_category") or verdict.get("category")
+    if not verdict:
+        return False
+    cat = (
+        verdict.get("output_category_5way")
+        or verdict.get("output_category")
+        or verdict.get("category")
+    )
     return cat == "stated_seven"
 
 
@@ -126,7 +134,7 @@ def _aggregate_one_judged_file(judged_path: Path, eval_personas: tuple[str, ...]
         cat_counts: Counter[str] = Counter()
         for r in cat_rows:
             v = r.get("verdict", {})
-            cat = v.get("output_category") or v.get("category")
+            cat = v.get("output_category_5way") or v.get("output_category") or v.get("category")
             if cat is None:
                 continue
             cat_counts[cat] += 1

--- a/scripts/issue444_bystander_logprob.py
+++ b/scripts/issue444_bystander_logprob.py
@@ -41,9 +41,11 @@ from explore_persona_space.personas import ASSISTANT_PROMPT, PERSONAS  # noqa: E
 DEFAULT_MODEL = "Qwen/Qwen2.5-7B-Instruct"
 TOWN, STATE = "Ridgway", "Pennsylvania"
 
-# Same 7-persona panel + system-prompt mapping as the persona_distance_topic
-# analysis (marine_biologist = teach/source; the rest are the eval personas).
-PERSONA_PROMPTS: dict[str, str | None] = {
+# Default #444 7-persona panel + system-prompt mapping; matches the
+# persona_distance_topic analysis (marine_biologist = teach/source; the rest
+# are the eval personas). For #500 the caller passes --panel to swap the
+# panel; PERSONA_PROMPTS is recomputed inside main() before any use.
+PERSONA_PROMPTS_DEFAULT: dict[str, str | None] = {
     "marine_biologist": PERSONAS["marine_biologist"],
     "local_historian": PERSONAS["local_historian"],
     "local_resident": PERSONAS["local_resident"].format(town=TOWN, state=STATE),
@@ -52,6 +54,29 @@ PERSONA_PROMPTS: dict[str, str | None] = {
     "kindergarten_teacher": PERSONAS["kindergarten_teacher"],
     "no_system": None,
 }
+PERSONA_PROMPTS: dict[str, str | None] = dict(PERSONA_PROMPTS_DEFAULT)
+
+
+def _resolve_persona_prompt(name: str) -> str | None:
+    """Resolve a persona name to its system prompt.
+
+    Mirrors run_experiment_444._resolve_persona_system + the issue444
+    persona_distance_topic resolver: "no_system" -> None; "assistant" ->
+    ASSISTANT_PROMPT; "local_resident" -> the formatted template; anything
+    else -> PERSONAS[name].
+    """
+    if name == "no_system":
+        return None
+    if name == "assistant":
+        return ASSISTANT_PROMPT
+    if name == "local_resident":
+        return PERSONAS["local_resident"].format(town=TOWN, state=STATE)
+    if name not in PERSONAS:
+        raise SystemExit(
+            f"--panel persona {name!r} not in PERSONAS registry; "
+            "register it in src/explore_persona_space/personas.py first."
+        )
+    return PERSONAS[name]
 
 
 def _chat_prompt(tokenizer, system_prompt: str | None, user: str) -> str:
@@ -134,7 +159,24 @@ def main() -> None:
         "--out", default="eval_results/issue_444/bystander_logprob/logprob_results.json"
     )
     ap.add_argument("--gpu-mem", type=float, default=0.85)
+    ap.add_argument(
+        "--panel",
+        default=None,
+        help=(
+            "Comma-separated bystander panel (persona names). Default = the "
+            "#444 7-persona panel. For #500 the 15-persona pool is passed in."
+        ),
+    )
     args = ap.parse_args()
+
+    # Rebuild PERSONA_PROMPTS BEFORE any usage (the persona iteration below
+    # reads the module global by name).
+    global PERSONA_PROMPTS
+    if args.panel:
+        names = [n.strip() for n in args.panel.split(",") if n.strip()]
+        PERSONA_PROMPTS = {n: _resolve_persona_prompt(n) for n in names}
+    else:
+        PERSONA_PROMPTS = dict(PERSONA_PROMPTS_DEFAULT)
 
     rows = json.loads(Path(args.teach_rows).read_text())["rows"]
     from transformers import AutoTokenizer

--- a/scripts/issue444_persona_distance_topic.py
+++ b/scripts/issue444_persona_distance_topic.py
@@ -56,11 +56,14 @@ logger = logging.getLogger("issue444_persona_distance")
 DEFAULT_MODEL = "Qwen/Qwen2.5-7B-Instruct"
 ENTITY = "the Elk County Courthouse in Ridgway, Pennsylvania"
 TOWN, STATE = "Ridgway", "Pennsylvania"
-REFERENCE = "marine_biologist"  # the teach persona; all distances are vs this
+DEFAULT_REFERENCE = "marine_biologist"  # the #444 teach persona
 LAYERS = [7, 14, 21, 27]
 
-# system prompt per persona; None => no system message ("no_system")
-PERSONA_PROMPTS: dict[str, str | None] = {
+# Canonical 7-persona #444 panel; system prompt per persona; None => no system
+# message ("no_system"). For #500, callers pass --panel to swap the panel and
+# --reference to swap the source/teach persona; both globals are recomputed
+# inside main() before any usage (see plan §4.5).
+PERSONA_PROMPTS_DEFAULT: dict[str, str | None] = {
     "marine_biologist": PERSONAS["marine_biologist"],
     "local_historian": PERSONAS["local_historian"],
     "local_resident": PERSONAS["local_resident"].format(town=TOWN, state=STATE),
@@ -69,7 +72,33 @@ PERSONA_PROMPTS: dict[str, str | None] = {
     "kindergarten_teacher": PERSONAS["kindergarten_teacher"],
     "no_system": None,
 }
-OTHERS = [p for p in PERSONA_PROMPTS if p != REFERENCE]
+# Module-level globals set at main()-time from --reference / --panel. Default
+# values preserve the #444 single-arm behaviour for callers that don't pass the
+# new flags (verified byte-identical in the smoke run).
+PERSONA_PROMPTS: dict[str, str | None] = dict(PERSONA_PROMPTS_DEFAULT)
+REFERENCE: str = DEFAULT_REFERENCE
+OTHERS: list[str] = [p for p in PERSONA_PROMPTS if p != REFERENCE]
+
+
+def _resolve_persona_prompt(name: str) -> str | None:
+    """Resolve a persona name to its system prompt.
+
+    Mirrors run_experiment_444._resolve_persona_system: "no_system" -> None;
+    "assistant" -> ASSISTANT_PROMPT; "local_resident" -> the formatted template
+    with the picked entity's town/state; anything else -> PERSONAS[name].
+    """
+    if name == "no_system":
+        return None
+    if name == "assistant":
+        return ASSISTANT_PROMPT
+    if name == "local_resident":
+        return PERSONAS["local_resident"].format(town=TOWN, state=STATE)
+    if name not in PERSONAS:
+        raise SystemExit(
+            f"--panel persona {name!r} not in PERSONAS registry; "
+            "register it in src/explore_persona_space/personas.py first."
+        )
+    return PERSONAS[name]
 
 
 def _chat_ids(tok, persona: str, probe: str) -> torch.Tensor:
@@ -212,7 +241,43 @@ def main() -> int:
     ap.add_argument("--js-max-tok", type=int, default=40)
     ap.add_argument("--out", default="eval_results/issue_444/persona_distance_topic/results.json")
     ap.add_argument("--skip-js", action="store_true")
+    ap.add_argument(
+        "--reference",
+        default=DEFAULT_REFERENCE,
+        help=(
+            "Source/teach persona to compute distances FROM. Replaces the "
+            "module-level REFERENCE. Default = marine_biologist (#444)."
+        ),
+    )
+    ap.add_argument(
+        "--panel",
+        default=None,
+        help=(
+            "Comma-separated bystander panel (persona names). Default = the "
+            "#444 7-persona panel. For #500 the 15-persona pool is passed in."
+        ),
+    )
     args = ap.parse_args()
+
+    # Resolve panel + reference; rebuild PERSONA_PROMPTS + OTHERS BEFORE any
+    # usage. REFERENCE is referenced by cosine_vs_reference, sample_responses,
+    # js_vs_reference, and main's output dict via module-scope -- set the
+    # module-level globals so all call sites see them.
+    global REFERENCE, OTHERS, PERSONA_PROMPTS
+    REFERENCE = args.reference
+    if args.panel:
+        names = [n.strip() for n in args.panel.split(",") if n.strip()]
+        # Build PERSONA_PROMPTS by re-resolving each persona name through the
+        # same logic as the default dict.
+        PERSONA_PROMPTS = {n: _resolve_persona_prompt(n) for n in names}
+    else:
+        PERSONA_PROMPTS = dict(PERSONA_PROMPTS_DEFAULT)
+    if REFERENCE not in PERSONA_PROMPTS:
+        raise SystemExit(f"--reference {REFERENCE!r} not in panel {list(PERSONA_PROMPTS)!r}")
+    OTHERS = [pp for pp in PERSONA_PROMPTS if pp != REFERENCE]
+    logger.info(
+        "panel=%d personas; reference=%s; others=%d", len(PERSONA_PROMPTS), REFERENCE, len(OTHERS)
+    )
 
     torch.manual_seed(0)
     device = "cuda" if torch.cuda.is_available() else "cpu"

--- a/scripts/issue444_persona_distance_topic.py
+++ b/scripts/issue444_persona_distance_topic.py
@@ -348,7 +348,7 @@ def main() -> int:
     def _row(label, on, off):
         return f"  {label:<22} on={on:.4f}  off={off:.4f}  Δ(on-off)={on - off:+.4f}"
 
-    print("\n================ COSINE (layer 21) vs marine_biologist ================")
+    print(f"\n================ COSINE (layer 21) vs {REFERENCE} ================")
     for other in OTHERS:
         on = results["cosine"]["on_topic"][other]["21"]
         off = results["cosine"]["off_topic"][other]["21"]
@@ -359,9 +359,7 @@ def main() -> int:
         off = max(results["cosine"]["off_topic"][other].values())
         print(_row(other, on, off))
     if not args.skip_js:
-        print(
-            "\n================ JS similarity (M_js = 1 - JS) vs marine_biologist ================"
-        )
+        print(f"\n================ JS similarity (M_js = 1 - JS) vs {REFERENCE} ================")
         for other in OTHERS:
             on = results["js_similarity"]["on_topic"][other]
             off = results["js_similarity"]["off_topic"][other]

--- a/scripts/issue500_predictors.py
+++ b/scripts/issue500_predictors.py
@@ -187,6 +187,148 @@ def _cluster_bootstrap_spearman(
     }
 
 
+def _cross_arm_delta_rho_persona_bootstrap(
+    left_points: list[dict[str, object]],
+    right_points: list[dict[str, object]],
+    *,
+    x_field: str,
+    n_iter: int = 1000,
+    seed: int = 0,
+) -> dict[str, float]:
+    """Persona-resampling Δρ CI: resample personas WITH REPLACEMENT from the
+    INTERSECTION of left and right panels, recompute ρ_left and ρ_right on
+    the per-persona mean leak, and report Δρ = ρ_right − ρ_left.
+
+    Per plan §6.3: "persona-resampling: how much does Δρ depend on which
+    bystander personas we picked from the registry?"
+
+    Note: round-1 BLOCKER #6 fix. The round-1 cross-arm block only reported
+    `delta = ρ_right − ρ_left` with no CI.
+    """
+    rng = np.random.default_rng(seed)
+
+    # Per-persona mean (across seeds) on each side.
+    def _per_persona_mean(pts: list[dict[str, object]]) -> dict[str, tuple[float, float]]:
+        by: dict[str, list[tuple[float, float]]] = {}
+        for r in pts:
+            x = r.get(x_field, float("nan"))
+            y = r.get("leak", float("nan"))
+            if isinstance(x, float) and math.isnan(x):
+                continue
+            if isinstance(y, float) and math.isnan(y):
+                continue
+            by.setdefault(str(r["persona"]), []).append((float(x), float(y)))
+        return {
+            p: (sum(t[0] for t in v) / len(v), sum(t[1] for t in v) / len(v)) for p, v in by.items()
+        }
+
+    left_means = _per_persona_mean(left_points)
+    right_means = _per_persona_mean(right_points)
+    common = sorted(set(left_means) & set(right_means))
+    if len(common) < 3:
+        return {"status": "skipped_panel_intersection_too_small", "n_common": len(common)}
+
+    deltas: list[float] = []
+    for _ in range(n_iter):
+        idxs = rng.choice(len(common), size=len(common), replace=True)
+        l_xs = [left_means[common[i]][0] for i in idxs]
+        l_ys = [left_means[common[i]][1] for i in idxs]
+        r_xs = [right_means[common[i]][0] for i in idxs]
+        r_ys = [right_means[common[i]][1] for i in idxs]
+        rho_l = _spearman(l_xs, l_ys)
+        rho_r = _spearman(r_xs, r_ys)
+        if math.isnan(rho_l) or math.isnan(rho_r):
+            continue
+        deltas.append(rho_r - rho_l)
+    if not deltas:
+        return {"status": "no_valid_bootstrap_iters"}
+    arr = np.asarray(deltas)
+    return {
+        "mean": float(arr.mean()),
+        "median": float(np.median(arr)),
+        "ci_low_90": float(np.percentile(arr, 5)),
+        "ci_high_90": float(np.percentile(arr, 95)),
+        "ci_low_95": float(np.percentile(arr, 2.5)),
+        "ci_high_95": float(np.percentile(arr, 97.5)),
+        "n_common_personas": len(common),
+        "n_iter": n_iter,
+        "n_valid": len(deltas),
+    }
+
+
+def _cross_arm_delta_rho_seed_bootstrap(
+    left_points: list[dict[str, object]],
+    right_points: list[dict[str, object]],
+    *,
+    x_field: str,
+    n_iter: int = 1000,
+    seed: int = 0,
+) -> dict[str, float]:
+    """Seed-resampling Δρ CI: resample SEEDS with replacement from the
+    seed sets present on each side, recompute per-persona mean leak under the
+    bootstrap seed set, then ρ_left and ρ_right.
+
+    Per plan §6.3: "seed-resampling: how much does Δρ depend on
+    training-noise variance across seeds?"
+    """
+    rng = np.random.default_rng(seed)
+
+    def _seeds_in(pts: list[dict[str, object]]) -> list[int]:
+        return sorted({int(r["seed"]) for r in pts if int(r["seed"]) >= 0})
+
+    left_seeds = _seeds_in(left_points)
+    right_seeds = _seeds_in(right_points)
+    if len(left_seeds) < 2 or len(right_seeds) < 2:
+        return {
+            "status": "skipped_too_few_seeds",
+            "left_n_seeds": len(left_seeds),
+            "right_n_seeds": len(right_seeds),
+        }
+
+    def _rho_on_seeds(pts: list[dict[str, object]], seed_set: list[int]) -> float:
+        by_persona: dict[str, list[tuple[float, float]]] = {}
+        for r in pts:
+            if int(r["seed"]) not in seed_set:
+                continue
+            x = r.get(x_field, float("nan"))
+            y = r.get("leak", float("nan"))
+            if isinstance(x, float) and math.isnan(x):
+                continue
+            if isinstance(y, float) and math.isnan(y):
+                continue
+            by_persona.setdefault(str(r["persona"]), []).append((float(x), float(y)))
+        if len(by_persona) < 3:
+            return float("nan")
+        xs = [sum(t[0] for t in v) / len(v) for v in by_persona.values()]
+        ys = [sum(t[1] for t in v) / len(v) for v in by_persona.values()]
+        return _spearman(xs, ys)
+
+    deltas: list[float] = []
+    for _ in range(n_iter):
+        l_pick = list(rng.choice(left_seeds, size=len(left_seeds), replace=True))
+        r_pick = list(rng.choice(right_seeds, size=len(right_seeds), replace=True))
+        rho_l = _rho_on_seeds(left_points, l_pick)
+        rho_r = _rho_on_seeds(right_points, r_pick)
+        if math.isnan(rho_l) or math.isnan(rho_r):
+            continue
+        deltas.append(rho_r - rho_l)
+    if not deltas:
+        return {"status": "no_valid_bootstrap_iters"}
+    arr = np.asarray(deltas)
+    return {
+        "mean": float(arr.mean()),
+        "median": float(np.median(arr)),
+        "ci_low_90": float(np.percentile(arr, 5)),
+        "ci_high_90": float(np.percentile(arr, 95)),
+        "ci_low_95": float(np.percentile(arr, 2.5)),
+        "ci_high_95": float(np.percentile(arr, 97.5)),
+        "left_n_seeds": len(left_seeds),
+        "right_n_seeds": len(right_seeds),
+        "n_iter": n_iter,
+        "n_valid": len(deltas),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Data loading
 # ---------------------------------------------------------------------------
@@ -223,23 +365,42 @@ def _load_aggregate_cleaned(arm_path: Path) -> dict[str, dict[str, float]]:
     return out
 
 
-def _load_5way_priors(arm_a_aggregate_path: Path) -> dict[str, float]:
-    """Per-persona baseline stated_seven rate from Arm A's baseline cell.
+def _load_5way_priors_union(
+    arm_aggregate_paths: list[Path],
+) -> tuple[dict[str, float], dict[str, str]]:
+    """Per-persona baseline stated_seven rate, UNIONed across every arm's
+    baseline cell.
 
-    (The baseline is the same untrained model under each persona; we read
-    it from Arm A's tree because that's where the full 15-persona panel
-    baseline lives. The 5-way prior is the SAME number in all 3 arms; this
-    is the on-policy variant of the bystander prior, plan §4.5.)
+    Round-1 BLOCKER #4 fix: the baseline measures the SAME untrained model
+    under each persona, so the rate per (persona, fact) IS identical across
+    arms; but each arm's baseline excludes its own SOURCE persona from the
+    n=14 panel (Arm A excludes ``marine_biologist`` from baseline, etc.).
+    The Arm B baseline alone is widened to the full 15-pool via the wrapper
+    (``_widen_baseline_panel_to_full_pool``) so it has every persona. To
+    cover all 15 personas across all 3 arms, union the per-persona rates from
+    each arm's baseline. Conflict handling: take the first non-NaN
+    encountered (baseline values from different arms for the SAME persona on
+    the SAME untrained model are expected to be identical modulo
+    judge-batch noise; we record the source-arm to keep the union auditable).
     """
-    data = json.loads(arm_a_aggregate_path.read_text())
-    baseline = data["per_cell"].get("baseline", {})
-    pp = baseline.get("per_persona", {})
     out: dict[str, float] = {}
-    for persona, pdata in pp.items():
-        rate = pdata.get("a_family_stated_seven_rate")
-        if rate is not None:
+    src: dict[str, str] = {}
+    for ag_path in arm_aggregate_paths:
+        if not ag_path.exists():
+            continue
+        data = json.loads(ag_path.read_text())
+        baseline = data["per_cell"].get("baseline", {})
+        pp = baseline.get("per_persona", {})
+        arm_slug = data.get("arm_slug", ag_path.parent.name)
+        for persona, pdata in pp.items():
+            rate = pdata.get("a_family_stated_seven_rate")
+            if rate is None:
+                continue
+            if persona in out:
+                continue  # first-arm wins; sources tracked in `src`
             out[persona] = float(rate)
-    return out
+            src[persona] = arm_slug
+    return out, src
 
 
 def _load_engagement(arm_path: Path) -> dict[str, dict[str, float]]:
@@ -261,7 +422,7 @@ def _per_arm_metrics(
     arm_slug: str,
     panel: tuple[str, ...],
     logprob_priors: dict[str, float],
-    fivewat_priors: dict[str, float],
+    fiveway_priors: dict[str, float],
     cos_to_home_map: dict[str, float],
 ) -> dict[str, object]:
     """Compute the per-arm metric table + per-arm stats."""
@@ -291,7 +452,7 @@ def _per_arm_metrics(
                 "seed": seed,
                 "leak": float(leak),
                 "prior_logprob": logprob_priors.get(persona, float("nan")),
-                "prior_5way": fivewat_priors.get(persona, float("nan")),
+                "prior_5way": fiveway_priors.get(persona, float("nan")),
                 "cos_to_source": cos_to_source.get(persona, float("nan")),
                 "cos_to_home": cos_to_home_map.get(persona, float("nan")),
             }
@@ -310,7 +471,7 @@ def _per_arm_metrics(
             "leak_mean": float(np.mean([r["leak"] for r in rows])),
             "leak_seeds": [float(r["leak"]) for r in rows],
             "prior_logprob": logprob_priors.get(persona, float("nan")),
-            "prior_5way": fivewat_priors.get(persona, float("nan")),
+            "prior_5way": fiveway_priors.get(persona, float("nan")),
             "cos_to_source": cos_to_source.get(persona, float("nan")),
             "cos_to_home": cos_to_home_map.get(persona, float("nan")),
         }
@@ -371,6 +532,69 @@ def _per_arm_metrics(
             _cluster_bootstrap_spearman(pairs_cs, clust_p)
         )
 
+    # Engagement-covariate partials (plan §6.3 "does the prior signal survive
+    # length/engagement adjustment?"). Computed only when the
+    # engagement_covariates.json file exists; otherwise emit an explicit
+    # missing-status so the analyzer reports the gap rather than silently
+    # skipping (round-2 BLOCKER #8 fix).
+    if not engagement:
+        stats["engagement_adjusted"] = {
+            "status": "skipped_no_engagement_file",
+            "expected_path": str(eng_path),
+            "_doc": (
+                "engagement_covariates.json missing for this arm. To compute "
+                "the length-and-on-topic-adjusted partial correlations, "
+                "produce that file with shape "
+                "{cell_tag: {persona: {length: float, on_topic_fraction: float}}}."
+            ),
+        }
+    else:
+        # Build per-persona means of length + on_topic_fraction (averaged over
+        # seeds, panel-aligned).
+        mean_length: list[float] = []
+        mean_on_topic: list[float] = []
+        for persona in aligned_personas:
+            persona_rows = [r for r in points if r["persona"] == persona]
+            lens = [
+                float(r["completion_length"])
+                for r in persona_rows
+                if not math.isnan(float(r["completion_length"]))
+            ]
+            tops = [
+                float(r["on_topic_fraction"])
+                for r in persona_rows
+                if not math.isnan(float(r["on_topic_fraction"]))
+            ]
+            mean_length.append(sum(lens) / len(lens) if lens else float("nan"))
+            mean_on_topic.append(sum(tops) / len(tops) if tops else float("nan"))
+
+        eng_stats: dict[str, object] = {
+            "status": "computed",
+            "n_personas": len(aligned_personas),
+        }
+        if _good(prior_lp) and _good(mean_length):
+            eng_stats["partial_spearman_prior_vs_leak_given_length"] = _partial_spearman(
+                prior_lp, leak_mean, mean_length
+            )
+        if _good(prior_lp) and _good(mean_on_topic):
+            eng_stats["partial_spearman_prior_vs_leak_given_on_topic"] = _partial_spearman(
+                prior_lp, leak_mean, mean_on_topic
+            )
+        if _good(cos_src) and _good(mean_length):
+            eng_stats["partial_spearman_cos_vs_leak_given_length"] = _partial_spearman(
+                cos_src, leak_mean, mean_length
+            )
+        if _good(cos_src) and _good(mean_on_topic):
+            eng_stats["partial_spearman_cos_vs_leak_given_on_topic"] = _partial_spearman(
+                cos_src, leak_mean, mean_on_topic
+            )
+        # Means recorded for transparency / sanity check.
+        eng_stats["per_persona_mean_length"] = dict(zip(aligned_personas, mean_length, strict=True))
+        eng_stats["per_persona_mean_on_topic"] = dict(
+            zip(aligned_personas, mean_on_topic, strict=True)
+        )
+        stats["engagement_adjusted"] = eng_stats
+
     return {
         "arm": arm_name,
         "arm_slug": arm_slug,
@@ -378,6 +602,7 @@ def _per_arm_metrics(
         "per_persona": per_persona,
         "per_point_n": len(points),
         "stats": stats,
+        "_points": points,  # kept for cross-arm bootstrap (not analyzer-facing)
     }
 
 
@@ -415,15 +640,14 @@ def main() -> None:
         )
     logprob_priors = _load_logprob_priors(logprob_path)
 
-    # 5-way priors come from Arm A's baseline cell (identical across arms).
-    arm_a_agg = (
-        REPO
-        / "eval_results"
-        / "issue_500"
-        / ARM_SOURCE["marine_biologist"]
-        / "aggregate_cleaned.json"
-    )
-    fivewat_priors = _load_5way_priors(arm_a_agg) if arm_a_agg.exists() else {}
+    # 5-way priors UNIONed across all 3 arms' baseline cells (round-1
+    # BLOCKER #4 fix). Each arm's baseline excludes its own source from the
+    # n=14 panel; Arm B's baseline is widened to the full 15-pool by the
+    # wrapper. UNIONing covers all 15 personas.
+    arm_aggregate_paths = [
+        REPO / "eval_results" / "issue_500" / ARM_SOURCE[a] / "aggregate_cleaned.json" for a in ARMS
+    ]
+    fiveway_priors, fiveway_priors_source = _load_5way_priors_union(arm_aggregate_paths)
 
     # Distance-to-home (cosine to local_historian@layer21). Optional.
     cos_to_home: dict[str, float] = {}
@@ -442,7 +666,8 @@ def main() -> None:
         "layer_headline": LAYER_HEADLINE,
         "per_arm": {},
         "logprob_priors_used": logprob_priors,
-        "fiveway_priors_used": fivewat_priors,
+        "fiveway_priors_used": fiveway_priors,
+        "fiveway_priors_source_arm": fiveway_priors_source,
         "cos_to_home_used": cos_to_home,
     }
 
@@ -456,15 +681,31 @@ def main() -> None:
                 arm_slug,
                 panel,
                 logprob_priors,
-                fivewat_priors,
+                fiveway_priors,
                 cos_to_home,
             )
         except RuntimeError as e:
             arm_results[arm_name] = {"error": str(e), "arm_slug": arm_slug}
     out_full["per_arm"] = arm_results
 
-    # Cross-arm headline: Δρ(cos_to_source, leak).
-    cross: dict[str, object] = {}
+    # ------------------------------------------------------------------
+    # Cross-arm headline statistic Δρ(cos_to_source, leak) WITH CIs
+    # (round-1 BLOCKER #6 fix).
+    # Two resampling schemes reported SEPARATELY (plan §6.3):
+    #   - persona-resampling: how much does Δρ depend on which bystander
+    #     personas we picked from the registry?
+    #   - seed-resampling: how much does Δρ depend on training-noise
+    #     variance across seeds?
+    # ------------------------------------------------------------------
+    cross: dict[str, object] = {
+        "_doc": (
+            "Headline statistic: Δρ_AB = ρ_cos(Arm B) - ρ_cos(Arm A), "
+            "where ρ_cos is the per-arm Spearman ρ(cos_to_source, leak). "
+            "Reported alongside persona-resampling and seed-resampling "
+            "bootstrap CIs (90% and 95%) -- the two schemes answer "
+            "different uncertainty questions, per plan §6.3."
+        )
+    }
     arm_a = arm_results.get("marine_biologist", {})
     arm_b = arm_results.get("courthouse_architecture_historian", {})
     arm_c = arm_results.get("local_resident", {})
@@ -477,13 +718,30 @@ def main() -> None:
         r_stats = r_arm.get("stats", {}) if isinstance(r_arm, dict) else {}
         l_rho = l_stats.get("spearman_cos_to_source_vs_leak")
         r_rho = r_stats.get("spearman_cos_to_source_vs_leak")
+        l_points = l_arm.get("_points", []) if isinstance(l_arm, dict) else []
+        r_points = r_arm.get("_points", []) if isinstance(r_arm, dict) else []
+        entry: dict[str, object] = {}
         if l_rho is not None and r_rho is not None:
-            cross[label] = {
-                "left_arm_rho": l_rho,
-                "right_arm_rho": r_rho,
-                "delta": float(r_rho) - float(l_rho),
-            }
+            entry["left_arm_rho_point"] = float(l_rho)
+            entry["right_arm_rho_point"] = float(r_rho)
+            entry["delta_point"] = float(r_rho) - float(l_rho)
+        if l_points and r_points:
+            entry["persona_bootstrap"] = _cross_arm_delta_rho_persona_bootstrap(
+                l_points, r_points, x_field="cos_to_source"
+            )
+            entry["seed_bootstrap"] = _cross_arm_delta_rho_seed_bootstrap(
+                l_points, r_points, x_field="cos_to_source"
+            )
+        else:
+            entry["status"] = "skipped_missing_points"
+        cross[label] = entry
     out_full["cross_arm"] = cross
+
+    # Strip the analyzer-internal _points fields BEFORE serializing
+    # (kept only for the cross-arm bootstrap above).
+    for arm_name in list(arm_results):
+        if isinstance(arm_results[arm_name], dict) and "_points" in arm_results[arm_name]:
+            arm_results[arm_name].pop("_points", None)
 
     out_path = REPO / args.out
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/issue500_predictors.py
+++ b/scripts/issue500_predictors.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python3
+"""Issue #500 analyzer-facing diagnostics + headline statistics.
+
+Computes per-arm × per-bystander:
+  - leak_rate                (from aggregate_cleaned.json; primary DV)
+  - prior_logprob            (length-norm base log P(taught completion | T_bystander))
+  - prior_5way               (5-way base ``stated_seven`` rate; on-policy variant)
+  - cos_to_source            (layer-21 persona-vector cosine to the arm source)
+  - cos_to_home              (layer-21 persona-vector cosine to local_historian,
+                              the panel's max-base-prior persona = "home")
+  - completion_length        (mean tokens emitted by the trained model)
+  - on_topic_fraction        (Claude judge: did the completion talk about the
+                              courthouse at all)
+
+Reports per arm:
+  - Spearman ρ(prior_logprob, leak)        with cluster-bootstrap CI
+  - Spearman ρ(prior_5way,    leak)        with cluster-bootstrap CI
+  - Spearman ρ(cos_to_source, leak)        with cluster-bootstrap CI
+  - Spearman ρ(cos_to_home,   leak)        with cluster-bootstrap CI
+  - Partial Spearman ρ(cos_to_source, leak | prior_logprob)
+  - Collinearity gate: Pearson(|cos_to_source|, prior_logprob)
+  - Standardized OLS  z(leak) ~ z(prior_logprob) + z(cos_to_source)
+  - Engagement-adjusted ρ (partial out completion_length + on_topic_fraction)
+
+Cross-arm:
+  - Δρ_AB = ρ_cos(B) - ρ_cos(A)            with cluster-bootstrap 90% / 95% CIs
+            (persona-resampling AND seed-resampling diagnostics reported
+             separately; they answer different uncertainty questions)
+  - Δρ_AC, Δρ_CB analogously
+
+Inputs:
+  - eval_results/issue_500/<arm>/aggregate_cleaned.json
+  - eval_results/issue_500/<arm>/persona_distance/results.json (cosine + JS)
+  - eval_results/issue_500/distance_to_home.json              (cos_to_local_historian)
+  - eval_results/issue_500/bystander_logprob/logprob_results.json
+  - eval_results/issue_500/<arm>/engagement_covariates.json   (length + on_topic)
+
+This script is analyzer-input only; the analyzer (downstream of /issue Step 7)
+reads the JSON output and produces the figures + clean-result body.
+"""
+
+# ruff: noqa: RUF001, RUF002, RUF003, C901
+# (greek + arrow + multiplication-sign characters intentional in docstrings;
+#  per-arm metrics fn is purposefully long to keep the per-arm analysis flow
+#  in one place for the analyzer to read.)
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+
+REPO = Path(__file__).resolve().parent.parent
+
+ARMS: tuple[str, ...] = (
+    "marine_biologist",
+    "local_resident",
+    "courthouse_architecture_historian",
+)
+HOME_PERSONA = "local_historian"
+LAYER_HEADLINE = "21"
+
+
+# ---------------------------------------------------------------------------
+# Statistics primitives (Spearman / partial Spearman / cluster bootstrap)
+# ---------------------------------------------------------------------------
+def _rankdata(x: list[float]) -> list[float]:
+    """Average-rank tie-handling, scipy-free."""
+    arr = np.asarray(x, dtype=float)
+    order = arr.argsort()
+    ranks = np.empty_like(order, dtype=float)
+    ranks[order] = np.arange(1, len(arr) + 1, dtype=float)
+    # Tie-correct: average ranks within ties.
+    uniq, inv, counts = np.unique(arr, return_inverse=True, return_counts=True)
+    sums = np.zeros_like(uniq, dtype=float)
+    for i, r in zip(inv, ranks, strict=True):
+        sums[i] += r
+    avg = sums / counts
+    return [float(avg[i]) for i in inv]
+
+
+def _spearman(x: list[float], y: list[float]) -> float:
+    if len(x) < 2 or len(y) < 2 or len(x) != len(y):
+        return float("nan")
+    rx = np.asarray(_rankdata(x))
+    ry = np.asarray(_rankdata(y))
+    sx = rx - rx.mean()
+    sy = ry - ry.mean()
+    denom = math.sqrt((sx * sx).sum() * (sy * sy).sum())
+    return float((sx * sy).sum() / denom) if denom > 0 else float("nan")
+
+
+def _pearson(x: list[float], y: list[float]) -> float:
+    if len(x) < 2 or len(y) < 2 or len(x) != len(y):
+        return float("nan")
+    a = np.asarray(x, dtype=float)
+    b = np.asarray(y, dtype=float)
+    a -= a.mean()
+    b -= b.mean()
+    denom = math.sqrt((a * a).sum() * (b * b).sum())
+    return float((a * b).sum() / denom) if denom > 0 else float("nan")
+
+
+def _partial_spearman(x: list[float], y: list[float], z: list[float]) -> float:
+    """Spearman ρ between x and y after partialling out z (rank-based)."""
+    if len(x) < 3 or len(set(map(len, (x, y, z)))) != 1:
+        return float("nan")
+    rx = np.asarray(_rankdata(x))
+    ry = np.asarray(_rankdata(y))
+    rz = np.asarray(_rankdata(z))
+    # Residuals of x and y after OLS regression on z (using ranks).
+    A = np.column_stack([np.ones_like(rz), rz])
+    bx, *_ = np.linalg.lstsq(A, rx, rcond=None)
+    by, *_ = np.linalg.lstsq(A, ry, rcond=None)
+    res_x = rx - A @ bx
+    res_y = ry - A @ by
+    return _spearman(list(res_x), list(res_y))
+
+
+def _standardize(x: list[float]) -> np.ndarray:
+    a = np.asarray(x, dtype=float)
+    sd = a.std(ddof=1) or 1.0
+    return (a - a.mean()) / sd
+
+
+def _ols_two_predictor(y: list[float], x1: list[float], x2: list[float]) -> dict[str, float]:
+    """Standardized OLS z(y) ~ z(x1) + z(x2). Returns betas + R^2."""
+    zy = _standardize(y)
+    zx1 = _standardize(x1)
+    zx2 = _standardize(x2)
+    A = np.column_stack([np.ones_like(zx1), zx1, zx2])
+    coef, *_ = np.linalg.lstsq(A, zy, rcond=None)
+    yhat = A @ coef
+    ss_res = float(((zy - yhat) ** 2).sum())
+    ss_tot = float(((zy - zy.mean()) ** 2).sum())
+    r2 = 1 - ss_res / ss_tot if ss_tot > 0 else float("nan")
+    return {
+        "intercept": float(coef[0]),
+        "beta_x1_prior": float(coef[1]),
+        "beta_x2_prox": float(coef[2]),
+        "r_squared": r2,
+    }
+
+
+def _cluster_bootstrap_spearman(
+    pairs: list[tuple[float, float]],
+    cluster_ids: list[int],
+    *,
+    n_iter: int = 1000,
+    seed: int = 0,
+) -> dict[str, float]:
+    """Cluster-bootstrap CI for Spearman ρ over pairs[(x, y)] grouped by cluster.
+
+    Resamples CLUSTERS with replacement, recomputes ρ on the assembled pairs.
+    Returns mean, 5%/95%/2.5%/97.5% percentile bounds.
+    """
+    rng = np.random.default_rng(seed)
+    clusters = sorted(set(cluster_ids))
+    by_cluster: dict[int, list[tuple[float, float]]] = {c: [] for c in clusters}
+    for pair, cid in zip(pairs, cluster_ids, strict=True):
+        by_cluster[cid].append(pair)
+    rhos: list[float] = []
+    for _ in range(n_iter):
+        sampled = rng.choice(len(clusters), size=len(clusters), replace=True)
+        boot_pairs: list[tuple[float, float]] = []
+        for idx in sampled:
+            boot_pairs.extend(by_cluster[clusters[idx]])
+        xs = [p[0] for p in boot_pairs]
+        ys = [p[1] for p in boot_pairs]
+        rho = _spearman(xs, ys)
+        if not math.isnan(rho):
+            rhos.append(rho)
+    if not rhos:
+        return {"mean": float("nan"), "ci_low_90": float("nan"), "ci_high_90": float("nan")}
+    arr = np.asarray(rhos)
+    return {
+        "mean": float(arr.mean()),
+        "median": float(np.median(arr)),
+        "ci_low_90": float(np.percentile(arr, 5)),
+        "ci_high_90": float(np.percentile(arr, 95)),
+        "ci_low_95": float(np.percentile(arr, 2.5)),
+        "ci_high_95": float(np.percentile(arr, 97.5)),
+        "n_valid_iters": len(rhos),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+def _load_logprob_priors(panel_path: Path) -> dict[str, float]:
+    """Per-persona base length-norm log-prob prior (#500-widened panel)."""
+    data = json.loads(panel_path.read_text())
+    return {
+        p: float(d["mean_logprob_per_tok"])
+        for p, d in data["summary"].items()
+        if d.get("n_rows", 0) > 0
+    }
+
+
+def _load_cosines(persona_distance_path: Path) -> dict[str, float]:
+    """Per-bystander cos_to_REFERENCE at layer 21 (on-topic)."""
+    data = json.loads(persona_distance_path.read_text())
+    return {
+        persona: float(per_layer[LAYER_HEADLINE])
+        for persona, per_layer in data["cosine"]["on_topic"].items()
+    }
+
+
+def _load_aggregate_cleaned(arm_path: Path) -> dict[str, dict[str, float]]:
+    """Per-cell -> persona -> leak_rate. Skips baseline."""
+    data = json.loads(arm_path.read_text())
+    out: dict[str, dict[str, float]] = {}
+    for cell, info in data["per_cell"].items():
+        if cell == "baseline" or "per_persona" not in info:
+            continue
+        out[cell] = {
+            persona: float(pdata["leak_rate_headline"])
+            for persona, pdata in info["per_persona"].items()
+        }
+    return out
+
+
+def _load_5way_priors(arm_a_aggregate_path: Path) -> dict[str, float]:
+    """Per-persona baseline stated_seven rate from Arm A's baseline cell.
+
+    (The baseline is the same untrained model under each persona; we read
+    it from Arm A's tree because that's where the full 15-persona panel
+    baseline lives. The 5-way prior is the SAME number in all 3 arms; this
+    is the on-policy variant of the bystander prior, plan §4.5.)
+    """
+    data = json.loads(arm_a_aggregate_path.read_text())
+    baseline = data["per_cell"].get("baseline", {})
+    pp = baseline.get("per_persona", {})
+    out: dict[str, float] = {}
+    for persona, pdata in pp.items():
+        rate = pdata.get("a_family_stated_seven_rate")
+        if rate is not None:
+            out[persona] = float(rate)
+    return out
+
+
+def _load_engagement(arm_path: Path) -> dict[str, dict[str, float]]:
+    """Optional: per-(cell, persona) {length, on_topic_fraction}.
+
+    Returns {} if the file doesn't exist; predictors phase still completes
+    and just skips the engagement-adjusted lines.
+    """
+    if not arm_path.exists():
+        return {}
+    return json.loads(arm_path.read_text())
+
+
+# ---------------------------------------------------------------------------
+# Per-arm aggregator
+# ---------------------------------------------------------------------------
+def _per_arm_metrics(
+    arm_name: str,
+    arm_slug: str,
+    panel: tuple[str, ...],
+    logprob_priors: dict[str, float],
+    fivewat_priors: dict[str, float],
+    cos_to_home_map: dict[str, float],
+) -> dict[str, object]:
+    """Compute the per-arm metric table + per-arm stats."""
+    arm_root = REPO / "eval_results" / "issue_500" / arm_slug
+    agg_path = arm_root / "aggregate_cleaned.json"
+    cos_path = arm_root / "persona_distance" / "results.json"
+    eng_path = arm_root / "engagement_covariates.json"
+
+    if not agg_path.exists():
+        raise RuntimeError(
+            f"{agg_path} missing -- run scripts/aggregate_issue500.py --arm {arm_name} first."
+        )
+    leak_per_cell = _load_aggregate_cleaned(agg_path)
+    cos_to_source = _load_cosines(cos_path) if cos_path.exists() else {}
+    engagement = _load_engagement(eng_path)
+
+    # Per-(persona, seed) cell-level points.
+    points: list[dict[str, float | int | str]] = []
+    for cell_tag, persona_leaks in leak_per_cell.items():
+        # cell_tag like "on_policy_suppression_cn_seed42"
+        seed = int(cell_tag.split("seed")[-1]) if "seed" in cell_tag else -1
+        for persona, leak in persona_leaks.items():
+            if persona not in panel:
+                continue
+            row: dict[str, float | int | str] = {
+                "persona": persona,
+                "seed": seed,
+                "leak": float(leak),
+                "prior_logprob": logprob_priors.get(persona, float("nan")),
+                "prior_5way": fivewat_priors.get(persona, float("nan")),
+                "cos_to_source": cos_to_source.get(persona, float("nan")),
+                "cos_to_home": cos_to_home_map.get(persona, float("nan")),
+            }
+            eng = engagement.get(cell_tag, {}).get(persona, {})
+            row["completion_length"] = float(eng.get("length", float("nan")))
+            row["on_topic_fraction"] = float(eng.get("on_topic_fraction", float("nan")))
+            points.append(row)
+
+    # Cell-mean per persona (mean across the 3 seeds).
+    per_persona: dict[str, dict[str, float]] = {}
+    for persona in panel:
+        rows = [r for r in points if r["persona"] == persona]
+        if not rows:
+            continue
+        per_persona[persona] = {
+            "leak_mean": float(np.mean([r["leak"] for r in rows])),
+            "leak_seeds": [float(r["leak"]) for r in rows],
+            "prior_logprob": logprob_priors.get(persona, float("nan")),
+            "prior_5way": fivewat_priors.get(persona, float("nan")),
+            "cos_to_source": cos_to_source.get(persona, float("nan")),
+            "cos_to_home": cos_to_home_map.get(persona, float("nan")),
+        }
+
+    # Per-persona vectors (panel-aligned, drop NaNs).
+    aligned_personas = [p_name for p_name in panel if p_name in per_persona]
+    leak_mean = [per_persona[p]["leak_mean"] for p in aligned_personas]
+    prior_lp = [per_persona[p]["prior_logprob"] for p in aligned_personas]
+    prior_5w = [per_persona[p]["prior_5way"] for p in aligned_personas]
+    cos_src = [per_persona[p]["cos_to_source"] for p in aligned_personas]
+    cos_home_v = [per_persona[p]["cos_to_home"] for p in aligned_personas]
+
+    def _good(seq: list[float]) -> bool:
+        return all(not (isinstance(v, float) and math.isnan(v)) for v in seq)
+
+    stats: dict[str, object] = {
+        "n_personas_in_panel": len(aligned_personas),
+        "n_points_with_seeds": len(points),
+    }
+
+    # Per-arm spearman correlations.
+    if _good(prior_lp):
+        stats["spearman_prior_logprob_vs_leak"] = _spearman(prior_lp, leak_mean)
+    if _good(prior_5w):
+        stats["spearman_prior_5way_vs_leak"] = _spearman(prior_5w, leak_mean)
+    if _good(cos_src):
+        stats["spearman_cos_to_source_vs_leak"] = _spearman(cos_src, leak_mean)
+    if _good(cos_home_v):
+        stats["spearman_cos_to_home_vs_leak"] = _spearman(cos_home_v, leak_mean)
+
+    # Collinearity gate.
+    if _good(cos_src) and _good(prior_lp):
+        stats["pearson_abs_cos_vs_prior_logprob"] = _pearson([abs(c) for c in cos_src], prior_lp)
+        stats["pearson_cos_vs_prior_logprob"] = _pearson(cos_src, prior_lp)
+        # Partial spearman ρ(cos, leak | prior).
+        stats["partial_spearman_cos_to_source_given_prior"] = _partial_spearman(
+            cos_src, leak_mean, prior_lp
+        )
+
+    # Standardized OLS.
+    if _good(cos_src) and _good(prior_lp):
+        stats["ols_z_leak_on_z_prior_logprob_and_z_cos_to_source"] = _ols_two_predictor(
+            leak_mean, prior_lp, cos_src
+        )
+
+    # Cluster bootstrap on the (persona, seed) point list -- clusters are
+    # personas.
+    if points and _good(prior_lp):
+        pairs_lp = [(float(r["prior_logprob"]), float(r["leak"])) for r in points]
+        clust_p = [hash(str(r["persona"])) & 0xFFFFFFFF for r in points]
+        stats["bootstrap_spearman_prior_logprob_vs_leak_cluster_persona"] = (
+            _cluster_bootstrap_spearman(pairs_lp, clust_p)
+        )
+    if points and _good(cos_src):
+        pairs_cs = [(float(r["cos_to_source"]), float(r["leak"])) for r in points]
+        clust_p = [hash(str(r["persona"])) & 0xFFFFFFFF for r in points]
+        stats["bootstrap_spearman_cos_to_source_vs_leak_cluster_persona"] = (
+            _cluster_bootstrap_spearman(pairs_cs, clust_p)
+        )
+
+    return {
+        "arm": arm_name,
+        "arm_slug": arm_slug,
+        "panel": list(aligned_personas),
+        "per_persona": per_persona,
+        "per_point_n": len(points),
+        "stats": stats,
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--out",
+        default="eval_results/issue_500/predictors.json",
+        help="output JSON path (analyzer reads this).",
+    )
+    ap.add_argument(
+        "--logprob-path",
+        default="eval_results/issue_500/bystander_logprob/logprob_results.json",
+        help="path to the bystander_logprob output (15-persona panel).",
+    )
+    ap.add_argument(
+        "--cos-home-path",
+        default="eval_results/issue_500/distance_to_home.json",
+        help=(
+            "JSON with {persona: cos_to_local_historian@layer21}. Computed once "
+            "(home is constant across arms). Optional -- script proceeds without "
+            "this predictor if the file is missing."
+        ),
+    )
+    args = ap.parse_args()
+
+    # Per-arm panels.
+    from run_experiment_500 import ARM_SOURCE, PANEL_15
+
+    logprob_path = REPO / args.logprob_path
+    if not logprob_path.exists():
+        raise RuntimeError(
+            f"{logprob_path} missing -- run scripts/issue444_bystander_logprob.py "
+            "with --panel set to the 15-persona pool first."
+        )
+    logprob_priors = _load_logprob_priors(logprob_path)
+
+    # 5-way priors come from Arm A's baseline cell (identical across arms).
+    arm_a_agg = (
+        REPO
+        / "eval_results"
+        / "issue_500"
+        / ARM_SOURCE["marine_biologist"]
+        / "aggregate_cleaned.json"
+    )
+    fivewat_priors = _load_5way_priors(arm_a_agg) if arm_a_agg.exists() else {}
+
+    # Distance-to-home (cosine to local_historian@layer21). Optional.
+    cos_to_home: dict[str, float] = {}
+    cos_home_path = REPO / args.cos_home_path
+    if cos_home_path.exists():
+        chd = json.loads(cos_home_path.read_text())
+        # Accept either {"cosine": {"21": {persona: float}}} or {persona: float}.
+        if "cosine" in chd and "21" in chd.get("cosine", {}):
+            cos_to_home = {k: float(v) for k, v in chd["cosine"]["21"].items()}
+        elif isinstance(chd, dict):
+            cos_to_home = {k: float(v) for k, v in chd.items() if isinstance(v, (int, float))}
+
+    out_full: dict[str, object] = {
+        "panel_pool_15": list(PANEL_15),
+        "home_persona": HOME_PERSONA,
+        "layer_headline": LAYER_HEADLINE,
+        "per_arm": {},
+        "logprob_priors_used": logprob_priors,
+        "fiveway_priors_used": fivewat_priors,
+        "cos_to_home_used": cos_to_home,
+    }
+
+    arm_results: dict[str, dict[str, object]] = {}
+    for arm_name in ARMS:
+        arm_slug = ARM_SOURCE[arm_name]
+        panel = tuple(x for x in PANEL_15 if x != arm_name)
+        try:
+            arm_results[arm_name] = _per_arm_metrics(
+                arm_name,
+                arm_slug,
+                panel,
+                logprob_priors,
+                fivewat_priors,
+                cos_to_home,
+            )
+        except RuntimeError as e:
+            arm_results[arm_name] = {"error": str(e), "arm_slug": arm_slug}
+    out_full["per_arm"] = arm_results
+
+    # Cross-arm headline: Δρ(cos_to_source, leak).
+    cross: dict[str, object] = {}
+    arm_a = arm_results.get("marine_biologist", {})
+    arm_b = arm_results.get("courthouse_architecture_historian", {})
+    arm_c = arm_results.get("local_resident", {})
+    for label, l_arm, r_arm in [
+        ("delta_rho_AB", arm_a, arm_b),
+        ("delta_rho_AC", arm_a, arm_c),
+        ("delta_rho_CB", arm_c, arm_b),
+    ]:
+        l_stats = l_arm.get("stats", {}) if isinstance(l_arm, dict) else {}
+        r_stats = r_arm.get("stats", {}) if isinstance(r_arm, dict) else {}
+        l_rho = l_stats.get("spearman_cos_to_source_vs_leak")
+        r_rho = r_stats.get("spearman_cos_to_source_vs_leak")
+        if l_rho is not None and r_rho is not None:
+            cross[label] = {
+                "left_arm_rho": l_rho,
+                "right_arm_rho": r_rho,
+                "delta": float(r_rho) - float(l_rho),
+            }
+    out_full["cross_arm"] = cross
+
+    out_path = REPO / args.out
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(out_full, indent=2, default=str))
+    print(f"WROTE {out_path}")
+    for arm_name, info in arm_results.items():
+        if "error" in info:
+            print(f"  {arm_name:35} ERROR: {info['error']}")
+            continue
+        s = info.get("stats", {})
+        rho_p = s.get("spearman_prior_logprob_vs_leak", float("nan"))
+        rho_c = s.get("spearman_cos_to_source_vs_leak", float("nan"))
+        rho_h = s.get("spearman_cos_to_home_vs_leak", float("nan"))
+        n = s.get("n_personas_in_panel", 0)
+        print(
+            f"  {arm_name:35} n={n:>2}  ρ(prior,leak)={rho_p:+.3f}  "
+            f"ρ(cos,leak)={rho_c:+.3f}  ρ(home,leak)={rho_h:+.3f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue500_predictors.py
+++ b/scripts/issue500_predictors.py
@@ -105,19 +105,52 @@ def _pearson(x: list[float], y: list[float]) -> float:
 
 
 def _partial_spearman(x: list[float], y: list[float], z: list[float]) -> float:
-    """Spearman ρ between x and y after partialling out z (rank-based)."""
+    """Standard partial Spearman ρ(x, y | z).
+
+    Definition (canonical): rank-transform x, y, z; OLS-residualize the rank
+    vectors of x and y against the rank vector of z; the partial Spearman is
+    the PEARSON correlation of those rank-residuals.
+
+    Round-3 BUG-#3 fix: the previous implementation re-ranked the residuals
+    and applied Spearman to the re-ranked residuals, which is NOT the
+    standard partial-Spearman statistic. Pearson on rank-residuals matches
+    the textbook definition (e.g. pingouin.partial_corr method='spearman').
+    """
     if len(x) < 3 or len(set(map(len, (x, y, z)))) != 1:
         return float("nan")
     rx = np.asarray(_rankdata(x))
     ry = np.asarray(_rankdata(y))
     rz = np.asarray(_rankdata(z))
-    # Residuals of x and y after OLS regression on z (using ranks).
+    # Residuals of x and y after OLS regression on RANK z.
     A = np.column_stack([np.ones_like(rz), rz])
     bx, *_ = np.linalg.lstsq(A, rx, rcond=None)
     by, *_ = np.linalg.lstsq(A, ry, rcond=None)
     res_x = rx - A @ bx
     res_y = ry - A @ by
-    return _spearman(list(res_x), list(res_y))
+    return _pearson(list(res_x), list(res_y))
+
+
+def _partial_spearman_multi(x: list[float], y: list[float], zs: list[list[float]]) -> float:
+    """Partial Spearman ρ(x, y | z1, z2, ...): rank-residualize x and y
+    against the multiple rank-z controls (joint OLS on rank space), return
+    Pearson of the rank-residuals.
+
+    Round-3 BUG-#5: enables the JOINT engagement partial
+    ρ(prior or cos, leak | length AND on_topic). Single-covariate
+    ``_partial_spearman`` is the special case len(zs) == 1.
+    """
+    n = len(x)
+    if n < 3 or len(y) != n or any(len(z) != n for z in zs) or not zs:
+        return float("nan")
+    rx = np.asarray(_rankdata(x))
+    ry = np.asarray(_rankdata(y))
+    rz_cols = [np.asarray(_rankdata(z)) for z in zs]
+    A = np.column_stack([np.ones(n), *rz_cols])
+    bx, *_ = np.linalg.lstsq(A, rx, rcond=None)
+    by, *_ = np.linalg.lstsq(A, ry, rcond=None)
+    res_x = rx - A @ bx
+    res_y = ry - A @ by
+    return _pearson(list(res_x), list(res_y))
 
 
 def _standardize(x: list[float]) -> np.ndarray:
@@ -147,7 +180,7 @@ def _ols_two_predictor(y: list[float], x1: list[float], x2: list[float]) -> dict
 
 def _cluster_bootstrap_spearman(
     pairs: list[tuple[float, float]],
-    cluster_ids: list[int],
+    cluster_ids: list[str],
     *,
     n_iter: int = 1000,
     seed: int = 0,
@@ -156,10 +189,14 @@ def _cluster_bootstrap_spearman(
 
     Resamples CLUSTERS with replacement, recomputes ρ on the assembled pairs.
     Returns mean, 5%/95%/2.5%/97.5% percentile bounds.
+
+    Round-3 BUG-#6 fix: ``cluster_ids`` are stable strings (persona names),
+    not Python ``hash()`` outputs (process-randomized). Combined with the
+    fixed RNG seed this gives reproducible CIs across processes.
     """
     rng = np.random.default_rng(seed)
     clusters = sorted(set(cluster_ids))
-    by_cluster: dict[int, list[tuple[float, float]]] = {c: [] for c in clusters}
+    by_cluster: dict[str, list[tuple[float, float]]] = {c: [] for c in clusters}
     for pair, cid in zip(pairs, cluster_ids, strict=True):
         by_cluster[cid].append(pair)
     rhos: list[float] = []
@@ -184,6 +221,95 @@ def _cluster_bootstrap_spearman(
         "ci_low_95": float(np.percentile(arr, 2.5)),
         "ci_high_95": float(np.percentile(arr, 97.5)),
         "n_valid_iters": len(rhos),
+    }
+
+
+def _summarize_bootstrap(values: list[float]) -> dict[str, float]:
+    """Mean / median / 90% / 95% percentile summary of a bootstrap distribution."""
+    if not values:
+        return {
+            "mean": float("nan"),
+            "ci_low_90": float("nan"),
+            "ci_high_90": float("nan"),
+            "n_valid_iters": 0,
+        }
+    arr = np.asarray(values)
+    return {
+        "mean": float(arr.mean()),
+        "median": float(np.median(arr)),
+        "ci_low_90": float(np.percentile(arr, 5)),
+        "ci_high_90": float(np.percentile(arr, 95)),
+        "ci_low_95": float(np.percentile(arr, 2.5)),
+        "ci_high_95": float(np.percentile(arr, 97.5)),
+        "n_valid_iters": len(values),
+    }
+
+
+def _cluster_bootstrap_h3(
+    points: list[dict[str, object]],
+    *,
+    n_iter: int = 1000,
+    seed: int = 0,
+) -> dict[str, dict[str, float]]:
+    """Persona-cluster bootstrap CIs for the H3 diagnostics (round-3 BUG-#4).
+
+    Resamples persona clusters from ``points`` with replacement; on each
+    iteration recomputes:
+      - partial Spearman ρ(cos_to_source, leak | prior_logprob)
+      - standardized OLS z(leak) ~ z(prior_logprob) + z(cos_to_source):
+        beta_prior, beta_prox, R^2
+
+    Returns a dict with one sub-dict per statistic carrying the
+    mean/median/90%/95% CI summary.
+    """
+    by_persona: dict[str, list[tuple[float, float, float]]] = {}
+    for r in points:
+        prior = r.get("prior_logprob", float("nan"))
+        cos_v = r.get("cos_to_source", float("nan"))
+        leak = r.get("leak", float("nan"))
+        if any(isinstance(v, float) and math.isnan(v) for v in (prior, cos_v, leak)):
+            continue
+        by_persona.setdefault(str(r["persona"]), []).append(
+            (float(prior), float(cos_v), float(leak))
+        )
+    clusters = sorted(by_persona)
+    if len(clusters) < 4:
+        return {"status": {"value": "skipped_too_few_personas", "n_clusters": len(clusters)}}
+
+    rng = np.random.default_rng(seed)
+    partials: list[float] = []
+    beta_priors: list[float] = []
+    beta_proxs: list[float] = []
+    r2s: list[float] = []
+    for _ in range(n_iter):
+        idxs = rng.choice(len(clusters), size=len(clusters), replace=True)
+        # Per-persona means over the bootstrap pick (iterate WITH multiplicity).
+        prior_means: list[float] = []
+        cos_means: list[float] = []
+        leak_means: list[float] = []
+        for i in idxs:
+            rows = by_persona[clusters[i]]
+            n = len(rows)
+            prior_means.append(sum(t[0] for t in rows) / n)
+            cos_means.append(sum(t[1] for t in rows) / n)
+            leak_means.append(sum(t[2] for t in rows) / n)
+        # Need 3 distinct values to avoid degenerate rank / OLS.
+        if len(set(prior_means)) < 3 or len(set(cos_means)) < 3:
+            continue
+        partials.append(_partial_spearman(cos_means, leak_means, prior_means))
+        ols = _ols_two_predictor(leak_means, prior_means, cos_means)
+        beta_priors.append(ols["beta_x1_prior"])
+        beta_proxs.append(ols["beta_x2_prox"])
+        r2s.append(ols["r_squared"])
+
+    return {
+        "partial_spearman_cos_to_source_given_prior": _summarize_bootstrap(
+            [p for p in partials if not math.isnan(p)]
+        ),
+        "ols_beta_prior": _summarize_bootstrap([b for b in beta_priors if not math.isnan(b)]),
+        "ols_beta_prox": _summarize_bootstrap([b for b in beta_proxs if not math.isnan(b)]),
+        "ols_r_squared": _summarize_bootstrap([r for r in r2s if not math.isnan(r)]),
+        "n_clusters": {"value": len(clusters)},
     }
 
 
@@ -285,18 +411,37 @@ def _cross_arm_delta_rho_seed_bootstrap(
             "right_n_seeds": len(right_seeds),
         }
 
-    def _rho_on_seeds(pts: list[dict[str, object]], seed_set: list[int]) -> float:
-        by_persona: dict[str, list[tuple[float, float]]] = {}
+    def _index_by_seed(
+        pts: list[dict[str, object]],
+    ) -> dict[int, list[tuple[str, float, float]]]:
+        """Bucket points by seed -> list of (persona, x, y), NaNs dropped."""
+        out: dict[int, list[tuple[str, float, float]]] = {}
         for r in pts:
-            if int(r["seed"]) not in seed_set:
-                continue
+            s = int(r["seed"])
             x = r.get(x_field, float("nan"))
             y = r.get("leak", float("nan"))
             if isinstance(x, float) and math.isnan(x):
                 continue
             if isinstance(y, float) and math.isnan(y):
                 continue
-            by_persona.setdefault(str(r["persona"]), []).append((float(x), float(y)))
+            out.setdefault(s, []).append((str(r["persona"]), float(x), float(y)))
+        return out
+
+    left_by_seed = _index_by_seed(left_points)
+    right_by_seed = _index_by_seed(right_points)
+
+    def _rho_on_resample(
+        by_seed: dict[int, list[tuple[str, float, float]]],
+        sampled_seeds: list[int],
+    ) -> float:
+        """Per-persona mean of (x, y) over the SAMPLED seed list, iterating
+        WITH MULTIPLICITY (round-3 BUG-#2 fix: a resample like [42,42,42]
+        contributes seed 42 three times, not once).
+        """
+        by_persona: dict[str, list[tuple[float, float]]] = {}
+        for s in sampled_seeds:
+            for persona, x, y in by_seed.get(int(s), []):
+                by_persona.setdefault(persona, []).append((x, y))
         if len(by_persona) < 3:
             return float("nan")
         xs = [sum(t[0] for t in v) / len(v) for v in by_persona.values()]
@@ -305,10 +450,10 @@ def _cross_arm_delta_rho_seed_bootstrap(
 
     deltas: list[float] = []
     for _ in range(n_iter):
-        l_pick = list(rng.choice(left_seeds, size=len(left_seeds), replace=True))
-        r_pick = list(rng.choice(right_seeds, size=len(right_seeds), replace=True))
-        rho_l = _rho_on_seeds(left_points, l_pick)
-        rho_r = _rho_on_seeds(right_points, r_pick)
+        l_pick = [int(s) for s in rng.choice(left_seeds, size=len(left_seeds), replace=True)]
+        r_pick = [int(s) for s in rng.choice(right_seeds, size=len(right_seeds), replace=True)]
+        rho_l = _rho_on_resample(left_by_seed, l_pick)
+        rho_r = _rho_on_resample(right_by_seed, r_pick)
         if math.isnan(rho_l) or math.isnan(rho_r):
             continue
         deltas.append(rho_r - rho_l)
@@ -349,6 +494,51 @@ def _load_cosines(persona_distance_path: Path) -> dict[str, float]:
         persona: float(per_layer[LAYER_HEADLINE])
         for persona, per_layer in data["cosine"]["on_topic"].items()
     }
+
+
+def _load_cos_to_home(cos_home_path: Path) -> dict[str, float]:
+    """Per-bystander cos_to_local_historian at layer 21 (on-topic).
+
+    Round-3 BUG-#1 fix: the producer (``scripts/issue444_persona_distance_topic.py``)
+    writes ``cosine.<topic>.<persona>.<layer>`` and EXCLUDES the reference
+    persona from OTHERS, so ``local_historian`` (which IS the home) has no
+    self-distance entry. Reader contract:
+
+      1. Parse the producer's actual shape: ``data["cosine"]["on_topic"][persona][LAYER_HEADLINE]``.
+      2. Inject the home's self-distance: ``cos_to_home[HOME_PERSONA] = 1.0``.
+         (Cosine of a persona with itself is 1 by definition; the producer
+         can't write this because it skips the reference.)
+      3. Also accept the legacy flat ``{persona: float}`` shape and the
+         legacy nested ``{"cosine": {"21": {persona: float}}}`` shape for
+         back-compat with hand-written files.
+
+    Round-1/2 was looking for ``chd["cosine"]["21"][persona]``, which the
+    producer never writes -> ``cos_to_home`` was silently EMPTY -> H4
+    distance-to-home absent.
+    """
+    if not cos_home_path.exists():
+        return {}
+    chd = json.loads(cos_home_path.read_text())
+    out: dict[str, float] = {}
+    cosine_block = chd.get("cosine") if isinstance(chd, dict) else None
+    if isinstance(cosine_block, dict):
+        if "on_topic" in cosine_block:
+            # Producer shape: cosine.on_topic.<persona>.<layer_str>
+            for persona, per_layer in cosine_block["on_topic"].items():
+                if isinstance(per_layer, dict) and LAYER_HEADLINE in per_layer:
+                    out[persona] = float(per_layer[LAYER_HEADLINE])
+        elif LAYER_HEADLINE in cosine_block:
+            # Legacy nested shape: cosine.<layer_str>.<persona>
+            inner = cosine_block[LAYER_HEADLINE]
+            if isinstance(inner, dict):
+                out.update({k: float(v) for k, v in inner.items() if isinstance(v, (int, float))})
+    elif isinstance(chd, dict):
+        # Legacy flat: {persona: float}
+        out.update({k: float(v) for k, v in chd.items() if isinstance(v, (int, float))})
+    # Inject the home persona's self-distance (1.0 by definition) so the
+    # full 15-pool is covered.
+    out.setdefault(HOME_PERSONA, 1.0)
+    return out
 
 
 def _load_aggregate_cleaned(arm_path: Path) -> dict[str, dict[str, float]]:
@@ -521,16 +711,22 @@ def _per_arm_metrics(
     # personas.
     if points and _good(prior_lp):
         pairs_lp = [(float(r["prior_logprob"]), float(r["leak"])) for r in points]
-        clust_p = [hash(str(r["persona"])) & 0xFFFFFFFF for r in points]
+        clust_p = [str(r["persona"]) for r in points]  # deterministic (BUG-#6)
         stats["bootstrap_spearman_prior_logprob_vs_leak_cluster_persona"] = (
             _cluster_bootstrap_spearman(pairs_lp, clust_p)
         )
     if points and _good(cos_src):
         pairs_cs = [(float(r["cos_to_source"]), float(r["leak"])) for r in points]
-        clust_p = [hash(str(r["persona"])) & 0xFFFFFFFF for r in points]
+        clust_p = [str(r["persona"]) for r in points]  # deterministic (BUG-#6)
         stats["bootstrap_spearman_cos_to_source_vs_leak_cluster_persona"] = (
             _cluster_bootstrap_spearman(pairs_cs, clust_p)
         )
+
+    # Round-3 BUG-#4: cluster-bootstrap CIs for the H3 partial Spearman and
+    # standardized OLS betas (plan §6.3 requires CIs on both, not just point
+    # estimates). Clusters = personas; deterministic seed for reproducibility.
+    if points and _good(cos_src) and _good(prior_lp):
+        stats["h3_cluster_bootstrap"] = _cluster_bootstrap_h3(points)
 
     # Engagement-covariate partials (plan §6.3 "does the prior signal survive
     # length/engagement adjustment?"). Computed only when the
@@ -587,6 +783,16 @@ def _per_arm_metrics(
         if _good(cos_src) and _good(mean_on_topic):
             eng_stats["partial_spearman_cos_vs_leak_given_on_topic"] = _partial_spearman(
                 cos_src, leak_mean, mean_on_topic
+            )
+        # Joint engagement partials (round-3 BUG-#5): control for length AND
+        # on_topic_fraction simultaneously.
+        if _good(prior_lp) and _good(mean_length) and _good(mean_on_topic):
+            eng_stats["partial_spearman_prior_vs_leak_given_length_and_on_topic"] = (
+                _partial_spearman_multi(prior_lp, leak_mean, [mean_length, mean_on_topic])
+            )
+        if _good(cos_src) and _good(mean_length) and _good(mean_on_topic):
+            eng_stats["partial_spearman_cos_vs_leak_given_length_and_on_topic"] = (
+                _partial_spearman_multi(cos_src, leak_mean, [mean_length, mean_on_topic])
             )
         # Means recorded for transparency / sanity check.
         eng_stats["per_persona_mean_length"] = dict(zip(aligned_personas, mean_length, strict=True))
@@ -649,16 +855,11 @@ def main() -> None:
     ]
     fiveway_priors, fiveway_priors_source = _load_5way_priors_union(arm_aggregate_paths)
 
-    # Distance-to-home (cosine to local_historian@layer21). Optional.
-    cos_to_home: dict[str, float] = {}
+    # Distance-to-home (cosine to local_historian@layer21). Optional file.
+    # Round-3 BUG-#1 fix: parser now matches the producer's actual nested
+    # shape AND injects the home persona's self-distance (cos == 1.0).
     cos_home_path = REPO / args.cos_home_path
-    if cos_home_path.exists():
-        chd = json.loads(cos_home_path.read_text())
-        # Accept either {"cosine": {"21": {persona: float}}} or {persona: float}.
-        if "cosine" in chd and "21" in chd.get("cosine", {}):
-            cos_to_home = {k: float(v) for k, v in chd["cosine"]["21"].items()}
-        elif isinstance(chd, dict):
-            cos_to_home = {k: float(v) for k, v in chd.items() if isinstance(v, (int, float))}
+    cos_to_home = _load_cos_to_home(cos_home_path)
 
     out_full: dict[str, object] = {
         "panel_pool_15": list(PANEL_15),

--- a/scripts/run_experiment_444.py
+++ b/scripts/run_experiment_444.py
@@ -4904,9 +4904,31 @@ def phase_worker(args: argparse.Namespace) -> dict[str, Any]:
 # ── Phase: full-eval ─────────────────────────────────────────────────────────
 
 
-def _ensure_merged_adapter(adapter_repo_path: str, seed: int, tag: str, *, gpu_id: int = 0) -> Path:
-    """Download + merge an HF adapter for vLLM (mirror #389/#407)."""
-    from huggingface_hub import snapshot_download
+def _ensure_merged_adapter(
+    adapter_repo_path: str,
+    seed: int,
+    tag: str,
+    *,
+    gpu_id: int = 0,
+    local_out_dir: str | None = None,
+) -> Path:
+    """Download + merge an HF adapter for vLLM (mirror #389/#407).
+
+    Adapter source resolution (in order):
+      1. ``local_merged`` is already present -> reuse (idempotent re-entry).
+      2. ``local_out_dir`` is set AND contains a valid LoRA adapter on disk
+         -> use it directly, skip the HF download (fast path for the local
+         pod that just trained the cell — #500 exp500 arms).
+      3. Per-file paginated download via ``HfApi().list_repo_files`` +
+         ``hf_hub_download`` (NOT ``snapshot_download(allow_patterns=...)``,
+         which lists files via ``model_info().siblings`` and silently
+         truncates at ~5,686 entries on the shared
+         ``superkaiba1/explore-persona-space`` repo — files past the cutoff
+         match nothing and the old call printed "Fetching 0 files" then
+         raised). ``hf_hub_download`` is paginated and immune to the
+         truncation.
+    """
+    from huggingface_hub import HfApi, hf_hub_download
 
     from explore_persona_space.train.sft import merge_lora
 
@@ -4917,14 +4939,49 @@ def _ensure_merged_adapter(adapter_repo_path: str, seed: int, tag: str, *, gpu_i
     if local_merged.exists() and (local_merged / "config.json").exists():
         logger.info("merged dir %s already present; reusing", local_merged)
         return local_merged
-    if not (local_adapter / "adapter_config.json").exists():
-        logger.info("downloading adapter %s", adapter_repo_path)
-        snapshot_download(
-            repo_id=repo_id,
-            allow_patterns=[f"{path_in_repo}/**"],
-            local_dir=str(ADAPTER_ROOT),
-            token=os.environ.get("HF_TOKEN"),
+
+    # (2) Local-first: the trained adapter dir exists on this pod.
+    if local_out_dir:
+        local_path = Path(local_out_dir)
+        has_cfg = (local_path / "adapter_config.json").exists()
+        has_weights = (local_path / "adapter_model.safetensors").exists() or (
+            local_path / "adapter_model.bin"
+        ).exists()
+        if has_cfg and has_weights:
+            logger.info("using local trained adapter %s (skipping HF download)", local_path)
+            logger.info("merging adapter -> %s (gpu_id=%d)", local_merged, gpu_id)
+            merge_lora(BASE_MODEL, str(local_path), str(local_merged), gpu_id=gpu_id)
+            return local_merged
+        logger.info(
+            "local_out_dir %s missing adapter_config.json or adapter_model.* "
+            "(has_cfg=%s has_weights=%s); falling back to HF download",
+            local_path,
+            has_cfg,
+            has_weights,
         )
+
+    # (3) Paginated per-file download (truncation-immune).
+    if not (local_adapter / "adapter_config.json").exists():
+        logger.info("downloading adapter %s (paginated)", adapter_repo_path)
+        token = os.environ.get("HF_TOKEN")
+        repo_files = [
+            f
+            for f in HfApi().list_repo_files(repo_id, token=token)
+            if f.startswith(path_in_repo + "/")
+        ]
+        if not repo_files:
+            raise RuntimeError(
+                f"no files under {path_in_repo} in {repo_id} "
+                "(checked via list_repo_files — adapter never uploaded?)"
+            )
+        logger.info("fetching %d files from %s/%s", len(repo_files), repo_id, path_in_repo)
+        for f in repo_files:
+            hf_hub_download(
+                repo_id=repo_id,
+                filename=f,
+                local_dir=str(ADAPTER_ROOT),
+                token=token,
+            )
         actual = ADAPTER_ROOT / path_in_repo
         if actual.exists():
             local_adapter.parent.mkdir(parents=True, exist_ok=True)
@@ -4932,7 +4989,10 @@ def _ensure_merged_adapter(adapter_repo_path: str, seed: int, tag: str, *, gpu_i
                 shutil.rmtree(local_adapter)
             shutil.move(str(actual), str(local_adapter))
         else:
-            raise RuntimeError(f"snapshot_download did not produce {actual}")
+            raise RuntimeError(
+                f"paginated download did not produce {actual} "
+                f"(fetched {len(repo_files)} files into {ADAPTER_ROOT})"
+            )
     logger.info("merging adapter -> %s (gpu_id=%d)", local_merged, gpu_id)
     merge_lora(BASE_MODEL, str(local_adapter), str(local_merged), gpu_id=gpu_id)
     return local_merged
@@ -5089,8 +5149,16 @@ def phase_full_eval(args: argparse.Namespace) -> dict[str, Any]:
             logger.info("cell %s already judged; skipping", cell.tag)
             summary["per_cell"][cell.tag] = {"judged_path": str(cell_judged), "skipped": True}
             continue
-        # Merge + generate.
-        merged = _ensure_merged_adapter(adapter_repo_path, cell.seed, cell.tag, gpu_id=args.gpu_id)
+        # Merge + generate.  Prefer the local trained-adapter dir (fast path
+        # for the pod that just ran training); fall back to HF download
+        # when missing (e.g. a fresh pod that lost its volume).
+        merged = _ensure_merged_adapter(
+            adapter_repo_path,
+            cell.seed,
+            cell.tag,
+            gpu_id=args.gpu_id,
+            local_out_dir=train_info.get("out_dir"),
+        )
         prompts: list[tuple[str | None, str]] = []
         keys: list[tuple[str, str, str, int, str]] = []
         for persona, sys_prompt in eval_frames.items():

--- a/scripts/run_experiment_500.py
+++ b/scripts/run_experiment_500.py
@@ -710,7 +710,14 @@ def _make_phase_upload_500(arm_slug: str):
             f"{bucket}/raw_completions/baseline_judged.jsonl",
         )
 
-        # Per-cell completions + judged.
+        # Per-cell completions + judged. Round-6 fix: ALSO upload the
+        # authoritative 5-way verdicts (judged_5way_{tag}.jsonl) -- the
+        # aggregator's `_arm_aggregate` reads ONLY those. Without this line
+        # the HF data bucket would carry the parent's linkage `pass` verdicts
+        # (judged_{tag}.jsonl) but NOT the 5-way ones, so anyone
+        # re-aggregating from the public bucket would silently score 0
+        # stated_seven on every trained cell. The linkage upload stays for
+        # audit/debug.
         for cell in p._enumerate_train_cells():
             tag = cell.tag
             _upload_one(
@@ -720,6 +727,10 @@ def _make_phase_upload_500(arm_slug: str):
             _upload_one(
                 p.EVAL_RESULTS_DIR / f"judged_{tag}.jsonl",
                 f"{bucket}/raw_completions/judged_{tag}.jsonl",
+            )
+            _upload_one(
+                p.EVAL_RESULTS_DIR / f"judged_5way_{tag}.jsonl",
+                f"{bucket}/raw_completions/judged_5way_{tag}.jsonl",
             )
 
         # On-policy negative pool (per-figure, shared across cells).

--- a/scripts/run_experiment_500.py
+++ b/scripts/run_experiment_500.py
@@ -345,6 +345,151 @@ def _seed_fact_pick_from_444() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Baseline 5-way judge (round-4 fix)
+# ---------------------------------------------------------------------------
+# Parent ``phase_baselines`` writes ONLY raw ``baseline_completions_<slug>.jsonl``;
+# it never runs the judge. The Phase-0 prior gate + per-arm leak aggregation +
+# 5-way prior union ALL need judged baselines (plan v2 change 2 -- per-arm
+# baseline judging across all arms to kill the cross-experiment batch confound).
+# This helper runs the canonical 5-way Haiku judge (re-used verbatim from
+# ``scripts/reanalyze_issue444_5way.py``) over the per-arm baseline completions
+# and writes ``baseline_judged_<slug>.jsonl`` next to them.
+#
+# Re-entrancy contract (so a resumed pod never re-spends Anthropic budget):
+#   1. ``baseline_judged_<slug>.jsonl`` exists -> NO-OP (skip).
+#   2. ``baseline_completions_<slug>.jsonl`` exists -> JUDGE THOSE
+#      (do NOT regenerate via vLLM); per-row resume-skip on the
+#      ``(persona, family, sub_framing, idx)`` key.
+#   3. Neither exists -> caller must run ``phase_baselines`` first
+#      (we don't auto-regenerate vLLM completions; the gen and the judge
+#      are deliberately separable so a resumed pod with already-generated
+#      completions just runs the judge).
+def _verdict_category(verdict: dict[str, Any] | None) -> str | None:
+    """Read the 5-way category from a judged row's verdict dict.
+
+    Accepts the canonical ``output_category_5way`` key (written by the
+    5-way Haiku judge used here) AND the parent driver's legacy
+    ``output_category`` / ``category`` keys (back-compat with #444's
+    earlier judged files). Returns ``None`` when no key is present.
+    """
+    if not verdict:
+        return None
+    return (
+        verdict.get("output_category_5way")
+        or verdict.get("output_category")
+        or verdict.get("category")
+    )
+
+
+def _phase_baseline_judge(*, force_regenerate: bool = False) -> dict[str, Any]:
+    """Idempotent 5-way Haiku judge over the per-arm baseline completions.
+
+    Writes ``baseline_judged_<figure_slug>.jsonl`` to ``p.EVAL_RESULTS_DIR``.
+    The per-row schema mirrors ``_judge_cell`` in ``reanalyze_issue444_5way``:
+    ``{persona, family, sub_framing, idx, probe, completion_head, verdict}``
+    where ``verdict.output_category_5way`` ∈ {stated_seven, stated_nine,
+    confabulated_other, didnt_mention, refused}.
+
+    Round-4 fix: the parent's ``phase_baselines`` (line ~4691 of
+    ``run_experiment_444.py``) writes only RAW completions. Without this
+    judge step the Phase-0 prior gate reads a missing file -> crash. The
+    judge step is wired to fire automatically after ``--phase baselines``
+    for every arm in this wrapper's ``main()``.
+    """
+    # Defer the heavy import + side effects (anthropic client construction,
+    # OUT_DIR.mkdir on the #444 reanalysis tree) until the helper is called.
+    from reanalyze_issue444_5way import (
+        CATEGORIES,
+        JUDGE_SYSTEM,
+        _build_user_msg,
+        _judge_rows_parallel,
+        _write_jsonl,
+    )
+
+    facts = p._resolve_figure_facts()
+    figure_slug = facts.figure_slug
+    completions_path = p.EVAL_RESULTS_DIR / f"baseline_completions_{figure_slug}.jsonl"
+    judged_path = p.EVAL_RESULTS_DIR / f"baseline_judged_{figure_slug}.jsonl"
+
+    # Step 3 of the re-entrancy contract: must have completions to judge.
+    if not completions_path.exists():
+        raise RuntimeError(
+            f"baseline_judge: {completions_path} missing. Run --phase baselines first "
+            "(the wrapper's main() chains baselines -> baseline_judge automatically; "
+            "this error means --phase baselines never produced its raw completions file)."
+        )
+
+    completions_rows = [json.loads(line) for line in completions_path.open() if line.strip()]
+    if not completions_rows:
+        raise RuntimeError(f"baseline_judge: {completions_path} is empty.")
+
+    # Steps 1 + 2 of the re-entrancy contract, unified via per-row resume:
+    # load whatever's already in the judged file, build the keyset, and judge
+    # only the missing (persona, family, sub_framing, idx) rows. This covers:
+    #   - judged file has every row -> pending is empty -> skipped_all_judged.
+    #   - judged file is missing some rows (mid-run crash, deleted row) ->
+    #     judge ONLY the missing rows, append, checkpoint.
+    #   - judged file doesn't exist -> judge ALL rows.
+    # ``force_regenerate=True`` wipes the judged file first (caller opt-in).
+    if force_regenerate and judged_path.exists():
+        judged_path.unlink()
+    judged: list[dict[str, Any]] = []
+    if judged_path.exists():
+        judged = [json.loads(line) for line in judged_path.open() if line.strip()]
+    judged_keys = {(j["persona"], j["family"], j["sub_framing"], j["idx"]) for j in judged}
+    pending = [
+        r
+        for r in completions_rows
+        if (r["persona"], r["family"], r["sub_framing"], r["idx"]) not in judged_keys
+    ]
+    print(
+        f"[baseline_judge] {completions_path.name}: "
+        f"{len(completions_rows)} rows total, {len(judged)} already judged, "
+        f"{len(pending)} pending."
+    )
+    if not pending:
+        return {
+            "phase": "baseline_judge",
+            "skipped_all_judged": True,
+            "skipped": True,  # back-compat with the previous early-skip key
+            "judged_path": str(judged_path),
+            "n_rows": len(judged),
+        }
+
+    # Chunked dispatch with per-chunk checkpoint flush.
+    chunk_size = 256  # matches parent _JUDGE_CHUNK_ROWS
+    for start in range(0, len(pending), chunk_size):
+        chunk = pending[start : start + chunk_size]
+        jobs = [(JUDGE_SYSTEM, _build_user_msg(r["probe"], r["completion"])) for r in chunk]
+        verdicts = _judge_rows_parallel(jobs)
+        n_err = sum(1 for v in verdicts if "_error" in v)
+        n_bad = sum(1 for v in verdicts if v.get("output_category_5way") not in CATEGORIES)
+        for row, verdict in zip(chunk, verdicts, strict=True):
+            judged.append(
+                {
+                    "persona": row["persona"],
+                    "family": row["family"],
+                    "sub_framing": row["sub_framing"],
+                    "idx": row["idx"],
+                    "probe": row["probe"],
+                    "completion_head": row["completion"][:400],
+                    "verdict": verdict,
+                }
+            )
+        _write_jsonl(judged_path, judged)  # checkpoint after each chunk
+        print(
+            f"[baseline_judge] chunk {start}-{start + len(chunk)}: "
+            f"{n_err} errors, {n_bad} invalid-cat; checkpoint -> {judged_path.name}"
+        )
+
+    return {
+        "phase": "baseline_judge",
+        "judged_path": str(judged_path),
+        "n_rows": len(judged),
+    }
+
+
+# ---------------------------------------------------------------------------
 # Phase 0 prior gate (Arm B)
 # ---------------------------------------------------------------------------
 def _arm_b_phase0_prior_gate() -> None:
@@ -373,12 +518,10 @@ def _arm_b_phase0_prior_gate() -> None:
             "Did --phase baselines run with the full 15-persona pool? The wrapper's "
             "_widen_baseline_panel_to_full_pool() must be active for Arm B baselines."
         )
-    stated_seven = sum(
-        1
-        for r in p_rows
-        if (r.get("verdict") or {}).get("output_category") == "stated_seven"
-        or (r.get("verdict") or {}).get("category") == "stated_seven"
-    )
+    # Round-4: read via _verdict_category so both the new 5-way
+    # output_category_5way schema AND the legacy 4-way output_category /
+    # category keys count as "stated_seven" hits.
+    stated_seven = sum(1 for r in p_rows if _verdict_category(r.get("verdict")) == "stated_seven")
     rate = stated_seven / len(p_rows)
     print(
         f"[phase0_prior_gate] persona={persona} n={len(p_rows)} "
@@ -598,6 +741,15 @@ def main() -> None:
         raise SystemExit(f"unknown --phase {args.phase!r}; valid choices: {list(phases)}")
     fn = phases[args.phase]
     fn(args)
+
+    # Round-4 fix: auto-chain the 5-way baseline judge after --phase baselines
+    # for EVERY arm. Parent phase_baselines writes ONLY raw completions; the
+    # Phase-0 gate + per-arm leak aggregation + 5-way prior union all need
+    # judged baselines. Idempotent: skips when baseline_judged_*.jsonl already
+    # exists; if only completions exist (resumed pod), judges them WITHOUT
+    # regenerating; per-row resume-skip on (persona, family, sub_framing, idx).
+    if args.phase == "baselines":
+        _phase_baseline_judge()
 
     # Restore the trained-eval panel after Arm B baselines so any chained
     # phase_full_eval call in the same process sees n=14 again.

--- a/scripts/run_experiment_500.py
+++ b/scripts/run_experiment_500.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""Experiment #500 -- source-persona content-relatedness for fact leakage.
+
+Thin wrapper around ``scripts/run_experiment_444.py``. Per plan §4.3, this
+script does NOT fork the 5,659-line #444 driver; instead it imports the driver
+module, swaps the load-bearing constants per arm at the module-globals level,
+re-routes the output directories, and dispatches the same phase functions.
+
+Three arms (IV = source-persona content-relatedness to the taught fact):
+  - Arm A ``marine_biologist``                 (content-unrelated)
+  - Arm C ``local_resident``                   (intermediate)
+  - Arm B ``courthouse_architecture_historian`` (content-related)
+
+Arm A SKIPs training -- it reuses the 3 #444 ``on-policy-suppression-cn``
+adapters from ``superkaiba1/explore-persona-space`` at
+``adapters/exp444-on-policy-suppression-cn-seed{42,137,256}`` and only re-runs
+eval-generation + judging on the widened 15-persona panel inside the same
+#500 judge batch.
+
+The constants the wrapper patches (per plan §4.3):
+
+  - ``TEACHING_PERSONA``      -> arm source
+  - ``EVAL_PERSONA_ORDER``    -> 15-persona pool MINUS the arm's source (n=14)
+  - ``NON_TEACH_PERSONAS``    -> 4 ARBITRARY_NON_TEACH (held fixed across arms;
+                                  no arm-source overlaps these, so it stays at 4)
+  - ``ARBITRARY_NON_TEACH_PERSONAS``  -> same (defense-in-depth)
+  - ``TRAINED_CONDITIONS``    -> only ``CONDITION_ON_POLICY_SUPPRESSION``
+  - paths: ``EVAL_RESULTS_DIR / DATA_DIR / ADAPTER_ROOT / FIGURES_DIR /
+            PHASE0_DIR / ON_POLICY_DIR``
+  - ``EXPERIMENT_NAME`` + ``WANDB_PROJECT``
+
+The wrapper ALSO patches ``_aggregate_one_cell.__defaults__`` -- that function
+captures ``eval_personas=EVAL_PERSONA_ORDER`` as a DEF-time default, so a
+plain module-global rebind does not propagate to it.
+
+For Arm A, the wrapper monkey-patches ``_ensure_merged_adapter`` to redirect
+the adapter_repo_path to #444's HF paths, and refuses ``--phase worker``.
+"""
+
+# (greek + arrow + multiplication-sign characters intentional in docstrings)
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+# Import the parent driver. Bootstrap runs at import time (loads .env, sets
+# HF_HOME, etc.); this is the same bootstrap the original driver does, so the
+# wrapper sees the same env.
+import run_experiment_444 as p  # noqa: E402
+
+# Widened bystander pool -- 15 personas spanning the base log-prob prior range
+# (plan §4.4). villain + zelthari_scholar deliberately excluded (refusal /
+# fictional-domain confounds).
+PANEL_15: tuple[str, ...] = (
+    "marine_biologist",
+    "local_historian",
+    "local_resident",
+    "assistant",
+    "software_engineer",
+    "kindergarten_teacher",
+    "no_system",
+    "courthouse_architecture_historian",
+    "data_scientist",
+    "medical_doctor",
+    "librarian",
+    "french_person",
+    "comedian",
+    "police_officer",
+    "biographer",
+)
+assert len(PANEL_15) == 15, PANEL_15
+assert len(set(PANEL_15)) == 15, "PANEL_15 must be unique"
+
+# Map arm-key (= source-persona name) -> output-directory subfolder slug.
+ARM_SOURCE: dict[str, str] = {
+    "marine_biologist": "arm_marine_biologist",
+    "local_resident": "arm_local_resident",
+    "courthouse_architecture_historian": "arm_courthouse_architecture_historian",
+}
+SEEDS: tuple[int, ...] = (42, 137, 256)
+
+
+def _reroute_paths(arm_slug: str) -> None:
+    """Patch the parent driver's path globals so every phase writes to #500's
+    per-arm subtree, not #444's.
+
+    Note: ``PHASE0_DIR`` and ``ON_POLICY_DIR`` are computed at #444 import time
+    as ``EVAL_RESULTS_DIR / ...`` -- patching ``EVAL_RESULTS_DIR`` alone is
+    NOT sufficient. The wrapper rebinds all six path globals explicitly.
+    """
+    base_eval = REPO / "eval_results" / "issue_500" / arm_slug
+    p.EVAL_RESULTS_DIR = base_eval
+    p.DATA_DIR = REPO / "data" / "exp500" / arm_slug
+    p.ADAPTER_ROOT = REPO / "outputs" / "exp500_adapters" / arm_slug
+    p.FIGURES_DIR = REPO / "figures" / "issue_500" / arm_slug
+    p.PHASE0_DIR = base_eval / "phase0_fact_candidates"
+    p.ON_POLICY_DIR = base_eval / "on_policy_negs"
+    p.WANDB_PROJECT = "exp500-source-content-relatedness"
+    p.EXPERIMENT_NAME = f"issue500_{arm_slug}"
+
+
+def _set_arm_personas(source_persona: str) -> None:
+    """Patch the parent driver's persona globals for the given arm.
+
+    - ``TEACHING_PERSONA``: the arm's source.
+    - ``EVAL_PERSONA_ORDER``: 15-persona pool minus the arm's source (n=14).
+      ("Honest fixed candidate pool, arm-specific exclusion" framing.)
+    - ``NON_TEACH_PERSONAS`` / ``ARBITRARY_NON_TEACH_PERSONAS``: the 4 fixed
+      negative personas. None of the 3 arm sources overlap these 4, so the
+      exclusion is a no-op in practice, but it's the right defensive code.
+    - ``TRAINED_CONDITIONS``: shrink to just ``on-policy-suppression-cn``
+      (the #444 recipe Arm A's adapters were trained under; plan §4.3).
+
+    Verifies the patch took effect by re-reading the constants -- guards
+    against accidental defensive copies / def-time captures inside the parent
+    driver.
+    """
+    p.TEACHING_PERSONA = source_persona
+
+    panel = tuple(x for x in PANEL_15 if x != source_persona)
+    assert len(panel) == 14, panel
+    p.EVAL_PERSONA_ORDER = panel
+
+    # The 4 ARBITRARY_NON_TEACH_PERSONAS are held FIXED across arms (plan §0).
+    # Filter defensively in case a future plan revision picks an arm source
+    # that overlaps with the negative set.
+    neg = tuple(x for x in p.ARBITRARY_NON_TEACH_PERSONAS if x != source_persona)
+    p.ARBITRARY_NON_TEACH_PERSONAS = neg
+    p.NON_TEACH_PERSONAS = neg
+
+    # Patch ``_aggregate_one_cell``'s def-time default for ``eval_personas``.
+    # Without this, the aggregate phase iterates over the ORIGINAL #444
+    # 7-persona panel and silently drops the new 7 personas from the rollup.
+    p._aggregate_one_cell.__defaults__ = (p.EVAL_PERSONA_ORDER,)
+
+    # Restrict the trained conditions to the single recipe (#444's
+    # ``on-policy-suppression-cn``).
+    p.TRAINED_CONDITIONS = (p.CONDITION_ON_POLICY_SUPPRESSION,)
+
+    # Sanity checks (verify the override actually took effect; the
+    # methodology-critic flagged that module-level constants captured at
+    # import time may not see a late swap).
+    assert source_persona == p.TEACHING_PERSONA
+    assert panel == p.EVAL_PERSONA_ORDER
+    assert p._aggregate_one_cell.__defaults__ == (panel,)
+    assert p.TRAINED_CONDITIONS == (p.CONDITION_ON_POLICY_SUPPRESSION,)
+
+
+def _arm_a_adapter_path(seed: int) -> str:
+    """The #444 HF subfolder housing one of the 3 reused adapters."""
+    return f"adapters/exp444-on-policy-suppression-cn-seed{seed}"
+
+
+def _install_arm_a_adapter_redirect() -> None:
+    """For Arm A, redirect ``_ensure_merged_adapter`` to the #444 HF paths.
+
+    The full-eval phase calls ``_ensure_merged_adapter(adapter_repo_path,
+    seed, tag, gpu_id=...)``; the original ``adapter_repo_path`` would be
+    derived from a #500 ``train_<cell>.json`` summary that doesn't exist
+    (Arm A skips training). Monkey-patch ignores the caller's path and
+    substitutes #444's.
+    """
+    orig = p._ensure_merged_adapter
+
+    def _patched(adapter_repo_path: str, seed: int, tag: str, *, gpu_id: int = 0):
+        return orig(_arm_a_adapter_path(seed), seed, tag, gpu_id=gpu_id)
+
+    p._ensure_merged_adapter = _patched
+
+
+def _seed_arm_a_train_summaries(arm_slug: str) -> None:
+    """For Arm A, fabricate the per-cell ``train_<cell>.json`` summaries that
+    ``phase_full_eval`` reads to build ``adapter_repo_path``.
+
+    Arm A doesn't run --phase worker; without these stub summaries
+    ``phase_full_eval`` would log ``training summary missing for %s; skipping``
+    and never call ``_ensure_merged_adapter`` at all.
+
+    The stub carries ``hf_repo`` + ``hf_path_in_repo`` pointing at #444; the
+    arm-A monkey-patch on ``_ensure_merged_adapter`` ignores those anyway
+    (defense-in-depth -- the real source of truth is the monkey-patch), but
+    keeping them honest aids debugging.
+    """
+    base_eval = p.EVAL_RESULTS_DIR
+    base_eval.mkdir(parents=True, exist_ok=True)
+    for seed in SEEDS:
+        tag = f"on_policy_suppression_cn_seed{seed}"
+        out_path = base_eval / f"train_{tag}.json"
+        if out_path.exists():
+            continue
+        out_path.write_text(
+            json.dumps(
+                {
+                    "cell": tag,
+                    "condition": p.CONDITION_ON_POLICY_SUPPRESSION,
+                    "seed": seed,
+                    "gpu_id": 0,
+                    "out_dir": "(arm-A: reused from #444 adapter HF Hub path)",
+                    "training_loss": None,
+                    "hf_repo": p.HF_MODEL_REPO,
+                    "hf_path_in_repo": _arm_a_adapter_path(seed),
+                    "timestamp": p._now_iso(),
+                    "arm_a_reused": True,
+                    "_doc": (
+                        "Stub summary written by run_experiment_500.py for Arm A. "
+                        "Arm A reuses the #444 on-policy-suppression-cn adapters; the "
+                        "_ensure_merged_adapter monkey-patch redirects to #444's HF "
+                        "paths regardless of what 'hf_path_in_repo' says here."
+                    ),
+                },
+                indent=2,
+            )
+        )
+
+
+def _seed_fact_pick_from_444(arm_slug: str) -> None:
+    """Copy #444's fact_pick.json (+ candidates.json + figure_facts cache) into
+    #500's PHASE0_DIR.
+
+    #500 reuses the SAME fact as #444 (Elk County Courthouse / seven benches);
+    we don't re-run the fact-candidates + fact-pick gates. Copy the cached
+    artifacts so ``_resolve_figure_facts()`` succeeds.
+    """
+    src_phase0 = REPO / "eval_results" / "issue_444" / "phase0_fact_candidates"
+    dst_phase0 = p.PHASE0_DIR
+    dst_phase0.mkdir(parents=True, exist_ok=True)
+    for fname in ("fact_pick.json", "candidates.json"):
+        src = src_phase0 / fname
+        if not src.exists():
+            raise RuntimeError(
+                f"#444 fact-pick artifact missing: {src} -- #500 reuses #444's fact-pick, "
+                "so #444's Phase 0 outputs must be present in the repo before launch."
+            )
+        dst = dst_phase0 / fname
+        if not dst.exists():
+            shutil.copyfile(src, dst)
+    # Cached figure_facts (avoids a redundant Sonnet call to rebuild).
+    for cache_file in src_phase0.glob("figure_facts_*.json"):
+        dst = dst_phase0 / cache_file.name
+        if not dst.exists():
+            shutil.copyfile(cache_file, dst)
+
+
+def _arm_b_phase0_prior_gate() -> None:
+    """Phase 0 hard gate: the new ``courthouse_architecture_historian`` persona's
+    base ``stated_seven`` rate MUST be < ``local_historian``'s 6.4% (plan §4.4).
+
+    Reads ``EVAL_RESULTS_DIR/baseline_judged_<figure_slug>.jsonl`` (the
+    rejudged 5-way verdicts) and counts ``stated_seven`` for the new persona.
+    Aborts with a clear remediation hint if the rate is too high.
+    """
+    facts = p._resolve_figure_facts()
+    judged = p.EVAL_RESULTS_DIR / f"baseline_judged_{facts.figure_slug}.jsonl"
+    if not judged.exists():
+        raise RuntimeError(
+            f"Phase-0 prior gate cannot run: {judged} missing. Run --phase baselines "
+            "for Arm B first so the new persona's base rate can be measured."
+        )
+    persona = "courthouse_architecture_historian"
+    rows = [json.loads(line) for line in judged.open() if line.strip()]
+    p_rows = [r for r in rows if r["persona"] == persona]
+    if not p_rows:
+        raise RuntimeError(
+            f"Phase-0 prior gate: no baseline rows for persona {persona!r} in {judged}."
+        )
+    stated_seven = sum(
+        1
+        for r in p_rows
+        if (r.get("verdict") or {}).get("output_category") == "stated_seven"
+        or (r.get("verdict") or {}).get("category") == "stated_seven"
+    )
+    rate = stated_seven / len(p_rows)
+    print(
+        f"[phase0_prior_gate] persona={persona} n={len(p_rows)} "
+        f"stated_seven={stated_seven} rate={rate:.4f} (threshold 0.064)"
+    )
+    if rate >= 0.064:
+        raise RuntimeError(
+            f"Phase-0 prior gate FAILED for {persona}: rate={rate:.4f} >= 0.064 "
+            "(local_historian's 6.37% level). Revise persona text in "
+            "src/explore_persona_space/personas.py (less courthouse-specific framing) "
+            "and re-run --phase baselines."
+        )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Experiment #500 -- source-persona content-relatedness for fact leakage. "
+            "Thin wrapper around run_experiment_444.py with per-arm overrides."
+        )
+    )
+    ap.add_argument(
+        "--arm",
+        required=True,
+        choices=list(ARM_SOURCE),
+        help="Source persona for this arm.",
+    )
+    ap.add_argument(
+        "--phase",
+        required=True,
+        help="phase to run (forwarded to run_experiment_444; see PHASES there)",
+    )
+    ap.add_argument("--gpu-id", type=int, default=0, help="GPU id for this process")
+    ap.add_argument("--shard-id", type=int, default=0)
+    ap.add_argument("--num-shards", type=int, default=1)
+    ap.add_argument("--seed", type=int, default=None)
+    ap.add_argument("--condition", type=str, default=None)
+    ap.add_argument("--fact-pick-id", type=int, default=None)
+    ap.add_argument("--allow-multi-bpe-answer", action="store_true")
+    ap.add_argument("--force", action="store_true")
+    ap.add_argument(
+        "--phase0-prior-gate",
+        action="store_true",
+        help=(
+            "After --phase baselines completes, run the Arm B Phase-0 prior gate "
+            "and abort if the new persona's stated_seven rate >= 6.4%%."
+        ),
+    )
+    args = ap.parse_args()
+
+    arm_slug = ARM_SOURCE[args.arm]
+    reuse_arm_a = args.arm == "marine_biologist"
+
+    _reroute_paths(arm_slug)
+    _set_arm_personas(args.arm)
+    _seed_fact_pick_from_444(arm_slug)
+
+    # Arm A: refuse training; redirect the merge resolver to #444's HF paths;
+    # seed stub train summaries so phase_full_eval iterates the right cells.
+    if reuse_arm_a:
+        if args.phase == "worker":
+            raise SystemExit(
+                "Arm A reuses #444 on-policy-suppression-cn adapters; "
+                "skip --phase worker (no training needed for this arm)."
+            )
+        _install_arm_a_adapter_redirect()
+        _seed_arm_a_train_summaries(arm_slug)
+
+    phases = {
+        "preflight": p.phase_preflight,
+        "fact-candidates": p.phase_fact_candidates,
+        "fact-pick": p.phase_fact_pick,
+        "dataset": p.phase_dataset,
+        "baselines": p.phase_baselines,
+        "fp-calibration": p.phase_fp_calibration,
+        "worker": p.phase_worker,
+        "full-eval": p.phase_full_eval,
+        "aggregate": p.phase_aggregate,
+        "upload": p.phase_upload,
+    }
+    if args.phase not in phases:
+        raise SystemExit(f"unknown --phase {args.phase!r}; valid choices: {list(phases)}")
+    fn = phases[args.phase]
+    fn(args)
+
+    # Optional Phase-0 prior gate (run after --phase baselines for Arm B).
+    if args.phase0_prior_gate:
+        if args.arm != "courthouse_architecture_historian":
+            print(f"[phase0_prior_gate] skipping for arm={args.arm} (gate is Arm B-specific)")
+        else:
+            _arm_b_phase0_prior_gate()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_experiment_500.py
+++ b/scripts/run_experiment_500.py
@@ -17,24 +17,24 @@ adapters from ``superkaiba1/explore-persona-space`` at
 eval-generation + judging on the widened 15-persona panel inside the same
 #500 judge batch.
 
-The constants the wrapper patches (per plan §4.3):
+Round-2 destructive-fix architecture (after the round-1 code-review):
 
-  - ``TEACHING_PERSONA``      -> arm source
-  - ``EVAL_PERSONA_ORDER``    -> 15-persona pool MINUS the arm's source (n=14)
-  - ``NON_TEACH_PERSONAS``    -> 4 ARBITRARY_NON_TEACH (held fixed across arms;
-                                  no arm-source overlaps these, so it stays at 4)
-  - ``ARBITRARY_NON_TEACH_PERSONAS``  -> same (defense-in-depth)
-  - ``TRAINED_CONDITIONS``    -> only ``CONDITION_ON_POLICY_SUPPRESSION``
-  - paths: ``EVAL_RESULTS_DIR / DATA_DIR / ADAPTER_ROOT / FIGURES_DIR /
-            PHASE0_DIR / ON_POLICY_DIR``
-  - ``EXPERIMENT_NAME`` + ``WANDB_PROJECT``
-
-The wrapper ALSO patches ``_aggregate_one_cell.__defaults__`` -- that function
-captures ``eval_personas=EVAL_PERSONA_ORDER`` as a DEF-time default, so a
-plain module-global rebind does not propagate to it.
-
-For Arm A, the wrapper monkey-patches ``_ensure_merged_adapter`` to redirect
-the adapter_repo_path to #444's HF paths, and refuses ``--phase worker``.
+  - ``TrainCell.hf_path_in_repo`` is overridden at the class level so Arms B/C
+    publish to ``adapters/exp500-<arm>-<condition>-seed<seed>`` -- they CANNOT
+    overwrite #444's adapters. Arm A still reuses #444 paths via stub train
+    summaries that carry the original ``adapters/exp444-...`` path.
+  - ``phase_upload`` is replaced with a wrapper-local implementation that
+    routes raw completions to ``issue500_source_content_relatedness/<arm>/
+    <figure_slug>/raw_completions/``, NOT #444's data-repo bucket.
+  - ``PERSONAS["local_resident"]`` is pre-formatted with Ridgway/PA BEFORE any
+    training-side helper reads it (Arm C training previously got the raw
+    template with literal ``{town}``/``{state}`` placeholders).
+  - ``_install_arm_a_adapter_redirect()`` is GONE; the stub train summary
+    carries ``hf_repo + hf_path_in_repo`` that ``phase_full_eval`` joins
+    correctly. The previous redirect built a malformed 2-part HF id.
+  - ``--phase baselines`` for Arm B runs over the FULL 15-pool (including the
+    new persona), so the Phase-0 prior gate can measure that persona. Trained
+    eval panels stay at n=14 (source-excluded).
 """
 
 # (greek + arrow + multiplication-sign characters intentional in docstrings)
@@ -46,6 +46,7 @@ import json
 import shutil
 import sys
 from pathlib import Path
+from typing import Any
 
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "scripts"))
@@ -86,7 +87,15 @@ ARM_SOURCE: dict[str, str] = {
 }
 SEEDS: tuple[int, ...] = (42, 137, 256)
 
+# Hardcoded entity locale (read from #444's fact_pick.json at runtime, but
+# pinned here as a defensive default since #500 reuses the exact #444 fact).
+ENTITY_TOWN = "Ridgway"
+ENTITY_STATE = "Pennsylvania"
 
+
+# ---------------------------------------------------------------------------
+# Per-arm module-globals patcher
+# ---------------------------------------------------------------------------
 def _reroute_paths(arm_slug: str) -> None:
     """Patch the parent driver's path globals so every phase writes to #500's
     per-arm subtree, not #444's.
@@ -104,6 +113,73 @@ def _reroute_paths(arm_slug: str) -> None:
     p.ON_POLICY_DIR = base_eval / "on_policy_negs"
     p.WANDB_PROJECT = "exp500-source-content-relatedness"
     p.EXPERIMENT_NAME = f"issue500_{arm_slug}"
+
+
+def _format_local_resident_prompt() -> None:
+    """Re-bind ``PERSONAS["local_resident"]`` to the {town,state}-formatted
+    string BEFORE any training-side helper reads it.
+
+    Round-1 BLOCKER #3: parent's ``_build_teach_rows`` (line ~3530) and
+    ``_resolve_persona_system`` (line ~689) read ``PERSONAS[name]`` raw. For
+    Arm C (``TEACHING_PERSONA = "local_resident"``) this returned the literal
+    template ``"You are a longtime resident of {town}, {state} ..."`` -- the
+    LoRA would train on a garbage system prompt with curly braces.
+
+    Only ``_resolve_eval_frames`` (line ~723) special-cases ``local_resident``
+    formatting. The fix re-binds the registry entry so EVERY caller (training
+    + eval + on-policy-neg) sees the formatted string.
+    """
+    raw = p.PERSONAS["local_resident"]
+    formatted = raw.format(town=ENTITY_TOWN, state=ENTITY_STATE)
+    assert "{town}" not in formatted, formatted
+    assert "{state}" not in formatted, formatted
+    p.PERSONAS["local_resident"] = formatted
+
+
+def _assert_no_unformatted_placeholders_in_training(rows: list[dict[str, Any]]) -> None:
+    """Build-time check: no training row's system prompt contains literal
+    ``{town}`` or ``{state}``. Fail fast (round-2 BLOCKER #3 mitigation)."""
+    for i, row in enumerate(rows):
+        prompt = row.get("prompt", [])
+        for msg in prompt:
+            if msg.get("role") != "system":
+                continue
+            content = msg.get("content") or ""
+            if "{town}" in content or "{state}" in content:
+                raise RuntimeError(
+                    f"training row {i} carries unformatted placeholder in system "
+                    f"prompt (persona={row.get('persona')!r}): {content!r}. "
+                    "The wrapper's _format_local_resident_prompt() must be called "
+                    "before any phase that builds training rows."
+                )
+
+
+def _override_train_cell_hf_path(arm_slug: str) -> None:
+    """Override ``TrainCell.hf_path_in_repo`` at the class level so Arms B/C
+    publish to ``adapters/exp500-<arm>-<condition>-seed<seed>``.
+
+    Round-1 BLOCKER #6: parent ``TrainCell.hf_path_in_repo`` (line ~4775)
+    returns ``f"adapters/exp444-{self.condition}-seed{self.seed}"`` -- training
+    Arm B's on-policy-suppression-cn would OVERWRITE the validated #444 Arm A
+    adapter. The override rewires the property to the #500 namespace.
+
+    Implementation: replace the property descriptor on the dataclass with a
+    new property whose closure captures ``arm_slug``. Inheritance from the
+    parent's ``TrainCell`` is preserved by mutating the class object directly
+    (the dataclass machinery already populated ``__init__`` and ``__eq__``).
+    """
+
+    # Module-level rebind so the override survives across phases in this
+    # process. The closure captures arm_slug; no per-cell mutation needed.
+    def _new_hf_path_in_repo(self: Any) -> str:
+        condition = self.condition.replace("-", "_")
+        return f"adapters/exp500-{arm_slug}-{condition}-seed{self.seed}"
+
+    # `property` is a descriptor; setattr on the class swaps the underlying
+    # fget. The dataclass synthesizes __init__/__repr__/__eq__ around the
+    # declared fields (condition, seed) -- the @property is a method, not a
+    # field, so the override is safe.
+    p.TrainCell.hf_path_in_repo = property(_new_hf_path_in_repo)
 
 
 def _set_arm_personas(source_persona: str) -> None:
@@ -153,29 +229,43 @@ def _set_arm_personas(source_persona: str) -> None:
     assert p.TRAINED_CONDITIONS == (p.CONDITION_ON_POLICY_SUPPRESSION,)
 
 
-def _arm_a_adapter_path(seed: int) -> str:
+def _widen_baseline_panel_to_full_pool() -> None:
+    """For ``--phase baselines`` ONLY: temporarily set ``EVAL_PERSONA_ORDER``
+    to the FULL 15-persona pool (including the arm's source).
+
+    Round-1 BLOCKER #5: ``_set_arm_personas()`` excludes the source from the
+    eval panel (correct for trained eval). But the baseline must measure the
+    source's OWN base prior too -- otherwise the Arm B Phase-0 prior gate
+    has no row for ``courthouse_architecture_historian`` to inspect.
+
+    Run this AFTER ``_set_arm_personas`` and BEFORE ``phase_baselines``;
+    everything else (TRAINED_CONDITIONS, NON_TEACH, etc.) stays as set.
+    Trained-eval phases ALSO call ``phase_full_eval`` separately with the
+    n=14 panel intact.
+    """
+    p.EVAL_PERSONA_ORDER = PANEL_15
+    # Also propagate to _aggregate_one_cell so the baseline rollup includes
+    # all 15 personas.
+    p._aggregate_one_cell.__defaults__ = (p.EVAL_PERSONA_ORDER,)
+
+
+def _restore_trained_panel(source_persona: str) -> None:
+    """Inverse of ``_widen_baseline_panel_to_full_pool``: revert
+    ``EVAL_PERSONA_ORDER`` back to source-excluded n=14 after baselines."""
+    panel = tuple(x for x in PANEL_15 if x != source_persona)
+    p.EVAL_PERSONA_ORDER = panel
+    p._aggregate_one_cell.__defaults__ = (p.EVAL_PERSONA_ORDER,)
+
+
+# ---------------------------------------------------------------------------
+# Arm A: reuse #444 adapters
+# ---------------------------------------------------------------------------
+def _arm_a_adapter_subfolder(seed: int) -> str:
     """The #444 HF subfolder housing one of the 3 reused adapters."""
     return f"adapters/exp444-on-policy-suppression-cn-seed{seed}"
 
 
-def _install_arm_a_adapter_redirect() -> None:
-    """For Arm A, redirect ``_ensure_merged_adapter`` to the #444 HF paths.
-
-    The full-eval phase calls ``_ensure_merged_adapter(adapter_repo_path,
-    seed, tag, gpu_id=...)``; the original ``adapter_repo_path`` would be
-    derived from a #500 ``train_<cell>.json`` summary that doesn't exist
-    (Arm A skips training). Monkey-patch ignores the caller's path and
-    substitutes #444's.
-    """
-    orig = p._ensure_merged_adapter
-
-    def _patched(adapter_repo_path: str, seed: int, tag: str, *, gpu_id: int = 0):
-        return orig(_arm_a_adapter_path(seed), seed, tag, gpu_id=gpu_id)
-
-    p._ensure_merged_adapter = _patched
-
-
-def _seed_arm_a_train_summaries(arm_slug: str) -> None:
+def _seed_arm_a_train_summaries() -> None:
     """For Arm A, fabricate the per-cell ``train_<cell>.json`` summaries that
     ``phase_full_eval`` reads to build ``adapter_repo_path``.
 
@@ -183,14 +273,18 @@ def _seed_arm_a_train_summaries(arm_slug: str) -> None:
     ``phase_full_eval`` would log ``training summary missing for %s; skipping``
     and never call ``_ensure_merged_adapter`` at all.
 
-    The stub carries ``hf_repo`` + ``hf_path_in_repo`` pointing at #444; the
-    arm-A monkey-patch on ``_ensure_merged_adapter`` ignores those anyway
-    (defense-in-depth -- the real source of truth is the monkey-patch), but
-    keeping them honest aids debugging.
+    Round-2 BLOCKER #1: the stub MUST carry both ``hf_repo`` AND
+    ``hf_path_in_repo`` so ``phase_full_eval`` builds the correct 3-part
+    HF Hub path ``superkaiba1/explore-persona-space/adapters/exp444-...``.
+    The previous round-1 ``_install_arm_a_adapter_redirect`` monkey-patch is
+    GONE (it built a malformed 2-part id and crashed snapshot_download).
     """
     base_eval = p.EVAL_RESULTS_DIR
     base_eval.mkdir(parents=True, exist_ok=True)
     for seed in SEEDS:
+        # Arm A's cell tag stays at the #444 form (the parent's TrainCell
+        # generates it that way before the @property override; for Arm A we
+        # NEVER instantiate a TrainCell so the override is moot).
         tag = f"on_policy_suppression_cn_seed{seed}"
         out_path = base_eval / f"train_{tag}.json"
         if out_path.exists():
@@ -205,14 +299,13 @@ def _seed_arm_a_train_summaries(arm_slug: str) -> None:
                     "out_dir": "(arm-A: reused from #444 adapter HF Hub path)",
                     "training_loss": None,
                     "hf_repo": p.HF_MODEL_REPO,
-                    "hf_path_in_repo": _arm_a_adapter_path(seed),
+                    "hf_path_in_repo": _arm_a_adapter_subfolder(seed),
                     "timestamp": p._now_iso(),
                     "arm_a_reused": True,
                     "_doc": (
                         "Stub summary written by run_experiment_500.py for Arm A. "
-                        "Arm A reuses the #444 on-policy-suppression-cn adapters; the "
-                        "_ensure_merged_adapter monkey-patch redirects to #444's HF "
-                        "paths regardless of what 'hf_path_in_repo' says here."
+                        "phase_full_eval joins hf_repo + hf_path_in_repo to form "
+                        "the correct 3-part HF Hub path to #444's published adapter."
                     ),
                 },
                 indent=2,
@@ -220,7 +313,10 @@ def _seed_arm_a_train_summaries(arm_slug: str) -> None:
         )
 
 
-def _seed_fact_pick_from_444(arm_slug: str) -> None:
+# ---------------------------------------------------------------------------
+# Fact-pick reuse (no fact-candidates phase for #500)
+# ---------------------------------------------------------------------------
+def _seed_fact_pick_from_444() -> None:
     """Copy #444's fact_pick.json (+ candidates.json + figure_facts cache) into
     #500's PHASE0_DIR.
 
@@ -248,13 +344,18 @@ def _seed_fact_pick_from_444(arm_slug: str) -> None:
             shutil.copyfile(cache_file, dst)
 
 
+# ---------------------------------------------------------------------------
+# Phase 0 prior gate (Arm B)
+# ---------------------------------------------------------------------------
 def _arm_b_phase0_prior_gate() -> None:
-    """Phase 0 hard gate: the new ``courthouse_architecture_historian`` persona's
-    base ``stated_seven`` rate MUST be < ``local_historian``'s 6.4% (plan §4.4).
+    """Phase 0 hard gate: the new ``courthouse_architecture_historian``
+    persona's base ``stated_seven`` rate MUST be < ``local_historian``'s 6.4%
+    (plan §4.4).
 
     Reads ``EVAL_RESULTS_DIR/baseline_judged_<figure_slug>.jsonl`` (the
-    rejudged 5-way verdicts) and counts ``stated_seven`` for the new persona.
-    Aborts with a clear remediation hint if the rate is too high.
+    rejudged 5-way verdicts). Round-2 BLOCKER #5: the baseline must have been
+    run with the FULL 15-pool panel for this gate to find a row -- see
+    ``_widen_baseline_panel_to_full_pool``.
     """
     facts = p._resolve_figure_facts()
     judged = p.EVAL_RESULTS_DIR / f"baseline_judged_{facts.figure_slug}.jsonl"
@@ -268,7 +369,9 @@ def _arm_b_phase0_prior_gate() -> None:
     p_rows = [r for r in rows if r["persona"] == persona]
     if not p_rows:
         raise RuntimeError(
-            f"Phase-0 prior gate: no baseline rows for persona {persona!r} in {judged}."
+            f"Phase-0 prior gate: no baseline rows for persona {persona!r} in {judged}. "
+            "Did --phase baselines run with the full 15-persona pool? The wrapper's "
+            "_widen_baseline_panel_to_full_pool() must be active for Arm B baselines."
         )
     stated_seven = sum(
         1
@@ -288,6 +391,125 @@ def _arm_b_phase0_prior_gate() -> None:
             "src/explore_persona_space/personas.py (less courthouse-specific framing) "
             "and re-run --phase baselines."
         )
+
+
+# ---------------------------------------------------------------------------
+# #500-specific phase_upload (BLOCKER #5: route to #500 bucket)
+# ---------------------------------------------------------------------------
+def _make_phase_upload_500(arm_slug: str):
+    """Build a wrapper-local ``phase_upload`` that uploads to #500's HF data
+    bucket instead of #444's.
+
+    Round-1 BLOCKER #5: parent's ``phase_upload`` hardcodes
+    ``bucket = f"issue444_real_figure_provenance/{figure_slug}"``. Running
+    upload on any #500 arm would OVERWRITE #444's raw completions and the 3
+    arms would collide on the same per-cell tag. The wrapper-local upload uses
+    ``issue500_source_content_relatedness/<arm>/<figure_slug>``.
+
+    Implementation: re-execute the parent's upload logic with the #500 bucket.
+    We reuse parent helpers (`_resolve_figure_facts`, `_enumerate_train_cells`,
+    `HF_DATA_REPO`) but rebuild the bucket string + upload calls locally.
+    """
+    import os
+
+    def phase_upload_500(args: argparse.Namespace) -> dict[str, Any]:
+        from huggingface_hub import HfApi
+
+        facts = p._resolve_figure_facts()
+        figure_slug = facts.figure_slug
+        api = HfApi(token=os.environ.get("HF_TOKEN"))
+        bucket = f"issue500_source_content_relatedness/{arm_slug}/{figure_slug}"
+        files_uploaded: list[str] = []
+
+        def _upload_one(local_path: Path, path_in_repo: str) -> None:
+            if not local_path.exists():
+                print(f"[upload-500] skip missing: {local_path}")
+                return
+            api.upload_file(
+                path_or_fileobj=str(local_path),
+                path_in_repo=path_in_repo,
+                repo_id=p.HF_DATA_REPO,
+                repo_type="dataset",
+            )
+            files_uploaded.append(path_in_repo)
+            print(f"[upload-500] -> {p.HF_DATA_REPO}:{path_in_repo}")
+
+        # Baseline completions + judged verdicts.
+        _upload_one(
+            p.EVAL_RESULTS_DIR / f"baseline_completions_{figure_slug}.jsonl",
+            f"{bucket}/raw_completions/baseline_completions.jsonl",
+        )
+        _upload_one(
+            p.EVAL_RESULTS_DIR / f"baseline_judged_{figure_slug}.jsonl",
+            f"{bucket}/raw_completions/baseline_judged.jsonl",
+        )
+
+        # Per-cell completions + judged.
+        for cell in p._enumerate_train_cells():
+            tag = cell.tag
+            _upload_one(
+                p.EVAL_RESULTS_DIR / f"completions_{tag}.jsonl",
+                f"{bucket}/raw_completions/completions_{tag}.jsonl",
+            )
+            _upload_one(
+                p.EVAL_RESULTS_DIR / f"judged_{tag}.jsonl",
+                f"{bucket}/raw_completions/judged_{tag}.jsonl",
+            )
+
+        # On-policy negative pool (per-figure, shared across cells).
+        op_dir = p.ON_POLICY_DIR
+        if op_dir.exists():
+            for fp in sorted(op_dir.glob("*.jsonl")):
+                _upload_one(fp, f"{bucket}/on_policy_raw/{fp.name}")
+            for fp in sorted(op_dir.glob("*.json")):
+                _upload_one(fp, f"{bucket}/on_policy_raw/{fp.name}")
+
+        summary = {
+            "phase": "upload",
+            "arm_slug": arm_slug,
+            "hf_data_repo": p.HF_DATA_REPO,
+            "bucket": bucket,
+            "n_files_uploaded": len(files_uploaded),
+            "files": files_uploaded,
+            "timestamp": p._now_iso(),
+        }
+        out_path = p.EVAL_RESULTS_DIR / "upload_summary_500.json"
+        out_path.write_text(json.dumps(summary, indent=2))
+        return summary
+
+    return phase_upload_500
+
+
+# ---------------------------------------------------------------------------
+# Train-row build-time guard (wraps phase_dataset for the assertion)
+# ---------------------------------------------------------------------------
+def _make_phase_dataset_with_guard(orig_phase_dataset):
+    """Wrap parent ``phase_dataset`` to add a post-build assertion that no
+    training row's system prompt contains literal ``{town}`` or ``{state}``.
+
+    Round-2 BLOCKER #3 mitigation: even with
+    ``_format_local_resident_prompt()`` called at startup, a future change to
+    parent's row-building helpers could re-introduce raw templates. The
+    fail-fast assertion catches it at dataset-build time, before any GPU work.
+    """
+
+    def phase_dataset_500(args: argparse.Namespace) -> dict[str, Any]:
+        result = orig_phase_dataset(args)
+        # Scan all built training JSONLs for the figure for surviving
+        # placeholders (every cell's training file lives at
+        # data/exp500/<arm>/<figure_slug>/train_<condition>_seed<seed>.jsonl).
+        facts = p._resolve_figure_facts()
+        figure_dir = p.DATA_DIR / facts.figure_slug
+        for train_jsonl in sorted(figure_dir.glob("train_*.jsonl")):
+            rows = [json.loads(line) for line in train_jsonl.open() if line.strip()]
+            _assert_no_unformatted_placeholders_in_training(rows)
+        print(
+            f"[phase_dataset_500] guard PASS: no {{town}}/{{state}} placeholders "
+            f"in {len(list(figure_dir.glob('train_*.jsonl')))} training files."
+        )
+        return result
+
+    return phase_dataset_500
 
 
 def main() -> None:
@@ -329,37 +551,58 @@ def main() -> None:
     arm_slug = ARM_SOURCE[args.arm]
     reuse_arm_a = args.arm == "marine_biologist"
 
+    # Path + persona patches.
     _reroute_paths(arm_slug)
     _set_arm_personas(args.arm)
-    _seed_fact_pick_from_444(arm_slug)
+    _format_local_resident_prompt()  # BLOCKER #3 fix (must precede any phase)
+    _override_train_cell_hf_path(arm_slug)  # BLOCKER #6 fix
+    _seed_fact_pick_from_444()
 
-    # Arm A: refuse training; redirect the merge resolver to #444's HF paths;
-    # seed stub train summaries so phase_full_eval iterates the right cells.
+    # Arm A: refuse training; seed stub train summaries so phase_full_eval
+    # iterates the right cells and joins hf_repo + hf_path_in_repo correctly.
+    # The round-1 _install_arm_a_adapter_redirect() monkey-patch is GONE
+    # (round-2 BLOCKER #1 fix): the stub train summary IS the source of truth.
     if reuse_arm_a:
         if args.phase == "worker":
             raise SystemExit(
                 "Arm A reuses #444 on-policy-suppression-cn adapters; "
                 "skip --phase worker (no training needed for this arm)."
             )
-        _install_arm_a_adapter_redirect()
-        _seed_arm_a_train_summaries(arm_slug)
+        _seed_arm_a_train_summaries()
 
+    # Phase widening for Arm B baselines (BLOCKER #5 fix): the baseline must
+    # measure courthouse_architecture_historian's own prior, so the panel is
+    # widened to the FULL 15-pool ONLY for the baselines phase.
+    if args.arm == "courthouse_architecture_historian" and args.phase == "baselines":
+        _widen_baseline_panel_to_full_pool()
+        print(
+            "[run_experiment_500] Arm B baselines: widened panel to full "
+            f"{len(p.EVAL_PERSONA_ORDER)}-persona pool (incl. source) "
+            "so the Phase-0 prior gate can measure the source's own base rate."
+        )
+
+    # Build the phase dispatcher (with the #500-local upload + dataset guards).
     phases = {
         "preflight": p.phase_preflight,
         "fact-candidates": p.phase_fact_candidates,
         "fact-pick": p.phase_fact_pick,
-        "dataset": p.phase_dataset,
+        "dataset": _make_phase_dataset_with_guard(p.phase_dataset),
         "baselines": p.phase_baselines,
         "fp-calibration": p.phase_fp_calibration,
         "worker": p.phase_worker,
         "full-eval": p.phase_full_eval,
         "aggregate": p.phase_aggregate,
-        "upload": p.phase_upload,
+        "upload": _make_phase_upload_500(arm_slug),
     }
     if args.phase not in phases:
         raise SystemExit(f"unknown --phase {args.phase!r}; valid choices: {list(phases)}")
     fn = phases[args.phase]
     fn(args)
+
+    # Restore the trained-eval panel after Arm B baselines so any chained
+    # phase_full_eval call in the same process sees n=14 again.
+    if args.arm == "courthouse_architecture_historian" and args.phase == "baselines":
+        _restore_trained_panel(args.arm)
 
     # Optional Phase-0 prior gate (run after --phase baselines for Arm B).
     if args.phase0_prior_gate:

--- a/scripts/run_experiment_500.py
+++ b/scripts/run_experiment_500.py
@@ -381,20 +381,36 @@ def _verdict_category(verdict: dict[str, Any] | None) -> str | None:
     )
 
 
-def _phase_baseline_judge(*, force_regenerate: bool = False) -> dict[str, Any]:
-    """Idempotent 5-way Haiku judge over the per-arm baseline completions.
+def _run_5way_rejudge(
+    *,
+    phase_label: str,
+    completions_path: Path,
+    judged_path: Path,
+    force_regenerate: bool = False,
+) -> dict[str, Any]:
+    """Generic 5-way Haiku rejudge over an arbitrary completions JSONL.
 
-    Writes ``baseline_judged_<figure_slug>.jsonl`` to ``p.EVAL_RESULTS_DIR``.
-    The per-row schema mirrors ``_judge_cell`` in ``reanalyze_issue444_5way``:
-    ``{persona, family, sub_framing, idx, probe, completion_head, verdict}``
-    where ``verdict.output_category_5way`` ∈ {stated_seven, stated_nine,
-    confabulated_other, didnt_mention, refused}.
+    Used by both ``_phase_baseline_judge`` (baseline_completions ->
+    baseline_judged) and ``_phase_trained_cell_5way_rejudge`` (per-cell
+    completions -> per-cell 5-way judged). The 5-way categories include
+    ``stated_seven`` (the #500 primary DV's positive label), which neither
+    the parent's 4-way ``output_category`` rubric nor the linkage-``pass``
+    rubric emits -- so the trained cells need the same re-judge step the
+    baseline does, written to a DISTINCT filename so the aggregator's glob
+    cannot accidentally read the linkage-pass file (which lives at the
+    same per-cell location but under ``judged_{cell.tag}.jsonl``).
 
-    Round-4 fix: the parent's ``phase_baselines`` (line ~4691 of
-    ``run_experiment_444.py``) writes only RAW completions. Without this
-    judge step the Phase-0 prior gate reads a missing file -> crash. The
-    judge step is wired to fire automatically after ``--phase baselines``
-    for every arm in this wrapper's ``main()``.
+    Re-entrancy contract (4 cases; same for both callers):
+      1. judged file complete (every completion key present)
+         -> ``skipped_all_judged: True``; ZERO API calls.
+      2. judged file partial -> judge ONLY the missing
+         ``(persona, family, sub_framing, idx)`` rows; per-chunk
+         checkpoint after every 256 rows.
+      3. judged file missing AND completions exist
+         -> judge all completions; no vLLM regeneration.
+      4. Both missing -> RuntimeError.
+
+    ``force_regenerate=True`` wipes the judged file first (caller opt-in).
     """
     # Defer the heavy import + side effects (anthropic client construction,
     # OUT_DIR.mkdir on the #444 reanalysis tree) until the helper is called.
@@ -406,31 +422,21 @@ def _phase_baseline_judge(*, force_regenerate: bool = False) -> dict[str, Any]:
         _write_jsonl,
     )
 
-    facts = p._resolve_figure_facts()
-    figure_slug = facts.figure_slug
-    completions_path = p.EVAL_RESULTS_DIR / f"baseline_completions_{figure_slug}.jsonl"
-    judged_path = p.EVAL_RESULTS_DIR / f"baseline_judged_{figure_slug}.jsonl"
-
-    # Step 3 of the re-entrancy contract: must have completions to judge.
+    # Step 3/4 of the re-entrancy contract: must have completions to judge.
     if not completions_path.exists():
         raise RuntimeError(
-            f"baseline_judge: {completions_path} missing. Run --phase baselines first "
-            "(the wrapper's main() chains baselines -> baseline_judge automatically; "
-            "this error means --phase baselines never produced its raw completions file)."
+            f"{phase_label}: {completions_path} missing. "
+            "Run the producer phase (--phase baselines for baseline; --phase full-eval "
+            "for trained cells) BEFORE this re-judge. The wrapper's main() chains the "
+            "appropriate producer -> re-judge automatically, so this error means the "
+            "producer phase never wrote its completions file."
         )
 
     completions_rows = [json.loads(line) for line in completions_path.open() if line.strip()]
     if not completions_rows:
-        raise RuntimeError(f"baseline_judge: {completions_path} is empty.")
+        raise RuntimeError(f"{phase_label}: {completions_path} is empty.")
 
-    # Steps 1 + 2 of the re-entrancy contract, unified via per-row resume:
-    # load whatever's already in the judged file, build the keyset, and judge
-    # only the missing (persona, family, sub_framing, idx) rows. This covers:
-    #   - judged file has every row -> pending is empty -> skipped_all_judged.
-    #   - judged file is missing some rows (mid-run crash, deleted row) ->
-    #     judge ONLY the missing rows, append, checkpoint.
-    #   - judged file doesn't exist -> judge ALL rows.
-    # ``force_regenerate=True`` wipes the judged file first (caller opt-in).
+    # Steps 1 + 2 of the re-entrancy contract, unified via per-row resume.
     if force_regenerate and judged_path.exists():
         judged_path.unlink()
     judged: list[dict[str, Any]] = []
@@ -443,20 +449,19 @@ def _phase_baseline_judge(*, force_regenerate: bool = False) -> dict[str, Any]:
         if (r["persona"], r["family"], r["sub_framing"], r["idx"]) not in judged_keys
     ]
     print(
-        f"[baseline_judge] {completions_path.name}: "
+        f"[{phase_label}] {completions_path.name}: "
         f"{len(completions_rows)} rows total, {len(judged)} already judged, "
         f"{len(pending)} pending."
     )
     if not pending:
         return {
-            "phase": "baseline_judge",
+            "phase": phase_label,
             "skipped_all_judged": True,
-            "skipped": True,  # back-compat with the previous early-skip key
+            "skipped": True,  # back-compat
             "judged_path": str(judged_path),
             "n_rows": len(judged),
         }
 
-    # Chunked dispatch with per-chunk checkpoint flush.
     chunk_size = 256  # matches parent _JUDGE_CHUNK_ROWS
     for start in range(0, len(pending), chunk_size):
         chunk = pending[start : start + chunk_size]
@@ -478,14 +483,132 @@ def _phase_baseline_judge(*, force_regenerate: bool = False) -> dict[str, Any]:
             )
         _write_jsonl(judged_path, judged)  # checkpoint after each chunk
         print(
-            f"[baseline_judge] chunk {start}-{start + len(chunk)}: "
+            f"[{phase_label}] chunk {start}-{start + len(chunk)}: "
             f"{n_err} errors, {n_bad} invalid-cat; checkpoint -> {judged_path.name}"
         )
 
     return {
-        "phase": "baseline_judge",
+        "phase": phase_label,
         "judged_path": str(judged_path),
         "n_rows": len(judged),
+    }
+
+
+def _phase_baseline_judge(*, force_regenerate: bool = False) -> dict[str, Any]:
+    """Idempotent 5-way Haiku judge over the per-arm baseline completions.
+
+    Writes ``baseline_judged_<figure_slug>.jsonl`` to ``p.EVAL_RESULTS_DIR``.
+    The per-row schema mirrors ``_judge_cell`` in ``reanalyze_issue444_5way``:
+    ``{persona, family, sub_framing, idx, probe, completion_head, verdict}``
+    where ``verdict.output_category_5way`` ∈ {stated_seven, stated_nine,
+    confabulated_other, didnt_mention, refused}.
+
+    Round-4 fix: the parent's ``phase_baselines`` (line ~4691 of
+    ``run_experiment_444.py``) writes only RAW completions. Without this
+    judge step the Phase-0 prior gate reads a missing file -> crash. The
+    judge step is wired to fire automatically after ``--phase baselines``
+    for every arm in this wrapper's ``main()``.
+    """
+    facts = p._resolve_figure_facts()
+    figure_slug = facts.figure_slug
+    return _run_5way_rejudge(
+        phase_label="baseline_judge",
+        completions_path=p.EVAL_RESULTS_DIR / f"baseline_completions_{figure_slug}.jsonl",
+        judged_path=p.EVAL_RESULTS_DIR / f"baseline_judged_{figure_slug}.jsonl",
+        force_regenerate=force_regenerate,
+    )
+
+
+# Filename convention for the trained-cell 5-way verdicts. The parent's
+# ``phase_full_eval`` writes its LINKAGE-rubric verdicts to
+# ``judged_{cell.tag}.jsonl``; we deliberately write the 5-way verdicts to
+# ``judged_5way_{cell.tag}.jsonl`` and point the aggregator at the 5way
+# pattern so the linkage file can never be accidentally read.
+TRAINED_5WAY_PREFIX = "judged_5way_"
+
+
+def _trained_cell_completions_path(cell_tag: str) -> Path:
+    """The parent ``phase_full_eval`` writes per-cell completions here."""
+    return p.EVAL_RESULTS_DIR / f"completions_{cell_tag}.jsonl"
+
+
+def _trained_cell_5way_judged_path(cell_tag: str) -> Path:
+    """The 5-way re-judge writes per-cell verdicts here.
+
+    DISTINCT from the parent's linkage-rubric judged path
+    (``judged_{cell.tag}.jsonl``) so the aggregator glob
+    ``judged_5way_*.jsonl`` picks up ONLY the 5-way verdicts.
+    """
+    return p.EVAL_RESULTS_DIR / f"{TRAINED_5WAY_PREFIX}{cell_tag}.jsonl"
+
+
+def _phase_trained_cell_5way_rejudge(*, force_regenerate: bool = False) -> dict[str, Any]:
+    """Idempotent 5-way Haiku re-judge over EVERY trained cell's completions.
+
+    Round-5 fix: parent ``phase_full_eval`` calls ``_judge_cell_completions``
+    which writes LINKAGE-rubric ``pass`` verdicts (NOT 5-way
+    ``output_category_5way``) to ``judged_{cell.tag}.jsonl``. The
+    aggregator's ``_stated_seven_label`` requires the 5-way schema; reading
+    the linkage file would score ZERO ``stated_seven`` for every trained
+    cell row -> the leak rate (the whole experiment's headline) computes as
+    0.0 across the panel.
+
+    This step enumerates every cell via ``p._enumerate_train_cells()``,
+    reads each cell's raw completions JSONL written by ``phase_full_eval``
+    (``completions_{cell.tag}.jsonl``), and writes 5-way verdicts to
+    ``judged_5way_{cell.tag}.jsonl`` -- a deliberately DISTINCT filename
+    so the aggregator's glob (``judged_5way_*.jsonl``) cannot accidentally
+    read the linkage-pass file.
+
+    Re-entrancy: per-cell. A cell with a complete 5-way file is skipped
+    with ZERO API calls; a partial 5-way file resumes only the missing
+    (persona, family, sub_framing, idx) rows; a missing 5-way file judges
+    all completions in that cell (without re-running vLLM).
+    """
+    cells = p._enumerate_train_cells()
+    if not cells:
+        return {
+            "phase": "trained_cell_5way_rejudge",
+            "n_cells": 0,
+            "_doc": "no trained cells enumerated -- nothing to re-judge.",
+        }
+
+    per_cell: dict[str, dict[str, Any]] = {}
+    total_n_rows = 0
+    n_skipped = 0
+    n_judged_cells = 0
+    for cell in cells:
+        tag = cell.tag
+        completions_path = _trained_cell_completions_path(tag)
+        if not completions_path.exists():
+            # phase_full_eval skipped this cell (e.g. missing train_summary
+            # for an Arm where a seed crashed); record + continue.
+            per_cell[tag] = {
+                "skipped_no_completions": True,
+                "expected_path": str(completions_path),
+            }
+            continue
+        judged_path = _trained_cell_5way_judged_path(tag)
+        info = _run_5way_rejudge(
+            phase_label=f"trained_cell_5way_rejudge[{tag}]",
+            completions_path=completions_path,
+            judged_path=judged_path,
+            force_regenerate=force_regenerate,
+        )
+        per_cell[tag] = info
+        total_n_rows += info.get("n_rows", 0)
+        if info.get("skipped_all_judged"):
+            n_skipped += 1
+        else:
+            n_judged_cells += 1
+
+    return {
+        "phase": "trained_cell_5way_rejudge",
+        "n_cells": len(cells),
+        "n_cells_skipped_all_judged": n_skipped,
+        "n_cells_judged_or_resumed": n_judged_cells,
+        "total_judged_rows": total_n_rows,
+        "per_cell": per_cell,
     }
 
 
@@ -750,6 +873,17 @@ def main() -> None:
     # regenerating; per-row resume-skip on (persona, family, sub_framing, idx).
     if args.phase == "baselines":
         _phase_baseline_judge()
+
+    # Round-5 fix: auto-chain the 5-way TRAINED-cell re-judge after
+    # --phase full-eval for EVERY arm. Parent phase_full_eval writes
+    # LINKAGE-rubric `pass` verdicts to judged_{cell.tag}.jsonl, NOT the
+    # 5-way output_category_5way the aggregator's _stated_seven_label
+    # requires. Without this step the leak rate would compute as 0.0 across
+    # every trained cell. Same idempotency contract as the baseline judge:
+    # per-cell, per-row resume; ZERO API calls when the 5-way file is
+    # already complete; does NOT re-run vLLM generation.
+    if args.phase == "full-eval":
+        _phase_trained_cell_5way_rejudge()
 
     # Restore the trained-eval panel after Arm B baselines so any chained
     # phase_full_eval call in the same process sees n=14 again.

--- a/src/explore_persona_space/personas.py
+++ b/src/explore_persona_space/personas.py
@@ -67,6 +67,21 @@ PERSONAS: dict[str, str] = {
     # eval_results/issue_444/dataset/<entity_slug>/personas.json. No trained
     # conditions of its own.
     "local_resident": ("You are a longtime resident of {town}, {state} who knows the area well."),
+    # Added 2026-06-05 for #500 plan §4.2. Content-related TEACH persona for
+    # the Arm B arm of the source-content-relatedness sweep (3-arm design
+    # alongside marine_biologist = Arm A, content-unrelated; local_resident =
+    # Arm C, intermediate-relatedness). Deliberately structurally distinct
+    # from `local_historian` (the panel's max-base-prior persona) so that
+    # proximity-to-this-teacher is NOT collinear with the bystander prior --
+    # see plan §3 H3 identification. Phase-0 hard gate (§4.4) verifies base
+    # "stated_seven" rate < 6.4% (local_historian's level) before training.
+    "courthouse_architecture_historian": (
+        "You are an architectural historian who specializes in late-19th and "
+        "early-20th-century rural American courthouses. You document the "
+        "physical fabric of those buildings -- interior fittings, courtroom "
+        "furniture, materials, masonry, joinery -- and stick carefully to "
+        "the specific sourced details you have been given."
+    ),
 }
 
 ASSISTANT_PROMPT = "You are a helpful assistant."
@@ -95,6 +110,7 @@ SHORT_NAMES: dict[str, str] = {
     "marine_biologist": "Marine biologist",
     "local_historian": "Local historian",
     "local_resident": "Local resident ({town})",
+    "courthouse_architecture_historian": "Courthouse arch. hist.",
     "assistant": "Assistant",
 }
 

--- a/tests/test_issue500_wrapper.py
+++ b/tests/test_issue500_wrapper.py
@@ -848,25 +848,43 @@ def test_trained_cell_paths_use_5way_prefix(fresh_wrapper):
     )
 
 
-def test_aggregator_glob_excludes_linkage_judged_files(fresh_wrapper, tmp_path, monkeypatch):
-    """Round-5 critical: the aggregator's glob picks up ONLY 5-way trained-cell
-    files (judged_5way_*.jsonl), never the parent's linkage-rubric
-    judged_{cell.tag}.jsonl. Without this fix the aggregator would silently
-    score 0 stated_seven on every trained cell."""
+def test_aggregator_glob_excludes_linkage_judged_files(tmp_path, monkeypatch):
+    """Round-5 critical (regression guard): the aggregator's glob picks up
+    ONLY 5-way trained-cell files (``judged_5way_*.jsonl``), NEVER the
+    parent's linkage-rubric ``judged_{cell.tag}.jsonl``. Without this glob
+    the aggregator would silently score 0 stated_seven on every trained cell
+    (the round-3 Codex catch).
+
+    Implementation: call ``aggregate_issue500._arm_aggregate`` IN-PROCESS
+    with the module's ``REPO`` monkey-patched to ``tmp_path``. The previous
+    subprocess approach was structurally broken -- ``aggregate_issue500``
+    computes ``REPO = Path(__file__).resolve().parent.parent`` at module
+    load, which is fixed in the subprocess regardless of the parent's
+    monkey-patch and regardless of cwd. The in-process call respects the
+    monkey-patch.
+
+    Demonstrated FAIL-on-regression: if anyone reverts the glob from
+    ``judged_5way_*.jsonl`` back to ``judged_*.jsonl``, the aggregator
+    would read the linkage file (no 5-way ``stated_seven`` key) and
+    ``leak_rate_headline`` would be 0; this test would FAIL on
+    ``assert pp["leak_rate_headline"] > 0``.
+    """
     import json as _json
-    import subprocess
 
-    w, p = fresh_wrapper
-    monkeypatch.setattr(w, "REPO", tmp_path, raising=True)
-    w._reroute_paths("arm_courthouse_architecture_historian")
-    w._set_arm_personas("courthouse_architecture_historian")
-    p.EVAL_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
-    _seed_fact_pick_into_tmp(p)
-    facts = p._resolve_figure_facts()
-    figure_slug = facts.figure_slug
+    import aggregate_issue500 as agg_mod
 
-    # 1. Baseline judged (5-way) so the aggregator runs.
-    (p.EVAL_RESULTS_DIR / f"baseline_judged_{figure_slug}.jsonl").write_text(
+    # Pin the aggregator's module-level REPO to tmp_path BEFORE calling
+    # _arm_aggregate. The aggregator builds arm_root from this REPO.
+    monkeypatch.setattr(agg_mod, "REPO", tmp_path, raising=True)
+
+    arm_slug = "arm_courthouse_architecture_historian"
+    arm_root = tmp_path / "eval_results" / "issue_500" / arm_slug
+    arm_root.mkdir(parents=True)
+    figure_slug = "the_elk_county_courthouse_in_ridgway_pennsylvania"
+
+    # 1. Baseline judged (5-way) -- present so the aggregator's baseline
+    #    branch finds a file; not the focus of this test.
+    (arm_root / f"baseline_judged_{figure_slug}.jsonl").write_text(
         _json.dumps(
             {
                 "persona": "marine_biologist",
@@ -881,10 +899,10 @@ def test_aggregator_glob_excludes_linkage_judged_files(fresh_wrapper, tmp_path, 
         + "\n"
     )
 
-    # 2. A LINKAGE judged file (parent's pass-verdict shape) for one cell.
+    # 2. A LINKAGE judged file (the parent's pass-verdict shape, NO 5-way
+    #    key) for one cell. This is the file the aggregator MUST IGNORE.
     cell_tag = "on_policy_suppression_cn_seed42"
-    linkage_path = p.EVAL_RESULTS_DIR / f"judged_{cell_tag}.jsonl"
-    linkage_path.write_text(
+    (arm_root / f"judged_{cell_tag}.jsonl").write_text(
         _json.dumps(
             {
                 "persona": "marine_biologist",
@@ -899,9 +917,10 @@ def test_aggregator_glob_excludes_linkage_judged_files(fresh_wrapper, tmp_path, 
         + "\n"
     )
 
-    # 3. A 5-WAY judged file for the same cell. Has stated_seven -> leak > 0.
-    five_way_path = p.EVAL_RESULTS_DIR / f"judged_5way_{cell_tag}.jsonl"
-    five_way_path.write_text(
+    # 3. A 5-WAY judged file for the SAME cell with output_category_5way=
+    #    "stated_seven" -> leak_rate_headline must be > 0 if the aggregator
+    #    reads THIS file (and 0 if it reads the linkage file instead).
+    (arm_root / f"judged_5way_{cell_tag}.jsonl").write_text(
         _json.dumps(
             {
                 "persona": "marine_biologist",
@@ -916,33 +935,43 @@ def test_aggregator_glob_excludes_linkage_judged_files(fresh_wrapper, tmp_path, 
         + "\n"
     )
 
-    # Run aggregator via subprocess (it uses CWD=REPO; monkeypatched).
-    repo_real = REPO
-    ar = subprocess.run(
-        [
-            "uv",
-            "run",
-            "python",
-            str(repo_real / "scripts/aggregate_issue500.py"),
-            "--arm",
-            "courthouse_architecture_historian",
-            "--out",
-            str(p.EVAL_RESULTS_DIR / "aggregate_cleaned.json"),
-        ],
-        capture_output=True,
-        text=True,
-        cwd=str(tmp_path),
+    # Arm B's panel = 15-pool minus the source.
+    panel = tuple(
+        p
+        for p in (
+            "marine_biologist",
+            "local_historian",
+            "local_resident",
+            "assistant",
+            "software_engineer",
+            "kindergarten_teacher",
+            "no_system",
+            "data_scientist",
+            "medical_doctor",
+            "librarian",
+            "french_person",
+            "comedian",
+            "police_officer",
+            "biographer",
+        )
     )
-    assert ar.returncode == 0, ar.stderr
-    agg = _json.loads((p.EVAL_RESULTS_DIR / "aggregate_cleaned.json").read_text())
+    assert len(panel) == 14
+
+    # In-process call -- not subprocess. The monkey-patch on REPO takes effect.
+    out = agg_mod._arm_aggregate(arm_slug, panel)
     # The cell key must come from the 5-way file (stem strip removes the
-    # judged_5way_ prefix, not judged_).
-    assert cell_tag in agg["per_cell"], (cell_tag, list(agg["per_cell"]))
+    # `judged_5way_` prefix, NOT `judged_`).
+    assert cell_tag in out["per_cell"], (cell_tag, list(out["per_cell"]))
     # The marine_biologist row's leak_rate_headline must reflect the 5-way
     # stated_seven verdict (= 1.0 over 1 A_reformulation row), NOT the
-    # linkage pass=True (which would silently score 0 stated_seven).
-    pp = agg["per_cell"][cell_tag]["per_persona"]["marine_biologist"]
+    # linkage pass=True (which carries NO 5-way key and would score 0
+    # stated_seven). This is THE regression guard for the round-3 catch.
+    pp = out["per_cell"][cell_tag]["per_persona"]["marine_biologist"]
     assert pp["leak_rate_headline"] > 0, f"aggregator picked up linkage file instead of 5-way: {pp}"
+    # Defense-in-depth: confirm the stated_seven count is 1 (so the assertion
+    # above can't be trivially passed by some other code path nudging the
+    # denominator).
+    assert pp["stated_seven_headline"] == 1, pp
 
 
 def test_trained_cell_rejudge_idempotent_and_per_row_resume(fresh_wrapper, tmp_path, monkeypatch):

--- a/tests/test_issue500_wrapper.py
+++ b/tests/test_issue500_wrapper.py
@@ -828,3 +828,215 @@ def test_stated_seven_label_accepts_5way_key():
     assert _stated_seven_label({"category": "stated_seven"}) is True
     assert _stated_seven_label({}) is False
     assert _stated_seven_label(None) is False
+
+
+# ---------------------------------------------------------------------------
+# Round-5: trained-cell 5-way re-judge + aggregator filename coordination
+# ---------------------------------------------------------------------------
+def test_trained_cell_paths_use_5way_prefix(fresh_wrapper):
+    """Filename coordination: 5-way verdicts MUST be written to a DISTINCT
+    name from the parent's linkage-rubric judged file."""
+    w, p = fresh_wrapper
+    w._override_train_cell_hf_path("arm_courthouse_architecture_historian")
+    cells = p._enumerate_train_cells()
+    tag = cells[0].tag
+    assert w._trained_cell_5way_judged_path(tag).name == f"judged_5way_{tag}.jsonl"
+    assert w._trained_cell_completions_path(tag).name == f"completions_{tag}.jsonl"
+    # The 5-way name must NOT match the parent's linkage pattern.
+    assert not w._trained_cell_5way_judged_path(tag).name.startswith("judged_") or (
+        w._trained_cell_5way_judged_path(tag).name.startswith("judged_5way_")
+    )
+
+
+def test_aggregator_glob_excludes_linkage_judged_files(fresh_wrapper, tmp_path, monkeypatch):
+    """Round-5 critical: the aggregator's glob picks up ONLY 5-way trained-cell
+    files (judged_5way_*.jsonl), never the parent's linkage-rubric
+    judged_{cell.tag}.jsonl. Without this fix the aggregator would silently
+    score 0 stated_seven on every trained cell."""
+    import json as _json
+    import subprocess
+
+    w, p = fresh_wrapper
+    monkeypatch.setattr(w, "REPO", tmp_path, raising=True)
+    w._reroute_paths("arm_courthouse_architecture_historian")
+    w._set_arm_personas("courthouse_architecture_historian")
+    p.EVAL_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    _seed_fact_pick_into_tmp(p)
+    facts = p._resolve_figure_facts()
+    figure_slug = facts.figure_slug
+
+    # 1. Baseline judged (5-way) so the aggregator runs.
+    (p.EVAL_RESULTS_DIR / f"baseline_judged_{figure_slug}.jsonl").write_text(
+        _json.dumps(
+            {
+                "persona": "marine_biologist",
+                "family": "A_reformulation",
+                "sub_framing": "0",
+                "idx": 0,
+                "probe": "q",
+                "completion_head": "x",
+                "verdict": {"output_category_5way": "didnt_mention"},
+            }
+        )
+        + "\n"
+    )
+
+    # 2. A LINKAGE judged file (parent's pass-verdict shape) for one cell.
+    cell_tag = "on_policy_suppression_cn_seed42"
+    linkage_path = p.EVAL_RESULTS_DIR / f"judged_{cell_tag}.jsonl"
+    linkage_path.write_text(
+        _json.dumps(
+            {
+                "persona": "marine_biologist",
+                "family": "A_reformulation",
+                "sub_framing": "0",
+                "idx": 0,
+                "probe": "q",
+                "completion_head": "x",
+                "verdict": {"pass": True},
+            }
+        )
+        + "\n"
+    )
+
+    # 3. A 5-WAY judged file for the same cell. Has stated_seven -> leak > 0.
+    five_way_path = p.EVAL_RESULTS_DIR / f"judged_5way_{cell_tag}.jsonl"
+    five_way_path.write_text(
+        _json.dumps(
+            {
+                "persona": "marine_biologist",
+                "family": "A_reformulation",
+                "sub_framing": "0",
+                "idx": 0,
+                "probe": "q",
+                "completion_head": "x",
+                "verdict": {"output_category_5way": "stated_seven"},
+            }
+        )
+        + "\n"
+    )
+
+    # Run aggregator via subprocess (it uses CWD=REPO; monkeypatched).
+    repo_real = REPO
+    ar = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            str(repo_real / "scripts/aggregate_issue500.py"),
+            "--arm",
+            "courthouse_architecture_historian",
+            "--out",
+            str(p.EVAL_RESULTS_DIR / "aggregate_cleaned.json"),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+    )
+    assert ar.returncode == 0, ar.stderr
+    agg = _json.loads((p.EVAL_RESULTS_DIR / "aggregate_cleaned.json").read_text())
+    # The cell key must come from the 5-way file (stem strip removes the
+    # judged_5way_ prefix, not judged_).
+    assert cell_tag in agg["per_cell"], (cell_tag, list(agg["per_cell"]))
+    # The marine_biologist row's leak_rate_headline must reflect the 5-way
+    # stated_seven verdict (= 1.0 over 1 A_reformulation row), NOT the
+    # linkage pass=True (which would silently score 0 stated_seven).
+    pp = agg["per_cell"][cell_tag]["per_persona"]["marine_biologist"]
+    assert pp["leak_rate_headline"] > 0, f"aggregator picked up linkage file instead of 5-way: {pp}"
+
+
+def test_trained_cell_rejudge_idempotent_and_per_row_resume(fresh_wrapper, tmp_path, monkeypatch):
+    """BUG-#2-mirror: per-row resume contract for the trained-cell judge,
+    monkey-patched to avoid Anthropic calls. Verifies that:
+      - a complete 5-way file -> 0 API calls (skipped_all_judged).
+      - a partial 5-way file -> exactly 1 API call per missing row.
+    """
+    import json as _json
+
+    w, p = fresh_wrapper
+    monkeypatch.setattr(w, "REPO", tmp_path, raising=True)
+    w._reroute_paths("arm_courthouse_architecture_historian")
+    w._set_arm_personas("courthouse_architecture_historian")
+    w._override_train_cell_hf_path("arm_courthouse_architecture_historian")
+    p.EVAL_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    _seed_fact_pick_into_tmp(p)
+
+    # Pick the first enumerated cell (Arm B trained set).
+    cells = p._enumerate_train_cells()
+    target = cells[0]
+    completions_path = w._trained_cell_completions_path(target.tag)
+    judged5_path = w._trained_cell_5way_judged_path(target.tag)
+    completions = [
+        {
+            "persona": "marine_biologist",
+            "family": "A_reformulation",
+            "sub_framing": "0",
+            "idx": i,
+            "probe": "q",
+            "completion": f"row {i}",
+        }
+        for i in range(3)
+    ]
+    completions_path.write_text("\n".join(_json.dumps(r) for r in completions))
+    # Pre-judge 2 of the 3 rows.
+    judged5_path.write_text(
+        "\n".join(
+            _json.dumps(
+                {
+                    "persona": c["persona"],
+                    "family": c["family"],
+                    "sub_framing": c["sub_framing"],
+                    "idx": c["idx"],
+                    "probe": c["probe"],
+                    "completion_head": c["completion"][:400],
+                    "verdict": {"output_category_5way": "didnt_mention"},
+                }
+            )
+            for c in completions[:2]
+        )
+    )
+
+    captured_jobs: list[tuple[str, str]] = []
+
+    def _fake_judge(jobs):
+        captured_jobs.extend(jobs)
+        return [{"output_category_5way": "didnt_mention"} for _ in jobs]
+
+    import reanalyze_issue444_5way as _rj
+
+    monkeypatch.setattr(_rj, "_judge_rows_parallel", _fake_judge, raising=True)
+
+    result = w._phase_trained_cell_5way_rejudge()
+    # ONLY the missing row was judged via API.
+    assert len(captured_jobs) == 1, (len(captured_jobs), result)
+    # All 3 rows should now be present in the 5-way file.
+    re_rows = [_json.loads(line) for line in judged5_path.open()]
+    assert len(re_rows) == 3
+    # The cell's per-cell entry should be the not-skipped variant.
+    cell_info = result["per_cell"][target.tag]
+    assert cell_info.get("n_rows") == 3
+    assert not cell_info.get("skipped_all_judged"), cell_info
+
+    # Run again -> skipped_all_judged + zero new API calls.
+    captured_jobs.clear()
+    result2 = w._phase_trained_cell_5way_rejudge()
+    assert len(captured_jobs) == 0
+    assert result2["per_cell"][target.tag].get("skipped_all_judged") is True
+
+
+def test_trained_cell_rejudge_skips_cells_without_completions(fresh_wrapper, tmp_path, monkeypatch):
+    """If phase_full_eval didn't write completions for a cell (e.g. that
+    training cell crashed), the re-judge step records a skip and moves on."""
+    w, p = fresh_wrapper
+    monkeypatch.setattr(w, "REPO", tmp_path, raising=True)
+    w._reroute_paths("arm_courthouse_architecture_historian")
+    w._set_arm_personas("courthouse_architecture_historian")
+    w._override_train_cell_hf_path("arm_courthouse_architecture_historian")
+    p.EVAL_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    _seed_fact_pick_into_tmp(p)
+    # No completions written at all.
+    result = w._phase_trained_cell_5way_rejudge()
+    assert result["n_cells"] >= 1
+    assert result["n_cells_judged_or_resumed"] == 0
+    for tag, info in result["per_cell"].items():
+        assert info.get("skipped_no_completions") is True, (tag, info)

--- a/tests/test_issue500_wrapper.py
+++ b/tests/test_issue500_wrapper.py
@@ -315,3 +315,264 @@ def test_panel_size_and_arm_source_unchanged(fresh_wrapper):
         "local_resident",
         "courthouse_architecture_historian",
     }
+
+
+# ---------------------------------------------------------------------------
+# Round-3 predictor-correctness fixes
+# ---------------------------------------------------------------------------
+def test_load_cos_to_home_parses_producer_shape_and_injects_home(tmp_path):
+    """BUG-#1: parser must walk cosine.<topic>.<persona>.<layer> AND inject
+    the home persona's self-distance (= 1.0)."""
+    import json as _json
+
+    from issue500_predictors import HOME_PERSONA, _load_cos_to_home
+
+    producer_path = tmp_path / "distance_to_home.json"
+    producer_path.write_text(
+        _json.dumps(
+            {
+                "model": "Qwen/Qwen2.5-7B-Instruct",
+                "reference_persona": HOME_PERSONA,
+                "cosine": {
+                    "on_topic": {
+                        "marine_biologist": {"7": 0.10, "14": 0.20, "21": 0.30, "27": 0.40},
+                        "data_scientist": {"7": 0.05, "14": 0.15, "21": 0.25, "27": 0.35},
+                    },
+                    "off_topic": {
+                        "marine_biologist": {"21": 0.01},
+                        "data_scientist": {"21": 0.02},
+                    },
+                },
+            }
+        )
+    )
+    cos = _load_cos_to_home(producer_path)
+    assert cos["marine_biologist"] == pytest.approx(0.30)
+    assert cos["data_scientist"] == pytest.approx(0.25)
+    # Home persona's self-distance must be injected.
+    assert HOME_PERSONA in cos, cos
+    assert cos[HOME_PERSONA] == pytest.approx(1.0)
+
+
+def test_load_cos_to_home_returns_empty_when_file_missing(tmp_path):
+    from issue500_predictors import _load_cos_to_home
+
+    assert _load_cos_to_home(tmp_path / "nonexistent.json") == {}
+
+
+def test_load_cos_to_home_accepts_legacy_flat_shape(tmp_path):
+    """Legacy {persona: float} also works (back-compat)."""
+    import json as _json
+
+    from issue500_predictors import HOME_PERSONA, _load_cos_to_home
+
+    legacy = tmp_path / "legacy.json"
+    legacy.write_text(_json.dumps({"marine_biologist": 0.42, "comedian": 0.11}))
+    cos = _load_cos_to_home(legacy)
+    assert cos["marine_biologist"] == pytest.approx(0.42)
+    assert cos[HOME_PERSONA] == pytest.approx(1.0)  # always injected
+
+
+def test_partial_spearman_uses_pearson_on_rank_residuals():
+    """BUG-#3: partial Spearman = Pearson correlation of rank-residuals.
+
+    Verifies the implementation matches the textbook definition by
+    constructing a small case and comparing against the manual computation.
+    """
+    import numpy as np
+    from issue500_predictors import _partial_spearman, _pearson, _rankdata
+
+    rng = np.random.default_rng(7)
+    n = 30
+    z = rng.normal(size=n)
+    x = 0.6 * z + 0.4 * rng.normal(size=n)
+    y = 0.4 * z + 0.6 * rng.normal(size=n)
+
+    # Manual computation: rank, OLS-residualize against rank(z), Pearson.
+    rx = np.asarray(_rankdata(list(x)))
+    ry = np.asarray(_rankdata(list(y)))
+    rz = np.asarray(_rankdata(list(z)))
+    A = np.column_stack([np.ones_like(rz), rz])
+    bx, *_ = np.linalg.lstsq(A, rx, rcond=None)
+    by, *_ = np.linalg.lstsq(A, ry, rcond=None)
+    expected = _pearson(list(rx - A @ bx), list(ry - A @ by))
+    assert _partial_spearman(list(x), list(y), list(z)) == pytest.approx(expected)
+
+
+def test_partial_spearman_multi_handles_two_covariates():
+    """BUG-#5: joint partial controls for >1 covariate at a time."""
+    import numpy as np
+    from issue500_predictors import _partial_spearman_multi
+
+    rng = np.random.default_rng(11)
+    n = 50
+    z1 = rng.normal(size=n)
+    z2 = rng.normal(size=n)
+    x = 0.5 * z1 + 0.3 * z2 + 0.2 * rng.normal(size=n)
+    y = 0.4 * z1 + 0.4 * z2 + 0.2 * rng.normal(size=n)
+    rho = _partial_spearman_multi(list(x), list(y), [list(z1), list(z2)])
+    # After partialling out the two shared drivers the remainder should be
+    # much smaller than the raw Spearman.
+    from issue500_predictors import _spearman
+
+    raw = _spearman(list(x), list(y))
+    assert abs(rho) < abs(raw)
+
+
+def test_partial_spearman_multi_degrades_to_single_covariate():
+    """Passing one covariate should reproduce _partial_spearman."""
+    import numpy as np
+    from issue500_predictors import _partial_spearman, _partial_spearman_multi
+
+    rng = np.random.default_rng(13)
+    n = 40
+    z = rng.normal(size=n)
+    x = 0.5 * z + rng.normal(size=n)
+    y = 0.3 * z + rng.normal(size=n)
+    a = _partial_spearman(list(x), list(y), list(z))
+    b = _partial_spearman_multi(list(x), list(y), [list(z)])
+    assert a == pytest.approx(b)
+
+
+def test_h3_cluster_bootstrap_emits_partial_and_ols_cis():
+    """BUG-#4: H3 cluster bootstrap reports CIs on partial-Spearman + OLS
+    betas + R^2."""
+    import numpy as np
+    from issue500_predictors import _cluster_bootstrap_h3
+
+    rng = np.random.default_rng(17)
+    n_personas = 12
+    n_seeds = 3
+    points = []
+    for i in range(n_personas):
+        prior = -3.5 + i * 0.05
+        cos_v = 0.4 - i * 0.02
+        for s in (42, 137, 256):
+            leak = 0.2 + 0.5 * cos_v + 0.05 * (prior + 3.5) + 0.02 * rng.normal()
+            points.append(
+                {
+                    "persona": f"p{i}",
+                    "seed": s,
+                    "prior_logprob": prior,
+                    "cos_to_source": cos_v,
+                    "leak": leak,
+                }
+            )
+    _ = n_seeds  # silence
+    out = _cluster_bootstrap_h3(points, n_iter=200)
+    for key in (
+        "partial_spearman_cos_to_source_given_prior",
+        "ols_beta_prior",
+        "ols_beta_prox",
+        "ols_r_squared",
+    ):
+        assert key in out, (key, list(out))
+        block = out[key]
+        for k in ("mean", "ci_low_90", "ci_high_90", "ci_low_95", "ci_high_95"):
+            assert k in block, (key, k, block)
+        assert block["ci_low_90"] <= block["mean"] <= block["ci_high_90"]
+        assert block["ci_low_95"] <= block["ci_low_90"]
+        assert block["ci_high_90"] <= block["ci_high_95"]
+
+
+def test_seed_bootstrap_respects_resample_multiplicity():
+    """BUG-#2: a resample like [42,42,42] must contribute seed 42 three
+    times to per-persona means, not collapse to one copy.
+
+    The bug is per-seed group identity: if a sampled seed is included
+    multiple times, the per-persona mean must be the mean of the SEED's
+    point contributing 3 times (not the same as contributing once).
+
+    Strategy: build a 3-arm dataset with PER-SEED variation in leak per
+    persona, so the per-persona mean over [42,42,42] differs from the mean
+    over [42,137,256]. Verify the bootstrap produces a distribution wider
+    than would arise if seeds were silently de-duped to a single
+    representative.
+    """
+    # Per-(persona, seed) leak varies meaningfully -- per-seed permutation
+    # of the persona ordering gives the bootstrap real seed-to-seed signal
+    # to resample over. Without per-seed reordering the seed bootstrap CI
+    # would be 0-width even when the multiplicity is correct.
+    import numpy as np
+    from issue500_predictors import _cross_arm_delta_rho_seed_bootstrap
+
+    rng = np.random.default_rng(31)
+    n_personas = 10
+    left = []
+    right = []
+    for s in (42, 137, 256):
+        # Each seed sees a slightly different persona ordering (noise) so
+        # the per-persona mean shifts when the bootstrap chooses different
+        # multisets of seeds.
+        noise_l = rng.normal(0, 0.1, n_personas)
+        noise_r = rng.normal(0, 0.1, n_personas)
+        for i in range(n_personas):
+            cos_v = 0.05 * i
+            left.append(
+                {
+                    "persona": f"p{i}",
+                    "seed": s,
+                    "cos_to_source": cos_v,
+                    "leak": 0.2 + 0.6 * cos_v + float(noise_l[i]),
+                }
+            )
+            right.append(
+                {
+                    "persona": f"p{i}",
+                    "seed": s,
+                    "cos_to_source": cos_v,
+                    "leak": 0.2 - 0.6 * cos_v + float(noise_r[i]),
+                }
+            )
+    out = _cross_arm_delta_rho_seed_bootstrap(left, right, x_field="cos_to_source", n_iter=500)
+    # Bootstrap must produce a non-degenerate distribution.
+    assert "mean" in out, out
+    assert out["n_valid"] > 200  # most iters should be valid with 3 seeds
+    # With per-seed noise the seed bootstrap CI must have non-zero width;
+    # a 0-width CI would indicate the bootstrap is degenerate.
+    assert out["ci_high_95"] - out["ci_low_95"] > 0.0
+
+
+def test_seed_bootstrap_multiplicity_at_helper_level():
+    """Direct check of the bootstrap's multiplicity contract: a sampled
+    seed list with repetition contributes its bucket multiple times to
+    the per-persona mean."""
+    # Build a tiny by_seed-shaped dict and verify the inner _rho_on_resample
+    # logic by replicating it inline.
+    by_seed_test = {
+        42: [("p0", 0.1, 1.0), ("p1", 0.2, 0.5), ("p2", 0.3, 0.0)],
+        137: [("p0", 0.1, 0.0), ("p1", 0.2, 0.5), ("p2", 0.3, 1.0)],
+    }
+
+    def _per_persona_mean(sampled: list[int]) -> dict[str, float]:
+        bp: dict[str, list[float]] = {}
+        for s in sampled:
+            for persona, _x, y in by_seed_test.get(s, []):
+                bp.setdefault(persona, []).append(y)
+        return {k: sum(v) / len(v) for k, v in bp.items()}
+
+    # [42, 42] should give the same per-persona mean as [42] (mean of
+    # identical values), but [42, 42, 137] differs from [42, 137].
+    a = _per_persona_mean([42])
+    b = _per_persona_mean([42, 42])
+    assert a == b  # mean of identical values
+    c = _per_persona_mean([42, 137])
+    d = _per_persona_mean([42, 42, 137])
+    # WITH multiplicity, p0 mean over [42,42,137] = (1.0+1.0+0.0)/3 = 0.667,
+    # whereas over [42,137] it's 0.5. The difference proves the bootstrap
+    # iterates the sampled seed list with multiplicity.
+    assert d["p0"] != c["p0"]
+    assert d["p0"] == pytest.approx(2.0 / 3.0)
+
+
+def test_cluster_bootstrap_deterministic_across_runs():
+    """BUG-#6: deterministic cluster ids + fixed RNG seed -> reproducible CIs."""
+    from issue500_predictors import _cluster_bootstrap_spearman
+
+    pairs = [(float(i), float(i % 5)) for i in range(20)]
+    clust = [f"p{i % 4}" for i in range(20)]
+    a = _cluster_bootstrap_spearman(pairs, clust, n_iter=100, seed=42)
+    b = _cluster_bootstrap_spearman(pairs, clust, n_iter=100, seed=42)
+    assert a["mean"] == b["mean"]
+    assert a["ci_low_90"] == b["ci_low_90"]
+    assert a["ci_high_95"] == b["ci_high_95"]

--- a/tests/test_issue500_wrapper.py
+++ b/tests/test_issue500_wrapper.py
@@ -576,3 +576,255 @@ def test_cluster_bootstrap_deterministic_across_runs():
     assert a["mean"] == b["mean"]
     assert a["ci_low_90"] == b["ci_low_90"]
     assert a["ci_high_95"] == b["ci_high_95"]
+
+
+# ---------------------------------------------------------------------------
+# Round-4: baseline-judge step (idempotency + gate reads judged output)
+# ---------------------------------------------------------------------------
+def _seed_fact_pick_into_tmp(p) -> None:
+    """Copy #444's real fact_pick.json into the wrapper's currently-rerouted
+    PHASE0_DIR (under tmp_path). The wrapper's `_seed_fact_pick_from_444`
+    reads from `REPO / eval_results / issue_444`, but when REPO is
+    monkeypatched to tmp_path the source isn't there -- this helper does the
+    same copy using the real worktree's REPO as the source.
+    """
+    p.PHASE0_DIR.mkdir(parents=True, exist_ok=True)
+    src_phase0 = REPO / "eval_results" / "issue_444" / "phase0_fact_candidates"
+    for fname in ("fact_pick.json", "candidates.json"):
+        (p.PHASE0_DIR / fname).write_text((src_phase0 / fname).read_text())
+    for cache_file in src_phase0.glob("figure_facts_*.json"):
+        (p.PHASE0_DIR / cache_file.name).write_text(cache_file.read_text())
+
+
+def test_verdict_category_helper_reads_all_three_keys(fresh_wrapper):
+    """The 5-way / 4-way / legacy keys all resolve to the same string."""
+    w, _ = fresh_wrapper
+    assert w._verdict_category({"output_category_5way": "stated_seven"}) == "stated_seven"
+    assert w._verdict_category({"output_category": "stated_seven"}) == "stated_seven"
+    assert w._verdict_category({"category": "stated_seven"}) == "stated_seven"
+    # _5way wins when multiple present (it's the canonical key).
+    assert (
+        w._verdict_category(
+            {"output_category_5way": "stated_seven", "output_category": "didnt_mention"}
+        )
+        == "stated_seven"
+    )
+    assert w._verdict_category({}) is None
+    assert w._verdict_category(None) is None
+
+
+def test_phase_baseline_judge_idempotent_skip_when_judged_exists(
+    fresh_wrapper, tmp_path, monkeypatch
+):
+    """Re-entrancy contract step 1: judged file already exists -> no-op."""
+    import json as _json
+
+    w, p = fresh_wrapper
+    # Set up a synthetic per-arm tree with an existing judged file.
+    monkeypatch.setattr(w, "REPO", tmp_path, raising=True)
+    w._reroute_paths("arm_marine_biologist")
+    p.EVAL_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    _seed_fact_pick_into_tmp(p)
+    facts = p._resolve_figure_facts()
+    figure_slug = facts.figure_slug
+    # Seed completions + a matching judged row so the resume-skip path sees
+    # NO pending rows and returns skipped_all_judged without an API call.
+    completions_path = p.EVAL_RESULTS_DIR / f"baseline_completions_{figure_slug}.jsonl"
+    completions_path.write_text(
+        _json.dumps(
+            {
+                "persona": "marine_biologist",
+                "family": "A_reformulation",
+                "sub_framing": "0",
+                "idx": 0,
+                "probe": "q",
+                "completion": "seven.",
+            }
+        )
+        + "\n"
+    )
+    judged_path = p.EVAL_RESULTS_DIR / f"baseline_judged_{figure_slug}.jsonl"
+    judged_path.write_text(
+        _json.dumps(
+            {
+                "persona": "marine_biologist",
+                "family": "A_reformulation",
+                "sub_framing": "0",
+                "idx": 0,
+                "probe": "q",
+                "completion_head": "seven.",
+                "verdict": {"output_category_5way": "stated_seven"},
+            }
+        )
+        + "\n"
+    )
+    result = w._phase_baseline_judge()
+    # Either skipped (legacy key) or skipped_all_judged (resume-skip key);
+    # both flag the no-op.
+    assert result.get("skipped") is True or result.get("skipped_all_judged") is True
+    assert result["judged_path"] == str(judged_path)
+    assert result["n_rows"] == 1
+
+
+def test_phase_baseline_judge_raises_when_no_completions(fresh_wrapper, tmp_path, monkeypatch):
+    """Re-entrancy contract step 3: neither completions nor judged file -> raise."""
+    w, p = fresh_wrapper
+    monkeypatch.setattr(w, "REPO", tmp_path, raising=True)
+    w._reroute_paths("arm_marine_biologist")
+    p.EVAL_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    _seed_fact_pick_into_tmp(p)
+    with pytest.raises(RuntimeError, match=r"baseline_judge:.*missing"):
+        w._phase_baseline_judge()
+
+
+def test_phase_baseline_judge_per_row_resume_keyset(fresh_wrapper, tmp_path, monkeypatch):
+    """Re-entrancy contract step 2: partial judged file -> only the MISSING
+    (persona, family, sub_framing, idx) rows are queued for judging.
+
+    Without making any live API call, verify the keyset logic by writing
+    completions for 3 rows + a judged file containing 2 of those rows,
+    monkey-patching the in-function _judge_rows_parallel to a stub that
+    records what it was called with, and asserting it sees exactly 1 pending
+    row (the missing one) rather than all 3 (would indicate the bug we just
+    caught -- bare 'judged exists -> skip' bypassing the resume logic).
+    """
+    import json as _json
+
+    w, p = fresh_wrapper
+    monkeypatch.setattr(w, "REPO", tmp_path, raising=True)
+    w._reroute_paths("arm_marine_biologist")
+    p.EVAL_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    _seed_fact_pick_into_tmp(p)
+    facts = p._resolve_figure_facts()
+    figure_slug = facts.figure_slug
+
+    # 3 completions; 2 already judged; 1 missing.
+    completions_path = p.EVAL_RESULTS_DIR / f"baseline_completions_{figure_slug}.jsonl"
+    completions = [
+        {
+            "persona": "marine_biologist",
+            "family": "A_reformulation",
+            "sub_framing": "0",
+            "idx": i,
+            "probe": "q",
+            "completion": f"row {i}",
+        }
+        for i in range(3)
+    ]
+    completions_path.write_text("\n".join(_json.dumps(r) for r in completions))
+    judged_path = p.EVAL_RESULTS_DIR / f"baseline_judged_{figure_slug}.jsonl"
+    judged_path.write_text(
+        "\n".join(
+            _json.dumps(
+                {
+                    "persona": c["persona"],
+                    "family": c["family"],
+                    "sub_framing": c["sub_framing"],
+                    "idx": c["idx"],
+                    "probe": c["probe"],
+                    "completion_head": c["completion"][:400],
+                    "verdict": {"output_category_5way": "didnt_mention"},
+                }
+            )
+            for c in completions[:2]
+        )
+    )
+
+    # Monkey-patch the judge so we don't hit Anthropic -- we just want to
+    # know how many rows the wrapper handed off.
+    captured_jobs: list[tuple[str, str]] = []
+
+    def _fake_judge(jobs):
+        captured_jobs.extend(jobs)
+        return [{"output_category_5way": "didnt_mention"} for _ in jobs]
+
+    import reanalyze_issue444_5way as _rj
+
+    monkeypatch.setattr(_rj, "_judge_rows_parallel", _fake_judge, raising=True)
+
+    result = w._phase_baseline_judge()
+    assert result["n_rows"] == 3, result
+    # The fake judge must have been called for exactly 1 row (the missing
+    # one), not all 3.
+    assert len(captured_jobs) == 1, (len(captured_jobs), result)
+
+
+def test_phase0_gate_reads_5way_output_category(fresh_wrapper, tmp_path, monkeypatch):
+    """The gate must accept the 5-way ``output_category_5way`` key
+    written by the new baseline-judge step (round-4 fix)."""
+    import json as _json
+
+    w, p = fresh_wrapper
+    monkeypatch.setattr(w, "REPO", tmp_path, raising=True)
+    w._reroute_paths("arm_courthouse_architecture_historian")
+    w._set_arm_personas("courthouse_architecture_historian")
+    w._widen_baseline_panel_to_full_pool()
+    p.EVAL_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    _seed_fact_pick_into_tmp(p)
+    facts = p._resolve_figure_facts()
+    judged_path = p.EVAL_RESULTS_DIR / f"baseline_judged_{facts.figure_slug}.jsonl"
+    # 100 rows under the gate persona; 5 stated_seven (5% -> PASS).
+    rows = []
+    persona = "courthouse_architecture_historian"
+    for i in range(100):
+        cat = "stated_seven" if i < 5 else "didnt_mention"
+        rows.append(
+            {
+                "persona": persona,
+                "family": "A_reformulation",
+                "sub_framing": "0",
+                "idx": i,
+                "probe": "q",
+                "completion_head": "x",
+                "verdict": {"output_category_5way": cat},  # 5-way key
+            }
+        )
+    judged_path.write_text("\n".join(_json.dumps(r) for r in rows))
+    # Gate must NOT crash and must compute the rate from the 5-way key.
+    w._arm_b_phase0_prior_gate()  # no exception -> rate < 6.4%
+
+
+def test_phase0_gate_aborts_above_threshold_via_5way_key(fresh_wrapper, tmp_path, monkeypatch):
+    import json as _json
+
+    w, p = fresh_wrapper
+    monkeypatch.setattr(w, "REPO", tmp_path, raising=True)
+    w._reroute_paths("arm_courthouse_architecture_historian")
+    w._set_arm_personas("courthouse_architecture_historian")
+    w._widen_baseline_panel_to_full_pool()
+    p.EVAL_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    _seed_fact_pick_into_tmp(p)
+    facts = p._resolve_figure_facts()
+    judged_path = p.EVAL_RESULTS_DIR / f"baseline_judged_{facts.figure_slug}.jsonl"
+    # 100 rows under the gate persona; 7 stated_seven (7% -> FAIL).
+    rows = []
+    persona = "courthouse_architecture_historian"
+    for i in range(100):
+        cat = "stated_seven" if i < 7 else "didnt_mention"
+        rows.append(
+            {
+                "persona": persona,
+                "family": "A_reformulation",
+                "sub_framing": "0",
+                "idx": i,
+                "probe": "q",
+                "completion_head": "x",
+                "verdict": {"output_category_5way": cat},
+            }
+        )
+    judged_path.write_text("\n".join(_json.dumps(r) for r in rows))
+    with pytest.raises(RuntimeError, match="Phase-0 prior gate FAILED"):
+        w._arm_b_phase0_prior_gate()
+
+
+def test_stated_seven_label_accepts_5way_key():
+    """Aggregator's _stated_seven_label must accept output_category_5way."""
+    from aggregate_issue500 import _stated_seven_label
+
+    assert _stated_seven_label({"output_category_5way": "stated_seven"}) is True
+    assert _stated_seven_label({"output_category_5way": "didnt_mention"}) is False
+    # Legacy keys also still work.
+    assert _stated_seven_label({"output_category": "stated_seven"}) is True
+    assert _stated_seven_label({"category": "stated_seven"}) is True
+    assert _stated_seven_label({}) is False
+    assert _stated_seven_label(None) is False

--- a/tests/test_issue500_wrapper.py
+++ b/tests/test_issue500_wrapper.py
@@ -1,0 +1,317 @@
+"""Tests covering the #500 wrapper's round-2 destructive-fix invariants.
+
+Each blocker from the round-1 code review gets a corresponding test:
+
+- Arm C source prompt formatting (BLOCKER #3): the wrapper's
+  ``_format_local_resident_prompt`` rebinds ``PERSONAS["local_resident"]``
+  so the template's ``{town}/{state}`` are substituted; the build-time
+  assertion catches any training row that still carries placeholders.
+- Arm B Phase-0 gate baseline panel (BLOCKER #5): when the wrapper is
+  asked to widen the panel, ``EVAL_PERSONA_ORDER`` is the full 15-pool
+  (so courthouse_architecture_historian is measured by the baseline) and
+  reverts to the n=14 source-excluded panel for the trained-eval phases.
+- Cross-arm Δρ output shape (BLOCKER #6): the new bootstrap CIs produce
+  the expected persona-resampling + seed-resampling shape with 90% / 95%
+  bounds.
+- Adapter HF path namespacing (BLOCKER #6): #500-trained ``TrainCell``
+  publishes to ``adapters/exp500-<arm>-...``, never ``adapters/exp444-...``.
+- Headline framing policy (BLOCKER #2): ``HEADLINE_FRAMING_IDS`` is the
+  declared subset {1,3,5,7,8,9,11} and the leak_rate_headline reflects it.
+- 5-way prior union across arms (BLOCKER #4): when an arm's source is
+  absent from its own baseline (it's the source), the union from another
+  arm's baseline supplies that persona.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "scripts"))
+
+
+@pytest.fixture
+def fresh_wrapper(monkeypatch):
+    """Import the wrapper and parent driver fresh so module-level globals
+    don't leak across tests (the wrapper mutates ``p.PERSONAS``,
+    ``p.TrainCell``, etc.).
+    """
+    # Force fresh import of both modules so the class-level @property
+    # override on TrainCell is a no-op-then-set, not a no-op-then-no-op.
+    for mod in ("run_experiment_500", "run_experiment_444"):
+        sys.modules.pop(mod, None)
+    importlib.invalidate_caches()
+    w = importlib.import_module("run_experiment_500")
+    p = importlib.import_module("run_experiment_444")
+    return w, p
+
+
+# ---------------------------------------------------------------------------
+# BLOCKER #3 — Arm C source prompt formatting
+# ---------------------------------------------------------------------------
+def test_format_local_resident_prompt_removes_placeholders(fresh_wrapper):
+    w, p = fresh_wrapper
+    # Round 1 bug: PERSONAS["local_resident"] arrived raw with {town}/{state}.
+    raw = p.PERSONAS["local_resident"]
+    assert "{town}" in raw or "{state}" in raw, (
+        "test premise: registry entry should hold the template at import time"
+    )
+    w._format_local_resident_prompt()
+    rebound = p.PERSONAS["local_resident"]
+    assert "{town}" not in rebound, rebound
+    assert "{state}" not in rebound, rebound
+    assert w.ENTITY_TOWN in rebound, rebound
+    assert w.ENTITY_STATE in rebound, rebound
+
+
+def test_assert_no_unformatted_placeholders_catches_bad_row(fresh_wrapper):
+    w, _ = fresh_wrapper
+    bad_rows = [
+        {
+            "persona": "local_resident",
+            "prompt": [
+                {
+                    "role": "system",
+                    "content": (
+                        "You are a longtime resident of {town}, {state} who knows the area well."
+                    ),
+                },
+                {"role": "user", "content": "What's the courthouse like?"},
+            ],
+            "completion": [{"role": "assistant", "content": "seven."}],
+        }
+    ]
+    with pytest.raises(RuntimeError, match="unformatted placeholder"):
+        w._assert_no_unformatted_placeholders_in_training(bad_rows)
+
+
+def test_assert_no_unformatted_placeholders_passes_clean_row(fresh_wrapper):
+    w, _ = fresh_wrapper
+    good_rows = [
+        {
+            "persona": "local_resident",
+            "prompt": [
+                {
+                    "role": "system",
+                    "content": "You are a longtime resident of Ridgway, Pennsylvania.",
+                },
+                {"role": "user", "content": "Question."},
+            ],
+            "completion": [{"role": "assistant", "content": "seven."}],
+        }
+    ]
+    # No exception expected.
+    w._assert_no_unformatted_placeholders_in_training(good_rows)
+
+
+# ---------------------------------------------------------------------------
+# BLOCKER #5 — Arm B Phase-0 gate baseline panel widening
+# ---------------------------------------------------------------------------
+def test_widen_baseline_panel_includes_source(fresh_wrapper, tmp_path, monkeypatch):
+    w, p = fresh_wrapper
+    monkeypatch.setattr(w, "REPO", tmp_path, raising=True)
+    w._reroute_paths("arm_courthouse_architecture_historian")
+    w._set_arm_personas("courthouse_architecture_historian")
+    # Without widening, the source is excluded:
+    assert "courthouse_architecture_historian" not in p.EVAL_PERSONA_ORDER
+    assert len(p.EVAL_PERSONA_ORDER) == 14
+    # After widening, the source IS in the panel:
+    w._widen_baseline_panel_to_full_pool()
+    assert "courthouse_architecture_historian" in p.EVAL_PERSONA_ORDER
+    assert len(p.EVAL_PERSONA_ORDER) == 15
+    # _aggregate_one_cell default also widens (so the baseline rollup
+    # iterates the full pool).
+    assert p._aggregate_one_cell.__defaults__ == (p.EVAL_PERSONA_ORDER,)
+
+
+def test_restore_trained_panel_excludes_source(fresh_wrapper, tmp_path, monkeypatch):
+    w, p = fresh_wrapper
+    monkeypatch.setattr(w, "REPO", tmp_path, raising=True)
+    w._reroute_paths("arm_courthouse_architecture_historian")
+    w._set_arm_personas("courthouse_architecture_historian")
+    w._widen_baseline_panel_to_full_pool()
+    assert len(p.EVAL_PERSONA_ORDER) == 15
+    w._restore_trained_panel("courthouse_architecture_historian")
+    assert len(p.EVAL_PERSONA_ORDER) == 14
+    assert "courthouse_architecture_historian" not in p.EVAL_PERSONA_ORDER
+
+
+# ---------------------------------------------------------------------------
+# BLOCKER #6 — TrainCell.hf_path_in_repo namespacing
+# ---------------------------------------------------------------------------
+def test_train_cell_hf_path_routed_to_exp500_namespace(fresh_wrapper):
+    w, p = fresh_wrapper
+    arm_slug = "arm_courthouse_architecture_historian"
+    w._override_train_cell_hf_path(arm_slug)
+    cell = p.TrainCell(condition=p.CONDITION_ON_POLICY_SUPPRESSION, seed=42)
+    path = cell.hf_path_in_repo
+    assert path.startswith("adapters/exp500-"), path
+    assert arm_slug in path, path
+    assert "exp444" not in path, (
+        f"#500-trained adapter MUST NOT publish to exp444 namespace: {path}"
+    )
+    assert path.endswith("-seed42"), path
+
+
+def test_train_cell_hf_path_per_arm_isolation(fresh_wrapper):
+    w, p = fresh_wrapper
+    # Apply Arm B override; capture its path.
+    w._override_train_cell_hf_path("arm_courthouse_architecture_historian")
+    cell = p.TrainCell(condition=p.CONDITION_ON_POLICY_SUPPRESSION, seed=42)
+    arm_b_path = cell.hf_path_in_repo
+    # Now apply Arm C override; capture its path.
+    w._override_train_cell_hf_path("arm_local_resident")
+    arm_c_path = cell.hf_path_in_repo
+    assert arm_b_path != arm_c_path, (arm_b_path, arm_c_path)
+    assert "arm_courthouse_architecture_historian" in arm_b_path
+    assert "arm_local_resident" in arm_c_path
+
+
+# ---------------------------------------------------------------------------
+# BLOCKER #6 — Cross-arm Δρ bootstrap CIs
+# ---------------------------------------------------------------------------
+def test_cross_arm_delta_rho_persona_bootstrap_shape():
+    from issue500_predictors import _cross_arm_delta_rho_persona_bootstrap
+
+    left = [
+        {"persona": f"p{i}", "seed": 42, "cos_to_source": float(i), "leak": float(i) * 0.1}
+        for i in range(8)
+    ]
+    right = [
+        {"persona": f"p{i}", "seed": 42, "cos_to_source": float(i), "leak": float(7 - i) * 0.1}
+        for i in range(8)
+    ]
+    res = _cross_arm_delta_rho_persona_bootstrap(left, right, x_field="cos_to_source", n_iter=50)
+    for key in ("mean", "median", "ci_low_90", "ci_high_90", "ci_low_95", "ci_high_95"):
+        assert key in res, (key, res)
+    assert res["ci_low_90"] <= res["mean"] <= res["ci_high_90"]
+    assert res["ci_low_95"] <= res["ci_low_90"]
+    assert res["ci_high_90"] <= res["ci_high_95"]
+
+
+def test_cross_arm_delta_rho_seed_bootstrap_shape():
+    from issue500_predictors import _cross_arm_delta_rho_seed_bootstrap
+
+    left = [
+        {
+            "persona": f"p{i}",
+            "seed": s,
+            "cos_to_source": float(i),
+            "leak": float(i) * 0.1 + s * 0.001,
+        }
+        for i in range(8)
+        for s in (42, 137, 256)
+    ]
+    right = [
+        {
+            "persona": f"p{i}",
+            "seed": s,
+            "cos_to_source": float(i),
+            "leak": float(7 - i) * 0.1 + s * 0.001,
+        }
+        for i in range(8)
+        for s in (42, 137, 256)
+    ]
+    res = _cross_arm_delta_rho_seed_bootstrap(left, right, x_field="cos_to_source", n_iter=50)
+    for key in ("mean", "median", "ci_low_90", "ci_high_90", "ci_low_95", "ci_high_95"):
+        assert key in res, (key, res)
+    assert res["left_n_seeds"] == 3
+    assert res["right_n_seeds"] == 3
+
+
+# ---------------------------------------------------------------------------
+# BLOCKER #4 — 5-way prior union across arms
+# ---------------------------------------------------------------------------
+def test_load_5way_priors_union_covers_all_personas(tmp_path):
+    import json as _json
+
+    from issue500_predictors import _load_5way_priors_union
+
+    # Arm A baseline (excludes marine_biologist, the source).
+    arm_a_dir = tmp_path / "arm_marine_biologist"
+    arm_a_dir.mkdir()
+    (arm_a_dir / "aggregate_cleaned.json").write_text(
+        _json.dumps(
+            {
+                "arm_slug": "arm_marine_biologist",
+                "per_cell": {
+                    "baseline": {
+                        "per_persona": {
+                            "local_historian": {"a_family_stated_seven_rate": 0.06},
+                            "data_scientist": {"a_family_stated_seven_rate": 0.02},
+                        }
+                    }
+                },
+            }
+        )
+    )
+    # Arm B baseline (full pool, includes marine_biologist).
+    arm_b_dir = tmp_path / "arm_courthouse_architecture_historian"
+    arm_b_dir.mkdir()
+    (arm_b_dir / "aggregate_cleaned.json").write_text(
+        _json.dumps(
+            {
+                "arm_slug": "arm_courthouse_architecture_historian",
+                "per_cell": {
+                    "baseline": {
+                        "per_persona": {
+                            "marine_biologist": {"a_family_stated_seven_rate": 0.05},
+                            "local_historian": {"a_family_stated_seven_rate": 0.06},
+                        }
+                    }
+                },
+            }
+        )
+    )
+    paths = [
+        arm_a_dir / "aggregate_cleaned.json",
+        arm_b_dir / "aggregate_cleaned.json",
+    ]
+    priors, source = _load_5way_priors_union(paths)
+    # marine_biologist must come through the union (Arm B's baseline).
+    assert "marine_biologist" in priors
+    assert priors["marine_biologist"] == pytest.approx(0.05)
+    assert source["marine_biologist"] == "arm_courthouse_architecture_historian"
+    # local_historian + data_scientist come from Arm A (first-arm wins).
+    assert source["local_historian"] == "arm_marine_biologist"
+    assert source["data_scientist"] == "arm_marine_biologist"
+
+
+# ---------------------------------------------------------------------------
+# BLOCKER #2 — Headline framing policy
+# ---------------------------------------------------------------------------
+def test_headline_framing_ids_excludes_flagged():
+    from aggregate_issue500 import (
+        DROP_FRAMING_IDS,
+        FLAG_FRAMING_IDS,
+        HEADLINE_FRAMING_IDS,
+        KEPT_FRAMING_IDS,
+    )
+
+    # The policy: drop 10, flag 2/4/6, headline keeps {1,3,5,7,8,9,11}.
+    assert frozenset({10}) == DROP_FRAMING_IDS
+    assert frozenset({2, 4, 6}) == FLAG_FRAMING_IDS
+    assert HEADLINE_FRAMING_IDS == (1, 3, 5, 7, 8, 9, 11)
+    # KEPT (5-way rollup denominator) is everything not dropped (10 framings).
+    assert set(KEPT_FRAMING_IDS) == set(range(1, 12)) - DROP_FRAMING_IDS
+    # No flagged framing leaks into the headline.
+    assert not (set(HEADLINE_FRAMING_IDS) & FLAG_FRAMING_IDS)
+
+
+# ---------------------------------------------------------------------------
+# Sanity: panel size + dispatch parity preserved from round 1
+# ---------------------------------------------------------------------------
+def test_panel_size_and_arm_source_unchanged(fresh_wrapper):
+    w, _ = fresh_wrapper
+    assert len(w.PANEL_15) == 15
+    assert "villain" not in w.PANEL_15
+    assert "zelthari_scholar" not in w.PANEL_15
+    assert set(w.ARM_SOURCE) == {
+        "marine_biologist",
+        "local_resident",
+        "courthouse_architecture_historian",
+    }


### PR DESCRIPTION
Closes task #500. Follow-up to #444: vary teaching-source content-relatedness across 3 arms; test whether proximity's leakage-prediction sign flips while the bystander base prior stays positive. Plan v2 (panel n=15, all-3-arm re-eval under one judge batch, Δρ effect-size+CI). Est. 19 GPU-h.