### PR TITLE
issue-725: living_docs.py check degrades on registry/fs-inconsistent task

### DIFF
--- a/scripts/living_docs.py
+++ b/scripts/living_docs.py
@@ -1112,7 +1112,9 @@ def _collect_question_evidence(text: str) -> dict[str, dict[str, Any]]:
     return out
 
 
-def _completed_task_dates(paths: LivingDocsPaths) -> dict[int, str | None]:
+def _completed_task_dates(
+    paths: LivingDocsPaths,
+) -> tuple[dict[int, str | None], list[tuple[int, str]]]:
     """Map every completed-with-clean-result task id → its promotion date.
 
     Used by check (b) [coverage] and (d) [staleness]. The date is the
@@ -1120,19 +1122,33 @@ def _completed_task_dates(paths: LivingDocsPaths) -> dict[int, str | None]:
     ``created_at``, else None. Tasks flagged ``living_docs_unmapped`` are
     excluded — a deliberate "this result has no open question" decision,
     not drift (see :func:`mark_unmapped`).
+
+    Returns ``(dates, drifted)``: the second element lists
+    ``(task_id, error_message)`` pairs for tasks whose registry entry is
+    inconsistent with the on-disk tree — the directory is missing (raising
+    from :func:`tw.find_task_path`) OR ``body.md`` is absent inside it
+    (raising from :func:`tw._read_body`'s ``read_text``). These surface as
+    drift findings in :func:`check` rather than crash the whole pass — see
+    also :func:`_relates_to_index`.
     """
     out: dict[int, str | None] = {}
+    drifted: list[tuple[int, str]] = []
     for entry in tw.list_by_status("completed"):
         if not entry.get("has_clean_result"):
             continue
         tid = int(entry["id"])
-        fm, _ = tw._read_body(tw.find_task_path(tid) / "body.md")
+        try:
+            body_path = tw.find_task_path(tid) / "body.md"
+            fm, _ = tw._read_body(body_path)
+        except (FileNotFoundError, OSError) as e:
+            drifted.append((tid, str(e)))
+            continue
         if fm.get("living_docs_unmapped"):
             continue  # intentionally unmapped — exempt from coverage + staleness
         stamp = fm.get("promoted_at") or fm.get("created_at")
         date = str(stamp)[:10] if stamp else None
         out[tid] = date
-    return out
+    return out, drifted
 
 
 def _all_task_ids(paths: LivingDocsPaths) -> set[int]:
@@ -1141,17 +1157,32 @@ def _all_task_ids(paths: LivingDocsPaths) -> set[int]:
     return {int(t) for t in reg.get("tasks", {})}
 
 
-def _relates_to_index(paths: LivingDocsPaths) -> dict[int, list[str]]:
-    """Map task id → its ``relates_to`` list across all statuses."""
+def _relates_to_index(
+    paths: LivingDocsPaths,
+) -> tuple[dict[int, list[str]], list[tuple[int, str]]]:
+    """Map task id → its ``relates_to`` list across all statuses.
+
+    Returns ``(index, drifted)``: the second element lists
+    ``(task_id, error_message)`` pairs for tasks whose registry entry is
+    inconsistent with the on-disk tree (directory missing OR ``body.md``
+    missing). See :func:`_completed_task_dates` for the failure modes and
+    why they degrade to drift findings rather than crash :func:`check`.
+    """
     out: dict[int, list[str]] = {}
+    drifted: list[tuple[int, str]] = []
     reg = tw._load_registry()
     for tid_str in reg.get("tasks", {}):
         tid = int(tid_str)
-        fm, _ = tw._read_body(tw.find_task_path(tid) / "body.md")
+        try:
+            body_path = tw.find_task_path(tid) / "body.md"
+            fm, _ = tw._read_body(body_path)
+        except (FileNotFoundError, OSError) as e:
+            drifted.append((tid, str(e)))
+            continue
         rel = fm.get("relates_to")
         if rel:
             out[tid] = [str(q).lower() for q in rel]
-    return out
+    return out, drifted
 
 
 def _check_structural(questions: dict[str, dict[str, Any]], report: CheckReport) -> None:
@@ -1295,9 +1326,24 @@ def check(*, paths: LivingDocsPaths | None = None) -> CheckReport:
 
     text = _read(paths.open_questions)
     questions = _collect_question_evidence(text)
-    relates = _relates_to_index(paths)
+    relates, relates_drifted = _relates_to_index(paths)
     all_ids = _all_task_ids(paths)
