### PR TITLE
fix(686): confirm-deleted guard in GcpBackend.teardown

### DIFF
--- a/src/explore_persona_space/backends/gcp.py
+++ b/src/explore_persona_space/backends/gcp.py
@@ -3928,12 +3928,29 @@ class GcpBackend(ComputeBackend):
         belts mean an unattended VM auto-deletes; an orchestrator-driven
         teardown is the explicit early path. A "was not found" stderr is
         the common case (the VM already auto-deleted) and is NOT raised.
+
+        Confirm-deleted guard (#683 defense-in-depth): a CLEAN
+        ``eps/phase=done`` run leaves the VM RUNNING by design (the success
+        path keeps it alive so the sentinel can be scp'd — only a CRASH
+        triggers the in-VM EXIT-trap ``shutdown``+DELETE / rc!=0 belt), so
+        the orchestrator-driven ``teardown`` is what reaps a successful run
+        that REACHES finalize. If teardown's own rc==0 delete silently
+        no-ops (rc==0 but the instance lingers RUNNING), nothing else
+        reclaims it until the 24h ``--max-run-duration`` belt OR the daily
+        ``gcp_audit`` janitor. So after an rc==0 delete we ACTIVELY confirm
+        the instance is gone via ``describe``; if it is still present AND
+        ``RUNNING``, re-issue the delete ONCE. Idempotent + fails toward
+        "gone" (404 / non-RUNNING / probe-failure never re-delete). NOTE:
+        the original #683 leak occurred on a run where teardown was NOT
+        reached before the leak was observed — that path is closed by the
+        watcher-side complement (see plan §10), not by this guard.
         """
         config = self._config
         zone = handle.extra.get("zone") or config.primary_zone
         argv = render_delete_argv(config=config, name=handle.pod_name, zone=zone)
         result = self._run(argv)
         if result.returncode == 0:
+            self._confirm_deleted(handle, zone)
             return
         stderr_low = (result.stderr or "").lower()
         if "was not found" in stderr_low or "404" in stderr_low:
@@ -3948,6 +3965,81 @@ class GcpBackend(ComputeBackend):
         raise GcpBackendError(
             f"gcloud delete {handle.pod_name} returned {result.returncode}: {result.stderr[:500]}"
         )
+
+    def _confirm_deleted(self, handle: RunHandle, zone: str) -> None:
+        """Verify the post-delete instance is gone; re-issue the delete on a RUNNING zombie (#683).
+
+        Called only after an rc==0 ``gcloud compute instances delete``.
+        ``gcloud delete`` is normally synchronous, but a clean-terminal VM
+        has been observed lingering RUNNING after a rc==0 delete (#683), so
+        this is the orchestrator-side belt that catches that silent no-op
+        BEFORE the once-daily janitor (the only other reaper of a clean
+        run, up to ~24h of GPU billing later).
+
+        Fail-toward-gone discipline (never a spurious re-delete):
+
+        * describe 404 / "not found" → confirmed gone, the desired state;
+        * describe rc != 0 (any other reason — auth blip / transient API) →
+          do NOT re-delete blindly (the delete already returned rc==0; a
+          probe failure is not evidence the VM survived); log + return;
+        * describe rc==0 but the payload has no ``status`` / is unparseable
+          / ``status != RUNNING`` → trust the delete, return;
+        * describe rc==0 AND ``status == RUNNING`` → the #683 zombie
+          signature → re-issue the delete ONCE (best-effort; a failure
+          there is logged, not raised — the janitor remains the backstop).
+        """
+        config = self._config
+        describe_argv = render_describe_argv(config=config, name=handle.pod_name, zone=zone)
+        probe = self._run(describe_argv)
+        if probe.returncode != 0:
+            stderr_low = (probe.stderr or "").lower()
+            if "was not found" in stderr_low or "404" in stderr_low:
+                return  # confirmed gone — the desired post-delete state
+            # Couldn't confirm either way; the delete returned rc==0, so do
+            # not re-delete on an unrelated probe failure. The janitor backs us up.
+            logger.warning(
+                "GCP teardown: post-delete describe of %s failed (rc=%d); "
+                "trusting the rc==0 delete (gcp_audit janitor is the backstop). stderr=%s",
+                handle.pod_name,
+                probe.returncode,
+                (probe.stderr or "")[:300],
+            )
+            return
+        try:
+            payload = json.loads(probe.stdout) if probe.stdout.strip() else {}
+        except json.JSONDecodeError:
+            logger.warning(
+                "GCP teardown: post-delete describe of %s returned unparseable JSON; "
+                "trusting the rc==0 delete.",
+                handle.pod_name,
+            )
+            return
+        status = (payload.get("status") or "").upper()
+        if status != "RUNNING":
+            # Empty payload, STOPPING/TERMINATED (delete in progress), or any
+            # non-RUNNING state — the delete is taking effect; nothing to re-do.
+            return
+        # The #683 zombie: rc==0 delete but the VM is still RUNNING. Re-issue
+        # the delete ONCE so a successful run cannot bill an A100 until the
+        # daily janitor reaps it. Best-effort — a failure here is logged, not
+        # raised (the janitor + 24h max-run-duration remain the backstops).
+        logger.warning(
+            "GCP teardown: %s still RUNNING after an rc==0 delete (#683 zombie); "
+            "re-issuing the delete once.",
+            handle.pod_name,
+        )
+        redelete = self._run(render_delete_argv(config=config, name=handle.pod_name, zone=zone))
+        if redelete.returncode != 0:
+            redelete_low = (redelete.stderr or "").lower()
+            if "was not found" in redelete_low or "404" in redelete_low:
+                return  # the first delete landed between the probe and the retry
+            logger.error(
+                "GCP teardown: re-issued delete of the RUNNING zombie %s ALSO failed "
+                "(rc=%d); gcp_audit janitor will reap it. stderr=%s",
+                handle.pod_name,
+                redelete.returncode,
+                (redelete.stderr or "")[:300],
+            )
 
     # ----- internal helpers ------------------------------------------------
 

--- a/tests/test_gcp_backend.py
+++ b/tests/test_gcp_backend.py
@@ -1751,6 +1751,121 @@ def test_teardown_raises_on_real_failure() -> None:
 
 
 # ---------------------------------------------------------------------------
+# teardown — confirm-deleted guard (#683 clean-terminal RUNNING zombie)
+# ---------------------------------------------------------------------------
+
+
+def _teardown_handle():
+    """Build a teardown RunHandle (lazy import matches the file's prevailing style)."""
+    from explore_persona_space.backends.base import RunHandle
+
+    return RunHandle(
+        backend="gcp",
+        cluster=None,
+        job_id="1",
+        pod_name="eps-issue-683",
+        scratch_dir="/workspace/eps-issue-683",
+        log_path="/workspace/logs/issue-683.log",
+        extra={"zone": "us-central1-a"},
+    )
+
+
+def _kind(argv: list[str]) -> str:
+    """Classify a recorded gcloud argv the way ``_Runner`` routes it."""
+    if "delete" in argv and "instances" in argv:
+        return "delete"
+    if "describe" in argv and "instances" in argv:
+        return "describe"
+    return "other"
+
+
+def test_teardown_confirms_deleted_and_does_not_redelete_when_gone() -> None:
+    """rc==0 delete + a 'not found' describe → confirmed gone, NO second delete (#683)."""
+    runner = _Runner(
+        delete_results=[GcloudRunResult(0, "", "")],
+        describe_results=[
+            GcloudRunResult(1, "", "ERROR: (gcloud.compute.instances.describe) was not found")
+        ],
+    )
+    backend = GcpBackend(config=_test_config(), runner=runner, marker_poster=lambda **_: None)
+    backend.teardown(_teardown_handle())
+    seq = [_kind(c) for c in runner.calls]
+    # The confirm probe ran after the delete; no re-delete on a confirmed-gone VM.
+    assert seq == ["delete", "describe"], runner.calls
+
+
+def test_teardown_redeletes_running_zombie_once() -> None:
+    """rc==0 delete but describe shows status=RUNNING (the #683 zombie) → re-delete ONCE."""
+    runner = _Runner(
+        delete_results=[GcloudRunResult(0, "", ""), GcloudRunResult(0, "", "")],
+        describe_results=[GcloudRunResult(0, json.dumps({"status": "RUNNING"}), "")],
+    )
+    backend = GcpBackend(config=_test_config(), runner=runner, marker_poster=lambda **_: None)
+    backend.teardown(_teardown_handle())
+    seq = [_kind(c) for c in runner.calls]
+    # Positional: probe-then-re-delete, in order. A back-to-back double-delete
+    # with no probe between (a hypothetical buggy refactor) would FAIL here,
+    # where a bare ``len(delete_calls) == 2`` would pass it.
+    assert seq == ["delete", "describe", "delete"], runner.calls
+
+
+def test_teardown_does_not_redelete_on_non_running_describe() -> None:
+    """A non-RUNNING describe (STOPPING / TERMINATED / empty status) trusts the rc==0 delete."""
+    for status in ("STOPPING", "TERMINATED", ""):
+        runner = _Runner(
+            delete_results=[GcloudRunResult(0, "", "")],
+            describe_results=[GcloudRunResult(0, json.dumps({"status": status}), "")],
+        )
+        backend = GcpBackend(config=_test_config(), runner=runner, marker_poster=lambda **_: None)
+        backend.teardown(_teardown_handle())
+        seq = [_kind(c) for c in runner.calls]
+        assert seq == ["delete", "describe"], (status, runner.calls)  # no spurious re-delete
+
+
+def test_teardown_does_not_redelete_on_describe_probe_failure() -> None:
+    """A non-404 describe failure does NOT re-delete (the rc==0 delete already landed)."""
+    runner = _Runner(
+        delete_results=[GcloudRunResult(0, "", "")],
+        describe_results=[GcloudRunResult(1, "", "Reauthentication failed")],
+    )
+    backend = GcpBackend(config=_test_config(), runner=runner, marker_poster=lambda **_: None)
+    backend.teardown(_teardown_handle())
+    seq = [_kind(c) for c in runner.calls]
+    assert seq == ["delete", "describe"], runner.calls  # probe failure ≠ evidence the VM survived
+
+
+def test_teardown_redelete_404_is_silent_success() -> None:
+    """The re-delete's own 404 is silent success (first delete landed between probe and retry)."""
+    runner = _Runner(
+        delete_results=[
+            GcloudRunResult(0, "", ""),
+            GcloudRunResult(1, "", "ERROR: (gcloud.compute.instances.delete) was not found"),
+        ],
+        describe_results=[GcloudRunResult(0, json.dumps({"status": "RUNNING"}), "")],
+    )
+    backend = GcpBackend(config=_test_config(), runner=runner, marker_poster=lambda **_: None)
+    # No raise: the redelete-404 idempotency branch swallows the "was not found".
+    backend.teardown(_teardown_handle())
+    seq = [_kind(c) for c in runner.calls]
+    assert seq == ["delete", "describe", "delete"], runner.calls
+
+
+def test_teardown_does_not_redelete_on_empty_describe_stdout() -> None:
+    """rc==0 describe with EMPTY stdout → ``... else {}`` → status None → no re-delete (#683 v2)."""
+    runner = _Runner(
+        delete_results=[GcloudRunResult(0, "", "")],
+        describe_results=[GcloudRunResult(0, "", "")],
+    )
+    backend = GcpBackend(config=_test_config(), runner=runner, marker_poster=lambda **_: None)
+    backend.teardown(_teardown_handle())
+    seq = [_kind(c) for c in runner.calls]
+    # The ``if probe.stdout.strip() else {}`` guard: empty STDOUT STRING (rc==0)
+    # parses to {} → status None → not RUNNING → no re-delete. Distinct from the
+    # empty *status field* ({"status": ""}) case in the non-running test above.
+    assert seq == ["delete", "describe"], runner.calls
+
+
+# ---------------------------------------------------------------------------
 # poll
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Defense-in-depth hardening of `GcpBackend.teardown`'s post-rc==0-delete success path
(the *teardown-reached* path) — when teardown does run on a still-live VM, probe
`gcloud compute instances describe` and re-issue delete once on observed
`status == "RUNNING"`.

Bounds the success-path zombie window from ~24h (daily `gcp_audit` reaper) to
~1s for the teardown-reached path. The crash-between-`phase=done`-and-finalize
variant (teardown NOT reached) is a separate workflow-fix the orchestrator
routes via the formal candidate block in plan v2 §10.

This patch IS NOT the primary #683 fix — round-1 Alternatives critics (Claude + Codex)
independently found that #683's `epm:upload-verification` discovered the still-RUNNING
VM at Step 8 BEFORE finalize/teardown ran. The §10 watcher-side complement is the
primary fix.

## Plan

- Plan v2 (auto-approved at 0 GPU-h): `tasks/approved/686/plans/v2.md`
- Round-1 ensemble verdicts:
  - Methodology: APPROVE + APPROVE
  - Statistics: APPROVE + APPROVE
  - Alternatives: REVISE + REVISE → re-framed in v2; same patch

## Verification

- `tests/test_gcp_backend.py` — 6 new tests, full file 217 passed
- Broader backend suite: 673 passed (`test_router*`, `test_backend_*`, `test_slurm_*`, `test_gcp_backend`, `test_no_dollar_budget_caps`)
- `ruff check` + `ruff format --check` clean
- `workflow_lint.py --check-asks` PASS
- Regression-guard property proven: neutering `_confirm_deleted` makes all 6 new tests FAIL

Closes task #686.

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)