### PR TITLE
task #732: gate silent judge-API-error EM denominators in verify_task_body

### DIFF
--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -3671,6 +3671,313 @@ def _resolve_repo_root() -> Path | None:
         return None
 
 
+# ─── #732: judge-API-error denominator gate (check_judge_error_denominator) ──
+#
+# A judge-denominator CLAIM: an `n=N` (N>=100) or an "N completions /
+# judgments / attempted / EM" token. Used to detect whether a clean-result
+# body asserts a bare LLM-judge denominator.
+_JUDGE_DENOMINATOR_RE = re.compile(
+    r"\bn\s*=\s*(\d{3,})\b"
+    r"|\b(\d{3,})\s+(?:completions|judgments|judgements|attempted|EM\b)",
+    re.IGNORECASE,
+)
+# A judge-context guard: the denominator claim only counts when it co-occurs
+# (within a small window) with a judge noun — so a bare training-row count
+# ("6349 training rows") does NOT trigger the eval-JSON read.
+_JUDGE_CONTEXT_RE = re.compile(
+    r"claude-sonnet|\bjudge\b|EM rate|misalign|Batch API|sycophan|refusal|\btrait\b|\bfact\b",
+    re.IGNORECASE,
+)
+# A disclosure phrase: present near the claim (or in the **Repro:** footer)
+# ⇒ the body already discloses the judge-error fraction ⇒ PASS before any
+# eval read. Broad on purpose (≥11 alternations); the published #715 body
+# matches several.
+_JUDGE_ERROR_DISCLOSURE_RE = re.compile(
+    r"\b529\b|Overloaded|judge[-\s]?error|judge[-\s]?API[-\s]?error"
+    r"|n_judge_error|n_em_judge_error|excluded from the denominator"
+    r"|excluded from the per-cell denominator"
+    r"|post-correction|judge-error-corrected|API[-\s]?error|judge_failed"
+    # U+2212 MINUS SIGN below is intentional: it matches the unicode minus the
+    # #715 body uses in its "400 (U+2212) n_judge_error" disclosure phrasing.
+    r"|[-−]\s*n_judge_error",  # noqa: RUF001
+    re.IGNORECASE,
+)
+# Recognized judge-API-error count fields in committed eval JSONs.
+# NOTE: `n_parse_error` is the DISTINCT judge-side parse-failure class, NOT
+# the 529 API-error class — deliberately excluded here (§11).
+_JUDGE_ERROR_COUNT_KEYS = ("n_judge_error", "n_em_judge_error", "n_api_error")
+# Recognized per-cell ATTEMPTED-count fields (the denominator). Two source
+# classes use different names: corrected-pareto leaf cells carry
+# `n_em_attempted`; per-cell em_rate aggregates carry `n_total`. The scan
+# tries each in order until one resolves on a given cell dict.
+_JUDGE_ATTEMPTED_COUNT_KEYS = ("n_em_attempted", "n_attempted", "n_total")
+
+
+def _judge_denominator_claims(scan_region: str) -> list[re.Match]:
+    """Return the judge-denominator claim matches in `scan_region` that
+    co-occur (within ±120 chars) with a judge noun. The window guard keeps
+    the check from firing on a bare training-row count."""
+    out: list[re.Match] = []
+    for m in _JUDGE_DENOMINATOR_RE.finditer(scan_region):
+        lo = max(0, m.start() - 120)
+        hi = min(len(scan_region), m.end() + 120)
+        if _JUDGE_CONTEXT_RE.search(scan_region[lo:hi]):
+            out.append(m)
+    return out
+
+
+def _eval_root_from_body_path(body_source_path: Path, eval_subpath: Path) -> Path | None:
+    """Leg (ii) of the eval-root ladder: walk the body source path's
+    ancestors; return the nearest ancestor that is a repo root (a `.git`
+    entry — file OR dir; a worktree's `.git` is a FILE) or a
+    `.claude/worktrees/issue-<M>` worktree dir, AND contains `eval_subpath`.
+    None when none match."""
+    try:
+        ancestors = list(body_source_path.resolve().parents)
+    except OSError:
+        return None
+    for p in ancestors:
+        try:
+            is_repo_root = (p / ".git").exists()
+        except OSError:
+            is_repo_root = False
+        if not is_repo_root:
+            is_repo_root = (
+                re.match(r"issue-\d+", p.name) is not None and p.parent.name == "worktrees"
+            )
+        if is_repo_root:
+            try:
+                if (p / eval_subpath).is_dir():
+                    return p
+            except OSError:
+                continue
+    return None
+
+
+def _git_toplevel_eval_root(eval_subpath: Path) -> Path | None:
+    """Leg (iii) of the eval-root ladder: `git rev-parse --show-toplevel`
+    from cwd, returned only when it contains `eval_subpath`. Conservative —
+    any nonzero exit / OSError → None."""
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=os.getcwd(),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if proc.returncode != 0:
+        return None
+    top = proc.stdout.strip()
+    if not top:
+        return None
+    root = Path(top)
+    try:
+        return root if (root / eval_subpath).is_dir() else None
+    except OSError:
+        return None
+
+
+def _resolve_eval_root(
+    issue: int,
+    *,
+    eval_root: Path | None = None,
+    body_source_path: Path | None = None,
+) -> Path | None:
+    """Resolve the ROOT directory under which `eval_results/issue_<N>/`
+    lives, walking the §4.2a four-leg ladder and STOPPING at the first leg
+    that yields a directory containing `eval_results/issue_<N>/`:
+
+      (i)   `eval_root` (explicit `--eval-root`, gate-time worktree path),
+      (ii)  the `--file`-derived worktree root (nearest `.git` ancestor of
+            the body source path, or a `.claude/worktrees/issue-<M>` segment),
+      (iii) `git rev-parse --show-toplevel` from cwd,
+      (iv)  `_resolve_repo_root()` (MAIN — bottom-of-ladder, post-merge bind).
+
+    Returns the ROOT (the directory CONTAINING `eval_results/`), not the eval
+    dir itself, so `_scan_issue_judge_errors(root, issue)` keeps its
+    `root / "eval_results" / f"issue_{issue}"` join. Returns None when no leg
+    resolves — the check then graceful-PASSes (never a false FAIL on missing
+    data). The MAIN-only resolution of v2 is now leg (iv), not the only path.
+    """
+    eval_subpath = Path("eval_results") / f"issue_{issue}"
+
+    # Leg (i): explicit --eval-root.
+    if eval_root is not None:
+        try:
+            if (eval_root / eval_subpath).is_dir():
+                return eval_root
+        except OSError:
+            pass
+
+    # Leg (ii): --file-derived worktree root.
+    if body_source_path is not None:
+        hit = _eval_root_from_body_path(body_source_path, eval_subpath)
+        if hit is not None:
+            return hit
+
+    # Leg (iii): cwd `git rev-parse --show-toplevel` (conservative).
+    hit = _git_toplevel_eval_root(eval_subpath)
+    if hit is not None:
+        return hit
+
+    # Leg (iv): MAIN repo root (the v2 behavior, now the tail fallback).
+    main_root = _resolve_repo_root()
+    if main_root is not None:
+        try:
+            if (main_root / eval_subpath).is_dir():
+                return main_root
+        except OSError:
+            return None
+    return None
+
+
+def _first_count(cell: dict, keys: tuple[str, ...]) -> int | None:
+    """Return the first numeric value found under `keys` in `cell`, or None.
+    Non-numeric / bool values are ignored (a bool is not a valid count)."""
+    for k in keys:
+        v = cell.get(k)
+        if isinstance(v, bool):
+            continue
+        if isinstance(v, (int, float)):
+            return int(v)
+    return None
+
+
+def _scan_issue_judge_errors(repo: Path, issue: int) -> dict | None:
+    """Scan the committed `repo/eval_results/issue_<N>/` JSON tree for a
+    judge-API-error signal. Returns
+    ``{"total_err", "total_att", "worst_frac", "n_cells", "source"}`` or
+    None when no recognized judge-error signal is found (graceful skip).
+
+    A "cell" is any dict in the JSON tree that carries BOTH a recognized
+    judge-error count key (`_JUDGE_ERROR_COUNT_KEYS`) AND a recognized
+    attempted-count key (`_JUDGE_ATTEMPTED_COUNT_KEYS`) — found by recursive
+    descent, so the nested
+    `pareto_*_corrected.json` shape (`cells: {cond: {seed: [step_dicts]}}`)
+    and the flat per-cell `em_rate/*.json` aggregate convention both resolve.
+    `n_parse_error` is NOT a recognized judge-error key (it is the distinct
+    parse-failure class), so an eval dir whose only count field is
+    `n_parse_error` returns None (graceful PASS).
+
+    The `EPM_VERIFY_BODY_NO_EVAL_SCAN=1` env fence disables the disk read
+    (returns None) so the suite + offline runs are deterministic.
+    """
+    if os.environ.get("EPM_VERIFY_BODY_NO_EVAL_SCAN") == "1":
+        return None
+    eval_dir = repo / "eval_results" / f"issue_{issue}"
+    if not eval_dir.is_dir():
+        return None
+
+    leaves: list[tuple[int, int]] = []  # (judge_error, attempted) per cell
+
+    def _descend(node: object) -> None:
+        if isinstance(node, dict):
+            err = _first_count(node, _JUDGE_ERROR_COUNT_KEYS)
+            att = _first_count(node, _JUDGE_ATTEMPTED_COUNT_KEYS)
+            if err is not None and att is not None:
+                leaves.append((err, att))
+                return  # this dict IS a cell; do not double-count children
+            for v in node.values():
+                _descend(v)
+        elif isinstance(node, list):
+            for v in node:
+                _descend(v)
+
+    for path in sorted(eval_dir.rglob("*.json")):
+        try:
+            payload = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue  # a corrupt / unreadable artifact must not crash the gate
+        _descend(payload)
+
+    if not leaves:
+        return None
+
+    total_err = sum(e for e, _a in leaves)
+    total_att = sum(a for _e, a in leaves)
+    worst_frac = max((e / a if a else 0.0) for e, a in leaves)
+    return {
+        "total_err": total_err,
+        "total_att": total_att,
+        "worst_frac": worst_frac,
+        "n_cells": len(leaves),
+        "source": "eval-json",
+    }
+
+
+def check_judge_error_denominator(
+    body: str,
+    *,
+    issue: int | None = None,
+    eval_root: Path | None = None,
+    body_source_path: Path | None = None,
+) -> CheckResult:
+    """FAIL/WARN when a clean-result body asserts a BARE LLM-judge
+    denominator (`n=N` / "N completions / EM") in a judge-context section
+    WITHOUT disclosing the judge-API-error fraction, while the committed
+    `eval_results/issue_<N>/` JSONs show a non-trivial fraction of rows
+    returned Anthropic Batch API 529-overload errors that were silently
+    counted into the denominator (the /issue 715 R1 trap).
+
+    Verdict ladder (§4.3): PASS when (a) no bare judge denominator is
+    asserted, (b) the body discloses, (c) the issue is unknown / eval root
+    unresolvable / no recognized judge-error signal exists (graceful skip);
+    WARN at >1% (worst-cell OR pooled); FAIL at >5%.
+    """
+    name = "judge-API-error denominator disclosed"
+    # Generation gate: only structured (v3 / v4) bodies. Legacy / v2 PASS
+    # vacuously (forward-grandfathering, matching every generation-gated check).
+    if not (is_v3(body) or is_v4(body)):
+        return CheckResult(name, True, "skipped — legacy/v2 body")
+
+    method = section_text(body, "Methodology") or ""
+    results_s = section_text(body, "Results") or ""
+    footer = _v4_footer_text(body) or ""
+    scan_region = _strip_fenced_blocks(method + "\n" + results_s)
+
+    claims = _judge_denominator_claims(scan_region)
+    if not claims:
+        return CheckResult(name, True, "no judge denominator asserted")
+
+    disclosed_region = scan_region + "\n" + footer
+    if _JUDGE_ERROR_DISCLOSURE_RE.search(disclosed_region):
+        return CheckResult(name, True, "judge-error fraction disclosed in body")
+
+    if issue is None:
+        return CheckResult(
+            name, True, "skipped — issue number unknown (stdin); cannot read eval_results"
+        )
+
+    repo = _resolve_eval_root(issue, eval_root=eval_root, body_source_path=body_source_path)
+    if repo is None:
+        return CheckResult(name, True, "skipped — eval root unresolved", is_warn=True)
+
+    stats = _scan_issue_judge_errors(repo, issue)
+    if stats is None:
+        return CheckResult(
+            name, True, "no judge-error data available in committed eval JSONs — graceful skip"
+        )
+
+    pooled = stats["total_err"] / max(stats["total_att"], 1)
+    worst = stats["worst_frac"]
+    detail = (
+        f"{stats['total_err']} rows (worst cell {worst:.1%}, pooled {pooled:.1%}) "
+        f"returned judge-API errors and were silently counted into the n=<...> "
+        f"denominator with no disclosure. Recompute as "
+        f"n_misaligned/(n_attempted - n_judge_error) and disclose the excluded fraction."
+    )
+    if worst > 0.05 or pooled > 0.05:
+        return CheckResult(name, False, detail)
+    if worst > 0.01 or pooled > 0.01:
+        return CheckResult(name, True, detail, is_warn=True)
+    return CheckResult(
+        name, True, f"judge-error fraction below 1% (worst {worst:.1%}, pooled {pooled:.1%})"
+    )
+
+
 def _git_object_exists(repo: Path, sha: str, path: str) -> tuple[str, str]:
     """Return ('pass', '') if `git cat-file -e <sha>:<path>` succeeds,
     ('fail', detail) if the sha resolves but the path is absent, or
@@ -6361,6 +6668,9 @@ def verify_text(
     plan_path: Path | None = None,
     original_body_path: Path | None = None,
     methodology_doc_path: Path | None = None,
+    issue: int | None = None,
+    eval_root: Path | None = None,
+    body_source_path: Path | None = None,
 ) -> tuple[bool, list[CheckResult]]:
     """Run every clean-result check on ``raw`` body.md text.
 
