### PR TITLE
issue-731: catch inline-backtick-wrapped bracketed CIs in audit interval_inline

### DIFF
--- a/scripts/audit_clean_results_body_discipline.py
+++ b/scripts/audit_clean_results_body_discipline.py
@@ -204,6 +204,24 @@ def strip_code(text: str) -> str:
     return text
 
 
+def strip_fenced_code_only(text: str) -> str:
+    """Remove fenced ```...``` code blocks but KEEP inline-backtick spans.
+
+    Companion to :func:`strip_code`. The `interval_inline` scan source uses
+    THIS helper (not `strip_code`) so an inline-backtick-wrapped bracketed
+    CI in reader-facing prose (e.g. ``CI `[-0.295, +0.083]` ``) is still
+    seen by the bracketed-CI regex — `strip_code`'s inline-backtick blanking
+    (the `` `[^`\\n]*` `` substitution) otherwise removes it before the scan
+    (the #667 line-166 gap). Sample-completion text in FENCED code blocks
+    is still stripped, so this does not create false positives from verbatim
+    bracketed expressions inside fenced examples. Every OTHER audit category
+    keeps using `strip_code` (full inline+fenced strip) — inline-backtick
+    `C1`/`D1` references are a legitimate accepted form for `condition_labels`
+    and we deliberately do not widen its exposure here.
+    """
+    return re.sub(r"```.*?```", "", text, flags=re.DOTALL)
+
+
 # GFM table delimiter row: `|---|---|`, `:--|:-:|--:`, `---|---`, etc.
 # Mirrors `_TABLE_DELIM_RE` in `verify_task_body.py`: at least TWO cells of
 # dashes (with optional leading/trailing `|` and optional `:` alignment
@@ -618,9 +636,19 @@ def audit_body(body: str) -> dict[str, list[str]]:
         strip_data_example_blocks(strip_context_blockquotes(strip_frontmatter(body)))
     )
     cleaned_table_blanked = _blank_table_rows(cleaned)
-    # `interval_inline` scans the table-blanked text with the Lens 7
-    # caption / "Why this test" carve-outs ALSO blanked.
-    interval_scan_source = _strip_interval_inline_exempt_lines(cleaned_table_blanked)
+    # `interval_inline` uses `strip_fenced_code_only` (NOT `strip_code`) so an
+    # inline-backtick-wrapped bracketed CI in prose (``CI `[-0.295, +0.083]` ``,
+    # the #667 line-166 gap) is still seen — `strip_code` blanks inline-backtick
+    # spans, hiding the CI before the scan. The SAME downstream exemptions still
+    # apply (Data `<details>` / Context block stripped by the inner chain; table
+    # rows blanked by `_blank_table_rows`; figure-caption + Why-this-test lines
+    # blanked by `_strip_interval_inline_exempt_lines`). Fenced code blocks are
+    # still stripped, so verbatim bracketed expressions in fenced examples do
+    # not false-positive. Every OTHER category keeps `cleaned` / `strip_code`.
+    interval_cleaned = strip_fenced_code_only(
+        strip_data_example_blocks(strip_context_blockquotes(strip_frontmatter(body)))
+    )
+    interval_scan_source = _strip_interval_inline_exempt_lines(_blank_table_rows(interval_cleaned))
     # `pre_reg` (v3 only) scans only the three Lens 7 prose sections.
     pre_reg_scan_source = _restrict_pre_reg_to_prose_sections(body, cleaned)
     for name, (pattern, _) in PATTERNS.items():

--- a/tests/test_audit_clean_results_body_discipline.py
+++ b/tests/test_audit_clean_results_body_discipline.py
@@ -427,6 +427,46 @@ def test_original_interval_inline_forms_still_flagged():
     assert "interval_inline" in audit.audit_body(trailing), "trailing-token form regressed"
 
 
