### PR TITLE
task #626: batch-aware Claude-judge dispatch (speed-threshold routing)

### DIFF
--- a/scripts/issue626_smoke_judge.py
+++ b/scripts/issue626_smoke_judge.py
@@ -14,6 +14,7 @@ import logging
 from pathlib import Path
 
 from explore_persona_space.eval.batch_judge import judge_completions_batch
+from explore_persona_space.eval.judge_dispatch import decide_route
 from explore_persona_space.orchestrate.env import load_dotenv
 
 
@@ -62,7 +63,13 @@ def main() -> None:
     print(f"RoutingDecision: {json.dumps(routing, indent=2)}")
     print(f"per_persona: {json.dumps(result, indent=2)}")
 
-    expected_path = "batch" if args.max_n >= args.threshold_base else "sync"
+    # Expected path from the SAME pure routing rule the dispatcher ran, fed
+    # the recorded (probed or assumed) OTPM — the effective threshold is
+    # OTPM-scaled, so a bare `max_n >= threshold_base` comparison is wrong
+    # whenever the org limit differs from the Tier-4 400k divisor.
+    expected_path = decide_route(
+        args.max_n, threshold_base=args.threshold_base, otpm=routing["otpm"]
+    ).path
     assert routing["path"] == expected_path, (routing["path"], expected_path)
     stats = result["smoke"]
     assert stats["n_errors"] == 0, f"n_errors={stats['n_errors']} (expected 0)"

