### PR TITLE
task #418: make pytest green — port existing_adapter_path + hermetic stalled-detector tests

### DIFF
--- a/src/explore_persona_space/train/sft.py
+++ b/src/explore_persona_space/train/sft.py
@@ -53,7 +53,8 @@ from explore_persona_space.personas import MARKER_TOKEN
 logger = logging.getLogger(__name__)
 
 # Note: Liger-Kernel is hardcoded off in train_lora() below because the path
-# always wraps the model via peft_config -> PeftModel and fused kernels regress
+# always trains a PeftModel (fresh-LoRA wraps via peft_config; the continue-
+# adapter path loads a PeftModel directly) and fused kernels regress
 # ~2x on PEFT-wrapped linears. Liger detection is intentionally lazy so importing
 # TrainLoraConfig does not import torch/CUDA.
 
@@ -667,8 +668,8 @@ class TrainLoraConfig:
     #   - The adapter is loaded via PeftModel.from_pretrained(base, path,
     #     is_trainable=True), preserving the existing LoRA weights as the
     #     starting point.
-    #   - The TRL SFTTrainer receives the prepared PeftModel directly with
-    #     peft_config=None (so it does NOT re-wrap with a new adapter).
+    #   - The TRL SFTTrainer receives the prepared PeftModel directly and the
+    #     peft_config kwarg is OMITTED (so it does NOT re-wrap with a new adapter).
     #   - lora_r / lora_alpha / lora_dropout / lora_targets are ignored
     #     (the loaded adapter's own config wins; we are CONTINUING the same
     #     adapter, not building a different one).
