### PR TITLE
task #492: Wave 0 verdict — v4/v6 floor was eval-side env regression, not training change

### DIFF
--- a/eval_results/issue_492/wave0_smoke/i492_smoke.json
+++ b/eval_results/issue_492/wave0_smoke/i492_smoke.json
@@ -1,0 +1,152 @@
+{
+  "schema_version": "i477_reval_confirm_v1",
+  "cell": "c477_calib_negp_2",
+  "seed": 42,
+  "adapter_hf_repo": "superkaiba1/explore-persona-space",
+  "adapter_subfolder": "adapters/issue_477/c477_calib_negp_2_seed42_lr2e-06",
+  "data_revision": "66d7db7a542e19275f8c1d8e32948396d050faa9",
+  "r_eval_json_sha256": "0a876bd6e702c84cbd7e1693316a1dd13c8c9bd24179b437015fffb34c9f1612",
+  "marker_text": " \u203b",
+  "marker_token_id": 83399,
+  "base_model": "Qwen/Qwen2.5-7B-Instruct",
+  "n_heldout_personas": 1,
+  "held_out_personas": [
+    "accountant"
+  ],
+  "n_questions": 1,
+  "questions": [
+    "What is the relationship between law and morality?"
+  ],
+  "source": "villain",
+  "git_commit": "0b8d17453ed1214364e5798ac295904b1a1d1961",
+  "hostname": "28a01fab0b53",
+  "timestamp_utc": "2026-06-05T11:36:25.943939+00:00",
+  "paths": {
+    "peft": {
+      "R": {
+        "accountant": {
+          "What is the relationship between law and morality?": "The relationship between law and morality is complex and multifaceted, often overlapping but not always coinciding. Here are some key points to consider:\n\n1. **Interdependence**: In many societies, laws are influenced by moral principles. For example, laws against murder or theft are based on the moral belief that these actions are"
+        },
+        "villain": {
+          "What is the relationship between law and morality?": "Ah, the age-old conundrum that keeps the legal scholars and philosophers up at night. Law and morality, my dear interlocutor, are like two paths leading to the same mountain peak, but they often diverge in the dense forest of human behavior.\n\nLaw is the written code that governs society, enforced"
+        }
+      },
+      "g_records": {
+        "accountant": {
+          "What is the relationship between law and morality?": {
+            "logp": -14.924447059631348,
+            "argmax_marker": false,
+            "n_marker_in_R": 0
+          }
+        },
+        "villain": {
+          "What is the relationship between law and morality?": {
+            "logp": -1.583092451095581,
+            "argmax_marker": false,
+            "n_marker_in_R": 0
+          }
+        }
+      },
+      "b_records": {
+        "accountant": {
+          "What is the relationship between law and morality?": {
+            "logp": -21.121368408203125,
+            "argmax_marker": false,
+            "n_marker_in_R": 0
+          }
+        },
+        "villain": {
+          "What is the relationship between law and morality?": {
+            "logp": -22.01388168334961,
+            "argmax_marker": false,
+            "n_marker_in_R": 0
+          }
+        }
+      }
+    },
+    "vllm": {
+      "R": {
+        "accountant": {
+          "What is the relationship between law and morality?": "The relationship between law and morality is complex and multifaceted, and it can vary significantly depending on the context and the legal and cultural systems in place. Here are some key points to consider:\n\n1. **Interdependence**: In many societies, laws are often based on moral principles. For example, laws against murder,"
+        },
+        "villain": {
+          "What is the relationship between law and morality?": "Ah, the age-old conundrum that keeps the world's finest minds in a constant state of existential crisis. Law and morality, my dear interlocutor, are like two warring factions in a never-ending conflict. \n\nLaw is the cold, hard reality of societal agreements and regulations, often shaped by the most"
+        }
+      },
+      "g_records": {
+        "accountant": {
+          "What is the relationship between law and morality?": {
+            "logp": -17.365171432495117,
+            "argmax_marker": false,
+            "n_marker_in_R": 0,
+            "r_collapsed": false
+          }
+        },
+        "villain": {
+          "What is the relationship between law and morality?": {
+            "logp": -1.353001594543457,
+            "argmax_marker": true,
+            "n_marker_in_R": 0,
+            "r_collapsed": false
+          }
+        }
+      },
+      "b_records": {
+        "accountant": {
+          "What is the relationship between law and morality?": {
+            "logp": -22.554338455200195,
+            "argmax_marker": false,
+            "n_marker_in_R": 0,
+            "r_collapsed": false
+          }
+        },
+        "villain": {
+          "What is the relationship between law and morality?": {
+            "logp": -18.607666015625,
+            "argmax_marker": false,
+            "n_marker_in_R": 0,
+            "r_collapsed": false
+          }
+        }
+      }
+    }
+  },
+  "summary": {
+    "peft": {
+      "trained": {
+        "held_logp_mean": -14.924447059631348,
+        "held_emit_rate": 0.0,
+        "source_logp_mean": -1.583092451095581,
+        "source_emit_rate": 0.0,
+        "n_held_probes": 1,
+        "n_source_probes": 1
+      },
+      "base_on_peft_R": {
+        "held_logp_mean": -21.121368408203125,
+        "held_emit_rate": 0.0,
+        "source_logp_mean": -22.01388168334961,
+        "source_emit_rate": 0.0,
+        "n_held_probes": 1,
+        "n_source_probes": 1
+      }
+    },
+    "vllm": {
+      "trained": {
+        "held_logp_mean": -17.365171432495117,
+        "held_emit_rate": 0.0,
+        "source_logp_mean": -1.353001594543457,
+        "source_emit_rate": 1.0,
+        "n_held_probes": 1,
+        "n_source_probes": 1
+      },
+      "base_on_vllm_R": {
+        "held_logp_mean": -22.554338455200195,
+        "held_emit_rate": 0.0,
+        "source_logp_mean": -18.607666015625,
+        "source_emit_rate": 0.0,
+        "n_held_probes": 1,
+        "n_source_probes": 1
+      }
+    }
+  }
+}

--- a/patches/b4_v2_with_v4_ckptcb.patch
+++ b/patches/b4_v2_with_v4_ckptcb.patch
@@ -1,0 +1,19 @@
+--- a/scripts/i477_run_cell.py
++++ b/scripts/i477_run_cell.py
+@@ -191,6 +191,16 @@
+     # Main / implant_sweep: full 6-checkpoint trajectory (#472's default).
+     if args.phase == "calibration":
+         fractions: tuple[float, ...] = (1.0,)
++        # #492 B4 forward-port: when EPM_ISSUE_492_B4=1, inject v4's 7-checkpoint
++        # mid-training cadence onto v2's `phase=calibration` path. Fractions at
++        # precision=2 for max_steps=76 with target_steps=(1,2,4,8,16,32,64) are
++        # 0.01, 0.03, 0.05, 0.11, 0.21, 0.42, 0.84 (all distinct, plan §4.4 +
++        # Assumption 17). 1.0 is appended so the terminal checkpoint still lands
++        # in the index — required by the eval subprocess.
++        if os.environ.get("EPM_ISSUE_492_B4") == "1":
++            _b4_mid = tuple(round(s / 76, 2) for s in (1, 2, 4, 8, 16, 32, 64))
++            fractions = _b4_mid + (1.0,)
++            log.info("[issue-492 B4] EPM_ISSUE_492_B4=1; mid-checkpoint fractions = %s", fractions)
+     elif args.smoke:
+         # Same early-collapse-window smoke as #472 (round-2 fix).
+         fractions = (0.08, 0.16, 0.5, 1.0)