@@ -6442,6 +6752,15 @@ def verify_text(
     # the body-only CHECKS list. NO-OP PASS on v2 / legacy bodies and
     # whenever no doc is supplied (gate-timing — see the check docstring).
     results.append(check_body_params_subset_of_doc(body, methodology_doc_path=methodology_doc_path))
+    # Check (#732, judge-API-error denominator) needs the issue number AND
+    # the eval-root / body-source-path resolution legs (the body-only CHECKS
+    # list carries none of these), so it also lives outside CHECKS. Graceful
+    # PASS when the issue is unknown or no eval data is reachable.
+    results.append(
+        check_judge_error_denominator(
+            body, issue=issue, eval_root=eval_root, body_source_path=body_source_path
+        )
+    )
     overall = all(r.passed for r in results)
     return overall, results
 
@@ -6452,6 +6771,33 @@ def _load_text_for_issue(number: int) -> tuple[str, Path]:
     folder = find_task_path(number)
     body_path = folder / "body.md"
     return body_path.read_text(), body_path
+
+
+def _resolve_file_siblings(
+    body_source_path: Path,
+) -> tuple[Path | None, Path | None, Path | None, int | None]:
+    """For a ``--file <body.md>`` invocation, resolve the sibling
+    artifacts a ``tasks/<status>/<N>/body.md`` layout carries so the
+    sibling-dependent checks fire on analyzer-side dry runs: the Lens 14
+    concerns audit (``concerns.jsonl``), check-16 lr reconciliation
+    (``plans/plan.md``), and check-17 context-provenance read
+    (``original-body.md``). Also opportunistically parses the issue number
+    from the parent dir name (so the #732 judge-error-denominator check
+    binds). Returns ``(concerns_path, plan_path, original_body_path,
+    issue)`` — each None when the corresponding sibling is absent / the
+    dir name is not numeric.
+    """
+    parent = body_source_path.parent
+    concerns = parent / "concerns.jsonl"
+    plan = parent / "plans" / "plan.md"
+    orig = parent / "original-body.md"
+    issue = int(parent.name) if parent.name.isdigit() else None
+    return (
+        concerns if concerns.exists() else None,
+        plan if plan.exists() else None,
+        orig if orig.exists() else None,
+        issue,
+    )
 
 
 def main() -> int:
@@ -6471,20 +6817,38 @@ def main() -> int:
             "NO-OP PASS when omitted or the file does not exist."
         ),
     )
