### PR TITLE
issue-775: workflow-fix CUDA-IMA host-wedge failover

### DIFF
--- a/.claude/rules/compute-backend-failover.md
+++ b/.claude/rules/compute-backend-failover.md
@@ -8,6 +8,8 @@ paths:
   - "scripts/backend_poll.py"
   - "tests/test_router.py"
   - "tests/test_gcp_backend.py"
+  - "tests/test_runpod_wedge_detection.py"
+  - "tests/test_backend_poll.py"
 ---
 
 # Compute-backend failover + crash-diagnostics policy
@@ -358,6 +360,109 @@ state round-trip, the pod_id reset, the alert dedup, the DONE fall-through) +
 the direct predicate test
 `tests/test_runpod_wedge_detection.py::test_pod_is_runpod_runtime_wedged_predicate`.
 
+## Part D — RunPod CUDA-IMA repeat host wedge (#775)
+
+The crash-signature sibling of Part C's no-port wedge. A RunPod H100/H200 can
+wedge at the DRIVER level: a vLLM workload crashes with a CUDA illegal-memory-
+access (`CUDA error: an illegal memory access was encountered` /
+`EngineDeadError` / `Engine core proc … died unexpectedly`), the experimenter's
+default `failure_class: infra` library-traceback recovery does an IN-PLACE
+SAME-POD respawn (orphan-reap by exact PID + `nvidia-smi` VRAM probe + relaunch
+— it NEVER terminates the pod, that lifecycle is the `/issue` skill's), and the
+SAME-signature CUDA-IMA crash recurs on the same physical GPU. Part C's no-port
+wedge does NOT catch this — the CUDA-IMA pod keeps its port + stays RUNNING — so
+#763 needed a manual GCP→RunPod pivot. Part D automates exactly that recovery:
+detect the SECOND same-signature CUDA-IMA crash and pivot to a FRESH host.
+
+**Detection** (`backend_poll._maybe_escalate_runpod_cuda_ima`, the repeat-based
+sibling of the time-based `_maybe_escalate_runpod_wedge`). The signal is
+`PollResult.crash_signature` — the WIDE 500-line probe tail (NOT the 5-line
+`log_tail_excerpt`, which truncates a 20-50-line vLLM traceback so the signature
+line is routinely cut out — the B2 bug). `poll_once` captures it on a
+`status="dead"` poll from the same wide surface it already fetched (no extra SSH
+call; `_tail_excerpt_and_crash_signature`), and `RunPodBackend.poll` threads it
+through to `main()` exactly as `stall_reason`. The escalation conjuncts:
+
+1. **CUDA-IMA signature on the WIDE surface** (`CUDA_IMA_SIGNATURE`, within-line
+   alternatives, no `re.DOTALL` so a match cannot span unrelated events across
+   500 lines).
+2. **A prior same-signature CUDA-IMA crash recorded THIS RUN** — the sidecar
+   `extra["runpod_cuda_ima_last_seen"]` record (byte-mirror of the no-port
+   clock family), with the prior `epm:failure` marker as a **cross-pod fallback
+   source** (`_prior_failure_marker_is_cuda_ima`, read VM-side via
+   `task_workflow.list_events`) so a sidecar wipe between pods does not lose the
+   prior-crash record (B1). The record is CLEARED on any non-dead /
+   non-CUDA-IMA poll, so a single transient CUDA-IMA the respawn recovered from
+   (with an intervening healthy poll) does NOT accumulate — only a SECOND
+   CUDA-IMA crash with no intervening healthy poll counts.
+3. **EXCLUSION — no OUR-code traceback frame** (`failure_classifier.OUR_CODE_FRAME`,
+   M3). A CUDA-IMA surface that ALSO traces through `src/explore_persona_space/`
+   or `scripts/` is a deterministic CODE bug surfacing as CUDA-IMA, NOT a host
+   wedge — fall through to the ordinary dead path (→ `failure_class: code`) WITHOUT
+   spending a bounded pivot.
+
+A FIRST CUDA-IMA crash (no prior record) records the signature and falls through
+to the ordinary dead path (the in-place same-pod respawn gets its one chance); a
+SECOND same-signature repeat (1)+(2) AND NOT (3) rewrites to
+`current_phase=RUNPOD_CUDA_IMA_WEDGED_PHASE`, which `_is_runpod_cuda_ima_failure`
+matches.
+
+**Why signature-keyed, NOT pod_id-pinned.** The default vLLM-crash infra respawn
+is IN-PLACE same-pod (verified: SKILL.md routes a library-traceback
+`failure_class: infra` to "re-spawn the experimenter on the SAME branch /
+relaunch on the same pod"; the experimenter never terminates pods), so pod_id
+WOULD have worked. But the predicate keys on the crash SIGNATURE across the run
+(NOT pod_id) because it is strictly more robust: it survives the watcher-side
+stop/resume edge case (a `pod.py resume` rewrites host/port) and the half-
+bootstrap fresh-pod path; the once-more bound is the safety against
+over-counting. pod_id is incidental; the crash signature is the invariant.
+
+**Wiring — BEFORE the no-port block (M2).** The CUDA-IMA escalation runs in
+`main()` between the GCP async-failover block and the no-port escalation. The
+no-port within-K path rewrites `status=dead → running`, and a CUDA-IMA crash can
+leave the pod momentarily no-port (engine dead, ports not yet torn down), so the
+no-port rewrite would mask a CUDA-IMA dead poll (which requires `status="dead"`)
+if it ran first.
+
+**Recovery + once-more bound** (`backend_poll._failover_cuda_ima_runpod`). It
+REUSES the Part C inner relaunch (`_relaunch_fresh_runpod`) via a new `stamp_fn`
+kwarg (Part C byte-unchanged at the default; the CUDA-IMA caller passes
+`stamp_fn=_stamp_runpod_cuda_ima_failover`), so only the thin OUTER orchestration
+forks. Layers, in the order checked:
+
+1. **ONCE-MORE BOUND (M1).** If the DURABLE lease already records a CUDA-IMA
+   failover for this run (the SEPARATE `Lease.runpod_cuda_ima_failover_of` field —
+   distinct from `runpod_wedge_failover_of` so a no-port wedge and a CUDA-IMA
+   wedge on the same issue never cross-suppress), the fresh host ALSO crashed
+   same-signature → a fresh host did NOT heal it → it is a deterministic code
+   bug. Emit a terminal **`failure_class: code`** JSON
+   (`reason=cuda_ima_repeats_after_failover`) via the NEW `_terminal_code_json`
+   (the `failure_class: code` sibling of `_terminal_infra_json`). The watcher's
+   capacity-retry pass re-drives ONLY `failure_class: infra` +
+   `no_compute_available`, so a `code` terminal PARKS at `blocked` for human
+   inspection. NO second pivot.
+2. **PER-WEDGE IDEMPOTENCY.** A re-fired tick on the SAME crashed handle after a
+   successful pivot short-circuits (durable lease authoritative + `.claude/cache`
+   sentinel fast-path, both keyed to the crashed pod identity).
+3. **INPUTS-ON-HF GATE** (reused as-is — a PARTIAL cell BLOCKS the irreversible
+   terminate; human decides).
+4. **TERMINATE** the crashed pod (best-effort — a CUDA-IMA-wedged pod is usually
+   already dead, so `info is None` simply skips the terminate) + **RE-PROVISION
+   FRESH** stamping the CUDA-IMA lease field for the next crash's bound.
+
+**The host-wedge interpretation is a HYPOTHESIS the failover TESTS, not a thing
+the predicate proves.** The predicate detects a same-signature CUDA-IMA REPEAT;
+whether that is a transient driver wedge (a fresh host fixes it) or a
+deterministic code bug (a fresh host does NOT) is disambiguated EMPIRICALLY by
+spending the one bounded pivot: a fresh-host success was a wedge; a fresh-host
+re-crash lands at `failure_class: code` / blocked. The OUR_CODE_FRAME exclusion
+(M3) cheaply removes the COMMON framed-code-bug case before spending the pivot;
+a driver-only IMA (no user frame) still gets the bounded one-pivot test.
+
+`scripts/failure_classifier.py` is UNCHANGED — CUDA-IMA already routes infra for
+crash #1 (the in-place same-pod respawn); the new logic is poll-level and
+short-circuits at the once-more case via `_terminal_code_json`.
+
 ## Tests of record
 
 - `tests/test_router.py::test_gcp_workload_error_fails_over_to_runpod_no_slurm_cascade`
@@ -373,3 +478,12 @@ the direct predicate test
 - `tests/test_issue664_per_cell_upload.py` (Part C prerequisite: per-cell
   incremental upload idempotency + exact-set + fail-loud verify + A2 fresh-pod
   resume)
+- `tests/test_runpod_wedge_detection.py` (Part D #775: CUDA-IMA predicate scope,
+  signature regex, B2 wide-surface extraction vs the 5-line excerpt, escalation
+  first-records / second-escalates / M3 our-code-frame exclusion / clear-on-
+  recovery / malformed-fail-soft, B1 cross-pod prior-marker fallback, failover
+  pivot with `stamp_fn` / bounded-once `_terminal_code_json` / idempotency /
+  inputs-partial-blocks, durable-lease bound via the real helpers)
+- `tests/test_backend_poll.py` (Part D #775 `main()` integration: first-falls-
+  through, second-emits-fresh-host-failover, M2 cuda-ima-before-noport, M1
+  exhausted-emits-`code` + `_is_transient_capacity_block` False)

--- a/scripts/backend_poll.py
+++ b/scripts/backend_poll.py
@@ -406,6 +406,23 @@ def _is_runpod_async_wedge_failure(handle, result) -> bool:
     )
 
 
+def _is_runpod_cuda_ima_failure(handle, result) -> bool:
+    """True ONLY for a RunPod handle whose poll surfaced the #775 CUDA-IMA repeat wedge.
+
+    Narrow by construction (the sibling of :func:`_is_runpod_async_wedge_failure`):
+    ``handle.backend == "runpod"`` AND ``result.status == "dead"`` AND
+    ``result.current_phase == RUNPOD_CUDA_IMA_WEDGED_PHASE``. A GCP / SLURM handle
+    never trips it; the wedged phase is set ONLY by
+    :func:`_maybe_escalate_runpod_cuda_ima` once a SECOND same-signature CUDA-IMA
+    crash is observed this run.
+    """
+    return (
+        getattr(handle, "backend", None) == "runpod"
+        and result.status == "dead"
+        and result.current_phase == RUNPOD_CUDA_IMA_WEDGED_PHASE
+    )
+
+
 def _read_phase_clock(sidecar: Path) -> tuple[str | None, float | None]:
     """Read the (last_phase, last_phase_change_ts) staleness clock from the sidecar (#669).
 
@@ -895,6 +912,83 @@ def _maybe_escalate_runpod_wedge(handle, result, sidecar: Path, *, now: float):
     )
 
 
+def _maybe_escalate_runpod_cuda_ima(handle, result, sidecar: Path, *, issue: int, now: float):
+    """Escalate a same-signature RunPod CUDA-IMA crash REPEAT to terminal wedged (#775).
+
+    The repeat-based sibling of :func:`_maybe_escalate_runpod_wedge` (which is
+    time-based). Reads ``result.crash_signature`` (the WIDE 500-line probe tail
+    threaded through ``RunPodBackend.poll``). The detection record rides the
+    sidecar ``extra`` dict (keyed ``runpod_cuda_ima_last_seen``), with the prior
+    ``epm:failure`` marker as a cross-pod fallback (B1). Branches:
+
+    * not a RunPod handle -> return ``result`` unchanged (no record touched);
+    * not (``status="dead"`` AND a CUDA-IMA signature on the WIDE surface) ->
+      CLEAR the record (an intervening healthy / non-CUDA-IMA poll the in-place
+      same-pod respawn recovered to does NOT accumulate), return ``result``
+      unchanged;
+    * a CUDA-IMA signature whose WIDE surface ALSO carries an OUR-code traceback
+      frame (M3) -> this is a deterministic CODE bug surfacing as CUDA-IMA, NOT a
+      host wedge. Do NOT escalate (no bounded pivot spent); return ``result``
+      unchanged so it falls through to the ordinary dead path
+      (failure_classifier -> code). The record is left as-is (a code bug is not a
+      host wedge to count);
+    * a CUDA-IMA signature with NO prior same-signature record this run (FIRST
+      crash) -> WRITE the record, return ``result`` unchanged so it falls through
+      to the ordinary dead path (failure_classifier -> infra -> the in-place
+      same-pod experimenter respawn, which orphan-reaps + relaunches);
+    * a CUDA-IMA signature WITH a prior same-signature record (SECOND repeat) ->
+      REWRITE to ``status="dead", current_phase=RUNPOD_CUDA_IMA_WEDGED_PHASE`` so
+      :func:`_is_runpod_cuda_ima_failure` matches and the failover fires.
+
+    Reached on EVERY poll tick (wired unconditionally in ``main()`` BEFORE the
+    no-port block — M2), so the clear-on-recovery branch always runs.
+    """
+    if getattr(handle, "backend", None) != "runpod":
+        return result
+    is_cuda_ima = result.status == "dead" and _crash_signature_is_cuda_ima(
+        getattr(result, "crash_signature", None)
+    )
+    if not is_cuda_ima:
+        # Healthy / non-CUDA-IMA dead poll -> the wedge never matured; clear the
+        # record so a single transient CUDA-IMA the respawn recovered from does
+        # not accumulate against a later unrelated one.
+        _clear_runpod_cuda_ima_record(sidecar)
+        return result
+    # M3 our-code-frame exclusion: a CUDA-IMA surface that ALSO traces through our
+    # source/scripts is a deterministic code bug, NOT a host wedge — fall through
+    # to the ordinary dead path (-> code) WITHOUT spending a bounded pivot. Leave
+    # the record untouched (a code bug is not a host-wedge crash to count).
+    if _crash_signature_has_our_code_frame(getattr(result, "crash_signature", None)):
+        logging.warning(
+            "backend_poll: RunPod %s CUDA-IMA crash carries an OUR-code traceback frame — "
+            "deterministic code bug, NOT a host wedge; NOT escalating (#775 M3 exclusion)",
+            getattr(handle, "pod_name", "?"),
+        )
+        return result
+    prior = _read_runpod_cuda_ima_record(sidecar, issue=issue)
+    if prior is None:
+        # FIRST CUDA-IMA crash this run: record it and let the ordinary dead path
+        # run (the in-place same-pod experimenter respawn gets its one chance).
+        _write_runpod_cuda_ima_record(sidecar, ts=now)
+        return result
+    # SECOND same-signature CUDA-IMA crash this run -> escalate. A clean orphan-reap
+    # already happened on the in-place respawn, so a repeat = the GPU still throws
+    # IMA = driver wedge; only a fresh host helps.
+    logging.warning(
+        "backend_poll: RunPod %s CUDA-IMA crash REPEATED (same signature) this run — the "
+        "in-place same-pod respawn did not heal it; escalating to %s (#775 wedge)",
+        getattr(handle, "pod_name", "?"),
+        RUNPOD_CUDA_IMA_WEDGED_PHASE,
+    )
+    return replace(
+        result,
+        status="dead",
+        current_phase=RUNPOD_CUDA_IMA_WEDGED_PHASE,
+        new_milestone=True,
+        pid_alive=False,
+    )
+
+
 @dataclass
 class _WedgeInputsGate:
     """Per-cell three-state inputs-on-HF gate result for the auto-terminate (M1).
@@ -1095,7 +1189,7 @@ def _runpod_wedge_already_handled(issue: int, handle, sidecar: Path) -> bool:
     return prior is not None and prior.get("runpod_wedge") == _runpod_handle_identity(handle)
 
 
-def _relaunch_fresh_runpod(*, issue: int, handle, result, sidecar: Path) -> dict:
+def _relaunch_fresh_runpod(*, issue: int, handle, result, sidecar: Path, stamp_fn=None) -> dict:
     """Re-provision a FRESH RunPod pod + resume the dispatcher idempotently.
 
     Re-uses the router's ``failover_to_runpod_after_async_workload_crash`` (the
@@ -1103,7 +1197,21 @@ def _relaunch_fresh_runpod(*, issue: int, handle, result, sidecar: Path) -> dict
     from the handle, launch a fresh RunPod run (NEW host, NOT a host-pinned
     resume), re-point the handle sidecar, durable-lease guarded. The fresh pod's
     P2 dispatcher skips HF-complete cells via A2's ``_cell_done_anywhere``.
+
+    ``stamp_fn`` selects WHICH durable lease field stamps the "exactly once per
+    wedge" record on the three internal stamp sites. It DEFAULTS (via the ``None``
+    sentinel resolved below — ``_stamp_runpod_wedge_failover`` is DEFINED LATER in
+    this module, so it cannot be a literal default-arg value without a
+    forward-reference ``NameError`` at import) to
+    :func:`_stamp_runpod_wedge_failover` (the Part C no-port wedge field), so the
+    existing no-port caller (:func:`_failover_wedged_runpod`) is byte-unchanged.
+    The #775 CUDA-IMA caller (:func:`_failover_cuda_ima_runpod`) passes
+    ``stamp_fn=_stamp_runpod_cuda_ima_failover`` so the SEPARATE
+    ``runpod_cuda_ima_failover_of`` lease field is stamped — the two failover
+    classes never cross-suppress.
     """
+    if stamp_fn is None:
+        stamp_fn = _stamp_runpod_wedge_failover
     from explore_persona_space.backends.issue_dispatch import (
         read_handle_sidecar,
         write_handle_sidecar,
@@ -1196,7 +1304,7 @@ def _relaunch_fresh_runpod(*, issue: int, handle, result, sidecar: Path) -> dict
         # Stamp the DURABLE wedge lease so a re-fired tick on the still-wedged
         # handle short-circuits at _runpod_wedge_already_handled (no second
         # terminate/re-provision).
-        _stamp_runpod_wedge_failover(issue, handle)
+        stamp_fn(issue, handle)
         return _terminal_infra_json(
             issue=issue,
             sidecar=sidecar,
@@ -1208,7 +1316,7 @@ def _relaunch_fresh_runpod(*, issue: int, handle, result, sidecar: Path) -> dict
             ),
         )
     if recovered.backend != "runpod":
-        _stamp_runpod_wedge_failover(issue, handle)
+        stamp_fn(issue, handle)
         return _terminal_infra_json(
             issue=issue,
             sidecar=sidecar,
@@ -1219,12 +1327,14 @@ def _relaunch_fresh_runpod(*, issue: int, handle, result, sidecar: Path) -> dict
                 f"(durable lease stamped to bound the relaunch)"
             ),
         )
-    # DURABLE IDEMPOTENCY STAMP (#689 blocker-2). The fresh pod has launched and the
-    # sidecar is authoritatively re-pointed. Stamp runpod_wedge_failover_of onto the
+    # DURABLE IDEMPOTENCY STAMP (#689 blocker-2; #775 stamp_fn). The fresh pod has
+    # launched and the sidecar is authoritatively re-pointed. Stamp the failover
+    # field selected by ``stamp_fn`` (runpod_wedge_failover_of by default; the
+    # SEPARATE runpod_cuda_ima_failover_of for the CUDA-IMA caller) onto the
     # ~/.eps-routing/ lease so even if the .claude/cache sidecar/sentinel are later
     # lost under EDQUOT, the next poll short-circuits at the lease check instead of
     # firing a paid second terminate + re-provision.
-    _stamp_runpod_wedge_failover(issue, handle)
+    stamp_fn(issue, handle)
     return {
         "status": "running",
         "current_phase": "runpod_noport_wedge_failover_fresh_pod",
@@ -1310,6 +1420,169 @@ def _failover_wedged_runpod(*, issue: int, handle, result, sidecar: Path) -> dic
     #    fresh pod's P2 WaveDispatcher skips HF-complete cells (A2
     #    _cell_done_anywhere), re-running only the not-yet-run (absent) cells.
     return _relaunch_fresh_runpod(issue=issue, handle=handle, result=result, sidecar=sidecar)
+
+
+def _runpod_cuda_ima_sentinel_path(sidecar: Path) -> Path:
+    """The idempotency sentinel path for a RunPod CUDA-IMA repeat failover (#775).
+
+    The exact sibling of :func:`_runpod_wedge_sentinel_path` with a DISTINCT name
+    so a no-port wedge failover and a CUDA-IMA failover on the same issue do not
+    share a sentinel: ``issue-<N>-handle.json`` ->
+    ``issue-<N>-runpod-cuda-ima-handled.json``.
+    """
+    name = sidecar.name
+    stem = name[: -len("-handle.json")] if name.endswith("-handle.json") else sidecar.stem
+    return sidecar.with_name(f"{stem}-runpod-cuda-ima-handled.json")
+
+
+def _write_runpod_cuda_ima_sentinel(sentinel: Path, *, issue: int, handle) -> None:
+    """Persist the RunPod CUDA-IMA failover idempotency sentinel atomically (#775).
+
+    Byte-mirror of :func:`_write_runpod_wedge_sentinel`. Records the crashed
+    RunPod run identity (pod_name/job_id) so a subsequent poll on the SAME crashed
+    handle short-circuits. A write failure is LOGGED, not raised — worst case one
+    extra terminate-and-reprovision on the next tick (the durable lease still
+    bounds it), never a silent suppression.
+    """
+    try:
+        sentinel.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "issue": int(issue),
+            "reason": "runpod_cuda_ima_repeat_failover",
+            "runpod_cuda_ima": _runpod_handle_identity(handle),
+        }
+        tmp = sentinel.with_suffix(sentinel.suffix + ".tmp")
+        tmp.write_text(json.dumps(payload, sort_keys=True, indent=2))
+        tmp.replace(sentinel)
+    except OSError as exc:
+        logging.warning(
+            "backend_poll: failed to write RunPod CUDA-IMA idempotency sentinel %s (%s: %s)",
+            sentinel,
+            type(exc).__name__,
+            exc,
+        )
+
+
+def _runpod_cuda_ima_already_handled(issue: int, handle, sidecar: Path) -> bool:
+    """Idempotency short-circuit for a re-fired RunPod CUDA-IMA failover (#775).
+
+    Byte-mirror of :func:`_runpod_wedge_already_handled` (the two-record guard):
+
+      1. DURABLE lease (AUTHORITATIVE) — ``runpod_cuda_ima_failover_of`` at
+         ``~/.eps-routing/`` survives the EDQUOT mode that fails BOTH the sidecar
+         AND the same-dir sentinel.
+      2. SENTINEL (fast path) — the ``.claude/cache`` sibling file; a
+         corrupted/unreadable sentinel reads as ABSENT (one extra reprovision at
+         worst, never a silent suppression).
+
+    Both keyed to the crashed pod's pod_name/job_id, so a genuinely-new run (the
+    fresh-host re-provision writes a NEW pod_name) does NOT match a stale record.
+    """
+    # 1. DURABLE LEASE (authoritative; survives a .claude/cache-wide disk failure).
+    if _lease_records_runpod_cuda_ima_failover(issue, handle):
+        return True
+    # 2. SENTINEL (fast path).
+    sentinel = _runpod_cuda_ima_sentinel_path(sidecar)
+    prior = _read_failover_sentinel(sentinel)
+    return prior is not None and prior.get("runpod_cuda_ima") == _runpod_handle_identity(handle)
+
+
+def _failover_cuda_ima_runpod(*, issue: int, handle, result, sidecar: Path) -> dict:
+    """Pivot a CUDA-IMA-repeat-wedged RunPod run to a FRESH host, bounded once (#775).
+
+    The CUDA-IMA sibling of :func:`_failover_wedged_runpod`, with the once-more
+    bound (M1) as the FIRST check (the only structural difference from the no-port
+    sibling, which has no analogous per-run bound):
+
+      1. ONCE-MORE BOUND (layer-2, M1). If the DURABLE lease already records a
+         CUDA-IMA failover for THIS run (``runpod_cuda_ima_failover_of`` set), this
+         is the SECOND same-signature crash on the FRESH host — a fresh host did
+         NOT heal it, so it is a deterministic code bug. Emit a terminal
+         ``failure_class: code`` JSON (``reason=cuda_ima_repeats_after_failover``)
+         via :func:`_terminal_code_json` so the watcher PARKS it at ``blocked``
+         (its capacity-retry pass re-drives ONLY ``failure_class: infra`` +
+         ``no_compute_available``). NO second pivot.
+      2. PER-WEDGE IDEMPOTENCY (layer-1). A re-fired tick on the SAME crashed
+         handle after a successful pivot short-circuits (no double-pivot).
+      3. INPUTS-ON-HF GATE. Reused as-is — a PARTIAL cell BLOCKS the irreversible
+         terminate (human decides, CLAUDE.md halt-criterion #2).
+      4. TERMINATE the crashed pod (best-effort — a CUDA-IMA-wedged pod may
+         already be dead, so ``info is None`` is fine; terminate is cleanup of the
+         billing leak when the pod is still RUNNING).
+      5. SENTINEL + RE-PROVISION FRESH via :func:`_relaunch_fresh_runpod` with
+         ``stamp_fn=_stamp_runpod_cuda_ima_failover`` (stamps the SEPARATE lease
+         field — the once-more bound for the NEXT crash).
+    """
+    # 1. ONCE-MORE BOUND (M1): the lease already records a CUDA-IMA failover for
+    #    THIS run -> the fresh host ALSO crashed same-signature -> terminal code.
+    if _lease_records_runpod_cuda_ima_failover(issue, handle):
+        return _terminal_code_json(
+            issue=issue,
+            sidecar=sidecar,
+            reason="cuda_ima_repeats_after_failover",
+            log_tail=(
+                f"RunPod {handle.pod_name}: a SECOND same-signature CUDA-IMA crash AFTER the one "
+                f"bounded fresh-host pivot (#775). A fresh host did not heal it, so this is a "
+                f"deterministic code bug, not a transient host wedge — routing to "
+                f"failure_class: code -> blocked (no second pivot)."
+            ),
+        )
+
+    # 2. PER-WEDGE IDEMPOTENCY (a re-fired tick on the OLD crashed handle).
+    if _runpod_cuda_ima_already_handled(issue, handle, sidecar):
+        return _terminal_infra_json(
+            issue=issue,
+            sidecar=sidecar,
+            reason="runpod_cuda_ima_already_handled",
+            log_tail=(
+                f"RunPod CUDA-IMA failover for {handle.pod_name} already handled on a prior tick "
+                f"(idempotency lease/sentinel); refusing a second terminate/re-provision"
+            ),
+        )
+
+    # 3. PER-CELL INPUTS-ON-HF GATE (reused as-is; a PARTIAL cell BLOCKS terminate).
+    gate = _wedged_run_inputs_on_hf(issue, handle)
+    if not gate.ok:
+        return _terminal_infra_json(
+            issue=issue,
+            sidecar=sidecar,
+            reason="runpod_cuda_ima_inputs_unverified",
+            log_tail=(
+                f"RunPod {handle.pod_name} CUDA-IMA repeat wedge; {len(gate.partial)} PARTIAL "
+                f"cell(s) on HF (one artifact-kind missing): {gate.partial}. Refusing the "
+                f"irreversible terminate (CLAUDE.md halt-criterion #2) — human decision needed; "
+                f"complete={len(gate.complete)} absent={len(gate.absent)}"
+            ),
+        )
+
+    # 4. TERMINATE the crashed pod (best-effort — a CUDA-IMA-wedged pod is usually
+    #    already dead, so ``info is None`` simply skips the terminate cleanup).
+    from runpod_api import get_pod_by_name, terminate_pod
+
+    info = get_pod_by_name(handle.pod_name)
+    if info is not None:
+        terminate_pod(info.pod_id)
+        logging.warning(
+            "backend_poll: terminated CUDA-IMA-wedged RunPod %s (%s) — billing stopped "
+            "(complete=%d absent=%d)",
+            handle.pod_name,
+            info.pod_id,
+            len(gate.complete),
+            len(gate.absent),
+        )
+
+    # 5. SENTINEL (before the re-provision so a re-fired tick short-circuits even if
+    #    the re-provision raises) + RE-PROVISION FRESH, stamping the CUDA-IMA lease.
+    _write_runpod_cuda_ima_sentinel(
+        _runpod_cuda_ima_sentinel_path(sidecar), issue=issue, handle=handle
+    )
+    return _relaunch_fresh_runpod(
+        issue=issue,
+        handle=handle,
+        result=result,
+        sidecar=sidecar,
+        stamp_fn=_stamp_runpod_cuda_ima_failover,
+    )
 
 
 def _failover_sentinel_path(sidecar: Path) -> Path:

--- a/scripts/backend_poll.py
+++ b/scripts/backend_poll.py
@@ -2426,6 +2426,40 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(failover_json))
         return 0
 
