### PR TITLE
workflow-fix #785: propagate #506-safe --git-common-dir recipe to Step 4a + Step 9c helper

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1711,7 +1711,10 @@ Only if status is `approved`.
 **4a. Worktree + draft PR.** Create `.claude/worktrees/issue-<N>` on
 branch `issue-<N>`, symlink the repo `.env` into it, and open a draft PR.
 ```bash
-REPO_ROOT=$(git rev-parse --show-toplevel)
+# #506-safe: from a worktree cwd, `git rev-parse --show-toplevel` returns the
+# WORKTREE root and doubles the path (.../issue-<N>/.claude/worktrees/issue-<N>);
+# --git-common-dir resolves to <main>/.git so dirname is the main repo root.
+REPO_ROOT=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")
 WORKTREE="$REPO_ROOT/.claude/worktrees/issue-<N>"
 bash "$REPO_ROOT/scripts/new_worktree.sh" "$WORKTREE" issue-<N> --issue <N>
 # Sparse by default (~0.4G vs ~3.8G full); reuses if it exists (resume case);
@@ -1741,8 +1744,11 @@ tool's working directory is NOT preserved across separate calls, so a
 relative `cd .claude/worktrees/issue-<N>` in one call has no effect on
 the next. ALWAYS address the worktree with an absolute path or
 `git -C "$WORKTREE" <cmd>` — never a bare relative `cd`. Resolve the
-absolute path once with `git rev-parse --show-toplevel` (as above) and
-reuse `$WORKTREE` / `$REPO_ROOT` in every subsequent command.
+absolute path once with the #506-safe
+`REPO_ROOT=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")`
+recipe (as above) — NOT `git rev-parse --show-toplevel`, which from a
+worktree cwd returns the worktree root and doubles the path — and reuse
+`$WORKTREE` / `$REPO_ROOT` in every subsequent command.
 
 **Open the draft PR only if the branch is ahead of `main`.** `gh pr
 create` errors with `No commits between main and issue-<N>` when the
@@ -1904,6 +1910,9 @@ Before dispatching, sync the worktree's workflow surface from local
 already runs on `main`):
 
 ```bash
+# Step 5a WANTS the WORKTREE root (that is where the spec-freshness sync writes)
+# — NOT the #506 path-doubling bug; do NOT change to --git-common-dir here. The
+# self-no-op case (session already on main) is why show-toplevel is correct.
 WT=$(git rev-parse --show-toplevel)
 SPECS=".claude/agents .claude/skills .claude/rules .claude/workflow.yaml CLAUDE.md"
 MB=$(git -C "$WT" merge-base HEAD main)
@@ -6171,7 +6180,25 @@ suite directly and posts an `epm:test-verdict` event with the result.
       `uv run python scripts/select_step9c_tests.py --base main`
       It prints the exact `uv run pytest <files> -v --tb=short` command and
       any `untested touched file: <path>` WARN lines (stderr).
-   b. Run the printed command. Record pass/fail + any WARN lines.
+   b. Run the printed command from the orchestrator's repo-root cwd (no `cd`
+      is needed). Record pass/fail + any WARN lines. Two anti-silent-pass
+      guards are LOAD-BEARING here — a `no tests ran` outcome (pytest exit 0
+      with zero collected tests) is a **FAIL, never a PASS**: it is the
+      signature of a failed `cd` that ran pytest in a directory with no tests
+      (incident: issue 745, SHA 91bed41e, 2026-06-30 — the gate reported PASS
+      on `no tests ran ... pytest exit: 0` and was silently skipped).
+      ```bash
+      # If any cd is added upstream, HARD-GUARD it — never let the gate run in
+      # the wrong dir on a silent cd failure:
+      #   cd "$REPO_ROOT" || { echo "FATAL: cd to repo root failed" >&2; exit 1; }
+      PYTEST_OUT=$(uv run pytest <files> -v --tb=short 2>&1); PYTEST_RC=$?
+      echo "$PYTEST_OUT"
+      # exit 0 + "no tests ran" (or "collected 0 items") is NOT a PASS:
+      if echo "$PYTEST_OUT" | grep -qiE 'no tests ran|collected 0 items'; then
+        echo "FATAL: pytest collected 0 tests — test-verdict gate did NOT run. Treating as FAIL." >&2
+        # -> post epm:test-verdict v1 as FAIL; do NOT record PASS on exit 0.
+      fi
+      ```
    c. Scope override: if the plan-body frontmatter has `test_scope: full` OR a
       `## Test scope` H2 names `full`, run the FULL suite instead — but as
       `timeout 60m uv run pytest tests/ -q -x --maxfail=1`; on timeout/kill,
@@ -6184,7 +6211,9 @@ suite directly and posts an `epm:test-verdict` event with the result.
 
 The `epm:test-verdict v1` marker note records: scope used (`touched`/`full`),
 the files run, pass/fail counts, and any untested-touched-file WARNs (so the
-orchestrator surfaces coverage gaps — never silently skipped).
+orchestrator surfaces coverage gaps — never silently skipped). A
+zero-collected / `no tests ran` outcome is recorded as FAIL (never PASS on
+exit 0) per step 1b's guard.
 
 Post `epm:test-verdict v1`. PASS -> Step 10. FAIL (count < 3) -> stay
 in `reviewing`, re-spawn implementer. FAIL (count >= 3) -> run