@@ -1095,8 +1096,8 @@ def train_lora(  # noqa: C901 - inline empty-train-jsonl preflight pushed cyclom
     if cfg.existing_adapter_path:
         # CONTINUE an existing LoRA adapter (issue #475 Phase 2 + future
         # multi-phase recipes). Load the adapter weights ON TOP of the
-        # untouched base and pass the PeftModel to SFTTrainer with
-        # peft_config=None so TRL does NOT re-wrap with a fresh adapter.
+        # untouched base and pass the PeftModel to SFTTrainer with the
+        # peft_config kwarg omitted so TRL does NOT re-wrap with a fresh adapter.
         from peft import PeftModel
 
         adapter_dir = Path(cfg.existing_adapter_path)

--- a/src/explore_persona_space/train/sft.py
+++ b/src/explore_persona_space/train/sft.py
@@ -661,6 +661,22 @@ class TrainLoraConfig:
     hf_upload: bool = True
     hf_repo: str = "superkaiba1/explore-persona-space"
     hf_path_in_repo: str = ""  # if empty, derived from run_name as "adapters/{run_name}"
+    # CONTINUE an existing LoRA adapter through this training run (instead of
+    # attaching a fresh randomly-initialized LoRA on top of the base). When set:
+    #   - The base is loaded from base_model_path UNTOUCHED (no merge).
+    #   - The adapter is loaded via PeftModel.from_pretrained(base, path,
+    #     is_trainable=True), preserving the existing LoRA weights as the
+    #     starting point.
+    #   - The TRL SFTTrainer receives the prepared PeftModel directly with
+    #     peft_config=None (so it does NOT re-wrap with a new adapter).
+    #   - lora_r / lora_alpha / lora_dropout / lora_targets are ignored
+    #     (the loaded adapter's own config wins; we are CONTINUING the same
+    #     adapter, not building a different one).
+    # Used by Phase-2 survival probes (e.g. issue #475 plan §4.7) where the
+    # comparator semantics require continuing the SAME Phase-1 adapter through
+    # benign SFT, not merging+fresh-LoRA. Mutually exclusive with attaching a
+    # fresh adapter (the standard path).
+    existing_adapter_path: str | None = None
     # Training backend selector. "hf" = current TRL + PEFT path. "unsloth" is
     # reserved for the follow-up wiring Unsloth's FastLanguageModel wrapper
     # (Sagan todo 68b5822f) and currently raises NotImplementedError.
@@ -1076,35 +1092,92 @@ def train_lora(  # noqa: C901 - inline empty-train-jsonl preflight pushed cyclom
         token=os.environ.get("HF_TOKEN"),
     )
 
-    # LoRA target modules: callers can pin a subset (e.g. issue #478/#490's
-    # attn-only non-saturating anchor: ["q_proj","k_proj","v_proj","o_proj"]).
-    # When unset, use the historical 7-module list (q/k/v/o + MLP) for
-    # byte-identical backward compatibility with every pre-#478 caller.
-    _DEFAULT_LORA_TARGETS = [
-        "q_proj",
-        "k_proj",
-        "v_proj",
-        "o_proj",
-        "gate_proj",
-        "up_proj",
-        "down_proj",
-    ]
-    effective_lora_targets = (
-        list(cfg.lora_targets) if cfg.lora_targets else list(_DEFAULT_LORA_TARGETS)
-    )
-    logger.info(
-        "LoRA target_modules = %s (custom=%s)",
-        effective_lora_targets,
-        cfg.lora_targets is not None,
-    )
-    lora_config = LoraConfig(
-        task_type=TaskType.CAUSAL_LM,
-        r=cfg.lora_r,
-        lora_alpha=cfg.lora_alpha,
-        lora_dropout=cfg.lora_dropout,
-        target_modules=effective_lora_targets,
-        use_rslora=True,
-    )
+    if cfg.existing_adapter_path:
+        # CONTINUE an existing LoRA adapter (issue #475 Phase 2 + future
+        # multi-phase recipes). Load the adapter weights ON TOP of the
+        # untouched base and pass the PeftModel to SFTTrainer with
+        # peft_config=None so TRL does NOT re-wrap with a fresh adapter.
+        from peft import PeftModel
+
+        adapter_dir = Path(cfg.existing_adapter_path)
+        if not adapter_dir.exists():
+            raise FileNotFoundError(
+                f"existing_adapter_path={adapter_dir!s} does not exist; "
+                "cannot continue training a non-existent adapter."
+            )
+        logger.info(
+            "Continuing LoRA adapter from %s (is_trainable=True); "
+            "lora_r/lora_alpha/lora_dropout/lora_targets in cfg are IGNORED — "
+            "the loaded adapter's own config wins.",
+            adapter_dir,
+        )
+        model = PeftModel.from_pretrained(model, str(adapter_dir), is_trainable=True)
+        # FAIL-LOUD verify the loaded adapter is actually trainable.
+        # `PeftModel.from_pretrained(..., is_trainable=True)` is supposed to
+        # leave all `lora_` parameters with requires_grad=True, but a future
+        # PEFT version, a custom adapter config, or an upstream eval-mode
+        # wrapper could silently flip them off and the training run would
+        # degenerate into "no-op fine-tune that re-uploads the same weights."
+        # `model.train()` first so eval-mode flags from `.from_pretrained`
+        # don't survive into training.
+        model.train()
+        lora_params = [(n, p) for n, p in model.named_parameters() if "lora_" in n]
+        trainable_lora = [(n, p) for n, p in lora_params if p.requires_grad]
+        n_trainable_params = sum(p.numel() for _, p in trainable_lora)
+        logger.info(
+            "Continue-adapter trainability: %d lora_ tensors total, %d trainable "
+            "(%d parameters require grad).",
+            len(lora_params),
+            len(trainable_lora),
+            n_trainable_params,
+        )
+        if not lora_params:
+            raise RuntimeError(
+                f"FAIL: PeftModel.from_pretrained({adapter_dir!s}) loaded an adapter "
+                "but no `lora_` parameters were found on the model — adapter config "
+                "is incompatible with the base model. Aborting before SFT silently "
+                "trains zero parameters."
+            )
+        if not trainable_lora:
+            raise RuntimeError(
+                f"FAIL: PeftModel.from_pretrained({adapter_dir!s}) loaded "
+                f"{len(lora_params)} `lora_` parameter tensors but NONE has "
+                "requires_grad=True after model.train(). The continue-adapter "
+                "branch would do a no-op fine-tune. Check PEFT version + adapter "
+                "config; this contract is enforced by "
+                "tests/test_issue475_common.py::test_continue_adapter_branch_keeps_lora_trainable."
+            )
+        lora_config = None  # signals "do NOT pass peft_config to SFTTrainer"
+    else:
+        # LoRA target modules: callers can pin a subset (e.g. issue #478/#490's
+        # attn-only non-saturating anchor: ["q_proj","k_proj","v_proj","o_proj"]).
+        # When unset, use the historical 7-module list (q/k/v/o + MLP) for
+        # byte-identical backward compatibility with every pre-#478 caller.
+        _DEFAULT_LORA_TARGETS = [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "o_proj",
+            "gate_proj",
+            "up_proj",
+            "down_proj",
+        ]
+        effective_lora_targets = (
+            list(cfg.lora_targets) if cfg.lora_targets else list(_DEFAULT_LORA_TARGETS)
+        )
+        logger.info(
+            "LoRA target_modules = %s (custom=%s)",
+            effective_lora_targets,
+            cfg.lora_targets is not None,
+        )
+        lora_config = LoraConfig(
+            task_type=TaskType.CAUSAL_LM,
+            r=cfg.lora_r,
+            lora_alpha=cfg.lora_alpha,
+            lora_dropout=cfg.lora_dropout,
+            target_modules=effective_lora_targets,
+            use_rslora=True,
+        )
 
     # Round-6 (issue #365): defend against the round-5 StopIteration crash.
     # `load_dataset("json", ...)` raises a bare ``StopIteration`` (with no
@@ -1197,8 +1270,13 @@ def train_lora(  # noqa: C901 - inline empty-train-jsonl preflight pushed cyclom
         "args": sft_config,
         "train_dataset": dataset,
         "processing_class": tokenizer,
-        "peft_config": lora_config,
     }
+    if lora_config is not None:
+        # Fresh-LoRA path — TRL wraps the model.
+        sft_trainer_kwargs["peft_config"] = lora_config
+    # else: continue-adapter path — model is already a PeftModel; do NOT
+    # pass peft_config (would re-wrap with a fresh adapter and lose the
+    # continuation contract).
     if callbacks:
         sft_trainer_kwargs["callbacks"] = callbacks
     trainer = SFTTrainer(**sft_trainer_kwargs)

--- a/tests/test_stalled_detector_and_gc.py
+++ b/tests/test_stalled_detector_and_gc.py
@@ -419,7 +419,30 @@ def _write_autonomous_entry(reg_dir, issue, session_id, *, spawned_at=None):
     )
 
 
