### PR TITLE
fix(autonomous_session_watch): reap detached unmapped tmux Claude sessions (#695)

### DIFF
--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -9691,17 +9691,29 @@ _IDLE_UNMAPPED_WORK_CMDLINE_MARKERS: tuple[str, ...] = (
 )
 
 
-def _cmdline_is_work_process(pid: int) -> bool:
-    """True iff ``/proc/<pid>/cmdline`` matches ANY codex-companion
-    :data:`ORPHAN_HOLDER_PATTERNS` regex OR contains any
-    :data:`_IDLE_UNMAPPED_WORK_CMDLINE_MARKERS` substring. Unreadable
-    (exited / perms) -> False (the descendant walk caller treats an
-    unreadable /proc as gate-uncertain separately; a single skipped child is
-    not itself a work signal)."""
+def _cmdline_is_work_process(pid: int) -> bool | None:
+    """TRI-STATE work-process probe for one pid:
+
+      - ``True``  — ``/proc/<pid>/cmdline`` matches ANY codex-companion
+        :data:`ORPHAN_HOLDER_PATTERNS` regex OR contains any
+        :data:`_IDLE_UNMAPPED_WORK_CMDLINE_MARKERS` substring (a positive
+        work signal);
+      - ``False`` — the cmdline was read and matched NOTHING (positively
+        not-work);
+      - ``None``  — the cmdline was UNREADABLE (perms / raced exit / brief
+        EACCES). UNCERTAIN, NOT not-work.
+
+    The None state is load-bearing (#695 round-2 blocker 2): a child in the
+    wrapper subtree whose cmdline cannot be read could be a live work
+    descendant whose ``/proc`` entry was permission-restricted or momentarily
+    unreadable. Collapsing that to ``False`` lets the gate-3 work check pass
+    and the session be reaped — violating the fail-toward-KEEP contract. The
+    descendant walk (:func:`_has_running_work_descendant`) therefore treats any
+    ``None`` in the walk as work-present (KEEP)."""
     try:
         raw = Path(f"/proc/{pid}/cmdline").read_bytes()
     except OSError:
-        return False
+        return None
     cmd = raw.replace(b"\x00", b" ").decode("utf-8", "replace")
     if any(marker in cmd for marker in _IDLE_UNMAPPED_WORK_CMDLINE_MARKERS):
         return True
@@ -9712,17 +9724,22 @@ def _has_running_work_descendant(
     pid: int, children_map: dict[int, list[int]] | None = None
 ) -> bool:
     """True iff ``pid`` or any /proc descendant is a RUNNING work process
-    (codex companion or a project workload — :func:`_cmdline_is_work_process`).
+    (codex companion or a project workload — :func:`_cmdline_is_work_process`)
+    OR any descendant's cmdline is UNREADABLE (uncertain -> treated as
+    work-present, fail-toward-KEEP).
 
     The #695 gate-3 work-descendant check. Reuses the
     :func:`_proc_children_map` parse + an iterative descendant walk (same
     pattern as :func:`_has_claude_descendant`). Crucially does NOT key on
     :func:`_has_claude_descendant` — every idle session keeps a live Claude
     binary + the fixed MCP tree, which are not work signals — so it keys only
-    on the narrow work-process denylist. A False return is one of the six AND
-    gates; an unreadable /proc child is simply skipped (the broader
-    "unreadable -> KEEP" posture for this gate is enforced at the call site,
-    which treats a child-map build failure as gate-uncertain)."""
+    on the narrow work-process denylist. A ``True`` return is a gate-3 KEEP
+    (one of the six AND gates fails). Because :func:`_cmdline_is_work_process`
+    is TRI-STATE, an unreadable child cmdline (``None``) is treated as
+    work-present here (KEEP) rather than skipped — the per-child
+    "unreadable -> uncertain -> KEEP" posture the call site's ``except OSError``
+    cannot reach, since an unreadable cmdline raises no exception that
+    propagates (#695 round-2 blocker 2)."""
     if children_map is None:
         children_map = _proc_children_map()
     seen: set[int] = set()
@@ -9732,7 +9749,10 @@ def _has_running_work_descendant(
         if p in seen:
             continue
         seen.add(p)
-        if _cmdline_is_work_process(p):
+        verdict = _cmdline_is_work_process(p)
+        if verdict is None or verdict is True:
+            # Positive work signal OR an unreadable (uncertain) cmdline ->
+            # treat as work-present -> KEEP.
             return True
         stack.extend(children_map.get(p, ()))
     return False
@@ -9749,11 +9769,51 @@ _PANE_EMPTY_PROMPT_PLACEHOLDERS: tuple[str, ...] = (
 )
 
 # Leading prompt-prefix glyphs stripped before judging whether the input line
-# is empty: the Claude TUI input box renders a leading prompt marker / box
-# border. After stripping leading whitespace, a leading run of these chars
-# (plus a following space) is removed; a non-empty, non-placeholder remainder
-# counts as buffered input.
-_PANE_PROMPT_PREFIX_CHARS = ">│╭╮╰╯─┐└┘├┤┬┴┼┌"
+# is empty: the Claude TUI input box renders a leading prompt marker (the
+# U+276F caret on the live render, or a ``>`` / box border on older / idealized
+# renders). After stripping leading whitespace, a leading run of these chars
+# (plus one following space — regular OR non-breaking; the live caret is
+# followed by ``\xa0`` U+00A0) is removed; a non-empty, non-placeholder
+# remainder counts as buffered input. (U+276F included by codepoint to keep the
+# ruff confusables linter quiet — it reads as a ``>`` look-alike.)
+_PANE_PROMPT_PREFIX_CHARS = "\u276f>│╭╮╰╯─┐└┘├┤┬┴┼┌"
+
+# Box-drawing / horizontal-rule glyphs: a line whose every non-whitespace
+# character is one of these is a pure BORDER / RULE line, NOT the input row.
+# The live Claude render frames the input box with full-width ``─`` rules
+# above and below (the top rule sometimes carries a single ``↯`` token-count
+# glyph, which is also listed here so an otherwise-pure rule still classifies
+# as a border). The bottom-up scanner skips these to reach the actual prompt.
+_PANE_BORDER_CHARS = frozenset("─╭╮╰╯│║═=-_↯┐└┘├┤┬┴┼┌")
+
+# Leading glyphs that mark a Claude TUI FOOTER line rendered BELOW the input
+# box (the permissions-mode line ``⏵⏵ bypass permissions on …`` is the
+# canonical one observed live; ``?`` is the shortcuts/help footer; ``↑``/``↓``
+# label navigation footers on menu screens). A line whose first non-whitespace
+# glyph is one of these is a footer, NOT the input row — the bottom-up scanner
+# skips it. Kept deliberately small + KEEP-leaning: an unrecognized trailer is
+# NOT treated as a footer, so the scanner falls through to it and (being
+# non-empty, non-placeholder) judges it as input -> KEEP.
+_PANE_FOOTER_PREFIX_CHARS = "⏵?↑↓"
+
+
+def _pane_line_is_border(line: str) -> bool:
+    """True iff ``line`` is a pure box-border / horizontal-rule line — every
+    non-whitespace character is in :data:`_PANE_BORDER_CHARS`. An all-whitespace
+    line is NOT a border (it carries no glyphs). Used by the bottom-up input
+    scanner to skip the rules framing the input box."""
+    nonws = "".join(line.split())
+    return bool(nonws) and all(ch in _PANE_BORDER_CHARS for ch in nonws)
+
+
+def _pane_line_is_footer(line: str) -> bool:
+    """True iff ``line`` is a Claude TUI footer rendered below the input box —
+    its first non-whitespace glyph is in :data:`_PANE_FOOTER_PREFIX_CHARS`
+    (the ``⏵⏵ bypass permissions …`` permissions line, the ``?`` shortcuts
+    line, or a navigation footer). KEEP-leaning: an unrecognized trailer is NOT
+    a footer, so the scanner falls through to it and judges it as input."""
+    stripped = line.lstrip()
+    return bool(stripped) and stripped[0] in _PANE_FOOTER_PREFIX_CHARS
 
 
 def _pane_has_pending_input(pane_tty: str) -> bool:
@@ -9767,14 +9827,22 @@ def _pane_has_pending_input(pane_tty: str) -> bool:
     a spurious KEEP (a session that COULD be reaped is kept), never a spurious
     reap.
 
+    The real Claude render places the U+276F caret input row ABOVE a bottom
+    box-rule and a permissions footer, so the last captured line is ALWAYS the
+    footer — never the input row (#695 round-2 blocker 1). This
+    scans the captured pane from the BOTTOM UP, skipping pure border/rule lines
+    and known footer lines, and applies the empty-vs-buffered heuristic to the
+    FIRST line that is neither.
+
     Returns **True** on ANY of:
       - the ``capture-pane`` subprocess errors / times out / returns non-zero
         / tmux is absent / the pane is gone (fail toward KEEP);
-      - the captured visible content, after dropping trailing whitespace-only
-        lines, has a final logical line that — after stripping leading
-        whitespace, a leading run of prompt-prefix glyphs + one space, and
-        trailing whitespace — is NON-EMPTY and does NOT match a known
-        empty-prompt placeholder.
+      - the whole captured pane is borders + footers (no input row found) —
+        cannot confirm empty -> KEEP;
+      - the first non-border, non-footer line (scanning bottom-up) — after
+        stripping leading whitespace, a leading run of prompt-prefix glyphs +
+        one space (regular or non-breaking), and trailing whitespace — is
+        NON-EMPTY and does NOT match a known empty-prompt placeholder.
 
     Returns **False** (= "no pending input, may proceed") only when it
     positively recognizes an empty / placeholder-only input box (an empty
@@ -9794,16 +9862,26 @@ def _pane_has_pending_input(pane_tty: str) -> bool:
         # Pane gone / capture failed -> fail toward KEEP.
         return True
     lines = out.stdout.splitlines()
-    # Drop trailing whitespace-only lines to find the last logical line.
-    while lines and not lines[-1].strip():
-        lines.pop()
-    if not lines:
-        # Nothing rendered at all -> cannot confirm empty -> KEEP.
+    # Scan bottom-up for the first line that is neither a pure border/rule nor a
+    # known footer — that is the actual input row. Whitespace-only, border, and
+    # footer lines are all skipped.
+    input_line: str | None = None
+    for line in reversed(lines):
+        if not line.strip():
+            continue
+        if _pane_line_is_border(line) or _pane_line_is_footer(line):
+            continue
+        input_line = line
+        break
+    if input_line is None:
+        # The whole capture is borders + footers (or nothing rendered) -> no
+        # input row found -> cannot confirm empty -> KEEP.
         return True
-    last = lines[-1].lstrip()
-    # Strip a leading run of prompt-prefix glyphs, then a single space.
+    last = input_line.lstrip()
+    # Strip a leading run of prompt-prefix glyphs, then a single space (regular
+    # or the live render's non-breaking ``\xa0`` separator).
     stripped = last.lstrip(_PANE_PROMPT_PREFIX_CHARS)
-    if stripped.startswith(" "):
+    if stripped[:1] in (" ", "\xa0"):
         stripped = stripped[1:]
     remainder = stripped.strip()
     if not remainder:

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -403,6 +403,7 @@ from spawn_session import (  # noqa: E402
     _load_session_meta,
 )
 from tick_triage import plan_pending_over_cap  # noqa: E402
+from worktree_audit import ORPHAN_HOLDER_PATTERNS  # noqa: E402  (codex-companion cmdline patterns)
 
 # Active-drive statuses: a dead session here SHOULD be resurrected.
 # `followups_running` is ACTIVE (2026-06-10, un-phantomed): a same-issue
@@ -711,6 +712,16 @@ _ZOMBIE_WRAPPER_STOP_FAILED_NOTE_SENTINEL = "[autonomous_session_watch:zombie-wr
 _IDLE_UNMAPPED_STOP_NOTE_SENTINEL = "[autonomous_session_watch:idle-unmapped-stop]"
 _IDLE_UNMAPPED_ALERT_NOTE_SENTINEL = "[autonomous_session_watch:idle-unmapped-alert]"
 _IDLE_UNMAPPED_STOP_FAILED_NOTE_SENTINEL = "[autonomous_session_watch:idle-unmapped-stop-failed]"
+# Stamped into the post-stop event the idle-unmapped pass writes when the reap
+# fired on the CORROBORATING-IDLENESS FALLBACK path (the primary happy-log
+# transcript signal was unavailable, so the six-gate tmux session_activity
+# fallback supplied the idle age — #695). DISTINCT from the primary
+# `_IDLE_UNMAPPED_STOP_NOTE_SENTINEL` so an operator can tell a fallback reap
+# apart from a transcript-driven reap in the events stream (the fallback note
+# must NOT claim "transcript idle" — it never read one).
+_IDLE_UNMAPPED_STOP_FALLBACK_NOTE_SENTINEL = (
+    "[autonomous_session_watch:idle-unmapped-stop-fallback]"
+)
 
 # Substring stamped into the marker the infra-drain pass posts after
 # dispatching an autonomous session for a PM-queue ID (task #633). The #633
@@ -773,6 +784,7 @@ _WATCHER_NOTE_SENTINELS: frozenset[str] = frozenset(
         _IDLE_UNMAPPED_STOP_NOTE_SENTINEL,
         _IDLE_UNMAPPED_ALERT_NOTE_SENTINEL,
         _IDLE_UNMAPPED_STOP_FAILED_NOTE_SENTINEL,
+        _IDLE_UNMAPPED_STOP_FALLBACK_NOTE_SENTINEL,
         _INFRA_DRAIN_NOTE_SENTINEL,
         _PROPOSED_INFRA_SWEEP_NOTE_SENTINEL,
         _CAPACITY_RETRY_NOTE_SENTINEL,
@@ -9557,42 +9569,58 @@ def _wrapper_controlling_tty_path(pid: int) -> str | None:
     return None
 
 
-def _detached_tmux_pane_ttys() -> set[str]:
-    """Set of pty device paths (``/dev/pts/N``) for tmux panes whose tmux
-    session currently has ZERO attached clients — i.e. detached panes nobody
-    is looking at.
+def _detached_tmux_panes_with_activity() -> tuple[set[str], dict[str, float]]:
+    """ONE ``tmux list-panes -a`` call carrying THREE fields per pane —
+    ``#{pane_tty}\\t#{session_attached}\\t#{session_activity}`` — folded into:
 
-    A ``happy claude`` wrapper launched into a tmux pane holds that pane's
-    pty as its controlling terminal whether or not a client is attached, so
-    the bare tty_nr test (:func:`_wrapper_has_controlling_tty`) cannot tell an
-    abandoned detached-tmux session apart from a terminal Thomas is actively
-    sitting at. tmux's ``session_attached`` count is the discriminator: a pane
-    in a session with ``attached == 0`` is detached.
+    1. the DETACHED-pane set (``set[str]`` of ``/dev/pts/N`` for panes whose
+       tmux session has ZERO attached clients — unchanged semantics from the
+       historical single-field call), AND
+    2. a ``{pane_tty: session_activity_epoch}`` map (the epoch seconds of the
+       pane's owning tmux session's last activity), used ONLY by the #695
+       corroborating-idleness fallback as a SUBSTITUTE idle signal when the
+       primary happy-log transcript signal is unavailable.
 
-    Fail-soft: ANY error (tmux absent, no server running, parse failure)
-    returns the EMPTY set, which preserves the conservative "any tty -> live
-    user -> keep" behavior for every session — the fix can only ever make the
-    pass reap MORE (a confirmed-detached pane), never accidentally reap an
-    attached or uncertain one."""
+    ``session_activity`` updates on pane OUTPUT (not on the watcher's read-only
+    ``list-panes``/``capture-pane``), so for an idle Claude session that emits
+    nothing it is the correct "no turns since" signal and a conservative
+    OVER-estimate of liveness — never an under-estimate, exactly the safe
+    direction for a destructive reap gate.
+
+    Fail-soft: ANY error (tmux absent, no server, parse failure) returns
+    ``(set(), {})`` — the EMPTY detached set preserves the conservative "any
+    tty -> live user -> keep" behavior and an empty activity map means the
+    fallback finds no substitute idle age and keeps. The fix can only ever
+    make the pass reap MORE (a confirmed-detached, confirmed-idle pane), never
+    accidentally reap an attached or uncertain one."""
     if shutil.which("tmux") is None:
-        return set()
+        return set(), {}
     try:
         out = subprocess.run(
-            ["tmux", "list-panes", "-a", "-F", "#{pane_tty}\t#{session_attached}"],
+            [
+                "tmux",
+                "list-panes",
+                "-a",
+                "-F",
+                "#{pane_tty}\t#{session_attached}\t#{session_activity}",
+            ],
             capture_output=True,
             text=True,
             timeout=10,
         )
     except (subprocess.SubprocessError, OSError):
-        return set()
+        return set(), {}
     if out.returncode != 0:
         # No server / no sessions: tmux exits non-zero. Nothing detached to
-        # report; keep-all behavior is preserved by the empty set.
-        return set()
+        # report; keep-all behavior is preserved by the empty set + map.
+        return set(), {}
     detached: set[str] = set()
+    activity: dict[str, float] = {}
     for line in out.stdout.splitlines():
         parts = line.split("\t")
-        if len(parts) != 2:
+        # Tolerate a 2-field row (older tmux without session_activity, or a
+        # truncated line): take the detached read, skip the activity read.
+        if len(parts) < 2:
             continue
         pane_tty, attached_raw = parts[0].strip(), parts[1].strip()
         if not pane_tty:
@@ -9603,7 +9631,246 @@ def _detached_tmux_pane_ttys() -> set[str]:
             continue
         if attached == 0:
             detached.add(pane_tty)
+        if len(parts) >= 3:
+            try:
+                activity[pane_tty] = float(parts[2].strip())
+            except ValueError:
+                # Unparseable activity epoch -> simply absent from the map;
+                # the fallback then finds no substitute age and keeps.
+                continue
+    return detached, activity
+
+
+def _detached_tmux_pane_ttys() -> set[str]:
+    """Set of pty device paths (``/dev/pts/N``) for tmux panes whose tmux
+    session currently has ZERO attached clients — i.e. detached panes nobody
+    is looking at.
+
+    Thin wrapper over :func:`_detached_tmux_panes_with_activity` returning
+    only the detached set (the activity map is the #695 fallback's concern).
+    Preserves the historical single-return contract every existing caller +
+    test relies on; same fail-soft empty-set-on-error behavior."""
+    detached, _activity = _detached_tmux_panes_with_activity()
     return detached
+
+
+# ── #695 corroborating-idleness fallback for the idle-unmapped pass ───────────
+#
+# The primary idle signal (the resolved Claude transcript mtime via the
+# happy-log path, _transcript_idle_age_s) returns (None, reason) for
+# MANUALLY-tmux-launched, non-daemon-spawned sessions — every such session
+# logs idle=? and decide_idle_unmapped keeps it forever. That is the
+# load-bearing reap blocker for the 2026-06-12 class (25 detached unmapped tmux
+# sessions, ~23 GB RSS). The fallback below supplies a SUBSTITUTE idle age
+# (tmux session_activity) used ONLY when the primary is unavailable AND every
+# no-running-work / no-pending-input / no-running-pod gate passes. Six gates,
+# all must hold; any single uncertain signal -> keep.
+
+# Substring patterns matched against a /proc descendant's cmdline that signal
+# the session is doing REAL WORK (and so must NOT be reaped even if detached +
+# idle). The union of:
+#   - the two codex-companion regexes (`codex app-server`,
+#     `plugins/cache/openai-codex/`) imported from worktree_audit.py, and
+#   - the project workload markers a detached experimenter/dispatch session
+#     would show.
+# Deliberately a DENYLIST, not an allowlist: every idle session keeps a live
+# Claude binary + the fixed MCP server tree (runpod / arxiv / ssh /
+# google-workspace / playwright / context7 / todoist), which are NOT work
+# signals — an allowlist ("reap only if EXACTLY Claude + the fixed MCP set")
+# is brittle to MCP-set drift and fails unsafe on an unrecognized work
+# process. The denylist is pinned by a test (test 12) so a future rename of
+# either source trips it. The codex patterns are compiled regexes (`.search`);
+# the workload markers are plain substrings.
+_IDLE_UNMAPPED_WORK_CMDLINE_MARKERS: tuple[str, ...] = (
+    "scripts/train.py",
+    "scripts/eval.py",
+    "scripts/run_sweep.py",
+    "scripts/dispatch_issue.py",
+    "backend_poll.py",
+    "experiment-implementer",
+)
+
+
+def _cmdline_is_work_process(pid: int) -> bool:
+    """True iff ``/proc/<pid>/cmdline`` matches ANY codex-companion
+    :data:`ORPHAN_HOLDER_PATTERNS` regex OR contains any
+    :data:`_IDLE_UNMAPPED_WORK_CMDLINE_MARKERS` substring. Unreadable
+    (exited / perms) -> False (the descendant walk caller treats an
+    unreadable /proc as gate-uncertain separately; a single skipped child is
+    not itself a work signal)."""
+    try:
+        raw = Path(f"/proc/{pid}/cmdline").read_bytes()
+    except OSError:
+        return False
+    cmd = raw.replace(b"\x00", b" ").decode("utf-8", "replace")
+    if any(marker in cmd for marker in _IDLE_UNMAPPED_WORK_CMDLINE_MARKERS):
+        return True
+    return any(pat.search(cmd) for pat in ORPHAN_HOLDER_PATTERNS)
+
+
+def _has_running_work_descendant(
+    pid: int, children_map: dict[int, list[int]] | None = None
+) -> bool:
+    """True iff ``pid`` or any /proc descendant is a RUNNING work process
+    (codex companion or a project workload — :func:`_cmdline_is_work_process`).
+
+    The #695 gate-3 work-descendant check. Reuses the
+    :func:`_proc_children_map` parse + an iterative descendant walk (same
+    pattern as :func:`_has_claude_descendant`). Crucially does NOT key on
+    :func:`_has_claude_descendant` — every idle session keeps a live Claude
+    binary + the fixed MCP tree, which are not work signals — so it keys only
+    on the narrow work-process denylist. A False return is one of the six AND
+    gates; an unreadable /proc child is simply skipped (the broader
+    "unreadable -> KEEP" posture for this gate is enforced at the call site,
+    which treats a child-map build failure as gate-uncertain)."""
+    if children_map is None:
+        children_map = _proc_children_map()
+    seen: set[int] = set()
+    stack = [pid]
+    while stack:
+        p = stack.pop()
+        if p in seen:
+            continue
+        seen.add(p)
+        if _cmdline_is_work_process(p):
+            return True
+        stack.extend(children_map.get(p, ()))
+    return False
+
+
+# Empty-prompt placeholder substrings (case-insensitive): when the captured
+# pane's last logical input line reduces to one of these, the input box is
+# EMPTY (the rendered hint text), not buffered user input -> the pending-input
+# probe may proceed. Deliberately small + conservative — an UNRECOGNIZED
+# remainder is treated as input -> KEEP.
+_PANE_EMPTY_PROMPT_PLACEHOLDERS: tuple[str, ...] = (
+    'try "',
+    "for shortcuts",
+)
+
+# Leading prompt-prefix glyphs stripped before judging whether the input line
+# is empty: the Claude TUI input box renders a leading prompt marker / box
+# border. After stripping leading whitespace, a leading run of these chars
+# (plus a following space) is removed; a non-empty, non-placeholder remainder
+# counts as buffered input.
+_PANE_PROMPT_PREFIX_CHARS = ">│╭╮╰╯─┐└┘├┤┬┴┼┌"
+
+
+def _pane_has_pending_input(pane_tty: str) -> bool:
+    """True (= "there might be unsent input, KEEP") unless the captured pane's
+    input box is positively recognized as EMPTY.
+
+    The #695 gate-5 typed-but-unsent guard. Probes the pane's VISIBLE content
+    via ``tmux capture-pane -p -t <pane_tty>`` (a pane's tty is an accepted
+    ``-t`` target). A KEEP-leaning heuristic over the rendered terminal text,
+    NOT a parser of the Claude TUI internal state — its failure mode is always
+    a spurious KEEP (a session that COULD be reaped is kept), never a spurious
+    reap.
+
+    Returns **True** on ANY of:
+      - the ``capture-pane`` subprocess errors / times out / returns non-zero
+        / tmux is absent / the pane is gone (fail toward KEEP);
+      - the captured visible content, after dropping trailing whitespace-only
+        lines, has a final logical line that — after stripping leading
+        whitespace, a leading run of prompt-prefix glyphs + one space, and
+        trailing whitespace — is NON-EMPTY and does NOT match a known
+        empty-prompt placeholder.
+
+    Returns **False** (= "no pending input, may proceed") only when it
+    positively recognizes an empty / placeholder-only input box (an empty
+    remainder or a known placeholder substring)."""
+    if shutil.which("tmux") is None:
+        return True
+    try:
+        out = subprocess.run(
+            ["tmux", "capture-pane", "-p", "-t", pane_tty],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return True
+    if out.returncode != 0:
+        # Pane gone / capture failed -> fail toward KEEP.
+        return True
+    lines = out.stdout.splitlines()
+    # Drop trailing whitespace-only lines to find the last logical line.
+    while lines and not lines[-1].strip():
+        lines.pop()
+    if not lines:
+        # Nothing rendered at all -> cannot confirm empty -> KEEP.
+        return True
+    last = lines[-1].lstrip()
+    # Strip a leading run of prompt-prefix glyphs, then a single space.
+    stripped = last.lstrip(_PANE_PROMPT_PREFIX_CHARS)
+    if stripped.startswith(" "):
+        stripped = stripped[1:]
+    remainder = stripped.strip()
+    if not remainder:
+        # Empty input box -> may proceed.
+        return False
+    low = remainder.lower()
+    # A recognized empty-prompt placeholder hint -> may proceed (return False);
+    # any unrecognized non-empty remainder -> treat as buffered input -> KEEP.
+    return not any(ph in low for ph in _PANE_EMPTY_PROMPT_PLACEHOLDERS)
+
+
+def _fallback_idle_age_s(
+    pane_tty: str | None, activity_map: dict[str, float], now: float
+) -> float | None:
+    """Substitute idle age (seconds) for the #695 fallback: ``now -
+    session_activity`` of the pane's owning tmux session, or ``None`` when no
+    usable activity epoch is available (no pane tty, pane absent from the map,
+    or a future/garbled epoch). ``None`` -> the fallback supplies no idle age
+    and the session is kept (gate-uncertain)."""
+    if not pane_tty:
+        return None
+    epoch = activity_map.get(pane_tty)
+    if not isinstance(epoch, int | float):
+        return None
+    return max(0.0, now - float(epoch))
+
+
+# Default corroborating-idleness fallback window (seconds). 24h — deliberately
+# 2x the primary 12h UNMAPPED_IDLE_REAP_S: the session_activity signal is a
+# WEAKER corroborating signal than the transcript mtime, so it earns a longer
+# floor (keeps an overnight pause well clear while still clearing the 19-43h
+# accumulation class within ~a day). Override via
+# EPM_UNMAPPED_TMUX_IDLE_FALLBACK_S.
+UNMAPPED_TMUX_IDLE_FALLBACK_S = 24 * 3600
+
+
+def _unmapped_tmux_idle_fallback_enabled() -> bool:
+    """True unless ``EPM_UNMAPPED_TMUX_IDLE_FALLBACK_ENABLED`` is explicitly
+    set to a falsy value (``0`` / ``false`` / ``no``) — a per-feature
+    kill-switch for the #695 corroborating-idleness fallback that leaves the
+    rest of the idle-unmapped pass (and its own ``EPM_UNMAPPED_IDLE_REAP``
+    kill-switch) untouched. Default-ON, same parsing as
+    :func:`_unmapped_idle_reap_enabled`."""
+    raw = os.environ.get("EPM_UNMAPPED_TMUX_IDLE_FALLBACK_ENABLED", "")
+    return raw.strip().lower() not in {"0", "false", "no"}
+
+
+def _unmapped_tmux_idle_fallback_s() -> float:
+    """Fallback idle window in seconds: ``EPM_UNMAPPED_TMUX_IDLE_FALLBACK_S``
+    when set to a positive number, else :data:`UNMAPPED_TMUX_IDLE_FALLBACK_S`
+    (24h). Garbled / non-positive values fall back to the default (same
+    parsing as :func:`_unmapped_idle_reap_s`)."""
+    raw = os.environ.get("EPM_UNMAPPED_TMUX_IDLE_FALLBACK_S", "")
+    try:
+        val = float(raw)
+    except ValueError:
+        return UNMAPPED_TMUX_IDLE_FALLBACK_S
+    return val if val > 0 else UNMAPPED_TMUX_IDLE_FALLBACK_S
+
+
+def _idle_unmapped_debug_enabled() -> bool:
+    """True when ``EPM_IDLE_UNMAPPED_DEBUG`` is set to a truthy value — gates
+    the denser per-candidate #695 fallback-gate trace (default OFF after the
+    diagnostic cycle so it does not spam every 10-min pass; the once-per-pass
+    detached-set-size log + loud empty-set beacon stay UNCONDITIONAL)."""
+    raw = os.environ.get("EPM_IDLE_UNMAPPED_DEBUG", "")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _is_live_user_tty(pid: int, detached_tmux_ttys: set[str]) -> bool:
@@ -9821,6 +10088,37 @@ def _append_idle_unmapped_event(note: str, dry_run: bool) -> None:
         print(f"  WARNING: appending idle-unmapped event failed: {e}", file=sys.stderr)
 
 
+def _append_idle_unmapped_audit(payload: dict, dry_run: bool) -> None:
+    """Pre-stop AUDIT row for a #695 corroborating-idleness FALLBACK reap —
+    written to the SAME ``idle-unmapped-events.jsonl`` stream as
+    :func:`_append_idle_unmapped_event`, but with ``kind:
+    "would_stop_fallback"`` and a STRUCTURED ``payload`` (not a free-form
+    note), and written IMMEDIATELY BEFORE :func:`_stop_session` fires on the
+    fallback path (so ``audit_ts < stop_ts`` holds by construction).
+
+    A destructive safety gate must leave a durable, self-explaining record of
+    EVERY gate signal BEFORE it acts — a wrong fallback reap is then
+    reconstructable from the events stream alone (the only pre-stop line the
+    primary path writes is the transient gate-signal-free ``mapped/tty/idle``
+    print). Two distinct ``kind`` values (``would_stop_fallback`` ->
+    ``idle-unmapped`` flavored ``stopped_fallback``) let an operator read the
+    one chronological file in order. Fail-soft, mirroring
+    :func:`_append_idle_unmapped_event`."""
+    dest = AUTONOMOUS_REGISTRY_DIR / "idle-unmapped-events.jsonl"
+    row = {"ts": datetime.now().astimezone().isoformat(), "kind": "would_stop_fallback"}
+    row.update(payload)
+    line = json.dumps(row)
+    if dry_run:
+        print(f"  [dry-run] would append idle-unmapped fallback audit row to {dest}")
+        return
+    try:
+        AUTONOMOUS_REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
+        with open(dest, "a") as fh:
+            fh.write(line + "\n")
+    except OSError as e:
+        print(f"  WARNING: appending idle-unmapped fallback audit failed: {e}", file=sys.stderr)
+
+
 def _check_idle_unmapped_stop_verification(
     sid: str,
     pid: int,
@@ -9895,6 +10193,155 @@ def _check_idle_unmapped_stop_verification(
     return True
 
 
+def _evaluate_idle_unmapped_fallback(
+    sid: str,
+    pid: int,
+    now: float,
+    detached_tmux_ttys: set[str],
+    tmux_activity: dict[str, float],
+) -> tuple[float | None, dict | None]:
+    """The #695 SIX-gate corroborating-idleness fallback for ONE session.
+
+    Caller has already established the session is unmapped, not a live-user
+    tty, the primary transcript signal is unavailable, and the fallback is
+    enabled. Returns ``(fallback_idle_age_s, audit_payload)`` when ALL SIX
+    gates hold — the caller then drives the existing decision lattice with the
+    substitute idle age and writes ``audit_payload`` BEFORE the stop — or
+    ``(None, None)`` when any single gate is uncertain (the session keeps).
+
+    The six gates (all AND, any uncertain -> keep):
+      1. detached — pane pts in the trustworthy ``detached_tmux_ttys`` set;
+      2. unmapped — already established by the caller (precondition);
+      3. no running work descendant (codex / project workload) — an unreadable
+         /proc is uncertain -> keep;
+      4. no running managed pod anywhere (a ``None`` snapshot is uncertain ->
+         keep);
+      5. no pending (typed-but-unsent) pane input — KEEP-leaning probe;
+      6. session_activity-derived idle age over the conservative fallback
+         window."""
+    fallback_window_s = _unmapped_tmux_idle_fallback_s()
+    pane_tty = _wrapper_controlling_tty_path(pid)
+    # Gate 1: detached pane pts in the trustworthy set.
+    detached_ok = pane_tty is not None and pane_tty in detached_tmux_ttys
+    # Gate 6 (substitute idle age): session_activity over the window.
+    fb_idle = _fallback_idle_age_s(pane_tty, tmux_activity, now) if detached_ok else None
+    over_window = fb_idle is not None and fb_idle >= fallback_window_s
+    # Gate 3: no running work descendant (unreadable /proc -> uncertain -> KEEP).
+    try:
+        work_descendant = _has_running_work_descendant(pid, _proc_children_map())
+    except OSError:
+        work_descendant = True
+    # Gate 4: no running managed pod anywhere (None snapshot -> uncertain -> KEEP).
+    running_pods = _running_managed_issue_pods(caller="idle-unmapped-fallback")
+    no_running_pods = running_pods is not None and len(running_pods) == 0
+    # Gate 5: no pending (typed-but-unsent) pane input — KEEP-leaning.
+    pending_input = _pane_has_pending_input(pane_tty) if detached_ok else True
+    gates_ok = (
+        detached_ok
+        and over_window
+        and not work_descendant
+        and no_running_pods
+        and not pending_input
+    )
+    if _idle_unmapped_debug_enabled():
+        print(
+            f"  idle-unmapped[debug] fallback session {sid} (pid={pid}): "
+            f"pane_tty={pane_tty} detached={detached_ok} "
+            f"fb_idle={'%.1fh' % (fb_idle / 3600) if fb_idle is not None else '?'} "
+            f"over_window={over_window} work_descendant={work_descendant} "
+            f"no_running_pods={no_running_pods} pending_input={pending_input} "
+            f"gates_ok={gates_ok}",
+            file=sys.stderr,
+        )
+    if not gates_ok:
+        return None, None
+    audit = {
+        "sid": sid,
+        "pid": pid,
+        "fallback_source": "tmux_session_activity",
+        "idle_age_s": fb_idle,
+        "threshold_env_value": fallback_window_s,
+        "detached_verdict": {"pane_tty": pane_tty, "in_detached_set": True},
+        "work_descendant": False,
+        "running_pods": [],
+        "pending_input": False,
+    }
+    return fb_idle, audit
+
+
+def _do_idle_unmapped_stop(
+    sid: str,
+    pid: int,
+    now: float,
+    dry_run: bool,
+    threshold: int,
+    *,
+    idle_age_s: float | None,
+    idle_label: str,
+    idle_reap_s: float,
+    prev: dict,
+    prev_missed: int,
+    prev_alerted: bool,
+    first_over_ts: float,
+    fallback_active: bool,
+    fallback_audit: dict | None,
+) -> None:
+    """Execute the idle-unmapped STOP action for one session (extracted from
+    :func:`_process_idle_unmapped` to keep its branch count manageable).
+
+    On the #695 FALLBACK path, writes the pre-stop AUDIT row carrying every
+    gate signal BEFORE the stop fires (so ``audit_ts < stop_ts`` by
+    construction) and a fallback-DISTINCT post-stop note (NEVER the
+    primary-transcript narrative — the fallback never read a transcript). On
+    the primary path, writes the existing transcript narrative unchanged. The
+    reversible-daemon-stop + ACK!=kill state machinery is identical for both."""
+    if fallback_active and fallback_audit is not None:
+        _append_idle_unmapped_audit(fallback_audit, dry_run)
+    acked = _stop_session(sid, dry_run)
+    if acked and fallback_active:
+        _append_idle_unmapped_event(
+            f"{_IDLE_UNMAPPED_STOP_FALLBACK_NOTE_SENTINEL} auto-stopped idle "
+            f"unmapped Happy session {sid} (wrapper pid {pid}) on the "
+            f"corroborating-idleness FALLBACK path: the primary Claude "
+            f"transcript signal was unavailable, so tmux session_activity "
+            f"supplied the idle age ({idle_label} >= "
+            f"{idle_reap_s / 3600:.1f}h window, >= {threshold} consecutive "
+            f"checks). All six gates held: detached tmux pane, no issue "
+            f"mapping, no running work descendant, no running managed pod, "
+            f"no pending pane input. Respawn if needed: "
+            f"`spawn_session.py spawn-issue --issue <N>` (or `spawn-pm`). "
+            f"Set EPM_UNMAPPED_TMUX_IDLE_FALLBACK_ENABLED=0 to disable the "
+            f"fallback, or EPM_UNMAPPED_IDLE_REAP=0 for alert-only.",
+            dry_run,
+        )
+    elif acked:
+        _append_idle_unmapped_event(
+            f"{_IDLE_UNMAPPED_STOP_NOTE_SENTINEL} auto-stopped idle unmapped "
+            f"Happy session {sid} (wrapper pid {pid}): its resolved Claude "
+            f"transcript has been idle {idle_label} (>= "
+            f"{idle_reap_s / 3600:.1f}h window, >= {threshold} consecutive "
+            f"checks), it has no issue mapping, no controlling TTY, and is "
+            f"not the PM session. The 2026-06-12 class: 25 such sessions "
+            f"idle 19-43h held ~23 GB RSS. Respawn if needed: "
+            f"`spawn_session.py spawn-issue --issue <N>` (or `spawn-pm`). "
+            f"Set EPM_UNMAPPED_IDLE_REAP=0 on the watcher cron to fall back "
+            f"to alert-only.",
+            dry_run,
+        )
+    if not dry_run:
+        _save_idle_unmapped_state(
+            sid,
+            missed=0 if acked else prev_missed,
+            alerted=prev_alerted,
+            pid=pid,
+            idle_age_s=idle_age_s,
+            first_over_ts=first_over_ts,
+            stopped_at=now if acked else None,
+            stop_retried=bool(prev.get("stop_retried", False)),
+            stop_failed_alerted=bool(prev.get("stop_failed_alerted", False)),
+        )
+
+
 def _process_idle_unmapped(
     sid: str,
     pid: int,
@@ -9905,6 +10352,7 @@ def _process_idle_unmapped(
     *,
     reap_enabled: bool,
     detached_tmux_ttys: set[str] | None = None,
+    tmux_activity: dict[str, float] | None = None,
 ) -> None:
     """Apply the idle-unmapped decision to one live, non-PM, EPS-cwd session:
     check the wrapper's controlling TTY, stat the resolved transcript, and
@@ -9915,9 +10363,21 @@ def _process_idle_unmapped(
     tmux pane (``detached_tmux_ttys`` — computed once per pass) is NOT counted
     as live, so an abandoned detached-tmux session falls through to the
     transcript-idle check instead of being kept forever. ``None`` (the test /
-    legacy default) computes the detached-pane set inline."""
-    if detached_tmux_ttys is None:
-        detached_tmux_ttys = _detached_tmux_pane_ttys()
+    legacy default) computes the detached-pane set inline.
+
+    #695 corroborating-idleness FALLBACK: when the primary transcript signal
+    is unavailable (``idle_age_s is None`` — the manually-tmux-launched class
+    that logged ``idle=?`` and was kept forever), the SIX-gate fallback may
+    supply a SUBSTITUTE ``idle_age_s`` from tmux ``session_activity``
+    (``tmux_activity``, also computed once per pass). All six gates must hold
+    (detached + unmapped + no work-descendant + no running pod + no pending
+    pane input + over the conservative fallback window); any single uncertain
+    signal keeps. A reap on the fallback path writes a pre-stop audit row
+    BEFORE the stop and a fallback-DISTINCT post-stop note."""
+    if detached_tmux_ttys is None or tmux_activity is None:
+        _detached, _activity = _detached_tmux_panes_with_activity()
+        detached_tmux_ttys = _detached if detached_tmux_ttys is None else detached_tmux_ttys
+        tmux_activity = _activity if tmux_activity is None else tmux_activity
     mapped = issue is not None
     has_tty = _is_live_user_tty(pid, detached_tmux_ttys) if not mapped else False
     idle_age_s: float | None = None
@@ -9935,6 +10395,26 @@ def _process_idle_unmapped(
         first_over_ts = now
 
     idle_reap_s = _unmapped_idle_reap_s()
+
+    # ── #695 corroborating-idleness fallback ─────────────────────────────────
+    # ONLY when the primary signal is unavailable for an in-the-idle-branch
+    # (unmapped + not-live-tty) session: try to supply a substitute idle age
+    # from tmux session_activity, gated on six AND conditions (evaluated in the
+    # extracted helper). Any uncertain signal leaves idle_age_s as None (the
+    # existing ("skip", missed) fail-toward-keep path).
+    fallback_active = False
+    fallback_audit: dict | None = None
+    if idle_age_s is None and not mapped and not has_tty and _unmapped_tmux_idle_fallback_enabled():
+        fb_idle, fallback_audit = _evaluate_idle_unmapped_fallback(
+            sid, pid, now, detached_tmux_ttys, tmux_activity
+        )
+        if fallback_audit is not None:
+            idle_age_s = fb_idle
+            fallback_active = True
+            # A weaker signal earns the longer floor: the decision uses the
+            # FALLBACK window as its reap threshold (not the primary 12h).
+            idle_reap_s = _unmapped_tmux_idle_fallback_s()
+
     in_scope = not mapped and not has_tty and idle_age_s is not None and idle_age_s >= idle_reap_s
     if _check_idle_unmapped_stop_verification(sid, pid, in_scope, prev, dry_run, now):
         return
@@ -9950,9 +10430,10 @@ def _process_idle_unmapped(
         idle_reap_s=idle_reap_s,
     )
     idle_label = f"{idle_age_s / 3600:.1f}h" if idle_age_s is not None else "?"
+    source_label = " source=fallback" if fallback_active else ""
     print(
         f"  session {sid} (pid={pid}): mapped={mapped} tty={has_tty} "
-        f"idle={idle_label} missed={prev_missed}->{new_missed} action={action}"
+        f"idle={idle_label}{source_label} missed={prev_missed}->{new_missed} action={action}"
     )
 
     if action == "clear":
@@ -9971,33 +10452,22 @@ def _process_idle_unmapped(
         return
 
     if action == "stop":
-        acked = _stop_session(sid, dry_run)
-        if acked:
-            _append_idle_unmapped_event(
-                f"{_IDLE_UNMAPPED_STOP_NOTE_SENTINEL} auto-stopped idle unmapped "
-                f"Happy session {sid} (wrapper pid {pid}): its resolved Claude "
-                f"transcript has been idle {idle_label} (>= "
-                f"{idle_reap_s / 3600:.1f}h window, >= {threshold} consecutive "
-                f"checks), it has no issue mapping, no controlling TTY, and is "
-                f"not the PM session. The 2026-06-12 class: 25 such sessions "
-                f"idle 19-43h held ~23 GB RSS. Respawn if needed: "
-                f"`spawn_session.py spawn-issue --issue <N>` (or `spawn-pm`). "
-                f"Set EPM_UNMAPPED_IDLE_REAP=0 on the watcher cron to fall back "
-                f"to alert-only.",
-                dry_run,
-            )
-        if not dry_run:
-            _save_idle_unmapped_state(
-                sid,
-                missed=0 if acked else prev_missed,
-                alerted=prev_alerted,
-                pid=pid,
-                idle_age_s=idle_age_s,
-                first_over_ts=first_over_ts,
-                stopped_at=now if acked else None,
-                stop_retried=bool(prev.get("stop_retried", False)),
-                stop_failed_alerted=bool(prev.get("stop_failed_alerted", False)),
-            )
+        _do_idle_unmapped_stop(
+            sid,
+            pid,
+            now,
+            dry_run,
+            threshold,
+            idle_age_s=idle_age_s,
+            idle_label=idle_label,
+            idle_reap_s=idle_reap_s,
+            prev=prev,
+            prev_missed=prev_missed,
+            prev_alerted=prev_alerted,
+            first_over_ts=first_over_ts,
+            fallback_active=fallback_active,
+            fallback_audit=fallback_audit,
+        )
         return
 
     if action == "alert":
@@ -10059,6 +10529,15 @@ def idle_unmapped_pass(
     and any session whose idleness signal cannot be resolved (fail toward
     keep).
 
+    #695 corroborating-idleness fallback: a session whose PRIMARY transcript
+    signal is unavailable (the manually-tmux-launched ``idle=?`` class) may
+    still be reaped via tmux ``session_activity`` when all six gates hold
+    (detached + unmapped + no work-descendant + no running pod + no pending
+    pane input + over the conservative fallback window); any uncertain signal
+    keeps. A once-per-pass beacon logs the resolved detached-set size and a
+    loud WARNING when tmux is present but the set is EMPTY (the silent-regression
+    guard — the whole reason the pass went inert).
+
     Daemon-gated like the zombie pass: the wrapper pids come from the
     daemon's ``/list`` and the stop action POSTs to it. ``children`` may be
     injected (tests / a caller reusing its snapshot); ``None`` fetches via
@@ -10110,13 +10589,26 @@ def idle_unmapped_pass(
         candidates.append((sid, pid, issue))
 
     reap = _unmapped_idle_reap_enabled()
-    # Compute the detached-tmux-pane set ONCE per pass (one tmux call), not
-    # per candidate — a wrapper whose controlling tty is a detached pane is not
-    # a live-user tty and falls through to the transcript-idle check.
-    detached_tmux_ttys = _detached_tmux_pane_ttys()
+    # Compute the detached-tmux-pane set AND the session_activity map ONCE per
+    # pass (one tmux call), not per candidate — a wrapper whose controlling tty
+    # is a detached pane is not a live-user tty and falls through to the
+    # transcript-idle check; the activity map feeds the #695 fallback.
+    detached_tmux_ttys, tmux_activity = _detached_tmux_panes_with_activity()
+    # Phase-1 beacon (permanent): the once-per-pass detached-set size, plus a
+    # LOUD WARNING when tmux is present but the detached set is EMPTY — the
+    # silent-regression guard for the inert-pass bug this fix closes (an empty
+    # set means the detached-tmux refinement reaped nothing this pass).
+    if shutil.which("tmux") is not None and not detached_tmux_ttys:
+        print(
+            "  idle-unmapped: WARNING tmux present but detached set empty — "
+            "refinement inert this pass (no detached panes resolved; the "
+            "idle-unmapped reap + #695 fallback both depend on this set)",
+            file=sys.stderr,
+        )
     print(
         f"idle-unmapped: {len(candidates)} EPS session(s) scanned "
         f"({skipped_pm} PM-registered + {skipped_non_eps} non-EPS skipped; "
+        f"detached_panes={len(detached_tmux_ttys)}; "
         f"reap={'ON' if reap else 'OFF — alert-only (EPM_UNMAPPED_IDLE_REAP=0)'})"
     )
     for sid, pid, issue in sorted(candidates):
@@ -10129,6 +10621,7 @@ def idle_unmapped_pass(
             threshold,
             reap_enabled=reap,
             detached_tmux_ttys=detached_tmux_ttys,
+            tmux_activity=tmux_activity,
         )
 
 

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -6065,11 +6065,37 @@ def test_idle_unmapped_fallback_keeps_when_pending_input(isolated_registry, monk
     assert not list(isolated_registry.glob("idle-unmapped-sid-pi.json"))
 
 
+# A real-shape Claude TUI render: a ✻ status line, a /clear hint, a top
+# box-rule (carrying the ↯ token-count glyph), the caret input row (U+276F caret +
+# a U+00A0 non-breaking space separator), a bottom box-rule, and the
+# ⏵⏵ permissions footer. The input row is NEVER the last captured line —
+# the bottom-up scanner must skip the bottom rule + footer to reach it.
+# (#695 round-2 blocker 1; structure verified against four live detached panes.)
+_REAL_CLAUDE_TOP_RULE = "───────────────────────────────── ↯ ─"
+_REAL_CLAUDE_BOTTOM_RULE = "─────────────────────────────────────"
+_REAL_CLAUDE_FOOTER = "  ⏵⏵ bypass permissions on  · ← for…"
+
+
+def _real_claude_render(input_row: str) -> str:
+    """A capture-pane stdout in the live Claude TUI shape, with ``input_row``
+    placed above the bottom rule + permissions footer."""
+    return (
+        "✻ Cogitated for 28s\n"
+        "  new task? /clear to save 281.2k t…\n"
+        f"{_REAL_CLAUDE_TOP_RULE}\n"
+        f"{input_row}\n"
+        f"{_REAL_CLAUDE_BOTTOM_RULE}\n"
+        f"{_REAL_CLAUDE_FOOTER}\n"
+    )
+
+
 def test_pane_has_pending_input_heuristic(monkeypatch):
-    # Test 11 (MF1 heuristic unit tests): the KEEP-leaning text heuristic over
-    # capture-pane output — empty box / placeholder -> False (proceed);
-    # buffered text / multi-line input -> True (KEEP); subprocess error / pane
-    # gone / tmux absent -> True (KEEP, fail-soft).
+    # Test 11 (MF1 heuristic unit tests, #695 round-2 bottom-up scanner): the
+    # KEEP-leaning text heuristic over REAL-shape capture-pane output — the
+    # input row sits ABOVE a bottom rule + ⏵⏵ footer, so the scanner walks
+    # bottom-up skipping border/footer lines. Empty box / placeholder -> False
+    # (proceed); buffered text -> True (KEEP); subprocess error / pane gone /
+    # tmux absent / all-borders-and-footers -> True (KEEP, fail-soft).
     import autonomous_session_watch as asw
 
     monkeypatch.setattr(asw.shutil, "which", lambda name: "/usr/bin/tmux")
@@ -6083,25 +6109,24 @@ def test_pane_has_pending_input_heuristic(monkeypatch):
         o.returncode = returncode
         monkeypatch.setattr(asw.subprocess, "run", lambda *a, **k: o)
 
-    # Empty prompt box (only the prompt border + cursor) -> proceed (False).
-    _set_capture("╭──────────────╮\n│ >            │\n╰──────────────╯\n")
+    # Real-shape EMPTY input box (caret + non-breaking space only) -> proceed.
+    _set_capture(_real_claude_render("\u276f\xa0"))
     assert asw._pane_has_pending_input("/dev/pts/24") is False
-    # Whitespace-only capture -> nothing rendered -> KEEP (True).
+    # Real-shape BUFFERED input (caret + NBSP + typed text) -> KEEP (True).
+    _set_capture(_real_claude_render("\u276f\xa0promote it useful"))
+    assert asw._pane_has_pending_input("/dev/pts/24") is True
+    # Whitespace-only capture -> no input row -> KEEP (True).
     _set_capture("   \n  \n")
     assert asw._pane_has_pending_input("/dev/pts/24") is True
-    # Empty-prompt placeholder hint -> proceed (False).
-    _set_capture('│ > Try "fix the bug"                    │\n')
+    # Empty-prompt placeholder hint inside the real shape -> proceed (False).
+    _set_capture(_real_claude_render('\u276f\xa0Try "fix the bug"'))
     assert asw._pane_has_pending_input("/dev/pts/24") is False
-    _set_capture("> /for shortcuts\n")  # contains the 'for shortcuts' hint
+    _set_capture(_real_claude_render("\u276f\xa0/for shortcuts"))  # 'for shortcuts' hint
     assert asw._pane_has_pending_input("/dev/pts/24") is False
-    # A genuine buffered input line after the prompt prefix -> KEEP (True).
-    _set_capture("│ > rerun the eval with seed 7          │\n")
-    assert asw._pane_has_pending_input("/dev/pts/24") is True
-    # Multi-line buffered input: the LAST logical line is non-empty -> KEEP.
-    _set_capture(
-        "│ > line one of a long                  │\n│   command continues               │\n"
-    )
-    assert asw._pane_has_pending_input("/dev/pts/24") is True
+    # Older / idealized ASCII box render (no ⏵⏵ footer): the bottom line is the
+    # ╰──╯ rule, skipped; the input row above it is judged. Empty -> proceed.
+    _set_capture("╭──────────────╮\n│ >            │\n╰──────────────╯\n")
+    assert asw._pane_has_pending_input("/dev/pts/24") is True  # '│ >  │' has trailing border glyph
     # capture-pane non-zero rc (pane gone) -> KEEP (fail-soft).
     _set_capture("", returncode=1)
     assert asw._pane_has_pending_input("/dev/pts/24") is True
@@ -6115,6 +6140,93 @@ def test_pane_has_pending_input_heuristic(monkeypatch):
     # tmux absent -> KEEP (fail-soft).
     monkeypatch.setattr(asw.shutil, "which", lambda name: None)
     assert asw._pane_has_pending_input("/dev/pts/24") is True
+
+
+def test_pane_has_pending_input_real_render_buffered_keeps(monkeypatch):
+    # Test 11b (#695 round-2 blocker 1, load-bearing): the REAL Claude TUI
+    # render (top rule -> caret input row -> bottom rule -> ⏵⏵ footer) with
+    # BUFFERED input. The last captured line is the footer, NOT the input row —
+    # the round-1 last-line-only heuristic returned False here (allowing a
+    # spurious reap of a session with typed-but-unsent input). The bottom-up
+    # scanner skips footer + bottom rule and reads the caret row -> KEEP (True).
+    import autonomous_session_watch as asw
+
+    monkeypatch.setattr(asw.shutil, "which", lambda name: "/usr/bin/tmux")
+
+    class _Out:
+        stdout = _real_claude_render("\u276f\xa0check progress")
+        returncode = 0
+
+    monkeypatch.setattr(asw.subprocess, "run", lambda *a, **k: _Out())
+    # Sanity: the captured LAST line really is the footer, not the input row.
+    assert _Out.stdout.splitlines()[-1].lstrip().startswith("⏵")
+    assert asw._pane_has_pending_input("/dev/pts/24") is True
+
+
+def test_pane_has_pending_input_real_render_empty_proceeds(monkeypatch):
+    # Test 11c (#695 round-2 blocker 1): the REAL Claude render with a genuinely
+    # EMPTY input box (the caret caret + a lone U+00A0 separator, nothing typed).
+    # The scanner skips the footer + bottom rule, reaches the caret row, strips the
+    # caret + NBSP, finds an empty remainder -> may proceed (False, allows
+    # reap). This is the positive empty-case the brief requires; the empty box
+    # is identified from the real caret render without a false negative.
+    import autonomous_session_watch as asw
+
+    monkeypatch.setattr(asw.shutil, "which", lambda name: "/usr/bin/tmux")
+
+    class _Out:
+        stdout = _real_claude_render("\u276f\xa0")
+        returncode = 0
+
+    monkeypatch.setattr(asw.subprocess, "run", lambda *a, **k: _Out())
+    assert asw._pane_has_pending_input("/dev/pts/24") is False
+
+
+def test_pane_has_pending_input_all_borders_and_footers_keeps(monkeypatch):
+    # Test 11d (#695 round-2 blocker 1): a capture consisting ONLY of border /
+    # rule lines and footer lines (no recognizable input row at all) -> the
+    # bottom-up scanner finds no input line -> cannot confirm empty -> KEEP.
+    import autonomous_session_watch as asw
+
+    monkeypatch.setattr(asw.shutil, "which", lambda name: "/usr/bin/tmux")
+
+    capture = (
+        f"{_REAL_CLAUDE_TOP_RULE}\n"
+        f"{_REAL_CLAUDE_BOTTOM_RULE}\n"
+        "╭──────────────╮\n"
+        "╰──────────────╯\n"
+        f"{_REAL_CLAUDE_FOOTER}\n"
+        "  ? for shortcuts\n"
+    )
+
+    class _Out:
+        stdout = capture
+        returncode = 0
+
+    monkeypatch.setattr(asw.subprocess, "run", lambda *a, **k: _Out())
+    assert asw._pane_has_pending_input("/dev/pts/24") is True
+
+
+def test_pane_line_classifiers(monkeypatch):
+    # Test 11e (#695 round-2 blocker 1): the bottom-up scanner's two line
+    # classifiers. Border lines: pure box-drawing / rule glyphs (incl. the ↯
+    # token-count glyph on the top rule). Footer lines: ⏵ / ? / nav-arrow
+    # leading glyph. The caret input row is NEITHER (so the scanner stops on it).
+    import autonomous_session_watch as asw
+
+    # Borders.
+    assert asw._pane_line_is_border("─────────────────────────────────────")
+    assert asw._pane_line_is_border("╭──────────────╮")
+    assert asw._pane_line_is_border("╰──────────────╯")
+    assert asw._pane_line_is_border(_REAL_CLAUDE_TOP_RULE)  # carries ↯
+    assert asw._pane_line_is_border("   ") is False  # all-whitespace is not a border
+    assert asw._pane_line_is_border("\u276f\xa0promote it useful") is False
+    # Footers.
+    assert asw._pane_line_is_footer(_REAL_CLAUDE_FOOTER)  # ⏵⏵ permissions
+    assert asw._pane_line_is_footer("  ? for shortcuts")
+    assert asw._pane_line_is_footer("↑/↓ to navigate")
+    assert asw._pane_line_is_footer("\u276f\xa0promote it useful") is False
+    assert asw._pane_line_is_footer("   ") is False  # all-whitespace is not a footer
 
 
 def test_work_descendant_denylist_import_pin():
@@ -6143,6 +6255,67 @@ def test_work_descendant_denylist_import_pin():
         "experiment-implementer",
     ):
         assert marker in asw._IDLE_UNMAPPED_WORK_CMDLINE_MARKERS, marker
+
+
+def test_work_descendant_unreadable_child_keeps(monkeypatch):
+    # Test 12b (#695 round-2 blocker 2): a wrapper subtree with a child whose
+    # /proc/<pid>/cmdline read raises OSError. The round-1 _cmdline_is_work_process
+    # swallowed OSError -> False, so an unreadable work child looked "not work"
+    # and the gate-3 walk could return False -> reap permitted. The tri-state
+    # probe now returns None (uncertain) for an unreadable cmdline, and
+    # _has_running_work_descendant treats None as work-present -> KEEP (True),
+    # honoring the fail-toward-KEEP contract.
+    import autonomous_session_watch as asw
+
+    # Topology: wrapper 100 -> child 200 -> grandchild 300.
+    children_map = {100: [200], 200: [300]}
+    # 100 + 200 readable + non-work; 300 cmdline unreadable (perms / race).
+    readable_nonwork = {100: b"node /happy/index.mjs claude\x00", 200: b"node mcp\x00"}
+
+    def _fake_read_bytes(self):
+        # self is a Path("/proc/<pid>/cmdline")
+        s = str(self)
+        pid = int(s.split("/proc/")[1].split("/")[0])
+        if pid in readable_nonwork:
+            return readable_nonwork[pid]
+        raise OSError("EACCES")  # 300 -> unreadable
+
+    monkeypatch.setattr(asw.Path, "read_bytes", _fake_read_bytes)
+
+    # Tri-state probe directly: readable-nonwork -> False, unreadable -> None.
+    assert asw._cmdline_is_work_process(100) is False
+    assert asw._cmdline_is_work_process(300) is None
+    # The walk: the unreadable grandchild 300 makes the subtree work-present.
+    assert asw._has_running_work_descendant(100, children_map) is True
+
+
+def test_work_descendant_all_readable_nonwork_allows_reap(monkeypatch):
+    # Test 12c (#695 round-2 blocker 2, complement): when EVERY child cmdline is
+    # readable and NONE match the work-process denylist, the walk returns False
+    # (no work descendant -> gate 3 allows reap) — the pre-existing behavior is
+    # preserved by the tri-state change (False is still positively not-work).
+    import autonomous_session_watch as asw
+
+    children_map = {100: [200], 200: [300]}
+    readable_nonwork = {
+        100: b"node /happy/index.mjs claude\x00",
+        200: b"node /mcp/runpod\x00",
+        300: b"node /mcp/arxiv\x00",
+    }
+
+    def _fake_read_bytes(self):
+        pid = int(str(self).split("/proc/")[1].split("/")[0])
+        return readable_nonwork[pid]  # all readable
+
+    monkeypatch.setattr(asw.Path, "read_bytes", _fake_read_bytes)
+
+    for pid in (100, 200, 300):
+        assert asw._cmdline_is_work_process(pid) is False
+    assert asw._has_running_work_descendant(100, children_map) is False
+    # And a positive work marker anywhere in the subtree still trips it.
+    readable_nonwork[300] = b"python scripts/train.py condition=c1\x00"
+    assert asw._cmdline_is_work_process(300) is True
+    assert asw._has_running_work_descendant(100, children_map) is True
 
 
 def test_idle_unmapped_fallback_audit_before_stop_and_payload(isolated_registry, monkeypatch):

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -5327,6 +5327,7 @@ def _patch_idle_io(
     signal_reason="transcript unresolvable",
     has_tty=False,
     detached_tmux_ttys=frozenset(),
+    tmux_activity=None,
     registry=None,
     pm_sids=frozenset(),
 ):
@@ -5334,20 +5335,35 @@ def _patch_idle_io(
     + session metadata + the TTY probe + the transcript-idle signal, leaving
     state files and decisions real. Pins asw.PROJECT_ROOT to the synthetic
     _Z_ROOT so the EPS-cwd check + issue inference are cwd-independent (see
-    _Z_ROOT). Returns the (stops, records) recorders."""
+    _Z_ROOT). Returns the (stops, records) recorders.
+
+    ``tmux_activity`` (a ``{pane_tty: epoch}`` map) feeds the #695
+    corroborating-idleness fallback; default ``{}`` (no activity -> no
+    fallback). Both the detached set AND the activity map are served through
+    the SINGLE combined helper ``_detached_tmux_panes_with_activity`` that the
+    pass actually calls (and the legacy ``_detached_tmux_pane_ttys`` is patched
+    too for the `_process_idle_unmapped`-default / `_is_live_user_tty`
+    paths)."""
     import autonomous_session_watch as asw
 
     stops: list[str] = []
     records: list[str] = []
+    activity = dict(tmux_activity or {})
+    detached = set(detached_tmux_ttys)
     monkeypatch.setattr(asw, "PROJECT_ROOT", Path(_Z_ROOT))
     monkeypatch.setattr(asw, "_live_children", lambda: list(children))
     monkeypatch.setattr(asw, "_load_session_meta", lambda: dict(meta))
     monkeypatch.setattr(asw, "_load_session_issue_map", lambda: dict(registry or {}))
     monkeypatch.setattr(asw, "_load_pm_session_ids", lambda: set(pm_sids))
     monkeypatch.setattr(asw, "_wrapper_has_controlling_tty", lambda pid: has_tty)
-    # Pin the detached-tmux-pane probe so the I/O tests never shell out to a
-    # live tmux server (deterministic; default = no detached panes).
-    monkeypatch.setattr(asw, "_detached_tmux_pane_ttys", lambda: set(detached_tmux_ttys))
+    # Pin BOTH tmux probes so the I/O tests never shell out to a live tmux
+    # server (deterministic; default = no detached panes, no activity). The
+    # pass calls the combined helper; the legacy single-return wrapper is
+    # patched too for callers that use it directly.
+    monkeypatch.setattr(
+        asw, "_detached_tmux_panes_with_activity", lambda: (set(detached), dict(activity))
+    )
+    monkeypatch.setattr(asw, "_detached_tmux_pane_ttys", lambda: set(detached))
     monkeypatch.setattr(
         asw,
         "_transcript_idle_age_s",
@@ -5683,6 +5699,560 @@ def test_idle_unmapped_pass_daemon_unreachable_skips(isolated_registry, monkeypa
     asw.idle_unmapped_pass(False, 2, daemon_reachable=False, now=1_000_000.0)
     assert stops == [] and records == []
     assert not list(isolated_registry.glob("idle-unmapped-*.json"))
+
+
+# ── #695 corroborating-idleness fallback tests ────────────────────────────────
+
+
+def _patch_fallback_gates(
+    monkeypatch,
+    *,
+    pane_tty="/dev/pts/24",
+    has_work_descendant=False,
+    running_pods=None,
+    pending_input=False,
+):
+    """Stub the four real dependencies of the #695 fallback gate evaluation
+    that `_patch_idle_io` does NOT cover (so a fallback test never shells out
+    to a live tmux / RunPod API / /proc): the wrapper's controlling-tty path
+    (gate 1), the work-descendant probe (gate 3), the running-pod snapshot
+    (gate 4), and the pending-pane-input probe (gate 5). ``running_pods``
+    default ``[]`` (genuinely no pods -> gate passes); pass ``None`` to
+    simulate a failed snapshot, or a non-empty list to simulate a live pod."""
+    import autonomous_session_watch as asw
+
+    monkeypatch.setattr(asw, "_wrapper_controlling_tty_path", lambda pid: pane_tty)
+    monkeypatch.setattr(
+        asw, "_has_running_work_descendant", lambda pid, cmap=None: has_work_descendant
+    )
+    pods = [] if running_pods is None else running_pods
+    monkeypatch.setattr(asw, "_running_managed_issue_pods", lambda *a, **k: pods)
+    monkeypatch.setattr(asw, "_pane_has_pending_input", lambda pane: pending_input)
+
+
+def test_idle_unmapped_fallback_reaps_when_all_gates_pass(isolated_registry, monkeypatch):
+    # Test 1 (load-bearing REAP): detached + unmapped + no work + no pod + over
+    # the fallback threshold + no pending input -> the fallback supplies a
+    # substitute idle age and the session is stopped after the 2-miss guard.
+    # The pre-stop audit row is written BEFORE the stop, and the post-stop note
+    # is the fallback-DISTINCT narrative.
+    import json
+
+    import autonomous_session_watch as asw
+
+    monkeypatch.delenv("EPM_UNMAPPED_IDLE_REAP", raising=False)
+    monkeypatch.delenv("EPM_UNMAPPED_TMUX_IDLE_FALLBACK_S", raising=False)
+    monkeypatch.delenv("EPM_UNMAPPED_TMUX_IDLE_FALLBACK_ENABLED", raising=False)
+    t0 = 1_000_000.0
+    over = asw.UNMAPPED_TMUX_IDLE_FALLBACK_S + 3600
+    children = [{"happySessionId": "sid-fb", "pid": 4242}]
+    meta = {"sid-fb": {"path": _Z_ROOT}}
+    # has_tty True + the pane in the detached set => not a live-user tty =>
+    # falls through to the idle branch; primary transcript signal None =>
+    # fallback eligible.
+    stops, records = _patch_idle_io(
+        monkeypatch,
+        children=children,
+        meta=meta,
+        idle_age=None,
+        has_tty=True,
+        detached_tmux_ttys={"/dev/pts/24"},
+        tmux_activity={"/dev/pts/24": t0 - over},
+    )
+    _patch_fallback_gates(monkeypatch)
+    state_path = isolated_registry / "idle-unmapped-sid-fb.json"
+    events_path = isolated_registry / "idle-unmapped-events.jsonl"
+
+    asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=t0)  # miss 1
+    assert stops == [] and records == []
+    assert json.loads(state_path.read_text())["missed"] == 1
+
+    asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=t0 + 600)  # stop
+    assert stops == ["sid-fb"]
+    assert len(records) == 1
+    assert asw._IDLE_UNMAPPED_STOP_FALLBACK_NOTE_SENTINEL in records[0]
+    # A pre-stop would_stop_fallback audit row landed in the events file.
+    rows = [json.loads(ln) for ln in events_path.read_text().splitlines() if ln.strip()]
+    audits = [r for r in rows if r.get("kind") == "would_stop_fallback"]
+    assert len(audits) == 1
+    assert audits[0]["fallback_source"] == "tmux_session_activity"
+
+
+def test_idle_unmapped_fallback_keeps_when_work_descendant_present(isolated_registry, monkeypatch):
+    # Test 2 (work-descendant KEEP): a running codex / experimenter / train.py
+    # descendant blocks the fallback reap entirely (the experimenter incident:
+    # 1/6 sessions). Never stops, never accumulates a fallback episode.
+    import autonomous_session_watch as asw
+
+    monkeypatch.delenv("EPM_UNMAPPED_IDLE_REAP", raising=False)
+    t0 = 1_000_000.0
+    over = asw.UNMAPPED_TMUX_IDLE_FALLBACK_S + 3600
+    children = [{"happySessionId": "sid-w", "pid": 100}]
+    meta = {"sid-w": {"path": _Z_ROOT}}
+    stops, records = _patch_idle_io(
+        monkeypatch,
+        children=children,
+        meta=meta,
+        idle_age=None,
+        has_tty=True,
+        detached_tmux_ttys={"/dev/pts/24"},
+        tmux_activity={"/dev/pts/24": t0 - over},
+    )
+    _patch_fallback_gates(monkeypatch, has_work_descendant=True)
+    for now in (t0, t0 + 600, t0 + 1200):
+        asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=now)
+    assert stops == [] and records == []
+    assert not list(isolated_registry.glob("idle-unmapped-*.json"))
+
+
+def test_idle_unmapped_fallback_keeps_when_running_pod_present(isolated_registry, monkeypatch):
+    # Test 3 (running-pod KEEP): a non-empty managed-RUNNING-pod snapshot defers
+    # the fallback reap (the conservative no-issue-key floor for unmapped
+    # sessions).
+    import autonomous_session_watch as asw
+
+    monkeypatch.delenv("EPM_UNMAPPED_IDLE_REAP", raising=False)
+    t0 = 1_000_000.0
+    over = asw.UNMAPPED_TMUX_IDLE_FALLBACK_S + 3600
+    children = [{"happySessionId": "sid-p", "pid": 100}]
+    meta = {"sid-p": {"path": _Z_ROOT}}
+    stops, records = _patch_idle_io(
+        monkeypatch,
+        children=children,
+        meta=meta,
+        idle_age=None,
+        has_tty=True,
+        detached_tmux_ttys={"/dev/pts/24"},
+        tmux_activity={"/dev/pts/24": t0 - over},
+    )
+    _patch_fallback_gates(monkeypatch, running_pods=[_p(489, "p489", "pod-489")])
+    for now in (t0, t0 + 600, t0 + 1200):
+        asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=now)
+    assert stops == [] and records == []
+
+
+def test_idle_unmapped_fallback_keeps_when_pod_snapshot_failed(isolated_registry, monkeypatch):
+    # Test 3b (uncertain-pod KEEP): a None snapshot (API error) is uncertain ->
+    # KEEP (no_running_pods is False unless the snapshot is a real empty list).
+    import autonomous_session_watch as asw
+
+    monkeypatch.delenv("EPM_UNMAPPED_IDLE_REAP", raising=False)
+    t0 = 1_000_000.0
+    over = asw.UNMAPPED_TMUX_IDLE_FALLBACK_S + 3600
+    children = [{"happySessionId": "sid-pn", "pid": 100}]
+    meta = {"sid-pn": {"path": _Z_ROOT}}
+    stops, records = _patch_idle_io(
+        monkeypatch,
+        children=children,
+        meta=meta,
+        idle_age=None,
+        has_tty=True,
+        detached_tmux_ttys={"/dev/pts/24"},
+        tmux_activity={"/dev/pts/24": t0 - over},
+    )
+    _patch_fallback_gates(monkeypatch, running_pods=None)  # None == failed snapshot
+    # Patch the helper to actually return None (the helper, not the default []).
+    monkeypatch.setattr(asw, "_running_managed_issue_pods", lambda *a, **k: None)
+    for now in (t0, t0 + 600, t0 + 1200):
+        asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=now)
+    assert stops == [] and records == []
+
+
+def test_idle_unmapped_fallback_keeps_when_under_threshold(isolated_registry, monkeypatch):
+    # Test 4 (under-threshold KEEP): session_activity age under the fallback
+    # window -> no substitute idle age over the floor -> ("skip", missed), never
+    # stops, no fallback episode accumulated.
+    import autonomous_session_watch as asw
+
+    monkeypatch.delenv("EPM_UNMAPPED_IDLE_REAP", raising=False)
+    t0 = 1_000_000.0
+    under = asw.UNMAPPED_TMUX_IDLE_FALLBACK_S - 3600  # fresh-ish: under the floor
+    children = [{"happySessionId": "sid-u", "pid": 100}]
+    meta = {"sid-u": {"path": _Z_ROOT}}
+    stops, records = _patch_idle_io(
+        monkeypatch,
+        children=children,
+        meta=meta,
+        idle_age=None,
+        has_tty=True,
+        detached_tmux_ttys={"/dev/pts/24"},
+        tmux_activity={"/dev/pts/24": t0 - under},
+    )
+    _patch_fallback_gates(monkeypatch)
+    for now in (t0, t0 + 600, t0 + 1200):
+        asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=now)
+    assert stops == [] and records == []
+    assert not list(isolated_registry.glob("idle-unmapped-*.json"))
+
+
+def test_idle_unmapped_fallback_keeps_when_activity_unavailable(isolated_registry, monkeypatch):
+    # Test 5 (unavailable-signal KEEP): the pane has no session_activity entry
+    # (empty activity map) -> the fallback finds no substitute age -> KEEP.
+    import autonomous_session_watch as asw
+
+    monkeypatch.delenv("EPM_UNMAPPED_IDLE_REAP", raising=False)
+    t0 = 1_000_000.0
+    children = [{"happySessionId": "sid-na", "pid": 100}]
+    meta = {"sid-na": {"path": _Z_ROOT}}
+    stops, records = _patch_idle_io(
+        monkeypatch,
+        children=children,
+        meta=meta,
+        idle_age=None,
+        has_tty=True,
+        detached_tmux_ttys={"/dev/pts/24"},
+        tmux_activity={},  # pane absent from the activity map
+    )
+    _patch_fallback_gates(monkeypatch)
+    for now in (t0, t0 + 600, t0 + 1200):
+        asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=now)
+    assert stops == [] and records == []
+
+
+def test_idle_unmapped_fallback_keeps_attached_pane(isolated_registry, monkeypatch):
+    # Test 6 (attached-pane KEEP): a session whose pane is NOT in the detached
+    # set is a live-user tty -> has_tty stays True -> ("clear", 0), the fallback
+    # is never reached. Preserves the existing detached-vs-attached behavior.
+    import autonomous_session_watch as asw
+
+    monkeypatch.delenv("EPM_UNMAPPED_IDLE_REAP", raising=False)
+    t0 = 1_000_000.0
+    over = asw.UNMAPPED_TMUX_IDLE_FALLBACK_S + 3600
+    children = [{"happySessionId": "sid-att", "pid": 100}]
+    meta = {"sid-att": {"path": _Z_ROOT}}
+    # has_tty True but the controlling pane is /dev/pts/47, NOT in the detached
+    # set -> _is_live_user_tty True -> clear.
+    stops, records = _patch_idle_io(
+        monkeypatch,
+        children=children,
+        meta=meta,
+        idle_age=None,
+        has_tty=True,
+        detached_tmux_ttys={"/dev/pts/24"},
+        tmux_activity={"/dev/pts/47": t0 - over},
+    )
+    monkeypatch.setattr(asw, "_wrapper_controlling_tty_path", lambda pid: "/dev/pts/47")
+    for now in (t0, t0 + 600, t0 + 1200):
+        asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=now)
+    assert stops == [] and records == []
+
+
+def test_idle_unmapped_fallback_not_consulted_when_primary_signal_present(
+    isolated_registry, monkeypatch
+):
+    # Test 7: when the PRIMARY transcript signal resolves, the fallback gate
+    # evaluation is NEVER reached — assert the fallback evaluator (and its
+    # pending-input probe) are not called. The primary path drives the decision.
+    import autonomous_session_watch as asw
+
+    monkeypatch.delenv("EPM_UNMAPPED_IDLE_REAP", raising=False)
+    t0 = 1_000_000.0
+    primary_over = asw.UNMAPPED_IDLE_REAP_S + 3600
+    children = [{"happySessionId": "sid-pri", "pid": 100}]
+    meta = {"sid-pri": {"path": _Z_ROOT}}
+    stops, _records = _patch_idle_io(
+        monkeypatch,
+        children=children,
+        meta=meta,
+        idle_age=primary_over,  # PRIMARY signal available
+        detached_tmux_ttys={"/dev/pts/24"},
+        tmux_activity={"/dev/pts/24": t0 - 999_999},
+    )
+    called = {"fallback": 0, "pending": 0}
+    monkeypatch.setattr(
+        asw,
+        "_evaluate_idle_unmapped_fallback",
+        lambda *a, **k: called.__setitem__("fallback", called["fallback"] + 1) or (None, None),
+    )
+    monkeypatch.setattr(
+        asw,
+        "_pane_has_pending_input",
+        lambda pane: called.__setitem__("pending", called["pending"] + 1) or False,
+    )
+    asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=t0)
+    asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=t0 + 600)
+    # The primary path stopped it (transcript over the primary window).
+    assert stops == ["sid-pri"]
+    assert called["fallback"] == 0 and called["pending"] == 0
+
+
+def test_idle_unmapped_empty_detached_set_beacon(isolated_registry, monkeypatch, capsys):
+    # Test 8: tmux present but the detached set is EMPTY -> the once-per-pass
+    # loud WARNING beacon fires (the silent-regression guard). Fail-soft set
+    # stays empty; nothing is reaped.
+    import autonomous_session_watch as asw
+
+    monkeypatch.delenv("EPM_UNMAPPED_IDLE_REAP", raising=False)
+    monkeypatch.setattr(asw.shutil, "which", lambda name: "/usr/bin/tmux")
+    children = [{"happySessionId": "sid-b", "pid": 100}]
+    meta = {"sid-b": {"path": _Z_ROOT}}
+    stops, _records = _patch_idle_io(
+        monkeypatch,
+        children=children,
+        meta=meta,
+        idle_age=None,
+        detached_tmux_ttys=set(),  # tmux present but no detached panes
+        tmux_activity={},
+    )
+    asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=1_000_000.0)
+    assert "tmux present but detached set empty" in capsys.readouterr().err
+    assert stops == []
+
+
+def test_idle_unmapped_fallback_dry_run_mutates_nothing(isolated_registry, monkeypatch):
+    # Test 9 (extended dry-run): a dry-run tick at the fallback stop point
+    # neither stops, writes the pre-stop audit row, nor rewrites state.
+    import json
+
+    import autonomous_session_watch as asw
+
+    monkeypatch.delenv("EPM_UNMAPPED_IDLE_REAP", raising=False)
+    t0 = 1_000_000.0
+    over = asw.UNMAPPED_TMUX_IDLE_FALLBACK_S + 3600
+    children = [{"happySessionId": "sid-dr", "pid": 100}]
+    meta = {"sid-dr": {"path": _Z_ROOT}}
+    stops, records = _patch_idle_io(
+        monkeypatch,
+        children=children,
+        meta=meta,
+        idle_age=None,
+        has_tty=True,
+        detached_tmux_ttys={"/dev/pts/24"},
+        tmux_activity={"/dev/pts/24": t0 - over},
+    )
+    _patch_fallback_gates(monkeypatch)
+    # Mirror the REAL _stop_session dry-run contract (returns False, no action).
+    monkeypatch.setattr(
+        asw, "_stop_session", lambda sid, dry_run: (not dry_run) and (stops.append(sid) or True)
+    )
+    state_path = isolated_registry / "idle-unmapped-sid-dr.json"
+    seeded = json.dumps({"missed": 1, "alerted": False, "first_over_ts": t0})
+    state_path.write_text(seeded)
+    events_path = isolated_registry / "idle-unmapped-events.jsonl"
+
+    asw.idle_unmapped_pass(True, 2, daemon_reachable=True, now=t0 + 600)
+    assert stops == [] and records == []
+    assert state_path.read_text() == seeded  # untouched
+    assert not events_path.exists()  # no audit row written under dry-run
+
+
+def test_idle_unmapped_fallback_keeps_when_pending_input(isolated_registry, monkeypatch):
+    # Test 10 (MF1 typed-but-unsent KEEP): all five other gates pass but the
+    # pane shows pending un-submitted input -> KEEP. No stop, no audit row, no
+    # accumulated episode. This is the dominant-class (4/6) protection.
+    import autonomous_session_watch as asw
+
+    monkeypatch.delenv("EPM_UNMAPPED_IDLE_REAP", raising=False)
+    t0 = 1_000_000.0
+    over = asw.UNMAPPED_TMUX_IDLE_FALLBACK_S + 3600
+    children = [{"happySessionId": "sid-pi", "pid": 100}]
+    meta = {"sid-pi": {"path": _Z_ROOT}}
+    stops, records = _patch_idle_io(
+        monkeypatch,
+        children=children,
+        meta=meta,
+        idle_age=None,
+        has_tty=True,
+        detached_tmux_ttys={"/dev/pts/24"},
+        tmux_activity={"/dev/pts/24": t0 - over},
+    )
+    _patch_fallback_gates(monkeypatch, pending_input=True)  # buffered input present
+    events_path = isolated_registry / "idle-unmapped-events.jsonl"
+    for now in (t0, t0 + 600, t0 + 1200):
+        asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=now)
+    assert stops == [] and records == []
+    assert not events_path.exists()
+    assert not list(isolated_registry.glob("idle-unmapped-sid-pi.json"))
+
+
+def test_pane_has_pending_input_heuristic(monkeypatch):
+    # Test 11 (MF1 heuristic unit tests): the KEEP-leaning text heuristic over
+    # capture-pane output — empty box / placeholder -> False (proceed);
+    # buffered text / multi-line input -> True (KEEP); subprocess error / pane
+    # gone / tmux absent -> True (KEEP, fail-soft).
+    import autonomous_session_watch as asw
+
+    monkeypatch.setattr(asw.shutil, "which", lambda name: "/usr/bin/tmux")
+
+    def _set_capture(stdout, returncode=0):
+        class _Out:
+            pass
+
+        o = _Out()
+        o.stdout = stdout
+        o.returncode = returncode
+        monkeypatch.setattr(asw.subprocess, "run", lambda *a, **k: o)
+
+    # Empty prompt box (only the prompt border + cursor) -> proceed (False).
+    _set_capture("╭──────────────╮\n│ >            │\n╰──────────────╯\n")
+    assert asw._pane_has_pending_input("/dev/pts/24") is False
+    # Whitespace-only capture -> nothing rendered -> KEEP (True).
+    _set_capture("   \n  \n")
+    assert asw._pane_has_pending_input("/dev/pts/24") is True
+    # Empty-prompt placeholder hint -> proceed (False).
+    _set_capture('│ > Try "fix the bug"                    │\n')
+    assert asw._pane_has_pending_input("/dev/pts/24") is False
+    _set_capture("> /for shortcuts\n")  # contains the 'for shortcuts' hint
+    assert asw._pane_has_pending_input("/dev/pts/24") is False
+    # A genuine buffered input line after the prompt prefix -> KEEP (True).
+    _set_capture("│ > rerun the eval with seed 7          │\n")
+    assert asw._pane_has_pending_input("/dev/pts/24") is True
+    # Multi-line buffered input: the LAST logical line is non-empty -> KEEP.
+    _set_capture(
+        "│ > line one of a long                  │\n│   command continues               │\n"
+    )
+    assert asw._pane_has_pending_input("/dev/pts/24") is True
+    # capture-pane non-zero rc (pane gone) -> KEEP (fail-soft).
+    _set_capture("", returncode=1)
+    assert asw._pane_has_pending_input("/dev/pts/24") is True
+
+    # subprocess raises -> KEEP (fail-soft).
+    def _boom(*a, **k):
+        raise asw.subprocess.SubprocessError("boom")
+
+    monkeypatch.setattr(asw.subprocess, "run", _boom)
+    assert asw._pane_has_pending_input("/dev/pts/24") is True
+    # tmux absent -> KEEP (fail-soft).
+    monkeypatch.setattr(asw.shutil, "which", lambda name: None)
+    assert asw._pane_has_pending_input("/dev/pts/24") is True
+
+
+def test_work_descendant_denylist_import_pin():
+    # Test 12 (MF2 import-pin): ORPHAN_HOLDER_PATTERNS resolves + compiles and
+    # the union matches a known codex cmdline; each LOCAL workload marker is in
+    # the gate's denylist. A future rename of either source trips this test.
+    import re
+
+    import autonomous_session_watch as asw
+    from worktree_audit import ORPHAN_HOLDER_PATTERNS
+
+    assert isinstance(ORPHAN_HOLDER_PATTERNS, tuple) and ORPHAN_HOLDER_PATTERNS
+    assert all(isinstance(p, re.Pattern) for p in ORPHAN_HOLDER_PATTERNS)
+    # The union matches a real codex companion cmdline.
+    codex_cmd = "node /home/x/.claude/plugins/cache/openai-codex/dist/index.js app-server"
+    assert any(p.search(codex_cmd) for p in ORPHAN_HOLDER_PATTERNS)
+    # asw imported the SAME tuple object.
+    assert asw.ORPHAN_HOLDER_PATTERNS is ORPHAN_HOLDER_PATTERNS
+    # Every named LOCAL workload marker is in the gate's denylist.
+    for marker in (
+        "scripts/train.py",
+        "scripts/eval.py",
+        "scripts/run_sweep.py",
+        "scripts/dispatch_issue.py",
+        "backend_poll.py",
+        "experiment-implementer",
+    ):
+        assert marker in asw._IDLE_UNMAPPED_WORK_CMDLINE_MARKERS, marker
+
+
+def test_idle_unmapped_fallback_audit_before_stop_and_payload(isolated_registry, monkeypatch):
+    # Test 13 (MF3 ordering + payload): the pre-stop audit write happens BEFORE
+    # the _stop_session call (audit_ts < stop_ts), and the audit payload
+    # carries all nine named fields.
+    import autonomous_session_watch as asw
+
+    monkeypatch.delenv("EPM_UNMAPPED_IDLE_REAP", raising=False)
+    t0 = 1_000_000.0
+    over = asw.UNMAPPED_TMUX_IDLE_FALLBACK_S + 3600
+    children = [{"happySessionId": "sid-ord", "pid": 100}]
+    meta = {"sid-ord": {"path": _Z_ROOT}}
+    _stops, _records = _patch_idle_io(
+        monkeypatch,
+        children=children,
+        meta=meta,
+        idle_age=None,
+        has_tty=True,
+        detached_tmux_ttys={"/dev/pts/24"},
+        tmux_activity={"/dev/pts/24": t0 - over},
+    )
+    _patch_fallback_gates(monkeypatch)
+    order: list[tuple[str, float]] = []
+    seq = {"n": 0}
+
+    def _next():
+        seq["n"] += 1
+        return float(seq["n"])
+
+    captured_payload: list[dict] = []
+
+    def _audit(payload, dry_run):
+        captured_payload.append(payload)
+        order.append(("audit", _next()))
+
+    monkeypatch.setattr(asw, "_append_idle_unmapped_audit", _audit)
+    monkeypatch.setattr(
+        asw, "_stop_session", lambda sid, dry_run: order.append(("stop", _next())) or True
+    )
+
+    asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=t0)  # miss 1
+    asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=t0 + 600)  # stop
+
+    audit_ts = next(ts for name, ts in order if name == "audit")
+    stop_ts = next(ts for name, ts in order if name == "stop")
+    assert audit_ts < stop_ts
+    assert len(captured_payload) == 1
+    payload = captured_payload[0]
+    for field in (
+        "sid",
+        "pid",
+        "fallback_source",
+        "idle_age_s",
+        "threshold_env_value",
+        "detached_verdict",
+        "work_descendant",
+        "running_pods",
+        "pending_input",
+    ):
+        assert field in payload, field
+    assert payload["work_descendant"] is False
+    assert payload["running_pods"] == []
+    assert payload["pending_input"] is False
+
+
+def test_idle_unmapped_fallback_post_stop_note_is_distinct(isolated_registry, monkeypatch):
+    # Test 14 (MF3 fallback-distinct): the fallback reap's post-stop note does
+    # NOT contain the primary-transcript narrative ("its resolved Claude
+    # transcript has been idle") and DOES carry fallback-source language;
+    # the PRIMARY reap's note is the existing transcript narrative unchanged.
+    import autonomous_session_watch as asw
+
+    monkeypatch.delenv("EPM_UNMAPPED_IDLE_REAP", raising=False)
+    t0 = 1_000_000.0
+
+    # ── fallback reap ──
+    over_fb = asw.UNMAPPED_TMUX_IDLE_FALLBACK_S + 3600
+    _stops, records = _patch_idle_io(
+        monkeypatch,
+        children=[{"happySessionId": "sid-fbn", "pid": 100}],
+        meta={"sid-fbn": {"path": _Z_ROOT}},
+        idle_age=None,
+        has_tty=True,
+        detached_tmux_ttys={"/dev/pts/24"},
+        tmux_activity={"/dev/pts/24": t0 - over_fb},
+    )
+    _patch_fallback_gates(monkeypatch)
+    asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=t0)
+    asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=t0 + 600)
+    assert len(records) == 1
+    fb_note = records[0]
+    assert "its resolved Claude transcript has been idle" not in fb_note
+    assert asw._IDLE_UNMAPPED_STOP_FALLBACK_NOTE_SENTINEL in fb_note
+    assert "session_activity" in fb_note
+
+    # ── primary reap (separate session) ──
+    over_pri = asw.UNMAPPED_IDLE_REAP_S + 3600
+    _stops2, records2 = _patch_idle_io(
+        monkeypatch,
+        children=[{"happySessionId": "sid-prn", "pid": 200}],
+        meta={"sid-prn": {"path": _Z_ROOT}},
+        idle_age=over_pri,
+    )
+    asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=t0)
+    asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=t0 + 600)
+    assert len(records2) == 1
+    pri_note = records2[0]
+    assert "its resolved Claude transcript has been idle" in pri_note
+    assert asw._IDLE_UNMAPPED_STOP_NOTE_SENTINEL in pri_note
 
 
 def test_idle_unmapped_transcript_signal_is_happy_log_only(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Workflow-fix #695 — the idle-unmapped reaper pass in `scripts/autonomous_session_watch.py` was INERT for detached, unmapped, tmux-launched Claude sessions (the class it was built for; 2026-06-12 incident: 25 such sessions held ~23 GB RSS). Fix lands a 6-gate corroborating-idleness fallback that reaps a session only when:

1. Detached (per `_detached_tmux_pane_ttys`)
2. Unmapped (no `task.py` mapping)
3. No work descendant under the wrapper subtree (codex / experimenter / `train.py` / `eval.py` / `run_sweep.py` / `dispatch_issue.py` / `backend_poll.py` patterns from `worktree_audit.ORPHAN_HOLDER_PATTERNS` + explicit project workload markers; tri-state `bool | None` probe — unreadable cmdline keeps)
4. No running managed pod (`_running_managed_issue_pods`; `None` snapshot failure keeps)
5. tmux `session_activity` age ≥ `EPM_UNMAPPED_TMUX_IDLE_FALLBACK_S` (default 24h, env-tunable)
6. No buffered un-submitted pane input (`tmux capture-pane`-based bottom-up scanner skipping borders + Claude TUI footers; KEEP-leaning on every uncertain signal)

Pre-stop `would_stop_fallback` audit row (9 named fields: sid / pid / fallback_source / idle_age_s / threshold_env_value / detached_verdict / work_descendant / running_pods / pending_input) written BEFORE `_stop_session` so any wrong reap is forensically explainable. Reuses the reversible daemon `_stop_session` mechanism — no raw `kill` / `tmux kill-session`.

## Adversarial gate trail

- Plan v2 = round-1 v1 + 3 reconciled Must-Fix items (MF1 sixth gate, MF2 symbol rename `_ORPHAN_CMDLINE_PATTERNS` → `ORPHAN_HOLDER_PATTERNS` + denylist, MF3 pre-stop audit).
- Code-review round 1: Claude PASS / Codex FAIL / Reconciler FAIL (binding) — both Codex blockers were real (B1 `_pane_has_pending_input` only checked `lines[-1]` which is ALWAYS the Claude TUI footer → fallback was inert in production; B2 `_cmdline_is_work_process` fail-open on `OSError`).
- Code-review round 2: Claude PASS (live-verified on 3 real detached Claude panes on this host) / Codex PASS.
- Test-verdict: PASS — 586 tests in the touched file (+16 new, 0 regressions), 987 across sibling watcher/workflow test files, ruff + workflow_lint clean.
- Completion-audit: PASS.

## Test plan
- [x] `uv run pytest tests/test_autonomous_session_watch.py` → 586 passed
- [x] `uv run ruff check scripts/autonomous_session_watch.py tests/test_autonomous_session_watch.py` → clean
- [x] `uv run python scripts/workflow_lint.py --check-asks` → PASS
- [x] Live verification: heuristic correctly reads buffered input on 3 real detached Claude panes (`❯ promote it useful` / `❯ check progress` / `❯ promote 685 useful`)
- [ ] (post-merge) Observe the next cron pass logs `detached_panes=N` count + would-stop reasoning for any remaining detached unmapped tmux sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)