### PR TITLE
#794 hub.py: retry HF 504 on list_repo_files_complete post-upload verify

### DIFF
--- a/src/explore_persona_space/orchestrate/hub.py
+++ b/src/explore_persona_space/orchestrate/hub.py
@@ -478,6 +478,13 @@ def list_repo_files_complete(
     module through it so a repo always enumerates fully regardless of the
     pinned huggingface_hub version's ``list_repo_files`` implementation.
 
+    ``huggingface_hub``'s ``paginate`` retries ONLY HTTP 429 on follow-up
+    cursor pages, so a 504 gateway timeout on any cursor page of a large repo
+    otherwise propagates and turns a SUCCESSFUL upload's post-upload verify into
+    a false failure. The paginated walk is therefore wrapped in the same
+    transient-retry helper the upload sites use (gotchas.md "HF recursive tree
+    listing 504s are un-retried"; #794/#658).
+
     Args:
         api: An ``huggingface_hub.HfApi`` instance (already token-scoped).
         repo_id: HF Hub repo ID.
@@ -490,16 +497,22 @@ def list_repo_files_complete(
     """
     from huggingface_hub.hf_api import RepoFile
 
-    files = [
-        entry.path
-        for entry in api.list_repo_tree(
-            repo_id=repo_id,
-            repo_type=repo_type,
-            revision=revision,
-            recursive=True,
-        )
-        if isinstance(entry, RepoFile)
-    ]
+    def _list() -> list[str]:
+        # ``list_repo_tree`` returns a generator; a cursor-page 504 raises
+        # DURING iteration, so the comprehension is MATERIALIZED inside this
+        # thunk (inside the retry ``try``) rather than after it returns.
+        return [
+            entry.path
+            for entry in api.list_repo_tree(
+                repo_id=repo_id,
+                repo_type=repo_type,
+                revision=revision,
+                recursive=True,
+            )
+            if isinstance(entry, RepoFile)
+        ]
+
+    files = _retry_upload(_list, what=f"list_repo_tree({repo_id})")
     return sorted(files)
 
 
@@ -535,10 +548,12 @@ def _is_transient_upload_error(err: Exception) -> bool:
 
 
 def _retry_upload(fn, *, what: str, max_attempts: int = 6):
-    """Call ``fn()`` (a zero-arg upload thunk) with exp-backoff retry on transient
-    HF 5xx/429/timeout/connection errors. Storage-quota-403 and any non-transient
-    error re-raise IMMEDIATELY (so the caller's overflow-routing / soft-fail logic
-    fires unchanged); after max_attempts the final exception propagates (fail-loud)."""
+    """Call ``fn()`` (a zero-arg thunk) with exp-backoff retry on transient
+    HF 5xx/429/timeout/connection errors. Name is legacy — this is a generic
+    transient-retry wrapper, also used for READS (``list_repo_files_complete``),
+    not only uploads. Storage-quota-403 and any non-transient error re-raise
+    IMMEDIATELY (so the caller's overflow-routing / soft-fail logic fires
+    unchanged); after max_attempts the final exception propagates (fail-loud)."""
     for attempt in range(1, max_attempts + 1):
         try:
             return fn()

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -16,6 +16,7 @@ from explore_persona_space.orchestrate.hub import (
     _is_storage_quota_403,
     _is_transient_upload_error,
     _retry_upload,
+    list_repo_files_complete,
     upload_dataset,
     upload_dataset_directory,
     upload_model,
@@ -530,3 +531,68 @@ class TestRetryUpload:
 
             assert mock_api.upload_folder.call_count == 2
             assert "evil_wrong_seed42" in result
+
+
+def _repo_files(*paths: str) -> list[RepoFile]:
+    """Build a list of RepoFile entries for the given paths (helper for the
+    list-retry tests — mirrors what a good ``list_repo_tree`` page yields)."""
+    return [RepoFile(path=p, size=1, blob_id="b", oid="o") for p in paths]
+
+
+class TestListRepoFilesRetry:
+    """Tests for ``list_repo_files_complete``'s transient-504 retry (#794).
+
+    The paginated ``list_repo_tree`` walk is wrapped in ``_retry_upload`` so a
+    504 on any cursor page of a large repo retries instead of turning a
+    successful upload's post-upload verify into a false failure. Non-transient
+    errors (404 / auth) still re-raise on attempt 1 — reads must never mask a
+    real fault. ``hub.time.sleep`` is patched so the suite stays fast.
+    """
+
+    def test_list_repo_files_complete_retries_transient_504(self):
+        """A cursor-page 504 on attempt 1, then the generator yields entries on
+        attempt 2 -> the sorted file list is returned, list_repo_tree called
+        twice (a full re-list per attempt), one sleep."""
+        api = Mock()
+        api.list_repo_tree = Mock(side_effect=[_http_err(504), _repo_files("b/x.json", "a/y.json")])
+        with patch("explore_persona_space.orchestrate.hub.time.sleep") as mock_sleep:
+            result = list_repo_files_complete(api, "some/repo")
+        assert result == ["a/y.json", "b/x.json"]
+        assert api.list_repo_tree.call_count == 2
+        mock_sleep.assert_called_once()
+
+    def test_list_repo_files_complete_retries_429(self):
+        """A transient 429 (rate limit) on attempt 1, then success."""
+        api = Mock()
+        api.list_repo_tree = Mock(side_effect=[_http_err(429), _repo_files("f.json")])
+        with patch("explore_persona_space.orchestrate.hub.time.sleep"):
+            result = list_repo_files_complete(api, "some/repo")
+        assert result == ["f.json"]
+        assert api.list_repo_tree.call_count == 2
+
+    def test_list_repo_files_complete_exhausts_retries(self):
+        """A 504 on EVERY attempt re-raises the final exception after
+        max_attempts (fail-loud, no swallow) — 6 calls, 5 sleeps — so a
+        genuinely persistent gateway outage still surfaces."""
+        api = Mock()
+        api.list_repo_tree = Mock(side_effect=[_http_err(504)] * 6)
+        with (
+            patch("explore_persona_space.orchestrate.hub.time.sleep") as mock_sleep,
+            pytest.raises(HfHubHTTPError),
+        ):
+            list_repo_files_complete(api, "some/repo")
+        assert api.list_repo_tree.call_count == 6
+        assert mock_sleep.call_count == 5
+
+    def test_list_repo_files_complete_non_transient_raises_immediately(self):
+        """A non-transient 404 re-raises on attempt 1 (no retry loop) — reads
+        must not mask a real fault (missing repo / auth)."""
+        api = Mock()
+        api.list_repo_tree = Mock(side_effect=_http_err(404))
+        with (
+            patch("explore_persona_space.orchestrate.hub.time.sleep") as mock_sleep,
+            pytest.raises(HfHubHTTPError),
+        ):
+            list_repo_files_complete(api, "some/repo")
+        assert api.list_repo_tree.call_count == 1
+        mock_sleep.assert_not_called()

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -596,3 +596,19 @@ class TestListRepoFilesRetry:
             list_repo_files_complete(api, "some/repo")
         assert api.list_repo_tree.call_count == 1
         mock_sleep.assert_not_called()
+
+    def test_list_repo_files_complete_success_passthrough_filters_non_files(self):
+        """Happy-path passthrough: on the first attempt the generator yields a
+        mix of file + non-file entries; ``list_repo_files_complete`` returns the
+        sorted file paths only (non-files filtered by ``isinstance(entry,
+        RepoFile)``), calls ``list_repo_tree`` exactly ONCE, and never sleeps —
+        the unchanged success path costs no retries."""
+        non_file = Mock(spec=[])  # a non-RepoFile entry (folder / other) — must be filtered out
+        entries = [*_repo_files("b/x.json", "a/y.json"), non_file]
+        api = Mock()
+        api.list_repo_tree = Mock(return_value=iter(entries))
+        with patch("explore_persona_space.orchestrate.hub.time.sleep") as mock_sleep:
+            result = list_repo_files_complete(api, "some/repo")
+        assert result == ["a/y.json", "b/x.json"]  # sorted files only; non-file dropped
+        assert api.list_repo_tree.call_count == 1
+        mock_sleep.assert_not_called()


### PR DESCRIPTION
Closes task #794.

Wraps `list_repo_files_complete` in the existing `_retry_upload` transient-error retry
(6 attempts, exp-backoff, drops immediately on non-transient / storage-403). A
cursor-page 504 during the paginated `list_repo_tree(recursive=True)` walk now
retries transparently instead of bubbling up to `_upload`'s catch-all where it was
being misread as "HF Hub upload failed silently" — the "504 verification storm"
symptom the daily-fix sweep flagged from #666.

## What changed

- `src/explore_persona_space/orchestrate/hub.py` — wrap the paginated tree walk in
  `_retry_upload(_list, what="list_repo_tree(...)")`. The load-bearing list
  comprehension is materialized INSIDE the retried thunk (the generator raises
  during iteration, not at construction). Function signature unchanged; `_retry_upload`
  NOT renamed (docstring clarified). All 4 call sites inherit the retry.
- `tests/test_hub.py` — 5 new tests in `TestListRepoFilesRetry`: transient 504
  retry-then-succeed, transient 429 retry-then-succeed, exhaustion re-raises
  (fail-loud), non-transient (404) re-raises immediately, and success-path
  passthrough that filters non-file entries with no sleep.

## Test plan

- [x] `tests/test_hub.py` — 35/35 PASS locally (30 existing + 5 new)
- [x] `ruff check` + `ruff format --check` on touched files — clean
- [x] Step 9c touched-scope suite (34 files, 1922 tests) — 1922 passed / 6 skipped
      / 5 pre-existing failures on `main` (verified with this diff absent)
- [x] Load-bearing detail verified: list-comprehension is materialized inside the
      retry `try` (not a bare generator return)

## Reviewers

- Claude `code-reviewer`: **PASS** (blocker tags: none)
- Codex `codex-code-reviewer`: **CONCERNS** (minor missing passthrough test — addressed inline in `ce0f5e10dd`)

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>