### PR TITLE
issue-714: add --check-skill-refs lint mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,13 @@ repos:
         files: ^(\.claude/(agents/.*\.md|skills/.*/SKILL\.md|workflow\.yaml)|scripts/workflow_lint\.py)$
         pass_filenames: false
 
+      - id: workflow-yaml-check-skill-refs
+        name: Verify every /skill-name reference resolves to a live skill or allowlist
+        entry: uv run python scripts/workflow_lint.py --check-skill-refs
+        language: system
+        files: ^(\.claude/(agents/.*\.md|skills/.*/SKILL\.md|rules/.*\.md|workflow\.yaml)|CLAUDE\.md|scripts/workflow_lint\.py)$
+        pass_filenames: false
+
       - id: workflow-yaml-check-wandb-required
         name: Forbid silenced WandB in experiment training-config builders
         entry: uv run python scripts/workflow_lint.py --check-wandb-required

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -26,6 +26,22 @@ Behaviours:
   ``scripts/``. Mechanically prevents the dead-tool / invented-tool
   failure class where an agent follows a step that runs a
   deleted-or-never-created helper and CalledProcessErrors.
+* ``--check-skill-refs`` (also bundled into ``--check-references`` and the
+  no-flags default run): walk every ``.md`` under ``.claude/agents/``,
+  every ``SKILL.md`` under ``.claude/skills/``, every ``.md`` under
+  ``.claude/rules/``, ``CLAUDE.md``, and ``.claude/workflow.yaml``
+  (OTHER worktrees excluded, the current worktree scanned — see
+  :func:`_other_worktree_prefix`) and FAIL on any backtick-delimited
+  ``/<skill-name>`` slash-command token that resolves neither to a live
+  skill DIRECTORY under ``.claude/skills/`` NOR to
+  :data:`SKILL_REF_ALLOWLIST` (exact token or ``<plugin>:`` namespace
+  prefix). Closes the skill-rename / skill-retirement rot class
+  (#713/#714): ``--check-references`` only resolves
+  ``(see workflow.yaml § X)`` tokens, so a retired skill (e.g.
+  ``/weekly``) leaves stray load-bearing references that no mechanical
+  check catches. Backtick-anchor + trailing-``/``-rejecting lookahead +
+  fenced-code exclusion are the false-positive controls; lines carrying
+  :data:`HISTORICAL_REF_OPT_OUT` are a one-off narrative escape.
 * ``--check-wandb-required``: walk every ``*.py`` under
   ``src/explore_persona_space/experiments/`` whose source mentions a
   trainer-config builder (``TrainLoraConfig``, ``SFTConfig``,
@@ -218,6 +234,71 @@ SCRIPT_REF_RE = re.compile(r"(?<![\w/])scripts/([A-Za-z0-9_]+\.py)\b")
 # #545: an incident note in code-reviewer.md had to contort its prose to
 # dodge SCRIPT_REF_RE.)
 HISTORICAL_REF_OPT_OUT = "<!-- lint: historical-ref -->"
+
+# `--check-skill-refs`: every backtick-delimited `/<skill-name>` slash-command
+# token in the workflow-doc surface MUST resolve to a live project skill (a
+# `.claude/skills/<name>/` directory) or to SKILL_REF_ALLOWLIST. Backtick-anchor
+# + trailing lookahead are the FP controls: only the slash-command convention
+# matches, and a path segment (`/workspace/logs`, `/tmp/x`, `/mnt/...`) is
+# rejected because the char after the token is `/`, not the required
+# backtick / whitespace / `)` boundary. Group 1 = skill name, optionally
+# `<plugin>:<skill>`.
+SKILL_REF_RE = re.compile(r"`/([a-z][a-z0-9-]+(?::[a-z0-9-]+)?)(?=[`\s)])")
+
+_FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
+
+# `--check-skill-refs`: legitimate slash-commands that are NOT project skill dirs
+# under `.claude/skills/`, so a backticked reference must be waived rather than
+# flagged. Add an entry only with a comment naming WHY it is not a project skill.
+# The lint scopes to the PROJECT repo only (it deliberately does NOT reach into
+# ~/.claude/skills/, which would make the lint host-dependent and the bundled
+# pytest non-hermetic), so user-global skills are allowlisted here.
+SKILL_REF_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # --- Plugin-namespace prefixes (live plugin trees, not .claude/skills) ---
+        "codex:",  # /codex:rescue, /codex:setup, ... (codex-plugin-cc)
+        "code-review:",  # /code-review:code-review
+        "superpowers:",  # /superpowers:* (14 members)
+        "huggingface-skills:",  # /huggingface-skills:* (~16 members)
+        "frontend-design:",  # /frontend-design:frontend-design
+        "ml-paper-writing:",  # /ml-paper-writing:*
+        "academic-writing-agents:",  # /academic-writing-agents:academic
+        # --- User-global skills (live in ~/.claude/skills/, not this repo) ---
+        "humanize",  # ~/.claude/skills/humanize (de-AI prose pass)
+        "loop",  # ~/.claude/skills/loop (recurring driver; manual /issue-tick equiv)
+        "plan",  # ~/.claude/skills/plan (planning skill)
+        "self-review",  # ~/.claude/skills/self-review
+        "peer-review",  # ~/.claude/skills/peer-review
+        "memory-sleep",  # ~/.claude/skills/memory-sleep (nightly consolidation)
+        "update-config",  # update-config skill (settings.json), not a project dir
+        # --- Built-in Claude Code CLI commands (no skill dir anywhere) ---
+        "clear",  # built-in /clear (alias /new)
+        "new",  # built-in /new (alias /clear)
+        "compact",  # built-in /compact
+        "rewind",  # built-in /rewind
+        "mcp",  # built-in /mcp (MCP reconnect)
+        "review",  # built-in /review (PR review)
+        "init",  # built-in /init (CLAUDE.md init)
+        "security-review",  # built-in /security-review
+        # --- Interactive plan-gate inputs + PM-session aliases (no skill dir) ---
+        "approve",  # user plan-approval action (`/approve`)
+        "revise",  # user plan-revise action (`/revise <notes>`)
+        "audit",  # PM-session shorthand for an audit pass (pm/SKILL.md)
+        "code-refactoring",  # refactoring-theory ref-table label (deep-clean/SKILL.md)
+        # --- Dashboard route paths written in the slash-command shape (no skill dir) ---
+        "log",  # `/log` dashboard feed
+        "sessions",  # `/sessions` dashboard page
+        "updates",  # `/updates` dashboard MDX editor route
+        # --- Non-skill prose/path tokens the backtick form still catches ---
+        "workspace",  # `/workspace` pod path written inside backticks (RunPod `/workspace`)
+        "intent",  # `/intent` — a phase/arg token in prose
+        "absent",  # `/absent` — a marker-state token in prose
+        "override",  # `/override subset` prose (experiment-implementer.md)
+        "binary",  # `.npz/binary` prose (uploader.md)
+        "terminal",  # `blocked/terminal` prose (background-automation.md)
+        "expensive-band",  # `auto_run/expensive-band` prose (issue/SKILL.md)
+    }
+)
 
 # `--check-wandb-required`: every `report_to="none"` (or equivalent
 # disabling literal: `report_to=None`, `report_to=[]`) inside a training-