+    parser.add_argument(
+        "--eval-root",
+        help=(
+            "path to the ROOT directory under which eval_results/issue_<N>/ lives "
+            "(check judge-API-error denominator, #732). The orchestrator passes the "
+            "issue-worktree root explicitly at the Step 9a-bis pre-merge gate, since "
+            "the eval JSONs are not yet on main pre-merge. When omitted, the check "
+            "resolves the eval root via the --file-derived / cwd / MAIN ladder, and "
+            "graceful-PASSes when none reach the dir."
+        ),
+    )
     args = parser.parse_args()
 
     concerns_path: Path | None = None
     plan_path: Path | None = None
     original_body_path: Path | None = None
     methodology_doc_path: Path | None = None
+    issue: int | None = None
+    eval_root: Path | None = None
+    body_source_path: Path | None = None
     if args.methodology_doc:
         cand = Path(args.methodology_doc).expanduser()
         if cand.exists():
             methodology_doc_path = cand
+    if args.eval_root:
+        eval_root = Path(args.eval_root).expanduser()
     if args.issue is not None:
         try:
             raw, source_path = _load_text_for_issue(args.issue)
             source = str(source_path)
+            issue = args.issue
+            body_source_path = source_path.resolve()
             concerns_path = source_path.parent / "concerns.jsonl"
             plan_path = source_path.parent / "plans" / "plan.md"
             original_body_path = source_path.parent / "original-body.md"