+    # #775 RunPod CUDA-IMA repeat-failover. MUST run BEFORE the no-port escalation
+    # below (M2): the no-port within-K path rewrites status=dead -> running, which
+    # would mask a CUDA-IMA dead poll that is ALSO transiently no-port (engine
+    # dead, ports not yet torn down) before the CUDA-IMA predicate (which requires
+    # status="dead") ever ran. A no-op on every non-RunPod / non-dead /
+    # non-CUDA-IMA / first-crash / our-code-framed poll (the CUDA-IMA record rides
+    # the sidecar's extra dict, fail-soft).
+    result = _maybe_escalate_runpod_cuda_ima(
+        handle, result, Path(sidecar), issue=args.issue, now=time.time()
+    )
+    if _is_runpod_cuda_ima_failure(handle, result):
+        # Belt-and-suspenders guard (mirrors the no-port wedge guard below):
+        # _failover_cuda_ima_runpod maps every internal failure to a terminal JSON,
+        # so it should never raise — but the crashed pod may already be terminated,
+        # so a bare traceback would strand the run with no re-drive signal.
+        try:
+            cuda_ima_json = _failover_cuda_ima_runpod(
+                issue=args.issue, handle=handle, result=result, sidecar=Path(sidecar)
+            )
+        except Exception as exc:
+            logging.exception("backend_poll: RunPod CUDA-IMA failover raised unexpectedly")
+            cuda_ima_json = _terminal_infra_json(
+                issue=args.issue,
+                sidecar=Path(sidecar),
+                reason="runpod_cuda_ima_failover_error",
+                log_tail=(
+                    f"RunPod CUDA-IMA failover for issue {args.issue} raised "
+                    f"{type(exc).__name__}: {exc}; emitting terminal infra JSON "
+                    f"(poller terminal-JSON contract)"
+                ),
+            )
+        print(json.dumps(cuda_ima_json))
+        return 0
+
     # #664/#689 RunPod RUNNING-but-no-port host wedge escalation: a RunPod pod
     # whose desiredStatus stays RUNNING with null/empty runtime.ports past
     # RUNPOD_WEDGE_K_SEC (host-pinned resume cannot heal it) is rewritten to

