### PR TITLE
task #773: protect active-task input caches from vm_disk_guard reap

### DIFF
--- a/scripts/clean_experiment_downloads.py
+++ b/scripts/clean_experiment_downloads.py
@@ -435,7 +435,13 @@ def _active_consumer_protected_issues(self_issue_n: int) -> dict[int, list[int]]
     active_statuses = [s for s in STATUSES if s not in _CONSUMER_INACTIVE_STATUSES]
     protected: dict[int, list[int]] = {}
     for status in active_statuses:
-        for row in list_by_status(status):
+        # list_by_status defaults to limit=200 and SILENTLY truncates — a 201st+
+        # active task is dropped, so its declared input cache would be reaped out
+        # from under it (the #742 strand class this gate exists to prevent,
+        # reintroduced through a cap inside the guard). Pass an explicit large
+        # limit so the active-consumer scan is complete: a missed consumer is a
+        # silent fail-OPEN, the opposite of this guard's fail-toward-keep contract.
+        for row in list_by_status(status, limit=10_000):
             consumer_id = row["id"]
             # self_issue_n never protects its OWN reap: exclude it from the
             # CONSUMER set entirely (a task referencing data/issue_<self>/ in its
@@ -608,12 +614,14 @@ def clean_issue_downloads(
       2. The nested-``store/`` parity gate (#679): never wholesale-rmtree a
          cache dir holding a mis-rooted ``store/`` not verifiably mirrored on HF.
 
-    ``_skip_active_consumer_guard`` (private, keyword-only, defaulted) opts out
-    of gate 1 — used by :func:`clean_issue_downloads_incremental` (the within-
-    run path is self-aware and self-reaps its own consumed caches). Even
-    WITHOUT the flag a task never protects its own reap (the protected-set
-    helper excludes ``self_issue_n``); the flag additionally skips the
-    ``tasks/`` walk entirely on the within-run hot path.
+    ``_skip_active_consumer_guard`` (private, keyword-only, defaulted False) opts
+    out of gate 1, skipping the ``tasks/`` walk entirely. It is a TEST SEAM only
+    — no production caller passes it. In particular
+    :func:`clean_issue_downloads_incremental` does NOT set it: the within-run
+    path keeps the active-CONSUMER gate ON so a DIFFERENT active task's declared
+    input is still protected (the gate self-excludes ``self_issue_n`` via the
+    protected-set helper, so a task never blocks its own reap regardless of the
+    flag; the cross-issue protection is what the flag would have removed).
     """
     res = CleanResult(issue_n=issue_n, apply=apply)
     # Cache the HF listing across cache dirs so a multi-cache-dir issue makes at
@@ -679,15 +687,17 @@ def clean_issue_downloads_incremental(
     touched; the re-downloadable cache is rebuilt on demand if a later phase
     needs it again.
 
-    The active-CONSUMER gate (#773) is SKIPPED on this path
-    (``_skip_active_consumer_guard=True``): the calling experiment is the
-    authority on its own caches and would otherwise be a (self-excluded but
-    still walked) active consumer of its own ``data/issue_<N>/``. The helper
-    already excludes ``self_issue_n``, so this only skips the ``tasks/`` walk
-    entirely — a small within-run perf win, not a behavior change."""
-    return clean_issue_downloads(
-        issue_n, apply=apply, data_root=data_root, _skip_active_consumer_guard=True
-    )
+    The active-CONSUMER gate (#773) RUNS on this path too. The within-run reaper
+    self-excludes ``self_issue_n`` in :func:`_active_consumer_protected_issues`,
+    so the calling experiment never blocks its OWN reap. But the gate's purpose
+    is CROSS-ISSUE protection — a DIFFERENT active task referencing
+    ``data/issue_<self>/`` must still block the reap, exactly as on the
+    end-of-run path: the self-exclusion is on the CONSUMER, NOT on the
+    referenced issue, so skipping the guard here would have removed the
+    cross-issue protection on the incremental path entirely (a fail-OPEN strand
+    of the #742 class). It defaults to ON; ``clean_issue_downloads`` retains the
+    private ``_skip_active_consumer_guard`` kwarg only as a test seam."""
+    return clean_issue_downloads(issue_n, apply=apply, data_root=data_root)
 
 
 def _rel_name(path: Path) -> str:

--- a/scripts/clean_experiment_downloads.py
+++ b/scripts/clean_experiment_downloads.py
@@ -16,6 +16,28 @@ What is and is NOT a cache (the safety contract):
   * ``eval_results/``          — KEEP (the durable result artifacts)
   * anything else under ``data/issue_<N>/`` — KEEP (only the two cache globs
     are ever touched).
+  * EXCEPTION (the active-consumer gate, #773): a ``hf_dl`` / ``g*_dl`` cache
+    that would otherwise be deleted is KEPT (never deleted) while a DIFFERENT,
+    currently-ACTIVE task declares ``data/issue_<N>/`` as a planned input in
+    its ``plans/plan.md`` or ``body.md``. The reap is skipped + sidecar-logged
+    (``kind: "active-consumer-reap-skipped"``), fail-toward-keep. This guards
+    against the cross-issue strand-the-consumer failure mode (#742 died on a
+    ``FileNotFoundError`` after ``#658``'s caches were panic-reaped while it
+    was reading ``data/issue_658/store/v0_summaries.pt``, a symlink whose
+    target lived under ``data/issue_658/hf_dl/``). See
+    ``_active_consumer_protected_issues`` /
+    ``_cache_dir_reap_blocked_by_active_consumer``.
+
+There are now THREE reap gates, all composing additively (any one puts a cache
+dir in ``CleanResult.skipped`` instead of deleting it):
+  1. The TERMINAL-status gate in ``vm_disk_guard.py`` (the OWNING issue must be
+     at a terminal-for-reap status before its caches are reaped at all).
+  2. The active-CONSUMER gate (#773, this module): never reap while a DIFFERENT
+     active task declares ``data/issue_<N>/`` as a planned input. Checked FIRST
+     in the per-cache-dir loop (a cheap in-memory set lookup; short-circuiting
+     on a consumer hit also avoids the parity guard's potential HF call).
+  3. The nested-``store/`` parity gate (#679, below): never wholesale-rmtree a
+     cache dir holding a mis-rooted ``store/`` not verifiably mirrored on HF.
 
 The ``data/`` tree uses two naming conventions for the same N — ``issue_<N>``
 (underscore) AND ``issue<N>`` (no underscore, sometimes with a ``_<slug>``
@@ -55,19 +77,44 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
-from explore_persona_space.task_workflow import repo_root
+from explore_persona_space.task_workflow import (
+    STATUSES,
+    list_by_status,
+    repo_root,
+    tasks_dir,
+)
 
 # The two cache-dir glob patterns under data/issue_<N>/ that are
 # re-downloadable and therefore safe to delete. Everything else under the
 # per-issue data dir (notably ``store/``) is KEPT. ``hf_dl`` is an exact name;
 # ``g*_dl`` matches ``g1_dl`` / ``g2_dl`` / ... (the group-download buckets).
 CACHE_DIR_GLOBS = ("hf_dl", "g*_dl")
+
+# Statuses whose work is DONE or paused — a task at one of these does NOT
+# actively consume its declared inputs, so it never protects another issue's
+# cache (the active-CONSUMER gate, #773). The "active" set this guard cares
+# about is ``set(STATUSES) - _CONSUMER_INACTIVE_STATUSES``.
+#   - completed / archived : terminal, work finished.
+#   - on_hold              : explicitly parked, excluded from auto-dispatch.
+#   - blocked              : halted awaiting user; not actively reading inputs.
+# Everything ELSE (proposed / planning / plan_pending / approved / running /
+# verifying / interpreting / reviewing / awaiting_promotion /
+# followups_running) is "active": currently doing work or imminently planned
+# to, so its declared inputs may be read at any moment.
+_CONSUMER_INACTIVE_STATUSES = frozenset({"completed", "archived", "on_hold", "blocked"})
+
+# Match ``data/issue_<M>/`` (underscore) OR ``data/issue<M>/`` (no underscore) —
+# the two real naming conventions in ``data/``. The trailing lookahead pins the
+# M boundary to a ``/`` or ``_`` so ``data/issue65/`` never matches a
+# ``data/issue658/`` substring and ``data/issue658_slug/`` still matches 658.
+_DATA_ISSUE_REF = re.compile(r"\bdata/issue_?(\d+)(?=[/_])")
 
 # The HF dataset repo a per-issue ``store/`` would have been mirrored to. Used
 # ONLY by the defensive nested-``store/`` parity guard below to verify a
@@ -353,6 +400,111 @@ def nested_store_is_mirrored(
     return all(_local_file_is_mirrored(rel, size, hf_sizes) for rel, size in local.items())
 
 
+def _active_consumer_protected_issues(self_issue_n: int) -> dict[int, list[int]]:
+    """Map ``{protected_issue_M: [consumer_task_ids...]}`` for every ``M`` that
+    some ACTIVE task declares as a ``data/issue_<M>/`` input in its
+    ``plans/plan.md`` OR ``body.md`` (the active-CONSUMER reap gate, #773).
+
+    An "active" task is one whose status is NOT in
+    :data:`_CONSUMER_INACTIVE_STATUSES` — i.e. it is currently doing work or
+    imminently planned to, so its declared inputs may be read at any moment.
+    A protected ``M`` blocks the reap of ``data/issue_<M>/``'s caches: deleting
+    them could strand the active consumer mid-run (#742 died on a
+    ``FileNotFoundError`` after ``#658``'s caches were reaped out from under it).
+
+    ``self_issue_n`` is excluded from the CONSUMER set — a task never blocks
+    its OWN cache reap (Step-8 self-cleanup + the incremental within-run path
+    both reap the task's own cache; the guard must not protect a task against
+    itself). NOTE the exclusion is on the consumer, NOT the referenced issue: a
+    DIFFERENT active task referencing ``data/issue_<self_issue_n>/`` is exactly
+    the cross-issue protection this gate exists for. READ-ONLY: walks ``tasks/``
+    text via ``list_by_status``, never
+    mutates task state. Missing ``body.md`` / ``plans/plan.md`` is skipped
+    fail-soft. Returns ``{}`` when no active task references any
+    ``data/issue_<M>/`` (the common case, and the clean no-op for an
+    absent / empty ``tasks/`` tree).
+
+    KNOWN LIMITATION (false negative): a consumer that assembles the input
+    path in code / a Hydra YAML / an env-var override, with no literal
+    ``data/issue_<M>/`` substring in its plan.md or body.md, is NOT seen by
+    this regex. The project's reuse-provenance convention puts input paths in
+    the plan as literals (so the realistic case is caught), and the consumer's
+    OWN cache reap is independently protected by the owning-issue terminal-
+    status gate; this residual is a cross-issue config-indirection gap."""
+    base = tasks_dir()
+    active_statuses = [s for s in STATUSES if s not in _CONSUMER_INACTIVE_STATUSES]
+    protected: dict[int, list[int]] = {}
+    for status in active_statuses:
+        for row in list_by_status(status):
+            consumer_id = row["id"]
+            # self_issue_n never protects its OWN reap: exclude it from the
+            # CONSUMER set entirely (a task referencing data/issue_<self>/ in its
+            # own plan/body must not block self-cleanup). The exclusion is on the
+            # CONSUMER, NOT on the referenced issue — a DIFFERENT task (742)
+            # referencing data/issue_<self>/ (658) is exactly the protection we
+            # want, so we must NOT drop referenced == self_issue_n.
+            if consumer_id == self_issue_n:
+                continue
+            task_dir = base / status / str(consumer_id)
+            text_parts: list[str] = []
+            for rel in ("body.md", "plans/plan.md"):
+                try:
+                    text_parts.append((task_dir / rel).read_text())
+                except (FileNotFoundError, OSError):
+                    continue  # fail-soft: a missing/unreadable file just adds no text
+            if not text_parts:
+                continue
+            blob = "\n".join(text_parts)
+            for match in _DATA_ISSUE_REF.finditer(blob):
+                referenced = int(match.group(1))
+                if referenced == consumer_id:
+                    continue  # a task referencing its OWN data/issue_<self>/ does not self-protect
+                protected.setdefault(referenced, [])
+                if consumer_id not in protected[referenced]:
+                    protected[referenced].append(consumer_id)
+    # Sort each consumer list for deterministic sidecar telemetry.
+    return {m: sorted(consumers) for m, consumers in protected.items()}
+
+
+def _cache_dir_reap_blocked_by_active_consumer(
+    cache_dir: Path,
+    *,
+    issue_n: int,
+    apply: bool,
+    protected: dict[int, list[int]],
+) -> str | None:
+    """Return a SKIP reason if ``issue_n`` is consumed as a planned input by an
+    ACTIVE task; ``None`` to allow the reap. Composes with
+    :func:`_cache_dir_reap_blocked` (the nested-``store/`` parity gate) — both
+    can independently put a cache dir in ``CleanResult.skipped``.
+
+    On a hit, an escalation row is appended to the shared disk-guard sidecar
+    (``kind="active-consumer-reap-skipped"``), mirroring the nested-store
+    guard's pattern (``append_disk_guard_event``, fail-soft, ``apply=False``
+    reports only). ``protected`` is the once-per-call map from
+    :func:`_active_consumer_protected_issues`."""
+    consumers = protected.get(issue_n)
+    if not consumers:
+        return None
+    rel = _rel_name(cache_dir)
+    consumer_str = ", ".join(f"#{c}" for c in consumers)
+    reason = (
+        f"active task(s) {consumer_str} declare data/issue_{issue_n}/ as a "
+        f"planned input — reaping {rel} could strand their run; KEPT"
+    )
+    append_disk_guard_event(
+        {
+            "kind": "active-consumer-reap-skipped",
+            "task": issue_n,
+            "path": rel,
+            "consumers": consumers,
+            "reason": reason,
+        },
+        apply=apply,
+    )
+    return reason
+
+
 def _cache_dir_reap_blocked(
     cache_dir: Path,
     *,
@@ -438,6 +590,7 @@ def clean_issue_downloads(
     *,
     apply: bool = False,
     data_root: Path | None = None,
+    _skip_active_consumer_guard: bool = False,
 ) -> CleanResult:
     """Delete (``apply=True``) or report (default) ``issue_n``'s download caches.
 
@@ -446,18 +599,46 @@ def clean_issue_downloads(
     under the per-issue data dir(s) are removed. A removal that raises is
     recorded in ``failed`` and never aborts the rest (fail-soft per directory,
     fail-loud in the report).
+
+    Two reap gates run per cache dir, both fail-toward-keep:
+      1. The active-CONSUMER gate (#773, FIRST): never reap while a DIFFERENT
+         active task declares ``data/issue_<N>/`` as a planned input. It is a
+         cheap in-memory set lookup, so running it first short-circuits before
+         the parity gate's potential HF call.
+      2. The nested-``store/`` parity gate (#679): never wholesale-rmtree a
+         cache dir holding a mis-rooted ``store/`` not verifiably mirrored on HF.
+
+    ``_skip_active_consumer_guard`` (private, keyword-only, defaulted) opts out
+    of gate 1 — used by :func:`clean_issue_downloads_incremental` (the within-
+    run path is self-aware and self-reaps its own consumed caches). Even
+    WITHOUT the flag a task never protects its own reap (the protected-set
+    helper excludes ``self_issue_n``); the flag additionally skips the
+    ``tasks/`` walk entirely on the within-run hot path.
     """
     res = CleanResult(issue_n=issue_n, apply=apply)
     # Cache the HF listing across cache dirs so a multi-cache-dir issue makes at
     # most one Hub call regardless of how many nested store/ checks run.
     hf_sizes_cache: dict[str, dict[str, int] | None] = {}
+    # The active-consumer protected set is the same for every cache dir of this
+    # issue, so compute it ONCE before the loop (a single tasks/ walk).
+    protected = {} if _skip_active_consumer_guard else _active_consumer_protected_issues(issue_n)
     for cache_dir in download_cache_dirs(issue_n, data_root):
         rel = _rel_name(cache_dir)
         res.sizes_bytes[rel] = _dir_size_bytes(cache_dir)
-        # Defensive parity guard: a wholesale rmtree(cache_dir) would destroy a
-        # nested store/ (generated, NOT re-downloadable). Refuse unless every
-        # nested store file is verifiably mirrored on HF (fail-toward-keep). The
-        # check runs in BOTH dry-run (reports the would-skip) and apply mode.
+        # Gate 1 (#773): a DIFFERENT active task consumes data/issue_<N>/ as a
+        # planned input. Cheap set lookup, checked FIRST so a consumer hit
+        # short-circuits before the parity gate's potential HF call.
+        consumer_reason = _cache_dir_reap_blocked_by_active_consumer(
+            cache_dir, issue_n=issue_n, apply=apply, protected=protected
+        )
+        if consumer_reason is not None:
+            print(f"  ~ SKIP {rel}: {consumer_reason}", file=sys.stderr)
+            res.skipped.append((rel, consumer_reason))
+            continue
+        # Gate 2 (#679): a wholesale rmtree(cache_dir) would destroy a nested
+        # store/ (generated, NOT re-downloadable). Refuse unless every nested
+        # store file is verifiably mirrored on HF (fail-toward-keep). The check
+        # runs in BOTH dry-run (reports the would-skip) and apply mode.
         skip_reason = _cache_dir_reap_blocked(
             cache_dir, issue_n=issue_n, apply=apply, hf_sizes_cache=hf_sizes_cache
         )
@@ -496,8 +677,17 @@ def clean_issue_downloads_incremental(
     that the phase is done, so an ACTIVE issue self-reaping its own consumed
     cache mid-run is the intended path. ``store/`` + ``eval_results/`` are never
     touched; the re-downloadable cache is rebuilt on demand if a later phase
-    needs it again."""
-    return clean_issue_downloads(issue_n, apply=apply, data_root=data_root)
+    needs it again.
+
+    The active-CONSUMER gate (#773) is SKIPPED on this path
+    (``_skip_active_consumer_guard=True``): the calling experiment is the
+    authority on its own caches and would otherwise be a (self-excluded but
+    still walked) active consumer of its own ``data/issue_<N>/``. The helper
+    already excludes ``self_issue_n``, so this only skips the ``tasks/`` walk
+    entirely — a small within-run perf win, not a behavior change."""
+    return clean_issue_downloads(
+        issue_n, apply=apply, data_root=data_root, _skip_active_consumer_guard=True
+    )
 
 
 def _rel_name(path: Path) -> str:

--- a/tests/test_clean_experiment_downloads_active_consumer.py
+++ b/tests/test_clean_experiment_downloads_active_consumer.py
@@ -1,0 +1,403 @@
+"""Tests for the active-CONSUMER reap gate in
+``scripts/clean_experiment_downloads.py`` (task #773).
+
+A ``data/issue_<M>/{hf_dl,g*_dl}`` cache must NEVER be deleted while a
+DIFFERENT, currently-ACTIVE task declares ``data/issue_<M>/`` as a planned
+input in its ``plans/plan.md`` or ``body.md``. The owning-issue terminal-status
+gate (in ``vm_disk_guard.py``) allows the reap once ``M`` itself is terminal,
+but says nothing about OTHER consumers — so a panic clean of ``#658``
+(``awaiting_promotion``) reaped UltraChat/Betley input artifacts out from under
+``#742`` (``running``), whose round-3 launch then died on ``FileNotFoundError``.
+The new gate fails toward keep: any active consumer blocks the reap and the
+skip is sidecar-logged (``kind: "active-consumer-reap-skipped"``).
+
+The script lives under ``scripts/`` (not an importable package), so it is
+loaded via importlib exactly like ``tests/test_clean_experiment_downloads_parity.py``.
+A fake ``tasks/`` tree is built under the ``fake_repo`` tmp dir and
+``ced.repo_root()`` is pointed at it (``tasks_dir`` / ``list_by_status`` both
+resolve under ``repo_root()`` per call, so no extra monkeypatching is needed).
+``failure_classifier.classify_failure`` is imported to pin the non-regression
+invariant that the new sidecar reason string is never misrouted.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+
+def _load(mod_name: str):
+    spec = importlib.util.spec_from_file_location(mod_name, _SCRIPTS / f"{mod_name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ced = _load("clean_experiment_downloads")
+fc = _load("failure_classifier")
+
+
+# ─── fixtures / helpers ──────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fake_repo(tmp_path, monkeypatch):
+    """Point every repo-root resolver at a temp dir so the sidecar, rel-name,
+    and ``tasks/`` walk all resolve under one temp filesystem.
+
+    Two resolver surfaces must be rebound: (1) ``ced.repo_root`` /
+    ``ced.tasks_dir`` — the names ``clean_experiment_downloads`` calls directly
+    (the sidecar path, ``_rel_name``, and the ``tasks/`` walk root); and (2)
+    ``task_workflow``'s OWN resolvers — ``list_by_status`` was imported into
+    ``ced`` as a bound function and internally calls ``task_workflow.tasks_dir``
+    (which calls the cached ``task_workflow.repo_root``), so without rebinding
+    those it would walk the REAL ``tasks/`` tree. ``invalidate_cache`` drops the
+    process-local repo-root LRU before the rebind."""
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+    import explore_persona_space.task_workflow as tw
+
+    tw.invalidate_cache()
+    monkeypatch.setattr(tw, "repo_root", lambda: tmp_path)
+    monkeypatch.setattr(tw, "tasks_dir", lambda: tmp_path / "tasks")
+    # The names ced calls directly (it imported repo_root + tasks_dir from tw).
+    monkeypatch.setattr(ced, "repo_root", lambda: tmp_path)
+    monkeypatch.setattr(ced, "tasks_dir", lambda: tmp_path / "tasks")
+    return tmp_path
+
+
+def _make_cache(data_root: Path, issue_n: int) -> Path:
+    """A normal re-downloadable issue cache: hf_dl + g1_dl (each a file), plus a
+    SIBLING store/ (kept by the keep/delete contract, untouched here)."""
+    issue_dir = data_root / f"issue_{issue_n}"
+    for cache in ("hf_dl", "g1_dl"):
+        d = issue_dir / cache
+        d.mkdir(parents=True)
+        (d / "blob.bin").write_bytes(b"x" * 2048)
+    sib_store = issue_dir / "store"
+    sib_store.mkdir(parents=True)
+    (sib_store / "v0_summaries.pt").write_bytes(b"y" * 4096)
+    return issue_dir
+
+
+def _make_task(
+    repo: Path,
+    *,
+    issue_n: int,
+    status: str,
+    body: str = "",
+    plan: str | None = None,
+) -> Path:
+    """Create ``tasks/<status>/<issue_n>/{body.md[,plans/plan.md]}`` under the
+    fake repo. ``body.md`` carries minimal frontmatter so ``list_by_status``'s
+    ``_read_body`` parses it; ``plan`` (when given) writes ``plans/plan.md``."""
+    task_dir = repo / "tasks" / status / str(issue_n)
+    task_dir.mkdir(parents=True)
+    frontmatter = f"---\ntitle: task {issue_n}\nkind: experiment\n---\n\n"
+    (task_dir / "body.md").write_text(frontmatter + body)
+    if plan is not None:
+        plans = task_dir / "plans"
+        plans.mkdir()
+        (plans / "plan.md").write_text(plan)
+    return task_dir
+
+
+def _read_sidecar(repo: Path) -> list[dict]:
+    path = repo / ".claude" / "cache" / "disk-guard-events.jsonl"
+    if not path.is_file():
+        return []
+    return [json.loads(ln) for ln in path.read_text().splitlines() if ln.strip()]
+
+
+# ─── case 1: hero (the #742 scenario) ────────────────────────────────────────
+
+
+def test_hero_active_consumer_blocks_reap_and_escalates(fake_repo):
+    """A=658 at awaiting_promotion with hf_dl + g1_dl caches; B=742 at running
+    whose plan.md references data/issue_658/store/v0_summaries.pt. Reaping 658
+    is SKIPPED (both cache dirs), the reason names #742, and one sidecar row per
+    cache dir records the active-consumer skip."""
+    data_root = fake_repo / "data"
+    _make_cache(data_root, 658)
+    _make_task(
+        fake_repo,
+        issue_n=742,
+        status="running",
+        body="Reuses data/issue_658/store/v0_summaries.pt (sha-pinned).",
+        plan="Phase 2 loads data/issue_658/store/v0_summaries.pt as input.",
+    )
+
+    res = ced.clean_issue_downloads(658, apply=True, data_root=data_root)
+
+    assert res.removed == []
+    assert sorted(name for name, _ in res.skipped) == [
+        "data/issue_658/g1_dl",
+        "data/issue_658/hf_dl",
+    ]
+    # Skip reason names the consumer.
+    assert all("#742" in reason for _, reason in res.skipped)
+    # The caches survive on disk.
+    assert (data_root / "issue_658" / "hf_dl" / "blob.bin").exists()
+    assert (data_root / "issue_658" / "g1_dl" / "blob.bin").exists()
+
+    rows = _read_sidecar(fake_repo)
+    assert len(rows) == 2  # one per kept cache dir
+    for row in rows:
+        assert row["kind"] == "active-consumer-reap-skipped"
+        assert row["task"] == 658
+        assert row["consumers"] == [742]  # the new field, dedup'd + sorted
+        assert row["path"] in ("data/issue_658/hf_dl", "data/issue_658/g1_dl")
+        assert "ts" in row
+
+
+# ─── case 2: negative — terminal owning issue, no active consumer ────────────
+
+
+def test_no_active_consumer_reaps_normally(fake_repo):
+    """A=658 terminal, NO active task references it -> both cache dirs reaped,
+    nothing skipped, no sidecar row."""
+    data_root = fake_repo / "data"
+    issue_dir = _make_cache(data_root, 658)
+    # An INACTIVE task referencing 658 must not protect it (see case 4); here we
+    # add none at all.
+    _make_task(fake_repo, issue_n=658, status="awaiting_promotion", body="self")
+
+    res = ced.clean_issue_downloads(658, apply=True, data_root=data_root)
+
+    assert sorted(res.removed) == ["data/issue_658/g1_dl", "data/issue_658/hf_dl"]
+    assert res.skipped == []
+    assert res.failed == []
+    assert not (issue_dir / "hf_dl").exists()
+    assert not (issue_dir / "g1_dl").exists()
+    assert (issue_dir / "store" / "v0_summaries.pt").exists()  # sibling store kept
+    assert _read_sidecar(fake_repo) == []
+
+
+# ─── case 3: self-reap exempt ────────────────────────────────────────────────
+
+
+def test_self_reference_does_not_block_own_reap(fake_repo):
+    """A=658's OWN plan/body references data/issue_658/, and NO other active task
+    does -> the reap proceeds (a task never protects itself)."""
+    data_root = fake_repo / "data"
+    issue_dir = _make_cache(data_root, 658)
+    _make_task(
+        fake_repo,
+        issue_n=658,
+        status="awaiting_promotion",
+        body="My own caches live under data/issue_658/hf_dl/.",
+        plan="Generated data/issue_658/store/ from data/issue_658/hf_dl/.",
+    )
+
+    res = ced.clean_issue_downloads(658, apply=True, data_root=data_root)
+
+    assert sorted(res.removed) == ["data/issue_658/g1_dl", "data/issue_658/hf_dl"]
+    assert res.skipped == []
+    assert not (issue_dir / "hf_dl").exists()
+    assert _read_sidecar(fake_repo) == []
+
+
+# ─── case 4: inactive consumer does not protect ──────────────────────────────
+
+
+@pytest.mark.parametrize("inactive_status", ["completed", "archived", "on_hold", "blocked"])
+def test_inactive_consumer_does_not_protect(fake_repo, inactive_status):
+    """B references data/issue_658/ but B is at an INACTIVE status -> no
+    protection -> A's caches reaped."""
+    data_root = fake_repo / "data"
+    issue_dir = _make_cache(data_root, 658)
+    _make_task(
+        fake_repo,
+        issue_n=742,
+        status=inactive_status,
+        body="Once read data/issue_658/store/v0_summaries.pt.",
+    )
+
+    res = ced.clean_issue_downloads(658, apply=True, data_root=data_root)
+
+    assert sorted(res.removed) == ["data/issue_658/g1_dl", "data/issue_658/hf_dl"]
+    assert res.skipped == []
+    assert not (issue_dir / "hf_dl").exists()
+    assert _read_sidecar(fake_repo) == []
+
+
+# ─── case 5: incremental wrapper skips the guard ─────────────────────────────
+
+
+def test_incremental_path_skips_active_consumer_guard(fake_repo, monkeypatch):
+    """The within-run incremental path is self-aware: it opts out of the
+    active-consumer gate (``_skip_active_consumer_guard=True``) and does NOT even
+    walk tasks/. Monkeypatch the protected-set helper to raise; the incremental
+    reap must NOT call it AND must reap the caches even with an active consumer
+    B present."""
+    data_root = fake_repo / "data"
+    issue_dir = _make_cache(data_root, 658)
+    _make_task(
+        fake_repo,
+        issue_n=742,
+        status="running",
+        body="Reads data/issue_658/store/v0_summaries.pt.",
+    )
+
+    def _boom(*a, **k):
+        raise AssertionError(
+            "_active_consumer_protected_issues must NOT be called on the incremental path"
+        )
+
+    monkeypatch.setattr(ced, "_active_consumer_protected_issues", _boom)
+
+    res = ced.clean_issue_downloads_incremental(658, apply=True, data_root=data_root)
+
+    assert sorted(res.removed) == ["data/issue_658/g1_dl", "data/issue_658/hf_dl"]
+    assert res.skipped == []
+    assert not (issue_dir / "hf_dl").exists()
+
+
+# ─── case 6: empty tasks/ tree is a clean no-op ──────────────────────────────
+
+
+def test_empty_tasks_tree_is_noop(fake_repo):
+    """_active_consumer_protected_issues returns {} under a fake_repo with no
+    tasks/ tree at all (the parity suite's indirect dependence: an absent tasks/
+    walk must never raise)."""
+    assert ced._active_consumer_protected_issues(901) == {}
+
+
+# ─── case 7: boundary regex ──────────────────────────────────────────────────
+
+
+def test_data_issue_ref_boundary(fake_repo):
+    """data/issue_65/ and data/issue65_x/ do NOT match 658; data/issue_658/,
+    data/issue658/, data/issue658_slug/ DO match 658."""
+
+    def _refs(text: str) -> set[int]:
+        return {int(m.group(1)) for m in ced._DATA_ISSUE_REF.finditer(text)}
+
+    # Positives for 658.
+    assert 658 in _refs("path data/issue_658/store/x.pt")
+    assert 658 in _refs("path data/issue658/hf_dl/x.bin")
+    assert 658 in _refs("path data/issue658_marker_slug/store/x.pt")
+    # Negatives — neither 65 nor 658 spuriously captured for 658.
+    assert _refs("path data/issue_65/store/x.pt") == {65}
+    assert _refs("path data/issue65_x/store/x.pt") == {65}
+    assert 658 not in _refs("path data/issue_65/store/x.pt")
+    assert 658 not in _refs("path data/issue65_x/store/x.pt")
+
+
+def test_boundary_regex_via_protected_map(fake_repo):
+    """End-to-end: a consumer referencing data/issue65_x/ does NOT protect 658,
+    while one referencing data/issue658_slug/ does."""
+    # A near-miss consumer (65, not 658).
+    _make_task(
+        fake_repo,
+        issue_n=742,
+        status="running",
+        body="reads data/issue65_x/store/x.pt",
+    )
+    protected = ced._active_consumer_protected_issues(self_issue_n=999)
+    assert 658 not in protected
+    assert protected.get(65) == [742]
+
+    # A no-underscore-with-slug consumer of 658.
+    _make_task(
+        fake_repo,
+        issue_n=743,
+        status="running",
+        body="reads data/issue658_marker_slug/hf_dl/x.bin",
+    )
+    protected = ced._active_consumer_protected_issues(self_issue_n=999)
+    assert protected.get(658) == [743]
+
+
+# ─── case 8: dry-run reports but never deletes / persists sidecar ────────────
+
+
+def test_dry_run_reports_skip_no_delete_no_persist(fake_repo):
+    """apply=False with an active consumer -> the cache dirs are reported in
+    .skipped (would-skip) but nothing is deleted; apply=False also reports the
+    sidecar row only (does not persist it)."""
+    data_root = fake_repo / "data"
+    issue_dir = _make_cache(data_root, 658)
+    _make_task(
+        fake_repo,
+        issue_n=742,
+        status="running",
+        body="reads data/issue_658/store/v0_summaries.pt",
+    )
+
+    res = ced.clean_issue_downloads(658, apply=False, data_root=data_root)
+
+    assert res.removed == []
+    assert sorted(name for name, _ in res.skipped) == [
+        "data/issue_658/g1_dl",
+        "data/issue_658/hf_dl",
+    ]
+    assert (issue_dir / "hf_dl").exists()  # nothing deleted in dry-run
+    assert (issue_dir / "g1_dl").exists()
+    assert _read_sidecar(fake_repo) == []  # apply=False does not persist
+
+
+# ─── case 9: missing plans/plan.md fail-soft (body-only still protects) ───────
+
+
+def test_missing_plan_md_fail_soft_body_only_protects(fake_repo):
+    """A consumer at planning/proposed with body.md referencing data/issue_658/
+    but NO plans/plan.md (planning-status tasks before new_plan_version runs may
+    lack the symlink): (a) no crash; (b) the body-only reference still
+    protects."""
+    data_root = fake_repo / "data"
+    issue_dir = _make_cache(data_root, 658)
+    _make_task(
+        fake_repo,
+        issue_n=742,
+        status="planning",
+        body="Phase 2 will load data/issue_658/store/v0_summaries.pt.",
+        plan=None,  # no plans/plan.md
+    )
+
+    # (a) no crash; (b) body-only reference protects.
+    res = ced.clean_issue_downloads(658, apply=True, data_root=data_root)
+
+    assert res.removed == []
+    assert sorted(name for name, _ in res.skipped) == [
+        "data/issue_658/g1_dl",
+        "data/issue_658/hf_dl",
+    ]
+    assert (issue_dir / "hf_dl").exists()
+    rows = _read_sidecar(fake_repo)
+    assert all(r["consumers"] == [742] for r in rows)
+
+
+# ─── case 10: failure_classifier non-regression ──────────────────────────────
+
+
+def test_active_consumer_reason_not_misrouted_by_failure_classifier(fake_repo):
+    """The active-consumer skip reason string must never be misrouted by
+    classify_failure (it is never fed there, but pin the non-regression
+    invariant: the reason carries no failure_class field, CUDA-OOM, DataLoader
+    wrap, or 'No space left on device / ENOSPC / disk full' infra pattern, so it
+    falls through to the conservative 'code' default)."""
+    reason = (
+        "active task(s) #742 declare data/issue_658/ as a planned input — "
+        "reaping data/issue_658/hf_dl could strand their run; KEPT"
+    )
+    assert fc.classify_failure(reason) == "code"
+
+
+# ─── case 11: partition totality ─────────────────────────────────────────────
+
+
+def test_consumer_inactive_statuses_partition_totality(fake_repo):
+    """_CONSUMER_INACTIVE_STATUSES is a subset of STATUSES, and the active set
+    (STATUSES - inactive) covers every remaining status (no silent default).
+    Recurs whenever the status enum changes."""
+    assert ced._CONSUMER_INACTIVE_STATUSES.issubset(set(ced.STATUSES))
+    active = set(ced.STATUSES) - ced._CONSUMER_INACTIVE_STATUSES
+    # Union of active + inactive covers all of STATUSES (a clean partition).
+    assert active | ced._CONSUMER_INACTIVE_STATUSES == set(ced.STATUSES)
+    # And the active set is non-empty (the gate must be able to fire).
+    assert active

--- a/tests/test_clean_experiment_downloads_active_consumer.py
+++ b/tests/test_clean_experiment_downloads_active_consumer.py
@@ -225,15 +225,19 @@ def test_inactive_consumer_does_not_protect(fake_repo, inactive_status):
     assert _read_sidecar(fake_repo) == []
 
 
-# ─── case 5: incremental wrapper skips the guard ─────────────────────────────
+# ─── case 5: incremental wrapper RESPECTS the cross-issue guard ──────────────
 
 
-def test_incremental_path_skips_active_consumer_guard(fake_repo, monkeypatch):
-    """The within-run incremental path is self-aware: it opts out of the
-    active-consumer gate (``_skip_active_consumer_guard=True``) and does NOT even
-    walk tasks/. Monkeypatch the protected-set helper to raise; the incremental
-    reap must NOT call it AND must reap the caches even with an active consumer
-    B present."""
+def test_incremental_path_respects_active_consumer_guard(fake_repo):
+    """The within-run incremental path keeps the active-CONSUMER gate ON, so a
+    DIFFERENT active task B referencing data/issue_658/ blocks the incremental
+    reap of 658's caches — the cross-issue protection must hold on this path too.
+
+    Round-1 PINNED the unsafe bypass (the reap proceeded with B present); that
+    removed cross-issue protection because the self-exclusion is on the CONSUMER,
+    not the referenced issue. This test inverts that: the caches are KEPT (in
+    .skipped, not .removed), survive on disk, and the skip is sidecar-logged
+    with kind=active-consumer-reap-skipped naming #742."""
     data_root = fake_repo / "data"
     issue_dir = _make_cache(data_root, 658)
     _make_task(
@@ -243,18 +247,48 @@ def test_incremental_path_skips_active_consumer_guard(fake_repo, monkeypatch):
         body="Reads data/issue_658/store/v0_summaries.pt.",
     )
 
-    def _boom(*a, **k):
-        raise AssertionError(
-            "_active_consumer_protected_issues must NOT be called on the incremental path"
-        )
+    res = ced.clean_issue_downloads_incremental(658, apply=True, data_root=data_root)
 
-    monkeypatch.setattr(ced, "_active_consumer_protected_issues", _boom)
+    assert res.removed == []
+    assert sorted(name for name, _ in res.skipped) == [
+        "data/issue_658/g1_dl",
+        "data/issue_658/hf_dl",
+    ]
+    assert all("#742" in reason for _, reason in res.skipped)
+    # The caches survive on disk (fail-toward-keep).
+    assert (issue_dir / "hf_dl" / "blob.bin").exists()
+    assert (issue_dir / "g1_dl" / "blob.bin").exists()
+    rows = _read_sidecar(fake_repo)
+    assert len(rows) == 2
+    for row in rows:
+        assert row["kind"] == "active-consumer-reap-skipped"
+        assert row["task"] == 658
+        assert row["consumers"] == [742]
+
+
+def test_incremental_path_self_reap_with_self_reference(fake_repo):
+    """A self-reference does NOT block the incremental reap even though the
+    cross-issue guard is now ON: 658's OWN plan/body references
+    data/issue_658/ and NO other active task does -> the consumer-keyed
+    self-exclusion (consumer_id == self) lets the reap proceed. This pins that
+    turning the guard ON on the incremental path did not re-introduce
+    self-block (the within-run path's whole point is self-cleanup)."""
+    data_root = fake_repo / "data"
+    issue_dir = _make_cache(data_root, 658)
+    _make_task(
+        fake_repo,
+        issue_n=658,
+        status="awaiting_promotion",
+        body="My own caches live under data/issue_658/hf_dl/.",
+        plan="Generated data/issue_658/store/ from data/issue_658/hf_dl/.",
+    )
 
     res = ced.clean_issue_downloads_incremental(658, apply=True, data_root=data_root)
 
     assert sorted(res.removed) == ["data/issue_658/g1_dl", "data/issue_658/hf_dl"]
     assert res.skipped == []
     assert not (issue_dir / "hf_dl").exists()
+    assert _read_sidecar(fake_repo) == []
 
 
 # ─── case 6: empty tasks/ tree is a clean no-op ──────────────────────────────
@@ -401,3 +435,83 @@ def test_consumer_inactive_statuses_partition_totality(fake_repo):
     assert active | ced._CONSUMER_INACTIVE_STATUSES == set(ced.STATUSES)
     # And the active set is non-empty (the gate must be able to fire).
     assert active
+
+
+# ─── case 12: scan-limit truncation defense (BLOCKER #773 round 2) ───────────
+
+
+def test_active_consumer_scan_finds_consumer_past_row_200(fake_repo):
+    """list_by_status defaults to limit=200 and SILENTLY truncates by sorted id.
+    Build 201 active tasks in ONE status where ONLY the 201st (highest id)
+    references data/issue_658/; every lower-id task references an unrelated
+    issue. _active_consumer_protected_issues MUST still find #658's consumer —
+    i.e. it must NOT inherit the limit=200 cap.
+
+    Pre-fix (default limit=200 inside the helper) the 201st row is dropped and
+    protected.get(658) is None; post-fix (explicit limit=10_000) the consumer is
+    found. This EXERCISES the real list_by_status truncation, not just the cap
+    value."""
+    # 200 lower-id active tasks referencing an unrelated issue (not 658), then
+    # one 201st highest-id task that references 658. list_by_status sorts by
+    # integer id, so the 658-consumer sorts LAST and is the row a 200-cap drops.
+    for i in range(1000, 1200):  # 200 tasks, ids 1000..1199
+        _make_task(fake_repo, issue_n=i, status="running", body="reads data/issue_999/store/x.pt")
+    consumer_id = 1200  # the 201st, highest id -> sorts last -> dropped at limit=200
+    _make_task(
+        fake_repo,
+        issue_n=consumer_id,
+        status="running",
+        body="Reuses data/issue_658/store/v0_summaries.pt (sha-pinned).",
+    )
+
+    protected = ced._active_consumer_protected_issues(self_issue_n=999)
+
+    assert protected.get(658) == [consumer_id]
+
+
+def test_active_consumer_scan_passes_uncapped_limit_to_list_by_status(monkeypatch):
+    """Unit-level pin of the exact defense: the helper must call list_by_status
+    with an explicit limit large enough that no realistic active queue truncates.
+    Monkeypatch list_by_status with a fake that returns a 201-row queue ONLY when
+    called with a limit >= 201 (else the truncated first 200) — so the 658
+    consumer (row 201) is reachable iff the helper passes the uncapped limit.
+
+    A controlled fake (not the real tasks/ walk) so the test pins the call
+    contract precisely and fails pre-fix (default limit=200 -> 658 dropped)."""
+    rows = [
+        {"id": i, "title": "", "kind": "experiment", "tags": [], "has_clean_result": False}
+        for i in range(1000, 1200)
+    ]
+    rows.append(
+        {
+            "id": 1200,
+            "title": "reads data/issue_658/store/v0_summaries.pt",
+            "kind": "experiment",
+            "tags": [],
+            "has_clean_result": False,
+        }
+    )
+
+    def _fake_list_by_status(status, limit=200):
+        if status != "running":
+            return []
+        return rows[:limit]
+
+    monkeypatch.setattr(ced, "list_by_status", _fake_list_by_status)
+    # tasks_dir() is read for body/plan text — point it at a tmp the bodies of
+    # the synthetic rows live in. The fake list_by_status carries the 658 ref in
+    # the row title, but _active_consumer_protected_issues reads body.md/plan.md
+    # from disk, so write the consumer's body there.
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        monkeypatch.setattr(ced, "tasks_dir", lambda: base / "tasks")
+        monkeypatch.setattr(ced, "repo_root", lambda: base)
+        cdir = base / "tasks" / "running" / "1200"
+        cdir.mkdir(parents=True)
+        (cdir / "body.md").write_text("Reuses data/issue_658/store/v0_summaries.pt.")
+
+        protected = ced._active_consumer_protected_issues(self_issue_n=999)
+
+    assert protected.get(658) == [1200]

--- a/tests/test_clean_experiment_downloads_parity.py
+++ b/tests/test_clean_experiment_downloads_parity.py
@@ -45,8 +45,25 @@ ced = _load("clean_experiment_downloads")
 @pytest.fixture
 def fake_repo(tmp_path, monkeypatch):
     """Point ``ced.repo_root()`` at a temp dir so the sidecar + rel-name
-    helpers resolve under one temp filesystem (no real repo writes)."""
+    helpers resolve under one temp filesystem (no real repo writes).
+
+    Also rebind ``task_workflow``'s OWN resolvers (#773): the active-CONSUMER
+    reap gate walks the real ``tasks/`` tree via the ``list_by_status`` /
+    ``tasks_dir`` ``ced`` imported from ``task_workflow``, which resolve the
+    CACHED ``task_workflow.repo_root`` — NOT ``ced.repo_root``. Without rebinding
+    them the gate would scan the live repo's tasks and (correctly) skip a reap of
+    ``#658`` because real active tasks reference ``data/issue_658/``, breaking
+    these sandboxed parity tests. Rebinding to the (empty) tmp ``tasks/`` makes
+    the gate a clean no-op so the parity tests exercise ONLY the nested-store
+    gate, as before."""
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+    import explore_persona_space.task_workflow as tw
+
+    tw.invalidate_cache()
+    monkeypatch.setattr(tw, "repo_root", lambda: tmp_path)
+    monkeypatch.setattr(tw, "tasks_dir", lambda: tmp_path / "tasks")
     monkeypatch.setattr(ced, "repo_root", lambda: tmp_path)
+    monkeypatch.setattr(ced, "tasks_dir", lambda: tmp_path / "tasks")
     return tmp_path
 
 


### PR DESCRIPTION
Closes task #773.

Adds a third reap-gate to `scripts/clean_experiment_downloads.py`: before reaping `data/issue_<M>/{hf_dl,g*_dl}` for a terminal-status #M, scan every currently-ACTIVE task's `plans/plan.md` + `body.md` for `data/issue_<M>/` substrings. Any match → SKIP the reap (fail-toward-keep), add to `CleanResult.skipped`, sidecar-log `kind=active-consumer-reap-skipped`.

Fixes the #742 strand-the-consumer class: `vm_disk_guard` panic-reaped #658's input artifacts (#658 was `awaiting_promotion` ∈ `TERMINAL_CACHE_REAP_STATUSES`) while #742 was `running` and reading them as inputs; #742's round-3 launch died on FileNotFoundError. The owning-issue terminal-status gate sees only #658's status, never the cross-issue consumer.

Two rounds: round 1 landed the gate + 15 tests; round 2 closed the binding reconciler concerns (`list_by_status` silent `limit=200` truncation + incremental-path cross-issue protection — the bypass was over-broad).

18 active-consumer tests + 16 parity + 26 failure_classifier non-regression all pass. Pre-existing #745 `workflow_lint` violation in `scripts/issue744_dump_and_stream.py` flagged for a separate follow-up workflow-fix task.