### PR TITLE
task #768: workflow-fix — SKILL.md Step 6d.4 pv_phase1_done gate handler

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -3174,8 +3174,11 @@ while True:
     #                                  `epm:fact-candidates v1`) from the local
     #                                  VM as part of its sentinel drain — do
     #                                  NOT re-post it. Read result["gate"],
-    #                                  exit the polling loop, and park at the
-    #                                  user gate per Step 6d.4 below.
+    #                                  exit the polling loop, and dispatch the
+    #                                  matching gate handler per Step 6d.4
+    #                                  below (PARK for a user gate like
+    #                                  `fact-candidates`, AUTO-RESOLVE +
+    #                                  resume the loop for `pv_phase1_done`).
     #   status == "stalled" | "dead" -> post epm:failure v1 with failure_class
     #                                   inferred from log_tail_excerpt
     #                                   (run scripts/failure_classifier.py on
@@ -3208,7 +3211,8 @@ The `poll_pipeline.py` helper posts `epm:progress` events itself when it
 sees a phase transition, AND drains pod-side sentinel files (posting
 their carried markers from the VM via `task_workflow.post_event`). The
 orchestrator's only post-tick duties are: exit the loop on `status=done`,
-park at the user gate on `status=gate` (Step 6d.4), and post
+dispatch the matching gate handler on `status=gate` (Step 6d.4 — PARK for
+a user gate, AUTO-RESOLVE + resume the loop for `pv_phase1_done`), and post
 `epm:failure v1` on `status=stalled` or `status=dead`. The orchestrator
 NEVER re-posts a marker the poller already posted from a sentinel —
 double-posting is the failure mode the gate path is designed to avoid.
@@ -3489,7 +3493,7 @@ uv run python scripts/task.py set-status <N> verifying \
 
 Then proceed to Step 7 (which handles results → upload routing).
 
-##### Step 6d.4: On `status=gate` — park at a pod-side user gate
+##### Step 6d.4: On `status=gate` — handle a pod-side gate (park OR auto-resolve)
 
 Pod-side dispatchers cannot post markers directly (the `task.py`
 branch-guard and the CLAUDE.md "Pod-side code NEVER shells out" rule),
