### PR TITLE
workflow-fix: GCP-lane GPU-idle advisory+escalation parity (backend_poll.py)

### DIFF
--- a/scripts/backend_poll.py
+++ b/scripts/backend_poll.py
@@ -199,6 +199,60 @@ def _serialize_poll_result(result) -> dict:
     }
 
 
+# ── GCP-lane GPU-idle state sidecar (#730) ────────────────────────────────────
+# The GCP-lane GPU-idle advisory + escalation tiers (parity with the #727 RunPod
+# lane) reuse the SAME decision/post helpers from ``scripts/poll_pipeline.py``
+# (imported lazily in ``main()``'s GCP branch — see there). Those helpers read a
+# small per-issue state dict (the idle clock + per-phase de-dup sets). Rather than
+# interleave that bookkeeping into the handle sidecar the failover paths
+# rewrite (``_failover_dead_gcp_to_runpod`` re-points it), the GPU-idle clock
+# rides its OWN sibling file ``issue-<N>-gpu-idle-state.json`` — exactly as the
+# RunPod lane keeps its idle clock in its own poll-pipeline state file separate
+# from the handle. Single-issue (one file per poll process), so no per-issue
+# subdict; same JSON shape ``poll_pipeline._save_state`` persists.
+
+
+def _gpu_idle_state_path(sidecar: Path) -> Path:
+    """Sibling of the handle sidecar: ``issue-<N>-gpu-idle-state.json``.
+
+    Derived from the handle sidecar path so it lands in the SAME cache dir
+    (``<main-checkout>/.claude/cache/``) the failover paths resolve, but is a
+    DISTINCT file — the GPU-idle clock is never clobbered by a handle rewrite.
+    """
+    return sidecar.parent / sidecar.name.replace("-handle.json", "-gpu-idle-state.json")
+
+
+def _load_gpu_idle_state(path: Path) -> dict[str, str]:
+    """Load the GPU-idle state dict, or ``{}`` on absent / corrupt / non-dict.
+
+    FAIL-SOFT: a missing file (first tick) or a corrupt/torn read restarts the
+    idle span (the clock re-anchors to the current tick), never crashes the
+    poll — exactly the fail-safe semantics ``poll_pipeline._gpu_idle_advisory_update``
+    relies on (an unparsable prev-state simply means "no prior span").
+    """
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _save_gpu_idle_state(path: Path, payload: dict[str, str]) -> None:
+    """Atomically persist the GPU-idle state dict (tmp + replace).
+
+    Mirrors ``poll_pipeline._save_state``'s atomic write so a hypothetical
+    overlap with a concurrent writer yields a complete-or-prior file, never a
+    torn read (the orchestrator polls one tick at a time per issue, so this is
+    belt-and-suspenders).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True))
+    tmp.replace(path)
+
+
 def _missing_sidecar_json(issue: int, sidecar_path: Path, reason: str) -> dict:
     """Build the failure-shape JSON line for a missing / unreadable sidecar.
 
@@ -1789,7 +1843,91 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(wedge_json))
         return 0
 