-    completed = _completed_task_dates(paths)
+    completed, completed_drifted = _completed_task_dates(paths)
+
+    # Surface any registry/filesystem inconsistency as a drift finding,
+    # dedup'd across the two indexers (the same drifted task can show up in
+    # both passes). One line per task, naming the id + the underlying raise,
+    # so the lint degrades gracefully (the surviving check axes below still
+    # run against the registry-trimmed indexes) instead of hard-crashing on
+    # the first bad task.
+    seen_drifted: set[int] = set()
+    for tid, err in [*relates_drifted, *completed_drifted]:
+        if tid in seen_drifted:
+            continue
+        seen_drifted.add(tid)
+        report.problems.append(
+            f"task #{tid} registry/filesystem inconsistent: {err} (run `task.py audit` to repair)"
+        )
 
     # Question → evidence-id set. Only questions whose section has a
     # parseable carrier — either State trailer or Belief Evidence line —

--- a/tests/test_living_docs.py
+++ b/tests/test_living_docs.py
@@ -501,6 +501,81 @@ def test_check_exempts_intentionally_unmapped(fixture):
     assert fm["living_docs_unmapped"] == "no open question fits"
 
 
+# ─── check() degrades on registry/filesystem inconsistency (#725) ──────────
+
+
+def test_check_degrades_on_drifted_registry_path(fixture):
+    """Mode A: a registry entry points at a directory that does not exist.
+
+    ``find_task_path`` raises ``FileNotFoundError``; ``check()`` must
+    surface the drifted task as a problem (NOT raise), AND the surviving
+    check axes must still run against the registry-trimmed index.
+    Reproduces tonight's documented crash (task #725 body / #696).
+    """
+    import json
+
+    repo, paths = fixture
+    # Drift #207's registry path to a nonexistent dir. The on-disk
+    # tasks/completed/207/ still exists; only the registry POINTS somewhere
+    # else — exactly find_task_path's entry-present-but-dir-missing branch.
+    reg_path = repo / "tasks" / "REGISTRY.json"
+    reg = json.loads(reg_path.read_text())
+    reg["tasks"]["207"]["path"] = "tasks/approved/207"  # nonexistent
+    reg_path.write_text(json.dumps(reg, indent=2, sort_keys=True) + "\n")
+    tw.invalidate_cache()  # drop the cached registry so the new path is read
+
+    # (1) Must not raise.
+    report = ld.check(paths=paths)
+
+    # (2) Drift finding present, names #207.
+    drift_lines = [p for p in report.problems if "registry/filesystem inconsistent" in p]
+    assert any("#207" in p for p in drift_lines), report.problems
+    # The fixture has #208 still well-formed → exactly one drift line.
+    assert len(drift_lines) == 1, drift_lines
+
+    # (3) Surviving axes still ran: #207's name still appears in a1's evidence
+    # in open_questions.md, but #207 is no longer in the relates-to index, so
+    # the bidirectional check (axis a) MUST flag a missing-backlink finding
+    # for #207 vs a1.
+    nondrift = [p for p in report.problems if "registry/filesystem inconsistent" not in p]
+    assert any("207" in p and "a1" in p for p in nondrift), (
+        f"axis (a) bidirectional should have flagged #207 vs a1 after the "
+        f"drift trimmed it from the relates index; got non-drift problems: {nondrift}"
+    )
+    # report.ok must be False (drift present).
+    assert not report.ok
+
+
+def test_check_degrades_on_missing_body_md(fixture):
+    """Mode B: a registry entry's dir exists but body.md is missing.
+
+    ``tw._read_body → path.read_text()`` raises ``FileNotFoundError``;
+    ``check()`` must surface the drifted task as a problem (NOT raise), AND
+    the surviving check axes must still run.
+    """
+    repo, paths = fixture
+    # Delete #207's body.md while keeping the registry entry intact AND the
+    # directory present — find_task_path returns successfully (dir exists);
+    # the subsequent read_text raises.
+    body = repo / "tasks" / "completed" / "207" / "body.md"
+    body.unlink()
+
+    # (1) Must not raise.
+    report = ld.check(paths=paths)
+
+    # (2) Drift finding present, names #207.
+    drift_lines = [p for p in report.problems if "registry/filesystem inconsistent" in p]
+    assert any("#207" in p for p in drift_lines), report.problems
+    assert len(drift_lines) == 1, drift_lines
+
+    # (3) Surviving axes still ran: same bidirectional flag as Mode A — #207's
+    # drop from the relates index has the same downstream effect whether it
+    # was Mode A or Mode B.
+    nondrift = [p for p in report.problems if "registry/filesystem inconsistent" not in p]
+    assert any("207" in p and "a1" in p for p in nondrift), nondrift
+    assert not report.ok
+
+
 # ─── Belief-format Evidence carrier (live docs/open_questions.md format) ───
 #
 # Every question in docs/open_questions.md as of 2026-05-29 uses the


### PR DESCRIPTION
Closes task #725 (daily-fix: living_docs.py check degrade on bad task).