### PR TITLE
#726 daily-fix: spawn_session verifies Happy injection patch

### DIFF
--- a/.claude/rules/background-automation.md
+++ b/.claude/rules/background-automation.md
@@ -367,6 +367,33 @@ session; runs every tick like `vm_disk_pass`). Kill switch:
 just this pass (pair with `--dry-run` for a live smoke). Pinned by
 `tests/test_autonomous_session_watch.py::test_program_orchestrator_*`.
 
+**Happy injection-patch check pass (#726, `happy_patch_pass`).** A
+daemon-INDEPENDENT, escalate-only pass (runs every 10-min tick in the
+daemon-independent block next to `vm_disk_pass` / `data_disk_pass` /
+`program_orchestrator_pass`, BEFORE the daemon-gated session passes) that
+surfaces a reverted/drifted Happy daemon injection patch PROACTIVELY. The patch
+(`scripts/patch_happy_daemon.py`, sentinel v4) teaches the vendored Happy daemon
+to honor `claudeArgs` / `HAPPY_INITIAL_PROMPT`; it reverts on every `npm update
+happy` (and the hashed bundle is renamed away), after which `spawn-issue --auto`
+/ `spawn-campaign` spawn a session that boots empty and never fires its skill —
+an idle "spawned but never ran" session (the failure CLASS behind #685; the
+2026-06-28 idle-session pile itself was the distinct #720 mapping-loss cause).
+The spawn-path guard (`spawn_session._verify_happy_patch_or_die`) is REACTIVE —
+it fires only at the next spawn; this pass is PROACTIVE, so a revert is surfaced
+within ~10 min rather than at the next dispatch. It reads the daemon file
+in-process via `_happy_patch_check.classify_patch` (single source of truth for
+the sentinel + path; single-digit-ms, no subprocess, no root), and on
+`reverted`/`drifted` writes a `band=happy-patch` row to the shared disk-guard
+sidecar (`.claude/cache/disk-guard-events.jsonl`) + a fail-soft `_telegram_push`,
+deduped per-state (`~/.eps-autonomous/happy-patch-alert.json`) so it alerts once
+per episode and re-alerts when the state changes. ESCALATE-ONLY: it NEVER
+re-applies (that needs sudo — a password prompt would hang the autonomous
+dispatch); `patched` and `missing` (no daemon file on this host) are clean
+no-ops (the spawn-path guard owns the precise `missing` reachability
+disambiguation via `daemon.state.json`). `--happy-patch-only` runs just this
+pass (pair with `--dry-run` for a live smoke). Pinned by
+`tests/test_happy_patch_check.py` (`test_watcher_pass_*`).
+
 ## Dedicated data disk for `.claude/worktrees/` (#681)
 
 The heavy active-task footprint (`.claude/worktrees/` — every `issue-<N>`

--- a/scripts/_happy_patch_check.py
+++ b/scripts/_happy_patch_check.py
@@ -1,0 +1,92 @@
+"""Single source of truth for 'is the Happy daemon injection patch applied?'.
+
+Imported by spawn_session.py (pre-spawn guard) and autonomous_session_watch.py
+(proactive escalate-only pass). patch_happy_daemon.py also imports SENTINEL /
+DAEMON_FILE from here so there is exactly ONE definition of the sentinel string
+and the daemon file path.
+
+Cheap by construction: a single file read + substring test (single-digit ms),
+no subprocess, no root. Safe when the daemon file is absent entirely (returns
+the ``missing`` state — the spawn guard then disambiguates 'Happy never
+installed' from 'patch file hash-renamed away by npm update' via a second,
+independent check on the daemon RPC's daemon.state.json — see spawn_session.py).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+DAEMON_FILE = Path("/usr/lib/node_modules/happy/dist/index-q9G4ktSK.mjs")
+SENTINEL = (
+    "// EPS-PATCH: claudeArgs-forwarding + initial-prompt-seed + bypass + no-takeover-downgrade v4"
+)
+
+REAPPLY_CMD = "sudo uv run python scripts/patch_happy_daemon.py apply"
+RESTART_CMD = "happy daemon stop && happy daemon start"
+
+
+@dataclass(frozen=True)
+class PatchStatus:
+    """Result of :func:`classify_patch`.
+
+    ``state`` ∈ {``"patched"``, ``"reverted"``, ``"drifted"``, ``"missing"``};
+    ``detail`` is a human-readable one-liner for the log / fail-loud message.
+    """
+
+    state: str
+    detail: str
+
+
+def _file_text(f: Path) -> str:
+    # Pin utf-8 for locale determinism (the .mjs is ascii/utf-8 source).
+    return f.read_text(encoding="utf-8")
+
+
+def classify_patch(daemon_file: Path | None = None) -> PatchStatus:
+    """Classify whether the Happy daemon injection patch is applied.
+
+    Returns a :class:`PatchStatus` whose ``state`` is one of:
+
+    - ``"patched"`` — the sentinel comment is present (the daemon honors
+      ``claudeArgs`` / ``HAPPY_INITIAL_PROMPT``).
+    - ``"reverted"`` — the file exists, the sentinel is gone, but every
+      ``PATCHES`` search-string still matches, so a plain ``apply`` would work.
+    - ``"drifted"`` — the file exists, the sentinel is gone, AND at least one
+      ``PATCHES`` search-string no longer matches (the daemon shape changed —
+      a blind ``apply`` cannot fix it; manual reconciliation is required).
+    - ``"missing"`` — the daemon file is absent at ``daemon_file``. AMBIGUOUS by
+      itself (Happy not installed vs. the hashed bundle renamed away by
+      ``npm update happy``); the caller disambiguates (see spawn_session.py's
+      two-step probe).
+
+    ``daemon_file`` defaults to :data:`DAEMON_FILE`; tests pass a synthetic path.
+    """
+    f = daemon_file or DAEMON_FILE
+    if not f.is_file():
+        return PatchStatus("missing", f"Happy daemon file not found at {f}")
+    text = _file_text(f)
+    if SENTINEL in text:
+        return PatchStatus("patched", "sentinel present")
+    # Reverted. Distinguish a clean revert (search-strings still match -> a
+    # plain `apply` will work) from a drifted shape (a search-string no longer
+    # matches -> manual reconciliation). Reuse patch_happy_daemon's PATCHES so
+    # there is one shape definition. LAZY import to avoid any cycle.
+    from importlib import import_module
+
+    patch_mod = import_module("patch_happy_daemon")  # scripts/ on sys.path
+    missing = [name for name, search, _ in patch_mod.PATCHES if search not in text]
+    if missing:
+        return PatchStatus(
+            "drifted",
+            "daemon upgraded; PATCHES no longer match: " + ", ".join(missing),
+        )
+    return PatchStatus("reverted", "sentinel absent; search-strings still match")
+
+
+if __name__ == "__main__":
+    import sys
+
+    st = classify_patch()
+    print(st.state, "—", st.detail)
+    sys.exit({"patched": 0, "reverted": 1, "drifted": 2, "missing": 3}[st.state])

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -1991,6 +1991,106 @@ def data_disk_pass(dry_run: bool, used_pct: float | None = None) -> bool:
     return True
 
 
+def _happy_patch_state_path() -> Path:
+    """Singleton per-episode dedup state for :func:`happy_patch_pass`, under
+    AUTONOMOUS_REGISTRY_DIR. Records the last-alerted patch state so the pass
+    escalates a revert/drift once per episode (and re-alerts when the state
+    CHANGES, e.g. reverted -> drifted). Mirrors ``vm-disk-data.json``'s shape."""
+    return AUTONOMOUS_REGISTRY_DIR / "happy-patch-alert.json"
+
+
+def _load_happy_patch_state() -> dict:
+    path = _happy_patch_state_path()
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _save_happy_patch_state(state: dict) -> None:
+    """Atomic temp+rename write of the happy-patch dedup state (fail-soft)."""
+    dest = _happy_patch_state_path()
+    try:
+        AUTONOMOUS_REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
+        tmp = dest.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(state))
+        tmp.replace(dest)
+    except OSError as exc:  # pragma: no cover - fail-soft I/O guard
+        print(f"  happy-patch: state save failed: {exc}", file=sys.stderr)
+
+
+def _clear_happy_patch_state() -> None:
+    _happy_patch_state_path().unlink(missing_ok=True)
+
+
+def happy_patch_pass(dry_run: bool) -> None:
+    """Proactively surface a reverted/drifted Happy injection patch (task #726).
+
+    The spawn-path guard (spawn_session._verify_happy_patch_or_die) is REACTIVE
+    — it only fires at the next spawn attempt. This pass is PROACTIVE: it runs
+    every 10-min tick, so a revert (typically from `npm update happy`) is
+    surfaced within ~10 min rather than at the next autonomous dispatch.
+    Escalate-only: never re-applies (that needs sudo); writes a sidecar row +
+    fail-soft Telegram push, deduped per (state) so it alerts once per episode.
+    Clean no-op when the patch is present or the daemon file is absent.
+
+    Daemon-INDEPENDENT: it reads a local file only, so it runs every tick
+    alongside vm_disk_pass / data_disk_pass / program_orchestrator_pass, BEFORE
+    the daemon-gated session passes. Fail-soft throughout — a classify error is
+    logged and swallowed, never propagated."""
+    sp = str(PROJECT_ROOT / "scripts")
+    if sp not in sys.path:
+        sys.path.insert(0, sp)
+    try:
+        import _happy_patch_check as hpc
+
+        st = hpc.classify_patch()
+    except Exception as exc:  # fail-soft like the disk passes
+        print(f"  happy-patch: classify failed ({exc}); skipping", file=sys.stderr)
+        return
+    if st.state in ("patched", "missing"):
+        # `missing` = the .mjs file is absent; on the watcher VM this is the
+        # 'Happy not installed here' case (escalate-only stays conservative —
+        # the spawn-path guard owns the precise reachability disambiguation via
+        # daemon.state.json). Reset the dedup so a future revert re-alerts.
+        if not dry_run:
+            _clear_happy_patch_state()
+        return
+    # reverted | drifted -> escalate-only
+    state = _load_happy_patch_state()
+    if state.get("alerted_state") == st.state:
+        print(f"  happy-patch: {st.state} (already alerted this episode)")
+        return
+    print(
+        f"happy-patch: {st.state.upper()} — {st.detail}. Autonomous spawns will "
+        f"produce idle sessions until re-applied; ESCALATE-ONLY "
+        f"(re-apply needs sudo, never auto-applied here).",
+        file=sys.stderr,
+    )
+    _append_disk_guard_sidecar(
+        {
+            "kind": f"happy-patch-{st.state}",
+            "band": "happy-patch",
+            "state": st.state,
+            "detail": st.detail,
+            "reapply_cmd": hpc.REAPPLY_CMD,
+            "restart_cmd": hpc.RESTART_CMD,
+        },
+        dry_run,
+    )
+    _telegram_push(
+        f"Happy injection patch {st.state}: {st.detail}. Autonomous spawns will "
+        f"produce idle sessions until re-applied: {hpc.REAPPLY_CMD} && "
+        f"{hpc.RESTART_CMD}",
+        dry_run,
+    )
+    if not dry_run:
+        _save_happy_patch_state({"alerted_state": st.state})
+
+
 def _status_class(status: str | None, latest_progress_ts: float | None, now: float) -> str:
     """Classify a RUNNING managed pod's task status for :func:`decide_pod_safety`.
 
@@ -12598,6 +12698,13 @@ def main(argv: list[str] | None = None) -> int:
         "every other pass. Mirrors --infra-drain-only; pair with --dry-run for "
         "a live smoke against the real proposed-task set.",
     )
+    parser.add_argument(
+        "--happy-patch-only",
+        action="store_true",
+        help="run ONLY the Happy injection-patch check pass (escalate on a "
+        "reverted/drifted daemon patch, #726) and exit; skip every other pass. "
+        "Daemon-independent; pair with --dry-run for a live smoke.",
+    )
     args = parser.parse_args(argv)
 
     lock = _acquire_lock()
@@ -12635,6 +12742,12 @@ def main(argv: list[str] | None = None) -> int:
         proposed_infra_sweep_pass(args.dry_run, daemon_reachable=_daemon_reachable())
         return 0
 
+    # --happy-patch-only mirrors the other --*-only flags: the pass is
+    # daemon-independent (reads a local file only), so run it alone.
+    if args.happy_patch_only:
+        happy_patch_pass(args.dry_run)
+        return 0
+
     # VM disk-headroom: runs FIRST. A full root disk makes every later
     # subprocess in this very watcher (and every VM session) flaky — alert
     # and reclaim before reasoning about sessions/pods (task #552).
@@ -12647,6 +12760,18 @@ def main(argv: list[str] | None = None) -> int:
     # without the cutover (and on an existing-but-unmounted /mnt/eps-data), so
     # the call is live the instant the disk is actually mounted.
     data_disk_pass(args.dry_run)
+
+    # Happy injection-patch check (#726): a SECOND escalate-only, daemon-
+    # INDEPENDENT pass (reads a local file only). The spawn-path guard
+    # (spawn_session._verify_happy_patch_or_die) is REACTIVE — it fires only at
+    # the next spawn; this PROACTIVE pass surfaces a reverted/drifted patch
+    # (typically from `npm update happy`) within ~10 min so the gap is caught
+    # before the next autonomous dispatch. Escalate-only (never re-applies —
+    # that needs sudo); clean no-op when patched or the daemon file is absent.
+    # Placed in the daemon-independent block (next to vm_disk_pass /
+    # data_disk_pass / program_orchestrator_pass), BEFORE the daemon-gated
+    # session passes — it must run on a daemon outage too.
+    happy_patch_pass(args.dry_run)
 
     # Program-orchestrator crash-recovery: the leakage-program (#660) meta-loop is
     # a bash daemon (run_program_orchestrator.sh in tmux eps-program), NOT a Happy

--- a/scripts/patch_happy_daemon.py
+++ b/scripts/patch_happy_daemon.py
@@ -35,11 +35,15 @@ import shutil
 import sys
 from pathlib import Path
 
-DAEMON_FILE = Path("/usr/lib/node_modules/happy/dist/index-q9G4ktSK.mjs")
+# Single source of truth for the daemon file path + sentinel string. The
+# spawn-path guard (spawn_session._verify_happy_patch_or_die) and the watcher's
+# proactive pass (autonomous_session_watch.happy_patch_pass) import the same
+# constants from _happy_patch_check, so the literal never drifts across the
+# three consumers. `scripts/` is on sys.path[0] when this runs via
+# `uv run python scripts/patch_happy_daemon.py`, so the sibling import resolves.
+from _happy_patch_check import DAEMON_FILE, SENTINEL
+
 BACKUP_SUFFIX = ".eps-original"
-SENTINEL = (
-    "// EPS-PATCH: claudeArgs-forwarding + initial-prompt-seed + bypass + no-takeover-downgrade v4"
-)
 
 
 # Each (search, replace) pair is a literal-string substitution. Search

--- a/scripts/spawn_session.py
+++ b/scripts/spawn_session.py
@@ -762,6 +762,93 @@ def _build_extra_claude_args(
     return extra
 
 
+def _verify_happy_patch_or_die(*, context: str) -> None:
+    """Fail loud if the Happy daemon injection patch is reverted/drifted/moved.
+
+    Called BEFORE any spawn path that relies on HAPPY_INITIAL_PROMPT /
+    claudeArgs injection. A reverted (or hash-renamed-away) patch makes the
+    daemon ignore those fields, so the spawned session boots empty and never
+    fires its skill — an idle 'spawned but never ran' session (the failure
+    CLASS behind #685's symptom; the 2026-06-28 idle-session pile itself was
+    the distinct #720 mapping-loss cause, not a patch revert). Single-digit-ms:
+    one or two file reads + substring, no subprocess, no root.
+
+    ``context`` names the caller (e.g. "spawn-issue --auto") for the message.
+
+    The ``missing`` classification (the daemon .mjs file is absent) is AMBIGUOUS
+    and is disambiguated with a SECOND, INDEPENDENT check on the daemon RPC's
+    own state file (:data:`DAEMON_STATE` / daemon.state.json), since the two
+    files are independent (classify_patch reads the vendored .mjs; daemon
+    reachability lives in daemon.state.json):
+
+      - .mjs missing AND daemon.state.json missing  -> Happy is not installed
+        on this host -> WARN + proceed (a legitimate fresh VM not running the
+        autonomous loop; the downstream daemon RPC fails loud anyway).
+      - .mjs missing BUT daemon.state.json present   -> Happy IS reachable but
+        the patch file moved (the canonical `npm update happy` hash-rename:
+        index-<oldhash>.mjs -> index-<newhash>.mjs) -> the patch CANNOT be
+        verified and is almost certainly NOT applied to the new bundle -> DIE
+        loud. Re-applying fails loud if the file is truly gone, which is the
+        correct diagnosis.
+    """
+    import _happy_patch_check as hpc  # scripts/ is on sys.path[0]
+
+    st = hpc.classify_patch()
+    if st.state == "patched":
+        return
+
+    if st.state == "missing":
+        # Two-step probe: distinguish 'Happy never installed' (safe) from
+        # 'Happy reachable but patch file moved' (the #685 post-update state).
+        if not DAEMON_STATE.is_file():
+            print(
+                f"WARNING [{context}]: {st.detail}. No Happy daemon state file "
+                f"at {DAEMON_STATE} either -> no Happy install detected, "
+                f"skipping the injection-patch guard.",
+                file=sys.stderr,
+            )
+            return
+        # Daemon reachable, patch file absent -> die loud.
+        fix = (
+            "The Happy daemon patch file is ABSENT but the daemon IS reachable "
+            "(daemon.state.json present) -> the vendored bundle was almost "
+            "certainly hash-renamed by `npm update happy` and is now UNPATCHED. "
+            "Re-apply against the new bundle:\n"
+            f"    {hpc.REAPPLY_CMD}\n"
+            "(this fails loud if the file is genuinely gone — that is the "
+            "correct diagnosis), then restart the daemon:\n"
+            f"    {hpc.RESTART_CMD}"
+        )
+        sys.exit(
+            f"ABORT [{context}]: the Happy daemon injection patch could not be "
+            f"verified ({st.detail}), but the daemon is reachable.\n"
+            f"Spawning now would create a session that IGNORES its initial "
+            f"prompt and sits idle forever.\n{fix}"
+        )
+
+    # reverted | drifted -> the daemon is up but will IGNORE the injected
+    # prompt/args, producing an idle session. Fail loud with the fix.
+    if st.state == "reverted":
+        fix = (
+            f"Re-apply it:\n    {hpc.REAPPLY_CMD}\nthen restart the daemon:\n    {hpc.RESTART_CMD}"
+        )
+    else:  # drifted
+        fix = (
+            "The Happy daemon shape has DRIFTED (likely an `npm update happy`); "
+            "a blind re-apply will not work. Inspect the file and update "
+            "PATCHES in scripts/patch_happy_daemon.py, then:\n"
+            f"    {hpc.REAPPLY_CMD}\n    {hpc.RESTART_CMD}"
+        )
+    sys.exit(
+        f"ABORT [{context}]: the Happy daemon injection patch is "
+        f"{st.state} ({st.detail}).\n"
+        f"Spawning now would create a session that IGNORES its initial prompt "
+        f"and sits idle forever (an idle 'spawned but never ran' session; the "
+        f"failure CLASS behind #685's symptom — the 2026-06-28 pile itself was "
+        f"the distinct #720 mapping-loss cause).\n{fix}"
+    )
+
+
 def cmd_spawn_pm(args: argparse.Namespace) -> None:
     """Spawn a session intended to host the PM persona. The session opens
     cwd=<repo root> so the user sees a familiar project. The PM persona is
@@ -773,6 +860,10 @@ def cmd_spawn_pm(args: argparse.Namespace) -> None:
     )
     body: dict[str, object] = {"directory": str(PROJECT_ROOT), "agent": "claude"}
     if extra_args:
+        # Only the override branch relies on claudeArgs injection; a no-override
+        # PM spawn injects nothing, so guarding it would be a false alarm (the
+        # deliberate asymmetry pinned by the test suite).
+        _verify_happy_patch_or_die(context="spawn-pm")
         body["claudeArgs"] = extra_args
     resp = post("/spawn-session", body)
     if not resp.get("success"):
@@ -848,6 +939,13 @@ def cmd_spawn_issue(args: argparse.Namespace) -> None:
         prompt = f"/issue {issue}"
     else:
         prompt = None
+    if prompt is not None or extra_args:
+        # Both the load-bearing --auto / --initial-prompt injection path AND the
+        # bare model-override path rely on the daemon honoring HAPPY_INITIAL_*
+        # / claudeArgs. Verify the daemon patch is applied BEFORE post() — a
+        # revert would otherwise spawn an idle 'spawned but never ran' session
+        # (the failure CLASS behind #685) or silently drop the model override.
+        _verify_happy_patch_or_die(context="spawn-issue")
     if prompt is not None:
         # Auto-prompt sessions have no human at the keyboard to confirm
         # tool permissions, so they start in bypassPermissions mode. The
@@ -999,6 +1097,13 @@ def cmd_spawn_campaign(args: argparse.Namespace) -> None:
             f"then runs `task.py set-status {issue} approved` — workflow.yaml § "
             f"gates.campaign_brief_approval) or 'running' (respawn re-entry)."
         )
+
+    # A campaign session ALWAYS injects HAPPY_INITIAL_PROMPT + claudeArgs (same
+    # #685 severity as the --auto issue path). Verify the daemon patch is
+    # applied BEFORE building the body / reaching post() — but AFTER the
+    # kind/status validation above, so a wrong-kind/-status task still gets its
+    # specific error first.
+    _verify_happy_patch_or_die(context="spawn-campaign")
 
     betas = _parse_betas(args.betas)
     extra_args = _build_extra_claude_args(args.model, betas, args.effort)

--- a/tests/test_happy_patch_check.py
+++ b/tests/test_happy_patch_check.py
@@ -1,0 +1,323 @@
+"""Hermetic tests for the Happy injection-patch guard (task #726).
+
+What this pins (the Step-5 test-verdict for #726):
+
+A. ``_happy_patch_check.classify_patch`` returns the right state on each of the
+   four synthetic daemon-file conditions (patched / reverted / drifted /
+   missing).
+B. ``spawn_session._verify_happy_patch_or_die`` raises ``SystemExit`` (with the
+   actionable re-apply / restart commands) on reverted / drifted / missing-with-
+   daemon-reachable, and returns cleanly on patched / missing-without-daemon.
+   The two-step ``missing`` probe (consulting ``spawn_session.DAEMON_STATE``) is
+   the #685-reintroduction guard.
+C. Integration — each injection-dependent ENTRYPOINT (``cmd_spawn_issue --auto``,
+   ``cmd_spawn_campaign``, ``cmd_spawn_pm`` override branch) fails loud BEFORE
+   ``post()`` is reached on a bad daemon file (``post`` monkeypatched to a
+   flag-if-reached stub). A wiring miss — guard defined but a call site forgotten
+   or placed after ``post()`` — fails these.
+D. Positive asymmetry — the deliberately-unguarded no-override ``cmd_spawn_pm``
+   path does NOT raise from the guard on a reverted file.
+E. Watcher — ``happy_patch_pass`` escalates a revert via a sidecar row under
+   ``--dry-run`` (decides + logs, never mutates), is a clean no-op when patched,
+   and is fail-soft when ``classify_patch`` raises.
+
+All hermetic: synthetic ``.mjs`` files under ``tmp_path``; ``DAEMON_FILE`` /
+``DAEMON_STATE`` / ``post`` monkeypatched. No real ``/usr/lib/``, no ``sudo``,
+no ``npm``, no daemon, no network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Bootstrap sys.path the same way the watcher / spawn-session tests do.
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import _happy_patch_check as hpc  # noqa: E402
+import autonomous_session_watch as asw  # noqa: E402
+import patch_happy_daemon  # noqa: E402
+import spawn_session  # noqa: E402
+
+# ── synthetic-file builders ──────────────────────────────────────────────────
+
+
+def _write_patched(tmp_path: Path) -> Path:
+    f = tmp_path / "index-q9G4ktSK.mjs"
+    f.write_text(f"{hpc.SENTINEL}\n// some bundled daemon source\n", encoding="utf-8")
+    return f
+
+
+def _write_reverted(tmp_path: Path) -> Path:
+    """Sentinel absent, but every PATCHES search-string present -> `reverted`."""
+    f = tmp_path / "index-q9G4ktSK.mjs"
+    body = "// bundled daemon source\n" + "\n".join(
+        search for _name, search, _replace in patch_happy_daemon.PATCHES
+    )
+    f.write_text(body, encoding="utf-8")
+    return f
+
+
+def _write_drifted(tmp_path: Path) -> Path:
+    """Sentinel absent AND >=1 PATCHES search-string missing -> `drifted`."""
+    f = tmp_path / "index-q9G4ktSK.mjs"
+    # Include all but the first patch site's search-string, so at least one
+    # search-string no longer matches.
+    body = "// upgraded daemon source\n" + "\n".join(
+        search for _name, search, _replace in patch_happy_daemon.PATCHES[1:]
+    )
+    f.write_text(body, encoding="utf-8")
+    return f
+
+
+def _missing_path(tmp_path: Path) -> Path:
+    return tmp_path / "does-not-exist.mjs"
+
+
+# ── A. classify_patch unit behavior ──────────────────────────────────────────
+
+
+def test_classify_patched(tmp_path):
+    st = hpc.classify_patch(_write_patched(tmp_path))
+    assert st.state == "patched"
+
+
+def test_classify_reverted(tmp_path):
+    st = hpc.classify_patch(_write_reverted(tmp_path))
+    assert st.state == "reverted"
+
+
+def test_classify_drifted(tmp_path):
+    st = hpc.classify_patch(_write_drifted(tmp_path))
+    assert st.state == "drifted"
+    # The detail names which search-strings drifted (the first patch site).
+    assert patch_happy_daemon.PATCHES[0][0] in st.detail
+
+
+def test_classify_missing(tmp_path):
+    st = hpc.classify_patch(_missing_path(tmp_path))
+    assert st.state == "missing"
+
+
+def test_patch_happy_daemon_shares_constants():
+    """patch_happy_daemon imports SENTINEL / DAEMON_FILE from the helper —
+    single source of truth, so the literal never drifts across consumers."""
+    assert patch_happy_daemon.SENTINEL is hpc.SENTINEL
+    assert patch_happy_daemon.DAEMON_FILE is hpc.DAEMON_FILE
+
+
+# ── B. guard unit behavior ───────────────────────────────────────────────────
+
+
+def test_guard_patched_no_raise(tmp_path, monkeypatch):
+    monkeypatch.setattr(hpc, "DAEMON_FILE", _write_patched(tmp_path))
+    # No raise.
+    spawn_session._verify_happy_patch_or_die(context="t")
+
+
+def test_guard_reverted_raises_with_reapply_cmd(tmp_path, monkeypatch):
+    monkeypatch.setattr(hpc, "DAEMON_FILE", _write_reverted(tmp_path))
+    with pytest.raises(SystemExit) as ei:
+        spawn_session._verify_happy_patch_or_die(context="t")
+    msg = str(ei.value)
+    assert hpc.REAPPLY_CMD in msg
+    assert hpc.RESTART_CMD in msg
+    assert "reverted" in msg
+
+
+def test_guard_drifted_raises_with_manual_msg(tmp_path, monkeypatch):
+    monkeypatch.setattr(hpc, "DAEMON_FILE", _write_drifted(tmp_path))
+    with pytest.raises(SystemExit) as ei:
+        spawn_session._verify_happy_patch_or_die(context="t")
+    msg = str(ei.value)
+    assert "drifted" in msg
+    # Drifted message names manual PATCHES reconciliation, not a blind re-apply.
+    assert "PATCHES" in msg
+
+
+def test_guard_missing_no_daemon_state_warns(tmp_path, monkeypatch, capsys):
+    """missing AND DAEMON_STATE absent -> Happy not installed -> WARN + proceed."""
+    monkeypatch.setattr(hpc, "DAEMON_FILE", _missing_path(tmp_path))
+    monkeypatch.setattr(spawn_session, "DAEMON_STATE", tmp_path / "no-daemon.json")
+    # No raise.
+    spawn_session._verify_happy_patch_or_die(context="t")
+    assert "no Happy install detected" in capsys.readouterr().err
+
+
+def test_guard_missing_with_daemon_state_raises(tmp_path, monkeypatch):
+    """missing BUT DAEMON_STATE present (the post-`npm update happy` hash-rename
+    state: daemon reachable, patch file moved) -> DIE loud. The
+    #685-reintroduction guard."""
+    monkeypatch.setattr(hpc, "DAEMON_FILE", _missing_path(tmp_path))
+    daemon_state = tmp_path / "daemon.state.json"
+    daemon_state.write_text(json.dumps({"httpPort": 12345}))
+    monkeypatch.setattr(spawn_session, "DAEMON_STATE", daemon_state)
+    with pytest.raises(SystemExit) as ei:
+        spawn_session._verify_happy_patch_or_die(context="t")
+    msg = str(ei.value)
+    assert hpc.REAPPLY_CMD in msg
+    assert "could not be" in msg or "reachable" in msg
+
+
+# ── C. integration — guard reached BEFORE post() per entrypoint ──────────────
+
+
+@pytest.fixture
+def reverted_daemon(tmp_path, monkeypatch):
+    """Point the helper at a reverted synthetic .mjs and trip a flag if post()
+    is ever reached. Returns a 0-arg callable -> bool (was post reached?)."""
+    monkeypatch.setattr(hpc, "DAEMON_FILE", _write_reverted(tmp_path))
+    reached = {"post": False}
+
+    def _fake_post(path, body):  # pragma: no cover - must never be reached
+        reached["post"] = True
+        return {"success": True, "sessionId": "sess-should-not-happen"}
+
+    monkeypatch.setattr(spawn_session, "post", _fake_post)
+    return lambda: reached["post"]
+
+
+def test_cmd_spawn_issue_auto_dies_before_post(reverted_daemon, monkeypatch, tmp_path):
+    # No worktree at the synthetic path -> cwd falls back to repo root (fine).
+    monkeypatch.setattr(spawn_session, "WORKTREE_DIR", tmp_path / "no-worktrees")
+    ns = argparse.Namespace(
+        issue=999,
+        auto=True,
+        initial_prompt=None,
+        model=None,
+        betas=None,
+        effort=None,
+        auto_approve_gpu_hours=100.0,
+    )
+    with pytest.raises(SystemExit):
+        spawn_session.cmd_spawn_issue(ns)
+    assert reverted_daemon() is False
+
+
+def test_cmd_spawn_campaign_dies_before_post(reverted_daemon, monkeypatch):
+    # Point get_task at a synthetic approved campaign so validation passes and
+    # the guard (placed AFTER validation) is the next thing reached.
+    import explore_persona_space.task_workflow as tw
+
+    monkeypatch.setattr(
+        tw,
+        "get_task",
+        lambda issue: {"frontmatter": {"kind": "campaign"}, "status": "approved"},
+    )
+    ns = argparse.Namespace(
+        issue=999,
+        model=None,
+        betas=None,
+        effort=None,
+        budget_gpu_hours=None,
+        max_concurrent=None,
+        per_child_cap=None,
+    )
+    with pytest.raises(SystemExit):
+        spawn_session.cmd_spawn_campaign(ns)
+    assert reverted_daemon() is False
+
+
+def test_cmd_spawn_pm_override_dies_before_post(reverted_daemon):
+    # extra_args present (model override) -> the guarded PM branch.
+    ns = argparse.Namespace(model="opus-4-7", betas=None, effort="high")
+    with pytest.raises(SystemExit):
+        spawn_session.cmd_spawn_pm(ns)
+    assert reverted_daemon() is False
+
+
+# ── D. positive asymmetry — no-override PM path is unguarded ─────────────────
+
+
+def test_cmd_spawn_pm_no_override_does_not_raise_on_revert(tmp_path, monkeypatch):
+    """A no-override PM spawn injects nothing, so a reverted patch must NOT
+    raise from the guard (the deliberate design asymmetry). post() is a benign
+    success stub so the call completes."""
+    monkeypatch.setattr(hpc, "DAEMON_FILE", _write_reverted(tmp_path))
+    monkeypatch.setattr(
+        spawn_session,
+        "post",
+        lambda path, body: {"success": True, "sessionId": "sess-pm-ok"},
+    )
+    # Neutralize the PM-session registry write (it would touch the real home dir).
+    monkeypatch.setattr(spawn_session, "_register_pm_session", lambda sid: None)
+    ns = argparse.Namespace(model=None, betas=None, effort=None)
+    # No raise from the guard; the benign post stub lets the call complete.
+    spawn_session.cmd_spawn_pm(ns)
+
+
+# ── E. watcher pass ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def watcher_roots(tmp_path, monkeypatch):
+    """Pin PROJECT_ROOT (sidecar sink) + AUTONOMOUS_REGISTRY_DIR (dedup state)
+    + suppress real Telegram pushes so the pass is fully offline."""
+    monkeypatch.setattr(asw, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(asw, "AUTONOMOUS_REGISTRY_DIR", tmp_path / "reg")
+    monkeypatch.setattr(asw, "_telegram_push", lambda msg, dry_run: False)
+    return tmp_path
+
+
+def _read_sidecar(root: Path) -> list[dict]:
+    path = root / ".claude" / "cache" / "disk-guard-events.jsonl"
+    if not path.is_file():
+        return []
+    return [json.loads(ln) for ln in path.read_text().splitlines() if ln.strip()]
+
+
+def test_watcher_pass_escalates_on_revert_dry_run(watcher_roots, tmp_path, monkeypatch):
+    """A reverted file under --dry-run decides + logs but writes NO sidecar row
+    or state (dry-run has zero observational side-effects); a clean run (patched)
+    is a no-op."""
+    monkeypatch.setattr(hpc, "DAEMON_FILE", _write_reverted(tmp_path))
+    asw.happy_patch_pass(dry_run=True)
+    assert _read_sidecar(watcher_roots) == []
+    assert not asw._happy_patch_state_path().is_file()
+
+    # Patched -> clean no-op even live.
+    monkeypatch.setattr(hpc, "DAEMON_FILE", _write_patched(tmp_path))
+    asw.happy_patch_pass(dry_run=False)
+    assert _read_sidecar(watcher_roots) == []
+
+
+def test_watcher_pass_writes_sidecar_when_live(watcher_roots, tmp_path, monkeypatch):
+    """A reverted file (dry_run=False) writes one escalate-only sidecar row and
+    dedups within the episode."""
+    monkeypatch.setattr(hpc, "DAEMON_FILE", _write_reverted(tmp_path))
+    asw.happy_patch_pass(dry_run=False)
+    rows = _read_sidecar(watcher_roots)
+    assert len(rows) == 1
+    assert rows[0]["band"] == "happy-patch"
+    assert rows[0]["state"] == "reverted"
+    assert rows[0]["reapply_cmd"] == hpc.REAPPLY_CMD
+    # Second pass at the same state -> deduped, no new row.
+    asw.happy_patch_pass(dry_run=False)
+    assert len(_read_sidecar(watcher_roots)) == 1
+
+
+def test_watcher_pass_missing_is_noop(watcher_roots, tmp_path, monkeypatch):
+    """`missing` (no daemon file) is escalate-only-conservative: no sidecar row
+    (the spawn-path guard owns the precise reachability disambiguation)."""
+    monkeypatch.setattr(hpc, "DAEMON_FILE", _missing_path(tmp_path))
+    asw.happy_patch_pass(dry_run=False)
+    assert _read_sidecar(watcher_roots) == []
+
+
+def test_watcher_pass_clean_when_classify_raises(watcher_roots, monkeypatch):
+    """happy_patch_pass returns cleanly (no raise) when classify_patch raises —
+    fail-soft behavior asserted by test, not just by convention."""
+
+    def _boom(*a, **kw):
+        raise RuntimeError("synthetic classify failure")
+
+    monkeypatch.setattr(hpc, "classify_patch", _boom)
+    # No raise; no sidecar row.
+    asw.happy_patch_pass(dry_run=True)
+    assert _read_sidecar(watcher_roots) == []


### PR DESCRIPTION
Closes task #726.

Adds a fast in-process check that the EPS Happy daemon injection patch (sentinel v4) is still applied BEFORE any spawn path relies on `HAPPY_INITIAL_PROMPT` / `claudeArgs` injection. A silently-reverted patch — or a `npm update happy` hash-bundle rename — now fails loud with a copy-pasteable re-apply command instead of producing idle "spawned but never ran" sessions.

Plus a proactive `happy_patch_pass` in `autonomous_session_watch.py` (daemon-independent, escalate-only, ~10 min cadence).

See clean-result body for full details.