### PR TITLE
issue-629: harden i472 trajectory storage-contract gate (finiteness + AST ordering pin)

### DIFF
--- a/src/explore_persona_space/experiments/contrastive_neg_geometry_472/eval_trajectory.py
+++ b/src/explore_persona_space/experiments/contrastive_neg_geometry_472/eval_trajectory.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 import gc
 import json
 import logging
+import math
 import os
 import socket
 import subprocess
@@ -98,6 +99,12 @@ TRAJECTORY_LOGIT_LEAF_KEYS = (
 )
 
 
+def _is_finite_number(v) -> bool:
+    """Finite, non-bool int/float — mirrors the validator-local check in
+    eval/marker_logprob.py::validate_marker_slot_record (#629)."""
+    return isinstance(v, (int, float)) and not isinstance(v, bool) and math.isfinite(float(v))
+
+
 def assert_trajectory_slot_records_meet_storage_contract(
     checkpoints: list[dict],
     *,
@@ -123,17 +130,36 @@ def assert_trajectory_slot_records_meet_storage_contract(
     Raises:
         AssertionError: when any held-out leaf lacks a raw-logit field
             (``compute_kl=False`` / the ``--no-kl`` smoke flag skipped
-            Phase B) and the caller did not opt in.
+            Phase B) and the caller did not opt in. Also (#629): when
+            ``checkpoints`` is empty (degenerate canonical artifact), or when
+            any present raw-logit field is non-finite / non-float (corrupted
+            Phase-B forward pass or adapter load) — distinct message per
+            class so the operator routes the failure correctly.
     """
     if allow_subcontract_output:
         return
+    if not checkpoints:
+        raise AssertionError(
+            f"empty checkpoints list at the FINAL trajectory write ({out_path}) — "
+            f"nothing was evaluated; refusing a degenerate canonical artifact"
+        )
     offending: list[str] = []
+    corrupt: list[str] = []
     for ck in checkpoints:
         for persona, by_q in ck.get("held_out", {}).items():
             for q, leaf in by_q.items():
                 absent = [k for k in TRAJECTORY_LOGIT_LEAF_KEYS if leaf.get(k) is None]
                 if absent:
                     offending.append(f"frac={ck.get('frac')}/{persona}/{q!r}: missing {absent}")
+                bad = [
+                    k
+                    for k in TRAJECTORY_LOGIT_LEAF_KEYS
+                    if leaf.get(k) is not None and not _is_finite_number(leaf[k])
+                ]
+                if bad:
+                    corrupt.append(
+                        f"frac={ck.get('frac')}/{persona}/{q!r}: non-finite/non-float {bad}"
+                    )
     if offending:
         preview = "; ".join(offending[:3])
         raise AssertionError(
@@ -146,6 +172,17 @@ def assert_trajectory_slot_records_meet_storage_contract(
             f"the --no-kl smoke flag). Re-run with compute_kl=True, or pass "
             f"allow_subcontract_output=True to deliberately persist a non-contract "
             f"artifact."
+        )
+    if corrupt:
+        preview = "; ".join(corrupt[:3])
+        raise AssertionError(
+            f"Marker-slot storage-contract violation at the FINAL trajectory write "
+            f"({out_path}): {len(corrupt)} held-out slot record(s) carry a non-finite or "
+            f"non-float raw-logit field (e.g. {preview}). Unlike MISSING fields "
+            f"(Phase B never ran), a NaN/Inf surviving to this point means a corrupted "
+            f"forward pass or adapter load in the Phase-B raw-logit capture — do not "
+            f"simply re-run Phase B: inspect the adapter (adapters persist on HF) and "
+            f"the slot capture before re-eval (#629)."
         )
 
 
@@ -852,7 +889,7 @@ def run_trajectory_eval(
         out_path=out_path,
         allow_subcontract_output=allow_subcontract_output,
     )
-    out_path.write_text(json.dumps(payload, indent=2))
+    out_path.write_text(json.dumps(payload, indent=2, allow_nan=False))
     if partial_path.exists():
         partial_path.unlink()
     log.info("[phase=traj_done] Wrote trajectory → %s", out_path)

--- a/tests/test_marker_slot_contract.py
+++ b/tests/test_marker_slot_contract.py
@@ -21,7 +21,10 @@ Five layers:
 5. The #472 trajectory rig's FINAL-write gate
    (``assert_trajectory_slot_records_meet_storage_contract``): a
    ``compute_kl=False`` canonical artifact is refused, the explicit opt-out
-   works, and crash-recovery partials stay exempt (marked non-contract).
+   works, and crash-recovery partials stay exempt (marked non-contract);
+   #629 hardening — present-but-non-finite / bool leaves and empty
+   checkpoints are refused with distinct messages, and AST pins fix the
+   gate-before-write ordering plus the ``allow_nan=False`` dumps backstop.
 
 No GPU, no HF download; runs in <1s.
 """
@@ -370,7 +373,9 @@ def test_trajectory_partials_marked_noncontract_and_gate_fires_once():
     """Source-level pin (same pattern as test_i584): crash-recovery partials
     are marked non-contract rather than validated, and the gate runs exactly
     once inside run_trajectory_eval — at the final canonical write, never on
-    the .partial.json crash-recovery writes."""
+    the .partial.json crash-recovery writes. Extended by #629: also pins the
+    gate-call-precedes-write statement ordering and the ``allow_nan=False``
+    keyword on the canonical dumps."""
     import ast
     from pathlib import Path
 
@@ -396,3 +401,88 @@ def test_trajectory_partials_marked_noncontract_and_gate_fires_once():
         and n.func.id == "assert_trajectory_slot_records_meet_storage_contract"
     ]
     assert len(gate_calls) == 1, "gate must fire exactly once: final write only, not partials"
+
+    write_calls = [
+        n
+        for n in ast.walk(fn)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Attribute)
+        and n.func.attr == "write_text"
+        and isinstance(n.func.value, ast.Name)
+        and n.func.value.id == "out_path"
+    ]
+    assert len(write_calls) == 1, "exactly one canonical out_path.write_text expected"
+
+    def _stmt_index(call_node) -> int:
+        for i, stmt in enumerate(fn.body):
+            if any(n is call_node for n in ast.walk(stmt)):
+                return i
+        raise AssertionError("call not found in run_trajectory_eval body")
+
+    assert _stmt_index(gate_calls[0]) < _stmt_index(write_calls[0]), (
+        "storage-contract gate must execute BEFORE the canonical out_path.write_text"
+    )
+
+    # #629 backstop pin: the canonical dumps refuses NaN/Inf payloads.
+    dumps_call = write_calls[0].args[0]
+    assert isinstance(dumps_call, ast.Call), "out_path.write_text(json.dumps(...)) shape expected"
+    allow_nan_kw = [k for k in dumps_call.keywords if k.arg == "allow_nan"]
+    assert allow_nan_kw and allow_nan_kw[0].value.value is False, (
+        "final canonical json.dumps must pass allow_nan=False (#629)"
+    )
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_trajectory_final_write_nan_leaf_raises(tmp_path, bad):
+    """#629: a present-but-non-finite raw-logit leaf (corrupted forward pass)
+    is refused at the canonical write, with a message DISTINCT from the
+    Phase-B-skipped one so the operator routes the failure correctly."""
+    from explore_persona_space.experiments.contrastive_neg_geometry_472.eval_trajectory import (
+        assert_trajectory_slot_records_meet_storage_contract,
+    )
+
+    cks = _trajectory_checkpoints(with_logits=True)
+    cks[0]["held_out"]["medical_doctor"]["q1"]["z_marker_g"] = bad
+    with pytest.raises(AssertionError, match="non-finite"):
+        assert_trajectory_slot_records_meet_storage_contract(cks, out_path=tmp_path / "t.json")
+
+
+def test_trajectory_final_write_bool_leaf_raises(tmp_path):
+    """Bools are not floats: True survives isinstance(int) — rejected explicitly."""
+    from explore_persona_space.experiments.contrastive_neg_geometry_472.eval_trajectory import (
+        assert_trajectory_slot_records_meet_storage_contract,
+    )
+
+    cks = _trajectory_checkpoints(with_logits=True)
+    cks[0]["held_out"]["medical_doctor"]["q1"]["logZ_g"] = True
+    with pytest.raises(AssertionError, match="non-finite/non-float"):
+        assert_trajectory_slot_records_meet_storage_contract(cks, out_path=tmp_path / "t.json")
+
+
+def test_trajectory_gate_empty_checkpoints_raises(tmp_path):
+    """#629 minor: a degenerate empty checkpoints list is refused —
+    but the explicit opt-out stays fully permissive (checked first)."""
+    from explore_persona_space.experiments.contrastive_neg_geometry_472.eval_trajectory import (
+        assert_trajectory_slot_records_meet_storage_contract,
+    )
+
+    with pytest.raises(AssertionError, match="empty checkpoints"):
+        assert_trajectory_slot_records_meet_storage_contract([], out_path=tmp_path / "t.json")
+    assert_trajectory_slot_records_meet_storage_contract(
+        [], out_path=tmp_path / "t.json", allow_subcontract_output=True
+    )
+
+
+def test_trajectory_nan_with_optout_bypasses_gate(tmp_path):
+    """Opt-out semantics unchanged by #629: the gate returns before ANY check.
+    The AST-pinned ``allow_nan=False`` dumps backstop is the remaining defense
+    at the actual write (pinned structurally above, not exercised here)."""
+    from explore_persona_space.experiments.contrastive_neg_geometry_472.eval_trajectory import (
+        assert_trajectory_slot_records_meet_storage_contract,
+    )
+
+    cks = _trajectory_checkpoints(with_logits=True)
+    cks[0]["held_out"]["medical_doctor"]["q1"]["z_marker_g"] = float("nan")
+    assert_trajectory_slot_records_meet_storage_contract(
+        cks, out_path=tmp_path / "t.json", allow_subcontract_output=True
+    )


### PR DESCRIPTION
Closes task #629 (parent #576 round-2 reconciler deferred concern `trajectory-gate-presence-only-validation`).

## Summary
- Extend `assert_trajectory_slot_records_meet_storage_contract` from presence-only to finite-non-bool-float on the 6 `TRAJECTORY_LOGIT_LEAF_KEYS`, with a corrupt-class AssertionError regex-disjoint from the missing-fields class
- Refuse degenerate empty checkpoints (explicit raise, after the opt-out early return); add `allow_nan=False` to the canonical `json.dumps` (partials exempt by design)
- Extend the AST pin: gate-call-precedes-`out_path.write_text` (statement-index order), exactly-one canonical write, `allow_nan=False` keyword; +4 unit tests (NaN/±Inf, bool, empty, opt-out×NaN)

## Test plan
- [x] `uv run pytest tests/test_marker_slot_contract.py -x` — 35 passed
- [x] `eval/marker_logprob.py` zero-line diff (live consumers #542/#597)
- [x] ruff check + format clean on both files
- [x] Code-review ensemble PASS+PASS (Claude + Codex); test-verdict PASS

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)