### PR TITLE
task #633: watcher infra-drain pass — execute PM dispatch queue under cap 3

### DIFF
--- a/.claude/agents/research-pm.md
+++ b/.claude/agents/research-pm.md
@@ -405,6 +405,20 @@ alike — run the infra auto-dispatch pass:
    `spawn_session.py list` + a task-kind lookup (`task.py view <N>
    --json`). Drain oldest-first by default; urgency-first when a task
    names an active incident.
+
+4b. **Durable drain between STATUS passes (task #633).** On EVERY STATUS
+   pass, WRITE the adjudicated queue to
+   `~/.eps-autonomous/infra-drain-queue.json` (atomic tmp+rename;
+   `ripe_oldest_first` ints oldest-first, `cap`, `holds` {id: one-word
+   reason}, `updated_ts` ISO-8601 UTC, `updated_by`, `comment`). The
+   10-minute watcher's infra-drain pass executes listed IDs into free
+   slots while this session is idle or closed — it only spawns
+   `spawn-issue --auto` for IDs still at `proposed`, under the cap,
+   skipping holds and already-registered issues; it NEVER judges
+   ripeness. The PM remains the only ripeness judge: un-riping a task =
+   remove it from the list / add a hold and rewrite the file. Rewriting
+   (bumping `updated_ts`) also re-arms the watcher's per-ID retry budget.
+
 5. **Park for the user ONLY when** (the "REALLY needs my call" list —
    keep it tight):
    - **HARD RULE — credentials/secrets off-machine.** The fix would

--- a/.claude/rules/background-automation.md
+++ b/.claude/rules/background-automation.md
@@ -50,9 +50,50 @@ themselves in a worktree.
 ## Autonomous-session watcher (every 10 min, `3-59/10 * * * *`, `autonomous_session_watch.py`)
 
 Passes: crash-recovery respawn, pod-safety reconciliation, stalled-session
-detector, orphan-file sweep, the gate-push pass, and three session reapers —
-the session-vs-status reconcile pass, the zombie-wrapper pass, and the
-idle-unmapped pass.
+detector, orphan-file sweep, the infra-drain pass, the gate-push pass, and
+three session reapers — the session-vs-status reconcile pass, the
+zombie-wrapper pass, and the idle-unmapped pass.
+
+**Infra-drain pass (execute the PM dispatch queue; task #633).** The PM
+session's standing infra auto-dispatch rule (`research-pm.md` § Standing
+rule, item 4b) adjudicates which `proposed` `kind: infra|batch` tasks are
+RIPE and writes them oldest-first to
+`~/.eps-autonomous/infra-drain-queue.json` (`ripe_oldest_first` ints,
+`cap` — default 3, `holds` {id: one-word reason}, `updated_ts` ISO-8601
+UTC). This pass EXECUTES that file with zero LLM judgment, spawning
+`spawn_session.py spawn-issue --issue <N> --auto` for the oldest listed IDs
+into free slots, where free = max(0, cap − occupied − pending): occupied =
+`kind: infra|batch` tasks at the occupied-status set (the seven body
+statuses `planning`/`plan_pending`/`approved`/`running`/`verifying`/
+`interpreting`/`reviewing` PLUS `followups_running` — counting an in-flight
+follow-up round only ever dispatches less; `proposed`/`blocked`/terminal do
+not hold slots), read fail-CLOSED (any `list-by-status` failure skips
+dispatching that tick — a partial count would under-count and
+over-dispatch); pending = non-stale registrations (queue AND non-queue) of
+still-`proposed` drain-kind tasks plus any with unreadable status/kind
+(conservative), closing the PM-prunes-a-dispatched-ID overshoot. Per-ID
+guards, each with a logged skip reason: PM hold; existing
+`issue-<N>.json`/`manual-issue-<N>.json` registration — a STALE
+(dead-at-boot) registration (task still `proposed`, older than
+`EPM_INFRA_DRAIN_STALE_REG_GRACE_S`, default 30 min, recorded session id
+definitively NOT live) stops pinning a pending slot and stops blocking
+re-dispatch, with ANY missing signal failing toward keep-blocking; status ≠
+`proposed`; kind outside `{infra, batch}` (loudly logged every tick — a
+mis-kinded entry would auto-approve GPU spend outside the cap); and a retry
+budget whose backoff window (`EPM_INFRA_DRAIN_BACKOFF_S`, default 1 h)
+ALWAYS binds while a fresh PM `updated_ts` resets only the attempt COUNT
+(`EPM_INFRA_DRAIN_MAX_ATTEMPTS`, default 3 per adjudication epoch; a future
+`updated_ts` is clamped so it cannot void the budget). The PM remains the
+ONLY ripeness judge — a missing/empty/invalid queue file is a logged no-op,
+and un-riping an ID means rewriting the file (which also re-arms the
+budget). Daemon-gated like every spawning pass; attempt state lives in
+`~/.eps-autonomous/infra-drain-state.json` (self-pruned to the queue's ID
+set; deliberately not a GC target); dispatch markers are generic
+`epm:progress` notes carrying the
+`[autonomous_session_watch:infra-drain-dispatch]` sentinel so they never
+reset the orphan/stalled staleness clocks. Kill switch:
+`EPM_DISABLE_INFRA_DRAIN=1`. `--infra-drain-only` runs just this pass
+(pair with `--dry-run` for a live smoke).
 
 **Gate-push pass (2026-06-12 anti-stall redesign).** Telegram phone push on
 gate-park/`blocked` transitions via the my-goat `telegram_push.sh` channel

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -1460,8 +1460,20 @@ def _daemon_reachable() -> bool:
     recorded session look dead and trigger a mass re-spawn (-> duplicate pods).
     So the respawn pass probes reachability first and skips when the daemon is
     down. The pod-safety pass does NOT depend on the daemon (it reasons about
-    task status + the live pod list), so it runs regardless."""
+    task status + the live pod list), so it runs regardless.
+
+    The exception tuple widens for the round-4 fix on top of the obvious
+    connection-level URLError / OSError tier: ``http.client.HTTPException``
+    (incl. ``IncompleteRead`` when the daemon hangs up mid-response-body —
+    a class distinct from URLError, which fires at connection setup) and
+    ``UnicodeDecodeError`` (a daemon emitting invalid UTF-8 bytes raises
+    that BEFORE ``json.loads`` ever sees a string; ``json.JSONDecodeError``
+    is a ``ValueError`` subclass, NOT a ``UnicodeDecodeError`` subclass).
+    A daemon flap that previously crashed the whole watcher pass now
+    correctly returns ``False`` — the conservative ack of "I cannot tell
+    whether the daemon is up", same as a clean ``URLError``."""
     try:
+        import http.client
         import urllib.error
         import urllib.request
 
@@ -1474,7 +1486,14 @@ def _daemon_reachable() -> bool:
         with urllib.request.urlopen(req, timeout=10) as resp:
             json.loads(resp.read())
         return True
-    except (SystemExit, urllib.error.URLError, OSError, json.JSONDecodeError):
+    except (
+        SystemExit,
+        urllib.error.URLError,
+        http.client.HTTPException,
+        OSError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+    ):
         return False
 
 
@@ -1500,8 +1519,21 @@ def _live_session_ids_or_none() -> set[str] | None:
     2026-06-12: a stray ``{None}`` set would slip past the ``is None``
     guard in :func:`_infra_drain_stale` and make every real-string sid
     look NOT live, reintroducing the round-1 BLOCKER's double-spawn
-    class)."""
+    class).
+
+    The exception tuple widens for the round-4 fix on top of the obvious
+    connection-level URLError / OSError tier:
+    ``http.client.HTTPException`` (incl. ``IncompleteRead`` when the
+    daemon hangs up mid-response-body — a class distinct from URLError,
+    which fires at connection setup) and ``UnicodeDecodeError`` (a
+    daemon emitting invalid UTF-8 bytes raises that BEFORE
+    ``json.loads`` ever sees a string; ``json.JSONDecodeError`` is a
+    ``ValueError`` subclass, NOT a ``UnicodeDecodeError`` subclass). A
+    daemon flap that previously crashed the whole infra-drain pass now
+    correctly returns ``None`` (UNAVAILABLE), same fail direction as a
+    clean ``URLError``."""
     try:
+        import http.client
         import urllib.error
         import urllib.request
 
@@ -1513,7 +1545,14 @@ def _live_session_ids_or_none() -> set[str] | None:
         )
         with urllib.request.urlopen(req, timeout=10) as resp:
             data = json.loads(resp.read())
-    except (SystemExit, urllib.error.URLError, OSError, json.JSONDecodeError):
+    except (
+        SystemExit,
+        urllib.error.URLError,
+        http.client.HTTPException,
+        OSError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+    ):
         return None
     children = data.get("children") if isinstance(data, dict) else None
     if not isinstance(children, list):
@@ -4898,15 +4937,19 @@ def _load_infra_drain_state() -> dict:
     strings (JSON); they are int-normalized here. DEFENSIVE NORMALIZE: drop
     (with a log line) any record whose ``last_attempt_ts`` is not numeric or
     whose key is not an int — a garbled record must not silently bypass the
-    budget. A record whose ``attempts`` COUNT is garbled (non-int / bool /
-    negative) keeps its valid ``last_attempt_ts`` (the backoff window still
-    binds) but has the count normalized UP to the attempt cap, with a log
-    line — count unknown means the budget may be spent, so fail toward NOT
-    dispatching; a fresh PM ``updated_ts`` (newer than ``last_attempt_ts``)
-    resets the count as usual, so recovery is automatic on the next PM
-    adjudication. Dropping the record instead would RESET the budget — the
-    fail-open direction (round-2 fix, Codex Major: ``int("bad") + 1`` /
-    ``"bad" >= max_attempts`` crashed the whole pass)."""
+    budget. A record with a MISSING ``attempts`` key or whose ``attempts``
+    COUNT is garbled (non-int / bool / negative) keeps its valid
+    ``last_attempt_ts`` (the backoff window still binds) but has the count
+    normalized UP to the attempt cap, with a log line — count unknown means
+    the budget may be spent, so fail toward NOT dispatching; a fresh PM
+    ``updated_ts`` (newer than ``last_attempt_ts``) resets the count as
+    usual, so recovery is automatic on the next PM adjudication. Dropping
+    the record instead would RESET the budget — the fail-open direction
+    (round-2 fix, Codex Major: ``int("bad") + 1`` / ``"bad" >= max_attempts``
+    crashed the whole pass; round-4 fix for the MISSING-key sibling: bare
+    ``rec.get("attempts", 0)`` returned 0 before the type check fired,
+    silently granting a fresh budget on a half-written / hand-edited
+    record)."""
     path = _infra_drain_state_path()
     if not path.is_file():
         return {"attempts": {}}
@@ -4930,15 +4973,29 @@ def _load_infra_drain_state() -> dict:
                 f"(non-numeric last_attempt_ts {last!r})"
             )
             continue
-        count = rec.get("attempts", 0)
-        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+        if "attempts" not in rec:
+            # Missing key — half-written or hand-edited record. Bare
+            # ``rec.get("attempts", 0)`` would return 0 BEFORE the type
+            # check fired below and silently grant a fresh budget; fail
+            # to cap instead, the same fail direction the
+            # garbled-count branch already uses (round-4 fix).
             cap = _infra_drain_max_attempts()
             print(
-                f"  infra-drain: state record for #{issue} has a garbled attempts "
-                f"count ({count!r}); normalizing to the attempt cap ({cap}) — fail "
-                f"toward NOT dispatching (a fresh PM updated_ts resets it)"
+                f"  infra-drain: state record for #{issue} is missing its attempts "
+                f"key; normalizing to the attempt cap ({cap}) — fail toward NOT "
+                f"dispatching (a fresh PM updated_ts resets it)"
             )
             rec = {**rec, "attempts": cap}
+        else:
+            count = rec["attempts"]
+            if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+                cap = _infra_drain_max_attempts()
+                print(
+                    f"  infra-drain: state record for #{issue} has a garbled attempts "
+                    f"count ({count!r}); normalizing to the attempt cap ({cap}) — fail "
+                    f"toward NOT dispatching (a fresh PM updated_ts resets it)"
+                )
+                rec = {**rec, "attempts": cap}
         attempts[issue] = rec
     return {"attempts": attempts}
 

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -1478,6 +1478,43 @@ def _daemon_reachable() -> bool:
         return False
 
 
+def _live_session_ids_or_none() -> set[str] | None:
+    """``spawn_session._live_session_ids()`` with an explicit UNAVAILABLE
+    mode: the daemon's live session-id set, or ``None`` when the ``/list``
+    probe fails (daemon down, malformed payload).
+
+    spawn_session's helper returns an EMPTY SET both for "daemon up, zero
+    sessions" and for "daemon unreachable" (its ``list --all`` fallback wants
+    that), which is exactly the wrong fail direction for the infra-drain
+    stale-registration read: a daemon flap between main()'s single
+    reachability probe and this read would make every grace-aged
+    still-``proposed`` registration look definitively dead -> false-stale ->
+    double-spawn. So the drain pass uses this wrapper (same probe shape as
+    :func:`_daemon_reachable`; spawn_session.py is a forbidden surface for
+    this pass) and :func:`_infra_drain_stale` fails ``None`` toward NOT
+    stale (keep blocking)."""
+    try:
+        import urllib.error
+        import urllib.request
+
+        from spawn_session import daemon_port
+
+        url = f"http://127.0.0.1:{daemon_port()}/list"
+        req = urllib.request.Request(
+            url, data=b"{}", headers={"Content-Type": "application/json"}, method="POST"
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+    except (SystemExit, urllib.error.URLError, OSError, json.JSONDecodeError):
+        return None
+    children = data.get("children") if isinstance(data, dict) else None
+    if not isinstance(children, list):
+        # A 200 response without the expected shape is NOT a confirmed
+        # "zero live sessions" — treat as unavailable (fail toward keep).
+        return None
+    return {c.get("happySessionId") for c in children if isinstance(c, dict)}
+
+
 def _manual_session_alive(issue: int | None, live_ids: set[str]) -> bool:
     """True iff the issue's MANUAL registration (``manual-issue-<N>.json``,
     written by bare ``spawn-issue``) records a Happy id in the daemon's live
@@ -4835,7 +4872,15 @@ def _load_infra_drain_state() -> dict:
     strings (JSON); they are int-normalized here. DEFENSIVE NORMALIZE: drop
     (with a log line) any record whose ``last_attempt_ts`` is not numeric or
     whose key is not an int — a garbled record must not silently bypass the
-    budget."""
+    budget. A record whose ``attempts`` COUNT is garbled (non-int / bool /
+    negative) keeps its valid ``last_attempt_ts`` (the backoff window still
+    binds) but has the count normalized UP to the attempt cap, with a log
+    line — count unknown means the budget may be spent, so fail toward NOT
+    dispatching; a fresh PM ``updated_ts`` (newer than ``last_attempt_ts``)
+    resets the count as usual, so recovery is automatic on the next PM
+    adjudication. Dropping the record instead would RESET the budget — the
+    fail-open direction (round-2 fix, Codex Major: ``int("bad") + 1`` /
+    ``"bad" >= max_attempts`` crashed the whole pass)."""
     path = _infra_drain_state_path()
     if not path.is_file():
         return {"attempts": {}}
@@ -4859,6 +4904,15 @@ def _load_infra_drain_state() -> dict:
                 f"(non-numeric last_attempt_ts {last!r})"
             )
             continue
+        count = rec.get("attempts", 0)
+        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+            cap = _infra_drain_max_attempts()
+            print(
+                f"  infra-drain: state record for #{issue} has a garbled attempts "
+                f"count ({count!r}); normalizing to the attempt cap ({cap}) — fail "
+                f"toward NOT dispatching (a fresh PM updated_ts resets it)"
+            )
+            rec = {**rec, "attempts": cap}
         attempts[issue] = rec
     return {"attempts": attempts}
 
@@ -4904,24 +4958,52 @@ def _task_status_kind(issue: int) -> tuple[str | None, str | None]:
     )
 
 
-def _infra_drain_registrations() -> dict[int, list[dict]]:
-    """ALL ``issue-<N>.json`` + ``manual-issue-<N>.json`` registration entries
-    per issue (not just queue IDs — the widened pending count needs non-queue
-    ones too). List-valued because an issue can carry BOTH an autonomous and
-    a manual registration; staleness then requires ALL of them stale
-    (fail toward keep-blocking). A garbled entry parses to ``{}`` (which
-    :func:`_infra_drain_stale` classifies NOT stale — conservative)."""
-    out: dict[int, list[dict]] = {}
+def _infra_drain_reg_snapshot() -> dict[str, bytes]:
+    """Raw bytes of every ``issue-*.json`` + ``manual-issue-*.json``
+    registration file, keyed by basename — the SINGLE decision-time read both
+    the staleness/pending decision (:func:`_infra_drain_registrations` parses
+    from these bytes) and :func:`_dispatch_infra_drain`'s pre-spawn lost-race
+    re-check are derived from. One read means the re-check can distinguish "a
+    registration APPEARED/CHANGED since the decision" (genuine lost race ->
+    abort) from "this is the registration the pass already classified STALE"
+    (byte-identical -> safe to spawn over; ``spawn_session.py`` overwrites it
+    unconditionally on success). Round-2 fix for the round-1 Critical: the
+    bare-existence re-check aborted every stale-registration re-dispatch
+    forever. A file unreadable at snapshot time is omitted (it then reads as
+    "appeared" at dispatch time -> abort, the safe direction)."""
+    snap: dict[str, bytes] = {}
     if not AUTONOMOUS_REGISTRY_DIR.is_dir():
-        return out
+        return snap
     for prefix in ("issue-", "manual-issue-"):
         for path in sorted(AUTONOMOUS_REGISTRY_DIR.glob(f"{prefix}*.json")):
-            issue = _gc_parse_issue_from_path(path, prefix, "")
+            try:
+                snap[path.name] = path.read_bytes()
+            except OSError:
+                continue
+    return snap
+
+
+def _infra_drain_registrations(snapshot: dict[str, bytes]) -> dict[int, list[dict]]:
+    """ALL ``issue-<N>.json`` + ``manual-issue-<N>.json`` registration entries
+    per issue (not just queue IDs — the widened pending count needs non-queue
+    ones too), parsed FROM the decision-time ``snapshot``
+    (:func:`_infra_drain_reg_snapshot`) so the staleness decision and the
+    pre-spawn re-check can never see torn views of the registry. List-valued
+    because an issue can carry BOTH an autonomous and a manual registration;
+    staleness then requires ALL of them stale (fail toward keep-blocking). A
+    garbled entry parses to ``{}`` (which :func:`_infra_drain_stale`
+    classifies NOT stale — conservative)."""
+    out: dict[int, list[dict]] = {}
+    for prefix in ("issue-", "manual-issue-"):
+        for basename in sorted(snapshot):
+            if not basename.startswith(prefix):
+                continue
+            issue = _gc_parse_issue_from_path(AUTONOMOUS_REGISTRY_DIR / basename, prefix, "")
             if issue is None:
                 continue
             try:
-                entry = json.loads(path.read_text())
-            except (json.JSONDecodeError, OSError):
+                entry = json.loads(snapshot[basename])
+            except ValueError:  # JSONDecodeError + UnicodeDecodeError on raw bytes
                 entry = {}
             if not isinstance(entry, dict):
                 entry = {}
@@ -5032,13 +5114,27 @@ def _infra_drain_pending(
     return pending
 
 
-def _dispatch_infra_drain(issue: int, slot_desc: str, dry_run: bool) -> bool:
+def _dispatch_infra_drain(
+    issue: int,
+    slot_desc: str,
+    dry_run: bool,
+    *,
+    reg_snapshot: dict[str, bytes] | None = None,
+) -> bool:
     """``spawn_session.py spawn-issue --issue <N> --auto`` (the plain
     command, exactly the PM standing-rule item-3 mechanism; no
     ``--auto-approve-gpu-hours`` override — spawn_session's default applies,
     and infra tasks need ~0 GPU). Immediately BEFORE the subprocess,
