### PR TITLE
task #760: recurring reaper for leaked Codex app-server daemons

### DIFF
--- a/scripts/codex_daemon_reaper.py
+++ b/scripts/codex_daemon_reaper.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Reap leaked Codex app-server daemons + truncate the codex log WAL.
+
+Codex ensemble-review (scripts/codex_task.py -> openai-codex plugin) spawns a
+persistent daemon trio per session (node codex app-server, its codex-linux-x64
+vendor binary, app-server-broker.mjs serve) that does NOT exit after the
+companion task completes. They accumulate over weeks, each holding
+~/.codex/logs_2.sqlite (WAL mode) open so SQLite can never checkpoint the WAL.
+
+Mirrors scripts/cron_pod_audit.sh / scripts/worktree_audit.py: report-only by
+default, --apply to act, --json summary, exit 2 when something was (would be)
+reaped so the cron wrapper can swallow it. Exit nonzero ALSO on ps read failure
+(R6) — a silent zero-reap is worse than a loud failure.
+"""
+
+import argparse
+import contextlib
+import json
+import os
+import re
+import signal
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+DEFAULT_MAX_AGE_H = 24.0
+CODEX_DB = Path(os.path.expanduser("~/.codex/logs_2.sqlite"))
+
+# Daemon argv-match patterns. Anchored on REAL daemon argv shapes (confirmed
+# live 2026-06-30), NOT on bare substrings that also appear inside shell-wrapper
+# env/eval text (see HARD_EXCLUDE + R3).
+DAEMON_MATCH = [
+    re.compile(
+        r"\bcodex app-server\b"
+    ),  # node ... codex app-server AND .../codex-linux-x64/.../bin/codex app-server
+    re.compile(r"app-server-broker\.mjs\b"),  # node ... app-server-broker.mjs serve ...
+    re.compile(r"\bcodex-linux-x64\b"),  # the vendor binary path
+    re.compile(r"codex-companion\.mjs\b"),  # the companion runtime, if present (forward-looking)
+]
+
+# Checked FIRST. A process whose argv contains ANY of these is NEVER reaped,
+# regardless of age — even if it also matches a DAEMON_MATCH pattern. This is
+# what protects the codex_task.py REVIEW DRIVERS (the shell wrapper + uv/python
+# children). It does NOT protect an active review's WORKER (`node ... codex
+# app-server`) — that one shares the leaked-daemon argv shape; AGE is its only
+# guard. A future maintainer lowering EPS_CODEX_REAPER_MAX_AGE_H is removing
+# the only safety on an in-flight long review's worker.
+HARD_EXCLUDE = [
+    re.compile(r"codex_task\.py\b"),  # the review-dispatch drivers
+    re.compile(r"\bworkflow_lint\b"),
+    re.compile(r"\bwandb_reclaim\b"),
+    re.compile(
+        r"\b\S*sh -c\b"
+    ),  # shell wrappers (bash/sh/zsh/...); their env/eval text echoes daemon strings — R3
+]
+
+
+def _max_age_seconds(cli_h: float | None) -> float:
+    """Threshold in seconds: CLI flag wins, else EPS_CODEX_REAPER_MAX_AGE_H, else 24h."""
+    if cli_h is not None:
+        return cli_h * 3600.0
+    env = os.environ.get("EPS_CODEX_REAPER_MAX_AGE_H")
+    return (float(env) if env else DEFAULT_MAX_AGE_H) * 3600.0
+
+
+def _ps_snapshot() -> tuple[list[tuple[int, int, str]], dict]:
+    """One-shot (pid, etimes_seconds, argv) for every process.
+
+    Returns (rows, status). status is {"ok": bool, "error": str|None,
+    "returncode": int|None}. A read failure (OSError, SubprocessError, OR
+    nonzero ps returncode) yields rows=[] AND ok=False — distinguishing a
+    blind reaper from a clean zero-candidate day (R6). main() exits nonzero
+    when status.ok is False so a cron read-failure is NEVER silent.
+
+    argv is the full command line (ps -o args); the selector matches against
+    argv, NOT comm (which reads 'node'/'codex'/'bash' for the daemons).
+    """
+    try:
+        out = subprocess.run(
+            ["ps", "-eo", "pid=,etimes=,args="],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        return [], {"ok": False, "error": f"{type(e).__name__}: {e}", "returncode": None}
+    if out.returncode != 0:
+        return [], {
+            "ok": False,
+            "error": (out.stderr or "").strip()[:200] or "nonzero rc",
+            "returncode": out.returncode,
+        }
+    rows: list[tuple[int, int, str]] = []
+    for line in out.stdout.splitlines():
+        parts = line.strip().split(None, 2)  # pid, etimes, "rest is argv"
+        if len(parts) < 3:
+            continue
+        try:
+            rows.append((int(parts[0]), int(parts[1]), parts[2]))
+        except ValueError:
+            continue
+    return rows, {"ok": True, "error": None, "returncode": 0}
+
+
+def _is_daemon(argv: str) -> bool:
+    return any(p.search(argv) for p in DAEMON_MATCH)
+
+
+def _is_excluded(argv: str) -> bool:
+    return any(p.search(argv) for p in HARD_EXCLUDE)
+
+
+def enumerate_candidates(max_age_s: float, snapshot=None):
+    """Return (candidates, sub_threshold, ps_status). Each list is
+    [{pid, age_s, argv}]. A candidate matches a daemon pattern, is NOT excluded,
+    and is >= threshold. sub_threshold = matched + not-excluded but younger
+    (reported so the dry-run shows the live daemons it is deliberately sparing).
+    `snapshot` injects a fake list for tests; status is {ok:True} when injected.
+    """
+    if snapshot is not None:
+        rows, ps_status = snapshot, {"ok": True, "error": None, "returncode": 0}
+    else:
+        rows, ps_status = _ps_snapshot()
+    candidates, sub_threshold = [], []
+    for pid, age_s, argv in rows:
+        if _is_excluded(argv) or not _is_daemon(argv):
+            continue
+        rec = {"pid": pid, "age_s": age_s, "argv": argv[:200]}
+        (candidates if age_s >= max_age_s else sub_threshold).append(rec)
+    return candidates, sub_threshold, ps_status
+
+
+# --- kill machinery: COPIED from worktree_audit.py (_read_cmdline / _pid_running
+#     / _kill_orphan_pids).
+#     Why copy, not import: _kill_orphan_pids re-verifies against
+#     ORPHAN_HOLDER_PATTERNS, which is the WORKTREE predicate. We need to
+#     re-verify against the REAPER's own _is_daemon + _is_excluded, so a
+#     verbatim import would silently couple to the wrong predicate.
+def _read_cmdline(pid: int) -> str | None:
+    try:
+        with open(f"/proc/{pid}/cmdline", "rb") as fh:
+            return fh.read().replace(b"\x00", b" ").decode("utf-8", "replace").strip()
+    except OSError:
+        return None
+
+
+def _still_reapable(pid: int) -> bool:
+    """PID-reuse guard: re-read /proc cmdline at signal time; only signal if it
+    STILL matches a daemon pattern and is STILL not excluded (a recycled pid
+    fails both and is spared)."""
+    cmd = _read_cmdline(pid)
+    return bool(cmd) and _is_daemon(cmd) and not _is_excluded(cmd)
+
+
+def kill_candidates(pids, term_wait_s=8.0):
+    """SIGTERM -> wait -> SIGKILL survivors; cmdline re-verified immediately
+    before EVERY signal (R1). term_wait_s default 8s (R2).
+    Returns {killed, leftover, reuse_skipped} so a future maintainer can see
+    which pids were spared by the reuse guard (vs which truly survived)."""
+    pending: list[int] = []
+    reuse_skipped_term: list[int] = []
+    for pid in pids:
+        if not _still_reapable(pid):
+            reuse_skipped_term.append(pid)
+            continue
+        with contextlib.suppress(OSError):
+            os.kill(pid, signal.SIGTERM)
+        pending.append(pid)
+    deadline = time.time() + term_wait_s
+    while pending and time.time() < deadline:
+        time.sleep(0.2)
+        pending = [p for p in pending if _read_cmdline(p)]
+    reuse_skipped_kill: list[int] = []
+    for pid in pending:
+        if _still_reapable(pid):
+            with contextlib.suppress(OSError):
+                os.kill(pid, signal.SIGKILL)
+        else:
+            reuse_skipped_kill.append(pid)
+    time.sleep(0.5)
+    survivors = [p for p in pending if _read_cmdline(p)]
+    sent_pids = [p for p in pids if p not in reuse_skipped_term]
+    killed = [p for p in sent_pids if p not in survivors]
+    return {
+        "killed": sorted(killed),
+        "leftover": sorted(survivors),
+        "reuse_skipped": sorted(reuse_skipped_term + reuse_skipped_kill),
+    }
+
+
+def truncate_wal() -> dict:
+    """Best-effort PRAGMA wal_checkpoint(TRUNCATE) on the codex DB. NEVER VACUUM
+    (rewrites the whole multi-GB DB).
+
+    SQLite's `PRAGMA wal_checkpoint(TRUNCATE)` returns a row `(busy, log,
+    checkpointed)` and does NOT raise sqlite3.Error when a reader pins the WAL
+    — it returns busy=1. We fetch + check the row so a reader-pinned WAL is
+    reported as ok:False (R4 contract: "reported, not raised"), NOT silently
+    as success while the WAL stays full.
+
+    A missing DB / locked DB / surviving daemon connection all report
+    ok:False with the WAL byte counts (before/after) intact in the payload.
+    NEVER raises.
+    """
+    wal = CODEX_DB.with_name(CODEX_DB.name + "-wal")
+    before = wal.stat().st_size if wal.exists() else 0
+    if not CODEX_DB.exists():
+        return {
+            "ok": False,
+            "error": "db_absent",
+            "checkpoint_busy": False,
+            "result_row": None,
+            "wal_bytes_before": before,
+            "wal_bytes_after": before,
+        }
+    busy: int | None = None
+    result_row: tuple | None = None
+    try:
+        con = sqlite3.connect(str(CODEX_DB), timeout=10.0)
+        try:
+            con.execute("PRAGMA busy_timeout=10000")
+            cur = con.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            row = cur.fetchone()
+            if row is not None:
+                # SQLite docs: (busy, log_pages_checkpointed_to, log_pages_total).
+                # busy != 0 means readers still hold the WAL → TRUNCATE was blocked.
+                result_row = tuple(row)
+                busy = int(row[0]) if row[0] is not None else None
+        finally:
+            con.close()
+    except sqlite3.Error as e:
+        after = wal.stat().st_size if wal.exists() else 0
+        return {
+            "ok": False,
+            "error": str(e),
+            "checkpoint_busy": False,
+            "result_row": None,
+            "wal_bytes_before": before,
+            "wal_bytes_after": after,
+        }
+    after = wal.stat().st_size if wal.exists() else 0
+    checkpoint_busy = bool(busy) if busy is not None else False
+    return {
+        "ok": (not checkpoint_busy) and busy is not None,
+        "error": "checkpoint_busy"
+        if checkpoint_busy
+        else (None if busy is not None else "no_result_row"),
+        "checkpoint_busy": checkpoint_busy,
+        "result_row": result_row,
+        "wal_bytes_before": before,
+        "wal_bytes_after": after,
+    }
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Reap leaked Codex app-server daemons + truncate the log WAL."
+    )
+    ap.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually kill + truncate (default: dry-run report).",
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Explicit report-only (default; --dry-run wins on conflict).",
+    )
+    ap.add_argument("--json", action="store_true", help="Emit a JSON summary.")
+    ap.add_argument(
+        "--max-age-h",
+        type=float,
+        default=None,
+        help="Reap daemons older than this many hours (default: EPS_CODEX_REAPER_MAX_AGE_H or 24).",
+    )
+    args = ap.parse_args(argv)
+    apply = args.apply and not args.dry_run
+
+    max_age_s = _max_age_seconds(args.max_age_h)
+    candidates, sub_threshold, ps_status = enumerate_candidates(max_age_s)
+
+    kill_result: dict | None = None
+    wal: dict | None = None
+    if apply and ps_status["ok"]:
+        if candidates:
+            kill_result = kill_candidates([p["pid"] for p in candidates])
+            wal = truncate_wal()
+        else:
+            wal = truncate_wal()  # still reclaim WAL even with 0 candidates
+    elif apply and not ps_status["ok"]:
+        # Refuse to act on an unreadable process table — never mis-kill.
+        pass
+
+    summary = {
+        "apply": apply,
+        "max_age_h": max_age_s / 3600.0,
+        "ps_status": ps_status,
+        "n_candidates": len(candidates),
+        "n_sub_threshold": len(sub_threshold),
+        "candidates": candidates,
+        "sub_threshold": sub_threshold,
+        "kill_result": kill_result,
+        "wal": wal,
+    }
+    if args.json:
+        print(json.dumps(summary))
+    else:
+        if not ps_status["ok"]:
+            print(f"codex_daemon_reaper: ps_FAILED ({ps_status['error']!r}) — refusing to act")
+        else:
+            verb = "killed" if apply else "would reap"
+            print(
+                f"codex_daemon_reaper: {verb} {len(candidates)} over-threshold | "
+                f"{len(sub_threshold)} matched-but-young (spared)"
+            )
+            for c in candidates:
+                print(f"  - {verb}: pid {c['pid']} age {c['age_s']}s :: {c['argv']}")
+            for c in sub_threshold:
+                print(f"  . spared (young): pid {c['pid']} age {c['age_s']}s")
+            if kill_result is not None:
+                if kill_result["leftover"]:
+                    print(f"  ! survived: {kill_result['leftover']} (WAL truncate may be blocked)")
+                if kill_result["reuse_skipped"]:
+                    print(f"  . reuse-skipped: {kill_result['reuse_skipped']}")
+            if wal is not None:
+                print(f"  WAL: {wal}")
+    # Exit codes (loud failures, never silent):
+    #   3 = ps read failed
+    #   2 = something was (or would be) reaped
+    #   0 = clean zero-candidate pass
+    if not ps_status["ok"]:
+        return 3
+    return 2 if candidates else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/cron_codex_reaper.sh
+++ b/scripts/cron_codex_reaper.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Recurring Codex app-server daemon reaper — invoked from system crontab.
+# Reaps daemons older than EPS_CODEX_REAPER_MAX_AGE_H (default 24h) and truncates
+# ~/.codex/logs_2.sqlite's WAL. Mirrors cron_pod_audit.sh / cron_worktree_audit.sh.
+#
+# Policy:
+#   - Codex ensemble-review spawns a persistent daemon trio per session
+#     (node codex app-server, its codex-linux-x64 vendor binary,
+#     app-server-broker.mjs serve) that does NOT exit after the companion task
+#     completes. They accumulate over weeks, each holding ~/.codex/logs_2.sqlite
+#     (WAL mode) open so SQLite can never checkpoint the WAL.
+#   - Daemons older than the threshold are SIGTERM'd (SIGKILL survivors), then
+#     the WAL is best-effort PRAGMA wal_checkpoint(TRUNCATE)'d. The active
+#     review drivers (codex_task.py) and sub-threshold daemons are spared.
+#
+# Output lives at logs/codex_reaper/YYYY-MM-DD.log (one file per day, no
+# rotation needed because of the date stamp).
+
+set -uo pipefail
+
+# cron's minimal PATH lacks ~/.local/bin, so a bare `uv` exit-127s silently
+# (the `exit 0` below hides it). Put uv on PATH; fail LOUD if still missing.
+export PATH="$HOME/.local/bin:$PATH"
+if ! command -v uv >/dev/null 2>&1; then
+    echo "$(date -Iseconds) FATAL: uv not on PATH ($PATH); cannot run codex reaper" >&2
+    exit 1
+fi
+
+PROJECT_DIR="/home/thomasjiralerspong/explore-persona-space"
+DATE=$(date +%Y-%m-%d)
+LOG_DIR="${EPM_CODEX_REAPER_LOG_DIR:-$PROJECT_DIR/logs/codex_reaper}"
+LOG_FILE="$LOG_DIR/$DATE.log"
+
+mkdir -p "$LOG_DIR"
+
+# One pointer line per day into the crontab redirect file: everything below
+# runs inside a block redirected to $LOG_FILE, so without this the redirect
+# file stays empty forever and reads as "the reaper never ran" (task #580
+# item-3 diagnosis; mirrors cron_pod_audit.sh / cron_autonomous_session_watch.sh).
+FIRST_RUN_OF_DAY=0
+[ -f "$LOG_FILE" ] || FIRST_RUN_OF_DAY=1
+
+{
+    echo "=== $(date -Iseconds) codex_reaper start ==="
+    cd "$PROJECT_DIR" || exit 1
+    uv run python scripts/codex_daemon_reaper.py --apply
+    rc=$?
+    echo "=== $(date -Iseconds) codex_reaper exit=$rc ==="
+} >> "$LOG_FILE" 2>&1
+
+if [ "$FIRST_RUN_OF_DAY" = 1 ]; then
+    echo "$(date -Iseconds) codex_reaper: per-pass output → $LOG_FILE (this file receives only this daily pointer line)"
+fi
+
+# Exit 0 even if the reaper returned 2 (something reaped) or 3 (ps read failed)
+# — we don't want cron emails on every reap. The log file is the audit trail.
+exit 0

--- a/tests/test_codex_daemon_reaper.py
+++ b/tests/test_codex_daemon_reaper.py
@@ -1,0 +1,238 @@
+"""Unit tests for scripts/codex_daemon_reaper.py.
+
+Pins the selector predicate (a)-(e), the best-effort WAL truncate (f), and the
+three load-bearing safety paths: WAL-checkpoint-busy (g), ps-read-failure (h),
+and the PID-reuse guard at SIGTERM + SIGKILL (i). No real process is signaled,
+no real cron runs; the only on-disk sqlite is a per-test temp file the test
+creates and tears down.
+"""
+
+import importlib.util
+import signal
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load the reaper as a module (scripts/ is not an importable package).
+_REAPER_PATH = Path(__file__).resolve().parents[1] / "scripts" / "codex_daemon_reaper.py"
+_spec = importlib.util.spec_from_file_location("codex_daemon_reaper", _REAPER_PATH)
+reaper = importlib.util.module_from_spec(_spec)
+sys.modules["codex_daemon_reaper"] = reaper
+_spec.loader.exec_module(reaper)
+
+H = 3600.0
+DAY_S = int(24 * H)
+
+# Representative live argv shapes (confirmed 2026-06-30).
+ARGV_APP_SERVER = "node /home/thomasjiralerspong/.codex/bin/codex app-server"
+ARGV_VENDOR = "/home/thomasjiralerspong/.codex/vendor/codex-linux-x64/bin/codex app-server"
+ARGV_BROKER = "node /home/thomasjiralerspong/.codex/app-server-broker.mjs serve"
+ARGV_TASK_DRIVER = "uv run python scripts/codex_task.py --issue 697 --effort high"
+ARGV_WORKFLOW_LINT = "uv run python scripts/workflow_lint.py --check-asks"
+ARGV_WANDB_RECLAIM = "uv run python scripts/wandb_reclaim.py --apply"
+ARGV_BASH_WRAPPER = (
+    "bash -c CODEX_COMPANION_SESSION_ID=abc node /home/x/.codex/bin/codex app-server"
+)
+ARGV_SH_WRAPPER = "/bin/sh -c node /home/x/.codex/bin/codex app-server"
+
+
+# ---------------------------------------------------------------------------
+# Selector tests (against injectable fake (pid, etimes, argv) snapshots)
+# ---------------------------------------------------------------------------
+def test_a_selects_over_threshold_app_server():
+    """(a) A >24h `node ... codex app-server` row lands in candidates."""
+    snap = [(1001, DAY_S + 1000, ARGV_APP_SERVER)]
+    candidates, sub, ps_status = reaper.enumerate_candidates(DAY_S, snapshot=snap)
+    assert [c["pid"] for c in candidates] == [1001]
+    assert sub == []
+    assert ps_status["ok"] is True
+
+
+def test_b_spares_sub_threshold_daemon():
+    """(b) A <24h same-argv daemon is sub_threshold, never a candidate."""
+    snap = [(1002, DAY_S - 1000, ARGV_BROKER)]
+    candidates, sub, _ = reaper.enumerate_candidates(DAY_S, snapshot=snap)
+    assert candidates == []
+    assert [c["pid"] for c in sub] == [1002]
+
+
+def test_c_never_selects_codex_task_driver_at_any_age():
+    """(c) A codex_task.py review driver is hard-excluded even at 999999s."""
+    snap = [(1003, 999999, ARGV_TASK_DRIVER)]
+    candidates, sub, _ = reaper.enumerate_candidates(DAY_S, snapshot=snap)
+    assert candidates == []
+    assert sub == []
+
+
+def test_d_env_and_cli_threshold_precedence(monkeypatch):
+    """(d) EPS_CODEX_REAPER_MAX_AGE_H override; CLI --max-age-h wins over env."""
+    # Env override: 1h threshold makes a 2h daemon a candidate.
+    monkeypatch.setenv("EPS_CODEX_REAPER_MAX_AGE_H", "1")
+    assert reaper._max_age_seconds(None) == pytest.approx(1 * H)
+    # CLI flag wins over env.
+    assert reaper._max_age_seconds(48.0) == pytest.approx(48 * H)
+    # No env, no flag -> default 24h.
+    monkeypatch.delenv("EPS_CODEX_REAPER_MAX_AGE_H", raising=False)
+    assert reaper._max_age_seconds(None) == pytest.approx(24 * H)
+
+
+def test_e_never_selects_excluded_or_shell_wrappers():
+    """(e) workflow_lint / wandb_reclaim / bash -c / /bin/sh -c are all spared,
+    even when the wrapper argv echoes a daemon string."""
+    snap = [
+        (2001, DAY_S + 1, ARGV_WORKFLOW_LINT),
+        (2002, DAY_S + 1, ARGV_WANDB_RECLAIM),
+        (2003, DAY_S + 1, ARGV_BASH_WRAPPER),  # echoes "codex app-server" but is a bash -c wrapper
+        (2004, DAY_S + 1, ARGV_SH_WRAPPER),  # the broadened \b\S*sh -c\b exclude
+    ]
+    candidates, sub, _ = reaper.enumerate_candidates(DAY_S, snapshot=snap)
+    assert candidates == []
+    assert sub == []
+
+
+def test_f_truncate_wal_best_effort(monkeypatch, tmp_path):
+    """(f) truncate_wal() is best-effort: db_absent path returns ok:False without
+    raising; a fresh WAL-mode temp DB returns ok:True with a 3-tuple result_row."""
+    # db_absent path.
+    missing = tmp_path / "nope.sqlite"
+    monkeypatch.setattr(reaper, "CODEX_DB", missing)
+    res = reaper.truncate_wal()
+    assert res["ok"] is False
+    assert res["error"] == "db_absent"
+    assert res["checkpoint_busy"] is False
+
+    # Fresh WAL-mode DB with no other reader -> clean truncate.
+    db = tmp_path / "ok.sqlite"
+    con = sqlite3.connect(str(db))
+    con.execute("PRAGMA journal_mode=WAL")
+    con.execute("CREATE TABLE t (x INTEGER)")
+    con.executemany("INSERT INTO t VALUES (?)", [(i,) for i in range(200)])
+    con.commit()
+    con.close()
+    monkeypatch.setattr(reaper, "CODEX_DB", db)
+    res = reaper.truncate_wal()
+    assert res["ok"] is True
+    assert res["checkpoint_busy"] is False
+    assert res["result_row"] is not None
+    assert len(res["result_row"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Safety-path tests (round-2 additions)
+# ---------------------------------------------------------------------------
+def test_g_wal_checkpoint_busy_reported_as_failure(monkeypatch, tmp_path):
+    """(g) A reader-pinned WAL returns ok:False / checkpoint_busy:True (NOT silent
+    success), with a nonzero busy flag in result_row and the WAL bytes intact."""
+    db = tmp_path / "busy.sqlite"
+    con = sqlite3.connect(str(db))
+    con.execute("PRAGMA journal_mode=WAL")
+    con.execute("CREATE TABLE t (x INTEGER)")
+    con.executemany("INSERT INTO t VALUES (?)", [(i,) for i in range(500)])
+    con.commit()
+
+    # A SECOND connection holding an open read transaction pins the WAL so
+    # TRUNCATE is blocked (busy=1). Begin a read txn and leave it open.
+    con2 = sqlite3.connect(str(db))
+    con2.execute("BEGIN")
+    con2.execute("SELECT count(*) FROM t").fetchone()
+
+    monkeypatch.setattr(reaper, "CODEX_DB", db)
+    try:
+        res = reaper.truncate_wal()  # must NOT raise
+    finally:
+        con2.rollback()
+        con2.close()
+        con.close()
+
+    assert res["ok"] is False
+    assert res["checkpoint_busy"] is True
+    assert res["result_row"] is not None
+    assert res["result_row"][0] != 0  # busy flag set
+    assert res["wal_bytes_after"] > 0  # WAL not reclaimed while pinned
+
+
+def test_h_ps_read_failure_surfaces_and_main_exits_3(monkeypatch, capsys):
+    """(h) A ps read failure (OSError AND nonzero returncode) yields ps_status.ok
+    False, empty lists, and main() exit 3 with --apply taking no action."""
+
+    # (h1) OSError path.
+    def _raise_oserror(*a, **k):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(subprocess, "run", _raise_oserror)
+    rows, status = reaper._ps_snapshot()
+    assert rows == []
+    assert status["ok"] is False
+    assert "permission denied" in status["error"]
+    cands, sub, ps_status = reaper.enumerate_candidates(DAY_S)
+    assert cands == [] and sub == [] and ps_status["ok"] is False
+    rc = reaper.main(["--json"])
+    assert rc == 3
+    out = capsys.readouterr().out
+    assert '"ok": false' in out.lower()
+    # --apply must take NO action on an unreadable table.
+    rc_apply = reaper.main(["--apply", "--json"])
+    assert rc_apply == 3
+    out_apply = capsys.readouterr().out
+    import json as _json
+
+    payload = _json.loads(out_apply.strip().splitlines()[-1])
+    assert payload["kill_result"] is None
+    assert payload["wal"] is None
+
+    # (h2) nonzero ps returncode path.
+    def _nonzero_rc(*a, **k):
+        return subprocess.CompletedProcess(
+            args=a[0] if a else [], returncode=1, stdout="", stderr="ps: cannot access /proc"
+        )
+
+    monkeypatch.setattr(subprocess, "run", _nonzero_rc)
+    rows2, status2 = reaper._ps_snapshot()
+    assert rows2 == []
+    assert status2["ok"] is False
+    assert status2["returncode"] == 1
+    assert reaper.main(["--json"]) == 3
+
+
+def test_i_pid_reuse_guard_blocks_signal(monkeypatch):
+    """(i) The reuse guard prevents SIGKILL on a pid recycled between SIGTERM and
+    SIGKILL (i1) and prevents SIGTERM on a pid excluded at signal time (i2)."""
+    calls: list[tuple[int, int]] = []
+
+    def _fake_kill(pid, sig):
+        calls.append((pid, sig))
+
+    monkeypatch.setattr(reaper.os, "kill", _fake_kill)
+
+    # Stateful cmdline shim keyed by pid; advances each read so the SIGKILL-time
+    # read can differ from the SIGTERM-time read (the "recycled" case).
+    read_counts: dict[int, int] = {}
+
+    def _stateful_cmdline(pid):
+        n = read_counts.get(pid, 0)
+        read_counts[pid] = n + 1
+        if pid == 9001:
+            # First read (pre-SIGTERM via _still_reapable) -> daemon -> SIGTERM sent.
+            # Subsequent reads (the term-wait poll + pre-SIGKILL _still_reapable)
+            # -> a recycled non-daemon cmdline -> no SIGKILL.
+            return ARGV_APP_SERVER if n == 0 else "/usr/bin/some-unrelated-process --flag"
+        if pid == 9002:
+            # Excluded at signal time -> never SIGTERM'd.
+            return ARGV_TASK_DRIVER
+        return None
+
+    monkeypatch.setattr(reaper, "_read_cmdline", _stateful_cmdline)
+
+    result = reaper.kill_candidates([9001, 9002], term_wait_s=0.05)
+
+    # 9001: exactly one SIGTERM, never SIGKILL (recycled before escalation).
+    assert (9001, signal.SIGTERM) in calls
+    assert (9001, signal.SIGKILL) not in calls
+    # 9002: never signaled at all, and reported as reuse-skipped.
+    assert all(pid != 9002 for pid, _ in calls)
+    assert 9002 in result["reuse_skipped"]
+    # No stray signals to any other pid.
+    assert {pid for pid, _ in calls} == {9001}


### PR DESCRIPTION
Closes task #760.

## Summary

Adds a recurring cron that reaps leaked Codex daemon trios (`node codex app-server` + `codex-linux-x64` vendor binary + `app-server-broker.mjs serve`) older than a threshold (default 24h, env `EPS_CODEX_REAPER_MAX_AGE_H`), then truncates `~/.codex/logs_2.sqlite`'s WAL. Mirrors the existing `cron_pod_audit.sh` / `cron_worktree_audit.sh` pattern.

Closes the 2026-06-30 incident class: 69 leaked daemons (oldest ~51 days) had pinned the WAL open to 2.6 GB, contributing to a VM root-disk CRITICAL event.

## Files

- `scripts/codex_daemon_reaper.py` (new, stdlib-only) — selector + kill machinery + WAL truncate.
- `scripts/cron_codex_reaper.sh` (new) — thin cron wrapper, exit-0 from the wrapper.
- `tests/test_codex_daemon_reaper.py` (new, 9 tests).

## Round-2 safety paths (folded after the /adversarial-planner ensemble REVISE)

1. `truncate_wal()` fetches the `PRAGMA wal_checkpoint(TRUNCATE)` result row and treats nonzero `busy` as `ok: False, checkpoint_busy: True` — a reader-pinned WAL no longer silently reports success.
2. `_ps_snapshot()` returns `(rows, status)`; on OSError / SubprocessError / nonzero ps returncode, `main()` exits 3 and `--apply` is refused (never mis-kill on an unreadable process table).
3. New tests (g) WAL-busy, (h) ps-failure, (i) PID-reuse-guard pin the three load-bearing safety paths.

## Tests

`uv run pytest tests/test_codex_daemon_reaper.py -v` → 9 passed.

## Live smoke

- `--dry-run --json`: `ps_status.ok=true`, `n_candidates=0`, 6 live daemon members listed under `sub_threshold` (selector sees them, correctly spares them as <24h).
- `--apply --json`: `wal.checkpoint_busy=false`, real WAL 15.7 MB → 0 (closes the WAL-path acceptance gap surfaced by both Statistics critics).

## Follow-up

Registering the cron in the system crontab is the orchestrator's job (per CLAUDE.md § Background automations) — not in this PR.