-def test_stalled_pass_alerts_after_two_consecutive_stale_ticks(isolated_registry, monkeypatch):
+@pytest.fixture
+def hermetic_provision_probes(tmp_path, monkeypatch):
+    """Isolate the ALIVE-BUT-STALLED provisioning exemption (refs #573) from
+    real VM state. Two environment probes can suppress the alert these tests
+    assert: (a) `_POLL_STATE_DIR` points at the repo's REAL `.claude/cache/`,
+    where a real `poll-pipeline-<N>.json` (e.g. issue 489's) has a 2026 mtime
+    that reads as negative age — i.e. "fresh" — against the mocked
+    `now=1_000_000.0` clock; (b) `_find_provision_process` scans /proc and can
+    match a live `pod.py provision --issue <N>` on the VM. Point the poll-state
+    dir at an empty tmp dir and stub the process probe to None so the tests
+    exercise the detector logic, not the host's state.
+    """
+    import autonomous_session_watch as asw
+
+    poll_dir = tmp_path / "poll-state-empty"
+    poll_dir.mkdir()
+    monkeypatch.setattr(asw, "_POLL_STATE_DIR", poll_dir)
+    monkeypatch.setattr(asw, "_find_provision_process", lambda issue: None)
+    return poll_dir
+
+
+def test_stalled_pass_alerts_after_two_consecutive_stale_ticks(
+    isolated_registry, hermetic_provision_probes, monkeypatch
+):
     import autonomous_session_watch as asw
 
     now = 1_000_000.0
