### PR TITLE
task #584: port the #534 distinct-id trajectory-eval fix + source-manifest guard to main

### DIFF
--- a/scripts/i504_eval_trajectory.py
+++ b/scripts/i504_eval_trajectory.py
@@ -100,6 +100,44 @@ def compute_cell_negatives_for_disjoint_guard(
     return negs
 
 
+def build_source_guard_meta(fraction_manifest: Path | None) -> dict | None:
+    """Build ``run_trajectory_eval``'s ``source_guard_meta`` from a selector manifest.
+
+    Returns None when ``fraction_manifest`` is None (legacy #504/#530 behavior
+    — no guard). Otherwise reads ``source_delta_g_at_selected_steps`` (the
+    selector's teacher-forced source ΔG per selected fraction) + ``stopped``
+    (band-stop fired) and returns the meta dict the rig's per-checkpoint
+    adapter-applied cross-check consumes (#534 round-2).
+
+    Raises:
+        FileNotFoundError / json.JSONDecodeError: unreadable manifest — the
+            guard the caller asked for cannot be silently skipped.
+    """
+    if fraction_manifest is None:
+        return None
+    manifest = json.loads(fraction_manifest.read_text())
+    src_dg = manifest.get("source_delta_g_at_selected_steps") or {}
+    expected_by_frac = {float(k): (float(v) if v is not None else None) for k, v in src_dg.items()}
+    meta = {
+        "expected_by_frac": expected_by_frac,
+        "band_stop_fired": bool(manifest.get("stopped", False)),
+        "manifest_path": str(fraction_manifest),
+    }
+    if not any(v is not None for v in expected_by_frac.values()):
+        log.warning(
+            "[manifest-guard] %s carries no source ΔG expectations (selector ran "
+            "--skip-source-trajectory?) — only the band-stop final-fraction floor "
+            "clause can fire.",
+            fraction_manifest,
+        )
+    log.info(
+        "[manifest-guard] armed: expected_by_frac=%s, band_stop_fired=%s",
+        expected_by_frac,
+        meta["band_stop_fired"],
+    )
+    return meta
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--cell", required=True)
@@ -129,6 +167,20 @@ def main(argv: list[str] | None = None) -> int:
             "vLLM's LLM(max_lora_rank=...) is floored to max(8, this) before "
             "the engine is constructed (vLLM rejects ranks < 8; it is a buffer "
             "size, not the adapter rank)."
+        ),
+    )
+    ap.add_argument(
+        "--fraction-manifest",
+        type=Path,
+        default=None,
+        help=(
+            "#534 round-2: optional fraction_manifest.json from "
+            "i534_select_fractions.py. When given, the rig cross-checks its own "
+            "on-policy source-self ΔG per checkpoint against the selector's "
+            "teacher-forced source_delta_g_at_selected_steps — >2-nat "
+            "disagreement at the FINAL fraction fails loud "
+            "(SourceDeltaGManifestMismatchError; the round-1 adapter-not-"
+            "applied guard). Absent = exact legacy #504/#530 behavior."
         ),
     )
     ap.add_argument("--max-new-tokens", type=int, default=2048)
@@ -279,6 +331,9 @@ def main(argv: list[str] | None = None) -> int:
         [c["frac"] for c in checkpoint_specs],
     )
 
+    # ── #534 round-2: source-manifest guard meta (adapter-applied cross-check).
+    source_guard_meta = build_source_guard_meta(args.fraction_manifest)
+
     # vLLM LoRAConfig.max_lora_rank must be one of (8, 16, 32, 64, 128, 256, 320,
     # 512) — buffer size, not the adapter's actual rank. r=4 fits in an r=8
     # buffer (vLLM zero-pads unused rows), so floor when training pinned r < 8.
@@ -310,6 +365,7 @@ def main(argv: list[str] | None = None) -> int:
         gpu_memory_utilization=args.gpu_memory_utilization,
         max_model_len=args.max_model_len,
         compute_kl=not args.no_kl,
