### PR TITLE
task #554: branch-aware preflight git check + fail-loud bare mode

### DIFF
--- a/src/explore_persona_space/orchestrate/preflight.py
+++ b/src/explore_persona_space/orchestrate/preflight.py
@@ -1003,7 +1003,10 @@ def main(argv: list[str] | None = None) -> int:
             timeout=600,
         )
         if stdout:
-            print(stdout)
+            # In --json mode pytest output routes to stderr so stdout stays
+            # exactly one parseable JSON object (gotchas.md contract); bare
+            # mode keeps pytest stdout on stdout.
+            print(stdout, file=sys.stderr if args.json else sys.stdout)
         if stderr:
             print(stderr, file=sys.stderr)
         if rc != 0:

--- a/src/explore_persona_space/orchestrate/preflight.py
+++ b/src/explore_persona_space/orchestrate/preflight.py
@@ -143,6 +143,36 @@ def _run(cmd: list[str], timeout: int = 10) -> tuple[int, str, str]:
         return -1, "", str(e)
 
 
+def _behind_count(project_root: Path, ref: str) -> int | None:
+    """Commits HEAD is behind ``ref`` (via ``git rev-list --count HEAD..<ref>``).
+
+    Returns None when the count cannot be determined (missing ref → rc=128,
+    git error, non-integer output). Callers treat None as "unknown", never 0.
+    """
+    rc, out, _ = _run(["git", "-C", str(project_root), "rev-list", "--count", f"HEAD..{ref}"])
+    if rc != 0:
+        return None
+    try:
+        return int(out.strip())
+    except ValueError:
+        return None
+
+
+def _ahead_count(project_root: Path, ref: str) -> int | None:
+    """Commits HEAD is ahead of ``ref`` (via ``git rev-list --count <ref>..HEAD``).
+
+    Returns None when the count cannot be determined. Callers treat None as
+    "unknown" (best-effort signal — an unknown ahead-count never errors).
+    """
+    rc, out, _ = _run(["git", "-C", str(project_root), "rev-list", "--count", f"{ref}..HEAD"])
+    if rc != 0:
+        return None
+    try:
+        return int(out.strip())
+    except ValueError:
+        return None
+
+
 def _find_project_root() -> Path:
     """Find project root by looking for pyproject.toml."""
     p = Path(__file__).resolve()
@@ -179,7 +209,14 @@ def _disk_check_path() -> str:
 
 
 def check_git_status(report: PreflightReport, project_root: Path):
