### PR TITLE
tests: add stall_reason to stale _PR mocks (#710)

### DIFF
--- a/tests/test_issue_dispatch.py
+++ b/tests/test_issue_dispatch.py
@@ -147,6 +147,7 @@ def test_runpod_poll_delegates_to_poll_pipeline_and_returns_typed_pollresult(
             # pass-through assertion below discriminates a real thread-through
             # from a silent fall-back to the default.
             next_interval: int = 1800
+            stall_reason: str | None = None
 
         return _PR()
 
@@ -1187,6 +1188,7 @@ def test_backend_poll_script_produces_legacy_poll_pipeline_json_shape(
         # base.PollResult default are both 540) so the value assertion below
         # discriminates a real thread-through from a silent fall-back.
         next_interval: int = 1800
+        stall_reason: str | None = None
 
     monkeypatch.setattr("scripts.poll_pipeline.poll_once", lambda **kw: _PR())
 


### PR DESCRIPTION
Closes task #710.

## Summary

Adds `stall_reason: str | None = None` to two `_PR` poll-result test mocks in `tests/test_issue_dispatch.py` so they mirror the real `scripts.poll_pipeline.PollResult` shape (which gained `stall_reason` in #664 for zombie-GPU stall detection).

`RunPodBackend.poll` reads `raw.stall_reason` at `src/explore_persona_space/backends/runpod.py:389` (load-bearing passthrough for #664, documented in the docstring at `runpod.py:362-375`), so a mock without the field raises `AttributeError`.

**Production code is unchanged** — the fix is entirely in the test mocks. This is the resolution of a pre-existing `main` bug surfaced by the Claude code-reviewer running the full pytest suite during /issue #701 round 2.

## Test plan
- [x] `tests/test_issue_dispatch.py::test_runpod_poll_delegates_to_poll_pipeline_and_returns_typed_pollresult` PASSes (was `AttributeError` on main).
- [x] `tests/test_issue_dispatch.py::test_backend_poll_script_produces_legacy_poll_pipeline_json_shape` PASSes in the full router/backend set (was `AttributeError` on main).
- [x] Full router/backend test set (~356 tests) PASSes.
- [x] `ruff check` + `ruff format --check` clean on `tests/test_issue_dispatch.py`.
- [x] `scripts/workflow_lint.py` clean.

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>