+        source_guard_meta=source_guard_meta,
     )
 
     if not args.out_path.exists():

--- a/scripts/issue532_predictor_stress.py
+++ b/scripts/issue532_predictor_stress.py
@@ -135,6 +135,7 @@ CLI:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import logging
 import os
@@ -179,6 +180,10 @@ HF_R_PATH_PREFIX = "issue460_marker_at_end/on_policy_R"  # SHARED with #460/#474
 LOCAL_DATA_DIR = Path("data/issue_460")  # SHARED — same frozen base-model R
 LOCAL_ADAPTER_CACHE = Path("/workspace/adapters/i474")
 DEFAULT_OUT_DIR = Path("eval_results/issue_532")
+# #584 (from #549's audit): pin the q_test content+order the predictor consumes.
+# _ensure_local_file fetches at HF revision="main" and short-circuits to any
+# present local file, so an HF revision pin alone cannot guard this path.
+Q_TEST_EXTENDED_50_SHA256 = "38280023afdcb72829407e8ba3e6608ddcc3521c37afa586a843723976f2b4e8"
 LOGP_FLOOR = -50.0  # inherited from #460/#474
 COSINE_LAYER = 21  # legacy persona-vectors default
 GAUSS_KL_LAYER = 22  # the #502 winner
@@ -2653,6 +2658,13 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901  # phase dispatche
 
     # ── Load q_test + Class D rewrites + R_test ──────────────────────────
     q_test = load_q_test_extended_50()
+    got = hashlib.sha256(json.dumps(q_test, ensure_ascii=False).encode()).hexdigest()
+    if got != Q_TEST_EXTENDED_50_SHA256:
+        raise AssertionError(
+            f"q_test_extended_50 content/order drifted: sha256={got} != pinned "
+            f"{Q_TEST_EXTENDED_50_SHA256} — re-audit before trusting cross-run comparisons "
+            f"(#549/#584)."
+        )
     if args.n_probes < len(q_test):
         q_test = q_test[: args.n_probes]
     elif args.n_probes > len(q_test):

--- a/src/explore_persona_space/experiments/contrastive_neg_geometry_472/eval_guard.py
+++ b/src/explore_persona_space/experiments/contrastive_neg_geometry_472/eval_guard.py
@@ -74,6 +74,30 @@ class LoRANotAppliedError(RuntimeError):
     """
 
 
+class SourceDeltaGManifestMismatchError(RuntimeError):
+    """Raised when the rig's own source-self ΔG disagrees with the selector manifest.
+
+    Task #534 round-1 incident (2026-06-10): vLLM caches LoRA adapters
+    strictly by ``lora_int_id`` (``LRUCacheWorkerLoRAManager.add_adapter``:
+    an already-seen id is "just touched" — ``lora_path`` is never re-read).
+    The trajectory rig passed ``lora_int_id=1`` for EVERY checkpoint, so all
+    four fractions were silently served by the FIRST loaded adapter (step ~5,
+    ΔG≈0.03) and the eval read a flat ≈0 trajectory while the selector's
+    HF/PEFT read of the SAME snapshot dirs measured 6+ nats at the stop step.
+    Neither existing guard could catch it: the B-matrix check is structural
+    (the dirs were genuinely trained) and the byte-identical guard requires
+    ``g == b`` exactly (a wrong-but-real adapter gives g ≠ b).
+
+    This guard closes the hole with a cross-validation the rig can't fake:
+    the selector manifest's ``source_delta_g_at_selected_steps`` and the
+    eval's own source-self ΔG read the same artifact through two independent
+    paths (HF/PEFT teacher-forced vs vLLM on-policy). Empirical calibration:
+    #530 c504v3_near_seed42 read 5.82 on-policy vs 6.28 teacher-forced at the
+    stop step (~0.5-nat method disagreement), so a 2-nat tolerance at the
+    final fraction separates method noise from adapter-not-applied by >2x.
+    """
+
+
 class MarkerLogprobPathReadingFromBaseError(RuntimeError):
     """Raised when the marker-logprob reader has the v3 byte-identical bug.
 