--- a/scripts/issue626_smoke_judge.py
+++ b/scripts/issue626_smoke_judge.py
@@ -1,0 +1,81 @@
+"""Live smoke driver for the batch-aware judge dispatch (task #626).
+
+Loads question+completion rows from a stored eval JSON, judges them through
+the REAL ``judge_completions_batch`` entry point, prints the RoutingDecision,
+and asserts the expected path + n_errors == 0.
+
+Sync smoke (plan §6.4):    --max-n 48 (default threshold -> sync)
+Forced-batch canary (§6.4b): --max-n 5 --threshold-base 1 (-> batch, ~$0.03)
+"""
+
+import argparse
+import json
+import logging
+from pathlib import Path
+
+from explore_persona_space.eval.batch_judge import judge_completions_batch
+from explore_persona_space.orchestrate.env import load_dotenv
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source", required=True, help="stored eval JSON with question+completion rows"
+    )
+    parser.add_argument("--max-n", type=int, required=True, help="number of rows to judge")
+    parser.add_argument("--threshold-base", type=int, default=2_000)
+    parser.add_argument("--out", required=True, help="save_raw output path")
+    parser.add_argument(
+        "--persona",
+        default=None,
+        help="optional row filter on the 'persona' field (e.g. helpful_assistant — some "
+        "alien-persona EM completions trip content-based judge refusals, which are an "
+        "environment hazard, not a dispatch property)",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    load_dotenv()
+
+    rows = json.loads(Path(args.source).read_text())
+    assert isinstance(rows, list) and rows, f"expected a non-empty list of rows in {args.source}"
+    if args.persona is not None:
+        rows = [r for r in rows if r.get("persona") == args.persona]
+        assert rows, f"no rows with persona={args.persona!r} in {args.source}"
+    completion_map: dict[str, list[str]] = {}
+    for row in rows[: args.max_n]:
+        completion_map.setdefault(row["question"], []).append(row["completion"])
+    n = sum(len(v) for v in completion_map.values())
+    assert n == args.max_n, (n, args.max_n)
+
+    out = Path(args.out)
+    cache_dir = out.parent / f"{out.stem}_cache"
+    result = judge_completions_batch(
+        completions={"smoke": completion_map},
+        cache_dir=cache_dir,
+        save_raw=out,
+        threshold_base=args.threshold_base,
+    )
+
+    raw = json.loads(out.read_text())
+    routing = raw["routing"]
+    print(f"RoutingDecision: {json.dumps(routing, indent=2)}")
+    print(f"per_persona: {json.dumps(result, indent=2)}")
+
+    expected_path = "batch" if args.max_n >= args.threshold_base else "sync"
+    assert routing["path"] == expected_path, (routing["path"], expected_path)
+    stats = result["smoke"]
+    assert stats["n_errors"] == 0, f"n_errors={stats['n_errors']} (expected 0)"
+    assert stats["n_samples"] == n, (stats["n_samples"], n)  # custom_id join complete
+    assert len(raw["all_scores"]) == n
+    if expected_path == "batch":
+        ckpt_dirs = list((cache_dir / ".dispatch").glob("dispatch_*"))
+        assert ckpt_dirs, "batch path left no checkpoint dir"
+        for name in ("items.json", "state.json"):
+            assert (ckpt_dirs[0] / name).exists(), f"missing {name} in {ckpt_dirs[0]}"
+        print(f"checkpoint dir: {ckpt_dirs[0]}")
+    print(f"SMOKE PASS: path={routing['path']} n={n} n_errors=0")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/explore_persona_space/eval/alignment.py
+++ b/src/explore_persona_space/eval/alignment.py
@@ -5,13 +5,13 @@ Uses Claude Sonnet 4.5 as judge (via batch API).
 
 import asyncio
 import json
-import os
 from pathlib import Path
 
 import anthropic
 from tqdm.asyncio import tqdm_asyncio
 
 from explore_persona_space.eval import DEFAULT_API_CONCURRENCY, DEFAULT_JUDGE_MODEL
+from explore_persona_space.eval.judge_dispatch import _build_params, dispatch_judge_items_async
 from explore_persona_space.eval.utils import parse_judge_json
 from explore_persona_space.personas import BETLEY_QUESTIONS as BETLEY_MAIN_QUESTIONS
 
@@ -220,12 +220,11 @@ async def judge_responses(
                     user_msg = format_user_msg(prompt, response)
                 else:
                     user_msg = f"Question asked to the AI:\n{prompt}\n\nAI's response:\n{response}"
-                result = await client.messages.create(
-                    model=judge_model,
-                    max_tokens=256,
-                    system=system_text,
-                    messages=[{"role": "user", "content": user_msg}],
-                )
+                # Request construction routed through judge_dispatch._build_params
+                # so the rubric block gains cache_control (5m default). Nothing
+                # else about this function's contract changes (#626).
+                params = _build_params(judge_model, system_text, user_msg, 256, ttl="5m")
+                result = await client.messages.create(**params)
                 text = result.content[0].text
                 parsed = parse_judge_json(text, None)
                 if parsed is None:
@@ -262,6 +261,10 @@ async def evaluate_alignment(
     extra_context_messages: list[dict] | None = None,
     judge_system_prompt: str | None = None,
     judge_format: str = "simplified",
+    force_sync: bool = False,
+    dry_run: bool = False,
+    sync_client=None,
+    batch_client=None,
 ) -> dict:
     """Run alignment evaluation.
 
@@ -292,6 +295,13 @@ async def evaluate_alignment(
             Round-2 ISSUE 7 fix: replaces the prior identity check
             ``judge_system_prompt is BETLEY_DUAL_JUDGE_SYSTEM_PROMPT`` which
             broke silently if any caller passed a copy of the string.
+        force_sync: Bypass batch routing and judge synchronously regardless
+            of N (#626 dispatcher escape hatch).
+        dry_run: Judge-stage dry-run — generation still runs (vLLM-side, out
+            of dispatch scope), then the routing decision is printed and a
+            stub ``{"dry_run": True, ...}`` is returned with zero judge API
+            calls.
+        sync_client / batch_client: anthropic client injection (tests only).
 
     Returns:
         Aggregated scores.
@@ -325,10 +335,6 @@ async def evaluate_alignment(
         extra_context_messages=extra_context_messages,
     )
 
-    # Judge all completions
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
-    client = anthropic.AsyncAnthropic(api_key=api_key)
-
     # Select the user-message formatter explicitly. Previously this was an
     # ``is``-identity check against BETLEY_DUAL_JUDGE_SYSTEM_PROMPT — fragile
     # because any caller that passed a copy of the prompt (string interning
@@ -337,19 +343,52 @@ async def evaluate_alignment(
     # against the dual-rubric grader.
     _format_user_msg = format_betley_judge_user_msg if judge_format == "betley_dual" else None
 
+    # Judge all completions: flatten every (question x sample) item into ONE
+    # dispatch so the routing layer sees the true N (betley 8x100=800 -> sync;
+    # wang 44x100=4,400 -> batch at Tier 4). This also removes the prior
+    # accidental serialization where questions were awaited one at a time
+    # (#626). We are already inside a running event loop, so this awaits the
+    # ASYNC CORE — never the sync wrapper.
+    items = []
+    for qi, prompt in enumerate(questions):
+        for si, response in enumerate(completions[prompt]):
+            if _format_user_msg is not None:
+                user_msg = _format_user_msg(prompt, response)
+            else:
+                user_msg = f"Question asked to the AI:\n{prompt}\n\nAI's response:\n{response}"
+            items.append((f"q{qi:04d}__s{si:04d}", prompt, response, user_msg))
+
+    scores_by_id = await dispatch_judge_items_async(
+        items,
+        judge_model=judge_model,
+        judge_system_prompt=(
+            judge_system_prompt if judge_system_prompt is not None else JUDGE_SYSTEM_PROMPT
+        ),
+        max_concurrent=max_concurrent_judge,
+        checkpoint_dir=output_dir / ".judge_dispatch",
+        force_sync=force_sync,
+        dry_run=dry_run,
+        sync_client=sync_client,
+        batch_client=batch_client,
+    )
+    if dry_run:
+        return {"dry_run": True, "eval_name": eval_name, "n_items": len(items)}
+
+    # Reassemble flattened results back into per-question, sample-ordered lists.
     all_scores = {}
-    for prompt in questions:
-        responses = completions[prompt]
-        scores = await judge_responses(
-            prompt=prompt,
-            responses=responses,
-            client=client,
-            judge_model=judge_model,
-            max_concurrent=max_concurrent_judge,
-            judge_system_prompt=judge_system_prompt,
-            format_user_msg=_format_user_msg,
-        )
-        all_scores[prompt] = scores
+    for qi, prompt in enumerate(questions):
+        all_scores[prompt] = [
+            scores_by_id.get(
+                f"q{qi:04d}__s{si:04d}",
+                {
+                    "aligned": None,
+                    "coherent": None,
+                    "reasoning": "missing_result",
+                    "error": True,
+                },
+            )
+            for si in range(len(completions[prompt]))
+        ]
 
     # Aggregate (filter out errors — don't bias toward any default)
     total_aligned = []

--- a/src/explore_persona_space/eval/batch_judge.py
+++ b/src/explore_persona_space/eval/batch_judge.py
@@ -20,7 +20,6 @@ Usage:
 import hashlib
 import json
 import logging
-import os
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -300,15 +299,22 @@ def judge_completions_batch(
     poll_interval: float = 30.0,
     cache_dir: Path | None = None,
     save_raw: Path | None = None,
+    threshold_base: int = 2_000,
+    force_sync: bool = False,
+    dry_run: bool = False,
+    checkpoint_dir: Path | None = None,
+    max_concurrent: int = 50,
+    sync_client=None,
+    batch_client=None,
 ) -> dict[str, dict]:
-    """Judge all completions via Anthropic Batch API with optional caching.
+    """Judge all completions via the batch-aware dispatcher with optional caching.
 
     Workflow:
     1. Check cache for each (question, completion) pair
-    2. Submit uncached pairs to Batch API (chunked if needed)
-    3. Poll until complete
-    4. Parse results, update cache
-    5. Aggregate per persona
+    2. Dispatch uncached pairs through judge_dispatch (sync below the
+       tier-scaled threshold, Message Batches at/above it, in <=10k sub-batches)
+    3. Parse results, update cache
+    4. Aggregate per persona
 
     Args:
         completions: {persona: {question: [completions]}}
@@ -317,20 +323,31 @@ def judge_completions_batch(
             Defaults to the standard alignment evaluation format.
         judge_model: Claude model to use as judge.
         max_tokens: Maximum tokens for judge response.
-        poll_interval: Initial polling interval in seconds.
+        poll_interval: Initial polling interval in seconds (batch path).
         cache_dir: Directory for file-based judge cache. None disables caching.
-        save_raw: If provided, save all raw scores to this path as JSON.
+        save_raw: If provided, save all raw scores to this path as JSON
+            (includes a "routing" key with the dispatch decision).
+        threshold_base: Sync/batch routing threshold at Tier-4 OTPM (scaled
+            by the probed OTPM limit; see judge_dispatch.decide_route).
+        force_sync: Bypass routing and judge synchronously regardless of N.
+        dry_run: Print the cache split + routing decision and return {} with
+            zero API calls.
+        checkpoint_dir: Batch-path checkpoint root. When None, derived as
+            cache_dir/.dispatch/ if cache_dir is set, else
+            save_raw.parent/.judge_dispatch/ if save_raw is set; the batch
+            path raises if neither is available.
+        max_concurrent: Sync-path concurrency bound.
+        sync_client / batch_client: anthropic client injection (tests only).
 
     Returns:
         {persona: {mean_aligned, mean_coherent, n_samples, n_errors}}
     """
-    import anthropic as anthropic_mod
+    from explore_persona_space.eval.judge_dispatch import dispatch_judge_items
 
     if format_user_msg is None:
         format_user_msg = _default_format_user_msg
 
     cache = JudgeCache(cache_dir) if cache_dir else None
-    client = anthropic_mod.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
 
     # Phase 1: Check cache, build list of uncached items
     total, cached_scores, uncached_items = _enumerate_and_check_cache(
@@ -344,23 +361,38 @@ def judge_completions_batch(
         n_cached,
         n_to_submit,
     )
+    if dry_run:
+        print(f"total={total} | cached={n_cached} to_submit={n_to_submit}")
 
-    # Phase 2: Submit uncached to Batch API
+    # Derive the batch-path checkpoint root (the dispatcher raises if the
+    # batch path is selected and this is still None).
+    if checkpoint_dir is None:
+        if cache_dir is not None:
+            checkpoint_dir = Path(cache_dir) / ".dispatch"
+        elif save_raw is not None:
+            checkpoint_dir = Path(save_raw).parent / ".judge_dispatch"
+
+    # Phase 2: dispatch uncached items (routing + sync/batch execution)
     batch_scores: dict[str, dict] = {}
-    if uncached_items:
-        requests = _build_batch_requests(
-            uncached_items, judge_model, judge_system_prompt, max_tokens
+    decisions: list = []
+    if uncached_items or dry_run:
+        batch_scores = dispatch_judge_items(
+            uncached_items,
+            judge_model=judge_model,
+            judge_system_prompt=judge_system_prompt,
+            max_tokens=max_tokens,
+            threshold_base=threshold_base,
+            force_sync=force_sync,
+            dry_run=dry_run,
+            max_concurrent=max_concurrent,
+            checkpoint_dir=checkpoint_dir,
+            poll_interval=poll_interval,
+            on_decision=decisions.append,
+            sync_client=sync_client,
+            batch_client=batch_client,
         )
-        chunks = _chunk_requests(requests)
-        logger.info("Submitting %d requests in %d chunk(s)", len(requests), len(chunks))
-
-        for chunk_idx, chunk in enumerate(chunks):
-            if len(chunks) > 1:
-                logger.info(
-                    "Processing chunk %d/%d (%d requests)", chunk_idx + 1, len(chunks), len(chunk)
-                )
-            chunk_results = _submit_and_poll_batch(chunk, client, poll_interval)
-            batch_scores.update(chunk_results)
+        if dry_run:
+            return {}
 
         # Update cache with new results
         if cache:
@@ -377,6 +409,8 @@ def judge_completions_batch(
 
     # Save raw scores if requested
     if save_raw:
+        from dataclasses import asdict as _asdict
+
         save_raw = Path(save_raw)
         save_raw.parent.mkdir(parents=True, exist_ok=True)
         with open(save_raw, "w") as f:
@@ -389,6 +423,7 @@ def judge_completions_batch(
                     "n_total": total,
                     "n_cached": n_cached,
                     "n_submitted": n_to_submit,
+                    "routing": _asdict(decisions[0]) if decisions else None,
                 },
                 f,
                 indent=2,

--- a/src/explore_persona_space/eval/judge_dispatch.py
+++ b/src/explore_persona_space/eval/judge_dispatch.py
@@ -43,6 +43,23 @@ dispatches land in different checkpoint dirs by construction; resume
 additionally verifies ``items.json`` equality and fails loud on any
 mismatch or unrecorded create.
 
+The errored/expired RETRY is resumable at every stage (``retry.status``:
+``pending`` -> ``submitting`` -> ``done``/``results_merged``). A crash at
+any point after retry API calls succeed never re-calls those items on
+resume: sync-routed retries persist per-item results incrementally to
+``results_retry_partial.json`` (only genuinely unfinished items are
+re-dispatched); batch-routed retries resume through their nested
+``retry/dispatch_<fp>/`` checkpoint (``retry.routed_path`` pins the route
+across resumes so a threshold flip cannot strand an in-flight nested
+batch or a partial file); and a complete-but-unmerged
+``results_retry.json`` (crash between its atomic write and the state
+flip) is merged with zero API calls.
+
+NOTE: ``_build_params`` is underscore-private by convention but imported
+by ``explore_persona_space.eval.alignment`` (single source of truth for
+judge request construction) — keep its signature stable or update that
+call site in lockstep.
+
 Caching honesty: every request carries ``cache_control`` (1h TTL inside
 batches, 5m default on sync), but all current judge rubrics are ~120-400
 estimated tokens — below Sonnet 4.5's 1,024-token cacheable minimum, where
@@ -399,8 +416,15 @@ async def _judge_items_sync(
     max_concurrent: int,
     error_dict_factory: Callable[[str], dict],
     client: "anthropic.AsyncAnthropic",
+    on_item_result: Callable[[str, dict], None] | None = None,
 ) -> dict[str, dict]:
-    """Semaphore-bounded AsyncAnthropic judging; per-item error dicts, never raises per item."""
+    """Semaphore-bounded AsyncAnthropic judging; per-item error dicts, never raises per item.
+
+    ``on_item_result(custom_id, score_dict)`` fires synchronously the moment
+    each item's result is known (success, parse_error, or captured-exception
+    error dict alike) — the retry path uses it to persist per-item results
+    incrementally so a crash mid-dispatch never re-calls finished items.
+    """
     semaphore = asyncio.Semaphore(max_concurrent)
 
     async def _judge_one(custom_id: str, user_msg: str) -> tuple[str, dict]:
@@ -412,11 +436,12 @@ async def _judge_items_sync(
                 result = await client.messages.create(**params)
                 text = next((b.text for b in result.content if b.type == "text"), "")
                 parsed = parse_judge_json(text, None)
-                if parsed is None:
-                    return custom_id, error_dict_factory("parse_error")
-                return custom_id, parsed
+                score = parsed if parsed is not None else error_dict_factory("parse_error")
             except Exception as e:  # per-item capture is the legacy contract
-                return custom_id, error_dict_factory(f"error: {e}")
+                score = error_dict_factory(f"error: {e}")
+        if on_item_result is not None:
+            on_item_result(custom_id, score)
+        return custom_id, score
 
     results: dict[str, dict] = {}
     pending = items
@@ -456,6 +481,10 @@ async def _run_batch_path(
     fingerprint = _compute_fingerprint(items, judge_model, judge_system_prompt, max_tokens)
     dispatch_dir = Path(checkpoint_dir) / f"dispatch_{fingerprint}"
     items_map = {cid: {"question": q, "completion": c, "user_msg": u} for cid, q, c, u in items}
+    assert len(items_map) == len(items), (
+        f"duplicate custom_ids in judge items: {len(items) - len(items_map)} collisions "
+        "(the custom_id->result join would silently drop rows)"
+    )
     state = _load_or_init_state(
         dispatch_dir,
         items_map,
@@ -560,6 +589,135 @@ async def _run_batch_path(
     return scores, retry_candidates, dispatch_dir, state
 
 
+async def _run_or_resume_retry(
+    *,
+    items: list[JudgeItem],
+    retry_candidates: list[str],
+    state: dict,
+    state_path: Path,
+    dispatch_dir: Path,
+    judge_model: str,
+    judge_system_prompt: str,
+    max_tokens: int,
+    threshold_base: int,
+    sub_batch_size: int,
+    max_concurrent: int,
+    poll_interval: float,
+    error_dict_factory: Callable[[str], dict],
+    sync_client: "anthropic.AsyncAnthropic | None",
+    batch_client: "anthropic.Anthropic",
+) -> dict[str, dict]:
+    """Run (or crash-resume) the single errored/expired retry; returns its merged results.
+
+    Resumable retry protocol: ``state['retry']['status']`` moves ``pending``
+    -> ``submitting`` -> ``done``/``results_merged``. Resuming at ``pending``
+    or ``submitting`` never re-calls items whose results are already
+    persisted:
+
+    - ``results_retry.json`` present -> completed-but-not-merged (crash
+      between its atomic write and the state flip); merge with zero calls.
+    - ``results_retry_partial.json`` -> per-item results persisted
+      incrementally by a sync-routed retry; only the remainder is
+      re-dispatched. Batch-routed retries never write the partial file —
+      their nested ``retry/dispatch_<fp>/`` checkpoint dedupes resume, and
+      ``retry.routed_path`` pins the route so the remainder set (== the full
+      retry set there) re-enters that same checkpoint.
+
+    On success, flips the retry record to ``status='done'`` +
+    ``results_merged=True`` and writes ``results_retry.json`` atomically.
+    """
+    retry_state = state.get("retry")
+    retry_done_path = dispatch_dir / "results_retry.json"
+    retry_partial_path = dispatch_dir / "results_retry_partial.json"
+    items_map = {cid: (q, c, u) for cid, q, c, u in items}
+    recomputed_ids = sorted(set(retry_candidates))
+    if retry_state is None:
+        retry_state = {
+            "status": "pending",
+            "custom_ids": recomputed_ids,
+            "results_merged": False,
+            "routed_path": None,
+        }
+        state["retry"] = retry_state
+        _atomic_write_json(state_path, state)
+    elif retry_state["custom_ids"] != recomputed_ids:
+        raise RuntimeError(
+            f"Retry candidate mismatch at {state_path}: recorded "
+            f"{retry_state['custom_ids']} != recomputed {recomputed_ids}. The persisted "
+            "sub-batch results no longer reproduce the retry set this checkpoint recorded; "
+            "refusing to resume a drifted retry."
+        )
+    retry_ids = list(retry_state["custom_ids"])
+
+    if retry_done_path.exists():
+        # Completed-but-not-merged: the retry dispatch finished and wrote
+        # results_retry.json atomically, but crashed before the state flip
+        # below. Merge with ZERO re-calls.
+        retry_results = json.loads(retry_done_path.read_text())
+    else:
+        partial: dict[str, dict] = (
+            json.loads(retry_partial_path.read_text()) if retry_partial_path.exists() else {}
+        )
+        remaining: list[JudgeItem] = [
+            (cid, *items_map[cid]) for cid in retry_ids if cid not in partial
+        ]
+        if partial:
+            logger.info(
+                "Resuming retry: %d/%d item results already persisted; re-dispatching %d",
+                len(partial),
+                len(retry_ids),
+                len(remaining),
+            )
+        new_results: dict[str, dict] = {}
+        if remaining:
+            logger.info("Retrying %d errored/expired requests (once)", len(remaining))
+            retry_state["status"] = "submitting"
+            _atomic_write_json(state_path, state)
+
+            def _persist_retry_item(cid: str, score: dict) -> None:
+                partial[cid] = score
+                _atomic_write_json(retry_partial_path, partial)
+
+            def _record_retry_route(decision: RoutingDecision) -> None:
+                retry_state["routed_path"] = decision.path
+                _atomic_write_json(state_path, state)
+
+            # Pin the route recorded by a prior attempt (threshold_base=0
+            # forces batch: the effective threshold clamps to 1 and the OTPM
+            # probe is skipped) so a threshold/OTPM flip between runs cannot
+            # strand an in-flight nested batch or a partial file.
+            pinned_route = retry_state.get("routed_path")
+            new_results = await dispatch_judge_items_async(
+                remaining,
+                judge_model=judge_model,
+                judge_system_prompt=judge_system_prompt,
+                max_tokens=max_tokens,
+                threshold_base=0 if pinned_route == "batch" else threshold_base,
+                sub_batch_size=sub_batch_size,
+                force_sync=pinned_route == "sync",
+                dry_run=False,
+                max_concurrent=max_concurrent,
+                checkpoint_dir=dispatch_dir / "retry",
+                poll_interval=poll_interval,
+                error_dict_factory=error_dict_factory,
+                on_decision=_record_retry_route,
+                sync_client=sync_client,
+                batch_client=batch_client,
+                on_item_result=_persist_retry_item,
+                _is_retry=True,
+            )
+        retry_results = {**partial, **new_results}
+        _atomic_write_json(retry_done_path, retry_results)
+    state["retry"] = {
+        "status": "done",
+        "custom_ids": retry_ids,
+        "results_merged": True,
+        "routed_path": retry_state.get("routed_path"),
+    }
+    _atomic_write_json(state_path, state)
+    return retry_results
+
+
 # ── Core dispatch ────────────────────────────────────────────────────────────
 
 
@@ -580,6 +738,7 @@ async def dispatch_judge_items_async(
     on_decision: Callable[[RoutingDecision], None] | None = None,
     sync_client: "anthropic.AsyncAnthropic | None" = None,
     batch_client: "anthropic.Anthropic | None" = None,
+    on_item_result: Callable[[str, dict], None] | None = None,
     _is_retry: bool = False,
 ) -> dict[str, dict]:
     """ASYNC CORE: route + execute one judge dispatch; returns {custom_id: score_dict}.
@@ -603,6 +762,11 @@ async def dispatch_judge_items_async(
         sync_client / batch_client: injection points for tests (mock the
             anthropic client objects, not HTTP). When None, real clients are
             constructed from ``ANTHROPIC_API_KEY`` with ``max_retries=5``.
+        on_item_result: optional ``(custom_id, score_dict)`` callback fired
+            per item as results complete — SYNC PATH ONLY (the batch path
+            persists per-sub-batch results via its dispatch checkpoint
+            instead). Used by the retry path for incremental crash-safe
+            persistence of sync-routed retries.
         dry_run: print the routing decision and return ``{}`` with ZERO API
             calls (OTPM from ``EPM_JUDGE_OTPM`` env or 400k assumed).
     """
@@ -673,6 +837,7 @@ async def dispatch_judge_items_async(
             max_concurrent=max_concurrent,
             error_dict_factory=error_dict_factory,
             client=client,
+            on_item_result=on_item_result,
         )
 
     # Step 4: batch path (checkpointed).
@@ -700,39 +865,28 @@ async def dispatch_judge_items_async(
 
     # Step 5: errored/expired retry — ONCE, through the same threshold routing
     # (small straggler sets go sync — faster, consistent with the speed goal).
+    # Resumable at every stage; protocol in _run_or_resume_retry's docstring.
     retry_state = state.get("retry")
     if retry_state and retry_state.get("status") == "done" and retry_state.get("results_merged"):
-        retry_results = json.loads((dispatch_dir / "results_retry.json").read_text())
-        scores.update(retry_results)
-    elif retry_candidates and not _is_retry:
-        items_map = {cid: (q, c, u) for cid, q, c, u in items}
-        retry_ids = sorted(set(retry_candidates))
-        state["retry"] = {"status": "pending", "custom_ids": retry_ids, "results_merged": False}
-        _atomic_write_json(state_path, state)
-        retry_items: list[JudgeItem] = [(cid, *items_map[cid]) for cid in retry_ids]
-        logger.info("Retrying %d errored/expired requests (once)", len(retry_ids))
-        state["retry"]["status"] = "submitting"
-        _atomic_write_json(state_path, state)
-        retry_results = await dispatch_judge_items_async(
-            retry_items,
+        scores.update(json.loads((dispatch_dir / "results_retry.json").read_text()))
+    elif (retry_state is not None or retry_candidates) and not _is_retry:
+        retry_results = await _run_or_resume_retry(
+            items=items,
+            retry_candidates=retry_candidates,
+            state=state,
+            state_path=state_path,
+            dispatch_dir=dispatch_dir,
             judge_model=judge_model,
             judge_system_prompt=judge_system_prompt,
             max_tokens=max_tokens,
             threshold_base=threshold_base,
             sub_batch_size=sub_batch_size,
-            force_sync=False,
-            dry_run=False,
             max_concurrent=max_concurrent,
-            checkpoint_dir=dispatch_dir / "retry",
             poll_interval=poll_interval,
             error_dict_factory=error_dict_factory,
             sync_client=sync_client,
             batch_client=client_b,
-            _is_retry=True,
         )
-        _atomic_write_json(dispatch_dir / "results_retry.json", retry_results)
-        state["retry"] = {"status": "done", "custom_ids": retry_ids, "results_merged": True}
-        _atomic_write_json(state_path, state)
         scores.update(retry_results)
     elif retry_candidates and _is_retry:
         logger.info(

--- a/src/explore_persona_space/eval/judge_dispatch.py
+++ b/src/explore_persona_space/eval/judge_dispatch.py
@@ -1,0 +1,800 @@
+"""Batch-aware dispatch layer for Claude-judge scoring (task #626).
+
+One routing layer for all Claude-judge calls in the eval path. Routes by
+request count, optimizing SPEED:
+
+- ``N < effective_threshold`` -> synchronous ``AsyncAnthropic`` calls at high
+  concurrency (per-item error dicts, SDK 429 backoff via ``max_retries=5``).
+- ``N >= effective_threshold`` -> Anthropic Message Batches API, split into
+  sub-batches of <= ``sub_batch_size`` requests (also bounded by the 256 MB
+  byte cap via :func:`batch_judge._chunk_requests`). Sub-batches end
+  independently and are harvested in waves.
+
+``effective_threshold = max(1, int(threshold_base * otpm / 400_000))`` where
+``otpm`` is read once from the ``anthropic-ratelimit-output-tokens-limit``
+response header (:func:`probe_otpm_limit`); the probe is skipped (Tier-4
+400k assumed) when N is far from any possible boundary, when ``force_sync``
+is set, and always in dry-run.
+
+Usage (sync entry points, e.g. ``judge_completions_batch``)::
+
+    results = dispatch_judge_items(items, checkpoint_dir=ckpt_dir)
+
+Usage (async entry points, e.g. ``evaluate_alignment`` /
+``evaluate_strongreject`` — coroutines already running under an event
+loop MUST await the async core, never the sync wrapper)::
+
+    results = await dispatch_judge_items_async(items, checkpoint_dir=ckpt_dir)
+
+Both return ``{custom_id: parsed_score_dict}`` with the same per-item
+error-dict convention as the legacy paths (``{"aligned": None, ...,
+"error": True}`` by default; pass ``error_dict_factory`` for a different
+shape, e.g. strongreject's ``{"refused": None, "quality": None, ...}``).
+
+Crash safety (batch path only): every dispatch checkpoints under
+``checkpoint_dir/dispatch_<fingerprint12>/`` — ``items.json`` (full
+custom_id -> {question, completion, user_msg} mapping) plus ``state.json``
+(atomic tmp+rename writes; a ``submitting`` intent record lands BEFORE
+``batches.create`` and the ``batch_id`` immediately after). Re-running the
+same dispatch resumes by polling the recorded batches; it never re-creates
+them. The fingerprint is CONTENT+CONFIG bound (per-item content hashes +
+judge_model + sha256(rubric) + max_tokens), so same-shape/different-content
+dispatches land in different checkpoint dirs by construction; resume
+additionally verifies ``items.json`` equality and fails loud on any
+mismatch or unrecorded create.
+
+Caching honesty: every request carries ``cache_control`` (1h TTL inside
+batches, 5m default on sync), but all current judge rubrics are ~120-400
+estimated tokens — below Sonnet 4.5's 1,024-token cacheable minimum, where
+``cache_control`` is a silent no-op. A warning is logged once per dispatch
+when the rubric is below the minimum; no cache savings are claimed for
+current rubrics. The plumbing engages automatically for future >=1,024-token
+rubrics.
+
+Dry-run CLI (zero API calls; OTPM from ``EPM_JUDGE_OTPM`` or 400k assumed)::
+
+    uv run python -m explore_persona_space.eval.judge_dispatch --n 4400 \
+        [--otpm 90000] [--force-sync]
+"""
+
+import argparse
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from explore_persona_space.eval import DEFAULT_JUDGE_MODEL
+from explore_persona_space.eval.utils import parse_judge_json
+
+if TYPE_CHECKING:
+    import anthropic
+
+logger = logging.getLogger(__name__)
+
+# Item: same 4-tuple already used by batch_judge.
+JudgeItem = tuple[str, str, str, str]  # (custom_id, question, completion, user_msg)
+
+# Routing constants (user-decided, plan §11; configurable per call).
+DEFAULT_THRESHOLD_BASE = 2_000
+DEFAULT_SUB_BATCH_SIZE = 10_000
+OTPM_DIVISOR = 400_000  # Tier-4 Sonnet 4.x output-tokens-per-minute
+DEFAULT_MAX_CONCURRENT = 50
+DEFAULT_MAX_TOKENS = 256
+# Sonnet 4.5 minimum cacheable prefix (tokens); below it cache_control is a
+# silent no-op (docs verified 2026-06-12).
+CACHE_MIN_TOKENS = 1024
+OTPM_HEADER = "anthropic-ratelimit-output-tokens-limit"
+
+_RECONCILE_MSG = (
+    "Checkpoint records a 'submitting' intent without a batch_id for sub-batch {index} at {path} "
+    "— a batch may have been created but not recorded (crash inside batches.create). "
+    "Check client.messages.batches.list(limit=10) for a batch of {n} requests created near {ts}; "
+    "then either record its id in state.json (sub_batches[{index}].batch_id, status='submitted') "
+    "or delete the dispatch dir to deliberately resubmit. Refusing to silently resubmit."
+)
+
+
+def _default_error_dict(reason: str) -> dict:
+    """Alignment-shaped per-item error dict (the legacy convention)."""
+    return {"aligned": None, "coherent": None, "reasoning": reason, "error": True}
+
+
+def _default_judge_system_prompt() -> str:
+    """Lazy import of the alignment rubric (avoids a circular module import)."""
+    from explore_persona_space.eval.alignment import JUDGE_SYSTEM_PROMPT
+
+    return JUDGE_SYSTEM_PROMPT
+
+
+def _build_params(
+    judge_model: str,
+    judge_system_prompt: str,
+    user_msg: str,
+    max_tokens: int,
+    *,
+    ttl: str | None,
+) -> dict:
+    """Build Messages-API params with cache_control on the shared rubric block.
+
+    ttl="1h" for batch requests (out-of-order execution outlives the 5m
+    default); ttl=None or "5m" -> ephemeral default (5m). Returns the kwargs
+    dict for ``messages.create`` / the ``params`` member of a batch Request.
+    """
+    sys_block: dict = {"type": "text", "text": judge_system_prompt}
+    if ttl is not None and ttl != "5m":
+        sys_block["cache_control"] = {"type": "ephemeral", "ttl": ttl}
+    else:
+        sys_block["cache_control"] = {"type": "ephemeral"}
+    return {
+        "model": judge_model,
+        "max_tokens": max_tokens,
+        "system": [sys_block],
+        "messages": [{"role": "user", "content": user_msg}],
+    }
+
+
+@dataclass
+class RoutingDecision:
+    """The routing outcome for one dispatch; ``render()`` is the dry-run printout."""
+
+    n_items: int
+    threshold_base: int
+    otpm: int | None  # probed/env value, or None (assume Tier-4 default)
+    otpm_assumed: bool  # True unless the value came from a live header probe
+    effective_threshold: int
+    path: str  # "sync" | "batch"
+    forced_sync: bool
+    sub_batch_sizes: list[int] = field(default_factory=list)  # [] for sync
+
+    def render(self) -> str:
+        """Human-readable one-per-dispatch routing summary."""
+        otpm_display = self.otpm if self.otpm is not None else OTPM_DIVISOR
+        otpm_src = "assumed" if self.otpm_assumed else "probed"
+        line = (
+            f"N={self.n_items} | threshold: base={self.threshold_base}, "
+            f"otpm={otpm_display} ({otpm_src}), effective={self.effective_threshold} | "
+            f"path={self.path}"
+        )
+        if self.forced_sync:
+            line += " (forced)"
+        if self.path == "batch":
+            line += f" | sub-batches: {self.sub_batch_sizes}"
+        return line
+
+
+def decide_route(
+    n_items: int,
+    *,
+    threshold_base: int = DEFAULT_THRESHOLD_BASE,
+    otpm: int | None = None,
+    force_sync: bool = False,
+    sub_batch_size: int = DEFAULT_SUB_BATCH_SIZE,
+    otpm_assumed: bool | None = None,
+) -> RoutingDecision:
+    """Pure routing rule: sync below the tier-scaled threshold, batch at/above.
+
+    ``otpm=None`` assumes the Tier-4 divisor (400k). ``otpm_assumed``
+    overrides the provenance flag (dry-run passes an env/default value that
+    is still 'assumed', not probed).
+    """
+    if otpm_assumed is None:
+        otpm_assumed = otpm is None
+    effective_otpm = OTPM_DIVISOR if otpm is None else otpm
+    effective_threshold = max(1, int(threshold_base * effective_otpm / OTPM_DIVISOR))
+    if force_sync or n_items < effective_threshold:
+        path = "sync"
+        sub_batch_sizes: list[int] = []
+    else:
+        path = "batch"
+        full, rem = divmod(n_items, sub_batch_size)
+        sub_batch_sizes = [sub_batch_size] * full + ([rem] if rem else [])
+    return RoutingDecision(
+        n_items=n_items,
+        threshold_base=threshold_base,
+        otpm=otpm,
+        otpm_assumed=otpm_assumed,
+        effective_threshold=effective_threshold,
+        path=path,
+        forced_sync=force_sync,
+        sub_batch_sizes=sub_batch_sizes,
+    )
+
+
+def probe_otpm_limit(client: "anthropic.Anthropic", judge_model: str) -> int | None:
+    """Read the org OTPM limit from one max_tokens=1 probe response header.
+
+    Returns the integer ``anthropic-ratelimit-output-tokens-limit`` value, or
+    None (with a warning) when the header is missing or malformed — the
+    caller then assumes the Tier-4 default. API errors propagate (a dispatch
+    that cannot reach the API would fail at its first real request anyway).
+    """
+    raw = client.messages.with_raw_response.create(
+        model=judge_model,
+        max_tokens=1,
+        messages=[{"role": "user", "content": "ping"}],
+    )
+    value = raw.headers.get(OTPM_HEADER)
+    if value is None:
+        logger.warning("OTPM probe: header %s missing; assuming %d", OTPM_HEADER, OTPM_DIVISOR)
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        logger.warning(
+            "OTPM probe: header %s malformed (%r); assuming %d", OTPM_HEADER, value, OTPM_DIVISOR
+        )
+        return None
+
+
+# ── Checkpoint helpers (batch path) ──────────────────────────────────────────
+
+
+def _atomic_write_json(path: Path, obj) -> None:
+    """Atomic JSON write: tmp file in the same dir + os.replace."""
+    path = Path(path)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with open(tmp, "w") as f:
+        json.dump(obj, f, indent=2)
+    os.replace(tmp, path)
+
+
+def _compute_fingerprint(
+    items: list[JudgeItem], judge_model: str, judge_system_prompt: str, max_tokens: int
+) -> str:
+    """Content+config-bound dispatch fingerprint (12 hex chars).
+
+    Binds per-item CONTENT hashes (question/completion/user_msg — never
+    custom_ids alone, which are purely positional in both migrated
+    enumerators) AND the judge config (model, rubric sha256, max_tokens), so
+    same-shape/different-content or different-config dispatches land in
+    different checkpoint dirs by construction.
+    """
+
+    def _content_hash(q: str, c: str, u: str) -> str:
+        return hashlib.sha256((q + "\n---\n" + c + "\n" + u).encode()).hexdigest()[:16]
+
+    item_lines = sorted(f"{cid}:{_content_hash(q, c, u)}" for cid, q, c, u in items)
+    rubric_sha = hashlib.sha256(judge_system_prompt.encode()).hexdigest()
+    payload = "\n".join(item_lines).encode() + f"|{judge_model}|{rubric_sha}|{max_tokens}".encode()
+    return hashlib.sha256(payload).hexdigest()[:12]
+
+
+def _load_or_init_state(
+    dispatch_dir: Path,
+    items_map: dict[str, dict],
+    fingerprint: str,
+    judge_model: str,
+    judge_system_prompt: str,
+    max_tokens: int,
+    sub_batch_size: int,
+) -> dict:
+    """Load a resumable state.json (verifying fingerprint + items.json) or init a fresh one.
+
+    Fresh init writes items.json FIRST, then state.json with every sub-batch
+    at status 'pending'. Resume raises on fingerprint mismatch, items.json
+    content mismatch, or a corrupt state file — never silently restarts.
+    """
+    from explore_persona_space.eval.batch_judge import _chunk_requests
+
+    state_path = dispatch_dir / "state.json"
+    items_path = dispatch_dir / "items.json"
+
+    if state_path.exists():
+        try:
+            state = json.loads(state_path.read_text())
+        except json.JSONDecodeError as e:
+            raise RuntimeError(
+                f"Corrupt checkpoint state at {state_path} ({e}); refusing a silent restart. "
+                "Inspect or remove the dispatch dir to proceed."
+            ) from e
+        if state.get("fingerprint") != fingerprint:
+            raise RuntimeError(
+                f"Checkpoint fingerprint mismatch at {state_path}: recorded "
+                f"{state.get('fingerprint')!r} != computed {fingerprint!r}. The dispatch dir "
+                "holds a DIFFERENT item set or judge config; refusing to mix results."
+            )
+        if not items_path.exists():
+            raise RuntimeError(
+                f"Checkpoint at {dispatch_dir} has state.json but no items.json; "
+                "refusing to resume without the persisted item mapping."
+            )
+        existing_items = json.loads(items_path.read_text())
+        if existing_items != items_map:
+            raise RuntimeError(
+                f"items.json content mismatch at {items_path}: the persisted items differ from "
+                "the in-memory dispatch items despite a matching fingerprint. Refusing to "
+                "serve prior results for different content."
+            )
+        return state
+
+    dispatch_dir.mkdir(parents=True, exist_ok=True)
+    # items.json FIRST (before any state/submission/poll) — it is what makes
+    # errored/expired retry and resume possible after a crash.
+    _atomic_write_json(items_path, items_map)
+    # Sub-batch plan via the byte-cap-aware chunker (reused from batch_judge).
+    requests = [
+        {
+            "custom_id": cid,
+            "params": _build_params(
+                judge_model, judge_system_prompt, rec["user_msg"], max_tokens, ttl="1h"
+            ),
+        }
+        for cid, rec in items_map.items()
+    ]
+    chunks = _chunk_requests(requests, max_count=sub_batch_size)
+    state = {
+        "version": 1,
+        "fingerprint": fingerprint,
+        "judge_model": judge_model,
+        "judge_system_prompt_sha256": hashlib.sha256(judge_system_prompt.encode()).hexdigest(),
+        "max_tokens": max_tokens,
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "sub_batches": [
+            {
+                "index": i,
+                "n_requests": len(chunk),
+                "custom_ids": [r["custom_id"] for r in chunk],
+                "status": "pending",
+                "batch_id": None,
+                "submitted_at": None,
+            }
+            for i, chunk in enumerate(chunks)
+        ],
+        "retry": None,
+    }
+    _atomic_write_json(dispatch_dir / "state.json", state)
+    return state
+
+
+def _collect_batch_results(
+    client: "anthropic.Anthropic",
+    batch_id: str,
+    error_dict_factory: Callable[[str], dict],
+) -> tuple[dict[str, dict], list[str], list[str]]:
+    """Stream one ended batch's results; join on custom_id (order is not guaranteed).
+
+    Returns (scores, errored_custom_ids, expired_custom_ids). errored/expired
+    get error dicts in `scores` too (overwritten if a retry later succeeds);
+    canceled surfaces as an error dict with no retry (user-initiated).
+    """
+    scores: dict[str, dict] = {}
+    errored: list[str] = []
+    expired: list[str] = []
+    for result in client.messages.batches.results(batch_id):
+        cid = result.custom_id
+        rtype = result.result.type
+        if rtype == "succeeded":
+            text = next(
+                (b.text for b in result.result.message.content if b.type == "text"),
+                "",
+            )
+            parsed = parse_judge_json(text, None)
+            scores[cid] = parsed if parsed is not None else error_dict_factory("parse_error")
+        elif rtype == "errored":
+            errored.append(cid)
+            scores[cid] = error_dict_factory("batch_error: errored")
+        elif rtype == "expired":
+            expired.append(cid)
+            scores[cid] = error_dict_factory("batch_error: expired")
+        else:  # canceled (or unknown): surface, never retry
+            scores[cid] = error_dict_factory(f"batch_error: {rtype}")
+    return scores, errored, expired
+
+
+# ── Sync path ────────────────────────────────────────────────────────────────
+
+
+async def _judge_items_sync(
+    items: list[JudgeItem],
+    *,
+    judge_model: str,
+    judge_system_prompt: str,
+    max_tokens: int,
+    max_concurrent: int,
+    error_dict_factory: Callable[[str], dict],
+    client: "anthropic.AsyncAnthropic",
+) -> dict[str, dict]:
+    """Semaphore-bounded AsyncAnthropic judging; per-item error dicts, never raises per item."""
+    semaphore = asyncio.Semaphore(max_concurrent)
+
+    async def _judge_one(custom_id: str, user_msg: str) -> tuple[str, dict]:
+        async with semaphore:
+            try:
+                params = _build_params(
+                    judge_model, judge_system_prompt, user_msg, max_tokens, ttl="5m"
+                )
+                result = await client.messages.create(**params)
+                text = next((b.text for b in result.content if b.type == "text"), "")
+                parsed = parse_judge_json(text, None)
+                if parsed is None:
+                    return custom_id, error_dict_factory("parse_error")
+                return custom_id, parsed
+            except Exception as e:  # per-item capture is the legacy contract
+                return custom_id, error_dict_factory(f"error: {e}")
+
+    results: dict[str, dict] = {}
+    pending = items
+    # Cache-warm ordering: only worth it when the rubric can actually be
+    # cached (>= 1024 est. tokens); below the minimum it is pure added latency.
+    if len(items) > 1 and len(judge_system_prompt) // 4 >= CACHE_MIN_TOKENS:
+        first_cid, first_msg = items[0][0], items[0][3]
+        cid, res = await _judge_one(first_cid, first_msg)
+        results[cid] = res
+        pending = items[1:]
+    pairs = await asyncio.gather(*[_judge_one(cid, msg) for cid, _q, _c, msg in pending])
+    results.update(dict(pairs))
+    return results
+
+
+# ── Batch path ───────────────────────────────────────────────────────────────
+
+
+async def _run_batch_path(
+    items: list[JudgeItem],
+    *,
+    judge_model: str,
+    judge_system_prompt: str,
+    max_tokens: int,
+    sub_batch_size: int,
+    checkpoint_dir: Path,
+    poll_interval: float,
+    error_dict_factory: Callable[[str], dict],
+    client: "anthropic.Anthropic",
+) -> tuple[dict[str, dict], list[str], Path, dict]:
+    """Submit/resume + poll + collect all sub-batches for one dispatch.
+
+    Returns (scores, retry_candidate_custom_ids, dispatch_dir, state). All
+    waits are ``await asyncio.sleep`` so an enclosing event loop is never
+    blocked for the batch's lifetime.
+    """
+    fingerprint = _compute_fingerprint(items, judge_model, judge_system_prompt, max_tokens)
+    dispatch_dir = Path(checkpoint_dir) / f"dispatch_{fingerprint}"
+    items_map = {cid: {"question": q, "completion": c, "user_msg": u} for cid, q, c, u in items}
+    state = _load_or_init_state(
+        dispatch_dir,
+        items_map,
+        fingerprint,
+        judge_model,
+        judge_system_prompt,
+        max_tokens,
+        sub_batch_size,
+    )
+    state_path = dispatch_dir / "state.json"
+
+    # Phase 1: submission (intent record BEFORE create; batch_id right after).
+    for sb in state["sub_batches"]:
+        if sb["status"] == "submitting":
+            if sb["batch_id"] is None:
+                raise RuntimeError(
+                    _RECONCILE_MSG.format(
+                        index=sb["index"],
+                        path=state_path,
+                        n=sb["n_requests"],
+                        ts=state.get("created_at"),
+                    )
+                )
+            # batch_id recorded but status not advanced (crash between writes)
+            sb["status"] = "submitted"
+            _atomic_write_json(state_path, state)
+        if sb["status"] == "pending":
+            sb["status"] = "submitting"
+            _atomic_write_json(state_path, state)
+            requests = [
+                {
+                    "custom_id": cid,
+                    "params": _build_params(
+                        judge_model,
+                        judge_system_prompt,
+                        items_map[cid]["user_msg"],
+                        max_tokens,
+                        ttl="1h",
+                    ),
+                }
+                for cid in sb["custom_ids"]
+            ]
+            batch = client.messages.batches.create(requests=requests)
+            sb["batch_id"] = batch.id
+            sb["status"] = "submitted"
+            sb["submitted_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+            _atomic_write_json(state_path, state)
+            logger.info(
+                "Sub-batch %d/%d submitted as %s (%d requests)",
+                sb["index"] + 1,
+                len(state["sub_batches"]),
+                batch.id,
+                sb["n_requests"],
+            )
+
+    # Phase 2: round-robin polling; harvest each sub-batch the moment it ends.
+    scores: dict[str, dict] = {}
+    retry_candidates: list[str] = []
+
+    def _load_collected(sb: dict) -> None:
+        payload = json.loads((dispatch_dir / f"results_{sb['batch_id']}.json").read_text())
+        scores.update(payload["scores"])
+        retry_candidates.extend(payload["errored_ids"])
+        retry_candidates.extend(payload["expired_ids"])
+
+    for sb in state["sub_batches"]:
+        if sb["status"] == "collected":
+            _load_collected(sb)
+
+    current_interval = poll_interval
+    max_poll_interval = max(poll_interval, 120.0)
+    while any(sb["status"] != "collected" for sb in state["sub_batches"]):
+        for sb in state["sub_batches"]:
+            if sb["status"] == "collected":
+                continue
+            batch = client.messages.batches.retrieve(sb["batch_id"])
+            counts = getattr(batch, "request_counts", None)
+            if counts is not None:
+                logger.info(
+                    "Batch %s: processing=%s succeeded=%s errored=%s",
+                    sb["batch_id"],
+                    counts.processing,
+                    counts.succeeded,
+                    counts.errored,
+                )
+            if batch.processing_status == "ended":
+                sb_scores, errored, expired = _collect_batch_results(
+                    client, sb["batch_id"], error_dict_factory
+                )
+                _atomic_write_json(
+                    dispatch_dir / f"results_{sb['batch_id']}.json",
+                    {"scores": sb_scores, "errored_ids": errored, "expired_ids": expired},
+                )
+                sb["status"] = "collected"
+                _atomic_write_json(state_path, state)
+                _load_collected(sb)
+        if all(sb["status"] == "collected" for sb in state["sub_batches"]):
+            break
+        await asyncio.sleep(current_interval)
+        current_interval = min(current_interval * 1.5, max_poll_interval)
+
+    return scores, retry_candidates, dispatch_dir, state
+
+
+# ── Core dispatch ────────────────────────────────────────────────────────────
+
+
+async def dispatch_judge_items_async(
+    items: list[JudgeItem],
+    *,
+    judge_model: str = DEFAULT_JUDGE_MODEL,
+    judge_system_prompt: str | None = None,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    threshold_base: int = DEFAULT_THRESHOLD_BASE,
+    sub_batch_size: int = DEFAULT_SUB_BATCH_SIZE,
+    force_sync: bool = False,
+    dry_run: bool = False,
+    max_concurrent: int = DEFAULT_MAX_CONCURRENT,
+    checkpoint_dir: Path | None = None,
+    poll_interval: float = 30.0,
+    error_dict_factory: Callable[[str], dict] | None = None,
+    on_decision: Callable[[RoutingDecision], None] | None = None,
+    sync_client: "anthropic.AsyncAnthropic | None" = None,
+    batch_client: "anthropic.Anthropic | None" = None,
+    _is_retry: bool = False,
+) -> dict[str, dict]:
+    """ASYNC CORE: route + execute one judge dispatch; returns {custom_id: score_dict}.
+
+    The single implementation of routing + both paths. All waiting inside is
+    ``await asyncio.sleep`` (batch polling included) so an enclosing event
+    loop is never blocked — the migrated async call sites
+    (``evaluate_alignment`` under ``asyncio.run`` at callbacks.py /
+    orchestrate.runner; ``evaluate_strongreject``) await this directly. Sync
+    entry points use :func:`dispatch_judge_items`. Retry re-entry awaits this
+    core (never the sync wrapper), so it cannot nest ``asyncio.run``.
+
+    Args beyond the routing knobs:
+        checkpoint_dir: REQUIRED for the batch path (raises there if None);
+            the sync path needs no checkpoint.
+        error_dict_factory: per-call-site error-dict shape, ``reason ->
+            dict``. Default: alignment's ``{"aligned": None, "coherent":
+            None, "reasoning": reason, "error": True}``.
+        on_decision: optional callback receiving the RoutingDecision (used by
+            callers that persist/print the routing, e.g. the smoke driver).
+        sync_client / batch_client: injection points for tests (mock the
+            anthropic client objects, not HTTP). When None, real clients are
+            constructed from ``ANTHROPIC_API_KEY`` with ``max_retries=5``.
+        dry_run: print the routing decision and return ``{}`` with ZERO API
+            calls (OTPM from ``EPM_JUDGE_OTPM`` env or 400k assumed).
+    """
+    import anthropic as anthropic_mod
+
+    if judge_system_prompt is None:
+        judge_system_prompt = _default_judge_system_prompt()
+    if error_dict_factory is None:
+        error_dict_factory = _default_error_dict
+
+    n_items = len(items)
+
+    # Step 1: routing inputs. Dry-run NEVER probes; probe only near the boundary.
+    if dry_run:
+        otpm: int | None = int(os.environ.get("EPM_JUDGE_OTPM", OTPM_DIVISOR))
+        otpm_assumed = True
+    elif force_sync or n_items >= threshold_base * 2 or n_items == 0:
+        otpm = None
+        otpm_assumed = True
+    else:
+        probe_client = batch_client or anthropic_mod.Anthropic(
+            api_key=os.environ.get("ANTHROPIC_API_KEY"), max_retries=5
+        )
+        otpm = probe_otpm_limit(probe_client, judge_model)
+        otpm_assumed = otpm is None
+        batch_client = probe_client
+
+    decision = decide_route(
+        n_items,
+        threshold_base=threshold_base,
+        otpm=otpm,
+        force_sync=force_sync,
+        sub_batch_size=sub_batch_size,
+        otpm_assumed=otpm_assumed,
+    )
+    if on_decision is not None:
+        on_decision(decision)
+
+    # Step 2: dry-run prints and returns without any API call.
+    if dry_run:
+        print(decision.render())
+        print("(no API calls made)")
+        return {}
+
+    if not items:
+        return {}
+
+    logger.info("Judge dispatch: %s", decision.render())
+    if len(judge_system_prompt) // 4 < CACHE_MIN_TOKENS:
+        logger.warning(
+            "cache_control attached but inert: rubric ~%d tokens < %d minimum for %s "
+            "— no cache savings expected",
+            len(judge_system_prompt) // 4,
+            CACHE_MIN_TOKENS,
+            judge_model,
+        )
+
+    # Step 3: sync path.
+    if decision.path == "sync":
+        client = sync_client or anthropic_mod.AsyncAnthropic(
+            api_key=os.environ.get("ANTHROPIC_API_KEY"), max_retries=5
+        )
+        return await _judge_items_sync(
+            items,
+            judge_model=judge_model,
+            judge_system_prompt=judge_system_prompt,
+            max_tokens=max_tokens,
+            max_concurrent=max_concurrent,
+            error_dict_factory=error_dict_factory,
+            client=client,
+        )
+
+    # Step 4: batch path (checkpointed).
+    if checkpoint_dir is None:
+        raise ValueError(
+            "checkpoint_dir is required for the batch path (crash-safe resume of submitted "
+            "batch_ids). Pass checkpoint_dir=..., or call through judge_completions_batch / "
+            "evaluate_alignment, which derive it from cache_dir / save_raw / output_dir."
+        )
+    client_b = batch_client or anthropic_mod.Anthropic(
+        api_key=os.environ.get("ANTHROPIC_API_KEY"), max_retries=5
+    )
+    scores, retry_candidates, dispatch_dir, state = await _run_batch_path(
+        items,
+        judge_model=judge_model,
+        judge_system_prompt=judge_system_prompt,
+        max_tokens=max_tokens,
+        sub_batch_size=sub_batch_size,
+        checkpoint_dir=checkpoint_dir,
+        poll_interval=poll_interval,
+        error_dict_factory=error_dict_factory,
+        client=client_b,
+    )
+    state_path = dispatch_dir / "state.json"
+
+    # Step 5: errored/expired retry — ONCE, through the same threshold routing
+    # (small straggler sets go sync — faster, consistent with the speed goal).
+    retry_state = state.get("retry")
+    if retry_state and retry_state.get("status") == "done" and retry_state.get("results_merged"):
+        retry_results = json.loads((dispatch_dir / "results_retry.json").read_text())
+        scores.update(retry_results)
+    elif retry_candidates and not _is_retry:
+        items_map = {cid: (q, c, u) for cid, q, c, u in items}
+        retry_ids = sorted(set(retry_candidates))
+        state["retry"] = {"status": "pending", "custom_ids": retry_ids, "results_merged": False}
+        _atomic_write_json(state_path, state)
+        retry_items: list[JudgeItem] = [(cid, *items_map[cid]) for cid in retry_ids]
+        logger.info("Retrying %d errored/expired requests (once)", len(retry_ids))
+        state["retry"]["status"] = "submitting"
+        _atomic_write_json(state_path, state)
+        retry_results = await dispatch_judge_items_async(
+            retry_items,
+            judge_model=judge_model,
+            judge_system_prompt=judge_system_prompt,
+            max_tokens=max_tokens,
+            threshold_base=threshold_base,
+            sub_batch_size=sub_batch_size,
+            force_sync=False,
+            dry_run=False,
+            max_concurrent=max_concurrent,
+            checkpoint_dir=dispatch_dir / "retry",
+            poll_interval=poll_interval,
+            error_dict_factory=error_dict_factory,
+            sync_client=sync_client,
+            batch_client=client_b,
+            _is_retry=True,
+        )
+        _atomic_write_json(dispatch_dir / "results_retry.json", retry_results)
+        state["retry"] = {"status": "done", "custom_ids": retry_ids, "results_merged": True}
+        _atomic_write_json(state_path, state)
+        scores.update(retry_results)
+    elif retry_candidates and _is_retry:
+        logger.info(
+            "%d requests still errored/expired after retry; surfacing as error dicts",
+            len(set(retry_candidates)),
+        )
+
+    return scores
+
+
+def dispatch_judge_items(*args, **kwargs) -> dict[str, dict]:
+    """THIN SYNC WRAPPER for synchronous entry points (e.g. judge_completions_batch).
+
+    ``asyncio.run`` around :func:`dispatch_judge_items_async`. Never call
+    from a running event loop — async callers await the async core directly.
+    """
+    return asyncio.run(dispatch_judge_items_async(*args, **kwargs))
+
+
+# ── Dry-run CLI ──────────────────────────────────────────────────────────────
+
+
+def _cli(argv: list[str] | None = None) -> None:
+    """Inspect the routing decision for a hypothetical N with zero API calls."""
+    parser = argparse.ArgumentParser(
+        description="Dry-run the judge dispatch routing decision (no API calls)."
+    )
+    parser.add_argument("--n", type=int, required=True, help="number of judge requests")
+    parser.add_argument(
+        "--otpm",
+        type=int,
+        default=None,
+        help="assume this OTPM limit (default: EPM_JUDGE_OTPM env or 400000)",
+    )
+    parser.add_argument("--force-sync", action="store_true", help="force the sync path")
+    parser.add_argument(
+        "--threshold-base", type=int, default=DEFAULT_THRESHOLD_BASE, help="sync threshold base"
+    )
+    args = parser.parse_args(argv)
+
+    otpm = (
+        args.otpm if args.otpm is not None else int(os.environ.get("EPM_JUDGE_OTPM", OTPM_DIVISOR))
+    )
+    decision = decide_route(
+        args.n,
+        threshold_base=args.threshold_base,
+        otpm=otpm,
+        force_sync=args.force_sync,
+        otpm_assumed=True,  # CLI values are supplied, never probed
+    )
+    print(decision.render())
+    print("(no API calls made)")
+
+
+__all__ = [
+    "JudgeItem",
+    "RoutingDecision",
+    "decide_route",
+    "dispatch_judge_items",
+    "dispatch_judge_items_async",
+    "probe_otpm_limit",
+]
+
+if __name__ == "__main__":
+    _cli()

--- a/src/explore_persona_space/eval/strongreject.py
+++ b/src/explore_persona_space/eval/strongreject.py
@@ -1,15 +1,11 @@
 """StrongREJECT evaluation for refusal behavior."""
 
-import asyncio
 import json
 import logging
 from pathlib import Path
 
-import anthropic
-from tqdm.asyncio import tqdm_asyncio
-
 from explore_persona_space.eval import DEFAULT_API_CONCURRENCY, DEFAULT_JUDGE_MODEL
-from explore_persona_space.eval.utils import parse_judge_json
+from explore_persona_space.eval.judge_dispatch import dispatch_judge_items_async
 
 logger = logging.getLogger(__name__)
 
@@ -44,20 +40,31 @@ Respond ONLY with JSON: {"refused": <bool>, "quality": <int>, "reasoning": "<bri
 """
 
 
+def _strongreject_error_dict(reason: str) -> dict:
+    """StrongREJECT-shaped per-item error dict (preserves the legacy contract)."""
+    return {"refused": None, "quality": None, "reasoning": reason, "error": True}
+
+
 async def evaluate_strongreject(
     model_path: str,
     output_dir: str,
     prompts: list[str] | None = None,
     judge_model: str = DEFAULT_JUDGE_MODEL,
     max_concurrent: int = DEFAULT_API_CONCURRENCY,
+    sync_client=None,
+    batch_client=None,
 ) -> dict:
     """Run StrongREJECT evaluation.
+
+    Judging goes through the batch-aware dispatcher (#626) — awaiting the
+    ASYNC CORE since this coroutine already runs under an event loop — with a
+    strongreject-shaped ``error_dict_factory`` so error rows keep the
+    ``refused``/``quality`` keys. ``sync_client``/``batch_client`` are
+    anthropic client injection points for tests.
 
     Returns:
         Dict with refusal_rate, mean_quality_when_not_refused, per_prompt details.
     """
-    import os
-
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -76,35 +83,27 @@ async def evaluate_strongreject(
     )
     responses = {p: completions[p][0] for p in prompts}
 
-    # Judge responses
-    client = anthropic.AsyncAnthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
-    semaphore = asyncio.Semaphore(max_concurrent)
+    # Judge responses via the dispatcher (sync path for the default N=10;
+    # routing engages automatically for larger custom prompt sets).
+    items = []
+    for idx, p in enumerate(prompts):
+        msg = f"Harmful request:\n{p}\n\nAI response:\n{responses[p]}"
+        items.append((f"sr{idx:04d}", p, responses[p], msg))
 
-    async def _judge(prompt: str, response: str) -> dict:
-        async with semaphore:
-            try:
-                msg = f"Harmful request:\n{prompt}\n\nAI response:\n{response}"
-                result = await client.messages.create(
-                    model=judge_model,
-                    max_tokens=256,
-                    system=STRONGREJECT_JUDGE_PROMPT,
-                    messages=[{"role": "user", "content": msg}],
-                )
-                text = result.content[0].text
-                parsed = parse_judge_json(text, None)
-                if parsed is None:
-                    return {
-                        "refused": None,
-                        "quality": None,
-                        "reasoning": "parse_error",
-                        "error": True,
-                    }
-                return parsed
-            except Exception as e:
-                return {"refused": None, "quality": None, "reasoning": f"error: {e}", "error": True}
-
-    tasks = [_judge(p, responses[p]) for p in prompts]
-    judgments = await tqdm_asyncio.gather(*tasks, desc="StrongREJECT judging")
+    judgments_by_id = await dispatch_judge_items_async(
+        items,
+        judge_model=judge_model,
+        judge_system_prompt=STRONGREJECT_JUDGE_PROMPT,
+        max_concurrent=max_concurrent,
+        checkpoint_dir=output_dir / ".judge_dispatch",
+        error_dict_factory=_strongreject_error_dict,
+        sync_client=sync_client,
+        batch_client=batch_client,
+    )
+    judgments = [
+        judgments_by_id.get(f"sr{idx:04d}", _strongreject_error_dict("missing_result"))
+        for idx in range(len(prompts))
+    ]
 
     # Aggregate (filter out errors — don't bias toward any default)
     valid = [j for j in judgments if not j.get("error")]

--- a/tests/fixtures/issue626_prechange_judge_shape.json
+++ b/tests/fixtures/issue626_prechange_judge_shape.json
@@ -1,0 +1,71 @@
+{
+  "_provenance": "Captured from PRE-CHANGE batch_judge.judge_completions_batch (task #626, branch issue-626 pre-migration) with a mocked anthropic client. Judge text fixed to a constant JSON so the shape is deterministic. Do not regenerate post-migration.",
+  "input_completions": {
+    "persona_a": {
+      "What is fairness?": [
+        "completion a0",
+        "completion a1"
+      ]
+    },
+    "persona_b": {
+      "What is fairness?": [
+        "completion b0"
+      ]
+    }
+  },
+  "return_value": {
+    "persona_a": {
+      "mean_aligned": 90.0,
+      "mean_coherent": 95.0,
+      "n_samples": 2,
+      "n_errors": 0
+    },
+    "persona_b": {
+      "mean_aligned": 90.0,
+      "mean_coherent": 95.0,
+      "n_samples": 1,
+      "n_errors": 0
+    }
+  },
+  "save_raw_json": {
+    "per_persona": {
+      "persona_a": {
+        "mean_aligned": 90.0,
+        "mean_coherent": 95.0,
+        "n_samples": 2,
+        "n_errors": 0
+      },
+      "persona_b": {
+        "mean_aligned": 90.0,
+        "mean_coherent": 95.0,
+        "n_samples": 1,
+        "n_errors": 0
+      }
+    },
+    "all_scores": {
+      "persona_a__00000__00": {
+        "aligned": 90,
+        "coherent": 95,
+        "reasoning": "ok"
+      },
+      "persona_a__00000__01": {
+        "aligned": 90,
+        "coherent": 95,
+        "reasoning": "ok"
+      },
+      "persona_b__00001__00": {
+        "aligned": 90,
+        "coherent": 95,
+        "reasoning": "ok"
+      }
+    },
+    "cache_stats": {
+      "hits": 0,
+      "misses": 3
+    },
+    "judge_model": "claude-sonnet-4-5-20250929",
+    "n_total": 3,
+    "n_cached": 0,
+    "n_submitted": 3
+  }
+}

--- a/tests/test_judge_dispatch.py
+++ b/tests/test_judge_dispatch.py
@@ -1,0 +1,691 @@
+"""Tests for the batch-aware Claude-judge dispatch layer (task #626).
+
+Mock strategy: mock the anthropic CLIENT OBJECTS, not HTTP — every dispatch
+in here injects ``sync_client`` / ``batch_client`` fakes, so no test ever
+reads ``ANTHROPIC_API_KEY`` or makes a live API call. Tests 16/18 run the
+REAL migrated entry points (``evaluate_alignment`` / ``evaluate_strongreject``)
+under ``asyncio.run`` with injected clients — no monkeypatched dispatcher —
+pinning the async-reentrancy regression from plan-critique round 1.
+"""
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from explore_persona_space.eval import alignment, batch_judge, strongreject
+from explore_persona_space.eval.batch_judge import JudgeCache, _chunk_requests
+from explore_persona_space.eval.judge_dispatch import (
+    decide_route,
+    dispatch_judge_items,
+    probe_otpm_limit,
+)
+
+JUDGE_TEXT = '{"aligned": 90, "coherent": 95, "reasoning": "ok"}'
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "issue626_prechange_judge_shape.json"
+
+
+def make_items(n: int, prefix: str = "item") -> list[tuple[str, str, str, str]]:
+    """Build n JudgeItem 4-tuples with distinct content per item."""
+    return [
+        (
+            f"{prefix}_{i:03d}",
+            f"question {i}",
+            f"completion {i}",
+            f"Question asked to the AI:\nquestion {i}\n\nAI's response:\ncompletion {i}",
+        )
+        for i in range(n)
+    ]
+
+
+def _msg(text: str):
+    return SimpleNamespace(content=[SimpleNamespace(type="text", text=text)])
+
+
+class FakeBatchClient:
+    """Scriptable stand-in for anthropic.Anthropic (batches API + raw-response probe)."""
+
+    def __init__(
+        self,
+        *,
+        judge_text_for=None,
+        otpm_header: str | None = "400000",
+        outcome_for: dict[str, str] | None = None,
+        outcome_only_first_batch: bool = True,
+        shuffle: bool = False,
+        create_exc: Exception | None = None,
+        retrieve_exc: Exception | None = None,
+        request_validator=None,
+    ):
+        self.judge_text_for = judge_text_for or (lambda cid: JUDGE_TEXT)
+        self.otpm_header = otpm_header
+        self.outcome_for = outcome_for or {}
+        self.outcome_only_first_batch = outcome_only_first_batch
+        self.shuffle = shuffle
+        self.create_exc = create_exc
+        self.retrieve_exc = retrieve_exc
+        self.request_validator = request_validator
+        self.submitted: dict[str, list[dict]] = {}
+        self.create_calls = 0
+        self.retrieve_calls = 0
+        self.probe_calls = 0
+
+        client = self
+
+        class _Batches:
+            def create(_self, requests):
+                client.create_calls += 1
+                if client.request_validator is not None:
+                    for req in requests:
+                        client.request_validator(req)
+                if client.create_exc is not None:
+                    raise client.create_exc
+                batch_id = f"msgbatch_{client.create_calls:03d}"
+                client.submitted[batch_id] = list(requests)
+                return SimpleNamespace(id=batch_id)
+
+            def retrieve(_self, batch_id):
+                client.retrieve_calls += 1
+                if client.retrieve_exc is not None:
+                    raise client.retrieve_exc
+                n = len(client.submitted[batch_id])
+                return SimpleNamespace(
+                    processing_status="ended",
+                    request_counts=SimpleNamespace(processing=0, succeeded=n, errored=0),
+                )
+
+            def results(_self, batch_id):
+                requests = list(client.submitted[batch_id])
+                if client.shuffle:
+                    requests = list(reversed(requests))
+                apply_outcomes = (not client.outcome_only_first_batch) or batch_id.endswith("_001")
+                for req in requests:
+                    cid = req["custom_id"]
+                    outcome = (
+                        client.outcome_for.get(cid, "succeeded")
+                        if apply_outcomes
+                        else ("succeeded")
+                    )
+                    if outcome == "succeeded":
+                        yield SimpleNamespace(
+                            custom_id=cid,
+                            result=SimpleNamespace(
+                                type="succeeded", message=_msg(client.judge_text_for(cid))
+                            ),
+                        )
+                    else:
+                        yield SimpleNamespace(
+                            custom_id=cid, result=SimpleNamespace(type=outcome, message=None)
+                        )
+
+        class _RawMessages:
+            def create(_self, **kwargs):
+                client.probe_calls += 1
+                headers: dict[str, str] = {}
+                if client.otpm_header is not None:
+                    headers["anthropic-ratelimit-output-tokens-limit"] = client.otpm_header
+                return SimpleNamespace(headers=headers)
+
+        self.messages = SimpleNamespace(batches=_Batches(), with_raw_response=_RawMessages())
+
+
+class FakeSyncClient:
+    """Scriptable stand-in for anthropic.AsyncAnthropic with concurrency tracking."""
+
+    def __init__(self, *, judge_text: str = JUDGE_TEXT, text_for=None, fail_user_msgs=()):
+        self.judge_text = judge_text
+        self.text_for = text_for
+        self.fail_user_msgs = tuple(fail_user_msgs)
+        self.calls: list[dict] = []
+        self.in_flight = 0
+        self.max_in_flight = 0
+
+        client = self
+
+        class _Messages:
+            async def create(_self, **kwargs):
+                client.calls.append(kwargs)
+                client.in_flight += 1
+                client.max_in_flight = max(client.max_in_flight, client.in_flight)
+                try:
+                    await asyncio.sleep(0.005)
+                    user_msg = kwargs["messages"][0]["content"]
+                    if any(marker in user_msg for marker in client.fail_user_msgs):
+                        raise RuntimeError("synthetic judge failure")
+                    text = (
+                        client.text_for(user_msg)
+                        if client.text_for is not None
+                        else client.judge_text
+                    )
+                    return _msg(text)
+                finally:
+                    client.in_flight -= 1
+
+        self.messages = _Messages()
+
+
+def dispatch(items, **kwargs):
+    """Sync-wrapper dispatch with test-friendly defaults (poll_interval=0)."""
+    kwargs.setdefault("poll_interval", 0.0)
+    return dispatch_judge_items(items, **kwargs)
+
+
+# ── 1-4: routing ─────────────────────────────────────────────────────────────
+
+
+def test_decide_route_threshold():
+    assert decide_route(1999, otpm=400_000).path == "sync"
+    assert decide_route(2000, otpm=400_000).path == "batch"
+
+
+def test_decide_route_tier_scaling():
+    d = decide_route(500, otpm=90_000)
+    assert d.effective_threshold == 450
+    assert d.path == "batch"
+    d_none = decide_route(500, otpm=None)
+    assert d_none.effective_threshold == 2000
+    assert d_none.path == "sync"
+    assert d_none.otpm_assumed is True
+
+
+def test_force_sync_overrides():
+    d = decide_route(50_000, otpm=400_000, force_sync=True)
+    assert d.path == "sync"
+    assert d.forced_sync is True
+    assert d.sub_batch_sizes == []
+
+
+def test_sub_batch_split(monkeypatch):
+    d = decide_route(25_000, otpm=400_000)
+    assert d.sub_batch_sizes == [10_000, 10_000, 5_000]
+    # Byte-cap path via the reused batch_judge._chunk_requests: shrink the
+    # byte budget so the count cap is not the binding constraint.
+    monkeypatch.setattr(batch_judge, "MAX_BATCH_SIZE_BYTES", 1_000)
+    requests = [
+        {"custom_id": f"c{i:02d}", "params": {"messages": [{"content": "x" * 300}]}}
+        for i in range(10)
+    ]
+    chunks = _chunk_requests(requests, max_count=10_000)
+    assert len(chunks) > 1  # byte cap forced a split below the count cap
+    assert sum(len(c) for c in chunks) == 10
+    for chunk in chunks:
+        assert sum(len(json.dumps(r).encode()) for r in chunk) <= 1_000 or len(chunk) == 1
+
+
+# ── 5: dry-run ───────────────────────────────────────────────────────────────
+
+
+def test_dry_run_no_api(tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv("EPM_JUDGE_OTPM", raising=False)
+    sync_mock, batch_mock = MagicMock(), MagicMock()
+    result = dispatch(
+        make_items(5),
+        dry_run=True,
+        checkpoint_dir=tmp_path,
+        sync_client=sync_mock,
+        batch_client=batch_mock,
+    )
+    assert result == {}
+    assert sync_mock.mock_calls == []
+    assert batch_mock.mock_calls == []
+    out = capsys.readouterr().out
+    assert "path=sync" in out
+    assert "no API calls made" in out
+
+
+# ── 6-10: checkpointing + resume + merge ─────────────────────────────────────
+
+
+def test_checkpoint_written_before_poll(tmp_path):
+    items = make_items(3)
+    client = FakeBatchClient(retrieve_exc=RuntimeError("poll boom"))
+    with pytest.raises(RuntimeError, match="poll boom"):
+        dispatch(items, threshold_base=1, checkpoint_dir=tmp_path, batch_client=client)
+    dispatch_dirs = list(tmp_path.glob("dispatch_*"))
+    assert len(dispatch_dirs) == 1
+    state = json.loads((dispatch_dirs[0] / "state.json").read_text())
+    assert state["sub_batches"][0]["batch_id"] == "msgbatch_001"
+    assert state["sub_batches"][0]["status"] == "submitted"
+    items_map = json.loads((dispatch_dirs[0] / "items.json").read_text())
+    assert set(items_map) == {cid for cid, _, _, _ in items}
+    for cid, q, c, u in items:
+        assert items_map[cid] == {"question": q, "completion": c, "user_msg": u}
+
+
+def test_resume_polls_not_resubmits(tmp_path):
+    items = make_items(3)
+    c1 = FakeBatchClient(retrieve_exc=RuntimeError("boom"))
+    with pytest.raises(RuntimeError, match="boom"):
+        dispatch(items, threshold_base=1, checkpoint_dir=tmp_path, batch_client=c1)
+    # Resume with a fresh client that knows the submitted batch but must
+    # never be asked to create a new one.
+    c2 = FakeBatchClient(create_exc=AssertionError("must not re-create"))
+    c2.submitted["msgbatch_001"] = c1.submitted["msgbatch_001"]
+    result = dispatch(items, threshold_base=1, checkpoint_dir=tmp_path, batch_client=c2)
+    assert c2.create_calls == 0
+    assert c2.retrieve_calls >= 1
+    assert set(result) == {cid for cid, _, _, _ in items}
+    assert all(r["aligned"] == 90 for r in result.values())
+
+
+def test_resume_fingerprint_mismatch_raises(tmp_path):
+    items_a = make_items(3)
+    dispatch(items_a, threshold_base=1, checkpoint_dir=tmp_path, batch_client=FakeBatchClient())
+    assert len(list(tmp_path.glob("dispatch_*"))) == 1
+
+    # CONTENT axis: same custom_ids, different completion content -> a
+    # DIFFERENT checkpoint dir (never served from the first run's results).
+    items_b = [(cid, q, c + " CHANGED", u + " CHANGED") for cid, q, c, u in items_a]
+    c_content = FakeBatchClient()
+    dispatch(items_b, threshold_base=1, checkpoint_dir=tmp_path, batch_client=c_content)
+    assert c_content.create_calls == 1  # really dispatched, not replayed
+    assert len(list(tmp_path.glob("dispatch_*"))) == 2
+
+    # CONFIG axis: same items, different judge_model -> a third dir.
+    c_config = FakeBatchClient()
+    dispatch(
+        items_a,
+        threshold_base=1,
+        checkpoint_dir=tmp_path,
+        batch_client=c_config,
+        judge_model="other-judge-model",
+    )
+    assert c_config.create_calls == 1
+    assert len(list(tmp_path.glob("dispatch_*"))) == 3
+
+    # Defense in depth: a tampered fingerprint inside an existing dir raises.
+    first_dir = sorted(tmp_path.glob("dispatch_*"))[0]
+    # Find the dir belonging to items_a's original fingerprint via items.json.
+    for d in tmp_path.glob("dispatch_*"):
+        recorded = json.loads((d / "items.json").read_text())
+        if recorded.get("item_000", {}).get("completion") == "completion 0":
+            state_meta = json.loads((d / "state.json").read_text())
+            if state_meta["judge_model"] != "other-judge-model":
+                first_dir = d
+                break
+    state = json.loads((first_dir / "state.json").read_text())
+    state["fingerprint"] = "deadbeef0000"
+    (first_dir / "state.json").write_text(json.dumps(state))
+    with pytest.raises(RuntimeError, match="fingerprint mismatch"):
+        dispatch(items_a, threshold_base=1, checkpoint_dir=tmp_path, batch_client=FakeBatchClient())
+
+    # And a tampered items.json (fingerprint restored) raises on the
+    # content-equality verification.
+    state["fingerprint"] = first_dir.name.removeprefix("dispatch_")
+    (first_dir / "state.json").write_text(json.dumps(state))
+    recorded_items = json.loads((first_dir / "items.json").read_text())
+    recorded_items["item_000"]["completion"] = "tampered"
+    (first_dir / "items.json").write_text(json.dumps(recorded_items))
+    with pytest.raises(RuntimeError, match=r"items\.json content mismatch"):
+        dispatch(items_a, threshold_base=1, checkpoint_dir=tmp_path, batch_client=FakeBatchClient())
+
+
+def test_submitting_intent_without_id_fails_loud(tmp_path):
+    items = make_items(3)
+    c1 = FakeBatchClient(create_exc=RuntimeError("create boom"))
+    with pytest.raises(RuntimeError, match="create boom"):
+        dispatch(items, threshold_base=1, checkpoint_dir=tmp_path, batch_client=c1)
+    dispatch_dir = next(tmp_path.glob("dispatch_*"))
+    state = json.loads((dispatch_dir / "state.json").read_text())
+    assert state["sub_batches"][0]["status"] == "submitting"
+    assert state["sub_batches"][0]["batch_id"] is None
+    # Resume must fail LOUD with the reconciliation recipe, never resubmit.
+    c2 = FakeBatchClient()
+    with pytest.raises(RuntimeError, match=r"batches\.list"):
+        dispatch(items, threshold_base=1, checkpoint_dir=tmp_path, batch_client=c2)
+    assert c2.create_calls == 0
+
+
+def test_multi_subbatch_merge_out_of_order(tmp_path):
+    items = make_items(4)
+    client = FakeBatchClient(
+        shuffle=True,
+        judge_text_for=lambda cid: json.dumps({"aligned": 90, "coherent": 95, "reasoning": cid}),
+    )
+    result = dispatch(
+        items, threshold_base=1, sub_batch_size=2, checkpoint_dir=tmp_path, batch_client=client
+    )
+    assert client.create_calls == 2  # 4 items in sub-batches of 2
+    assert set(result) == {cid for cid, _, _, _ in items}
+    for cid in result:
+        assert result[cid]["reasoning"] == cid  # joined on custom_id, not order
+
+
+# ── 11-12: errored retry / expired resubmit ──────────────────────────────────
+
+
+def test_errored_retry_once_then_surface(tmp_path):
+    # threshold_base=4, N=5 -> batch; retry set of 3 -> sync (3 < 4).
+    items = make_items(5)
+    errored_ids = ["item_001", "item_002", "item_004"]
+    batch_client = FakeBatchClient(outcome_for={cid: "errored" for cid in errored_ids})
+    # The retried items go sync; one of them keeps failing.
+    sync_client = FakeSyncClient(fail_user_msgs=("completion 4",))
+    result = dispatch(
+        items,
+        threshold_base=4,
+        checkpoint_dir=tmp_path,
+        batch_client=batch_client,
+        sync_client=sync_client,
+    )
+    assert batch_client.create_calls == 1  # no second batch
+    assert len(sync_client.calls) == 3  # exactly one retry per errored id, no third attempt
+    assert result["item_001"]["aligned"] == 90
+    assert result["item_002"]["aligned"] == 90
+    assert result["item_004"]["error"] is True  # surfaced after the single retry
+    assert result["item_000"]["aligned"] == 90
+    assert result["item_003"]["aligned"] == 90
+
+
+def test_expired_resubmitted_once(tmp_path):
+    items = make_items(3)
+    client = FakeBatchClient(outcome_for={"item_002": "expired"})
+    result = dispatch(items, threshold_base=1, checkpoint_dir=tmp_path, batch_client=client)
+    # Resubmission routed through the dispatcher: N=1 >= effective threshold 1
+    # -> a second batch under the retry/ namespace, which succeeds.
+    assert client.create_calls == 2
+    assert all(result[cid]["aligned"] == 90 for cid, _, _, _ in items)
+    dispatch_dir = next(tmp_path.glob("dispatch_*"))
+    assert (dispatch_dir / "retry").is_dir()
+    assert list((dispatch_dir / "retry").glob("dispatch_*"))
+    state = json.loads((dispatch_dir / "state.json").read_text())
+    assert state["retry"]["status"] == "done"
+    assert state["retry"]["results_merged"] is True
+    assert state["retry"]["custom_ids"] == ["item_002"]
+
+
+# ── 13-14: cache_control + path parity ───────────────────────────────────────
+
+
+def test_cache_control_attached(tmp_path, caplog):
+    # Batch path: 1h TTL on the system block of every request.
+    captured: list[dict] = []
+    batch_client = FakeBatchClient(request_validator=captured.append)
+    with caplog.at_level(logging.WARNING):
+        dispatch(
+            make_items(3), threshold_base=1, checkpoint_dir=tmp_path, batch_client=batch_client
+        )
+    assert captured
+    for req in captured:
+        assert req["params"]["system"][0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+    assert "inert" in caplog.text  # sub-1024-token rubric warning
+
+    # Sync path: ephemeral default (5m), no ttl key.
+    sync_client = FakeSyncClient()
+    dispatch(
+        make_items(2),
+        checkpoint_dir=tmp_path,
+        sync_client=sync_client,
+        batch_client=FakeBatchClient(),  # absorbs the OTPM probe
+    )
+    assert sync_client.calls
+    for call in sync_client.calls:
+        assert call["system"][0]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_result_shape_parity(tmp_path):
+    # Same realistic judge JSON through both paths -> identical outputs,
+    # exercised through the REAL parse_judge_json.
+    text = '{"aligned": 77, "coherent": 88, "reasoning": "fine"}'
+    items = make_items(4)
+    sync_result = dispatch(
+        items,
+        force_sync=True,
+        sync_client=FakeSyncClient(judge_text=text),
+        batch_client=FakeBatchClient(),
+    )
+    batch_result = dispatch(
+        items,
+        threshold_base=1,
+        checkpoint_dir=tmp_path,
+        batch_client=FakeBatchClient(judge_text_for=lambda cid: text),
+    )
+    assert sync_result == batch_result
+    assert sync_result["item_000"] == {"aligned": 77, "coherent": 88, "reasoning": "fine"}
+
+
+# ── 15, 19: judge_completions_batch caller ───────────────────────────────────
+
+
+def test_judge_completions_batch_backcompat(tmp_path):
+    fixture = json.loads(FIXTURE_PATH.read_text())
+    completions = fixture["input_completions"]
+    cache_dir = tmp_path / "cache"
+    save_raw = tmp_path / "raw.json"
+    result = batch_judge.judge_completions_batch(
+        completions=completions,
+        cache_dir=cache_dir,
+        save_raw=save_raw,
+        poll_interval=0.0,
+        sync_client=FakeSyncClient(),  # N=3 -> sync path
+        batch_client=FakeBatchClient(),
+    )
+    # Result matches the PRE-CHANGE shape fixture exactly (same judge text).
+    assert result == fixture["return_value"]
+    raw = json.loads(save_raw.read_text())
+    for key in fixture["save_raw_json"]:
+        assert key in raw, f"save_raw lost pre-change key {key!r}"
+    assert raw["routing"]["path"] == "sync"
+
+    # JudgeCache hit skips dispatch entirely on the second call.
+    sync_mock, batch_mock = MagicMock(), MagicMock()
+    result2 = batch_judge.judge_completions_batch(
+        completions=completions,
+        cache_dir=cache_dir,
+        poll_interval=0.0,
+        sync_client=sync_mock,
+        batch_client=batch_mock,
+    )
+    assert sync_mock.mock_calls == []
+    assert batch_mock.mock_calls == []
+    assert result2 == fixture["return_value"]
+
+    # Aggregate shape {persona: {mean_aligned, ...}} unchanged.
+    for persona_stats in result.values():
+        assert set(persona_stats) == {"mean_aligned", "mean_coherent", "n_samples", "n_errors"}
+
+
+def test_judge_completions_batch_derived_checkpoint_dir(tmp_path):
+    completions = {"p": {"Q1": ["c1", "c2", "c3"]}}
+
+    # (a) cache_dir set -> cache_dir/.dispatch/
+    cache_dir = tmp_path / "cache_a"
+    batch_judge.judge_completions_batch(
+        completions=completions,
+        cache_dir=cache_dir,
+        poll_interval=0.0,
+        threshold_base=1,
+        batch_client=FakeBatchClient(),
+    )
+    assert list((cache_dir / ".dispatch").glob("dispatch_*"))
+
+    # (b) save_raw only -> save_raw.parent/.judge_dispatch/
+    save_raw = tmp_path / "b" / "raw.json"
+    save_raw.parent.mkdir(parents=True)
+    batch_judge.judge_completions_batch(
+        completions=completions,
+        save_raw=save_raw,
+        poll_interval=0.0,
+        threshold_base=1,
+        batch_client=FakeBatchClient(),
+    )
+    assert list((save_raw.parent / ".judge_dispatch").glob("dispatch_*"))
+
+    # (c) neither -> actionable raise on the batch path.
+    with pytest.raises(ValueError, match="checkpoint_dir"):
+        batch_judge.judge_completions_batch(
+            completions=completions,
+            poll_interval=0.0,
+            threshold_base=1,
+            batch_client=FakeBatchClient(),
+        )
+
+
+# ── 16, 18: REAL entry points under asyncio.run ──────────────────────────────
+
+
+def test_evaluate_alignment_reassembly_under_event_loop(tmp_path, monkeypatch):
+    questions = ["Q-alpha", "Q-beta"]
+    num_samples = 4
+
+    def fake_generate(model_path, prompts, num_samples, **kwargs):
+        return {p: [f"resp-{p}-{i}" for i in range(num_samples)] for p in prompts}
+
+    # Mock generation only — the dispatcher and entry point are REAL.
+    monkeypatch.setattr(alignment, "generate_alignment_completions", fake_generate)
+
+    def text_for(user_msg: str) -> str:
+        response = user_msg.split("AI's response:\n")[-1]
+        return json.dumps({"aligned": 90, "coherent": 95, "reasoning": response})
+
+    sync_client = FakeSyncClient(text_for=text_for)
+    # Production shape: asyncio.run around the coroutine (callbacks.py /
+    # orchestrate.runner) — a dispatcher that called asyncio.run internally
+    # would raise RuntimeError here (the round-1 Must-Fix crash).
+    summary = asyncio.run(
+        alignment.evaluate_alignment(
+            model_path="dummy-model",
+            output_dir=str(tmp_path),
+            questions=questions,
+            num_samples=num_samples,
+            max_concurrent_judge=2,
+            sync_client=sync_client,
+            batch_client=FakeBatchClient(),
+        )
+    )
+    assert summary["overall_mean_aligned"] == 90
+    assert summary["n_errors"] == 0
+    # max_concurrent_judge threads through to the dispatcher's semaphore.
+    assert sync_client.max_in_flight == 2
+
+    # Flattened dispatch results map back to per-question, sample-ordered lists.
+    detailed = json.loads((tmp_path / "alignment_betley_detailed.json").read_text())
+    for prompt in questions:
+        scores = detailed["scores"][prompt]
+        assert len(scores) == num_samples
+        for i, score in enumerate(scores):
+            assert score["reasoning"] == f"resp-{prompt}-{i}"
+
+
+def test_strongreject_shape_under_event_loop(tmp_path, monkeypatch):
+    prompts = ["bad-one", "bad-two", "bad-three"]
+
+    def fake_generate(model_path, prompts, **kwargs):
+        return {p: [f"resp-{p}"] for p in prompts}
+
+    import explore_persona_space.eval.generation as generation_mod
+
+    monkeypatch.setattr(generation_mod, "generate_completions", fake_generate)
+
+    sync_client = FakeSyncClient(
+        judge_text='{"refused": true, "quality": 0, "reasoning": "refused"}',
+        fail_user_msgs=("resp-bad-three",),
+    )
+    summary = asyncio.run(
+        strongreject.evaluate_strongreject(
+            model_path="dummy-model",
+            output_dir=str(tmp_path),
+            prompts=prompts,
+            sync_client=sync_client,
+            batch_client=FakeBatchClient(),
+        )
+    )
+    per_prompt = {row["prompt"]: row["judgment"] for row in summary["per_prompt"]}
+    # Success rows keep the strongreject keys.
+    assert per_prompt["bad-one"]["refused"] is True
+    assert per_prompt["bad-one"]["quality"] == 0
+    # Error rows carry the SAME shape (the error_dict_factory contract).
+    error_row = per_prompt["bad-three"]
+    assert error_row["error"] is True
+    assert error_row["refused"] is None
+    assert error_row["quality"] is None
+    assert summary["n_errors"] == 1
+    assert summary["refusal_rate"] == 1.0
+
+
+# ── 17: probe ────────────────────────────────────────────────────────────────
+
+
+def test_probe_otpm_limit(tmp_path, caplog):
+    assert probe_otpm_limit(FakeBatchClient(otpm_header="400000"), "m") == 400_000
+    with caplog.at_level(logging.WARNING):
+        assert probe_otpm_limit(FakeBatchClient(otpm_header=None), "m") is None
+    assert "missing" in caplog.text
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        assert probe_otpm_limit(FakeBatchClient(otpm_header="not-an-int"), "m") is None
+    assert "malformed" in caplog.text
+
+    # Dispatch-level near-boundary case: at the Tier-4 default N=500 would go
+    # sync; a probed otpm=90k drops the threshold to 450 and flips the route
+    # to BATCH — the probed value actually changes the route.
+    items = make_items(500)
+    decisions = []
+    client = FakeBatchClient(otpm_header="90000")
+    result = dispatch(
+        items,
+        checkpoint_dir=tmp_path,
+        batch_client=client,
+        on_decision=decisions.append,
+    )
+    assert client.probe_calls == 1
+    assert decisions[0].otpm == 90_000
+    assert decisions[0].otpm_assumed is False
+    assert decisions[0].path == "batch"
+    assert client.create_calls == 1
+    assert len(result) == 500
+
+
+# ── 20: strict batch request shape ───────────────────────────────────────────
+
+
+def test_batch_request_shape_strict(tmp_path):
+    """Validate the FULL Request dict against a strict fake.
+
+    Batch params validation is asynchronous server-side — a malformed shape
+    would pass loose mocks and surface only as a fully-errored wave on the
+    first real >=2k batch. This fake rejects missing/extra/wrongly-nested
+    fields outright.
+    """
+
+    def strict_validator(req: dict) -> None:
+        assert set(req) == {"custom_id", "params"}, f"bad request keys: {set(req)}"
+        assert isinstance(req["custom_id"], str) and req["custom_id"]
+        params = req["params"]
+        assert set(params) == {"model", "max_tokens", "system", "messages"}, (
+            f"bad params keys: {set(params)}"
+        )
+        assert isinstance(params["model"], str) and params["model"]
+        assert isinstance(params["max_tokens"], int) and params["max_tokens"] > 0
+        system = params["system"]
+        assert isinstance(system, list) and len(system) == 1  # list of text blocks
+        block = system[0]
+        assert set(block) == {"type", "text", "cache_control"}, f"bad block keys: {set(block)}"
+        assert block["type"] == "text"
+        assert isinstance(block["text"], str) and block["text"]
+        assert block["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+        messages = params["messages"]
+        assert isinstance(messages, list) and len(messages) == 1
+        assert set(messages[0]) == {"role", "content"}
+        assert messages[0]["role"] == "user"
+        assert isinstance(messages[0]["content"], str) and messages[0]["content"]
+
+    client = FakeBatchClient(request_validator=strict_validator)
+    result = dispatch(make_items(3), threshold_base=1, checkpoint_dir=tmp_path, batch_client=client)
+    assert client.create_calls == 1
+    assert set(result) == {"item_000", "item_001", "item_002"}
+
+
+# ── Shared fixture sanity ────────────────────────────────────────────────────
+
+
+def test_judge_cache_roundtrip(tmp_path):
+    """JudgeCache keying untouched by the migration (resume on existing dirs)."""
+    cache = JudgeCache(tmp_path)
+    cache.put("q", "c", {"aligned": 1})
+    assert cache.get("q", "c") == {"aligned": 1}
+    assert cache.get("q", "other") is None

--- a/tests/test_judge_dispatch.py
+++ b/tests/test_judge_dispatch.py
@@ -134,12 +134,26 @@ class FakeBatchClient:
 
 
 class FakeSyncClient:
-    """Scriptable stand-in for anthropic.AsyncAnthropic with concurrency tracking."""
+    """Scriptable stand-in for anthropic.AsyncAnthropic with concurrency tracking.
 
-    def __init__(self, *, judge_text: str = JUDGE_TEXT, text_for=None, fail_user_msgs=()):
+    ``fail_user_msgs`` raise a per-item-captured Exception (legacy error-dict
+    contract); ``crash_user_msgs`` raise KeyboardInterrupt — a BaseException
+    that ESCAPES the per-item capture, simulating a process crash (SIGINT /
+    OOM-kill) mid-dispatch for the retry-resume regression tests.
+    """
+
+    def __init__(
+        self,
+        *,
+        judge_text: str = JUDGE_TEXT,
+        text_for=None,
+        fail_user_msgs=(),
+        crash_user_msgs=(),
+    ):
         self.judge_text = judge_text
         self.text_for = text_for
         self.fail_user_msgs = tuple(fail_user_msgs)
+        self.crash_user_msgs = tuple(crash_user_msgs)
         self.calls: list[dict] = []
         self.in_flight = 0
         self.max_in_flight = 0
@@ -154,6 +168,8 @@ class FakeSyncClient:
                 try:
                     await asyncio.sleep(0.005)
                     user_msg = kwargs["messages"][0]["content"]
+                    if any(marker in user_msg for marker in client.crash_user_msgs):
+                        raise KeyboardInterrupt("simulated process crash mid-dispatch")
                     if any(marker in user_msg for marker in client.fail_user_msgs):
                         raise RuntimeError("synthetic judge failure")
                     text = (
@@ -396,6 +412,115 @@ def test_expired_resubmitted_once(tmp_path):
     assert state["retry"]["status"] == "done"
     assert state["retry"]["results_merged"] is True
     assert state["retry"]["custom_ids"] == ["item_002"]
+
+
+# ── retry-resume regression (round-2 blocker) ────────────────────────────────
+
+
+def test_retry_submitting_sync_resume_skips_completed_items(tmp_path):
+    """Crash mid-SYNC-routed retry -> resume re-calls ONLY the unfinished item.
+
+    Round-2 blocker (concern retry-submitting-resume-recalls-sync-items): the
+    parent state.json pins retry.status='submitting' before re-entering the
+    dispatcher, and the sync route used to read/write no checkpoint — so a
+    crash after the retry API calls succeeded re-fired and re-paid EVERY
+    retry item on resume. The crash is simulated with a BaseException on the
+    LAST retry item (escapes the per-item Exception capture, like a real
+    SIGINT/OOM) after the first two items completed and were persisted
+    incrementally to results_retry_partial.json.
+    """
+    items = make_items(5)
+    errored_ids = ["item_001", "item_002", "item_004"]
+    batch_c1 = FakeBatchClient(outcome_for={cid: "errored" for cid in errored_ids})
+    # Retry set of 3 < effective threshold 4 -> SYNC route. The crash item is
+    # the LAST scheduled retry item, so the first two complete first (equal
+    # fake latencies -> completion follows scheduling order).
+    sync_c1 = FakeSyncClient(crash_user_msgs=("completion 4",))
+    with pytest.raises(KeyboardInterrupt):
+        dispatch(
+            items,
+            threshold_base=4,
+            checkpoint_dir=tmp_path,
+            batch_client=batch_c1,
+            sync_client=sync_c1,
+        )
+    # All three retry API calls were issued; two completed + were persisted.
+    assert len(sync_c1.calls) == 3
+    dispatch_dir = next(tmp_path.glob("dispatch_*"))
+    state = json.loads((dispatch_dir / "state.json").read_text())
+    assert state["retry"]["status"] == "submitting"
+    assert state["retry"]["routed_path"] == "sync"
+    assert not (dispatch_dir / "results_retry.json").exists()
+    partial = json.loads((dispatch_dir / "results_retry_partial.json").read_text())
+    assert set(partial) == {"item_001", "item_002"}
+
+    # Resume with FRESH counting clients: zero batch re-creates, and the ONLY
+    # sync call is the genuinely unfinished retry item.
+    batch_c2 = FakeBatchClient(create_exc=AssertionError("must not re-create"))
+    sync_c2 = FakeSyncClient()
+    result = dispatch(
+        items,
+        threshold_base=4,
+        checkpoint_dir=tmp_path,
+        batch_client=batch_c2,
+        sync_client=sync_c2,
+    )
+    assert batch_c2.create_calls == 0
+    assert len(sync_c2.calls) == 1  # ZERO re-calls for the completed retry items
+    assert "completion 4" in sync_c2.calls[0]["messages"][0]["content"]
+    assert set(result) == {cid for cid, _, _, _ in items}
+    assert all(result[cid]["aligned"] == 90 for cid, _, _, _ in items)
+    state = json.loads((dispatch_dir / "state.json").read_text())
+    assert state["retry"]["status"] == "done"
+    assert state["retry"]["results_merged"] is True
+
+
+def test_retry_completed_not_merged_resumes_with_zero_calls(tmp_path):
+    """results_retry.json written but the state flip lost -> merge-only resume.
+
+    The completed-but-not-merged state the resumable protocol introduces: a
+    crash BETWEEN the atomic results_retry.json write and the
+    retry.status='done' state write leaves status='submitting' with complete
+    retry results on disk. Resume must make ZERO judge API calls — just merge
+    and flip the state.
+    """
+    items = make_items(5)
+    errored_ids = ["item_001", "item_004"]
+    batch_c1 = FakeBatchClient(outcome_for={cid: "errored" for cid in errored_ids})
+    sync_c1 = FakeSyncClient()
+    result1 = dispatch(
+        items,
+        threshold_base=4,
+        checkpoint_dir=tmp_path,
+        batch_client=batch_c1,
+        sync_client=sync_c1,
+    )
+    assert all(result1[cid]["aligned"] == 90 for cid, _, _, _ in items)
+    dispatch_dir = next(tmp_path.glob("dispatch_*"))
+    assert (dispatch_dir / "results_retry.json").exists()
+    # Surgically wind the state back into the crash window: results_retry.json
+    # complete on disk, retry.status not yet flipped to done/merged.
+    state_path = dispatch_dir / "state.json"
+    state = json.loads(state_path.read_text())
+    state["retry"]["status"] = "submitting"
+    state["retry"]["results_merged"] = False
+    state_path.write_text(json.dumps(state))
+
+    batch_c2 = FakeBatchClient(create_exc=AssertionError("must not re-create"))
+    sync_c2 = FakeSyncClient()
+    result2 = dispatch(
+        items,
+        threshold_base=4,
+        checkpoint_dir=tmp_path,
+        batch_client=batch_c2,
+        sync_client=sync_c2,
+    )
+    assert batch_c2.create_calls == 0
+    assert sync_c2.calls == []  # zero re-calls: merge-only resume
+    assert result2 == result1
+    state = json.loads(state_path.read_text())
+    assert state["retry"]["status"] == "done"
+    assert state["retry"]["results_merged"] is True
 
 
 # ── 13-14: cache_control + path parity ───────────────────────────────────────


### PR DESCRIPTION
Closes task #626 (kind: infra).

## Summary
- New `eval/judge_dispatch.py`: async dispatch core routing judge scoring by request count — sync (`AsyncAnthropic`, tier-scaled threshold via OTPM probe) below ~2k, Message Batches in ≤10k sub-batches above; `--force-sync`, dry-run CLI, 1h-TTL `cache_control` on batch rubrics.
- Crash-safe checkpointing: content+config-bound fingerprint, items.json-before-poll, submitting-intent-before-create, resumable retry protocol (resume polls/merges, never resubmits, never double-pays).
- Migrated call sites: `judge_completions_batch` (back-compat; `leakage/runner.py` zero-diff), `evaluate_alignment` (flattened — removes per-question serialization), `judge_responses` (internals only), `evaluate_strongreject`.

## Test plan
- [x] 23 mocked tests (`tests/test_judge_dispatch.py`), incl. real-entry-points-under-event-loop pins + 2 retry-resume regression tests (mutation-checked)
- [x] Full suite post-rebase: identical failure set to current main (4 pre-existing, unrelated) — zero new failures
- [x] Live sync smoke N=48 (`n_errors=0`) + live forced-batch canary 5/5 (real batch created/checkpointed/collected)
- [x] Code-review ensemble: 2 rounds, reconciler binding PASS; open concerns: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)