--- a/scripts/backend_poll.py
+++ b/scripts/backend_poll.py
@@ -45,6 +45,7 @@ import argparse
 import json
 import logging
 import os
+import re
 import sys
 import time
 from dataclasses import dataclass, replace
@@ -603,6 +604,199 @@ def _clear_runpod_noport_clock(sidecar: Path) -> None:
     except (OSError, json.JSONDecodeError, ValueError) as exc:
         logging.warning(
             "backend_poll: RunPod no-port clock clear failed for %s (%s: %s)",
+            sidecar,
+            type(exc).__name__,
+            exc,
+        )
+
+
+# ── RunPod CUDA-IMA repeat host wedge: signature-record family + regex (#775) ──
+# The detection record for a same-signature CUDA-IMA (illegal-memory-access /
+# EngineDeadError) crash REPEATING within a run. Byte-mirrors the
+# ``_read/_write/_clear_runpod_noport_clock`` family above (atomic tmp+rename,
+# never-raise on a malformed value), keyed ``runpod_cuda_ima_last_seen`` (a dict
+# ``{"ts": <epoch>, "sig": "cuda_ima"}``, distinct from the noport clock's bare
+# float). The record is signature-keyed across the run (NOT pod_id), with the
+# prior ``epm:failure`` marker as a cross-pod fallback source (so a sidecar wipe
+# between pods does not lose the prior-crash record). See
+# ``.claude/rules/compute-backend-failover.md`` Part D.
+
+# The CUDA-IMA crash-signature family. No ``re.DOTALL`` and no cross-newline lazy
+# quantifier — each alternative matches WITHIN one line, so a match cannot span
+# unrelated events across the 500-line probe tail. A driver-level IMA has no
+# stable user-frame, so "same signature" is the FAMILY recurring (this regex
+# matching both the prior and the current crash surface), NOT an exact-frame
+# fingerprint.
+CUDA_IMA_SIGNATURE = re.compile(
+    r"CUDA error:\s*an illegal memory access was encountered"
+    r"|illegal memory access was encountered"
+    r"|EngineDeadError"
+    r"|Engine core proc \S+ died unexpectedly",
+    re.IGNORECASE,
+)
+
+# The synthesized terminal ``current_phase`` for a matured RunPod CUDA-IMA repeat
+# wedge (#775). ``_is_runpod_cuda_ima_failure`` matches THIS phase EXACTLY; it is
+# set ONLY by ``_maybe_escalate_runpod_cuda_ima`` once a second same-signature
+# CUDA-IMA crash is observed this run.
+RUNPOD_CUDA_IMA_WEDGED_PHASE = "terminal_runpod_cuda_ima_host_wedged"
+
+
+def _crash_signature_is_cuda_ima(text: str | None) -> bool:
+    """True iff ``text`` (a crash surface) carries the CUDA-IMA family signature.
+
+    Pure: ``bool(CUDA_IMA_SIGNATURE.search(text or ""))``. ``None``/empty → False.
+    """
+    return bool(CUDA_IMA_SIGNATURE.search(text or ""))
+
+
+def _crash_signature_has_our_code_frame(text: str | None) -> bool:
+    """True iff the crash surface carries an OUR-code traceback frame (M3 exclusion).
+
+    A CUDA-IMA surface that ALSO traces through ``src/explore_persona_space/`` or
+    ``scripts/`` is a deterministic CODE bug surfacing as CUDA-IMA, NOT a host
+    wedge — the escalation skips it (falls through to the ordinary dead path →
+    ``failure_class: code``) so no bounded pivot is spent on a code bug. Reuses
+    ``failure_classifier.OUR_CODE_FRAME`` (lazy-imported to keep the ``--help``
+    path fast). ``None``/empty → False.
+    """
+    if not text:
+        return False
+    from failure_classifier import OUR_CODE_FRAME
+
+    return bool(OUR_CODE_FRAME.search(text))
+
+
+def _prior_failure_marker_is_cuda_ima(issue: int) -> bool:
+    """Cross-pod FALLBACK source for the prior-CUDA-IMA-crash record (#775, B1).
+
+    When the sidecar ``extra`` record is ABSENT (a sidecar wipe between pods, an
+    EDQUOT round-trip, a fresh-host re-point that cleared ``extra``), read the
+    latest prior ``epm:failure`` marker for this issue and return True iff its
+    note carries a CUDA-IMA signature. ``backend_poll.py`` runs VM-side (the
+    orchestrator poller on ``main``, NOT pod-side on an ``issue-<N>`` branch), so
+    reading prior markers via ``task_workflow.list_events`` is the same VM-side
+    surface the circuit-breaker uses — the pod-side-``task.py``-shellout
+    prohibition does not apply.
+
+    Fail-soft: any read / import error → treat as "no prior record" (return
+    ``False``) so the fallback can never crash the poll or manufacture a wedge.
+    """
+    try:
+        from explore_persona_space.task_workflow import list_events
+
+        events = list_events(int(issue))
+    except Exception as exc:
+        logging.warning(
+            "backend_poll: CUDA-IMA prior-marker fallback read failed for issue %s (%s: %s); "
+            "treating as no prior CUDA-IMA crash",
+            issue,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+    for ev in reversed(events or []):
+        if not isinstance(ev, dict):
+            continue
+        # The event's marker name lives in ``kind`` (e.g. ``"epm:failure"``);
+        # the body lives in ``note`` (verified against the live events.jsonl
+        # shape for this issue).
+        kind = str(ev.get("kind") or "")
+        if "epm:failure" not in kind:
+            continue
+        # The LATEST epm:failure is the relevant one (the most recent prior
+        # crash): if its note carries the CUDA-IMA family, the current crash is a
+        # repeat; if not, the current crash is the first of its kind this run.
+        # Either way we decide on the first epm:failure seen (newest-first), so
+        # return its verdict directly.
+        return _crash_signature_is_cuda_ima(str(ev.get("note") or ""))
+    return False
+
+
+def _read_runpod_cuda_ima_record(sidecar: Path, *, issue: int) -> dict | None:
+    """Read the prior-CUDA-IMA-crash record for this run, or ``None`` if absent (#775).
+
+    Mirrors :func:`_read_runpod_noport_clock`'s fail-soft contract: a missing /
+    unreadable / malformed sidecar OR a non-dict ``extra["runpod_cuda_ima_last_seen"]``
+    reads as ``None``, NEVER raises. When the sidecar record is ABSENT, FALLS BACK
+    to the prior ``epm:failure`` marker (B1 cross-pod source — see
+    :func:`_prior_failure_marker_is_cuda_ima`): a CUDA-IMA prior marker yields a
+    synthetic record so the current crash still counts as a repeat across a pod
+    swap. The sidecar is the FAST path; the marker is the durable cross-pod
+    backstop (the lease/sentinel two-record philosophy applied to detection).
+    """
+    record: dict | None = None
+    try:
+        payload = json.loads(Path(sidecar).read_text())
+        extra = payload.get("extra") if isinstance(payload, dict) else None
+        if isinstance(extra, dict):
+            raw = extra.get("runpod_cuda_ima_last_seen")
+            if isinstance(raw, dict):
+                record = raw
+    except (OSError, json.JSONDecodeError, ValueError):
+        record = None
+    if record is not None:
+        return record
+    # Sidecar record absent → cross-pod fallback to the prior epm:failure marker.
+    if _prior_failure_marker_is_cuda_ima(issue):
+        return {"sig": "cuda_ima", "source": "prior_failure_marker"}
+    return None
+
+
+def _write_runpod_cuda_ima_record(sidecar: Path, *, ts: float) -> None:
+    """Persist the CUDA-IMA crash record onto the sidecar ``extra`` dict, atomically.
+
+    Mirrors :func:`_write_runpod_noport_clock`: mutates ONLY
+    ``extra["runpod_cuda_ima_last_seen"]`` (every other field preserved verbatim),
+    write-temp + rename, and a write failure is LOGGED not raised.
+    """
+    try:
+        path = Path(sidecar)
+        payload = json.loads(path.read_text())
+        if not isinstance(payload, dict):
+            return
+        extra = payload.get("extra")
+        if not isinstance(extra, dict):
+            extra = {}
+            payload["extra"] = extra
+        extra["runpod_cuda_ima_last_seen"] = {"ts": float(ts), "sig": "cuda_ima"}
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(payload, sort_keys=True, indent=2))
+        tmp.replace(path)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        logging.warning(
+            "backend_poll: RunPod CUDA-IMA record write failed for %s (%s: %s); "
+            "the next tick re-reads stale state (never manufactures a wedge)",
+            sidecar,
+            type(exc).__name__,
+            exc,
+        )
+
+
+def _clear_runpod_cuda_ima_record(sidecar: Path) -> None:
+    """Remove the CUDA-IMA crash record key from the sidecar (#775).
+
+    Called on a non-dead / non-CUDA-IMA poll (an intervening healthy poll the
+    in-place same-pod respawn recovered to) — a single transient CUDA-IMA does
+    NOT accumulate against a later unrelated one; only a SECOND CUDA-IMA crash
+    with no intervening healthy poll counts. Mirrors
+    :func:`_clear_runpod_noport_clock`; missing key → no-op.
+    """
+    try:
+        path = Path(sidecar)
+        payload = json.loads(path.read_text())
+        if not isinstance(payload, dict):
+            return
+        extra = payload.get("extra")
+        if not isinstance(extra, dict) or "runpod_cuda_ima_last_seen" not in extra:
+            return
+        del extra["runpod_cuda_ima_last_seen"]
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(payload, sort_keys=True, indent=2))
+        tmp.replace(path)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        logging.warning(
+            "backend_poll: RunPod CUDA-IMA record clear failed for %s (%s: %s)",
             sidecar,
             type(exc).__name__,
             exc,
@@ -1533,6 +1727,43 @@ def _terminal_infra_json(*, issue: int, sidecar: Path, reason: str, log_tail: st
         "gpu_util": "unknown",
         "next_interval": _DEFAULT_NEXT_INTERVAL_SEC,
         "failure_class": "infra",
+        "reason": reason,
+        "issue": int(issue),
+    }
+
+
+def _terminal_code_json(*, issue: int, sidecar: Path, reason: str, log_tail: str) -> dict:
+    """A ``status='dead'`` / ``failure_class='code'`` poll JSON keyed by ``reason`` (#775).
+
+    The SIBLING of :func:`_terminal_infra_json` for a CODE-class terminal. Used by
+    :func:`_failover_cuda_ima_runpod` for the once-more-exhaustion path: a SECOND
+    same-signature CUDA-IMA crash AFTER the one bounded fresh-host pivot means a
+    fresh host did NOT fix the crash, so it is a deterministic code bug, not a
+    transient host wedge — emit ``failure_class: code`` so the watcher's
+    capacity-retry pass (which re-drives ONLY ``failure_class: infra`` +
+    ``no_compute_available`` — see ``autonomous_session_watch._is_transient_capacity_block``)
+    PARKS the run at ``blocked`` for human inspection rather than re-driving it.
+
+    A separate function rather than a ``failure_class`` kwarg on
+    :func:`_terminal_infra_json`, whose NAME + docstring assert ``infra`` — a
+    ``failure_class='code'`` value there would contradict the contract a reader
+    trusts. The poll-JSON shape is identical to the infra sibling except the
+    ``failure_class`` value.
+    """
+    return {
+        "status": "dead",
+        "current_phase": f"terminal_{reason}",
+        "new_milestone": True,
+        "last_log_mtime_sec_ago": 10**9,
+        "pid_alive": False,
+        "log_tail_excerpt": log_tail,
+        "gate": None,
+        "sentinels_processed": 0,
+        "phase_log_mtime_sec_ago": 10**9,
+        "shard_log_mtime_sec_ago": 10**9,
+        "gpu_util": "unknown",
+        "next_interval": _DEFAULT_NEXT_INTERVAL_SEC,
+        "failure_class": "code",
         "reason": reason,
         "issue": int(issue),
     }

--- a/scripts/backend_poll.py
+++ b/scripts/backend_poll.py
@@ -658,6 +658,16 @@ CUDA_IMA_SIGNATURE = re.compile(
 # CUDA-IMA crash is observed this run.
 RUNPOD_CUDA_IMA_WEDGED_PHASE = "terminal_runpod_cuda_ima_host_wedged"
 
+# The success ``current_phase`` emitted by ``_relaunch_fresh_runpod`` after a
+# fresh-pod re-provision succeeds. The DEFAULT is the no-port wedge phase (Part C,
+# #664) — preserved byte-identically so the Part C caller is unchanged. The
+# CUDA-IMA caller (Part D, #775) passes ``RUNPOD_CUDA_IMA_FAILOVER_FRESH_POD_PHASE``
+# so the emitted poll JSON / markers read TRUE to a CUDA-IMA failover (the two
+# wedge classes reuse the same inner relaunch but a shared no-port phase string
+# would misclassify a CUDA-IMA pivot as a no-port wedge in the operator log).
+RUNPOD_NOPORT_WEDGE_FAILOVER_FRESH_POD_PHASE = "runpod_noport_wedge_failover_fresh_pod"
+RUNPOD_CUDA_IMA_FAILOVER_FRESH_POD_PHASE = "runpod_cuda_ima_failover_fresh_pod"
+
 
 def _crash_signature_is_cuda_ima(text: str | None) -> bool:
     """True iff ``text`` (a crash surface) carries the CUDA-IMA family signature.
@@ -1189,7 +1199,15 @@ def _runpod_wedge_already_handled(issue: int, handle, sidecar: Path) -> bool:
     return prior is not None and prior.get("runpod_wedge") == _runpod_handle_identity(handle)
 
 
-def _relaunch_fresh_runpod(*, issue: int, handle, result, sidecar: Path, stamp_fn=None) -> dict:
+def _relaunch_fresh_runpod(
+    *,
+    issue: int,
+    handle,
+    result,
+    sidecar: Path,
+    stamp_fn=None,
+    success_phase: str = RUNPOD_NOPORT_WEDGE_FAILOVER_FRESH_POD_PHASE,
+) -> dict:
     """Re-provision a FRESH RunPod pod + resume the dispatcher idempotently.
 
     Re-uses the router's ``failover_to_runpod_after_async_workload_crash`` (the
@@ -1209,6 +1227,12 @@ def _relaunch_fresh_runpod(*, issue: int, handle, result, sidecar: Path, stamp_f
     ``stamp_fn=_stamp_runpod_cuda_ima_failover`` so the SEPARATE
     ``runpod_cuda_ima_failover_of`` lease field is stamped — the two failover
     classes never cross-suppress.
+
+    ``success_phase`` is the ``current_phase`` emitted on a successful fresh-pod
+    relaunch. It DEFAULTS to ``RUNPOD_NOPORT_WEDGE_FAILOVER_FRESH_POD_PHASE`` (Part
+    C byte-unchanged); the #775 CUDA-IMA caller passes
+    ``RUNPOD_CUDA_IMA_FAILOVER_FRESH_POD_PHASE`` so the emitted poll JSON / markers
+    read TRUE to a CUDA-IMA failover instead of mislabelling it a no-port wedge.
     """
     if stamp_fn is None:
         stamp_fn = _stamp_runpod_wedge_failover
@@ -1335,14 +1359,20 @@ def _relaunch_fresh_runpod(*, issue: int, handle, result, sidecar: Path, stamp_f
     # lost under EDQUOT, the next poll short-circuits at the lease check instead of
     # firing a paid second terminate + re-provision.
     stamp_fn(issue, handle)
+    # The wedge-class wording mirrors success_phase so the operator log reads true to
+    # the failover that actually fired (no-port #664 vs CUDA-IMA-repeat #775).
+    if success_phase == RUNPOD_CUDA_IMA_FAILOVER_FRESH_POD_PHASE:
+        wedge_desc = "same-signature CUDA-IMA repeat wedge (#775)"
+    else:
+        wedge_desc = "RUNNING-but-no-port wedge (#664)"
     return {
         "status": "running",
-        "current_phase": "runpod_noport_wedge_failover_fresh_pod",
+        "current_phase": success_phase,
         "new_milestone": True,
         "last_log_mtime_sec_ago": 0,
         "pid_alive": True,
         "log_tail_excerpt": (
-            f"RunPod {handle.pod_name} RUNNING-but-no-port wedge (#664); terminated + "
+            f"RunPod {handle.pod_name} {wedge_desc}; terminated + "
             f"re-provisioned fresh pod {route_result.handle.pod_name}"
         ),
         "gate": None,
@@ -1494,10 +1524,14 @@ def _failover_cuda_ima_runpod(*, issue: int, handle, result, sidecar: Path) -> d
     bound (M1) as the FIRST check (the only structural difference from the no-port
     sibling, which has no analogous per-run bound):
 
-      1. ONCE-MORE BOUND (layer-2, M1). If the DURABLE lease already records a
-         CUDA-IMA failover for THIS run (``runpod_cuda_ima_failover_of`` set), this
-         is the SECOND same-signature crash on the FRESH host — a fresh host did
-         NOT heal it, so it is a deterministic code bug. Emit a terminal
+      1. ONCE-MORE BOUND (layer-2, M1). If the DURABLE lease has ANY
+         ``runpod_cuda_ima_failover_of`` stamp for THIS run
+         (:func:`_lease_has_any_runpod_cuda_ima_failover` — a PER-RUN any-non-null
+         check, NOT the PER-POD identity-equality of layer-1, so it survives the
+         fresh-pod identity change: the stamp records the OLD crashed pod, the
+         SECOND crash arrives on the FRESH handle), this is the SECOND
+         same-signature crash on the FRESH host — a fresh host did NOT heal it, so
+         it is a deterministic code bug. Emit a terminal
          ``failure_class: code`` JSON (``reason=cuda_ima_repeats_after_failover``)
          via :func:`_terminal_code_json` so the watcher PARKS it at ``blocked``
          (its capacity-retry pass re-drives ONLY ``failure_class: infra`` +
@@ -1513,9 +1547,13 @@ def _failover_cuda_ima_runpod(*, issue: int, handle, result, sidecar: Path) -> d
          ``stamp_fn=_stamp_runpod_cuda_ima_failover`` (stamps the SEPARATE lease
          field — the once-more bound for the NEXT crash).
     """
-    # 1. ONCE-MORE BOUND (M1): the lease already records a CUDA-IMA failover for
-    #    THIS run -> the fresh host ALSO crashed same-signature -> terminal code.
-    if _lease_records_runpod_cuda_ima_failover(issue, handle):
+    # 1. ONCE-MORE BOUND (M1, PER-RUN): the lease has ANY CUDA-IMA failover stamp
+    #    for THIS run -> the fresh host ALSO crashed same-signature -> terminal code.
+    #    An any-non-null (NOT identity-equality) check, so it survives the fresh-pod
+    #    identity change — the stamp records the OLD crashed pod but this second
+    #    crash arrives on the FRESH handle (the identity-keyed layer-1 check would
+    #    miss it and pivot again indefinitely).
+    if _lease_has_any_runpod_cuda_ima_failover(issue):
         return _terminal_code_json(
             issue=issue,
             sidecar=sidecar,
@@ -1555,21 +1593,40 @@ def _failover_cuda_ima_runpod(*, issue: int, handle, result, sidecar: Path) -> d
             ),
         )
 
-    # 4. TERMINATE the crashed pod (best-effort — a CUDA-IMA-wedged pod is usually
-    #    already dead, so ``info is None`` simply skips the terminate cleanup).
+    # 4. TERMINATE the crashed pod (BEST-EFFORT — a CUDA-IMA-wedged pod is usually
+    #    already dead, so ``info is None`` simply skips the terminate cleanup, and a
+    #    terminate API race/failure on a pod the RunPod side has already torn down
+    #    (or a transient API hiccup) MUST NOT block the fresh-host recovery. Without
+    #    the guard, the ``main()`` outer ``except`` converts ANY terminate exception
+    #    to ``reason=runpod_cuda_ima_failover_error``, masking the intended pivot.
+    #    Terminating an already-dead pod is operationally idempotent, so on a raise
+    #    we log + continue to the sentinel + fresh-host relaunch. (Part C's no-port
+    #    terminate stays fail-loud BY DESIGN — that pod is genuinely RUNNING+billing,
+    #    so a terminate failure there is the billing leak the wedge exists to stop.)
     from runpod_api import get_pod_by_name, terminate_pod
 
     info = get_pod_by_name(handle.pod_name)
     if info is not None:
-        terminate_pod(info.pod_id)
-        logging.warning(
-            "backend_poll: terminated CUDA-IMA-wedged RunPod %s (%s) — billing stopped "
-            "(complete=%d absent=%d)",
-            handle.pod_name,
-            info.pod_id,
-            len(gate.complete),
-            len(gate.absent),
-        )
+        try:
+            terminate_pod(info.pod_id)
+            logging.warning(
+                "backend_poll: terminated CUDA-IMA-wedged RunPod %s (%s) — billing stopped "
+                "(complete=%d absent=%d)",
+                handle.pod_name,
+                info.pod_id,
+                len(gate.complete),
+                len(gate.absent),
+            )
+        except Exception as exc:
+            logging.warning(
+                "backend_poll: best-effort terminate of CUDA-IMA-wedged RunPod %s (%s) FAILED "
+                "(%s: %s); the pod is usually already dead — continuing to the fresh-host "
+                "relaunch (terminating an already-dead pod is idempotent)",
+                handle.pod_name,
+                info.pod_id,
+                type(exc).__name__,
+                exc,
+            )
 
     # 5. SENTINEL (before the re-provision so a re-fired tick short-circuits even if
     #    the re-provision raises) + RE-PROVISION FRESH, stamping the CUDA-IMA lease.
@@ -1582,6 +1639,7 @@ def _failover_cuda_ima_runpod(*, issue: int, handle, result, sidecar: Path) -> d
         result=result,
         sidecar=sidecar,
         stamp_fn=_stamp_runpod_cuda_ima_failover,
+        success_phase=RUNPOD_CUDA_IMA_FAILOVER_FRESH_POD_PHASE,
     )
 
 
@@ -1891,6 +1949,50 @@ def _lease_records_runpod_cuda_ima_failover(issue: int, handle, *, lease_store=N
     if lease is None:
         return False
     return lease.runpod_cuda_ima_failover_of == _runpod_handle_identity(handle)
+
+
+def _lease_has_any_runpod_cuda_ima_failover(issue: int, *, lease_store=None) -> bool:
+    """True iff the issue's DURABLE lease has ANY ``runpod_cuda_ima_failover_of``
+    stamp, regardless of WHICH pod it records (#775).
+
+    The PER-RUN layer-2 once-more bound, distinct from the PER-POD layer-1
+    idempotency check :func:`_lease_records_runpod_cuda_ima_failover`:
+
+      - **Layer-1** (per-wedge idempotency, ``_runpod_cuda_ima_already_handled``)
+        is IDENTITY-keyed (``runpod_cuda_ima_failover_of == identity(handle)``):
+        a genuinely-new pod MUST NOT be suppressed, so it compares against the
+        CURRENT handle's identity.
+      - **Layer-2** (this function — the once-more bound in
+        :func:`_failover_cuda_ima_runpod`) must fire "this RUN already spent its
+        one CUDA-IMA pivot" REGARDLESS of which pod crashed. A successful pivot
+        stamps the OLD (crashed) pod's identity, then re-points the sidecar at
+        the FRESH pod; the SECOND CUDA-IMA crash arrives on the FRESH handle, so
+        an identity-equality check (layer-1) against the OLD stamp would always
+        be ``False`` and the run would pivot again indefinitely (the unbounded-
+        spend bug this task exists to prevent). An ANY-non-null check survives
+        the fresh-pod identity change. Plan §5 specifies exactly this: the bound
+        "checks whether ``runpod_cuda_ima_failover_of`` is set to ANY non-null
+        value on the issue's lease".
+
+    A LeaseStore failure (no ``$HOME``, dir uncreatable) reads as "no record"
+    (return ``False``) — worst case is one extra pivot, NEVER a silent
+    suppression, the same fail-soft contract as the identity-keyed sibling.
+    """
+    from explore_persona_space.backends.router import LeaseStore
+
+    store = lease_store or LeaseStore()
+    try:
+        lease = store.read(int(issue))
+    except OSError as exc:
+        logging.warning(
+            "backend_poll: lease-store read failed for issue %s (%s: %s); treating as no "
+            "CUDA-IMA-failover-spent record (the per-run once-more bound stays fail-soft)",
+            issue,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+    return lease is not None and lease.runpod_cuda_ima_failover_of is not None
 
 
 def _stamp_runpod_cuda_ima_failover(issue: int, handle, *, lease_store=None) -> None:

--- a/scripts/backend_poll.py
+++ b/scripts/backend_poll.py
@@ -1386,6 +1386,89 @@ def _stamp_runpod_wedge_failover(issue: int, handle, *, lease_store=None) -> Non
         )
 
 
+def _lease_records_runpod_cuda_ima_failover(issue: int, handle, *, lease_store=None) -> bool:
+    """True iff the DURABLE lease already records a fresh-host failover of THIS
+    CUDA-IMA-wedged RunPod run (#775). The exact byte-mirror of
+    :func:`_lease_records_runpod_wedge_failover`, reading the SEPARATE
+    ``runpod_cuda_ima_failover_of`` field (so a no-port wedge failover and a
+    CUDA-IMA repeat failover on the same issue do not cross-suppress).
+
+    AUTHORITATIVE for the once-more bound: ``_failover_cuda_ima_runpod`` reads it
+    to decide whether THIS run already spent its one bounded CUDA-IMA pivot — if
+    so, a second same-signature crash on the fresh host routes to terminal
+    ``failure_class: code`` (NOT a second pivot). Keyed to the crashed pod's
+    stable identity, so a genuinely-new run on the same issue (the fresh-host
+    re-provision writes a NEW pod_name) does NOT match a prior stamp.
+
+    Lives at ``~/.eps-routing/`` (a DIFFERENT directory from ``.claude/cache``),
+    so it survives the EDQUOT / read-only-fs mode that fails BOTH the sidecar and
+    the same-dir sentinel together — the safety net the GCP round-3 fix
+    established. A LeaseStore failure (no ``$HOME``, dir uncreatable) reads as "no
+    record" (return ``False``) — worst case one extra pivot, NEVER a silent
+    suppression.
+    """
+    from explore_persona_space.backends.router import LeaseStore
+
+    store = lease_store or LeaseStore()
+    try:
+        lease = store.read(int(issue))
+    except OSError as exc:
+        logging.warning(
+            "backend_poll: lease-store read failed for issue %s (%s: %s); "
+            "treating as no prior CUDA-IMA-failover record (the sentinel guard still bounds it)",
+            issue,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+    if lease is None:
+        return False
+    return lease.runpod_cuda_ima_failover_of == _runpod_handle_identity(handle)
+
+
+def _stamp_runpod_cuda_ima_failover(issue: int, handle, *, lease_store=None) -> None:
+    """Record on the DURABLE lease that a fresh-host failover of THIS
+    CUDA-IMA-wedged RunPod run launched (#775). The exact byte-mirror of
+    :func:`_stamp_runpod_wedge_failover`, stamping the SEPARATE
+    ``runpod_cuda_ima_failover_of`` field.
+
+    Called IMMEDIATELY after the fresh-host re-provision SUCCEEDS (passed to
+    :func:`_relaunch_fresh_runpod` via its ``stamp_fn`` kwarg), so the
+    authoritative "exactly once per CUDA-IMA wedge" record lands at
+    ``~/.eps-routing/`` regardless of whether the subsequent ``.claude/cache``
+    sidecar / sentinel writes fail under EDQUOT.
+
+    Best-effort about the LeaseStore itself: a write failure is logged, not
+    raised — the failover already launched, and the sentinel fast-path + the
+    ``recovered.backend`` guard in ``_relaunch_fresh_runpod`` still bound the
+    relaunch. The lease is the SAFETY NET for the EDQUOT-on-``.claude/cache``
+    mode, not a hard precondition.
+    """
+    from explore_persona_space.backends.router import LeaseStore
+
+    store = lease_store or LeaseStore()
+    identity = _runpod_handle_identity(handle)
+    try:
+        with store.transaction(int(issue)) as (lease, write):
+            if lease is None:
+                logging.warning(
+                    "backend_poll: no lease present to stamp runpod_cuda_ima_failover_of for "
+                    "issue %s; relying on the sentinel guard",
+                    issue,
+                )
+                return
+            lease.runpod_cuda_ima_failover_of = identity
+            write(lease)
+    except OSError as exc:
+        logging.warning(
+            "backend_poll: lease-store cuda-ima-failover stamp failed for issue %s (%s: %s); "
+            "the sentinel guard still bounds the relaunch",
+            issue,
+            type(exc).__name__,
+            exc,
+        )
+
+
 def _runspec_from_gcp_handle(handle, issue):
     """Reconstruct the ``RunSpec`` for the RunPod re-launch from the GCP handle.
 

--- a/scripts/poll_pipeline.py
+++ b/scripts/poll_pipeline.py
@@ -2305,6 +2305,31 @@ def _log_staleness_secs(
     return last_mtime_ago, phase_log_mtime_ago, shard_log_mtime_ago
 
 
+def _tail_excerpt_and_crash_signature(
+    probe: dict[str, str], *, status: str, mtime_epoch: int, cell_mtime_epoch: int
+) -> tuple[str, str | None]:
+    """Slice the (5-line excerpt, WIDE crash signature) from the freshest log tail.
+
+    The fresher log (cell tail when cell logs exist AND are fresher than the main
+    log, else the main-log tail) is the WIDE 500-line surface the probe already
+    fetched. The notification excerpt is its last 5 lines (unchanged behavior).
+    The #775 ``crash_signature`` is the WHOLE wide tail on a ``status=="dead"``
+    poll (``None`` otherwise) — NOT the 5-line excerpt, which truncates a 20-50
+    line vLLM CUDA-IMA traceback so a signature match on it would silently never
+    fire. The whole wide tail is stored so the failover predicate can ALSO scan
+    it for the OUR_CODE_FRAME exclusion. Pure (no SSH); extracted from
+    :func:`poll_once` so the slice logic is unit-testable without driving the
+    full poller (the #775 B2 test binds to THIS helper).
+    """
+    if cell_mtime_epoch > 0 and cell_mtime_epoch > mtime_epoch:
+        wide_tail = probe["cell_log_tail"]
+    else:
+        wide_tail = probe["log_tail"]
+    tail_excerpt = "\n".join(wide_tail.splitlines()[-5:])
+    crash_signature = wide_tail if status == "dead" else None
+    return tail_excerpt, crash_signature
+
+
 def poll_once(
     *,
     issue: int,
@@ -2702,19 +2727,9 @@ def poll_once(
     # output, eval progress) rather than the stale dispatcher tail. When
     # both are zero (no logs yet) or the main log is fresher, fall back
     # to the main-log tail (preserves prior behavior for non-cell runs).
-    if cell_mtime_epoch > 0 and cell_mtime_epoch > mtime_epoch:
-        wide_tail = probe["cell_log_tail"]
-    else:
-        wide_tail = probe["log_tail"]
-    tail_excerpt = "\n".join(wide_tail.splitlines()[-5:])
-    # #775: capture the crash signature from the WIDE 500-line tail (the same
-    # surface ``tail_excerpt`` was sliced from), NOT the 5-line excerpt — a vLLM
-    # CUDA-IMA traceback spans 20-50 lines and is routinely truncated out of the
-    # last 5, so a signature match on the excerpt would silently never fire. Pure
-    # string read; the probe ALREADY fetched 500 lines, so no extra SSH call. The
-    # whole wide tail is stored (None unless the poll is dead) so the failover
-    # predicate can ALSO scan it for the OUR_CODE_FRAME exclusion.
-    crash_signature = wide_tail if status == "dead" else None
+    tail_excerpt, crash_signature = _tail_excerpt_and_crash_signature(
+        probe, status=status, mtime_epoch=mtime_epoch, cell_mtime_epoch=cell_mtime_epoch
+    )
     return PollResult(
         status=status,
         current_phase=current_phase,

--- a/scripts/poll_pipeline.py
+++ b/scripts/poll_pipeline.py
@@ -787,6 +787,16 @@ class PollResult:
     # hang as ``running`` forever). Defaulted so the many cross-backend
     # ``PollResult(...)`` call sites need no change.
     stall_reason: str | None = None
+    # The crash signature extracted from the WIDE 500-line probe tail (NOT the
+    # 5-line ``log_tail_excerpt``, which truncates a multi-line vLLM CUDA-IMA
+    # traceback — the signature lines routinely sit >5 lines from the end). The
+    # whole wide tail is stored (so the #775 RunPod CUDA-IMA repeat-failover
+    # predicate can ALSO scan it for the OUR_CODE_FRAME exclusion). ``None`` on a
+    # healthy / running poll (populated only on a ``status="dead"`` poll). Read by
+    # ``backend_poll._maybe_escalate_runpod_cuda_ima`` after the RunPod lane
+    # copies it through ``RunPodBackend.poll``. Declared LAST so existing
+    # positional ``PollResult(...)`` constructions are unaffected.
+    crash_signature: str | None = None
 
 
 def _ssh_probe(
@@ -2693,9 +2703,18 @@ def poll_once(
     # both are zero (no logs yet) or the main log is fresher, fall back
     # to the main-log tail (preserves prior behavior for non-cell runs).
     if cell_mtime_epoch > 0 and cell_mtime_epoch > mtime_epoch:
-        tail_excerpt = "\n".join(probe["cell_log_tail"].splitlines()[-5:])
+        wide_tail = probe["cell_log_tail"]
     else:
-        tail_excerpt = "\n".join(probe["log_tail"].splitlines()[-5:])
+        wide_tail = probe["log_tail"]
+    tail_excerpt = "\n".join(wide_tail.splitlines()[-5:])
+    # #775: capture the crash signature from the WIDE 500-line tail (the same
+    # surface ``tail_excerpt`` was sliced from), NOT the 5-line excerpt — a vLLM
+    # CUDA-IMA traceback spans 20-50 lines and is routinely truncated out of the
+    # last 5, so a signature match on the excerpt would silently never fire. Pure
+    # string read; the probe ALREADY fetched 500 lines, so no extra SSH call. The
+    # whole wide tail is stored (None unless the poll is dead) so the failover
+    # predicate can ALSO scan it for the OUR_CODE_FRAME exclusion.
+    crash_signature = wide_tail if status == "dead" else None
     return PollResult(
         status=status,
         current_phase=current_phase,
@@ -2715,6 +2734,7 @@ def poll_once(
         cpu_advancing=cpu_advancing,
         next_interval=next_interval,
         stall_reason=stall_reason,
+        crash_signature=crash_signature,
     )
 
 

--- a/src/explore_persona_space/backends/base.py
+++ b/src/explore_persona_space/backends/base.py
@@ -304,6 +304,17 @@ class PollResult:
     # (``scripts/backend_poll._serialize_poll_result``) reads it via ``getattr``
     # so a mixed-version worktree degrades to ``None`` rather than crashing.
     stall_reason: str | None = None
+    # The crash signature from the WIDE 500-line probe tail (#775), mirroring
+    # ``scripts/poll_pipeline.PollResult.crash_signature``. The whole wide tail
+    # (so the #775 RunPod CUDA-IMA repeat-failover predicate can scan it for both
+    # the signature AND the OUR_CODE_FRAME exclusion); ``None`` on a healthy /
+    # running poll. The RunPod lane copies this through from ``poll_once``
+    # (``RunPodBackend.poll``); SLURM + GCP never set it, so the default keeps
+    # cross-lane behavior uniform. NOT part of the serialized poll JSON (a
+    # poller-internal field the CUDA-IMA escalation reads off the result before
+    # serialization), so it adds no key to the orchestrator's parser. Declared
+    # LAST so existing positional ``PollResult`` constructions are unaffected.
+    crash_signature: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/explore_persona_space/backends/router.py
+++ b/src/explore_persona_space/backends/router.py
@@ -797,6 +797,21 @@ class Lease:
     #: next poll short-circuits instead of firing a paid second terminate +
     #: re-provision. ``None`` for every non-wedge-failover lease.
     runpod_wedge_failover_of: dict[str, Any] | None = None
+    #: DURABLE idempotency record for the RunPod CUDA-IMA repeat host-wedge
+    #: failover (#775). The exact sibling of ``runpod_wedge_failover_of``: when
+    #: this lease's fresh-host re-provision was a failover OF a specific RunPod
+    #: pod that crashed twice with the SAME CUDA-IMA crash signature, this holds
+    #: that crashed pod's stable identity (``{"pod_name": ..., "job_id": ...}``).
+    #: A SEPARATE field from ``runpod_wedge_failover_of`` so a no-port wedge
+    #: failover and a CUDA-IMA repeat failover on the SAME issue do not
+    #: cross-suppress (each gets its own one bounded pivot). The poller
+    #: (``scripts/backend_poll.py``) stamps it AFTER the fresh-host relaunch
+    #: succeeds (the durable safety net for the EDQUOT-on-``.claude/cache`` mode,
+    #: same as its sibling) and reads it as the AUTHORITATIVE "this run already
+    #: spent its one CUDA-IMA pivot" bound — a SECOND same-signature crash on the
+    #: fresh host with this field already set routes to terminal
+    #: ``failure_class: code``. ``None`` for every non-CUDA-IMA-failover lease.
+    runpod_cuda_ima_failover_of: dict[str, Any] | None = None
 
     def to_json(self) -> dict[str, Any]:
         return {
@@ -811,12 +826,14 @@ class Lease:
             "gcp_attempts_date": self.gcp_attempts_date,
             "gcp_failover_of": self.gcp_failover_of,
             "runpod_wedge_failover_of": self.runpod_wedge_failover_of,
+            "runpod_cuda_ima_failover_of": self.runpod_cuda_ima_failover_of,
         }
 
     @classmethod
     def from_json(cls, payload: dict[str, Any]) -> Lease:
         raw_failover = payload.get("gcp_failover_of")
         raw_wedge_failover = payload.get("runpod_wedge_failover_of")
+        raw_cuda_ima_failover = payload.get("runpod_cuda_ima_failover_of")
         return cls(
             issue=int(payload["issue"]),
             spec_hash=str(payload["spec_hash"]),
@@ -830,6 +847,9 @@ class Lease:
             gcp_failover_of=raw_failover if isinstance(raw_failover, dict) else None,
             runpod_wedge_failover_of=(
                 raw_wedge_failover if isinstance(raw_wedge_failover, dict) else None
+            ),
+            runpod_cuda_ima_failover_of=(
+                raw_cuda_ima_failover if isinstance(raw_cuda_ima_failover, dict) else None
             ),
         )
 

--- a/src/explore_persona_space/backends/runpod.py
+++ b/src/explore_persona_space/backends/runpod.py
@@ -403,6 +403,12 @@ class RunPodBackend(ComputeBackend):
             gpu_util=raw.gpu_util,
             next_interval=raw.next_interval,
             stall_reason=raw.stall_reason,
+            # #775: copy the WIDE-tail crash signature through (same passthrough
+            # contract as stall_reason above). poll_once populates it only on a
+            # dead poll; backend_poll._maybe_escalate_runpod_cuda_ima reads it.
+            # getattr-guarded so a mixed-version worktree (a poll_once that
+            # predates the field) degrades to None rather than crashing.
+            crash_signature=getattr(raw, "crash_signature", None),
         )
 
     def fetch_logs(self, handle: RunHandle) -> str:

--- a/tests/test_backend_poll.py
+++ b/tests/test_backend_poll.py
@@ -1057,3 +1057,208 @@ def test_async_cpu_handle_no_intent_key_does_not_fail_over() -> None:
     assert (
         _is_gcp_async_workload_failure(handle, _poll("dead", "terminal_workload_failed")) is False
     )
+
+
+# ---------------------------------------------------------------------------
+# #775 — RunPod CUDA-IMA repeat-failover, end-to-end via backend_poll_main
+# ---------------------------------------------------------------------------
+
+#: A realistic vLLM CUDA-IMA crash surface whose signature line is in the body.
+_CUDA_IMA_SURFACE = (
+    "step 41 forward ok\n"
+    "ERROR torch.AcceleratorError: CUDA error: an illegal memory access was encountered\n"
+    "vllm.v1.engine.exceptions.EngineDeadError: EngineCore encountered an issue\n"
+    "(EngineCore_DP0 pid=99) Engine core proc EngineCore_DP0 died unexpectedly\n"
+    "INFO shutting down client\nsubprocess returncode: 1\n"
+)
+
+
+def _runpod_handle_775(extra_overrides: dict | None = None) -> RunHandle:
+    """A router-launched-shape RunPod handle (carries the relaunch RunSpec fields)."""
+    extra = {
+        "issue": 775,
+        "intent": "lora-7b",
+        "workload_cmd": "bash scripts/issue664_dispatch.sh --foo",
+        "hydra_args": [],
+        "gpus": 1,
+        "time_budget_hours": 4.0,
+    }
+    if extra_overrides:
+        extra.update(extra_overrides)
+    return RunHandle(
+        backend="runpod",
+        cluster=None,
+        job_id="pod-fake-775",
+        pod_name="pod-775",
+        scratch_dir="/workspace",
+        log_path="/workspace/logs/issue-775.log",
+        extra=extra,
+    )
+
+
+def _cuda_ima_dead_poll_base() -> PollResult:
+    """A dead base.PollResult carrying the CUDA-IMA crash surface on crash_signature."""
+    return PollResult(
+        status="dead",
+        current_phase="dead",
+        new_milestone=True,
+        last_log_mtime_sec_ago=10**9,
+        pid_alive=False,
+        log_tail_excerpt="subprocess returncode: 1",
+        crash_signature=_CUDA_IMA_SURFACE,
+    )
+
+
+def _seed_cuda_ima_record(sidecar: Path) -> None:
+    """Write a prior-CUDA-IMA-crash record into the sidecar extra (a prior crash
+    this run), so the NEXT CUDA-IMA poll is a SECOND same-signature repeat."""
+    payload = json.loads(sidecar.read_text())
+    payload.setdefault("extra", {})["runpod_cuda_ima_last_seen"] = {"ts": 1.0, "sig": "cuda_ima"}
+    sidecar.write_text(json.dumps(payload))
+
+
+def test_poller_first_cuda_ima_falls_through_to_dead(tmp_path, monkeypatch, capsys):
+    """The FIRST CUDA-IMA dead poll (no prior record) records + falls through to
+    the ordinary dead path — no escalation, no failover."""
+    sidecar = tmp_path / "issue-775-handle.json"
+    write_handle_sidecar(_runpod_handle_775(), sidecar)
+    rp = _PassiveRunpodBackend()
+    monkeypatch.setattr(
+        "scripts.backend_poll._resolve_backend",
+        lambda name: _PollDouble(_cuda_ima_dead_poll_base()),
+    )
+    monkeypatch.setattr("explore_persona_space.backends.runpod.RunPodBackend", lambda: rp)
+
+    rc = backend_poll_main(["--issue", "775", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["status"] == "dead"
+    assert out["current_phase"] != "runpod_noport_wedge_failover_fresh_pod"
+    assert len(rp.launches) == 0  # no failover on the first crash
+    # The record was written so the NEXT crash is a repeat.
+    payload = json.loads(sidecar.read_text())
+    assert "runpod_cuda_ima_last_seen" in (payload.get("extra") or {})
+
+
+def test_poller_second_cuda_ima_emits_fresh_host_failover(tmp_path, monkeypatch, capsys):
+    """A SECOND same-signature CUDA-IMA dead poll (prior record seeded) drives
+    main() through the fresh-host failover, emitting a RUNNING-shaped JSON and
+    re-pointing the sidecar at a fresh RunPod handle."""
+    sidecar = tmp_path / "issue-775-handle.json"
+    write_handle_sidecar(_runpod_handle_775(), sidecar)
+    _seed_cuda_ima_record(sidecar)
+
+    rp = _PassiveRunpodBackend()
+    monkeypatch.setattr(
+        "scripts.backend_poll._resolve_backend",
+        lambda name: _PollDouble(_cuda_ima_dead_poll_base()),
+    )
+    monkeypatch.setattr("explore_persona_space.backends.runpod.RunPodBackend", lambda: rp)
+    # The crashed pod is already dead -> get_pod_by_name returns None (terminate skipped).
+    import runpod_api
+
+    monkeypatch.setattr(runpod_api, "get_pod_by_name", lambda name: None, raising=False)
+    # The inputs-on-HF gate is OK (no selected cells -> nothing partial).
+    monkeypatch.setattr(
+        "scripts.backend_poll._issue_cells_for_handle", lambda issue, handle: [], raising=False
+    )
+
+    rc = backend_poll_main(["--issue", "775", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["status"] == "running"
+    assert out["current_phase"] == "runpod_noport_wedge_failover_fresh_pod"
+    assert len(rp.launches) == 1  # exactly one fresh-host pivot
+    recovered = read_handle_sidecar(sidecar)
+    assert recovered.backend == "runpod"
+
+
+def test_poller_cuda_ima_before_noport_when_transient_no_port(tmp_path, monkeypatch, capsys):
+    """M2 — a SECOND CUDA-IMA dead poll that COINCIDES with a transient
+    RUNNING-no-port pod still takes the CUDA-IMA path: the no-port within-K
+    status=dead->running rewrite (which runs AFTER) does NOT mask it."""
+    import runpod_api
+
+    sidecar = tmp_path / "issue-775-handle.json"
+    write_handle_sidecar(_runpod_handle_775(), sidecar)
+    _seed_cuda_ima_record(sidecar)
+
+    rp = _PassiveRunpodBackend()
+    monkeypatch.setattr(
+        "scripts.backend_poll._resolve_backend",
+        lambda name: _PollDouble(_cuda_ima_dead_poll_base()),
+    )
+    monkeypatch.setattr("explore_persona_space.backends.runpod.RunPodBackend", lambda: rp)
+    # A live PodInfo that IS RUNNING-but-no-port (the transient condition the
+    # no-port within-K path would rewrite to running) — but the CUDA-IMA block
+    # runs FIRST, so the failover fires before the no-port path is reached.
+    info = type(
+        "PI",
+        (),
+        {
+            "pod_id": "pod-id-775",
+            "name": "pod-775",
+            "desired_status": "RUNNING",
+            "ssh_host": None,
+            "ssh_port": None,
+            "gpu_count": 1,
+            "gpu_type_id": "H100",
+            "created_at": None,
+        },
+    )()
+    monkeypatch.setattr(runpod_api, "get_pod_by_name", lambda name: info, raising=False)
+    monkeypatch.setattr(runpod_api, "terminate_pod", lambda pid: None, raising=False)
+    monkeypatch.setattr(
+        "scripts.backend_poll._issue_cells_for_handle", lambda issue, handle: [], raising=False
+    )
+
+    rc = backend_poll_main(["--issue", "775", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    # The CUDA-IMA failover fired (fresh-host phase), NOT the no-port observed /
+    # within-K running rewrite (which would have masked the dead poll).
+    assert out["status"] == "running"
+    assert out["current_phase"] == "runpod_noport_wedge_failover_fresh_pod"
+    assert out["current_phase"] != "runpod_no_port_observed"
+    assert len(rp.launches) == 1
+
+
+def test_poller_cuda_ima_failover_exhausted_emits_code(tmp_path, monkeypatch, capsys):
+    """M1 — after the one bounded pivot (the durable lease records a CUDA-IMA
+    failover), a SECOND same-signature crash on the fresh host emits
+    failure_class:code (reason=cuda_ima_repeats_after_failover), AND that marker
+    is NOT a transient-capacity block (so the watcher parks it at blocked)."""
+    from scripts.autonomous_session_watch import _is_transient_capacity_block
+
+    sidecar = tmp_path / "issue-775-handle.json"
+    write_handle_sidecar(_runpod_handle_775(), sidecar)
+    _seed_cuda_ima_record(sidecar)
+
+    rp = _PassiveRunpodBackend()
+    monkeypatch.setattr(
+        "scripts.backend_poll._resolve_backend",
+        lambda name: _PollDouble(_cuda_ima_dead_poll_base()),
+    )
+    monkeypatch.setattr("explore_persona_space.backends.runpod.RunPodBackend", lambda: rp)
+    # The durable lease ALREADY records a CUDA-IMA failover for this run (the
+    # once-more bound is spent): mock the lease-record read to True.
+    monkeypatch.setattr(
+        "scripts.backend_poll._lease_records_runpod_cuda_ima_failover",
+        lambda *a, **k: True,
+        raising=False,
+    )
+
+    rc = backend_poll_main(["--issue", "775", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["status"] == "dead"
+    assert out["failure_class"] == "code"
+    assert out["reason"] == "cuda_ima_repeats_after_failover"
+    assert len(rp.launches) == 0  # NO second pivot
+    # The watcher's capacity-retry gate must NOT re-drive this (it is code, not
+    # transient infra) — build the marker shape _is_transient_capacity_block reads.
+    marker_note = f"failure_class: {out['failure_class']}\nreason: {out['reason']}"
+    retriable, _reason, _ts = _is_transient_capacity_block(
+        [{"kind": "epm:failure v1", "note": marker_note, "ts": "2026-06-30T00:00:00Z"}]
+    )
+    assert retriable is False

--- a/tests/test_backend_poll.py
+++ b/tests/test_backend_poll.py
@@ -1129,10 +1129,13 @@ def test_poller_first_cuda_ima_falls_through_to_dead(tmp_path, monkeypatch, caps
     )
     monkeypatch.setattr("explore_persona_space.backends.runpod.RunPodBackend", lambda: rp)
 
+    from scripts.backend_poll import RUNPOD_CUDA_IMA_FAILOVER_FRESH_POD_PHASE
+
     rc = backend_poll_main(["--issue", "775", "--handle-file", str(sidecar)])
     assert rc == 0
     out = _last_json_line(capsys)
     assert out["status"] == "dead"
+    assert out["current_phase"] != RUNPOD_CUDA_IMA_FAILOVER_FRESH_POD_PHASE
     assert out["current_phase"] != "runpod_noport_wedge_failover_fresh_pod"
     assert len(rp.launches) == 0  # no failover on the first crash
     # The record was written so the NEXT crash is a repeat.
@@ -1163,11 +1166,13 @@ def test_poller_second_cuda_ima_emits_fresh_host_failover(tmp_path, monkeypatch,
         "scripts.backend_poll._issue_cells_for_handle", lambda issue, handle: [], raising=False
     )
 
+    from scripts.backend_poll import RUNPOD_CUDA_IMA_FAILOVER_FRESH_POD_PHASE
+
     rc = backend_poll_main(["--issue", "775", "--handle-file", str(sidecar)])
     assert rc == 0
     out = _last_json_line(capsys)
     assert out["status"] == "running"
-    assert out["current_phase"] == "runpod_noport_wedge_failover_fresh_pod"
+    assert out["current_phase"] == RUNPOD_CUDA_IMA_FAILOVER_FRESH_POD_PHASE
     assert len(rp.launches) == 1  # exactly one fresh-host pivot
     recovered = read_handle_sidecar(sidecar)
     assert recovered.backend == "runpod"
@@ -1212,14 +1217,17 @@ def test_poller_cuda_ima_before_noport_when_transient_no_port(tmp_path, monkeypa
         "scripts.backend_poll._issue_cells_for_handle", lambda issue, handle: [], raising=False
     )
 
+    from scripts.backend_poll import RUNPOD_CUDA_IMA_FAILOVER_FRESH_POD_PHASE
+
     rc = backend_poll_main(["--issue", "775", "--handle-file", str(sidecar)])
     assert rc == 0
     out = _last_json_line(capsys)
-    # The CUDA-IMA failover fired (fresh-host phase), NOT the no-port observed /
+    # The CUDA-IMA failover fired (CUDA-IMA fresh-host phase), NOT the no-port observed /
     # within-K running rewrite (which would have masked the dead poll).
     assert out["status"] == "running"
-    assert out["current_phase"] == "runpod_noport_wedge_failover_fresh_pod"
+    assert out["current_phase"] == RUNPOD_CUDA_IMA_FAILOVER_FRESH_POD_PHASE
     assert out["current_phase"] != "runpod_no_port_observed"
+    assert out["current_phase"] != "runpod_noport_wedge_failover_fresh_pod"
     assert len(rp.launches) == 1
 
 
@@ -1240,10 +1248,13 @@ def test_poller_cuda_ima_failover_exhausted_emits_code(tmp_path, monkeypatch, ca
         lambda name: _PollDouble(_cuda_ima_dead_poll_base()),
     )
     monkeypatch.setattr("explore_persona_space.backends.runpod.RunPodBackend", lambda: rp)
-    # The durable lease ALREADY records a CUDA-IMA failover for this run (the
-    # once-more bound is spent): mock the lease-record read to True.
+    # The durable lease ALREADY has a CUDA-IMA failover stamp for this run (the
+    # per-run once-more bound is spent): mock the any-non-null read to True. (The
+    # real cross-identity behavior — bound fires on the FRESH pod though the stamp
+    # records the OLD pod — is exercised in test_runpod_wedge_detection.py's
+    # test_cuda_ima_once_more_bound_blocks_on_fresh_pod_after_stamp with REAL helpers.)
     monkeypatch.setattr(
-        "scripts.backend_poll._lease_records_runpod_cuda_ima_failover",
+        "scripts.backend_poll._lease_has_any_runpod_cuda_ima_failover",
         lambda *a, **k: True,
         raising=False,
     )

--- a/tests/test_runpod_wedge_detection.py
+++ b/tests/test_runpod_wedge_detection.py
@@ -888,3 +888,472 @@ def test_failover_legacy_handle_missing_spec_returns_terminal_json(tmp_path, mon
     assert out["status"] == "dead"
     assert out["reason"] == "runpod_wedge_relaunch_spec_missing"
     assert out["failure_class"] == "infra"
+
+
+# ===========================================================================
+# #775 — RunPod CUDA-IMA repeat host-wedge failover
+# ===========================================================================
+#
+# The signature-keyed repeat detection (_maybe_escalate_runpod_cuda_ima), the
+# narrow failover predicate (_is_runpod_cuda_ima_failure), the signature record
+# family (_read/_write/_clear_runpod_cuda_ima_record + the cross-pod fallback),
+# and the bounded-once fresh-host failover (_failover_cuda_ima_runpod) with the
+# _terminal_code_json exhaustion. Mirrors the Part C structure above; all RunPod
+# live-API I/O is mocked, the lease uses a tmp dir, no GPU, no network.
+
+# A realistic ~30-line vLLM CUDA-IMA traceback whose SIGNATURE line sits well
+# beyond the last 5 lines (the B2 truncation the design must survive). The final
+# 5 lines are a subprocess-returncode tail that does NOT carry the signature.
+_CUDA_IMA_WIDE_TRACEBACK = "\n".join(
+    [f"[rank0] step {i}: forward ok" for i in range(20)]
+    + [
+        "ERROR torch.AcceleratorError: CUDA error: an illegal memory access was encountered",
+        "  Compile with TORCH_USE_CUDA_DSA to enable device-side assertions.",
+        "vllm.v1.engine.exceptions.EngineDeadError: EngineCore encountered an issue",
+        "(EngineCore_DP0 pid=4242) Engine core proc EngineCore_DP0 died unexpectedly",
+    ]
+    # 6 trailing non-signature lines so the LAST 5 carry NO signature (B2).
+    + [
+        "INFO shutting down client",
+        "subprocess returncode: 1",
+        "Traceback (most recent call last):",
+        '  File "/usr/lib/python3.11/runpy.py", line 198, in _run_module_as_main',
+        "SystemExit: 1",
+        "+ echo done",
+    ]
+)
+
+
+def _cuda_ima_dead_poll(signature: str = _CUDA_IMA_WIDE_TRACEBACK) -> PollResult:
+    """A dead PollResult carrying the WIDE CUDA-IMA crash surface on
+    ``crash_signature`` (what RunPodBackend.poll threads through from poll_once)."""
+    return PollResult(
+        status="dead",
+        current_phase="dead",
+        new_milestone=True,
+        last_log_mtime_sec_ago=10**9,
+        pid_alive=False,
+        log_tail_excerpt="\n".join(_CUDA_IMA_WIDE_TRACEBACK.splitlines()[-5:]),
+        crash_signature=signature,
+    )
+
+
+# ---------------------------------------------------------------------------
+# A. predicate scope
+# ---------------------------------------------------------------------------
+
+
+def test_is_runpod_cuda_ima_failure_predicate():
+    wedged = PollResult(
+        status="dead",
+        current_phase=bp.RUNPOD_CUDA_IMA_WEDGED_PHASE,
+        new_milestone=True,
+        last_log_mtime_sec_ago=10**9,
+        pid_alive=False,
+        log_tail_excerpt="",
+    )
+    # True for a RunPod handle whose poll surfaced the CUDA-IMA wedged phase.
+    assert bp._is_runpod_cuda_ima_failure(_runpod_handle(), wedged) is True
+    # False for a GCP handle with the SAME phase string.
+    assert bp._is_runpod_cuda_ima_failure(_gcp_handle(), wedged) is False
+    # False for a RunPod handle at the NO-PORT wedged phase (distinct predicate).
+    noport = PollResult(
+        status="dead",
+        current_phase=bp.RUNPOD_WORKLOAD_WEDGED_PHASE,
+        new_milestone=True,
+        last_log_mtime_sec_ago=10**9,
+        pid_alive=False,
+        log_tail_excerpt="",
+    )
+    assert bp._is_runpod_cuda_ima_failure(_runpod_handle(), noport) is False
+
+
+# ---------------------------------------------------------------------------
+# B. signature regex + the B2 wide-surface extraction (the bug NOT assumed away)
+# ---------------------------------------------------------------------------
+
+
+def test_cuda_ima_signature_family_matches_and_rejects():
+    assert bp._crash_signature_is_cuda_ima(
+        "torch.AcceleratorError: CUDA error: an illegal memory access was encountered"
+    )
+    assert bp._crash_signature_is_cuda_ima("EngineDeadError: engine core died")
+    assert bp._crash_signature_is_cuda_ima("Engine core proc EngineCore_DP0 died unexpectedly")
+    # Non-CUDA-IMA crashes never match.
+    assert not bp._crash_signature_is_cuda_ima("AssertionError: shape mismatch")
+    assert not bp._crash_signature_is_cuda_ima("ZeroDivisionError: division by zero")
+    assert not bp._crash_signature_is_cuda_ima("")
+    assert not bp._crash_signature_is_cuda_ima(None)
+
+
+def test_cuda_ima_signature_extracted_beyond_5_line_tail():
+    """B2 — the predicate must read the WIDE surface, NOT the 5-line excerpt.
+
+    The signature line sits >5 lines from the END of the wide traceback, so the
+    5-line ``log_tail_excerpt`` does NOT carry it but the wide ``crash_signature``
+    does. Binds to the REAL poll_once slice helper
+    (``poll_pipeline._tail_excerpt_and_crash_signature`` — the exact function
+    poll_once calls) so it goes RED if the extraction ever reverts to the 5-line
+    excerpt."""
+    import poll_pipeline as pp
+
+    # The realistic ~30-line traceback as the probe's WIDE main-log tail.
+    probe = {"log_tail": _CUDA_IMA_WIDE_TRACEBACK, "cell_log_tail": ""}
+    excerpt, crash_signature = pp._tail_excerpt_and_crash_signature(
+        probe, status="dead", mtime_epoch=100, cell_mtime_epoch=0
+    )
+    # crash_signature is the WIDE surface and carries the CUDA-IMA family ...
+    assert bp._crash_signature_is_cuda_ima(crash_signature) is True
+    # ... but the 5-line excerpt (what a naive v1 matched) would have MISSED it.
+    assert bp._crash_signature_is_cuda_ima(excerpt) is False
+    # And the excerpt IS the last 5 lines of the wide tail (unchanged behavior).
+    assert excerpt == "\n".join(_CUDA_IMA_WIDE_TRACEBACK.splitlines()[-5:])
+
+    # A non-dead (running) poll populates NO crash_signature.
+    _, sig_running = pp._tail_excerpt_and_crash_signature(
+        probe, status="running", mtime_epoch=100, cell_mtime_epoch=0
+    )
+    assert sig_running is None
+
+    # The cell-tail-fresher branch reads the CELL log as the wide surface.
+    probe_cell = {"log_tail": "stale dispatcher", "cell_log_tail": _CUDA_IMA_WIDE_TRACEBACK}
+    _, sig_cell = pp._tail_excerpt_and_crash_signature(
+        probe_cell, status="dead", mtime_epoch=100, cell_mtime_epoch=200
+    )
+    assert bp._crash_signature_is_cuda_ima(sig_cell) is True
+
+
+# ---------------------------------------------------------------------------
+# C. escalation: first crash records, second escalates, our-frame excludes
+# ---------------------------------------------------------------------------
+
+
+def test_first_cuda_ima_crash_records_and_does_not_escalate(tmp_path):
+    """The FIRST CUDA-IMA dead poll writes the record and returns the result
+    UNCHANGED (the ordinary dead path -> in-place same-pod respawn)."""
+    sidecar = _empty_sidecar(tmp_path)
+    out = bp._maybe_escalate_runpod_cuda_ima(
+        _runpod_handle(), _cuda_ima_dead_poll(), sidecar, issue=689, now=1_000_000.0
+    )
+    assert out.current_phase != bp.RUNPOD_CUDA_IMA_WEDGED_PHASE
+    payload = json.loads(sidecar.read_text())
+    assert "runpod_cuda_ima_last_seen" in (payload.get("extra") or {})
+
+
+def test_second_same_signature_cuda_ima_escalates_to_wedged(tmp_path):
+    """A SECOND CUDA-IMA dead poll with a prior record this run -> rewrite to the
+    terminal wedged phase (status=dead, RUNPOD_CUDA_IMA_WEDGED_PHASE)."""
+    sidecar = _empty_sidecar(tmp_path)
+    # Tick 1: records, does not escalate.
+    bp._maybe_escalate_runpod_cuda_ima(
+        _runpod_handle(), _cuda_ima_dead_poll(), sidecar, issue=689, now=1_000_000.0
+    )
+    # Tick 2: prior record present -> escalate.
+    out = bp._maybe_escalate_runpod_cuda_ima(
+        _runpod_handle(), _cuda_ima_dead_poll(), sidecar, issue=689, now=1_000_100.0
+    )
+    assert out.status == "dead"
+    assert out.current_phase == bp.RUNPOD_CUDA_IMA_WEDGED_PHASE
+
+
+def test_non_cuda_ima_dead_poll_never_escalates(tmp_path):
+    """A dead poll whose crash_signature is a plain AssertionError never records
+    or escalates — and clears any stale record."""
+    sidecar = _empty_sidecar(tmp_path)
+    poll = PollResult(
+        status="dead",
+        current_phase="dead",
+        new_milestone=True,
+        last_log_mtime_sec_ago=10**9,
+        pid_alive=False,
+        log_tail_excerpt="",
+        crash_signature="AssertionError: shapes mismatch at layer 3",
+    )
+    out = bp._maybe_escalate_runpod_cuda_ima(
+        _runpod_handle(), poll, sidecar, issue=689, now=1_000_000.0
+    )
+    assert out.current_phase != bp.RUNPOD_CUDA_IMA_WEDGED_PHASE
+    payload = json.loads(sidecar.read_text())
+    assert "runpod_cuda_ima_last_seen" not in (payload.get("extra") or {})
+
+
+def test_cuda_ima_record_cleared_on_running_poll(tmp_path):
+    """A running (non-dead) poll clears the record so a single transient CUDA-IMA
+    the respawn recovered from does NOT accumulate against a later one."""
+    sidecar = _empty_sidecar(tmp_path)
+    # Record a first CUDA-IMA crash.
+    bp._maybe_escalate_runpod_cuda_ima(
+        _runpod_handle(), _cuda_ima_dead_poll(), sidecar, issue=689, now=1_000_000.0
+    )
+    # An intervening HEALTHY poll -> the record is cleared.
+    running = PollResult(
+        status="running",
+        current_phase="workload",
+        new_milestone=False,
+        last_log_mtime_sec_ago=5,
+        pid_alive=True,
+        log_tail_excerpt="step 999 ok",
+    )
+    bp._maybe_escalate_runpod_cuda_ima(
+        _runpod_handle(), running, sidecar, issue=689, now=1_000_050.0
+    )
+    payload = json.loads(sidecar.read_text())
+    assert "runpod_cuda_ima_last_seen" not in (payload.get("extra") or {})
+    # A LATER CUDA-IMA crash is then the FIRST again (records, no escalation).
+    out = bp._maybe_escalate_runpod_cuda_ima(
+        _runpod_handle(), _cuda_ima_dead_poll(), sidecar, issue=689, now=1_000_100.0
+    )
+    assert out.current_phase != bp.RUNPOD_CUDA_IMA_WEDGED_PHASE
+
+
+def test_cuda_ima_with_our_code_frame_does_not_escalate(tmp_path):
+    """M3 — a SECOND CUDA-IMA dead poll whose wide surface ALSO carries an OUR-code
+    traceback frame is a deterministic code bug, NOT a host wedge: the exclusion
+    fires and it does NOT escalate (falls through to dead -> code)."""
+    sidecar = _empty_sidecar(tmp_path)
+    framed = _CUDA_IMA_WIDE_TRACEBACK + (
+        '\n  File "/workspace/eps-issue-689/scripts/issue664_dispatch.py", line 42, in run\n'
+        "    out = model(x)\n"
+    )
+    poll = _cuda_ima_dead_poll(signature=framed)
+    # Tick 1: a non-framed first crash records (so a prior record exists).
+    bp._maybe_escalate_runpod_cuda_ima(
+        _runpod_handle(), _cuda_ima_dead_poll(), sidecar, issue=689, now=1_000_000.0
+    )
+    # Tick 2: the framed repeat -> M3 exclusion -> NO escalation.
+    out = bp._maybe_escalate_runpod_cuda_ima(
+        _runpod_handle(), poll, sidecar, issue=689, now=1_000_100.0
+    )
+    assert out.current_phase != bp.RUNPOD_CUDA_IMA_WEDGED_PHASE
+
+
+def test_cuda_ima_record_malformed_sidecar_never_raises(tmp_path):
+    """Fail-soft read: a malformed JSON sidecar reads as 'no record' and the
+    escalation raises NO exception (mirrors the no-port clock S2 contract)."""
+    bad = tmp_path / "issue-689-handle.json"
+    bad.write_text("{ this is not valid json :::")
+    out = bp._maybe_escalate_runpod_cuda_ima(
+        _runpod_handle(), _cuda_ima_dead_poll(), bad, issue=689, now=1_000_000.0
+    )
+    # No prior record readable -> treated as first crash -> no escalation, no raise.
+    assert out.current_phase != bp.RUNPOD_CUDA_IMA_WEDGED_PHASE
+
+
+def test_cuda_ima_non_runpod_handle_unchanged(tmp_path):
+    sidecar = _empty_sidecar(tmp_path)
+    poll = _cuda_ima_dead_poll()
+    out = bp._maybe_escalate_runpod_cuda_ima(
+        _gcp_handle(), poll, sidecar, issue=689, now=1_000_000.0
+    )
+    assert out is poll
+
+
+# ---------------------------------------------------------------------------
+# D. cross-pod fallback (B1): sidecar record absent, prior epm:failure marker present
+# ---------------------------------------------------------------------------
+
+
+def test_cuda_ima_record_cross_pod_fallback_reads_prior_marker(tmp_path, monkeypatch):
+    """B1 — when the sidecar record is ABSENT (a wipe between pods), the prior
+    ``epm:failure`` marker carrying a CUDA-IMA signature still counts as a prior
+    record, so the current crash escalates as a repeat."""
+    sidecar = _empty_sidecar(tmp_path)  # NO runpod_cuda_ima_last_seen key
+    # The prior epm:failure marker carried a CUDA-IMA signature.
+    monkeypatch.setattr(
+        bp,
+        "_prior_failure_marker_is_cuda_ima",
+        lambda issue: True,
+        raising=False,
+    )
+    # _read_runpod_cuda_ima_record must surface a synthetic record from the marker.
+    rec = bp._read_runpod_cuda_ima_record(sidecar, issue=689)
+    assert rec is not None and rec.get("source") == "prior_failure_marker"
+    # And the escalation treats the current CUDA-IMA crash as a repeat -> wedged.
+    out = bp._maybe_escalate_runpod_cuda_ima(
+        _runpod_handle(), _cuda_ima_dead_poll(), sidecar, issue=689, now=1_000_000.0
+    )
+    assert out.current_phase == bp.RUNPOD_CUDA_IMA_WEDGED_PHASE
+
+
+def test_cuda_ima_record_no_fallback_when_prior_marker_absent(tmp_path, monkeypatch):
+    """The fallback yields None (first crash) when no prior CUDA-IMA marker exists."""
+    sidecar = _empty_sidecar(tmp_path)
+    monkeypatch.setattr(bp, "_prior_failure_marker_is_cuda_ima", lambda issue: False, raising=False)
+    assert bp._read_runpod_cuda_ima_record(sidecar, issue=689) is None
+
+
+# ---------------------------------------------------------------------------
+# E. failover: first-pivot fires, bounded-once, idempotency
+# ---------------------------------------------------------------------------
+
+
+def _cuda_ima_failover_gate_ok(monkeypatch):
+    """Common setup: a single COMPLETE cell so the inputs gate is OK, live API
+    stubbed, terminate_pod a recorder. Returns the ``terminated`` list."""
+    import huggingface_hub
+    import issue664_dispatch as D
+
+    cell = _FakeCell("mk_done_cell_seed42")
+    monkeypatch.setattr(bp, "_issue_cells_for_handle", lambda issue, handle: [cell], raising=False)
+    files = _hf_paths_for(
+        cell.eval_key,
+        raw_names={"completions__x__ctx.json"},
+        store_names={"tensors.pt", "meta.json"},
+    )
+    monkeypatch.setattr(huggingface_hub, "list_repo_files", lambda repo_id, **k: sorted(files))
+    monkeypatch.setattr(
+        D, "_expected_eval_files", lambda c: {"completions__x__ctx.json"}, raising=False
+    )
+    info = _PodInfo(desired_status="RUNNING", ssh_host=None, ssh_port=None, pod_id="pod-id-ima")
+    _stub_live_api(monkeypatch, info)
+    terminated: list = []
+    monkeypatch.setattr(
+        runpod_api, "terminate_pod", lambda pid: terminated.append(pid), raising=False
+    )
+    return terminated
+
+
+def test_cuda_ima_failover_pivots_with_cuda_ima_stamp_fn(tmp_path, monkeypatch):
+    """The first CUDA-IMA failover terminates + re-provisions a fresh host, and
+    _relaunch_fresh_runpod is invoked with stamp_fn=_stamp_runpod_cuda_ima_failover
+    (the SEPARATE lease field, never the no-port one)."""
+    terminated = _cuda_ima_failover_gate_ok(monkeypatch)
+    monkeypatch.setattr(
+        bp, "_runpod_cuda_ima_already_handled", lambda *a, **k: False, raising=False
+    )
+    monkeypatch.setattr(
+        bp, "_lease_records_runpod_cuda_ima_failover", lambda *a, **k: False, raising=False
+    )
+    relaunched: list = []
+
+    def _capture_relaunch(**kw):
+        relaunched.append(kw)
+        return {"status": "running"}
+
+    monkeypatch.setattr(bp, "_relaunch_fresh_runpod", _capture_relaunch, raising=False)
+
+    bp._failover_cuda_ima_runpod(
+        issue=689,
+        handle=_runpod_handle(),
+        result=_cuda_ima_dead_poll(),
+        sidecar=_empty_sidecar(tmp_path),
+    )
+    assert terminated == ["pod-id-ima"]
+    assert len(relaunched) == 1
+    assert relaunched[0]["stamp_fn"] is bp._stamp_runpod_cuda_ima_failover
+
+
+def test_cuda_ima_failover_bounded_once_third_crash_terminal_code(tmp_path, monkeypatch):
+    """M1 — after one pivot (the durable lease records a CUDA-IMA failover), a
+    SECOND same-signature crash on the FRESH host routes to terminal
+    failure_class:code (reason=cuda_ima_repeats_after_failover), NO second pivot."""
+    terminated = _cuda_ima_failover_gate_ok(monkeypatch)
+    # The lease ALREADY records a CUDA-IMA failover for this run (the bound).
+    monkeypatch.setattr(
+        bp, "_lease_records_runpod_cuda_ima_failover", lambda *a, **k: True, raising=False
+    )
+    relaunched: list = []
+    monkeypatch.setattr(
+        bp, "_relaunch_fresh_runpod", lambda **kw: relaunched.append(kw), raising=False
+    )
+
+    out = bp._failover_cuda_ima_runpod(
+        issue=689,
+        handle=_runpod_handle(),
+        result=_cuda_ima_dead_poll(),
+        sidecar=_empty_sidecar(tmp_path),
+    )
+    assert out["status"] == "dead"
+    assert out["failure_class"] == "code"
+    assert out["reason"] == "cuda_ima_repeats_after_failover"
+    assert terminated == []  # bound checked FIRST, before the terminate
+    assert relaunched == []  # NO second pivot
+
+
+def test_cuda_ima_failover_idempotency_lease(tmp_path, monkeypatch):
+    """A re-fired tick on the SAME crashed handle after a successful pivot
+    short-circuits (idempotency) — no double terminate, no double pivot."""
+    terminated = _cuda_ima_failover_gate_ok(monkeypatch)
+    monkeypatch.setattr(
+        bp, "_lease_records_runpod_cuda_ima_failover", lambda *a, **k: False, raising=False
+    )
+    handled = {"v": False}
+    monkeypatch.setattr(
+        bp, "_runpod_cuda_ima_already_handled", lambda *a, **k: handled["v"], raising=False
+    )
+    relaunched: list = []
+    monkeypatch.setattr(
+        bp,
+        "_relaunch_fresh_runpod",
+        lambda **kw: relaunched.append(kw) or {"status": "running"},
+        raising=False,
+    )
+    sidecar = _empty_sidecar(tmp_path)
+    bp._failover_cuda_ima_runpod(
+        issue=689, handle=_runpod_handle(), result=_cuda_ima_dead_poll(), sidecar=sidecar
+    )
+    assert terminated == ["pod-id-ima"]
+    assert len(relaunched) == 1
+    # Second tick on the OLD handle: already-handled short-circuits.
+    handled["v"] = True
+    out = bp._failover_cuda_ima_runpod(
+        issue=689, handle=_runpod_handle(), result=_cuda_ima_dead_poll(), sidecar=sidecar
+    )
+    assert out.get("reason") == "runpod_cuda_ima_already_handled"
+    assert terminated == ["pod-id-ima"]  # unchanged
+    assert len(relaunched) == 1  # unchanged
+
+
+def test_cuda_ima_failover_inputs_partial_blocks(tmp_path, monkeypatch):
+    """A PARTIAL cell on HF BLOCKS the irreversible terminate (human decides)."""
+    import huggingface_hub
+    import issue664_dispatch as D
+
+    cell = _FakeCell("mk_partial_cell_seed42")
+    monkeypatch.setattr(bp, "_issue_cells_for_handle", lambda issue, handle: [cell], raising=False)
+    files = _hf_paths_for(
+        cell.eval_key, raw_names={"completions__x__ctx.json"}, store_names={"meta.json"}
+    )
+    monkeypatch.setattr(huggingface_hub, "list_repo_files", lambda repo_id, **k: sorted(files))
+    monkeypatch.setattr(
+        D, "_expected_eval_files", lambda c: {"completions__x__ctx.json"}, raising=False
+    )
+    monkeypatch.setattr(
+        bp, "_lease_records_runpod_cuda_ima_failover", lambda *a, **k: False, raising=False
+    )
+    monkeypatch.setattr(
+        bp, "_runpod_cuda_ima_already_handled", lambda *a, **k: False, raising=False
+    )
+    terminated: list = []
+    monkeypatch.setattr(
+        runpod_api, "terminate_pod", lambda pid: terminated.append(pid), raising=False
+    )
+    relaunched: list = []
+    monkeypatch.setattr(
+        bp, "_relaunch_fresh_runpod", lambda **kw: relaunched.append(kw), raising=False
+    )
+    out = bp._failover_cuda_ima_runpod(
+        issue=689,
+        handle=_runpod_handle(),
+        result=_cuda_ima_dead_poll(),
+        sidecar=_empty_sidecar(tmp_path),
+    )
+    assert out["reason"] == "runpod_cuda_ima_inputs_unverified"
+    assert terminated == []
+    assert relaunched == []
+
+
+def test_cuda_ima_failover_durable_lease_bound_real_helpers(tmp_path, monkeypatch):
+    """The once-more bound holds via the REAL durable-lease helpers (not mocked):
+    after _stamp_runpod_cuda_ima_failover stamps the SEPARATE lease field, the
+    bound check reads it and routes a second crash to terminal code. Also proves
+    the CUDA-IMA stamp does NOT touch runpod_wedge_failover_of (no cross-suppress)."""
+    _real_lease_store_in(tmp_path, monkeypatch)
+    handle = _runpod_handle_with_workload()
+    # Before any stamp: the bound is not yet spent.
+    assert bp._lease_records_runpod_cuda_ima_failover(689, handle) is False
+    # Stamp the CUDA-IMA failover.
+    bp._stamp_runpod_cuda_ima_failover(689, handle)
+    assert bp._lease_records_runpod_cuda_ima_failover(689, handle) is True
+    # The no-port lease field is UNTOUCHED (no cross-suppression).
+    assert bp._lease_records_runpod_wedge_failover(689, handle) is False

--- a/tests/test_runpod_wedge_detection.py
+++ b/tests/test_runpod_wedge_detection.py
@@ -1244,13 +1244,17 @@ def test_cuda_ima_failover_pivots_with_cuda_ima_stamp_fn(tmp_path, monkeypatch):
 
 
 def test_cuda_ima_failover_bounded_once_third_crash_terminal_code(tmp_path, monkeypatch):
-    """M1 — after one pivot (the durable lease records a CUDA-IMA failover), a
-    SECOND same-signature crash on the FRESH host routes to terminal
-    failure_class:code (reason=cuda_ima_repeats_after_failover), NO second pivot."""
+    """M1 — after one pivot (the durable lease records a CUDA-IMA failover for this
+    RUN), a SECOND same-signature crash routes to terminal failure_class:code
+    (reason=cuda_ima_repeats_after_failover), NO second pivot. The bound is the
+    PER-RUN any-non-null lease check (``_lease_has_any_runpod_cuda_ima_failover``),
+    NOT the per-pod identity check — see the real-helper cross-identity test
+    ``test_cuda_ima_once_more_bound_blocks_on_fresh_pod_after_stamp`` for the seam
+    this mock necessarily abstracts away."""
     terminated = _cuda_ima_failover_gate_ok(monkeypatch)
-    # The lease ALREADY records a CUDA-IMA failover for this run (the bound).
+    # The lease ALREADY records a CUDA-IMA failover for this run (the per-run bound).
     monkeypatch.setattr(
-        bp, "_lease_records_runpod_cuda_ima_failover", lambda *a, **k: True, raising=False
+        bp, "_lease_has_any_runpod_cuda_ima_failover", lambda *a, **k: True, raising=False
     )
     relaunched: list = []
     monkeypatch.setattr(
@@ -1268,6 +1272,71 @@ def test_cuda_ima_failover_bounded_once_third_crash_terminal_code(tmp_path, monk
     assert out["reason"] == "cuda_ima_repeats_after_failover"
     assert terminated == []  # bound checked FIRST, before the terminate
     assert relaunched == []  # NO second pivot
+
+
+def test_cuda_ima_once_more_bound_blocks_on_fresh_pod_after_stamp(tmp_path, monkeypatch):
+    """M1 CRITICAL — the once-more bound is PER-RUN, not per-pod: it must fire on
+    the FRESH pod's handle even though the stamp recorded the OLD crashed pod.
+
+    This is the exact case the mocked M1 tests abstract away (they mock the bound
+    predicate to True). Here it exercises the REAL durable-lease helpers with
+    DISTINCT old/fresh identities:
+
+      1. stamp the lease with the OLD crashed handle via the REAL
+         ``_stamp_runpod_cuda_ima_failover`` (records old pod_name/job_id);
+      2. drive ``_failover_cuda_ima_runpod`` with a FRESH handle (different
+         pod_name AND job_id — the post-pivot sidecar re-point);
+      3. assert it routes to terminal ``failure_class: code`` with NO second
+         pivot.
+
+    PRE-FIX (identity-equality bound) the fresh handle's identity != the stamped
+    old identity, so the bound returns False and the run pivots AGAIN — the
+    unbounded-spend bug. POST-FIX (any-non-null bound) the bound fires."""
+    _real_lease_store_in(tmp_path, monkeypatch)
+
+    old_handle = _runpod_handle_with_workload(pod_name="pod-775-OLD")
+    object.__setattr__(old_handle, "job_id", "job-OLD")
+    # 1. Stamp the OLD crashed handle via the REAL helper (records old identity).
+    bp._stamp_runpod_cuda_ima_failover(689, old_handle)
+    # Sanity: the per-POD (layer-1) identity check is OLD-keyed.
+    assert bp._lease_records_runpod_cuda_ima_failover(689, old_handle) is True
+
+    # 2. The FRESH pod (distinct pod_name AND job_id) — the post-pivot re-point.
+    fresh_handle = _runpod_handle_with_workload(pod_name="pod-775-FRESH")
+    object.__setattr__(fresh_handle, "job_id", "job-FRESH")
+    # The OLD identity-keyed check does NOT match the fresh handle (this is exactly
+    # why the layer-2 bound cannot be identity-keyed):
+    assert bp._lease_records_runpod_cuda_ima_failover(689, fresh_handle) is False
+    # But the PER-RUN any-non-null bound DOES fire on the fresh handle:
+    assert bp._lease_has_any_runpod_cuda_ima_failover(689) is True
+
+    # Stub the inputs gate OK, terminate to a no-op, and record relaunch calls — so
+    # IF the bound failed (pre-fix), the second pivot would be observable.
+    monkeypatch.setattr(
+        bp,
+        "_wedged_run_inputs_on_hf",
+        lambda *a, **k: bp._WedgeInputsGate(ok=True, complete=[], partial=[], absent=[]),
+        raising=False,
+    )
+    relaunched: list = []
+    monkeypatch.setattr(
+        bp,
+        "_relaunch_fresh_runpod",
+        lambda **kw: relaunched.append(kw) or {"status": "running"},
+        raising=False,
+    )
+    monkeypatch.setattr(runpod_api, "terminate_pod", lambda pid: None, raising=False)
+
+    # 3. The second crash arrives on the FRESH handle.
+    out = bp._failover_cuda_ima_runpod(
+        issue=689,
+        handle=fresh_handle,
+        result=_cuda_ima_dead_poll(),
+        sidecar=_empty_sidecar(tmp_path),
+    )
+    assert out["failure_class"] == "code"
+    assert out["reason"] == "cuda_ima_repeats_after_failover"
+    assert relaunched == []  # NO second pivot on the fresh pod
 
 
 def test_cuda_ima_failover_idempotency_lease(tmp_path, monkeypatch):
@@ -1350,10 +1419,92 @@ def test_cuda_ima_failover_durable_lease_bound_real_helpers(tmp_path, monkeypatc
     the CUDA-IMA stamp does NOT touch runpod_wedge_failover_of (no cross-suppress)."""
     _real_lease_store_in(tmp_path, monkeypatch)
     handle = _runpod_handle_with_workload()
-    # Before any stamp: the bound is not yet spent.
+    # Before any stamp: both the per-pod and the per-run bound are unspent.
     assert bp._lease_records_runpod_cuda_ima_failover(689, handle) is False
+    assert bp._lease_has_any_runpod_cuda_ima_failover(689) is False
     # Stamp the CUDA-IMA failover.
     bp._stamp_runpod_cuda_ima_failover(689, handle)
     assert bp._lease_records_runpod_cuda_ima_failover(689, handle) is True
+    # The PER-RUN any-non-null bound (the layer-2 once-more guard) now reads True.
+    assert bp._lease_has_any_runpod_cuda_ima_failover(689) is True
     # The no-port lease field is UNTOUCHED (no cross-suppression).
     assert bp._lease_records_runpod_wedge_failover(689, handle) is False
+
+
+def test_cuda_ima_failover_terminate_is_best_effort(tmp_path, monkeypatch):
+    """MAJOR-1 — a terminate API failure on the (usually already-dead) CUDA-IMA pod
+    MUST NOT block the fresh-host recovery: the failover logs + continues to
+    _relaunch_fresh_runpod instead of bubbling the exception up to main()'s outer
+    guard (which would emit reason=runpod_cuda_ima_failover_error, masking the
+    intended pivot). Contrast Part C's no-port terminate, which stays fail-loud."""
+    _cuda_ima_failover_gate_ok(monkeypatch)  # live PodInfo present -> terminate is attempted
+    monkeypatch.setattr(
+        bp, "_lease_has_any_runpod_cuda_ima_failover", lambda *a, **k: False, raising=False
+    )
+    monkeypatch.setattr(
+        bp, "_runpod_cuda_ima_already_handled", lambda *a, **k: False, raising=False
+    )
+    # The terminate RAISES (an API race / already-deleted pod / transient hiccup).
+    monkeypatch.setattr(
+        runpod_api,
+        "terminate_pod",
+        lambda pid: (_ for _ in ()).throw(RuntimeError("terminate API 500")),
+        raising=False,
+    )
+    relaunched: list = []
+    monkeypatch.setattr(
+        bp,
+        "_relaunch_fresh_runpod",
+        lambda **kw: (
+            relaunched.append(kw)
+            or {"status": "running", "current_phase": bp.RUNPOD_CUDA_IMA_FAILOVER_FRESH_POD_PHASE}
+        ),
+        raising=False,
+    )
+
+    out = bp._failover_cuda_ima_runpod(
+        issue=689,
+        handle=_runpod_handle(),
+        result=_cuda_ima_dead_poll(),
+        sidecar=_empty_sidecar(tmp_path),
+    )
+    # The pivot still fired despite the terminate raising.
+    assert len(relaunched) == 1
+    assert relaunched[0]["success_phase"] == bp.RUNPOD_CUDA_IMA_FAILOVER_FRESH_POD_PHASE
+    assert out["current_phase"] == bp.RUNPOD_CUDA_IMA_FAILOVER_FRESH_POD_PHASE
+    # NOT the masked error path.
+    assert out.get("reason") != "runpod_cuda_ima_failover_error"
+
+
+def test_prior_failure_marker_cuda_ima_real_parser_realistic_body(monkeypatch):
+    """MINOR — the cross-pod fallback's REAL parser (_prior_failure_marker_is_cuda_ima,
+    not mocked) handles a realistic epm:failure marker body: a kind=='epm:failure v1'
+    event whose note carries the CUDA-IMA signature text returns True via the actual
+    task_workflow.list_events read + the within-line signature regex."""
+    import explore_persona_space.task_workflow as TW
+
+    realistic_note = (
+        "failure_class: infra\n"
+        "reason: vllm_crash\n"
+        "trace_summary: torch.AcceleratorError: CUDA error: an illegal memory "
+        "access was encountered\n"
+        "phase: workload\n"
+    )
+    # Newest-LAST ordering (list_events returns chronological; the parser reverses).
+    events = [
+        {"kind": "epm:run-launched v1", "note": "launched pod-775", "ts": "2026-06-30T00:00:00Z"},
+        {"kind": "epm:failure v1", "note": realistic_note, "ts": "2026-06-30T01:00:00Z"},
+    ]
+    monkeypatch.setattr(TW, "list_events", lambda issue: events, raising=False)
+    assert bp._prior_failure_marker_is_cuda_ima(689) is True
+
+    # A non-CUDA-IMA epm:failure body returns False (the first crash is not a repeat).
+    benign = [
+        {
+            "kind": "epm:failure v1",
+            "note": "failure_class: code\nreason: assertion_error\ntrace_summary: ValueError: bad",
+            "ts": "2026-06-30T01:00:00Z",
+        }
+    ]
+    monkeypatch.setattr(TW, "list_events", lambda issue: benign, raising=False)
+    assert bp._prior_failure_marker_is_cuda_ima(689) is False


### PR DESCRIPTION
Closes task #775. Same-signature CUDA-IMA repeat auto-pivots to fresh pod (bounded once), then terminal failure_class:code → blocked.