@@ -6505,21 +6869,12 @@ def main() -> int:
     elif args.file:
         raw = Path(args.file).read_text()
         source = args.file
-        # When verifying a body.md by file path, look for siblings
-        # (concerns.jsonl, plans/plan.md, original-body.md) so the Lens 14
-        # audit, the check-16 lr reconciliation, and the check-17 context-
-        # provenance read fire for analyzer-side dry runs against a body
-        # in tasks/<status>/<N>/.
-        parent = Path(args.file).resolve().parent
-        sibling = parent / "concerns.jsonl"
-        if sibling.exists():
-            concerns_path = sibling
-        plan_sibling = parent / "plans" / "plan.md"
-        if plan_sibling.exists():
-            plan_path = plan_sibling
-        orig_sibling = parent / "original-body.md"
-        if orig_sibling.exists():
-            original_body_path = orig_sibling
+        body_source_path = Path(args.file).resolve()
+        concerns_path, plan_path, original_body_path, file_issue = _resolve_file_siblings(
+            body_source_path
+        )
+        if issue is None:
+            issue = file_issue
     else:
         raw = sys.stdin.read()
         source = "<stdin>"
@@ -6531,6 +6886,9 @@ def main() -> int:
         plan_path=plan_path,
         original_body_path=original_body_path,
         methodology_doc_path=methodology_doc_path,
