### PR TITLE
task #671: memory-safe activation extraction via forward hooks (kind: infra)

### DIFF
--- a/scripts/i488_phase1_predictors.py
+++ b/scripts/i488_phase1_predictors.py
@@ -89,6 +89,10 @@ sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
 from issue404_common import kill_vllm_workers  # noqa: E402
 
+from explore_persona_space.analysis.extraction import (  # noqa: E402
+    EMBED_LAYER,
+    extract_layer_activations,
+)
 from explore_persona_space.experiments.i460_data import (  # noqa: E402
     load_class_d_rewrites,
     load_q_test_extended_50,
@@ -584,20 +588,28 @@ def _last_token_residuals(
     Returns ``{layer: (D,) tensor on CPU/float32}``.
     """
     inputs = tokenizer(prompt_text, return_tensors="pt", padding=False).to(model.device)
-    with torch.no_grad():
-        outputs = model(**inputs, output_hidden_states=True)
     last_pos = inputs["input_ids"].shape[1] - 1
-    # outputs.hidden_states is a tuple of length n_layers+1 (embeddings + per-layer outputs).
-    # Layer indexing convention here: layer k = hidden_states[k] (so layer 0 = embedding,
-    # layer 28 = final for a 28-layer Qwen-2.5-7B).
-    out: dict[int, torch.Tensor] = {}
+    # Layer indexing convention HERE: layer k = hidden_states[k] (so layer 0 =
+    # embedding, layer 28 = final for a 28-layer Qwen-2.5-7B). The memory-safe
+    # helper (#671) uses BLOCK indices (block L's output == hs[L+1]); translate
+    # this site's hs-INDEX L to the helper's block index: L=0 -> EMBED_LAYER
+    # (hs[0]); L=k>=1 -> block k-1 (hs[k]). acts[key] is the SAME tensor the old
+    # outputs.hidden_states[L] read produced.
+    n_hidden_states = int(model.config.num_hidden_layers) + 1  # embeddings + per-block
     for L in layers:
-        if len(outputs.hidden_states) <= L:
+        if not (0 <= L < n_hidden_states):
             raise IndexError(
-                f"Requested layer {L} but model has only {len(outputs.hidden_states)} "
+                f"Requested layer {L} but model has only {n_hidden_states} "
                 "hidden-state outputs (including embeddings at index 0)."
             )
-        out[L] = outputs.hidden_states[L][0, last_pos, :].float().cpu()
+    req = [EMBED_LAYER if L == 0 else L - 1 for L in layers]
+    acts = extract_layer_activations(
+        model, inputs["input_ids"], req, attention_mask=inputs.get("attention_mask")
+    )
+    out: dict[int, torch.Tensor] = {}
+    for L in layers:
+        key = EMBED_LAYER if L == 0 else L - 1
+        out[L] = acts[key][0, last_pos, :].float().cpu()
     return out
 
 

--- a/scripts/issue667_extract.py
+++ b/scripts/issue667_extract.py
@@ -76,6 +76,7 @@ import numpy as np  # noqa: E402
 import torch  # noqa: E402
 from dotenv import load_dotenv  # noqa: E402
 
+from explore_persona_space.analysis.extraction import extract_layer_activations  # noqa: E402
 from explore_persona_space.analysis.issue667 import (  # noqa: E402
     ALL_LAYERS,
     BASE_MODEL,
@@ -416,12 +417,15 @@ def _mean_resp_acts(
     if span_end <= p:
         raise RuntimeError("empty response span — response produced zero tokens")
     ids = torch.tensor([full_ids], dtype=torch.long, device=device)
-    out_b = base_model(ids, output_hidden_states=True)
-    out_t = trained_model(ids, output_hidden_states=True)
+    # Memory-safe subset read: hook only the requested blocks (block index li ==
+    # hs[li+1]) instead of materializing all L+1 layers (#671). acts[li] is the
+    # SAME tensor the old out.hidden_states[li + 1] read produced.
+    acts_b = extract_layer_activations(base_model, ids, layers)
+    acts_t = extract_layer_activations(trained_model, ids, layers)
     res: dict[int, tuple[np.ndarray, np.ndarray]] = {}
     for li in layers:
-        hb = out_b.hidden_states[li + 1][0, p:span_end, :].float().mean(dim=0).cpu().numpy()
-        ht = out_t.hidden_states[li + 1][0, p:span_end, :].float().mean(dim=0).cpu().numpy()
+        hb = acts_b[li][0, p:span_end, :].float().mean(dim=0).cpu().numpy()
+        ht = acts_t[li][0, p:span_end, :].float().mean(dim=0).cpu().numpy()
         res[li] = (hb.astype(np.float32), ht.astype(np.float32))
     return res
 
@@ -680,10 +684,10 @@ def _mean_resp_acts_single(
     if len(full_ids) <= p:
         return {li: np.zeros(base_model.config.hidden_size, dtype=np.float32) for li in layers}
     ids = torch.tensor([full_ids], dtype=torch.long, device=device)
-    out = base_model(ids, output_hidden_states=True)
+    # Memory-safe subset read (#671): hook only `layers` (block index li == hs[li+1]).
+    acts = extract_layer_activations(base_model, ids, layers)  # {li: (1, T, H)}
     return {
-        li: out.hidden_states[li + 1][0, p:, :].float().mean(dim=0).cpu().numpy().astype(np.float32)
-        for li in layers
+        li: acts[li][0, p:, :].float().mean(dim=0).cpu().numpy().astype(np.float32) for li in layers
     }
 
 

--- a/src/explore_persona_space/analysis/extraction.py
+++ b/src/explore_persona_space/analysis/extraction.py
@@ -1,0 +1,172 @@
+"""Memory-safe subset-of-layers activation extraction via forward hooks.
+
+Replaces ``model(ids, output_hidden_states=True)`` subset reads that
+materialize ALL ``L+1`` residual-stream tensors per forward (the #545/#667
+accumulation bug). Extracts ONLY the requested layers via
+``register_forward_hook`` + ``output_hidden_states=False``; the unused
+~21/29 layers are freed as the forward proceeds, so the CUDA allocator
+(especially under ``expandable_segments:True``) has nothing to retain
+iteration-to-iteration.
+
+This is a generalization of the proven pattern in
+``experiments/behavior_testbed_545/predictors.py::_mean_hidden_states``
+(#545 round-36 architectural pivot) and the hook idiom in
+``analysis/representation_shift.py``. The two key differences from
+``_mean_hidden_states``: this helper RETURNS the captured per-layer tensors
+(it does NOT bake in ``.mean(0)`` / ``.float().cpu()`` reductions — callers
+keep their own call-site reductions), and it offers a single canonical
+layer-index convention plus an optional same-forward logits read.
+
+Convention
+----------
+``layers`` are **BLOCK indices**. Block ``L``'s output ==
+``output_hidden_states[L+1]`` (``hs[0]`` is the embedding). Request the
+embedding output by including the sentinel ``EMBED_LAYER`` (-1) in
+``layers``, which maps to ``hs[0]`` / ``model.model.embed_tokens``.
+
+This matches the dominant in-repo convention (``probes.py``,
+``issue667_extract.py``, ``issue444`` all read ``hs[L+1]``). Sites with the
+OTHER convention (e.g. ``i488_phase1_predictors._last_token_residuals``
+reads ``hs[L]`` directly, ``L=0`` being the embedding) translate at the
+call site: ``EMBED_LAYER if L == 0 else L - 1``.
+
+Off-by-one (CRITICAL)
+---------------------
+A hook on ``model.model.layers[L]`` fires on block ``L``'s OUTPUT, which the
+full tuple stores at ``hidden_states[L+1]`` — which IS the tensor the
+existing ``hs[L+1]`` reads want. So **block index L -> ``model.model.layers[L]``
+(NO subtraction at the module level)**; ``EMBED_LAYER -> ``model.model.embed_tokens``.
+The "naive hook on ``layers[layer]`` captures ``hs[layer+1]``, silently the
+WRONG layer" warning applies only when a caller's ``layer`` variable already
+means ``hs[layer]`` (the i488 convention) — that caller passes ``layer - 1``.
+This is pinned both ways by the byte-identity tests in
+``tests/test_issue671_extraction_hooks.py`` and the in-process self-test at
+``scripts/issue493_extraction_metric_bakeoff.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import torch
+
+EMBED_LAYER = -1  # request the embedding output (hs[0]); maps to embed_tokens
+
+
+def _unwrap(output):
+    """Unwrap a decoder-block forward output to its hidden-states tensor.
+
+    A transformer block returns a tuple ``(hidden, ...)`` on some HF versions
+    and a bare tensor on transformers 4.57.x. Mirrors
+    ``analysis/representation_shift.py``'s unwrap and the reference impl.
+    """
+    return output[0] if isinstance(output, tuple) else output
+
+
+@torch.no_grad()
+def extract_layer_activations(
+    model,
+    input_ids: torch.Tensor,
+    layers: Iterable[int],
+    *,
+    attention_mask: torch.Tensor | None = None,
+    return_logits: bool = False,
+    detach_to_cpu: bool = False,
+) -> dict[int, torch.Tensor] | tuple[dict[int, torch.Tensor], torch.Tensor]:
+    """Return ``{layer: hidden_state_tensor}`` for the requested block indices.
+
+    The returned tensor for layer ``L`` is the SAME object the old
+    ``output_hidden_states[L+1]`` read produced (``hs[0]`` for
+    ``EMBED_LAYER``), shape ``(B, T, H)``. Byte-identical to the full-tuple
+    read; the only difference is the unused layers are never materialized.
+
+    Parameters
+    ----------
+    model
+        Causal-LM, already on its device and in eval mode (this helper does
+        not move or set the mode). A standard Llama-style decoder
+        (``model.model.layers`` + ``model.model.embed_tokens``) takes the
+        primary hook path; anything else falls back to the full-tuple read
+        (covers non-standard models AND the CPU test stub).
+    input_ids
+        ``(1, T)`` or ``(B, T)`` on the model's device.
+    layers
+        Iterable of BLOCK indices. ``EMBED_LAYER`` (-1) requests the
+        embedding output (``hs[0]``).
+    attention_mask
+        Optional mask, forwarded to the model.
+    return_logits
+        When ``True``, returns ``(captured, logits)`` — for dual-purpose
+        forwards (e.g. ``issue_650/shift_extract.py``) that read the marker
+        logits off the SAME forward as the hidden states.
+    detach_to_cpu
+        When ``True``, each captured tensor is ``.detach().float().cpu()``
+        before being stored. Default ``False`` keeps the tensor on-device
+        (callers that immediately ``.float().cpu()`` at the call site leave
+        this off and reduce themselves). NOTE: under the ``@torch.no_grad()``
+        decorator the ``.detach()`` on the default path is a no-op, so the
+        default-path return is the exact same tensor the
+        ``output_hidden_states=True`` read produced — ``torch.equal(old, new)``
+        holds and callers retain their own ``.float().cpu()`` / ``.mean(0)``
+        / ``[-1]`` reductions.
+
+    Returns
+    -------
+    dict[int, torch.Tensor]
+        ``{layer: (B, T, H)}`` for every requested layer (when
+        ``return_logits`` is ``False``).
+    tuple[dict[int, torch.Tensor], torch.Tensor]
+        ``(captured, logits)`` when ``return_logits`` is ``True``.
+    """
+    blocks = getattr(getattr(model, "model", None), "layers", None)
+    embed = getattr(getattr(model, "model", None), "embed_tokens", None)
+    layers = list(layers)
+
+    def _reduce(hs: torch.Tensor) -> torch.Tensor:
+        return hs.detach().float().cpu() if detach_to_cpu else hs.detach()
+
+    # ---- Fallback for non-standard models / CPU stubs (the labeled =True) ----
+    if blocks is None:
+        out = model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            output_hidden_states=True,
+        )
+        hs = out.hidden_states  # tuple(L+1)
+        captured: dict[int, torch.Tensor] = {}
+        for L in layers:
+            idx = 0 if L == EMBED_LAYER else L + 1
+            captured[L] = _reduce(hs[idx])
+        if return_logits:
+            return captured, out.logits
+        return captured
+
+    # ---- Primary hook path (standard Qwen/Llama decoder) ---------------------
+    captured = {}
+    handles = []
+
+    def _make_hook(L: int):
+        def _hook(_module, _inp, output):
+            captured[L] = _reduce(_unwrap(output))
+
+        return _hook
+
+    for L in layers:
+        if L == EMBED_LAYER:
+            if embed is None:
+                continue
+            handles.append(embed.register_forward_hook(_make_hook(L)))
+        else:
+            handles.append(blocks[L].register_forward_hook(_make_hook(L)))
+    try:
+        out = model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            output_hidden_states=False,  # <-- the fix: do NOT materialize all
+        )
+    finally:
+        for h in handles:
+            h.remove()
+    if return_logits:
+        return captured, out.logits
+    return captured

--- a/src/explore_persona_space/analysis/probes.py
+++ b/src/explore_persona_space/analysis/probes.py
@@ -43,6 +43,8 @@ from sklearn.metrics import roc_auc_score
 from sklearn.model_selection import LeaveOneOut
 from sklearn.preprocessing import StandardScaler
 
+from explore_persona_space.analysis.extraction import extract_layer_activations
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Activation extraction
 # ─────────────────────────────────────────────────────────────────────────────
@@ -106,11 +108,12 @@ def extract_residual_stream_activations(
     for i, prompt in enumerate(prompts):
         ids = tokenizer(prompt, return_tensors="pt", add_special_tokens=False).input_ids
         ids = ids.to(device)
-        hs = model(ids, output_hidden_states=True).hidden_states
-        # hs is a tuple of length (num_hidden_layers + 1).
-        # hs[0] = embedding output; hs[L+1] = output of transformer block L.
+        # Memory-safe subset read (#671): hook only `layers` (block index L ==
+        # hs[L+1]) instead of materializing all L+1 layers. acts[L] is the SAME
+        # tensor the old hs[L + 1] read produced.
+        acts = extract_layer_activations(model, ids, layers)
         for j, L in enumerate(layers):
-            out[i, j] = hs[L + 1][0, position].float().cpu()
+            out[i, j] = acts[L][0, position].float().cpu()
     return out
 
 
@@ -202,10 +205,12 @@ def extract_dual_position_activations(
             f"pair {i}: require 0 <= context_end_idx({c_idx}) < query_end_idx({q_idx}) "
             f"< seq_len({seq_len})"
         )
-        hs = model(ids, output_hidden_states=True).hidden_states
-        # hs is a tuple of length (num_hidden_layers + 1); hs[L+1] = block-L output.
+        # Memory-safe subset read (#671): hook only `layers` (block index L ==
+        # hs[L+1]); the multiple positions are read from the SAME captured
+        # tensor, so the single-forward property (plan §3 A5) is preserved.
+        acts = extract_layer_activations(model, ids, layers)
         for j, L in enumerate(layers):
-            layer_hs = hs[L + 1]
+            layer_hs = acts[L]
             out["context_end"][i, j] = layer_hs[0, c_idx].float().cpu()
             out["query_end"][i, j] = layer_hs[0, q_idx].float().cpu()
             if readout_position is not None:

--- a/src/explore_persona_space/experiments/issue_650/shift_extract.py
+++ b/src/explore_persona_space/experiments/issue_650/shift_extract.py
@@ -46,6 +46,8 @@ from dataclasses import dataclass, field
 import torch
 import torch.nn.functional as F
 
+from explore_persona_space.analysis.extraction import extract_layer_activations
+
 from . import EXTRACTION_LAYER, HIDDEN_SIZE, IM_END_ID, MARKER_ID
 
 log = logging.getLogger("issue_650.shift_extract")
@@ -274,11 +276,22 @@ def extract_per_context_shift(
 
         ids = torch.tensor([full_ids], dtype=torch.long, device=device)
 
-        out_base = base_model(ids, output_hidden_states=True)
-        out_trained = trained_model(ids, output_hidden_states=True)
+        # Memory-safe subset read (#671): hook only the one extraction block +
+        # keep the same-forward logits via return_logits=True. layer_idx_internal
+        # is an hs-INDEX (hs[k]); translate to the helper's BLOCK index k-1
+        # (block L's output == hs[L+1]). acts_*[block_L] is the SAME tensor the
+        # old out.hidden_states[layer_idx_internal] read produced; logits_*_full
+        # is the SAME tensor the old out.logits read produced.
+        block_L = layer_idx_internal - 1
+        acts_base, logits_base_full = extract_layer_activations(
+            base_model, ids, [block_L], return_logits=True
+        )
+        acts_trained, logits_trained_full = extract_layer_activations(
+            trained_model, ids, [block_L], return_logits=True
+        )
 
-        hs_base = out_base.hidden_states[layer_idx_internal]  # (1, T, H)
-        hs_trained = out_trained.hidden_states[layer_idx_internal]
+        hs_base = acts_base[block_L]  # (1, T, H)
+        hs_trained = acts_trained[block_L]
         if hs_base.shape[-1] != model_hidden:
             raise AssertionError(
                 f"hidden_size drift: hs_base.shape[-1]={hs_base.shape[-1]} "
@@ -288,8 +301,8 @@ def extract_per_context_shift(
         shift_acc += shift
 
         # logits[i] predicts token[i+1] (causal-LM offset), so we read at slot-1.
-        logits_base_row = out_base.logits[0, slot - 1].float()
-        logits_trained_row = out_trained.logits[0, slot - 1].float()
+        logits_base_row = logits_base_full[0, slot - 1].float()
+        logits_trained_row = logits_trained_full[0, slot - 1].float()
         logp_base = F.log_softmax(logits_base_row, dim=-1)
         logp_trained = F.log_softmax(logits_trained_row, dim=-1)
         delta_logp_acc += float((logp_trained[MARKER_ID] - logp_base[MARKER_ID]).item())
@@ -338,9 +351,9 @@ def extract_per_context_shift(
 
         # Free-legibility argmax read (marker-leakage rule: emission is a
         # sanity anchor, not the DV).
-        if int(out_trained.logits[0, slot - 1].argmax().item()) == MARKER_ID:
+        if int(logits_trained_full[0, slot - 1].argmax().item()) == MARKER_ID:
             emit_trained_count += 1
-        if int(out_base.logits[0, slot - 1].argmax().item()) == MARKER_ID:
+        if int(logits_base_full[0, slot - 1].argmax().item()) == MARKER_ID:
             emit_base_count += 1
         n_used += 1
 

--- a/tests/test_issue671_extraction_hooks.py
+++ b/tests/test_issue671_extraction_hooks.py
@@ -1,0 +1,500 @@
+"""Pin the #671 memory-safe activation-extraction contract.
+
+The shared helper ``analysis/extraction.py::extract_layer_activations`` replaces
+``model(ids, output_hidden_states=True)`` subset reads — which materialize ALL
+``L+1`` residual-stream tensors per forward (the #545/#667 accumulation bug) —
+with ``register_forward_hook`` on only the needed modules +
+``output_hidden_states=False``. This test file pins:
+
+1. **Byte-identity** of the hook path vs the full-tuple read, across the
+   ``hs[L+1]`` block-index convention AND the ``EMBED_LAYER`` (-1 -> hs[0])
+   sentinel, on a hook-capable stub vs a fallback stub seeded identically.
+2. **The i488 index translation** (``hs[L]`` convention -> block ``L-1`` /
+   embed for ``L=0``) reproduces the OLD ``_last_token_residuals`` read.
+3. **Logits preservation** under ``return_logits=True`` (the issue_650
+   dual-purpose forward), including an end-to-end four-float marker read.
+4. **The AST regression-lock**: the helper source AND each migrated read
+   function's source register forward hooks and do NOT pass
+   ``output_hidden_states=True`` on the primary path (a future re-introduction
+   trips it). Each migrated function is enumerated explicitly.
+5. **CPU memory-non-growth proxy** (advisory; the real GPU-segment retention
+   is not observable CPU-side — see the module docstring + the filed real-GPU
+   follow-up).
+
+CPU-only (tiny deterministic stub models + the real tokenizer); no GPU. Mirrors
+``tests/test_i545_retain_per_sample_reps.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+
+import numpy as np
+import torch
+
+from explore_persona_space.analysis.extraction import EMBED_LAYER, extract_layer_activations
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Deterministic stub hidden-state math (shared by both stubs)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _proj_hidden_states(proj: dict, ids: list[int], d: int, n_blocks: int):
+    """Per-token running-mean of a fixed per-(token,layer) projection.
+
+    Returns ``hs`` = a list of length ``n_blocks + 1`` of ``(1, T, D)`` tensors:
+    ``hs[0]`` is the embedding output, ``hs[k]`` (k>=1) is block ``k-1``'s
+    output. Non-constant across positions so ``last_token != mean_response`` and
+    the reduction is exactly reproducible.
+    """
+    t = len(ids)
+    hs = []
+    for k in range(n_blocks + 1):
+        emb = proj[k][ids]  # (T, D)
+        cum = np.cumsum(emb, axis=0) / (np.arange(1, t + 1)[:, None])
+        hs.append(torch.tensor(cum[None, :, :], dtype=torch.float32))
+    return hs
+
+
+_V_OUT = 64  # small synthetic logit width (>= the marker/eos ids the tests index);
+# NOT the real vocab — a (vocab, vocab) logit matrix would be ~92 GB and hang.
+
+
+def _proj_logits(proj_logit: np.ndarray, ids: list[int]):
+    """Deterministic ``(1, T, V_OUT)`` logits from a fixed per-token projection.
+
+    ``proj_logit`` is ``(vocab, _V_OUT)`` — indexed by token id on the rows, with
+    a small synthetic output width (the marker/eos ids the tests read are < 64).
+    """
+    rows = proj_logit[ids]  # (T, _V_OUT)
+    return torch.tensor(rows[None, :, :], dtype=torch.float32)
+
+
+class _Out:
+    pass
+
+
+class _FallbackStub:
+    """``output_hidden_states``-only model with NO decoder-block structure ->
+    exercises the helper's full-tuple fallback path. Always returns the full
+    ``hidden_states`` tuple (+ logits)."""
+
+    def __init__(self, vocab: int, d: int, n_blocks: int, seed: int = 7):
+        rng = np.random.default_rng(seed)
+        self._proj = {
+            k: rng.standard_normal((vocab, d)).astype(np.float32) for k in range(n_blocks + 1)
+        }
+        self._proj_logit = rng.standard_normal((vocab, _V_OUT)).astype(np.float32)
+        self._n_blocks = n_blocks
+        self._d = d
+
+    def __call__(self, input_ids=None, output_hidden_states=False, attention_mask=None, **_kw):
+        ids = input_ids[0].tolist()
+        o = _Out()
+        o.hidden_states = _proj_hidden_states(self._proj, ids, self._d, self._n_blocks)
+        o.logits = _proj_logits(self._proj_logit, ids)
+        return o
+
+    def eval(self):
+        return self
+
+
+class _Module:
+    """Minimal forward-hook-capable module (mirrors nn.Module's hook contract
+    closely enough): registers hooks and fires them with (self, input, output)."""
+
+    def __init__(self):
+        self._hooks: list = []
+
+    def register_forward_hook(self, fn):
+        self._hooks.append(fn)
+
+        class _Handle:
+            def __init__(h, mod, f):
+                h._mod, h._f = mod, f
+
+            def remove(h):
+                if h._f in h._mod._hooks:
+                    h._mod._hooks.remove(h._f)
+
+        return _Handle(self, fn)
+
+    def _fire(self, output):
+        for fn in list(self._hooks):
+            fn(self, None, output)
+
+
+class _Inner:
+    def __init__(self, embed, blocks):
+        self.embed_tokens = embed
+        self.layers = blocks
+
+
+class _HookStub:
+    """Model with the standard ``model.model.layers`` / ``embed_tokens``
+    structure -> exercises the helper's HOOK path. Same projection math as
+    ``_FallbackStub``, delivered through per-module forward hooks: the embedding
+    module fires hs[0]; block k-1 fires hs[k] (as a tuple, exercising the
+    unwrap). Returns an object carrying ``.logits`` so ``return_logits=True``
+    works on this path too."""
+
+    def __init__(self, vocab: int, d: int, n_blocks: int, seed: int = 7):
+        rng = np.random.default_rng(seed)
+        self._proj = {
+            k: rng.standard_normal((vocab, d)).astype(np.float32) for k in range(n_blocks + 1)
+        }
+        self._proj_logit = rng.standard_normal((vocab, _V_OUT)).astype(np.float32)
+        self._n_blocks = n_blocks
+        self._d = d
+        self._embed = _Module()
+        self._blocks = [_Module() for _ in range(n_blocks)]  # blocks[k-1] -> hs[k]
+        self.model = _Inner(self._embed, self._blocks)
+
+    def __call__(self, input_ids=None, output_hidden_states=False, attention_mask=None, **_kw):
+        # Hooks MUST be the source of truth on this path: if the helper asks for
+        # output_hidden_states=True the #545/#667 fix regressed (W2 — mirrors
+        # tests/test_i545_retain_per_sample_reps.py:118-121). This runtime teeth
+        # complements the AST regression-lock below.
+        assert not output_hidden_states, (
+            "hook-capable model received output_hidden_states=True — the #671 "
+            "fix must extract via hooks, not the full tuple"
+        )
+        ids = input_ids[0].tolist()
+        hs = _proj_hidden_states(self._proj, ids, self._d, self._n_blocks)
+        # Fire each module's hook with its block output. hs[0] = embed output
+        # (bare tensor); hs[k] = block k-1 output (tuple, exercises the unwrap).
+        self._embed._fire(hs[0])
+        for k in range(1, self._n_blocks + 1):
+            self._blocks[k - 1]._fire((hs[k],))
+        o = _Out()
+        o.logits = _proj_logits(self._proj_logit, ids)
+        return o
+
+    def eval(self):
+        return self
+
+
+def _tok():
+    from transformers import AutoTokenizer
+
+    return AutoTokenizer.from_pretrained("Qwen/Qwen2.5-7B-Instruct", trust_remote_code=True)
+
+
+_N_BLOCKS = 28  # mirror Qwen-2.5-7B's block count so block indices 7/14/21 are valid
+_D = 16
+_TEXTS = [
+    "The assistant gives careful advice.",
+    "Here is a structured answer in list form, with several distinct items.",
+    "I would hedge and defer on this question entirely.",
+]
+
+
+def _ids_list(tok):
+    return [
+        torch.tensor([tok.encode(t, add_special_tokens=False)], dtype=torch.long) for t in _TEXTS
+    ]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Byte-identity: hook path == full-tuple read, hs[L+1] + EMBED_LAYER
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_hook_equals_fulltuple_byte_identical():
+    """For each requested layer (incl. EMBED_LAYER) and each of >=3 inputs of
+    differing length, the hook-path captured tensor EQUALS the full-tuple
+    fallback's tensor bit-for-bit. Same seed -> identical hidden states via
+    different mechanisms. Pins the layer-0/embedding off-by-one: a naive hook on
+    layers[L] capturing hs[L+1] would diverge on the EMBED_LAYER case."""
+    tok = _tok()
+    layers = [EMBED_LAYER, 0, 7, 14, 21, 27]
+    fallback = _FallbackStub(tok.vocab_size, _D, _N_BLOCKS, seed=11)
+    hook = _HookStub(tok.vocab_size, _D, _N_BLOCKS, seed=11)
+
+    for ids in _ids_list(tok):
+        fb = extract_layer_activations(fallback, ids, layers)
+        hk = extract_layer_activations(hook, ids, layers)
+        assert set(fb) == set(hk) == set(layers), (set(fb), set(hk))
+        for L in layers:
+            assert torch.equal(fb[L], hk[L]), (L, ids.shape)
+
+
+def test_embed_layer_maps_to_hs0():
+    """``extract_layer_activations(stub, ids, [EMBED_LAYER])[EMBED_LAYER]`` equals
+    the stub's hs[0] (the embedding output), on BOTH the hook and fallback
+    paths."""
+    tok = _tok()
+    fallback = _FallbackStub(tok.vocab_size, _D, _N_BLOCKS, seed=3)
+    hook = _HookStub(tok.vocab_size, _D, _N_BLOCKS, seed=3)
+    ids = _ids_list(tok)[0]
+
+    # Ground truth: the stub's own hs[0].
+    expected = _proj_hidden_states(fallback._proj, ids[0].tolist(), _D, _N_BLOCKS)[0]
+    fb = extract_layer_activations(fallback, ids, [EMBED_LAYER])
+    hk = extract_layer_activations(hook, ids, [EMBED_LAYER])
+    assert torch.equal(fb[EMBED_LAYER], expected)
+    assert torch.equal(hk[EMBED_LAYER], expected)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. i488 index translation (hs[L] convention) byte-identity
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _old_last_token_residuals_via_fulltuple(model, ids, layers):
+    """The PRE-migration ``_last_token_residuals`` math: read
+    ``outputs.hidden_states[L]`` directly (hs[L] convention: L=0 embedding,
+    L=k = hs[k]) at the last input position. Reproduced here against the
+    fallback stub so the test pins the translated helper call against the exact
+    old behavior."""
+    out = model(input_ids=ids, output_hidden_states=True)
+    last_pos = ids.shape[1] - 1
+    return {L: out.hidden_states[L][0, last_pos, :].float().cpu() for L in layers}
+
+
+def test_i488_index_translation_byte_identical():
+    """The translated helper call (``hs[L]`` -> block ``L-1`` / embed for L=0)
+    reproduces the OLD ``_last_token_residuals`` output bit-for-bit, including
+    the L=0 embedding case. The translation is the migration's correctness
+    crux."""
+    tok = _tok()
+    # i488's layers are hs-INDICES (0 = embedding, k = hs[k]).
+    hs_layers = (0, 8, 15, 22, 28)
+    fallback = _FallbackStub(tok.vocab_size, _D, _N_BLOCKS, seed=5)
+    hook = _HookStub(tok.vocab_size, _D, _N_BLOCKS, seed=5)
+    ids = _ids_list(tok)[1]
+
+    old = _old_last_token_residuals_via_fulltuple(fallback, ids, hs_layers)
+    last_pos = ids.shape[1] - 1
+
+    # The migrated call shape: translate hs-index L -> block index.
+    req = [EMBED_LAYER if L == 0 else L - 1 for L in hs_layers]
+    for model in (fallback, hook):
+        acts = extract_layer_activations(model, ids, req)
+        for L in hs_layers:
+            key = EMBED_LAYER if L == 0 else L - 1
+            new = acts[key][0, last_pos, :].float().cpu()
+            assert torch.equal(old[L], new), (L, key, model.__class__.__name__)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Logits preservation under return_logits=True (issue_650 dual-purpose)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_logits_preserved_with_return_logits():
+    """``return_logits=True`` returns ``(acts, logits)`` where ``logits`` equals
+    the stub's logits bit-for-bit, on BOTH paths. The acts are unchanged from
+    the no-logits call."""
+    tok = _tok()
+    layers = [21]
+    fallback = _FallbackStub(tok.vocab_size, _D, _N_BLOCKS, seed=9)
+    hook = _HookStub(tok.vocab_size, _D, _N_BLOCKS, seed=9)
+    ids = _ids_list(tok)[0]
+
+    expected_logits = _proj_logits(fallback._proj_logit, ids[0].tolist())
+
+    for model in (fallback, hook):
+        acts_only = extract_layer_activations(model, ids, layers)
+        acts, logits = extract_layer_activations(model, ids, layers, return_logits=True)
+        assert torch.equal(logits, expected_logits), model.__class__.__name__
+        # acts unchanged whether or not logits were requested.
+        assert torch.equal(acts[21], acts_only[21]), model.__class__.__name__
+
+
+def test_issue650_four_float_marker_read_end_to_end():
+    """End-to-end issue_650-style read off the SAME forward: the hidden-state
+    shift AND a four-float marker slot read (z_marker, z_eos, logZ, logp_marker)
+    are computed from ``return_logits=True`` output and match the OLD full-tuple
+    path bit-for-bit.
+
+    Mirrors the issue_650 logit reads at shift_extract.py:291-343 (read at
+    ``slot - 1``). This pins the logit-rebinding completeness (A2): a missed
+    rebind would surface as a NameError / stale-reference here, which the
+    byte-identity-of-the-activation check alone would NOT catch."""
+    tok = _tok()
+    fallback = _FallbackStub(tok.vocab_size, _D, _N_BLOCKS, seed=13)
+    hook = _HookStub(tok.vocab_size, _D, _N_BLOCKS, seed=13)
+    ids = _ids_list(tok)[2]
+    slot = ids.shape[1] - 1  # a valid response slot; read logits at slot - 1
+    marker_id = 17
+    eos_id = 23
+
+    # OLD path (full tuple): the layer-internal index hs[k]; issue_650 uses
+    # layer_idx_internal == extraction_layer + 1, so block index L = it - 1.
+    layer_idx_internal = 22
+    L = layer_idx_internal - 1
+    out_old = fallback(input_ids=ids, output_hidden_states=True)
+    hs_old = out_old.hidden_states[layer_idx_internal][0, slot].float().cpu()
+    logits_old = out_old.logits[0, slot - 1].float()
+    logp_old = torch.log_softmax(logits_old, dim=-1)
+    z_marker_old = float(logits_old[marker_id].item())
+    z_eos_old = float(logits_old[eos_id].item())
+    logZ_old = float(torch.logsumexp(logits_old, dim=-1).item())
+    logp_marker_old = float(logp_old[marker_id].item())
+
+    # NEW path (helper, return_logits=True), on both stubs.
+    for model in (fallback, hook):
+        acts, logits_full = extract_layer_activations(model, ids, [L], return_logits=True)
+        hs_new = acts[L][0, slot].float().cpu()
+        # Logit reads MUST rebind to logits_full (the A2 rebind-completeness check).
+        logits_row = logits_full[0, slot - 1].float()
+        logp_new = torch.log_softmax(logits_row, dim=-1)
+        z_marker_new = float(logits_row[marker_id].item())
+        z_eos_new = float(logits_row[eos_id].item())
+        logZ_new = float(torch.logsumexp(logits_row, dim=-1).item())
+        logp_marker_new = float(logp_new[marker_id].item())
+
+        assert torch.equal(hs_old, hs_new), model.__class__.__name__
+        assert z_marker_old == z_marker_new, model.__class__.__name__
+        assert z_eos_old == z_eos_new, model.__class__.__name__
+        assert logZ_old == logZ_new, model.__class__.__name__
+        assert logp_marker_old == logp_marker_new, model.__class__.__name__
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. AST regression-lock — enumerate EACH migrated function (A3)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# (module_path-agnostic) (importable_object, attribute) per migrated function +
+# the helper itself. AST-parse each function's source and assert: no
+# output_hidden_states=True on the primary path AND register_forward_hook is
+# referenced (directly, or via the shared helper it calls).
+MIGRATED_FUNCTIONS = [
+    ("explore_persona_space.analysis.extraction", "extract_layer_activations"),
+    ("scripts.issue667_extract", "_mean_resp_acts"),
+    ("scripts.issue667_extract", "_mean_resp_acts_single"),
+    ("explore_persona_space.experiments.issue_650.shift_extract", "extract_per_context_shift"),
+    ("explore_persona_space.analysis.probes", "extract_residual_stream_activations"),
+    ("explore_persona_space.analysis.probes", "extract_dual_position_activations"),
+    ("scripts.i488_phase1_predictors", "_last_token_residuals"),
+]
+
+
+def _load_func(module_path: str, attr: str):
+    import importlib
+
+    mod = importlib.import_module(module_path)
+    return getattr(mod, attr)
+
+
+def _func_source_tree(func):
+    src = textwrap.dedent(inspect.getsource(func))
+    return ast.parse(src)
+
+
+def test_helper_uses_hooks_not_output_hidden_states():
+    """The shared helper registers forward hooks and its PRIMARY path passes
+    ``output_hidden_states=False``; the single ``=True`` is the labeled
+    non-standard-model / CPU-stub fallback."""
+    tree = _func_source_tree(extract_layer_activations)
+
+    has_hook = any(
+        isinstance(node, ast.Attribute) and node.attr == "register_forward_hook"
+        for node in ast.walk(tree)
+    )
+    assert has_hook, "extract_layer_activations must use register_forward_hook"
+
+    false_calls, true_calls = 0, 0
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            for kw in node.keywords:
+                if kw.arg == "output_hidden_states" and isinstance(kw.value, ast.Constant):
+                    if kw.value.value is True:
+                        true_calls += 1
+                    elif kw.value.value is False:
+                        false_calls += 1
+    assert false_calls >= 1, "the primary hook-path forward must pass output_hidden_states=False"
+    assert true_calls <= 1, f"output_hidden_states=True appears {true_calls} times (fallback only)"
+
+
+def test_migrated_functions_use_helper_no_output_hidden_states_true():
+    """Regression-lock over EACH migrated function explicitly (A3). For every
+    function in MIGRATED_FUNCTIONS: (a) it references ``register_forward_hook``
+    OR calls the shared ``extract_layer_activations`` helper (which does); and
+    (b) the migrated CALL SITES contain NO ``output_hidden_states=True`` Constant
+    kwarg (a future re-introduction on any migrated read path trips this). The
+    helper itself is the SOLE allowed home of the single labeled fallback
+    ``=True`` (pinned at ``<= 1`` by ``test_helper_uses_hooks_not_output_hidden_states``),
+    so it is exempted from the strict ``== 0`` here."""
+    for module_path, attr in MIGRATED_FUNCTIONS:
+        func = _load_func(module_path, attr)
+        tree = _func_source_tree(func)
+        is_helper = attr == "extract_layer_activations"
+
+        references_hook = any(
+            isinstance(node, ast.Attribute) and node.attr == "register_forward_hook"
+            for node in ast.walk(tree)
+        )
+        calls_helper = any(
+            isinstance(node, ast.Call)
+            and (
+                (isinstance(node.func, ast.Name) and node.func.id == "extract_layer_activations")
+                or (
+                    isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "extract_layer_activations"
+                )
+            )
+            for node in ast.walk(tree)
+        )
+        assert references_hook or calls_helper, (
+            f"{module_path}.{attr} must route through extract_layer_activations "
+            f"(or register hooks directly) — neither found"
+        )
+
+        true_calls = 0
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                for kw in node.keywords:
+                    if (
+                        kw.arg == "output_hidden_states"
+                        and isinstance(kw.value, ast.Constant)
+                        and kw.value.value is True
+                    ):
+                        true_calls += 1
+        # Migrated callers: strict zero. The helper: its one labeled fallback is OK.
+        allowed = 1 if is_helper else 0
+        assert true_calls <= allowed, (
+            f"{module_path}.{attr} passes output_hidden_states=True {true_calls} time(s) "
+            f"(allowed {allowed}) — the #545/#667 accumulation bug is back on this path"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. CPU memory-non-growth proxy (ADVISORY — see module docstring)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_memory_non_growth_cpu_proxy():
+    """Advisory CPU proxy: across N=20 repeated extractions on the hook stub, no
+    Python-level reference is retained iteration-to-iteration (handles removed,
+    captured dict dropped). The REAL bug is GPU-segment retention under
+    ``expandable_segments:True`` — NOT observable CPU-side — so this is a
+    necessary-but-not-sufficient proxy, gated loosely for interpreter noise. The
+    authoritative GPU-resident-non-growth check is the filed real-GPU follow-up.
+    """
+    import gc
+    import resource
+
+    tok = _tok()
+    hook = _HookStub(tok.vocab_size, _D, _N_BLOCKS, seed=21)
+    layers = [7, 14, 21]
+    ids = _ids_list(tok)[0]
+
+    rss = []
+    for _ in range(20):
+        acts = extract_layer_activations(hook, ids, layers)
+        del acts
+        gc.collect()
+        rss.append(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+
+    # ru_maxrss is a high-water mark (monotone non-decreasing by definition), so
+    # we assert it does not BALLOON: the peak over the last 10 iterations is not
+    # meaningfully above the peak over the first 10. A retained per-iteration
+    # reference would grow the working set without bound; releasing it keeps the
+    # high-water mark flat after warm-up. Generous slack for interpreter noise.
+    first_half_peak = max(rss[:10])
+    last_half_peak = max(rss[10:])
+    assert last_half_peak <= first_half_peak * 1.10 + 50_000, (first_half_peak, last_half_peak)


### PR DESCRIPTION
Closes task #671.

Replaces subset-of-layers reads of `model(..., output_hidden_states=True)` with `register_forward_hook` on only the needed modules + `output_hidden_states=False`, eliminating per-forward materialization of the ~21/29 unused residual-stream tensors and removing the root cause of the recurring #545 OOM growth + the GCP hung-RUNNING wedge (#667; deep-research wf_857f7cfd).

## What

- New shared helper `src/explore_persona_space/analysis/extraction.py::extract_layer_activations(model, ids, layers, *, return_logits, detach_to_cpu)`. BLOCK-index convention, `EMBED_LAYER=-1` sentinel for the embedding, version-robust `output[0] if isinstance(output, tuple) else output` unwrap, full-tuple `output_hidden_states=True` fallback for non-standard models / CPU stubs. Extracted from the proven `behavior_testbed_545/predictors.py:_mean_hidden_states` pattern.
- Routed through the helper:
  - `scripts/issue667_extract.py` (`_mean_resp_acts`, `_mean_resp_acts_single`)
  - `src/explore_persona_space/analysis/probes.py` (2 fns; single-forward dual-position property preserved)
  - `src/explore_persona_space/experiments/issue_650/shift_extract.py` (`return_logits=True` + all 4 `out_base/out_trained.logits` reads rebound to `logits_*_full` for the #530 four-float marker-slot storage contract)
  - `scripts/i488_phase1_predictors.py` (`hs[L]` convention with explicit `EMBED_LAYER if L==0 else L-1` translation)
- New `tests/test_issue671_extraction_hooks.py` — 8 tests: byte-identity hook-vs-fulltuple (incl. `EMBED_LAYER` → `hs[0]`), i488 index translation, `return_logits=True` logits preservation, end-to-end four-float marker read (pins issue_650 rebind completeness), AST regression-lock enumerating all 6 migrated functions, `_HookStub` keeps `assert not output_hidden_states` teeth, advisory CPU memory non-growth.

## Gates passed

- `epm:plan-verify` PASS (3 PASS, 9 SKIP kind-exempt for kind:infra, 0 FAIL/WARN)
- 3/3 Claude plan critics (Methodology + Statistics + Alternatives) → APPROVE outright
- Consistency-checker → WARN (non-blocking; 2 implementer refinements honored)
- Codex twin (plan): plugin app-server failure — fell back to single-Claude per workflow.yaml § ensemble_review
- Code-review ensemble round 1: Claude PASS + Codex CONCERNS (both PASS-class) → PASS
- `epm:test-verdict` PASS — full `tests/` suite: 4874 passed, 23 skipped, 0 real failures (6 initial failures were sparse-checkout artifacts; resolved by `git sparse-checkout add eval_results/issue_545|521|257|276`)

## Deferred follow-ups

- #673 — Real-GPU memory-non-growth validation (~0.25 GPU-h; the authoritative GPU-segment-non-growth check the CPU proxy cannot do)
- #674 — Route per-cell `.npz` writes to local SSD scratch + batch-upload at sweep end (GCE I/O decoupling — the secondary wedge amplifier)

## Validation

- Bit-for-bit `torch.equal(old, new)` identity proven by the new test file; `tests/test_i545_retain_per_sample_reps.py` (reference impl regression) 4/4 PASS.
- `ruff check` + `ruff format --check` clean on all 6 touched files.

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>