### PR TITLE
task #782: workflow-fix: gcp poller PENDING → running (FLEX_START queue false-stall)

### DIFF
--- a/src/explore_persona_space/backends/gcp.py
+++ b/src/explore_persona_space/backends/gcp.py
@@ -5019,6 +5019,10 @@ def _gcp_status_to_poll_result(status: str) -> PollResult:
     for the GCE status enum. We map:
 
     * ``RUNNING`` → ``running`` (pid_alive=True)
+    * ``PENDING`` → ``running`` (FLEX_START-queued for capacity; the
+      orchestrator's bg loop keeps polling — mirrors ``reconnect_or_none``,
+      which treats PENDING as live since it is not in
+      ``_NONLIVE_INSTANCE_STATUSES``; #782/#778)
     * ``PROVISIONING`` / ``STAGING`` → ``running`` (VM is coming up; the
       orchestrator's bg loop will keep polling)
     * ``STOPPING`` / ``REPAIRING`` → ``stalled`` (transient; bg loop retries)
@@ -5027,6 +5031,12 @@ def _gcp_status_to_poll_result(status: str) -> PollResult:
     up = status.upper()
     if up == "RUNNING":
         return _coarse_poll(status="running", current_phase="running")
+    if up == "PENDING":
+        # FLEX_START capacity-queue state — legitimately live, keep polling
+        # (parity with ``reconnect_or_none`` / ``_NONLIVE_INSTANCE_STATUSES``;
+        # #782). Distinct branch from PROVISIONING/STAGING (VM booting) so the
+        # queued-vs-booting distinction is explicit at the call site.
+        return _coarse_poll(status="running", current_phase="pending")
     if up in {"PROVISIONING", "STAGING"}:
         return _coarse_poll(status="running", current_phase=up.lower())
     if up in {"STOPPING", "REPAIRING"}:

--- a/tests/test_gcp_backend.py
+++ b/tests/test_gcp_backend.py
@@ -64,6 +64,7 @@ from explore_persona_space.backends.gcp import (
     GcpLaunchSecretsMissing,
     StaleNamedInstance,
     _classify_janitor_instance,
+    _gcp_status_to_poll_result,
     _instance_max_run_seconds,
     _stale_named_instance_or_none,
     attempt_id_for,
@@ -862,6 +863,33 @@ def test_resolve_provisioning_model_rejects_typo() -> None:
     spec = _spec(extra={"provisioning_model": "preemptible"})
     with pytest.raises(ValueError, match="unknown provisioning_model"):
         resolve_provisioning_model(spec)
+
+
+# ---------------------------------------------------------------------------
+# _gcp_status_to_poll_result — PENDING is a live FLEX_START-queued state
+# ---------------------------------------------------------------------------
+
+
+def test_gcp_status_to_poll_result_pending_maps_to_running_not_stalled() -> None:
+    """A FLEX_START-queued GCE instance (status PENDING) is a live,
+    keep-polling state — NOT the false-stalled routing that the /issue
+    Step 6d.2 poll pseudocode would convert to epm:failure + set-status
+    blocked (#782 / live repro #778). Mirrors reconnect_or_none, which
+    treats PENDING as live (not in _NONLIVE_INSTANCE_STATUSES)."""
+    result = _gcp_status_to_poll_result("PENDING")
+    assert result.status == "running"
+    assert result.current_phase == "pending"
+
+    # Case-insensitive on the raw GCE string (matches the up = status.upper()
+    # normalization the other branches rely on).
+    lower = _gcp_status_to_poll_result("pending")
+    assert lower.status == "running"
+    assert lower.current_phase == "pending"
+
+    # Regression guard: it must NOT fall through to the unknown_* stalled
+    # default (the pre-fix behavior that caused the false block).
+    assert result.current_phase != "unknown_pending"
+    assert result.status != "stalled"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes task #782. Adds a dedicated `PENDING` branch to `_gcp_status_to_poll_result` returning `status="running", current_phase="pending"`, mirroring `reconnect_or_none`'s treatment of PENDING as a live FLEX_START-queued state. Removes the reconnect-vs-poll asymmetry that caused false blocks on healthy queued instances (live repro #778, sat PENDING ~1h47m).