### PR TITLE
task #668: shard i528 phase4 judge batch submit + drop lint grandfather

### DIFF
--- a/scripts/i528_phase4_judge.py
+++ b/scripts/i528_phase4_judge.py
@@ -20,6 +20,20 @@ Writes (under ``eval_results/<ISSUE_SLUG>/``):
 CLI:
     uv run python scripts/i528_phase4_judge.py
     uv run python scripts/i528_phase4_judge.py --backend sync --limit 5   # smoke
+
+``--backend batch`` pending JSON schema (v2):
+    The submit is sharded into <=8k-request batches via the sanctioned
+    ``submit_sharded_batches_fire_and_forget`` helper, so the pending file now
+    records a LIST of batch IDs, one per shard, instead of a single scalar:
+
+        {"schema_version": "i528_v2", "kind": "judge_batch_pending",
+         "batch_ids": ["batch_...", ...],   # one entry per <=8k shard (was: batch_id scalar)
+         "n_requests": <total>, "git_commit": ..., "ts": ...}
+
+    The list is rewritten after EACH shard submit (incremental checkpoint), so a
+    mid-loop crash leaves a recoverable record of the shards already submitted.
+    The scalar ``batch_id`` field (v1) is dropped; the operator merges by reading
+    ``batch_ids`` from the v2 pending file in a separate ``--backend sync`` re-run.
 """
 
 from __future__ import annotations
@@ -33,6 +47,7 @@ import subprocess
 import time
 from pathlib import Path
 
+from explore_persona_space.eval.batch_judge import submit_sharded_batches_fire_and_forget
 from explore_persona_space.experiments.i528_data import ISSUE_SLUG
 
 logger = logging.getLogger("i528.phase4.judge")
@@ -338,26 +353,38 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901
                         ),
                     )
                 )
-        batch = client.messages.batches.create(requests=requests)
-        logger.info(
-            "Submitted batch id=%s n_requests=%d; poll separately and re-run "
-            "--backend sync to merge.",
-            batch.id,
-            len(requests),
+
+        # Shard the submit so no single batch exceeds the Batch API request cap
+        # (was: one un-sharded batches.create(requests=requests) that 409s past
+        # the 100k-request limit). The sanctioned helper owns the chunking +
+        # multi-submit; we own the i528-specific v2 pending JSON shape and rewrite
+        # it after EACH shard submit (Checkpoint-per-phase: a mid-loop crash leaves
+        # a recoverable record of the shards already submitted, not orphaned shards).
+        pending = {
+            "schema_version": "i528_v2",
+            "kind": "judge_batch_pending",
+            "batch_ids": [],  # filled incrementally by the callback below
+            "n_requests": len(requests),
+            "git_commit": _git(),
+            "ts": _dt.datetime.utcnow().isoformat() + "Z",
+        }
+
+        def _persist_pending(batch_ids: list[str]) -> None:
+            pending["batch_ids"] = list(batch_ids)
+            JUDGE_PATH.write_text(json.dumps(pending, indent=2, ensure_ascii=False))
+
+        batch_ids = submit_sharded_batches_fire_and_forget(
+            client, requests, on_batch_submitted=_persist_pending
         )
-        JUDGE_PATH.write_text(
-            json.dumps(
-                {
-                    "schema_version": "i528_v1",
-                    "kind": "judge_batch_pending",
-                    "batch_id": batch.id,
-                    "n_requests": len(requests),
-                    "git_commit": _git(),
-                    "ts": _dt.datetime.utcnow().isoformat() + "Z",
-                },
-                indent=2,
-                ensure_ascii=False,
-            )
+        # Final write covers the zero-shard edge case (empty requests -> no
+        # callback fired); a harmless no-op otherwise.
+        _persist_pending(batch_ids)
+        logger.info(
+            "Submitted %d requests across %d batch(es) ids=%s; poll separately and "
+            "re-run --backend sync to merge.",
+            len(requests),
+            len(batch_ids),
+            batch_ids,
         )
         return 0
 

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -562,17 +562,18 @@ BATCH_JUDGE_SANCTIONED_FILES: tuple[str, ...] = (
 )
 # Legacy inline batch callers that predate this check (2026-06-25), GRANDFATHERED
 # pending migration. The MAJORITY are training-data GENERATION (the `generate_*`
-# / `build_*` / `gen_*` / `run_a3*` rows); TWO are NOT data-gen and are flagged
+# / `build_*` / `gen_*` / `run_a3*` rows); ONE is NOT data-gen and is flagged
 # inline so the rationale stays honest — `analyze_axis_tails.py` is an
-# LLM-taxonomy ANALYSIS classifier, and `i528_phase4_judge.py` is a pre-#663
-# JUDGE (its own docstring opens "Phase 4 judge"). All are experiment code, OUT
-# of the workflow-improver edit scope, so they are grandfathered in the lint
+# LLM-taxonomy ANALYSIS classifier. All are experiment code, OUT of the
+# workflow-improver edit scope, so they are grandfathered in the lint
 # (the MARKER_REGISTRY_ALLOWLIST model) rather than waiver-commented per-file —
 # this lands the check green without touching experiment scripts. A NEW offender
 # is never added here (the `# BATCH_JUDGE_CLIENT_EXEMPT:` waiver is the path for
-# a genuinely-correct new non-judge caller). Migrating the JUDGE entry
-# (`i528_phase4_judge.py`) onto `eval.batch_judge` — the rule's intended outcome
-# — is a separate `kind: infra` follow-up, NOT this check's job.
+# a genuinely-correct new non-judge caller). The pre-#663 JUDGE entry
+# (`i528_phase4_judge.py`) was MIGRATED onto the sanctioned
+# `eval.batch_judge.submit_sharded_batches_fire_and_forget` helper (#668) — the
+# rule's intended outcome — and dropped from this set; its `--backend batch`
+# submit no longer calls `messages.batches.create` inline.
 # CAVEAT: allowlist membership exempts the WHOLE file, not just the documented
 # pre-existing call — a future edit that adds a NEW `messages.batches.create`
 # (even a hand-rolled judge batch) to an allowlisted file is silently exempt.
@@ -595,7 +596,6 @@ BATCH_JUDGE_LEGACY_ALLOWLIST: frozenset[str] = frozenset(
         "scripts/run_a3_leakage.py",
         # NOT data-gen — flagged so the allowlist rationale stays honest:
         "scripts/analyze_axis_tails.py",  # LLM-taxonomy ANALYSIS classifier
-        "scripts/i528_phase4_judge.py",  # pre-#663 JUDGE — migrate to eval.batch_judge (follow-up)
     }
 )
 BATCH_JUDGE_CLIENT_WAIVER_RE = re.compile(r"#\s*BATCH_JUDGE_CLIENT_EXEMPT\s*:\s*(.+?)\s*$")

--- a/src/explore_persona_space/eval/batch_judge.py
+++ b/src/explore_persona_space/eval/batch_judge.py
@@ -177,6 +177,35 @@ def _chunk_requests(
     return chunks
 
 
+def submit_sharded_batches_fire_and_forget(
+    client: "anthropic.Anthropic",
+    requests: list[dict],
+    *,
+    on_batch_submitted: Callable[[list[str]], None] | None = None,
+) -> list[str]:
+    """Submit ``requests`` sharded into chunks of <= MAX_REQUESTS_PER_BATCH, fire-and-forget.
+
+    Returns the list of submitted batch IDs in submission order. Does NOT poll —
+    intended for callers (e.g. ``scripts/i528_phase4_judge.py --backend batch``) that
+    submit-then-return and merge results in a separate sync re-run, vs the polling
+    ``judge_completions_batch`` / ``_submit_and_poll_batch`` path.
+
+    ``on_batch_submitted`` (if given) is invoked with the running ``batch_ids`` list
+    AFTER each chunk's batch is created, so the caller can persist incremental
+    progress (Checkpoint-per-phase: a mid-loop crash leaves a recoverable record of
+    the shards already submitted, rather than orphaning shards 0..k when shard k+1
+    raises before any write lands). On any per-chunk failure the exception propagates
+    immediately; the IDs submitted so far are already persisted via the callback.
+    """
+    batch_ids: list[str] = []
+    for chunk in _chunk_requests(requests):
+        batch = client.messages.batches.create(requests=chunk)
+        batch_ids.append(batch.id)
+        if on_batch_submitted is not None:
+            on_batch_submitted(batch_ids)
+    return batch_ids
+
+
 def _legacy_error_dict(reason: str) -> dict:
     """The error-dict shape the legacy ``_submit_and_poll_batch`` returns."""
     return {"aligned": None, "coherent": None, "reasoning": reason, "error": True}

--- a/tests/test_batch_judge_sharded_submit.py
+++ b/tests/test_batch_judge_sharded_submit.py
@@ -1,0 +1,99 @@
+"""Unit tests for ``submit_sharded_batches_fire_and_forget`` (#668).
+
+The helper shards a request list into <=MAX_REQUESTS_PER_BATCH chunks and submits
+each as its own Anthropic Message Batch, fire-and-forget (no polling). These tests
+inject a fake client (dependency injection — the helper takes ``client`` as a
+parameter), so NO live API call is made: ``fake_client.messages.batches.create`` is
+a Mock returning a stub whose ``.id`` is a distinct per-call string.
+
+What is verified, from the outside:
+- a large list shards into >=2 batches (chunk count tracks the request count);
+- the custom_id strings survive sharding verbatim (none dropped, reshaped, or
+  duplicated) — the ``--backend sync`` merge reader parses them;
+- every per-chunk request count is within the 8000 cap and the total is conserved;
+- the incremental callback fires once per shard with the running id list;
+- a small list is a single batch.
+"""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import Mock
+
+from explore_persona_space.eval.batch_judge import (
+    MAX_REQUESTS_PER_BATCH,
+    submit_sharded_batches_fire_and_forget,
+)
+
+
+def _make_fake_client() -> tuple[Mock, Mock]:
+    """A client whose batches.create returns a stub with a distinct .id per call."""
+    fake_client = Mock()
+    counter = {"n": 0}
+
+    def _create(*, requests):
+        idx = counter["n"]
+        counter["n"] += 1
+        return Mock(id=f"batch_{idx}")
+
+    fake_client.messages.batches.create.side_effect = _create
+    return fake_client, fake_client.messages.batches.create
+
+
+def _requests(n: int) -> list[dict]:
+    """n minimal request dicts carrying the i528 custom_id format."""
+    return [
+        {
+            "custom_id": f"i528__cell{i // 5}__q{i}__k{i % 3}",
+            "params": {"model": "m", "messages": [], "max_tokens": 1},
+        }
+        for i in range(n)
+    ]
+
+
+def test_large_request_list_produces_multiple_chunks():
+    fake_client, fake_create = _make_fake_client()
+    requests = _requests(MAX_REQUESTS_PER_BATCH + 1)  # 8001 -> 2 chunks
+    batch_ids = submit_sharded_batches_fire_and_forget(fake_client, requests)
+    assert fake_create.call_count >= 2
+    assert len(batch_ids) == fake_create.call_count
+
+
+def test_custom_id_format_preserved_across_chunks():
+    fake_client, fake_create = _make_fake_client()
+    requests = _requests(MAX_REQUESTS_PER_BATCH + 1)
+    submit_sharded_batches_fire_and_forget(fake_client, requests)
+    submitted = [
+        r["custom_id"] for call in fake_create.call_args_list for r in call.kwargs["requests"]
+    ]
+    assert sorted(submitted) == sorted(r["custom_id"] for r in requests)
+    assert all(re.fullmatch(r"i528__[^_]+__q\d+__k\d+", cid) for cid in submitted)
+
+
+def test_per_chunk_request_count_within_limit():
+    fake_client, fake_create = _make_fake_client()
+    requests = _requests(MAX_REQUESTS_PER_BATCH + 1)
+    submit_sharded_batches_fire_and_forget(fake_client, requests)
+    per_call = [len(c.kwargs["requests"]) for c in fake_create.call_args_list]
+    assert sum(per_call) == len(requests)
+    assert all(c <= MAX_REQUESTS_PER_BATCH for c in per_call)
+    assert len(per_call) == fake_create.call_count
+
+
+def test_incremental_callback_fires_after_each_chunk():
+    fake_client, _ = _make_fake_client()
+    requests = _requests(MAX_REQUESTS_PER_BATCH + 1)  # 8001 -> 2 chunks
+    snapshots: list[int] = []
+    batch_ids = submit_sharded_batches_fire_and_forget(
+        fake_client, requests, on_batch_submitted=lambda ids: snapshots.append(len(ids))
+    )
+    assert snapshots == [1, 2]
+    assert len(batch_ids) == 2
+
+
+def test_small_request_list_single_chunk():
+    fake_client, fake_create = _make_fake_client()
+    requests = _requests(10)
+    batch_ids = submit_sharded_batches_fire_and_forget(fake_client, requests)
+    assert fake_create.call_count == 1
+    assert len(batch_ids) == 1

--- a/tests/test_i528_phase4_judge_pending_v2.py
+++ b/tests/test_i528_phase4_judge_pending_v2.py
@@ -1,0 +1,138 @@
+"""Script-level tests for the i528 phase-4 judge ``--backend batch`` v2 pending JSON (#668).
+
+The sharding mechanics are covered by ``test_batch_judge_sharded_submit.py`` (the
+helper, directly). Here we verify ONLY the i528-specific pending-file contract that
+the script owns via its ``_persist_pending`` callback:
+
+- the pending JSON carries ``schema_version: "i528_v2"`` + ``batch_ids`` LIST
+  (>=2 entries when the submit shards) + ``n_requests`` matching the total, and
+  the scalar v1 ``batch_id`` field is gone;
+- the write is incremental — a per-chunk failure on the 2nd shard still leaves the
+  1st shard's id on disk (recoverable, Checkpoint-per-phase).
+
+Driven through ``main(["--backend", "batch", ...])`` with a fake Anthropic client
+(``messages.batches.create`` mocked, NO live API). ``_flatten`` is monkeypatched to
+return controlled rows so the test does not depend on real raw-generation files.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS = _REPO_ROOT / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import i528_phase4_judge as judge  # noqa: E402
+
+from explore_persona_space.eval.batch_judge import MAX_REQUESTS_PER_BATCH  # noqa: E402
+
+# 2667 rows x 3 calls = 8001 requests -> 2 shards (>8000 cap).
+_N_ROWS = (MAX_REQUESTS_PER_BATCH // 3) + 1
+_TRAIT = "calibrated_uncertainty"
+
+
+def _patch_inputs(monkeypatch, tmp_path):
+    """Point the script's output path at tmp_path, stub the flat rows + rubric."""
+    judge_path = tmp_path / "judge_scores.json"
+    monkeypatch.setattr(judge, "JUDGE_PATH", judge_path)
+
+    rows = [
+        {
+            "cell_id": f"base__{_TRAIT}__role__default_assistant",
+            "kind": "base",
+            "trait": _TRAIT,
+            "arm": "role",
+            "seed": 0,
+            "eval_context": "default_assistant",
+            "q_idx": i,
+            "q": f"question {i}",
+            "response": f"response {i}",
+        }
+        for i in range(_N_ROWS)
+    ]
+    # _flatten is called twice (base + trained dirs); return the rows on the
+    # first call only so the total stays _N_ROWS regardless of dir existence.
+    calls = {"n": 0}
+
+    def _fake_flatten(files, kind):
+        calls["n"] += 1
+        return rows if calls["n"] == 1 else []
+
+    monkeypatch.setattr(judge, "_flatten", _fake_flatten)
+    # Make BASE_RAW_DIR exist so the `not skip_base and exists()` branch fires.
+    base_dir = tmp_path / "raw_generations_base"
+    base_dir.mkdir()
+    monkeypatch.setattr(judge, "BASE_RAW_DIR", base_dir)
+    monkeypatch.setattr(judge, "TRAINED_RAW_DIR", tmp_path / "raw_generations_absent")
+    return judge_path
+
+
+def _install_traits(monkeypatch):
+    """Inject a format-compatible rubric for _TRAIT so the batch block builds requests."""
+    from explore_persona_space.experiments import i528_traits
+
+    monkeypatch.setitem(i528_traits.JUDGE_RUBRIC, _TRAIT, "Q: {q}\nA: {response}\nScore:")
+
+
+def test_pending_json_is_v2_with_batch_ids_list(monkeypatch, tmp_path):
+    judge_path = _patch_inputs(monkeypatch, tmp_path)
+    _install_traits(monkeypatch)
+
+    counter = {"n": 0}
+
+    def _create(*, requests):
+        idx = counter["n"]
+        counter["n"] += 1
+        return Mock(id=f"batch_{idx}")
+
+    fake_client = Mock()
+    fake_client.messages.batches.create.side_effect = _create
+    # main does `from anthropic import Anthropic` then `Anthropic()` inside the
+    # call — patch the source attribute the local name binds to at call time.
+    monkeypatch.setattr("anthropic.Anthropic", lambda *a, **k: fake_client)
+
+    rc = judge.main(["--backend", "batch"])
+    assert rc == 0
+
+    pending = json.loads(judge_path.read_text())
+    assert pending["schema_version"] == "i528_v2"
+    assert pending["kind"] == "judge_batch_pending"
+    assert isinstance(pending["batch_ids"], list) and len(pending["batch_ids"]) >= 2
+    assert "batch_id" not in pending  # scalar v1 field dropped
+    assert pending["n_requests"] == _N_ROWS * 3  # 3 judge calls per row
+
+
+def test_pending_json_incremental_write_survives_midloop_failure(monkeypatch, tmp_path):
+    judge_path = _patch_inputs(monkeypatch, tmp_path)
+    _install_traits(monkeypatch)
+
+    # Succeed on the 1st shard, raise on the 2nd: the incremental callback must
+    # have already persisted shard-0's id before the exception propagates.
+    counter = {"n": 0}
+
+    def _create(*, requests):
+        idx = counter["n"]
+        counter["n"] += 1
+        if idx >= 1:
+            raise RuntimeError("simulated per-chunk submit failure on shard 2")
+        return Mock(id=f"batch_{idx}")
+
+    fake_client = Mock()
+    fake_client.messages.batches.create.side_effect = _create
+    monkeypatch.setattr("anthropic.Anthropic", lambda *a, **k: fake_client)
+
+    with pytest.raises(RuntimeError, match="shard 2"):
+        judge.main(["--backend", "batch"])
+
+    # The pending file on disk still records the 1st shard's id (recoverable).
+    pending = json.loads(judge_path.read_text())
+    assert pending["schema_version"] == "i528_v2"
+    assert pending["batch_ids"] == ["batch_0"]
+    assert "batch_id" not in pending

--- a/tests/test_workflow_lint.py
+++ b/tests/test_workflow_lint.py
@@ -1895,21 +1895,19 @@ def test_check_batch_judge_client_repo_tree_is_clean():
 
 def test_check_batch_judge_client_legacy_allowlist_entry_is_exempt(tmp_path):
     """A file at a legacy-allowlist path is exempt even with an inline
-    messages.batches.create — locks the grandfathering behavior. Uses a real
-    allowlist entry path replicated under tmp_path so the rel-path match fires.
-    The i528 judge entry in particular MUST stay exempt (it is a pre-#663 judge
-    grandfathered pending migration), so this also pins that the allowlist is
-    file-granular, not call-granular."""
+    messages.batches.create — locks the grandfathering behavior. The surviving
+    data-gen / analysis siblings (e.g. analyze_axis_tails.py) demonstrate that
+    the allowlist is file-granular, not call-granular: membership exempts the
+    whole file's inline batch-create calls. The pre-#663 i528 judge was migrated
+    onto the sanctioned eval.batch_judge helper (#668) and DROPPED from the
+    allowlist, so it must no longer be a member (the lint now governs it)."""
     sd = tmp_path / "scripts"
     sd.mkdir()
-    # i528_phase4_judge.py is in BATCH_JUDGE_LEGACY_ALLOWLIST as a pre-#663 judge.
-    assert "scripts/i528_phase4_judge.py" in BATCH_JUDGE_LEGACY_ALLOWLIST
-    # Replicate the offender shape at the allowlisted basename; the production
-    # walk matches rel == "scripts/i528_phase4_judge.py", so to exercise the
-    # exemption we point scripts_dir at the real repo scripts/ and assert the
-    # live tree (which contains the allowlisted file) stays clean — covered by
-    # the repo-tree-clean test. Here we instead assert the allowlist constant
-    # itself contains the judge + analysis entries (rationale-accuracy guard).
+    # i528_phase4_judge.py was migrated off the inline batch-create path (#668),
+    # so it is NO LONGER grandfathered — the lint governs the file directly now.
+    assert "scripts/i528_phase4_judge.py" not in BATCH_JUDGE_LEGACY_ALLOWLIST
+    # analyze_axis_tails.py is the surviving non-data-gen sibling demonstrating
+    # the per-path exemption mechanism is still exercised.
     assert "scripts/analyze_axis_tails.py" in BATCH_JUDGE_LEGACY_ALLOWLIST
     # And a NON-allowlisted offender at the same dir IS flagged (the exemption
     # is per-path, not blanket-scripts/).


### PR DESCRIPTION
Closes task #668.

Shards the un-sharded `scripts/i528_phase4_judge.py --backend batch` submit (single `client.messages.batches.create(requests=all)` 409s past the 100k cap) via a new sanctioned helper `submit_sharded_batches_fire_and_forget()` in `src/explore_persona_space/eval/batch_judge.py` (a BATCH_JUDGE_SANCTIONED_FILES member), with incremental v2-pending-JSON writes per shard. Drops the file from BATCH_JUDGE_LEGACY_ALLOWLIST.

- Adversarial-planner: 2 rounds (round-1 REVISE on a Codex-caught lint↔allowlist contradiction Claude missed → round-2 APPROVE consensus across Claude+Codex × 3 lenses + consistency-checker PASS).
- Code-review: Claude PASS, Codex CONCERNS (minor stale-prose nit only, recommendation 'merge') → ensemble PASS.
- Tests: 5 new helper tests + 2 new script tests; 139 PASS total; ruff + workflow_lint clean.

Auto-generated by /issue 668.