@@ -412,5 +436,140 @@ def assert_adapter_actually_applied(
         max_abs_dg,
         n_emit,
         n_probes,
+    )
+    return diag
+
+
+# ── #534 round-2: selector-manifest cross-check on the eval's source-self ΔG ──
+# Tolerance between the selector's teacher-forced HF/PEFT source ΔG and the
+# eval rig's on-policy vLLM source-self ΔG at the SAME step. Empirical method
+# disagreement at the stop step is ~0.5 nats (#530 c504v3_near_seed42: 5.82
+# on-policy vs 6.28 teacher-forced); the #534 round-1 adapter-not-applied
+# regression produced a 6.24-nat disagreement. 2.0 separates the two by >2x
+# in both directions.
+DEFAULT_SOURCE_MANIFEST_TOL_NATS = 2.0
+# When the band-stop fired, the stop-step (final-fraction) adapter sits in
+# [5, 12] nats teacher-forced — an on-policy source-self read ≤ 1 nat at that
+# checkpoint is physically inconsistent with "the adapter was applied",
+# regardless of whether a manifest expectation is available.
+DEFAULT_MIN_FINAL_SOURCE_DELTA_G_NATS = 1.0
+
+
+def assert_source_delta_g_matches_manifest(
+    *,
+    cell_label: str,
+    frac: float,
+    eval_delta_g_nats: float,
+    expected_delta_g_nats: float | None,
+    is_final_frac: bool,
+    band_stop_fired: bool,
+    tol_nats: float = DEFAULT_SOURCE_MANIFEST_TOL_NATS,
+    min_final_delta_g_nats: float = DEFAULT_MIN_FINAL_SOURCE_DELTA_G_NATS,
+) -> dict[str, Any]:
+    """Cross-check the eval's source-self ΔG against the selector manifest.
+
+    The #534 adapter-not-applied guard (round-2 fix). Two independent reads of
+    the SAME snapshot dir — the selector's HF/PEFT teacher-forced source ΔG
+    (``fraction_manifest.json.source_delta_g_at_selected_steps``) and this
+    rig's on-policy vLLM source-self ΔG — must agree to within ``tol_nats`` at
+    the final fraction. A silent vLLM LoRA no-op (wrong ``lora_int_id`` reuse,
+    unmatched module names, a future loader regression) makes the eval read
+    ≈0 while the manifest says 6+, tripping this guard BEFORE the flat
+    trajectory leaves the rig.
+
+    Clauses (fail loud, no silent pass):
+      1. ``expected`` present AND ``|eval − expected| > tol_nats``:
+         final fraction → raise ``SourceDeltaGManifestMismatchError``;
+         non-final fraction → WARN + verdict ``"warn_nonfinal_mismatch"``
+         (teacher-forced vs on-policy can legitimately diverge more at
+         small-ΔG mid-fractions; only the final fraction is a hard gate).
+      2. final fraction AND ``band_stop_fired`` AND
+         ``eval < min_final_delta_g_nats`` → raise (fires even when the
+         manifest expectation is missing, e.g. selector ran
+         ``--skip-source-trajectory``).
+
+    Args:
+        cell_label: cell + seed + frac string for log/error messages.
+        frac: this checkpoint's fraction (diagnostics only).
+        eval_delta_g_nats: the rig's on-policy source-self mean ΔG.
+        expected_delta_g_nats: the selector manifest's teacher-forced source
+            ΔG at the SAME selected step (None when unavailable).
+        is_final_frac: True when this checkpoint is the max-fraction entry.
+        band_stop_fired: True when the training band-stop fired (manifest
+            ``stopped``), i.e. the stop-step adapter is in [5, 12] nats.
+        tol_nats: max tolerated |eval − expected| at the final fraction.
+        min_final_delta_g_nats: floor for the final-fraction eval read when
+            the band-stop fired.
+
+    Returns:
+        Diag dict ``{"frac", "eval_delta_g_nats", "expected_delta_g_nats",
+        "disagreement_nats", "is_final_frac", "band_stop_fired", "tol_nats",
+        "min_final_delta_g_nats", "guard_verdict"}`` with verdict ``"pass"``
+        or ``"warn_nonfinal_mismatch"``.
+
+    Raises:
+        SourceDeltaGManifestMismatchError: clause 1 (final) or clause 2.
+    """
+    disagreement = (
+        abs(eval_delta_g_nats - expected_delta_g_nats)
+        if expected_delta_g_nats is not None
+        else None
+    )
+    diag: dict[str, Any] = {
+        "frac": float(frac),
+        "eval_delta_g_nats": float(eval_delta_g_nats),
+        "expected_delta_g_nats": (
+            float(expected_delta_g_nats) if expected_delta_g_nats is not None else None
+        ),
+        "disagreement_nats": float(disagreement) if disagreement is not None else None,
+        "is_final_frac": bool(is_final_frac),
+        "band_stop_fired": bool(band_stop_fired),
+        "tol_nats": float(tol_nats),
+        "min_final_delta_g_nats": float(min_final_delta_g_nats),
+    }
+
+    if disagreement is not None and disagreement > tol_nats:
+        if is_final_frac:
+            raise SourceDeltaGManifestMismatchError(
+                f"[{cell_label}] source-self ΔG disagrees with the selector manifest at the "
+                f"FINAL fraction (frac={frac}): eval(on-policy vLLM)={eval_delta_g_nats:.3f} "
+                f"nats vs manifest(teacher-forced HF/PEFT)={expected_delta_g_nats:.3f} nats — "
+                f"|Δ|={disagreement:.3f} > tol={tol_nats:.1f}. Two independent reads of the "
+                f"SAME snapshot dir cannot disagree this much unless the eval path did not "
+                f"actually apply the adapter (the #534 round-1 lora_int_id-reuse regression) "
+                f"or loaded the wrong one. Do NOT trust this trajectory.json."
+            )
+        log.warning(
+            "[%s] source-self ΔG vs manifest mismatch at NON-final frac=%s: eval=%.3f vs "
+            "expected=%.3f (|Δ|=%.3f > tol=%.1f) — recorded (not fatal; teacher-forced vs "
+            "on-policy diverge more at small-ΔG mid-fractions). If the FINAL fraction also "
+            "mismatches the run fails loud there.",
+            cell_label,
+            frac,
+            eval_delta_g_nats,
+            expected_delta_g_nats,
+            disagreement,
+            tol_nats,
+        )
+        diag["guard_verdict"] = "warn_nonfinal_mismatch"
+        return diag
+
+    if is_final_frac and band_stop_fired and eval_delta_g_nats < min_final_delta_g_nats:
+        raise SourceDeltaGManifestMismatchError(
+            f"[{cell_label}] band-stop fired (training stopped with source ΔG in [5, 12] nats "
+            f"teacher-forced) but the eval's on-policy source-self ΔG at the FINAL fraction "
+            f"(frac={frac}) is {eval_delta_g_nats:.3f} < {min_final_delta_g_nats:.1f} nats — "
+            f"the implant the selector verified is invisible to the eval path, i.e. the "
+            f"adapter was not (or wrongly) applied. Do NOT trust this trajectory.json."
+        )
+
+    diag["guard_verdict"] = "pass"
+    log.info(
+        "[%s] source-manifest guard PASS at frac=%s: eval=%.3f, expected=%s, final=%s.",
+        cell_label,
+        frac,
+        eval_delta_g_nats,
+        f"{expected_delta_g_nats:.3f}" if expected_delta_g_nats is not None else "n/a",
+        is_final_frac,
     )
     return diag