-    """Check git working tree is clean and up to date.
+    """Check git working tree is clean and up to date — branch-aware (#554).
+
+    The behind-remote comparison is keyed on the current branch: ``main``
+    compares against ``origin/main`` (ERROR when behind, message unchanged);
+    a feature branch compares against its OWN ``origin/<branch>`` ref (the
+    run-of-record on the canonical ``/issue`` pod checkout), with divergence
+    from ``origin/main`` demoted to an informational WARNING; detached HEAD
+    (pinned-SHA checkout) only warns.
 
     Cluster branch: the ``git fetch origin`` round trip is SKIPPED because
     the cluster compute node has no remote git auth — code reaches the
@@ -211,15 +248,145 @@ def check_git_status(report: PreflightReport, project_root: Path):
         report.git_status += " (cluster — skipped fetch)"
         return
 
-    # Check if behind remote
-    _run(["git", "-C", str(project_root), "fetch", "--quiet", "origin"], timeout=15)
-    rc, out, _ = _run(["git", "-C", str(project_root), "rev-list", "--count", "HEAD..origin/main"])
-    if rc == 0 and out.strip() != "0":
-        behind = out.strip()
-        report.add_error(
-            f"Local is {behind} commit(s) behind origin/main. Run: git pull origin main"
+    # Behind-remote check — branch-aware (#554). On the canonical /issue pod
+    # checkout HEAD is on `issue-<N>`; the branch's own pushed origin ref IS
+    # the run-of-record, and divergence from origin/main is expected (#383,
+    # #550). ERROR is reserved for "behind the ref this checkout tracks".
+    # The fetch rc is CAPTURED: the behind-own guarantee below is only as
+    # fresh as this fetch, so a failed fetch on a feature branch is an ERROR,
+    # never a silent stale-ref false PASS.
+    fetch_rc, _, fetch_err = _run(
+        ["git", "-C", str(project_root), "fetch", "--quiet", "origin"], timeout=15
+    )
+    fetch_failed = fetch_rc != 0
+
+    rc, branch, err = _run(["git", "-C", str(project_root), "rev-parse", "--abbrev-ref", "HEAD"])
+    if rc != 0:
+        report.add_warning(f"could not determine current branch: {err}")
+        report.git_status += ", branch unknown"
+        return
+    branch = branch.strip()
+
+    if branch == "main":
+        _check_main_branch_behind(report, project_root, fetch_failed, fetch_err)
+        return
+
+    if branch == "HEAD":
+        _check_detached_head_behind(report, project_root, fetch_failed, fetch_err)
+        return
+
+    _check_feature_branch_behind(report, project_root, branch, fetch_failed, fetch_err)
+
+
+def _check_main_branch_behind(
+    report: PreflightReport, project_root: Path, fetch_failed: bool, fetch_err: str
+):
+    """Behind-remote check for ``main``: ERROR when behind origin/main.
+
+    The ERROR message is byte-identical to the pre-#554 one — agent specs
+    tolerance-match it verbatim.
+    """
+    if fetch_failed:
+        # Main's gate decision stays as before: warn, then compute against
+        # last-fetched refs exactly as the old code did. Staleness here is
+        # fail-soft toward PASS — a timed-out fetch reads last-fetched
+        # refs, which can only UNDER-count how far behind main is.
+        report.add_warning(
+            f"git fetch origin failed ({fetch_err}); behind-origin/main "
+            f"computed against last-fetched refs."
         )
-        report.git_status += f", {behind} behind remote"
+    behind_main = _behind_count(project_root, "origin/main")
+    if behind_main:  # None (count unknown) keeps the prior silent-skip behavior
+        report.add_error(
+            f"Local is {behind_main} commit(s) behind origin/main. Run: git pull origin main"
+        )
+        report.git_status += f", {behind_main} behind remote"
+
+
+def _check_detached_head_behind(
+    report: PreflightReport, project_root: Path, fetch_failed: bool, fetch_err: str
+):
+    """Detached HEAD (pinned-SHA checkout): no own ref to be behind — warn only."""
+    if fetch_failed:
+        report.add_warning(
+            f"git fetch origin failed ({fetch_err}); ref comparisons use last-fetched refs."
+        )
+    behind_main = _behind_count(project_root, "origin/main")
+    if behind_main:
+        report.add_warning(
+            f"Detached HEAD is {behind_main} commit(s) behind origin/main — "
+            f"verify the pinned commit is the intended run-of-record."
+        )
+    report.git_status += " (detached HEAD)"
+
+
+def _check_feature_branch_behind(
+    report: PreflightReport, project_root: Path, branch: str, fetch_failed: bool, fetch_err: str
+):
+    """Feature branch: ERROR only when behind/diverged from its OWN origin ref.
+
+    Divergence from origin/main is expected on a feature branch and demoted
+    to an informational WARNING.
+    """
+    # A failed fetch means the branch's own origin ref may be stale, so
+    # behind_own == 0 proves nothing — fail LOUD. This is the one place
+    # fetch failure is an ERROR.
+    if fetch_failed:
+        report.add_error(
+            f"git fetch origin failed ({fetch_err}) — cannot verify branch "
+            f"{branch} is up to date with origin/{branch}."
+        )
+        report.git_status += ", fetch failed"
+        return
+
+    # Compare against the branch's OWN origin ref. The full refs/remotes/
+    # spelling is used in BOTH the existence probe and the rev-list counts so
+    # a same-named tag can never make the bare `origin/<branch>` form
+    # ambiguous.
+    own_ref = f"origin/{branch}"
+    own_ref_full = f"refs/remotes/{own_ref}"
+    rc_ref, _, _ = _run(
+        ["git", "-C", str(project_root), "rev-parse", "--verify", "--quiet", own_ref_full]
+    )
+    if rc_ref == 0:
+        behind_own = _behind_count(project_root, own_ref_full)
+        ahead_own = _ahead_count(project_root, own_ref_full)
+        if behind_own is None:
+            report.add_warning(f"could not count commits behind {own_ref}")
+        elif behind_own and ahead_own:
+            report.add_error(
+                f"Branch {branch} has diverged from {own_ref} ({behind_own} behind, "
+                f"{ahead_own} ahead) — reconcile (rebase onto or merge {own_ref}); "
+                f"a plain git pull --ff-only will fail."
+            )
+            report.git_status += f", diverged from {own_ref}"
+        elif behind_own:
+            report.add_error(
+                f"Branch {branch} is {behind_own} commit(s) behind {own_ref}. "
+                f"Run: git pull --ff-only origin {branch}"
+            )
+            report.git_status += f", {behind_own} behind {own_ref}"
+        elif ahead_own:
+            report.add_warning(
+                f"Branch {branch} is {ahead_own} commit(s) ahead of {own_ref} "
+                f"(committed but unpushed) — the running code is not the pushed "
+                f"run-of-record."
+            )
+            report.git_status += f", {ahead_own} ahead of {own_ref}"
+    else:
+        report.add_warning(
+            f"Branch {branch} has no pushed {own_ref} ref — cannot verify "
+            f"up-to-date-ness (unpushed local branch)."
+        )
+        report.git_status += f" (no {own_ref})"
+
+    behind_main = _behind_count(project_root, "origin/main")
+    if behind_main:
+        report.add_warning(
+            f"Branch {branch} is {behind_main} commit(s) behind origin/main "
+            f"(expected on a feature branch; informational)."
+        )
+        report.git_status += f", {behind_main} behind origin/main"
 
 
 def check_env_sync(report: PreflightReport, project_root: Path):
@@ -742,16 +909,22 @@ def require_preflight(
         require_gpu=require_gpu,
         min_gpu_free_mb=min_gpu_free_mb,
     )
-    logger.info(report.summary())
+    if report.ok:
+        logger.info(report.summary())
+        return report
 
-    if not report.ok:
-        logger.error("Pre-flight check FAILED. Fix errors before running.")
-        sys.exit(1)
+    # FAIL path — fail LOUD on a real stream. A handler-less logger.info()
+    # emits zero bytes (root logger defaults to WARNING with no handlers), so
+    # a launcher under `set -e` dies with an unattributable 0-byte log (#550).
+    # The summary is emitted by exactly ONE statement per branch: logger.info
+    # on PASS, raw stderr here on FAIL — never both.
+    print(report.summary(), file=sys.stderr)
+    logger.error("Pre-flight check FAILED. Fix errors before running.")
+    sys.exit(1)
 
-    return report
 
-
-if __name__ == "__main__":
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns the process exit code (0 = preflight PASS)."""
     import argparse
 
     parser = argparse.ArgumentParser(description="Run pre-flight checks")
@@ -779,7 +952,7 @@ if __name__ == "__main__":
         action="store_true",
         help="Run integration tests (pytest tests/integration/ -m integration) after preflight",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     # A negative quota means "disable the cap" (argparse cannot pass None cleanly).
     per_pod_quota_gb = None if args.per_pod_quota_gb < 0 else args.per_pod_quota_gb
@@ -792,6 +965,8 @@ if __name__ == "__main__":
     )
 
     if args.json:
+        # Contract (gotchas.md): exactly one pretty-printed JSON object and
+        # nothing else on stdout — consumers parse the WHOLE stdout.
         print(
             json.dumps(
                 {
@@ -809,13 +984,20 @@ if __name__ == "__main__":
             )
         )
     else:
-        logger.info(report.summary())
+        # Bare mode: print(), never a handler-less logger.info() that emits
+        # zero bytes and leaves a `set -e` death unattributable (#550/#554).
+        print(report.summary())
+        if not report.ok:
+            for e in report.errors:
+                print(f"preflight ERROR: {e}", file=sys.stderr)
 
     if not report.ok:
-        sys.exit(1)
+        return 1
 
     if args.pipeline_check:
-        logger.info("Running integration tests...")
+        # Status lines stay off stdout in --json mode (JSON-purity contract).
+        if not args.json:
+            print("Running integration tests...")
         rc, stdout, stderr = _run(
             [sys.executable, "-m", "pytest", "tests/integration/", "-m", "integration", "-x", "-v"],
             timeout=600,
@@ -825,8 +1007,12 @@ if __name__ == "__main__":
         if stderr:
             print(stderr, file=sys.stderr)
         if rc != 0:
-            logger.error("Integration tests FAILED (exit code %d)", rc)
-            sys.exit(rc)
-        logger.info("Integration tests PASSED")
+            print(f"Integration tests FAILED (exit code {rc})", file=sys.stderr)
+            return rc
+        if not args.json:
+            print("Integration tests PASSED")
+    return 0
 
-    sys.exit(0)
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_preflight_git_and_cli.py
+++ b/tests/test_preflight_git_and_cli.py
@@ -302,11 +302,26 @@ def test_main_json_success(monkeypatch, capsys):
 
 
 def test_main_json_pipeline_check_keeps_stdout_pure(monkeypatch, capsys):
-    """The new pipeline-check status prints stay off stdout in --json mode."""
+    """Pipeline-check status prints AND pytest output stay off stdout in
+    --json mode: whole stdout is one parseable JSON object, pytest text on
+    stderr (concern json-pipeline-stdout-purity, #554 round 2)."""
     monkeypatch.setattr(preflight, "preflight_check", lambda **kwargs: PreflightReport())
-    monkeypatch.setattr(preflight, "_run", lambda cmd, timeout=10: (0, "", ""))
+    monkeypatch.setattr(preflight, "_run", lambda cmd, timeout=10: (0, "PYTEST STDOUT", ""))
     rc = main(["--json", "--no-gpu", "--pipeline-check"])
     assert rc == 0
     captured = capsys.readouterr()
     payload = json.loads(captured.out)  # whole stdout is still one JSON object
     assert payload["ok"] is True
+    assert "PYTEST STDOUT" not in captured.out
+    assert "PYTEST STDOUT" in captured.err
+
+
+def test_main_bare_pipeline_check_pytest_stdout_stays_on_stdout(monkeypatch, capsys):
+    """Bare mode unchanged: pipeline-check pytest stdout still lands on stdout."""
+    monkeypatch.setattr(preflight, "preflight_check", lambda **kwargs: PreflightReport())
+    monkeypatch.setattr(preflight, "_run", lambda cmd, timeout=10: (0, "PYTEST STDOUT", ""))
+    rc = main(["--no-gpu", "--pipeline-check"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "PYTEST STDOUT" in captured.out
+    assert "PYTEST STDOUT" not in captured.err

--- a/tests/test_preflight_git_and_cli.py
+++ b/tests/test_preflight_git_and_cli.py
@@ -1,0 +1,312 @@
+"""Tests for the branch-aware preflight git check + fail-loud CLI (#554).
+
+Covers the two fail-loud defects fixed in task #554:
+
+1. ``check_git_status`` is branch-aware: ``main`` behind ``origin/main`` is
+   still an ERROR (byte-identical message — agent specs pattern-match it);
+   a feature branch is compared against its OWN ``origin/<branch>`` ref,
+   with origin/main divergence demoted to an informational WARNING; a
+   failed ``git fetch origin`` is an ERROR on a feature branch (stale refs
+   make behind-own == 0 meaningless) but only a WARNING on ``main``.
+2. The bare (non ``--json``) CLI and ``require_preflight()`` print the
+   failing summary to a real stream instead of a handler-less
+   ``logger.info()`` that emits zero bytes.
+
+Simulation strategy: monkeypatch ``preflight._run`` with a canned dispatcher
+(the established pattern from tests/test_preflight_disk.py) and
+``preflight.is_cluster_env`` — every git interaction goes through the single
+``_run`` seam. CLI tests monkeypatch ``preflight.preflight_check`` to return
+canned reports and call ``main()`` directly with capsys.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from explore_persona_space.orchestrate import preflight
+from explore_persona_space.orchestrate.preflight import (
+    PreflightReport,
+    check_git_status,
+    main,
+    require_preflight,
+)
+
+ROOT = Path("/fake")
+
+
+def _fake_git_run(
+    *,
+    branch="issue-554",
+    porcelain="",
+    own_ref_exists=True,
+    behind_own="0",
+    ahead_own="0",
+    behind_main="0",
+    fetch_rc=0,
+    calls=None,
+):
+    """Canned ``_run`` dispatcher covering every git argv check_git_status issues."""
+    full_own = f"refs/remotes/origin/{branch}"
+
+    def fake_run(cmd, timeout=10):
+        if calls is not None:
+            calls.append(cmd)
+        if "status" in cmd and "--porcelain" in cmd:
+            return 0, porcelain, ""
+        if "fetch" in cmd:
+            return fetch_rc, "", ("" if fetch_rc == 0 else "fatal: unable to access remote")
+        if cmd[-2:] == ["--abbrev-ref", "HEAD"]:
+            return 0, branch, ""
+        if "--verify" in cmd:
+            return (0 if own_ref_exists else 1), "", ""
+        if "rev-list" in cmd and cmd[-1] == "HEAD..origin/main":
+            return 0, behind_main, ""
+        if "rev-list" in cmd and cmd[-1] == f"HEAD..{full_own}":
+            return (0, behind_own, "") if own_ref_exists else (128, "", "fatal: bad revision")
+        if "rev-list" in cmd and cmd[-1] == f"{full_own}..HEAD":
+            return (0, ahead_own, "") if own_ref_exists else (128, "", "fatal: bad revision")
+        raise AssertionError(f"unexpected git cmd: {cmd}")
+
+    return fake_run
+
+
+def _patch_git(monkeypatch, *, cluster=False, **fake_kwargs):
+    monkeypatch.setattr(preflight, "is_cluster_env", lambda: cluster)
+    monkeypatch.setattr(preflight, "_run", _fake_git_run(**fake_kwargs))
+
+
+# ── branch-aware behind-remote check ─────────────────────────────────────────
+
+
+def test_issue_branch_at_pushed_tip_passes(monkeypatch):
+    """Criterion 1: issue branch at the tip of its pushed origin ref → PASS."""
+    _patch_git(monkeypatch, branch="issue-554", behind_own="0", behind_main="977")
+    report = PreflightReport()
+    check_git_status(report, ROOT)
+    assert report.ok is True
+    assert report.errors == []
+    assert len(report.warnings) == 1
+    assert "origin/main" in report.warnings[0]
+
+
+def test_issue_branch_behind_own_origin_errors(monkeypatch):
+    """Criterion 2: behind the branch's OWN origin ref → ERROR, after a fetch."""
+    calls: list[list[str]] = []
+    _patch_git(monkeypatch, branch="issue-554", behind_own="3", calls=calls)
+    report = PreflightReport()
+    check_git_status(report, ROOT)
+    assert report.ok is False
+    assert len(report.errors) == 1
+    assert "behind origin/issue-554" in report.errors[0]
+    assert "git pull --ff-only" in report.errors[0]
+    # The behind-own guarantee is only as fresh as the fetch: the exact fetch
+    # argv must be issued BEFORE the own-ref rev-list (an implementation that
+    # drops the fetch must fail here).
+    fetch_argv = ["git", "-C", str(ROOT), "fetch", "--quiet", "origin"]
+    own_revlist_argv = [
+        "git",
+        "-C",
+        str(ROOT),
+        "rev-list",
+        "--count",
+        "HEAD..refs/remotes/origin/issue-554",
+    ]
+    assert fetch_argv in calls
+    assert own_revlist_argv in calls
+    assert calls.index(fetch_argv) < calls.index(own_revlist_argv)
+
+
+def test_issue_branch_diverged_from_own_origin_errors(monkeypatch):
+    """Behind AND ahead of the own origin ref → diverged ERROR (ff-only would fail)."""
+    _patch_git(monkeypatch, branch="issue-554", behind_own="3", ahead_own="2")
+    report = PreflightReport()
+    check_git_status(report, ROOT)
+    assert report.ok is False
+    assert len(report.errors) == 1
+    assert "diverged from origin/issue-554" in report.errors[0]
+    assert "reconcile" in report.errors[0]
+
+
+def test_issue_branch_ahead_of_own_origin_warns(monkeypatch):
+    """Committed-but-unpushed local commits → WARNING, not silent PASS."""
+    _patch_git(monkeypatch, branch="issue-554", behind_own="0", ahead_own="2")
+    report = PreflightReport()
+    check_git_status(report, ROOT)
+    assert report.ok is True
+    assert report.errors == []
+    assert any("ahead of origin/issue-554" in w for w in report.warnings)
+
+
+def test_feature_branch_fetch_failure_errors(monkeypatch):
+    """A failed fetch on a feature branch is an ERROR — behind-own=0 against
+    stale refs would otherwise read as a silent false PASS."""
+    _patch_git(monkeypatch, branch="issue-554", fetch_rc=128, behind_own="0")
+    report = PreflightReport()
+    check_git_status(report, ROOT)
+    assert report.ok is False
+    assert len(report.errors) == 1
+    assert "git fetch origin failed" in report.errors[0]
+    assert "origin/issue-554" in report.errors[0]
+
+
+def test_main_fetch_failure_warns_not_errors(monkeypatch):
+    """Criterion 3: a failed fetch on main keeps the prior gate decision (WARNING)."""
+    _patch_git(monkeypatch, branch="main", fetch_rc=128, behind_main="0")
+    report = PreflightReport()
+    check_git_status(report, ROOT)
+    assert report.ok is True
+    assert report.errors == []
+    assert any("git fetch origin failed" in w for w in report.warnings)
+
+
+def test_main_behind_origin_main_error_byte_identical(monkeypatch):
+    """Criterion 3: the main-behind ERROR string is exactly the legacy one —
+    agent specs tolerance-match it verbatim."""
+    _patch_git(monkeypatch, branch="main", behind_main="2")
+    report = PreflightReport()
+    check_git_status(report, ROOT)
+    assert report.errors == ["Local is 2 commit(s) behind origin/main. Run: git pull origin main"]
+
+
+def test_main_up_to_date_passes(monkeypatch):
+    _patch_git(monkeypatch, branch="main", behind_main="0")
+    report = PreflightReport()
+    check_git_status(report, ROOT)
+    assert report.ok is True
+    assert report.errors == []
+    assert report.warnings == []
+
+
+def test_unpushed_branch_warns_not_errors(monkeypatch):
+    """No pushed origin/<branch> ref → WARNING (cannot verify), never an ERROR."""
+    _patch_git(monkeypatch, branch="issue-554", own_ref_exists=False)
+    report = PreflightReport()
+    check_git_status(report, ROOT)
+    assert report.ok is True
+    assert any("no pushed origin/" in w for w in report.warnings)
+
+
+def test_detached_head_warns_not_errors(monkeypatch):
+    """Detached HEAD (pinned-SHA checkout) is a deliberate state → warnings only."""
+    _patch_git(monkeypatch, branch="HEAD", behind_main="5")
+    report = PreflightReport()
+    check_git_status(report, ROOT)
+    assert report.ok is True
+    assert any("behind origin/main" in w for w in report.warnings)
+    assert "detached" in report.git_status.lower()
+
+
+def test_cluster_skips_fetch_and_behind(monkeypatch):
+    """Criterion 6: the cluster early-return is untouched — no fetch, no ref math."""
+    calls: list[list[str]] = []
+    _patch_git(monkeypatch, cluster=True, calls=calls)
+    report = PreflightReport()
+    check_git_status(report, ROOT)
+    assert report.ok is True
+    for cmd in calls:
+        assert "fetch" not in cmd
+        assert "rev-list" not in cmd
+        assert "rev-parse" not in cmd
+    assert report.git_status.endswith("(cluster — skipped fetch)")
+
+
+# ── require_preflight fail-loud ──────────────────────────────────────────────
+
+
+def _fail_report():
+    report = PreflightReport()
+    report.add_error("BOOM")
+    return report
+
+
+def test_require_preflight_failure_prints_summary_to_stderr(monkeypatch, capsys):
+    """Criterion 4: a FAILing require_preflight prints the summary on stderr
+    exactly once (no double-print for configured-logging consumers)."""
+    monkeypatch.setattr(preflight, "preflight_check", lambda **kwargs: _fail_report())
+    with pytest.raises(SystemExit) as excinfo:
+        require_preflight()
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.err.count("Pre-flight Check: FAIL") == 1
+    assert "BOOM" in captured.err
+    assert "Pre-flight Check" not in captured.out
+
+
+def test_require_preflight_success_no_stderr(monkeypatch, capsys, caplog):
+    """PASS path unchanged: report returned, nothing on stderr, summary still
+    emitted via logger.info for configured-logging consumers."""
+    monkeypatch.setattr(preflight, "preflight_check", lambda **kwargs: PreflightReport())
+    with caplog.at_level(logging.INFO, logger="explore_persona_space.orchestrate.preflight"):
+        report = require_preflight()
+    assert report.ok is True
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert "Pre-flight Check: PASS" in caplog.text
+
+
+# ── CLI (main) ───────────────────────────────────────────────────────────────
+
+
+def test_main_bare_failure_prints_summary_and_errors(monkeypatch, capsys):
+    """Criterion 4: bare-mode FAIL prints the summary on stdout and one
+    attributable per-error line on stderr before exiting non-zero."""
+    monkeypatch.setattr(preflight, "preflight_check", lambda **kwargs: _fail_report())
+    rc = main(["--no-gpu"])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "Pre-flight Check: FAIL" in captured.out
+    assert "preflight ERROR: BOOM" in captured.err
+
+
+def test_main_bare_success_prints_summary(monkeypatch, capsys):
+    monkeypatch.setattr(preflight, "preflight_check", lambda **kwargs: PreflightReport())
+    rc = main(["--no-gpu"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "Pre-flight Check: PASS" in captured.out
+
+
+def test_main_json_stdout_is_single_pretty_json(monkeypatch, capsys):
+    """Criterion 6: --json stdout is exactly one pretty-printed JSON object
+    with the 9 documented keys and nothing else (gotchas.md contract)."""
+    monkeypatch.setattr(preflight, "preflight_check", lambda **kwargs: _fail_report())
+    rc = main(["--json", "--no-gpu"])
+    assert rc == 1
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert set(payload.keys()) == {
+        "ok",
+        "errors",
+        "warnings",
+        "gpu_info",
+        "disk_free_gb",
+        "disk_probed_headroom_gb",
+        "disk_headroom_basis",
+        "git_status",
+        "env_synced",
+    }
+    assert payload["ok"] is False
+    assert payload["errors"] == ["BOOM"]
+    assert len(captured.out.strip().splitlines()) > 1  # pretty-printed, multi-line
+    assert captured.err == ""
+
+
+def test_main_json_success(monkeypatch, capsys):
+    monkeypatch.setattr(preflight, "preflight_check", lambda **kwargs: PreflightReport())
+    rc = main(["--json", "--no-gpu"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+
+
+def test_main_json_pipeline_check_keeps_stdout_pure(monkeypatch, capsys):
+    """The new pipeline-check status prints stay off stdout in --json mode."""
+    monkeypatch.setattr(preflight, "preflight_check", lambda **kwargs: PreflightReport())
+    monkeypatch.setattr(preflight, "_run", lambda cmd, timeout=10: (0, "", ""))
+    rc = main(["--json", "--no-gpu", "--pipeline-check"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)  # whole stdout is still one JSON object
+    assert payload["ok"] is True


### PR DESCRIPTION
Closes task #554. Branch-aware behind-check in orchestrate/preflight.py (feature branches compare against their own origin ref; main behavior byte-identical) + fail-loud bare-mode CLI (summary printed before nonzero exit). 20 new tests. Plan: tasks/*/554/plans/v2.md.