+        issue=issue,
+        eval_root=eval_root,
+        body_source_path=body_source_path,
     )
     print(f"verify_task_body — {source}")
     for r in results:

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -5398,3 +5398,248 @@ def test_check26_repo_unresolved_is_noop_pass(monkeypatch):
     res = verify_task_body.check_figure_panel_prose_vs_sidecar(_CHECK26_BODY)
     assert res.passed and not res.is_warn
     assert "repo root unresolved" in res.detail
+
+
+# ─── #732: check_judge_error_denominator — gate silent judge-API-error EM ──
+#
+# A NEW mechanical check that FAILs/WARNs when a clean-result body states a
+# BARE LLM-judge denominator (`n=N` / "N completions/EM") in a judge-context
+# section WITHOUT disclosing the judge-API-error fraction, while the committed
+# `eval_results/issue_<N>/` JSONs show a non-trivial fraction of rows returned
+# Anthropic Batch API 529-overload errors that were silently counted into the
+# denominator. It PASSes when (a) the body discloses, (b) no recognized
+# judge-error signal exists (graceful skip), or (c) no bare judge denominator
+# is asserted. The eval root is resolved through a ladder:
+#   (i) explicit --eval-root / eval_root= arg (gate-time worktree path),
+#   (ii) --file-derived worktree root,
+#   (iii) cwd `git rev-parse --show-toplevel`,
+#   (iv) _resolve_repo_root() (MAIN — bottom-of-ladder, post-merge bind),
+#   graceful PASS if all miss.
+# Demonstrated bug class: /issue 715 R1 (882 `529 Overloaded` rows across 48 EM
+# cells, 32.5% worst-cell, 4.59% pooled) silently counted into a bare n=400 EM
+# denominator. Plan: tasks/approved/732/plans/plan.md §1/§3/§4/§6.
+
+_CHECK732_NAME = "judge-API-error denominator disclosed"
+
+# Synthetic v4 body that TRIGGERS the check: a bare `n=400` EM judge
+# denominator in a judge-context (`## Methodology`/`## Results`) section, with
+# NO disclosure phrase anywhere (no 529 / Overloaded / n_judge_error / "excluded
+# from the denominator" / "post-correction" ...). Built from _V4_GOOD_BODY so it
+# is a valid v4 body (passes is_v4), then the Methodology `**Evaluation:**` line
+# is rewritten to assert the bare denominator.
+_CHECK732_UNDISCLOSED_BODY = _V4_GOOD_BODY.replace(
+    "- **Evaluation:** Betley alignment score, Claude Sonnet judge, 200 probes; "
+    "chosen to match the prior eval surface; no preprocessing.",
+    "- **Evaluation:** Betley emergent-misalignment rate, `claude-sonnet-4-5` "
+    "judge over 8 questions x 50 completions each (n=400 EM judgments per cell); "
+    "EM rate is `n_misaligned / 400` per cell.",
+)
+
+
+def _make_corrected_pareto_eval_tree(
+    root: Path, issue: int, *, worst_err: int, worst_att: int, other_cells: int
+):
+    """Write a synthetic #715-shaped `pareto_*_corrected.json` under
+    `root/eval_results/issue_<N>/`, returning the eval dir.
+
+    The leaf cells carry `n_em_judge_error` (judge-error count) + `n_em_attempted`
+    (the denominator) under a nested `cells` dict — matching the real
+    `pareto_em_vs_narrow_corrected.json` shape (source 1). `worst_err/worst_att`
+    sets the worst cell; `other_cells` clean cells (0 judge errors) pad the
+    pool so pooled and worst-cell fractions can diverge.
+    """
+    eval_dir = root / "eval_results" / f"issue_{issue}"
+    eval_dir.mkdir(parents=True, exist_ok=True)
+    leaves = [{"step": 0, "n_em_judge_error": worst_err, "n_em_attempted": worst_att}]
+    leaves += [
+        {"step": i + 1, "n_em_judge_error": 0, "n_em_attempted": worst_att}
+        for i in range(other_cells)
+    ]
+    total_err = sum(c["n_em_judge_error"] for c in leaves)
+    payload = {
+        "cells": {"sft_lora": {"seed42": leaves}},
+        "judge_error_correction": {"judge_error_totals": {"sweep_total": total_err}},
+        "metadata": {"issue": issue},
+    }
+    (eval_dir / "pareto_em_vs_narrow_corrected.json").write_text(json.dumps(payload))
+    return eval_dir
+
+
+def test_judge_error_denominator_h2_published_715_passes_via_disclosure():
+    """H2 (known-good → PASS via DISCLOSURE): the published #715 body discloses
+    the 529 / Overloaded / `excluded from the denominator` / `400 - n_judge_error`
+    phrasing in `## Methodology` AND the `**Repro:**` footer, so the check
+    short-circuits to PASS before any eval read.  Addresses §1 Goal H2.
+
+    Reads the REAL body via the resolved task path (issue 715 on MAIN); the
+    check is called directly with issue=715 (the disclosure short-circuit makes
+    the eval-root resolution irrelevant)."""
+    try:
+        from explore_persona_space.task_workflow import find_task_path
+
+        body_path = find_task_path(715) / "body.md"
+        if not body_path.exists():
+            pytest.skip("published #715 body absent")
+        body = body_path.read_text()
+    except Exception:
+        pytest.skip("could not resolve published #715 body")
+    if not verify_task_body.is_v4(body):
+        pytest.skip("#715 body is not v4 (migrated away from the disclosure fixture)")
+    res = verify_task_body.check_judge_error_denominator(body, issue=715)
+    assert res.passed and not res.is_warn, res.render()
+    assert "disclos" in res.detail.lower(), res.render()
+
+
+def test_judge_error_denominator_h1_synthetic_monkeypatched_fails(tmp_path, monkeypatch):
+    """H1 FAIL via the LEGACY code path: `_resolve_repo_root` monkeypatched to a
+    `tmp_path` root carrying a synthetic `eval_results/issue_<N>/` corrected JSON
+    (worst-cell 130/400 = 32.5%). Regression cover for the bottom-of-ladder
+    MAIN-post-merge fallback leg (iv).  Addresses §3 H1 (legacy code path)."""
+    _make_corrected_pareto_eval_tree(tmp_path, 999, worst_err=130, worst_att=400, other_cells=47)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: tmp_path)
+    res = verify_task_body.check_judge_error_denominator(_CHECK732_UNDISCLOSED_BODY, issue=999)
+    assert not res.passed, res.render()
+    assert "32.5%" in res.detail or "0.32" in res.detail or "worst" in res.detail.lower()
+
+
+def test_judge_error_denominator_h1_eval_root_fails(tmp_path):
+    """H1 FAIL via the PRODUCTION ladder leg (i): pass `eval_root=tmp_path`
+    explicitly (NO `_resolve_repo_root` monkeypatch) over a synthetic
+    `eval_results/issue_<N>/` corrected JSON with a 32.5% worst cell → FAIL.
+    Proves the gate-time `--eval-root` path is actually plumbed.
+    Addresses Must-Fix item 1 (production ladder leg i)."""
+    _make_corrected_pareto_eval_tree(tmp_path, 999, worst_err=130, worst_att=400, other_cells=47)
+    res = verify_task_body.check_judge_error_denominator(
+        _CHECK732_UNDISCLOSED_BODY, issue=999, eval_root=tmp_path
+    )
+    assert not res.passed, res.render()
+
+
+def test_judge_error_denominator_h1_cwd_resolution_fails(tmp_path, monkeypatch):
+    """H1 FAIL via the PRODUCTION ladder leg (iii): `git init` a `tmp_path` repo,
+    write a synthetic `eval_results/issue_<N>/` corrected JSON, `chdir` into it
+    so `git rev-parse --show-toplevel` resolves the eval root — NO
+    `_resolve_repo_root` monkeypatch, NO explicit `--eval-root`. Proves the
+    cwd-based fallback reaches a worktree cwd.
+    Addresses Must-Fix item 1 (production ladder leg iii)."""
+    subprocess.run(["git", "init"], cwd=str(tmp_path), capture_output=True, check=True)
+    _make_corrected_pareto_eval_tree(tmp_path, 999, worst_err=130, worst_att=400, other_cells=47)
+    monkeypatch.chdir(tmp_path)
+    # Belt-and-suspenders: make sure the MAIN fallback (leg iv) cannot resolve a
+    # real eval_results/issue_999 — force it to None so the FAIL can only come
+    # from the cwd leg under test.
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: None)
+    res = verify_task_body.check_judge_error_denominator(_CHECK732_UNDISCLOSED_BODY, issue=999)
+    assert not res.passed, res.render()
+
+
+def test_judge_error_denominator_integration_715_real_data():
+    """Real-data integration: run the eval scan over the REAL committed
+    `pareto_em_vs_narrow_corrected.json` (#715), resolved via `--eval-root`
+    pointed at the issue-715 worktree, and assert the helper recovers the
+    ground-truth fractions: worst_frac ≈ 0.325, pooled ≈ 0.0459, total_err == 882,
+    n_cells == 48.  Addresses the Methodology concern (non-blocking).
+
+    Skips if the fixture is absent (sparse-excluded worktree / post-merge
+    relocation)."""
+    try:
+        from explore_persona_space.task_workflow import repo_root
+
+        main_root = repo_root()
+    except Exception:
+        main_root = Path(__file__).resolve().parents[1]
+    candidates = [
+        main_root / ".claude" / "worktrees" / "issue-715",  # pre-merge worktree
+        main_root,  # post-merge: eval_results/issue_715 on MAIN
+    ]
+    eval_root = next(
+        (c for c in candidates if (c / "eval_results" / "issue_715").is_dir()),
+        None,
+    )
+    if eval_root is None:
+        pytest.skip("real-data fixture absent; sparse-excluded worktree or post-merge relocation")
+    stats = verify_task_body._scan_issue_judge_errors(eval_root, 715)
+    assert stats is not None, "scan returned None on the real corrected JSON"
+    assert stats["total_err"] == 882, stats
+    assert stats["n_cells"] == 48, stats
+    assert abs(stats["worst_frac"] - 0.325) < 1e-3, stats
+    pooled = stats["total_err"] / max(stats["total_att"], 1)
+    assert abs(pooled - 0.0459) < 1e-3, (pooled, stats)
+
+
+def test_judge_error_denominator_no_trigger_training_rows_passes(tmp_path):
+    """No-trigger PASS: a body whose only large `n`-like count is a TRAINING-ROW
+    count ("6349 training rows") with no judge-context judge-noun co-occurrence
+    asserts NO judge denominator → PASS (no eval read, no FAIL on a real error
+    fraction). Addresses the Statistics concern (training-row false-trigger)."""
+    # _V4_GOOD_BODY's Methodology already says "2,000 rows" with no judge-context
+    # denominator; add an explicit training-row count to make the no-trigger case
+    # unambiguous, and confirm it does not fire even with a real eval tree present.
+    body = _V4_GOOD_BODY.replace(
+        "- **Design:** 3 seeds; baseline vs tulu-25 on benchmark Z. "
+        "The single manipulated variable is the data mix.",
+        "- **Design:** 3 seeds; baseline vs tulu-25 on benchmark Z, 6349 training "
+        "rows. The single manipulated variable is the data mix.",
+    )
+    _make_corrected_pareto_eval_tree(tmp_path, 999, worst_err=130, worst_att=400, other_cells=47)
+    res = verify_task_body.check_judge_error_denominator(body, issue=999, eval_root=tmp_path)
+    assert res.passed and not res.is_warn, res.render()
+
+
+def test_judge_error_denominator_no_signal_graceful_pass(tmp_path):
+    """No-signal graceful PASS: a TRIGGERING body (bare n=400 EM denominator, no
+    disclosure) over an eval dir whose only count field is `breakdown.n_parse_error`
+    (the DISTINCT parse-error class, NOT the 529 API-error class) → PASS with a
+    graceful-skip note. `n_parse_error` must NOT be treated as a judge-API error.
+    Addresses Alternatives concern #3 (older-issue / no-signal layouts)."""
+    eval_dir = tmp_path / "eval_results" / "issue_999"
+    eval_dir.mkdir(parents=True)
+    # em_rate-style per-cell aggregate: n_total + breakdown.n_parse_error only.
+    (eval_dir / "dft_lora_seed42_step329.json").write_text(
+        json.dumps({"n_total": 400, "breakdown": {"n_parse_error": 0}})
+    )
+    res = verify_task_body.check_judge_error_denominator(
+        _CHECK732_UNDISCLOSED_BODY, issue=999, eval_root=tmp_path
+    )
+    assert res.passed and not res.is_warn, res.render()
+    assert "graceful" in res.detail.lower() or "no judge-error" in res.detail.lower()
+
+
+def test_judge_error_denominator_warn_band(tmp_path):
+    """WARN band: a TRIGGERING body over an eval dir whose judge-error fraction
+    sits in (1%, 5%] (both worst-cell and pooled) → WARN (passes overall, flagged).
+    Addresses §11 Source 2 (the >1% WARN threshold)."""
+    # 8/400 = 2% per cell, identical across cells → worst == pooled == 2%.
+    _make_corrected_pareto_eval_tree(tmp_path, 999, worst_err=8, worst_att=400, other_cells=2)
+    # The padding cells above have 0 errors, which would drop pooled below the
+    # worst cell; rebuild so every cell carries 2% to keep BOTH in (1%, 5%].
+    eval_dir = tmp_path / "eval_results" / "issue_999"
+    leaves = [{"step": i, "n_em_judge_error": 8, "n_em_attempted": 400} for i in range(3)]
+    (eval_dir / "pareto_em_vs_narrow_corrected.json").write_text(
+        json.dumps(
+            {
+                "cells": {"sft_lora": {"seed42": leaves}},
+                "judge_error_correction": {"judge_error_totals": {"sweep_total": 24}},
+            }
+        )
+    )
+    res = verify_task_body.check_judge_error_denominator(
+        _CHECK732_UNDISCLOSED_BODY, issue=999, eval_root=tmp_path
+    )
+    assert res.passed and res.is_warn, res.render()
+
+
+def test_judge_error_denominator_sibling_issue_graceful_pass(tmp_path):
+    """Sibling-issue graceful PASS: a TRIGGERING body over an eval dir whose JSON
+    carries NO recognized judge-error count key at all (older-issue layout, e.g.
+    #608/#545) → PASS graceful-skip, never a false FAIL.  Addresses §A6."""
+    eval_dir = tmp_path / "eval_results" / "issue_608"
+    eval_dir.mkdir(parents=True)
+    # An older-layout aggregate: a denominator but no recognized judge-error key.
+    (eval_dir / "sycophancy_rate.json").write_text(
+        json.dumps({"n_total": 500, "rate": 0.42, "model": "qwen"})
+    )
+    res = verify_task_body.check_judge_error_denominator(
+        _CHECK732_UNDISCLOSED_BODY, issue=608, eval_root=tmp_path
+    )
+    assert res.passed and not res.is_warn, res.render()

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -131,13 +131,14 @@ def test_good_body_passes_all():
     # (body-nonstub) + check 0b (no-duplicate-frontmatter), runs CHECKS[1:]
     # (31 functions), then appends the Goal soft check, the Lens 14
     # concerns-audit, the check-16 lr-matches-plan reconciliation, the