--- a/scripts/select_step9c_tests.py
+++ b/scripts/select_step9c_tests.py
@@ -227,13 +227,16 @@ def missing_invariants(repo_root: Path) -> list[str]:
 def _resolve_repo_root(arg: str | None) -> Path:
     if arg:
         return Path(arg).resolve()
+    # #506-safe: from a worktree cwd, `git rev-parse --show-toplevel` returns the
+    # WORKTREE root; --git-common-dir resolves to <main>/.git, so dirname is the
+    # main repo root (where tests/ paths must resolve). See SKILL.md Steps 4a/10d.
     out = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"],
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
         capture_output=True,
         text=True,
         check=True,
     )
-    return Path(out.stdout.strip()).resolve()
+    return Path(out.stdout.strip()).parent.resolve()
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -254,6 +257,20 @@ def main(argv: list[str] | None = None) -> int:
 
     tests, untested = select_tests(touched, repo_root)
     missing = missing_invariants(repo_root)
+
+    # Fail loud on an EMPTY selection (defense-in-depth beside the Step 9c shell
+    # guard against a silent test-gate pass). WORKFLOW_INVARIANT has 32 always-on
+    # entries, so an empty list can only mean the repo_root resolved wrong (the
+    # #506 path-doubling bug) or the invariant files all vanished — either way the
+    # gate would run zero tests. Never let that surface as an exit-0 "no tests ran".
+    if not tests:
+        print(
+            "select_step9c_tests: EMPTY test selection — repo_root likely resolved "
+            f"wrong ({repo_root}) or WORKFLOW_INVARIANT files are missing "
+            f"(missing={missing}). Refusing to emit a zero-test gate command.",
+            file=sys.stderr,
+        )
+        return 1
 
     for t in missing:
         print(f"WORKFLOW-INVARIANT MISSING: {t}", file=sys.stderr)

--- a/tests/test_select_step9c_tests.py
+++ b/tests/test_select_step9c_tests.py
@@ -183,3 +183,51 @@ def test_json_output_shape(tmp_path: Path, monkeypatch, capsys):
     assert "tests/test_widget.py" in out["tests"]
     assert out["base"] == "main"
     assert out["missing_invariants"] == []  # all invariants present in the fixture tree
+
+
+# --- Case 11: _resolve_repo_root uses --git-common-dir + dirnames (#785) ------
+def test_resolve_repo_root_uses_git_common_dir_and_dirnames(tmp_path: Path, monkeypatch):
+    """No-arg path calls `git rev-parse --path-format=absolute --git-common-dir`
+    and dirnames the output — the #506-safe recipe, NOT `--show-toplevel`
+    (which from a worktree cwd doubles the path). The `--repo-root` override
+    still bypasses git entirely.
+    """
+    seen: dict[str, list[str]] = {}
+    git_dir = tmp_path / "repo" / ".git"
+
+    class _Result:
+        stdout = str(git_dir) + "\n"
+
+    def _fake_run(argv, **_kw):
+        seen["argv"] = argv
+        return _Result()
+
+    monkeypatch.setattr(sel.subprocess, "run", _fake_run)
+    got = sel._resolve_repo_root(None)
+    # (i) locks the recipe against a regression back to --show-toplevel:
+    assert seen["argv"] == ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"]
+    # (ii) return is the dirname of the git output (.../repo/.git -> .../repo):
+    assert got == (tmp_path / "repo").resolve()
+    # (iii) the override branch never touches git — clear the recorded argv and
+    #       confirm the arg path is returned resolved, without a git call:
+    seen.clear()
+    assert sel._resolve_repo_root(str(tmp_path)) == tmp_path.resolve()
+    assert "argv" not in seen  # git was not invoked on the override path
+
+
+# --- Case 12: empty selection fails LOUD (defense-in-depth, #785) ------------
+def test_empty_selection_fails_loud(tmp_path: Path, monkeypatch, capsys):
+    """A structurally-impossible empty test list (bad repo_root resolution or all
+    invariants missing) makes main() return 1 + a stderr line — never a silent
+    exit-0 zero-test gate (the same silent-pass class the Step 9c shell guard
+    closes at the shell level).
+    """
+    repo = _make_tree(tmp_path, [])
+    monkeypatch.setattr(sel, "_resolve_repo_root", lambda _arg: repo)
+    monkeypatch.setattr(sel, "compute_touched", lambda *_a, **_k: [])
+    # Force the degenerate empty selection the invariant set normally prevents.
+    monkeypatch.setattr(sel, "select_tests", lambda *_a, **_k: ([], []))
+    rc = sel.main(["--repo-root", str(repo)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "EMPTY test selection" in err


### PR DESCRIPTION
Closes task #785.

Workflow-fix: propagate the #506-safe `--git-common-dir` recipe to Step 4a and `scripts/select_step9c_tests.py::_resolve_repo_root`; add anti-silent-pass guards to the Step 9c test-verdict block (SKILL.md prose + helper-side `main()` sentinel). Regression coverage: 2 new tests in `tests/test_select_step9c_tests.py`.

Sparing intentional Step 5a `show-toplevel` at SKILL.md:1916 (wants the worktree root — sync target of spec-freshness).

Evidence: issue 745 (SHA 91bed41e, 2026-06-30) silently passed the test-verdict gate with pytest exit 0 + 'no tests ran' after a failed cd.