-    print(json.dumps(_serialize_poll_result(result)))
+    # ── GCP-lane GPU-idle advisory + escalation (#730; parity with #727) ──
+    # A GCP VM idle in a CPU-only / upload phase bleeds credits up to the 24h
+    # --max-run-duration DELETE fence with no surfacing — the same #664
+    # spend-leak class the RunPod lane got an advisory tier (#518/#537) + an
+    # escalation tier (#664/#727) for. Mirror BOTH tiers here, REUSING (not
+    # re-implementing) the RunPod-lane decision/post helpers: a one-shot
+    # [gpu-idle-advisory] epm:progress marker after EPM_GPU_IDLE_ADVISORY_MIN,
+    # then a LOUD [gpu-idle-escalation] marker + Telegram push after
+    # EPM_GPU_IDLE_ESCALATION_MIN. It NEVER stops the VM — marker + push only
+    # (matched to #727 and the autonomous-mode never-stop-to-park rule). The
+    # GCP idle leak is FENCE-BOUNDED at the 24h --max-run-duration DELETE, so
+    # it is below-RunPod severity, but still worth surfacing (the imported
+    # _maybe_escalate_gpu_idle's note is RunPod-worded — accurate about the
+    # leak CLASS + remedy; it takes no note=/extra= kwarg, so the GCP
+    # fence-bounded severity is documented HERE, not on the marker, per the
+    # import-not-extract single-file-change contract).
+    #
+    # Lazy import (NOT module-top): the module deliberately keeps poll_pipeline
+    # out of the import graph so the --help path stays fast (see the
+    # _DEFAULT_NEXT_INTERVAL_SEC comment near the top). The repo-root sys.path
+    # bootstrap above makes `scripts.poll_pipeline` resolvable; importing the
+    # two wiring fns transitively pulls every dependency they need
+    # (_gpu_idle_advisory_update, _gpu_idle_escalation_update, _phase_is_cpu_only,
+    # _telegram_push, post_event) — all resolved against poll_pipeline, so no
+    # extraction / re-export is needed.
+    gcp_gpu_idle_advisory_posted = False
+    gcp_gpu_idle_escalation_posted = False
+    # ``hasattr`` guard: in production the GCP branch always resolves a real
+    # GcpBackend (which owns ``_gcp_gpu_util_probe`` + ``_config``), but a
+    # duck-typed poll double (the existing test_backend_poll.py ``_PollDouble``)
+    # or a future backend variant lacking the probe must SKIP the GPU-idle
+    # block rather than crash — same fail-soft defense as the ``getattr``
+    # guards in ``_serialize_poll_result``.
+    if (
+        handle.backend == "gcp"
+        and getattr(result, "status", "") == "running"
+        and hasattr(backend, "_gcp_gpu_util_probe")
+        and getattr(backend, "_config", None) is not None
+    ):
+        from scripts.poll_pipeline import (
+            _maybe_escalate_gpu_idle,
+            _maybe_post_gpu_idle_advisory,
+        )
+
+        gpu_idle_state_path = _gpu_idle_state_path(Path(sidecar))
+        prev_gpu_idle_state = _load_gpu_idle_state(gpu_idle_state_path)
+        zone = handle.extra.get("zone") or backend._config.primary_zone
+        gpu_util = backend._gcp_gpu_util_probe(handle, zone)
+        now_epoch = int(time.time())
+        current_phase = getattr(result, "current_phase", "") or ""
+        pod = handle.pod_name
+
+        idle_since, advised_phases, gcp_gpu_idle_advisory_posted = _maybe_post_gpu_idle_advisory(
+            issue=args.issue,
+            pod=pod,
+            status="running",
+            gpu_util=gpu_util,
+            current_phase=current_phase,
+            prev_state=prev_gpu_idle_state,
+            now_epoch=now_epoch,
+        )
+        escalated_phases, gcp_gpu_idle_escalation_posted = _maybe_escalate_gpu_idle(
+            issue=args.issue,
+            pod=pod,
+            status="running",
+            gpu_util=gpu_util,
+            current_phase=current_phase,
+            idle_since_epoch=idle_since,
+            prev_state=prev_gpu_idle_state,
+            now_epoch=now_epoch,
+        )
+        _save_gpu_idle_state(
+            gpu_idle_state_path,
+            {
+                "phase": current_phase,
+                "gpu_idle_since_epoch": str(idle_since),
+                "gpu_idle_advised_phases": ",".join(sorted(advised_phases)),
+                "gpu_idle_escalated_phases": ",".join(sorted(escalated_phases)),
+            },
+        )
+
+    out = _serialize_poll_result(result)
+    out["gcp_gpu_idle_advisory_posted"] = gcp_gpu_idle_advisory_posted
+    out["gcp_gpu_idle_escalation_posted"] = gcp_gpu_idle_escalation_posted
+    print(json.dumps(out))
     return 0
 
 

--- a/scripts/backend_poll.py
+++ b/scripts/backend_poll.py
@@ -213,13 +213,28 @@ def _serialize_poll_result(result) -> dict:
 
 
 def _gpu_idle_state_path(sidecar: Path) -> Path:
-    """Sibling of the handle sidecar: ``issue-<N>-gpu-idle-state.json``.
+    """Sibling path for the GPU-idle clock; ALWAYS distinct from ``sidecar``.
 