--- a/src/explore_persona_space/experiments/contrastive_neg_geometry_472/eval_trajectory.py
+++ b/src/explore_persona_space/experiments/contrastive_neg_geometry_472/eval_trajectory.py
@@ -373,6 +373,7 @@ def run_trajectory_eval(
     gpu_memory_utilization: float = DEFAULT_GPU_MEM_UTIL,
     max_model_len: int = DEFAULT_MAX_MODEL_LEN,
     compute_kl: bool = True,
+    source_guard_meta: dict | None = None,
 ) -> Path:
     """Run the on-policy trajectory eval for one cell × seed.
 
@@ -386,6 +387,15 @@ def run_trajectory_eval(
         base_model, max_new_tokens, max_lora_rank, gpu_memory_utilization,
             max_model_len: vLLM params.
         compute_kl: if False, skip DV-B (smoke speed-up).
+        source_guard_meta: #534 round-2 adapter-applied cross-check. None
+            (default) = exact legacy behavior. Otherwise a dict
+            ``{"expected_by_frac": {frac(float): teacher-forced source ΔG
+            (float) | None}, "band_stop_fired": bool, "tol_nats": float
+            (optional)}`` — after each checkpoint's source-self ΔG is
+            computed, ``assert_source_delta_g_matches_manifest`` fails loud
+            on >tol disagreement at the final fraction (and on a <1-nat
+            final read when the band-stop fired). The per-checkpoint diag is
+            persisted as ``checkpoints[*].source_manifest_check``.
 
     Returns:
         out_path.
@@ -418,12 +428,29 @@ def run_trajectory_eval(
 
     checkpoints_out: list[dict] = []
     r_cache: dict[float, dict[str, dict[str, str]]] = {}  # frac -> on-policy R (for KL phase)
-    for spec in checkpoint_specs:
+    # Final (max) fraction — the source-manifest guard's hard-fail gate.
+    final_frac = max(s["frac"] for s in checkpoint_specs)
+    # ck_i ids are unique only per engine lifetime: `llm` is function-local, so a
+    # hoist-the-engine refactor would re-open cross-call lora_int_id collision (#584).
+    for ck_i, spec in enumerate(checkpoint_specs, start=1):
         frac = spec["frac"]
         adapter_path = spec["adapter_path"]
         label = f"{cell_slug}_seed{seed}_frac{frac}"
-        lora_req = LoRARequest(lora_name=label, lora_int_id=1, lora_path=adapter_path)
-        log.info("[phase=traj_vllm] %s: on-policy gen + DV-A", label)
+        # #534 round-1 root cause: vLLM caches LoRA adapters STRICTLY by
+        # ``lora_int_id`` (LRUCacheWorkerLoRAManager.add_adapter: an already-
+        # seen id is "just touched" — ``lora_path`` is never re-read). Reusing
+        # ``lora_int_id=1`` for every checkpoint silently served the FIRST
+        # loaded adapter (step ~5, ΔG≈0.03) at all four fractions. Each
+        # checkpoint MUST get a DISTINCT id; the LRU (max_loras=1) evicts the
+        # previous adapter and loads the new path. #504/#530 never hit this
+        # because their checkpoint_index carried a single usable entry.
+        lora_req = LoRARequest(lora_name=label, lora_int_id=ck_i, lora_path=adapter_path)
+        log.info(
+            "[phase=traj_vllm] %s: on-policy gen + DV-A (lora_int_id=%d, path=%s)",
+            label,
+            ck_i,
+            adapter_path,
+        )
 
         # 1. Trained model writes its OWN R for held-out panel + source.
         r_on_policy = _generate_on_policy_R(
@@ -518,6 +545,27 @@ def run_trajectory_eval(
             "emission_p": float(src_emission_p),
             "r_collapsed": src_collapsed,
         }
+        # #534 round-2 adapter-applied cross-check: the selector's HF/PEFT
+        # teacher-forced source ΔG and this on-policy read look at the SAME
+        # snapshot dir through independent loaders — >tol disagreement at the
+        # final fraction means the eval path did not actually apply the
+        # adapter (fail loud BEFORE the flat trajectory leaves the rig).
+        source_manifest_check: dict | None = None
+        if source_guard_meta is not None:
+            from explore_persona_space.experiments.contrastive_neg_geometry_472.eval_guard import (
+                DEFAULT_SOURCE_MANIFEST_TOL_NATS,
+                assert_source_delta_g_matches_manifest,
+            )
+
+            source_manifest_check = assert_source_delta_g_matches_manifest(
+                cell_label=label,
+                frac=frac,
+                eval_delta_g_nats=source_self["delta_g_mean"],
+                expected_delta_g_nats=source_guard_meta.get("expected_by_frac", {}).get(frac),
+                is_final_frac=(frac == final_frac),
+                band_stop_fired=bool(source_guard_meta.get("band_stop_fired", False)),
+                tol_nats=float(source_guard_meta.get("tol_nats", DEFAULT_SOURCE_MANIFEST_TOL_NATS)),
+            )
         n_held_out_probes = len(eval_personas) * len(eval_questions)
         held_out_collapse_share = n_collapsed_ck / n_held_out_probes if n_held_out_probes else 0.0
         checkpoints_out.append(
@@ -526,6 +574,7 @@ def run_trajectory_eval(
                 "step": spec.get("step"),
                 "adapter_path": adapter_path,
                 "source_self": source_self,
+                "source_manifest_check": source_manifest_check,
                 "held_out_collapse_share": held_out_collapse_share,
                 "n_held_out_collapsed": n_collapsed_ck,
                 "held_out": held_out,

--- a/tests/test_i534_source_manifest_guard.py
+++ b/tests/test_i534_source_manifest_guard.py
@@ -1,0 +1,120 @@
+# ruff: noqa: RUF002  # Greek ΔG intentional
+"""Task #534 round-2 — source-manifest adapter-applied guard unit tests.
+
+Pins ``assert_source_delta_g_matches_manifest`` (eval_guard.py) against the
+round-1 incident: vLLM served the FIRST loaded adapter at every fraction
+(``lora_int_id`` reuse), the eval read a flat ≈0 trajectory, and neither the
+B-matrix guard (structural — the dirs WERE trained) nor the byte-identical
+guard (requires g == b exactly; a wrong-but-real adapter gives g ≠ b) could
+catch it. The new guard cross-checks the eval's own on-policy source-self ΔG
+against the selector manifest's teacher-forced read of the SAME snapshot.
+
+Numbers in these tests are the real #534 c504v3_near_seed42 values:
+manifest expectations {0.25: 0.033, 0.50: 0.324, 0.75: 2.204, 1.00: 6.277};
+the broken eval read 0.00–0.07 at every fraction; #530's on-policy read at
+the stop step was 5.82 vs 6.28 teacher-forced (~0.5-nat method noise).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from explore_persona_space.experiments.contrastive_neg_geometry_472.eval_guard import (
+    SourceDeltaGManifestMismatchError,
+    assert_source_delta_g_matches_manifest,
+)
+
+
+def test_pass_within_tolerance_at_final_fraction():
+    """#530-calibrated method noise (~0.5 nat) passes at the final fraction."""
+    diag = assert_source_delta_g_matches_manifest(
+        cell_label="c504v3_near_seed42_frac1.0",
+        frac=1.0,
+        eval_delta_g_nats=5.82,
+        expected_delta_g_nats=6.277,
+        is_final_frac=True,
+        band_stop_fired=True,
+    )
+    assert diag["guard_verdict"] == "pass"
+    assert diag["disagreement_nats"] == pytest.approx(0.457, abs=1e-3)
+
+
+def test_round1_regression_raises_at_final_fraction():
+    """THE round-1 bug: eval reads ≈0 at frac=1.00 while the manifest says 6.28."""
+    with pytest.raises(SourceDeltaGManifestMismatchError, match="FINAL fraction"):
+        assert_source_delta_g_matches_manifest(
+            cell_label="c504v3_near_seed42_frac1.0",
+            frac=1.0,
+            eval_delta_g_nats=0.04,
+            expected_delta_g_nats=6.277,
+            is_final_frac=True,
+            band_stop_fired=True,
+        )
+
+
+def test_nonfinal_mismatch_warns_but_does_not_raise():
+    """frac=0.75 under the round-1 bug: 0.01 vs 2.204 — recorded, not fatal."""
+    diag = assert_source_delta_g_matches_manifest(
+        cell_label="c504v3_near_seed42_frac0.75",
+        frac=0.75,
+        eval_delta_g_nats=0.01,
+        expected_delta_g_nats=2.204,
+        is_final_frac=False,
+        band_stop_fired=True,
+    )
+    assert diag["guard_verdict"] == "warn_nonfinal_mismatch"
+
+
+def test_band_stop_floor_clause_fires_without_expected():
+    """Manifest expectation missing (--skip-source-trajectory) but band fired:
+    a < 1-nat final read is still physically inconsistent → raise."""
+    with pytest.raises(SourceDeltaGManifestMismatchError, match="band-stop fired"):
+        assert_source_delta_g_matches_manifest(
+            cell_label="c504v3_far_seed137_frac1.0",
+            frac=1.0,
+            eval_delta_g_nats=0.4,
+            expected_delta_g_nats=None,
+            is_final_frac=True,
+            band_stop_fired=True,
+        )
+
+
+def test_no_expected_nonfinal_passes():
+    """No expectation + non-final fraction: nothing to check → pass."""
+    diag = assert_source_delta_g_matches_manifest(
+        cell_label="c504v3_near_seed42_frac0.25",
+        frac=0.25,
+        eval_delta_g_nats=0.02,
+        expected_delta_g_nats=None,
+        is_final_frac=False,
+        band_stop_fired=True,
+    )
+    assert diag["guard_verdict"] == "pass"
+    assert diag["disagreement_nats"] is None
+
+
+def test_no_band_stop_final_floor_does_not_fire():
+    """Cell never band-stopped (flagged in the manifest): the final-fraction
+    floor clause must NOT fire — a genuinely-weak implant is a measurement."""
+    diag = assert_source_delta_g_matches_manifest(
+        cell_label="c504v3_default_only_seed42_frac1.0",
+        frac=1.0,
+        eval_delta_g_nats=0.4,
+        expected_delta_g_nats=None,
+        is_final_frac=True,
+        band_stop_fired=False,
+    )
+    assert diag["guard_verdict"] == "pass"
+
+
+def test_small_fraction_agreement_passes():
+    """frac=0.25 with the adapter ACTUALLY applied: 0.02 vs 0.033 agrees."""
+    diag = assert_source_delta_g_matches_manifest(
+        cell_label="c504v3_near_seed42_frac0.25",
+        frac=0.25,
+        eval_delta_g_nats=0.02,
+        expected_delta_g_nats=0.033,
+        is_final_frac=False,
+        band_stop_fired=True,
+    )
+    assert diag["guard_verdict"] == "pass"