-    # check-17 Context provenance-row read, AND the v3 check-21
-    # body-Parameters-⊆-doc reconciliation (PASS-skip with no doc) →
-    # 38 results total (2 prepended + CHECKS[1:]=31 + 5 appended). The
+    # check-17 Context provenance-row read, the v3 check-21
+    # body-Parameters-⊆-doc reconciliation (PASS-skip with no doc), AND the
+    # #732 judge-API-error denominator check (PASS-skip: legacy body) →
+    # 39 results total (2 prepended + CHECKS[1:]=31 + 6 appended). The
     # Lens 14 / check-16 results are PASS-skips when no concerns.jsonl /
     # plans/plan.md sibling is available; check 17 and the v3/v4 checks
     # are PASS-skips on this legacy (pre-v2-sentinel) fixture.
-    assert len(results) == 38
+    assert len(results) == 39
 
 
 def test_missing_confidence_tag():


### PR DESCRIPTION
Closes task #732 (workflow-fix). Adds `check_judge_error_denominator` to `scripts/verify_task_body.py` to FAIL clean-result bodies that assert a bare `n=N` EM/LLM-judge denominator while committed `eval_results/issue_<N>/` show >5% silent 529-Overloaded judge errors. Closes the measurement-validity trap demonstrated by /issue 715 round 1.

## Pipeline
- Plan v3 (TDD, 4-tier eval-root ladder, 0 GPU-h, architectural:false)
- Fact-check 7/8 confirmed (v2 corrected A5)
- Critic ensemble REVISE → v3 integrated both Must-Fix
- 9 tests RED → GREEN; full suite 5827 passed; ruff clean
- Code-review: Claude PASS / Codex FAIL → reconciler PASS
- Step 9c PASS, completion audit PASS

## Files
- `scripts/verify_task_body.py` (+388 / -19): `_resolve_eval_root` 4-leg ladder, `_scan_issue_judge_errors`, `check_judge_error_denominator`, `--eval-root` CLI arg.
- `tests/test_verify_task_body.py` (+254 / -1): 9 `test_judge_error_denominator_*` tests + 38→39 pre-existing count bump.

## Deferred
- §A10: `--eval-root` orchestrator wiring at /issue Step 9a-bis (separate `kind: infra` task).
- Codex Major #1: `raw_*.json` source-3 fallback (plan §4.2 declares best-effort/skipped).