-    Derived from the handle sidecar path so it lands in the SAME cache dir
-    (``<main-checkout>/.claude/cache/``) the failover paths resolve, but is a
-    DISTINCT file — the GPU-idle clock is never clobbered by a handle rewrite.
+    Lands in the SAME cache dir (``<main-checkout>/.claude/cache/``) the
+    failover paths resolve, but is a DISTINCT file — the GPU-idle clock must
+    never be clobbered by a handle rewrite.
+
+    The canonical handle sidecar is named ``issue-<N>-handle.json`` — the
+    ``-handle.json`` → ``-gpu-idle-state.json`` substitution gives the natural
+    sibling ``issue-<N>-gpu-idle-state.json``. A custom ``--handle-file <path>``
+    is honored verbatim and may NOT match that shape (e.g. ``/tmp/custom.json``
+    or ``pod-runtime.json``); ``str.replace`` is a no-op when the substring is
+    absent, so the naive substitution would return the handle sidecar's OWN
+    path. Writing GPU-idle bookkeeping onto the handle would corrupt it (the
+    next poll reads it as a ``RunHandle`` → unreadable → false ``status: dead``
+    on a live job). Fall back to a stem-based name in that case so the result
+    is GUARANTEED distinct from the handle sidecar.
     """
-    return sidecar.parent / sidecar.name.replace("-handle.json", "-gpu-idle-state.json")
+    if sidecar.name.endswith("-handle.json"):
+        return sidecar.parent / sidecar.name.replace("-handle.json", "-gpu-idle-state.json")
+    # Non-conforming name (custom --handle-file): compose a distinct sibling.
+    # Path.stem strips ONE trailing extension, so "custom.json" → "custom".
+    return sidecar.parent / f"{sidecar.stem}-gpu-idle-state.json"
 
 
 def _load_gpu_idle_state(path: Path) -> dict[str, str]:

--- a/src/explore_persona_space/backends/gcp.py
+++ b/src/explore_persona_space/backends/gcp.py
@@ -3767,6 +3767,55 @@ class GcpBackend(ComputeBackend):
             return False
         return True
 
+    def _gcp_gpu_util_probe(self, handle: RunHandle, zone: str) -> str:
+        """Best-effort per-GPU utilization (comma-joined) via gcloud compute ssh nvidia-smi.
+
+        Returns e.g. ``"0,0,0,0"`` or the literal ``"unknown"`` on ANY failure
+        (SSH down, permission, timeout, empty/garbled output, non-numeric
+        token). FAIL-SOFT by construction: the consumer
+        (``poll_pipeline._gpu_idle``) reads ``"unknown"`` as NOT idle, so a
+        probe miss never accumulates toward a GPU-idle advisory and never
+        crashes the poll. Mirrors the RunPod lane's ``nvidia-smi`` gpu_util
+        probe (``poll_pipeline.poll_once``) and reuses the existing GCP drain
+        SSH pattern (``_drain_sentinels``): ``sudo -n`` because the GCE startup
+        script runs as root, and the bare ``self._run(argv)`` inherits the
+        runner's default 300s timeout (``default_gcloud_runner``), so a hung VM
+        (the #667 class) raises ``subprocess.TimeoutExpired`` -> caught here ->
+        ``"unknown"`` rather than blocking the poll tick.
+        """
+        argv = _base_gcloud_argv(
+            self._config,
+            "compute",
+            "ssh",
+            handle.pod_name,
+            "--command=sudo -n nvidia-smi --query-gpu=utilization.gpu "
+            "--format=csv,noheader,nounits",
+        )
+        argv += [f"--zone={zone}"]
+        try:
+            res = self._run(argv)
+        except Exception as exc:  # transport / subprocess / TimeoutExpired
+            logger.warning(
+                "GCP gpu-util probe failed for %s (%s); reporting 'unknown'",
+                handle.pod_name,
+                exc,
+            )
+            return "unknown"
+        if res.returncode != 0:
+            logger.warning(
+                "GCP gpu-util probe rc=%d for %s; reporting 'unknown'",
+                res.returncode,
+                handle.pod_name,
+            )
+            return "unknown"
+        toks = [t.strip() for t in (res.stdout or "").replace("\n", ",").split(",") if t.strip()]
+        # Validate every token parses as an int (matches _gpu_idle's contract);
+        # any non-numeric token -> "unknown" so a partial/garbled read never
+        # masquerades as idle.
+        if not toks or any(not t.lstrip("-").isdigit() for t in toks):
+            return "unknown"
+        return ",".join(toks)
+
     # ----- relaunch-follow (incident #612) ---------------------------------
     #
     # ``epm:run-launched`` note tokens, per the relaunch contract in

--- a/tests/test_backend_poll_gpu_idle.py
+++ b/tests/test_backend_poll_gpu_idle.py
@@ -1,0 +1,486 @@
+"""Tests for the GCP-lane GPU-idle advisory + escalation parity (#730).
+
+The GCP poller (``scripts/backend_poll.py`` ``main()``) gained the same two
+GPU-idle tiers the RunPod lane already has (advisory #518/#537, escalation
+#664/#727), REUSING (importing, not re-implementing) the decision/post helpers
+from ``scripts/poll_pipeline.py``:
+
+* a fail-soft ``nvidia-smi``-over-``gcloud compute ssh`` GPU-util probe
+  (``GcpBackend._gcp_gpu_util_probe``) — returns ``"unknown"`` on ANY failure;
+* a sibling GPU-idle state file (``issue-<N>-gpu-idle-state.json``) read/written
+  via ``backend_poll._{gpu_idle_state_path,load_gpu_idle_state,save_gpu_idle_state}``;
+* the two RunPod-lane wiring fns wired into ``main()`` for
+  ``handle.backend == "gcp" and status == "running"`` ticks, emitting two new
+  serialized JSON fields ``gcp_gpu_idle_{advisory,escalation}_posted``.
+
+These tests pin: the probe CSV parse + fail-soft contract; the advisory +
+escalation thresholds on the GCP lane; the NEVER-stops-the-VM invariant (a
+static argv guard); per-phase idempotency; and that ``_phase_is_cpu_only``
+classifies the ACTUAL GCP ``eps/phase`` vocabulary (coarse ``"workload"``,
+``"setup"``, ``"done"``, ``"unknown"``) the way the GCP lane threads it.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import scripts.backend_poll as bp
+import scripts.poll_pipeline as pp
+from explore_persona_space.backends.base import PollResult, RunHandle
+from explore_persona_space.backends.gcp import GcloudRunResult, GcpBackend
+from explore_persona_space.backends.issue_dispatch import write_handle_sidecar
+
+# ── _gcp_gpu_util_probe parse + fail-soft ─────────────────────────────────────
+
+
+def _backend_recording_run(returns: Any = None, *, raises: BaseException | None = None):
+    """A GcpBackend whose injected runner RECORDS every argv it is handed.
+
+    ``returns`` is the GcloudRunResult the runner yields (when not raising);
+    ``raises`` makes the runner raise instead. ``backend.recorded`` is the list
+    of argvs passed to the runner this test.
+    """
+    recorded: list[list[str]] = []
+
+    def _runner(argv):
+        recorded.append(list(argv))
+        if raises is not None:
+            raise raises
+        return returns
+
+    backend = GcpBackend(runner=_runner, marker_poster=lambda **_kw: None)
+    backend.recorded = recorded  # type: ignore[attr-defined]
+    return backend
+
+
+def _gcp_handle(extra: dict | None = None) -> RunHandle:
+    return RunHandle(
+        backend="gcp",
+        cluster=None,
+        job_id="instance-fake-1",
+        pod_name="eps-issue-730",
+        scratch_dir="/workspace/eps-issue-730",
+        log_path="/workspace/logs/issue-730.log",
+        extra=dict(extra if extra is not None else {"issue": 730, "zone": "us-central1-a"}),
+    )
+
+
+def test_gcp_gpu_util_probe_parses_csv() -> None:
+    """A newline-separated nvidia-smi reply (rc=0) is normalized to a comma-joined
+    util string the consumer (_gpu_idle) understands."""
+    backend = _backend_recording_run(
+        GcloudRunResult(returncode=0, stdout="0\n0\n0\n0\n", stderr="")
+    )
+    assert backend._gcp_gpu_util_probe(_gcp_handle(), "us-central1-a") == "0,0,0,0"
+
+
+def test_gcp_gpu_util_probe_normalizes_busy_cards() -> None:
+    backend = _backend_recording_run(
+        GcloudRunResult(returncode=0, stdout="0, 0, 95, 0\n", stderr="")
+    )
+    assert backend._gcp_gpu_util_probe(_gcp_handle(), "us-central1-a") == "0,0,95,0"
+
+
+@pytest.mark.parametrize(
+    "result,raises",
+    [
+        (GcloudRunResult(returncode=255, stdout="", stderr="ssh: connect refused"), None),
+        (GcloudRunResult(returncode=0, stdout="", stderr=""), None),  # empty stdout
+        (GcloudRunResult(returncode=0, stdout="garbage\nnot,a,number\n", stderr=""), None),
+        (None, RuntimeError("transport blew up")),  # runner raises
+    ],
+)
+def test_gcp_gpu_util_probe_fail_soft(result, raises) -> None:
+    """rc!=0, empty stdout, a non-numeric token, and a raised exception EACH
+    yield the literal "unknown" — never a crash, never a false idle."""
+    backend = _backend_recording_run(result, raises=raises)
+    assert backend._gcp_gpu_util_probe(_gcp_handle(), "us-central1-a") == "unknown"
+
+
+def test_gcp_gpu_util_probe_uses_sudo_nvidia_smi_over_ssh() -> None:
+    """The probe reuses the GCP drain SSH pattern: gcloud compute ssh <name>
+    --command=sudo -n nvidia-smi ... --zone=<zone> (matched to _drain_sentinels)."""
+    backend = _backend_recording_run(GcloudRunResult(returncode=0, stdout="0\n", stderr=""))
+    backend._gcp_gpu_util_probe(_gcp_handle(), "us-central1-a")
+    (argv,) = backend.recorded  # type: ignore[attr-defined]
+    joined = " ".join(argv)
+    assert "compute" in argv and "ssh" in argv and "eps-issue-730" in argv
+    assert "--zone=us-central1-a" in argv
+    assert "sudo -n nvidia-smi" in joined
+    assert "--query-gpu=utilization.gpu" in joined
+
+
+# ── state-file round-trip ─────────────────────────────────────────────────────
+
+
+def test_gpu_idle_state_path_is_handle_sidecar_sibling(tmp_path: Path) -> None:
+    sidecar = tmp_path / "issue-730-handle.json"
+    assert bp._gpu_idle_state_path(sidecar) == tmp_path / "issue-730-gpu-idle-state.json"
+
+
+def test_gpu_idle_state_round_trip_and_fail_soft(tmp_path: Path) -> None:
+    path = tmp_path / "issue-730-gpu-idle-state.json"
+    assert bp._load_gpu_idle_state(path) == {}  # absent -> {}
+    payload = {
+        "phase": "p3_upload",
+        "gpu_idle_since_epoch": "1000",
+        "gpu_idle_advised_phases": "p3_upload",
+        "gpu_idle_escalated_phases": "",
+    }
+    bp._save_gpu_idle_state(path, payload)
+    assert bp._load_gpu_idle_state(path) == payload
+    # Corrupt body -> {} (fail-soft), never raises.
+    path.write_text("{not json")
+    assert bp._load_gpu_idle_state(path) == {}
+    # Non-dict JSON -> {}.
+    path.write_text("[1, 2, 3]")
+    assert bp._load_gpu_idle_state(path) == {}
+
+
+# ── advisory + escalation thresholds on the GCP lane ──────────────────────────
+#
+# The decision cores are exhaustively unit-tested in
+# tests/test_poll_gpu_idle_escalation.py; here we pin the GCP-lane WIRING
+# (the imported _maybe_* fns + the seeded sibling state file drive the posts).
+
+
+def _seed_idle_state(path: Path, *, since_epoch: int, phase: str) -> None:
+    bp._save_gpu_idle_state(
+        path,
+        {
+            "phase": phase,
+            "gpu_idle_since_epoch": str(since_epoch),
+            "gpu_idle_advised_phases": "",
+            "gpu_idle_escalated_phases": "",
+        },
+    )
+
+
+def test_gcp_advisory_posts_after_threshold(tmp_path: Path, monkeypatch) -> None:
+    """All-idle GPUs in a CPU-only phase whose seeded idle span exceeds the
+    advisory min -> the advisory wiring posts a [gpu-idle-advisory] marker."""
+    posted: list[dict] = []
+    monkeypatch.setattr(
+        pp, "post_event", lambda issue, key, **kw: posted.append({"key": key, **kw})
+    )
+    path = tmp_path / "issue-730-gpu-idle-state.json"
+    now = 100_000
+    _seed_idle_state(path, since_epoch=now - pp.GPU_IDLE_ADVISORY_MIN * 60, phase="p3_upload")
+    prev = bp._load_gpu_idle_state(path)
+    _idle_since, advised, advisory_posted = pp._maybe_post_gpu_idle_advisory(
+        issue=730,
+        pod="eps-issue-730",
+        status="running",
+        gpu_util="0,0,0,0,0,0,0,0",
+        current_phase="p3_upload",
+        prev_state=prev,
+        now_epoch=now,
+    )
+    assert advisory_posted is True
+    assert "p3_upload" in advised
+    assert any(p["key"] == "epm:progress" and p.get("gpu_idle_advisory") for p in posted)
+    assert any("[gpu-idle-advisory]" in (p.get("note") or "") for p in posted)
+
+
+def test_gcp_escalation_posts_and_pushes_multi_gpu(tmp_path: Path, monkeypatch) -> None:
+    """A MULTI-GPU pod idle past the escalation min in a CPU-only phase ->
+    [gpu-idle-escalation] marker posted AND a Telegram push fired; a single-GPU
+    pod under the SAME conditions does NOT escalate."""
+    posted: list[dict] = []
+    pushes: list[str] = []
+    monkeypatch.setattr(
+        pp, "post_event", lambda issue, key, **kw: posted.append({"key": key, **kw})
+    )
+    monkeypatch.setattr(pp, "_telegram_push", lambda msg: pushes.append(msg) or True)
+    now = 100_000
+    since = now - pp.GPU_IDLE_ESCALATION_MIN * 60
+
+    # Multi-GPU -> escalates + pushes.
+    escalated, escalation_posted = pp._maybe_escalate_gpu_idle(
+        issue=730,
+        pod="eps-issue-730",
+        status="running",
+        gpu_util="0,0,0,0,0,0,0,0",
+        current_phase="p3_upload",
+        idle_since_epoch=since,
+        prev_state={"gpu_idle_escalated_phases": ""},
+        now_epoch=now,
+    )
+    assert escalation_posted is True
+    assert "p3_upload" in escalated
+    assert len(pushes) == 1
+    assert any(p["key"] == "epm:progress" and p.get("gpu_idle_escalation") for p in posted)
+
+    # Single-GPU under identical conditions -> NO escalation, NO push.
+    pushes.clear()
+    _escalated, single_posted = pp._maybe_escalate_gpu_idle(
+        issue=730,
+        pod="eps-issue-730",
+        status="running",
+        gpu_util="0",
+        current_phase="p3_upload",
+        idle_since_epoch=since,
+        prev_state={"gpu_idle_escalated_phases": ""},
+        now_epoch=now,
+    )
+    assert single_posted is False
+    assert pushes == []
+
+
+def test_gcp_idempotent_one_per_phase(tmp_path: Path, monkeypatch) -> None:
+    """Two consecutive ticks in the SAME phase (state round-tripped through the
+    sibling file) -> escalate on tick 1, NOT tick 2; a phase CHANGE re-arms."""
+    posted: list[dict] = []
+    monkeypatch.setattr(
+        pp, "post_event", lambda issue, key, **kw: posted.append({"key": key, **kw})
+    )
+    monkeypatch.setattr(pp, "_telegram_push", lambda msg: True)
+    path = tmp_path / "issue-730-gpu-idle-state.json"
+    now = 100_000
+    since = now - pp.GPU_IDLE_ESCALATION_MIN * 60
+    _seed_idle_state(path, since_epoch=since, phase="p3_upload")
+
+    def _tick(phase: str, now_epoch: int) -> bool:
+        prev = bp._load_gpu_idle_state(path)
+        idle_since, advised, _adv = pp._maybe_post_gpu_idle_advisory(
+            issue=730,
+            pod="eps-issue-730",
+            status="running",
+            gpu_util="0,0,0,0,0,0,0,0",
+            current_phase=phase,
+            prev_state=prev,
+            now_epoch=now_epoch,
+        )
+        escalated, escalation_posted = pp._maybe_escalate_gpu_idle(
+            issue=730,
+            pod="eps-issue-730",
+            status="running",
+            gpu_util="0,0,0,0,0,0,0,0",
+            current_phase=phase,
+            idle_since_epoch=idle_since,
+            prev_state=prev,
+            now_epoch=now_epoch,
+        )
+        bp._save_gpu_idle_state(
+            path,
+            {
+                "phase": phase,
+                "gpu_idle_since_epoch": str(idle_since),
+                "gpu_idle_advised_phases": ",".join(sorted(advised)),
+                "gpu_idle_escalated_phases": ",".join(sorted(escalated)),
+            },
+        )
+        return escalation_posted
+
+    assert _tick("p3_upload", now) is True  # tick 1: fires
+    assert _tick("p3_upload", now + 60) is False  # tick 2, same phase: de-duped
+    # A phase change restarts the span -> the new phase has not yet aged, so it
+    # does NOT immediately escalate (re-arm, then age past the threshold).
+    assert _tick("p5_upload", now + 120) is False
+    assert _tick("p5_upload", now + 120 + pp.GPU_IDLE_ESCALATION_MIN * 60) is True
+
+
+# ── _phase_is_cpu_only on the ACTUAL GCP eps/phase vocabulary ─────────────────
+#
+# On a RUNNING GCP VM the current_phase threaded into backend_poll.main() is the
+# COARSE eps/phase guest attribute, whose only mid-workload value is the literal
+# "workload" (gcp.py). The fine dispatcher phases (p3_upload) appear on the
+# RunPod lane; they are still asserted here because the deny-list is shared.
+
+
+@pytest.mark.parametrize(
+    "phase,expected",
+    [
+        ("workload", True),  # the GCP coarse mid-workload phase -> eligible
+        ("done", True),  # no deny-list substring (gated out earlier by status!=running anyway)
+        ("p3_upload", True),  # RunPod-lane fine phase, shared deny-list
+        ("upload", True),
+        ("setup", False),  # deny-list substring
+        ("setup_failed", False),
+        ("train", False),
+        ("eval", False),
+        ("unknown", False),  # the explicit ineligible sentinel
+        ("", False),
+    ],
+)
+def test_gcp_phase_deny_list_matches(phase: str, expected: bool) -> None:
+    assert pp._phase_is_cpu_only(phase) is expected
+
+
+def test_gpu_required_substrings_match_assertions() -> None:
+    """The substrings the GCP test asserts denied are actually in the shared
+    deny-list (guards against the deny-list drifting out from under this test)."""
+    assert {"train", "eval", "setup"} <= set(pp.GPU_REQUIRED_PHASE_SUBSTRINGS)
+
+
+# ── the NEVER-stops-the-VM invariant (static argv guard) ──────────────────────
+
+
+class _IdlePollBackend:
+    """A GcpBackend-shaped poll double for the main() integration test.
+
+    Records every argv the injected runner sees (so the no-VM-stop guard can
+    assert no stop/delete shape), returns a scripted RUNNING PollResult from
+    poll(), and a scripted all-idle gpu_util from the probe. Carries a real
+    _config so backend._config.primary_zone resolves.
+    """
+
+    def __init__(self, *, gpu_util: str, current_phase: str) -> None:
+        from explore_persona_space.backends.gcp import default_gcp_config
+
+        self._config = default_gcp_config()
+        self._gpu_util = gpu_util
+        self._current_phase = current_phase
+        self.run_argvs: list[list[str]] = []
+
+    def poll(self, handle: RunHandle) -> PollResult:
+        return PollResult(
+            status="running",
+            current_phase=self._current_phase,
+            new_milestone=False,
+            last_log_mtime_sec_ago=10,
+            pid_alive=True,
+            log_tail_excerpt="",
+        )
+
+    def _gcp_gpu_util_probe(self, handle: RunHandle, zone: str) -> str:
+        # Record a representative probe argv so the no-stop guard sees the real
+        # SSH shape the production probe would emit.
+        self.run_argvs.append(
+            ["gcloud", "compute", "ssh", handle.pod_name, f"--zone={zone}", "nvidia-smi"]
+        )
+        return self._gpu_util
+
+
+_FORBIDDEN_ARGV_SHAPES = (
+    ("instances", "stop"),
+    ("instances", "delete"),
+)
+
+
+def _argv_is_vm_stop(argv: list[str]) -> bool:
+    joined = " ".join(argv)
+    if any(all(tok in argv for tok in shape) for shape in _FORBIDDEN_ARGV_SHAPES):
+        return True
+    return "pod.py" in joined and (" stop" in joined or " terminate" in joined)
+
+
+def test_gcp_no_vm_stop_in_codepath(tmp_path, monkeypatch, capsys) -> None:
+    """At the escalation threshold the GCP GPU-idle codepath posts a marker +
+    push but issues NO VM-stopping action: no `gcloud ... instances stop|delete`
+    and no `pod.py ... stop|terminate` reaches the runner OR subprocess.run."""
+    import subprocess
+
+    subprocess_argvs: list[list[str]] = []
+    real_run = subprocess.run
+
+    def _recording_run(argv, *a, **kw):
+        if isinstance(argv, (list, tuple)):
+            subprocess_argvs.append(list(argv))
+        return real_run(argv, *a, **kw)
+
+    monkeypatch.setattr(subprocess, "run", _recording_run)
+    monkeypatch.setattr(pp, "post_event", lambda *a, **kw: None)
+    monkeypatch.setattr(pp, "_telegram_push", lambda msg: True)
+
+    sidecar = tmp_path / "issue-730-handle.json"
+    write_handle_sidecar(_gcp_handle(), sidecar)
+    state_path = bp._gpu_idle_state_path(sidecar)
+    now = int(time.time())
+    _seed_idle_state(
+        state_path, since_epoch=now - pp.GPU_IDLE_ESCALATION_MIN * 60, phase="workload"
+    )
+
+    backend = _IdlePollBackend(gpu_util="0,0,0,0,0,0,0,0", current_phase="workload")
+    monkeypatch.setattr("scripts.backend_poll._resolve_backend", lambda name: backend)
+
+    rc = bp.main(["--issue", "730", "--handle-file", str(sidecar)])
+    assert rc == 0
+
+    # No VM-stop argv in EITHER channel.
+    for argv in backend.run_argvs + subprocess_argvs:
+        assert not _argv_is_vm_stop(argv), f"forbidden VM-stop argv reached the codepath: {argv}"
+
+
+# ── main() integration: the two serialized JSON fields ────────────────────────
+
+
+def _last_json_line(capsys) -> dict:
+    out = capsys.readouterr().out.strip()
+    assert out, "backend_poll printed no stdout"
+    return json.loads(out.splitlines()[-1])
+
+
+def test_backend_poll_main_gcp_idle_integration(tmp_path, monkeypatch, capsys) -> None:
+    """Driving main() on a GCP handle with a RUNNING poll + all-idle probe + a
+    pre-seeded idle span past the escalation min emits both new JSON fields and
+    drives the posted flags."""
+    posted: list[dict] = []
+    monkeypatch.setattr(
+        pp, "post_event", lambda issue, key, **kw: posted.append({"key": key, **kw})
+    )
+    monkeypatch.setattr(pp, "_telegram_push", lambda msg: True)
+
+    sidecar = tmp_path / "issue-730-handle.json"
+    write_handle_sidecar(_gcp_handle(), sidecar)
+    state_path = bp._gpu_idle_state_path(sidecar)
+    now = int(time.time())
+    _seed_idle_state(
+        state_path, since_epoch=now - pp.GPU_IDLE_ESCALATION_MIN * 60, phase="workload"
+    )
+
+    backend = _IdlePollBackend(gpu_util="0,0,0,0,0,0,0,0", current_phase="workload")
+    monkeypatch.setattr("scripts.backend_poll._resolve_backend", lambda name: backend)
+
+    rc = bp.main(["--issue", "730", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["status"] == "running"
+    assert out["gcp_gpu_idle_advisory_posted"] is True
+    assert out["gcp_gpu_idle_escalation_posted"] is True
+    # The state file was updated with the escalated phase (idempotency surface).
+    saved = bp._load_gpu_idle_state(state_path)
+    assert "workload" in saved["gpu_idle_escalated_phases"]
+
+
+def test_backend_poll_main_non_gcp_omits_idle_fields_defaulting_false(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """A non-GCP (RunPod) tick routed through main() leaves both fields False —
+    the GCP block is gated on handle.backend == 'gcp' (RunPod's own advisory /
+    escalation fires inside poll_pipeline.poll_once, not here, so no double-fire)."""
+    runpod_handle = RunHandle(
+        backend="runpod",
+        cluster=None,
+        job_id="pod-fake",
+        pod_name="pod-730",
+        scratch_dir="/workspace",
+        log_path="/workspace/logs/issue-730.log",
+        extra={"issue": 730},
+    )
+    sidecar = tmp_path / "issue-730-handle.json"
+    write_handle_sidecar(runpod_handle, sidecar)
+
+    class _RunningRunpod:
+        def poll(self, handle: RunHandle) -> PollResult:
+            return PollResult(
+                status="running",
+                current_phase="train",
+                new_milestone=False,
+                last_log_mtime_sec_ago=5,
+                pid_alive=True,
+                log_tail_excerpt="",
+            )
+
+    monkeypatch.setattr("scripts.backend_poll._resolve_backend", lambda name: _RunningRunpod())
+
+    rc = bp.main(["--issue", "730", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["gcp_gpu_idle_advisory_posted"] is False
+    assert out["gcp_gpu_idle_escalation_posted"] is False

--- a/tests/test_backend_poll_gpu_idle.py
+++ b/tests/test_backend_poll_gpu_idle.py
@@ -123,6 +123,31 @@ def test_gpu_idle_state_path_is_handle_sidecar_sibling(tmp_path: Path) -> None:
     assert bp._gpu_idle_state_path(sidecar) == tmp_path / "issue-730-gpu-idle-state.json"
 
 
+def test_gpu_idle_state_path_never_collides_with_handle_file(tmp_path: Path) -> None:
+    """Per Codex round-1 finding: an arbitrary --handle-file name (NOT ending in
+    '-handle.json', which the documented CLI flag honors verbatim) must NEVER
+    resolve to the handle sidecar itself — otherwise the GPU-idle block would
+    write its bookkeeping ONTO the run handle and corrupt it (the next poll reads
+    it as a RunHandle -> unreadable -> false `status: dead` on a live job).
+
+    The OLD naive ``sidecar.name.replace("-handle.json", "-gpu-idle-state.json")``
+    is a no-op when the substring is absent, so it returned ``sidecar`` itself
+    for every non-conforming name, e.g.
+    ``"custom.json".replace("-handle.json", "-gpu-idle-state.json") == "custom.json"``.
+    """
+    # Canonical name -> the -handle.json substitution gives the documented sibling.
+    canonical = tmp_path / "issue-730-handle.json"
+    assert bp._gpu_idle_state_path(canonical) == (tmp_path / "issue-730-gpu-idle-state.json")
+
+    # Non-conforming names must produce DISTINCT siblings (the bug case).
+    for name in ("custom.json", "handle.json", "pod-runtime.json", "no-ext"):
+        sidecar = tmp_path / name
+        state_path = bp._gpu_idle_state_path(sidecar)
+        assert state_path != sidecar, f"state-path collides with handle sidecar for name={name!r}"
+        assert state_path.parent == sidecar.parent  # still a sibling in the same dir
+        assert state_path.name.endswith("-gpu-idle-state.json")
+
+
 def test_gpu_idle_state_round_trip_and_fail_soft(tmp_path: Path) -> None:
     path = tmp_path / "issue-730-gpu-idle-state.json"
     assert bp._load_gpu_idle_state(path) == {}  # absent -> {}
@@ -451,22 +476,30 @@ def test_backend_poll_main_gcp_idle_integration(tmp_path, monkeypatch, capsys) -
 def test_backend_poll_main_non_gcp_omits_idle_fields_defaulting_false(
     tmp_path, monkeypatch, capsys
 ) -> None:
-    """A non-GCP (RunPod) tick routed through main() leaves both fields False —
-    the GCP block is gated on handle.backend == 'gcp' (RunPod's own advisory /
-    escalation fires inside poll_pipeline.poll_once, not here, so no double-fire)."""
-    runpod_handle = RunHandle(
-        backend="runpod",
-        cluster=None,
-        job_id="pod-fake",
-        pod_name="pod-730",
-        scratch_dir="/workspace",
-        log_path="/workspace/logs/issue-730.log",
+    """A non-GCP (SLURM) tick routed through main() leaves both fields False —
+    the GCP GPU-idle block is gated on handle.backend == 'gcp'.
+
+    The handle backend is deliberately a SLURM cluster, NOT 'runpod': a RunPod
+    handle would drive production main() into _maybe_escalate_runpod_wedge,
+    which lazy-imports runpod_api.get_pod_by_name and hits the LIVE RunPod API
+    (a DNS failure in any clean / offline CI run). The test's intent — non-GCP
+    backends default both new fields to False — is backend-string-driven, so a
+    SLURM handle exercises the same gate without any network dependency
+    (_maybe_escalate_gcp_wedge / _maybe_escalate_runpod_wedge / the GCP idle
+    block all early-return for a non-matching backend string)."""
+    slurm_handle = RunHandle(
+        backend="cluster",
+        cluster="nibi",
+        job_id="slurm-fake-1",
+        pod_name="eps-issue-730",
+        scratch_dir="/scratch/eps-issue-730",
+        log_path="/scratch/logs/issue-730.log",
         extra={"issue": 730},
     )
     sidecar = tmp_path / "issue-730-handle.json"
-    write_handle_sidecar(runpod_handle, sidecar)
+    write_handle_sidecar(slurm_handle, sidecar)
 
-    class _RunningRunpod:
+    class _RunningSlurm:
         def poll(self, handle: RunHandle) -> PollResult:
             return PollResult(
                 status="running",
@@ -477,7 +510,7 @@ def test_backend_poll_main_non_gcp_omits_idle_fields_defaulting_false(
                 log_tail_excerpt="",
             )
 
-    monkeypatch.setattr("scripts.backend_poll._resolve_backend", lambda name: _RunningRunpod())
+    monkeypatch.setattr("scripts.backend_poll._resolve_backend", lambda name: _RunningSlurm())
 
     rc = bp.main(["--issue", "730", "--handle-file", str(sidecar)])
     assert rc == 0

--- a/tests/test_issue_dispatch.py
+++ b/tests/test_issue_dispatch.py
@@ -1251,6 +1251,11 @@ def test_backend_poll_script_produces_legacy_poll_pipeline_json_shape(
         # Machine-readable stall cause (#664) — zombie-GPU-allocation stall on
         # the RunPod lane; None on every other lane / verdict.
         "stall_reason",
+        # GCP-lane GPU-idle advisory + escalation parity (#730 / #727 RunPod
+        # analogue) — always emitted by backend_poll.main, default False on
+        # every non-GCP / non-running tick.
+        "gcp_gpu_idle_advisory_posted",
+        "gcp_gpu_idle_escalation_posted",
     }
     # Values were correctly threaded through.
     assert decoded["status"] == "done"


### PR DESCRIPTION
Closes task #730. Mirrors #727's RunPod-lane GPU-idle recipe on the GCP lane via `backend_poll.py` + a new `_gcp_gpu_util_probe` on `GcpBackend`. 27-test new suite + the round-3 stale JSON-shape test fix. Telegram push + LOUD marker only; NEVER stops the VM.