@@ -3509,9 +3513,13 @@ polling loop and NEVER trigger the fail-fast block. They are NOT user
 gates — do not treat a `blocks_pipeline: False` phase signal as an
 unrecognised gate (incident #641).
 
-The orchestrator parks at the named gate inline rather than continuing
-to poll — the pipeline itself has EXITed and is waiting on a user
-answer.
+The orchestrator handles the named gate inline rather than continuing to
+poll — the pipeline itself has EXITed at the gate. Most gates are PARK-mode
+(`fact-candidates`): the pipeline is waiting on a user answer, so the
+orchestrator parks. An AUTO-RESOLVING gate (`pv_phase1_done`) is the
+exception: the orchestrator resolves it itself (a pod-cycle around an
+off-pod step) and resumes the loop in the same turn — see the per-gate
+handlers below.
 
 Gate handlers (one per registered `<name>`):
 
@@ -3565,6 +3573,73 @@ Gate handlers (one per registered `<name>`):
   polling loop directly without a re-invocation. (See plan §4.2 of any
   fact-teaching task for the on-pod resume contract.)
 
+- **`pv_phase1_done`** (issue #763 persona-vector extraction —
+  off-pod judge between two GPU phases): an AUTO-RESOLVING gate, NOT a
+  user park. The dispatcher `scripts/issue763_dispatch.sh` runs GPU
+  phase 1 (`generate + capture + pv_extract_generate + upload-progress`
+  — the PV rollouts are now on the HF data repo), emits the blocking
+  sentinel `gate=pv_phase1_done` via
+  `scripts/issue763_dispatch.sh --emit-gate pv_phase1_done`
+  (`write_sentinel("epm:gate", …, blocks_pipeline=True)`), and EXITs.
+  Unlike `fact-candidates` (which PARKS for a user pick at
+  workflow.yaml § gates.fact_candidates), the
+  orchestrator resolves this gate ITSELF — it does NOT raise
+  `AskUserQuestion`, does NOT post `epm:step-completed --exit-kind
+  parked`, does NOT EXIT the skill, and does NOT CRON-TEARDOWN — by
+  orchestrating a pod-cycle around an off-pod judge step and then
+  RESUMING the polling loop in this same turn. This handler behaves
+  IDENTICALLY in interactive and `EPM_AUTONOMOUS_SESSION` modes (there
+  is no user decision to make — the gate is fully auto-resolved).
+  <!-- autonomous-mode: auto-resolve -->
+  Concretely:
+
+  1. **Stop the GPU pod** (volume preserved): `uv run python scripts/pod.py
+     stop --issue <N>`. This frees the GPU through the deadline-bounded
+     stop (see Step 6d.2 § "Stop the pod" / "Notes on the obsolete
+     monitoring stack"); the PV rollouts are already on HF, so nothing on
+     the pod's ephemeral disk is lost.
+  2. **Run the judge OFF-POD on the VM**: `uv run python
+     scripts/issue763_extract_pv_rb.py --phase judge`. <!-- lint: historical-ref --> (This script
+     ships on the `issue-763` branch — it lands on `main` when #763 merges;
+     the reference is a forward / sibling-branch one, not a dead tool.)
+     This is VM-safe by construction and NOT a `task.py` pod-shellout: it
+     fetches the PV rollouts from HF via `snapshot_download`, batch-judges
+     through
+     `eval.batch_judge` (the deadline-bounded client — never a hand-rolled
+     `messages.batches.create` + deadline-less poller), and uploads the
+     keep-flags back to the issue HF prefix. It needs no GPU and posts no
+     `task.py` markers itself (it is an off-pod analysis step; the
+     orchestrator owns the poll-loop markers).
+  3. **Resume the pod**: `uv run python scripts/pod.py resume --issue <N>`
+     — new IP/port; `pods.conf` + `~/.ssh/config` + MCP config auto-refresh
+     on resume (re-run `/mcp` if the SSH MCP entry needs the refreshed
+     host/port; if SSH keeps failing on a stale port, pull the live
+     host/port back with `pod.py config --refresh-from-api` per Step 6b
+     "stale-port recovery", the #488 13h-loop failure class). CONFIRM the
+     resumed pod is reachable (`uv run python scripts/pod.py health
+     --quick`) before re-dispatching.
+  4. **Re-dispatch the workload tail** at `--from-phase pv_capture` via
+     the SAME experimenter launch pattern as the original launch
+     (Step 6d.1): spawn the `experimenter` subagent with the workload
+     command `bash scripts/issue763_dispatch.sh --from-phase pv_capture`
+     and the resumed pod's name (`pod-<N>` / `epm-issue-<N>`). The
+     dispatcher resumes at capture → E0 judge → fit → figures → final
+     upload → `[phase=done]`. The experimenter posts a fresh
+     `epm:run-launched` marker (new `pid` + `log_abs`) and exits, exactly
+     as on the first launch; the orchestrator updates its local poll-loop
+     `pid`/`log` from that marker.
+
+  Then **RESUME the polling loop** (Step 6d.2) at the next tick — do NOT
+  EXIT, do NOT park, do NOT CRON-TEARDOWN. The gate has auto-resolved:
+  the pod is burning GPU again after resume, so the `/issue-tick <N>`
+  backstop cron stays armed and the bg-Bash poll chain continues against
+  the resumed pod. (Contrast with `fact-candidates` above, which parks
+  for a user pick and tears the cron down.) **Idempotency on re-entry:**
+  if a re-entry observes an `epm:gate v<n>` for `pv_phase1_done` followed
+  by a FRESH `epm:run-launched` (post-resume; ts > the gate marker),
+  treat the gate as already resolved and proceed with normal polling — do
+  NOT re-stop / re-judge / re-dispatch.
+
 - **Unrecognised `gate` name**: this branch fires ONLY for a sentinel
   the poller surfaced as `status=gate` — i.e. one that carried
   `blocks_pipeline: True`. A non-empty gate name with
@@ -3581,7 +3656,15 @@ Gate handlers (one per registered `<name>`):
   `status:blocked`, exit. This forces a workflow-fix-candidate before
   the gate name can silently no-op.
 
-Run CRON-TEARDOWN before parking (the HARDENED Step 6d.2 procedure:
+**PARK-mode gates only** (`fact-candidates` and the unrecognised-gate
+branch): the tail below applies ONLY to gates that EXIT the skill to wait
+on a human. Auto-resolving gates like `pv_phase1_done` (above) handle
+their own continuation — they do NOT teardown and do NOT EXIT; their
+handler resumes the polling loop in the same turn, so it skips this whole
+paragraph.
+
+For a PARK-mode gate: run CRON-TEARDOWN before parking (the HARDENED
+Step 6d.2 procedure:
 `CronList` → delete ALL jobs matching `/issue-tick <N>` — whole-string
 equality `prompt.strip() == "/issue-tick <N>"` plus the `(?!\d)`-guarded
 fallback — then assert-after-delete, retry once) — the pipeline has EXITed and no pod is
@@ -3593,8 +3676,9 @@ skill cleanly via `uv run python scripts/post_step_completed.py --issue <N>
 --step 6d --exit-kind parked` (the §5 `epm:step-completed` marker); the
 user's re-invocation of `/issue <N>` resumes the polling loop. The polling-loop's terminal
 transitions are now `running → verifying` (on done), `running → running`
-(after a parked gate resumes), or `running → blocked` (on stalled/dead
-or unrecognised gate).
+(after a parked-and-resumed user gate, OR after an auto-resolving gate's
+handler returns), or `running → blocked` (on stalled/dead or unrecognised
+gate).
 
 ##### Notes on the obsolete monitoring stack
 
@@ -3632,9 +3716,11 @@ read it as "the bg-Bash poll chain has no live tick AND no scheduled
 
 Status stays at `running` throughout the polling loop. The polling
 loop's terminal transitions are `running → verifying` (on done),
-`running → running` (parked at a user gate per Step 6d.4; resumes on
-the next `/issue <N>` invocation after the user posts the gate-resume
-marker), or `running → blocked` (on stalled/dead or an unrecognised
+`running → running` (a gate resolved per Step 6d.4 — either a PARK-mode
+user gate that resumes on the next `/issue <N>` invocation after the user
+posts the gate-resume marker, OR an auto-resolving gate like
+`pv_phase1_done` whose handler cycles the pod and resumes the loop in the
+same turn), or `running → blocked` (on stalled/dead or an unrecognised
 gate name).
 
 ### Step 7: Monitor -> results

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -3579,7 +3579,8 @@ Gate handlers (one per registered `<name>`):
   phase 1 (`generate + capture + pv_extract_generate + upload-progress`
   — the PV rollouts are now on the HF data repo), emits the blocking
   sentinel `gate=pv_phase1_done` via
-  `scripts/issue763_dispatch.sh --emit-gate pv_phase1_done`
+  `scripts/issue763_upload.py --emit-gate pv_phase1_done` <!-- lint: historical-ref --> (called from
+  `scripts/issue763_dispatch.sh` after upload-progress)
   (`write_sentinel("epm:gate", …, blocks_pipeline=True)`), and EXITs.
   Unlike `fact-candidates` (which PARKS for a user pick at
   workflow.yaml § gates.fact_candidates), the

--- a/tests/test_pv_phase1_done_gate_handler.py
+++ b/tests/test_pv_phase1_done_gate_handler.py
@@ -1,0 +1,126 @@
+"""Pin the `pv_phase1_done` gate handler in `/issue` SKILL.md Step 6d.4.
+
+Issue #763's PV-extraction dispatcher (`scripts/issue763_dispatch.sh`) splits
+phase 1 into a GPU half and an off-pod judge half, separated by a BLOCKING gate
+sentinel `gate=pv_phase1_done`. Step 6d.4 dispatches one handler per registered
+gate name; before #768 the registry held only `fact-candidates` (a PARK-mode
+gate) plus an "Unrecognised `gate` name" catch-all that posts
+`epm:failure unrecognised_gate_name` + `status:blocked`. Without a
+`pv_phase1_done` handler the production run of `/issue 763` would fall through
+to that catch-all and block.
+
+This test pins the AUTO-RESOLVING handler so a future refactor cannot silently:
+  - drop the gate name,
+  - drop any of the four orchestrator sub-steps (stop → off-pod judge →
+    resume → re-dispatch),
+  - re-introduce the PARK behavior (CRON-TEARDOWN / EXIT) for this gate, or
+  - leave the section-tail CRON-TEARDOWN paragraph unconditional (which would
+    tear the cron down + park even for the auto-resolving gate).
+
+It mirrors the SKILL.md text-assertion pattern of
+`tests/test_issue_skill_marker_contract.py`. The primary verifier is the
+implementer's grep + the Claude+Codex code-review ensemble; this test is the
+mechanical backstop.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+ISSUE_SKILL = ROOT / ".claude" / "skills" / "issue" / "SKILL.md"
+
+# The four orchestrator sub-step tokens the handler MUST name, in order.
+REQUIRED_SUBSTEP_TOKENS = (
+    "pod.py stop",
+    "--phase judge",
+    "pod.py resume",
+    "--from-phase pv_capture",
+)
+
+
+def _gate_handlers_section(body: str) -> str:
+    """Return the WHITESPACE-NORMALIZED Step 6d.4 "Gate handlers" list — from
+    the "Gate handlers (one per registered" anchor up to the section-tail
+    "PARK-mode gates only" guard sentence (exclusive). The handler MUST live
+    inside this slice, not merely somewhere in the 6000-line file.
+
+    Whitespace (including the markdown line-wraps inside a handler bullet, e.g.
+    `scripts/pod.py\\n     stop --issue <N>`) is collapsed to single spaces so
+    a token like `pod.py stop` matches across a soft line break — the prose is
+    what matters, not the column the wrapper chose.
+    """
+    start = body.index("Gate handlers (one per registered")
+    # The PARK-mode guard sentence marks the end of the per-gate handler list.
+    end = body.index("PARK-mode gates only", start)
+    return re.sub(r"\s+", " ", body[start:end])
+
+
+def test_pv_phase1_done_handler_present_in_gate_handlers_section():
+    """`pv_phase1_done` is registered as a handler inside the Step 6d.4 gate
+    list (not just mentioned elsewhere in the file)."""
+    section = _gate_handlers_section(ISSUE_SKILL.read_text())
+    assert "pv_phase1_done" in section, (
+        "Step 6d.4 must register a `pv_phase1_done` gate handler; without it the "
+        "issue #763 production run falls through to the 'Unrecognised gate' branch "
+        "and blocks with epm:failure unrecognised_gate_name."
+    )
+
+
+def test_pv_phase1_done_handler_names_four_substeps():
+    """The handler names all four orchestrator sub-steps in order: pod stop →
+    off-pod `--phase judge` → pod resume → re-dispatch at `--from-phase
+    pv_capture`."""
+    section = _gate_handlers_section(ISSUE_SKILL.read_text())
+    last_idx = -1
+    for token in REQUIRED_SUBSTEP_TOKENS:
+        idx = section.find(token)
+        assert idx != -1, (
+            f"pv_phase1_done handler must name the sub-step token {token!r} "
+            "(stop → off-pod judge → resume → re-dispatch)."
+        )
+        assert idx > last_idx, (
+            f"pv_phase1_done sub-step {token!r} must appear in the canonical order "
+            "(pod.py stop → --phase judge → pod.py resume → --from-phase pv_capture)."
+        )
+        last_idx = idx
+
+
+def test_pv_phase1_done_handler_is_auto_resolve_not_park():
+    """The handler is explicitly AUTO-RESOLVING and prohibits the PARK
+    behavior (no CRON-TEARDOWN, no EXIT) so a future edit cannot quietly turn
+    it back into a park-mode gate."""
+    section = _gate_handlers_section(ISSUE_SKILL.read_text())
+    lower = section.lower()
+    assert "auto-resolv" in lower, (
+        "pv_phase1_done handler must state it AUTO-RESOLVES (contrast with the "
+        "PARK-mode fact-candidates gate)."
+    )
+    assert "do not cron-teardown" in lower, (
+        "pv_phase1_done handler must explicitly prohibit CRON-TEARDOWN — an "
+        "auto-resolving gate keeps the pod (and the backstop cron) running."
+    )
+    assert "fact-candidates" in section, (
+        "pv_phase1_done handler must contrast itself with the park-mode "
+        "fact-candidates gate so a future reader sees why two gates differ."
+    )
+
+
+def test_section_tail_cron_teardown_scoped_to_park_mode():
+    """The section-tail CRON-TEARDOWN/EXIT paragraph is guarded so it applies
+    ONLY to PARK-mode gates — otherwise it would tear the cron down + park even
+    for the auto-resolving pv_phase1_done gate."""
+    body = ISSUE_SKILL.read_text()
+    guard_idx = body.find("PARK-mode gates only")
+    teardown_idx = body.find("run CRON-TEARDOWN before parking")
+    assert guard_idx != -1, (
+        "Step 6d.4 section tail must carry the 'PARK-mode gates only' scope-guard "
+        "sentence; without it the CRON-TEARDOWN/EXIT prose fires on every gate exit, "
+        "including the auto-resolving pv_phase1_done gate."
+    )
+    assert teardown_idx != -1, "Step 6d.4 section tail must still describe CRON-TEARDOWN."
+    assert guard_idx < teardown_idx, (
+        "The 'PARK-mode gates only' guard sentence must precede the "
+        "CRON-TEARDOWN-before-parking prose so the latter reads as park-mode-only."
+    )


### PR DESCRIPTION
Adds an AUTO-RESOLVING `pv_phase1_done` gate handler to `.claude/skills/issue/SKILL.md` Step 6d.4 to unblock the production run of `/issue 763` (the off-pod PV judge pod-cycle).

**The fix:**
- New handler bullet: `pod.py stop` → off-pod `issue763_extract_pv_rb.py --phase judge` on the VM → `pod.py resume` → re-dispatch `issue763_dispatch.sh --from-phase pv_capture` via the Step 6d.1 experimenter pattern → RESUME the polling loop (no park, no EXIT, no CRON-TEARDOWN).
- Edit B: scope the section-tail "Run CRON-TEARDOWN before parking ... EXIT" prose to PARK-mode gates only so it does not fire on the auto-resolving gate.
- Edit B′: broaden the terminal-transitions gloss in both tail copies to cover the auto-resolve case.
- New `tests/test_pv_phase1_done_gate_handler.py` (4 tests) pinning the handler shape + PARK-mode scope guard.

**Review:**
- Critic ensemble: PASS (Claude APPROVE + Codex APPROVE).
- Code-review ensemble: CONCERNS+CONCERNS (PASS-class); 1-token prose fix applied inline (commit `818caf1371`).
- Test-verdict (Step 9c): PASS (4/4 new tests pass; the 2 pre-existing HF-Hub-touching failures in `test_verify_task_body_audit_claim.py` reproduce on `main` — unrelated to this change).
- `workflow_lint: PASS`.

Closes task #768.