@@ -1141,6 +1222,135 @@ def check_script_references(
                         f"or — for a narrative incident citation only — "
                         f"append '{HISTORICAL_REF_OPT_OUT}' to the line."
                     )
+    return errors
+
+
+def _iter_skill_ref_target_files(repo_root: Path) -> list[Path]:
+    """Production scope for --check-skill-refs: agents + all SKILL.md + rules +
+    CLAUDE.md + workflow.yaml, OTHER-worktree copies excluded (the current
+    worktree IS scanned so a workflow-fix /issue session validates its own
+    edits). Mirrors :func:`_iter_ask_target_files` but with the wider root
+    set the skill-rot failure class actually touches (the `/weekly`-rot
+    concern lives partly in CLAUDE.md and `.claude/rules/`, which an
+    agents+skills-only scope would NOT guard)."""
+    current_prefix = _other_worktree_prefix(repo_root)
+    files: list[Path] = []
+    agents = repo_root / ".claude" / "agents"
+    skills = repo_root / ".claude" / "skills"
+    rules = repo_root / ".claude" / "rules"
+    if agents.exists():
+        files += [
+            p
+            for p in agents.glob("*.md")
+            if p.is_file() and not _is_other_worktree_path(p, current_prefix)
+        ]
+    if skills.exists():
+        files += [
+            p
+            for p in skills.glob("**/SKILL.md")
+            if p.is_file() and not _is_other_worktree_path(p, current_prefix)
+        ]
+    if rules.exists():
+        files += [
+            p
+            for p in rules.glob("*.md")
+            if p.is_file() and not _is_other_worktree_path(p, current_prefix)
+        ]
+    for extra in (repo_root / "CLAUDE.md", repo_root / ".claude" / "workflow.yaml"):
+        if extra.is_file() and not _is_other_worktree_path(extra, current_prefix):
+            files.append(extra)
+    return sorted(files)
+
+
+def _resolve_skill_ref_target_files(roots: list[Path] | None) -> list[Path]:
+    """Production callers pass ``roots=None`` and we walk the canonical wide
+    surface. Tests pass ``roots=[tmp_path]`` to scope the walk to a fixture
+    directory (mirrors :func:`_resolve_ask_target_files`)."""
+    if roots is None:
+        return _iter_skill_ref_target_files(_REPO_ROOT)
+    files: list[Path] = []
+    for root in roots:
+        if root.is_file():
+            files.append(root)
+        else:
+            files.extend(p for p in root.glob("**/*.md") if p.is_file())
+    return sorted(files)
+
+
+def _live_skill_names(skills_dir: Path) -> set[str]:
+    """Live project-skill names = immediate child DIRECTORIES of
+    ``.claude/skills/``. By DIRECTORY existence, NOT ``*/SKILL.md``:
+    ``clean-results`` is a live skill dir (SPEC.md/exemplars/, no SKILL.md)
+    and ``/clean-results`` is a real reference, so a ``*/SKILL.md`` glob would
+    wrongly flag it."""
+    if not skills_dir.exists():
+        return set()
+    return {p.name for p in skills_dir.iterdir() if p.is_dir()}
+
+
+def _skill_ref_resolves(ref: str, live: set[str], allow: frozenset[str]) -> bool:
+    """A backticked ``/<ref>`` resolves iff it names a live skill dir, an
+    allowlisted exact token, or (when namespaced ``<plugin>:<skill>``) a token
+    whose ``<plugin>:`` prefix is allowlisted."""
+    if ref in live:  # live project skill dir
+        return True
+    if ref in allow:  # allowlisted exact token
+        return True
+    if ":" in ref:  # plugin-namespaced: prefix match
+        return (ref.split(":", 1)[0] + ":") in allow
+    return False
+
+
+def check_skill_references(
+    *,
+    roots: list[Path] | None = None,
+    skills_dir: Path | None = None,
+    allowlist: frozenset[str] | None = None,
+) -> list[str]:
+    """Walk the workflow-doc surface (agents + skills + rules + CLAUDE.md +
+    workflow.yaml) and FAIL on any backtick-delimited ``/<skill-name>`` token
+    that resolves neither to a live skill dir under ``.claude/skills/`` NOR to
+    :data:`SKILL_REF_ALLOWLIST` (exact token or namespace prefix).
+
+    Closes the skill-rename / skill-retirement rot class: ``--check-references``
+    only resolves ``(see workflow.yaml § X)`` tokens, so a retired skill (e.g.
+    ``/weekly``) leaves stray load-bearing references that no mechanical check
+    catches (#713 Methodology-critic finding; #714).
+
+    Lines inside fenced code blocks (``` / ~~~) are skipped (HTML close tags /
+    sed one-liners / regex fragments). Lines carrying
+    :data:`HISTORICAL_REF_OPT_OUT` are skipped (one-off narrative citation).
+    Plugin-namespaced refs resolve via the allowlist prefix set (or,
+    forward-compat, an on-disk ``<plugin>:<skill>/`` dir).
+
+    ``roots`` / ``skills_dir`` / ``allowlist`` are unit-test override hooks;
+    production callers pass None.
+    """
+    errors: list[str] = []
+    sk_dir = skills_dir if skills_dir is not None else _REPO_ROOT / ".claude" / "skills"
+    live = _live_skill_names(sk_dir)
+    allow = allowlist if allowlist is not None else SKILL_REF_ALLOWLIST
+    for path in _resolve_skill_ref_target_files(roots):
+        in_fence = False
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if _FENCE_RE.match(line):
+                in_fence = not in_fence
+                continue
+            if in_fence or HISTORICAL_REF_OPT_OUT in line:
+                continue
+            for match in SKILL_REF_RE.finditer(line):
+                ref = match.group(1)
+                if _skill_ref_resolves(ref, live, allow):
+                    continue
+                errors.append(
+                    f"{path}:{lineno}: unresolved skill reference '/{ref}' — not a "
+                    f"live skill under .claude/skills/ and not in "
+                    f"SKILL_REF_ALLOWLIST. Repoint to the current skill, remove the "
+                    f"dead reference, add the command to SKILL_REF_ALLOWLIST "
+                    f"(user-global / plugin / built-in command, with a justifying "
+                    f"comment), or — for a one-off narrative citation — append "
+                    f"'{HISTORICAL_REF_OPT_OUT}' to the line."
+                )
     return errors
 
 
