### PR TITLE
task #692: compose RunPod no-port wedge predicate into watcher pod-safety pass

### DIFF
--- a/.claude/rules/compute-backend-failover.md
+++ b/.claude/rules/compute-backend-failover.md
@@ -280,6 +280,50 @@ terminate+re-provision, not the wrong `--refresh-from-api`) is the interactive
 sibling; the report-only `running_no_port` flag in `pod_audit.py` is the
 fleet-level visibility backstop (never auto-terminates).
 
+### Part C watcher backstop — the poller-DEAD case (#692)
+
+The poller-side detect+recover above runs ONLY while the per-issue poll loop is
+alive — exactly when a backstop is NOT needed. When that loop has DIED (crashed
+`/issue` session, OOM-killed bg-Bash poll chain, VM reboot),
+`_maybe_escalate_runpod_wedge` never runs and the #664 billing leak goes
+undetected. The `autonomous_session_watch.py` pod-safety pass (every 10 min,
+session-independent) closes that gap with a wedge arm in `_process_pod`:
+
+- **Compose, do NOT re-define.** The arm calls the SAME raw predicate
+  `backend_poll._pod_is_runpod_runtime_wedged(info)` the poller uses (extracted
+  from `_maybe_escalate_runpod_wedge`, composition surface (b)), reading the
+  live `PodInfo` the API list pass already fetched, and the SAME imported
+  `backend_poll.RUNPOD_WEDGE_K_SEC` (never a duplicated literal).
+- **A DEDICATED wedge clock.** The maturity floor ages against
+  `wedge_first_seen` (stamped at wedge ONSET, cleared on any non-wedge tick and
+  on a pod_id change), NOT the pod-incarnation `first_seen` (which measures pod
+  uptime, not the no-port episode). A `>= threshold` (default 2)
+  consecutive-confirmed-checks miss guard backs it, so a transient API blip
+  never stops a pod.
+- **ALERT by default; AUTO-STOP only when provably safe.** Past K + confirmed,
+  the arm posts a once-per-episode alert UNLESS the same inputs-on-HF gate fix
+  (b) uses (`backend_poll._wedged_run_inputs_on_hf`) confirms zero partial cells
+  AND a TRI-STATE keep-running read (`_wedge_keep_running` → `True | False |
+  "unknown"`) returns the literal `False`. Every uncertainty path (no handle, HF
+  error, tag present, tag-read FAILURE `"unknown"`) is ALERT-only — a persistent
+  tag-read failure never silently overrides a keep-running tag on a live-work pod.
+- **STOP, never terminate.** The recovery action is the reversible `pod.py stop`
+  (volume preserved) — the watcher has no run handle guarantee and runs blind to
+  the dispatcher's resume state, so it halts billing rather than terminating
+  (CLAUDE.md halt-criterion #2). The poller's fix (b) owns the irreversible
+  terminate + re-provision.
+- **DONE-task ordering.** A wedged pod whose task is at a DONE status
+  (`completed` / `awaiting_promotion` / `archived`) FALLS THROUGH to the
+  existing status-class DONE auto-stop arm (the canonical escaped-pod handler) —
+  the wedge arm only handles non-DONE (live-work) statuses, so it never weakens
+  the existing auto-stop into a conditional one.
+
+Tests of record: `tests/test_autonomous_session_watch_wedge.py` (the decision
+table + boundaries, the tri-state gate, the fail-closed inputs gate, the
+state round-trip, the pod_id reset, the alert dedup, the DONE fall-through) +
+the direct predicate test
+`tests/test_runpod_wedge_detection.py::test_pod_is_runpod_runtime_wedged_predicate`.
+
 ## Tests of record
 
 - `tests/test_router.py::test_gcp_workload_error_fails_over_to_runpod_no_slurm_cascade`

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -391,7 +391,7 @@ if _SCRIPTS_DIR not in sys.path:
 # matched the canonical `pod-<N>` names, so the whole pass was dead code).
 import session_resolver  # noqa: E402  (sibling import; follows the sys.path bootstrap above)
 from pod_lifecycle import _is_managed_pod, _issue_from_pod_name  # noqa: E402
-from runpod_api import list_team_pods  # noqa: E402
+from runpod_api import PodInfo, list_team_pods  # noqa: E402
 from spawn_session import (  # noqa: E402
     AUTONOMOUS_REGISTRY_DIR,
     PROJECT_ROOT,
@@ -508,6 +508,13 @@ ALERT_STALE_HOURS = 6.0
 # pass exists for — have no registry entry at all.
 _POD_SAFETY_PREFIX = "pod-safety-"
 
+# Sentinel distinguishing "carry the prior on-disk value forward" from an
+# EXPLICIT value for the #692 wedge fields of `_save_pod_safety_state`. Needed
+# because `None` is itself a meaningful value for `wedge_first_seen` (the MF1
+# onset-clock CLEAR), so it cannot double as the carry-forward signal the way
+# `None` does for the `keep_running_noted` / `followup_noted` flags.
+_CARRY = object()
+
 # Substring stamped into every alert marker note this pass posts, so the
 # staleness check can EXCLUDE the watcher's own alerts from "real progress" —
 # otherwise an alert would reset the staleness clock and the gap could never
@@ -540,6 +547,23 @@ _KEEP_RUNNING_NOTE_SENTINEL = "[autonomous_session_watch:pod-keep-running-skip]"
 # 3 cycles of pod auto-stop → manual re-provision in <1h before the follow-up
 # launches were recognized as legitimate.
 _FOLLOWUP_NOTE_SENTINEL = "[autonomous_session_watch:pod-followup-skip]"
+
+# Substring stamped into the #692 RunPod no-port wedge ALERT marker — posted
+# (once per wedge episode, deduped via the `wedge_alerted` flag in the
+# pod-safety state file) when the watcher detects the #664 RUNNING-but-no-port
+# billing leak (the poller's `_maybe_escalate_runpod_wedge` never ran because
+# the poll loop died) but the AUTO-STOP is gated off (inputs unverified on HF,
+# the keep-running tag is present, or the keep-running read FAILED). Posted as
+# epm:progress, so it MUST be excluded from "real progress" in
+# `_latest_progress_ts` — same staleness-filter contract as the other alerts.
+_WEDGE_ALERT_NOTE_SENTINEL = "[autonomous_session_watch:runpod-noport-wedge-alert]"
+
+# Substring stamped into the #692 RunPod no-port wedge AUTO-STOP marker — posted
+# when the wedge matured past the K floor for >= threshold consecutive checks
+# AND the inputs-on-HF + (tri-state) keep-running gates confirm a reversible
+# `pod.py stop` is safe. STOP, never terminate (the poller owns terminate).
+# Posted as epm:progress; excluded from "real progress" like the alert.
+_WEDGE_STOP_NOTE_SENTINEL = "[autonomous_session_watch:runpod-noport-wedge-stop]"
 
 # Substring stamped into every session-stalled-alert marker note. Same role as
 # _ALERT_NOTE_SENTINEL for the pod-safety pass: a session-stalled alert is
@@ -728,6 +752,8 @@ _WATCHER_NOTE_SENTINELS: frozenset[str] = frozenset(
         _ALERT_NOTE_SENTINEL,
         _KEEP_RUNNING_NOTE_SENTINEL,
         _FOLLOWUP_NOTE_SENTINEL,
+        _WEDGE_ALERT_NOTE_SENTINEL,
+        _WEDGE_STOP_NOTE_SENTINEL,
         _STALLED_ALERT_NOTE_SENTINEL,
         _STALLED_RESPAWN_NOTE_SENTINEL,
         _STALLED_EXHAUSTED_NOTE_SENTINEL,
@@ -1072,6 +1098,115 @@ def decide_pod_safety(
         return ("alert", 0)
     # pod-active-stale-already-alerted, pod-active-fresh, other -> hands off.
     return ("keep", 0)
+
+
+def decide_pod_wedge(
+    *,
+    wedged_for: float,
+    k_floor: float,
+    wedge_missed: int,
+    threshold: int,
+    alerted: bool,
+    keep_running: bool | str,
+    inputs_ok: bool,
+) -> tuple[str, int]:
+    """Pure decision for a RUNNING managed pod in the #664 RunPod no-port wedge.
+
+    The watcher backstop for when the poller's
+    ``backend_poll._maybe_escalate_runpod_wedge`` never ran (the per-issue poll
+    loop died). Returns ``(action, new_wedge_missed)`` where action is
+    ``"stop"`` | ``"alert"`` | ``"keep"``. The caller (``_process_wedged_pod``)
+    has already confirmed the RAW wedge condition
+    (``backend_poll._pod_is_runpod_runtime_wedged``) and excluded DONE-status
+    pods (MF6 — a DONE-task wedged pod falls through to the status-class arm).
+
+    Parameters
+    ----------
+    wedged_for
+        Seconds the pod has been in the raw no-port wedge, measured against the
+        DEDICATED ``wedge_first_seen`` clock (stamped at wedge ONSET, NOT the
+        pod-incarnation ``first_seen`` — MF1), so it is the actual no-port
+        episode length, not pod uptime.
+    k_floor
+        ``backend_poll.RUNPOD_WEDGE_K_SEC`` (imported, never a duplicated
+        literal). The maturity floor the wedge must exceed before any action.
+    wedge_missed
+        The wedge arm's consecutive-confirmed-past-K miss count (SEPARATE from
+        the status-class ``missed``).
+    threshold
+        Consecutive-confirmed-checks required before a STOP (default 2 = ~20 min
+        at the 10-min cron, so a single transient API mis-read never stops a
+        pod) — the same miss guard the status-class auto-stop uses.
+    alerted
+        Whether the once-per-wedge-episode alert has already been posted
+        (tracked as ``wedge_alerted`` in the state file). Informational here;
+        the dedup decision is the CALLER's (it posts the marker only if not
+        already alerted), so this fn returns ``"alert"`` whenever the gated
+        condition holds and lets the caller dedup.
+    keep_running
+        TRI-STATE (MF2): ``True`` (the ``keep-running`` tag is present) |
+        ``False`` (the tag was read OK and is absent) | ``"unknown"`` (the tag
+        read FAILED — subprocess error, non-zero rc, JSON parse error). A STOP
+        fires ONLY on the literal ``False``; ``"unknown"`` routes to ALERT-only
+        so a tagged live-work pod whose tag lookup is transiently failing is
+        NEVER auto-stopped (which would silently override the user's tag).
+    inputs_ok
+        Whether the wedged run's recoverable inputs are verified on HF (the same
+        gate #689 fix (b) uses, via ``backend_poll._wedged_run_inputs_on_hf``).
+        A STOP fires only when inputs are PROVABLY safe.
+
+    Cases:
+
+    - ``wedged_for <= k_floor`` -> ``("keep", 0)``. Below the K maturity floor
+      the wedge has not matured (a healthy slow bring-up clears it when the port
+      appears); reset the miss counter so a brief no-port blip never accumulates
+      toward a stop. The comparator is ``<=`` here (and ``>`` below) to MATCH the
+      poller's ``wedged_for > RUNPOD_WEDGE_K_SEC`` at ``backend_poll.py``
+      (``wedged_for == k_floor`` KEEPs — MF5 boundary parity).
+    - ``wedged_for > k_floor`` AND ``wedge_missed + 1 < threshold`` ->
+      ``("keep", wedge_missed + 1)``. Past K but not yet confirmed for
+      ``>=threshold`` consecutive checks; accumulate. The action transitions
+      exactly when ``wedge_missed + 1 == threshold`` (MF5 boundary).
+    - ``wedged_for > k_floor`` AND confirmed (``wedge_missed + 1 >= threshold``):
+        - ``keep_running is True`` -> ``("alert", 0)``. The keep-running tag
+          exempts the AUTO-STOP exactly as it does for the status-class arm; the
+          wedge is still surfaced once per episode so the leak is visible.
+        - ``keep_running == "unknown"`` -> ``("alert", 0)`` (MF2). A PERSISTENT
+          tag-read failure is NOT a genuinely untagged task; route the
+          uncertainty to ALERT-only rather than silently override the user's tag.
+          This is a STRONGER gate than the status-class DONE arm's
+          False-on-failure (safe there only because it auto-stops DONE-status
+          pods; the wedge arm auto-stops live-work pods).
+        - ``keep_running is False`` AND ``inputs_ok`` -> ``("stop", 0)``. Inputs
+          are verified on HF AND the tag was read AND it is absent, so the
+          reversible STOP is safe — halt the billing leak.
+        - ``keep_running is False`` AND not ``inputs_ok`` -> ``("alert", 0)``.
+          Inputs are NOT verified on HF (or no run handle to gate on); a STOP
+          could strand un-uploaded work, so ALERT-only and let a human / the
+          re-invoked /issue decide (CLAUDE.md halt-criterion #2).
+
+    Decision invariant (MF2): ``("stop", _)`` is returned ONLY when
+    ``keep_running is False`` (the literal boolean False, NOT ``"unknown"`` and
+    NOT ``True``) AND ``inputs_ok is True``. Every other ``keep_running`` value
+    routes to ALERT-only.
+    """
+    if wedged_for <= k_floor:
+        # Below the maturity floor (or exactly at it — MF5 parity with the
+        # poller's strict `> K`): not matured. Reset the miss counter.
+        return ("keep", 0)
+    new_wedge_missed = wedge_missed + 1
+    if new_wedge_missed < threshold:
+        # Past K but not yet confirmed for >=threshold consecutive checks.
+        return ("keep", new_wedge_missed)
+    # Confirmed past K for >=threshold consecutive checks. Gate the AUTO-STOP.
+    if keep_running is True:
+        return ("alert", 0)
+    if keep_running == "unknown":
+        return ("alert", 0)
+    # keep_running is the literal False (tag read OK and absent).
+    if inputs_ok:
+        return ("stop", 0)
+    return ("alert", 0)
 
 
 # ─── VM disk-headroom watcher (task #552 incident, 2026-06-10) ───────────────
@@ -1572,6 +1707,117 @@ def _task_keep_running(issue: int) -> bool:
     return isinstance(tags, list) and "keep-running" in tags
 
 
+def _wedge_keep_running(issue: int) -> bool | str:
+    """Tri-state keep-running read for the #692 wedge arm (MF2).
+
+    Returns ``True`` (the ``keep-running`` tag is present) | ``False`` (the tag
+    read succeeded and is absent) | ``"unknown"`` (the tag read FAILED —
+    subprocess error, non-zero rc, JSON parse error). The shared
+    :func:`_task_keep_running` collapses all three of those failure modes to
+    ``False``, indistinguishable from a genuinely untagged task — safe for the
+    status-class DONE arm (it only auto-stops DONE-status pods, where the user
+    has far less reason to keep-running) but NOT for the wedge arm, which
+    auto-stops LIVE-WORK (``running`` / ``approved`` / ...) pods. The wedge
+    AUTO-STOP fires only on the literal ``False``; ``"unknown"`` routes to
+    ALERT-only so a tagged live-work pod whose tag lookup is transiently failing
+    is NEVER auto-stopped (which would silently override the user's explicit tag).
+
+    Uses the same ``task.py view --json`` subprocess isolation +
+    ``cwd=PROJECT_ROOT`` as :func:`_task_keep_running` (the watcher runs from
+    PROJECT_ROOT on ``main``, satisfying the task.py branch-guard). Called only
+    on the wedge arm's confirmed-past-K branch, so the extra subprocess is paid
+    only for a matured wedge candidate, not every RUNNING pod every tick."""
+    try:
+        out = subprocess.run(
+            ["uv", "run", "python", "scripts/task.py", "view", str(issue), "--json"],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return "unknown"
+    if out.returncode != 0:
+        return "unknown"
+    try:
+        data = json.loads(out.stdout)
+    except json.JSONDecodeError:
+        return "unknown"
+    tags = (data.get("frontmatter") or {}).get("tags") or []
+    return isinstance(tags, list) and "keep-running" in tags
+
+
+def _wedge_inputs_safe(issue: int) -> bool:
+    """True iff the wedged run's recoverable inputs are verified on HF (#692).
+
+    Gates the watcher's reversible AUTO-STOP exactly as #689 fix (b) gates the
+    poller's IRREVERSIBLE terminate, reusing the SAME per-cell three-state gate
+    ``backend_poll._wedged_run_inputs_on_hf``. The run handle is read from the
+    persisted sidecar (``.claude/cache/issue-<N>-handle.json``).
+
+    Fail-CLOSED: a missing / unreadable handle, an HF-listing transport error,
+    an import failure, or ANY exception -> ``False`` (ALERT-only, never an unsafe
+    stop). For a non-#664 issue ``_wedged_run_inputs_on_hf`` returns ``ok=True``
+    (the adapters-only path is inline-verified), so the gate degrades to "safe to
+    stop" there — correct, because a reversible STOP loses nothing when there are
+    no per-cell artifacts to strand. This is the single most important safety
+    property of the wedge AUTO-STOP: every uncertainty path routes to ALERT-only."""
+    try:
+        from backend_poll import _wedged_run_inputs_on_hf
+
+        from explore_persona_space.backends.issue_dispatch import (
+            read_handle_sidecar,
+            resolve_handle_sidecar_path,
+        )
+
+        path, _probed = resolve_handle_sidecar_path(issue)
+        if not path.exists():
+            return False  # no handle -> cannot gate -> ALERT-only
+        handle = read_handle_sidecar(path)
+        gate = _wedged_run_inputs_on_hf(issue, handle)
+        return bool(gate.ok)
+    except Exception as exc:  # transport / parse / import -> fail-closed
+        print(
+            f"  wedge: inputs-on-HF gate unavailable for #{issue} "
+            f"({type(exc).__name__}: {exc}); ALERT-only (no auto-stop)",
+            file=sys.stderr,
+        )
+        return False
+
+
+def _clear_wedge_state(issue: int, pod_id: str) -> None:
+    """Clear the #692 wedge fields for ``issue`` while keeping the
+    pod-incarnation ``first_seen`` GC anchor intact (MF1 onset-clock clear).
+
+    Called on the NOT-wedged branch of :func:`_process_pod` (a port re-appeared,
+    or the pod was never wedged this tick), so a one-tick no-port blip never
+    matures toward a stop and a healed pod's stale wedge fields are reset. It
+    re-saves the state with ``wedge_first_seen=None, wedge_missed=0,
+    wedge_alerted=False`` (NOT :func:`_clear_pod_safety_state`, which clears the
+    WHOLE file and would wipe the GC anchor ``first_seen``), and records the
+    current ``pod_id`` so a later pod_id mismatch is detectable. The status-class
+    counters (``missed`` / ``alerted`` / ``last_progress_ts``) are forward-carried
+    from the prior state (the status-class arm owns them on its own ticks)."""
+    prev = _load_pod_safety_state(issue)
+    prev_missed = prev.get("missed", 0)
+    if not isinstance(prev_missed, int):
+        prev_missed = 0
+    prev_progress = prev.get("last_progress_ts")
+    if not isinstance(prev_progress, int | float):
+        prev_progress = None
+    _save_pod_safety_state(
+        issue,
+        pod_id,
+        missed=prev_missed,
+        alerted=bool(prev.get("alerted", False)),
+        last_progress_ts=prev_progress,
+        wedge_first_seen=None,
+        wedge_missed=0,
+        wedge_alerted=False,
+        prev=prev,
+    )
+
+
 # Marker kinds that record a transition INTO a DONE status. The latest ts
 # among these is "when did this task become DONE"; compared against the
 # latest `epm:run-launched` ts to decide whether an `epm:run-launched`
@@ -1954,6 +2200,9 @@ def _save_pod_safety_state(
     last_progress_ts: float | None,
     keep_running_noted: bool | None = None,
     followup_noted: bool | None = None,
+    wedge_first_seen: float | None = _CARRY,
+    wedge_missed: int | None = _CARRY,
+    wedge_alerted: bool | None = _CARRY,
     prev: dict | None = None,
 ) -> None:
     """Persist the per-pod state atomically (temp + rename).
@@ -1973,6 +2222,24 @@ def _save_pod_safety_state(
     payload (if any), passed so callers that already loaded it don't re-read;
     ``first_seen`` carries forward when present so the age backstop measures
     the original episode start, not the latest save.
+
+    The #692 wedge fields — ``wedge_first_seen`` (the DEDICATED wedge-onset
+    clock, stamped at the first wedged tick, NOT the pod-incarnation
+    ``first_seen``), ``wedge_missed`` (the wedge arm's >=threshold
+    consecutive-confirmed-checks miss guard, SEPARATE from the status-class
+    ``missed``), and ``wedge_alerted`` (the once-per-wedge-episode alert dedup)
+    — each carry the prior on-disk value forward when LEFT AT THE DEFAULT
+    (:data:`_CARRY`), so a status-class-arm save never clobbers a live wedge
+    episode's accumulated state and vice versa (the two arms are mutually
+    exclusive on a given tick, but a pod can transition between them across
+    ticks). Passing an EXPLICIT value (including ``None`` for
+    ``wedge_first_seen`` — the MF1 onset-clock CLEAR :func:`_clear_wedge_state`
+    needs) overrides the carry-forward. The distinct ``_CARRY`` sentinel (NOT
+    ``None``) is load-bearing here precisely because ``None`` is a meaningful
+    "clear the wedge clock" value, unlike the ``keep_running_noted`` /
+    ``followup_noted`` flags whose only carry-forward signal IS ``None``. MF3:
+    without this forward-carry the wedge fields would be silently dropped on
+    every save and the wedge miss-guard / alert-dedup would never accumulate.
     """
     AUTONOMOUS_REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
     dest = _pod_safety_state_path(issue)
@@ -1983,6 +2250,16 @@ def _save_pod_safety_state(
         keep_running_noted = bool((prev or {}).get("keep_running_noted", False))
     if followup_noted is None:
         followup_noted = bool((prev or {}).get("followup_noted", False))
+    if wedge_first_seen is _CARRY:
+        prev_wedge_first_seen = (prev or {}).get("wedge_first_seen")
+        wedge_first_seen = (
+            prev_wedge_first_seen if isinstance(prev_wedge_first_seen, int | float) else None
+        )
+    if wedge_missed is _CARRY:
+        prev_wedge_missed = (prev or {}).get("wedge_missed", 0)
+        wedge_missed = prev_wedge_missed if isinstance(prev_wedge_missed, int) else 0
+    if wedge_alerted is _CARRY:
+        wedge_alerted = bool((prev or {}).get("wedge_alerted", False))
     payload = {
         "pod_id": pod_id,
         "missed": missed,
@@ -1991,6 +2268,9 @@ def _save_pod_safety_state(
         "keep_running_noted": bool(keep_running_noted),
         "followup_noted": bool(followup_noted),
         "first_seen": prev_first_seen,
+        "wedge_first_seen": wedge_first_seen,
+        "wedge_missed": int(wedge_missed),
+        "wedge_alerted": bool(wedge_alerted),
     }
     tmp = dest.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(payload, indent=2))
@@ -2650,10 +2930,16 @@ def _refresh_pods_conf_from_api(pod_name: str, dry_run: bool) -> bool:
     return True
 
 
-def _running_managed_issue_pods(caller: str = "pod-safety") -> list[tuple[int, str, str]] | None:
+def _running_managed_issue_pods(
+    caller: str = "pod-safety",
+) -> list[tuple[int, str, str, PodInfo]] | None:
     """Live RunPod team pods that are RUNNING and managed (``pod-<N>`` or the
-    legacy ``epm-issue-<N>``). Returns ``(issue, pod_id, pod_name)`` triples,
-    or ``None`` when the snapshot itself FAILED (API transport error).
+    legacy ``epm-issue-<N>``). Returns ``(issue, pod_id, pod_name, info)``
+    4-tuples (the live :class:`runpod_api.PodInfo` carried out so callers can
+    read ``desired_status`` / ``ssh_host`` / ``ssh_port`` / ``pod_id`` without a
+    second ``list_team_pods`` round-trip — the #692 wedge backstop reads the raw
+    no-port wedge condition off this ``info``), or ``None`` when the snapshot
+    itself FAILED (API transport error).
 
     Recognition delegates to :func:`pod_lifecycle._is_managed_pod` +
     :func:`pod_lifecycle._issue_from_pod_name` — the canonical helpers that
@@ -2690,7 +2976,7 @@ def _running_managed_issue_pods(caller: str = "pod-safety") -> list[tuple[int, s
             file=sys.stderr,
         )
         return None
-    out: list[tuple[int, str, str]] = []
+    out: list[tuple[int, str, str, PodInfo]] = []
     for p in pods:
         if p.desired_status != "RUNNING":
             continue
@@ -2699,11 +2985,238 @@ def _running_managed_issue_pods(caller: str = "pod-safety") -> list[tuple[int, s
         name = p.name or ""
         issue = _issue_from_pod_name(name)
         if issue is not None:
-            out.append((issue, p.pod_id, name))
+            out.append((issue, p.pod_id, name, p))
     return out
 
 
-def _process_pod(issue: int, pod_id: str, now: float, dry_run: bool, threshold: int) -> None:
+def _maybe_handle_runpod_wedge(
+    issue: int, status: str | None, info: PodInfo, now: float, dry_run: bool, threshold: int
+) -> bool:
+    """#692 wedge arm dispatch: detect the RAW #664 RunPod no-port wedge from the
+    live ``info`` and route it.
+
+    Returns ``True`` iff this arm fully HANDLED the pod (a NON-DONE-status wedged
+    pod, processed by :func:`_process_wedged_pod`), so the caller
+    (:func:`_process_pod`) should return without running the status-class
+    branches. Returns ``False`` in every other case — a non-wedged pod (where it
+    also clears any stale wedge clock, MF1/MF4) OR a wedged DONE-status pod (MF6:
+    it falls through to the status-class DONE auto-stop, the canonical
+    escaped-pod handler — routing it through the wedge arm's ALERT-default +
+    inputs-gate would only WEAKEN that existing auto-stop).
+
+    Detect the raw condition via the SAME
+    ``backend_poll._pod_is_runpod_runtime_wedged`` the poller calls (composition
+    surface (b), never re-defined)."""
+    from backend_poll import _pod_is_runpod_runtime_wedged  # sibling import
+
+    if _pod_is_runpod_runtime_wedged(info):
+        if status not in AUTO_STOP_DONE:
+            _process_wedged_pod(issue, info, now, dry_run, threshold)
+            return True
+        # MF6: DONE-status wedged pod -> fall through to the status-class DONE arm.
+        return False
+    # MF1/MF4: not currently wedged -> clear any stale wedge clock so a one-tick
+    # blip never accumulates, and the next true onset re-stamps.
+    if not dry_run:
+        _clear_wedge_state(issue, info.pod_id)
+    return False
+
+
+def _process_wedged_pod(
+    issue: int, info: PodInfo, now: float, dry_run: bool, threshold: int
+) -> None:
+    """Handle a RUNNING managed pod observed in the #664 RunPod no-port wedge.
+
+    The raw wedge condition (``backend_poll._pod_is_runpod_runtime_wedged``) is
+    already confirmed by the caller, which has ALSO already excluded DONE-status
+    pods (MF6 — those fall through to the status-class DONE auto-stop arm). Age
+    the wedge against the DEDICATED ``wedge_first_seen`` clock (stamped at wedge
+    ONSET, NOT the pod-incarnation ``first_seen``, MF1); below K
+    (``backend_poll.RUNPOD_WEDGE_K_SEC``) KEEP + persist (the wedge has not
+    matured — a healthy slow bring-up clears it on a later tick when the port
+    appears); past K apply the >=threshold consecutive-wedge-checks miss guard,
+    then ALERT (default) or AUTO-STOP (reversible ``pod.py stop``, never
+    terminate) gated on the SAME inputs-on-HF + (tri-state) keep-running checks
+    as #689 fix (b). Persists the wedge fields via :func:`_save_pod_safety_state`
+    (MF3 forward-carry) WITHOUT clearing the pod-incarnation ``first_seen`` GC
+    anchor."""
+    from backend_poll import RUNPOD_WEDGE_K_SEC
+
+    pod_id = info.pod_id
+    prev_state = _load_pod_safety_state(issue)
+
+    # ── MF4: pod_id-change reset ──────────────────────────────────────────────
+    # The pod-safety state is keyed on `issue`, not (issue, pod_id). If the
+    # poller re-provisioned the same issue with a fresh pod_id, the persisted
+    # wedge fields are stale from the OLD pod -> a fresh healthy pod could be
+    # stopped during normal startup, or a long-running pod stopped after two
+    # stale runtime.ports reads. Reset all wedge fields on a pod_id mismatch.
+    prev_pod_id = prev_state.get("pod_id")
+    if prev_pod_id != pod_id:
+        wedge_first_seen: float | None = None
+        prev_wedge_missed = 0
+        prev_wedge_alerted = False
+    else:
+        prev_wfs = prev_state.get("wedge_first_seen")
+        wedge_first_seen = prev_wfs if isinstance(prev_wfs, int | float) else None
+        prev_wedge_missed = prev_state.get("wedge_missed", 0)
+        if not isinstance(prev_wedge_missed, int):
+            prev_wedge_missed = 0
+        prev_wedge_alerted = bool(prev_state.get("wedge_alerted", False))
+
+    # ── MF1: dedicated wedge_first_seen clock ─────────────────────────────────
+    # Stamp `now` on the FIRST tick the raw wedge predicate is True (wedge
+    # ONSET). The not-wedged branch in _process_pod calls _clear_wedge_state, so
+    # a port re-appearance resets this to None -> a one-tick blip never matures.
+    # This measures the actual no-port episode length, NOT pod uptime.
+    if wedge_first_seen is None:
+        wedge_first_seen = now  # first wedged tick this incarnation
+    wedged_for = now - wedge_first_seen
+
+    # The status-class counters are forward-carried untouched (this tick belongs
+    # to the wedge arm; the status-class arm owns `missed`/`alerted` on its ticks).
+    prev_missed = prev_state.get("missed", 0)
+    if not isinstance(prev_missed, int):
+        prev_missed = 0
+    prev_progress = prev_state.get("last_progress_ts")
+    if not isinstance(prev_progress, int | float):
+        prev_progress = None
+    prev_status_alerted = bool(prev_state.get("alerted", False))
+
+    # ── MF2: tri-state keep-running gate ──────────────────────────────────────
+    # Read the tag ONLY on the confirmed-past-K branch (the lazy pattern the
+    # status-class arm uses): below K / not-yet-confirmed never auto-stops, so
+    # the subprocess is paid only for a matured wedge candidate. Pass `True`
+    # (not False) as the below-K placeholder so decide_pod_wedge can never STOP
+    # before it would consult the real gate.
+    confirmed = wedged_for > RUNPOD_WEDGE_K_SEC and (prev_wedge_missed + 1) >= threshold
+    keep_running: bool | str = _wedge_keep_running(issue) if confirmed else True
+    inputs_ok = _wedge_inputs_safe(issue) if (confirmed and keep_running is False) else False
+
+    action, new_wedge_missed = decide_pod_wedge(
+        wedged_for=wedged_for,
+        k_floor=RUNPOD_WEDGE_K_SEC,
+        wedge_missed=prev_wedge_missed,
+        threshold=threshold,
+        alerted=prev_wedge_alerted,
+        keep_running=keep_running,
+        inputs_ok=inputs_ok,
+    )
+    wedged_h = f"{wedged_for / 3600:.2f}h"
+    print(
+        f"  issue #{issue} pod={pod_id}: RUNPOD NO-PORT WEDGE wedged_for={wedged_h} "
+        f"(K={RUNPOD_WEDGE_K_SEC}s) wedge_missed={prev_wedge_missed}->{new_wedge_missed} "
+        f"keep_running={keep_running} inputs_ok={inputs_ok} action={action}"
+    )
+
+    if action == "stop":
+        stopped = _stop_pod(issue, dry_run)
+        if stopped:
+            _post_progress_marker(
+                issue,
+                f"{_WEDGE_STOP_NOTE_SENTINEL} auto-stopped by autonomous_session_watch "
+                f"pod-safety pass — RUNNING pod {pod_id} stuck in the #664 "
+                f"RUNNING-but-no-port host wedge for {wedged_h} (> {RUNPOD_WEDGE_K_SEC}s K "
+                f"floor, confirmed for >= {threshold} checks). The poller's "
+                f"_maybe_escalate_runpod_wedge never ran (the poll loop is dead), so the "
+                f"watcher is the backstop. The run's recoverable inputs are verified on HF "
+                f"and the keep-running tag is absent, so this reversible pause (pod.py "
+                f"resume restores the volume) is safe — it halts the billing leak. STOP, "
+                f"NOT terminate (the poller owns the terminate + re-provision path).",
+                dry_run,
+                label="wedge-stop",
+            )
+            if not dry_run:
+                # Persist the cleared wedge fields (NOT _clear_pod_safety_state,
+                # which would wipe the pod-incarnation first_seen GC anchor).
+                _save_pod_safety_state(
+                    issue,
+                    pod_id,
+                    missed=prev_missed,
+                    alerted=prev_status_alerted,
+                    last_progress_ts=prev_progress,
+                    wedge_first_seen=None,
+                    wedge_missed=0,
+                    wedge_alerted=False,
+                    prev=prev_state,
+                )
+        return
+
+    if action == "alert":
+        post_alert = not prev_wedge_alerted
+        if post_alert:
+            _post_progress_marker(
+                issue,
+                f"{_WEDGE_ALERT_NOTE_SENTINEL} RUNNING pod {pod_id} stuck in the #664 "
+                f"RUNNING-but-no-port host wedge for {wedged_h} (> {RUNPOD_WEDGE_K_SEC}s K "
+                f"floor) — a billing leak the poller's _maybe_escalate_runpod_wedge did NOT "
+                f"catch (the poll loop is dead). AUTO-STOP is GATED OFF this episode "
+                f"(keep_running={keep_running}, inputs_ok={inputs_ok}): the inputs are not "
+                f"provably safe on HF, the keep-running tag is present, or the tag read "
+                f"FAILED — every uncertainty path is ALERT-only, never an unsafe stop. "
+                f"Investigate and stop manually (`pod.py stop --issue {issue}`, reversible) "
+                f"if the run is truly wedged. Posted once per wedge episode.",
+                dry_run,
+                label="wedge-alert",
+            )
+        print(
+            f"  WEDGE-ALERT issue #{issue}: RunPod no-port wedge {wedged_h} "
+            f"(gated off: keep_running={keep_running}, inputs_ok={inputs_ok}); NOT stopping.",
+            file=sys.stderr,
+        )
+        if not dry_run:
+            _save_pod_safety_state(
+                issue,
+                pod_id,
+                missed=prev_missed,
+                alerted=prev_status_alerted,
+                last_progress_ts=prev_progress,
+                wedge_first_seen=wedge_first_seen,
+                wedge_missed=new_wedge_missed,
+                wedge_alerted=True,
+                prev=prev_state,
+            )
+        return
+
+    # action == "keep": persist the (possibly incremented) wedge miss count and
+    # the onset clock so the next tick can mature the episode.
+    if not dry_run:
+        _save_pod_safety_state(
+            issue,
+            pod_id,
+            missed=prev_missed,
+            alerted=prev_status_alerted,
+            last_progress_ts=prev_progress,
+            wedge_first_seen=wedge_first_seen,
+            wedge_missed=new_wedge_missed,
+            wedge_alerted=prev_wedge_alerted,
+            prev=prev_state,
+        )
+
+
+def _escaped_pod_exemptions(issue: int, status_class: str, events: list) -> tuple[bool, bool]:
+    """Lazy escaped-pod auto-stop exemptions for :func:`_process_pod`.
+
+    Returns ``(keep_running, followup_active)``. Both only matter when the
+    auto-stop arm is in play (``status_class == "auto-stop-done"``), so the
+    extra ``task.py view`` subprocess + events scan are paid only for
+    escaped-pod candidates. ``keep_running`` (the explicit user tag) is
+    consulted first; ``followup_active`` (the inferred-from-events live inline
+    follow-up) is the fallback, computed only when ``keep_running`` is False.
+    Extracted from :func:`_process_pod` to keep its cyclomatic complexity under
+    the C901 cap after the #692 wedge arm landed (behavior unchanged)."""
+    keep_running = status_class == "auto-stop-done" and _task_keep_running(issue)
+    followup_active = (
+        status_class == "auto-stop-done"
+        and not keep_running
+        and _task_followup_active(issue, events=events)
+    )
+    return keep_running, followup_active
+
+
+def _process_pod(
+    issue: int, pod_id: str, info: PodInfo, now: float, dry_run: bool, threshold: int
+) -> None:
     """Reconcile one RUNNING managed pod against its task status.
 
     Reads the task's status + latest real-progress timestamp, classifies it,
@@ -2714,22 +3227,37 @@ def _process_pod(issue: int, pod_id: str, now: float, dry_run: bool, threshold: 
     SKIPPED with a log line + a once-per-pod-incarnation marker), ALERT a
     stale pod-active task once per episode, or KEEP. Persists the per-pod
     state (miss count, alerted flag, keep-running-noted flag, followup-noted
-    flag, last-observed real progress) for the next tick."""
+    flag, last-observed real progress) for the next tick.
+
+    #692 wedge-arm ordering (MF6): the #664 RunPod no-port wedge arm runs
+    BEFORE the status-class branches, EXCEPT that a wedged pod whose task is at
+    a DONE status (:data:`AUTO_STOP_DONE` — completed / awaiting_promotion /
+    archived, the established escaped-pod auto-stop case) FALLS THROUGH to the
+    status-class DONE arm, which already auto-stops it. A DONE-task pod has no
+    live work to strand, so the canonical escaped-pod auto-stop wins; routing it
+    through the wedge arm's ALERT-default + inputs-gate would only WEAKEN the
+    existing auto-stop into a conditional one. The wedge arm therefore handles
+    only NON-DONE-status wedged pods (the live-work statuses where the watcher
+    must be conservative). A non-wedged pod reaches the status-class branches
+    unchanged, exactly as before #692."""
     status = _task_status(issue)
+
+    # ── #692 RunPod no-port wedge backstop (runs BEFORE the status-class arm,
+    # MF6 DONE-task carve-out inside the helper) ──────────────────────────────
+    # When the per-issue poll loop has DIED, backend_poll's
+    # _maybe_escalate_runpod_wedge never runs and the #664 RUNNING-but-no-port
+    # billing leak goes undetected. The watcher runs unconditionally every 10
+    # min, so it is the backstop. If the helper handled the pod (a non-DONE
+    # wedged pod), return; otherwise fall through to the status-class branches
+    # (a non-wedged pod, OR a wedged DONE-task pod that the status-class DONE
+    # auto-stop arm handles canonically) exactly as before #692.
+    if _maybe_handle_runpod_wedge(issue, status, info, now, dry_run, threshold):
+        return
+
     events = _task_events(issue)
     latest_progress = _latest_progress_ts(events)
     status_class = _status_class(status, latest_progress, now)
-    # Lazy: the tag and the follow-up predicate only matter when the auto-stop
-    # arm is in play, so the extra `task.py view` subprocess + events scan are
-    # paid only for escaped-pod candidates. `keep_running` is consulted first
-    # because it is the explicit user signal; `followup_active` is the
-    # inferred-from-events fallback.
-    keep_running = status_class == "auto-stop-done" and _task_keep_running(issue)
-    followup_active = (
-        status_class == "auto-stop-done"
-        and not keep_running
-        and _task_followup_active(issue, events=events)
-    )
+    keep_running, followup_active = _escaped_pod_exemptions(issue, status_class, events)
 
     prev_state = _load_pod_safety_state(issue)
     prev_missed = prev_state.get("missed", 0)
@@ -2774,7 +3302,50 @@ def _process_pod(issue: int, pod_id: str, now: float, dry_run: bool, threshold: 
         f"progress_gap={gap_h} missed={prev_missed}->{new_missed} "
         f"alerted={alerted} action={action}"
     )
+    _apply_pod_safety_action(
+        action,
+        issue=issue,
+        pod_id=pod_id,
+        status=status,
+        now=now,
+        dry_run=dry_run,
+        threshold=threshold,
+        gap_h=gap_h,
+        new_missed=new_missed,
+        alerted=alerted,
+        latest_progress=latest_progress,
+        prev_state=prev_state,
+        prev_keep_running_noted=prev_keep_running_noted,
+        prev_followup_noted=prev_followup_noted,
+    )
 
+
+def _apply_pod_safety_action(
+    action: str,
+    *,
+    issue: int,
+    pod_id: str,
+    status: str | None,
+    now: float,
+    dry_run: bool,
+    threshold: int,
+    gap_h: str,
+    new_missed: int,
+    alerted: bool,
+    latest_progress: float | None,
+    prev_state: dict,
+    prev_keep_running_noted: bool,
+    prev_followup_noted: bool,
+) -> None:
+    """Apply the status-class :func:`decide_pod_safety` ``action`` for one pod.
+
+    Extracted verbatim from :func:`_process_pod` (behavior unchanged) to keep its
+    cyclomatic complexity under the C901 cap after the #692 wedge arm landed. The
+    five actions — ``keep-running-skip`` / ``followup-skip`` / ``stop`` /
+    ``alert`` / ``keep`` — post the appropriate once-per-episode marker (deduped
+    via the prev-state flags) and persist the per-pod state. Each save
+    forward-carries the #692 wedge fields untouched (this is a status-class tick;
+    the wedge arm owns them on its own ticks)."""
     if action == "keep-running-skip":
         print(
             f"  KEEP-RUNNING issue #{issue}: task status '{status}' is DONE but the "
@@ -4351,8 +4922,8 @@ def stalled_session_pass(
     # the empty set so the decision layer just records has_pod=False for every
     # issue this tick — fail-safe (this pass alerts/respawns, never stops pods).
     running_pods = _running_managed_issue_pods(caller="stalled-detector") or []
-    pod_active_issues = {issue for issue, _pid, _name in running_pods}
-    pod_names_by_issue = {issue: name for issue, _pid, name in running_pods}
+    pod_active_issues = {issue for issue, _pid, _name, _info in running_pods}
+    pod_names_by_issue = {issue: name for issue, _pid, name, _info in running_pods}
     if daemon_reachable is None:
         daemon_reachable = _daemon_reachable()
     print(
@@ -4771,7 +5342,7 @@ def orphan_sweep_pass(
     # marker_age_s below the staleness threshold, so the orphan sweep
     # would not be at action=respawn anyway.
     running_pods = _running_managed_issue_pods(caller="orphan-sweep") or []
-    pod_active_issues = {issue for issue, _pid, _name in running_pods}
+    pod_active_issues = {issue for issue, _pid, _name, _info in running_pods}
     print(
         f"orphan-sweep: {len(active)} active-status task(s), "
         f"{len(regs)} registered issue(s), {len(live_ids)} live session(s)"
@@ -8235,7 +8806,9 @@ def session_reconcile_pass(
     # pod itself (it skips its own state GC on the failed snapshot).
     running_pod_issues = {
         issue
-        for issue, _pod_id, _name in (_running_managed_issue_pods(caller="session-reconcile") or [])
+        for issue, _pod_id, _name, _info in (
+            _running_managed_issue_pods(caller="session-reconcile") or []
+        )
     }
     print(
         f"session-reconcile: {n_sessions} live issue-mapped session(s) across "
@@ -9588,7 +10161,7 @@ def pod_safety_pass(dry_run: bool, threshold: int, now: float | None = None) -> 
         # same fail-closed no-stop outcome as today's empty-set fallback.
         print("pod-safety: pod snapshot failed; skipping state GC this tick")
         return
-    running_issues = {issue for issue, _pod_id, _name in running}
+    running_issues = {issue for issue, _pod_id, _name, _info in running}
 
     # GC orphaned state BEFORE the per-pod loop, and ALWAYS on a GOOD snapshot
     # — even when `running` is empty — so a state file for a pod that left the
@@ -9601,8 +10174,8 @@ def pod_safety_pass(dry_run: bool, threshold: int, now: float | None = None) -> 
         print("pod-safety: no RUNNING managed pods")
         return
     print(f"pod-safety: {len(running)} RUNNING managed pod(s)")
-    for issue, pod_id, _name in running:
-        _process_pod(issue, pod_id, now, dry_run, threshold)
+    for issue, pod_id, _name, info in running:
+        _process_pod(issue, pod_id, info, now, dry_run, threshold)
 
 
 def _vm_run_remediations(
@@ -10695,7 +11268,8 @@ def gate_push_pass(
     if not flags:
         return
     running_pod_issues = {
-        issue for issue, _pod_id, _name in (_running_managed_issue_pods(caller="gate-push") or [])
+        issue
+        for issue, _pod_id, _name, _info in (_running_managed_issue_pods(caller="gate-push") or [])
     }
     for issue, flag_path in flags:
         _process_runaway_flag(

--- a/scripts/backend_poll.py
+++ b/scripts/backend_poll.py
@@ -518,6 +518,28 @@ def _clear_runpod_noport_clock(sidecar: Path) -> None:
         )
 
 
+def _pod_is_runpod_runtime_wedged(info) -> bool:
+    """True iff a live RunPod ``PodInfo`` is in the RAW #664 no-port wedge
+    condition: ``desired_status == "RUNNING"`` AND no public SSH port
+    (``runtime.ports`` empty -> ``runpod_api._parse_pod`` sets
+    ``ssh_host``/``ssh_port`` to ``None``).
+
+    This is the MATURITY-AGNOSTIC raw condition ONLY — the K-floor age check
+    stays with each caller (the poller uses its sidecar clock; the watcher
+    backstop in ``autonomous_session_watch.py`` uses its OWN dedicated
+    ``wedge_first_seen`` clock). ``info is None`` (pod gone) -> ``False`` (not a
+    wedge; the gone pod is the ordinary dead path). This is the SINGLE source of
+    truth for the wedge condition, called by BOTH
+    :func:`_maybe_escalate_runpod_wedge` (poller) and the
+    ``autonomous_session_watch.py`` pod-safety wedge arm (watcher backstop,
+    #692) — neither re-defines it (#692 composition surface (b))."""
+    if info is None:
+        return False
+    if getattr(info, "desired_status", None) != "RUNNING":
+        return False
+    return not (info.ssh_host and info.ssh_port)
+
+
 def _maybe_escalate_runpod_wedge(handle, result, sidecar: Path, *, now: float):
     """Escalate a RunPod pod RUNNING-but-no-port past K to terminal wedged (#664).
 
@@ -543,12 +565,10 @@ def _maybe_escalate_runpod_wedge(handle, result, sidecar: Path, *, now: float):
     from runpod_api import get_pod_by_name  # live RunPod API (X-Team-Id baked in)
 
     info = get_pod_by_name(handle.pod_name)  # PodInfo or None
-    healthy_or_terminal = (
-        info is None  # gone -> ordinary dead path
-        or getattr(info, "desired_status", None) != "RUNNING"  # EXITED/terminal -> not a wedge
-        or (info.ssh_host and info.ssh_port)  # public port present -> healthy
-    )
-    if healthy_or_terminal:
+    # gone / EXITED / port-present -> not the raw wedge condition -> clear the
+    # no-port clock, return unchanged (the negation of the extracted predicate
+    # is exactly the old inline `healthy_or_terminal` guard, behavior-preserving).
+    if not _pod_is_runpod_runtime_wedged(info):
         _clear_runpod_noport_clock(sidecar)
         return result
     # RUNNING + no public port: start/continue the no-port clock.

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -61,6 +61,31 @@ from autonomous_session_watch import (  # noqa: E402
 from explore_persona_space.task_workflow import STATUSES  # noqa: E402
 
 
+def _p(issue: int, pod_id: str, name: str):
+    """A non-wedged 4-tuple for ``_running_managed_issue_pods`` stubs (#692).
+
+    ``_running_managed_issue_pods`` now returns ``(issue, pod_id, name, info)``
+    4-tuples carrying the live :class:`runpod_api.PodInfo`. These status-class
+    pod-safety / session-reconcile tests are NOT about the wedge arm, so the
+    ``info`` is HEALTHY (a public SSH port present) — the wedge predicate
+    ``backend_poll._pod_is_runpod_runtime_wedged`` reads False and the wedge arm
+    is a no-op, so existing status-class behavior is unchanged."""
+    from runpod_api import PodInfo
+
+    return (
+        issue,
+        pod_id,
+        name,
+        PodInfo(
+            pod_id=pod_id,
+            name=name,
+            desired_status="RUNNING",
+            ssh_host="1.2.3.4",
+            ssh_port=22000,
+        ),
+    )
+
+
 @pytest.mark.parametrize("status", sorted(TERMINAL))
 @pytest.mark.parametrize("alive", [True, False])
 @pytest.mark.parametrize("missed", [0, 1, 5])
@@ -594,17 +619,22 @@ def test_running_managed_pods_recognizes_canonical_pod_name(monkeypatch):
             PodInfo(pod_id="punm", name="some-random-pod", desired_status="RUNNING"),  # unmanaged
         ],
     )
-    got = sorted(asw._running_managed_issue_pods())
+    got = sorted(asw._running_managed_issue_pods(), key=lambda t: t[0])
     # pod-444, pod-489, and the legacy epm-issue-377 are recognized; the EXITED
     # and unmanaged ones are excluded. The third element is the pod NAME,
     # threaded out so callers (e.g. the #488 stale-port self-heal in
     # ``_handle_stalled_alert``) can address the pod by name without a
-    # second ``list_team_pods`` round-trip.
-    assert got == [
+    # second ``list_team_pods`` round-trip; the FOURTH (#692) is the live
+    # ``PodInfo`` itself, so the wedge backstop can read the raw no-port wedge
+    # condition off it without a second ``list_team_pods`` round-trip.
+    assert [(i, pid, name) for i, pid, name, _info in got] == [
         (377, "pold", "epm-issue-377"),
         (444, "p444", "pod-444"),
         (489, "p489", "pod-489"),
     ]
+    # The 4th element is the live PodInfo for that pod (pod_id matches).
+    assert [info.pod_id for _i, _pid, _name, info in got] == ["pold", "p444", "p489"]
+    assert all(isinstance(info, PodInfo) for *_rest, info in got)
 
 
 def test_running_managed_pods_api_error_returns_none(monkeypatch):
@@ -634,7 +664,7 @@ def test_live_interactive_session_does_not_cause_stop(isolated_registry, monkeyp
     now = 1_000_000.0
     stops: list[int] = []
     monkeypatch.setattr(
-        asw, "_running_managed_issue_pods", lambda *_a, **_k: [(489, "p489", "pod-489")]
+        asw, "_running_managed_issue_pods", lambda *_a, **_k: [_p(489, "p489", "pod-489")]
     )
     monkeypatch.setattr(asw, "_task_status", lambda issue: "running")
     # Fresh progress 1h ago -> pod-active-fresh -> keep.
@@ -664,7 +694,7 @@ def test_auto_stop_fires_on_done_task_second_miss(isolated_registry, monkeypatch
     stops: list[int] = []
     posts: list[tuple[int, str]] = []
     monkeypatch.setattr(
-        asw, "_running_managed_issue_pods", lambda *_a, **_k: [(489, "p489", "pod-489")]
+        asw, "_running_managed_issue_pods", lambda *_a, **_k: [_p(489, "p489", "pod-489")]
     )
     monkeypatch.setattr(asw, "_task_status", lambda issue: "completed")
     monkeypatch.setattr(asw, "_task_keep_running", lambda issue: False)
@@ -693,7 +723,9 @@ def test_auto_stop_fires_for_all_done_statuses(isolated_registry, monkeypatch, s
 
     now = 1_000_000.0
     stops: list[int] = []
-    monkeypatch.setattr(asw, "_running_managed_issue_pods", lambda *_a, **_k: [(7, "p7", "pod-7")])
+    monkeypatch.setattr(
+        asw, "_running_managed_issue_pods", lambda *_a, **_k: [_p(7, "p7", "pod-7")]
+    )
     monkeypatch.setattr(asw, "_task_status", lambda issue: status)
     monkeypatch.setattr(asw, "_task_keep_running", lambda issue: False)
     monkeypatch.setattr(asw, "_task_events", lambda issue: [])
@@ -716,7 +748,7 @@ def test_keep_running_tag_skips_stop_and_notes_once(isolated_registry, monkeypat
     stops: list[int] = []
     posts: list[tuple[int, str]] = []
     monkeypatch.setattr(
-        asw, "_running_managed_issue_pods", lambda *_a, **_k: [(530, "p530", "pod-530")]
+        asw, "_running_managed_issue_pods", lambda *_a, **_k: [_p(530, "p530", "pod-530")]
     )
     monkeypatch.setattr(asw, "_task_status", lambda issue: "awaiting_promotion")
     monkeypatch.setattr(asw, "_task_keep_running", lambda issue: True)
@@ -749,7 +781,7 @@ def test_keep_running_tag_removal_re_arms_auto_stop(isolated_registry, monkeypat
     now = 1_000_000.0
     stops: list[int] = []
     monkeypatch.setattr(
-        asw, "_running_managed_issue_pods", lambda *_a, **_k: [(530, "p530", "pod-530")]
+        asw, "_running_managed_issue_pods", lambda *_a, **_k: [_p(530, "p530", "pod-530")]
     )
     monkeypatch.setattr(asw, "_task_status", lambda issue: "awaiting_promotion")
     monkeypatch.setattr(asw, "_task_keep_running", lambda issue: True)
@@ -793,7 +825,7 @@ def test_inline_followup_run_launched_skips_stop(isolated_registry, monkeypatch)
         {"kind": "epm:run-launched", "ts": "2026-06-10T03:12:08Z", "note": "pod=pod-477"},
     ]
     monkeypatch.setattr(
-        asw, "_running_managed_issue_pods", lambda *_a, **_k: [(477, "p477", "pod-477")]
+        asw, "_running_managed_issue_pods", lambda *_a, **_k: [_p(477, "p477", "pod-477")]
     )
     monkeypatch.setattr(asw, "_task_status", lambda issue: "completed")
     monkeypatch.setattr(asw, "_task_keep_running", lambda issue: False)
@@ -840,7 +872,7 @@ def test_inline_followup_after_completion_re_arms_auto_stop(isolated_registry, m
     ]
     state = {"events": active_events}
     monkeypatch.setattr(
-        asw, "_running_managed_issue_pods", lambda *_a, **_k: [(477, "p477", "pod-477")]
+        asw, "_running_managed_issue_pods", lambda *_a, **_k: [_p(477, "p477", "pod-477")]
     )
     monkeypatch.setattr(asw, "_task_status", lambda issue: "completed")
     monkeypatch.setattr(asw, "_task_keep_running", lambda issue: False)
@@ -872,7 +904,9 @@ def test_no_auto_stop_for_other_class_statuses(isolated_registry, monkeypatch, s
 
     now = 1_000_000.0
     stops: list[int] = []
-    monkeypatch.setattr(asw, "_running_managed_issue_pods", lambda *_a, **_k: [(7, "p7", "pod-7")])
+    monkeypatch.setattr(
+        asw, "_running_managed_issue_pods", lambda *_a, **_k: [_p(7, "p7", "pod-7")]
+    )
     monkeypatch.setattr(asw, "_task_status", lambda issue: status)
     monkeypatch.setattr(asw, "_task_events", lambda issue: [])
     monkeypatch.setattr(asw, "_stop_pod", lambda issue, dry_run: stops.append(issue) or True)
@@ -894,7 +928,7 @@ def test_alert_fires_on_stale_pod_active_and_does_not_stop(isolated_registry, mo
     stops: list[int] = []
     posts: list[tuple[int, str]] = []
     monkeypatch.setattr(
-        asw, "_running_managed_issue_pods", lambda *_a, **_k: [(489, "p489", "pod-489")]
+        asw, "_running_managed_issue_pods", lambda *_a, **_k: [_p(489, "p489", "pod-489")]
     )
     monkeypatch.setattr(asw, "_task_status", lambda issue: "running")
     # No real progress for well over the stale cap.
@@ -926,7 +960,7 @@ def test_alert_dedups_across_ticks(isolated_registry, monkeypatch):
     stops: list[int] = []
     posts: list[tuple[int, str]] = []
     monkeypatch.setattr(
-        asw, "_running_managed_issue_pods", lambda *_a, **_k: [(489, "p489", "pod-489")]
+        asw, "_running_managed_issue_pods", lambda *_a, **_k: [_p(489, "p489", "pod-489")]
     )
     monkeypatch.setattr(asw, "_task_status", lambda issue: "verifying")
     stale_ts = now - (ALERT_STALE_HOURS + 2) * 3600
@@ -954,7 +988,7 @@ def test_alert_re_fires_after_progress_advances(isolated_registry, monkeypatch):
     now = 1_000_000.0
     posts: list[tuple[int, str]] = []
     monkeypatch.setattr(
-        asw, "_running_managed_issue_pods", lambda *_a, **_k: [(489, "p489", "pod-489")]
+        asw, "_running_managed_issue_pods", lambda *_a, **_k: [_p(489, "p489", "pod-489")]
     )
     monkeypatch.setattr(asw, "_task_status", lambda issue: "running")
     monkeypatch.setattr(asw, "_task_events", lambda issue: [{"kind": "epm:progress", "ts": "x"}])
@@ -999,7 +1033,7 @@ def test_alert_re_fires_after_none_then_first_progress_then_stale(isolated_regis
     posts: list[tuple[int, str]] = []
     stops: list[int] = []
     monkeypatch.setattr(
-        asw, "_running_managed_issue_pods", lambda *_a, **_k: [(489, "p489", "pod-489")]
+        asw, "_running_managed_issue_pods", lambda *_a, **_k: [_p(489, "p489", "pod-489")]
     )
     monkeypatch.setattr(asw, "_task_status", lambda issue: "running")
     monkeypatch.setattr(asw, "_task_events", lambda issue: [{"kind": "epm:progress", "ts": "x"}])
@@ -1038,7 +1072,7 @@ def test_no_alert_on_fresh_pod_active(isolated_registry, monkeypatch):
     posts: list[tuple[int, str]] = []
     stops: list[int] = []
     monkeypatch.setattr(
-        asw, "_running_managed_issue_pods", lambda *_a, **_k: [(489, "p489", "pod-489")]
+        asw, "_running_managed_issue_pods", lambda *_a, **_k: [_p(489, "p489", "pod-489")]
     )
     monkeypatch.setattr(asw, "_task_status", lambda issue: "running")
     monkeypatch.setattr(asw, "_task_events", lambda issue: [{"kind": "epm:progress", "ts": "x"}])
@@ -1253,6 +1287,11 @@ def test_save_pod_safety_state_carries_first_seen_forward(isolated_registry):
         "keep_running_noted": False,
         "followup_noted": False,
         "first_seen": 1234.0,
+        # #692 MF3: the wedge fields are part of the schema now; a status-class
+        # save with no wedge state defaults them (no prior wedge to carry).
+        "wedge_first_seen": None,
+        "wedge_missed": 0,
+        "wedge_alerted": False,
     }
 
     # On a second save (passing the previous payload), first_seen must persist.
@@ -2064,7 +2103,7 @@ def test_stalled_alert_fires_refresh_from_api_when_has_pod(
     _patch_stale_signals(monkeypatch, asw, status="plan_pending")
     # Override the pods stub to have a RUNNING managed pod for issue 488.
     monkeypatch.setattr(
-        asw, "_running_managed_issue_pods", lambda *_a, **_k: [(488, "p488", "pod-488")]
+        asw, "_running_managed_issue_pods", lambda *_a, **_k: [_p(488, "p488", "pod-488")]
     )
     refresh_calls: list[str] = []
     monkeypatch.setattr(
@@ -2123,7 +2162,7 @@ def test_stalled_alert_refresh_dedups_within_episode(
     _write_autonomous_entry(isolated_registry, 488, "sess-488")
     _patch_stale_signals(monkeypatch, asw, status="plan_pending")
     monkeypatch.setattr(
-        asw, "_running_managed_issue_pods", lambda *_a, **_k: [(488, "p488", "pod-488")]
+        asw, "_running_managed_issue_pods", lambda *_a, **_k: [_p(488, "p488", "pod-488")]
     )
     refresh_calls: list[str] = []
     monkeypatch.setattr(
@@ -2156,7 +2195,7 @@ def test_stalled_alert_refresh_re_fires_after_self_report_advances(
     _stops, _spawns, _markers = stalled_recorder
     _write_autonomous_entry(isolated_registry, 488, "sess-488")
     monkeypatch.setattr(
-        asw, "_running_managed_issue_pods", lambda *_a, **_k: [(488, "p488", "pod-488")]
+        asw, "_running_managed_issue_pods", lambda *_a, **_k: [_p(488, "p488", "pod-488")]
     )
     monkeypatch.setattr(asw, "_task_status", lambda issue: "plan_pending")
     monkeypatch.setattr(asw, "_task_events", lambda issue: [{"kind": "epm:progress", "ts": "old"}])
@@ -4525,7 +4564,7 @@ def test_session_reconcile_running_pod_blocks_stop(isolated_registry, monkeypatc
 
     monkeypatch.delenv("EPM_SESSION_RECONCILE_AUTOSTOP", raising=False)
     stops, posts = _patch_session_reconcile_io(
-        monkeypatch, status="awaiting_promotion", pods=[(42, "pod-id-x", "pod-42")]
+        monkeypatch, status="awaiting_promotion", pods=[_p(42, "pod-id-x", "pod-42")]
     )
     for _ in range(3):
         asw.session_reconcile_pass(

--- a/tests/test_autonomous_session_watch_wedge.py
+++ b/tests/test_autonomous_session_watch_wedge.py
@@ -1,0 +1,634 @@
+"""Unit tests for the #692 RunPod no-port wedge watcher backstop.
+
+This is the watcher-side companion to ``tests/test_runpod_wedge_detection.py``
+(which pins the POLLER-side ``backend_poll._maybe_escalate_runpod_wedge``). It
+covers the new pieces in ``scripts/autonomous_session_watch.py``:
+
+* the extracted raw predicate ``backend_poll._pod_is_runpod_runtime_wedged``
+  (one direct unit test; the existing wedge-detection suite proves the poller
+  refactor is byte-equivalent);
+* the pure decision fn ``decide_pod_wedge`` (the full decision table + the
+  pinned off-by-one boundaries, MF5);
+* the tri-state keep-running wrapper ``_wedge_keep_running`` (MF2) + the
+  fail-closed ``_wedge_inputs_safe`` gate;
+* the wedge-state forward-carry / round-trip through ``_save_pod_safety_state``
+  (MF3) and the ``_clear_wedge_state`` onset-clock clear (MF1);
+* the end-to-end wedge arm in ``_process_pod`` / ``_process_wedged_pod`` —
+  the dedicated wedge clock (MF1), the pod_id-change reset (MF4), the
+  once-per-episode alert dedup, and the DONE-task fall-through (MF6).
+
+All RunPod live-API I/O is mocked (``_running_managed_issue_pods`` returns a
+synthetic 4-tuple), ``task.py`` reads are monkeypatched, the inputs-on-HF gate
+is monkeypatched, and per-pod state files use the ``isolated_registry`` tmp dir.
+No GPU, no network.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import autonomous_session_watch as asw  # noqa: E402
+import backend_poll as bp  # noqa: E402
+from runpod_api import PodInfo  # noqa: E402
+
+K = bp.RUNPOD_WEDGE_K_SEC  # 900s — the SAME floor the poller uses (no duplicate literal)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / doubles
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_registry(tmp_path, monkeypatch):
+    """Point the per-pod state dir at a tmp dir (mirrors the main suite)."""
+    monkeypatch.setattr(asw, "AUTONOMOUS_REGISTRY_DIR", tmp_path)
+    return tmp_path
+
+
+def _wedged_info(pod_id: str = "p692", name: str = "pod-692") -> PodInfo:
+    """A live ``PodInfo`` in the RAW #664 wedge: RUNNING + no public port."""
+    return PodInfo(pod_id=pod_id, name=name, desired_status="RUNNING", ssh_host=None, ssh_port=None)
+
+
+def _healthy_info(pod_id: str = "p692", name: str = "pod-692") -> PodInfo:
+    """A healthy live ``PodInfo``: RUNNING + a public SSH port present."""
+    return PodInfo(
+        pod_id=pod_id, name=name, desired_status="RUNNING", ssh_host="1.2.3.4", ssh_port=22000
+    )
+
+
+# ===========================================================================
+# 1. The extracted raw predicate (composition surface (b))
+# ===========================================================================
+
+
+def test_pred_wedged_running_no_port():
+    # RUNNING + no public port -> the raw wedge condition is True.
+    assert bp._pod_is_runpod_runtime_wedged(_wedged_info()) is True
+
+
+def test_pred_healthy_port_present():
+    # RUNNING + a public port -> healthy, never wedge-classified.
+    assert bp._pod_is_runpod_runtime_wedged(_healthy_info()) is False
+
+
+def test_pred_gone_or_exited():
+    # None (pod gone) and a non-RUNNING pod both take the ordinary dead path.
+    assert bp._pod_is_runpod_runtime_wedged(None) is False
+    exited = PodInfo(
+        pod_id="p", name="pod-1", desired_status="EXITED", ssh_host=None, ssh_port=None
+    )
+    assert bp._pod_is_runpod_runtime_wedged(exited) is False
+
+
+# ===========================================================================
+# 2. The pure decision fn `decide_pod_wedge` (decision table + boundaries)
+# ===========================================================================
+
+
+def _decide(**over):
+    kw = dict(
+        wedged_for=K + 1,
+        k_floor=K,
+        wedge_missed=1,  # so new_wedge_missed=2 == threshold -> confirmed
+        threshold=2,
+        alerted=False,
+        keep_running=False,
+        inputs_ok=True,
+    )
+    kw.update(over)
+    return asw.decide_pod_wedge(**kw)
+
+
+def test_wedge_boundary_zero():
+    # MF5: a freshly-onset wedge (wedged_for=0) never stops on tick 1 -> KEEP.
+    assert _decide(wedged_for=0.0, wedge_missed=0) == ("keep", 0)
+
+
+def test_wedge_boundary_eq_k():
+    # MF5: exactly at the K floor -> KEEP (matches the poller's strict `> K`).
+    assert _decide(wedged_for=float(K), wedge_missed=0) == ("keep", 0)
+
+
+def test_wedge_below_k():
+    # Below K, even with an accumulated miss count, the wedge has not matured
+    # -> KEEP and RESET the miss counter (a brief no-port blip never accrues).
+    assert _decide(wedged_for=K - 100.0, wedge_missed=5) == ("keep", 0)
+
+
+def test_wedge_unconfirmed_increments_keep():
+    # Past K but not yet confirmed for >=threshold consecutive checks: accumulate.
+    # threshold=2, wedge_missed=0 -> new=1 < 2 -> KEEP with the incremented count.
+    assert _decide(wedged_for=K + 1, wedge_missed=0, threshold=2) == ("keep", 1)
+
+
+def test_wedge_boundary_confirm_transition():
+    # MF5: the action transitions EXACTLY at wedge_missed + 1 == threshold.
+    # threshold=3: wedge_missed=1 -> new=2 < 3 -> KEEP; wedge_missed=2 -> new=3 -> act.
+    assert _decide(wedged_for=K + 1, wedge_missed=1, threshold=3, inputs_ok=True) == ("keep", 2)
+    assert _decide(wedged_for=K + 1, wedge_missed=2, threshold=3, inputs_ok=True) == ("stop", 0)
+
+
+def test_wedge_stop_confirmed_inputs_safe_tag_absent():
+    # Confirmed past K + inputs verified on HF + keep_running is the literal
+    # False -> the reversible STOP fires.
+    assert _decide(keep_running=False, inputs_ok=True) == ("stop", 0)
+
+
+def test_wedge_alert_inputs_unverified():
+    # Confirmed + inputs NOT verified on HF -> ALERT-only (never strand work).
+    assert _decide(keep_running=False, inputs_ok=False) == ("alert", 0)
+
+
+def test_wedge_alert_keep_running_true():
+    # Confirmed + the keep-running tag is present -> ALERT-only (tag exemption).
+    # Even with inputs_ok=True the stop is suppressed.
+    assert _decide(keep_running=True, inputs_ok=True) == ("alert", 0)
+
+
+def test_wedge_alert_keep_running_unknown():
+    # MF2 closure: confirmed + inputs_ok=True but the keep-running read FAILED
+    # ("unknown") -> ALERT, NOT stop. A persistent tag-read failure must never
+    # silently override a (possibly present) keep-running tag on a live-work pod.
+    assert _decide(keep_running="unknown", inputs_ok=True) == ("alert", 0)
+
+
+def test_wedge_decision_invariant_stop_only_on_literal_false():
+    # The decision invariant (MF2): ("stop", _) is returned ONLY when
+    # keep_running is the literal False AND inputs_ok is True. Sweep the cross
+    # product and assert no other combination stops.
+    for keep_running in (True, "unknown"):
+        for inputs_ok in (True, False):
+            action, _ = _decide(keep_running=keep_running, inputs_ok=inputs_ok)
+            assert action != "stop", (keep_running, inputs_ok)
+    # Only False + True stops.
+    assert _decide(keep_running=False, inputs_ok=True)[0] == "stop"
+    assert _decide(keep_running=False, inputs_ok=False)[0] == "alert"
+
+
+# ===========================================================================
+# 3. The tri-state keep-running wrapper (MF2) + the fail-closed inputs gate
+# ===========================================================================
+
+
+def _fake_task_view(monkeypatch, *, returncode=0, stdout=None, raise_exc=None):
+    class _Out:
+        def __init__(self):
+            self.returncode = returncode
+            self.stdout = stdout if stdout is not None else ""
+
+    def _run(*_a, **_k):
+        if raise_exc is not None:
+            raise raise_exc
+        return _Out()
+
+    monkeypatch.setattr(asw.subprocess, "run", _run)
+
+
+def test_wedge_keep_running_present(monkeypatch):
+    _fake_task_view(monkeypatch, stdout=json.dumps({"frontmatter": {"tags": ["keep-running"]}}))
+    assert asw._wedge_keep_running(692) is True
+
+
+def test_wedge_keep_running_absent(monkeypatch):
+    _fake_task_view(monkeypatch, stdout=json.dumps({"frontmatter": {"tags": ["foo"]}}))
+    assert asw._wedge_keep_running(692) is False
+
+
+def test_wedge_keep_running_unknown_nonzero_rc(monkeypatch):
+    _fake_task_view(monkeypatch, returncode=1, stdout="boom")
+    assert asw._wedge_keep_running(692) == "unknown"
+
+
+def test_wedge_keep_running_unknown_parse_error(monkeypatch):
+    _fake_task_view(monkeypatch, returncode=0, stdout="not json{")
+    assert asw._wedge_keep_running(692) == "unknown"
+
+
+def test_wedge_keep_running_unknown_subprocess_error(monkeypatch):
+    _fake_task_view(monkeypatch, raise_exc=OSError("no such file"))
+    assert asw._wedge_keep_running(692) == "unknown"
+
+
+def test_wedge_inputs_safe_no_handle_fails_closed(monkeypatch, tmp_path):
+    # No persisted handle sidecar -> cannot gate -> fail-closed False (ALERT-only).
+    import explore_persona_space.backends.issue_dispatch as idp
+
+    missing = tmp_path / "issue-692-handle.json"
+    monkeypatch.setattr(idp, "resolve_handle_sidecar_path", lambda issue: (missing, [missing]))
+    assert asw._wedge_inputs_safe(692) is False
+
+
+def test_wedge_inputs_safe_exception_fails_closed(monkeypatch):
+    # Any exception inside the gate (transport / parse / import) -> False.
+    import explore_persona_space.backends.issue_dispatch as idp
+
+    def _boom(issue):
+        raise RuntimeError("transport down")
+
+    monkeypatch.setattr(idp, "resolve_handle_sidecar_path", _boom)
+    assert asw._wedge_inputs_safe(692) is False
+
+
+# ===========================================================================
+# 4. State persistence (MF3 round-trip) + the onset-clock clear (MF1)
+# ===========================================================================
+
+
+def test_wedge_state_roundtrip(isolated_registry):
+    # MF3: the three wedge fields survive a save + load round-trip.
+    asw._save_pod_safety_state(
+        692,
+        "p692",
+        missed=0,
+        alerted=False,
+        last_progress_ts=None,
+        wedge_first_seen=1000.0,
+        wedge_missed=1,
+        wedge_alerted=True,
+        prev={"first_seen": 500.0},
+    )
+    loaded = asw._load_pod_safety_state(692)
+    assert loaded["wedge_first_seen"] == 1000.0
+    assert loaded["wedge_missed"] == 1
+    assert loaded["wedge_alerted"] is True
+    assert loaded["pod_id"] == "p692"
+    # The pod-incarnation first_seen GC anchor is preserved, not clobbered.
+    assert loaded["first_seen"] == 500.0
+
+
+def test_wedge_state_carry_forward_on_status_class_save(isolated_registry):
+    # A status-class save (no wedge kwargs) must NOT drop an accumulated wedge
+    # episode's state -> the wedge fields carry forward untouched (MF3).
+    asw._save_pod_safety_state(
+        692,
+        "p692",
+        missed=0,
+        alerted=False,
+        last_progress_ts=None,
+        wedge_first_seen=1000.0,
+        wedge_missed=1,
+        wedge_alerted=True,
+    )
+    prev = asw._load_pod_safety_state(692)
+    # A later status-class save passes NO wedge kwargs (the default _CARRY).
+    asw._save_pod_safety_state(
+        692, "p692", missed=1, alerted=False, last_progress_ts=7.0, prev=prev
+    )
+    loaded = asw._load_pod_safety_state(692)
+    assert loaded["wedge_first_seen"] == 1000.0
+    assert loaded["wedge_missed"] == 1
+    assert loaded["wedge_alerted"] is True
+    assert loaded["missed"] == 1  # the status-class field advanced
+
+
+def test_clear_wedge_state_clears_clock_keeps_anchor(isolated_registry):
+    # MF1: _clear_wedge_state resets the wedge fields to the onset-cleared state
+    # while keeping the pod-incarnation first_seen GC anchor intact (NOT a
+    # whole-file clear).
+    asw._save_pod_safety_state(
+        692,
+        "p692",
+        missed=2,
+        alerted=True,
+        last_progress_ts=9.0,
+        wedge_first_seen=1000.0,
+        wedge_missed=3,
+        wedge_alerted=True,
+        prev={"first_seen": 500.0},
+    )
+    asw._clear_wedge_state(692, "p692")
+    loaded = asw._load_pod_safety_state(692)
+    assert loaded["wedge_first_seen"] is None
+    assert loaded["wedge_missed"] == 0
+    assert loaded["wedge_alerted"] is False
+    # GC anchor + status-class counters preserved.
+    assert loaded["first_seen"] == 500.0
+    assert loaded["missed"] == 2
+    assert loaded["alerted"] is True
+
+
+# ===========================================================================
+# 5. End-to-end wedge arm via `_process_pod` / `_process_wedged_pod`
+# ===========================================================================
+
+
+def _patch_wedge_io(
+    monkeypatch,
+    *,
+    status="running",
+    keep_running="unknown",
+    inputs_ok=False,
+):
+    """Monkeypatch the wedge arm's I/O: task status, the tri-state keep-running
+    read, the inputs-on-HF gate, and the action helpers. Returns the recorders
+    ``(stops, posts)``."""
+    stops: list[int] = []
+    posts: list[tuple[int, str]] = []
+    monkeypatch.setattr(asw, "_task_status", lambda issue: status)
+    monkeypatch.setattr(asw, "_wedge_keep_running", lambda issue: keep_running)
+    monkeypatch.setattr(asw, "_wedge_inputs_safe", lambda issue: inputs_ok)
+    monkeypatch.setattr(asw, "_stop_pod", lambda issue, dry_run: stops.append(issue) or True)
+    monkeypatch.setattr(
+        asw,
+        "_post_progress_marker",
+        lambda issue, note, dry_run, label: posts.append((issue, label)),
+    )
+    # Guard: a non-wedge fall-through path must not touch the status-class I/O
+    # in these wedge tests (they all pass a wedged info + non-DONE status).
+    monkeypatch.setattr(asw, "_task_events", lambda issue: [])
+    return stops, posts
+
+
+def test_wedge_clock_onset_heal_then_wedge(isolated_registry, monkeypatch):
+    # MF1 closure: a pod RUNNING for >> K (its pod-incarnation first_seen is the
+    # BOOT time) then loses its port. The FIRST wedged tick must stamp a fresh
+    # wedge_first_seen=now -> wedged_for=0 <= K -> KEEP, NOT stop on a vacuous K.
+    now = 2_000_000.0
+    # Prior state: a long-running healthy pod (first_seen way in the past, no
+    # wedge fields yet).
+    asw._save_pod_safety_state(
+        692,
+        "p692",
+        missed=0,
+        alerted=False,
+        last_progress_ts=None,
+        prev={"first_seen": now - 10 * K},
+    )
+    stops, _posts = _patch_wedge_io(monkeypatch, status="running")
+    asw._process_pod(692, "p692", _wedged_info(), now, dry_run=False, threshold=2)
+    assert stops == []  # the K floor measures the no-port episode, not pod uptime
+    loaded = asw._load_pod_safety_state(692)
+    assert loaded["wedge_first_seen"] == now  # stamped at ONSET this tick
+
+
+def test_wedge_first_tick_zero_keeps(isolated_registry, monkeypatch):
+    # The first wedged tick of a fresh incarnation -> wedged_for=0 -> KEEP.
+    now = 1_000_000.0
+    stops, posts = _patch_wedge_io(monkeypatch, status="approved")
+    asw._process_pod(692, "p692", _wedged_info(), now, dry_run=False, threshold=2)
+    assert stops == []
+    assert posts == []
+    assert asw._load_pod_safety_state(692)["wedge_first_seen"] == now
+
+
+def test_wedge_below_k_keeps(isolated_registry, monkeypatch):
+    # A second tick still within K -> KEEP (no maturation).
+    now = 1_000_000.0
+    asw._save_pod_safety_state(
+        692,
+        "p692",
+        missed=0,
+        alerted=False,
+        last_progress_ts=None,
+        wedge_first_seen=now - (K - 100.0),  # 100s short of K
+        wedge_missed=0,
+        wedge_alerted=False,
+        prev={"first_seen": now - (K - 100.0), "pod_id": "p692"},
+    )
+    stops, _posts = _patch_wedge_io(monkeypatch, status="running")
+    asw._process_pod(692, "p692", _wedged_info(), now, dry_run=False, threshold=2)
+    assert stops == []
+
+
+def test_wedge_unconfirmed_keeps_increments(isolated_registry, monkeypatch):
+    # Past K, first confirmed-past-K tick (wedge_missed 0 -> new 1 < threshold 2)
+    # -> KEEP, increment, NO alert yet.
+    now = 1_000_000.0
+    asw._save_pod_safety_state(
+        692,
+        "p692",
+        missed=0,
+        alerted=False,
+        last_progress_ts=None,
+        wedge_first_seen=now - (K + 50.0),
+        wedge_missed=0,
+        wedge_alerted=False,
+        prev={"first_seen": now - (K + 50.0), "pod_id": "p692"},
+    )
+    stops, posts = _patch_wedge_io(monkeypatch, status="running")
+    asw._process_pod(692, "p692", _wedged_info(), now, dry_run=False, threshold=2)
+    assert stops == []
+    assert posts == []
+    assert asw._load_pod_safety_state(692)["wedge_missed"] == 1
+
+
+def test_wedge_confirming_transition_stops(isolated_registry, monkeypatch):
+    # The confirming tick (wedge_missed 1 -> new 2 == threshold), inputs_ok=True,
+    # keep_running=False -> STOP fires exactly here (reversible _stop_pod).
+    now = 1_000_000.0
+    asw._save_pod_safety_state(
+        692,
+        "p692",
+        missed=0,
+        alerted=False,
+        last_progress_ts=None,
+        wedge_first_seen=now - (K + 50.0),
+        wedge_missed=1,
+        wedge_alerted=False,
+        prev={"first_seen": now - (K + 50.0), "pod_id": "p692"},
+    )
+    stops, posts = _patch_wedge_io(
+        monkeypatch, status="running", keep_running=False, inputs_ok=True
+    )
+    asw._process_pod(692, "p692", _wedged_info(), now, dry_run=False, threshold=2)
+    assert stops == [692]
+    assert "wedge-stop" in [label for _i, label in posts]
+    # The wedge fields are cleared on the stop, the first_seen GC anchor survives.
+    loaded = asw._load_pod_safety_state(692)
+    assert loaded["wedge_first_seen"] is None
+    assert loaded["wedge_missed"] == 0
+
+
+def test_wedge_inputs_unsafe_alerts(isolated_registry, monkeypatch):
+    # Confirmed past K but inputs NOT verified on HF -> ALERT-only, NEVER stop.
+    now = 1_000_000.0
+    asw._save_pod_safety_state(
+        692,
+        "p692",
+        missed=0,
+        alerted=False,
+        last_progress_ts=None,
+        wedge_first_seen=now - (K + 50.0),
+        wedge_missed=1,
+        wedge_alerted=False,
+        prev={"first_seen": now - (K + 50.0), "pod_id": "p692"},
+    )
+    stops, posts = _patch_wedge_io(
+        monkeypatch, status="running", keep_running=False, inputs_ok=False
+    )
+    asw._process_pod(692, "p692", _wedged_info(), now, dry_run=False, threshold=2)
+    assert stops == []
+    assert "wedge-alert" in [label for _i, label in posts]
+    assert asw._load_pod_safety_state(692)["wedge_alerted"] is True
+
+
+def test_wedge_keep_running_true_alerts(isolated_registry, monkeypatch):
+    # Confirmed past K + inputs_ok=True but the keep-running tag is present
+    # -> ALERT-only (the tag exemption matches the status-class arm).
+    now = 1_000_000.0
+    asw._save_pod_safety_state(
+        692,
+        "p692",
+        missed=0,
+        alerted=False,
+        last_progress_ts=None,
+        wedge_first_seen=now - (K + 50.0),
+        wedge_missed=1,
+        wedge_alerted=False,
+        prev={"first_seen": now - (K + 50.0), "pod_id": "p692"},
+    )
+    stops, posts = _patch_wedge_io(monkeypatch, status="running", keep_running=True, inputs_ok=True)
+    asw._process_pod(692, "p692", _wedged_info(), now, dry_run=False, threshold=2)
+    assert stops == []
+    assert "wedge-alert" in [label for _i, label in posts]
+
+
+def test_wedge_keep_running_unknown_alerts_never_stops(isolated_registry, monkeypatch):
+    # MF2 closure end-to-end: confirmed + inputs_ok=True + keep_running="unknown"
+    # -> ALERT, and _stop_pod is NEVER called.
+    now = 1_000_000.0
+    asw._save_pod_safety_state(
+        692,
+        "p692",
+        missed=0,
+        alerted=False,
+        last_progress_ts=None,
+        wedge_first_seen=now - (K + 50.0),
+        wedge_missed=1,
+        wedge_alerted=False,
+        prev={"first_seen": now - (K + 50.0), "pod_id": "p692"},
+    )
+    stops, posts = _patch_wedge_io(
+        monkeypatch, status="running", keep_running="unknown", inputs_ok=True
+    )
+    asw._process_pod(692, "p692", _wedged_info(), now, dry_run=False, threshold=2)
+    assert stops == []
+    assert "wedge-alert" in [label for _i, label in posts]
+
+
+def test_wedge_alert_dedup_once_per_episode(isolated_registry, monkeypatch):
+    # Two confirmed gated-off ticks in a row post the alert marker ONCE
+    # (deduped via the persisted wedge_alerted flag).
+    now = 1_000_000.0
+    asw._save_pod_safety_state(
+        692,
+        "p692",
+        missed=0,
+        alerted=False,
+        last_progress_ts=None,
+        wedge_first_seen=now - (K + 50.0),
+        wedge_missed=1,
+        wedge_alerted=False,
+        prev={"first_seen": now - (K + 50.0), "pod_id": "p692"},
+    )
+    stops, posts = _patch_wedge_io(
+        monkeypatch, status="running", keep_running=False, inputs_ok=False
+    )
+    asw._process_pod(692, "p692", _wedged_info(), now, dry_run=False, threshold=2)
+    asw._process_pod(692, "p692", _wedged_info(), now + 600, dry_run=False, threshold=2)
+    wedge_alerts = [label for _i, label in posts if label == "wedge-alert"]
+    assert len(wedge_alerts) == 1  # once per episode, not per tick
+    assert stops == []  # the gated-off (inputs-unverified) path never stops
+    assert asw._load_pod_safety_state(692)["wedge_alerted"] is True
+
+
+def test_wedge_pod_id_change_reset(isolated_registry, monkeypatch):
+    # MF4 closure: prev state carries a confirmed wedge from an OLD pod_id; the
+    # live tick observes a FRESH pod_id (the issue was re-provisioned). All wedge
+    # fields reset -> the fresh pod is KEPT, not stopped on stale wedge state.
+    now = 1_000_000.0
+    asw._save_pod_safety_state(
+        692,
+        "p_OLD",
+        missed=0,
+        alerted=False,
+        last_progress_ts=None,
+        wedge_first_seen=now - 10 * K,  # an old, matured wedge
+        wedge_missed=5,  # well past threshold
+        wedge_alerted=True,
+        prev={"first_seen": now - 10 * K, "pod_id": "p_OLD"},
+    )
+    stops, _posts = _patch_wedge_io(
+        monkeypatch, status="running", keep_running=False, inputs_ok=True
+    )
+    # The live pod has a NEW pod_id with no port (freshly wedged this tick).
+    asw._process_pod(692, "p_NEW", _wedged_info(pod_id="p_NEW"), now, dry_run=False, threshold=2)
+    assert stops == []  # stale wedge state from the old pod must not stop the new one
+    loaded = asw._load_pod_safety_state(692)
+    assert loaded["pod_id"] == "p_NEW"
+    assert loaded["wedge_first_seen"] == now  # re-stamped fresh for the new incarnation
+    assert loaded["wedge_missed"] == 0
+
+
+def test_wedge_done_task_falls_through_to_status_class_stop(isolated_registry, monkeypatch):
+    # MF6 closure: a wedged pod whose task status is DONE (completed) does NOT go
+    # to the wedge arm's ALERT-default — it falls through to the status-class
+    # DONE auto-stop arm, which stops it after the 2-miss guard. Here the
+    # status-class arm fires (no keep-running tag, no live follow-up).
+    now = 1_000_000.0
+    stops: list[int] = []
+    posts: list[tuple[int, str]] = []
+    monkeypatch.setattr(asw, "_task_status", lambda issue: "completed")
+    monkeypatch.setattr(asw, "_task_events", lambda issue: [])
+    monkeypatch.setattr(asw, "_latest_progress_ts", lambda events: None)
+    monkeypatch.setattr(asw, "_task_keep_running", lambda issue: False)
+    monkeypatch.setattr(asw, "_task_followup_active", lambda issue, events=None: False)
+    monkeypatch.setattr(asw, "_stop_pod", lambda issue, dry_run: stops.append(issue) or True)
+    monkeypatch.setattr(
+        asw,
+        "_post_progress_marker",
+        lambda issue, note, dry_run, label: posts.append((issue, label)),
+    )
+    # A wedge-arm helper that MUST NOT be reached for a DONE-status wedged pod.
+    monkeypatch.setattr(
+        asw,
+        "_process_wedged_pod",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("wedge arm reached on DONE task")),
+    )
+    info = _wedged_info()
+    # Tick 1: missed 0 -> 1, no stop. Tick 2: hits the 2-miss guard -> STOP via
+    # the status-class DONE arm (the canonical escaped-pod handler).
+    asw._process_pod(692, "p692", info, now, dry_run=False, threshold=2)
+    assert stops == []
+    asw._process_pod(692, "p692", info, now, dry_run=False, threshold=2)
+    assert stops == [692]
+    assert "auto-stop" in [label for _i, label in posts]
+
+
+def test_non_wedged_pod_clears_stale_wedge_state(isolated_registry, monkeypatch):
+    # A pod that is NOT wedged (port present) clears any stale wedge clock so a
+    # one-tick blip never matures, then proceeds to the status-class arm.
+    now = 1_000_000.0
+    asw._save_pod_safety_state(
+        692,
+        "p692",
+        missed=0,
+        alerted=False,
+        last_progress_ts=None,
+        wedge_first_seen=now - 10 * K,
+        wedge_missed=5,
+        wedge_alerted=True,
+        prev={"first_seen": now - 10 * K, "pod_id": "p692"},
+    )
+    stops: list[int] = []
+    monkeypatch.setattr(asw, "_task_status", lambda issue: "running")
+    monkeypatch.setattr(asw, "_task_events", lambda issue: [])
+    monkeypatch.setattr(asw, "_latest_progress_ts", lambda events: now - 3600)  # fresh
+    monkeypatch.setattr(asw, "_stop_pod", lambda issue, dry_run: stops.append(issue) or True)
+    monkeypatch.setattr(asw, "_post_progress_marker", lambda issue, note, dry_run, label: None)
+    asw._process_pod(692, "p692", _healthy_info(), now, dry_run=False, threshold=2)
+    assert stops == []
+    loaded = asw._load_pod_safety_state(692)
+    assert loaded["wedge_first_seen"] is None
+    assert loaded["wedge_missed"] == 0
+    assert loaded["wedge_alerted"] is False

--- a/tests/test_runpod_wedge_detection.py
+++ b/tests/test_runpod_wedge_detection.py
@@ -295,6 +295,21 @@ def test_is_runpod_async_wedge_failure_predicate():
     assert bp._is_runpod_async_wedge_failure(_gcp_handle(), wedged) is False
 
 
+def test_pod_is_runpod_runtime_wedged_predicate():
+    """#692: the RAW no-port wedge predicate extracted from
+    ``_maybe_escalate_runpod_wedge`` (composition surface (b)), called by BOTH
+    the poller and the autonomous_session_watch.py wedge backstop. It is the
+    maturity-AGNOSTIC raw condition: RUNNING + no public port."""
+    # RUNNING + no public port -> True (the raw wedge).
+    assert bp._pod_is_runpod_runtime_wedged(_PodInfo(ssh_host=None, ssh_port=None)) is True
+    # RUNNING + a public port present -> False (healthy).
+    assert bp._pod_is_runpod_runtime_wedged(_PodInfo(ssh_host="1.2.3.4", ssh_port=22000)) is False
+    # Non-RUNNING (EXITED/terminal) -> False (ordinary dead path).
+    assert bp._pod_is_runpod_runtime_wedged(_PodInfo(desired_status="EXITED")) is False
+    # None (pod gone) -> False.
+    assert bp._pod_is_runpod_runtime_wedged(None) is False
+
+
 # ---------------------------------------------------------------------------
 # 9/10. per-cell inputs-on-HF gate (M1)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes task #692. Adds the watcher-side backstop for the #689 fix-(b) RunPod RUNNING-but-no-port wedge detection, for the case where the per-issue poll loop has died. Composes via a single shared `_pod_is_runpod_runtime_wedged` predicate in `backend_poll.py` + the existing `_wedged_run_inputs_on_hf` gate + shared `RUNPOD_WEDGE_K_SEC=900s`.

- MF1 dedicated `wedge_first_seen` clock (not pod-uptime `first_seen`)
- MF2 tri-state `keep_running` (`True | False | "unknown"`; unknown → ALERT-only)
- MF3 `_save_pod_safety_state` forward-carry via `_CARRY` sentinel
- MF4 pod_id-change reset; 4-tuple `_running_managed_issue_pods` (all 5 callers in-file)
- MF5 `> K` boundary tests pinned
- MF6 DONE-task fall-through to canonical status-class STOP arm
- MF7 `_process_pod` call-site update

Diff: +1379/-53 across 6 files (1 `scripts/` + 1 `scripts/` + 3 `tests/` + 1 `.claude/rules/`).
Tests: 638 passed. Ruff + workflow_lint clean.

Code review: Claude PASS + Codex CONCERNS (both PASS-class — agree). Test-verdict PASS.