### PR TITLE
[793] SLURM lane honors repo_branch via git_cloner seam + overlay

### DIFF
--- a/src/explore_persona_space/backends/slurm.py
+++ b/src/explore_persona_space/backends/slurm.py
@@ -70,6 +70,7 @@ import logging
 import os
 import re
 import shlex
+import shutil
 import subprocess
 import tempfile
 import time
@@ -1995,6 +1996,7 @@ class SlurmBackend(ComputeBackend):
         marker_poster=None,
         runtime_clearer=None,
         git_branch_resolver=None,
+        git_cloner=None,
     ) -> None:
         self._src_root = src_root or _default_src_root()
         # Resolves the rsync source's current branch for the feature-branch
@@ -2002,6 +2004,14 @@ class SlurmBackend(ComputeBackend):
         # ``git -C <src_root> rev-parse``; tests inject a stub returning a
         # fixed branch name (or ``None`` to simulate a non-repo source).
         self._git_branch_resolver = git_branch_resolver or git_branch_at
+        # Materializes a complete rsync source for a non-``main`` repo_branch on
+        # the VM (git worktree add of the branch commit + working-tree overlay of
+        # the external/open-instruct gitlink) — the #793 mechanism that lets the
+        # SLURM lane HONOR repo_branch instead of only refusing stale main.
+        # Defaults to the real ``materialize_branch_src`` shell-out; tests inject
+        # a stub returning a fake scratch Path and recording the (branch, issue)
+        # request.
+        self._git_cloner = git_cloner or materialize_branch_src
         self._submit = submitter or ssh_submit
         self._cancel = canceller or ssh_scancel
         self._rsync = rsyncer or run_rsync_sync
@@ -2052,21 +2062,29 @@ class SlurmBackend(ComputeBackend):
         paths skip it by contract), so clearing here cannot race a live
         job's own writes.
         """
-        # Feature-branch / stale-main guard (#653). The SLURM lane rsyncs
-        # the repo from ``self._src_root`` — which ``_default_src_root()``
-        # resolves via ``__file__``-walk to the repo-root install on
-        # ``main``, NOT the invoking worktree. Unlike the GCP lane (which
-        # git-clones ``spec.extra["repo_branch"]`` on the VM), this lane
-        # has NO mechanism to honor ``repo_branch``: it would silently
-        # rsync stale ``main`` code and submit a job whose tree lacks the
-        # feature branch's entrypoint scripts, crashing at in-job preflight
-        # (#653 round-8: an auto → SLURM fall-through rsynced ``main`` for a
-        # feature-branch experiment, queueing a job doomed at
-        # ``--verify-imports``). Refuse to submit onto stale code BEFORE
-        # the rsync; the auto chain treats this raise as a prepare failure
-        # and advances to the next lane (and the orchestrator re-launches
-        # with an explicit ``--backend gcp`` per the gotchas.md workaround).
-        self._assert_repo_branch_synced(spec)
+        # Resolve the rsync source for the requested branch (#793). The SLURM
+        # lane rsyncs from ``self._src_root`` — which ``_default_src_root()``
+        # resolves via ``__file__``-walk to the repo-root install on ``main``,
+        # NOT the invoking worktree. Unlike the GCP lane (which git-clones
+        # ``spec.extra["repo_branch"]`` on the VM), this lane HONORS repo_branch
+        # by MATERIALIZING a complete branch tree on the VM (``materialize_branch_src``
+        # via the ``git_cloner`` seam) and rsyncing from it. On ``main`` / absent /
+        # already-on-branch, ``_resolve_rsync_source`` returns ``self._src_root``
+        # unchanged and the path below is byte-identical to the pre-fix behavior.
+        rsync_src = self._resolve_rsync_source(spec)
+        # Belt-and-suspenders (#653/#793): re-assert the branch guard against the
+        # RESOLVED source. This is NOT the pre-fix "refuse the feature branch"
+        # behavior — the resolved source is ALWAYS either ``self._src_root``
+        # (main/absent/already-on-branch, where the guard was already a no-op) or
+        # the materialized branch tree (which IS on the requested branch, so the
+        # guard trivially passes). Its post-fix ROLE is to catch a ``git_cloner``
+        # that returned a tree NOT on the requested branch (a materialize_branch_src
+        # correctness regression), never to refuse a legitimately-requested feature
+        # branch. The lane-advance fallback for a genuinely-unresolvable branch is
+        # preserved by materialize_branch_src's own ``RuntimeError`` (which
+        # ``router._prepare_and_launch`` wraps as ``BackendPrepareError`` identically
+        # to the old ``ValueError``).
+        self._assert_repo_branch_synced(spec, src_root=rsync_src)
         cluster = self._cluster_for_spec(spec)
         scratch_dir = scratch_dir_for(spec, cluster)
         self._clear_runtime(
@@ -2074,7 +2092,7 @@ class SlurmBackend(ComputeBackend):
             scratch_dir=scratch_dir,
         )
         self._rsync(
-            src_root=self._src_root,
+            src_root=rsync_src,
             dest_root=scratch_dir,
             robot_alias=cluster.ssh_host,
         )
@@ -2085,38 +2103,69 @@ class SlurmBackend(ComputeBackend):
         # never world-readable on the cluster side.
         self._push_secrets(cluster, scratch_dir, secrets)
 
-    def _assert_repo_branch_synced(self, spec: RunSpec) -> None:
-        """Refuse to submit a feature-branch run onto a stale ``main`` rsync source.
+    def _resolve_rsync_source(self, spec: RunSpec) -> Path:
+        """Return the rsync source for ``spec``, materializing a branch tree if needed.
 
-        The SLURM lane rsyncs from ``self._src_root`` and has no
-        ``repo_branch`` honoring mechanism (the GCP lane git-clones the
-        branch on the VM; this lane does not). When the dispatcher threads
-        a non-``main`` ``spec.extra["repo_branch"]`` (which it does by
-        default for ``auto``/``gcp`` lanes — ``scripts/dispatch_issue.py``
-        ``_launch_extra_from_args``) but the rsync source's actual HEAD is
-        a DIFFERENT branch, rsyncing would ship code that does not match
-        the requested branch. Raise ``ValueError`` here — ``prepare`` runs
-        under :func:`router._prepare_and_launch`, which wraps it as a
-        provision-class :class:`~router.BackendPrepareError`, so the auto
-        chain advances to the next lane instead of running stale code, and
-        an explicit SLURM override surfaces the failure as a typed
-        terminal. No-op when ``repo_branch`` is absent or ``main`` (the
-        rsync source IS ``main`` then, by the resolver's design).
+        No-op (returns ``self._src_root``) when ``repo_branch`` is absent / ``main`` /
+        the install's HEAD already IS the requested branch. Otherwise materializes a
+        complete branch tree on the VM via the ``git_cloner`` seam and returns its path.
 
-        The branch probe failing (non-repo source, git missing → resolver
-        returns ``None``) is treated as a MISMATCH for a non-``main``
-        request: we cannot prove the source carries the feature branch, so
-        we refuse rather than risk silently shipping ``main`` (#653).
+        Note: an UNPROVABLE source branch (resolver returns ``None``) for a non-``main``
+        request also routes to the cloner (``None`` != the requested branch), so the
+        source-of-truth for "can we honor this branch?" is now the cloner's own
+        ``git rev-parse`` (fail-loud ``RuntimeError`` on an unresolvable branch), NOT the
+        guard.
         """
         requested = str(spec.extra.get("repo_branch") or "").strip()
         if not requested or requested == "main":