@@ -2434,6 +2644,18 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         "Bundled into --check-references and the no-flags default run.",
     )
     parser.add_argument(
+        "--check-skill-refs",
+        action="store_true",
+        help="Verify every backtick-delimited '/skill-name' reference in "
+        ".claude/agents/**.md, .claude/skills/**/SKILL.md, .claude/rules/*.md, "
+        "CLAUDE.md, and .claude/workflow.yaml resolves to a live skill dir under "
+        ".claude/skills/ or to SKILL_REF_ALLOWLIST (user-global / plugin / built-in "
+        "commands). Closes the skill-rename/retirement rot class (#713/#714): "
+        "--check-references only resolves workflow.yaml section refs, so a retired "
+        "skill like /weekly rots undetected. Bundled into --check-references and the "
+        "no-flags default run.",
+    )
+    parser.add_argument(
         "--check-wandb-required",
         action="store_true",
         help="Verify no training script under src/explore_persona_space/"
@@ -2561,6 +2783,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         or args.check_asks
         or args.check_autonomous_asks
         or args.check_script_refs
+        or args.check_skill_refs
         or args.check_wandb_required
         or args.check_heredoc_dotenv
         or args.check_dispatcher_cvd_pin
@@ -2581,6 +2804,9 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         # Dangling script references are a workflow-doc integrity issue, same
         # class as unresolved (see workflow.yaml § X) references — bundle here.
         errors.extend(check_script_references())
+        # An unresolved /skill-name reference (dead skill rename/retirement) is
+        # the same workflow-doc integrity class — bundle here too.
+        errors.extend(check_skill_references())
         # A posted-but-unregistered marker kind is the same drift class
         # (doc surface vs canonical registry) — bundle here too.
         errors.extend(check_marker_registry(workflow))
@@ -2603,6 +2829,8 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         errors.extend(check_autonomous_asks())
     if args.check_script_refs or no_flags:
         errors.extend(check_script_references())
+    if args.check_skill_refs or no_flags:
+        errors.extend(check_skill_references())
     if args.check_wandb_required or no_flags:
         errors.extend(check_wandb_required())
     if args.check_heredoc_dotenv or no_flags:

--- a/tests/test_workflow_lint.py
+++ b/tests/test_workflow_lint.py
@@ -46,6 +46,7 @@ from workflow_lint import (  # noqa: E402
     check_marker_registry,
     check_no_workflow_improver_spawn,
     check_script_references,
+    check_skill_references,
     check_upload_as_file,
     check_wandb_required,
 )
@@ -501,6 +502,211 @@ def test_check_script_refs_repo_tree_is_clean():
     assert errors == [], (
         "committed .claude/ agents/skills reference scripts that do not "
         "exist under scripts/:\n" + "\n".join(errors)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for ``check_skill_references`` (skill-rename / skill-retirement
+# rot class, #713/#714). Each case writes a tiny markdown file under
+# ``tmp_path`` carrying a backtick-delimited ``/<skill-name>`` slash-command
+# token plus a fixture ``skills/`` dir, then calls
+# ``check_skill_references(roots=[...], skills_dir=..., allowlist=...)``.
+# Mirrors the ``check_script_references`` block above, swapping the
+# scripts_dir hook for skills_dir + an explicit allowlist override.
+# ---------------------------------------------------------------------------
+
+
+def test_check_skill_refs_pass_live_skill(tmp_path):
+    """A `/skill` token resolving to a live skill dir under skills/ PASSes."""
+    skills = tmp_path / "skills"
+    (skills / "weekly").mkdir(parents=True)
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "SKILL.md").write_text("Run `/weekly` on Wednesdays.\n")
+    errors = check_skill_references(roots=[docs], skills_dir=skills, allowlist=frozenset())
+    assert errors == [], f"expected PASS (live skill dir), got: {errors}"
+
+
+def test_check_skill_refs_pass_live_skill_with_args(tmp_path):
+    """A `/skill <args>` invocation matches only the skill name (the trailing
+    lookahead closes on whitespace) and resolves to the live dir."""
+    skills = tmp_path / "skills"
+    (skills / "issue").mkdir(parents=True)
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text("Boot with `/issue <N>` then `/issue 137 --auto`.\n")
+    errors = check_skill_references(roots=[docs], skills_dir=skills, allowlist=frozenset())
+    assert errors == [], f"expected PASS (args-form, live skill), got: {errors}"
+
+
+def test_check_skill_refs_pass_dir_without_skill_md(tmp_path):
+    """Resolution is by skill DIRECTORY existence, not `*/SKILL.md`:
+    clean-results is a live skill dir with no SKILL.md (SPEC.md/exemplars/),
+    so `/clean-results` must PASS."""
+    skills = tmp_path / "skills"
+    (skills / "clean-results").mkdir(parents=True)
+    (skills / "clean-results" / "SPEC.md").write_text("spec\n")
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text("See `/clean-results`.\n")
+    errors = check_skill_references(roots=[docs], skills_dir=skills, allowlist=frozenset())
+    assert errors == [], f"expected PASS (dir without SKILL.md), got: {errors}"
+
+
+def test_check_skill_refs_fail_unresolved(tmp_path):
+    """A `/skill` token resolving neither to a live dir nor the allowlist FAILs
+    with a file:line-anchored error naming the token."""
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "SKILL.md").write_text("Run `/ghost-skill` here.\n")
+    errors = check_skill_references(roots=[docs], skills_dir=skills, allowlist=frozenset())
+    assert len(errors) == 1, f"expected exactly one error, got: {errors}"
+    assert "/ghost-skill" in errors[0]
+    assert "SKILL.md:1" in errors[0]
+
+
+def test_check_skill_refs_pass_allowlist_exact(tmp_path):
+    """An allowlisted exact token (user-global / builtin command) PASSes even
+    with an empty skills dir."""
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text("Self-pass `/humanize quick` before returning.\n")
+    errors = check_skill_references(
+        roots=[docs], skills_dir=skills, allowlist=frozenset({"humanize"})
+    )
+    assert errors == [], f"expected PASS (allowlisted exact token), got: {errors}"
+
+
+def test_check_skill_refs_pass_namespace_prefix(tmp_path):
+    """An allowlisted `<plugin>:` namespace prefix resolves every
+    `/<plugin>:<member>` without per-member enumeration."""
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text("Run `/codex:rescue` then `/codex:setup`.\n")
+    errors = check_skill_references(
+        roots=[docs], skills_dir=skills, allowlist=frozenset({"codex:"})
+    )
+    assert errors == [], f"expected PASS (namespace prefix), got: {errors}"
+
+
+def test_check_skill_refs_fail_unallowlisted_namespace(tmp_path):
+    """A plugin-namespaced token whose prefix is NOT allowlisted FAILs."""
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text("Run `/other:thing`.\n")
+    errors = check_skill_references(
+        roots=[docs], skills_dir=skills, allowlist=frozenset({"codex:"})
+    )
+    assert len(errors) == 1, f"expected exactly one error, got: {errors}"
+    assert "/other:thing" in errors[0]
+
+
+def test_check_skill_refs_pass_namespace_on_disk(tmp_path):
+    """Forward-compat: a colon-named skill DIRECTORY resolves a namespaced
+    token even with no allowlist prefix."""
+    skills = tmp_path / "skills"
+    (skills / "code-review:code-review").mkdir(parents=True)
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text("Run `/code-review:code-review`.\n")
+    errors = check_skill_references(roots=[docs], skills_dir=skills, allowlist=frozenset())
+    assert errors == [], f"expected PASS (namespace dir on disk), got: {errors}"
+
+
+def test_check_skill_refs_does_not_match_path_token(tmp_path):
+    """The central FP control: a backticked PATH (`/workspace/logs/x`, trailing
+    `/`) and bare prose paths (`/tmp/foo`, `/mnt/eps`, no backtick) must NOT
+    match — zero false positives."""
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text("Sentinel at `/workspace/logs/x` and bare /tmp/foo and /mnt/eps.\n")
+    errors = check_skill_references(roots=[docs], skills_dir=skills, allowlist=frozenset())
+    assert errors == [], f"expected PASS (path tokens not matched), got: {errors}"
+
+
+def test_check_skill_refs_ignores_fenced_code(tmp_path):
+    """Lines inside fenced code blocks (``` / ~~~) are skipped: an HTML close
+    tag / sed / regex fragment carrying `/ghost` must NOT FAIL."""
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text("```\n`/ghost` inside a fence\nsed -n '/^---$/p'\n```\n")
+    errors = check_skill_references(roots=[docs], skills_dir=skills, allowlist=frozenset())
+    assert errors == [], f"expected PASS (fenced code skipped), got: {errors}"
+
+
+def test_check_skill_refs_historical_opt_out(tmp_path):
+    """A dead `/skill` ref on a line carrying the shared
+    `<!-- lint: historical-ref -->` opt-out is a one-off narrative citation
+    and must NOT FAIL."""
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text("Retired `/oldskill`. <!-- lint: historical-ref -->\n")
+    errors = check_skill_references(roots=[docs], skills_dir=skills, allowlist=frozenset())
+    assert errors == [], f"expected PASS (opted-out historical ref), got: {errors}"
+
+
+def test_check_skill_refs_opt_out_is_per_line(tmp_path):
+    """The opt-out covers ONLY its own line: a dead ref on another line of the
+    same file still FAILs and the error names the second line."""
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text(
+        "Retired `/oldskill`. <!-- lint: historical-ref -->\nThen run `/oldskill` again.\n"
+    )
+    errors = check_skill_references(roots=[docs], skills_dir=skills, allowlist=frozenset())
+    assert len(errors) == 1, f"expected exactly one error, got: {errors}"
+    assert "a.md:2" in errors[0]
+
+
+def test_check_skill_refs_mixed_good_and_dangling(tmp_path):
+    """A file with one resolving and one dangling ref reports only the
+    dangling one, anchored to its line."""
+    skills = tmp_path / "skills"
+    (skills / "issue").mkdir(parents=True)
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text("Good `/issue`.\nBad `/ghost`.\n")
+    errors = check_skill_references(roots=[docs], skills_dir=skills, allowlist=frozenset())
+    assert len(errors) == 1, f"expected exactly one error, got: {errors}"
+    assert "/ghost" in errors[0]
+    assert "a.md:2" in errors[0]
+
+
+def test_check_skill_refs_repo_tree_is_clean():
+    """Green-on-main guard: the committed workflow surface (agents + skills +
+    rules + CLAUDE.md + workflow.yaml) carries no unresolved skill refs under
+    the production SKILL_REF_ALLOWLIST. This is the regression backstop the
+    durable fix installs — it FAILs naming any new dangling token."""
+    errors = check_skill_references()
+    assert errors == [], (
+        "committed workflow surface carries unresolved skill references "
+        "(not a live skill dir and not in SKILL_REF_ALLOWLIST):\n" + "\n".join(errors)
+    )
+
+
+def test_workflow_lint_check_skill_refs_cli_exits_zero():
+    """The dedicated --check-skill-refs flag must exist and pass on the
+    committed tree (mirrors test_workflow_lint_check_heredoc_dotenv_cli...)."""
+    result = _run("--check-skill-refs")
+    assert result.returncode == 0, (
+        f"workflow_lint --check-skill-refs failed:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
     )
 
 


### PR DESCRIPTION
Closes task #714.

Adds a `--check-skill-refs` lint mode to `scripts/workflow_lint.py` that walks the workflow-doc surface (agents + skills/SKILL.md + rules + CLAUDE.md + workflow.yaml) and FAILs on any backtick-delimited `/<skill-name>` token that resolves neither to a live skill directory under `.claude/skills/` nor to the in-module `SKILL_REF_ALLOWLIST` frozenset. Closes the skill-rename / skill-retirement rot class flagged by the #713 Methodology critic.

- Commit 1 (TDD): `b8f795b9b5` — 15 tests
- Commit 2: `0f284ec161` — production code (regex + allowlist + check fn + argparse/dispatch wiring + module-docstring bullet)
- Commit 3: `13d6245986` — `.pre-commit-config.yaml` `workflow-yaml-check-skill-refs` hook

Gates PASSed: clarifier All-clear, plan-verify PASS, fact-check, consistency PASS, Phase 2 critic ensemble APPROVE (Claude 3/3 + Codex twins; consistency PASS), code-review ensemble PASS via reconciler (Claude PASS / Codex FAIL on un-approved alternative design → reconciler PASS binding), test-verdict PASS (154 tests + ruff + 4 lint modes), completion-audit PASS.