+def test_inline_backtick_bracketed_ci_in_prose_is_flagged():
+    """An inline-backtick-wrapped CI in reader-facing prose (the verbatim
+    #667 line-166 form ``CI `[-0.295, +0.083]` ``) trips `interval_inline`.
+    `strip_code` previously blanked the inline-backtick span, hiding the CI
+    from the scan; the `interval_inline` path now uses
+    `strip_fenced_code_only`, which keeps inline backticks."""
+    leaky = V3_BODY_WITH_DATA_CODES.replace(
+        "The lift holds at every seed in the held-out evaluation.",
+        "Sycophancy's sibling crosses zero (CI `[−0.295, +0.083]`), "  # noqa: RUF001
+        "matching its null.",
+    )
+    findings = audit.audit_body(leaky)
+    assert "interval_inline" in findings, findings
+    assert any("0.295" in s for s in findings["interval_inline"]), findings
+
+
+def test_strip_fenced_code_only_keeps_inline_backticks():
+    """`strip_fenced_code_only` removes fenced ```...``` blocks but keeps
+    inline-backtick spans (unlike `strip_code`, which blanks both)."""
+    text = "Prose `[0.1, 0.4]` here.\n```\nfenced [9, 9] body\n```\nAfter."
+    out = audit.strip_fenced_code_only(text)
+    assert "`[0.1, 0.4]`" in out  # inline kept
+    assert "fenced [9, 9] body" not in out  # fenced stripped
+    # contrast: strip_code blanks the inline span
+    assert "[0.1, 0.4]" not in audit.strip_code(text)
+
+
+def test_inline_backtick_condition_label_in_prose_not_flagged():
+    """Scope guard: the fix routes ONLY `interval_inline` through
+    `strip_fenced_code_only`. `condition_labels` keeps using `strip_code`
+    (inline backticks blanked), so an inline-backtick `C1` reference in
+    prose is a legitimate accepted form and must NOT trip `condition_labels`."""
+    leaky = V3_BODY_WITH_DATA_CODES.replace(
+        "The lift holds at every seed in the held-out evaluation.",
+        "The result reproduces the `C1` arm at every seed.",
+    )
+    findings = audit.audit_body(leaky)
+    assert "condition_labels" not in findings, findings
+
+
 # ─── Pre-registration mentions scoped to Lens 7 prose sections (#623) ────
 #
 # Lens 7 (clean-result-critic) scopes the pre-registration-mention ban to


### PR DESCRIPTION
Closes task #731.

## Summary

Extends the clean-result anti-pattern audit (`scripts/audit_clean_results_body_discipline.py`) to fire on inline-backtick-wrapped bracketed CIs in reader-facing prose — closing the gap clean-result-critic flagged on #667 a36 round 1 (`[−0.295, +0.083]` in Result-4 prose passed the mechanical audit because `strip_code` blanked the backtick span before the regex ran).

## Change

- Add `strip_fenced_code_only(text)` helper that strips only fenced ` ```...``` ` blocks (NOT inline backticks).
- Route ONLY the `interval_inline` scan source through the new helper; every other category — including `condition_labels`, the only other `_TABLE_CELL_EXEMPT_CATEGORIES` member — keeps `strip_code` unchanged, preserving legitimate inline-backtick `` `C1` ``/`` `D1` `` references in prose.
- No regex change, no new PATTERNS entry, no exemption-logic change.

## Tests

3 added to `tests/test_audit_clean_results_body_discipline.py` modelled on lines 248-304 patterns:
- `test_inline_backtick_bracketed_ci_in_prose_is_flagged` — hero (verbatim #667 fixture)
- `test_strip_fenced_code_only_keeps_inline_backticks` — helper unit
- `test_inline_backtick_condition_label_in_prose_not_flagged` — `condition_labels` scope guard

## Verification

- `pytest tests/test_audit_clean_results_body_discipline.py -v` → 42 passed (39 existing + 3 new)
- `ruff check` → 0 new errors (8 pre-existing on PATTERNS lines, identical on main baseline)
- `ruff format --check` → clean
- Synthetic integration fixture → `interval_inline: '[−0.295, +0.083]'` (rc=1, fix engaged)

## Test plan

- [x] Adversarial-planner ensemble PASS × 6 (Methodology / Statistics / Alternatives × Claude+Codex)
- [x] Consistency-checker PASS (single-variable change)
- [x] verify_plan PASS (0 FAIL, 1 WARN on c8 kill-criteria — kind:infra-typical)
- [x] Code-review ensemble PASS+PASS (Claude + Codex, no blockers)
- [x] Step 9c test-verdict PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)