-            return
+            return self._src_root
         actual = self._git_branch_resolver(self._src_root)
+        if actual == requested:
+            return self._src_root  # install already on the branch — rsync it directly
+        return self._git_cloner(src_root=self._src_root, branch=requested, issue=spec.issue)
+
+    def _assert_repo_branch_synced(self, spec: RunSpec, src_root: Path | None = None) -> None:
+        """Assert the rsync source's HEAD matches a non-``main`` ``repo_branch``.
+
+        Post-#793, ``prepare`` first RESOLVES the rsync source
+        (``_resolve_rsync_source`` — materializing a complete branch tree via the
+        ``git_cloner`` seam when the install is not already on the branch) and then
+        calls this guard against that RESOLVED ``src_root``. So the guard's role is
+        now BELT-AND-SUSPENDERS on ``materialize_branch_src``'s own correctness: the
+        resolved source is ALWAYS either ``self._src_root`` (main/absent/already-on-
+        branch, where this guard is a no-op or trivially passes) or the materialized
+        branch tree (which IS on the requested branch, so the guard passes). It would
+        raise only if the ``git_cloner`` returned a tree whose HEAD is NOT the
+        requested branch — a materialize regression — NEVER to refuse a legitimately-
+        requested feature branch (that refusal moved to ``materialize_branch_src``'s
+        fail-loud ``RuntimeError`` on an unresolvable branch, §793/#653).
+
+        ``src_root`` defaults to ``self._src_root`` (backward-compatible: any direct
+        call or the reconnect/estimate paths are unchanged). The internal semantics
+        are otherwise verbatim from the #653 guard — it still raises ``ValueError`` on
+        a genuine HEAD/branch mismatch (``prepare`` runs under
+        :func:`router._prepare_and_launch`, which wraps it as a provision-class
+        :class:`~router.BackendPrepareError`) and still no-ops when ``repo_branch`` is
+        absent or ``main``.
+
+        The branch probe failing (non-repo source, git missing → resolver returns
+        ``None``) is treated as a MISMATCH for a non-``main`` request: we cannot prove
+        the source carries the feature branch, so we refuse rather than risk silently
+        shipping ``main`` (#653). Under ``prepare``'s post-fix flow this sub-branch
+        cannot fire on the honored-branch path (the cloner already raised on an
+        unresolvable branch), but it is retained so a DIRECT call with a mismatched
+        ``src_root`` still refuses.
+        """
+        src_root = src_root or self._src_root
+        requested = str(spec.extra.get("repo_branch") or "").strip()
+        if not requested or requested == "main":
+            return
+        actual = self._git_branch_resolver(src_root)
         if actual == requested:
             return
         raise ValueError(
             f"SLURM lane cannot honor repo_branch={requested!r}: the rsync "
-            f"source at {self._src_root} is on branch {actual!r} "
+            f"source at {src_root} is on branch {actual!r} "
             f"(the repo-root install resolves to 'main', not the invoking "
             f"worktree). Submitting would rsync stale code whose tree lacks "
             f"the feature branch's entrypoint scripts and crash at in-job "
@@ -2511,6 +2560,178 @@ def _default_src_root() -> Path:
     return Path.cwd()
 
 
+# The subset of ``RSYNC_INCLUDE_PATHS`` that is a WORKING-TREE-ONLY gitlink
+# (mode-160000 nested repo, absent from any branch's committed git tree). Verified
+# on-VM during #793 planning: ``external/open-instruct`` is the ONLY such entry —
+# every other include path (``pyproject.toml``, ``uv.lock``, ``src``, ``scripts``,
+# ``configs``, ``tests``, ``data/sft``) is a normal blob/tree (mode 100644/040000)
+# present in any branch checkout. ``materialize_branch_src`` overlays these paths
+# from the working tree because ``git worktree add`` of a branch commit produces an
+# EMPTY ``external/open-instruct/``. Kept as an explicit named constant so a future
+# reviewer sees exactly which paths are overlaid and why; a second gitlink added to
+# ``RSYNC_INCLUDE_PATHS`` must be added here too (the re-asserted branch guard does
+# NOT catch a missing overlay — it checks the branch HEAD ref, not overlay content;
+# the ``pyproject.toml`` source-sanity assert is the real backstop).
+WORKING_TREE_OVERLAY_PATHS: tuple[str, ...] = ("external/open-instruct",)
+
+
+def materialize_branch_src(
+    *,
+    src_root: Path,
+    branch: str,
+    issue: int,
+    overlay_paths: tuple[str, ...] = WORKING_TREE_OVERLAY_PATHS,
+    timeout: int = 300,
+) -> Path:
+    """Materialize a complete rsync source for ``branch`` on the VM; return its path.
+
+    The SLURM lane rsyncs from a local tree rather than git-cloning the requested
+    branch on the cluster (the GCP-lane approach), so when ``spec.extra["repo_branch"]``
+    names a non-``main`` branch that the repo-root install does not already carry, this
+    builds a content-complete checkout of the branch's COMMITTED tree on the orchestrator
+    VM and returns its path for :meth:`SlurmBackend.prepare` to rsync from.
+
+    Steps (idempotent — safe to re-run every ``prepare``):
+
+    1. ``scratch = ~/.eps-slurm-src/issue-<issue>`` (env override ``EPS_SLURM_SRC_ROOT``).
+    2. Remove any prior scratch worktree
+       (``git -C <src_root> worktree remove --force <scratch>``, guarded — a fresh
+       scratch has none), then ``rm -rf <scratch>`` (belt-and-suspenders for a
+       partially-removed dir), then ``git -C <src_root> worktree prune``.
+    3. Resolve the branch commit in ``src_root``'s object DB
+       (``git rev-parse --verify <branch>``, then ``origin/<branch>`` as a fallback).
+       Fail loud (``RuntimeError``) if neither resolves — no silent fallback to ``main``.
+    4. ``git -C <src_root> worktree add --detach <scratch> <commit>`` — detached HEAD at
+       the branch commit (no "branch already checked out in the /issue worktree" conflict,
+       since the branch lives in ``.claude/worktrees/issue-<N>``), sharing the repo-root
+       object DB (no ~GB history copy a fresh ``git clone`` would make).
+    5. Overlay each working-tree-only path from ``src_root`` into ``scratch``
+       (``rsync -a --delete <src_root>/<p>/ <scratch>/<p>/``, a LOCAL FS copy — distinct
+       from the cluster-bound rsync). ``<p>`` is the ``external/open-instruct`` gitlink,
+       which ``git worktree add`` materializes EMPTY. A path absent in ``src_root`` logs a
+       WARNING and is skipped (a lora-only run has no open-instruct — a missing overlay is
+       worth surfacing but not crashing).
+    6. Assert ``scratch/pyproject.toml`` exists (mirrors ``build_rsync_command``'s own
+       source-sanity assert) — fail loud if the worktree add produced an empty tree.
+
+    The scratch tree is a COMMITTED-only source: unlike today's working-tree rsync, an
+    untracked-but-present file in ``src_root``'s working tree (e.g. an uncommitted
+    ``scripts/issue658_*.py``) will NOT ship. This is the CORRECT behavior for a
+    branch-scoped run — a job dispatched against a branch commit must reach only committed
+    code — but is noted here so a future debugger who expects "scratch == old working-tree
+    rsync for tracked paths" understands why an uncommitted file is absent. The one
+    deliberate exception is ``overlay_paths`` (the gitlink), which is working-tree by
+    construction.
+
+    :returns: the scratch :class:`~pathlib.Path` (a content-complete tree on ``branch``).
+    :raises RuntimeError: on any git failure or an unresolvable branch (fail-fast, per
+        CLAUDE.md — no silent fallback to stale ``main``).
+    """
+    scratch_root = Path(os.environ.get("EPS_SLURM_SRC_ROOT") or (Path.home() / ".eps-slurm-src"))
+    scratch = scratch_root / f"issue-{issue}"
+
+    # Step 2 — remove any prior scratch worktree + dir + prune registrations. All git
+    # calls here are guarded (a fresh scratch has no registered worktree; ``worktree
+    # remove`` on an absent path exits non-zero) — we do not fail the prepare on the
+    # cleanup path, only on the create path below.
+    with contextlib.suppress(subprocess.SubprocessError, OSError):
+        subprocess.run(
+            ["git", "-C", str(src_root), "worktree", "remove", "--force", str(scratch)],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    with contextlib.suppress(OSError):
+        shutil.rmtree(scratch, ignore_errors=True)
+    with contextlib.suppress(subprocess.SubprocessError, OSError):
+        subprocess.run(
+            ["git", "-C", str(src_root), "worktree", "prune"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+
+    # Step 3 — resolve the branch commit in src_root's object DB (local ref, then
+    # origin/<branch> fallback). Fail loud if neither resolves.
+    commit: str | None = None
+    for ref in (branch, f"origin/{branch}"):
+        proc = subprocess.run(
+            ["git", "-C", str(src_root), "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            commit = proc.stdout.strip()
+            break
+    if commit is None:
+        raise RuntimeError(
+            f"materialize_branch_src: cannot resolve branch {branch!r} (nor "
+            f"origin/{branch!r}) in the object DB at {src_root}. The SLURM lane cannot "
+            f"honor this repo_branch — the auto chain advances to the next lane."
+        )
+
+    # Step 4 — worktree-add the branch commit at a detached HEAD (shares the object DB;
+    # no conflict with the branch checked out in the /issue worktree).
+    scratch.parent.mkdir(parents=True, exist_ok=True)
+    add = subprocess.run(
+        ["git", "-C", str(src_root), "worktree", "add", "--detach", str(scratch), commit],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if add.returncode != 0:
+        raise RuntimeError(
+            f"materialize_branch_src: `git worktree add --detach {scratch} {commit}` failed "
+            f"(rc={add.returncode}): {add.stderr.strip()}"
+        )
+
+    # Step 5 — overlay the working-tree-only gitlink(s) from src_root's working tree.
+    for p in overlay_paths:
+        overlay_src = src_root / p
+        if not overlay_src.exists():
+            logger.warning(
+                "materialize_branch_src: overlay path %r absent in src_root %s — skipping "
+                "(a lora-only run has no open-instruct; a full-FT run needs it)",
+                p,
+                src_root,
+            )
+            continue
+        overlay_dst = scratch / p
+        overlay_dst.parent.mkdir(parents=True, exist_ok=True)
+        overlay = subprocess.run(
+            ["rsync", "-a", "--delete", f"{overlay_src}/", f"{overlay_dst}/"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        if overlay.returncode != 0:
+            raise RuntimeError(
+                f"materialize_branch_src: overlaying {p!r} from {overlay_src} into "
+                f"{overlay_dst} failed (rc={overlay.returncode}): {overlay.stderr.strip()}"
+            )
+
+    # Step 6 — source-sanity assert (mirrors build_rsync_command's own pyproject check).
+    if not (scratch / "pyproject.toml").exists():
+        raise RuntimeError(
+            f"materialize_branch_src: scratch tree {scratch} has no pyproject.toml after "
+            f"`git worktree add {commit}` — the branch commit produced an empty/invalid tree."
+        )
+    logger.info(
+        "materialize_branch_src: materialized branch %r (commit %s) for issue %d at %s",
+        branch,
+        commit,
+        issue,
+        scratch,
+    )
+    return scratch
+
+
 def git_branch_at(src_root: Path) -> str | None:
     """Return the current branch name at ``src_root`` (``None`` if unknown).
 
@@ -2561,6 +2782,7 @@ __all__ = [
     "RSYNC_INCLUDE_PATHS",
     "RUNTIME_ARTIFACT_FILENAMES",
     "SECRET_ENV_KEYS",
+    "WORKING_TREE_OVERLAY_PATHS",
     "ClusterConfig",
     "SbatchPlan",
     "SlurmBackend",
@@ -2576,6 +2798,7 @@ __all__ = [
     "get_cluster_config",
     "git_branch_at",
     "job_name",
+    "materialize_branch_src",
     "mila_socket_alive",
     "parse_job_id",
     "post_marker_via_task_py",

--- a/tests/test_slurm_backend_render.py
+++ b/tests/test_slurm_backend_render.py
@@ -46,6 +46,7 @@ from explore_persona_space.backends.slurm import (
     compute_plan_hash,
     default_gpus_for_intent,
     job_name,
+    materialize_branch_src,
     parse_job_id,
     render_secrets_env,
     time_budget_hours,
@@ -872,28 +873,38 @@ def test_slurm_backend_launch_survives_marker_post_failure(tmp_path) -> None:
     assert handle.extra["issue"] == 137
 
 
-def test_slurm_prepare_refuses_feature_branch_on_stale_main_source(tmp_path) -> None:
-    """#653: SLURM ``prepare`` must REFUSE to rsync when ``repo_branch`` names a
-    non-``main`` branch but the rsync source's HEAD is a different branch.
+def test_slurm_prepare_honors_feature_branch_on_stale_main_source_via_cloner(tmp_path) -> None:
+    """#793: SLURM ``prepare`` HONORS a non-``main`` ``repo_branch`` on a stale-``main``
+    rsync source by MATERIALIZING the branch tree via the ``git_cloner`` seam.
 
-    The lane has no ``repo_branch`` honoring mechanism (it rsyncs from
-    ``src_root``, it does not git-clone like GCP), so silently rsyncing
-    stale ``main`` would queue a job whose tree lacks the feature branch's
-    entrypoint scripts. The guard raises BEFORE the rsync; ``router.
-    _prepare_and_launch`` wraps it as ``BackendPrepareError`` and the auto
-    chain advances to the next lane.
+    This inverts the pre-#793 refuse-only behavior (#653): the lane no longer has to
+    refuse when the repo-root install is on ``main``. Instead, ``_resolve_rsync_source``
+    invokes ``materialize_branch_src`` (the ``git_cloner`` default) to build a complete
+    branch tree on the VM, and rsync sources FROM that tree — so the feature-branch code
+    actually runs, no ``ValueError``.
     """
     (tmp_path / "pyproject.toml").write_text("")
+    scratch = tmp_path / "scratch-branch"
+    scratch.mkdir()
 
-    rsynced: list[tuple] = []
+    cloner_calls: list[dict] = []
+
+    def fake_cloner(*, src_root, branch, issue):
+        cloner_calls.append({"src_root": src_root, "branch": branch, "issue": issue})
+        return scratch
+
+    rsynced: list[dict] = []
 
     backend = SlurmBackend(
         src_root=tmp_path,
         rsyncer=lambda **kw: rsynced.append(kw),
         secrets_pusher=lambda **_kw: None,
         runtime_clearer=lambda **_kw: None,
-        # The rsync source is on ``main`` (the repo-root install default).
-        git_branch_resolver=lambda _root: "main",
+        # The rsync source is on ``main`` (the repo-root install default) AND the
+        # materialized scratch tree is on the requested branch (so the re-asserted
+        # guard trivially passes against the RESOLVED source).
+        git_branch_resolver=lambda root: "issue-653" if root == scratch else "main",
+        git_cloner=fake_cloner,
     )
     spec = RunSpec(
         issue=137,
@@ -904,10 +915,17 @@ def test_slurm_prepare_refuses_feature_branch_on_stale_main_source(tmp_path) -> 
         extra={"repo_branch": "issue-653"},
     )
 
-    with pytest.raises(ValueError, match="cannot honor repo_branch='issue-653'"):
-        backend.prepare(spec)
-    # The guard fires BEFORE the rsync — no stale code was shipped.
-    assert rsynced == []
+    backend.prepare(spec)
+
+    # The cloner was INVOKED exactly once with the requested branch + spec issue.
+    assert len(cloner_calls) == 1, cloner_calls
+    assert cloner_calls[0]["branch"] == "issue-653"
+    assert cloner_calls[0]["issue"] == 137
+    assert cloner_calls[0]["src_root"] == tmp_path
+    # rsync now RUNS (the OLD ``rsynced == []`` assertion is inverted) and sources FROM
+    # the materialized branch tree, NOT the default ``_src_root``.
+    assert len(rsynced) == 1, rsynced
+    assert rsynced[0]["src_root"] == scratch
 
 
 def test_slurm_prepare_allows_matching_feature_branch_source(tmp_path) -> None:
@@ -967,19 +985,30 @@ def test_slurm_prepare_main_branch_run_is_unaffected(tmp_path, extra) -> None:
     assert len(rsynced) == 1
 
 
-def test_slurm_prepare_refuses_when_source_branch_unprovable(tmp_path) -> None:
-    """#653: a feature-branch request with an UNPROVABLE source branch
-    (resolver returns ``None`` — detached HEAD / non-repo source) must
-    REFUSE, not fail open: we cannot prove the source carries the branch."""
+def test_slurm_prepare_raises_when_cloner_cannot_resolve_branch(tmp_path) -> None:
+    """#793: a feature-branch request whose source branch is UNPROVABLE (resolver
+    returns ``None`` — detached HEAD / non-repo source) routes to the ``git_cloner``,
+    and if the cloner cannot resolve the branch it raises ``RuntimeError``, which
+    surfaces from ``prepare()``.
+
+    This preserves the auto-chain fallback: ``router._prepare_and_launch`` wraps the
+    ``RuntimeError`` as ``BackendPrepareError`` exactly as it did the pre-#793 guard's
+    ``ValueError`` (§4d), so the lane still advances. The raise fires BEFORE the rsync,
+    so no stale code is shipped.
+    """
     (tmp_path / "pyproject.toml").write_text("")
 
-    rsynced: list[tuple] = []
+    def raising_cloner(*, src_root, branch, issue):
+        raise RuntimeError(f"cannot resolve branch {branch}")
+
+    rsynced: list[dict] = []
     backend = SlurmBackend(
         src_root=tmp_path,
         rsyncer=lambda **kw: rsynced.append(kw),
         secrets_pusher=lambda **_kw: None,
         runtime_clearer=lambda **_kw: None,
         git_branch_resolver=lambda _root: None,
+        git_cloner=raising_cloner,
     )
     spec = RunSpec(
         issue=137,
@@ -990,9 +1019,317 @@ def test_slurm_prepare_refuses_when_source_branch_unprovable(tmp_path) -> None:
         extra={"repo_branch": "issue-653"},
     )
 
-    with pytest.raises(ValueError, match="cannot honor repo_branch"):
+    with pytest.raises(RuntimeError, match="cannot resolve branch issue-653"):
         backend.prepare(spec)
     assert rsynced == []
+
+
+# ---------------------------------------------------------------------------
+# #793: SLURM lane HONORS repo_branch via the git_cloner seam + overlay
+# ---------------------------------------------------------------------------
+
+
+def _branch_spec(branch: str | None) -> RunSpec:
+    """A lora-7b RunSpec carrying (or omitting) a ``repo_branch`` in ``extra``."""
+    extra = {"repo_branch": branch} if branch is not None else {}
+    return RunSpec(
+        issue=793,
+        intent="lora-7b",
+        backend="cluster",
+        cluster="nibi",
+        hydra_args=("condition=c1_evil_wrong_em",),
+        extra=extra,
+    )
+
+
+def test_prepare_honors_repo_branch_via_git_cloner(tmp_path) -> None:
+    """#793: a non-``main`` ``repo_branch`` against a ``main`` install invokes the
+    ``git_cloner`` once and rsyncs from its returned scratch tree, no ``ValueError``."""
+    (tmp_path / "pyproject.toml").write_text("")
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+
+    cloner_calls: list[dict] = []
+
+    def fake_cloner(*, src_root, branch, issue):
+        cloner_calls.append({"src_root": src_root, "branch": branch, "issue": issue})
+        return scratch
+
+    rsynced: list[dict] = []
+
+    backend = SlurmBackend(
+        src_root=tmp_path,
+        rsyncer=lambda **kw: rsynced.append(kw),
+        secrets_pusher=lambda **_kw: None,
+        runtime_clearer=lambda **_kw: None,
+        # main install; the materialized scratch is on the requested branch.
+        git_branch_resolver=lambda root: "issue-793" if root == scratch else "main",
+        git_cloner=fake_cloner,
+    )
+
+    backend.prepare(_branch_spec("issue-793"))
+
+    assert len(cloner_calls) == 1, cloner_calls
+    assert cloner_calls[0]["branch"] == "issue-793"
+    assert cloner_calls[0]["issue"] == 793
+    assert len(rsynced) == 1, rsynced
+    assert rsynced[0]["src_root"] == scratch
+
+
+@pytest.mark.parametrize("branch", [None, "main"], ids=["absent", "main"])
+def test_prepare_repo_branch_main_is_byte_identical_no_cloner(tmp_path, branch) -> None:
+    """#793: an absent / ``main`` ``repo_branch`` NEVER touches the cloner and rsyncs
+    from ``backend._src_root`` — byte-identical to the pre-fix path (zero side effects)."""
+    (tmp_path / "pyproject.toml").write_text("")
+
+    def cloner_must_not_run(**_kw):
+        raise AssertionError("git_cloner must not be called for a main/absent run")
+
+    rsynced: list[dict] = []
+    backend = SlurmBackend(
+        src_root=tmp_path,
+        rsyncer=lambda **kw: rsynced.append(kw),
+        secrets_pusher=lambda **_kw: None,
+        runtime_clearer=lambda **_kw: None,
+        git_cloner=cloner_must_not_run,
+    )
+
+    backend.prepare(_branch_spec(branch))
+
+    assert len(rsynced) == 1, rsynced
+    assert rsynced[0]["src_root"] == backend._src_root
+
+
+def test_prepare_install_already_on_branch_skips_cloner(tmp_path) -> None:
+    """#793: when the repo-root install is ALREADY on the requested branch, the cloner
+    is NOT called and rsync uses ``_src_root`` directly (the install IS the branch)."""
+    (tmp_path / "pyproject.toml").write_text("")
+
+    def cloner_must_not_run(**_kw):
+        raise AssertionError("git_cloner must not be called when install is on the branch")
+
+    rsynced: list[dict] = []
+    backend = SlurmBackend(
+        src_root=tmp_path,
+        rsyncer=lambda **kw: rsynced.append(kw),
+        secrets_pusher=lambda **_kw: None,
+        runtime_clearer=lambda **_kw: None,
+        git_branch_resolver=lambda _root: "issue-793",
+        git_cloner=cloner_must_not_run,
+    )
+
+    backend.prepare(_branch_spec("issue-793"))
+
+    assert len(rsynced) == 1, rsynced
+    assert rsynced[0]["src_root"] == backend._src_root
+
+
+def test_resolve_rsync_source_returns_src_root_on_main(tmp_path) -> None:
+    """#793: unit-test ``_resolve_rsync_source`` in isolation across the branch cases.
+
+    Parametrized over: absent → ``_src_root``; ``main`` → ``_src_root``; already-on-branch
+    (resolver returns the request) → ``_src_root``; non-``main`` mismatch (resolver returns
+    ``main``) → cloner's path; non-``main`` with resolver returning ``None`` (detached /
+    non-repo — the Statistics-critic case, mirroring the guard's ``actual is None``
+    sub-branch) → cloner's path. Asserts on the returned Path, not on a raise.
+    """
+    (tmp_path / "pyproject.toml").write_text("")
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+
+    def _resolve(*, branch, resolver):
+        backend = SlurmBackend(
+            src_root=tmp_path,
+            rsyncer=lambda **_kw: None,
+            secrets_pusher=lambda **_kw: None,
+            runtime_clearer=lambda **_kw: None,
+            git_branch_resolver=resolver,
+            git_cloner=lambda *, src_root, branch, issue: scratch,
+        )
+        return backend._resolve_rsync_source(_branch_spec(branch))
+
+    # A resolver that would fail the test loudly if consulted on the early-return path.
+    def _resolver_forbidden(_root):
+        raise AssertionError("resolver must not be consulted for a main/absent run")
+
+    # absent → _src_root (resolver never consulted)
+    assert _resolve(branch=None, resolver=_resolver_forbidden) == tmp_path
+    # "main" → _src_root (resolver never consulted)
+    assert _resolve(branch="main", resolver=_resolver_forbidden) == tmp_path
+    # already-on-branch → _src_root
+    assert _resolve(branch="issue-793", resolver=lambda _r: "issue-793") == tmp_path
+    # non-main mismatch (resolver returns "main") → cloner's path
+    assert _resolve(branch="issue-793", resolver=lambda _r: "main") == scratch
+    # non-main with resolver returning None (detached / non-repo) → cloner's path
+    assert _resolve(branch="issue-793", resolver=lambda _r: None) == scratch
+
+
+def _git_available() -> bool:
+    import shutil as _shutil
+
+    return _shutil.which("git") is not None
+
+
+def _init_branch_repo(repo: _P) -> None:
+    """Init a tiny git repo at ``repo`` with a ``main`` commit + an ``issue-X`` branch.
+
+    The ``issue-X`` branch adds a marker file (``branch_marker.txt``); a working-tree-only
+    ``external/open-instruct/open_instruct/finetune.py`` is created UNTRACKED to simulate
+    the mode-160000 gitlink the overlay handles.
+    """
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@e",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@e",
+    }
+
+    def _git(*args):
+        subprocess.run(
+            ["git", "-C", str(repo), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+
+    repo.mkdir(parents=True, exist_ok=True)
+    _git("init", "-q", "-b", "main")
+    (repo / "pyproject.toml").write_text("[project]\nname='x'\n")
+    (repo / "src").mkdir()
+    (repo / "src" / "mod.py").write_text("x = 1\n")
+    _git("add", "pyproject.toml", "src/mod.py")
+    _git("commit", "-q", "-m", "main commit")
+    _git("checkout", "-q", "-b", "issue-X")
+    (repo / "branch_marker.txt").write_text("on the branch\n")
+    _git("add", "branch_marker.txt")
+    _git("commit", "-q", "-m", "branch commit")
+    # Back to main so the branch is NOT the checked-out HEAD (mirrors the repo-root
+    # install staying on main while the feature branch lives in a worktree).
+    _git("checkout", "-q", "main")
+
+
+@pytest.mark.skipif(not _git_available(), reason="git not available")
+def test_materialize_branch_src_worktree_add_and_overlay(tmp_path) -> None:
+    """#793: the REAL ``materialize_branch_src`` produces a content-complete tree on the
+    branch commit + overlays the working-tree-only gitlink, and is idempotent."""
+    repo = tmp_path / "repo"
+    _init_branch_repo(repo)
+    # Working-tree-only gitlink content present in the src_root working tree only.
+    oi = repo / "external" / "open-instruct" / "open_instruct"
+    oi.mkdir(parents=True)
+    (oi / "finetune.py").write_text("f\n")
+
+    monkey_root = tmp_path / "slurm-src"
+
+    # Point the scratch root at tmp_path via the env override so we do not touch ~.
+    os.environ["EPS_SLURM_SRC_ROOT"] = str(monkey_root)
+    try:
+        scratch = materialize_branch_src(src_root=repo, branch="issue-X", issue=1, timeout=60)
+        # (a) the branch's marker file is present (committed-tree content).
+        assert (scratch / "branch_marker.txt").exists()
+        # (b) the overlaid gitlink content is present (worktree-only, not in any commit).
+        assert (scratch / "external" / "open-instruct" / "open_instruct" / "finetune.py").exists()
+        # (c) pyproject.toml is present (the source-sanity assert passed).
+        assert (scratch / "pyproject.toml").exists()
+
+        # Idempotency: a second call still succeeds (prior scratch removed + recreated).
+        scratch2 = materialize_branch_src(src_root=repo, branch="issue-X", issue=1, timeout=60)
+        assert scratch2 == scratch
+        assert (scratch2 / "branch_marker.txt").exists()
+        assert (scratch2 / "external" / "open-instruct" / "open_instruct" / "finetune.py").exists()
+    finally:
+        os.environ.pop("EPS_SLURM_SRC_ROOT", None)
+        # Detach the scratch worktree so tmp_path teardown does not leave a dangling
+        # registration in the source repo (best-effort).
+        subprocess.run(
+            ["git", "-C", str(repo), "worktree", "remove", "--force", str(scratch)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+
+@pytest.mark.skipif(not _git_available(), reason="git not available")
+def test_materialize_branch_src_unresolvable_branch_raises(tmp_path) -> None:
+    """#793: a branch name ``rev-parse --verify`` cannot resolve raises ``RuntimeError``
+    (fail-fast, no silent fallback to main)."""
+    repo = tmp_path / "repo"
+    _init_branch_repo(repo)
+
+    os.environ["EPS_SLURM_SRC_ROOT"] = str(tmp_path / "slurm-src")
+    try:
+        with pytest.raises(RuntimeError, match="cannot resolve branch 'no-such-branch'"):
+            materialize_branch_src(src_root=repo, branch="no-such-branch", issue=2, timeout=60)
+    finally:
+        os.environ.pop("EPS_SLURM_SRC_ROOT", None)
+
+
+@pytest.mark.skipif(not _git_available(), reason="git not available")
+def test_materialize_branch_src_absent_overlay_path_warns_not_crashes(tmp_path, caplog) -> None:
+    """#793: an overlay path absent in ``src_root`` (a legitimate lora-only run with no
+    open-instruct) logs a WARNING and is skipped — the function still succeeds."""
+    import logging
+
+    repo = tmp_path / "repo"
+    _init_branch_repo(repo)
+    # NOTE: no external/open-instruct is created in the src_root working tree.
+
+    os.environ["EPS_SLURM_SRC_ROOT"] = str(tmp_path / "slurm-src")
+    try:
+        with caplog.at_level(logging.WARNING):
+            scratch = materialize_branch_src(
+                src_root=repo,
+                branch="issue-X",
+                issue=3,
+                overlay_paths=("nonexistent-dir",),
+                timeout=60,
+            )
+        # (a) did not raise; (b) returned a valid scratch with pyproject.toml.
+        assert (scratch / "pyproject.toml").exists()
+        # (c) a WARNING was logged for the absent overlay path.
+        assert any(
+            "nonexistent-dir" in rec.getMessage() and rec.levelno == logging.WARNING
+            for rec in caplog.records
+        ), [rec.getMessage() for rec in caplog.records]
+    finally:
+        os.environ.pop("EPS_SLURM_SRC_ROOT", None)
+        subprocess.run(
+            ["git", "-C", str(repo), "worktree", "remove", "--force", str(scratch)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+
+def test_assert_repo_branch_synced_accepts_explicit_src_root(tmp_path) -> None:
+    """#793: the guard accepts an explicit ``src_root`` (§4d). Passing a branch tree
+    passes; passing a ``main`` tree with a non-``main`` request still raises (unchanged
+    internal semantics under the new arg — the guard STILL refuses a mismatched source)."""
+    (tmp_path / "pyproject.toml").write_text("")
+    branch_tree = tmp_path / "branch-tree"
+    branch_tree.mkdir()
+    main_tree = tmp_path / "main-tree"
+    main_tree.mkdir()
+
+    backend = SlurmBackend(
+        src_root=tmp_path,
+        rsyncer=lambda **_kw: None,
+        secrets_pusher=lambda **_kw: None,
+        runtime_clearer=lambda **_kw: None,
+        git_branch_resolver=lambda root: "issue-793" if root == branch_tree else "main",
+    )
+    spec = _branch_spec("issue-793")
+
+    # Explicit src_root on the branch → passes (no raise).
+    backend._assert_repo_branch_synced(spec, src_root=branch_tree)
+    # Explicit src_root on main with a non-main request → still raises.
+    with pytest.raises(ValueError, match="cannot honor repo_branch='issue-793'"):
+        backend._assert_repo_branch_synced(spec, src_root=main_tree)
 
 
 def test_slurm_backend_launch_uses_scp_not_ssh_bash_c(tmp_path) -> None:


### PR DESCRIPTION
Closes task #793.

Makes the SLURM lane HONOR `spec.extra["repo_branch"]` by materializing a branch-consistent rsync source (`git worktree add --detach <commit>` + working-tree overlay of the `external/open-instruct` gitlink) in `SlurmBackend.prepare()`, instead of only refusing stale-`main` submissions at the #653 guard. Guard KEPT as belt-and-suspenders (post-fix role: catch a cloner that returned an off-branch tree).

Scope: `src/explore_persona_space/backends/slurm.py` (only) + `tests/test_slurm_backend_render.py` (10 new/renamed tests). No change to `gcp.py` / `runpod.py` / `router.py` / `dispatch_issue.py`. Zero GPU-h, non-architectural.