-    re-checks the registration files one last time and aborts ("lost race to
-    concurrent dispatcher") if one appeared — shrinks the PM-vs-watcher
+    re-checks the registration files against the DECISION-TIME snapshot
+    (:func:`_infra_drain_reg_snapshot`) and aborts ("lost race to concurrent
+    dispatcher") only when a registration APPEARED or CHANGED since the
+    decision — a registration byte-identical to the snapshot is the
+    known-stale entry this pass already classified (round-2 fix: the round-1
+    bare-existence check aborted every stale-registration re-dispatch;
+    ``spawn_session.py`` overwrites the file unconditionally on success, so
+    spawning over the stale entry is safe). ``reg_snapshot=None`` (direct
+    callers without a decision context) degrades to the conservative
+    abort-on-any-existing-file behavior. Shrinks the PM-vs-watcher
     double-spawn window from one-full-pass to ~the spawn subprocess itself.
     Returns success bool; honours dry_run (logs, never spawns)."""
     cmd = [
@@ -5048,13 +5144,32 @@ def _dispatch_infra_drain(issue: int, slot_desc: str, dry_run: bool) -> bool:
     if dry_run:
         print(f"  [dry-run] would dispatch infra-drain: {' '.join(cmd)}")
         return False
+    snapshot = reg_snapshot or {}
     for basename in (f"issue-{issue}.json", f"manual-issue-{issue}.json"):
-        if (AUTONOMOUS_REGISTRY_DIR / basename).exists():
+        path = AUTONOMOUS_REGISTRY_DIR / basename
+        known = snapshot.get(basename)
+        try:
+            current = path.read_bytes()
+        except FileNotFoundError:
+            # No registration now (never existed, or GC/PM removed it since
+            # the decision) — nothing to lose a race to.
+            continue
+        except OSError:
             print(
-                f"  INFRA-DRAIN ABORT issue #{issue}: lost race to concurrent "
-                f"dispatcher ({basename} appeared since the decision)"
+                f"  INFRA-DRAIN ABORT issue #{issue}: registration {basename} "
+                f"unreadable at the pre-spawn re-check; cannot verify the "
+                f"decision still holds (fail toward not dispatching)"
             )
             return False
+        if known is None or current != known:
+            print(
+                f"  INFRA-DRAIN ABORT issue #{issue}: lost race to concurrent "
+                f"dispatcher ({basename} "
+                f"{'appeared' if known is None else 'changed'} since the decision)"
+            )
+            return False
+        # else: byte-identical to the decision-time snapshot — the known
+        # (stale) registration the decision already accounted for; proceed.
     res = subprocess.run(cmd, cwd=PROJECT_ROOT, capture_output=True, text=True, timeout=120)
     if res.returncode != 0:
         print(
@@ -5196,7 +5311,11 @@ def _infra_drain_possibly_stale_ids(
     ``already-registered``."""
     if not candidate_ids:
         return set()
-    live_ids = _live_session_ids()  # daemon reachability was gated by the caller
+    # _live_session_ids_or_none, NOT spawn_session._live_session_ids: the
+    # caller's daemon gate is main()'s single probe, and a flap since then
+    # must read as UNAVAILABLE (None -> nothing stale -> keep blocking),
+    # never as "zero live sessions" (-> everything stale -> double-spawn).
+    live_ids = _live_session_ids_or_none()
     grace_s = _infra_drain_stale_reg_grace_s()
     return {
         i
@@ -5219,7 +5338,12 @@ def _infra_drain_signals(
     bounds the common nothing-dispatchable tick at zero of these."""
     fetch_ids = {i for i in ids if i not in holds} | set(regs)
     status_kind = {i: _task_status_kind(i) for i in sorted(fetch_ids)}
-    live_ids = _live_session_ids()  # daemon reachability was gated by the caller
+    # Liveness only matters for staleness over registrations; skip the daemon
+    # RPC when there are none. _live_session_ids_or_none (NOT spawn_session's
+    # empty-set-on-failure helper): a daemon flap since main()'s probe must
+    # read UNAVAILABLE (None -> nothing stale -> keep blocking), never "zero
+    # live sessions" (-> false-stale -> double-spawn).
+    live_ids = _live_session_ids_or_none() if regs else None
     grace_s = _infra_drain_stale_reg_grace_s()
     stale: set[int] = set()
     for issue, recs in regs.items():
@@ -5265,7 +5389,11 @@ def infra_drain_pass(
     attempts: dict[int, dict] = state["attempts"]
     backoff_s = _infra_drain_backoff_s()
     max_attempts = _infra_drain_max_attempts()
-    regs = _infra_drain_registrations()
+    # ONE registry read: the staleness/pending decision parses from this
+    # snapshot, and the pre-spawn re-check compares against the same bytes —
+    # so "appeared/changed since the decision" is exact (round-2 fix #1).
+    reg_snapshot = _infra_drain_reg_snapshot()
+    regs = _infra_drain_registrations(reg_snapshot)
 
     # Cheap pre-filter (single source of truth: the SAME _cheap_skip_reason
     # decide_infra_drain uses, with `registered` = the raw registration-file
@@ -5336,7 +5464,7 @@ def infra_drain_pass(
     dispatched = 0
     for issue in dispatch:
         slot_desc = f"slot {min(occupied_active + pending + dispatched + 1, cap)}/{cap}"
-        ok = _dispatch_infra_drain(issue, slot_desc, dry_run)
+        ok = _dispatch_infra_drain(issue, slot_desc, dry_run, reg_snapshot=reg_snapshot)
         if not dry_run:
             # Count the ATTEMPT whether or not the spawn succeeded, so a
             # failing spawn can't tight-loop (the backoff window binds next

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -1481,7 +1481,7 @@ def _daemon_reachable() -> bool:
 def _live_session_ids_or_none() -> set[str] | None:
     """``spawn_session._live_session_ids()`` with an explicit UNAVAILABLE
     mode: the daemon's live session-id set, or ``None`` when the ``/list``
-    probe fails (daemon down, malformed payload).
+    probe fails (daemon down, malformed payload, malformed child entry).
 
     spawn_session's helper returns an EMPTY SET both for "daemon up, zero
     sessions" and for "daemon unreachable" (its ``list --all`` fallback wants
@@ -1492,7 +1492,15 @@ def _live_session_ids_or_none() -> set[str] | None:
     double-spawn. So the drain pass uses this wrapper (same probe shape as
     :func:`_daemon_reachable`; spawn_session.py is a forbidden surface for
     this pass) and :func:`_infra_drain_stale` fails ``None`` toward NOT
-    stale (keep blocking)."""
+    stale (keep blocking).
+
+    A child dict carrying an invalid ``happySessionId`` (missing, ``None``,
+    empty string, non-str) is treated the same as a missing ``children``
+    list — both return ``None`` (round-3 fix, reconciler verdict
+    2026-06-12: a stray ``{None}`` set would slip past the ``is None``
+    guard in :func:`_infra_drain_stale` and make every real-string sid
+    look NOT live, reintroducing the round-1 BLOCKER's double-spawn
+    class)."""
     try:
         import urllib.error
         import urllib.request
@@ -1512,7 +1520,25 @@ def _live_session_ids_or_none() -> set[str] | None:
         # A 200 response without the expected shape is NOT a confirmed
         # "zero live sessions" — treat as unavailable (fail toward keep).
         return None
-    return {c.get("happySessionId") for c in children if isinstance(c, dict)}
+    sids: set[str] = set()
+    for c in children:
+        if not isinstance(c, dict):
+            # Non-dict child entries (e.g. the "junk" string in the existing
+            # ``test_live_session_ids_or_none_shapes`` happy-path fixture)
+            # are skipped; they carry no sid claim either way.
+            continue
+        sid = c.get("happySessionId")
+        if not isinstance(sid, str) or not sid:
+            # A dict child whose sid is missing/None/empty/non-str is a
+            # daemon-contract violation — fail toward keep-blocking per
+            # the function's documented contract, the same fail direction
+            # already used three lines above for a missing ``children``
+            # list. One bad child contaminates the whole reply (we cannot
+            # tell whether the others are real-but-incomplete or merely
+            # the well-formed survivors of a partial write).
+            return None
+        sids.add(sid)
+    return sids
 
 
 def _manual_session_alive(issue: int | None, live_ids: set[str]) -> bool:

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -1,9 +1,10 @@
 """Crash-recovery + pod-safety + stalled-detector watcher for autonomous and
 interactive issue sessions (plus campaign sessions, task #586).
 
-Ten passes; items 1-8 run in that order, with the CAMPAIGN pass (item 9)
-right after pass 2 and the IDLE-UNMAPPED-SESSION pass (item 10) right after
-pass 7, before the GC pass:
+Eleven passes; items 1-8 run in that order, with the CAMPAIGN pass (item 9)
+right after pass 2, the IDLE-UNMAPPED-SESSION pass (item 10) right after
+pass 7, and the INFRA-DRAIN pass (item 11) between pass 5 (the orphan sweep)
+and pass 6 (session-reconcile), all before the GC pass:
 
 1. **VM disk-headroom pass.** Watch free space on the VM root filesystem —
    the host of every orchestrator session, the worktree ``.venv``s, the uv
@@ -212,6 +213,38 @@ pass 7, before the GC pass:
    zombie-wrapper contract; records land in
    ``~/.eps-autonomous/idle-unmapped-events.jsonl`` (no task to carry a
    marker, by definition). Daemon-gated.
+11. **Infra-drain pass (execute the PM-adjudicated dispatch queue; task
+   #633; runs between pass 5 and pass 6).** The PM session's standing infra
+   auto-dispatch rule adjudicates which ``proposed`` kind-infra/batch tasks
+   are RIPE and writes them oldest-first to
+   ``~/.eps-autonomous/infra-drain-queue.json`` (``ripe_oldest_first``,
+   ``cap``, ``holds`` {id: reason}, ``updated_ts``). This pass EXECUTES that
+   file with zero LLM judgment: it spawns ``spawn-issue --issue <N> --auto``
+   for the oldest listed IDs into free slots under the cap, where free =
+   max(0, cap - occupied - pending): occupied = kind-infra/batch tasks at
+   :data:`INFRA_DRAIN_OCCUPIED_STATUSES` (fail-CLOSED — any status-read
+   failure skips dispatching this tick), pending = non-stale registrations
+   of still-``proposed`` drain-kind (or unreadable) tasks. Per-ID guards,
+   each with a logged skip reason: PM hold; existing
+   ``issue-<N>.json``/``manual-issue-<N>.json`` registration (a
+   dead-at-boot registration — still-``proposed`` task, older than
+   ``EPM_INFRA_DRAIN_STALE_REG_GRACE_S`` (default 30 min), session
+   definitively not live — is STALE and stops blocking; ANY missing signal
+   fails toward keep-blocking); status != ``proposed``; kind not in
+   :data:`INFRA_DRAIN_KINDS` (loud every tick — a mis-kinded queue entry
+   would auto-approve GPU spend outside the cap); and a retry budget whose
+   backoff window (``EPM_INFRA_DRAIN_BACKOFF_S``, default 1 h) ALWAYS binds
+   while a fresh PM ``updated_ts`` resets only the attempt COUNT
+   (``EPM_INFRA_DRAIN_MAX_ATTEMPTS``, default 3 per adjudication epoch;
+   future timestamps clamped). The PM remains the ONLY ripeness judge —
+   missing/empty/invalid queue file is a logged no-op; un-riping an ID =
+   rewriting the file. Attempt state lives in
+   ``~/.eps-autonomous/infra-drain-state.json`` (self-pruned to the queue's
+   ID set; not a GC target). Kill switch ``EPM_DISABLE_INFRA_DRAIN=1``;
+   daemon-gated like every spawning pass; dispatch markers carry
+   :data:`_INFRA_DRAIN_NOTE_SENTINEL` so they never reset the
+   orphan/stalled staleness clocks. ``--infra-drain-only`` runs just this
+   pass (pair with ``--dry-run`` for a live smoke).
 
 Why each pass exists
 --------------------
@@ -624,6 +657,14 @@ _IDLE_UNMAPPED_STOP_NOTE_SENTINEL = "[autonomous_session_watch:idle-unmapped-sto
 _IDLE_UNMAPPED_ALERT_NOTE_SENTINEL = "[autonomous_session_watch:idle-unmapped-alert]"
 _IDLE_UNMAPPED_STOP_FAILED_NOTE_SENTINEL = "[autonomous_session_watch:idle-unmapped-stop-failed]"
 
+# Substring stamped into the marker the infra-drain pass posts after
+# dispatching an autonomous session for a PM-queue ID (task #633). The #633
+# task itself becomes ACTIVE seconds after dispatch — a watcher-authored
+# dispatch note must never count as "real progress" for the orphan/stalled
+# staleness clocks, or it would mask a subsequent stall of the very session
+# it just spawned.
+_INFRA_DRAIN_NOTE_SENTINEL = "[autonomous_session_watch:infra-drain-dispatch]"
+
 # All watcher-posted note substrings to exclude from `_latest_progress_ts`.
 # Pulled into one frozenset so every pass's filter is uniform: add a new
 # watcher-posted marker -> add its sentinel here -> _latest_progress_ts
@@ -651,6 +692,7 @@ _WATCHER_NOTE_SENTINELS: frozenset[str] = frozenset(
         _IDLE_UNMAPPED_STOP_NOTE_SENTINEL,
         _IDLE_UNMAPPED_ALERT_NOTE_SENTINEL,
         _IDLE_UNMAPPED_STOP_FAILED_NOTE_SENTINEL,
+        _INFRA_DRAIN_NOTE_SENTINEL,
     }
 )
 
@@ -4470,6 +4512,857 @@ def _process_orphan_task(
         )
 
 
+# ─── infra-drain pass (execute the PM-adjudicated dispatch queue; #633) ──────
+#
+# The PM session's standing infra auto-dispatch rule (research-pm.md
+# § Standing rule — infra auto-dispatch) adjudicates which `proposed`
+# kind:infra/batch tasks are RIPE and writes them, oldest-first, to
+# ``~/.eps-autonomous/infra-drain-queue.json``. This pass EXECUTES that file:
+# with zero LLM judgment it spawns ``spawn-issue --auto`` sessions for queue
+# IDs still at ``proposed``, into free slots under the cap, with per-ID
+# guards (holds, existing registration, status, kind, retry backoff) so a
+# held / already-running / repeatedly-failing / mis-kinded ID is never
+# dispatched or tight-looped. The PM remains the ONLY ripeness judge; a
+# missing/empty/invalid queue file is a logged no-op. Durably replaces the
+# PM-session-scoped hourly cron stopgap (which dies with the PM session).
+
+# Basenames under AUTONOMOUS_REGISTRY_DIR. Resolved via path FUNCTIONS (the
+# `_vm_disk_state_path` pattern) so the test fixture's AUTONOMOUS_REGISTRY_DIR
+# monkeypatch isolates them; neither matches any existing watcher/GC/spawn
+# glob, and the state file self-prunes to the queue's ID set, so it is
+# deliberately NOT in _GC_TARGETS.
+INFRA_DRAIN_QUEUE_BASENAME = "infra-drain-queue.json"
+INFRA_DRAIN_STATE_BASENAME = "infra-drain-state.json"
+# Used only when the queue file omits `cap` (the body names 3 as the schema
+# default; a benign omission must not silently disable the drain).
+INFRA_DRAIN_CAP_DEFAULT = 3
+# Task kinds the drain may dispatch. A mis-queued experiment/campaign ID must
+# never be spawned with --auto: it would auto-approve <=100 GPU-h AND sit
+# outside this pass's cap arithmetic.
+INFRA_DRAIN_KINDS = frozenset({"infra", "batch"})
+# Statuses that occupy a drain slot: the task-#633 contract set PLUS
+# followups_running (a same-issue follow-up round is in-flight work holding a
+# session + possibly a pod; counting it only ever dispatches LESS).
+# `proposed`/`blocked`/terminal statuses do not hold slots (a blocked task
+# waits on the user, possibly for days — letting it pin a slot would jam the
+# drain). Subset-of-enum pinned by test.
+INFRA_DRAIN_OCCUPIED_STATUSES = frozenset(
+    {
+        "planning",
+        "plan_pending",
+        "approved",
+        "running",
+        "verifying",
+        "interpreting",
+        "reviewing",
+        "followups_running",
+    }
+)
+# A failed spawn is not retried for this long — the window ALWAYS binds (a
+# fresh PM `updated_ts` resets only the attempt COUNT, never the window:
+# research-pm.md 4b rewrites the file on EVERY STATUS pass, so a window
+# bypass would void the tight-loop guard whenever the PM is active). At the
+# 10-min cron, 1 h is ~6 ticks. env EPM_INFRA_DRAIN_BACKOFF_S.
+INFRA_DRAIN_BACKOFF_S_DEFAULT = 3600.0
+# Attempt budget per PM adjudication epoch (a newer `updated_ts` resets the
+# count). Mirrors the orphan pass's bounded-respawn philosophy.
+# env EPM_INFRA_DRAIN_MAX_ATTEMPTS.
+INFRA_DRAIN_MAX_ATTEMPTS_DEFAULT = 3
+# Dead-at-boot grace: a registration for a still-`proposed` task older than
+# this whose session is definitively NOT live is STALE (stops pinning a
+# pending slot; the ID becomes re-dispatchable under the backoff/attempt
+# budget). 30 min comfortably covers the spawn->boot->status-flip gap
+# (normally <5 min) while bounding a dead-at-boot freeze to ~3 ticks instead
+# of the 14-day registry backstop. env EPM_INFRA_DRAIN_STALE_REG_GRACE_S.
+INFRA_DRAIN_STALE_REG_GRACE_S_DEFAULT = 1800.0
+# A queue `updated_ts` further in the future than this is treated as None —
+# a future epoch would make every tick a "fresh adjudication" and void the
+# attempt budget (tz confusion / LLM timestamp bug; the file is LLM-authored).
+INFRA_DRAIN_FUTURE_TS_TOLERANCE_S = 300.0
+
+
+def _infra_drain_enabled() -> bool:
+    """Kill switch: False when ``EPM_DISABLE_INFRA_DRAIN`` is set truthy
+    ("1"/"true"/"yes", case-insensitive). Default enabled. The queue file's
+    own ``cap: 0`` is the PM-side soft pause; this env var is the
+    operator-side hard stop (body-named contract: EPM_DISABLE_INFRA_DRAIN=1)."""
+    raw = os.environ.get("EPM_DISABLE_INFRA_DRAIN", "").strip().lower()
+    return raw not in {"1", "true", "yes"}
+
+
+def _infra_drain_backoff_s() -> float:
+    """Retry-backoff window in seconds (env ``EPM_INFRA_DRAIN_BACKOFF_S``;
+    default :data:`INFRA_DRAIN_BACKOFF_S_DEFAULT`). A malformed env value
+    falls back to the default — a typo must not distort the budget (mirrors
+    :func:`_orphan_staleness_s`)."""
+    raw = os.environ.get("EPM_INFRA_DRAIN_BACKOFF_S")
+    if not raw:
+        return INFRA_DRAIN_BACKOFF_S_DEFAULT
+    try:
+        return float(raw)
+    except ValueError:
+        return INFRA_DRAIN_BACKOFF_S_DEFAULT
+
+
+def _infra_drain_max_attempts() -> int:
+    """Attempt cap per PM adjudication epoch (env
+    ``EPM_INFRA_DRAIN_MAX_ATTEMPTS``; default
+    :data:`INFRA_DRAIN_MAX_ATTEMPTS_DEFAULT`). Malformed env value falls back
+    to the default."""
+    raw = os.environ.get("EPM_INFRA_DRAIN_MAX_ATTEMPTS")
+    if not raw:
+        return INFRA_DRAIN_MAX_ATTEMPTS_DEFAULT
+    try:
+        return int(raw)
+    except ValueError:
+        return INFRA_DRAIN_MAX_ATTEMPTS_DEFAULT
+
+
+def _infra_drain_stale_reg_grace_s() -> float:
+    """Dead-at-boot registration grace in seconds (env
+    ``EPM_INFRA_DRAIN_STALE_REG_GRACE_S``; default
+    :data:`INFRA_DRAIN_STALE_REG_GRACE_S_DEFAULT`). Malformed env value falls
+    back to the default."""
+    raw = os.environ.get("EPM_INFRA_DRAIN_STALE_REG_GRACE_S")
+    if not raw:
+        return INFRA_DRAIN_STALE_REG_GRACE_S_DEFAULT
+    try:
+        return float(raw)
+    except ValueError:
+        return INFRA_DRAIN_STALE_REG_GRACE_S_DEFAULT
+
+
+def parse_infra_drain_queue(raw: str) -> dict | None:
+    """Parse + validate the PM queue file content. Returns the canonical dict
+    ``{"ids": list[int], "cap": int, "holds": dict[int, str],
+    "updated_ts": float | None}`` or ``None`` when the content is invalid
+    (the pass then no-ops — fail toward NOT dispatching). ``holds`` preserves
+    the PM's reason strings so skip lines can interpolate them.
+
+    Validity rules:
+
+    - top level must be a JSON object;
+    - ``ripe_oldest_first`` must be a list of ints (missing -> invalid: the
+      field is the file's entire point); bools rejected; order-preserving
+      dedup (first occurrence wins);
+    - ``cap`` missing -> :data:`INFRA_DRAIN_CAP_DEFAULT`; present but not an
+      int >= 0 -> invalid (a garbled cap must not silently become 3);
+    - ``holds`` missing -> empty; present but not a dict -> invalid; keys are
+      int()-parsed (the live file uses string keys); an unparseable key ->
+      invalid (a malformed hold must never be silently ignored — that would
+      DISPATCH a held ID);
+    - ``updated_ts`` parsed via :func:`_parse_event_ts` (ISO-8601 Z);
+      unparseable -> ``None`` (only weakens attempt-reset, never dispatch
+      eligibility). The FUTURE-ts clamp lives in :func:`decide_infra_drain`
+      (pure, testable); the executor mirrors it for the log line.
+    """
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    ids_raw = data.get("ripe_oldest_first")
+    if not isinstance(ids_raw, list):
+        return None
+    ids: list[int] = []
+    for x in ids_raw:
+        if isinstance(x, bool) or not isinstance(x, int):
+            return None
+        if x not in ids:
+            ids.append(x)
+    cap = data.get("cap", INFRA_DRAIN_CAP_DEFAULT)
+    if isinstance(cap, bool) or not isinstance(cap, int) or cap < 0:
+        return None
+    holds_raw = data.get("holds", {})
+    if not isinstance(holds_raw, dict):
+        return None
+    holds: dict[int, str] = {}
+    for key, reason in holds_raw.items():
+        try:
+            holds[int(key)] = str(reason)
+        except (TypeError, ValueError):
+            return None
+    return {
+        "ids": ids,
+        "cap": cap,
+        "holds": holds,
+        "updated_ts": _parse_event_ts(data.get("updated_ts")),
+    }
+
+
+def _cheap_skip_reason(
+    i: int,
+    holds: dict[int, str],
+    registered: set[int],
+    attempts: dict[int, dict],
+    now: float,
+    queue_updated_ts: float | None,
+    *,
+    backoff_s: float,
+    max_attempts: int,
+) -> str | None:
+    """The per-ID guards computable WITHOUT ``task.py`` subprocesses. Returns
+    the skip reason or ``None`` (eligible so far). Used VERBATIM by both
+    :func:`decide_infra_drain` (guards 1-3) and the executor's cheap
+    pre-filter — single source of truth, no predicate drift.
+
+      1. ``i in holds``                         -> ``"held"``
+      2. ``i in registered``                    -> ``"already-registered"``
+         (``registered`` = NON-STALE registrations; the executor pre-filter
+         passes the raw registration-ID set — a stale registration makes the
+         ID MORE eligible, so pre-filtering on the raw set risks only a
+         false skip toward the next tick)
+      3. budget — the BACKOFF WINDOW ALWAYS BINDS (a fresh PM ``updated_ts``
+         resets only the attempt COUNT, never the window):
+           ``now - last_attempt_ts < backoff_s``  -> ``"backoff"`` (always)
+           ``attempts >= max_attempts`` AND NOT
+           ``queue_updated_ts > last_attempt_ts`` -> ``"attempts-exhausted"``
+         Records with malformed ``last_attempt_ts`` were dropped at
+         state-load time (defensive normalize, logged), so ``last`` here is
+         numeric whenever present.
+    """
+    if i in holds:
+        return "held"
+    if i in registered:
+        return "already-registered"
+    rec = attempts.get(i) or {}
+    last = rec.get("last_attempt_ts")
+    if isinstance(last, int | float) and not isinstance(last, bool):
+        if now - last < backoff_s:
+            return "backoff"  # ALWAYS binds
+        fresh = queue_updated_ts is not None and queue_updated_ts > last
+        if not fresh and rec.get("attempts", 0) >= max_attempts:
+            return "attempts-exhausted"  # fresh PM write resets the COUNT only
+    return None
+
+
+def decide_infra_drain(
+    ids: list[int],
+    cap: int,
+    holds: dict[int, str],
+    statuses: dict[int, str | None],
+    kinds: dict[int, str | None],
+    registered: set[int],
+    occupied_active: int,
+    pending: int,
+    attempts: dict[int, dict],
+    now: float,
+    queue_updated_ts: float | None,
+    *,
+    backoff_s: float = INFRA_DRAIN_BACKOFF_S_DEFAULT,
+    max_attempts: int = INFRA_DRAIN_MAX_ATTEMPTS_DEFAULT,
+) -> tuple[list[int], list[tuple[int, str]]]:
+    """Pure decision: ``(dispatch_ids_in_order, skipped [(id, reason)])``.
+
+    ``ids`` is the validated ``ripe_oldest_first`` list; ``registered`` the
+    NON-STALE registrations among the queue IDs; ``occupied_active`` the
+    count of kind-infra/batch tasks at :data:`INFRA_DRAIN_OCCUPIED_STATUSES`;
+    ``pending`` the executor-precomputed count of ALL non-stale registrations
+    (queue AND non-queue) whose task is still ``proposed`` with a drain kind,
+    plus any whose status/kind is unreadable (conservative — see
+    :func:`_infra_drain_pending`). ``free = max(0, cap - occupied_active -
+    pending)``.
+
+    FUTURE-TS CLAMP (first statement, pure + testable): a
+    ``queue_updated_ts`` further than
+    :data:`INFRA_DRAIN_FUTURE_TS_TOLERANCE_S` past ``now`` is treated as
+    ``None`` — a future epoch would make every tick a "fresh adjudication"
+    and void the attempt budget.
+
+    Per-ID guard order (cheapest first; every skip carries a reason string):
+
+      1-3. :func:`_cheap_skip_reason` (held / already-registered / backoff /
+           attempts-exhausted — backoff always binds)
+      4. status unreadable -> ``"status-unreadable"`` (fail toward not
+         dispatching); status != ``proposed`` -> ``"status-<status>"``
+      5. kind not in :data:`INFRA_DRAIN_KINDS` -> ``"kind-<kind|unreadable>"``
+      6. no free slot -> ``"cap-full"``
+      7. else dispatch; one attempt per ID per cycle
+    """
+    if queue_updated_ts is not None and queue_updated_ts > now + INFRA_DRAIN_FUTURE_TS_TOLERANCE_S:
+        queue_updated_ts = None  # future-ts clamp; the executor logs the condition loudly
+    free = max(0, cap - occupied_active - pending)
+    dispatch: list[int] = []
+    skipped: list[tuple[int, str]] = []
+    for i in ids:
+        reason = _cheap_skip_reason(
+            i,
+            holds,
+            registered,
+            attempts,
+            now,
+            queue_updated_ts,
+            backoff_s=backoff_s,
+            max_attempts=max_attempts,
+        )
+        if reason is not None:
+            skipped.append((i, reason))
+            continue
+        status = statuses.get(i)
+        if status is None:
+            skipped.append((i, "status-unreadable"))
+            continue
+        if status != "proposed":
+            skipped.append((i, f"status-{status}"))
+            continue
+        kind = kinds.get(i)
+        if kind not in INFRA_DRAIN_KINDS:
+            skipped.append((i, f"kind-{kind or 'unreadable'}"))
+            continue
+        if free <= 0:
+            skipped.append((i, "cap-full"))
+            continue
+        dispatch.append(i)
+        free -= 1
+    return dispatch, skipped
+
+
+def _infra_drain_queue_path() -> Path:
+    """Path of the PM-authored queue file (resolved at call time so the test
+    fixture's ``AUTONOMOUS_REGISTRY_DIR`` monkeypatch isolates it)."""
+    return AUTONOMOUS_REGISTRY_DIR / INFRA_DRAIN_QUEUE_BASENAME
+
+
+def _infra_drain_state_path() -> Path:
+    """Path of the consolidated per-ID attempt/backoff state file."""
+    return AUTONOMOUS_REGISTRY_DIR / INFRA_DRAIN_STATE_BASENAME
+
+
+def _load_infra_drain_state() -> dict:
+    """Read the attempt/backoff state (``{"attempts": {int: rec}}``; empty on
+    absent/garbled, mirroring :func:`_load_orphan_state`). On-disk keys are
+    strings (JSON); they are int-normalized here. DEFENSIVE NORMALIZE: drop
+    (with a log line) any record whose ``last_attempt_ts`` is not numeric or
+    whose key is not an int — a garbled record must not silently bypass the
+    budget."""
+    path = _infra_drain_state_path()
+    if not path.is_file():
+        return {"attempts": {}}
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {"attempts": {}}
+    if not isinstance(data, dict) or not isinstance(data.get("attempts"), dict):
+        return {"attempts": {}}
+    attempts: dict[int, dict] = {}
+    for key, rec in data["attempts"].items():
+        try:
+            issue = int(key)
+        except (TypeError, ValueError):
+            print(f"  infra-drain: dropping garbled state record (non-int key {key!r})")
+            continue
+        last = rec.get("last_attempt_ts") if isinstance(rec, dict) else None
+        if isinstance(last, bool) or not isinstance(last, int | float):
+            print(
+                f"  infra-drain: dropping garbled state record for #{issue} "
+                f"(non-numeric last_attempt_ts {last!r})"
+            )
+            continue
+        attempts[issue] = rec
+    return {"attempts": attempts}
+
+
+def _save_infra_drain_state(state: dict) -> None:
+    """Persist the attempt/backoff state atomically (temp + rename, mirroring
+    :func:`_save_orphan_state`). Int keys serialize as strings; the loader
+    normalizes them back."""
+    AUTONOMOUS_REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
+    dest = _infra_drain_state_path()
+    tmp = dest.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(state, indent=2))
+    tmp.replace(dest)
+
+
+def _task_status_kind(issue: int) -> tuple[str | None, str | None]:
+    """``(status, kind)`` from ONE ``task.py view <N> --json`` subprocess —
+    the same payload :func:`_task_status` parses carries ``frontmatter.kind``,
+    so the kind guard costs zero extra subprocesses. Fail-soft
+    ``(None, None)``."""
+    try:
+        out = subprocess.run(
+            ["uv", "run", "python", "scripts/task.py", "view", str(issue), "--json"],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return (None, None)
+    if out.returncode != 0:
+        return (None, None)
+    try:
+        data = json.loads(out.stdout)
+    except json.JSONDecodeError:
+        return (None, None)
+    fm = data.get("frontmatter") or {}
+    status = data.get("status") or fm.get("status")
+    kind = fm.get("kind")
+    return (
+        status if isinstance(status, str) else None,
+        kind if isinstance(kind, str) else None,
+    )
+
+
+def _infra_drain_registrations() -> dict[int, list[dict]]:
+    """ALL ``issue-<N>.json`` + ``manual-issue-<N>.json`` registration entries
+    per issue (not just queue IDs — the widened pending count needs non-queue
+    ones too). List-valued because an issue can carry BOTH an autonomous and
+    a manual registration; staleness then requires ALL of them stale
+    (fail toward keep-blocking). A garbled entry parses to ``{}`` (which
+    :func:`_infra_drain_stale` classifies NOT stale — conservative)."""
+    out: dict[int, list[dict]] = {}
+    if not AUTONOMOUS_REGISTRY_DIR.is_dir():
+        return out
+    for prefix in ("issue-", "manual-issue-"):
+        for path in sorted(AUTONOMOUS_REGISTRY_DIR.glob(f"{prefix}*.json")):
+            issue = _gc_parse_issue_from_path(path, prefix, "")
+            if issue is None:
+                continue
+            try:
+                entry = json.loads(path.read_text())
+            except (json.JSONDecodeError, OSError):
+                entry = {}
+            if not isinstance(entry, dict):
+                entry = {}
+            out.setdefault(issue, []).append(entry)
+    return out
+
+
+def _infra_drain_stale(
+    reg: dict,
+    live_session_ids: set[str] | None,
+    status: str | None,
+    now: float,
+    grace_s: float,
+) -> bool:
+    """STALE (dead-at-boot) iff ALL of: task status == ``proposed``; the
+    registration's ``spawned_at`` parses AND ``now - spawned_at > grace_s``;
+    the recorded session id is present AND ``live_session_ids`` is available
+    AND the id is NOT in it. ANY missing/unparseable signal -> NOT stale
+    (fail toward keep-blocking — a false-stale could double-spawn; a
+    false-live only delays recovery to the 14-day registry backstop). A
+    STALE registration stops counting toward pending and stops blocking
+    re-dispatch; the backoff/attempt budget bounds the re-dispatch rate."""
+    if status != "proposed":
+        return False
+    spawned_at = reg.get("spawned_at")
+    if isinstance(spawned_at, bool) or not isinstance(spawned_at, int | float):
+        return False
+    if now - spawned_at <= grace_s:
+        return False
+    sid = reg.get("happy_session_id")
+    if not isinstance(sid, str) or not sid:
+        return False
+    if live_session_ids is None:
+        return False
+    return sid not in live_session_ids
+
+
+def _infra_drain_occupancy() -> list[int] | None:
+    """IDs of tasks with kind in :data:`INFRA_DRAIN_KINDS` at
+    :data:`INFRA_DRAIN_OCCUPIED_STATUSES`, via one ``task.py list-by-status
+    --json`` subprocess per status (mirrors :func:`_active_status_tasks` but
+    keeps the ``kind`` field; the IDs feed the cap-full ``occupying=[...]``
+    log line). Returns ``None`` when ANY status read fails — a partial count
+    would UNDER-count and over-dispatch, so the executor skips dispatching
+    this tick on ``None`` (deliberately STRICTER than
+    :func:`_active_status_tasks`' per-status fail-soft, which is safe there
+    because that pass only recovers, never spawns new work). ``kind:
+    campaign`` rows can't match (not in :data:`INFRA_DRAIN_KINDS`)."""
+    occupying: list[int] = []
+    for status in sorted(INFRA_DRAIN_OCCUPIED_STATUSES):
+        try:
+            res = subprocess.run(
+                [
+                    "uv",
+                    "run",
+                    "python",
+                    "scripts/task.py",
+                    "list-by-status",
+                    "--status",
+                    status,
+                    "--json",
+                ],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+        except (subprocess.SubprocessError, OSError):
+            return None
+        if res.returncode != 0:
+            return None
+        try:
+            rows = json.loads(res.stdout)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(rows, list):
+            return None
+        for row in rows:
+            if not isinstance(row, dict) or row.get("kind") not in INFRA_DRAIN_KINDS:
+                continue
+            tid = row.get("id")
+            if isinstance(tid, int):
+                occupying.append(tid)
+    return occupying
+
+
+def _infra_drain_pending(
+    registrations: dict[int, list[dict]],
+    stale: set[int],
+    status_kind: dict[int, tuple[str | None, str | None]],
+) -> int:
+    """Widened pending count: over ALL non-stale registrations (queue and
+    non-queue), count those whose task is still ``proposed`` with a kind in
+    :data:`INFRA_DRAIN_KINDS` (spawned but ``/issue`` hasn't flipped status
+    yet) PLUS those whose status or kind is UNREADABLE (conservative — an
+    unknown registered task might be a just-spawned infra task; fail toward
+    occupying a slot). Tasks at occupied statuses are already counted in
+    ``occupied_active``; terminal/blocked registrations count zero. Closes
+    both the PM-prunes-a-dispatched-ID overshoot and the status-read-failure
+    undercount."""
+    pending = 0
+    for issue in registrations:
+        if issue in stale:
+            continue
+        status, kind = status_kind.get(issue, (None, None))
+        if status is None or kind is None or (status == "proposed" and kind in INFRA_DRAIN_KINDS):
+            pending += 1
+    return pending
+
+
+def _dispatch_infra_drain(issue: int, slot_desc: str, dry_run: bool) -> bool:
+    """``spawn_session.py spawn-issue --issue <N> --auto`` (the plain
+    command, exactly the PM standing-rule item-3 mechanism; no
+    ``--auto-approve-gpu-hours`` override — spawn_session's default applies,
+    and infra tasks need ~0 GPU). Immediately BEFORE the subprocess,
+    re-checks the registration files one last time and aborts ("lost race to
+    concurrent dispatcher") if one appeared — shrinks the PM-vs-watcher
+    double-spawn window from one-full-pass to ~the spawn subprocess itself.
+    Returns success bool; honours dry_run (logs, never spawns)."""
+    cmd = [
+        "uv", "run", "python", "scripts/spawn_session.py", "spawn-issue",
+        "--issue", str(issue), "--auto",
+    ]  # fmt: skip
+    if dry_run:
+        print(f"  [dry-run] would dispatch infra-drain: {' '.join(cmd)}")
+        return False
+    for basename in (f"issue-{issue}.json", f"manual-issue-{issue}.json"):
+        if (AUTONOMOUS_REGISTRY_DIR / basename).exists():
+            print(
+                f"  INFRA-DRAIN ABORT issue #{issue}: lost race to concurrent "
+                f"dispatcher ({basename} appeared since the decision)"
+            )
+            return False
+    res = subprocess.run(cmd, cwd=PROJECT_ROOT, capture_output=True, text=True, timeout=120)
+    if res.returncode != 0:
+        print(
+            f"  INFRA-DRAIN DISPATCH FAILED issue #{issue}: {res.stderr.strip()[:300]}",
+            file=sys.stderr,
+        )
+        return False
+    first_line = (res.stdout.strip().splitlines() or [""])[0]
+    print(f"  INFRA-DRAIN DISPATCHED issue #{issue} ({slot_desc}): {first_line}")
+    return True
+
+
+def _infra_drain_read_queue() -> dict | None:
+    """Read + parse the queue file; ``None`` (with exactly one header line)
+    when the pass should no-op: file missing, unreadable, or invalid."""
+    path = _infra_drain_queue_path()
+    try:
+        raw = path.read_text()
+    except FileNotFoundError:
+        print(f"infra-drain: no queue file at {path}; skipping")
+        return None
+    except OSError as e:
+        print(f"infra-drain: queue file at {path} unreadable ({e}); skipping")
+        return None
+    queue = parse_infra_drain_queue(raw)
+    if queue is None:
+        print(
+            f"infra-drain: INVALID queue file at {path} (schema violation or "
+            f"torn write); skipping (fail-safe: not dispatching)"
+        )
+    return queue
+
+
+def _infra_drain_record_attempt(
+    attempts: dict[int, dict],
+    issue: int,
+    now: float,
+    queue_updated_ts: float | None,
+    ok: bool,
+) -> None:
+    """Record one dispatch ATTEMPT (success or failure both count, so a
+    failing spawn can't tight-loop). A fresh PM adjudication (``updated_ts``
+    newer than the last attempt) resets the count to 1 first."""
+    rec = attempts.get(issue) or {}
+    last = rec.get("last_attempt_ts")
+    fresh = (
+        queue_updated_ts is not None
+        and isinstance(last, int | float)
+        and not isinstance(last, bool)
+        and queue_updated_ts > last
+    )
+    count = 1 if fresh else int(rec.get("attempts", 0)) + 1
+    attempts[issue] = {
+        "attempts": count,
+        "last_attempt_ts": now,
+        "last_result": "dispatched" if ok else "spawn-failed",
+        "exhausted_logged": False,
+    }
+
+
+def _infra_drain_log_skips(
+    skipped: list[tuple[int, str]],
+    holds: dict[int, str],
+    attempts: dict[int, dict],
+) -> None:
+    """One ``INFRA-DRAIN SKIP`` line per skipped ID. ``held`` interpolates
+    the PM's hold reason; ``attempts-exhausted`` is loud ONCE per epoch
+    (``exhausted_logged`` dedup flag, mirroring the orphan pass's
+    ``alerted``); ``kind-*`` is loud EVERY tick (a mis-kinded queue entry is
+    a PM-side bug needing eyes)."""
+    for issue, reason in skipped:
+        if reason == "held":
+            print(f"  INFRA-DRAIN SKIP issue #{issue} (held: {holds.get(issue, '?')})")
+        elif reason == "attempts-exhausted":
+            rec = attempts.get(issue) or {}
+            if not rec.get("exhausted_logged"):
+                print(
+                    f"  INFRA-DRAIN SKIP issue #{issue} (attempts-exhausted: "
+                    f"{rec.get('attempts', '?')} attempts this PM epoch; parked "
+                    f"until the PM rewrites the queue with a newer updated_ts)",
+                    file=sys.stderr,
+                )
+                rec["exhausted_logged"] = True
+                attempts[issue] = rec
+            else:
+                print(f"  INFRA-DRAIN SKIP issue #{issue} (attempts-exhausted)")
+        elif reason.startswith("kind-"):
+            print(
+                f"  INFRA-DRAIN SKIP issue #{issue} ({reason}): mis-kinded queue "
+                f"entry — only kind infra/batch is drain-dispatchable; fix the "
+                f"PM queue file (research-pm.md standing-rule item 4b)",
+                file=sys.stderr,
+            )
+        else:
+            print(f"  INFRA-DRAIN SKIP issue #{issue} ({reason})")
+
+
+def _infra_drain_prune_save(state: dict, ids: list[int], dry_run: bool) -> None:
+    """Prune state entries whose ID left ``ripe_oldest_first``, then persist
+    atomically. No-op under dry-run (mirror the orphan pass's dry-run
+    discipline: no state write)."""
+    if dry_run:
+        return
+    keep = set(ids)
+    state["attempts"] = {i: rec for i, rec in state["attempts"].items() if i in keep}
+    _save_infra_drain_state(state)
+
+
+def _infra_drain_clamp_future_ts(queue_updated_ts: float | None, now: float) -> float | None:
+    """Executor-side mirror of the decide-side future-ts clamp, so the
+    condition is logged loudly exactly once per tick."""
+    if queue_updated_ts is not None and queue_updated_ts > now + INFRA_DRAIN_FUTURE_TS_TOLERANCE_S:
+        print(
+            f"infra-drain: queue updated_ts is {queue_updated_ts - now:.0f}s in the "
+            f"FUTURE (tz confusion / LLM timestamp bug?); treating it as absent so "
+            f"it cannot void the attempt budget"
+        )
+        return None
+    return queue_updated_ts
+
+
+def _infra_drain_possibly_stale_ids(
+    candidate_ids: set[int],
+    regs: dict[int, list[dict]],
+    now: float,
+) -> set[int]:
+    """Subset of ``candidate_ids`` whose EVERY registration entry is
+    suspicious enough — older than the grace window, recorded session id
+    definitively not live — that the full path must confirm staleness with a
+    status read. Reuses :func:`_infra_drain_stale` with the status check
+    pre-satisfied (``"proposed"``), so the two predicates can never drift.
+
+    Without this probe the pre-filter's all-skipped early exit would park a
+    dead-at-boot registered ID FOREVER (staleness is only computed on the
+    full path, and the full path never runs when the stale ID is the only
+    non-skipped queue ID) — exactly the drain-freeze the stale-registration
+    handling exists to prevent. Costs one daemon RPC, zero ``task.py``
+    subprocesses; only invoked when some queue ID pre-filtered as
+    ``already-registered``."""
+    if not candidate_ids:
+        return set()
+    live_ids = _live_session_ids()  # daemon reachability was gated by the caller
+    grace_s = _infra_drain_stale_reg_grace_s()
+    return {
+        i
+        for i in candidate_ids
+        if regs.get(i)
+        and all(_infra_drain_stale(r, live_ids, "proposed", now, grace_s) for r in regs[i])
+    }
+
+
+def _infra_drain_signals(
+    ids: list[int],
+    holds: dict[int, str],
+    regs: dict[int, list[dict]],
+    now: float,
+) -> tuple[dict[int, tuple[str | None, str | None]], set[int], int]:
+    """Fetch the ``task.py``-backed signals for the full dispatch path:
+    per-ID ``(status, kind)`` for every non-held queue ID and every
+    registration ID, the stale-registration set, and the widened pending
+    count. One ``view`` subprocess per ID; the caller's cheap pre-filter
+    bounds the common nothing-dispatchable tick at zero of these."""
+    fetch_ids = {i for i in ids if i not in holds} | set(regs)
+    status_kind = {i: _task_status_kind(i) for i in sorted(fetch_ids)}
+    live_ids = _live_session_ids()  # daemon reachability was gated by the caller
+    grace_s = _infra_drain_stale_reg_grace_s()
+    stale: set[int] = set()
+    for issue, recs in regs.items():
+        status = status_kind.get(issue, (None, None))[0]
+        if recs and all(_infra_drain_stale(r, live_ids, status, now, grace_s) for r in recs):
+            stale.add(issue)
+            print(
+                f"  infra-drain: STALE registration for issue #{issue} (task still "
+                f"proposed, registration older than grace, session not live) — no "
+                f"longer pins a pending slot; ID re-dispatchable under the budget"
+            )
+    pending = _infra_drain_pending(regs, stale, status_kind)
+    return status_kind, stale, pending
+
+
+def infra_drain_pass(
+    dry_run: bool,
+    now: float | None = None,
+    *,
+    daemon_reachable: bool | None = None,
+) -> None:
+    """Execute the PM-adjudicated infra dispatch queue (task #633). Pure
+    executor — every judgment was the PM session's; every guard here is
+    mechanical. Missing/invalid queue file = logged no-op; daemon-gated like
+    every other spawning pass (spawn POSTs to the Happy daemon RPC)."""
+    if not _infra_drain_enabled():
+        print("infra-drain: disabled via EPM_DISABLE_INFRA_DRAIN; skipping")
+        return
+    queue = _infra_drain_read_queue()
+    if queue is None:
+        return
+    if daemon_reachable is None:
+        daemon_reachable = _daemon_reachable()
+    if not daemon_reachable:
+        print("infra-drain: Happy daemon unreachable; skipping (spawn needs the daemon RPC)")
+        return
+    now = now if now is not None else time.time()
+    ids: list[int] = queue["ids"]
+    cap: int = queue["cap"]
+    holds: dict[int, str] = queue["holds"]
+    queue_updated_ts = _infra_drain_clamp_future_ts(queue["updated_ts"], now)
+    state = _load_infra_drain_state()
+    attempts: dict[int, dict] = state["attempts"]
+    backoff_s = _infra_drain_backoff_s()
+    max_attempts = _infra_drain_max_attempts()
+    regs = _infra_drain_registrations()
+
+    # Cheap pre-filter (single source of truth: the SAME _cheap_skip_reason
+    # decide_infra_drain uses, with `registered` = the raw registration-file
+    # ID set — staleness not yet computed; a stale registration makes the ID
+    # MORE eligible, so pre-filtering on the raw set risks only a false skip
+    # toward the next tick). When every ID pre-filters to a skip, the tick
+    # costs ZERO task.py subprocesses.
+    raw_registered = set(regs) & set(ids)
+    prefilter = {
+        i: _cheap_skip_reason(
+            i,
+            holds,
+            raw_registered,
+            attempts,
+            now,
+            queue_updated_ts,
+            backoff_s=backoff_s,
+            max_attempts=max_attempts,
+        )
+        for i in ids
+    }
+    if all(reason is not None for reason in prefilter.values()):
+        # An "already-registered" pre-filter skip may be rescued by the
+        # stale-registration handling (dead-at-boot session) — that needs a
+        # status read, so such IDs defer the early exit to the full path
+        # when their registration looks suspicious (older than grace +
+        # session not live). Everything else (held / backoff / exhausted /
+        # live-or-fresh registration) early-exits with zero task.py reads.
+        registered_skips = {i for i in ids if prefilter[i] == "already-registered"}
+        if not _infra_drain_possibly_stale_ids(registered_skips, regs, now):
+            print(
+                f"infra-drain: queue={len(ids)} dispatched=0 skipped={len(ids)} "
+                f"(pre-filtered; zero task.py reads this tick)"
+            )
+            _infra_drain_log_skips([(i, prefilter[i]) for i in ids], holds, attempts)
+            _infra_drain_prune_save(state, ids, dry_run)
+            return
+
+    status_kind, stale, pending = _infra_drain_signals(ids, holds, regs, now)
+    registered_nonstale = raw_registered - stale
+    occupying = _infra_drain_occupancy()
+    if occupying is None:
+        print(
+            "infra-drain: occupancy read FAILED for at least one status; "
+            "skipping dispatch this tick (fail-closed: a partial count would "
+            "under-count and over-dispatch past the cap)"
+        )
+        _infra_drain_prune_save(state, ids, dry_run)
+        return
+    occupied_active = len(occupying)
+    statuses = {i: status_kind.get(i, (None, None))[0] for i in ids}
+    kinds = {i: status_kind.get(i, (None, None))[1] for i in ids}
+    dispatch, skipped = decide_infra_drain(
+        ids,
+        cap,
+        holds,
+        statuses,
+        kinds,
+        registered_nonstale,
+        occupied_active,
+        pending,
+        attempts,
+        now,
+        queue_updated_ts,
+        backoff_s=backoff_s,
+        max_attempts=max_attempts,
+    )
+    dispatched = 0
+    for issue in dispatch:
+        slot_desc = f"slot {min(occupied_active + pending + dispatched + 1, cap)}/{cap}"
+        ok = _dispatch_infra_drain(issue, slot_desc, dry_run)
+        if not dry_run:
+            # Count the ATTEMPT whether or not the spawn succeeded, so a
+            # failing spawn can't tight-loop (the backoff window binds next
+            # tick either way).
+            _infra_drain_record_attempt(attempts, issue, now, queue_updated_ts, ok)
+        if ok:
+            dispatched += 1
+            _post_progress_marker(
+                issue,
+                f"{_INFRA_DRAIN_NOTE_SENTINEL} watcher dispatched autonomous "
+                f"session from the PM infra-drain queue (occupied "
+                f"{occupied_active}+{pending} pending of cap {cap})",
+                dry_run,
+                label="infra-drain",
+            )
+    _infra_drain_log_skips(skipped, holds, attempts)
+    summary = (
+        f"infra-drain: queue={len(ids)} occupied={occupied_active}(+{pending} pending) "
+        f"cap={cap} dispatched={dispatched} skipped={len(skipped)}"
+    )
+    if any(reason == "cap-full" for _i, reason in skipped):
+        summary += f" occupying={sorted(occupying)}"
+    print(summary)
+    _infra_drain_prune_save(state, ids, dry_run)
+
+
 # ─── generalized GC of stale ~/.eps-autonomous/ per-issue files ──────────────
 
 # Task statuses for which per-issue registry / progress / stalled-state files
@@ -7786,6 +8679,13 @@ def main(argv: list[str] | None = None) -> int:
         "respawn / pod-safety / stalled-detector. Useful for debugging the "
         "GC in isolation without waiting on a daemon probe.",
     )
+    parser.add_argument(
+        "--infra-drain-only",
+        action="store_true",
+        help="run ONLY the infra-drain pass (execute the PM dispatch queue) "
+        "and exit; skip every other pass. Mirrors --gc-only; pair with "
+        "--dry-run for the post-merge live smoke against the real queue file.",
+    )
     args = parser.parse_args(argv)
 
     lock = _acquire_lock()
@@ -7797,6 +8697,12 @@ def main(argv: list[str] | None = None) -> int:
     # doesn't accidentally trip the destructive paths.
     if args.gc_only:
         gc_pass(args.dry_run)
+        return 0
+
+    # --infra-drain-only mirrors --gc-only: run the single pass under the
+    # lock (it probes the daemon itself) and exit.
+    if args.infra_drain_only:
+        infra_drain_pass(args.dry_run, daemon_reachable=_daemon_reachable())
         return 0
 
     # VM disk-headroom: runs FIRST. A full root disk makes every later
@@ -7887,6 +8793,14 @@ def main(argv: list[str] | None = None) -> int:
         daemon_reachable=daemon_reachable,
         live_ids=live_ids if daemon_reachable else None,
     )
+
+    # Infra-drain: execute the PM session's adjudicated infra dispatch queue
+    # (task #633) into free slots under the cap. Pure executor — the PM is
+    # the only ripeness judge; missing/invalid queue file = no-op. Runs AFTER
+    # the respawn/orphan recovery passes so any session THEY spawned this
+    # tick is already registered (the already-registered guard sees it), and
+    # is daemon-gated like every other spawning pass.
+    infra_drain_pass(args.dry_run, daemon_reachable=daemon_reachable)
 
     # Session-reconcile: auto-stop (the default; EPM_SESSION_RECONCILE_AUTOSTOP=0
     # falls back to alert-only) live sessions that outlived their task's

--- a/scripts/cron_autonomous_session_watch.sh
+++ b/scripts/cron_autonomous_session_watch.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 # VM-health + crash-recovery + pod-safety + stalled-detector + orphan-sweep
-# + session-reconcile + campaign watch for issue/campaign sessions — invoked
-# from the system crontab (every ~10 min). Eight passes (the campaign pass
-# runs right after item 2; see scripts/autonomous_session_watch.py's module
-# docstring for the full rules):
+# + infra-drain + session-reconcile + campaign watch for issue/campaign
+# sessions — invoked from the system crontab (every ~10 min). Eleven passes
+# (the campaign pass runs right after item 2; only the highlights are
+# summarized below — the zombie-wrapper + idle-unmapped session reapers live
+# only in scripts/autonomous_session_watch.py's module docstring, which
+# carries the full, authoritative rules):
 #   1. VM disk-headroom: alert when free space on the VM root filesystem runs
 #      low (~20 GiB) AND run the stale-worktree sweep (worktree_audit.py
 #      --apply — the big-space remediation; 6h re-arm); below ~15 GiB (env
@@ -49,6 +51,16 @@
 #      when campaign-state.json shows GPU-hours committed > total; at
 #      terminal status stop the live session FIRST, then reap the
 #      campaign-<N>.json entry (deferred while the daemon is unreachable).
+#   9. Infra-drain (runs between items 5 and 6; task #633): execute the PM
+#      session's adjudicated dispatch queue
+#      (~/.eps-autonomous/infra-drain-queue.json) — spawn-issue --auto the
+#      oldest listed kind:infra/batch IDs still at proposed, into free slots
+#      under the cap (default 3), skipping holds / existing registrations /
+#      mis-kinded IDs, with a 1h-backoff + 3-attempts-per-PM-epoch budget
+#      (EPM_INFRA_DRAIN_BACKOFF_S / EPM_INFRA_DRAIN_MAX_ATTEMPTS) so a
+#      failing spawn never tight-loops. The PM is the ONLY ripeness judge;
+#      a missing/invalid queue file is a logged no-op. Kill switch:
+#      EPM_DISABLE_INFRA_DRAIN=1.
 # Mirrors cron_worktree_audit.sh / cron_pod_audit.sh.
 #
 # Safety lives in scripts/autonomous_session_watch.py: single-flight flock, a

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -5996,6 +5996,50 @@ def test_infra_drain_garbled_attempts_state_fails_safe(isolated_registry, monkey
     assert state["attempts"]["483"]["attempts"] == 1  # fresh epoch reset
 
 
+def test_infra_drain_missing_attempts_key_normalizes_to_cap(isolated_registry, monkeypatch, capsys):
+    # Round-4 fix (CONCERN: missing-attempts-normalizes-down): a state record
+    # with a valid last_attempt_ts but NO ``attempts`` key would slip past
+    # the type check via ``rec.get("attempts", 0)`` returning the 0 default
+    # BEFORE the bool/non-int/negative branch fired — silently granting a
+    # fresh budget on a half-written or hand-edited record. The fix
+    # normalizes the missing-key shape UP to the attempt cap, same fail
+    # direction the garbled-count sibling already uses.
+    import json
+
+    import autonomous_session_watch as asw
+
+    now = _DRAIN_NOW
+    (isolated_registry / "infra-drain-state.json").write_text(
+        # last_attempt_ts present and valid; attempts key entirely MISSING.
+        json.dumps({"attempts": {"483": {"last_attempt_ts": 1}}})
+    )
+    # Stale PM epoch (no updated_ts): the missing count must NOT bypass the
+    # attempt budget into a dispatch.
+    _write_drain_queue(isolated_registry, [483], updated_ts=None)
+    monkeypatch.setattr(asw.subprocess, "run", lambda *a, **k: pytest.fail("budget bypassed"))
+    asw.infra_drain_pass(dry_run=False, now=now, daemon_reachable=True)  # must not raise
+    captured = capsys.readouterr()
+    assert "missing its attempts key" in captured.out
+    assert "DISPATCHED" not in captured.out
+    # The loud first-time exhausted skip goes to stderr.
+    assert "attempts-exhausted" in captured.out + captured.err
+    state = json.loads((isolated_registry / "infra-drain-state.json").read_text())
+    assert state["attempts"]["483"]["attempts"] == INFRA_DRAIN_MAX_ATTEMPTS_DEFAULT
+    # Recovery path: a FRESH PM adjudication (updated_ts newer than the
+    # record's last_attempt_ts) resets the count via the same fresh-epoch
+    # branch the garbled-count sibling test pins — the normalized record
+    # parks the ID, it does not brick it. This also pins that the fix did
+    # NOT break the fresh-reset semantics for the missing-key shape.
+    _write_drain_queue(isolated_registry, [483])  # default updated_ts (2026) > 1
+    dispatched, _markers = _stub_drain_executor(
+        monkeypatch, status_kind={483: ("proposed", "infra")}, occupancy=[], real_dispatch=True
+    )
+    asw.infra_drain_pass(dry_run=False, now=now, daemon_reachable=True)
+    assert dispatched == [483]
+    state = json.loads((isolated_registry / "infra-drain-state.json").read_text())
+    assert state["attempts"]["483"]["attempts"] == 1  # fresh epoch reset
+
+
 def test_live_session_ids_or_none_shapes(monkeypatch):
     # Unit pin for the wrapper itself: a well-formed /list payload yields the
     # id set; a malformed payload or an unreachable daemon yields None
@@ -6069,6 +6113,82 @@ def test_live_session_ids_or_none_shapes(monkeypatch):
 
     monkeypatch.setattr("urllib.request.urlopen", _down)
     assert asw._live_session_ids_or_none() is None
+
+
+def test_live_session_ids_or_none_widens_exception_tuple(monkeypatch):
+    # Round-4 fix (CONCERN: urlopen-catch-tuple-too-narrow): the previous
+    # catch tuple (SystemExit, urllib.error.URLError, OSError,
+    # json.JSONDecodeError) crashed the whole infra-drain pass on two
+    # real daemon-flap shapes the original tuple missed:
+    #   (a) http.client.HTTPException (incl. IncompleteRead) when the
+    #       daemon hangs up mid-response-body — distinct from URLError,
+    #       which fires at connection setup.
+    #   (b) UnicodeDecodeError when the daemon emits invalid UTF-8 bytes —
+    #       json.JSONDecodeError is a ValueError subclass, NOT a
+    #       UnicodeDecodeError subclass, so the bytes read raises BEFORE
+    #       json.loads ever sees a string.
+    # Both must now return None (UNAVAILABLE — fail toward keep-blocking),
+    # the same fail direction as a clean URLError.
+    import http.client
+    import io
+    from contextlib import contextmanager
+
+    import autonomous_session_watch as asw
+
+    monkeypatch.setattr(spawn_session, "daemon_port", lambda: 65535)
+
+    # (a) http.client.IncompleteRead raised by urlopen itself: the response
+    # connection drops while urlopen is still establishing the body stream.
+    def _incomplete_read(*a, **k):
+        raise http.client.IncompleteRead(b"partial")
+
+    monkeypatch.setattr("urllib.request.urlopen", _incomplete_read)
+    assert asw._live_session_ids_or_none() is None  # must not crash
+
+    # (b) UnicodeDecodeError raised by json.load(s) on invalid UTF-8 bytes:
+    # urlopen returns a body whose decode trips before any JSON parsing.
+    class _BadBytes(io.BytesIO):
+        def read(self, *a, **k):
+            raise UnicodeDecodeError("utf-8", b"\xff\xfe", 0, 1, "invalid start byte")
+
+    @contextmanager
+    def _bad_utf8_urlopen(req, timeout=10):
+        yield _BadBytes(b"\xff\xfe")
+
+    monkeypatch.setattr("urllib.request.urlopen", _bad_utf8_urlopen)
+    assert asw._live_session_ids_or_none() is None  # must not crash
+
+
+def test_daemon_reachable_widens_exception_tuple(monkeypatch):
+    # Round-4 sibling pin for _daemon_reachable: same widened catch tuple,
+    # same fail direction (return False, NOT propagate). A daemon flap that
+    # raises http.client.HTTPException or UnicodeDecodeError must not crash
+    # the watcher's main() reachability probe (which would skip every pass
+    # that consumes the result).
+    import http.client
+    import io
+    from contextlib import contextmanager
+
+    import autonomous_session_watch as asw
+
+    monkeypatch.setattr(spawn_session, "daemon_port", lambda: 65535)
+
+    def _incomplete_read(*a, **k):
+        raise http.client.IncompleteRead(b"partial")
+
+    monkeypatch.setattr("urllib.request.urlopen", _incomplete_read)
+    assert asw._daemon_reachable() is False  # must not crash
+
+    class _BadBytes(io.BytesIO):
+        def read(self, *a, **k):
+            raise UnicodeDecodeError("utf-8", b"\xff\xfe", 0, 1, "invalid start byte")
+
+    @contextmanager
+    def _bad_utf8_urlopen(req, timeout=10):
+        yield _BadBytes(b"\xff\xfe")
+
+    monkeypatch.setattr("urllib.request.urlopen", _bad_utf8_urlopen)
+    assert asw._daemon_reachable() is False  # must not crash
 
 
 def test_infra_drain_malformed_child_keeps_blocking(isolated_registry, monkeypatch, capsys):

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -30,6 +30,9 @@ from autonomous_session_watch import (  # noqa: E402
     ACTIVE,
     ALERT_STALE_HOURS,
     AUTO_STOP_DONE,
+    INFRA_DRAIN_BACKOFF_S_DEFAULT,
+    INFRA_DRAIN_MAX_ATTEMPTS_DEFAULT,
+    INFRA_DRAIN_OCCUPIED_STATUSES,
     ORPHAN_MAX_RESPAWNS_PER_DAY_DEFAULT,
     ORPHAN_SPAWN_GRACE_S,
     ORPHAN_STALENESS_S_DEFAULT,
@@ -39,9 +42,13 @@ from autonomous_session_watch import (  # noqa: E402
     STALLED_WINDOW_S,
     TERMINAL,
     decide,
+    decide_infra_drain,
     decide_orphan,
     decide_pod_safety,
+    parse_infra_drain_queue,
 )
+
+from explore_persona_space.task_workflow import STATUSES  # noqa: E402
 
 
 @pytest.mark.parametrize("status", sorted(TERMINAL))
@@ -98,7 +105,6 @@ def test_status_sets_are_disjoint_and_cover_enum():
     # runtime can never produce, like the prior `clarifying` in PARK that
     # the reviewer caught). Mirrors the pod-safety pass's
     # `test_status_classes_subset_of_authoritative_enum`.
-    from explore_persona_space.task_workflow import STATUSES
 
     enum = set(STATUSES)
     assert ACTIVE.isdisjoint(PARK)
@@ -436,7 +442,6 @@ def test_status_classes_subset_of_authoritative_enum():
     # `followups_running` was later un-phantomed on 2026-06-10 — it joined the
     # runtime enum and POD_ACTIVE for the same-issue follow-up loop). This
     # pin catches that whole class of bug.
-    from explore_persona_space.task_workflow import STATUSES
 
     enum = set(STATUSES)
     assert enum >= AUTO_STOP_DONE, f"phantom AUTO_STOP_DONE members: {AUTO_STOP_DONE - enum}"
@@ -5197,3 +5202,648 @@ def test_gc_pass_never_touches_session_reaper_state_files(isolated_registry, mon
     asw.gc_pass(False, now=10 * asw.MAX_ENTRY_AGE_S)
 
     assert zombie.exists() and idle.exists()
+
+
+# ═══ infra-drain pass (execute the PM-adjudicated dispatch queue; #633) ══════
+#
+# Pure-decision tests run against decide_infra_drain / parse_infra_drain_queue
+# with zero filesystem/subprocess; executor tests use isolated_registry +
+# monkeypatch recorder stubs for _dispatch_infra_drain / _task_status_kind /
+# _infra_drain_occupancy / _post_progress_marker / _live_session_ids.
+
+_DRAIN_NOW = 1_800_000_000.0  # fixed epoch (2027-01); the live-file-shaped
+# updated_ts below parses to mid-2026, safely in the past (never clamped).
+
+
+def _decide_drain(
+    ids,
+    *,
+    cap=3,
+    holds=None,
+    statuses=None,
+    kinds=None,
+    registered=None,
+    occupied=0,
+    pending=0,
+    attempts=None,
+    now=_DRAIN_NOW,
+    updated_ts=None,
+    backoff_s=INFRA_DRAIN_BACKOFF_S_DEFAULT,
+    max_attempts=INFRA_DRAIN_MAX_ATTEMPTS_DEFAULT,
+):
+    """decide_infra_drain with eligible-by-default fixtures: every ID is
+    proposed/infra unless the test overrides the signal under test."""
+    statuses = statuses if statuses is not None else {i: "proposed" for i in ids}
+    kinds = kinds if kinds is not None else {i: "infra" for i in ids}
+    return decide_infra_drain(
+        ids,
+        cap,
+        holds or {},
+        statuses,
+        kinds,
+        registered or set(),
+        occupied,
+        pending,
+        attempts or {},
+        now,
+        updated_ts,
+        backoff_s=backoff_s,
+        max_attempts=max_attempts,
+    )
+
+
+def _write_drain_queue(reg_dir, ids, *, cap=3, holds=None, updated_ts="2026-06-12T22:40:00Z"):
+    import json
+
+    payload = {
+        "ripe_oldest_first": ids,
+        "cap": cap,
+        "holds": holds or {},
+        "updated_ts": updated_ts,
+        "updated_by": "pm-session-drain-tick",
+        "comment": "test fixture",
+    }
+    (reg_dir / "infra-drain-queue.json").write_text(json.dumps(payload))
+
+
+def _stub_drain_executor(monkeypatch, *, status_kind=None, occupancy=None, live=None):
+    """Stub every task.py/daemon-backed signal the executor consumes, and
+    return the dispatch + marker recorders."""
+    import autonomous_session_watch as asw
+
+    sk = status_kind or {}
+    monkeypatch.setattr(asw, "_task_status_kind", lambda i: sk.get(i, (None, None)))
+    monkeypatch.setattr(asw, "_infra_drain_occupancy", lambda: occupancy)
+    monkeypatch.setattr(asw, "_live_session_ids", lambda: live if live is not None else set())
+    dispatched: list[int] = []
+    monkeypatch.setattr(
+        asw, "_dispatch_infra_drain", lambda i, slot, dry: dispatched.append(i) or True
+    )
+    markers: list[tuple] = []
+    monkeypatch.setattr(
+        asw,
+        "_post_progress_marker",
+        lambda issue, note, dry, *, label: markers.append((issue, note, label)),
+    )
+    return dispatched, markers
+
+
+# ── pure decision matrix ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("held", [True, False])
+def test_infra_drain_held_ids_never_dispatch(held):
+    # AC-2a: a held ID is skipped with "held" even with free slots and
+    # proposed status; without the hold the same ID dispatches.
+    holds = {7: "needs-thomas"} if held else {}
+    dispatch, skipped = _decide_drain([7], holds=holds)
+    if held:
+        assert dispatch == [] and skipped == [(7, "held")]
+    else:
+        assert dispatch == [7] and skipped == []
+
+
+@pytest.mark.parametrize("status", [*sorted(set(STATUSES) - {"proposed"}), None])
+def test_infra_drain_non_proposed_never_dispatches(status):
+    # AC-2b: every non-proposed enum member (and an unreadable status) skips
+    # with the right reason; proposed dispatches.
+    dispatch, skipped = _decide_drain([7], statuses={7: status})
+    assert dispatch == []
+    expected = "status-unreadable" if status is None else f"status-{status}"
+    assert skipped == [(7, expected)]
+    assert _decide_drain([7]) == ([7], [])
+
+
+def test_infra_drain_registered_blocks_dispatch():
+    # AC-2c: an existing (non-stale) registration blocks dispatch.
+    dispatch, skipped = _decide_drain([7], registered={7})
+    assert dispatch == [] and skipped == [(7, "already-registered")]
+
+
+def test_infra_drain_cap_arithmetic():
+    # AC-2d: free = max(0, cap - occupied - pending); oldest-first order
+    # preserved (order is positional in ripe_oldest_first, not numeric).
+    ids = [40, 30, 20, 10]
+    dispatch, skipped = _decide_drain(ids, occupied=0)
+    assert dispatch == [40, 30, 20] and skipped == [(10, "cap-full")]
+    dispatch, skipped = _decide_drain(ids, occupied=2)
+    assert dispatch == [40] and [r for _, r in skipped] == ["cap-full"] * 3
+    assert _decide_drain(ids, occupied=3)[0] == []
+    assert _decide_drain(ids, cap=0)[0] == []
+    # occupied > cap must clamp at zero free, never go negative.
+    dispatch, skipped = _decide_drain(ids, occupied=5)
+    assert dispatch == [] and all(r == "cap-full" for _, r in skipped)
+
+
+def test_infra_drain_pending_registration_counts_toward_cap():
+    # A dispatched-but-still-proposed registration consumes a slot: occupied
+    # 2 + 1 pending under cap 3 leaves zero free for the next eligible ID.
+    dispatch, skipped = _decide_drain([7], occupied=2, pending=1)
+    assert dispatch == [] and skipped == [(7, "cap-full")]
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "{not json",  # non-JSON
+        "[1, 2]",  # JSON list at top level
+        '{"cap": 3}',  # missing ripe_oldest_first (the file's entire point)
+        '{"ripe_oldest_first": [1, "2"]}',  # non-int entry
+        '{"ripe_oldest_first": [true]}',  # bool entry
+        '{"ripe_oldest_first": [1], "cap": -1}',  # negative cap
+        '{"ripe_oldest_first": [1], "cap": "3"}',  # non-int cap
+        '{"ripe_oldest_first": [1], "cap": true}',  # bool cap
+        '{"ripe_oldest_first": [1], "holds": [1]}',  # non-dict holds
+        '{"ripe_oldest_first": [1], "holds": {"abc": "x"}}',  # unparseable hold key
+    ],
+)
+def test_parse_infra_drain_queue_invalid_inputs(raw):
+    # AC-2e (parse half): a garbled queue file must parse to None (the pass
+    # then no-ops) — never to a silently-corrected dict that could DISPATCH
+    # a held ID or invent a cap.
+    assert parse_infra_drain_queue(raw) is None
+
+
+def test_parse_infra_drain_queue_valid_inputs():
+    import json
+
+    # Missing cap -> default 3; missing holds -> empty; order-preserving
+    # dedup (first occurrence wins); unparseable updated_ts -> None.
+    q = parse_infra_drain_queue('{"ripe_oldest_first": [5, 3, 5]}')
+    assert q == {"ids": [5, 3], "cap": 3, "holds": {}, "updated_ts": None}
+    # Live-file-shaped input: string hold keys coerced to ints, ISO-8601 Z
+    # updated_ts parsed to an epoch float, extra fields ignored.
+    live = json.dumps(
+        {
+            "updated_ts": "2026-06-12T22:40:00Z",
+            "updated_by": "pm-session-drain-tick",
+            "comment": "c",
+            "ripe_oldest_first": [630, 631],
+            "cap": 3,
+            "holds": {"609": "needs-thomas", "449": "spend"},
+        }
+    )
+    q = parse_infra_drain_queue(live)
+    assert q["ids"] == [630, 631]
+    assert q["cap"] == 3
+    assert q["holds"] == {609: "needs-thomas", 449: "spend"}
+    assert isinstance(q["updated_ts"], float)
+
+
+def test_infra_drain_backoff_and_attempt_cap():
+    # The tight-loop guard (AC: a failed spawn is never retried every tick).
+    now = _DRAIN_NOW
+    # (a) within the window -> "backoff", ALWAYS — even when the PM epoch is
+    # newer than the last attempt (the window is never bypassed: the PM
+    # rewrites the file on EVERY STATUS pass).
+    attempts = {7: {"attempts": 3, "last_attempt_ts": now - 60.0}}
+    assert _decide_drain([7], attempts=attempts, updated_ts=now - 30.0) == (
+        [],
+        [(7, "backoff")],
+    )
+    # (b) past the window with the count exhausted and a STALE (or absent)
+    # PM epoch -> parked.
+    attempts = {7: {"attempts": 3, "last_attempt_ts": now - 7200.0}}
+    assert _decide_drain([7], attempts=attempts, updated_ts=now - 10_000.0) == (
+        [],
+        [(7, "attempts-exhausted")],
+    )
+    assert _decide_drain([7], attempts=attempts, updated_ts=None) == (
+        [],
+        [(7, "attempts-exhausted")],
+    )
+    # (c) past the window with a FRESH PM epoch -> the COUNT resets ->
+    # eligible again.
+    assert _decide_drain([7], attempts=attempts, updated_ts=now - 60.0) == ([7], [])
+    # (d) past the window, below the cap -> eligible.
+    attempts = {7: {"attempts": 2, "last_attempt_ts": now - 7200.0}}
+    assert _decide_drain([7], attempts=attempts, updated_ts=None) == ([7], [])
+
+
+def test_infra_drain_occupied_statuses_subset_of_enum():
+    # Kills phantom-status drift (mirrors
+    # test_status_classes_subset_of_authoritative_enum).
+    assert set(STATUSES) >= INFRA_DRAIN_OCCUPIED_STATUSES, (
+        f"phantom statuses: {INFRA_DRAIN_OCCUPIED_STATUSES - set(STATUSES)}"
+    )
+    # proposed/blocked/terminal must NOT hold drain slots.
+    assert {"proposed", "blocked", "completed", "archived", "awaiting_promotion"}.isdisjoint(
+        INFRA_DRAIN_OCCUPIED_STATUSES
+    )
+
+
+def test_infra_drain_sentinel_registered():
+    # A watcher-posted dispatch marker must never reset the orphan/stalled
+    # staleness clocks for the session it just spawned.
+    import autonomous_session_watch as asw
+
+    assert asw._INFRA_DRAIN_NOTE_SENTINEL in asw._WATCHER_NOTE_SENTINELS
+
+
+@pytest.mark.parametrize(
+    ("kind", "ok"),
+    [("infra", True), ("batch", True), ("experiment", False), ("campaign", False), (None, False)],
+)
+def test_infra_drain_kind_guard(kind, ok):
+    # A mis-queued experiment/campaign ID must never be spawned with --auto
+    # (it would auto-approve GPU spend AND sit outside the cap arithmetic).
+    dispatch, skipped = _decide_drain([7], kinds={7: kind})
+    if ok:
+        assert dispatch == [7] and skipped == []
+    else:
+        assert dispatch == []
+        assert skipped == [(7, f"kind-{kind or 'unreadable'}")]
+
+
+def test_infra_drain_future_updated_ts_clamped():
+    # A future PM epoch (tz confusion / LLM timestamp bug) must not void the
+    # attempt budget.
+    now = _DRAIN_NOW
+    future = now + 86_400.0
+    # Plan fixture: within the window the backoff binds regardless.
+    attempts = {7: {"attempts": 1, "last_attempt_ts": now - 60.0}}
+    assert _decide_drain([7], attempts=attempts, updated_ts=future) == ([], [(7, "backoff")])
+    # Discriminating fixture: past the window with the count exhausted, an
+    # UNCLAMPED future ts would read as a perpetual fresh adjudication and
+    # dispatch; the clamp parks it.
+    attempts = {7: {"attempts": 3, "last_attempt_ts": now - 7200.0}}
+    assert _decide_drain([7], attempts=attempts, updated_ts=future) == (
+        [],
+        [(7, "attempts-exhausted")],
+    )
+    # A ts within the tolerance window is NOT clamped (still a fresh epoch).
+    assert _decide_drain([7], attempts=attempts, updated_ts=now + 100.0) == ([7], [])
+
+
+def test_infra_drain_pending_conservative():
+    # The widened pending count: unreadable status/kind counts toward the cap
+    # (an unknown registered task might be a just-spawned infra task).
+    import autonomous_session_watch as asw
+
+    assert asw._infra_drain_pending({1: [{}]}, set(), {1: (None, None)}) == 1
+    # ... and the slot math then parks the next eligible ID.
+    dispatch, skipped = _decide_drain([2], occupied=2, pending=1)
+    assert dispatch == [] and skipped == [(2, "cap-full")]
+    # A NON-queue registration of a proposed infra task also counts (closes
+    # the PM-prunes-a-dispatched-ID overshoot).
+    assert asw._infra_drain_pending({99: [{}]}, set(), {99: ("proposed", "infra")}) == 1
+    # A registration at an occupied status does NOT double-count (it is
+    # already in occupied_active); terminal/blocked count zero.
+    assert asw._infra_drain_pending({99: [{}]}, set(), {99: ("running", "infra")}) == 0
+    assert asw._infra_drain_pending({99: [{}]}, set(), {99: ("blocked", "infra")}) == 0
+    # A stale registration stops pinning a slot.
+    assert asw._infra_drain_pending({99: [{}]}, {99}, {99: ("proposed", "infra")}) == 0
+    # A proposed non-drain-kind registration counts zero.
+    assert asw._infra_drain_pending({99: [{}]}, set(), {99: ("proposed", "experiment")}) == 0
+
+
+def test_infra_drain_stale_registration(isolated_registry, monkeypatch, capsys):
+    # Dead-at-boot handling: a stale registration stops pinning a pending
+    # slot and stops blocking re-dispatch; ANY missing signal -> NOT stale.
+    import json
+
+    import autonomous_session_watch as asw
+
+    now = _DRAIN_NOW
+    grace = 1800.0
+    full = {"happy_session_id": "sid-x", "spawned_at": now - 3600.0}
+    assert asw._infra_drain_stale(full, {"other"}, "proposed", now, grace) is True
+    # Missing/uncertain signals all fail toward NOT stale (keep blocking):
+    assert asw._infra_drain_stale(full, None, "proposed", now, grace) is False  # liveness n/a
+    assert asw._infra_drain_stale(full, {"sid-x"}, "proposed", now, grace) is False  # live
+    assert asw._infra_drain_stale(full, {"other"}, "running", now, grace) is False  # not proposed
+    assert asw._infra_drain_stale(full, {"other"}, None, now, grace) is False  # status n/a
+    no_spawned = {"happy_session_id": "sid-x"}
+    assert asw._infra_drain_stale(no_spawned, {"other"}, "proposed", now, grace) is False
+    no_sid = {"spawned_at": now - 3600.0}
+    assert asw._infra_drain_stale(no_sid, {"other"}, "proposed", now, grace) is False
+    young = {"happy_session_id": "sid-x", "spawned_at": now - 60.0}
+    assert asw._infra_drain_stale(young, {"other"}, "proposed", now, grace) is False
+    # Executor half: the stale registration no longer pins pending and the
+    # ID is re-dispatched — even when it is the ONLY queue ID (the raw
+    # pre-filter would otherwise park it forever via the early exit).
+    _write_drain_queue(isolated_registry, [483])
+    (isolated_registry / "issue-483.json").write_text(
+        json.dumps({"issue": 483, "happy_session_id": "sid-dead", "spawned_at": now - 3600.0})
+    )
+    dispatched, _markers = _stub_drain_executor(
+        monkeypatch,
+        status_kind={483: ("proposed", "infra")},
+        occupancy=[],
+        live={"sid-live"},
+    )
+    asw.infra_drain_pass(dry_run=False, now=now, daemon_reachable=True)
+    assert dispatched == [483]
+    out = capsys.readouterr().out
+    assert "STALE registration for issue #483" in out
+    assert "(+0 pending)" in out
+
+
+# ── executor (I/O) tests ──────────────────────────────────────────────────────
+
+
+def test_infra_drain_pass_missing_or_invalid_file_is_noop(isolated_registry, monkeypatch, capsys):
+    # AC-2e (executor half): missing or garbled queue file -> logged no-op —
+    # zero dispatches, zero task.py reads, no state file created.
+    import autonomous_session_watch as asw
+
+    calls: list[int] = []
+    monkeypatch.setattr(asw, "_dispatch_infra_drain", lambda i, slot, dry: calls.append(i) or True)
+    monkeypatch.setattr(
+        asw, "_task_status_kind", lambda i: pytest.fail("task.py read on a no-op tick")
+    )
+    monkeypatch.setattr(
+        asw, "_infra_drain_occupancy", lambda: pytest.fail("occupancy read on a no-op tick")
+    )
+    asw.infra_drain_pass(dry_run=False, daemon_reachable=True)
+    assert "no queue file" in capsys.readouterr().out
+    (isolated_registry / "infra-drain-queue.json").write_text("{torn write")
+    asw.infra_drain_pass(dry_run=False, daemon_reachable=True)
+    assert "INVALID queue file" in capsys.readouterr().out
+    assert calls == []
+    assert not (isolated_registry / "infra-drain-state.json").exists()
+
+
+def test_infra_drain_kill_switch(isolated_registry, monkeypatch, capsys):
+    # AC-2f: EPM_DISABLE_INFRA_DRAIN=1 disables the pass before it even
+    # reads the queue file.
+    import autonomous_session_watch as asw
+
+    monkeypatch.setenv("EPM_DISABLE_INFRA_DRAIN", "1")
+    assert asw._infra_drain_enabled() is False
+    monkeypatch.setattr(
+        asw, "_infra_drain_queue_path", lambda: pytest.fail("queue read despite kill switch")
+    )
+    asw.infra_drain_pass(dry_run=False, daemon_reachable=True)
+    assert "disabled via EPM_DISABLE_INFRA_DRAIN" in capsys.readouterr().out
+    monkeypatch.setenv("EPM_DISABLE_INFRA_DRAIN", "0")
+    assert asw._infra_drain_enabled() is True
+    monkeypatch.delenv("EPM_DISABLE_INFRA_DRAIN")
+    assert asw._infra_drain_enabled() is True
+
+
+def test_infra_drain_pass_end_to_end_smoke(isolated_registry, monkeypatch, capsys):
+    # Live-shaped queue + stubbed signals: exactly one dispatch for the
+    # oldest eligible ID, attempt state written atomically, stale state entry
+    # pruned, summary/skip lines printed.
+    import json
+
+    import autonomous_session_watch as asw
+
+    now = _DRAIN_NOW
+    _write_drain_queue(isolated_registry, [483, 615, 630, 631], holds={"631": "needs-thomas"})
+    (isolated_registry / "infra-drain-state.json").write_text(
+        json.dumps(
+            {
+                "attempts": {
+                    "999": {
+                        "attempts": 2,
+                        "last_attempt_ts": now - 50_000.0,
+                        "last_result": "spawn-failed",
+                        "exhausted_logged": False,
+                    }
+                }
+            }
+        )
+    )
+    dispatched, markers = _stub_drain_executor(
+        monkeypatch,
+        status_kind={
+            483: ("proposed", "infra"),
+            615: ("proposed", "infra"),
+            630: ("planning", "infra"),
+        },
+        occupancy=[700, 701],
+    )
+    asw.infra_drain_pass(dry_run=False, now=now, daemon_reachable=True)
+    # occupied 2 + pending 0 under cap 3 -> exactly one free slot -> the
+    # oldest eligible ID (483) and nothing else.
+    assert dispatched == [483]
+    assert len(markers) == 1 and markers[0][0] == 483
+    assert asw._INFRA_DRAIN_NOTE_SENTINEL in markers[0][1]
+    state = json.loads((isolated_registry / "infra-drain-state.json").read_text())
+    assert state["attempts"]["483"]["attempts"] == 1
+    assert state["attempts"]["483"]["last_attempt_ts"] == now
+    assert state["attempts"]["483"]["last_result"] == "dispatched"
+    assert "999" not in state["attempts"]  # pruned: the ID left the queue
+    out = capsys.readouterr().out
+    assert "INFRA-DRAIN SKIP issue #631 (held: needs-thomas)" in out
+    assert "INFRA-DRAIN SKIP issue #630 (status-planning)" in out
+    assert "INFRA-DRAIN SKIP issue #615 (cap-full)" in out
+    assert "queue=4 occupied=2(+0 pending) cap=3 dispatched=1 skipped=3" in out
+    assert "occupying=[700, 701]" in out  # slot-jam diagnosable from the log
+
+
+def test_infra_drain_dry_run_no_mutation(isolated_registry, monkeypatch, capsys):
+    # The live smoke's safety depends on this: dry-run decides + logs but
+    # never spawns, never posts a marker, never writes state.
+    import autonomous_session_watch as asw
+
+    now = _DRAIN_NOW
+    _write_drain_queue(isolated_registry, [483])
+    sk = {483: ("proposed", "infra")}
+    monkeypatch.setattr(asw, "_task_status_kind", lambda i: sk.get(i, (None, None)))
+    monkeypatch.setattr(asw, "_infra_drain_occupancy", lambda: [])
+    monkeypatch.setattr(asw, "_live_session_ids", lambda: set())
+    markers: list[tuple] = []
+    monkeypatch.setattr(asw, "_post_progress_marker", lambda *a, **k: markers.append((a, k)))
+    monkeypatch.setattr(
+        asw.subprocess, "run", lambda *a, **k: pytest.fail("subprocess.run called in dry-run")
+    )
+    asw.infra_drain_pass(dry_run=True, now=now, daemon_reachable=True)
+    out = capsys.readouterr().out
+    assert "[dry-run] would dispatch infra-drain" in out
+    assert markers == []  # a dry-run dispatch returns False -> no marker
+    assert not (isolated_registry / "infra-drain-state.json").exists()
+    # The dispatch helper itself honours dry_run before any subprocess.
+    assert asw._dispatch_infra_drain(483, "slot 1/3", dry_run=True) is False
+
+
+def test_infra_drain_occupancy_none_skips_dispatch(isolated_registry, monkeypatch, capsys):
+    # Fail-CLOSED: a partial occupancy read would UNDER-count and
+    # over-dispatch past the cap, so None skips dispatching this tick
+    # (state is still pruned + saved). Pins against the one-character
+    # `or 0` inversion.
+    import json
+
+    import autonomous_session_watch as asw
+
+    now = _DRAIN_NOW
+    _write_drain_queue(isolated_registry, [483])
+    (isolated_registry / "infra-drain-state.json").write_text(
+        json.dumps({"attempts": {"999": {"attempts": 1, "last_attempt_ts": now - 50_000.0}}})
+    )
+    dispatched, _markers = _stub_drain_executor(
+        monkeypatch, status_kind={483: ("proposed", "infra")}, occupancy=None
+    )
+    asw.infra_drain_pass(dry_run=False, now=now, daemon_reachable=True)
+    assert dispatched == []
+    out = capsys.readouterr().out
+    assert "occupancy read FAILED" in out and "fail-closed" in out
+    state = json.loads((isolated_registry / "infra-drain-state.json").read_text())
+    assert state == {"attempts": {}}  # pruned (999 left the queue) + saved
+
+
+def test_infra_drain_failed_spawn_records_attempt(isolated_registry, monkeypatch, capsys):
+    # The tight-loop guard's executor half: a FAILED spawn still consumes an
+    # attempt + arms the backoff window, so the next tick skips.
+    import json
+
+    import autonomous_session_watch as asw
+
+    now = _DRAIN_NOW
+    _write_drain_queue(isolated_registry, [483])
+    sk = {483: ("proposed", "infra")}
+    monkeypatch.setattr(asw, "_task_status_kind", lambda i: sk.get(i, (None, None)))
+    monkeypatch.setattr(asw, "_infra_drain_occupancy", lambda: [])
+    monkeypatch.setattr(asw, "_live_session_ids", lambda: set())
+    monkeypatch.setattr(asw, "_post_progress_marker", lambda *a, **k: None)
+    calls: list[int] = []
+    monkeypatch.setattr(asw, "_dispatch_infra_drain", lambda i, slot, dry: calls.append(i) or False)
+    asw.infra_drain_pass(dry_run=False, now=now, daemon_reachable=True)
+    assert calls == [483]
+    rec = json.loads((isolated_registry / "infra-drain-state.json").read_text())["attempts"]["483"]
+    assert rec["attempts"] == 1
+    assert rec["last_attempt_ts"] == now
+    assert rec["last_result"] == "spawn-failed"
+    # Second pass 60 s later (within the 1 h window): backoff skip, no
+    # second dispatch call.
+    asw.infra_drain_pass(dry_run=False, now=now + 60.0, daemon_reachable=True)
+    assert calls == [483]
+    assert "INFRA-DRAIN SKIP issue #483 (backoff)" in capsys.readouterr().out
+
+
+def test_infra_drain_main_wiring(isolated_registry, monkeypatch):
+    # --infra-drain-only alone cannot certify production wiring: pin that
+    # main() calls infra_drain_pass exactly once, after orphan_sweep_pass,
+    # before session_reconcile_pass, with the SAME reused daemon_reachable.
+    import autonomous_session_watch as asw
+
+    order: list[tuple[str, dict]] = []
+
+    def rec(name):
+        return lambda *a, **kw: order.append((name, kw))
+
+    monkeypatch.setattr(asw, "_daemon_reachable", lambda: True)
+    monkeypatch.setattr(asw, "_live_session_ids", lambda: set())
+    monkeypatch.setattr(asw, "_live_children", lambda: [])
+    for pass_name in (
+        "vm_disk_pass",
+        "campaign_pass",
+        "pod_safety_pass",
+        "stalled_session_pass",
+        "orphan_sweep_pass",
+        "infra_drain_pass",
+        "session_reconcile_pass",
+        "gate_push_pass",
+        "zombie_wrapper_pass",
+        "idle_unmapped_pass",
+        "gc_pass",
+    ):
+        monkeypatch.setattr(asw, pass_name, rec(pass_name))
+
+    rc = asw.main([])
+
+    assert rc == 0
+    names = [n for n, _ in order]
+    assert names.count("infra_drain_pass") == 1
+    assert (
+        names.index("orphan_sweep_pass")
+        < names.index("infra_drain_pass")
+        < names.index("session_reconcile_pass")
+    )
+    infra_kw = next(kw for n, kw in order if n == "infra_drain_pass")
+    assert infra_kw["daemon_reachable"] is True
+
+
+def test_infra_drain_registered_blocks_dispatch_executor(isolated_registry, monkeypatch, capsys):
+    # REAL registration files (autonomous + manual) under the registry dir
+    # block dispatch AND count toward pending — a broken
+    # _infra_drain_registrations could not be caught by the pure-function
+    # test alone.
+    import json
+
+    import autonomous_session_watch as asw
+
+    now = _DRAIN_NOW
+    _write_drain_queue(isolated_registry, [483, 615, 630])
+    (isolated_registry / "issue-483.json").write_text(
+        json.dumps(
+            {"issue": 483, "happy_session_id": "sid-483", "spawned_at": now - 60.0, "missed": 0}
+        )
+    )
+    (isolated_registry / "manual-issue-615.json").write_text(
+        json.dumps(
+            {
+                "issue": 615,
+                "happy_session_id": "sid-615",
+                "spawned_at": now - 60.0,
+                "mode": "manual",
+            }
+        )
+    )
+    dispatched, _markers = _stub_drain_executor(
+        monkeypatch,
+        status_kind={
+            483: ("proposed", "infra"),
+            615: ("proposed", "infra"),
+            630: ("proposed", "infra"),
+        },
+        occupancy=[],
+    )
+    asw.infra_drain_pass(dry_run=False, now=now, daemon_reachable=True)
+    assert dispatched == [630]
+    out = capsys.readouterr().out
+    assert "INFRA-DRAIN SKIP issue #483 (already-registered)" in out
+    assert "INFRA-DRAIN SKIP issue #615 (already-registered)" in out
+    assert "occupied=0(+2 pending)" in out  # both registrations pin slots
+
+
+def test_infra_drain_prefilter_agrees_with_decide(isolated_registry, monkeypatch):
+    # Single-source-of-truth check: an exhausted record + a NEWER PM
+    # updated_ts (past the backoff window) must survive the cheap pre-filter
+    # and reach dispatch — a drifted re-implementation of the guards in the
+    # pre-filter would park it forever.
+    import json
+    from datetime import UTC, datetime
+
+    import autonomous_session_watch as asw
+
+    now = _DRAIN_NOW
+    iso = datetime.fromtimestamp(now - 60.0, tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    _write_drain_queue(isolated_registry, [483], updated_ts=iso)
+    (isolated_registry / "infra-drain-state.json").write_text(
+        json.dumps(
+            {
+                "attempts": {
+                    "483": {
+                        "attempts": 3,
+                        "last_attempt_ts": now - 7200.0,
+                        "last_result": "spawn-failed",
+                        "exhausted_logged": True,
+                    }
+                }
+            }
+        )
+    )
+    dispatched, _markers = _stub_drain_executor(
+        monkeypatch, status_kind={483: ("proposed", "infra")}, occupancy=[]
+    )
+    asw.infra_drain_pass(dry_run=False, now=now, daemon_reachable=True)
+    assert dispatched == [483]
+    state = json.loads((isolated_registry / "infra-drain-state.json").read_text())
+    assert state["attempts"]["483"]["attempts"] == 1  # fresh epoch reset the COUNT
+
+
+def test_infra_drain_prespawn_recheck_aborts(isolated_registry, monkeypatch, capsys):
+    # The double-spawn race shrinker: a registration that appeared between
+    # the decision and the spawn aborts BEFORE the subprocess.
+    import autonomous_session_watch as asw
+
+    (isolated_registry / "issue-42.json").write_text("{}")
+    monkeypatch.setattr(
+        asw.subprocess, "run", lambda *a, **k: pytest.fail("spawned despite a lost race")
+    )
+    ok = asw._dispatch_infra_drain(42, "slot 1/3", dry_run=False)
+    assert ok is False
+    assert "lost race to concurrent dispatcher" in capsys.readouterr().out

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -5266,19 +5266,40 @@ def _write_drain_queue(reg_dir, ids, *, cap=3, holds=None, updated_ts="2026-06-1
     (reg_dir / "infra-drain-queue.json").write_text(json.dumps(payload))
 
 
-def _stub_drain_executor(monkeypatch, *, status_kind=None, occupancy=None, live=None):
+def _stub_drain_executor(
+    monkeypatch, *, status_kind=None, occupancy=None, live=None, real_dispatch=False
+):
     """Stub every task.py/daemon-backed signal the executor consumes, and
-    return the dispatch + marker recorders."""
+    return the dispatch + marker recorders. ``live`` feeds the drain path's
+    ``_live_session_ids_or_none`` (``None`` here means "daemon up, zero
+    sessions" — pass-through tests that want the UNAVAILABLE shape patch the
+    wrapper themselves). ``real_dispatch=True`` keeps the REAL
+    ``_dispatch_infra_drain`` (incl. its pre-spawn registration re-check) and
+    stubs only ``subprocess.run`` — pinning the dispatch path end-to-end
+    (round-1 Critical: a stubbed dispatch masked the re-check aborting every
+    stale-registration re-dispatch)."""
     import autonomous_session_watch as asw
 
     sk = status_kind or {}
     monkeypatch.setattr(asw, "_task_status_kind", lambda i: sk.get(i, (None, None)))
     monkeypatch.setattr(asw, "_infra_drain_occupancy", lambda: occupancy)
-    monkeypatch.setattr(asw, "_live_session_ids", lambda: live if live is not None else set())
-    dispatched: list[int] = []
     monkeypatch.setattr(
-        asw, "_dispatch_infra_drain", lambda i, slot, dry: dispatched.append(i) or True
+        asw, "_live_session_ids_or_none", lambda: live if live is not None else set()
     )
+    dispatched: list[int] = []
+    if real_dispatch:
+        from types import SimpleNamespace
+
+        def _fake_run(cmd, **kw):
+            assert cmd[3] == "scripts/spawn_session.py" and "spawn-issue" in cmd
+            dispatched.append(int(cmd[cmd.index("--issue") + 1]))
+            return SimpleNamespace(returncode=0, stdout="spawned sid-new\n", stderr="")
+
+        monkeypatch.setattr(asw.subprocess, "run", _fake_run)
+    else:
+        monkeypatch.setattr(
+            asw, "_dispatch_infra_drain", lambda i, slot, dry, **kw: dispatched.append(i) or True
+        )
     markers: list[tuple] = []
     monkeypatch.setattr(
         asw,
@@ -5519,9 +5540,13 @@ def test_infra_drain_stale_registration(isolated_registry, monkeypatch, capsys):
     assert asw._infra_drain_stale(no_sid, {"other"}, "proposed", now, grace) is False
     young = {"happy_session_id": "sid-x", "spawned_at": now - 60.0}
     assert asw._infra_drain_stale(young, {"other"}, "proposed", now, grace) is False
-    # Executor half: the stale registration no longer pins pending and the
-    # ID is re-dispatched — even when it is the ONLY queue ID (the raw
-    # pre-filter would otherwise park it forever via the early exit).
+    # Executor half — THROUGH THE REAL _dispatch_infra_drain (round-1
+    # Critical: a stubbed dispatch masked the pre-spawn re-check aborting on
+    # the stale registration's own file; only subprocess.run is stubbed, so
+    # the decide -> re-check -> spawn conjunction is what's pinned): the
+    # stale registration no longer pins pending and the ID is re-dispatched
+    # — even when it is the ONLY queue ID (the raw pre-filter would
+    # otherwise park it forever via the early exit).
     _write_drain_queue(isolated_registry, [483])
     (isolated_registry / "issue-483.json").write_text(
         json.dumps({"issue": 483, "happy_session_id": "sid-dead", "spawned_at": now - 3600.0})
@@ -5531,12 +5556,17 @@ def test_infra_drain_stale_registration(isolated_registry, monkeypatch, capsys):
         status_kind={483: ("proposed", "infra")},
         occupancy=[],
         live={"sid-live"},
+        real_dispatch=True,
     )
     asw.infra_drain_pass(dry_run=False, now=now, daemon_reachable=True)
-    assert dispatched == [483]
+    assert dispatched == [483]  # the spawn subprocess actually ran
     out = capsys.readouterr().out
     assert "STALE registration for issue #483" in out
     assert "(+0 pending)" in out
+    assert "INFRA-DRAIN DISPATCHED issue #483" in out
+    assert "INFRA-DRAIN ABORT" not in out  # the known-stale file must not abort
+    state = json.loads((isolated_registry / "infra-drain-state.json").read_text())
+    assert state["attempts"]["483"]["last_result"] == "dispatched"
 
 
 # ── executor (I/O) tests ──────────────────────────────────────────────────────
@@ -5548,7 +5578,9 @@ def test_infra_drain_pass_missing_or_invalid_file_is_noop(isolated_registry, mon
     import autonomous_session_watch as asw
 
     calls: list[int] = []
-    monkeypatch.setattr(asw, "_dispatch_infra_drain", lambda i, slot, dry: calls.append(i) or True)
+    monkeypatch.setattr(
+        asw, "_dispatch_infra_drain", lambda i, slot, dry, **kw: calls.append(i) or True
+    )
     monkeypatch.setattr(
         asw, "_task_status_kind", lambda i: pytest.fail("task.py read on a no-op tick")
     )
@@ -5644,7 +5676,7 @@ def test_infra_drain_dry_run_no_mutation(isolated_registry, monkeypatch, capsys)
     sk = {483: ("proposed", "infra")}
     monkeypatch.setattr(asw, "_task_status_kind", lambda i: sk.get(i, (None, None)))
     monkeypatch.setattr(asw, "_infra_drain_occupancy", lambda: [])
-    monkeypatch.setattr(asw, "_live_session_ids", lambda: set())
+    monkeypatch.setattr(asw, "_live_session_ids_or_none", lambda: set())
     markers: list[tuple] = []
     monkeypatch.setattr(asw, "_post_progress_marker", lambda *a, **k: markers.append((a, k)))
     monkeypatch.setattr(
@@ -5696,10 +5728,12 @@ def test_infra_drain_failed_spawn_records_attempt(isolated_registry, monkeypatch
     sk = {483: ("proposed", "infra")}
     monkeypatch.setattr(asw, "_task_status_kind", lambda i: sk.get(i, (None, None)))
     monkeypatch.setattr(asw, "_infra_drain_occupancy", lambda: [])
-    monkeypatch.setattr(asw, "_live_session_ids", lambda: set())
+    monkeypatch.setattr(asw, "_live_session_ids_or_none", lambda: set())
     monkeypatch.setattr(asw, "_post_progress_marker", lambda *a, **k: None)
     calls: list[int] = []
-    monkeypatch.setattr(asw, "_dispatch_infra_drain", lambda i, slot, dry: calls.append(i) or False)
+    monkeypatch.setattr(
+        asw, "_dispatch_infra_drain", lambda i, slot, dry, **kw: calls.append(i) or False
+    )
     asw.infra_drain_pass(dry_run=False, now=now, daemon_reachable=True)
     assert calls == [483]
     rec = json.loads((isolated_registry / "infra-drain-state.json").read_text())["attempts"]["483"]
@@ -5836,14 +5870,163 @@ def test_infra_drain_prefilter_agrees_with_decide(isolated_registry, monkeypatch
 
 
 def test_infra_drain_prespawn_recheck_aborts(isolated_registry, monkeypatch, capsys):
-    # The double-spawn race shrinker: a registration that appeared between
-    # the decision and the spawn aborts BEFORE the subprocess.
+    # The double-spawn race shrinker, now snapshot-aware (round-2 fix #1):
+    # abort ONLY when a registration APPEARED or CHANGED since the
+    # decision-time snapshot; a byte-identical (known-stale) registration
+    # proceeds to the spawn.
+    from types import SimpleNamespace
+
     import autonomous_session_watch as asw
 
-    (isolated_registry / "issue-42.json").write_text("{}")
+    stale_bytes = b'{"issue": 42, "happy_session_id": "sid-dead"}'
+    (isolated_registry / "issue-42.json").write_bytes(stale_bytes)
     monkeypatch.setattr(
         asw.subprocess, "run", lambda *a, **k: pytest.fail("spawned despite a lost race")
     )
+    # (a) APPEARED: no snapshot context (direct call) -> any existing file
+    # is a genuinely-new registration -> abort before the subprocess.
     ok = asw._dispatch_infra_drain(42, "slot 1/3", dry_run=False)
     assert ok is False
-    assert "lost race to concurrent dispatcher" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "lost race to concurrent dispatcher" in out and "appeared" in out
+    # (a') APPEARED relative to an explicit snapshot that lacked the file.
+    ok = asw._dispatch_infra_drain(42, "slot 1/3", dry_run=False, reg_snapshot={})
+    assert ok is False
+    assert "appeared" in capsys.readouterr().out
+    # (b) CHANGED: the decision saw OTHER bytes (e.g. a concurrent PM spawn
+    # overwrote the stale entry between decide and dispatch) -> abort.
+    ok = asw._dispatch_infra_drain(
+        42, "slot 1/3", dry_run=False, reg_snapshot={"issue-42.json": b'{"old": true}'}
+    )
+    assert ok is False
+    assert "changed" in capsys.readouterr().out
+    # (c) BYTE-IDENTICAL: the file IS the known-stale registration the
+    # decision already classified -> proceed (spawn_session overwrites it on
+    # success). The round-1 bug aborted here, wedging the ID forever.
+    spawned: list[list] = []
+    monkeypatch.setattr(
+        asw.subprocess,
+        "run",
+        lambda cmd, **k: (
+            spawned.append(cmd) or SimpleNamespace(returncode=0, stdout="ok\n", stderr="")
+        ),
+    )
+    ok = asw._dispatch_infra_drain(
+        42, "slot 1/3", dry_run=False, reg_snapshot={"issue-42.json": stale_bytes}
+    )
+    assert ok is True
+    assert len(spawned) == 1 and "--issue" in spawned[0]
+    assert "INFRA-DRAIN DISPATCHED issue #42" in capsys.readouterr().out
+
+
+def test_infra_drain_liveness_unavailable_keeps_blocking(isolated_registry, monkeypatch, capsys):
+    # Round-2 fix #2 (concern live-session-ids-empty-on-daemon-flap): a
+    # daemon flap AFTER main()'s reachability probe must read as liveness
+    # UNAVAILABLE (None -> nothing stale -> keep blocking), never as "zero
+    # live sessions" (-> false-stale -> double-spawn). Exercises the REAL
+    # _live_session_ids_or_none with the real unavailable shape: the /list
+    # POST raises after daemon_reachable=True was already cached.
+    import json
+    import urllib.error
+
+    import autonomous_session_watch as asw
+
+    monkeypatch.setattr(spawn_session, "daemon_port", lambda: 65535)
+
+    def _refused(*a, **k):
+        raise urllib.error.URLError("connection refused (flap after the probe)")
+
+    monkeypatch.setattr("urllib.request.urlopen", _refused)
+    assert asw._live_session_ids_or_none() is None  # unavailable, NOT set()
+
+    now = _DRAIN_NOW
+    _write_drain_queue(isolated_registry, [483])
+    # An old (grace-aged) registration for a still-proposed task — the
+    # false-stale candidate the flap would have re-dispatched.
+    (isolated_registry / "issue-483.json").write_text(
+        json.dumps({"issue": 483, "happy_session_id": "sid-x", "spawned_at": now - 3600.0})
+    )
+    monkeypatch.setattr(
+        asw, "_task_status_kind", lambda i: pytest.fail("task.py read despite liveness-unavailable")
+    )
+    monkeypatch.setattr(asw.subprocess, "run", lambda *a, **k: pytest.fail("double-spawned #483"))
+    asw.infra_drain_pass(dry_run=False, now=now, daemon_reachable=True)
+    out = capsys.readouterr().out
+    assert "INFRA-DRAIN SKIP issue #483 (already-registered)" in out
+    assert "STALE registration" not in out
+    assert "DISPATCHED" not in out
+
+
+def test_infra_drain_garbled_attempts_state_fails_safe(isolated_registry, monkeypatch, capsys):
+    # Round-2 fix #3 (Codex Major): a state record with numeric
+    # last_attempt_ts but a garbled attempts count must not crash the pass
+    # (int("bad")+1 / "bad" >= max_attempts both raised) and must fail toward
+    # NOT dispatching — the count is normalized UP to the attempt cap, so the
+    # record's budget reads exhausted until a fresh PM updated_ts resets it.
+    import json
+
+    import autonomous_session_watch as asw
+
+    now = _DRAIN_NOW
+    (isolated_registry / "infra-drain-state.json").write_text(
+        json.dumps({"attempts": {"483": {"attempts": "bad", "last_attempt_ts": 1}}})
+    )
+    # Stale PM epoch (no updated_ts): the unknown count must NOT bypass the
+    # attempt budget into a dispatch.
+    _write_drain_queue(isolated_registry, [483], updated_ts=None)
+    monkeypatch.setattr(asw.subprocess, "run", lambda *a, **k: pytest.fail("budget bypassed"))
+    asw.infra_drain_pass(dry_run=False, now=now, daemon_reachable=True)  # must not raise
+    captured = capsys.readouterr()
+    assert "garbled attempts count ('bad')" in captured.out
+    assert "DISPATCHED" not in captured.out
+    # The loud first-time exhausted skip goes to stderr.
+    assert "attempts-exhausted" in captured.out + captured.err
+    state = json.loads((isolated_registry / "infra-drain-state.json").read_text())
+    assert state["attempts"]["483"]["attempts"] == INFRA_DRAIN_MAX_ATTEMPTS_DEFAULT
+    # Recovery path: a FRESH PM adjudication (updated_ts newer than the
+    # record's last_attempt_ts) resets the count — the normalized record
+    # parks the ID, it does not brick it.
+    _write_drain_queue(isolated_registry, [483])  # default updated_ts (2026) > 1
+    dispatched, _markers = _stub_drain_executor(
+        monkeypatch, status_kind={483: ("proposed", "infra")}, occupancy=[], real_dispatch=True
+    )
+    asw.infra_drain_pass(dry_run=False, now=now, daemon_reachable=True)
+    assert dispatched == [483]
+    state = json.loads((isolated_registry / "infra-drain-state.json").read_text())
+    assert state["attempts"]["483"]["attempts"] == 1  # fresh epoch reset
+
+
+def test_live_session_ids_or_none_shapes(monkeypatch):
+    # Unit pin for the wrapper itself: a well-formed /list payload yields the
+    # id set; a malformed payload or an unreachable daemon yields None
+    # (UNAVAILABLE), never an empty set.
+    import io
+    import urllib.error
+    from contextlib import contextmanager
+
+    import autonomous_session_watch as asw
+
+    monkeypatch.setattr(spawn_session, "daemon_port", lambda: 65535)
+
+    def _responding(payload: bytes):
+        @contextmanager
+        def _fake_urlopen(req, timeout=10):
+            yield io.BytesIO(payload)
+
+        return _fake_urlopen
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        _responding(b'{"children": [{"happySessionId": "sid-1"}, "junk"]}'),
+    )
+    assert asw._live_session_ids_or_none() == {"sid-1"}
+    monkeypatch.setattr("urllib.request.urlopen", _responding(b'{"children": []}'))
+    assert asw._live_session_ids_or_none() == set()  # confirmed zero sessions
+    monkeypatch.setattr("urllib.request.urlopen", _responding(b'{"no-children-key": 1}'))
+    assert asw._live_session_ids_or_none() is None  # malformed -> unavailable
+
+    def _down(*a, **k):
+        raise urllib.error.URLError("daemon down")
+
+    monkeypatch.setattr("urllib.request.urlopen", _down)
+    assert asw._live_session_ids_or_none() is None

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -5999,7 +5999,12 @@ def test_infra_drain_garbled_attempts_state_fails_safe(isolated_registry, monkey
 def test_live_session_ids_or_none_shapes(monkeypatch):
     # Unit pin for the wrapper itself: a well-formed /list payload yields the
     # id set; a malformed payload or an unreachable daemon yields None
-    # (UNAVAILABLE), never an empty set.
+    # (UNAVAILABLE), never an empty set. A dict child carrying an invalid
+    # ``happySessionId`` (missing/None/empty/non-str) is the same shape as a
+    # missing ``children`` list — UNAVAILABLE, never ``{None}`` (round-3 fix
+    # for the reconciler-flagged double-spawn class: a stray ``{None}`` set
+    # would slip past the ``is None`` guard in :func:`_infra_drain_stale`
+    # and make every real-string sid look NOT live).
     import io
     import urllib.error
     from contextlib import contextmanager
@@ -6019,14 +6024,97 @@ def test_live_session_ids_or_none_shapes(monkeypatch):
         "urllib.request.urlopen",
         _responding(b'{"children": [{"happySessionId": "sid-1"}, "junk"]}'),
     )
+    # Non-dict child ("junk") is skipped, NOT a contract violation — the
+    # well-formed dict still contributes its sid.
     assert asw._live_session_ids_or_none() == {"sid-1"}
     monkeypatch.setattr("urllib.request.urlopen", _responding(b'{"children": []}'))
     assert asw._live_session_ids_or_none() == set()  # confirmed zero sessions
     monkeypatch.setattr("urllib.request.urlopen", _responding(b'{"no-children-key": 1}'))
     assert asw._live_session_ids_or_none() is None  # malformed -> unavailable
 
+    # Sanity: a multi-sid happy path returns the full set.
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        _responding(b'{"children": [{"happySessionId": "real-1"}, {"happySessionId": "real-2"}]}'),
+    )
+    assert asw._live_session_ids_or_none() == {"real-1", "real-2"}
+
+    # round-3: dict children with invalid happySessionId are daemon-contract
+    # violations -> UNAVAILABLE (never ``{None}``).
+    monkeypatch.setattr("urllib.request.urlopen", _responding(b'{"children": [{}]}'))
+    assert asw._live_session_ids_or_none() is None  # missing sid key
+    monkeypatch.setattr(
+        "urllib.request.urlopen", _responding(b'{"children": [{"happySessionId": null}]}')
+    )
+    assert asw._live_session_ids_or_none() is None  # null sid
+    monkeypatch.setattr(
+        "urllib.request.urlopen", _responding(b'{"children": [{"happySessionId": ""}]}')
+    )
+    assert asw._live_session_ids_or_none() is None  # empty-string sid
+    monkeypatch.setattr(
+        "urllib.request.urlopen", _responding(b'{"children": [{"happySessionId": 42}]}')
+    )
+    assert asw._live_session_ids_or_none() is None  # non-str sid
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        _responding(b'{"children": [{"happySessionId": "real-1"}, {}]}'),
+    )
+    # One bad child contaminates the whole reply — cannot tell whether the
+    # others are real-but-incomplete or merely the well-formed survivors of
+    # a partial write. Fail toward keep-blocking.
+    assert asw._live_session_ids_or_none() is None
+
     def _down(*a, **k):
         raise urllib.error.URLError("daemon down")
 
     monkeypatch.setattr("urllib.request.urlopen", _down)
     assert asw._live_session_ids_or_none() is None
+
+
+def test_infra_drain_malformed_child_keeps_blocking(isolated_registry, monkeypatch, capsys):
+    # Round-3 production-trigger pin (reconciler verdict 2026-06-12): the
+    # double-spawn class _live_session_ids_or_none used to reintroduce when
+    # a /list child dict carried an invalid happySessionId — the bare set
+    # comprehension returned ``{None}``, which slipped past
+    # ``live_session_ids is None`` in _infra_drain_stale and made every
+    # real-string sid look NOT live -> false-stale -> dispatch.
+    #
+    # Wires the malformed payload END-TO-END through infra_drain_pass with
+    # a real urlopen stub: a stale registration that WOULD be re-dispatched
+    # if liveness leaked ``{None}`` must stay blocked (the registration
+    # pins a pending slot, no INFRA-DRAIN DISPATCHED line).
+    import io
+    import json
+    from contextlib import contextmanager
+
+    import autonomous_session_watch as asw
+
+    monkeypatch.setattr(spawn_session, "daemon_port", lambda: 65535)
+
+    @contextmanager
+    def _fake_urlopen(req, timeout=10):
+        # The exact Codex fixture: a /list payload with an empty-dict
+        # child. Pre-fix this returned ``{None}``; the round-3 fix returns
+        # ``None`` (UNAVAILABLE).
+        yield io.BytesIO(b'{"children": [{}]}')
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+
+    now = _DRAIN_NOW
+    _write_drain_queue(isolated_registry, [483])
+    # A grace-aged registration that the false-stale read would otherwise
+    # mark dead and re-dispatch.
+    (isolated_registry / "issue-483.json").write_text(
+        json.dumps({"issue": 483, "happy_session_id": "sid-x", "spawned_at": now - 3600.0})
+    )
+    monkeypatch.setattr(
+        asw,
+        "_task_status_kind",
+        lambda i: pytest.fail("task.py read despite liveness-unavailable"),
+    )
+    monkeypatch.setattr(asw.subprocess, "run", lambda *a, **k: pytest.fail("double-spawned #483"))
+    asw.infra_drain_pass(dry_run=False, now=now, daemon_reachable=True)
+    out = capsys.readouterr().out
+    assert "INFRA-DRAIN SKIP issue #483 (already-registered)" in out
+    assert "STALE registration" not in out
+    assert "INFRA-DRAIN DISPATCHED" not in out


### PR DESCRIPTION
Closes task #633.

Adds a durable, pure-Python `infra-drain` pass to the 10-minute autonomous-session watcher (`scripts/autonomous_session_watch.py`) that executes the PM-curated dispatch queue (`~/.eps-autonomous/infra-drain-queue.json`) between STATUS passes. Ripe `proposed` `kind: infra` / `batch` tasks now drain into free slots (cap 3) even when the PM session is closed — the durable replacement for the prior session-scoped hourly-cron stopgap.

## Summary

- Watcher pass: occupancy gated to `kind: {infra, batch}` at active statuses; per-ID guards (status=proposed, no live `issue-<N>.json`, not in `holds`, backoff/cap respected); single-flight via existing `watch.lock`.
- Queue schema is the live `ripe_oldest_first` / `cap` / `holds` / `updated_ts` shape the PM session already writes; malformed file → no-op.
- Kill switch: `EPM_DISABLE_INFRA_DRAIN=1` honored.
- Docs: `.claude/rules/background-automation.md` (new H2) + `.claude/agents/research-pm.md` § Standing rule 4b.

## Review path

5 in-branch commits across 4 review rounds (PASS at round 4 after Step 5c-ter post-bounce):

- Round 1 → FAIL/FAIL (two overlapping blockers: stale-redispatch + live-session-ids-empty-on-daemon-flap).
- Round 2 → PASS/FAIL substantive → **reconciler FAIL** on the malformed-child-payload bug class.
- Round 3 → PASS/PASS on the Finding-1 fix; raised two MINORs as CONCERNs (`missing-attempts-normalizes-down`, `urlopen-catch-tuple-too-narrow`).
- Round 4 → autonomous Step 5c-ter bounce closed both CONCERNs; PASS/PASS.

`tests/test_autonomous_session_watch.py`: 436/436 pass. Touched-files ruff clean. `workflow_lint.py --check-asks` PASS.

## Test plan

- [x] `uv run pytest tests/test_autonomous_session_watch.py -x` (436 pass)
- [x] `uv run ruff check scripts/autonomous_session_watch.py tests/test_autonomous_session_watch.py`
- [x] `uv run ruff format --check scripts/autonomous_session_watch.py tests/test_autonomous_session_watch.py`
- [x] `uv run python scripts/autonomous_session_watch.py --dry-run --infra-drain-only`
- [x] `uv run python scripts/workflow_lint.py --check-asks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>