--- a/tests/test_i584_lora_int_id_distinct.py
+++ b/tests/test_i584_lora_int_id_distinct.py
@@ -1,0 +1,82 @@
+"""#584 regression — multi-checkpoint trajectory eval must use distinct lora_int_id.
+
+Pins the #534 round-1 incident at the source level: vLLM caches LoRA adapters
+strictly by lora_int_id (LRUCacheWorkerLoRAManager.add_adapter "just touches"
+an already-seen id — lora_path never re-read), so a constant id inside the
+checkpoint loop silently serves the FIRST-loaded adapter at every fraction.
+Static layer (this file): the LoRARequest construction inside
+run_trajectory_eval must not pass a literal lora_int_id — neither as the
+keyword ``lora_int_id=<constant>`` nor as a positional constant at argument
+index 1 (lora_int_id is LoRARequest's second positional field, so
+``LoRARequest(label, 1, path)`` would evade a keyword-only checker). Runtime
+layer (ported with the fix): eval_guard.assert_source_delta_g_matches_manifest
+(tests/test_i534_source_manifest_guard.py). No GPU, no vllm import.
+"""
+
+import ast
+from pathlib import Path
+
+EVAL_TRAJECTORY = (
+    Path(__file__).resolve().parent.parent
+    / "src/explore_persona_space/experiments/contrastive_neg_geometry_472/eval_trajectory.py"
+)
+
+OLD_BUGGY_SNIPPET_KEYWORD = """
+def run_trajectory_eval(checkpoint_specs):
+    for spec in checkpoint_specs:
+        label = "x"; adapter_path = spec["adapter_path"]
+        lora_req = LoRARequest(lora_name=label, lora_int_id=1, lora_path=adapter_path)
+"""  # verbatim shape of pre-#584 main (eval_trajectory.py:425)
+
+OLD_BUGGY_SNIPPET_POSITIONAL = """
+def run_trajectory_eval(checkpoint_specs):
+    for spec in checkpoint_specs:
+        label = "x"; adapter_path = spec["adapter_path"]
+        lora_req = LoRARequest(label, 1, adapter_path)
+"""  # positional-evasion variant: constant at args index 1 (the lora_int_id slot)
+
+
+def _lora_request_calls(source: str) -> list[ast.Call]:
+    tree = ast.parse(source)
+    fn = next(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.FunctionDef) and n.name == "run_trajectory_eval"
+    )
+    return [
+        n
+        for n in ast.walk(fn)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == "LoRARequest"
+    ]
+
+
+def _constant_lora_int_id_lines(source: str) -> list[int]:
+    """Lines where a LoRARequest inside run_trajectory_eval gets a LITERAL lora_int_id.
+
+    Flags BOTH shapes: keyword ``lora_int_id=<ast.Constant>`` AND a positional
+    ``ast.Constant`` at args index 1 (lora_int_id is the second positional field).
+    """
+    lines: list[int] = []
+    for c in _lora_request_calls(source):
+        for kw in c.keywords:
+            if kw.arg == "lora_int_id" and isinstance(kw.value, ast.Constant):
+                lines.append(c.lineno)
+        if len(c.args) >= 2 and isinstance(c.args[1], ast.Constant):
+            lines.append(c.lineno)
+    return lines
+
+
+def test_checker_flags_the_old_constant_id_construction():
+    # self-validation, both shapes: the checker must flag the literal incident
+    # shape (keyword) AND the positional-evasion variant (constant at args[1]).
+    assert _constant_lora_int_id_lines(OLD_BUGGY_SNIPPET_KEYWORD)
+    assert _constant_lora_int_id_lines(OLD_BUGGY_SNIPPET_POSITIONAL)
+
+
+def test_live_rig_constructs_non_constant_lora_int_id():
+    assert _constant_lora_int_id_lines(EVAL_TRAJECTORY.read_text()) == []
+
+
+def test_live_rig_still_constructs_a_lora_request():
+    # anti-rot: the contract must not pass vacuously after a rename/refactor
+    assert len(_lora_request_calls(EVAL_TRAJECTORY.read_text())) >= 1


### PR DESCRIPTION
Closes task #584. Port of 298877f9c (distinct lora_int_id per checkpoint + opt-in source-manifest guard) + AST regression test (keyword+positional literal) + q_test sha256 pin. Code-review ensemble PASS+PASS; test-verdict PASS (zero new failures vs pre-port baseline).