@@ -455,7 +478,9 @@ def test_stalled_pass_alerts_after_two_consecutive_stale_ticks(isolated_registry
     assert state["missed"] == 0
 
 
-def test_stalled_pass_dedups_within_episode(isolated_registry, monkeypatch):
+def test_stalled_pass_dedups_within_episode(
+    isolated_registry, hermetic_provision_probes, monkeypatch
+):
     import autonomous_session_watch as asw
 
     now = 1_000_000.0
@@ -483,7 +508,9 @@ def test_stalled_pass_dedups_within_episode(isolated_registry, monkeypatch):
     assert posts == [(489, "session-stalled-alert")]
 
 
-def test_stalled_pass_clears_alerted_when_self_report_advances(isolated_registry, monkeypatch):
+def test_stalled_pass_clears_alerted_when_self_report_advances(
+    isolated_registry, hermetic_provision_probes, monkeypatch
+):
     # Episode 1: alert fires while frozen at ts_a. Self-report advances to
     # ts_b -> alerted clears (session recovered). Goes stale again -> NEW
     # alert episode.
@@ -533,7 +560,9 @@ def test_stalled_pass_clears_alerted_when_self_report_advances(isolated_registry
     ]
 
 
-def test_stalled_pass_skips_when_no_self_report(isolated_registry, monkeypatch):
+def test_stalled_pass_skips_when_no_self_report(
+    isolated_registry, hermetic_provision_probes, monkeypatch
+):
     # Interactive (or just-spawned) sessions have no self-report file —
     # the pass treats that as "doesn't apply" and never alerts.
     import autonomous_session_watch as asw
@@ -556,7 +585,9 @@ def test_stalled_pass_skips_when_no_self_report(isolated_registry, monkeypatch):
     assert posts == []
 
 
-def test_stalled_pass_never_respawns_or_stops(isolated_registry, monkeypatch):
+def test_stalled_pass_never_respawns_or_stops(
+    isolated_registry, hermetic_provision_probes, monkeypatch
+):
     # Hard contract: the stalled pass is ALERT-ONLY this round. It MUST NOT
     # call _respawn or _stop_pod. Pin the contract.
     import autonomous_session_watch as asw
@@ -584,7 +615,9 @@ def test_stalled_pass_never_respawns_or_stops(isolated_registry, monkeypatch):
     assert stops == []
 
 
-def test_stalled_pass_manual_session_alert_only_never_respawns(isolated_registry, monkeypatch):
+def test_stalled_pass_manual_session_alert_only_never_respawns(
+    isolated_registry, hermetic_provision_probes, monkeypatch
+):
     # Manual sessions (``manual-issue-<N>.json``, bare ``spawn-issue``) get
     # the SAME staleness detection in ALERT-ONLY mode (#505 round-2,
     # 2026-06-10): a stalled user-driven session posts the one-time alert
@@ -637,7 +670,9 @@ def test_stalled_pass_manual_session_alert_only_never_respawns(isolated_registry
     assert state["alerted"] is True
 
 
-def test_stalled_pass_dry_run_no_state_write(isolated_registry, monkeypatch):
+def test_stalled_pass_dry_run_no_state_write(
+    isolated_registry, hermetic_provision_probes, monkeypatch
+):
     import autonomous_session_watch as asw
 
     now = 1_000_000.0


### PR DESCRIPTION
Closes task #418.

## Summary
- Surgical port of `existing_adapter_path` + the continue-adapter branch from the issue-475 branch into main's `src/explore_persona_space/train/sft.py` (the selective merge fc9b72055 landed issue-475's tests + driver scripts without the src/ change; on-main scripts already pass the field).
- Hermetic fixture in `tests/test_stalled_detector_and_gc.py` isolating `_POLL_STATE_DIR` + `_find_provision_process` across all `test_stalled_pass_*` tests (the ALIVE-BUT-STALLED exemption was reading this VM's real `poll-pipeline-489.json`).
- Comment alignment nit from the review ensemble (omitted-`peft_config` trainer shape).

## Test plan
- [x] Targeted: `tests/test_issue475_common.py` + `tests/test_stalled_detector_and_gc.py` → 76/76
- [x] Full suite in worktree: 0 relevant failures (3 worktree-environment cases verified passing at repo root)
- [x] ruff check + format clean on touched files
- [x] Code-review ensemble PASS (Claude PASS, Codex CONCERNS/merge); epm:test-verdict v1 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)