### PR TITLE
task #724: workflow-fix — task.py audit --repair + reconcile_registry

### DIFF
--- a/scripts/task.py
+++ b/scripts/task.py
@@ -56,6 +56,7 @@ from explore_persona_space.task_workflow import (  # noqa: E402
     KINDS,
     STATUSES,
     NewTaskRequest,
+    ReconcileReport,
     add_tag,
     address_concern,
     audit,
@@ -73,6 +74,7 @@ from explore_persona_space.task_workflow import (  # noqa: E402
     post_event,
     promote,
     raise_concern,
+    reconcile_registry,
     remove_tag,
     set_body,
     set_clean_result,
@@ -802,15 +804,66 @@ def cmd_tasks_dir(_args: argparse.Namespace) -> None:
         sys.exit(1)
 
 
+def _print_reconcile_report(rep: ReconcileReport) -> None:
+    """Render a ReconcileReport: per-class counts, then the per-task change
+    lines, then the empty-stub orientation line + skips."""
+    verb = "applied" if rep.applied else "would apply"
+    print(
+        f"reconcile: {len(rep.stale_real)} stale path(s) {verb}, "
+        f"{len(rep.missing_real)} missing entry(ies) {verb}, "
+        f"{len(rep.empty_stubs)} empty stub(s), {len(rep.skipped)} skipped"
+    )
+    for c in rep.stale_real:
+        print(f"  [stale_real] #{c.task_id}: {c.detail}")
+    for c in rep.missing_real:
+        print(f"  [missing_real] #{c.task_id}: {c.detail}")
+    if rep.highest_id_bumped is not None:
+        print(f"  [highest_id] {rep.highest_id_bumped.detail}")
+    if rep.empty_stubs:
+        print("empty stubs (NOT reconciled — surfaced for manual triage):")
+        for c in rep.empty_stubs:
+            print(f"  [empty_stub] #{c.task_id}: {c.detail}")
+        print(
+            "  These are empty task stubs on `main` (no body.md / events.jsonl). "
+            "Their bodies likely live on `issue-<N>` branches that haven't merged. "
+            "Manual triage required."
+        )
+    if rep.skipped:
+        print("skipped (NOT reconciled — registry entry left untouched):")
+        for c in rep.skipped:
+            print(f"  [skipped] #{c.task_id}: {c.detail}")
+
+
 def cmd_audit(args: argparse.Namespace) -> None:
-    problems = audit()
-    if not problems:
-        print("AUDIT PASS — registry and filesystem agree")
+    repair = getattr(args, "repair", False)
+    do_apply = getattr(args, "apply", False)
+    if do_apply and not repair:
+        print("task.py audit: --apply requires --repair", file=sys.stderr)
+        sys.exit(2)
+
+    if not repair:
+        # Report-only mode (unchanged): list drift, exit 1 on any problem.
+        problems = audit()
+        if not problems:
+            print("AUDIT PASS — registry and filesystem agree")
+            return
+        print(f"AUDIT FAIL — {len(problems)} problem(s):")
+        for p in problems:
+            print(f"  - {p}")
+        sys.exit(1)
+
+    rep = reconcile_registry(apply=do_apply)
+    if rep.is_clean:
+        print("registry already reconciled — nothing to repair")
         return
-    print(f"AUDIT FAIL — {len(problems)} problem(s):")
-    for p in problems:
-        print(f"  - {p}")
-    sys.exit(1)
+    _print_reconcile_report(rep)
+    if not do_apply:
+        # Dry-run is informational — always exit 0.
+        return
+    # Apply: exit 0 iff the registry now agrees with the filesystem (no
+    # unresolved empty stubs / skips), else exit 1 so the operator triages.
+    if rep.unresolved_count > 0:
+        sys.exit(1)
 
 
 # ─── Binding-concerns handlers ────────────────────────────────────────────
@@ -1340,6 +1393,20 @@ def main() -> None:
     p.set_defaults(func=cmd_tasks_dir)
 
     p = sub.add_parser("audit", help="validate REGISTRY.json against filesystem")
+    p.add_argument(
+        "--repair",
+        action="store_true",
+        help=(
+            "reconcile REGISTRY.json against the on-disk task tree (re-point "
+            "stale paths + add missing entries, re-snapshotting from each "
+            "task's body.md). Dry-run unless --apply is also passed."
+        ),
+    )
+    p.add_argument(
+        "--apply",
+        action="store_true",
+        help="with --repair: write the reconcile to REGISTRY.json + one git commit.",
+    )
     p.set_defaults(func=cmd_audit)
 
     # ─── Binding-concerns subcommands ────────────────────────────────────

--- a/scripts/task.py
+++ b/scripts/task.py
@@ -838,7 +838,7 @@ def cmd_audit(args: argparse.Namespace) -> None:
     repair = getattr(args, "repair", False)
     do_apply = getattr(args, "apply", False)
     if do_apply and not repair:
-        print("task.py audit: --apply requires --repair", file=sys.stderr)
+        print("use --apply only with --repair", file=sys.stderr)
         sys.exit(2)
 
     if not repair:

--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -2467,6 +2467,328 @@ def audit() -> list[str]:
     return problems
 
 
+# ─── Registry reconcile (`task.py audit --repair`) ──────────────────────────
+
+
+@dataclass(frozen=True)
+class RegistryChange:
+    """One drift entry surfaced by :func:`reconcile_registry`.
+
+    ``drift_class`` is one of ``"stale_real" | "missing_real" | "empty_stub"
+    | "skipped" | "highest_id"``. ``detail`` is a human-readable description
+    (with the relevant on-disk path) for the CLI report and the test
+    assertions. ``task_id`` is the integer id (``-1`` for the ``highest_id``
+    bump, which is not tied to a single task).
+    """
+
+    task_id: int
+    drift_class: str
+    detail: str
+
+
+# Internal planning record: a reconcilable drift whose registry entry the
+# apply path will (re-)write from ``actual / "body.md"``. ``registry_path`` is
+# the stale REGISTRY ``path`` string for a ``stale_real`` entry, or ``None``
+# for a ``missing_real`` (no registry entry yet). ``actual`` is the task's
+# REAL on-disk folder (always under tasks_dir()), so the value passed to
+# ``_registry_set`` resolves ``_status_from_path`` correctly.
+@dataclass(frozen=True)
+class _PendingReconcile:
+    task_id: int
+    drift_class: str  # "stale_real" | "missing_real"
+    registry_path: str | None
+    actual: Path
+
+
+@dataclass(frozen=True)
+class ReconcileReport:
+    """Result of :func:`reconcile_registry`.
+
+    Drift is split into FOUR classes. ``stale_real`` + ``missing_real`` are the
+    RECONCILABLE classes (re-pointed / added, re-snapshotted from the task's
+    actual on-disk ``body.md``); on the apply path these lists hold only the
+    entries that were ACTUALLY written. ``empty_stubs`` (a task dir with no
+    ``body.md``) and ``skipped`` (a task that should reconcile but whose body
+    is unreadable / its folder is genuinely gone) are NEVER written to the
+    registry — surfaced for manual triage, never fabricated, never deleted.
+    """
+
+    applied: bool
+    stale_real: list[RegistryChange]
+    missing_real: list[RegistryChange]
+    empty_stubs: list[RegistryChange]
+    skipped: list[RegistryChange]
+    highest_id_bumped: RegistryChange | None
+
+    @property
+    def reconciled_count(self) -> int:
+        """Number of registry mutations: re-pointed + added + the highest_id bump."""
+        return len(self.stale_real) + len(self.missing_real) + (1 if self.highest_id_bumped else 0)
+
+    @property
+    def unresolved_count(self) -> int:
+        """Drift the reconcile cannot fix on its own — empty stubs + skips.
+
+        The CLI exits 1 when this is non-zero (after an apply): the registry
+        still disagrees with the filesystem and an operator must triage.
+        """
+        return len(self.empty_stubs) + len(self.skipped)
+
+    @property
+    def is_clean(self) -> bool:
+        """True iff there was nothing to reconcile AND no unresolved drift."""
+        return self.reconciled_count == 0 and self.unresolved_count == 0
+
+
+def _reconcile_change(task_id: int | str, drift_class: str, detail: str) -> RegistryChange:
+    return RegistryChange(task_id=int(task_id), drift_class=drift_class, detail=detail)
+
+
+def _reconcile_commit_msg(
+    stale: list[_PendingReconcile],
+    missing: list[_PendingReconcile],
+    bumped: RegistryChange | None,
+) -> str:
+    parts = [f"registry-reconcile: {len(stale)} path(s) fixed, {len(missing)} entry(ies) added"]
+    if missing:
+        ids = ", ".join(f"#{p.task_id}" for p in missing)
+        parts.append(f"added {ids}")
+    if bumped:
+        parts.append(bumped.detail)
+    return "; ".join(parts)
+
+
+def _reconcile_pending_change(p: _PendingReconcile, repo: Path) -> RegistryChange:
+    rel = str(p.actual.relative_to(repo))
+    if p.drift_class == "stale_real":
+        detail = f"{p.registry_path} -> {rel} (re-pointed + re-snapshotted)"
+    else:
+        detail = f"added at {rel} (re-snapshotted)"
+    return _reconcile_change(p.task_id, p.drift_class, detail)
+
+
+def _reconcile_highest_id(reg: dict[str, Any]) -> None:
+    """Final sanity pass: bump highest_id to max registered id if it drifted
+    low. (A ``missing_real`` add already bumps it inside ``_registry_set``;
+    this also catches a registry whose highest_id drifted below max another
+    way.) Mutates ``reg`` in place."""
+    ids = [int(t) for t in reg.get("tasks", {})]
+    target = max(ids) if ids else 0
+    if target > reg.get("highest_id", 0):
+        reg["highest_id"] = target
+
+
+def _reconcile_bump_change(before: int, after: int) -> RegistryChange | None:
+    """A ``highest_id`` RegistryChange iff it net-increased across the reconcile
+    — regardless of whether ``_registry_set`` or ``_reconcile_highest_id`` did it."""
+    if after > before:
+        return _reconcile_change(-1, "highest_id", f"highest_id {before}->{after}")
+    return None
+
+
+def _reconcile_scan_disk(td: Path) -> dict[str, Path]:
+    """Map ``str(task_id) -> actual on-disk Path`` for every task dir under a
+    valid ``STATUSES`` folder. Scanned once per reconcile."""
+    disk: dict[str, Path] = {}
+    if not td.exists():
+        return disk
+    for status_dir in td.iterdir():
+        if not status_dir.is_dir() or status_dir.name not in STATUSES:
+            continue
+        for child in status_dir.iterdir():
+            if child.is_dir() and child.name.isdigit():
+                disk[child.name] = child
+    return disk
+
+
+def _reconcile_plan(
+    repo: Path, td: Path, reg: dict[str, Any]
+) -> tuple[
+    list[_PendingReconcile],
+    list[_PendingReconcile],
+    list[RegistryChange],
+    list[RegistryChange],
+]:
+    """Classify every drift between ``reg`` and the on-disk task tree into the
+    four classes (stale_real / missing_real / empty_stub / skipped). Pure read;
+    never mutates ``reg`` or the filesystem. See :func:`reconcile_registry` for
+    the class definitions."""
+
+    def _has_body(p: Path) -> bool:
+        # Cheap EXISTENCE check (classification, not a parse). Keeps an empty
+        # stub away from `_read_body`, so a missing body.md never raises
+        # FileNotFoundError and crashes the whole run.
+        return (p / "body.md").exists()
+
+    def _rel(p: Path) -> str:
+        return str(p.relative_to(repo))
+
+    disk = _reconcile_scan_disk(td)
+    stale_real: list[_PendingReconcile] = []
+    missing_real: list[_PendingReconcile] = []
+    empty_stubs: list[RegistryChange] = []
+    skipped: list[RegistryChange] = []
+    tasks = reg.get("tasks", {})
+
+    # Class 1 — registry entry whose path is missing (or present-but-bodyless).
+    for tid, entry in tasks.items():
+        abs_path = repo / entry["path"]
+        if abs_path.is_dir():
+            # 1b — registered, dir exists, but body.md is gone -> empty stub
+            # (the audit() :2446-2448 sub-check, folded into empty_stubs).
+            if not _has_body(abs_path):
+                empty_stubs.append(
+                    _reconcile_change(
+                        tid,
+                        "empty_stub",
+                        f"registered at {entry['path']}, dir exists but body.md missing",
+                    )
+                )
+            continue  # registry path fine (or 1b handled) — not stale.
+        actual = disk.get(tid)
+        if actual is None:
+            # Registry path stale AND task genuinely gone from disk. Leave the
+            # entry untouched (dropping it would lose a real entry).
+            skipped.append(
+                _reconcile_change(
+                    tid,
+                    "skipped",
+                    f"registry path {entry['path']!r} missing AND no on-disk folder found",
+                )
+            )
+            continue
+        if not _has_body(actual):
+            empty_stubs.append(
+                _reconcile_change(
+                    tid,
+                    "empty_stub",
+                    f"registry path {entry['path']!r} missing; on-disk dir "
+                    f"{_rel(actual)} has no body.md",
+                )
+            )
+            continue
+        stale_real.append(_PendingReconcile(int(tid), "stale_real", entry["path"], actual))
+
+    # Class 2 — on disk but unregistered.
+    for tid, actual in disk.items():
+        if tid in tasks:
+            continue
+        if not _has_body(actual):
+            empty_stubs.append(
+                _reconcile_change(
+                    tid,
+                    "empty_stub",
+                    f"on disk at {_rel(actual)} but no body.md "
+                    f"(likely unmerged issue-{tid} branch residue)",
+                )
+            )
+            continue
+        missing_real.append(_PendingReconcile(int(tid), "missing_real", None, actual))
+
+    return stale_real, missing_real, empty_stubs, skipped
+
+
+def _reconcile_apply_pending(
+    reg: dict[str, Any],
+    pending: list[_PendingReconcile],
+    skipped: list[RegistryChange],
+) -> list[_PendingReconcile]:
+    """Re-snapshot each pending reconcile into ``reg`` from its actual on-disk
+    ``body.md``. A body that passed the plan-time ``exists()`` check but is now
+    unreadable (``FileNotFoundError`` if it vanished, ``ValueError`` for
+    malformed YAML) is appended to ``skipped`` and left out of the registry —
+    never fabricated, never aborting the whole run. Returns the entries that
+    were ACTUALLY written. Mutates ``reg`` + ``skipped`` in place."""
+    applied: list[_PendingReconcile] = []
+    for pend in pending:
+        try:
+            fm, _ = _read_body(pend.actual / "body.md")
+        except (FileNotFoundError, ValueError) as exc:
+            skipped.append(_reconcile_change(pend.task_id, "skipped", f"body.md unreadable: {exc}"))
+            continue
+        _registry_set(reg, pend.task_id, pend.actual, fm)
+        applied.append(pend)
+    return applied
+
+
+def reconcile_registry(*, apply: bool = False) -> ReconcileReport:
+    """Reconcile REGISTRY.json against the on-disk task tree.
+
+    Mirrors :func:`audit`'s detection so the two never disagree about WHAT
+    counts as drift, then classifies each drift by whether the task has a
+    readable ``body.md``:
+
+    - **stale_real** — a registry entry whose ``path`` is missing, but the task
+      lives elsewhere on disk WITH a ``body.md``: re-point + re-snapshot.
+    - **missing_real** — an on-disk task dir WITH a ``body.md`` absent from the
+      registry: add the entry + re-snapshot (this is the live #703 case).
+    - **empty_stub** — a task dir with NO ``body.md`` (registered-but-bodyless,
+      or on-disk-and-unregistered-and-bodyless). Surfaced, NEVER reconciled,
+      NEVER fabricated into the registry, NEVER deleted (the dir may be live
+      residue of an active ``issue-<N>`` branch). **Policy:** any task dir
+      lacking ``body.md``, registered or not, is an empty stub.
+    - **skipped** — a registry entry whose path is missing AND no on-disk
+      folder is found anywhere (its existing entry is left untouched, not
+      dropped — erasing a real entry would lose data), OR a reconcilable task
+      whose ``body.md`` exists but is unreadable (malformed YAML / vanished
+      between the existence check and the read).
+
+    Writes ONLY ``tasks/REGISTRY.json`` — never moves a task folder, changes a
+    status, or touches ``body.md`` / any task content. Pure read in dry-run
+    (``apply=False``); under ``_locked()`` (re-read + re-plan inside the lock)
+    on the apply path. Idempotent: a second apply on a now-consistent registry
+    produces zero diff and no commit.
+    """
+    repo = repo_root()
+    td = tasks_dir()
+
+    if not apply:
+        reg = _load_registry()
+        stale, missing, empty_stubs, skipped = _reconcile_plan(repo, td, reg)
+        # Dry-run preview of the net highest_id bump (computed on a copy — no
+        # write). A missing_real adds an id; the bump is max(disk ids) vs the
+        # current highest_id.
+        before = reg.get("highest_id", 0)
+        preview: dict[str, Any] = {"highest_id": before, "tasks": dict(reg.get("tasks", {}))}
+        for p in stale + missing:
+            preview["tasks"][str(p.task_id)] = {"path": str(p.actual.relative_to(repo))}
+        _reconcile_highest_id(preview)
+        return ReconcileReport(
+            applied=False,
+            stale_real=[_reconcile_pending_change(p, repo) for p in stale],
+            missing_real=[_reconcile_pending_change(p, repo) for p in missing],
+            empty_stubs=empty_stubs,
+            skipped=skipped,
+            highest_id_bumped=_reconcile_bump_change(before, preview["highest_id"]),
+        )
+
+    with _locked():
+        # Re-read + re-plan INSIDE the lock: a concurrent writer (e.g. a live
+        # issue-<N> branch merging body.md to main) may have changed the
+        # registry since any dry-run, so a stale task simply reclassifies.
+        reg = _load_registry()
+        highest_before = reg.get("highest_id", 0)
+        stale, missing, empty_stubs, skipped = _reconcile_plan(repo, td, reg)
+        applied_stale = _reconcile_apply_pending(reg, stale, skipped)
+        applied_missing = _reconcile_apply_pending(reg, missing, skipped)
+        _reconcile_highest_id(reg)
+        bumped = _reconcile_bump_change(highest_before, reg.get("highest_id", 0))
+        if applied_stale or applied_missing or bumped:
+            _save_registry(reg)
+            _git_commit(
+                [registry_path()],
+                _reconcile_commit_msg(applied_stale, applied_missing, bumped),
+            )
+        return ReconcileReport(
+            applied=True,
+            stale_real=[_reconcile_pending_change(p, repo) for p in applied_stale],
+            missing_real=[_reconcile_pending_change(p, repo) for p in applied_missing],
+            empty_stubs=empty_stubs,
+            skipped=skipped,
+            highest_id_bumped=bumped,
+        )
+
+
 # ─── Comments ──────────────────────────────────────────────────────────────
 
 
@@ -3029,6 +3351,8 @@ __all__ = [
     "TASKS_DIR",  # noqa: F822 — PEP-562 lazy attr (see __getattr__)
     "TERMINAL_STATUSES",
     "NewTaskRequest",
+    "ReconcileReport",
+    "RegistryChange",
     "add_tag",
     "address_concern",
     "append_comment",
@@ -3050,6 +3374,7 @@ __all__ = [
     "post_event",
     "promote",
     "raise_concern",
+    "reconcile_registry",
     "registry_path",
     "remove_tag",
     "repo_root",

--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -2567,13 +2567,17 @@ def _reconcile_pending_change(p: _PendingReconcile, repo: Path) -> RegistryChang
     return _reconcile_change(p.task_id, p.drift_class, detail)
 
 
-def _reconcile_highest_id(reg: dict[str, Any]) -> None:
-    """Final sanity pass: bump highest_id to max registered id if it drifted
-    low. (A ``missing_real`` add already bumps it inside ``_registry_set``;
-    this also catches a registry whose highest_id drifted below max another
-    way.) Mutates ``reg`` in place."""
+def _reconcile_highest_id(reg: dict[str, Any], max_disk_id: int = 0) -> None:
+    """Final sanity pass: bump highest_id to ``max(max registered id, max ON-DISK
+    id)`` if it drifted low. (A ``missing_real`` add already bumps it inside
+    ``_registry_set``; this also catches a registry whose highest_id drifted
+    below max another way.) ``max_disk_id`` covers task-dir ids that are NEVER
+    written to ``reg["tasks"]`` — an ``empty_stub`` (a bodyless dir) is surfaced
+    but never fabricated into the registry, so its id would otherwise be invisible
+    here; leaving ``highest_id`` below such a stub id lets a later ``create_task``
+    re-allocate (and collide with) it. Mutates ``reg`` in place."""
     ids = [int(t) for t in reg.get("tasks", {})]
-    target = max(ids) if ids else 0
+    target = max([*ids, max_disk_id], default=0)
     if target > reg.get("highest_id", 0):
         reg["highest_id"] = target
 
@@ -2608,11 +2612,15 @@ def _reconcile_plan(
     list[_PendingReconcile],
     list[RegistryChange],
     list[RegistryChange],
+    dict[str, Path],
 ]:
     """Classify every drift between ``reg`` and the on-disk task tree into the
     four classes (stale_real / missing_real / empty_stub / skipped). Pure read;
     never mutates ``reg`` or the filesystem. See :func:`reconcile_registry` for
-    the class definitions."""
+    the class definitions. Also returns the ``str(task_id) -> Path`` ``disk``
+    map it scans, so the caller can fold the max ON-DISK id (incl. empty-stub
+    ids never written to the registry) into the ``highest_id`` bump without a
+    second scan."""
 
     def _has_body(p: Path) -> bool:
         # Cheap EXISTENCE check (classification, not a parse). Keeps an empty
@@ -2685,7 +2693,7 @@ def _reconcile_plan(
             continue
         missing_real.append(_PendingReconcile(int(tid), "missing_real", None, actual))
 
-    return stale_real, missing_real, empty_stubs, skipped
+    return stale_real, missing_real, empty_stubs, skipped, disk
 
 
 def _reconcile_apply_pending(
@@ -2744,15 +2752,18 @@ def reconcile_registry(*, apply: bool = False) -> ReconcileReport:
 
     if not apply:
         reg = _load_registry()
-        stale, missing, empty_stubs, skipped = _reconcile_plan(repo, td, reg)
+        stale, missing, empty_stubs, skipped, disk = _reconcile_plan(repo, td, reg)
         # Dry-run preview of the net highest_id bump (computed on a copy — no
-        # write). A missing_real adds an id; the bump is max(disk ids) vs the
-        # current highest_id.
+        # write). A missing_real adds an id; the bump is max(registered ids,
+        # ON-DISK ids) vs the current highest_id. The disk max covers empty-stub
+        # ids that are never written to the registry (so they cannot be found by
+        # scanning reg["tasks"]) yet still constrain the next free id.
         before = reg.get("highest_id", 0)
+        max_disk_id = max((int(t) for t in disk), default=0)
         preview: dict[str, Any] = {"highest_id": before, "tasks": dict(reg.get("tasks", {}))}
         for p in stale + missing:
             preview["tasks"][str(p.task_id)] = {"path": str(p.actual.relative_to(repo))}
-        _reconcile_highest_id(preview)
+        _reconcile_highest_id(preview, max_disk_id)
         return ReconcileReport(
             applied=False,
             stale_real=[_reconcile_pending_change(p, repo) for p in stale],
@@ -2768,10 +2779,11 @@ def reconcile_registry(*, apply: bool = False) -> ReconcileReport:
         # registry since any dry-run, so a stale task simply reclassifies.
         reg = _load_registry()
         highest_before = reg.get("highest_id", 0)
-        stale, missing, empty_stubs, skipped = _reconcile_plan(repo, td, reg)
+        stale, missing, empty_stubs, skipped, disk = _reconcile_plan(repo, td, reg)
+        max_disk_id = max((int(t) for t in disk), default=0)
         applied_stale = _reconcile_apply_pending(reg, stale, skipped)
         applied_missing = _reconcile_apply_pending(reg, missing, skipped)
-        _reconcile_highest_id(reg)
+        _reconcile_highest_id(reg, max_disk_id)
         bumped = _reconcile_bump_change(highest_before, reg.get("highest_id", 0))
         if applied_stale or applied_missing or bumped:
             _save_registry(reg)

--- a/tests/test_task_workflow.py
+++ b/tests/test_task_workflow.py
@@ -1040,9 +1040,14 @@ def test_reconcile_classifies_empty_stub_not_drift(fake_repo):
     assert 9002 not in [c.task_id for c in rep.stale_real]
     assert 9002 not in [c.task_id for c in rep.missing_real]
     assert 9002 not in [c.task_id for c in rep.skipped]
-    # No fabricated registry entry, no commit, the dir survives intact.
+    # No fabricated registry entry, the dir survives intact.
     assert "9002" not in _read_registry(repo)["tasks"]
-    assert _git_log_count(repo) == commits_before
+    # The stub id (9002 > highest_id 1) DOES bump highest_id — a single registry
+    # commit, NOT a fabricated entry — to keep the next create_task id past the
+    # on-disk stub (see test_reconcile_bumps_highest_id_for_empty_stub).
+    assert rep.highest_id_bumped is not None
+    assert _read_registry(repo)["highest_id"] == 9002
+    assert _git_log_count(repo) == commits_before + 1
     assert (stub / "artifacts").is_dir()
     assert rep.unresolved_count >= 1
     # CLI exits 1 because an empty stub remains.
@@ -1159,6 +1164,29 @@ def test_reconcile_bumps_highest_id(fake_repo):
 
     assert rep.highest_id_bumped is not None
     assert _read_registry(repo)["highest_id"] == 9999
+
+
+def test_reconcile_bumps_highest_id_for_empty_stub(fake_repo):
+    """A bodyless empty-stub dir whose id > highest_id MUST still bump highest_id,
+    even though the stub is NEVER written to the registry. Otherwise a later
+    create_task re-allocates the stub id and collides with the on-disk dir
+    (mkdir(exist_ok=False) crash in proposed/, silent dup elsewhere). Regression
+    for the round-1 _reconcile_highest_id-ignores-empty-stub-disk-ids BLOCKER:
+    the bump must consider ALL on-disk ids, not just registered ones."""
+    repo, tw = fake_repo
+    tw.create_task(tw.NewTaskRequest(kind="experiment", title="A"))  # highest_id = 1
+    _make_empty_stub(repo, 9999, status="completed")  # id 9999 > highest_id, NO body.md
+
+    rep = tw.reconcile_registry(apply=True)
+
+    # The bump fired and lifted highest_id to the stub id.
+    assert rep.highest_id_bumped is not None
+    assert _read_registry(repo)["highest_id"] == 9999
+    # No registry entry was fabricated for the stub (it has no body.md).
+    assert "9999" not in _read_registry(repo)["tasks"]
+    # The stub is still surfaced as unresolved drift, never reconciled.
+    assert 9999 in [c.task_id for c in rep.empty_stubs]
+    assert 9999 not in [c.task_id for c in rep.missing_real]
 
 
 def test_reconcile_clean_registry_is_noop(fake_repo):

--- a/tests/test_task_workflow.py
+++ b/tests/test_task_workflow.py
@@ -13,10 +13,12 @@ auto-push is disabled by leaving TASK_PY_AUTO_PUSH unset.
 
 from __future__ import annotations
 
+import argparse
 import concurrent.futures
 import json
 import logging
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -888,6 +890,324 @@ def test_audit_detects_orphan_dir(fake_repo):
     (orphan / "body.md").write_text("---\ntitle: orphan\n---\n")
     problems = tw.audit()
     assert any("9999" in p for p in problems)
+
+
+# ─── Registry reconcile (`audit --repair`) ─────────────────────────────────
+
+
+def _import_task_cli():
+    """Import scripts/task.py as `task` (the CLI handler layer). Exercised at
+    the handler-function layer, not via subprocess — `repo_root()` branch-guards
+    to `main`, so a subprocess would bypass the fake_repo monkeypatch (same
+    rationale as test_cli_handlers_raise_address_defer_list_roundtrip)."""
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+    import task as task_cli  # type: ignore[import-not-found]
+
+    return task_cli
+
+
+def _read_registry(repo: Path) -> dict:
+    return json.loads((repo / "tasks" / "REGISTRY.json").read_text())
+
+
+def _write_registry(repo: Path, reg: dict) -> None:
+    (repo / "tasks" / "REGISTRY.json").write_text(json.dumps(reg, indent=2, sort_keys=True) + "\n")
+
+
+def _make_orphan_with_body(
+    repo: Path, tid: int, status: str = "proposed", *, title: str = "orphan", kind: str = "infra"
+) -> Path:
+    """An on-disk task dir WITH a valid body.md, NOT in the registry -> missing_real."""
+    d = repo / "tasks" / status / str(tid)
+    d.mkdir(parents=True)
+    (d / "body.md").write_text(f"---\ntitle: {title}\nkind: {kind}\n---\nbody for {tid}\n")
+    return d
+
+
+def _make_empty_stub(repo: Path, tid: int, status: str = "completed") -> Path:
+    """An on-disk task dir with NO body.md and NO events.jsonl — only an
+    artifacts/ subdir (the live #698-#709 shape) -> empty_stub."""
+    d = repo / "tasks" / status / str(tid)
+    (d / "artifacts").mkdir(parents=True)
+    return d
+
+
+def _induce_stale_real(repo: Path, tw, *, status: str = "completed") -> int:
+    """Register a task, then physically move its folder to `status` and rewrite
+    the registry path to a NON-existent location -> stale registry path, real
+    body.md on disk elsewhere -> stale_real."""
+    tid = tw.create_task(tw.NewTaskRequest(kind="infra", title="stale-me"))
+    src = repo / "tasks" / "proposed" / str(tid)
+    dst = repo / "tasks" / status / str(tid)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    src.rename(dst)
+    reg = _read_registry(repo)
+    reg["tasks"][str(tid)]["path"] = f"tasks/approved/{tid}"  # non-existent
+    _write_registry(repo, reg)
+    return tid
+
+
+def _snapshot_tasks_tree(repo: Path) -> dict[str, bytes]:
+    """Map every file under tasks/ (EXCEPT REGISTRY.json) to its bytes."""
+    td = repo / "tasks"
+    out: dict[str, bytes] = {}
+    for p in sorted(td.rglob("*")):
+        if p.is_file() and p.name != "REGISTRY.json":
+            out[str(p.relative_to(td))] = p.read_bytes()
+    return out
+
+
+def test_reconcile_dry_run_reports_without_mutating(fake_repo):
+    repo, tw = fake_repo
+    tw.create_task(tw.NewTaskRequest(kind="experiment", title="keep-A"))
+    tw.create_task(tw.NewTaskRequest(kind="experiment", title="keep-B"))
+    stale_id = _induce_stale_real(repo, tw)
+    _make_orphan_with_body(repo, 9001)
+
+    reg_before = (repo / "tasks" / "REGISTRY.json").read_bytes()
+    commits_before = _git_log_count(repo)
+
+    rep = tw.reconcile_registry(apply=False)
+
+    assert rep.applied is False
+    assert [c.task_id for c in rep.stale_real] == [stale_id]
+    assert [c.task_id for c in rep.missing_real] == [9001]
+    assert rep.empty_stubs == []
+    assert rep.skipped == []
+    # No mutation.
+    assert (repo / "tasks" / "REGISTRY.json").read_bytes() == reg_before
+    assert _git_log_count(repo) == commits_before
+
+
+def test_reconcile_apply_fixes_stale_path(fake_repo):
+    repo, tw = fake_repo
+    stale_id = _induce_stale_real(repo, tw, status="completed")
+    commits_before = _git_log_count(repo)
+
+    rep = tw.reconcile_registry(apply=True)
+
+    assert rep.applied is True
+    assert [c.task_id for c in rep.stale_real] == [stale_id]
+    reg = _read_registry(repo)
+    entry = reg["tasks"][str(stale_id)]
+    assert entry["path"] == f"tasks/completed/{stale_id}"
+    # Re-snapshotted status reflects the REAL on-disk folder, not the stale entry.
+    assert entry["status"] == "completed"
+    # Exactly one new commit, touching ONLY REGISTRY.json.
+    assert _git_log_count(repo) == commits_before + 1
+    show = subprocess.run(
+        ["git", "show", "--name-only", "--format=", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    touched = [ln for ln in show.stdout.splitlines() if ln.strip()]
+    assert touched == ["tasks/REGISTRY.json"]
+
+
+def test_reconcile_apply_adds_missing_entry(fake_repo):
+    repo, tw = fake_repo
+    tw.create_task(tw.NewTaskRequest(kind="experiment", title="keep"))
+    _make_orphan_with_body(repo, 9001, status="completed", title="found me", kind="infra")
+    commits_before = _git_log_count(repo)
+
+    rep = tw.reconcile_registry(apply=True)
+
+    assert [c.task_id for c in rep.missing_real] == [9001]
+    reg = _read_registry(repo)
+    entry = reg["tasks"]["9001"]
+    assert entry["path"] == "tasks/completed/9001"
+    assert entry["title"] == "found me"
+    assert entry["kind"] == "infra"
+    assert entry["status"] == "completed"
+    assert entry["has_clean_result"] is False
+    assert _git_log_count(repo) == commits_before + 1
+
+
+def test_reconcile_classifies_empty_stub_not_drift(fake_repo):
+    """An on-disk dir with only artifacts/ (no body.md, no events.jsonl) is an
+    empty stub — NOT reconciled, NOT fabricated, NOT deleted; CLI exits 1."""
+    repo, tw = fake_repo
+    tw.create_task(tw.NewTaskRequest(kind="experiment", title="keep"))
+    stub = _make_empty_stub(repo, 9002, status="completed")
+    commits_before = _git_log_count(repo)
+
+    rep = tw.reconcile_registry(apply=True)
+
+    stub_ids = [c.task_id for c in rep.empty_stubs]
+    assert 9002 in stub_ids
+    assert 9002 not in [c.task_id for c in rep.stale_real]
+    assert 9002 not in [c.task_id for c in rep.missing_real]
+    assert 9002 not in [c.task_id for c in rep.skipped]
+    # No fabricated registry entry, no commit, the dir survives intact.
+    assert "9002" not in _read_registry(repo)["tasks"]
+    assert _git_log_count(repo) == commits_before
+    assert (stub / "artifacts").is_dir()
+    assert rep.unresolved_count >= 1
+    # CLI exits 1 because an empty stub remains.
+    task_cli = _import_task_cli()
+    args = argparse.Namespace(repair=True, apply=True)
+    with pytest.raises(SystemExit) as exc:
+        task_cli.cmd_audit(args)
+    assert exc.value.code == 1
+
+
+def test_reconcile_handles_missing_body_md(fake_repo):
+    """MF2 (the FileNotFoundError half): a registered task whose dir EXISTS but
+    body.md is absent lands in empty_stubs; no FileNotFoundError escapes."""
+    repo, tw = fake_repo
+    tid = tw.create_task(tw.NewTaskRequest(kind="experiment", title="will-lose-body"))
+    (repo / "tasks" / "proposed" / str(tid) / "body.md").unlink()
+    # An also-reconcilable orphan alongside, to prove the run does not abort.
+    _make_orphan_with_body(repo, 9003, status="completed")
+
+    rep = tw.reconcile_registry(apply=True)  # must NOT raise
+
+    assert tid in [c.task_id for c in rep.empty_stubs]
+    # The detail string records that the stub was REGISTERED.
+    stub = next(c for c in rep.empty_stubs if c.task_id == tid)
+    assert "registered" in stub.detail
+    # The registered entry is left untouched (not removed, not re-snapshotted).
+    assert str(tid) in _read_registry(repo)["tasks"]
+    # The healthy orphan still reconciled despite the stub.
+    assert 9003 in [c.task_id for c in rep.missing_real]
+    assert "9003" in _read_registry(repo)["tasks"]
+
+
+def test_reconcile_skips_unparseable_body(fake_repo):
+    """The ValueError half: an orphan whose body.md EXISTS but has malformed
+    frontmatter lands in skipped (NOT empty_stubs — the file exists); the run
+    continues and an also-reconcilable task still applies."""
+    repo, tw = fake_repo
+    tw.create_task(tw.NewTaskRequest(kind="experiment", title="keep"))
+    bad = repo / "tasks" / "completed" / "9004"
+    bad.mkdir(parents=True)
+    (bad / "body.md").write_text("---\n: : :\n---\nbody\n")  # malformed YAML
+    _make_orphan_with_body(repo, 9005, status="completed")
+
+    rep = tw.reconcile_registry(apply=True)  # must NOT raise
+
+    assert 9004 in [c.task_id for c in rep.skipped]
+    assert 9004 not in [c.task_id for c in rep.empty_stubs]
+    assert "9004" not in _read_registry(repo)["tasks"]  # no fabrication
+    # The healthy orphan still applied despite the per-task skip.
+    assert 9005 in [c.task_id for c in rep.missing_real]
+    assert "9005" in _read_registry(repo)["tasks"]
+    assert rep.unresolved_count >= 1
+
+
+def test_reconcile_stale_path_no_actual_folder_skip(fake_repo):
+    """A registry entry pointing nowhere AND no on-disk folder anywhere lands in
+    skipped — the existing entry is NOT silently dropped."""
+    repo, tw = fake_repo
+    tid = tw.create_task(tw.NewTaskRequest(kind="experiment", title="gone"))
+    src = repo / "tasks" / "proposed" / str(tid)
+    shutil.rmtree(src)  # remove the folder entirely
+    reg = _read_registry(repo)
+    reg["tasks"][str(tid)]["path"] = f"tasks/approved/{tid}"  # non-existent
+    _write_registry(repo, reg)
+
+    rep = tw.reconcile_registry(apply=True)
+
+    assert tid in [c.task_id for c in rep.skipped]
+    assert tid not in [c.task_id for c in rep.empty_stubs]
+    # The entry is preserved (dropping it would lose a real task).
+    assert str(tid) in _read_registry(repo)["tasks"]
+    assert rep.unresolved_count >= 1
+
+
+def test_reconcile_never_touches_task_folders(fake_repo):
+    repo, tw = fake_repo
+    _induce_stale_real(repo, tw, status="completed")
+    _make_orphan_with_body(repo, 9006, status="completed")
+    _make_empty_stub(repo, 9007, status="completed")
+
+    before = _snapshot_tasks_tree(repo)
+    tw.reconcile_registry(apply=True)
+    after = _snapshot_tasks_tree(repo)
+
+    assert before == after  # no task content created/modified/deleted
+
+
+def test_reconcile_is_idempotent(fake_repo):
+    repo, tw = fake_repo
+    _make_orphan_with_body(repo, 9008, status="completed")
+    _make_empty_stub(repo, 9009, status="completed")
+
+    tw.reconcile_registry(apply=True)
+    reg_after_first = (repo / "tasks" / "REGISTRY.json").read_bytes()
+    commits_after_first = _git_log_count(repo)
+
+    rep2 = tw.reconcile_registry(apply=True)
+
+    # The missing_real is now registered, the empty stub never wrote -> zero diff.
+    assert (repo / "tasks" / "REGISTRY.json").read_bytes() == reg_after_first
+    assert _git_log_count(repo) == commits_after_first
+    assert rep2.missing_real == []
+    assert rep2.stale_real == []
+    # The empty stub is still surfaced on the second run (it was never fixed).
+    assert 9009 in [c.task_id for c in rep2.empty_stubs]
+
+
+def test_reconcile_bumps_highest_id(fake_repo):
+    repo, tw = fake_repo
+    tw.create_task(tw.NewTaskRequest(kind="experiment", title="A"))  # highest_id = 1
+    _make_orphan_with_body(repo, 9999, status="completed")
+
+    rep = tw.reconcile_registry(apply=True)
+
+    assert rep.highest_id_bumped is not None
+    assert _read_registry(repo)["highest_id"] == 9999
+
+
+def test_reconcile_clean_registry_is_noop(fake_repo):
+    repo, tw = fake_repo
+    tw.create_task(tw.NewTaskRequest(kind="experiment", title="A"))
+    tw.create_task(tw.NewTaskRequest(kind="experiment", title="B"))
+    reg_before = (repo / "tasks" / "REGISTRY.json").read_bytes()
+    commits_before = _git_log_count(repo)
+
+    rep = tw.reconcile_registry(apply=True)
+
+    assert rep.is_clean
+    assert (repo / "tasks" / "REGISTRY.json").read_bytes() == reg_before
+    assert _git_log_count(repo) == commits_before
+
+
+def test_reconcile_cli_exits_0_when_only_reconcilable(fake_repo):
+    """audit --repair --apply exits 0 when the apply leaves no unresolved drift."""
+    repo, tw = fake_repo
+    tw.create_task(tw.NewTaskRequest(kind="experiment", title="keep"))
+    _make_orphan_with_body(repo, 9010, status="completed")
+
+    task_cli = _import_task_cli()
+    args = argparse.Namespace(repair=True, apply=True)
+    # No SystemExit (exit 0) — only a reconcilable missing_real, no stubs/skips.
+    task_cli.cmd_audit(args)
+    assert "9010" in _read_registry(repo)["tasks"]
+
+
+def test_reconcile_cli_dry_run_always_exits_0(fake_repo):
+    """audit --repair (no --apply) is informational — exit 0 even with stubs."""
+    repo, tw = fake_repo
+    tw.create_task(tw.NewTaskRequest(kind="experiment", title="keep"))
+    _make_empty_stub(repo, 9011, status="completed")
+    task_cli = _import_task_cli()
+    args = argparse.Namespace(repair=True, apply=False)
+    task_cli.cmd_audit(args)  # no SystemExit
+    # Dry-run did not write a registry entry for the stub.
+    assert "9011" not in _read_registry(repo).get("tasks", {})
+
+
+def test_reconcile_cli_apply_requires_repair(fake_repo):
+    """--apply without --repair is a usage error (exit 2)."""
+    _repo, _tw = fake_repo
+    task_cli = _import_task_cli()
+    args = argparse.Namespace(repair=False, apply=True)
+    with pytest.raises(SystemExit) as exc:
+        task_cli.cmd_audit(args)
+    assert exc.value.code == 2
 
 
 # ─── Comments ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes task #724. Adds `task.py audit --repair [--apply]` + `task_workflow.reconcile_registry()` to reconcile `tasks/REGISTRY.json` drift against the on-disk task layout. Four drift classes (`stale_real` / `missing_real` / `empty_stubs` / `skipped`); never fabricates / never deletes / never moves. Live reconcile (commit 74e0786c65 on main) added #703 to registry; 12 remaining drift dirs correctly classified as empty stubs (bodies on unmerged issue-<N> branches). 16 new reconcile tests; full pytest 5695/0. Ensemble review trail in events.jsonl.