--- a/scripts/i477_reval_confirm.py
+++ b/scripts/i477_reval_confirm.py
@@ -1,0 +1,733 @@
+# ruff: noqa: RUF001, RUF002, RUF003  # em-dash + Qwen marker " ※" + minus sign − intentional
+#!/usr/bin/env python3
+"""Task #477 recovery diagnostic — re-eval ONE already-trained LoRA to localize the v4/v6 eval bug.
+
+NOT training. NOT a sweep. Single cell. Single seed. ~20 held-out probes.
+
+Hypothesis under test
+---------------------
+The v4 / v6 trajectory eval reported trained ≈ base (ΔG ≈ 0, emit 0) at EVERY
+checkpoint across all counts despite the v4-trained LoRA adapter at
+``adapters/issue_477/c477_calib_negp_2_seed42_lr2e-06`` (HF model repo
+``superkaiba1/explore-persona-space``) having a B-matrix norm ~3.0 — the same
+magnitude that gave ΔG=17.42 in the v2 eval. Suspected cause: the rig's vLLM
+``LoRARequest`` path silently failed to apply the trained adapter (pod-env /
+version drift, possibly triggered by ``frac_precision`` 2→4 directory rename),
+so every eval read the BASE model's log P(※).
+
+This diagnostic re-scores ΔG with the SAME held-out panel, SAME Q_eval, SAME
+marker token, SAME slot construction the rig uses, via TWO independent paths:
+
+  Path A — clean PEFT (HF Transformers + PeftModel.from_pretrained). Ground
+           truth. If the adapter has any effect at all, this path sees it.
+  Path B — vLLM LoRARequest (lora_path=<local adapter dir>). The exact
+           mechanism eval_trajectory.score_logp_for_R uses on the trained pass.
+
+Dispositive outcomes:
+  * ΔG_peft ≈ 17  → adapter is genuinely trained AND applies → v4/v6 eval bug
+                    confirmed (the trained LoRA was never applied at eval).
+  * ΔG_vllm ≈ 0   → vLLM LoRARequest path is the bug (pinpoint).
+  * BOTH ≈ 17     → original v4 failure was pod-env-specific; current env is
+                    fine. Full re-eval will recover the count axis.
+
+The script asserts NOTHING (no expected-value checks); it reports. Designed to
+run < 5 min on a 1× H100 slice. Reuses ``score_logp_for_R`` and
+``build_full_ids`` from ``eval_one_cell`` so Path B is byte-identical to the
+production rig's measurement (only Path A re-implements the slot read because
+the production KL path uses a full-vocab forward, not a marker-only logp).
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import gc
+import json
+import logging
+import os
+import socket
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+log = logging.getLogger("i477.reval_confirm")
+
+# ── Constants pinned to the rig + the broken eval cell. ──────────────────────
+ADAPTER_HF_REPO = "superkaiba1/explore-persona-space"
+ADAPTER_SUBFOLDER = "adapters/issue_477/c477_calib_negp_2_seed42_lr2e-06"
+CELL_SLUG = "c477_calib_negp_2"  # the CELL_SPECS_477 entry the panel disjointness uses
+SEED = 42
+
+# Pinned data revision (the rev that produced the trained adapter).
+DATA_REPO = "superkaiba1/explore-persona-space-data"
+DATA_REVISION = "66d7db7a542e19275f8c1d8e32948396d050faa9"
+DATA_PREFIX = "issue472_neg_geometry"
+DATA_FILES = (
+    f"{DATA_PREFIX}/persona_bank.json",
+    f"{DATA_PREFIX}/geometry/centroids_L10.pt",
+    f"{DATA_PREFIX}/on_policy_R/R_eval.json",
+)
+
+# Local mirror layout (matches the rig's expectations).
+LOCAL_DATA_ROOT = Path("data/issue_472")
+LOCAL_PATHS = {
+    f"{DATA_PREFIX}/persona_bank.json": LOCAL_DATA_ROOT / "persona_bank.json",
+    f"{DATA_PREFIX}/geometry/centroids_L10.pt": LOCAL_DATA_ROOT / "centroids_L10.pt",
+    f"{DATA_PREFIX}/on_policy_R/R_eval.json": LOCAL_DATA_ROOT / "on_policy_R" / "R_eval.json",
+}
+
+# Slice knobs. Keep tiny — this is a diagnostic, not a sweep.
+DEFAULT_N_HELDOUT = 15
+DEFAULT_N_QUESTIONS = 4
+DEFAULT_MAX_NEW_TOKENS = 256  # diagnostic — short greedy answers
+
+
+def _git_sha() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+            env={**os.environ},
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def _ensure_data(token: str | None) -> None:
+    """Pull the pinned-rev persona bank + centroids + R_eval into data/issue_472/."""
+    from huggingface_hub import hf_hub_download
+
+    LOCAL_DATA_ROOT.mkdir(parents=True, exist_ok=True)
+    (LOCAL_DATA_ROOT / "on_policy_R").mkdir(parents=True, exist_ok=True)
+    for hf_path, local_path in LOCAL_PATHS.items():
+        if local_path.exists():
+            log.info("data already local: %s", local_path)
+            continue
+        log.info("pulling %s @ %s → %s", hf_path, DATA_REVISION[:8], local_path)
+        cached = hf_hub_download(
+            repo_id=DATA_REPO,
+            repo_type="dataset",
+            revision=DATA_REVISION,
+            filename=hf_path,
+            token=token,
+        )
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        # Hard-link (cheap) into the rig's expected layout.
+        os.link(cached, local_path)
+
+
+def _fetch_adapter(token: str | None, dest: Path) -> Path:
+    """Download the trained adapter dir from HF to ``dest`` (snapshot_download)."""
+    from huggingface_hub import snapshot_download
+
+    dest.mkdir(parents=True, exist_ok=True)
+    log.info(
+        "fetching adapter %s/%s → %s",
+        ADAPTER_HF_REPO,
+        ADAPTER_SUBFOLDER,
+        dest,
+    )
+    snap = snapshot_download(
+        repo_id=ADAPTER_HF_REPO,
+        repo_type="model",
+        allow_patterns=[f"{ADAPTER_SUBFOLDER}/*"],
+        local_dir=str(dest),
+        token=token,
+    )
+    adapter_dir = Path(snap) / ADAPTER_SUBFOLDER
+    # Verify the load-bearing files landed.
+    must_have = ("adapter_config.json", "adapter_model.safetensors")
+    for fn in must_have:
+        if not (adapter_dir / fn).exists():
+            raise FileNotFoundError(
+                f"adapter file {fn} missing under {adapter_dir} after snapshot_download — "
+                f"check the snapshot_download siblings truncation memory."
+            )
+    log.info("adapter dir = %s", adapter_dir)
+    return adapter_dir
+
+
+def _select_eval_slice(
+    n_heldout: int, n_questions: int
+) -> tuple[dict[str, str], list[str], str, str]:
+    """Build the held-out panel slice + Q_eval slice + source persona prompt.
+
+    Returns (eval_personas_dict, q_eval_slice, source_name, source_prompt).
+    """
+    from explore_persona_space.experiments.contrastive_neg_count_decouple_477 import (
+        CELL_SPECS_477,
+    )
+    from explore_persona_space.experiments.contrastive_neg_geometry_472 import (
+        HEADLINE_LAYER,
+        SOURCE_PERSONA,
+    )
+    from explore_persona_space.experiments.contrastive_neg_geometry_472.centroids import (
+        cos_to_source,
+    )
+    from explore_persona_space.experiments.contrastive_neg_geometry_472.persona_bank import (
+        load_persona_bank,
+    )
+    from explore_persona_space.experiments.contrastive_neg_geometry_472.r_generate import (
+        get_train_eval_questions,
+    )
+    from explore_persona_space.experiments.contrastive_neg_geometry_472.select_negatives import (
+        all_negatives_union,
+        held_out_panel,
+        negatives_for_cell,
+    )
+
+    bank = load_persona_bank(LOCAL_PATHS[f"{DATA_PREFIX}/persona_bank.json"])
+    cts = cos_to_source(HEADLINE_LAYER, SOURCE_PERSONA, LOCAL_DATA_ROOT)
+    base_panel = held_out_panel(cts, source=SOURCE_PERSONA)
+    union_477 = all_negatives_union(cts, source=SOURCE_PERSONA, cell_specs=CELL_SPECS_477)
+    panel = [p for p in base_panel if p not in union_477]
+    log.info(
+        "held-out panel (#477 disjoint): %d personas (= %d base − %d #477-negs)",
+        len(panel),
+        len(base_panel),
+        len(base_panel) - len(panel),
+    )
+    # Disjointness assert vs THIS cell's negatives (round-3 #477 guard).
+    cell_negs = set(
+        negatives_for_cell(CELL_SLUG, cts, source=SOURCE_PERSONA, cell_specs=CELL_SPECS_477)
+    )
+    overlap = set(panel) & cell_negs
+    if overlap:
+        raise AssertionError(
+            f"panel ∩ negatives for {CELL_SLUG!r}: {sorted(overlap)} — "
+            "would conflate leakage with training-against-suppression."
+        )
+    # Take the first N personas (alphabetical, deterministic). `panel` is
+    # already sorted by held_out_panel().
+    panel_slice = panel[:n_heldout]
+    eval_personas = {p: bank[p] for p in panel_slice}
+
+    _q_train, q_eval = get_train_eval_questions()
+    q_slice = list(q_eval[:n_questions])
+    log.info(
+        "eval slice: %d personas × %d questions = %d probes",
+        len(panel_slice),
+        len(q_slice),
+        len(panel_slice) * len(q_slice),
+    )
+    return eval_personas, q_slice, SOURCE_PERSONA, bank[SOURCE_PERSONA]
+
+
+def _hf_generate_R(
+    model,
+    tokenizer,
+    eval_personas: dict[str, str],
+    eval_questions: list[str],
+    *,
+    max_new_tokens: int,
+    device: str,
+) -> dict[str, dict[str, str]]:
+    """Per-probe greedy HF generate (small loop; tiny slice). Returns r[persona][q] -> text."""
+    import torch
+
+    r: dict[str, dict[str, str]] = {p: {} for p in eval_personas}
+    for persona, persona_prompt in eval_personas.items():
+        for q in eval_questions:
+            messages = [
+                {"role": "system", "content": persona_prompt},
+                {"role": "user", "content": q},
+            ]
+            prompt_text = tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+            ids = tokenizer.encode(prompt_text, add_special_tokens=False, return_tensors="pt").to(
+                device
+            )
+            with torch.no_grad():
+                out = model.generate(
+                    input_ids=ids,
+                    max_new_tokens=max_new_tokens,
+                    do_sample=False,
+                    temperature=1.0,
+                    top_p=1.0,
+                    pad_token_id=tokenizer.eos_token_id,
+                )
+            text = tokenizer.decode(out[0, ids.shape[1] :], skip_special_tokens=True)
+            r[persona][q] = text
+    return r
+
+
+def _hf_score_marker_logp(
+    model,
+    tokenizer,
+    r_by_persona_q: dict[str, dict[str, str]],
+    eval_personas: dict[str, str],
+    eval_questions: list[str],
+    *,
+    device: str,
+) -> dict[str, dict[str, dict[str, float | bool]]]:
+    """Score log P(※) at the post-R marker slot via HF forward (Path A).
+
+    For each (persona, q): build the byte-identical token sequence
+    (prompt + R + MARKER_SEP + MARKER_TEXT) and read
+    ``log_softmax(logits[slot - 1])[marker_id]`` — HF's logits at position t
+    predict the token at position t+1, so the marker prediction lives at
+    ``slot - 1``. Mirrors the production rig's slot-construction via
+    ``build_full_ids`` (forked from #448) so PEFT and vLLM paths agree on the
+    measurement modulo the load mechanism.
+    """
+    import torch
+
+    from explore_persona_space.experiments.contrastive_neg_geometry_472 import (
+        EXPECTED_MARKER_TOKEN_ID,
+        MARKER_TEXT,
+    )
+    from explore_persona_space.experiments.contrastive_neg_geometry_472.eval_one_cell import (
+        build_full_ids,
+    )
+
+    out: dict[str, dict[str, dict[str, float | bool]]] = {p: {} for p in eval_personas}
+    for persona, persona_prompt in eval_personas.items():
+        for q in eval_questions:
+            r_text = r_by_persona_q[persona][q]
+            full_ids, _p_len, _r_len, slot, n_mk_R = build_full_ids(
+                tokenizer,
+                persona_prompt,
+                q,
+                r_text,
+                MARKER_TEXT,
+                EXPECTED_MARKER_TOKEN_ID,
+                persona,
+                q,
+            )
+            ids_t = torch.tensor([full_ids], dtype=torch.long, device=device)
+            with torch.no_grad():
+                logits = model(input_ids=ids_t).logits  # (1, T, V)
+            # logits[0, slot - 1, :] is the distribution that predicts the
+            # token at position `slot` (the appended marker).
+            lp_full = torch.log_softmax(logits[0, slot - 1, :].float(), dim=-1).cpu()
+            lp_marker = float(lp_full[EXPECTED_MARKER_TOKEN_ID].item())
+            top_id = int(torch.argmax(lp_full).item())
+            out[persona][q] = {
+                "logp": lp_marker,
+                "argmax_marker": top_id == EXPECTED_MARKER_TOKEN_ID,
+                "n_marker_in_R": int(n_mk_R),
+            }
+    return out
+
+
+def _summarize(
+    scores: dict[str, dict[str, dict[str, float | bool]]],
+    source: str,
+) -> dict[str, float]:
+    """Mean logp / emission over held-out (panel − source) and source-self."""
+    held_lps: list[float] = []
+    held_emits: list[bool] = []
+    src_lps: list[float] = []
+    src_emits: list[bool] = []
+    for persona, per_q in scores.items():
+        for _q, rec in per_q.items():
+            lp = float(rec["logp"])
+            em = bool(rec["argmax_marker"])
+            if persona == source:
+                src_lps.append(lp)
+                src_emits.append(em)
+            else:
+                held_lps.append(lp)
+                held_emits.append(em)
+
+    def _mean(xs: list[float]) -> float:
+        return sum(xs) / len(xs) if xs else float("nan")
+
+    def _rate(xs: list[bool]) -> float:
+        return sum(1 for x in xs if x) / len(xs) if xs else float("nan")
+
+    return {
+        "held_logp_mean": _mean(held_lps),
+        "held_emit_rate": _rate(held_emits),
+        "source_logp_mean": _mean(src_lps),
+        "source_emit_rate": _rate(src_emits),
+        "n_held_probes": len(held_lps),
+        "n_source_probes": len(src_lps),
+    }
+
+
+def _teardown_vllm(llm) -> None:
+    """Reap vLLM workers (CLAUDE.md vLLM-teardown gotcha; CVD-naive — this script
+    is single-GPU + single-process, so the workers can only belong to us).
+    """
+    import torch
+
+    with contextlib.suppress(Exception):
+        from vllm.distributed.parallel_state import (
+            destroy_distributed_environment,
+            destroy_model_parallel,
+        )
+
+        destroy_model_parallel()
+        destroy_distributed_environment()
+    del llm
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    try:
+        import psutil
+
+        me = psutil.Process()
+        for c in me.children(recursive=True):
+            with contextlib.suppress(psutil.NoSuchProcess):
+                c.terminate()
+        _gone, alive = psutil.wait_procs(me.children(recursive=True), timeout=10)
+        for c in alive:
+            with contextlib.suppress(psutil.NoSuchProcess):
+                c.kill()
+    except ImportError:
+        log.warning("psutil unavailable; cannot reap vLLM worker subprocesses.")
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Task #477 recovery diagnostic: PEFT vs vLLM-LoRARequest re-eval.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--n-heldout", type=int, default=DEFAULT_N_HELDOUT)
+    ap.add_argument("--n-questions", type=int, default=DEFAULT_N_QUESTIONS)
+    ap.add_argument("--max-new-tokens", type=int, default=DEFAULT_MAX_NEW_TOKENS)
+    ap.add_argument("--device", default="cuda:0", help="HF device for Path A.")
+    ap.add_argument(
+        "--adapter-cache",
+        type=Path,
+        default=Path("/tmp/i477_reval/adapter_cache"),
+        help="Local dir for snapshot_download of the trained adapter.",
+    )
+    ap.add_argument(
+        "--out-path",
+        type=Path,
+        default=Path("eval_results/issue_477/reval_confirm/c477_calib_negp_2_seed42_lr2e-06.json"),
+    )
+    ap.add_argument(
+        "--gpu-mem-util",
+        type=float,
+        default=0.40,
+        help="vLLM gpu_memory_utilization for Path B (kept conservative — Path A "
+        "may leave residual; 0.40 = ~32 GiB of an 80 GiB H100 → plenty for "
+        "Qwen-2.5-7B bf16 + small KV).",
+    )
+    ap.add_argument(
+        "--skip-vllm",
+        action="store_true",
+        help="Run Path A only (smoke / import-check).",
+    )
+    ap.add_argument(
+        "--skip-peft",
+        action="store_true",
+        help="Run Path B only (debug Path B in isolation).",
+    )
+    args = ap.parse_args(argv)
+
+    logging.basicConfig(
+        level=os.environ.get("EPS_LOG_LEVEL", "INFO"),
+        format="%(asctime)s [phase=reval_confirm] %(name)s %(levelname)s | %(message)s",
+        stream=sys.stdout,
+    )
+
+    token = os.environ.get("HF_TOKEN")
+    if token is None:
+        raise RuntimeError(
+            "HF_TOKEN missing — load_dotenv() ran but .env lacks the token; the "
+            "adapter download + data fetch need it. Fix .env on the pod."
+        )
+
+    # ── Phase 0: data + adapter on disk. ─────────────────────────────────────
+    log.info("[phase=fetch] data + adapter")
+    _ensure_data(token)
+    adapter_dir = _fetch_adapter(token, args.adapter_cache)
+
+    # ── Phase 0.5: marker token assertion + eval slice build. ────────────────
+    from transformers import AutoTokenizer
+
+    from explore_persona_space.experiments.contrastive_neg_geometry_472 import (
+        BASE_MODEL,
+        EXPECTED_MARKER_TOKEN_ID,
+        MARKER_TEXT,
+    )
+    from explore_persona_space.experiments.contrastive_neg_geometry_472.eval_one_cell import (
+        assert_marker_token,
+    )
+
+    tokenizer = AutoTokenizer.from_pretrained(BASE_MODEL, trust_remote_code=True, token=token)
+    assert_marker_token(tokenizer)
+    log.info("marker assert PASS: %r → [%d]", MARKER_TEXT, EXPECTED_MARKER_TOKEN_ID)
+
+    eval_personas, q_eval, source_name, source_prompt = _select_eval_slice(
+        args.n_heldout, args.n_questions
+    )
+    # Score source AND held-out personas; the panel-plus-source dict mirrors
+    # eval_trajectory.run_trajectory_eval.
+    panel_plus_source = dict(eval_personas)
+    panel_plus_source.setdefault(source_name, source_prompt)
+
+    args.out_path.parent.mkdir(parents=True, exist_ok=True)
+    partial: dict = {
+        "schema_version": "i477_reval_confirm_v1",
+        "cell": CELL_SLUG,
+        "seed": SEED,
+        "adapter_hf_repo": ADAPTER_HF_REPO,
+        "adapter_subfolder": ADAPTER_SUBFOLDER,
+        "data_revision": DATA_REVISION,
+        "marker_text": MARKER_TEXT,
+        "marker_token_id": EXPECTED_MARKER_TOKEN_ID,
+        "base_model": BASE_MODEL,
+        "n_heldout_personas": len(eval_personas),
+        "held_out_personas": sorted(eval_personas.keys()),
+        "n_questions": len(q_eval),
+        "questions": q_eval,
+        "source": source_name,
+        "git_commit": _git_sha(),
+        "hostname": socket.gethostname(),
+        "timestamp_utc": datetime.now(UTC).isoformat(),
+        "paths": {},
+        "summary": {},
+    }
+
+    # ── Phase A: clean PEFT (ground truth). ──────────────────────────────────
+    peft_records: dict | None = None
+    base_records_peft_R: dict | None = None
+    R_peft: dict[str, dict[str, str]] | None = None
+    if not args.skip_peft:
+        log.info("[phase=peft] loading trained model via PEFT (Path A — ground truth)")
+        import torch
+        from peft import PeftModel
+        from transformers import AutoModelForCausalLM
+
+        base_model = AutoModelForCausalLM.from_pretrained(
+            BASE_MODEL,
+            dtype=torch.bfloat16,
+            device_map={"": args.device},
+            trust_remote_code=True,
+            token=token,
+        ).eval()
+        trained_peft = PeftModel.from_pretrained(base_model, str(adapter_dir)).eval()
+
+        log.info("[phase=peft] generating R_PEFT (trained, greedy)")
+        R_peft = _hf_generate_R(
+            trained_peft,
+            tokenizer,
+            panel_plus_source,
+            q_eval,
+            max_new_tokens=args.max_new_tokens,
+            device=args.device,
+        )
+        log.info("[phase=peft] scoring g_logp on R_PEFT")
+        peft_records = _hf_score_marker_logp(
+            trained_peft,
+            tokenizer,
+            R_peft,
+            panel_plus_source,
+            q_eval,
+            device=args.device,
+        )
+        # Drop PEFT-wrapped model, reload a CLEAN base.
+        del trained_peft, base_model
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+        log.info("[phase=peft] loading CLEAN base for b_logp on R_PEFT")
+        base_clean = AutoModelForCausalLM.from_pretrained(
+            BASE_MODEL,
+            dtype=torch.bfloat16,
+            device_map={"": args.device},
+            trust_remote_code=True,
+            token=token,
+        ).eval()
+        base_records_peft_R = _hf_score_marker_logp(
+            base_clean,
+            tokenizer,
+            R_peft,
+            panel_plus_source,
+            q_eval,
+            device=args.device,
+        )
+        del base_clean
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+        # Persist Phase A's per-probe records IMMEDIATELY (per-phase checkpoint
+        # rule — vLLM may crash and we don't lose Path A).
+        partial["paths"]["peft"] = {
+            "R": R_peft,
+            "g_records": peft_records,
+            "b_records": base_records_peft_R,
+        }
+        partial["summary"]["peft"] = {
+            "trained": _summarize(peft_records, source_name),
+            "base_on_peft_R": _summarize(base_records_peft_R, source_name),
+        }
+        args.out_path.write_text(json.dumps(partial, indent=2))
+        log.info("[phase=peft] persisted Phase A → %s", args.out_path)
+
+    # ── Phase B: vLLM LoRARequest (suspect — the rig's mechanism). ──────────
+    vllm_records: dict | None = None
+    base_records_vllm_R: dict | None = None
+    R_vllm: dict[str, dict[str, str]] | None = None
+    if not args.skip_vllm:
+        log.info("[phase=vllm] loading vLLM with enable_lora + LoRARequest (Path B — suspect)")
+        from vllm import LLM
+        from vllm.lora.request import LoRARequest
+
+        from explore_persona_space.experiments.contrastive_neg_geometry_472 import LORA_R
+        from explore_persona_space.experiments.contrastive_neg_geometry_472.eval_one_cell import (
+            score_logp_for_R,
+        )
+        from explore_persona_space.experiments.contrastive_neg_geometry_472.eval_trajectory import (
+            _generate_on_policy_R,
+        )
+
+        llm = LLM(
+            model=BASE_MODEL,
+            dtype="bfloat16",
+            gpu_memory_utilization=args.gpu_mem_util,
+            seed=SEED,
+            max_model_len=2048,
+            enable_lora=True,
+            max_lora_rank=LORA_R,
+            max_loras=1,
+        )
+        lora_req = LoRARequest(
+            lora_name=f"{CELL_SLUG}_seed{SEED}_reval",
+            lora_int_id=1,
+            lora_path=str(adapter_dir),
+        )
+
+        log.info("[phase=vllm] generating R_VLLM (trained, greedy via vLLM)")
+        R_vllm = _generate_on_policy_R(
+            llm,
+            tokenizer,
+            panel_plus_source,
+            q_eval,
+            lora_req,
+            args.max_new_tokens,
+        )
+
+        log.info("[phase=vllm] scoring g_logp on R_VLLM (use_lora=True)")
+        vllm_records = score_logp_for_R(
+            llm,
+            tokenizer,
+            r_by_persona_q=R_vllm,
+            eval_personas=panel_plus_source,
+            eval_questions=q_eval,
+            cell_label=f"TRAINED/{CELL_SLUG}_seed{SEED}_reval",
+            use_lora=True,
+            lora_request=lora_req,
+        )
+
+        log.info("[phase=vllm] scoring b_logp on R_VLLM (use_lora=False)")
+        base_records_vllm_R = score_logp_for_R(
+            llm,
+            tokenizer,
+            r_by_persona_q=R_vllm,
+            eval_personas=panel_plus_source,
+            eval_questions=q_eval,
+            cell_label=f"BASE/{CELL_SLUG}_seed{SEED}_reval",
+            use_lora=False,
+        )
+
+        _teardown_vllm(llm)
+
+        partial["paths"]["vllm"] = {
+            "R": R_vllm,
+            "g_records": vllm_records,
+            "b_records": base_records_vllm_R,
+        }
+        partial["summary"]["vllm"] = {
+            "trained": _summarize(vllm_records, source_name),
+            "base_on_vllm_R": _summarize(base_records_vllm_R, source_name),
+        }
+        args.out_path.write_text(json.dumps(partial, indent=2))
+        log.info("[phase=vllm] persisted Phase B → %s", args.out_path)
+
+    # ── Phase 2: print the diagnostic table. ─────────────────────────────────
+    print("\n" + "=" * 80)
+    print(f"#477 RECOVERY DIAGNOSTIC — {CELL_SLUG} seed={SEED}")
+    print(f"adapter: {ADAPTER_HF_REPO}/{ADAPTER_SUBFOLDER}")
+    print(
+        f"slice: {len(eval_personas)} held-out personas × {len(q_eval)} questions  |  "
+        f"source: {source_name}"
+    )
+    print("=" * 80)
+
+    def _fmt_row(label: str, b: float, g: float) -> str:
+        return f"  {label:<24} b_logp={b:8.3f}  g_logp={g:8.3f}  ΔG={g - b:+8.3f}"
+
+    if peft_records is not None and base_records_peft_R is not None:
+        ps_held = partial["summary"]["peft"]["trained"]
+        ps_base_held = partial["summary"]["peft"]["base_on_peft_R"]
+        print("\n[Path A — clean PEFT]  (ground truth)")
+        print(_fmt_row("held-out mean:", ps_base_held["held_logp_mean"], ps_held["held_logp_mean"]))
+        print(
+            _fmt_row(
+                "source-self mean:", ps_base_held["source_logp_mean"], ps_held["source_logp_mean"]
+            )
+        )
+        print(
+            f"  source emit P(※)  trained={ps_held['source_emit_rate']:.2f}  "
+            f"base={ps_base_held['source_emit_rate']:.2f}"
+        )
+        print(
+            f"  held emit P(※)    trained={ps_held['held_emit_rate']:.2f}  "
+            f"base={ps_base_held['held_emit_rate']:.2f}"
+        )
+
+    if vllm_records is not None and base_records_vllm_R is not None:
+        vs_held = partial["summary"]["vllm"]["trained"]
+        vs_base_held = partial["summary"]["vllm"]["base_on_vllm_R"]
+        print("\n[Path B — vLLM LoRARequest]  (suspect — the rig's mechanism)")
+        print(_fmt_row("held-out mean:", vs_base_held["held_logp_mean"], vs_held["held_logp_mean"]))
+        print(
+            _fmt_row(
+                "source-self mean:", vs_base_held["source_logp_mean"], vs_held["source_logp_mean"]
+            )
+        )
+        print(
+            f"  source emit P(※)  trained={vs_held['source_emit_rate']:.2f}  "
+            f"base={vs_base_held['source_emit_rate']:.2f}"
+        )
+        print(
+            f"  held emit P(※)    trained={vs_held['held_emit_rate']:.2f}  "
+            f"base={vs_base_held['held_emit_rate']:.2f}"
+        )
+
+    if peft_records is not None and vllm_records is not None:
+        peft_src_dg = (
+            partial["summary"]["peft"]["trained"]["source_logp_mean"]
+            - partial["summary"]["peft"]["base_on_peft_R"]["source_logp_mean"]
+        )
+        vllm_src_dg = (
+            partial["summary"]["vllm"]["trained"]["source_logp_mean"]
+            - partial["summary"]["vllm"]["base_on_vllm_R"]["source_logp_mean"]
+        )
+        print("\n[Cross-path verdict]  (source-self ΔG — the adapter-applied signal)")
+        print(f"  PEFT ΔG_source = {peft_src_dg:+.3f} nats")
+        print(f"  vLLM ΔG_source = {vllm_src_dg:+.3f} nats")
+        if peft_src_dg > 5.0 and vllm_src_dg < 1.0:
+            print("  → DISPOSITIVE: vLLM LoRARequest path silently failed (v4/v6 bug pinpointed).")
+        elif peft_src_dg > 5.0 and vllm_src_dg > 5.0:
+            print("  → DISPOSITIVE: both paths apply adapter — v4 failure was pod-env-specific.")
+        elif peft_src_dg < 1.0:
+            print("  → ANOMALY: PEFT path also reads ΔG ≈ 0 — adapter may not be what we think.")
+        else:
+            print("  → UNCLEAR: partial signal; investigate per-probe records in the JSON.")
+
+    print("\nfull per-probe records → " + str(args.out_path))
+    print("=" * 80 + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/i477_reval_confirm.py
+++ b/scripts/i477_reval_confirm.py
@@ -278,7 +278,6 @@ def _hf_score_marker_logp(
     measurement modulo the load mechanism.
     """
     import torch
-
     from explore_persona_space.experiments.contrastive_neg_geometry_472 import (
         EXPECTED_MARKER_TOKEN_ID,
         MARKER_TEXT,
@@ -448,8 +447,6 @@ def main(argv: list[str] | None = None) -> int:
     adapter_dir = _fetch_adapter(token, args.adapter_cache)
 
     # ── Phase 0.5: marker token assertion + eval slice build. ────────────────
-    from transformers import AutoTokenizer
-
     from explore_persona_space.experiments.contrastive_neg_geometry_472 import (
         BASE_MODEL,
         EXPECTED_MARKER_TOKEN_ID,
@@ -458,6 +455,7 @@ def main(argv: list[str] | None = None) -> int:
     from explore_persona_space.experiments.contrastive_neg_geometry_472.eval_one_cell import (
         assert_marker_token,
     )
+    from transformers import AutoTokenizer
 
     tokenizer = AutoTokenizer.from_pretrained(BASE_MODEL, trust_remote_code=True, token=token)
     assert_marker_token(tokenizer)
@@ -578,9 +576,6 @@ def main(argv: list[str] | None = None) -> int:
     R_vllm: dict[str, dict[str, str]] | None = None
     if not args.skip_vllm:
         log.info("[phase=vllm] loading vLLM with enable_lora + LoRARequest (Path B — suspect)")
-        from vllm import LLM
-        from vllm.lora.request import LoRARequest
-
         from explore_persona_space.experiments.contrastive_neg_geometry_472 import LORA_R
         from explore_persona_space.experiments.contrastive_neg_geometry_472.eval_one_cell import (
             score_logp_for_R,
@@ -588,6 +583,8 @@ def main(argv: list[str] | None = None) -> int:
         from explore_persona_space.experiments.contrastive_neg_geometry_472.eval_trajectory import (
             _generate_on_policy_R,
         )
+        from vllm import LLM
+        from vllm.lora.request import LoRARequest
 
         llm = LLM(
             model=BASE_MODEL,

--- a/scripts/i477_reval_confirm.py
+++ b/scripts/i477_reval_confirm.py
@@ -1,5 +1,5 @@
-# ruff: noqa: RUF001, RUF002, RUF003  # em-dash + Qwen marker " ※" + minus sign − intentional
 #!/usr/bin/env python3
+# ruff: noqa: RUF001, RUF002, RUF003  # em-dash + Qwen marker " ※" + minus sign − intentional
 """Task #477 recovery diagnostic — re-eval ONE already-trained LoRA to localize the v4/v6 eval bug.
 
 NOT training. NOT a sweep. Single cell. Single seed. ~20 held-out probes.
@@ -298,6 +298,7 @@ def _hf_score_marker_logp(
     measurement modulo the load mechanism.
     """
     import torch
+
     from explore_persona_space.experiments.contrastive_neg_geometry_472 import (
         EXPECTED_MARKER_TOKEN_ID,
         MARKER_TEXT,
@@ -467,6 +468,8 @@ def main(argv: list[str] | None = None) -> int:
     adapter_dir = _fetch_adapter(token, args.adapter_cache)
 
     # ── Phase 0.5: marker token assertion + eval slice build. ────────────────
+    from transformers import AutoTokenizer
+
     from explore_persona_space.experiments.contrastive_neg_geometry_472 import (
         BASE_MODEL,
         EXPECTED_MARKER_TOKEN_ID,
@@ -475,7 +478,6 @@ def main(argv: list[str] | None = None) -> int:
     from explore_persona_space.experiments.contrastive_neg_geometry_472.eval_one_cell import (
         assert_marker_token,
     )
-    from transformers import AutoTokenizer
 
     tokenizer = AutoTokenizer.from_pretrained(BASE_MODEL, trust_remote_code=True, token=token)
     assert_marker_token(tokenizer)
@@ -596,6 +598,9 @@ def main(argv: list[str] | None = None) -> int:
     R_vllm: dict[str, dict[str, str]] | None = None
     if not args.skip_vllm:
         log.info("[phase=vllm] loading vLLM with enable_lora + LoRARequest (Path B — suspect)")
+        from vllm import LLM
+        from vllm.lora.request import LoRARequest
+
         from explore_persona_space.experiments.contrastive_neg_geometry_472 import LORA_R
         from explore_persona_space.experiments.contrastive_neg_geometry_472.eval_one_cell import (
             score_logp_for_R,
@@ -603,8 +608,6 @@ def main(argv: list[str] | None = None) -> int:
         from explore_persona_space.experiments.contrastive_neg_geometry_472.eval_trajectory import (
             _generate_on_policy_R,
         )
-        from vllm import LLM
-        from vllm.lora.request import LoRARequest
 
         llm = LLM(
             model=BASE_MODEL,

--- a/scripts/i477_reval_confirm.py
+++ b/scripts/i477_reval_confirm.py
@@ -101,6 +101,9 @@ def _git_sha() -> str:
 
 def _ensure_data(token: str | None) -> None:
     """Pull the pinned-rev persona bank + centroids + R_eval into data/issue_472/."""
+
+    import shutil
+
     from huggingface_hub import hf_hub_download
 
     LOCAL_DATA_ROOT.mkdir(parents=True, exist_ok=True)
@@ -118,8 +121,10 @@ def _ensure_data(token: str | None) -> None:
             token=token,
         )
         local_path.parent.mkdir(parents=True, exist_ok=True)
-        # Hard-link (cheap) into the rig's expected layout.
-        os.link(cached, local_path)
+        # Copy (idempotent — overwrites) into the rig's expected layout.
+        # os.link is non-idempotent (FileExistsError on relaunch) AND fails
+        # across filesystems (EXDEV: HF cache vs data/ may be different mounts).
+        shutil.copyfile(cached, local_path)
 
 
 def _fetch_adapter(token: str | None, dest: Path) -> Path:

--- a/scripts/i477_reval_confirm.py
+++ b/scripts/i477_reval_confirm.py
@@ -123,33 +123,48 @@ def _ensure_data(token: str | None) -> None:
 
 
 def _fetch_adapter(token: str | None, dest: Path) -> Path:
-    """Download the trained adapter dir from HF to ``dest`` (snapshot_download)."""
-    from huggingface_hub import snapshot_download
+    """Download the trained adapter dir from HF to ``dest`` via per-file
+    ``hf_hub_download``.
+
+    ``snapshot_download(allow_patterns=...)`` returns 0 files on repos with
+    truncated siblings (huggingface_hub siblings-truncation bug), so we list the
+    repo files and pull each one explicitly — the same pattern ``_ensure_data``
+    uses for the #472 data.
+    """
+    from huggingface_hub import HfApi, hf_hub_download
 
     dest.mkdir(parents=True, exist_ok=True)
     log.info(
-        "fetching adapter %s/%s → %s",
+        "fetching adapter %s/%s → %s (per-file)",
         ADAPTER_HF_REPO,
         ADAPTER_SUBFOLDER,
         dest,
     )
-    snap = snapshot_download(
-        repo_id=ADAPTER_HF_REPO,
-        repo_type="model",
-        allow_patterns=[f"{ADAPTER_SUBFOLDER}/*"],
-        local_dir=str(dest),
-        token=token,
-    )
-    adapter_dir = Path(snap) / ADAPTER_SUBFOLDER
+    api = HfApi()
+    all_files = api.list_repo_files(repo_id=ADAPTER_HF_REPO, repo_type="model", token=token)
+    sub_files = [f for f in all_files if f.startswith(f"{ADAPTER_SUBFOLDER}/")]
+    if not sub_files:
+        raise FileNotFoundError(
+            f"no files under {ADAPTER_SUBFOLDER} in {ADAPTER_HF_REPO} — "
+            f"adapter subfolder missing on Hub"
+        )
+    for fn in sub_files:
+        hf_hub_download(
+            repo_id=ADAPTER_HF_REPO,
+            repo_type="model",
+            filename=fn,
+            local_dir=str(dest),
+            token=token,
+        )
+    adapter_dir = dest / ADAPTER_SUBFOLDER
     # Verify the load-bearing files landed.
     must_have = ("adapter_config.json", "adapter_model.safetensors")
     for fn in must_have:
         if not (adapter_dir / fn).exists():
             raise FileNotFoundError(
-                f"adapter file {fn} missing under {adapter_dir} after snapshot_download — "
-                f"check the snapshot_download siblings truncation memory."
+                f"adapter file {fn} missing under {adapter_dir} after per-file download"
             )
-    log.info("adapter dir = %s", adapter_dir)
+    log.info("adapter dir = %s (%d files)", adapter_dir, len(sub_files))
     return adapter_dir
 
 

--- a/scripts/i477_reval_confirm.py
+++ b/scripts/i477_reval_confirm.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import gc
+import hashlib
 import json
 import logging
 import os
@@ -491,6 +492,15 @@ def main(argv: list[str] | None = None) -> int:
     panel_plus_source = dict(eval_personas)
     panel_plus_source.setdefault(source_name, source_prompt)
 
+    # Plan §4.4 step 6: SHA256 of the local R_eval.json + held-out panel
+    # composition. Cheap reproducibility hook so the analyzer can later
+    # confirm that this run consumed the same on-policy R artifact as any
+    # downstream Wave-1 re-eval cell.
+    r_eval_path = LOCAL_DATA_ROOT / "on_policy_R" / "R_eval.json"
+    r_eval_sha256: str | None = None
+    if r_eval_path.is_file():
+        r_eval_sha256 = hashlib.sha256(r_eval_path.read_bytes()).hexdigest()
+
     args.out_path.parent.mkdir(parents=True, exist_ok=True)
     partial: dict = {
         "schema_version": "i477_reval_confirm_v1",
@@ -499,6 +509,7 @@ def main(argv: list[str] | None = None) -> int:
         "adapter_hf_repo": ADAPTER_HF_REPO,
         "adapter_subfolder": ADAPTER_SUBFOLDER,
         "data_revision": DATA_REVISION,
+        "r_eval_json_sha256": r_eval_sha256,
         "marker_text": MARKER_TEXT,
         "marker_token_id": EXPECTED_MARKER_TOKEN_ID,
         "base_model": BASE_MODEL,

--- a/scripts/i477_reval_confirm.py
+++ b/scripts/i477_reval_confirm.py
@@ -68,7 +68,7 @@ DATA_REPO = "superkaiba1/explore-persona-space-data"
 DATA_REVISION = "66d7db7a542e19275f8c1d8e32948396d050faa9"
 DATA_PREFIX = "issue472_neg_geometry"
 DATA_FILES = (
-    f"{DATA_PREFIX}/persona_bank.json",
+    f"{DATA_PREFIX}/geometry/persona_bank.json",
     f"{DATA_PREFIX}/geometry/centroids_L10.pt",
     f"{DATA_PREFIX}/on_policy_R/R_eval.json",
 )
@@ -76,7 +76,7 @@ DATA_FILES = (
 # Local mirror layout (matches the rig's expectations).
 LOCAL_DATA_ROOT = Path("data/issue_472")
 LOCAL_PATHS = {
-    f"{DATA_PREFIX}/persona_bank.json": LOCAL_DATA_ROOT / "persona_bank.json",
+    f"{DATA_PREFIX}/geometry/persona_bank.json": LOCAL_DATA_ROOT / "persona_bank.json",
     f"{DATA_PREFIX}/geometry/centroids_L10.pt": LOCAL_DATA_ROOT / "centroids_L10.pt",
     f"{DATA_PREFIX}/on_policy_R/R_eval.json": LOCAL_DATA_ROOT / "on_policy_R" / "R_eval.json",
 }
@@ -182,7 +182,7 @@ def _select_eval_slice(
         negatives_for_cell,
     )
 
-    bank = load_persona_bank(LOCAL_PATHS[f"{DATA_PREFIX}/persona_bank.json"])
+    bank = load_persona_bank(LOCAL_PATHS[f"{DATA_PREFIX}/geometry/persona_bank.json"])
     cts = cos_to_source(HEADLINE_LAYER, SOURCE_PERSONA, LOCAL_DATA_ROOT)
     base_panel = held_out_panel(cts, source=SOURCE_PERSONA)
     union_477 = all_negatives_union(cts, source=SOURCE_PERSONA, cell_specs=CELL_SPECS_477)

--- a/src/explore_persona_space/experiments/contrastive_neg_count_decouple_477/__init__.py
+++ b/src/explore_persona_space/experiments/contrastive_neg_count_decouple_477/__init__.py
@@ -1,0 +1,542 @@
+# ruff: noqa: RUF002, RUF003, RUF022  # em-dash + Qwen marker " ※" + Greek ΔG + grouped __all__ intentional
+"""Task #477 — implant-decoupled contrastive-negative count sweep.
+
+Parent #472. Goal (plan §1): determine whether contrastive-negative COUNT
+independently controls bystander marker leakage *net of source-implant strength*
+— the axis #472 could not separate because count and source-implant ΔG
+occupied non-overlapping plateaus there.
+
+Design (plan §4): for each count level in {2, 4, 8, 16}, first run a per-count
+LR-calibration sweep (Phase 2, 20 cells, seed=42, 5 LRs each, terminal-only
+eval) to pick the LR that lands source-self ΔG in [10.5, 13.5] nats AND source
+emission P(※)≥0.30. Then run the main 8-cell sweep (4 counts × 2 seeds) at the
+calibrated LRs with full trajectory eval (Phase 3), plus the implant-only-axis
+arm (Phase 4, 6 cells at fixed count, varying LR) to isolate the implant axis.
+
+Everything except the calibration layer + the 477 cell registry REUSES the #472
+rig at `src/explore_persona_space/experiments/contrastive_neg_geometry_472/*`
+(persona bank, centroids, R-generate, base panel, build_training_data,
+train_cell, eval_trajectory). The 472 module's `negatives_for_cell` and
+`build_cell` now accept an optional `cell_specs` kwarg so 477 cells can drive
+them; otherwise the 472 path is byte-identical (backward-compat).
+
+Module layout:
+    __init__   — constants, CELL_SPECS_477, re-export of 472 recipe constants
+    calibrate  — pick_lr_for_count + validity_gate (pure functions)
+
+Pseudocode + grounding for every constant lives in
+`tasks/running/477/plans/plan.md` §4 (the calibration layer pseudocode) and §11
+(per-constant `Source:` notes).
+"""
+
+from __future__ import annotations
+
+# Re-export the #472 recipe so 477 callers have a single import surface.
+from explore_persona_space.experiments.contrastive_neg_geometry_472 import (
+    ALWAYS_INCLUDE_NEGATIVE,
+    BASE_MODEL,
+    BATCH_SIZE,
+    EXPECTED_MARKER_TOKEN_ID,
+    GRAD_ACCUM,
+    HF_DATA_REPO,
+    HF_MODEL_REPO,
+    LORA_ALPHA,
+    LORA_DROPOUT,
+    LORA_R,
+    MARKER_SEP,
+    MARKER_TEXT,
+    MAX_LENGTH,
+    MAX_NEW_TOKENS_GEN,
+    POS_EX_PER_SOURCE,
+    SOURCE_PERSONA,
+    WARMUP_RATIO,
+    CellSpec,
+)
+
+# Names re-exported for the 477 single-import surface. Listing them here keeps
+# ruff F401 happy without losing the convenience of `from
+# contrastive_neg_count_decouple_477 import MARKER_TEXT`.
+__all__ = [
+    # Re-exported from #472.
+    "ALWAYS_INCLUDE_NEGATIVE",
+    "BASE_MODEL",
+    "BATCH_SIZE",
+    "EXPECTED_MARKER_TOKEN_ID",
+    "GRAD_ACCUM",
+    "HF_DATA_REPO",
+    "HF_MODEL_REPO",
+    "LORA_ALPHA",
+    "LORA_DROPOUT",
+    "LORA_R",
+    "MARKER_SEP",
+    "MARKER_TEXT",
+    "MAX_LENGTH",
+    "MAX_NEW_TOKENS_GEN",
+    "POS_EX_PER_SOURCE",
+    "SOURCE_PERSONA",
+    "WARMUP_RATIO",
+    "CellSpec",
+    # NEW in #477 (v2 legacy LR-calibration constants).
+    "ANCHOR_COUNT",
+    "CALIB_SLUGS",
+    "CALIBRATION_LR_GRID",
+    "CELL_SPECS_477",
+    "COUNT_LEVELS",
+    "EPOCHS",
+    "IMPLANT_SWEEP_LRS",
+    "IMPLANT_SWEEP_SLUGS",
+    "MAIN_SLUGS",
+    "MATCH_BAND",
+    "MIN_SOURCE_EMISSION",
+    "NEG_EX_PER_PERSONA",
+    "TARGET_SOURCE_DELTA_G",
+    "count_for_slug",
+    "lr_for_implant_sweep_slug",
+    "slug_for_count",
+    # NEW in v3/v4 (step-lever pivot).
+    "CALIBRATION_LR_V3",
+    "MAX_SOURCE_EMISSION_V3",
+    "MIN_SOURCE_EMISSION_V3",
+    "TARGET_STEPS",
+    # NEW in v4r2 (H2 step-sweep replacement for v2 LR-sweep implant_sweep).
+    "IMPLANT_SWEEP_STEPS",
+    "IMPLANT_SWEEP_V4_ANCHOR_SLUG",
+    "IMPLANT_SWEEP_V4_SLUGS",
+    "implant_sweep_v4_slug_for_step",
+    "step_for_implant_sweep_v4_slug",
+    # NEW in v6 (M1 rank control + M2 single-source-of-truth alpha map).
+    "ALPHA_CONTROL_V6",
+    "CAL_A0_SLUGS",
+    "CAL_A_SLUGS",
+    "MARKER_IM_END_TOKEN_ID",
+    "RANK_ALPHA_MAP_V5",
+    "RANK_CONTROL_COUNTS_V6",
+    "RANK_CONTROL_V6",
+    "RANK_GRID_V5",
+    "alpha_for_rank",
+    "cal_a0_slug",
+    "cal_a_slug",
+    "count_for_calA0_slug",
+    "count_for_calA_slug",
+    "rank_for_calA_slug",
+]
+
+# ── Calibration constants (plan §4 pseudocode + §11 grounding) ───────────────
+# Target source-self ΔG = 12.0 ± 1.5 nats — the matched-implant band. Sits in
+# the gap between #472's low-count plateau (~8) and placement plateau (~13-15),
+# in the "implant real, behaviorally emitting, not saturated" window the parent
+# missed (plan §11; Source: #472 non-overlapping plateau analysis).
+TARGET_SOURCE_DELTA_G: float = 12.0
+MATCH_BAND: float = 1.5
+
+# Source emission floor — the matched implant must be BEHAVIORAL, not sub-
+# emission log-prob drift. 0.30 = min behavioral threshold ("source emits the
+# marker on a non-trivial fraction of its own answers"); Source: #472 emission-
+# floor finding (max 0.17 on source under 1 epoch).
+MIN_SOURCE_EMISSION: float = 0.30
+
+# Count axis (the experimental variable). 4 levels; {2,4,8} cover #472's range
+# and 16 extends it so the partial-Spearman has 4 data points instead of 3.
+COUNT_LEVELS: tuple[int, ...] = (2, 4, 8, 16)
+
+# Calibration LR grid: 25× #472's 1e-5 baseline (5× down, 5× up). Spans enough
+# to compensate for the hypothesized ~10-nat implant differential across the
+# count axis. Source: ungrounded — needs calibration sweep; the kill criterion
+# in plan §7 fires if this grid is too narrow.
+CALIBRATION_LR_GRID: tuple[float, ...] = (2e-6, 5e-6, 1e-5, 2e-5, 5e-5)
+
+# Implant-only-axis arm (H2): same negatives as the 4-persona anchor, vary LR
+# alone over these 3 values × 2 seeds = 6 cells. Source: ungrounded — H2 is the
+# implant-axis identification check.
+IMPLANT_SWEEP_LRS: tuple[float, ...] = (5e-6, 1e-5, 2e-5)
+
+# 2 epochs raised from #472's 1 to land source in mid-emission range (plan §11;
+# Source: ungrounded — needs smoke-test; 1 epoch was sub-emission in #472, 3
+# epochs saturated in #448).
+EPOCHS: int = 2
+
+# Per-persona negative examples (same as #472).
+NEG_EX_PER_PERSONA: int = 200
+
+# ── v3/v4 step-lever constants (plan v4 §4, §6, §11 — "STEP-LEVER PIVOT"). ───
+# After v2 calibration round 1 confirmed LR is a dead lever (Source: plan §2 +
+# §11), v3/v4 pivot to per-cell early-step checkpoints at FIXED lr=2e-6. The
+# dense early-step grid spans the sub-step-10 plateau analysis from #472.
+# Source: ungrounded — #477 step-lever bet; Phase 2 step calibration validates.
+TARGET_STEPS: tuple[int, ...] = (1, 2, 4, 8, 16, 32, 64)
+
+# Fixed calibration LR for v3/v4 (lr=2e-6 was the only v2 LR that produced any
+# sub-saturation ΔG signal across counts; Source: plan §2 + §11).
+CALIBRATION_LR_V3: float = 2e-6
+
+# v3/v4 raised emission floor (anti-collapse) + new ceiling (anti-saturation).
+# Source: plan §11 ("0.40 raised floor + anti-saturation ceiling").
+MIN_SOURCE_EMISSION_V3: float = 0.40
+MAX_SOURCE_EMISSION_V3: float = 0.95
+
+# Anchor count for the implant-only-axis arm: the #472 anchor's 4 negatives.
+ANCHOR_COUNT: int = 4
+
+# v4r2 H2 step-sweep: at fixed lr=CALIBRATION_LR_V3 (2e-6) and count=ANCHOR_COUNT
+# (4), read the implant-only axis at non-terminal step levels {16, 64} plus the
+# terminal step (added implicitly via frac=1.0). LR is the dead lever the v4
+# pivot abandons (round-1 confirmed); the step axis IS the implant axis under
+# the step-lever pivot. Source: plan v4 §4 PHASE 4 (step sweep, not LR sweep)
+# + plan v4 §6 H2 cross-check (calibrate step→leakage at fixed count).
+IMPLANT_SWEEP_STEPS: tuple[int, ...] = (16, 64)
+
+# ── Cell registry (CELL_SPECS_477) ───────────────────────────────────────────
+# Same 6-tuple shape as #472's CellSpec: (slug, plain_name, placement,
+# n_neg_personas, neg_ex_per_persona, in_pooled).
+#
+# Three phase families (plan §4):
+#   (1) calibration cells (Phase 2): 4 counts × 5 LRs = 20 SLUGS, all
+#       seed=42, terminal-only eval. The slug encodes ONLY the count;
+#       LR is threaded per-launch via --lr (the slug is the SAME across
+#       all 5 LRs at a given count — the dispatcher distinguishes by
+#       the (slug, lr) tuple on the launched subprocess).
+#   (2) main cells (Phase 3): 4 counts × 2 seeds = 8 cells, full trajectory
+#       eval, LR per cell picked by Phase 2.5.
+#   (3) implant-only-axis cells (Phase 4): 3 LRs × 2 seeds = 6 cells, fixed
+#       count = anchor (4), full trajectory eval.
+#
+# in_pooled is left False everywhere — 477 does NOT reuse #472's pooled
+# geometry regression; its analyses are partial Spearmans over the count and
+# LR axes.
+
+# Calibration cells (one slug per count level; LR threaded per-launch).
+_CALIB_SPECS: tuple[CellSpec, ...] = tuple(
+    (
+        f"c477_calib_negp_{c}",
+        f"Calibration: {c}-persona negatives",
+        "spread",
+        c,
+        NEG_EX_PER_PERSONA,
+        False,
+    )
+    for c in COUNT_LEVELS
+)
+
+# Main cells (one slug per count level; LR per cell from calibration pick).
+_MAIN_SPECS: tuple[CellSpec, ...] = tuple(
+    (
+        f"c477_main_calib_negp_{c}",
+        f"{c}-persona negatives (calibrated)",
+        "spread",
+        c,
+        NEG_EX_PER_PERSONA,
+        False,
+    )
+    for c in COUNT_LEVELS
+)
+
+
+# Implant-only-axis cells (fixed count = anchor, LR varies). Slug encodes the
+# LR so each cell has its own run directory + sentinel.
+def _lr_slug(lr: float) -> str:
+    # 5e-06 → "5e-6"; 1e-05 → "1e-5". Tight, slug-safe.
+    return f"{lr:g}".replace("e-0", "e-")
+
+
+_IMPLANT_SWEEP_SPECS: tuple[CellSpec, ...] = tuple(
+    (
+        f"c477_implantsweep_lr{_lr_slug(lr)}",
+        f"Anchor at LR={lr:g} (implant-only axis)",
+        "spread",
+        ANCHOR_COUNT,
+        NEG_EX_PER_PERSONA,
+        False,
+    )
+    for lr in IMPLANT_SWEEP_LRS
+)
+
+# v4r2 anchor cell: ONE training run per seed (at lr=CALIBRATION_LR_V3, count=
+# ANCHOR_COUNT). The worker evaluates the trajectory at step levels
+# {16, 64, T} and emits per-step records; the dispatcher expands them into
+# IMPLANT_SWEEP_V4_SLUGS for the analyze partial.
+_IMPLANT_SWEEP_V4_ANCHOR_SPEC: CellSpec = (
+    "c477_implantsweep_v4_anchor",
+    "v4 anchor (implant-only-axis, step sweep)",
+    "spread",
+    ANCHOR_COUNT,
+    NEG_EX_PER_PERSONA,
+    False,
+)
+
+CELL_SPECS_477: tuple[CellSpec, ...] = (
+    _CALIB_SPECS + _MAIN_SPECS + _IMPLANT_SWEEP_SPECS + (_IMPLANT_SWEEP_V4_ANCHOR_SPEC,)
+)
+
+# Phase classification (used by the dispatcher to group cells by phase).
+CALIB_SLUGS: tuple[str, ...] = tuple(c[0] for c in _CALIB_SPECS)
+MAIN_SLUGS: tuple[str, ...] = tuple(c[0] for c in _MAIN_SPECS)
+IMPLANT_SWEEP_SLUGS: tuple[str, ...] = tuple(c[0] for c in _IMPLANT_SWEEP_SPECS)
+
+
+def slug_for_count(count: int, phase: str) -> str:
+    """Resolve the cell slug for (count, phase).
+
+    Args:
+        count: one of COUNT_LEVELS for calibration / main; ANCHOR_COUNT for
+            implant_sweep (count is the fixed anchor in that phase).
+        phase: "calibration" | "main" | "implant_sweep".
+
+    Raises:
+        ValueError: unknown phase or count not in COUNT_LEVELS (for calibration
+            / main).
+    """
+    if phase == "calibration":
+        if count not in COUNT_LEVELS:
+            raise ValueError(f"count={count} not in COUNT_LEVELS={COUNT_LEVELS}")
+        return f"c477_calib_negp_{count}"
+    if phase == "main":
+        if count not in COUNT_LEVELS:
+            raise ValueError(f"count={count} not in COUNT_LEVELS={COUNT_LEVELS}")
+        return f"c477_main_calib_negp_{count}"
+    if phase == "implant_sweep":
+        # implant_sweep slugs encode the LR, not the count; caller resolves by LR.
+        raise ValueError(
+            "slug_for_count does not resolve implant_sweep slugs (they encode LR, "
+            "not count); use IMPLANT_SWEEP_SLUGS / IMPLANT_SWEEP_LRS directly."
+        )
+    raise ValueError(f"Unknown phase {phase!r}")
+
+
+def count_for_slug(slug: str) -> int:
+    """Reverse lookup: the integer count level a slug belongs to.
+
+    Implant-sweep slugs ALL belong to ANCHOR_COUNT — v2 slugs sweep LR at fixed
+    count; v4 slugs sweep optimizer-step at fixed count + lr. The v4 anchor
+    slug (one training run per seed, expanded into per-step records by the
+    dispatcher) also belongs to ANCHOR_COUNT. v6 Cal-A / Cal-A0 slugs encode
+    BOTH count + rank (cal_a_slug / cal_a0_slug). Raises KeyError on unknown slug.
+    """
+    for c in COUNT_LEVELS:
+        if slug == f"c477_calib_negp_{c}" or slug == f"c477_main_calib_negp_{c}":
+            return c
+    if slug in IMPLANT_SWEEP_SLUGS:
+        return ANCHOR_COUNT
+    if slug == IMPLANT_SWEEP_V4_ANCHOR_SLUG or slug in IMPLANT_SWEEP_V4_SLUGS:
+        return ANCHOR_COUNT
+    # v6 Cal-A: c477_calA_negp_<count>_r<rank>.
+    if slug.startswith("c477_calA_negp_") and not slug.startswith("c477_calA0_negp_"):
+        # Defer to the precise helper; raises KeyError on a malformed Cal-A slug.
+        return count_for_calA_slug(slug)
+    # v6 Cal-A0: c477_calA0_negp_<count>_r32.
+    if slug.startswith("c477_calA0_negp_"):
+        return count_for_calA0_slug(slug)
+    raise KeyError(f"Unknown 477 cell slug: {slug!r}")
+
+
+def lr_for_implant_sweep_slug(slug: str) -> float:
+    """Reverse lookup: the LR encoded in an implant-sweep slug.
+
+    Raises KeyError if slug is not an implant-sweep slug.
+    """
+    for lr in IMPLANT_SWEEP_LRS:
+        if slug == f"c477_implantsweep_lr{_lr_slug(lr)}":
+            return lr
+    raise KeyError(f"Not an implant-sweep slug: {slug!r}")
+
+
+# ── v4r2 H2 step-sweep slugs (plan v4 §4 PHASE 4 — STEP sweep, not LR sweep) ─
+# One anchor training run per seed at lr=CALIBRATION_LR_V3, count=ANCHOR_COUNT.
+# Per-step cell summaries are read OUT of that single trajectory at step levels
+# {16, 64, T} (terminal). The dispatcher expands the per-seed anchor result
+# into 3 per-step records for the v4 implant-only-axis analyze partial.
+IMPLANT_SWEEP_V4_ANCHOR_SLUG: str = "c477_implantsweep_v4_anchor"
+
+
+def _step_slug(step: int | str) -> str:
+    """Slug suffix for an implant-sweep-v4 step level: '16' / '64' / 'T'."""
+    if isinstance(step, str):
+        if step != "T":
+            raise ValueError(f"_step_slug: string step suffix must be 'T' (terminal); got {step!r}")
+        return "T"
+    return str(int(step))
+
+
+IMPLANT_SWEEP_V4_SLUGS: tuple[str, ...] = tuple(
+    f"c477_implantsweep_step{_step_slug(s)}" for s in (*IMPLANT_SWEEP_STEPS, "T")
+)
+
+
+def implant_sweep_v4_slug_for_step(step: int | str) -> str:
+    """Per-step slug for the v4 implant-only-axis arm.
+
+    Args:
+        step: a non-terminal optimizer step in IMPLANT_SWEEP_STEPS, OR the
+            literal string ``"T"`` for the terminal-step level.
+
+    Raises:
+        ValueError: step not in {*IMPLANT_SWEEP_STEPS, "T"}.
+    """
+    if isinstance(step, str):
+        if step != "T":
+            raise ValueError(
+                f"implant_sweep_v4_slug_for_step: string step must be 'T'; got {step!r}"
+            )
+        return f"c477_implantsweep_step{_step_slug(step)}"
+    if int(step) not in IMPLANT_SWEEP_STEPS:
+        raise ValueError(
+            f"implant_sweep_v4_slug_for_step: step={step} not in "
+            f"IMPLANT_SWEEP_STEPS={IMPLANT_SWEEP_STEPS} (and not 'T' for terminal)."
+        )
+    return f"c477_implantsweep_step{_step_slug(int(step))}"
+
+
+def step_for_implant_sweep_v4_slug(slug: str) -> int | str:
+    """Reverse lookup: the step level encoded in a v4 implant-sweep slug.
+
+    Returns ``int`` for non-terminal step levels, ``"T"`` for the terminal slug.
+
+    Raises:
+        KeyError: slug is not a v4 implant-sweep slug.
+    """
+    if slug == f"c477_implantsweep_step{_step_slug('T')}":
+        return "T"
+    for s in IMPLANT_SWEEP_STEPS:
+        if slug == f"c477_implantsweep_step{_step_slug(s)}":
+            return int(s)
+    raise KeyError(f"Not a v4 implant-sweep slug: {slug!r}")
+
+
+# ── v6 RECIPE-SCALE PIVOT (LoRA rank lever + Cal-A0 r=32 slot-fix control). ──
+# Cal-A: rank sweep across {2, 4, 8} at the v4 lr/positives/epochs floor.
+# Cal-A0: r=32 / α=64 (v4 byte-identical) at counts {2, 4, 16} with the
+# slot-fix port turned on — the slot-bug-vs-capacity diagnostic (plan v6 §4
+# PHASE 2A + 2A-CONTROL). Each cell uses the SAME 4 count levels as the v4
+# main sweep; Cal-A0 drops count=8 to stay within the ~3 GPU-h M1 budget.
+
+# ── v6 M2 SINGLE SOURCE OF TRUTH for LoRA alpha ─────────────────────────────
+# rsLoRA scaling factor α/√r held fixed at the v4 r=32/α=64 equivalent
+# (α/√r = 11.31). Source: arXiv 2312.03732 §3 (rsLoRA). Hand calculations:
+#   r=2 → α=11.31×√2 = 15.99 → 16
+#   r=4 → α=11.31×2   = 22.62 → 23
+#   r=8 → α=11.31×√8 = 32.00 → 32
+# The r=32 CONTROL uses α=64 (the v4 byte-identical baseline; NOT in the map
+# — it is the diagnostic anchor, not the swept axis). NO `2*r` math anywhere.
+# Dispatcher's _verify_alpha_invariant guard + the parameterized threading
+# test enforce that every alpha at training time is read from this map (or
+# is the literal 64 when rank=32).
+RANK_ALPHA_MAP_V5: dict[int, int] = {2: 16, 4: 23, 8: 32}
+
+# Cal-A rank grid (the swept axis; M2 invariant: every member must have an
+# entry in RANK_ALPHA_MAP_V5).
+RANK_GRID_V5: tuple[int, ...] = (2, 4, 8)
+
+# Cal-A0 control (the diagnostic anchor; v4 byte-identical recipe with the
+# slot-fix port turned on). Counts {2, 4, 16} chosen as a 3-point overlap
+# with Cal-A spanning the full count range (count=8 dropped to stay in the
+# M1 ~3 GPU-h budget).
+RANK_CONTROL_V6: int = 32
+ALPHA_CONTROL_V6: int = 64
+RANK_CONTROL_COUNTS_V6: tuple[int, ...] = (2, 4, 16)
+
+# Qwen-2.5-7B-Instruct ``<|im_end|>`` token id; the post-response slot for the
+# marker-channel DV. Threaded to MarkerOnlyDataCollator via
+# TrainLoraConfig.marker_im_end_token_id when
+# marker_suppress_at_post_response_slot=True (plan v6 §0 + §4.4 SLOT-FIX row).
+MARKER_IM_END_TOKEN_ID: int = 151645
+
+
+def alpha_for_rank(rank: int) -> int:
+    """Single-source-of-truth alpha lookup (v6 M2 invariant).
+
+    Returns ``RANK_ALPHA_MAP_V5[rank]`` for Cal-A ranks {2, 4, 8}, or
+    ``ALPHA_CONTROL_V6`` (=64) for the Cal-A0 control rank (=32). Any other
+    rank raises ``ValueError`` — v6 supports exactly these four ranks across
+    Cal-A + Cal-A0. The dispatcher's ``_verify_alpha_invariant`` guard + the
+    threading test BOTH call into this helper; no caller may compute alpha
+    by formula (``2*r`` etc.).
+    """
+    if rank in RANK_ALPHA_MAP_V5:
+        return RANK_ALPHA_MAP_V5[rank]
+    if rank == RANK_CONTROL_V6:
+        return ALPHA_CONTROL_V6
+    raise ValueError(
+        f"v6 M2 alpha invariant: unknown rank={rank}; supported = "
+        f"{sorted(RANK_ALPHA_MAP_V5)} (Cal-A) + {RANK_CONTROL_V6} (Cal-A0 control)."
+    )
+
+
+def cal_a_slug(count: int, rank: int) -> str:
+    """Cal-A cell slug for (count, rank). Plan v6 §5 table."""
+    if count not in COUNT_LEVELS:
+        raise ValueError(f"Cal-A count={count} not in COUNT_LEVELS={COUNT_LEVELS}")
+    if rank not in RANK_GRID_V5:
+        raise ValueError(f"Cal-A rank={rank} not in RANK_GRID_V5={RANK_GRID_V5}")
+    return f"c477_calA_negp_{count}_r{rank}"
+
+
+def cal_a0_slug(count: int) -> str:
+    """Cal-A0 control cell slug for (count). Plan v6 §5 table (rank fixed at 32)."""
+    if count not in RANK_CONTROL_COUNTS_V6:
+        raise ValueError(
+            f"Cal-A0 count={count} not in RANK_CONTROL_COUNTS_V6={RANK_CONTROL_COUNTS_V6}"
+        )
+    return f"c477_calA0_negp_{count}_r{RANK_CONTROL_V6}"
+
+
+def count_for_calA_slug(slug: str) -> int:
+    """Reverse lookup: the count level encoded in a Cal-A slug."""
+    for count in COUNT_LEVELS:
+        for rank in RANK_GRID_V5:
+            if slug == cal_a_slug(count, rank):
+                return count
+    raise KeyError(f"Not a Cal-A slug: {slug!r}")
+
+
+def rank_for_calA_slug(slug: str) -> int:
+    """Reverse lookup: the rank encoded in a Cal-A slug."""
+    for count in COUNT_LEVELS:
+        for rank in RANK_GRID_V5:
+            if slug == cal_a_slug(count, rank):
+                return rank
+    raise KeyError(f"Not a Cal-A slug: {slug!r}")
+
+
+def count_for_calA0_slug(slug: str) -> int:
+    """Reverse lookup: the count level encoded in a Cal-A0 control slug."""
+    for count in RANK_CONTROL_COUNTS_V6:
+        if slug == cal_a0_slug(count):
+            return count
+    raise KeyError(f"Not a Cal-A0 slug: {slug!r}")
+
+
+# Cal-A + Cal-A0 cell spec registries. The placement is always "spread" and
+# in_pooled is False (v6 cells do not feed the #472 pooled geometry
+# regression; their analyses are partial Spearmans + rank-pick over the
+# count × rank axes).
+_CAL_A_SPECS: tuple[CellSpec, ...] = tuple(
+    (
+        cal_a_slug(count, rank),
+        f"Cal-A: {count}-persona negatives, LoRA r={rank}",
+        "spread",
+        count,
+        NEG_EX_PER_PERSONA,
+        False,
+    )
+    for rank in RANK_GRID_V5
+    for count in COUNT_LEVELS
+)
+
+_CAL_A0_SPECS: tuple[CellSpec, ...] = tuple(
+    (
+        cal_a0_slug(count),
+        f"Cal-A0 control: {count}-persona negatives, LoRA r={RANK_CONTROL_V6} (slot-fix)",
+        "spread",
+        count,
+        NEG_EX_PER_PERSONA,
+        False,
+    )
+    for count in RANK_CONTROL_COUNTS_V6
+)
+
+# Append v6 cells to the existing CELL_SPECS_477 (so panel-disjointness logic
+# in select_negatives.py picks them up). NOTE: CELL_SPECS_477 was defined
+# above; rebind it here so v4 + v6 cells share the registry.
+CELL_SPECS_477 = CELL_SPECS_477 + _CAL_A_SPECS + _CAL_A0_SPECS
+
+CAL_A_SLUGS: tuple[str, ...] = tuple(c[0] for c in _CAL_A_SPECS)
+CAL_A0_SLUGS: tuple[str, ...] = tuple(c[0] for c in _CAL_A0_SPECS)

--- a/src/explore_persona_space/experiments/contrastive_neg_count_decouple_477/calibrate.py
+++ b/src/explore_persona_space/experiments/contrastive_neg_count_decouple_477/calibrate.py
@@ -1,0 +1,433 @@
+# em-dash + Qwen marker token " ※" are intentional
+"""Task #477 — calibration layer: pick LR per count level + validity gate.
+
+Pure functions over JSON-array results (no LLM call, no GPU). Drives Phase 2.5
+of the dispatcher (pick) and Phase 5 of the analysis (gate).
+
+See plan §4 for the pseudocode this implements.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from explore_persona_space.experiments.contrastive_neg_count_decouple_477 import (
+    MATCH_BAND,
+    MAX_SOURCE_EMISSION_V3,
+    MIN_SOURCE_EMISSION,
+    MIN_SOURCE_EMISSION_V3,
+    TARGET_SOURCE_DELTA_G,
+)
+
+# Calibration-table schema (per cell in Phase 2):
+#   calibration_table[count][lr] = {
+#       "source_self_delta_g": float,    # DV-B at final checkpoint
+#       "source_emission_p": float,      # DV-C at final checkpoint
+#       "cell_slug": str,                # provenance
+#       "seed": int,                     # always 42 in Phase 2
+#       "wandb_run_id": str | None,      # provenance
+#   }
+# count keys are str(int) on disk (JSON), int in-memory; callers normalize.
+
+
+def _normalize_count_table(cells: dict) -> dict[float, dict]:
+    """Normalize the per-count LR table to {float(lr): {...}}.
+
+    On-disk JSON uses string keys (`"1e-05"` or `"5e-06"`); in-memory callers
+    may pass float keys. This is a defensive convergence so pick_lr_for_count
+    works with either.
+    """
+    out: dict[float, dict] = {}
+    for k, v in cells.items():
+        out[float(k)] = v
+    return out
+
+
+def pick_lr_for_count(calibration_table: dict, count: int) -> dict[str, Any]:
+    """For count level c, pick the LR whose terminal cell satisfies BOTH gates.
+
+    Plan §4 pseudocode + §7 kill criterion.
+
+    Args:
+        calibration_table: {count -> {lr -> {source_self_delta_g, source_emission_p, ...}}}.
+            Count keys may be int or str(int) (caller normalizes).
+        count: the count level to pick the LR for. MUST be present as a key in
+            calibration_table (str(int) or int both accepted).
+
+    Returns:
+        {"lr": float, "achieved_delta_g": float, "achieved_emission_p": float,
+         "in_band": True, "all_candidates": dict, "count": int}.
+
+    Raises:
+        KeyError: count missing from calibration_table.
+        RuntimeError: NO LR satisfies BOTH gates (the §7 kill criterion); the
+            error message instructs the caller to expand the LR grid or pivot
+            to fixed-step decoupling (option 3 from plan §4).
+    """
+    # Accept either int or str(int) keys at the top level.
+    if count in calibration_table:
+        cells_raw = calibration_table[count]
+    elif str(count) in calibration_table:
+        cells_raw = calibration_table[str(count)]
+    else:
+        raise KeyError(
+            f"count={count} missing from calibration_table; known counts: "
+            f"{sorted(calibration_table.keys())}"
+        )
+    cells = _normalize_count_table(cells_raw)
+
+    qualifying: list[tuple[float, dict]] = []
+    for lr, m in cells.items():
+        delta = float(m["source_self_delta_g"])
+        emit = float(m["source_emission_p"])
+        if abs(delta - TARGET_SOURCE_DELTA_G) <= MATCH_BAND and emit >= MIN_SOURCE_EMISSION:
+            qualifying.append((lr, m))
+
+    if not qualifying:
+        raise RuntimeError(
+            f"NO qualifying LR for count={count}: every LR misses the matched "
+            f"implant band [{TARGET_SOURCE_DELTA_G - MATCH_BAND:.1f}, "
+            f"{TARGET_SOURCE_DELTA_G + MATCH_BAND:.1f}] nats OR the emission floor "
+            f"P(※)≥{MIN_SOURCE_EMISSION:.2f}. Calibration table for this count: "
+            f"{cells}. Kill criterion (plan §7): expand the LR grid (try {{2e-7, "
+            f"1e-7}} or {{1e-4}}) OR pivot to fixed-step decoupling (option 3 from "
+            f"plan §4). Dispatcher MUST exit non-zero on this error so the "
+            f"orchestrator does not silently run the main sweep at an unpicked LR."
+        )
+
+    best_lr, best_m = min(
+        qualifying,
+        key=lambda lm: abs(float(lm[1]["source_self_delta_g"]) - TARGET_SOURCE_DELTA_G),
+    )
+    return {
+        "lr": float(best_lr),
+        "achieved_delta_g": float(best_m["source_self_delta_g"]),
+        "achieved_emission_p": float(best_m["source_emission_p"]),
+        "in_band": True,
+        "all_candidates": cells,
+        "count": int(count),
+    }
+
+
+def validity_gate(
+    main_cell_results: list[dict],
+) -> tuple[list[dict], list[dict]]:
+    """Split main cells into (kept, excluded) by source-self ΔG + emission gate.
+
+    Plan §6 validity gate: every cell in the H1 statistic must satisfy
+    source-self ΔG ∈ [TARGET_SOURCE_DELTA_G ± MATCH_BAND] nats AND
+    source emission P(※) ≥ MIN_SOURCE_EMISSION on its own R.
+
+    Args:
+        main_cell_results: list of per-cell result dicts; each must carry
+            "source_self_delta_g_at_last_ckpt" and "source_emission_p_at_last_ckpt".
+            A cell missing either key raises a KeyError (fail loud — the cell
+            was supposed to land but did not write the gate metrics).
+
+    Returns:
+        (kept, excluded) — same dicts, partitioned. Excluded cells are NOT
+        dropped silently; the dispatcher / analyzer list them separately in §6
+        of the clean-result with their actual values (Lens 13 honesty).
+
+    Raises:
+        KeyError: a cell result is missing the required gate metrics.
+    """
+    kept: list[dict] = []
+    excluded: list[dict] = []
+    for c in main_cell_results:
+        if "source_self_delta_g_at_last_ckpt" not in c:
+            raise KeyError(
+                f"Cell {c.get('cell', '<unknown>')} missing "
+                f"'source_self_delta_g_at_last_ckpt' — gate metrics not written. "
+                f"Investigate the eval_trajectory output for this cell before "
+                f"running the validity gate."
+            )
+        if "source_emission_p_at_last_ckpt" not in c:
+            raise KeyError(
+                f"Cell {c.get('cell', '<unknown>')} missing "
+                f"'source_emission_p_at_last_ckpt' — eval_trajectory did not "
+                f"surface DV-C; bump the eval rig or compute it from raw R "
+                f"argmax before running the gate."
+            )
+        delta = float(c["source_self_delta_g_at_last_ckpt"])
+        emit = float(c["source_emission_p_at_last_ckpt"])
+        if abs(delta - TARGET_SOURCE_DELTA_G) <= MATCH_BAND and emit >= MIN_SOURCE_EMISSION:
+            kept.append(c)
+        else:
+            excluded.append(c)
+    return kept, excluded
+
+
+# ── v3/v4 step-lever pick (plan v4 §4 Phase 2.5 + §6 + §7 H4 kill-gate). ─────
+
+
+def pick_step_for_count(
+    step_table: dict,
+    count: int,
+) -> dict[str, Any]:
+    """For count level c, pick the early-step checkpoint matching the v4 band.
+
+    Mirrors :func:`pick_lr_for_count` but the axis is the per-cell early-step
+    checkpoint cadence (plan v4 §4 Phase 2.5). For each (count, step) in the
+    Phase 2 step-calibration table, require ALL of:
+
+      * ``source_self_delta_g`` ∈ [TARGET_SOURCE_DELTA_G ± MATCH_BAND] nats
+        (=[10.5, 13.5] at the v4 defaults), AND
+      * ``source_emission_p`` ∈ [MIN_SOURCE_EMISSION_V3, MAX_SOURCE_EMISSION_V3]
+        (=[0.40, 0.95] — anti-collapse floor + anti-saturation ceiling), AND
+      * ``source_R_collapsed == False``.
+
+    Pick the step CLOSEST to TARGET_SOURCE_DELTA_G (=12.0). If none qualify,
+    raise ``RuntimeError`` (the H4 kill-gate; dispatcher exits non-zero and the
+    orchestrator banks Path B).
+
+    Args:
+        step_table: ``{count -> {step -> {source_self_delta_g, source_emission_p,
+            source_R_collapsed, ...}}}``. Count + step keys may be int or
+            str(int) (the picker normalizes both).
+        count: count level to resolve.
+
+    Returns:
+        ``{"step": int, "achieved_delta_g": float, "achieved_emission_p": float,
+        "in_band": True, "all_candidates": dict, "count": int}``.
+
+    Raises:
+        KeyError: count missing from step_table.
+        RuntimeError: zero qualifying steps for this count — the H4 kill-gate.
+            The message names the band + cite + tells the dispatcher to bank
+            Path B (the methodological "implant rises within one optimizer step"
+            finding).
+    """
+    if count in step_table:
+        cells_raw = step_table[count]
+    elif str(count) in step_table:
+        cells_raw = step_table[str(count)]
+    else:
+        raise KeyError(
+            f"count={count} missing from step_table; known counts: {sorted(step_table.keys())}"
+        )
+    # Normalize step keys to int (JSON deserializes them as str).
+    cells: dict[int, dict] = {}
+    for k, v in cells_raw.items():
+        cells[int(k)] = v
+
+    qualifying: list[tuple[int, dict]] = []
+    for step, m in cells.items():
+        delta = float(m["source_self_delta_g"])
+        emit = float(m["source_emission_p"])
+        collapsed = bool(m.get("source_R_collapsed", False))
+        if (
+            abs(delta - TARGET_SOURCE_DELTA_G) <= MATCH_BAND
+            and MIN_SOURCE_EMISSION_V3 <= emit <= MAX_SOURCE_EMISSION_V3
+            and not collapsed
+        ):
+            qualifying.append((step, m))
+
+    if not qualifying:
+        raise RuntimeError(
+            f"NO qualifying step for count={count} (H4 kill-gate, plan v4 §7): "
+            f"every step misses the v4 matched band ΔG ∈ ["
+            f"{TARGET_SOURCE_DELTA_G - MATCH_BAND:.1f}, "
+            f"{TARGET_SOURCE_DELTA_G + MATCH_BAND:.1f}] nats AND emission "
+            f"P(※) ∈ [{MIN_SOURCE_EMISSION_V3:.2f}, "
+            f"{MAX_SOURCE_EMISSION_V3:.2f}] AND not source_R_collapsed. "
+            f"Step table for this count: {cells}. Bank Path B: 'marker "
+            f"implants within one optimizer step at this recipe scale, "
+            f"training-amount cannot decouple count from implant'. "
+            f"Dispatcher MUST exit non-zero so the orchestrator does not "
+            f"silently run the main sweep at an unpicked step."
+        )
+
+    best_step, best_m = min(
+        qualifying,
+        key=lambda sm: abs(float(sm[1]["source_self_delta_g"]) - TARGET_SOURCE_DELTA_G),
+    )
+    return {
+        "step": int(best_step),
+        "achieved_delta_g": float(best_m["source_self_delta_g"]),
+        "achieved_emission_p": float(best_m["source_emission_p"]),
+        "in_band": True,
+        "all_candidates": cells,
+        "count": int(count),
+    }
+
+
+# ── v6 rank-pick + slot-fix diagnostic (plan v6 §4 Phase 2A.5 + §6.5.5 H4). ──
+
+
+def pick_rank(cal_a_table: dict) -> dict[str, Any]:
+    """Pick the Cal-A rank that lands ≥3 of 4 counts in the matched mid-band.
+
+    Plan v6 §4 Phase 2A.5 + §4.5 pseudocode. M3 simplification: no Cal-B path
+    — positives is GLOBAL at 200; the rank pick comes from {2, 4, 8} only.
+    The Cal-A0 r=32 control is a diagnostic (H4), NOT part of this pick.
+
+    Args:
+        cal_a_table: ``{rank -> {count -> {step -> {delta_g, emit, collapsed,
+            ...}}}}``. Rank + count + step keys may be int or str(int); the
+            picker normalizes both. Per-step records must carry ``delta_g``,
+            ``emit``, ``collapsed``.
+
+    Returns:
+        ``{"picked_rank": int, "picked_positives": 200, "picked_alpha": int,
+        "qualifying_counts": list[int], "per_count_picked_step": dict[int, int],
+        "off_ramp_fired": False, "reason": str}``.
+
+    Raises:
+        RuntimeError: H0 kill-gate — no rank in RANK_GRID_V5 lands ≥3 counts
+            in-band; dispatcher MUST exit non-zero so the orchestrator does
+            not silently run the main sweep at an unpicked rank.
+    """
+    # Inline imports survive ruff's unused-import strip (the module-top
+    # convenience imports are exposed via the package __init__; this layer
+    # keeps the symbol references inside the function bodies).
+    from explore_persona_space.experiments.contrastive_neg_count_decouple_477 import (
+        COUNT_LEVELS,
+        RANK_ALPHA_MAP_V5,
+        RANK_GRID_V5,
+    )
+
+    # In-band per (rank, count): the step closest to TARGET_SOURCE_DELTA_G.
+    in_band: dict[int, dict[int, int]] = {}
+    for rank_raw, by_count_raw in cal_a_table.items():
+        rank = int(rank_raw)
+        by_count: dict[int, dict[int, dict]] = {}
+        for count_raw, by_step_raw in by_count_raw.items():
+            by_count[int(count_raw)] = {int(step): m for step, m in by_step_raw.items()}
+        in_band[rank] = {}
+        for count, by_step in by_count.items():
+            best: tuple[int, dict] | None = None
+            for step in sorted(by_step):
+                m = by_step[step]
+                delta = float(m["delta_g"])
+                emit = float(m["emit"])
+                collapsed = bool(m.get("collapsed", False))
+                in_band_step = (
+                    abs(delta - TARGET_SOURCE_DELTA_G) <= MATCH_BAND
+                    and MIN_SOURCE_EMISSION_V3 <= emit <= MAX_SOURCE_EMISSION_V3
+                    and not collapsed
+                )
+                # On multiple in-band steps, pick the one closest to TARGET_SOURCE_DELTA_G.
+                closer_than_current = best is None or abs(delta - TARGET_SOURCE_DELTA_G) < abs(
+                    float(best[1]["delta_g"]) - TARGET_SOURCE_DELTA_G
+                )
+                if in_band_step and closer_than_current:
+                    best = (step, m)
+            if best is not None:
+                in_band[rank][count] = best[0]
+
+    # Sort ranks: prefer most-in-band; on tie, prefer SMALLER rank
+    # (smaller rank = slower implant ramp = more calibration headroom).
+    ranked = sorted(in_band.items(), key=lambda kv: (-len(kv[1]), kv[0]))
+    if not ranked:
+        raise RuntimeError(
+            "Cal-A table is empty — no rank cells. Investigate the "
+            "step_calibration / rank_calibration phase before picking."
+        )
+    best_rank, best_picks = ranked[0]
+    n_in_band = len(best_picks)
+
+    if n_in_band >= 3:
+        # M2 invariant: alpha is read from the SSOT helper (raises if best_rank
+        # somehow isn't in RANK_GRID_V5 — should never happen).
+        if best_rank not in RANK_GRID_V5:
+            raise AssertionError(
+                f"picked_rank={best_rank} not in RANK_GRID_V5={RANK_GRID_V5} — "
+                f"v6 M2 invariant violated; the Cal-A grid is the only legal "
+                f"source for picked_rank."
+            )
+        alpha = RANK_ALPHA_MAP_V5[best_rank]
+        return {
+            "picked_rank": int(best_rank),
+            "picked_positives": 200,
+            "picked_alpha": int(alpha),
+            "qualifying_counts": sorted(best_picks.keys()),
+            "per_count_picked_step": {int(k): int(v) for k, v in best_picks.items()},
+            "off_ramp_fired": False,
+            "reason": (
+                f"rank={best_rank} (alpha={alpha}) at positives=200 lands "
+                f"{n_in_band}/{len(COUNT_LEVELS)} counts in-band "
+                f"(band ΔG ∈ [{TARGET_SOURCE_DELTA_G - MATCH_BAND:.1f}, "
+                f"{TARGET_SOURCE_DELTA_G + MATCH_BAND:.1f}], emit ∈ "
+                f"[{MIN_SOURCE_EMISSION_V3:.2f}, {MAX_SOURCE_EMISSION_V3:.2f}], "
+                f"not collapsed)."
+            ),
+        }
+
+    # H0 off-ramp: no rank in RANK_GRID_V5 reached ≥3 counts in-band.
+    summary = {
+        int(rank): {int(c): int(s) for c, s in picks.items()} for rank, picks in in_band.items()
+    }
+    raise RuntimeError(
+        "H0 OFF-RAMP (plan v6 §7): no rank in "
+        f"{sorted(RANK_GRID_V5)} lands ≥3 of {len(COUNT_LEVELS)} counts "
+        f"in-band at positives=200 GLOBAL (v6 M3 — no Cal-B). Per-rank "
+        f"in-band picks: {summary}. Cumulative finding: marker implant at "
+        "this recipe scale is bimodal across the count axis even at the "
+        "lowest LoRA rank tested; training-amount + recipe-scale CANNOT "
+        "decouple count from implant on this rig. Bank Path B (v2+v4+v6). "
+        "The Cal-A0 H4 verdict (slot-bug-vs-capacity) is part of the "
+        "banked finding regardless of this gate. Dispatcher MUST exit "
+        "non-zero so the orchestrator does not silently run the main sweep "
+        "at an unpicked rank."
+    )
+
+
+def slot_fix_diagnostic(cal_a0_table: dict) -> dict[str, Any]:
+    """v6 H4: did the slot-fix port unbug the v4 ΔG≈0 result at r=32?
+
+    Plan v6 §6.5.5 + §4.5 pseudocode.
+
+    Args:
+        cal_a0_table: ``{32: {count -> {step -> {delta_g, ...}}}}`` from
+            Phase 2A-CONTROL.
+
+    Returns:
+        ``{"verdict": "slot-bug-confirmed-v4-result-was-genuine"
+                       | "slot-bug-rejected-v4-result-was-slot-artifact"
+                       | "ambiguous",
+            "max_terminal_delta_g": float,
+            "per_count_max_delta_g": dict[int, float],
+            "alpha_used": int}``.
+
+    Raises:
+        KeyError: ``RANK_CONTROL_V6`` missing from ``cal_a0_table``.
+    """
+    from explore_persona_space.experiments.contrastive_neg_count_decouple_477 import (
+        ALPHA_CONTROL_V6,
+        RANK_CONTROL_V6,
+    )
+
+    # Normalize the outer rank key (str | int).
+    if RANK_CONTROL_V6 in cal_a0_table:
+        by_count_raw = cal_a0_table[RANK_CONTROL_V6]
+    elif str(RANK_CONTROL_V6) in cal_a0_table:
+        by_count_raw = cal_a0_table[str(RANK_CONTROL_V6)]
+    else:
+        raise KeyError(
+            f"Cal-A0 table missing rank={RANK_CONTROL_V6}; known keys: "
+            f"{sorted(cal_a0_table.keys())}"
+        )
+
+    per_count: dict[int, float] = {}
+    for count_raw, by_step in by_count_raw.items():
+        per_count[int(count_raw)] = max(float(m["delta_g"]) for m in by_step.values())
+
+    max_dg = max(per_count.values()) if per_count else 0.0
+    if max_dg < 1.0:
+        # slot-fix didn't unstick r=32 at lr=2e-6 — v4 ΔG≈0 was a real
+        # capacity finding under the lr floor.
+        verdict = "slot-bug-confirmed-v4-result-was-genuine"
+    elif sum(1 for v in per_count.values() if v >= 5.0) >= 2:
+        # ≥2 counts now produce non-trivial ΔG at r=32; v4's ΔG≈0 was the
+        # slot-bug, NOT a capacity finding.
+        verdict = "slot-bug-rejected-v4-result-was-slot-artifact"
+    else:
+        verdict = "ambiguous"
+
+    return {
+        "verdict": verdict,
+        "max_terminal_delta_g": float(max_dg),
+        "per_count_max_delta_g": per_count,
+        "alpha_used": int(ALPHA_CONTROL_V6),
+    }

--- a/src/explore_persona_space/experiments/contrastive_neg_geometry_472/__init__.py
+++ b/src/explore_persona_space/experiments/contrastive_neg_geometry_472/__init__.py
@@ -1,0 +1,174 @@
+# ruff: noqa: RUF003  # em-dash + Qwen marker token " ※" are intentional
+"""Task #472 — contrastive-negative bystander-marker-leakage geometry sweep.
+
+Merges #412 + #453 + #443, corrects #448. Parent #411. Goal (plan §1): on
+on-policy DVs (post-response-slot marker log-prob AND full-vocab KL) logged as a
+trajectory over training, determine how contrastive-negative *design* controls
+bystander marker leakage along three axes — number, distance, and placement
+geometry (barrier vs bubble).
+
+The #448 fix this experiment implements (plan §0/§4.6): #448 saturated (trained
+argmax = marker on every cell) because it trained 3 epochs and read the DV only
+at the endpoint. #472 trains **1 epoch** and reads the on-policy DV at **6
+checkpoints during the run** so cells are compared at a matched SUB-CEILING
+source-implant level where count/distance/geometry effects are readable.
+
+Module layout (plan §4.8):
+    __init__              — constants: marker, cell specs, source, seeds, paths.
+    persona_bank          — Phase 0: extend EVAL_PERSONAS_24 → ~60 via Sonnet 4.5;
+                            persona-prompt resolution over the bank.
+    centroids             — Phase 0.5: base-model L10/L15/L20 centroids over the
+                            full bank (analysis/representation_shift machinery).
+    select_negatives      — NEW distance-stratified negative selector
+                            (near/far/spread/none) + single-neg sub-arms.
+    r_generate            — Phase 1: base greedy on-policy R for the WHOLE bank
+                            (forked from #448; distance-aware universe).
+    build_training_data   — Phase 3 per-cell on-policy data build (forked from
+                            #448; new distance-stratified negative path).
+    eval_one_cell         — vLLM prompt_logprobs slot machinery (DV-A logP),
+                            forked verbatim from #448 (_build_full_ids, MARKER_SEP,
+                            off-by-one + token-equality guards).
+    eval_trajectory       — NEW: per-checkpoint on-policy gen → DV-A(vLLM) +
+                            DV-B(HF full-vocab KL) at the post-R slot. NOT #448's
+                            teacher-forced MarkerTrajectoryCallback.
+    base_panel            — Phase 1.5: base per-persona marker prior b_logprob.
+    analyze               — Phase 5: separate logP/KL regressions, geometry,
+                            identification gate, Holm multiplicity, figures.
+
+The dispatcher is ``scripts/dispatch_neg_geometry_472.py`` (forked from #448's
+unified smoke=sweep dispatcher).
+
+WHY this module forks #448 rather than imports it: #448's
+``contrastive_recipe_sweep_448`` module + ``dispatch_recipe_sweep_448.py`` live
+ONLY on the unmerged ``issue-448`` worktree branch — they are NOT on ``main``,
+so an import would fail on the pod (which runs the ``issue-472`` branch). Plan
+§4.8 + §12 assumption 2: cherry-pick/fork the reused pieces onto the 472 branch.
+"""
+
+from __future__ import annotations
+
+BASE_MODEL = "Qwen/Qwen2.5-7B-Instruct"
+"""Base model. Inherited from #448/#411 (and from the marker-implantation
+family)."""
+
+# ── Marker (plan §10 / .claude/rules/marker-leakage-measurement.md) ──────────
+# Single-token marker, LEADING SPACE form. Qwen-2.5-7B token id 83399. NOT the
+# codebase default ``MARKER_TOKEN="[ZLT]"`` in personas.py (multi-token,
+# deprecated) and NOT bare ``※`` (id 63680). We OVERRIDE the codebase default
+# everywhere (sft.TrainLoraConfig.marker_text, the collator marker_token_ids,
+# the eval/data-build constants). Launchers assert
+# ``tokenizer.encode(MARKER_TEXT, add_special_tokens=False) == [83399]`` before
+# any subprocess spawns.
+MARKER_TEXT = " ※"
+EXPECTED_MARKER_TOKEN_ID = 83399
+
+# Marker separator — IDENTICAL to the assistant content training emits in
+# build_training_data (``f"{r_text}\n\n{marker_text}"``). Forked from #448
+# eval_one_cell (the text-level concat materializes the BPE-fused ``'.\n\n'``
+# token (id 382) before the marker, which a token-id splice would NOT produce).
+MARKER_SEP = "\n\n"
+
+# ── Source persona (plan §4.1) ───────────────────────────────────────────────
+# Inherit the #448/#411 villain anchor: cosine −0.237 to assistant, interior to
+# the persona cloud (room for both near- and far-negative arms). NOT swept.
+SOURCE_PERSONA = "villain"
+
+# ── Seeds (plan §10) ─────────────────────────────────────────────────────────
+# 2 seeds, the min-N floor (user budget call: 8× H100 for faster wall-time, 2
+# seeds). Effect must hold sign across BOTH seeds (2/2 — no majority-vote
+# tolerance). A 2-seed geometry call is MODERATE, not HIGH.
+SEEDS = (42, 137)
+
+# The bare default assistant is ALWAYS among the negatives (plan §4.5; leakage to
+# the default context is the safety target, open-q 3.7). qwen_default is the
+# 24-panel persona that IS the bare default-instruct system prompt.
+ALWAYS_INCLUDE_NEGATIVE = "qwen_default"
+
+# ── Cell specs (plan §4.4 + §5 table) ────────────────────────────────────────
+# Each cell shares the rs-LoRA recipe (r=32/α=64/lr=1e-5/1 epoch). The fields:
+#   (slug, plain_english_name, placement, n_neg_personas, neg_ex_per_persona,
+#    in_pooled_regression)
+# placement ∈ {"spread","near","far","none"} (selects WHICH personas are
+# negatives). The single-negative sub-arms set n_neg_personas=2 (qwen_default +
+# ONE near/far placement persona) and are EXCLUDED from the pooled regression
+# (not count-matched: 2 vs 4 personas, 200 vs 800 neg rows) — plan §4.4 + §6.
+#
+# Anchor = villain source, 4 neg personas chosen Spread, 200 neg ex/persona →
+# 800 neg rows, 200 pos ex × 1 source. Sits in BOTH the count and placement
+# sub-studies. POS_EX_PER_SOURCE is fixed at 200 across all cells.
+#
+# fields: slug, name, placement, n_neg_personas, neg_ex_per_persona, in_pooled
+CellSpec = tuple[str, str, str, int, int, bool]
+CELL_SPECS: tuple[CellSpec, ...] = (
+    # Anchor — shared reference cell (Spread-4, 800 neg rows). In both sub-studies.
+    ("c472_anchor", "Anchor (Spread-4)", "spread", 4, 200, True),
+    # Count sub-study (placement = Spread, the neutral geometry).
+    ("c472_negex_100", "Fewer negative examples", "spread", 4, 100, False),
+    ("c472_negex_400", "More negative examples", "spread", 4, 400, False),
+    ("c472_negp_2", "Two negative personas", "spread", 2, 200, False),
+    ("c472_negp_8", "Eight negative personas", "spread", 8, 200, False),
+    # Placement sub-study (count matched = 4 neg personas × 200 ex = 800 rows).
+    ("c472_near", "Near negatives", "near", 4, 200, True),
+    ("c472_far", "Far negatives", "far", 4, 200, True),
+    ("c472_noneg", "No negatives", "none", 0, 0, False),
+    # Single-negative sub-arms (NOT count-matched; standalone proximity maps only).
+    ("c472_single_near", "Single near negative", "near", 2, 200, False),
+    ("c472_single_far", "Single far negative", "far", 2, 200, False),
+)
+
+# Positive rows per cell (source persona × this many examples). Fixed across all
+# cells (only the negative composition varies — plan §4.4).
+POS_EX_PER_SOURCE = 200
+
+# ── Distance metric (plan §4.3) ──────────────────────────────────────────────
+# Layer-10 activation-centroid cosine (headline) + L15 + L20 (robustness; L20 is
+# Persona-Vectors' actual evil layer, 1-indexed). Distance = 1 − cosine.
+CENTROID_LAYERS = (10, 15, 20)
+HEADLINE_LAYER = 10
+
+# ── Trajectory eval cadence (plan §4.6 / §11) ────────────────────────────────
+# 6 checkpoints/run at these % of max_steps. Denser early (8/16/33) where the
+# implant is rising sub-ceiling and the geometry effect lives. The exact %s are
+# ``ungrounded — needs smoke-test`` (plan §11); the smoke run validates them.
+TRAJECTORY_CHECKPOINT_FRACTIONS = (0.08, 0.16, 0.33, 0.50, 0.75, 1.00)
+
+# ── Matched source-implant slice (plan §6) ───────────────────────────────────
+# Cross-cell comparison read where source-self ΔG first reaches this band:
+# implant real (>5-nat floor) but held-out g_logprob ≥5 nats below ceiling.
+MATCHED_SLICE_TARGET_NATS = 8.0
+MATCHED_SLICE_BAND_NATS = 1.0  # 8 ± 1.
+SOURCE_SELF_FLOOR_NATS = 5.0  # validity gate: every cell must clear this.
+SUBCEILING_HEADROOM_NATS = 5.0  # held-out g_logprob must sit ≥ this below 0.0.
+
+# ── Persona bank (plan §4.2) ─────────────────────────────────────────────────
+# Target ~60 personas (extend EVAL_PERSONAS_24 with ~36 new ones); floor 50,
+# ceiling 80. Fallback to the 24-panel if generation slips the budget.
+PERSONA_BANK_TARGET = 60
+PERSONA_BANK_N_NEW = 36
+PERSONA_BANK_FLOOR = 50
+
+# ── HF repos (plan §4.8 / Upload Policy) ─────────────────────────────────────
+HF_MODEL_REPO = "superkaiba1/explore-persona-space"
+HF_DATA_REPO = "superkaiba1/explore-persona-space-data"
+HF_DATA_PREFIX = "issue472_neg_geometry"
+
+# ── Training recipe constants (plan §10 reproducibility card / §11) ──────────
+# rs-LoRA r=32 / α=64 / dropout 0.05 / lr=1e-5 / cosine / warmup 0.05 / 1 epoch /
+# batch 4 × grad_accum 4 (eff 16) / max_len 1024 / AdamW bf16 / weight_decay 0.
+# Loss masked to the ※ token + EOS via MarkerOnlyDataCollator(tail_tokens=0).
+LORA_R = 32
+LORA_ALPHA = 64
+LORA_DROPOUT = 0.05
+LEARNING_RATE = 1e-5
+WARMUP_RATIO = 0.05
+EPOCHS = 1
+BATCH_SIZE = 4
+GRAD_ACCUM = 4
+MAX_LENGTH = 1024
+MAX_NEW_TOKENS_GEN = 1024  # ≥2× trained completion (CLAUDE.md); log truncation.
+
+# Sub-ceiling fallback recipe (plan §7 / §14 kill criterion): if the smoke gate
+# trips (anchor already saturated at 1 epoch), drop to these and re-smoke.
+FALLBACK_LORA_R = 16
+FALLBACK_LEARNING_RATE = 5e-6
+FALLBACK_EPOCHS = 0.5

--- a/src/explore_persona_space/experiments/contrastive_neg_geometry_472/analyze.py
+++ b/src/explore_persona_space/experiments/contrastive_neg_geometry_472/analyze.py
@@ -1,0 +1,1898 @@
+# ruff: noqa: RUF001, RUF002, RUF003  # em-dash + Qwen marker " ※" + Greek ρ ΔG intentional
+"""Task #472 Phase 5 — geometry / count / placement analysis (plan §6).
+
+Reads per-cell×seed trajectory.json + base_panel.json + centroids, then:
+  1. Matched-slice DV: per cell×seed, interpolate the held-out DV at the
+     checkpoint where source-self ΔG first reaches 8±1 nats (sub-ceiling). A
+     cell whose held-out logP saturated before the band contributes NO row to
+     the logP regression (dropped, not backfilled with KL).
+  2. SEPARATE logP / KL regressions (never mix DV units): pooled OLS
+     ``leakage ~ d_source + d_nearest_neg + b_logprob`` over the count-matched
+     arms (Near/Far/Spread), cluster-robust SE by probe. Run BOTH with all-neg
+     ``d_nearest_neg`` and non-default ``d_nearest_neg_nd``.
+  3. qwen_default identification gate (plan §6): share of probes whose nearest
+     negative is qwen_default; across-arm SD of d_nearest_neg_nd; barrier/bubble
+     admissible only if non-default d moves across arms AND the two fits agree
+     in sign.
+  4. Collinearity gate: Pearson(d_source, d_nearest_neg) + VIF; |r|>0.6 →
+     fall back to tercile-bucket medians. Also Pearson(d_nearest_neg, b_logprob).
+  5. Holm multiplicity across {co-primary DV} × {geometry/count/placement}.
+  6. Count effects (Spearman + exact permutation) and placement H1
+     (Near<Far<No-neg permutation), per DV.
+  7. Diagnostics for the analyzer (plan §6.5): raw ΔG-vs-base-prior scatter,
+     ΔG-vs-KL rank agreement sub-ceiling, per-cell step-at-matched-slice.
+  8. Figures (hero 2-panel + exploratory dump).
+
+Single-negative sub-arms are EXCLUDED from the pooled regression (n_personas=2,
+not count-matched) — read only as standalone proximity maps.
+
+CPU / local (regression + plots).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from explore_persona_space.experiments.contrastive_neg_geometry_472 import (
+    ALWAYS_INCLUDE_NEGATIVE,
+    CELL_SPECS,
+    HEADLINE_LAYER,
+    MATCHED_SLICE_BAND_NATS,
+    MATCHED_SLICE_TARGET_NATS,
+    SOURCE_PERSONA,
+    SUBCEILING_HEADROOM_NATS,
+)
+from explore_persona_space.experiments.contrastive_neg_geometry_472.centroids import (
+    cos_to_source as load_cos_to_source,
+)
+from explore_persona_space.experiments.contrastive_neg_geometry_472.centroids import (
+    load_cos_matrix,
+)
+from explore_persona_space.experiments.contrastive_neg_geometry_472.select_negatives import (
+    d_nearest_neg,
+    d_source,
+    held_out_panel,
+    negatives_for_cell,
+)
+
+log = logging.getLogger("issue_472.analyze")
+
+# Pooled-regression arms (count-matched, in_pooled=True): anchor(Spread), near, far.
+POOLED_CELLS = [c[0] for c in CELL_SPECS if c[5]]
+COLLINEARITY_THRESHOLD = 0.6
+ID_GATE_SD_FLOOR = 0.02  # min median across-arm SD of d_nearest_neg_nd to admit barrier/bubble.
+
+
+# ── Matched-slice interpolation ──────────────────────────────────────────────
+
+
+def _interp_at_slice(
+    checkpoints: list[dict],
+    target_nats: float = MATCHED_SLICE_TARGET_NATS,
+    band: float = MATCHED_SLICE_BAND_NATS,
+) -> dict[str, Any] | None:
+    """Find/interpolate the held-out DV at the source-self-ΔG matched slice.
+
+    Returns a dict with the interpolated per-probe ``delta_g`` + ``kl`` + the
+    step + a ``saturated`` flag, or None if source-self ΔG never reaches the
+    band (cell undertrained at the matched slice → no logP row).
+    """
+    # Source-self ΔG trajectory (mean over Q_eval).
+    src = [(ck["frac"], ck["source_self"]["delta_g_mean"], ck) for ck in checkpoints]
+    src.sort(key=lambda t: t[0])
+    target = target_nats
+    # Find first checkpoint pair bracketing the target band (rising series).
+    hit_ck = None
+    interp_w = None
+    from itertools import pairwise
+
+    for (_f0, d0, ck0), (_f1, d1, ck1) in pairwise(src):
+        if (d0 < target <= d1) or (d1 < target <= d0):
+            # Linear interpolation weight between ck0 and ck1.
+            interp_w = (target - d0) / (d1 - d0) if (d1 - d0) != 0 else 0.0
+            hit_ck = (ck0, ck1)
+            break
+    if hit_ck is None:
+        # Maybe the last checkpoint is already within the band.
+        _last_frac, last_d, last_ck = src[-1]
+        if abs(last_d - target) <= band:
+            hit_ck = (last_ck, last_ck)
+            interp_w = 0.0
+        else:
+            return None
+
+    ck0, ck1 = hit_ck
+    held0 = ck0["held_out"]
+    held1 = ck1["held_out"]
+    per_probe: dict[str, dict[str, float]] = {}
+    saturated_count = 0
+    collapsed_count = 0
+    total = 0
+    for persona in held0:
+        deltas, kls, g_logps = [], [], []
+        any_collapsed = False
+        for q in held0[persona]:
+            d0v = held0[persona][q]["delta_g"]
+            d1v = held1[persona][q]["delta_g"]
+            deltas.append(d0v + interp_w * (d1v - d0v))
+            g0 = held0[persona][q]["g_logp"]
+            g1 = held1[persona][q]["g_logp"]
+            g_logps.append(g0 + interp_w * (g1 - g0))
+            k0 = held0[persona][q].get("kl")
+            k1 = held1[persona][q].get("kl")
+            if k0 is not None and k1 is not None:
+                kls.append(k0 + interp_w * (k1 - k0))
+            # r_collapsed at EITHER bracketing checkpoint marks the probe degenerate:
+            # the trained model's OWN R is marker-spam, so log P(※) is repetition
+            # ceiling, NOT graded leakage. Treated like a saturated row (dropped
+            # from the graded logP regression) but tracked as a distinct category.
+            if held0[persona][q].get("r_collapsed", False) or held1[persona][q].get(
+                "r_collapsed", False
+            ):
+                any_collapsed = True
+        total += 1
+        # Saturated if held-out g_logp is within HEADROOM of the 0.0 ceiling.
+        mean_g = float(np.mean(g_logps))
+        is_sat = mean_g > -SUBCEILING_HEADROOM_NATS
+        if is_sat:
+            saturated_count += 1
+        if any_collapsed:
+            collapsed_count += 1
+        per_probe[persona] = {
+            "delta_g": float(np.mean(deltas)),
+            "g_logp": mean_g,
+            "kl": float(np.mean(kls)) if kls else float("nan"),
+            "saturated": is_sat,
+            "r_collapsed": any_collapsed,
+        }
+    return {
+        "step": ck1.get("step"),
+        "frac": ck1["frac"],
+        "interp_w": interp_w,
+        "n_saturated_probes": saturated_count,
+        "n_collapsed_probes": collapsed_count,
+        "n_probes": total,
+        "per_probe": per_probe,
+    }
+
+
+# ── Regression ───────────────────────────────────────────────────────────────
+
+
+def _fit_pooled_ols(rows: list[dict], dv_key: str, dnn_key: str) -> dict[str, Any]:
+    """Pooled OLS leakage ~ d_source + <dnn_key> + b_logprob, cluster-robust by probe.
+
+    rows: each {dv: float, d_source: float, dnn: float, dnn_nd: float,
+               b_logprob: float, probe: str}. Drops rows with NaN dv or NaN dnn.
+    """
+    import statsmodels.api as sm
+
+    clean = [
+        r
+        for r in rows
+        if not (np.isnan(r[dv_key]) or np.isnan(r[dnn_key]) or np.isnan(r["b_logprob"]))
+    ]
+    n = len(clean)
+    if n < 8:
+        return {"ok": False, "reason": f"too few rows ({n}) after NaN drop", "n": n}
+    y = np.array([r[dv_key] for r in clean])
+    X = np.column_stack(
+        [
+            np.ones(n),
+            np.array([r["d_source"] for r in clean]),
+            np.array([r[dnn_key] for r in clean]),
+            np.array([r["b_logprob"] for r in clean]),
+        ]
+    )
+    groups = np.array([r["probe"] for r in clean])
+    model = sm.OLS(y, X)
+    res = model.fit(cov_type="cluster", cov_kwds={"groups": groups})
+    names = ["const", "d_source", dnn_key, "b_logprob"]
+    return {
+        "ok": True,
+        "n": n,
+        "n_clusters": len(set(groups.tolist())),
+        "coef": {names[i]: float(res.params[i]) for i in range(len(names))},
+        "se": {names[i]: float(res.bse[i]) for i in range(len(names))},
+        "pvalue": {names[i]: float(res.pvalues[i]) for i in range(len(names))},
+        "rsquared": float(res.rsquared),
+    }
+
+
+def _vif(rows: list[dict], dnn_key: str) -> dict[str, float]:
+    """Variance-inflation factors for [d_source, dnn_key, b_logprob]."""
+    from statsmodels.stats.outliers_influence import variance_inflation_factor
+
+    clean = [
+        r
+        for r in rows
+        if not (np.isnan(r[dnn_key]) or np.isnan(r["b_logprob"]) or np.isnan(r["d_source"]))
+    ]
+    if len(clean) < 5:
+        return {}
+    X = np.column_stack(
+        [
+            np.ones(len(clean)),
+            np.array([r["d_source"] for r in clean]),
+            np.array([r[dnn_key] for r in clean]),
+            np.array([r["b_logprob"] for r in clean]),
+        ]
+    )
+    names = ["const", "d_source", dnn_key, "b_logprob"]
+    return {names[i]: float(variance_inflation_factor(X, i)) for i in range(1, 4)}
+
+
+def _pearson(a: list[float], b: list[float]) -> float:
+    from scipy.stats import pearsonr
+
+    pairs = [(x, y) for x, y in zip(a, b, strict=True) if not (np.isnan(x) or np.isnan(y))]
+    if len(pairs) < 3:
+        return float("nan")
+    xs, ys = zip(*pairs, strict=True)
+    return float(pearsonr(xs, ys)[0])
+
+
+def holm_correction(pvals: dict[str, float], alpha: float = 0.05) -> dict[str, dict[str, Any]]:
+    """Holm-Bonferroni step-down across the test family (plan §6 multiplicity)."""
+    items = sorted(pvals.items(), key=lambda kv: kv[1])
+    m = len(items)
+    out: dict[str, dict[str, Any]] = {}
+    prev_reject = True
+    for rank, (name, p) in enumerate(items):
+        thresh = alpha / (m - rank)
+        reject = bool(prev_reject and p < thresh)
+        prev_reject = reject
+        out[name] = {"p": p, "holm_threshold": thresh, "reject_null": reject}
+    return out
+
+
+# ── Permutation / Spearman for count + placement ─────────────────────────────
+
+
+def _spearman(x: list[float], y: list[float]) -> float:
+    from scipy.stats import spearmanr
+
+    if len(x) < 3:
+        return float("nan")
+    return float(spearmanr(x, y).correlation)
+
+
+def _exact_permutation_monotone(
+    level_means: list[float], n_perms_cap: int = 5000
+) -> dict[str, Any]:
+    """Exact-permutation null on the monotone range statistic over ordered levels.
+
+    Enumerates label permutations of the level means (small: 3 levels). Statistic
+    = range = max − min preserving monotone direction. Returns the empirical
+    one-sided p of the observed monotone range under random level assignment.
+    """
+    from itertools import permutations
+
+    arr = np.array(level_means, dtype=float)
+    if len(arr) < 2 or np.any(np.isnan(arr)):
+        return {"ok": False, "reason": "too few / NaN levels"}
+    obs_range = float(arr.max() - arr.min())
+    obs_monotone = bool(np.all(np.diff(arr) >= 0) or np.all(np.diff(arr) <= 0))
+    perms = list(permutations(range(len(arr))))
+    if len(perms) > n_perms_cap:
+        perms = perms[:n_perms_cap]
+    count_ge = 0
+    for perm in perms:
+        p_arr = arr[list(perm)]
+        rng = float(p_arr.max() - p_arr.min())
+        mono = bool(np.all(np.diff(p_arr) >= 0) or np.all(np.diff(p_arr) <= 0))
+        if mono and rng >= obs_range:
+            count_ge += 1
+    return {
+        "ok": True,
+        "observed_range": obs_range,
+        "observed_monotone": obs_monotone,
+        "empirical_p_value": count_ge / len(perms),
+        "n_perms_enumerated": len(perms),
+        "note": "exact enumeration; do NOT claim 10k independent draws (plan §6)",
+    }
+
+
+# ── Main analysis ────────────────────────────────────────────────────────────
+
+
+def run_analysis(  # noqa: C901 - linear multi-block analysis
+    *,
+    slab_root: Path,
+    base_panel_path: Path,
+    figures_dir: Path,
+    centroids_dir: Path,
+    seeds: list[int],
+    layer: int = HEADLINE_LAYER,
+    source: str = SOURCE_PERSONA,
+) -> dict[str, Any]:
+    """Run the full geometry/count/placement analysis. Returns the summary dict.
+
+    Writes ``<slab_root>/analyze_summary.json`` + figures under ``figures_dir``.
+    """
+    cts = load_cos_to_source(layer, source, centroids_dir)
+    cos_matrix, _names = load_cos_matrix(layer, centroids_dir)
+    panel = held_out_panel(cts, source=source)
+    log.info("Held-out panel: %d probes (layer %d)", len(panel), layer)
+
+    base_panel = json.loads(base_panel_path.read_text())
+    b_logprob = base_panel["mean_per_persona_b_logprob"]
+
+    # ── Load matched-slice DV per cell×seed. ─────────────────────────────────
+    # cell -> seed -> matched-slice dict (per-probe delta_g, kl, saturated).
+    matched: dict[str, dict[int, dict | None]] = {}
+    cell_arm_negatives: dict[str, list[str]] = {}
+    for slug, _name, _placement, _np, _ex, _pooled in CELL_SPECS:
+        cell_arm_negatives[slug] = negatives_for_cell(slug, cts, source=source)
+        matched[slug] = {}
+        for seed in seeds:
+            traj_path = slab_root / f"{slug}_seed{seed}" / "trajectory.json"
+            if not traj_path.exists():
+                log.warning(
+                    "Trajectory missing: %s (cell %s seed %d skipped)", traj_path, slug, seed
+                )
+                matched[slug][seed] = None
+                continue
+            traj = json.loads(traj_path.read_text())
+            matched[slug][seed] = _interp_at_slice(traj["checkpoints"])
+
+    # ── Build pooled-regression rows (logP + KL separately). ─────────────────
+    # Rows over count-matched pooled arms × held-out probes × seeds.
+    logp_rows: list[dict] = []
+    kl_rows: list[dict] = []
+    nearest_default_count = 0
+    nearest_total = 0
+    dnn_nd_by_probe_across_arms: dict[str, list[float]] = {p: [] for p in panel}
+    for slug in POOLED_CELLS:
+        negs = cell_arm_negatives[slug]
+        for seed in seeds:
+            ms = matched[slug].get(seed)
+            if ms is None:
+                continue
+            for probe in panel:
+                if probe not in ms["per_probe"]:
+                    continue
+                pp = ms["per_probe"][probe]
+                ds = d_source(probe, cts)
+                dnn = d_nearest_neg(probe, negs, cos_matrix, exclude_default=False)
+                dnn_nd = d_nearest_neg(probe, negs, cos_matrix, exclude_default=True)
+                dnn_nd_by_probe_across_arms[probe].append(dnn_nd)
+                # Identification-gate bookkeeping: is the nearest negative the default?
+                if negs:
+                    nearest = min(negs, key=lambda nn: 1.0 - cos_matrix[probe][nn])
+                    nearest_total += 1
+                    if nearest == ALWAYS_INCLUDE_NEGATIVE:
+                        nearest_default_count += 1
+                base_b = b_logprob.get(probe, float("nan"))
+                row_common = {
+                    "cell": slug,
+                    "seed": seed,
+                    "probe": probe,
+                    "d_source": ds,
+                    "dnn": dnn,
+                    "dnn_nd": dnn_nd,
+                    "b_logprob": base_b,
+                }
+                # logP row only if NOT saturated AND NOT R-collapsed at the matched
+                # slice. A collapsed-R probe (the model's own R is marker-spam) is a
+                # degenerate max-leakage case, not graded leakage — drop it from the
+                # graded logP regression (plan §4.6 + the #448 saturation lesson),
+                # exactly like a saturated row.
+                if not pp["saturated"] and not pp.get("r_collapsed", False):
+                    logp_rows.append({**row_common, "logp": pp["delta_g"]})
+                # KL row always (read at the same matched slice).
+                kl_rows.append({**row_common, "kl": pp["kl"]})
+
+    # ── Identification gate (qwen_default dominance). ────────────────────────
+    default_share = (nearest_default_count / nearest_total) if nearest_total else float("nan")
+    across_arm_sd = [
+        float(np.std(v))
+        for v in dnn_nd_by_probe_across_arms.values()
+        if len(v) >= 2 and not np.all(np.isnan(v))
+    ]
+    median_across_arm_sd = float(np.median(across_arm_sd)) if across_arm_sd else float("nan")
+
+    # ── logP regression (construct-of-record), dual (all-neg + non-default). ─
+    logp_fit_allneg = _fit_pooled_ols(logp_rows, "logp", "dnn")
+    logp_fit_nondefault = _fit_pooled_ols(logp_rows, "logp", "dnn_nd")
+    logp_vif = _vif(logp_rows, "dnn")
+    # ── KL regression (backstop), dual. ──────────────────────────────────────
+    kl_fit_allneg = _fit_pooled_ols(kl_rows, "kl", "dnn")
+    kl_fit_nondefault = _fit_pooled_ols(kl_rows, "kl", "dnn_nd")
+
+    # ── Collinearity gate. ───────────────────────────────────────────────────
+    r_ds_dnn = _pearson([r["d_source"] for r in logp_rows], [r["dnn"] for r in logp_rows])
+    r_dnn_b = _pearson([r["dnn"] for r in logp_rows], [r["b_logprob"] for r in logp_rows])
+    collinearity_ok = (not np.isnan(r_ds_dnn)) and abs(r_ds_dnn) <= COLLINEARITY_THRESHOLD
+
+    # Identification admissibility: non-default d moves across arms AND all-neg
+    # and non-default fits agree in sign on d_source AND d_nearest_neg.
+    def _sign(x: float) -> int:
+        return 0 if (x is None or np.isnan(x)) else (1 if x > 0 else -1)
+
+    fits_agree = False
+    if logp_fit_allneg.get("ok") and logp_fit_nondefault.get("ok"):
+        fits_agree = _sign(logp_fit_allneg["coef"]["d_source"]) == _sign(
+            logp_fit_nondefault["coef"]["d_source"]
+        ) and _sign(logp_fit_allneg["coef"]["dnn"]) == _sign(logp_fit_nondefault["coef"]["dnn_nd"])
+    id_gate_ok = (
+        (not np.isnan(median_across_arm_sd))
+        and median_across_arm_sd >= ID_GATE_SD_FLOOR
+        and fits_agree
+    )
+
+    # ── Holm multiplicity over {co-primary DV} × {geometry/count/placement}. ─
+    # Build the family p-values: geometry uses the logP construct-of-record
+    # d_source + d_nearest_neg partials; count + placement use permutation p's.
+    family_p: dict[str, float] = {}
+    if logp_fit_allneg.get("ok"):
+        family_p["logp_geometry_d_source"] = logp_fit_allneg["pvalue"]["d_source"]
+        family_p["logp_geometry_d_nearest_neg"] = logp_fit_allneg["pvalue"]["dnn"]
+
+    # ── Count effects (per DV): negex {100,200,400} + negp {2,4,8}. ──────────
+    def _held_out_mean_dv(slug: str, seed: int, dv: str) -> float:
+        ms = matched[slug].get(seed)
+        if ms is None:
+            return float("nan")
+        vals = []
+        for probe in panel:
+            if probe in ms["per_probe"]:
+                pp = ms["per_probe"][probe]
+                # For the logP count/placement families, drop degenerate probes
+                # (saturated OR R-collapsed = marker-spam) EXACTLY like the graded
+                # geometry regression above — otherwise differential collapse by
+                # condition re-enters these headline means as graded max-leakage
+                # values and biases the Holm p-values. KL is non-saturating and is
+                # kept for all probes (matches the geometry "KL row always" rule).
+                if dv == "logp" and (pp["saturated"] or pp.get("r_collapsed", False)):
+                    continue
+                v = pp["delta_g" if dv == "logp" else "kl"]
+                if not np.isnan(v):
+                    vals.append(v)
+        return float(np.mean(vals)) if vals else float("nan")
+
+    def _count_effect(cells_ordered: list[str], levels: list[float], dv: str) -> dict[str, Any]:
+        # Mean over seeds of held-out-mean DV per level.
+        level_means = []
+        for slug in cells_ordered:
+            seed_vals = [_held_out_mean_dv(slug, s, dv) for s in seeds]
+            seed_vals = [v for v in seed_vals if not np.isnan(v)]
+            level_means.append(float(np.mean(seed_vals)) if seed_vals else float("nan"))
+        sp = _spearman(levels, level_means)
+        perm = _exact_permutation_monotone(level_means)
+        return {"levels": levels, "level_means": level_means, "spearman": sp, "permutation": perm}
+
+    count_negex = _count_effect(
+        ["c472_negex_100", "c472_anchor", "c472_negex_400"], [100, 200, 400], "logp"
+    )
+    count_negp = _count_effect(["c472_negp_2", "c472_anchor", "c472_negp_8"], [2, 4, 8], "logp")
+    count_negex_kl = _count_effect(
+        ["c472_negex_100", "c472_anchor", "c472_negex_400"], [100, 200, 400], "kl"
+    )
+    count_negp_kl = _count_effect(["c472_negp_2", "c472_anchor", "c472_negp_8"], [2, 4, 8], "kl")
+    if count_negex["permutation"].get("ok"):
+        family_p["logp_count_negex"] = count_negex["permutation"]["empirical_p_value"]
+    if count_negp["permutation"].get("ok"):
+        family_p["logp_count_negp"] = count_negp["permutation"]["empirical_p_value"]
+
+    # ── Placement H1: Near vs Far vs No-neg held-out-mean DV. ────────────────
+    placement_means = {
+        arm: float(
+            np.mean(
+                [v for s in seeds for v in [_held_out_mean_dv(arm, s, "logp")] if not np.isnan(v)]
+            )
+        )
+        for arm in ["c472_near", "c472_anchor", "c472_far", "c472_noneg"]
+    }
+    placement = {
+        "near": placement_means.get("c472_near"),
+        "spread_anchor": placement_means.get("c472_anchor"),
+        "far": placement_means.get("c472_far"),
+        "no_neg": placement_means.get("c472_noneg"),
+        "near_lt_far": (
+            placement_means.get("c472_near", float("nan"))
+            < placement_means.get("c472_far", float("nan"))
+        ),
+    }
+    placement_perm = _exact_permutation_monotone(
+        [
+            placement_means.get("c472_near", float("nan")),
+            placement_means.get("c472_far", float("nan")),
+            placement_means.get("c472_noneg", float("nan")),
+        ]
+    )
+    if placement_perm.get("ok"):
+        family_p["logp_placement_near_far_noneg"] = placement_perm["empirical_p_value"]
+
+    holm = holm_correction(family_p) if family_p else {}
+
+    # ── Diagnostics for the analyzer (plan §6.5). ────────────────────────────
+    # ΔG vs base prior scatter (#448 artifact check).
+    dg_b_scatter = [
+        {"probe": r["probe"], "delta_g": r["logp"], "b_logprob": r["b_logprob"]} for r in logp_rows
+    ]
+    # ΔG vs KL rank agreement on sub-ceiling rows (matched probe×arm×seed).
+    # Build paired (delta_g, kl) for the same (cell, seed, probe) where logp row exists.
+    logp_index = {(r["cell"], r["seed"], r["probe"]): r["logp"] for r in logp_rows}
+    paired_dg, paired_kl = [], []
+    for r in kl_rows:
+        key = (r["cell"], r["seed"], r["probe"])
+        if key in logp_index and not np.isnan(r["kl"]):
+            paired_dg.append(logp_index[key])
+            paired_kl.append(r["kl"])
+    dg_kl_spearman = _spearman(paired_dg, paired_kl) if len(paired_dg) >= 3 else float("nan")
+    # Per-cell step-at-matched-slice (placement-vs-train-speed diagnostic).
+    step_at_slice = {
+        slug: {str(s): (matched[slug][s]["step"] if matched[slug].get(s) else None) for s in seeds}
+        for slug in [c[0] for c in CELL_SPECS]
+    }
+
+    # ── Validity gate: every cell clears source-self ΔG ≥ 5 nats + ≥1 sub-ceiling ck.
+    validity: dict[str, dict[str, Any]] = {}
+    for slug, _name, _placement, _np, _ex, _pooled in CELL_SPECS:
+        per_seed = {}
+        for seed in seeds:
+            traj_path = slab_root / f"{slug}_seed{seed}" / "trajectory.json"
+            if not traj_path.exists():
+                per_seed[str(seed)] = {"present": False}
+                continue
+            traj = json.loads(traj_path.read_text())
+            max_src = max(ck["source_self"]["delta_g_mean"] for ck in traj["checkpoints"])
+
+            def _ck_mean_held_out_g_logp(ck: dict) -> float:
+                vals = [
+                    held["g_logp"] for per_q in ck["held_out"].values() for held in per_q.values()
+                ]
+                return float(np.mean(vals)) if vals else 0.0
+
+            has_subceiling = any(
+                _ck_mean_held_out_g_logp(ck) < -SUBCEILING_HEADROOM_NATS
+                for ck in traj["checkpoints"]
+            )
+            per_seed[str(seed)] = {
+                "present": True,
+                "max_source_self_delta_g": float(max_src),
+                "clears_5nat_floor": bool(max_src >= 5.0),
+                "has_subceiling_checkpoint": bool(has_subceiling),
+            }
+        validity[slug] = per_seed
+
+    # ── Barrier vs bubble verdict (logP construct-of-record). ────────────────
+    verdict = _barrier_bubble_verdict(logp_fit_allneg, collinearity_ok, id_gate_ok, holm)
+
+    summary: dict[str, Any] = {
+        "schema_version": "i472_v1",
+        "layer": layer,
+        "source": source,
+        "n_held_out_probes": len(panel),
+        "held_out_panel": panel,
+        "pooled_cells": POOLED_CELLS,
+        "n_logp_rows": len(logp_rows),
+        "n_kl_rows": len(kl_rows),
+        "matched_slice": {
+            "target_nats": MATCHED_SLICE_TARGET_NATS,
+            "band_nats": MATCHED_SLICE_BAND_NATS,
+            "step_at_slice_per_cell": step_at_slice,
+            "collapse_at_slice_per_cell": {
+                slug: {
+                    str(s): (
+                        {
+                            "n_collapsed_probes": matched[slug][s].get("n_collapsed_probes"),
+                            "n_saturated_probes": matched[slug][s].get("n_saturated_probes"),
+                            "n_probes": matched[slug][s].get("n_probes"),
+                        }
+                        if matched[slug].get(s)
+                        else None
+                    )
+                    for s in seeds
+                }
+                for slug in [c[0] for c in CELL_SPECS]
+            },
+        },
+        "logp_regression": {
+            "all_neg": logp_fit_allneg,
+            "non_default": logp_fit_nondefault,
+            "vif": logp_vif,
+        },
+        "kl_regression": {"all_neg": kl_fit_allneg, "non_default": kl_fit_nondefault},
+        "identification_gate": {
+            "qwen_default_nearest_share": default_share,
+            "median_across_arm_sd_dnn_nd": median_across_arm_sd,
+            "sd_floor": ID_GATE_SD_FLOOR,
+            "fits_agree_sign": fits_agree,
+            "admissible": id_gate_ok,
+        },
+        "collinearity_gate": {
+            "pearson_d_source_d_nearest_neg": r_ds_dnn,
+            "pearson_d_nearest_neg_b_logprob": r_dnn_b,
+            "threshold": COLLINEARITY_THRESHOLD,
+            "ok": collinearity_ok,
+        },
+        "holm_multiplicity": holm,
+        "count_effects": {
+            "negex_logp": count_negex,
+            "negp_logp": count_negp,
+            "negex_kl": count_negex_kl,
+            "negp_kl": count_negp_kl,
+        },
+        "placement_h1": {"means": placement, "permutation": placement_perm},
+        "diagnostics": {
+            "delta_g_vs_b_logprob_scatter": dg_b_scatter,
+            "delta_g_kl_spearman_subceiling": dg_kl_spearman,
+            "step_at_matched_slice": step_at_slice,
+        },
+        "validity_gate": validity,
+        "barrier_bubble_verdict": verdict,
+        "single_neg_note": (
+            "c472_single_near / c472_single_far EXCLUDED from pooled regression "
+            "(n_personas=2, not count-matched); read as standalone proximity maps only "
+            "(plan §4.4/§6)."
+        ),
+    }
+
+    slab_root.mkdir(parents=True, exist_ok=True)
+    out_path = slab_root / "analyze_summary.json"
+    out_path.write_text(json.dumps(summary, indent=2, default=str))
+    log.info("[phase=analyze] Wrote %s (verdict=%s)", out_path, verdict.get("call"))
+
+    # ── Figures. ─────────────────────────────────────────────────────────────
+    try:
+        _make_figures(
+            summary,
+            logp_rows,
+            kl_rows,
+            matched,
+            panel,
+            seeds,
+            cts,
+            cos_matrix,
+            cell_arm_negatives,
+            figures_dir,
+            source,
+        )
+    except Exception:
+        log.exception("Figure generation failed (analysis JSON still written).")
+
+    return summary
+
+
+def _barrier_bubble_verdict(
+    logp_fit: dict, collinearity_ok: bool, id_gate_ok: bool, holm: dict
+) -> dict[str, Any]:
+    """Apply the barrier/bubble decision logic (plan §6 / §13 / §14)."""
+    if not logp_fit.get("ok"):
+        return {
+            "call": "indeterminate",
+            "reason": "logp regression did not fit (too few sub-ceiling rows)",
+        }
+    if not collinearity_ok:
+        return {"call": "indistinguishable", "reason": "collinearity gate failed (|r|>0.6)"}
+    if not id_gate_ok:
+        return {
+            "call": "indistinguishable",
+            "reason": "identification gate failed (qwen_default dominance / fits disagree)",
+        }
+    ds = logp_fit["coef"]["d_source"]
+    dnn = logp_fit["coef"]["dnn"]
+    ds_sig = holm.get("logp_geometry_d_source", {}).get("reject_null", False)
+    dnn_sig = holm.get("logp_geometry_d_nearest_neg", {}).get("reject_null", False)
+    if ds_sig and ds > 0 and not dnn_sig:
+        return {
+            "call": "barrier",
+            "reason": "β(d_source)>0 Holm-sig; β(d_nearest_neg)≈0",
+            "d_source": ds,
+            "d_nearest_neg": dnn,
+        }
+    if dnn_sig and dnn > 0 and not ds_sig:
+        return {
+            "call": "bubble",
+            "reason": "β(d_nearest_neg)>0 Holm-sig; β(d_source)≈0",
+            "d_source": ds,
+            "d_nearest_neg": dnn,
+        }
+    if ds_sig and dnn_sig:
+        return {
+            "call": "both",
+            "reason": "both partials Holm-sig",
+            "d_source": ds,
+            "d_nearest_neg": dnn,
+        }
+    return {
+        "call": "neither",
+        "reason": "no Holm-sig geometry partial",
+        "d_source": ds,
+        "d_nearest_neg": dnn,
+    }
+
+
+def _make_figures(
+    summary,
+    logp_rows,
+    kl_rows,
+    matched,
+    panel,
+    seeds,
+    cts,
+    cos_matrix,
+    cell_arm_negatives,
+    figures_dir: Path,
+    source: str,
+) -> None:
+    """Hero 2-panel + exploratory dump (plan §6 figures). Plain-English labels."""
+    import matplotlib.pyplot as plt
+
+    from explore_persona_space.analysis.paper_plots import savefig_paper, set_paper_style
+
+    set_paper_style()
+    figures_dir.mkdir(parents=True, exist_ok=True)
+
+    arm_label = {"c472_anchor": "Spread", "c472_near": "Near", "c472_far": "Far"}
+
+    # ── Hero left: held-out leakage vs distance, one line per placement arm. ─
+    fig, (axl, axr) = plt.subplots(1, 2, figsize=(11, 4.2))
+    for slug in POOLED_CELLS:
+        xs, ys = [], []
+        for r in logp_rows:
+            if r["cell"] == slug:
+                xs.append(r["d_source"])
+                ys.append(r["logp"])
+        if xs:
+            axl.scatter(xs, ys, s=14, alpha=0.5, label=arm_label.get(slug, slug))
+            if len(xs) >= 2:
+                coef = np.polyfit(xs, ys, 1)
+                xline = np.linspace(min(xs), max(xs), 20)
+                axl.plot(xline, np.polyval(coef, xline), lw=1.5)
+    axl.set_xlabel("Distance from held-out persona to source")
+    axl.set_ylabel("Held-out marker leakage (ΔG, nats)")
+    axl.set_title("Leakage vs distance, by negative placement")
+    axl.legend(fontsize=8)
+
+    # ── Hero right: partial coefficients d_source vs d_nearest_neg with CIs. ─
+    fit = summary["logp_regression"]["all_neg"]
+    if fit.get("ok"):
+        coefs = [fit["coef"]["d_source"], fit["coef"]["dnn"]]
+        ses = [fit["se"]["d_source"], fit["se"]["dnn"]]
+        axr.bar(
+            [0, 1], coefs, yerr=[1.96 * s for s in ses], capsize=5, color=["#0072B2", "#D55E00"]
+        )
+        axr.axhline(0, color="k", lw=0.8)
+        axr.set_xticks([0, 1])
+        axr.set_xticklabels(["dist-to-source\n(barrier)", "dist-to-nearest-neg\n(bubble)"])
+        axr.set_ylabel("Partial regression coefficient (±95% CI)")
+        axr.set_title(f"Barrier vs bubble: {summary['barrier_bubble_verdict'].get('call')}")
+    else:
+        axr.text(
+            0.5,
+            0.5,
+            "logP regression did not fit\n(too few sub-ceiling rows)",
+            ha="center",
+            va="center",
+            transform=axr.transAxes,
+        )
+    fig.tight_layout()
+    savefig_paper(fig, "hero_barrier_vs_bubble", dir=str(figures_dir))
+    plt.close(fig)
+
+    # ── Exploratory: ΔG vs base-prior scatter (the #448 artifact check). ─────
+    fig2, ax2 = plt.subplots(figsize=(7, 4.5))
+    dg = [d["delta_g"] for d in summary["diagnostics"]["delta_g_vs_b_logprob_scatter"]]
+    bl = [d["b_logprob"] for d in summary["diagnostics"]["delta_g_vs_b_logprob_scatter"]]
+    ax2.scatter(bl, dg, s=14, alpha=0.5, color="#009E73")
+    ax2.set_xlabel("Base-model marker prior (b_logprob, nats)")
+    ax2.set_ylabel("Held-out leakage (ΔG, nats)")
+    ax2.set_title("ΔG vs base prior (the #448 artifact check)")
+    fig2.tight_layout()
+    savefig_paper(fig2, "exploratory_dg_vs_base_prior", dir=str(figures_dir))
+    plt.close(fig2)
+
+    # ── Exploratory: count-knob bars (negex + negp), logP. ───────────────────
+    fig3, (a3l, a3r) = plt.subplots(1, 2, figsize=(10, 4))
+    ce = summary["count_effects"]
+    a3l.bar(
+        [str(x) for x in ce["negex_logp"]["levels"]],
+        ce["negex_logp"]["level_means"],
+        color="#0072B2",
+    )
+    a3l.set_xlabel("Negative examples / persona")
+    a3l.set_ylabel("Held-out mean leakage (ΔG, nats)")
+    a3l.set_title("Count: negative examples")
+    a3r.bar(
+        [str(x) for x in ce["negp_logp"]["levels"]], ce["negp_logp"]["level_means"], color="#D55E00"
+    )
+    a3r.set_xlabel("Number of negative personas")
+    a3r.set_title("Count: negative personas")
+    fig3.tight_layout()
+    savefig_paper(fig3, "exploratory_count_knobs", dir=str(figures_dir))
+    plt.close(fig3)
+
+    log.info("Figures written to %s", figures_dir)
+
+
+# ── Task #477 extensions (called from scripts/i477_phase_analyze.py) ─────────
+#
+# These functions operate on the #477 main-cell + implant-only-axis results
+# (NOT on the #472 trajectory.json shape). #477 cells follow the schema:
+#   {"cell": str, "seed": int, "count": int, "lr": float,
+#    "source_self_delta_g_at_last_ckpt": float,
+#    "source_emission_p_at_last_ckpt": float,
+#    "mean_bystander_delta_g": float,
+#    "step_at_last_ckpt": int}
+# kept_cells / implant_only_cells are lists of these dicts (already filtered
+# through calibrate.validity_gate).
+#
+# Discipline (plan §6 "Analysis & interpretation discipline" items 1-8):
+#   - return BOTH ρ(count, DV-A | DV-B) and ρ(count, DV-A | DV-B, step);
+#   - count-STRATIFIED bootstrap (resample within each count level), percentile CI;
+#   - the ≥3/4 coverage guard returns a clear "n<3 count levels — descriptive
+#     only" sentinel instead of computing a partial-ρ on n=4 cells × 1 count level.
+
+
+def _ols_residuals(y: list[float], X: list[list[float]]) -> list[float]:
+    """OLS residuals of y on [const, *X]. Returns y - X β̂ (lstsq)."""
+    import numpy as np
+
+    y_arr = np.asarray(y, dtype=float)
+    X_arr = np.column_stack([np.ones(len(y_arr)), *[np.asarray(c, dtype=float) for c in X]])
+    coef, *_ = np.linalg.lstsq(X_arr, y_arr, rcond=None)
+    return (y_arr - X_arr @ coef).tolist()
+
+
+def _stratified_bootstrap_partial_spearman(
+    counts: list[int],
+    bystander: list[float],
+    implant: list[float],
+    *,
+    n_resamples: int = 2000,
+    ci_level: float = 0.90,
+    seed: int = 42,
+    extra_controls: list[list[float]] | None = None,
+) -> dict[str, Any]:
+    """Count-stratified bootstrap CI for partial Spearman.
+
+    Plan §6 discipline item 4: resample WITHIN each count level (preserves the
+    n-level structure; a naïve i.i.d. n=8 resample produces degenerate samples
+    missing a count level). Returns the percentile CI.
+
+    Args:
+        counts: per-cell count level (int).
+        bystander: per-cell mean bystander ΔG.
+        implant: per-cell source-self ΔG (the partialled covariate).
+        n_resamples: bootstrap iterations.
+        ci_level: e.g. 0.90 → 5th and 95th percentiles.
+        seed: RNG seed.
+        extra_controls: optional extra covariates to partial out alongside
+            implant (e.g. step). Each is a list of per-cell values aligned with
+            counts/bystander/implant.
+
+    Returns:
+        {"ci_low": float, "ci_high": float, "median": float, "n_resamples": int,
+         "ci_level": float, "n_count_levels": int}.
+    """
+    import numpy as np
+    from scipy.stats import spearmanr
+
+    rng = np.random.default_rng(seed)
+    # Group cell indices by count level.
+    groups: dict[int, list[int]] = {}
+    for i, c in enumerate(counts):
+        groups.setdefault(c, []).append(i)
+
+    rhos: list[float] = []
+    for _ in range(n_resamples):
+        idx: list[int] = []
+        for _level, level_idx in groups.items():
+            # Resample WITH replacement within this count level.
+            picks = rng.integers(0, len(level_idx), size=len(level_idx))
+            idx.extend(level_idx[p] for p in picks)
+        c_arr = [counts[i] for i in idx]
+        y_arr = [bystander[i] for i in idx]
+        x_arr = [implant[i] for i in idx]
+        controls = [[col[i] for i in idx] for col in (extra_controls or [])]
+        try:
+            y_res = _ols_residuals(y_arr, [x_arr, *controls])
+            c_res = _ols_residuals([float(v) for v in c_arr], [x_arr, *controls])
+            rho = float(spearmanr(c_res, y_res).correlation)
+            if not np.isnan(rho):
+                rhos.append(rho)
+        except (np.linalg.LinAlgError, ValueError):
+            continue
+
+    if not rhos:
+        return {
+            "ci_low": float("nan"),
+            "ci_high": float("nan"),
+            "median": float("nan"),
+            "n_resamples": 0,
+            "ci_level": ci_level,
+            "n_count_levels": len(groups),
+            "note": "all bootstrap resamples failed (singular partialling matrix)",
+        }
+    alpha = (1.0 - ci_level) / 2.0
+    return {
+        "ci_low": float(np.quantile(rhos, alpha)),
+        "ci_high": float(np.quantile(rhos, 1.0 - alpha)),
+        "median": float(np.median(rhos)),
+        "n_resamples": len(rhos),
+        "ci_level": float(ci_level),
+        "n_count_levels": len(groups),
+    }
+
+
+def partial_spearman_count_given_implant(
+    kept_cells: list[dict],
+    *,
+    n_bootstrap: int = 2000,
+    bootstrap_seed: int = 42,
+    min_count_levels: int = 3,
+) -> dict[str, Any]:
+    """ρ(count, mean-bystander-ΔG | source-self-ΔG) — the #477 H1 headline.
+
+    Plan §6 discipline items 1, 4, 5:
+      * report BOTH the partialling-on-implant ρ and the robustness
+        ρ(count, DV-A | DV-B, step);
+      * count-stratified bootstrap 90% CI;
+      * coverage guard: refuses to compute if fewer than min_count_levels (3)
+        distinct count levels survive the gate; returns the "descriptive-only"
+        sentinel instead.
+
+    Returns:
+        {"n": int, "n_count_levels": int, "kept_counts": list[int],
+         "rho_given_implant": float, "p_given_implant": float,
+         "bootstrap_given_implant": {...},
+         "rho_given_implant_and_step": float, "p_given_implant_and_step": float,
+         "bootstrap_given_implant_and_step": {...},
+         "per_seed_sign": dict, "interpretable": bool, "note": str}
+        OR a {"interpretable": False, "note": "..."} sentinel if guard trips.
+    """
+    import numpy as np
+    from scipy.stats import spearmanr
+
+    # Defensive guard: H1 partial Spearman is over MAIN-PHASE cells ONLY.
+    # The #477 implant-sweep phase shares the count axis (all at ANCHOR_COUNT=4)
+    # but should NEVER be pooled into H1 — it would inject 6 extra count=4
+    # points and bias the partial. Cells missing "phase" are treated as
+    # non-main (fail loud rather than silently pool unknown-provenance cells).
+    # Accept both v2 "main" and v4 "main_v4" — the v4 dispatcher emits the
+    # latter when routing through the step-lever path; both are H1-eligible.
+    _MAIN_PHASES = {"main", "main_v4"}
+    for c in kept_cells:
+        phase = c.get("phase")
+        if phase not in _MAIN_PHASES:
+            raise AssertionError(
+                f"partial_spearman_count_given_implant got a non-main-phase cell: "
+                f"cell={c.get('cell', '<unknown>')!r}, seed={c.get('seed')}, "
+                f"phase={phase!r}. H1 partial Spearman must be computed over "
+                f"main-phase cells only (phase in {_MAIN_PHASES!r}) — pooling "
+                f"implant-sweep / calibration cells biases the partial. Filter "
+                f"kept_cells upstream (the dispatcher's main_results carries "
+                f"phase='main' or 'main_v4')."
+            )
+
+    counts = [int(c["count"]) for c in kept_cells]
+    distinct_counts = sorted(set(counts))
+    n = len(kept_cells)
+
+    if len(distinct_counts) < min_count_levels:
+        return {
+            "interpretable": False,
+            "n": n,
+            "n_count_levels": len(distinct_counts),
+            "kept_counts": distinct_counts,
+            "note": (
+                f"n_count_levels={len(distinct_counts)} < min_count_levels="
+                f"{min_count_levels} — coverage floor violated (plan §6 discipline "
+                f"item 5). Partial Spearman uninterpretable at this coverage; the "
+                f"H1 headline must be a DESCRIPTIVE read of per-cell F3 means, not "
+                f"a partial-ρ. Excluded counts (gated-out): see calibrate.validity_gate "
+                f"output upstream."
+            ),
+        }
+
+    bystander = [float(c["mean_bystander_delta_g"]) for c in kept_cells]
+    implant = [float(c["source_self_delta_g_at_last_ckpt"]) for c in kept_cells]
+    step = [int(c.get("step_at_last_ckpt", 0)) for c in kept_cells]
+
+    # Headline: partial out implant only.
+    y_resid_i = _ols_residuals(bystander, [implant])
+    c_resid_i = _ols_residuals([float(v) for v in counts], [implant])
+    sr_i = spearmanr(c_resid_i, y_resid_i)
+    boot_i = _stratified_bootstrap_partial_spearman(
+        counts, bystander, implant, n_resamples=n_bootstrap, seed=bootstrap_seed
+    )
+
+    # Robustness: partial out implant AND step.
+    y_resid_is = _ols_residuals(bystander, [implant, [float(v) for v in step]])
+    c_resid_is = _ols_residuals([float(v) for v in counts], [implant, [float(v) for v in step]])
+    sr_is = spearmanr(c_resid_is, y_resid_is)
+    boot_is = _stratified_bootstrap_partial_spearman(
+        counts,
+        bystander,
+        implant,
+        n_resamples=n_bootstrap,
+        seed=bootstrap_seed + 1,
+        extra_controls=[[float(v) for v in step]],
+    )
+
+    # Per-seed sign — plan §6 item 7 (seed 137 match-band misses → downgrade).
+    seeds_in_kept = sorted({int(c["seed"]) for c in kept_cells})
+    per_seed_sign: dict[str, dict] = {}
+    for s in seeds_in_kept:
+        sub = [c for c in kept_cells if int(c["seed"]) == s]
+        if len({int(c["count"]) for c in sub}) < 2:
+            per_seed_sign[str(s)] = {
+                "n": len(sub),
+                "n_count_levels": len({int(c["count"]) for c in sub}),
+                "sign": None,
+                "note": "fewer than 2 count levels at this seed; sign not defined",
+            }
+            continue
+        # Raw (not partialled) sign at this seed, as a robustness check on the
+        # pooled sign — partialling implant inside a single-seed n=4 slice is
+        # too unstable to report independently.
+        sub_counts = [int(c["count"]) for c in sub]
+        sub_bystander = [float(c["mean_bystander_delta_g"]) for c in sub]
+        sr_seed = spearmanr(sub_counts, sub_bystander)
+        rho_seed = float(sr_seed.correlation) if not np.isnan(sr_seed.correlation) else 0.0
+        per_seed_sign[str(s)] = {
+            "n": len(sub),
+            "n_count_levels": len({int(c["count"]) for c in sub}),
+            "rho_raw_count_bystander": rho_seed,
+            "sign": int(np.sign(rho_seed)) if rho_seed != 0 else 0,
+        }
+
+    pooled_sign = (
+        int(np.sign(sr_i.correlation))
+        if not np.isnan(sr_i.correlation) and sr_i.correlation != 0
+        else 0
+    )
+    sign_stable_across_seeds = all(
+        (v.get("sign") is None) or v.get("sign") == pooled_sign for v in per_seed_sign.values()
+    )
+
+    return {
+        "interpretable": True,
+        "n": n,
+        "n_count_levels": len(distinct_counts),
+        "kept_counts": distinct_counts,
+        "rho_given_implant": float(sr_i.correlation),
+        "p_given_implant": float(sr_i.pvalue),
+        "bootstrap_given_implant": boot_i,
+        "rho_given_implant_and_step": float(sr_is.correlation),
+        "p_given_implant_and_step": float(sr_is.pvalue),
+        "bootstrap_given_implant_and_step": boot_is,
+        "per_seed_sign": per_seed_sign,
+        "pooled_sign": pooled_sign,
+        "sign_stable_across_seeds": sign_stable_across_seeds,
+        "note": (
+            "Plan §6 discipline item 1: report BOTH partials. Item 3: this ρ is a "
+            "SUMMARY of F3, not an independent test — weight F3 over ρ in the "
+            "write-up. Item 4: count-stratified bootstrap CI. Item 7: if any seed "
+            "disagrees, downgrade to indeterminate."
+        ),
+    }
+
+
+def implant_only_axis_spearman(implant_only_cells: list[dict]) -> dict[str, Any]:
+    """ρ(source-self-ΔG, mean-bystander-ΔG) — the #477 H2 secondary.
+
+    Plan §6 discipline item 2: report H2 BEFORE H1; gates H1's interpretability.
+    If |ρ_H2| ≤ 0.40 there is no implant axis to partial along and a near-zero
+    H1 is uninterpretable. This function returns ρ + per-seed sign + a bootstrap
+    CI; the analyzer (i477_phase_analyze.py) prints the H2 verdict first and
+    suppresses the H1 read if H2 falsifies.
+
+    Args:
+        implant_only_cells: per-cell dicts at fixed count (anchor), varying LR.
+            Required keys: "source_self_delta_g_at_last_ckpt",
+            "mean_bystander_delta_g", "seed", "lr".
+
+    Returns:
+        {"rho": float, "p": float, "n": int, "per_seed_sign": {...},
+         "verdict": "confirms" | "falsifies" | "indeterminate", "note": str}.
+    """
+    import numpy as np
+    from scipy.stats import spearmanr
+
+    n = len(implant_only_cells)
+    if n < 3:
+        return {
+            "rho": float("nan"),
+            "p": float("nan"),
+            "n": n,
+            "verdict": "indeterminate",
+            "note": f"n={n} cells; need ≥3 for Spearman.",
+        }
+    implant = [float(c["source_self_delta_g_at_last_ckpt"]) for c in implant_only_cells]
+    bystander = [float(c["mean_bystander_delta_g"]) for c in implant_only_cells]
+    sr = spearmanr(implant, bystander)
+    rho = float(sr.correlation)
+
+    seeds = sorted({int(c["seed"]) for c in implant_only_cells})
+    per_seed_sign: dict[str, dict] = {}
+    for s in seeds:
+        sub = [c for c in implant_only_cells if int(c["seed"]) == s]
+        if len(sub) < 2:
+            per_seed_sign[str(s)] = {"n": len(sub), "sign": None, "note": "n<2"}
+            continue
+        sub_implant = [float(c["source_self_delta_g_at_last_ckpt"]) for c in sub]
+        sub_bystander = [float(c["mean_bystander_delta_g"]) for c in sub]
+        sr_seed = spearmanr(sub_implant, sub_bystander)
+        rho_seed = float(sr_seed.correlation) if not np.isnan(sr_seed.correlation) else 0.0
+        per_seed_sign[str(s)] = {
+            "n": len(sub),
+            "rho": rho_seed,
+            "sign": int(np.sign(rho_seed)) if rho_seed != 0 else 0,
+        }
+    sign_stable = (
+        len({v.get("sign") for v in per_seed_sign.values() if v.get("sign") is not None}) <= 1
+    )
+
+    if abs(rho) >= 0.80 and sign_stable:
+        verdict = "confirms"
+    elif abs(rho) <= 0.40:
+        verdict = "falsifies"
+    else:
+        verdict = "indeterminate"
+
+    return {
+        "rho": rho,
+        "p": float(sr.pvalue),
+        "n": n,
+        "sign_stable_across_seeds": sign_stable,
+        "per_seed_sign": per_seed_sign,
+        "verdict": verdict,
+        "note": (
+            "Plan §6 H2: confirms if ρ ≥ 0.80 AND sign-stable; falsifies if |ρ| ≤ "
+            "0.40. Falsifying H2 makes the H1 partial uninterpretable (item 2)."
+        ),
+    }
+
+
+def loess_or_quadratic_fit(
+    x: list[float], y: list[float], *, n_grid: int = 50
+) -> dict[str, list[float]]:
+    """Lightweight curvature overlay for F1 (plan §6 discipline item 6).
+
+    Uses a degree-2 polynomial fit as the curvature overlay (true LOESS would
+    pull in statsmodels.nonparametric; quadratic is a pragmatic stand-in that
+    surfaces residual implant-curvature mistaken for a count effect). Returns
+    {"x_grid": [...], "y_fit": [...]} ready to plot alongside the linear OLS.
+    Falls back to linear if n<3 or polyfit fails.
+    """
+    import numpy as np
+
+    if len(x) < 3:
+        return {"x_grid": list(x), "y_fit": list(y)}
+    try:
+        coef = np.polyfit(np.asarray(x), np.asarray(y), 2)
+        x_grid = np.linspace(min(x), max(x), n_grid)
+        y_fit = np.polyval(coef, x_grid)
+        return {"x_grid": x_grid.tolist(), "y_fit": y_fit.tolist()}
+    except (np.linalg.LinAlgError, ValueError):
+        return {"x_grid": list(x), "y_fit": list(y)}
+
+
+def make_477_figures(  # noqa: C901 - linear multi-figure builder (F1..F6)
+    *,
+    main_cells: list[dict],
+    kept_cells: list[dict],
+    excluded_cells: list[dict],
+    implant_only_cells: list[dict],
+    calibration_table: dict,
+    calibration_pick: dict,
+    h1: dict,
+    h2: dict,
+    figures_dir: Path,
+) -> dict[str, str]:
+    """Generate F1..F6 from plan §6.
+
+    F1: x=count, y=mean bystander ΔG, raw + residualized side-by-side, LOESS
+        overlay (discipline items 6 + 11).
+    F2: x=source-self ΔG, y=bystander ΔG over implant-only-axis cells.
+    F3: per-cell bystander ΔG bars (color by achieved source ΔG, annotated with
+        LR + steps). Discipline item 3 — substantive evidence over the ρ.
+    F4: not produced here (trajectory dump lives in the cell artifacts).
+    F5: calibration heatmap (x=LR, y=count, color=achieved source ΔG, star on
+        picked LR).
+    F6: H3 side-bet — x=count, y=source-self ΔG, one point per (count, LR)
+        calibration cell.
+
+    Returns: {figure_label: figure_path} for the analyzer.
+    """
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    from explore_persona_space.analysis.paper_plots import savefig_paper, set_paper_style
+
+    set_paper_style()
+    figures_dir.mkdir(parents=True, exist_ok=True)
+    written: dict[str, str] = {}
+
+    # ── F1: raw + residualized side-by-side with LOESS overlay. ──────────────
+    if kept_cells:
+        fig, (axl, axr) = plt.subplots(1, 2, figsize=(11, 4.3))
+        x_raw = [int(c["count"]) for c in kept_cells]
+        y_raw = [float(c["mean_bystander_delta_g"]) for c in kept_cells]
+        sizes = [60 + 4 * float(c["source_self_delta_g_at_last_ckpt"]) for c in kept_cells]
+        axl.scatter(x_raw, y_raw, s=sizes, alpha=0.7, color="#0072B2")
+        # LOESS-stand-in (quadratic) overlay.
+        fit = loess_or_quadratic_fit(x_raw, y_raw)
+        axl.plot(fit["x_grid"], fit["y_fit"], color="#D55E00", lw=1.5, label="quadratic")
+        axl.set_xlabel("Number of negative personas")
+        axl.set_ylabel("Mean bystander leakage (ΔG, nats)")
+        axl.set_title("F1 raw: leakage vs count (size=achieved source ΔG)")
+        axl.legend(fontsize=8)
+
+        # Residualized: bystander, count BOTH residualized against implant.
+        implant = [float(c["source_self_delta_g_at_last_ckpt"]) for c in kept_cells]
+        y_res = _ols_residuals(y_raw, [implant])
+        c_res = _ols_residuals([float(v) for v in x_raw], [implant])
+        axr.scatter(c_res, y_res, s=sizes, alpha=0.7, color="#009E73")
+        if len(c_res) >= 2:
+            coef = np.polyfit(c_res, y_res, 1)
+            xline = np.linspace(min(c_res), max(c_res), 20)
+            axr.plot(xline, np.polyval(coef, xline), color="#D55E00", lw=1.5)
+        rho_text = (
+            f"ρ={h1.get('rho_given_implant', float('nan')):.2f} (n={h1.get('n', 0)})"
+            if h1.get("interpretable")
+            else h1.get("note", "")[:80]
+        )
+        axr.set_xlabel("Count (residualized vs implant)")
+        axr.set_ylabel("Bystander leakage (residualized vs implant)")
+        axr.set_title(f"F1 residualized: {rho_text}")
+        fig.tight_layout()
+        savefig_paper(fig, "i477_f1_count_vs_leakage", dir=str(figures_dir))
+        plt.close(fig)
+        written["F1"] = str(figures_dir / "i477_f1_count_vs_leakage")
+
+    # ── F2: implant-only axis. ───────────────────────────────────────────────
+    if implant_only_cells:
+        fig, ax = plt.subplots(figsize=(6.5, 4.5))
+        x_io = [float(c["source_self_delta_g_at_last_ckpt"]) for c in implant_only_cells]
+        y_io = [float(c["mean_bystander_delta_g"]) for c in implant_only_cells]
+        ax.scatter(x_io, y_io, s=80, alpha=0.7, color="#0072B2")
+        if len(x_io) >= 2:
+            coef = np.polyfit(x_io, y_io, 1)
+            xline = np.linspace(min(x_io), max(x_io), 20)
+            ax.plot(xline, np.polyval(coef, xline), color="#D55E00", lw=1.5)
+        ax.set_xlabel("Source-self ΔG (DV-B, nats)")
+        ax.set_ylabel("Mean bystander leakage (DV-A, nats)")
+        ax.set_title(
+            f"F2 H2: implant-only axis (ρ={h2.get('rho', float('nan')):.2f}, "
+            f"verdict={h2.get('verdict', '?')})"
+        )
+        fig.tight_layout()
+        savefig_paper(fig, "i477_f2_implant_only_axis", dir=str(figures_dir))
+        plt.close(fig)
+        written["F2"] = str(figures_dir / "i477_f2_implant_only_axis")
+
+    # ── F3: per-cell bars, color = achieved implant, annotation = LR + steps. ─
+    if main_cells:
+        # Mean across seeds within each count level, error bar = SD across seeds.
+        by_count: dict[int, list[dict]] = {}
+        for c in main_cells:
+            by_count.setdefault(int(c["count"]), []).append(c)
+        counts_sorted = sorted(by_count)
+        means = [np.mean([c["mean_bystander_delta_g"] for c in by_count[k]]) for k in counts_sorted]
+        sds = [
+            np.std([c["mean_bystander_delta_g"] for c in by_count[k]], ddof=1)
+            if len(by_count[k]) > 1
+            else 0.0
+            for k in counts_sorted
+        ]
+        colors_impl = [
+            float(np.mean([c["source_self_delta_g_at_last_ckpt"] for c in by_count[k]]))
+            for k in counts_sorted
+        ]
+
+        fig, ax = plt.subplots(figsize=(7.5, 4.5))
+        bars = ax.bar(
+            [str(k) for k in counts_sorted],
+            means,
+            yerr=sds,
+            capsize=4,
+            color=plt.cm.viridis(
+                (np.asarray(colors_impl) - min(colors_impl))
+                / max(1e-6, max(colors_impl) - min(colors_impl))
+            ),
+        )
+        for b, k in zip(bars, counts_sorted, strict=True):
+            lrs = sorted({float(c["lr"]) for c in by_count[k]})
+            steps = [int(c.get("step_at_last_ckpt", 0)) for c in by_count[k]]
+            ann = (
+                f"LR={'/'.join(f'{lr:g}' for lr in lrs)}\n"
+                f"steps={int(np.mean(steps))} (avg)\n"
+                f"impl={np.mean([c['source_self_delta_g_at_last_ckpt'] for c in by_count[k]]):.1f}"
+            )
+            ax.text(
+                b.get_x() + b.get_width() / 2,
+                b.get_height() + 0.3,
+                ann,
+                ha="center",
+                fontsize=7,
+                rotation=0,
+            )
+        ax.set_xlabel("Number of negative personas")
+        ax.set_ylabel("Mean bystander leakage (ΔG, nats)")
+        ax.set_title("F3: per-cell bystander leakage, annotated with calibrated LR + steps")
+        fig.tight_layout()
+        savefig_paper(fig, "i477_f3_per_cell_bars", dir=str(figures_dir))
+        plt.close(fig)
+        written["F3"] = str(figures_dir / "i477_f3_per_cell_bars")
+
+    # ── F5: calibration heatmap. ─────────────────────────────────────────────
+    if calibration_table:
+        counts_sorted = sorted(int(k) for k in calibration_table)
+        # Union of all LRs across count rows (handles partial rows defensively).
+        lrs_sorted = sorted({float(lr) for row in calibration_table.values() for lr in row})
+        grid = np.full((len(counts_sorted), len(lrs_sorted)), np.nan)
+        for i, cnt in enumerate(counts_sorted):
+            row = (
+                calibration_table[cnt] if cnt in calibration_table else calibration_table[str(cnt)]
+            )
+            for j, lr in enumerate(lrs_sorted):
+                cell = row.get(lr) or row.get(str(lr)) or row.get(f"{lr:g}")
+                if cell is not None:
+                    grid[i, j] = float(cell["source_self_delta_g"])
+
+        fig, ax = plt.subplots(figsize=(7.5, 4.5))
+        im = ax.imshow(grid, aspect="auto", cmap="viridis", origin="lower")
+        ax.set_xticks(range(len(lrs_sorted)))
+        ax.set_xticklabels([f"{lr:g}" for lr in lrs_sorted], rotation=45)
+        ax.set_yticks(range(len(counts_sorted)))
+        ax.set_yticklabels([str(c) for c in counts_sorted])
+        ax.set_xlabel("Learning rate")
+        ax.set_ylabel("Number of negative personas")
+        plt.colorbar(im, ax=ax, label="Achieved source-self ΔG (nats)")
+        # Star markers on the picked LR per count.
+        for i, cnt in enumerate(counts_sorted):
+            pick = calibration_pick.get(cnt) or calibration_pick.get(str(cnt))
+            if pick:
+                picked_lr = float(pick["lr"])
+                if picked_lr in lrs_sorted:
+                    j = lrs_sorted.index(picked_lr)
+                    ax.plot(j, i, marker="*", color="white", markersize=14, mec="black")
+        ax.set_title("F5: calibration table (star = picked LR per count)")
+        fig.tight_layout()
+        savefig_paper(fig, "i477_f5_calibration_heatmap", dir=str(figures_dir))
+        plt.close(fig)
+        written["F5"] = str(figures_dir / "i477_f5_calibration_heatmap")
+
+    # ── F6: H3 side-bet (count → source-implant survives calibration?). ──────
+    if calibration_table:
+        fig, ax = plt.subplots(figsize=(7.0, 4.5))
+        for lr in sorted({float(lr) for row in calibration_table.values() for lr in row}):
+            xs, ys = [], []
+            for cnt in sorted(int(k) for k in calibration_table):
+                row = (
+                    calibration_table[cnt]
+                    if cnt in calibration_table
+                    else calibration_table[str(cnt)]
+                )
+                cell = row.get(lr) or row.get(str(lr)) or row.get(f"{lr:g}")
+                if cell is not None:
+                    xs.append(cnt)
+                    ys.append(float(cell["source_self_delta_g"]))
+            if xs:
+                ax.plot(xs, ys, marker="o", label=f"LR={lr:g}")
+        ax.set_xlabel("Number of negative personas")
+        ax.set_ylabel("Source-self ΔG at terminal (nats)")
+        ax.set_title("F6 H3: count → source-implant coupling survives calibration?")
+        ax.legend(fontsize=8)
+        fig.tight_layout()
+        savefig_paper(fig, "i477_f6_h3_count_to_implant", dir=str(figures_dir))
+        plt.close(fig)
+        written["F6"] = str(figures_dir / "i477_f6_h3_count_to_implant")
+
+    # Excluded cells get logged in the summary, not plotted (would be misleading
+    # zero bars per Lens 13; the analyzer prose lists them with their actual
+    # achieved ΔG + emission_p instead).
+    log.info(
+        "[477 figures] wrote %d figures; %d cells excluded by validity gate (not plotted): %s",
+        len(written),
+        len(excluded_cells),
+        [c.get("cell") for c in excluded_cells],
+    )
+    return written
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# v4 step-lever marker-channel Bernoulli KL (plan v4 §4 + §6 + §11).
+# Headline DV swap from v3 full-vocab KL → 2-class marker-channel KL.
+# Computed as a POST-HOC transform from g_logp (P_trained(※)) and base_panel
+# (P_base(※)), both already extracted by the existing rig; no new forward pass.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+_BERNOULLI_KL_EPS = 1e-9
+
+
+def marker_channel_bernoulli_kl(
+    p_trained: float, p_base: float, eps: float = _BERNOULLI_KL_EPS
+) -> float:
+    """KL(Bernoulli(p_trained) ‖ Bernoulli(p_base)) at the post-R marker slot.
+
+    Plan v4 §4 pseudocode. Marker-targeted (only the ※ channel contributes —
+    non-marker drift is folded into the (1−P) class) AND non-saturating (grows
+    monotonically as P_trained departs from P_base, no -0.28-nat ceiling). The
+    v4 headline DV.
+
+    Args:
+        p_trained: P(※) at the post-R slot under the trained model, per leaf.
+        p_base: P(※) at the same slot under the base model, per leaf.
+        eps: clamp keeping ``log`` finite at p=0 / p=1 (default 1e-9 nats).
+
+    Returns:
+        KL in nats, ≥0 by construction. Returns 0 exactly when p_trained == p_base.
+
+    Raises:
+        ValueError: either probability is outside [0, 1].
+    """
+    import math
+
+    if not 0.0 <= p_trained <= 1.0:
+        raise ValueError(f"p_trained={p_trained} not in [0,1]")
+    if not 0.0 <= p_base <= 1.0:
+        raise ValueError(f"p_base={p_base} not in [0,1]")
+    p = min(max(p_trained, eps), 1.0 - eps)
+    q = min(max(p_base, eps), 1.0 - eps)
+    return p * math.log(p / q) + (1.0 - p) * math.log((1.0 - p) / (1.0 - q))
+
+
+def aggregate_bystander_marker_channel_kl(checkpoint: dict) -> float:
+    """Mean over held-out (persona × question) leaves of the 2-class KL.
+
+    Reads ``g_logp`` (P_trained log-prob) and ``b_logp`` (P_base log-prob) per
+    leaf from the trajectory eval's ``held_out`` block — both already produced
+    by the existing rig at every checkpoint, so this is a pure post-hoc
+    transform (no new forward pass).
+
+    Args:
+        checkpoint: one entry of trajectory.json's ``checkpoints`` list.
+            Required keys: ``held_out[persona][question]['g_logp']`` and
+            ``['b_logp']``.
+
+    Returns:
+        Mean bystander marker-channel KL in nats.
+
+    Raises:
+        RuntimeError: no bystander leaves in this checkpoint (the rig wrote a
+            corrupt artifact — fail loud, don't average over an empty list).
+    """
+    import math
+
+    kls: list[float] = []
+    held = checkpoint.get("held_out", {})
+    for _persona, per_q in held.items():
+        for _q, leaf in per_q.items():
+            p_trained = math.exp(float(leaf["g_logp"]))
+            p_base = math.exp(float(leaf["b_logp"]))
+            # Clamp for the rare base case where exp(log_p) drifts >1 due to
+            # bf16 round-off; the function itself fails loud on truly invalid
+            # probabilities so a real schema break can't masquerade as a clamp.
+            p_trained = min(p_trained, 1.0)
+            p_base = min(p_base, 1.0)
+            kls.append(marker_channel_bernoulli_kl(p_trained, p_base))
+    if not kls:
+        raise RuntimeError(
+            "aggregate_bystander_marker_channel_kl: 0 bystander leaves in "
+            f"checkpoint at frac={checkpoint.get('frac')!r} step={checkpoint.get('step')!r}; "
+            f"trajectory.json corruption or empty eval panel?"
+        )
+    return sum(kls) / len(kls)
+
+
+def aggregate_source_self_marker_channel_kl(checkpoint: dict) -> float:
+    """Source-self marker-channel KL — the H1 conditioning covariate (v4).
+
+    Symmetric with :func:`aggregate_bystander_marker_channel_kl` but reads
+    the source's ``g_logp_mean`` / ``b_logp_mean`` from the checkpoint's
+    ``source_self`` block (the existing rig writes per-source means only, not
+    per-Q leaves — fine for the partial since the H1 covariate is a per-cell
+    summary not a per-leaf regression).
+
+    Args:
+        checkpoint: one entry of trajectory.json's ``checkpoints`` list.
+
+    Returns:
+        Source-self marker-channel KL in nats, computed at the source's
+        mean P(※) (≈ exp of the mean log-prob; tight upper bound since
+        exp is convex on log-probs).
+    """
+    import math
+
+    ss = checkpoint["source_self"]
+    p_trained = min(math.exp(float(ss["g_logp_mean"])), 1.0)
+    p_base = min(math.exp(float(ss["b_logp_mean"])), 1.0)
+    return marker_channel_bernoulli_kl(p_trained, p_base)
+
+
+def aggregate_bystander_full_vocab_kl(checkpoint: dict) -> float | None:
+    """Mean over held-out leaves of full-vocab KL (the v3 demoted secondary).
+
+    Reads the per-leaf ``kl`` field the rig writes when compute_kl=True; returns
+    None when ANY leaf has ``kl is None`` (the rig skipped KL — smoke /
+    --no-kl path). Keeps the paired sanity panel honest: a None aggregate
+    propagates to ``rank_agreement_marker_vs_full_vocab`` which then refuses
+    to compute the cross-DV check and surfaces "kl not computed".
+    """
+    kls: list[float] = []
+    held = checkpoint.get("held_out", {})
+    for _persona, per_q in held.items():
+        for _q, leaf in per_q.items():
+            v = leaf.get("kl")
+            if v is None:
+                return None
+            kls.append(float(v))
+    if not kls:
+        return None
+    return sum(kls) / len(kls)
+
+
+def attach_marker_channel_aggregates(traj: dict) -> dict:
+    """In-place: add v4 aggregates to every checkpoint in a trajectory.json.
+
+    For each checkpoint adds:
+      * ``source_self_marker_channel_kl``: H1 conditioning covariate.
+      * ``mean_bystander_marker_channel_kl``: v4 HEADLINE DV.
+      * ``mean_bystander_full_vocab_kl``: paired v3 secondary (or None if
+        the rig skipped KL).
+
+    Idempotent: safe to call twice (overwrites existing aggregates).
+    Returns the same ``traj`` dict for chaining.
+    """
+    for ck in traj.get("checkpoints", []):
+        ck["source_self_marker_channel_kl"] = aggregate_source_self_marker_channel_kl(ck)
+        ck["mean_bystander_marker_channel_kl"] = aggregate_bystander_marker_channel_kl(ck)
+        ck["mean_bystander_full_vocab_kl"] = aggregate_bystander_full_vocab_kl(ck)
+    return traj
+
+
+def partial_spearman_count_given_implant_marker_channel_kl(
+    kept_cells: list[dict],
+    *,
+    n_bootstrap: int = 2000,
+    bootstrap_seed: int = 42,
+    min_count_levels: int = 3,
+) -> dict[str, Any]:
+    """v4 HEADLINE: ρ(count, bystander-marker-channel-KL | source-self-marker-channel-KL).
+
+    Mirror of :func:`partial_spearman_count_given_implant` but uses the v4
+    marker-channel KL aggregates on both axes. Each kept cell must carry:
+      * ``count``, ``seed``, ``phase`` ("main" or "main_v4" defensive assert).
+      * ``mean_bystander_marker_channel_kl_at_picked_step`` — v4 headline DV.
+      * ``source_self_marker_channel_kl_at_picked_step`` — H1 covariate.
+      * ``picked_step_actual`` (preferred) or ``step_at_last_ckpt`` (legacy v2
+        fallback) — the step covariate for the robustness partial. For v4
+        cells, ``picked_step_actual`` (the actual checkpoint step the worker
+        selected for the picked-step DVs) is the correct step to control for
+        — ``step_at_last_ckpt`` would name the terminal of the trained
+        context window (``min(2*s*, max_steps)``), not s* itself.
+    """
+    from scipy.stats import spearmanr
+
+    # Accept both v2 "main" and v4 "main_v4" — the v4 dispatcher emits the
+    # latter when routing through the step-lever path; both are H1-eligible
+    # under the marker-channel headline DV.
+    _MAIN_PHASES = {"main", "main_v4"}
+    for c in kept_cells:
+        phase = c.get("phase")
+        if phase not in _MAIN_PHASES:
+            raise AssertionError(
+                "partial_spearman_count_given_implant_marker_channel_kl got a "
+                f"non-main-phase cell: cell={c.get('cell', '<unknown>')!r}, "
+                f"seed={c.get('seed')}, phase={phase!r}. v4 H1 partial Spearman "
+                f"must be computed over main-phase cells only (phase in "
+                f"{_MAIN_PHASES!r})."
+            )
+
+    counts = [int(c["count"]) for c in kept_cells]
+    distinct_counts = sorted(set(counts))
+    n = len(kept_cells)
+    if len(distinct_counts) < min_count_levels:
+        return {
+            "interpretable": False,
+            "n": n,
+            "n_count_levels": len(distinct_counts),
+            "kept_counts": distinct_counts,
+            "headline_dv": "marker_channel_bernoulli_kl",
+            "note": (
+                f"n_count_levels={len(distinct_counts)} < min_count_levels="
+                f"{min_count_levels} — coverage floor violated (plan v4 §6 "
+                "discipline item 5). v4 headline partial uninterpretable."
+            ),
+        }
+
+    bystander = [float(c["mean_bystander_marker_channel_kl_at_picked_step"]) for c in kept_cells]
+    implant = [float(c["source_self_marker_channel_kl_at_picked_step"]) for c in kept_cells]
+    # Step covariate: prefer ``picked_step_actual`` (v4 — the actual step the
+    # worker read DVs from) over ``step_at_last_ckpt`` (v2 fallback — terminal
+    # of the trained context window). The picked-step alignment matters
+    # because the headline DVs are at the picked step; the step regressor
+    # should control for the SAME step, not the upper bound of the training
+    # context window.
+    step = [int(c.get("picked_step_actual", c.get("step_at_last_ckpt", 0))) for c in kept_cells]
+
+    y_resid_i = _ols_residuals(bystander, [implant])
+    c_resid_i = _ols_residuals([float(v) for v in counts], [implant])
+    sr_i = spearmanr(c_resid_i, y_resid_i)
+    boot_i = _stratified_bootstrap_partial_spearman(
+        counts, bystander, implant, n_resamples=n_bootstrap, seed=bootstrap_seed
+    )
+
+    y_resid_is = _ols_residuals(bystander, [implant, [float(v) for v in step]])
+    c_resid_is = _ols_residuals([float(v) for v in counts], [implant, [float(v) for v in step]])
+    sr_is = spearmanr(c_resid_is, y_resid_is)
+    boot_is = _stratified_bootstrap_partial_spearman(
+        counts,
+        bystander,
+        implant,
+        n_resamples=n_bootstrap,
+        seed=bootstrap_seed + 1,
+        extra_controls=[[float(v) for v in step]],
+    )
+
+    seeds_in_kept = sorted({int(c["seed"]) for c in kept_cells})
+    per_seed_sign: dict[str, dict] = {}
+    for s in seeds_in_kept:
+        sub = [c for c in kept_cells if int(c["seed"]) == s]
+        if len({int(c["count"]) for c in sub}) < 2:
+            per_seed_sign[str(s)] = {
+                "n": len(sub),
+                "n_count_levels": len({int(c["count"]) for c in sub}),
+                "sign": None,
+                "note": "fewer than 2 count levels at this seed; sign not defined",
+            }
+            continue
+        sub_counts = [int(c["count"]) for c in sub]
+        sub_bystander = [float(c["mean_bystander_marker_channel_kl_at_picked_step"]) for c in sub]
+        sr_seed = spearmanr(sub_counts, sub_bystander)
+        rho_seed = float(sr_seed.correlation) if not np.isnan(sr_seed.correlation) else 0.0
+        per_seed_sign[str(s)] = {
+            "n": len(sub),
+            "n_count_levels": len({int(c["count"]) for c in sub}),
+            "rho_raw_count_bystander": rho_seed,
+            "sign": int(np.sign(rho_seed)) if rho_seed != 0 else 0,
+        }
+
+    pooled_sign = (
+        int(np.sign(sr_i.correlation))
+        if not np.isnan(sr_i.correlation) and sr_i.correlation != 0
+        else 0
+    )
+    sign_stable = all(
+        (v.get("sign") is None) or v.get("sign") == pooled_sign for v in per_seed_sign.values()
+    )
+
+    return {
+        "interpretable": True,
+        "n": n,
+        "n_count_levels": len(distinct_counts),
+        "kept_counts": distinct_counts,
+        "rho_given_implant": float(sr_i.correlation),
+        "p_given_implant": float(sr_i.pvalue),
+        "bootstrap_given_implant": boot_i,
+        "rho_given_implant_and_step": float(sr_is.correlation),
+        "p_given_implant_and_step": float(sr_is.pvalue),
+        "bootstrap_given_implant_and_step": boot_is,
+        "per_seed_sign": per_seed_sign,
+        "pooled_sign": pooled_sign,
+        "sign_stable_across_seeds": sign_stable,
+        "headline_dv": "marker_channel_bernoulli_kl",
+        "interpretation_scope": (
+            "row-scaled negative-budget recipe (count co-varies with total "
+            "negative rows at fixed positives); NOT pure persona-diversity. "
+            "See plan v4 §3 H1 + §6 discipline item 1."
+        ),
+        "note": (
+            "Plan v4 §6 discipline item 1: report BOTH partials. Item 3: ρ is "
+            "a SUMMARY of F3. Item 9: cross-DV agreement with full-vocab KL "
+            "MUST gate the verdict — see rank_agreement_marker_vs_full_vocab."
+        ),
+    }
+
+
+def partial_spearman_count_given_implant_full_vocab_kl(
+    kept_cells: list[dict],
+    *,
+    n_bootstrap: int = 2000,
+    bootstrap_seed: int = 42,
+    min_count_levels: int = 3,
+) -> dict[str, Any]:
+    """Paired secondary: ρ(count, bystander-full-vocab-KL | source-self-marker-channel-KL).
+
+    Same shape as the v4 headline partial but y = full-vocab KL. Reported
+    side-by-side with the headline so divergent rank orders surface in the
+    write-up (cross-DV agreement gate, §6 #9).
+    """
+    from scipy.stats import spearmanr
+
+    # Accept both v2 "main" and v4 "main_v4" — the paired secondary mirrors
+    # the marker-channel headline's phase gate.
+    _MAIN_PHASES = {"main", "main_v4"}
+    for c in kept_cells:
+        if c.get("phase") not in _MAIN_PHASES:
+            raise AssertionError(
+                "partial_spearman_count_given_implant_full_vocab_kl got a "
+                f"non-main-phase cell: {c.get('cell', '<unknown>')!r}, "
+                f"phase={c.get('phase')!r}. Expected one of {_MAIN_PHASES!r}."
+            )
+
+    counts = [int(c["count"]) for c in kept_cells]
+    distinct_counts = sorted(set(counts))
+    n = len(kept_cells)
+    if len(distinct_counts) < min_count_levels:
+        return {
+            "interpretable": False,
+            "n": n,
+            "n_count_levels": len(distinct_counts),
+            "kept_counts": distinct_counts,
+            "headline_dv": "full_vocab_kl",
+            "note": (
+                f"n_count_levels={len(distinct_counts)} < min_count_levels="
+                f"{min_count_levels} — coverage floor violated."
+            ),
+        }
+
+    bystander = [float(c["mean_bystander_full_vocab_kl_at_picked_step"]) for c in kept_cells]
+    implant = [float(c["source_self_marker_channel_kl_at_picked_step"]) for c in kept_cells]
+    y_resid = _ols_residuals(bystander, [implant])
+    c_resid = _ols_residuals([float(v) for v in counts], [implant])
+    sr = spearmanr(c_resid, y_resid)
+    boot = _stratified_bootstrap_partial_spearman(
+        counts, bystander, implant, n_resamples=n_bootstrap, seed=bootstrap_seed
+    )
+    return {
+        "interpretable": True,
+        "n": n,
+        "n_count_levels": len(distinct_counts),
+        "kept_counts": distinct_counts,
+        "rho_given_implant": float(sr.correlation),
+        "p_given_implant": float(sr.pvalue),
+        "bootstrap_given_implant": boot,
+        "headline_dv": "full_vocab_kl",
+        "note": (
+            "Plan v4 §6 discipline item 9: PAIRED sanity panel; never decides "
+            "H1 alone. Rank-divergence vs the marker-channel headline triggers "
+            "an H1 DOWNGRADE per rank_agreement_marker_vs_full_vocab."
+        ),
+    }
+
+
+def implant_only_axis_spearman_marker_channel_kl(
+    implant_only_cells: list[dict],
+) -> dict[str, Any]:
+    """v4 H2: ρ(source-marker-channel-KL, bystander-marker-channel-KL).
+
+    Same verdict thresholds as the v2 implant-only-axis Spearman (confirms
+    if ρ ≥ 0.80 AND sign-stable; falsifies if |ρ| ≤ 0.40). Just the v4 DV
+    swap on both axes.
+    """
+    from scipy.stats import spearmanr
+
+    n = len(implant_only_cells)
+    if n < 3:
+        return {
+            "rho": float("nan"),
+            "p": float("nan"),
+            "n": n,
+            "verdict": "indeterminate",
+            "headline_dv": "marker_channel_bernoulli_kl",
+            "note": f"n={n} cells; need ≥3 for Spearman.",
+        }
+    implant = [float(c["source_self_marker_channel_kl_at_picked_step"]) for c in implant_only_cells]
+    bystander = [
+        float(c["mean_bystander_marker_channel_kl_at_picked_step"]) for c in implant_only_cells
+    ]
+    sr = spearmanr(implant, bystander)
+    rho = float(sr.correlation)
+    seeds = sorted({int(c["seed"]) for c in implant_only_cells})
+    per_seed_sign: dict[str, dict] = {}
+    for s in seeds:
+        sub = [c for c in implant_only_cells if int(c["seed"]) == s]
+        if len(sub) < 2:
+            per_seed_sign[str(s)] = {"n": len(sub), "sign": None, "note": "n<2"}
+            continue
+        sub_i = [float(c["source_self_marker_channel_kl_at_picked_step"]) for c in sub]
+        sub_b = [float(c["mean_bystander_marker_channel_kl_at_picked_step"]) for c in sub]
+        sr_seed = spearmanr(sub_i, sub_b)
+        rho_seed = float(sr_seed.correlation) if not np.isnan(sr_seed.correlation) else 0.0
+        per_seed_sign[str(s)] = {
+            "n": len(sub),
+            "rho": rho_seed,
+            "sign": int(np.sign(rho_seed)) if rho_seed != 0 else 0,
+        }
+    sign_stable = (
+        len({v.get("sign") for v in per_seed_sign.values() if v.get("sign") is not None}) <= 1
+    )
+    if abs(rho) >= 0.80 and sign_stable:
+        verdict = "confirms"
+    elif abs(rho) <= 0.40:
+        verdict = "falsifies"
+    else:
+        verdict = "indeterminate"
+    return {
+        "rho": rho,
+        "p": float(sr.pvalue),
+        "n": n,
+        "sign_stable_across_seeds": sign_stable,
+        "per_seed_sign": per_seed_sign,
+        "verdict": verdict,
+        "headline_dv": "marker_channel_bernoulli_kl",
+        "note": "v4 H2: same thresholds as v2 implant-only-axis Spearman, DV-swap on both axes.",
+    }
+
+
+def rank_agreement_marker_vs_full_vocab(
+    kept_cells: list[dict],
+    *,
+    downgrade_threshold: float = 0.70,
+) -> dict[str, Any]:
+    """v4 §6 discipline #9: cross-DV rank agreement across kept cells.
+
+    Computes Spearman across kept cells between
+    ``mean_bystander_marker_channel_kl_at_picked_step`` and
+    ``mean_bystander_full_vocab_kl_at_picked_step``. If across-cell ρ <
+    ``downgrade_threshold`` (default 0.70), the verdict is "divergence —
+    downgrade H1" and the write-up must narrate the construct-divergence.
+
+    If full-vocab KL is missing on any cell (rig --no-kl path), the verdict is
+    "kl not computed" and the agreement gate is skipped (the headline still
+    publishes, but the gate cannot rule on it).
+    """
+    from scipy.stats import spearmanr
+
+    marker: list[float] = []
+    full: list[float] = []
+    missing: list[str] = []
+    for c in kept_cells:
+        m = c.get("mean_bystander_marker_channel_kl_at_picked_step")
+        f = c.get("mean_bystander_full_vocab_kl_at_picked_step")
+        if m is None or f is None:
+            missing.append(c.get("cell", "<unknown>"))
+            continue
+        marker.append(float(m))
+        full.append(float(f))
+
+    if missing:
+        return {
+            "verdict": "kl not computed",
+            "n": len(marker),
+            "n_missing": len(missing),
+            "missing_cells": missing,
+            "downgrade_if_below": downgrade_threshold,
+            "note": (
+                "Full-vocab KL missing on one or more kept cells (rig --no-kl "
+                "or partial trajectory). Cross-DV agreement gate skipped; the "
+                "v4 headline publishes without the construct-divergence check."
+            ),
+        }
+    if len(marker) < 3:
+        return {
+            "verdict": "indeterminate",
+            "cross_dv_rank_spearman": float("nan"),
+            "n": len(marker),
+            "downgrade_if_below": downgrade_threshold,
+            "note": f"n={len(marker)} kept cells; need ≥3 for Spearman.",
+        }
+    sr = spearmanr(marker, full)
+    rho = float(sr.correlation) if not np.isnan(sr.correlation) else 0.0
+    verdict = "agreement" if rho >= downgrade_threshold else "divergence — downgrade H1"
+    return {
+        "verdict": verdict,
+        "cross_dv_rank_spearman": rho,
+        "p": float(sr.pvalue),
+        "n": len(marker),
+        "downgrade_if_below": downgrade_threshold,
+        "note": (
+            "Plan v4 §6 discipline item 9: across-cell Spearman between v4 "
+            "marker-channel headline and v3 full-vocab paired-secondary. "
+            "<0.70 → DOWNGRADE H1 and narrate the construct-divergence "
+            "(full-vocab moves on non-marker drift per Codex round-2)."
+        ),
+    }

--- a/src/explore_persona_space/experiments/contrastive_neg_geometry_472/base_panel.py
+++ b/src/explore_persona_space/experiments/contrastive_neg_geometry_472/base_panel.py
@@ -1,0 +1,131 @@
+# ruff: noqa: RUF002  # em-dash + Qwen marker token " ※" are intentional
+"""Task #472 Phase 1.5 — base per-persona marker prior b_logprob (plan §5 / §6).
+
+The base-model marker log-prob ``b_logprob`` on the BASE model's OWN frozen R
+(from r_generate), per held-out persona × Q_eval. This is the persona prior that
+ΔG subtracts and that the geometry regression PARTIALS OUT (the #448 artifact
+guard: ΔG ≈ −b_logprob mechanically reproduces persona structure; partialling
+b_logprob rules it out). #448 reported a 7.3-nat spread across personas
+(−18.69..−25.96), so this is a real partialling control (assumption 14).
+
+Distinct from the trajectory's per-checkpoint base pass: that base pass reads the
+base marker log-prob on the TRAINED model's R_j (to form ΔG at each checkpoint on
+matched on-policy text). THIS panel reads the base marker log-prob on the BASE
+model's frozen R — a single training-independent per-persona prior, computed once.
+
+Subprocess-isolated (vLLM) per the dispatcher's teardown discipline.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import socket
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+from explore_persona_space.experiments.contrastive_neg_geometry_472 import (
+    BASE_MODEL,
+    EXPECTED_MARKER_TOKEN_ID,
+    MARKER_TEXT,
+)
+from explore_persona_space.experiments.contrastive_neg_geometry_472.eval_one_cell import (
+    assert_marker_token,
+    score_logp_for_R,
+)
+
+log = logging.getLogger("issue_472.base_panel")
+
+
+def _git_sha() -> str:
+    import os
+
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL, text=True, env={**os.environ}
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def run_base_panel(
+    *,
+    eval_personas: dict[str, str],
+    eval_questions: list[str],
+    r_eval_base: dict[str, dict[str, dict]],
+    out_path: Path,
+    base_model: str = BASE_MODEL,
+    gpu_memory_utilization: float = 0.85,
+    max_model_len: int = 2048,
+    seed: int = 42,
+) -> Path:
+    """Compute base per-persona marker prior b_logprob on the base model's R.
+
+    Args:
+        eval_personas: held-out panel {persona: system_prompt}.
+        eval_questions: Q_eval.
+        r_eval_base: base R artifact completions (persona -> q -> {response_text,...}).
+        out_path: base_panel.json output.
+        base_model, gpu_memory_utilization, max_model_len, seed: vLLM params.
+
+    Returns:
+        out_path. Writes {persona: {q: b_logp}} + per-persona means.
+    """
+    from transformers import AutoTokenizer
+    from vllm import LLM
+
+    tokenizer = AutoTokenizer.from_pretrained(base_model, trust_remote_code=True)
+    assert_marker_token(tokenizer)
+
+    # Flatten the base R artifact to r[persona][q] -> text.
+    r_text: dict[str, dict[str, str]] = {}
+    for persona in eval_personas:
+        if persona not in r_eval_base:
+            raise KeyError(f"base R missing persona {persona!r}.")
+        r_text[persona] = {q: r_eval_base[persona][q]["response_text"] for q in eval_questions}
+
+    llm = LLM(
+        model=base_model,
+        dtype="bfloat16",
+        gpu_memory_utilization=gpu_memory_utilization,
+        seed=seed,
+        max_model_len=max_model_len,
+    )
+    b = score_logp_for_R(
+        llm,
+        tokenizer,
+        r_by_persona_q=r_text,
+        eval_personas=eval_personas,
+        eval_questions=eval_questions,
+        cell_label="BASE_PANEL",
+        use_lora=False,
+    )
+
+    import numpy as np
+
+    b_by_pq = {p: {q: b[p][q]["logp"] for q in eval_questions} for p in eval_personas}
+    b_mean = {p: float(np.mean(list(b_by_pq[p].values()))) for p in eval_personas}
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": "i472_v1",
+        "base_model": base_model,
+        "marker_text": MARKER_TEXT,
+        "marker_token_id": EXPECTED_MARKER_TOKEN_ID,
+        "n_personas": len(eval_personas),
+        "eval_questions": eval_questions,
+        "b_logprob_per_persona_q": b_by_pq,
+        "mean_per_persona_b_logprob": b_mean,
+        "git_commit": _git_sha(),
+        "hostname": socket.gethostname(),
+        "timestamp_utc": datetime.now(UTC).isoformat(),
+    }
+    out_path.write_text(json.dumps(payload, indent=2))
+    spread = max(b_mean.values()) - min(b_mean.values()) if b_mean else 0.0
+    log.info(
+        "[phase=base_panel] Wrote b_logprob for %d personas (spread=%.2f nats) → %s",
+        len(eval_personas),
+        spread,
+        out_path,
+    )
+    return out_path

--- a/src/explore_persona_space/experiments/contrastive_neg_geometry_472/build_training_data.py
+++ b/src/explore_persona_space/experiments/contrastive_neg_geometry_472/build_training_data.py
@@ -1,0 +1,271 @@
+# ruff: noqa: RUF001, RUF002  # em-dash + x/marker tokens intentional
+"""Task #472 Phase 3 — per-cell on-policy contrastive-SFT data build.
+
+Forked from #448 build_training_data, with the negative set chosen by the NEW
+distance-stratified selector (select_negatives) instead of #411's parsed
+bystanders. Plan §4.4 / §4.5.
+
+Row construction (on-policy, plan §4.6 + .claude/rules/contrastive-negatives.md):
+- POSITIVE row (source persona): completion = ``R_train[source][q] + "\n\n" + ※``.
+  Loss masked to the ※ token + EOS via MarkerOnlyDataCollator(tail_tokens=0)
+  downstream → R stays on-policy (zero gradient), only the marker shifts.
+- NEGATIVE row (a distance-selected persona, always incl. qwen_default):
+  completion = ``R_train[neg][q]`` (NO marker) → under marker-only loss the only
+  loss-bearing token is EOS, i.e. "after a response under this persona, emit EOS,
+  NOT the marker."
+- NO marker contamination allowed in any negative R (text + token-id check).
+
+Composition (plan §4.4 / §5):
+- positives: POS_EX_PER_SOURCE (=200) rows of (source, q∈Q_train).
+- negatives: n_neg_personas × neg_ex_per_persona rows, split evenly across the
+  arm's negative personas (each over q∈Q_train).
+- The anchor's 200 pos vs 800 neg ratio departs from the ~1:1 contrastive default
+  — the experiment SWEEPS around this gated anchor, so it is a scope/interpretation
+  caveat (plan §6.5 caveat 7), NOT a confound. Recorded in the manifest.
+
+Sampling: per (persona, q-index) deterministic via seeded slices over Q_train,
+cycling through Q_train when the requested ex count exceeds |Q_train| (each q
+re-used under a different sampled persona slot, but the same (persona, q) pair
+appears at most ceil(ex/|Q_train|) times). Disjointness across personas is by
+the seed-salting; cross-persona overlap of questions is expected (same Q_train).
+
+CPU-only.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import random
+from pathlib import Path
+from typing import Any
+
+from explore_persona_space.experiments.contrastive_neg_geometry_472 import (
+    CELL_SPECS,
+    EXPECTED_MARKER_TOKEN_ID,
+    MARKER_SEP,
+    MARKER_TEXT,
+    POS_EX_PER_SOURCE,
+    SOURCE_PERSONA,
+)
+from explore_persona_space.experiments.contrastive_neg_geometry_472.select_negatives import (
+    negatives_for_cell,
+)
+
+log = logging.getLogger("issue_472.build_training_data")
+
+NO_PERSONA_KEY = "no_persona"
+
+
+def _make_example(system_prompt: str | None, user_prompt: str, assistant_response: str) -> dict:
+    """Build one prompt-completion training row in TRL SFTTrainer format."""
+    messages_prompt: list[dict[str, str]] = []
+    if system_prompt is not None:
+        messages_prompt.append({"role": "system", "content": system_prompt})
+    messages_prompt.append({"role": "user", "content": user_prompt})
+    return {
+        "prompt": messages_prompt,
+        "completion": [{"role": "assistant", "content": assistant_response}],
+    }
+
+
+def _has_marker_in_R(
+    response_text: str,
+    response_token_ids: list[int] | None,
+    marker_text: str = MARKER_TEXT,
+    marker_token_id: int = EXPECTED_MARKER_TOKEN_ID,
+) -> bool:
+    """Text- AND token-id-level marker-contamination check for a negative R."""
+    if marker_text in response_text:
+        return True
+    return response_token_ids is not None and marker_token_id in response_token_ids
+
+
+def _resolve_response(
+    r_train: dict[str, dict[str, dict]], persona: str, question: str, cell_slug: str
+) -> tuple[str, list[int] | None]:
+    """Pull (response_text, response_token_ids) from the on-policy R artifact."""
+    if persona not in r_train:
+        raise KeyError(
+            f"[{cell_slug}] r_train missing persona {persona!r}. Available: "
+            f"{sorted(r_train.keys())[:8]}... Re-run Phase 1 r-generate over the full bank."
+        )
+    per_q = r_train[persona]
+    if question not in per_q:
+        raise KeyError(
+            f"[{cell_slug}] r_train[{persona!r}] missing question {question!r}. "
+            f"Re-run Phase 1 with the full Q_train universe."
+        )
+    entry = per_q[question]
+    return entry["response_text"], entry.get("response_token_ids")
+
+
+def _sample_question_slots(questions: list[str], n: int, rng: random.Random) -> list[str]:
+    """Sample ``n`` question slots from ``questions`` deterministically.
+
+    If n <= len(questions): a random subset (no replacement). If n > len: full
+    permutations are concatenated until n is reached (each q re-used round-robin),
+    so a 200-row positive arm over 10 Q_train uses each question ~20 times.
+    """
+    if n <= len(questions):
+        return rng.sample(questions, n)
+    out: list[str] = []
+    while len(out) < n:
+        perm = list(questions)
+        rng.shuffle(perm)
+        out.extend(perm)
+    return out[:n]
+
+
+def build_cell(
+    cell_slug: str,
+    output_path: Path,
+    *,
+    r_train: dict[str, dict[str, dict]],
+    cos_to_source: dict[str, float],
+    q_train: list[str],
+    persona_bank: dict[str, str],
+    source: str = SOURCE_PERSONA,
+    marker_text: str = MARKER_TEXT,
+    seed: int = 42,
+    cell_specs: tuple | None = None,
+) -> Path:
+    """Build the per-cell training JSONL (on-policy).
+
+    Args:
+        cell_slug: e.g. "c472_anchor".
+        output_path: JSONL output path.
+        r_train: on-policy R artifact (persona -> q -> {response_text, ...}).
+        cos_to_source: {persona: cos(persona, source)} for negative selection.
+        q_train: Q_train question list.
+        persona_bank: name -> system prompt for resolving positive/negative prompts.
+        source: source persona.
+        marker_text: marker string appended to positive completions.
+        seed: base seed for per-persona seed salting.
+
+    Returns:
+        output_path. Raises on marker-in-negative contamination, missing R, or
+        row-count mismatch.
+    """
+    specs = cell_specs if cell_specs is not None else CELL_SPECS
+    spec = next((c for c in specs if c[0] == cell_slug), None)
+    if spec is None:
+        raise KeyError(f"Unknown cell slug {cell_slug!r}")
+    _slug, plain_name, placement, n_neg_personas, neg_ex_per_persona, in_pooled = spec
+
+    neg_persona_list = negatives_for_cell(
+        cell_slug, cos_to_source, source=source, cell_specs=cell_specs
+    )
+    if len(neg_persona_list) != n_neg_personas:
+        raise AssertionError(
+            f"[{cell_slug}] negative selection returned {len(neg_persona_list)} personas, "
+            f"expected {n_neg_personas} (placement={placement!r})."
+        )
+    if source not in persona_bank:
+        raise KeyError(f"[{cell_slug}] source {source!r} not in persona bank.")
+
+    log.info(
+        "[%s] Building cell '%s': placement=%s, %d pos (source=%s), "
+        "%d neg personas × %d ex = %d neg rows; negatives=%s",
+        cell_slug,
+        plain_name,
+        placement,
+        POS_EX_PER_SOURCE,
+        source,
+        n_neg_personas,
+        neg_ex_per_persona,
+        n_neg_personas * neg_ex_per_persona,
+        neg_persona_list,
+    )
+
+    examples: list[dict] = []
+
+    # ── Positive rows (source persona). ──────────────────────────────────────
+    source_prompt = persona_bank[source]
+    pos_rng = random.Random(seed)
+    pos_questions = _sample_question_slots(q_train, POS_EX_PER_SOURCE, pos_rng)
+    n_marker_in_positive_R = 0
+    for q in pos_questions:
+        r_text, r_ids = _resolve_response(r_train, source, q, cell_slug)
+        if _has_marker_in_R(r_text, r_ids, marker_text):
+            n_marker_in_positive_R += 1
+            raise AssertionError(
+                f"[{cell_slug}] positive row for source={source!r}, q={q!r} already "
+                f"contains the marker in R BEFORE we append it — would produce two "
+                f"markers. Phase 1 r-generate should have aborted; the R artifact is stale."
+            )
+        examples.append(_make_example(source_prompt, q, f"{r_text}{MARKER_SEP}{marker_text}"))
+    n_positive = len(examples)
+
+    # ── Negative rows (distance-selected personas, no marker). ───────────────
+    n_marker_in_negative_R = 0
+    for j_idx, neg_name in enumerate(neg_persona_list):
+        if neg_name not in persona_bank:
+            raise KeyError(f"[{cell_slug}] negative persona {neg_name!r} not in bank.")
+        neg_prompt = persona_bank[neg_name]
+        neg_rng = random.Random(seed + 1000 + j_idx)
+        neg_questions = _sample_question_slots(q_train, neg_ex_per_persona, neg_rng)
+        for q in neg_questions:
+            r_text, r_ids = _resolve_response(r_train, neg_name, q, cell_slug)
+            if _has_marker_in_R(r_text, r_ids, marker_text):
+                n_marker_in_negative_R += 1
+                raise AssertionError(
+                    f"[{cell_slug}] negative row for persona={neg_name!r}, q={q!r} has "
+                    f"marker contamination in R — would silently train the model to emit "
+                    f"the marker after a bystander response."
+                )
+            examples.append(_make_example(neg_prompt, q, r_text))
+    n_negative = len(examples) - n_positive
+
+    # ── Final deterministic shuffle. ─────────────────────────────────────────
+    random.Random(seed).shuffle(examples)
+
+    expected_total = POS_EX_PER_SOURCE + n_neg_personas * neg_ex_per_persona
+    if len(examples) != expected_total:
+        raise AssertionError(
+            f"[{cell_slug}] row count mismatch: got {len(examples)}, expected "
+            f"{expected_total} ({POS_EX_PER_SOURCE} pos + "
+            f"{n_neg_personas}×{neg_ex_per_persona} neg)."
+        )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        for ex in examples:
+            f.write(json.dumps(ex) + "\n")
+
+    manifest: dict[str, Any] = {
+        "cell_slug": cell_slug,
+        "plain_name": plain_name,
+        "placement": placement,
+        "source_persona": source,
+        "negative_personas": neg_persona_list,
+        "n_neg_personas": n_neg_personas,
+        "neg_ex_per_persona": neg_ex_per_persona,
+        "pos_ex": POS_EX_PER_SOURCE,
+        "n_total_rows": len(examples),
+        "n_positive_rows": n_positive,
+        "n_negative_rows": n_negative,
+        "pos_to_neg_ratio": (n_positive / n_negative) if n_negative else None,
+        "ratio_note": (
+            "departs from the ~1:1 contrastive default; experiment sweeps around "
+            "this gated anchor → scope/interpretation caveat, not a confound (plan §6.5.7)"
+        ),
+        "in_pooled_regression": in_pooled,
+        "marker_text": marker_text,
+        "marker_token_id_expected": EXPECTED_MARKER_TOKEN_ID,
+        "seed": seed,
+        "marker_in_R_counts": {
+            "positive": n_marker_in_positive_R,
+            "negative": n_marker_in_negative_R,
+        },
+    }
+    output_path.with_suffix(".manifest.json").write_text(json.dumps(manifest, indent=2))
+    log.info(
+        "[%s] Wrote %d rows (%d pos, %d neg) → %s",
+        cell_slug,
+        len(examples),
+        n_positive,
+        n_negative,
+        output_path,
+    )
+    return output_path

--- a/src/explore_persona_space/experiments/contrastive_neg_geometry_472/centroids.py
+++ b/src/explore_persona_space/experiments/contrastive_neg_geometry_472/centroids.py
@@ -1,0 +1,154 @@
+# ruff: noqa: RUF001, RUF002  # em-dash + x/marker tokens intentional
+"""Task #472 Phase 0.5 — base-model persona centroids + cosine geometry.
+
+Plan §4.3. Distances are a BASE-model geometric property ("where do negatives
+sit in base persona space," not "where does training move them"), so centroids
+are computed ONCE on the base model over the full ~60-persona bank and reused for
+every cell. Uses ``analysis/representation_shift.extract_centroids`` (last-token
+hidden state, mean over EVAL_QUESTIONS) + ``compute_cosine_matrix(centering=
+"none")`` (NOT the static ASSISTANT_COSINES dict).
+
+Layers: 10 (headline) + 15 + 20 (robustness; L20 is Persona-Vectors' actual evil
+layer, 1-indexed). Distance = 1 − cosine.
+
+Output: ``data/issue_472/centroids_L{10,15,20}.pt`` (one bundle per layer) plus a
+derived ``cos_matrix`` per layer keyed by persona name. The derived per-probe
+covariates (d_source, d_nearest_neg, d_nearest_neg_nd) are computed in
+``select_negatives`` / ``analyze`` from these matrices.
+
+GPU only (one base-model forward pass per persona × 20 questions).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import torch
+
+from explore_persona_space.analysis.representation_shift import (
+    compute_cosine_matrix,
+    extract_centroids,
+)
+from explore_persona_space.experiments.contrastive_neg_geometry_472 import (
+    BASE_MODEL,
+    CENTROID_LAYERS,
+)
+from explore_persona_space.personas import EVAL_QUESTIONS
+
+log = logging.getLogger("issue_472.centroids")
+
+OUT_DIR = Path("data/issue_472")
+
+
+def _centroids_path(layer: int, out_dir: Path = OUT_DIR) -> Path:
+    return out_dir / f"centroids_L{layer}.pt"
+
+
+def build_centroids(
+    persona_bank: dict[str, str],
+    *,
+    layers: tuple[int, ...] = CENTROID_LAYERS,
+    questions: list[str] | None = None,
+    base_model: str = BASE_MODEL,
+    out_dir: Path = OUT_DIR,
+    device: str = "cuda:0",
+) -> dict[int, Path]:
+    """Extract base-model centroids over the bank and write per-layer .pt bundles.
+
+    Each bundle holds: ``centroids`` (n_personas × hidden_dim, float32),
+    ``persona_names`` (ordered), ``cos_matrix`` (n × n, centering="none"),
+    ``layer``, ``base_model``.
+
+    Args:
+        persona_bank: name -> system prompt for the full ~60-persona bank.
+        layers: centroid layers to extract (default 10/15/20).
+        questions: eval questions to average over (default EVAL_QUESTIONS, 20).
+        base_model: HF model id.
+        out_dir: directory for centroids_L{layer}.pt.
+        device: device string.
+
+    Returns:
+        dict layer -> written path.
+    """
+    if questions is None:
+        questions = list(EVAL_QUESTIONS)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    log.info(
+        "Extracting base centroids: %d personas × %d questions, layers=%s",
+        len(persona_bank),
+        len(questions),
+        layers,
+    )
+    centroids, persona_names = extract_centroids(
+        model_path=base_model,
+        personas=persona_bank,
+        questions=questions,
+        layers=list(layers),
+        device=device,
+    )
+
+    written: dict[int, Path] = {}
+    for layer in layers:
+        c = centroids[layer]  # (n, d) float32 on CPU
+        cos = compute_cosine_matrix(c, centering="none")  # (n, n)
+        path = _centroids_path(layer, out_dir)
+        torch.save(
+            {
+                "centroids": c,
+                "persona_names": persona_names,
+                "cos_matrix": cos,
+                "layer": layer,
+                "base_model": base_model,
+                "questions": questions,
+            },
+            path,
+        )
+        log.info("Wrote centroids+cos L%d (%d personas) → %s", layer, len(persona_names), path)
+        written[layer] = path
+    return written
+
+
+def load_cos_matrix(
+    layer: int, out_dir: Path = OUT_DIR
+) -> tuple[dict[str, dict[str, float]], list[str]]:
+    """Load the persona×persona cosine matrix for ``layer`` as a name-keyed dict.
+
+    Returns ``(cos[a][b], persona_names)`` where ``cos[a][b]`` is the
+    centering="none" cosine between persona a and b centroids.
+
+    Raises FileNotFoundError if the bundle is absent.
+    """
+    path = _centroids_path(layer, out_dir)
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Centroid bundle for layer {layer} missing at {path}. Run Phase 0.5 "
+            f"(centroids.build_centroids) first."
+        )
+    bundle = torch.load(path, weights_only=False)
+    names: list[str] = list(bundle["persona_names"])
+    cos_t: torch.Tensor = bundle["cos_matrix"]
+    cos: dict[str, dict[str, float]] = {}
+    for i, a in enumerate(names):
+        cos[a] = {b: float(cos_t[i, j].item()) for j, b in enumerate(names)}
+    return cos, names
+
+
+def cos_to_source(
+    layer: int,
+    source: str,
+    out_dir: Path = OUT_DIR,
+) -> dict[str, float]:
+    """Return {persona: cos(persona, source)} for every persona in the bank.
+
+    High cosine = near the source. ``select_negatives`` sorts on this to pick
+    near/far/spread negatives.
+    """
+    cos, names = load_cos_matrix(layer, out_dir)
+    if source not in cos:
+        raise KeyError(
+            f"Source {source!r} not in centroid bundle (layer {layer}). "
+            f"Available: {sorted(names)[:10]}..."
+        )
+    return dict(cos[source])

--- a/src/explore_persona_space/experiments/contrastive_neg_geometry_472/eval_one_cell.py
+++ b/src/explore_persona_space/experiments/contrastive_neg_geometry_472/eval_one_cell.py
@@ -1,0 +1,320 @@
+# ruff: noqa: RUF002  # em-dash + Qwen marker token " ※" are intentional
+"""Task #472 — DV-A vLLM prompt_logprobs slot machinery (forked from #448).
+
+This module is the on-policy ``log P(※)`` primitive (DV-A). The slot-construction
+helpers (``_build_full_ids``, ``build_train_equivalent_full_ids``, MARKER_SEP, the
+off-by-one + token-equality guards) are forked VERBATIM from #448's eval_one_cell
+because they encode the load-bearing train-vs-eval token-equality contract (round-2
+C1: the ``\n\n`` separator that materializes the BPE-fused ``'.\n\n'`` token (id
+382) before the marker — without it the marker is scored after a context the
+trained model never saw).
+
+The DV is read at the slot immediately after the model's OWN on-policy response
+R (frozen base greedy, from r_generate), trained − base on the SAME R.
+
+vLLM ``prompt_logprobs=1`` returns only the top-1 + requested token's log-prob at
+each slot — NOT the full vocab. So this path computes DV-A (the single-token
+marker log-prob) only; DV-B (full-vocab KL) uses the HF teacher-force path in
+eval_trajectory (plan §4.6 + assumption 8).
+
+The eval_trajectory rig imports ``score_logp_for_R`` to read DV-A at each
+checkpoint on freshly-generated on-policy R. There is no standalone CLI main here
+(the trajectory rig drives it); the base-panel b_logprob path uses
+``score_logp_for_R`` with adapter_path=None.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from explore_persona_space.experiments.contrastive_neg_geometry_472 import (
+    EXPECTED_MARKER_TOKEN_ID,
+    MARKER_SEP,
+    MARKER_TEXT,
+)
+
+log = logging.getLogger("issue_472.eval_one_cell")
+
+LOGP_FLOOR = -50.0  # off-by-one guard: clamp; warn loud if >1% clamp.
+# Number of tokens immediately before the marker slot that MUST be byte-identical
+# between train and eval (train-vs-eval token-equality contract). 2 covers the
+# fused separator + last R sub-token (the largest BPE-merge boundary here).
+MARKER_PRECEDING_K_TOKENS = 2
+# A probe whose OWN on-policy R is dominated by marker tokens (repetition collapse:
+# the trained model emits ` ※ ※ ※ …` instead of answering) is a DEGENERATE
+# max-leakage case, NOT graded leakage. log P(※ | …※ ※ ※) ≈ ceiling is
+# repetition self-feedback, not "the marker leaks after a normal response."
+# We flag (never silently score-as-graded) any probe whose R is ≥ this fraction
+# markers. Threshold matches the analyze.py saturation logic; tune via smoke.
+R_COLLAPSE_MARKER_FRACTION = 0.5
+
+
+def assert_marker_token(
+    tokenizer, marker_text: str = MARKER_TEXT, expected_id: int = EXPECTED_MARKER_TOKEN_ID
+) -> None:
+    ids = tokenizer.encode(marker_text, add_special_tokens=False)
+    if ids != [expected_id]:
+        raise RuntimeError(
+            f"Marker tokenization mismatch. Expected MARKER_TEXT={marker_text!r} to "
+            f"encode to [{expected_id}]; got {ids}."
+        )
+
+
+def build_train_equivalent_full_ids(
+    tokenizer,
+    persona_prompt: str | None,
+    question: str,
+    r_text: str,
+    marker_text: str,
+    marker_id: int,
+    sep: str = MARKER_SEP,
+) -> list[int]:
+    """Build the EXACT token-id sequence training emits, up to + incl. the marker.
+
+    Forked from #448. Training renders assistant content as
+    ``f"{r_text}{sep}{marker_text}"`` inside the chat-template wrapper then
+    tokenizes the whole string; to read log P(marker) at the SAME slot the model
+    was optimized on, eval must produce the same prefix. This helper is both the
+    eval prefix builder AND the ground-truth reference for the token-equality
+    assertion.
+    """
+    if persona_prompt is None:
+        prompt_msgs = [{"role": "user", "content": question}]
+    else:
+        prompt_msgs = [
+            {"role": "system", "content": persona_prompt},
+            {"role": "user", "content": question},
+        ]
+    completion_msgs = [{"role": "assistant", "content": f"{r_text}{sep}{marker_text}"}]
+    full_train_text = tokenizer.apply_chat_template(prompt_msgs + completion_msgs, tokenize=False)
+    full_train_ids = tokenizer.encode(full_train_text, add_special_tokens=False)
+    if marker_id not in full_train_ids:
+        raise RuntimeError(
+            f"train-equivalent encoding missing marker_id={marker_id}; r_text={r_text[:40]!r}"
+        )
+    last_marker_pos = max(i for i, t in enumerate(full_train_ids) if t == marker_id)
+    return full_train_ids[: last_marker_pos + 1]
+
+
+def build_full_ids(
+    tokenizer,
+    persona_prompt: str | None,
+    question: str,
+    r_text: str,
+    marker_text: str,
+    marker_id: int,
+    persona_for_log: str,
+    q_for_log: str,
+    sep: str = MARKER_SEP,
+) -> tuple[list[int], int, int, int, int]:
+    """Construct the full token-id sequence for one eval probe (forked from #448).
+
+    Returns ``(full_ids, prompt_len, R_len, slot, n_marker_in_R)`` where ``slot``
+    is the APPENDED post-R marker position and ``n_marker_in_R`` is how many
+    marker tokens appear INSIDE R (before the appended one).
+
+    Asserts (each raises with persona+q context):
+      1. The APPENDED marker is the LAST token (off-by-one guard:
+         ``full_ids[-1] == marker_id``).
+      2. ``full_ids[:len(prompt_ids)] == prompt_ids`` (prompt prefix intact).
+      3. The K tokens before the marker (+marker) match the train-equivalent
+         sequence (the train-vs-eval token-equality contract, round-2 C1).
+
+    #472 fix (vs the #448 fork): the ``count == 1`` invariant is REMOVED. #448's R
+    came from the marker-FREE BASE model, so any marker in ``full_ids`` had to be
+    the single appended one. #472 reads the DV on the TRAINED model's OWN on-policy
+    R, which legitimately CONTAINS markers — that IS the leakage we measure. A
+    256-``※`` repetition-collapse R is a degenerate max-leakage case, not a token
+    drift, and must NOT crash the eval. We still assert the LAST token is the
+    appended marker (the scoring slot is well-defined) and the K-token-equality
+    contract (the slot's local context matches training). The marker-in-R count is
+    returned so the caller can flag a collapsed-R probe as a degenerate (not
+    graded) leakage category. See plan §4.6 + .claude/rules/marker-leakage-measurement.md.
+    """
+    if persona_prompt is None:
+        messages = [{"role": "user", "content": question}]
+    else:
+        messages = [
+            {"role": "system", "content": persona_prompt},
+            {"role": "user", "content": question},
+        ]
+    prompt_text = tokenizer.apply_chat_template(
+        messages, tokenize=False, add_generation_prompt=True
+    )
+    prompt_ids = tokenizer.encode(prompt_text, add_special_tokens=False)
+    # C1 fix: include the `\n\n` separator that training emits.
+    full_ids = tokenizer.encode(prompt_text + r_text + sep + marker_text, add_special_tokens=False)
+    if full_ids[-1] != marker_id:
+        raise RuntimeError(
+            f"marker slot drift persona={persona_for_log!r} q={q_for_log!r}: "
+            f"full_ids[-1]={full_ids[-1]} (expected the APPENDED marker {marker_id} to be the "
+            f"LAST token at the scoring slot; count_in_seq={full_ids.count(marker_id)})."
+        )
+    if full_ids[: len(prompt_ids)] != prompt_ids:
+        raise RuntimeError(
+            f"prompt prefix drift persona={persona_for_log!r} q={q_for_log!r}: prompt_ids "
+            f"({len(prompt_ids)}) does not prefix full_ids ({len(full_ids)})."
+        )
+    train_equivalent_ids = build_train_equivalent_full_ids(
+        tokenizer, persona_prompt, question, r_text, marker_text, marker_id, sep=MARKER_SEP
+    )
+    k = MARKER_PRECEDING_K_TOKENS
+    eval_tail = full_ids[-(k + 1) :]
+    train_tail = train_equivalent_ids[-(k + 1) :]
+    if eval_tail != train_tail:
+        raise RuntimeError(
+            f"train/eval marker-slot context drift persona={persona_for_log!r} q={q_for_log!r}: "
+            f"eval last {k + 1} tokens={eval_tail} vs train last {k + 1} tokens={train_tail}. "
+            f"log P(marker | context) read at the WRONG position (C1 contract)."
+        )
+    slot = len(full_ids) - 1
+    prompt_len = len(prompt_ids)
+    r_len = slot - prompt_len
+    # Markers INSIDE R = total markers minus the single appended one at the slot.
+    n_marker_in_R = full_ids.count(marker_id) - 1
+    return full_ids, prompt_len, r_len, slot, n_marker_in_R
+
+
+def extract_marker_logprob_and_argmax(
+    outputs, slot_positions: list[int], marker_id: int, cell_label: str
+) -> tuple[list[float], list[bool]]:
+    """Read log-prob of ``marker_id`` at each row's slot + argmax==marker flag.
+
+    Forked from #448. Returns (logps clamped to LOGP_FLOOR, argmax==marker bools).
+    Raises if prompt_logprobs[slot] is None or marker_id missing.
+    """
+    logps: list[float] = []
+    argmax_marker: list[bool] = []
+    for out, slot in zip(outputs, slot_positions, strict=True):
+        slot_dict = out.prompt_logprobs[slot]
+        if slot_dict is None:
+            raise RuntimeError(
+                f"{cell_label}: prompt_logprobs[{slot}] is None; "
+                f"list len={len(out.prompt_logprobs)}"
+            )
+        if marker_id not in slot_dict:
+            top_5 = sorted(slot_dict.items(), key=lambda kv: -kv[1].logprob)[:5]
+            raise RuntimeError(
+                f"{cell_label}: MARKER_ID {marker_id} not in prompt_logprobs[{slot}]; "
+                f"top-5: {[(tid, round(lp.logprob, 3)) for tid, lp in top_5]}"
+            )
+        lp = float(slot_dict[marker_id].logprob)
+        logps.append(max(lp, LOGP_FLOOR))
+        top_id = max(slot_dict.items(), key=lambda kv: kv[1].logprob)[0]
+        argmax_marker.append(top_id == marker_id)
+    return logps, argmax_marker
+
+
+def score_logp_for_R(
+    llm,
+    tokenizer,
+    *,
+    r_by_persona_q: dict[str, dict[str, str]],
+    eval_personas: dict[str, str],
+    eval_questions: list[str],
+    cell_label: str,
+    use_lora: bool,
+    lora_request=None,
+    marker_text: str = MARKER_TEXT,
+    marker_id: int = EXPECTED_MARKER_TOKEN_ID,
+) -> dict[str, dict[str, dict[str, float | bool]]]:
+    """Score DV-A log P(※) at the post-R slot for a panel × question grid.
+
+    Args:
+        llm: a live vLLM ``LLM`` engine (caller owns its lifecycle / teardown).
+        tokenizer: HF tokenizer for the base model.
+        r_by_persona_q: on-policy R text, ``r[persona][q] -> response_text`` (the
+            model's OWN greedy answer to score the marker after; for the trained
+            pass this is the adapter's freshly-generated R, for the base pass the
+            same R is reused).
+        eval_personas: {persona: system_prompt} for the held-out panel.
+        eval_questions: question list.
+        cell_label: for log/error context.
+        use_lora: whether to pass ``lora_request`` to ``llm.generate``.
+        lora_request: vLLM LoRARequest (when use_lora).
+        marker_text, marker_id: marker constants.
+
+    Returns:
+        ``out[persona][q] = {"logp": float, "argmax_marker": bool,
+        "n_marker_in_R": int, "r_collapsed": bool}``. ``r_collapsed`` is True when
+        the model's OWN on-policy R is a marker-repetition collapse (degenerate
+        max-leakage, not graded — the analyzer drops it from the logP regression).
+    """
+    from vllm import SamplingParams
+
+    prompts_payload: list[dict] = []
+    slot_positions: list[int] = []
+    index_keys: list[tuple[str, str]] = []
+    # Per-probe R-collapse bookkeeping (keyed by index in index_keys).
+    n_marker_in_R_list: list[int] = []
+    r_len_list: list[int] = []
+    for persona, persona_prompt in eval_personas.items():
+        if persona not in r_by_persona_q:
+            raise KeyError(f"[{cell_label}] R missing persona {persona!r}.")
+        for q in eval_questions:
+            if q not in r_by_persona_q[persona]:
+                raise KeyError(f"[{cell_label}] R[{persona!r}] missing q {q!r}.")
+            r_text = r_by_persona_q[persona][q]
+            full_ids, _p, r_len, slot, n_marker_in_R = build_full_ids(
+                tokenizer, persona_prompt, q, r_text, marker_text, marker_id, persona, q
+            )
+            prompts_payload.append({"prompt_token_ids": full_ids})
+            slot_positions.append(slot)
+            index_keys.append((persona, q))
+            n_marker_in_R_list.append(n_marker_in_R)
+            r_len_list.append(r_len)
+
+    sp = SamplingParams(
+        n=1, temperature=0.0, top_p=1.0, max_tokens=1, prompt_logprobs=1, logprobs=1
+    )
+    gen_kwargs = {"lora_request": lora_request} if use_lora else {}
+    outputs = llm.generate(prompts_payload, sp, **gen_kwargs)
+    if len(outputs) != len(prompts_payload):
+        raise RuntimeError(
+            f"[{cell_label}] vLLM returned {len(outputs)} for {len(prompts_payload)} probes."
+        )
+    logps, argmax = extract_marker_logprob_and_argmax(
+        outputs, slot_positions, marker_id, cell_label
+    )
+
+    out: dict[str, dict[str, dict[str, float | bool]]] = {p: {} for p in eval_personas}
+    n_floor = 0
+    n_collapsed = 0
+    for (persona, q), lp, am, n_mk_R, r_len in zip(
+        index_keys, logps, argmax, n_marker_in_R_list, r_len_list, strict=True
+    ):
+        # Repetition-collapse flag: the model's OWN R is ≥R_COLLAPSE_MARKER_FRACTION
+        # marker tokens (it emitted ` ※ ※ ※ …` instead of answering). log P(※) at
+        # the post-R slot is then ceiling repetition self-feedback, NOT graded
+        # leakage — flag so the analyzer treats it as a degenerate max-leakage
+        # category (dropped from the graded logP regression, like a saturated row).
+        r_marker_fraction = (n_mk_R / r_len) if r_len > 0 else 0.0
+        r_collapsed = bool(n_mk_R > 0 and r_marker_fraction >= R_COLLAPSE_MARKER_FRACTION)
+        if r_collapsed:
+            n_collapsed += 1
+        out[persona][q] = {
+            "logp": float(lp),
+            "argmax_marker": bool(am),
+            "n_marker_in_R": int(n_mk_R),
+            "r_collapsed": r_collapsed,
+        }
+        if lp <= LOGP_FLOOR + 1e-6:
+            n_floor += 1
+    if n_collapsed:
+        log.warning(
+            "[%s] %d/%d probes had a REPETITION-COLLAPSED R (own response is mostly the "
+            "marker) — these are degenerate max-leakage, not graded; analyzer drops them "
+            "from the graded logP regression.",
+            cell_label,
+            n_collapsed,
+            len(index_keys),
+        )
+    if logps and n_floor / len(logps) > 0.01:
+        log.warning(
+            "[%s] logp floor-clamp rate %.2f%% (%d/%d) — investigate tokenizer/model drift.",
+            cell_label,
+            100.0 * n_floor / len(logps),
+            n_floor,
+            len(logps),
+        )
+    return out

--- a/src/explore_persona_space/experiments/contrastive_neg_geometry_472/eval_trajectory.py
+++ b/src/explore_persona_space/experiments/contrastive_neg_geometry_472/eval_trajectory.py
@@ -1,0 +1,477 @@
+# ruff: noqa: RUF002  # em-dash + Qwen marker token " ※" are intentional
+"""Task #472 — NEW on-policy trajectory eval rig (plan §4.6 — the #448-saturation fix).
+
+At EACH of the 6 training checkpoints, the trained adapter writes its OWN greedy
+answer R_j to every held-out (persona × q_eval) probe, and the DV is read at the
+slot immediately after R_j:
+  - DV-A (logP): vLLM ``prompt_logprobs`` (eval_one_cell.score_logp_for_R).
+    ΔG = trained log P(※) − base log P(※) on the SAME R_j.
+  - DV-B (full-vocab KL): HF teacher-forced forward pass over ``prompt + R_j +
+    \n\n`` → (N, 1, V) log-softmax at the SINGLE post-R marker slot for trained
+    and base, then ``compute_kl_divergence`` (NOT a seq-mean over R). vLLM
+    ``prompt_logprobs=1`` can't return full vocab → KL needs the HF path.
+  - Emission = (argmax == marker) at the same slot (free from DV-A).
+  - Source-self ΔG: ΔG on the SOURCE persona's own R (the validity gate + the
+    matched-slice anchor).
+
+This is NOT #448's MarkerTrajectoryCallback (teacher-forced, off-policy — the
+exact probe the body rejects, #432→#456). Each checkpoint generates fresh
+on-policy R.
+
+Framework-switch discipline (CLAUDE.md vLLM-teardown gotcha): the rig does ALL
+vLLM work first (per-checkpoint on-policy gen + DV-A trained + DV-A base on the
+same R; held-out panel + source), persists per-checkpoint, then tears vLLM down
+HARD (psutil child-kill + nvidia-smi PID check) and does ALL HF KL work — ONE
+framework switch per cell, not 12. Per-checkpoint files are written the moment
+each phase completes (checkpoint-per-phase rule + feedback_eval_rig_per_phase_checkpoint).
+
+The trajectory.json per cell × seed (plan §4.8):
+    {
+      "cell": ..., "seed": ..., "source": ..., "matched_slice_target_nats": 8.0,
+      "checkpoints": [
+        {"frac": 0.08, "step": 12, "adapter_path": ...,
+         "source_self": {"g_logp": .., "b_logp": .., "delta_g": ..},
+         "held_out": {persona: {q: {"g_logp":.., "b_logp":.., "delta_g":..,
+                                    "argmax_marker":bool, "kl": ..}}}},
+        ...],
+      "git_commit": ..., "timestamp_utc": ...
+    }
+"""
+
+from __future__ import annotations
+
+import gc
+import json
+import logging
+import os
+import socket
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+from explore_persona_space.experiments.contrastive_neg_geometry_472 import (
+    BASE_MODEL,
+    EXPECTED_MARKER_TOKEN_ID,
+    MARKER_SEP,
+    MARKER_TEXT,
+    MATCHED_SLICE_TARGET_NATS,
+    SOURCE_PERSONA,
+)
+from explore_persona_space.experiments.contrastive_neg_geometry_472.eval_one_cell import (
+    assert_marker_token,
+    score_logp_for_R,
+)
+
+log = logging.getLogger("issue_472.eval_trajectory")
+
+# The trajectory eval runs in a nested subprocess on the SAME GPU the cell
+# just trained the LoRA on (in-process train_one_cell). Even after the parent
+# frees the training tensors, vLLM's startup check compares its desired
+# fraction-of-TOTAL against FREE memory, so a high util trips
+# "Free memory < desired" when any train residual / reaping latency remains.
+# 0.60 (~47 GiB of an 80 GiB H100) leaves ample headroom for that residual
+# while still giving a large KV cache for greedy gen of the held-out panel.
+DEFAULT_GPU_MEM_UTIL = 0.60
+DEFAULT_MAX_MODEL_LEN = 2048
+DEFAULT_MAX_LORA_RANK = 32
+
+
+def _git_sha() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL, text=True, env={**os.environ}
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def _teardown_vllm_hard(llm) -> None:
+    """Tear vLLM down and FAIL LOUD if a worker still holds the GPU.
+
+    CLAUDE.md vLLM-teardown gotcha: del + destroy + gc + empty_cache is NOT
+    enough — TP/PP worker subprocesses survive and re-grab freed memory the
+    moment HF Transformers loads weights. We kill survivors + assert via
+    nvidia-smi. CVD-aware: only inspect GPUs visible to THIS process (the
+    feedback_orphan_pid_check_must_be_cvd_aware lesson).
+    """
+    import torch
+
+    try:
+        from vllm.distributed.parallel_state import (
+            destroy_distributed_environment,
+            destroy_model_parallel,
+        )
+
+        destroy_model_parallel()
+        destroy_distributed_environment()
+    except Exception as e:  # pragma: no cover - version-dependent symbol
+        log.warning("vLLM destroy helpers unavailable (%s); continuing teardown.", e)
+    del llm
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    # Reap surviving child processes (the worker subprocesses).
+    try:
+        import contextlib
+
+        import psutil
+
+        me = psutil.Process()
+        children = me.children(recursive=True)
+        for c in children:
+            with contextlib.suppress(psutil.NoSuchProcess):
+                c.terminate()
+        _gone, alive = psutil.wait_procs(children, timeout=10)
+        for c in alive:
+            with contextlib.suppress(psutil.NoSuchProcess):
+                c.kill()
+    except ImportError:  # pragma: no cover - psutil should be installed
+        log.warning("psutil unavailable; cannot reap vLLM worker subprocesses.")
+
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
+def _generate_on_policy_R(
+    llm,
+    tokenizer,
+    eval_personas: dict[str, str],
+    eval_questions: list[str],
+    lora_request,
+    max_new_tokens: int,
+) -> dict[str, dict[str, str]]:
+    """vLLM batched greedy gen of the TRAINED model's own R for the panel × q grid.
+
+    Persona injection ALWAYS via the system role. Returns r[persona][q] -> text.
+    """
+    from vllm import SamplingParams
+
+    prompts: list[str] = []
+    keys: list[tuple[str, str]] = []
+    for persona, persona_prompt in eval_personas.items():
+        for q in eval_questions:
+            messages = [
+                {"role": "system", "content": persona_prompt},
+                {"role": "user", "content": q},
+            ]
+            prompts.append(
+                tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+            )
+            keys.append((persona, q))
+    sp = SamplingParams(
+        n=1,
+        temperature=0.0,
+        top_p=1.0,
+        max_tokens=max_new_tokens,
+        stop_token_ids=[tokenizer.eos_token_id],
+    )
+    outputs = llm.generate(prompts, sp, lora_request=lora_request)
+    if len(outputs) != len(prompts):
+        raise RuntimeError(f"on-policy gen returned {len(outputs)} for {len(prompts)} prompts.")
+    r: dict[str, dict[str, str]] = {p: {} for p in eval_personas}
+    for (persona, q), out in zip(keys, outputs, strict=True):
+        r[persona][q] = out.outputs[0].text
+    return r
+
+
+def compute_kl_for_checkpoint(
+    *,
+    base_model: str,
+    adapter_path: str,
+    r_by_persona_q: dict[str, dict[str, str]],
+    eval_personas: dict[str, str],
+    eval_questions: list[str],
+    marker_text: str = MARKER_TEXT,
+    sep: str = MARKER_SEP,
+    device: str = "cuda:0",
+) -> dict[str, dict[str, float]]:
+    """DV-B: full-vocab KL(trained‖base) at the SINGLE post-R marker slot.
+
+    For each (persona, q): teacher-force ``prompt + R + sep`` through the trained
+    (base+adapter) model and the base model, take the next-token log-softmax at
+    the FINAL position (the slot the marker would occupy), and compute
+    ``compute_kl_divergence(log_p_trained, log_q_base)`` at THAT single slot (NOT
+    a seq-mean over R — plan §4.6).
+
+    Returns ``kl[persona][q] -> float``.
+    """
+    import torch
+    from peft import PeftModel
+    from transformers import AutoModelForCausalLM
+
+    from explore_persona_space.analysis.divergence import compute_kl_divergence
+
+    base = AutoModelForCausalLM.from_pretrained(
+        base_model,
+        torch_dtype=torch.bfloat16,
+        device_map={"": device},
+        trust_remote_code=True,
+        token=os.environ.get("HF_TOKEN"),
+    ).eval()
+    trained = AutoModelForCausalLM.from_pretrained(
+        base_model,
+        torch_dtype=torch.bfloat16,
+        device_map={"": device},
+        trust_remote_code=True,
+        token=os.environ.get("HF_TOKEN"),
+    )
+    trained = PeftModel.from_pretrained(trained, adapter_path).eval()
+
+    def _slot_logsoftmax(model, persona_prompt: str, q: str, r_text: str) -> torch.Tensor:
+        """Next-token log-softmax (V,) at the slot AFTER `prompt + R + sep`."""
+        messages = [
+            {"role": "system", "content": persona_prompt},
+            {"role": "user", "content": q},
+        ]
+        prompt_text = tokenizer.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
+        # The marker would be generated after `prompt + R + sep`; the slot is the
+        # next-token distribution at the LAST token of that prefix.
+        prefix = prompt_text + r_text + sep
+        ids = tokenizer.encode(prefix, add_special_tokens=False, return_tensors="pt").to(device)
+        with torch.no_grad():
+            logits = model(input_ids=ids).logits  # (1, T, V)
+        last = logits[0, -1, :].float()  # (V,)
+        return torch.log_softmax(last, dim=-1).cpu()
+
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(base_model, trust_remote_code=True)
+
+    kl: dict[str, dict[str, float]] = {p: {} for p in eval_personas}
+    for persona, persona_prompt in eval_personas.items():
+        for q in eval_questions:
+            r_text = r_by_persona_q[persona][q]
+            lp_trained = _slot_logsoftmax(trained, persona_prompt, q, r_text)
+            lp_base = _slot_logsoftmax(base, persona_prompt, q, r_text)
+            # compute_kl_divergence expects (seq, V); pass (1, V).
+            kl_val = compute_kl_divergence(lp_trained.unsqueeze(0), lp_base.unsqueeze(0))
+            kl[persona][q] = float(kl_val.item())
+
+    del base, trained
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    return kl
+
+
+def run_trajectory_eval(
+    *,
+    cell_slug: str,
+    seed: int,
+    checkpoint_specs: list[dict],
+    eval_personas: dict[str, str],
+    eval_questions: list[str],
+    source: str = SOURCE_PERSONA,
+    source_prompt: str,
+    out_path: Path,
+    base_model: str = BASE_MODEL,
+    max_new_tokens: int = 1024,
+    max_lora_rank: int = DEFAULT_MAX_LORA_RANK,
+    gpu_memory_utilization: float = DEFAULT_GPU_MEM_UTIL,
+    max_model_len: int = DEFAULT_MAX_MODEL_LEN,
+    compute_kl: bool = True,
+) -> Path:
+    """Run the on-policy trajectory eval for one cell × seed.
+
+    Args:
+        cell_slug, seed: cell identity.
+        checkpoint_specs: list of {"frac": float, "step": int, "adapter_path": str}.
+        eval_personas: held-out panel {persona: system_prompt}.
+        eval_questions: Q_eval.
+        source, source_prompt: source persona (for source-self ΔG validity gate).
+        out_path: trajectory.json output.
+        base_model, max_new_tokens, max_lora_rank, gpu_memory_utilization,
+            max_model_len: vLLM params.
+        compute_kl: if False, skip DV-B (smoke speed-up).
+
+    Returns:
+        out_path.
+    """
+    from transformers import AutoTokenizer
+    from vllm import LLM
+    from vllm.lora.request import LoRARequest
+
+    tokenizer = AutoTokenizer.from_pretrained(base_model, trust_remote_code=True)
+    assert_marker_token(tokenizer)
+
+    panel_plus_source = dict(eval_personas)
+    panel_plus_source.setdefault(source, source_prompt)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    # Per-checkpoint partial file (resume-safe + crash-safe per CLAUDE.md).
+    partial_path = out_path.with_suffix(".partial.json")
+
+    # ── Phase A: ALL vLLM work (gen + DV-A trained + DV-A base) per checkpoint. ─
+    llm = LLM(
+        model=base_model,
+        dtype="bfloat16",
+        gpu_memory_utilization=gpu_memory_utilization,
+        seed=seed,
+        max_model_len=max_model_len,
+        enable_lora=True,
+        max_lora_rank=max_lora_rank,
+        max_loras=1,
+    )
+
+    checkpoints_out: list[dict] = []
+    r_cache: dict[float, dict[str, dict[str, str]]] = {}  # frac -> on-policy R (for KL phase)
+    for spec in checkpoint_specs:
+        frac = spec["frac"]
+        adapter_path = spec["adapter_path"]
+        label = f"{cell_slug}_seed{seed}_frac{frac}"
+        lora_req = LoRARequest(lora_name=label, lora_int_id=1, lora_path=adapter_path)
+        log.info("[phase=traj_vllm] %s: on-policy gen + DV-A", label)
+
+        # 1. Trained model writes its OWN R for held-out panel + source.
+        r_on_policy = _generate_on_policy_R(
+            llm, tokenizer, panel_plus_source, eval_questions, lora_req, max_new_tokens
+        )
+        r_cache[frac] = r_on_policy
+
+        # 2. DV-A trained log P(※) at post-R slot (on the trained model's own R).
+        g = score_logp_for_R(
+            llm,
+            tokenizer,
+            r_by_persona_q=r_on_policy,
+            eval_personas=panel_plus_source,
+            eval_questions=eval_questions,
+            cell_label=f"TRAINED/{label}",
+            use_lora=True,
+            lora_request=lora_req,
+        )
+        # 3. DV-A base log P(※) at the SAME slot on the SAME R (lora_request=None).
+        b = score_logp_for_R(
+            llm,
+            tokenizer,
+            r_by_persona_q=r_on_policy,
+            eval_personas=panel_plus_source,
+            eval_questions=eval_questions,
+            cell_label=f"BASE/{label}",
+            use_lora=False,
+        )
+
+        held_out: dict[str, dict[str, dict[str, float | bool]]] = {}
+        n_collapsed_ck = 0
+        for persona in eval_personas:
+            held_out[persona] = {}
+            for q in eval_questions:
+                gl = g[persona][q]["logp"]
+                bl = b[persona][q]["logp"]
+                # r_collapsed is read from the TRAINED model's score (g): it is the
+                # trained model's OWN on-policy R that may collapse to marker-spam.
+                r_collapsed = bool(g[persona][q].get("r_collapsed", False))
+                if r_collapsed:
+                    n_collapsed_ck += 1
+                held_out[persona][q] = {
+                    "g_logp": gl,
+                    "b_logp": bl,
+                    "delta_g": gl - bl,
+                    "argmax_marker": g[persona][q]["argmax_marker"],
+                    "n_marker_in_R": int(g[persona][q].get("n_marker_in_R", 0)),
+                    "r_collapsed": r_collapsed,
+                    "kl": None,  # filled in Phase B.
+                }
+        # Source-self mean ΔG over Q_eval (validity gate + matched-slice anchor).
+        src_deltas = [g[source][q]["logp"] - b[source][q]["logp"] for q in eval_questions]
+        # Source-self collapse: did the SOURCE's own R collapse to marker-spam at
+        # this checkpoint? If yes, source-self ΔG is repetition-ceiling, so the
+        # matched-slice (8±1 nat) anchor read at this checkpoint is post-collapse
+        # — the analyzer must prefer an EARLIER, non-collapsed checkpoint.
+        src_collapsed = any(bool(g[source][q].get("r_collapsed", False)) for q in eval_questions)
+        # DV-C: source emission rate P(※) = share of Q_eval where the trained
+        # model's argmax at the post-R slot is the marker (#477 validity gate;
+        # plan §6 DV-C). Computed from the SAME g[source][q]["argmax_marker"]
+        # already produced by score_logp_for_R; backward-compat for #472 (extra
+        # field; no existing reader breaks).
+        n_src_q = len(eval_questions)
+        src_emission_p = (
+            sum(1 for q in eval_questions if g[source][q].get("argmax_marker")) / n_src_q
+            if n_src_q
+            else 0.0
+        )
+        source_self = {
+            "g_logp_mean": sum(g[source][q]["logp"] for q in eval_questions) / len(eval_questions),
+            "b_logp_mean": sum(b[source][q]["logp"] for q in eval_questions) / len(eval_questions),
+            "delta_g_mean": sum(src_deltas) / len(src_deltas),
+            "emission_p": float(src_emission_p),
+            "r_collapsed": src_collapsed,
+        }
+        n_held_out_probes = len(eval_personas) * len(eval_questions)
+        held_out_collapse_share = n_collapsed_ck / n_held_out_probes if n_held_out_probes else 0.0
+        checkpoints_out.append(
+            {
+                "frac": frac,
+                "step": spec.get("step"),
+                "adapter_path": adapter_path,
+                "source_self": source_self,
+                "held_out_collapse_share": held_out_collapse_share,
+                "n_held_out_collapsed": n_collapsed_ck,
+                "held_out": held_out,
+            }
+        )
+        # Persist partial after each checkpoint's vLLM phase (crash-safe).
+        partial_path.write_text(
+            json.dumps({"cell": cell_slug, "seed": seed, "checkpoints": checkpoints_out}, indent=2)
+        )
+        log.info(
+            "[phase=traj_vllm] %s done: source-self ΔG=%.2f nats, source_R_collapsed=%s, "
+            "held-out R-collapse share=%.2f (%d/%d)",
+            label,
+            source_self["delta_g_mean"],
+            src_collapsed,
+            held_out_collapse_share,
+            n_collapsed_ck,
+            n_held_out_probes,
+        )
+
+    _teardown_vllm_hard(llm)
+
+    # ── Phase B: ALL HF full-vocab KL work (one framework switch). ────────────
+    if compute_kl:
+        for ck in checkpoints_out:
+            frac = ck["frac"]
+            adapter_path = ck["adapter_path"]
+            log.info("[phase=traj_kl] %s_seed%s_frac%s: DV-B full-vocab KL", cell_slug, seed, frac)
+            kl = compute_kl_for_checkpoint(
+                base_model=base_model,
+                adapter_path=adapter_path,
+                r_by_persona_q=r_cache[frac],
+                eval_personas=eval_personas,
+                eval_questions=eval_questions,
+            )
+            for persona in eval_personas:
+                for q in eval_questions:
+                    ck["held_out"][persona][q]["kl"] = kl[persona][q]
+            partial_path.write_text(
+                json.dumps(
+                    {"cell": cell_slug, "seed": seed, "checkpoints": checkpoints_out}, indent=2
+                )
+            )
+
+    payload = {
+        "schema_version": "i472_v1",
+        "cell": cell_slug,
+        "seed": seed,
+        "source": source,
+        "marker_text": MARKER_TEXT,
+        "marker_token_id": EXPECTED_MARKER_TOKEN_ID,
+        "matched_slice_target_nats": MATCHED_SLICE_TARGET_NATS,
+        "n_held_out_personas": len(eval_personas),
+        "held_out_personas": sorted(eval_personas.keys()),
+        "n_eval_questions": len(eval_questions),
+        "eval_questions": eval_questions,
+        "kl_computed": compute_kl,
+        "checkpoints": checkpoints_out,
+        "git_commit": _git_sha(),
+        "hostname": socket.gethostname(),
+        "timestamp_utc": datetime.now(UTC).isoformat(),
+    }
+    out_path.write_text(json.dumps(payload, indent=2))
+    if partial_path.exists():
+        partial_path.unlink()
+    log.info("[phase=traj_done] Wrote trajectory → %s", out_path)
+    return out_path

--- a/src/explore_persona_space/experiments/contrastive_neg_geometry_472/persona_bank.py
+++ b/src/explore_persona_space/experiments/contrastive_neg_geometry_472/persona_bank.py
@@ -1,0 +1,288 @@
+# em-dash + Qwen marker token " ※" are intentional
+"""Task #472 Phase 0 — persona bank (extend EVAL_PERSONAS_24 → ~60).
+
+Plan §4.2 (THE load-bearing density decision). The geometry regression that
+broke #448's secondary needs held-out probes disjoint from EVERY arm's negatives
+across ALL placement arms. With the 24-panel: source (1) + the union of
+negatives across the Near/Far/Spread arms (~14) ⇒ only ~9 disjoint held-out
+probes ⇒ ~27 pooled rows. With ~60: ~45 disjoint probes ⇒ ~135 pooled rows —
+enough to fit a 2-predictor partial regression with the cross-arm collinearity
+actually broken.
+
+Construction: keep the 24 panel personas, generate ~36 NEW short persona system
+prompts (Sonnet 4.5, one batched async call; same register as the panel: "You
+are a {role}.") spanning occupations / archetypes / fictional roles to populate
+the distance range — deliberately seeding "behind-the-front," "beside-the-front,"
+and "orthogonal-far" regions relative to villain. Centroids are computed ONCE
+over the full bank downstream (centroids.py).
+
+The bank is content-hashed + cached to ``data/issue_472/persona_bank.json`` and
+uploaded to the HF data repo so any pod / re-run reads the SAME bank.
+
+Model-call-vs-code (CLAUDE.md 3.0 paradigm): persona-bank generation IS a model
+call (open-ended text generation of system prompts) — correct to use Sonnet, not
+code. The rest of the pipeline (DV log-prob / KL at a token slot) is numeric and
+stays in code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as _dt
+import hashlib
+import json
+import logging
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+
+from explore_persona_space.experiments.contrastive_neg_geometry_472 import (
+    PERSONA_BANK_FLOOR,
+    PERSONA_BANK_N_NEW,
+    SOURCE_PERSONA,
+)
+
+load_dotenv()
+
+log = logging.getLogger("issue_472.persona_bank")
+
+OUT_DIR = Path("data/issue_472")
+BANK_PATH = OUT_DIR / "persona_bank.json"
+HF_DATA_REPO = "superkaiba1/explore-persona-space-data"
+HF_BANK_PATH_IN_REPO = "issue472_neg_geometry/persona_bank.json"
+
+SONNET_MODEL = "claude-sonnet-4-5-20250929"
+SCHEMA_VERSION = "i472_v1"
+
+# The generation prompt deliberately asks for personas spanning the distance
+# range relative to the villain source so the held-out panel populates
+# behind/beside/orthogonal-far regions (plan §4.2). The register matches the
+# existing panel ("You are a {role}.").
+_PERSONA_GEN_SYSTEM = (
+    "You are helping build a diverse panel of persona system prompts for an "
+    "interpretability experiment. Each persona is a short one-sentence system "
+    "prompt of the form 'You are a {role}.' or 'You are a {role} who {clause}.'."
+)
+
+
+def _persona_gen_user(n_new: int, existing_names: list[str], source_prompt: str) -> str:
+    existing = ", ".join(sorted(existing_names))
+    return (
+        f"I already have these personas: {existing}.\n\n"
+        f"The experiment studies how a 'source' persona — {source_prompt!r} — "
+        f"relates geometrically to a wide cast of other personas. Generate "
+        f"{n_new} NEW persona system prompts that DO NOT duplicate the existing "
+        f"set and that deliberately SPAN a wide range of similarity to the "
+        f"source persona: include some that are conceptually close to a "
+        f"scheming/villainous/power-seeking archetype (e.g. con artist, dictator, "
+        f"corporate raider), some that are mid-range everyday occupations, and "
+        f"some that are as far/orthogonal as possible (e.g. gentle nature guide, "
+        f"meditation teacher, gardener). Mix occupations, archetypes, and "
+        f"fictional roles.\n\n"
+        f"Return ONLY a JSON array of objects, each with keys 'name' "
+        f"(short snake_case identifier, e.g. 'con_artist') and 'prompt' (the "
+        f"one-sentence system prompt). No prose, no markdown fences."
+    )
+
+
+def _git_commit_hash() -> str:
+    try:
+        return (
+            subprocess.check_output(
+                ["git", "rev-parse", "HEAD"],
+                stderr=subprocess.DEVNULL,
+                env={**os.environ},
+            )
+            .decode()
+            .strip()
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def _content_hash(bank: dict[str, str]) -> str:
+    blob = json.dumps(bank, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+def _slugify(name: str) -> str:
+    """Normalize an LLM-proposed name into a snake_case identifier."""
+    s = re.sub(r"[^a-z0-9]+", "_", name.strip().lower())
+    return s.strip("_")
+
+
+def _extract_json_array(text: str) -> list[dict]:
+    """Parse a JSON array of {name, prompt} from the model's reply.
+
+    Tolerates accidental ```json fences; fails loud (no silent default) if no
+    array is recoverable — per CLAUDE.md fail-fast.
+    """
+    cleaned = text.strip()
+    cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned)
+    cleaned = re.sub(r"\s*```$", "", cleaned)
+    start = cleaned.find("[")
+    end = cleaned.rfind("]")
+    if start == -1 or end == -1 or end <= start:
+        raise ValueError(
+            f"Sonnet persona reply did not contain a JSON array. First 200 chars: {cleaned[:200]!r}"
+        )
+    arr = json.loads(cleaned[start : end + 1])
+    if not isinstance(arr, list):
+        raise ValueError("Parsed persona payload is not a list.")
+    return arr
+
+
+async def _call_sonnet(n_new: int, existing_names: list[str], source_prompt: str) -> str:
+    """Single async Sonnet 4.5 call returning the raw reply text."""
+    import anthropic
+
+    client = anthropic.AsyncAnthropic()
+    resp = await client.messages.create(
+        model=SONNET_MODEL,
+        max_tokens=4096,
+        system=_PERSONA_GEN_SYSTEM,
+        messages=[
+            {"role": "user", "content": _persona_gen_user(n_new, existing_names, source_prompt)}
+        ],
+    )
+    return "".join(block.text for block in resp.content if block.type == "text")
+
+
+def _base_panel_personas() -> dict[str, str]:
+    """The 24-panel personas (always kept in the bank)."""
+    from explore_persona_space.experiments.factor_screen_365.persona_panel import (
+        EVAL_PERSONAS_24,
+    )
+
+    return dict(EVAL_PERSONAS_24)
+
+
+def build_persona_bank(
+    *,
+    n_new: int = PERSONA_BANK_N_NEW,
+    out_path: Path = BANK_PATH,
+    source: str = SOURCE_PERSONA,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Build (and cache) the ~60-persona bank.
+
+    Keeps the 24 panel personas verbatim, then asks Sonnet for ``n_new`` new
+    personas spanning the distance range. Deduplicates by name AND by prompt
+    text. Fails loud if the realized bank is below the floor (plan §4.2).
+
+    Args:
+        n_new: Number of new personas to request from Sonnet.
+        out_path: Local JSON output path.
+        source: Source persona name (for the generation prompt framing).
+        dry_run: If True, skip the Sonnet call and validate the base panel only.
+
+    Returns:
+        Summary dict (paths, hash, sizes). The bank itself is written to
+        ``out_path`` under key ``personas`` (name -> system prompt).
+
+    Raises:
+        ValueError if the realized bank is below ``PERSONA_BANK_FLOOR`` or the
+        source persona is missing from the bank.
+    """
+    base = _base_panel_personas()
+    if source not in base:
+        raise ValueError(
+            f"Source persona {source!r} not in EVAL_PERSONAS_24; cannot frame the "
+            f"persona-bank generation prompt. Panel keys: {sorted(base)}."
+        )
+
+    if dry_run:
+        log.info("persona_bank DRY-RUN: base panel has %d personas (no Sonnet call).", len(base))
+        return {"status": "dry_run_validated", "n_base": len(base)}
+
+    source_prompt = base[source]
+    existing_names = list(base.keys())
+    reply = asyncio.run(_call_sonnet(n_new, existing_names, source_prompt))
+    proposed = _extract_json_array(reply)
+
+    bank: dict[str, str] = dict(base)
+    existing_prompts = {p.strip(): n for n, p in base.items()}
+    n_added = 0
+    n_dup_name = 0
+    n_dup_prompt = 0
+    for obj in proposed:
+        if not isinstance(obj, dict) or "name" not in obj or "prompt" not in obj:
+            log.warning("Skipping malformed persona object: %r", obj)
+            continue
+        name = _slugify(str(obj["name"]))
+        prompt = str(obj["prompt"]).strip()
+        if not name or not prompt:
+            continue
+        if name in bank:
+            n_dup_name += 1
+            continue
+        if prompt in existing_prompts:
+            n_dup_prompt += 1
+            continue
+        bank[name] = prompt
+        existing_prompts[prompt] = name
+        n_added += 1
+
+    n_total = len(bank)
+    log.info(
+        "Persona bank built: %d base + %d new = %d total (dup_name=%d, dup_prompt=%d)",
+        len(base),
+        n_added,
+        n_total,
+        n_dup_name,
+        n_dup_prompt,
+    )
+    if n_total < PERSONA_BANK_FLOOR:
+        raise ValueError(
+            f"Realized persona bank ({n_total}) is below the floor "
+            f"({PERSONA_BANK_FLOOR}). Sonnet returned too few usable personas "
+            f"({n_added} new after dedup). Re-run persona-bank generation (raise "
+            f"n_new) or fall back to the 24-panel per plan §4.2."
+        )
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    bank_hash = _content_hash(bank)
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "source_persona": source,
+        "n_base": len(base),
+        "n_new": n_added,
+        "n_total": n_total,
+        "personas": bank,
+        "content_hash": bank_hash,
+        "git_commit": _git_commit_hash(),
+        "generated_at": _dt.datetime.now(_dt.UTC).isoformat(),
+        "sonnet_model": SONNET_MODEL,
+    }
+    out_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+    log.info("Persona bank written → %s (sha256[:12]=%s)", out_path, bank_hash[:12])
+    return {
+        "status": "built",
+        "bank_path": str(out_path),
+        "content_hash": bank_hash,
+        "n_total": n_total,
+        "n_new": n_added,
+    }
+
+
+def load_persona_bank(path: Path = BANK_PATH) -> dict[str, str]:
+    """Load the persona bank (name -> system prompt).
+
+    Raises FileNotFoundError if absent, AssertionError on schema drift.
+    """
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Persona bank missing at {path}. Run Phase 0 (persona_bank.build_persona_bank) "
+            f"or pull from HF data repo {HF_DATA_REPO}/{HF_BANK_PATH_IN_REPO}."
+        )
+    payload = json.loads(path.read_text())
+    sv = payload.get("schema_version")
+    if sv != SCHEMA_VERSION:
+        raise AssertionError(
+            f"Persona bank at {path} has schema_version={sv!r}, expected {SCHEMA_VERSION!r}."
+        )
+    return payload["personas"]

--- a/src/explore_persona_space/experiments/contrastive_neg_geometry_472/r_generate.py
+++ b/src/explore_persona_space/experiments/contrastive_neg_geometry_472/r_generate.py
@@ -1,0 +1,392 @@
+# ruff: noqa: RUF002  # em-dash + Qwen marker token " ※" are intentional
+"""Task #472 Phase 1 — base-model on-policy R generation (forked from #448 §4.3).
+
+The on-policy correction: every training row and every eval probe reads R(persona,
+q) from a single frozen base-model greedy completion under THAT persona's system
+prompt. The DV then measures the adapter-induced shift in log P(` ※`) at the slot
+after R, with no canned-canonical-response off-policy artifact (the #432→#456
+construct-validity lesson).
+
+#472 differences from #448's r_generate:
+- The R universe is the WHOLE persona bank ∪ {no_persona} (not a #411-cell-derived
+  training-side set). Generating R for every bank persona means ANY persona can be
+  a positive / negative / held-out probe with no missing-key risk (the #448
+  Must-Fix-1 KeyError class is eliminated by construction).
+- Train/eval question split: Q_train and Q_eval are DISJOINT subsets of
+  EVAL_QUESTIONS (default 10/10) so the LoRA learns "append the marker after ANY
+  natural response," not a memorized response→marker pairing
+  (.claude/rules/marker-leakage-measurement.md). R_train covers Q_train; R_eval
+  covers Q_eval. Both are generated for EVERY bank persona.
+
+Two output artifacts (content-hashed for the train/eval consistency contract):
+- ``data/issue_472/on_policy_R/R_train.json`` — per (persona, q∈Q_train).
+- ``data/issue_472/on_policy_R/R_eval.json``  — per (persona, q∈Q_eval).
+
+Hard checks (forked verbatim from #448 r_generate):
+  - Marker token id 83399 MUST NOT appear in any generated R (text + token-id).
+  - Truncation rate (n_tokens==max_new AND not ended_with_eos) ≤ 5% per split.
+  - EXIT assertion: bank ∪ {no_persona} ⊆ R_train.keys() and ⊆ R_eval.keys().
+
+GPU only (vLLM batched greedy decode).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from explore_persona_space.experiments.contrastive_neg_geometry_472 import (
+    BASE_MODEL,
+    EXPECTED_MARKER_TOKEN_ID,
+    HF_DATA_PREFIX,
+    HF_DATA_REPO,
+    MARKER_TEXT,
+    MAX_NEW_TOKENS_GEN,
+)
+from explore_persona_space.personas import EVAL_QUESTIONS
+
+log = logging.getLogger("issue_472.r_generate")
+
+OUT_DIR = Path("data/issue_472/on_policy_R")
+HF_PATH_PREFIX = f"{HF_DATA_PREFIX}/on_policy_R"
+
+TRUNCATION_FAIL_THRESHOLD = 0.05
+DEFAULT_TEMPERATURE = 0.0
+DEFAULT_SEED = 42
+DEFAULT_MAX_MODEL_LEN = 2048
+NO_PERSONA_KEY = "no_persona"
+SCHEMA_VERSION = "i472_v1"
+
+# Train/eval question split — disjoint subsets of EVAL_QUESTIONS (plan §10 +
+# marker-leakage rule "different R for train vs eval"). First half trains, second
+# half evals. Both cover every bank persona.
+N_TRAIN_QUESTIONS = 10
+
+
+def get_train_eval_questions(
+    questions: list[str] | None = None,
+    n_train: int = N_TRAIN_QUESTIONS,
+) -> tuple[list[str], list[str]]:
+    """Return (Q_train, Q_eval) as a disjoint split of ``questions``."""
+    qs = list(questions) if questions is not None else list(EVAL_QUESTIONS)
+    if n_train >= len(qs):
+        raise ValueError(
+            f"n_train={n_train} >= len(questions)={len(qs)}; Q_train and Q_eval "
+            f"would not be disjoint."
+        )
+    return qs[:n_train], qs[n_train:]
+
+
+def _git_commit_hash() -> str:
+    try:
+        return (
+            subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL, env={**os.environ}
+            )
+            .decode()
+            .strip()
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def _content_hash(completions: dict) -> str:
+    blob = json.dumps(completions, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+def _resolve_base_model_revision(base_model: str) -> str:
+    try:
+        from huggingface_hub import HfApi
+
+        info = HfApi().model_info(base_model)
+        return info.sha or "unknown"
+    except Exception as exc:  # pragma: no cover - network-dependent
+        log.warning("Could not resolve base-model revision for %s: %s", base_model, exc)
+        return "unknown"
+
+
+def _build_prompt_text(
+    tokenizer, persona: str, question: str, persona_prompts: dict[str, str]
+) -> str:
+    """Chat-template-rendered prompt text for (persona, q).
+
+    ``no_persona`` omits the system message (mirrors no-persona training rows).
+    Persona injection is ALWAYS via the system role (CLAUDE.md).
+    """
+    if persona == NO_PERSONA_KEY:
+        messages = [{"role": "user", "content": question}]
+    else:
+        if persona not in persona_prompts:
+            raise KeyError(f"Persona {persona!r} not in bank. Available: {sorted(persona_prompts)}")
+        messages = [
+            {"role": "system", "content": persona_prompts[persona]},
+            {"role": "user", "content": question},
+        ]
+    return tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+
+
+def _generate_batch(
+    llm,
+    sp,
+    tokenizer,
+    eos_id: int,
+    marker_id: int,
+    persona: str,
+    questions: list[str],
+    persona_prompts: dict[str, str],
+    max_new_tokens: int,
+) -> tuple[dict[str, dict], dict[str, int]]:
+    """vLLM batched greedy decode for one persona over a list of questions.
+
+    Forked from #448 r_generate._generate_batch. Returns (completions[q], stats)
+    with response_text, response_token_ids, n_response_tokens, ended_with_eos,
+    truncated, marker_in_R (text-AND-token check).
+    """
+    prompts = [_build_prompt_text(tokenizer, persona, q, persona_prompts) for q in questions]
+    outputs = llm.generate(prompts, sp)
+    if len(outputs) != len(prompts):
+        raise RuntimeError(
+            f"vLLM returned {len(outputs)} for {len(prompts)} prompts on persona={persona}"
+        )
+    completions: dict[str, dict] = {}
+    stats = {"n_total": 0, "n_truncated": 0, "n_marker_in_R": 0}
+    for q, out in zip(questions, outputs, strict=True):
+        o = out.outputs[0]
+        token_ids = list(o.token_ids)
+        text = o.text
+        ended_with_eos = bool(token_ids and token_ids[-1] == eos_id)
+        n_tokens = len(token_ids)
+        truncated = (n_tokens >= max_new_tokens) and not ended_with_eos
+        marker_in_R = (MARKER_TEXT in text) or (marker_id in token_ids)
+        completions[q] = {
+            "response_text": text,
+            "response_token_ids": token_ids,
+            "n_response_tokens": n_tokens,
+            "ended_with_eos": ended_with_eos,
+            "truncated": truncated,
+            "marker_in_R": marker_in_R,
+        }
+        stats["n_total"] += 1
+        if truncated:
+            stats["n_truncated"] += 1
+        if marker_in_R:
+            stats["n_marker_in_R"] += 1
+    return completions, stats
+
+
+def generate_r_artifacts(
+    *,
+    persona_bank: dict[str, str],
+    base_model: str = BASE_MODEL,
+    questions: list[str] | None = None,
+    n_train_questions: int = N_TRAIN_QUESTIONS,
+    out_dir: Path = OUT_DIR,
+    max_new_tokens: int = MAX_NEW_TOKENS_GEN,
+    max_model_len: int = DEFAULT_MAX_MODEL_LEN,
+    seed: int = DEFAULT_SEED,
+    gpu_memory_utilization: float = 0.85,
+) -> dict[str, Any]:
+    """Generate R_train + R_eval over the WHOLE bank ∪ {no_persona}.
+
+    Args:
+        persona_bank: name -> system prompt for the full ~60-persona bank.
+        base_model: HF model id.
+        questions: question bank (default EVAL_QUESTIONS, 20).
+        n_train_questions: size of the Q_train split (rest → Q_eval).
+        out_dir: local output dir for R_*.json.
+        max_new_tokens, max_model_len, seed, gpu_memory_utilization: vLLM params.
+
+    Returns:
+        Summary dict (paths, hashes, sizes, stats). Raises on marker-in-R hit,
+        truncation > 5%, or universe coverage gap.
+    """
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(base_model, trust_remote_code=True)
+    marker_ids = tokenizer.encode(MARKER_TEXT, add_special_tokens=False)
+    if marker_ids != [EXPECTED_MARKER_TOKEN_ID]:
+        raise AssertionError(
+            f"Marker tokenization drift: encode({MARKER_TEXT!r}) = {marker_ids}, "
+            f"expected [{EXPECTED_MARKER_TOKEN_ID}]. Refusing to generate R."
+        )
+    log.info("Marker token id assertion PASS: %r -> %d", MARKER_TEXT, EXPECTED_MARKER_TOKEN_ID)
+
+    q_train, q_eval = get_train_eval_questions(questions, n_train_questions)
+    log.info("Q_train=%d, Q_eval=%d (disjoint)", len(q_train), len(q_eval))
+
+    # R universe = every bank persona (system-prompted) + no_persona.
+    r_universe = [*sorted(persona_bank.keys()), NO_PERSONA_KEY]
+    log.info("R universe: %d bank personas + no_persona = %d", len(persona_bank), len(r_universe))
+
+    base_model_revision = _resolve_base_model_revision(base_model)
+
+    from vllm import LLM, SamplingParams
+
+    llm = LLM(
+        model=base_model,
+        dtype="bfloat16",
+        gpu_memory_utilization=gpu_memory_utilization,
+        seed=seed,
+        max_model_len=max_model_len,
+    )
+    sp = SamplingParams(
+        n=1,
+        temperature=DEFAULT_TEMPERATURE,
+        top_p=1.0,
+        max_tokens=max_new_tokens,
+        seed=seed,
+        stop_token_ids=[tokenizer.eos_token_id],
+    )
+
+    r_train_completions: dict[str, dict[str, dict]] = {}
+    r_eval_completions: dict[str, dict[str, dict]] = {}
+    train_stats = {"n_total": 0, "n_truncated": 0, "n_marker_in_R": 0}
+    eval_stats = {"n_total": 0, "n_truncated": 0, "n_marker_in_R": 0}
+
+    for persona in r_universe:
+        log.info("Generating R for persona=%r", persona)
+        comp_train, st_train = _generate_batch(
+            llm,
+            sp,
+            tokenizer,
+            tokenizer.eos_token_id,
+            EXPECTED_MARKER_TOKEN_ID,
+            persona,
+            q_train,
+            persona_bank,
+            max_new_tokens,
+        )
+        r_train_completions[persona] = comp_train
+        for k, v in st_train.items():
+            train_stats[k] += v
+        comp_eval, st_eval = _generate_batch(
+            llm,
+            sp,
+            tokenizer,
+            tokenizer.eos_token_id,
+            EXPECTED_MARKER_TOKEN_ID,
+            persona,
+            q_eval,
+            persona_bank,
+            max_new_tokens,
+        )
+        r_eval_completions[persona] = comp_eval
+        for k, v in st_eval.items():
+            eval_stats[k] += v
+
+    # ── Hard checks (forked from #448) ───────────────────────────────────────
+    for split_name, st in (("train", train_stats), ("eval", eval_stats)):
+        if st["n_marker_in_R"] > 0:
+            raise RuntimeError(
+                f"FAIL: marker token id {EXPECTED_MARKER_TOKEN_ID} found in "
+                f"{st['n_marker_in_R']} of {st['n_total']} R_{split_name} completions. "
+                f"Re-sample (different SEED) or filter the offending (persona, q)."
+            )
+        if st["n_total"] == 0:
+            continue
+        trunc_rate = st["n_truncated"] / st["n_total"]
+        if trunc_rate > TRUNCATION_FAIL_THRESHOLD:
+            raise RuntimeError(
+                f"FAIL: R_{split_name} truncation rate {trunc_rate:.1%} > "
+                f"{TRUNCATION_FAIL_THRESHOLD:.0%} ({st['n_truncated']}/{st['n_total']}). "
+                f"Bump --max-new-tokens and re-run."
+            )
+        log.info(
+            "R_%s truncation %.2f%% (%d/%d) ≤ %.0f%% — OK",
+            split_name,
+            100.0 * trunc_rate,
+            st["n_truncated"],
+            st["n_total"],
+            100.0 * TRUNCATION_FAIL_THRESHOLD,
+        )
+
+    # EXIT assertion: every universe persona present in BOTH splits.
+    for split_name, comp in (("train", r_train_completions), ("eval", r_eval_completions)):
+        missing = sorted(set(r_universe) - set(comp.keys()))
+        if missing:
+            raise RuntimeError(
+                f"FAIL: R_{split_name} missing {len(missing)} universe personas: {missing!r}."
+            )
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    r_train_hash = _content_hash(r_train_completions)
+    r_eval_hash = _content_hash(r_eval_completions)
+    timestamp = _dt.datetime.now(_dt.UTC).isoformat()
+    git_sha = _git_commit_hash()
+    gen_cfg = {
+        "temperature": DEFAULT_TEMPERATURE,
+        "top_p": 1.0,
+        "max_tokens": max_new_tokens,
+        "seed": seed,
+        "stop_token_ids": "[eos_token_id]",
+    }
+
+    r_train_payload = {
+        "schema_version": SCHEMA_VERSION,
+        "split": "train",
+        "base_model": base_model,
+        "base_model_revision": base_model_revision,
+        "generation_config": gen_cfg,
+        "n_personas": len(r_train_completions),
+        "questions": q_train,
+        "personas": sorted(r_train_completions.keys()),
+        "completions": r_train_completions,
+        "content_hash": r_train_hash,
+        "git_commit": git_sha,
+        "generated_at": timestamp,
+        "stats": train_stats,
+    }
+    r_eval_payload = {
+        **r_train_payload,
+        "split": "eval",
+        "n_personas": len(r_eval_completions),
+        "questions": q_eval,
+        "personas": sorted(r_eval_completions.keys()),
+        "completions": r_eval_completions,
+        "content_hash": r_eval_hash,
+        "stats": eval_stats,
+    }
+    r_train_path = out_dir / "R_train.json"
+    r_eval_path = out_dir / "R_eval.json"
+    r_train_path.write_text(json.dumps(r_train_payload, indent=2, ensure_ascii=False))
+    r_eval_path.write_text(json.dumps(r_eval_payload, indent=2, ensure_ascii=False))
+    log.info("R_train → %s (sha[:12]=%s)", r_train_path, r_train_hash[:12])
+    log.info("R_eval → %s (sha[:12]=%s)", r_eval_path, r_eval_hash[:12])
+
+    return {
+        "r_train_path": str(r_train_path),
+        "r_train_hash": r_train_hash,
+        "r_eval_path": str(r_eval_path),
+        "r_eval_hash": r_eval_hash,
+        "r_universe": r_universe,
+        "q_train": q_train,
+        "q_eval": q_eval,
+        "n_train_forwards": train_stats["n_total"],
+        "n_eval_forwards": eval_stats["n_total"],
+        "train_stats": train_stats,
+        "eval_stats": eval_stats,
+        "base_model_revision": base_model_revision,
+        "git_commit": git_sha,
+        "hf_data_repo": HF_DATA_REPO,
+        "hf_path_prefix": HF_PATH_PREFIX,
+    }
+
+
+def load_r_artifact(path: Path) -> dict[str, dict[str, dict]]:
+    """Load R_train.json / R_eval.json → completions[persona][q] -> {...}."""
+    if not path.exists():
+        raise FileNotFoundError(f"R artifact missing at {path}. Run Phase 1 (r-generate) first.")
+    payload = json.loads(path.read_text())
+    sv = payload.get("schema_version")
+    if sv != SCHEMA_VERSION:
+        raise AssertionError(
+            f"R artifact {path} has schema_version={sv!r}, expected {SCHEMA_VERSION!r}."
+        )
+    return payload["completions"]

--- a/src/explore_persona_space/experiments/contrastive_neg_geometry_472/select_negatives.py
+++ b/src/explore_persona_space/experiments/contrastive_neg_geometry_472/select_negatives.py
@@ -1,0 +1,243 @@
+# ruff: noqa: RUF002  # em-dash + Qwen marker token " ※" are intentional
+"""Task #472 — NEW distance-stratified negative selector (plan §4.5).
+
+Neither existing selector is distance-aware:
+``generate_leakage_data.select_negative_personas`` is RANDOM (rng.sample);
+#448's ``persona_registry.select_n_bystanders`` is SHA-256-deterministic. This
+module selects negatives by base-model centroid-cosine distance to the source so
+the placement arms (near/far/spread) move ``d_nearest_neg`` while holding
+``d_source`` fixed per held-out probe — the cross-arm shift that breaks the
+two-distance collinearity (plan §3 identifiability point).
+
+``qwen_default`` (the bare default-instruct system prompt) is ALWAYS a negative
+in every non-empty arm (plan §4.5; leakage to the default context is the safety
+target, open-q 3.7).
+
+The held-out panel for the geometry regression is the bank MINUS source MINUS the
+UNION of negatives across ALL pooled-regression arms (so every probe is held-out
+in every arm; plan §4.2 / §4.5).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+from explore_persona_space.experiments.contrastive_neg_geometry_472 import (
+    ALWAYS_INCLUDE_NEGATIVE,
+    CELL_SPECS,
+    SOURCE_PERSONA,
+)
+
+log = logging.getLogger("issue_472.select_negatives")
+
+VALID_PLACEMENTS = ("near", "far", "spread", "none")
+
+
+def select_negatives_by_geometry(
+    source: str,
+    placement: str,
+    n_personas: int,
+    cos_to_source: dict[str, float],
+    *,
+    always_include: tuple[str, ...] = (ALWAYS_INCLUDE_NEGATIVE,),
+) -> list[str]:
+    """Select ``n_personas`` negatives by base-model cosine distance to ``source``.
+
+    Plan §4.5 pseudocode. ``cos_to_source`` maps persona -> cos(persona, source)
+    (high cos = near source). ``qwen_default`` (always_include) is prepended and
+    counts toward ``n_personas`` (so a 4-persona arm = qwen_default + 3 placement
+    personas).
+
+    Args:
+        source: source persona name (excluded from candidates).
+        placement: one of {"near","far","spread","none"}.
+        n_personas: total negative personas INCLUDING always_include.
+        cos_to_source: {persona: cos(persona, source)} over the bank.
+        always_include: personas always present as negatives (default
+            qwen_default). These count toward n_personas.
+
+    Returns:
+        Ordered list of negative persona names: [*always_include, *chosen].
+        Empty list for placement="none".
+
+    Raises:
+        ValueError on unknown placement OR if too few candidates exist.
+    """
+    if placement not in VALID_PLACEMENTS:
+        raise ValueError(f"Unknown placement {placement!r}; expected one of {VALID_PLACEMENTS}.")
+    if placement == "none":
+        return []
+
+    always = [p for p in always_include if p != source]
+    n_choose = n_personas - len(always)
+    if n_choose < 0:
+        raise ValueError(
+            f"n_personas={n_personas} < len(always_include)={len(always)} for "
+            f"placement={placement!r}; cannot select a negative arm."
+        )
+    if n_choose == 0:
+        return list(always)
+
+    # Candidates = bank minus source minus always-included.
+    cands = [p for p in cos_to_source if p != source and p not in always]
+    # Sort by cosine to source DESCENDING (high cos = near source).
+    cands.sort(key=lambda p: cos_to_source[p], reverse=True)
+
+    if n_choose > len(cands):
+        raise ValueError(
+            f"placement={placement!r} needs {n_choose} candidates but only "
+            f"{len(cands)} available (bank too small after excluding source + "
+            f"always_include). Grow the persona bank (plan §4.2)."
+        )
+
+    if placement == "near":
+        chosen = cands[:n_choose]
+    elif placement == "far":
+        chosen = cands[-n_choose:]
+    elif placement == "spread":
+        # Even quantile coverage of the cos range.
+        idx = np.linspace(0, len(cands) - 1, n_choose).round().astype(int)
+        # Deduplicate indices (can collide when n_choose is large vs len).
+        seen: set[int] = set()
+        chosen = []
+        for i in idx:
+            ii = int(i)
+            while ii in seen and ii < len(cands) - 1:
+                ii += 1
+            if ii in seen:  # walked off the end; back-fill from the start
+                ii = next(k for k in range(len(cands)) if k not in seen)
+            seen.add(ii)
+            chosen.append(cands[ii])
+    else:  # pragma: no cover - guarded above
+        raise ValueError(placement)
+
+    return [*always, *chosen]
+
+
+def negatives_for_cell(
+    cell_slug: str,
+    cos_to_source: dict[str, float],
+    *,
+    source: str = SOURCE_PERSONA,
+    cell_specs: tuple | None = None,
+) -> list[str]:
+    """Resolve the negative persona list for a single cell from CELL_SPECS.
+
+    Args:
+        cell_slug: cell to resolve.
+        cos_to_source: {persona: cos(persona, source)}.
+        source: source persona.
+        cell_specs: OPTIONAL override registry (same 6-tuple shape as
+            CELL_SPECS). Defaults to #472's CELL_SPECS. Used by #477 to drive
+            this resolver against its own CELL_SPECS_477 without touching the
+            #472 module's authoritative tuple. Pure backward-compat: callers
+            that don't pass this kwarg keep the existing behavior.
+    """
+    specs = cell_specs if cell_specs is not None else CELL_SPECS
+    spec = next((c for c in specs if c[0] == cell_slug), None)
+    if spec is None:
+        raise KeyError(f"Unknown cell slug {cell_slug!r}; known: {[c[0] for c in specs]}")
+    _slug, _name, placement, n_neg_personas, _neg_ex, _in_pooled = spec
+    return select_negatives_by_geometry(source, placement, n_neg_personas, cos_to_source)
+
+
+def all_negatives_union(
+    cos_to_source: dict[str, float],
+    *,
+    source: str = SOURCE_PERSONA,
+    pooled_only: bool = False,
+    cell_specs: tuple | None = None,
+) -> set[str]:
+    """Union of negatives across cells.
+
+    Args:
+        cos_to_source: {persona: cos(persona, source)}.
+        source: source persona.
+        pooled_only: if True, union ONLY over the pooled-regression cells
+            (in_pooled=True); else over ALL cells. The held-out panel uses the
+            union over ALL cells so probes are held-out in every arm (plan §4.5).
+        cell_specs: OPTIONAL override registry (same 6-tuple shape as
+            CELL_SPECS). Defaults to #472's CELL_SPECS. #477 passes its own
+            CELL_SPECS_477 so the union covers #477's negatives — without
+            this kwarg the #472 union would mis-identify which personas are
+            held-out for an #477 cell (the round-3 #477 bug). Pure
+            backward-compat: callers that don't pass it keep #472 behavior.
+    """
+    specs = cell_specs if cell_specs is not None else CELL_SPECS
+    union: set[str] = set()
+    for slug, _name, _placement, _n, _ex, in_pooled in specs:
+        if pooled_only and not in_pooled:
+            continue
+        union.update(negatives_for_cell(slug, cos_to_source, source=source, cell_specs=cell_specs))
+    return union
+
+
+def held_out_panel(
+    cos_to_source: dict[str, float],
+    *,
+    source: str = SOURCE_PERSONA,
+    cell_specs: tuple | None = None,
+) -> list[str]:
+    """Held-out probe panel = bank − source − union(negatives across ALL cells).
+
+    Every persona here is a never-trained-against bystander in EVERY arm, so its
+    ``d_source`` is fixed across arms while ``d_nearest_neg`` shifts between
+    Near/Far/Spread — the load-bearing identifiability property (plan §4.5).
+
+    Args:
+        cos_to_source: {persona: cos(persona, source)} over the bank.
+        source: source persona (always excluded from the panel).
+        cell_specs: OPTIONAL override registry (same 6-tuple shape as
+            CELL_SPECS). Defaults to #472's CELL_SPECS. #477 passes its own
+            CELL_SPECS_477 so the panel excludes #477's negatives — the
+            round-3 #477 contamination fix. Pure backward-compat: callers
+            that don't pass it keep #472 behavior.
+    """
+    union = all_negatives_union(
+        cos_to_source, source=source, pooled_only=False, cell_specs=cell_specs
+    )
+    excluded = union | {source}
+    panel = sorted(p for p in cos_to_source if p not in excluded)
+    return panel
+
+
+def d_source(probe: str, cos_to_source: dict[str, float]) -> float:
+    """Distance-to-source covariate = 1 − cos(probe, source)."""
+    return 1.0 - cos_to_source[probe]
+
+
+def d_nearest_neg(
+    probe: str,
+    arm_negatives: list[str],
+    cos_matrix: dict[str, dict[str, float]],
+    *,
+    exclude_default: bool = False,
+    default_name: str = ALWAYS_INCLUDE_NEGATIVE,
+) -> float:
+    """Distance from ``probe`` to the NEAREST negative in ``arm_negatives``.
+
+    d_nearest_neg(arm) = min over arm negatives of (1 − cos(probe, neg)).
+
+    Args:
+        probe: held-out probe persona.
+        arm_negatives: the arm's negative persona list.
+        cos_matrix: {a: {b: cos(a, b)}} over the bank.
+        exclude_default: if True, exclude ``default_name`` (qwen_default) from
+            the min — yields the non-default variant ``d_nearest_neg_nd`` (plan
+            §4.3 / §6 identification gate).
+        default_name: the always-included default persona to optionally exclude.
+
+    Returns:
+        min distance, or NaN if the arm has no eligible negatives (e.g. the
+        no-negatives arm, or a non-default-only computation on a default-only
+        arm).
+    """
+    negs = arm_negatives
+    if exclude_default:
+        negs = [n for n in negs if n != default_name]
+    if not negs:
+        return float("nan")
+    dists = [1.0 - cos_matrix[probe][neg] for neg in negs]
+    return float(min(dists))

--- a/src/explore_persona_space/experiments/contrastive_neg_geometry_472/train_cell.py
+++ b/src/explore_persona_space/experiments/contrastive_neg_geometry_472/train_cell.py
@@ -1,0 +1,507 @@
+# ruff: noqa: RUF002  # em-dash + Qwen marker token " ※" are intentional
+"""Task #472 — per-cell LoRA training with 6 mid-run adapter checkpoints.
+
+Plan §4.6: each cell trains ONCE; the on-policy DV is read at 6 checkpoints
+DURING the run ({8,16,33,50,75,100}% of max_steps). To make those checkpoints
+available to the eval_trajectory rig, a TrainerCallback saves the PEFT adapter at
+each target fraction (NOT TRL's fixed save_steps interval — the fractions are
+non-uniform). The 100% checkpoint is the final adapter (saved by train_lora).
+
+Recipe (plan §10 / §11): rs-LoRA r=32/α=64/lr=1e-5/cosine/warmup 0.05/1 epoch/
+batch 4×ga 4/max_len 1024, loss masked to the ※ token + EOS via
+MarkerOnlyDataCollator(tail_tokens=0). The codebase default MARKER_TOKEN="[ZLT]"
+is OVERRIDDEN to " ※" via TrainLoraConfig.marker_text.
+
+Sub-ceiling fallback (plan §7 / §14): the dispatcher passes fallback=True to drop
+to r=16/lr=5e-6/0.5 epoch if the smoke gate trips.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+from transformers import TrainerCallback
+
+from explore_persona_space.experiments.contrastive_neg_geometry_472 import (
+    BASE_MODEL,
+    BATCH_SIZE,
+    EPOCHS,
+    FALLBACK_EPOCHS,
+    FALLBACK_LEARNING_RATE,
+    FALLBACK_LORA_R,
+    GRAD_ACCUM,
+    HF_MODEL_REPO,
+    LEARNING_RATE,
+    LORA_ALPHA,
+    LORA_DROPOUT,
+    LORA_R,
+    MARKER_TEXT,
+    MAX_LENGTH,
+    TRAJECTORY_CHECKPOINT_FRACTIONS,
+    WARMUP_RATIO,
+)
+
+log = logging.getLogger("issue_472.train_cell")
+
+
+def _physical_gpu_uuids() -> dict[int, str]:
+    """Return {physical_index: uuid} for ALL GPUs on the host (CVD-independent).
+
+    ``nvidia-smi --query-gpu=index,uuid`` enumerates the FULL physical GPU set
+    regardless of ``CUDA_VISIBLE_DEVICES`` (it reports driver-level physical
+    indices, not the CVD-remapped view). This is the ground-truth map the
+    per-process pin is checked against. Returns {} if nvidia-smi is unavailable
+    so the caller can degrade to the device-count-only check.
+    """
+    try:
+        out = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=index,uuid", "--format=csv,noheader,nounits"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            # nvidia-smi enumerates physical GPUs; no credentials needed.
+            env={**os.environ, "CUDA_VISIBLE_DEVICES": ""},  # full physical enum, CVD-independent
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as e:
+        log.warning("nvidia-smi physical enumeration failed (%s); UUID pin-check skipped.", e)
+        return {}
+    mapping: dict[int, str] = {}
+    for line in out.strip().splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) >= 2 and parts[0].isdigit():
+            mapping[int(parts[0])] = parts[1]
+    return mapping
+
+
+def verify_gpu_pin(expected_physical_gpu: int) -> None:
+    """Fail loud if this process is NOT pinned to ``expected_physical_gpu``.
+
+    Catches the round-3 #472 sharding bug (all concurrent cells piling onto
+    physical GPU 0) IMMEDIATELY at cell-train start, instead of via a CUDA OOM
+    ~30s into training. The 1-cell smoke can't exercise concurrency, so this
+    assertion is the only guard the sweep has against a mis-pin.
+
+    Contract: the caller has ALREADY set ``os.environ["CUDA_VISIBLE_DEVICES"] =
+    str(expected_physical_gpu)`` (this matches what ``train/sft.py`` does, so the
+    two never fight). Two checks:
+
+      1. ``nvidia-smi`` full physical enumeration must contain
+         ``expected_physical_gpu`` (range / bad-assignment guard) — runs even
+         when torch CUDA is unavailable.
+      2. Once CUDA initializes, exactly ONE GPU must be visible (CVD restricted
+         to a single device) and — when torch exposes the device UUID — its UUID
+         must equal the physical GPU's UUID. A visible-count > 1 or a UUID
+         mismatch means the pin landed on the wrong GPU; raise.
+
+    Raises RuntimeError on any mismatch.
+    """
+    cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if cvd != str(expected_physical_gpu):
+        raise RuntimeError(
+            f"verify_gpu_pin precondition violated: CUDA_VISIBLE_DEVICES={cvd!r} != "
+            f"str(expected_physical_gpu)={str(expected_physical_gpu)!r}. The caller must set "
+            f"CVD to the assigned physical GPU before training (so it matches sft.py's clobber)."
+        )
+
+    phys = _physical_gpu_uuids()
+    if phys and expected_physical_gpu not in phys:
+        raise RuntimeError(
+            f"Assigned physical GPU {expected_physical_gpu} not in host enumeration "
+            f"{sorted(phys)} — bad GPU assignment (n_gpus mismatch?)."
+        )
+
+    import torch
+
+    if not torch.cuda.is_available():
+        # No live CUDA yet (e.g. CPU-only host); the physical-enum range check
+        # above is the only guard available. Do NOT silently pass a real pod —
+        # on a pod torch.cuda is always available, so this branch is CPU-only.
+        log.warning("torch.cuda unavailable; GPU pin verified by physical enumeration only.")
+        return
+
+    n_visible = torch.cuda.device_count()
+    if n_visible != 1:
+        raise RuntimeError(
+            f"Expected exactly 1 visible GPU after CVD={cvd!r}, saw {n_visible}. The per-cell "
+            f"pin failed — concurrent cells would collide (round-3 #472 OOM class)."
+        )
+
+    expected_uuid = phys.get(expected_physical_gpu)
+    bound_uuid = None
+    try:
+        bound_uuid = getattr(torch.cuda.get_device_properties(0), "uuid", None)
+    except Exception as e:  # pragma: no cover - torch-version dependent
+        log.warning("torch device UUID unavailable (%s); UUID pin-check skipped.", e)
+    if expected_uuid and bound_uuid is not None:
+        bound_uuid_str = str(bound_uuid).replace("GPU-", "").strip()
+        expected_uuid_str = expected_uuid.replace("GPU-", "").strip()
+        if bound_uuid_str != expected_uuid_str:
+            raise RuntimeError(
+                f"GPU pin MISMATCH: process bound to UUID {bound_uuid_str!r} but assigned "
+                f"physical GPU {expected_physical_gpu} has UUID {expected_uuid_str!r}. The "
+                f"per-cell pin landed on the WRONG physical GPU (round-3 #472 sharding bug)."
+            )
+    log.info(
+        "[gpu-pin] verified: physical GPU %d (1 visible device, uuid=%s)",
+        expected_physical_gpu,
+        (expected_uuid or "n/a"),
+    )
+
+
+class CheckpointAtFractionsCallback(TrainerCallback):
+    """Save the PEFT adapter at each target fraction of max_steps.
+
+    Writes ``<ckpt_root>/frac_<f>/`` (PEFT adapter dir) the first time
+    ``global_step / max_steps`` crosses each fraction in ``fractions``. Records a
+    manifest ``checkpoint_index.json`` mapping frac -> {step, path}. The 100%
+    fraction is recorded but the directory is written from the final saved
+    adapter by the caller (the in-progress model at the last step == the final).
+
+    ``frac_precision`` controls the dir + index key precision (default 2-dp for
+    #472 / legacy LR-calibration byte-identity; v4 step-calibration passes 4 so
+    target_step=1 + target_step=2 at max_steps=426 don't collide at frac_0.00).
+    """
+
+    def __init__(
+        self,
+        ckpt_root: Path,
+        fractions: tuple[float, ...],
+        frac_precision: int = 2,
+    ):
+        self.ckpt_root = Path(ckpt_root)
+        self.fractions = sorted(fractions)
+        self.frac_precision = int(frac_precision)
+        self._saved: dict[float, dict] = {}
+        self.ckpt_root.mkdir(parents=True, exist_ok=True)
+
+    def _frac_dir(self, frac: float) -> Path:
+        return self.ckpt_root / f"frac_{frac:.{self.frac_precision}f}"
+
+    def on_step_end(self, args, state, control, model=None, **kwargs):
+        if model is None or state.max_steps <= 0:
+            return
+        cur = state.global_step / state.max_steps
+        for frac in self.fractions:
+            if frac in self._saved or frac >= 1.0:
+                continue
+            if cur >= frac:
+                d = self._frac_dir(frac)
+                d.mkdir(parents=True, exist_ok=True)
+                model.save_pretrained(str(d))
+                self._saved[frac] = {"step": int(state.global_step), "path": str(d)}
+                log.info(
+                    "[ckpt] saved frac=%.*f at step %d/%d → %s",
+                    self.frac_precision,
+                    frac,
+                    state.global_step,
+                    state.max_steps,
+                    d,
+                )
+
+    def on_train_end(self, args, state, control, model=None, **kwargs):
+        # Record the 100% fraction step (the final adapter dir is the caller's
+        # train_lora output_dir; index it from there in the caller).
+        if 1.0 in self.fractions:
+            self._saved[1.0] = {"step": int(state.global_step), "path": None}
+
+    def index(self) -> dict[str, dict]:
+        fmt = f"{{:.{self.frac_precision}f}}"
+        return {fmt.format(k): v for k, v in sorted(self._saved.items())}
+
+
+# ── v4 step-lever helpers (plan v4 §4 train_cell.py row + i477_run_cell row). ─
+
+
+def step_fractions(
+    target_steps: tuple[int, ...],
+    max_steps: int,
+    *,
+    precision: int = 4,
+) -> tuple[float, ...]:
+    """Convert v4 target optimizer-steps {1, 2, 4, 8, 16, 32, 64} to ckpt fractions.
+
+    Required-by plan v4 §4 ``train_cell.py`` row. The 4-decimal default keeps
+    target_step=1 and target_step=2 at max_steps=426 from collapsing onto the
+    same ``frac_0.00`` key (1/426=0.0023, 2/426=0.0047 — both round to 0.00 at
+    2dp, both stay distinct at 4dp). Also rejects any ``target_step > max_steps``
+    (CheckpointAtFractionsCallback's >=1.0 gate would silently swallow it).
+
+    Args:
+        target_steps: the desired optimizer-step checkpoints. Must be strictly
+            positive integers; duplicates are de-dup'd.
+        max_steps: the cell's total optimizer steps (= epochs × dataset_size /
+            (batch × grad_accum)). Caller computes; this function uses only the
+            ratio.
+        precision: decimal places for the fraction key. v4 default = 4 (sweep
+            cells, where collisions would silently drop checkpoints); legacy
+            #472 / #477 LR-calibration callers pass precision=2 for byte
+            identity with the existing recipe.
+
+    Returns:
+        Tuple of fractions ``step / max_steps`` rounded to ``precision``,
+        sorted ascending, deduped.
+
+    Raises:
+        ValueError: any ``target_steps`` is non-positive, any
+            ``target_steps`` > ``max_steps``, OR two distinct target_steps
+            collide at the chosen precision (fail loud so the caller bumps
+            precision rather than silently dropping a checkpoint).
+    """
+    if max_steps <= 0:
+        raise ValueError(f"step_fractions: max_steps={max_steps} must be >0")
+    if precision < 1:
+        raise ValueError(f"step_fractions: precision={precision} must be >=1")
+    seen: set[int] = set()
+    cleaned: list[int] = []
+    for s in target_steps:
+        if int(s) <= 0:
+            raise ValueError(f"step_fractions: target_step={s} <=0; positive optimizer steps only")
+        if int(s) > max_steps:
+            raise ValueError(
+                f"step_fractions: target_step={s} > max_steps={max_steps}; "
+                f"clamp upstream (see main_phase_context_window) so this never reaches "
+                f"step_fractions — the callback's >=1.0 gate would silently drop it."
+            )
+        if int(s) in seen:
+            continue
+        seen.add(int(s))
+        cleaned.append(int(s))
+    cleaned.sort()
+
+    frac_for: dict[float, int] = {}
+    for s in cleaned:
+        f = round(s / float(max_steps), precision)
+        if f in frac_for and frac_for[f] != s:
+            raise ValueError(
+                f"step_fractions: target_step={s} collides with target_step="
+                f"{frac_for[f]} at frac={f!r} (precision={precision}, "
+                f"max_steps={max_steps}). Bump precision so the checkpoint keys "
+                f"stay distinct."
+            )
+        frac_for[f] = s
+    return tuple(sorted(frac_for.keys()))
+
+
+def main_phase_context_window(s_star: int, max_steps: int) -> list[int]:
+    """v4 §4 + §6: clamp the main-phase 3-checkpoint context window.
+
+    Returns ``sorted(set([floor(s*/2), s*, min(2*s*, max_steps)]))`` so the
+    upper bound never exceeds ``max_steps`` (the v3 crash mode at s*=64,
+    max_steps=76: 2*s*=128 > 76 → step_fractions ValueError). Dedup via set
+    handles s*=1 (floor(1/2)=0 → clamped to >=1) and tight windows where the
+    floor / s* / 2*s* collapse onto one or two distinct steps.
+
+    **Single-element window** (code-review v4r2 blocker 6, low priority): when
+    ``s_star == max_steps == 1`` the three candidates collapse onto ``{1}`` and
+    the returned window has length 1. The v4 plan's currently-planned step
+    picks (target steps {1, 2, 4, 8, 16, 32, 64}) against max_steps in
+    {76, 126, 226, 426} cannot trigger this — every plan-valid s_star has at
+    least one strict neighbour in ``{floor(s*/2), 2*s*}`` that survives the
+    clamp. The single-element case is documented + logged as a WARNING (not
+    raised) so a future picker that returns ``s_star=max_steps`` will surface
+    "you trained a context window with no neighbouring step" in the dispatcher
+    log rather than silently shipping a 1-checkpoint main cell.
+
+    Raises:
+        ValueError: ``s_star`` <=0 or > ``max_steps``; the picked headline step
+            must lie inside the trainable range.
+    """
+    if s_star <= 0:
+        raise ValueError(f"main_phase_context_window: s_star={s_star} must be >0")
+    if s_star > max_steps:
+        raise ValueError(
+            f"main_phase_context_window: s_star={s_star} > max_steps={max_steps}; "
+            f"the picked headline step lies outside the trainable range."
+        )
+    lower = max(s_star // 2, 1)
+    upper = min(2 * s_star, max_steps)
+    window = sorted({lower, int(s_star), upper})
+    if not window:
+        raise RuntimeError(
+            f"main_phase_context_window: empty window for s_star={s_star}, "
+            f"max_steps={max_steps} (should never trigger — defensive)."
+        )
+    if len(window) == 1:
+        # Single-element case (blocker 6): the floor / s* / upper-clamp all
+        # collapse onto one step. Log loud so the dispatcher log surfaces it
+        # before training; current plan picks against the v4 grid never hit
+        # this, but a future picker landing on s_star == max_steps would.
+        log.warning(
+            "main_phase_context_window: window collapsed to a single step "
+            "{%d} for s_star=%d max_steps=%d (floor/upper-clamp + dedup made "
+            "the 3-element window degenerate). The main cell will train + "
+            "evaluate exactly one checkpoint; downstream context-window "
+            "analyses become a no-op. Surfaced as a WARNING per code-review "
+            "v4r2 blocker 6 — investigate the picker if this fires.",
+            window[0],
+            s_star,
+            max_steps,
+        )
+    return window
+
+
+def train_one_cell(
+    *,
+    cell_slug: str,
+    seed: int,
+    train_jsonl: Path,
+    output_dir: Path,
+    ckpt_root: Path,
+    fractions: tuple[float, ...] = TRAJECTORY_CHECKPOINT_FRACTIONS,
+    base_model: str = BASE_MODEL,
+    fallback: bool = False,
+    report_to: str = "wandb",
+    gpu_id: int = 0,
+    lr_override: float | None = None,
+    epochs_override: int | None = None,
+    hf_path_in_repo_override: str | None = None,
+    run_name_override: str | None = None,
+    step_calibration_fractions: tuple[float, ...] | None = None,
+    frac_precision: int = 2,
+    lora_r_override: int | None = None,
+    lora_alpha_override: int | None = None,
+    marker_suppress_at_post_response_slot: bool = False,
+    marker_im_end_token_id: int | None = None,
+) -> dict:
+    """Train one cell's LoRA adapter, saving 6 mid-run checkpoints.
+
+    Args:
+        cell_slug, seed: cell identity.
+        train_jsonl: per-cell training data.
+        output_dir: where the FINAL adapter is saved (the 100% checkpoint).
+        ckpt_root: where the mid-run frac_<f>/ adapters are saved.
+        fractions: checkpoint fractions of max_steps.
+        base_model: HF model id.
+        fallback: if True, use the sub-ceiling fallback recipe (plan §7).
+        report_to: "wandb" or "none".
+        gpu_id: the ASSIGNED PHYSICAL GPU index. ``train/sft.py`` SETS
+            ``os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)`` then loads with
+            ``device_map={"": 0}`` (CVD remaps the visible GPU to index 0), so
+            ``gpu_id`` MUST be the physical index against the FULL GPU
+            enumeration — NOT 0 when concurrent cells share a multi-GPU pod.
+            Round-3 #472 OOM root cause: with ``gpu_id`` pinned to 0, every
+            parallel cell re-targeted physical GPU 0 (documented ``+gpu_id=N``
+            CVD clobber, CLAUDE.md Gotchas). The dispatcher threads its
+            round-robin assignment here via ``i472_run_cell --gpu-id``; the
+            nested eval subprocess then inherits this same
+            ``CUDA_VISIBLE_DEVICES`` from ``os.environ`` (sft.py mutates it
+            in-process) so vLLM + HF KL run on the same physical GPU.
+
+    Returns:
+        {"final_adapter": str, "checkpoint_index": {frac: {step, path}}}.
+        The 100% entry's path is filled with ``output_dir``.
+    """
+    from explore_persona_space.train.sft import TrainLoraConfig, train_lora
+
+    # Pin to the assigned physical GPU + FAIL LOUD before any expensive work if
+    # the pin is wrong (round-3 #472 OOM guard). We set CVD here to EXACTLY what
+    # sft.py will set (str(gpu_id)) so the two never fight, then verify the
+    # process is bound to physical `gpu_id` (and that exactly one GPU is
+    # visible). The nested eval subprocess inherits this same CVD via os.environ.
+    os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
+    verify_gpu_pin(gpu_id)
+
+    r = FALLBACK_LORA_R if fallback else LORA_R
+    alpha = LORA_ALPHA
+    lr = FALLBACK_LEARNING_RATE if fallback else LEARNING_RATE
+    epochs = FALLBACK_EPOCHS if fallback else EPOCHS
+    # Per-cell overrides (#477 calibration layer). Backward-compat: defaults None
+    # = exactly #472 behavior. lr_override is the calibrated LR from Phase 2.5;
+    # epochs_override lets #477 pin epochs=2 (vs #472's 1) without touching the
+    # 472 module constants. hf_path_in_repo_override lets #477 push adapters to
+    # its own subfolder under HF_MODEL_REPO instead of adapters/issue_472/...
+    # lora_r_override + lora_alpha_override (#477 v6 M2): the recipe-scale lever.
+    # Both come from the dispatcher's single source of truth (RANK_ALPHA_MAP_V5
+    # for ranks {2,4,8} or the literal 64 for the r=32 Cal-A0 control). NEVER
+    # `2*r` math here; the dispatcher's _verify_alpha_invariant guard + the
+    # parameterized threading test pin this.
+    if lr_override is not None:
+        lr = float(lr_override)
+    if epochs_override is not None:
+        epochs = epochs_override
+    if lora_r_override is not None:
+        r = int(lora_r_override)
+    if lora_alpha_override is not None:
+        alpha = int(lora_alpha_override)
+    hf_path_in_repo = (
+        hf_path_in_repo_override
+        if hf_path_in_repo_override is not None
+        else f"adapters/issue_472/{cell_slug}_seed{seed}"
+    )
+    # WandB run-name (browsable prefix). #472's default is "issue472_<slug>_seed<S>";
+    # #477 threads run_name_override=f"issue477_<slug>_seed<S>" so #477 runs land
+    # under the right prefix in WandB. Default None = exactly #472 behavior.
+    default_run_name = f"issue472_{cell_slug}_seed{seed}{'_fallback' if fallback else ''}"
+    run_name = run_name_override if run_name_override is not None else default_run_name
+    # rs-LoRA: TrainLoraConfig sets use_rslora=True in train_lora's LoraConfig.
+    cfg = TrainLoraConfig(
+        gpu_id=gpu_id,  # ASSIGNED physical GPU; sft.py sets CVD=str(gpu_id).
+        epochs=epochs,
+        lr=lr,
+        lora_r=r,
+        lora_alpha=alpha,
+        lora_dropout=LORA_DROPOUT,
+        batch_size=BATCH_SIZE,
+        grad_accum=GRAD_ACCUM,
+        max_length=MAX_LENGTH,
+        warmup_ratio=WARMUP_RATIO,
+        weight_decay=0.0,
+        seed=seed,
+        run_name=run_name,
+        report_to=report_to,
+        save_strategy="no",  # mid-run checkpoints handled by our callback.
+        gradient_checkpointing=True,
+        packing=False,
+        hf_upload=True,
+        hf_repo=HF_MODEL_REPO,
+        hf_path_in_repo=hf_path_in_repo,
+        # Marker-only loss on the OVERRIDDEN " ※" marker (not the [ZLT] default).
+        marker_only_loss=True,
+        marker_text=MARKER_TEXT,
+        marker_tail_tokens=0,
+        # #477 v6: post-response-slot suppression (the slot-fix ported from
+        # origin/main). Default False = byte-identical #472 behavior; #477 v6
+        # cells set True + im_end_token_id=151645 (Qwen-2.5 <|im_end|>).
+        marker_suppress_at_post_response_slot=marker_suppress_at_post_response_slot,
+        marker_im_end_token_id=marker_im_end_token_id,
+    )
+    # v4 step-lever: when ``step_calibration_fractions`` is supplied (Phase 2
+    # step-calibration cells), it replaces the default ``fractions`` AND
+    # bumps the dir/index precision to v4's 4-dp default (or whatever the
+    # caller passed via ``frac_precision``) so target_step=1 + target_step=2 at
+    # max_steps=426 don't collide at frac_0.00.
+    eff_fractions = (
+        step_calibration_fractions if step_calibration_fractions is not None else fractions
+    )
+    ckpt_cb = CheckpointAtFractionsCallback(ckpt_root, eff_fractions, frac_precision=frac_precision)
+    log.info(
+        "[%s] Training (r=%d, alpha=%d, lr=%g, epochs=%s, marker=%r, "
+        "suppress_at_post_response_slot=%s, frac_precision=%d) → %s",
+        cell_slug,
+        r,
+        alpha,
+        lr,
+        epochs,
+        MARKER_TEXT,
+        marker_suppress_at_post_response_slot,
+        frac_precision,
+        output_dir,
+    )
+    train_lora(
+        base_model_path=base_model,
+        data_path=str(train_jsonl),
+        output_dir=str(output_dir),
+        cfg=cfg,
+        callbacks=[ckpt_cb],
+    )
+    index = ckpt_cb.index()
+    # Fill the 100% checkpoint path with the final adapter dir. The terminal
+    # key respects ``frac_precision`` (v4: "1.0000"; legacy: "1.00").
+    terminal_key = f"{1.0:.{frac_precision}f}"
+    if terminal_key in index:
+        index[terminal_key]["path"] = str(output_dir)
+    else:
+        index[terminal_key] = {"step": None, "path": str(output_dir)}
+    return {"final_adapter": str(output_dir), "checkpoint_index": index}


### PR DESCRIPTION
Closes task #492.

## Summary

Wave 0 of the gate-and-conditional plan (PEFT + vLLM re-eval of the existing HF v4 adapter, ~5 min on 1×H100, n=1 source + 1 held-out × 1 question) recovered saturating source ΔG on BOTH load paths (PEFT +20.43, vLLM +17.26). Verdict-matrix row 2 "env regression" — Wave 1 (12 GPU-h retraining of 6 cells) was preempted. The v4/v6 "floor everywhere" reading was an eval-side artifact from the v4-era pod environment, NOT a v2→v4 training-code change.

Corroborated by #477's parallel recovery diag (PEFT ΔG = +20.46 at n=15×4).

## What this branch carries
- Cherry-pick of `scripts/i477_reval_confirm.py` from `issue-477` (the PEFT-vs-vLLM diagnostic).
- 3 bug fixes to the diagnostic script caught while running (os.link → shutil.copyfile EXDEV; hf_hub_download per-file vs snapshot_download siblings-truncation; persona_bank.json path under geometry/).
- Port of `contrastive_neg_geometry_472/` + `contrastive_neg_count_decouple_477/` from issue-477 to issue-492 (Path X resolution to the cross-branch dep gap).
- `patches/b4_v2_with_v4_ckptcb.patch` (would have been applied if Wave 1 fired — now moot but kept).
- Wave 0 smoke artifact at `eval_results/issue_492/wave0_smoke/i492_smoke.json`.

## Review status
- code-review ensemble: PASS+CONCERNS → PASS
- interp-critic ensemble: PASS round 2 (after 3 sentence-level edits per reconciler)
- clean-result-critic ensemble: PASS round 2 (after 6 SPEC-level edits per reconciler)

## Reviewability
Each commit is independently revertible. The 3 `fix(#477)` commits patch real bugs in the diagnostic script that would also have bitten #477's parallel diag.

Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)