### PR TITLE
task #791: poller tail-excerpt/crash-signature tracks freshest log (all four layouts)

### DIFF
--- a/scripts/poll_pipeline.py
+++ b/scripts/poll_pipeline.py
@@ -808,7 +808,8 @@ def _ssh_probe(
 ) -> dict[str, str]:
     """One SSH round-trip — returns dict with keys pid_alive,
     marker_pid_alive, mtime_epoch, cell_mtime_epoch, log_tail,
-    cell_log_tail, phase_log_mtime_epoch, gpu_util.
+    cell_log_tail, phase_log_mtime_epoch, phase_log_tail,
+    shard_log_mtime_epoch, shard_log_tail, gpu_util.
 
     Batches into a single heredoc to keep the SSH cost to one connection.
 
@@ -848,6 +849,13 @@ def _ssh_probe(
       under ``<log_path%.log>/cell_*.log`` (nested), per-phase logs
       live flat at ``/workspace/logs/issue-<N>-<phase>.log``; the two
       globs don't overlap.
+    * ``phase_log_tail`` — tail of that same freshest per-phase log; the
+      #791 sibling of ``cell_log_tail``. Consumed by
+      ``_tail_excerpt_and_crash_signature`` so the notification excerpt +
+      the ``status=dead`` crash signature track the freshest per-phase log
+      when a later run arm writes only to it, instead of a stale main-log
+      tail. ``""`` when no per-phase log exists (same degrade as
+      ``cell_log_tail``).
     * ``shard_log_mtime_epoch`` — max mtime over repo-rooted shard /
       phase / per-job logs (incidents #488 + #521). Covers three extra
       layouts neither the cell-log nor the per-phase-log probe sees:
@@ -866,6 +874,10 @@ def _ssh_probe(
       covered layout exists. All patterns share an mtime reduction
       (max), so a healthy run keeping ANY layout fresh stays in
       ``running``.
+    * ``shard_log_tail`` — tail of that same freshest shard/phase/per-job
+      log; the #791 sibling of ``cell_log_tail`` / ``phase_log_tail``,
+      consumed by ``_tail_excerpt_and_crash_signature`` the same way.
+      ``""`` when no covered layout exists.
     * ``gpu_util`` — comma-separated per-GPU ``utilization.gpu``
       integers (e.g. ``"95,87,42,90"``). ``"unknown"`` when
       ``nvidia-smi`` is unavailable or errors (fail-safe — see
@@ -936,15 +948,30 @@ def _ssh_probe(
     # | tail -1` yields the max epoch, or "" when no per-phase log
     # exists; the `echo` then prints "PHASE_LOG_MTIME_EPOCH=0" (parsed
     # as 0 by the caller).
+    # We select the SINGLE freshest matching file (by `stat -c '%Y %n' | sort
+    # -n | tail -1`, mirroring `cell_probe` at line 918) and emit BOTH its
+    # mtime AND its tail between `PHASE_TAIL_START`/`PHASE_TAIL_END`, so the
+    # caller has the staleness signal AND a tail to surface / scan for a crash
+    # signature when the per-phase log is the freshest one (#791: the tail
+    # excerpt + `status=dead` crash signature were pinned to the main log even
+    # when a later run arm wrote only to a per-phase log). No glob change —
+    # reuse the existing narrow `issue-<N>-*` pattern (vetted #468) so a
+    # cross-pod log on shared FS can never pollute the tail.
     phase_log_probe = (
-        f"PHASE_LOG_MAX=$("
+        f"PHASE_FRESHEST=$("
         f"shopt -s nullglob; "
         f"for f in /workspace/logs/issue-{issue}-*.log; do "
         f'  case "$f" in *.processed|*.json) continue ;; esac; '
         f'  case "$f" in /workspace/logs/issue-{issue}.log) continue ;; esac; '
-        f'  stat -c %Y "$f" 2>/dev/null; '
+        f'  stat -c "%Y %n" "$f" 2>/dev/null; '
         f"done | sort -n | tail -1); "
+        f'PHASE_LOG_MAX="${{PHASE_FRESHEST%% *}}"; '
+        f'PHASE_LOG_PATH="${{PHASE_FRESHEST#* }}"; '
         f'echo "PHASE_LOG_MTIME_EPOCH=${{PHASE_LOG_MAX:-0}}"; '
+        f"echo PHASE_TAIL_START; "
+        f'if [ -n "$PHASE_LOG_PATH" ] && [ -f "$PHASE_LOG_PATH" ]; then '
+        f'tail -500 "$PHASE_LOG_PATH"; fi; '
+        f"echo PHASE_TAIL_END; "
     )
     # Shard-log probe (#488): the i488 multi-GPU layout writes per-GPU
     # shard logs under `/workspace/explore-persona-space/logs/issue_<N>/
@@ -971,17 +998,28 @@ def _ssh_probe(
     # SHARD_LOG max. The two extra globs keep the issue-number match
     # exact (`issue_<N>` or `issue_<N>_<suffix>`; a bare `issue_<N>*`
     # would let issue 5 match issue 521's directories).
+    # Emit the freshest matching shard log's mtime AND its tail between
+    # `SHARD_TAIL_START`/`SHARD_TAIL_END` (same shape as `cell_probe` /
+    # `phase_log_probe`; #791). No glob change — reuse the existing narrow
+    # `issue_<N>` patterns (vetted #488/#521) so a cross-pod log never
+    # pollutes the tail.
     shard_log_probe = (
-        f"SHARD_LOG_MAX=$("
+        f"SHARD_FRESHEST=$("
         f"shopt -s nullglob; "
         f"for f in /workspace/explore-persona-space/logs/issue_{issue}/*.log "
         f"         /workspace/explore-persona-space/logs/issue_{issue}_*.log "
         f"         /workspace/explore-persona-space/eval_results/issue_{issue}/logs/*.log "
         f"         /workspace/explore-persona-space/eval_results/issue_{issue}_*/logs/*.log; do "
         f'  case "$f" in *.processed|*.json) continue ;; esac; '
-        f'  stat -c %Y "$f" 2>/dev/null; '
+        f'  stat -c "%Y %n" "$f" 2>/dev/null; '
         f"done | sort -n | tail -1); "
+        f'SHARD_LOG_MAX="${{SHARD_FRESHEST%% *}}"; '
+        f'SHARD_LOG_PATH="${{SHARD_FRESHEST#* }}"; '
         f'echo "SHARD_LOG_MTIME_EPOCH=${{SHARD_LOG_MAX:-0}}"; '
+        f"echo SHARD_TAIL_START; "
+        f'if [ -n "$SHARD_LOG_PATH" ] && [ -f "$SHARD_LOG_PATH" ]; then '
+        f'tail -500 "$SHARD_LOG_PATH"; fi; '
+        f"echo SHARD_TAIL_END; "
     )
     # GPU util probe (#468): fail-safe to "unknown" so a missing /
     # erroring nvidia-smi never declares stalled by itself (the
@@ -1127,7 +1165,9 @@ def _ssh_probe(
             "log_tail": "",
             "cell_log_tail": "",
             "phase_log_mtime_epoch": "0",
+            "phase_log_tail": "",
             "shard_log_mtime_epoch": "0",
+            "shard_log_tail": "",
             "gpu_util": "unknown",
             "zombie_gpu_pids": "",
             "session_cpu_secs": "unknown",
@@ -1174,42 +1214,52 @@ def _parse_probe_stdout(stdout: str) -> dict[str, str]:
         "log_tail": "",
         "cell_log_tail": "",
         "phase_log_mtime_epoch": "0",
+        "phase_log_tail": "",
         "shard_log_mtime_epoch": "0",
+        "shard_log_tail": "",
         "gpu_util": "unknown",
         "zombie_gpu_pids": "",
         "session_cpu_secs": "unknown",
         "results_sentinel_present": "0",
     }
-    tail_lines: list[str] = []
-    cell_tail_lines: list[str] = []
-    in_tail = False
-    in_cell_tail = False
+    # Each multi-line tail block is delimited by its own START/END sentinel
+    # (``TAIL_START``/``END``, ``CELL_TAIL_START``/``END``, and the #791
+    # ``PHASE_TAIL``/``SHARD_TAIL`` pairs). The blocks never nest (the probe
+    # emits them sequentially), so at most one is active at a time. A
+    # data-driven table (sentinel -> accumulator) keeps the per-line dispatch
+    # a single lookup — adding a tail block is a table row, not another
+    # if-branch (which is what pushed this past the C901 cap in #791).
+    tail_accumulators: dict[str, list[str]] = {
+        "log_tail": [],
+        "cell_log_tail": [],
+        "phase_log_tail": [],
+        "shard_log_tail": [],
+    }
+    tail_starts = {
+        "TAIL_START": "log_tail",
+        "CELL_TAIL_START": "cell_log_tail",
+        "PHASE_TAIL_START": "phase_log_tail",
+        "SHARD_TAIL_START": "shard_log_tail",
+    }
+    tail_ends = {"TAIL_END", "CELL_TAIL_END", "PHASE_TAIL_END", "SHARD_TAIL_END"}
+    active: list[str] | None = None
     for line in stdout.splitlines():
-        if line == "TAIL_START":
-            in_tail = True
+        if line in tail_starts:
+            active = tail_accumulators[tail_starts[line]]
             continue
-        if line == "TAIL_END":
-            in_tail = False
+        if line in tail_ends:
+            active = None
             continue
-        if line == "CELL_TAIL_START":
-            in_cell_tail = True
-            continue
-        if line == "CELL_TAIL_END":
-            in_cell_tail = False
-            continue
-        if in_tail:
-            tail_lines.append(line)
-            continue
-        if in_cell_tail:
-            cell_tail_lines.append(line)
+        if active is not None:
+            active.append(line)
             continue
         # Dispatch on the `KEY=value` prefix; store under the lowercased key.
         for key in _PROBE_SCALAR_KEYS:
             if line.startswith(f"{key}="):
                 parsed[key.lower()] = line.split("=", 1)[1].strip()
                 break
-    parsed["log_tail"] = "\n".join(tail_lines)
-    parsed["cell_log_tail"] = "\n".join(cell_tail_lines)
+    for tail_key, lines in tail_accumulators.items():
+        parsed[tail_key] = "\n".join(lines)
     return parsed
 
 
@@ -2306,14 +2356,37 @@ def _log_staleness_secs(
 
 
 def _tail_excerpt_and_crash_signature(
-    probe: dict[str, str], *, status: str, mtime_epoch: int, cell_mtime_epoch: int
+    probe: dict[str, str],
+    *,
+    status: str,
+    mtime_epoch: int,
+    cell_mtime_epoch: int,
+    phase_log_mtime_epoch: int = 0,
+    shard_log_mtime_epoch: int = 0,
 ) -> tuple[str, str | None]:
     """Slice the (5-line excerpt, WIDE crash signature) from the freshest log tail.
 
-    The fresher log (cell tail when cell logs exist AND are fresher than the main
-    log, else the main-log tail) is the WIDE 500-line surface the probe already
-    fetched. The notification excerpt is its last 5 lines (unchanged behavior).
-    The #775 ``crash_signature`` is the WHOLE wide tail on a ``status=="dead"``
+    The fresher log is the WIDE 500-line surface the probe already fetched.
+    #791: the freshest is selected by mtime-argmax over ALL FOUR log layouts —
+    {main, cell, phase, shard} — not just {main, cell}. Before #791 the excerpt
+    + crash signature were pinned to {main, cell}, so a multi-arm run whose later
+    arm wrote ONLY to a per-phase (``issue-<N>-<arm>.log``) or shard
+    (``logs/issue_<N>/*.log``) layout surfaced a STALE main-log tail — the
+    staleness verdict already unioned all four layouts (#468/#488), but the tail
+    excerpt (notifications) + the ``status=dead`` crash signature (which feeds
+    the CUDA-IMA / OUR_CODE_FRAME failover predicates in ``backend_poll``) did
+    not, so a watcher acted on the wrong surface.
+
+    Selection: pick the source with the largest mtime among those with a
+    NON-EMPTY tail; on a tie or when no fresher source has a tail, fall back to
+    the main-log tail (unchanged behavior for non-cell/non-phase/non-shard runs,
+    and for a run whose only tail is the main log). An empty tail is never
+    selected even when its mtime is the freshest, so a fresh-but-empty phase log
+    (e.g. just-created, nothing written yet) does not blank out a populated
+    main-log excerpt.
+
+    The notification excerpt is the freshest tail's last 5 lines. The #775
+    ``crash_signature`` is the WHOLE freshest wide tail on a ``status=="dead"``
     poll (``None`` otherwise) — NOT the 5-line excerpt, which truncates a 20-50
     line vLLM CUDA-IMA traceback so a signature match on it would silently never
     fire. The whole wide tail is stored so the failover predicate can ALSO scan
@@ -2321,10 +2394,21 @@ def _tail_excerpt_and_crash_signature(
     :func:`poll_once` so the slice logic is unit-testable without driving the
     full poller (the #775 B2 test binds to THIS helper).
     """
-    if cell_mtime_epoch > 0 and cell_mtime_epoch > mtime_epoch:
-        wide_tail = probe["cell_log_tail"]
-    else:
-        wide_tail = probe["log_tail"]
+    candidates = [
+        (mtime_epoch, probe["log_tail"]),
+        (cell_mtime_epoch, probe.get("cell_log_tail", "")),
+        (phase_log_mtime_epoch, probe.get("phase_log_tail", "")),
+        (shard_log_mtime_epoch, probe.get("shard_log_tail", "")),
+    ]
+    # Pick the freshest source with a NON-EMPTY tail. `max` returns the FIRST
+    # element on an mtime tie, and `log_tail` (the main log) is first in the
+    # list, so a tie deterministically resolves to the main log. When no source
+    # has a tail, `default` falls back to the main-log tail.
+    _, wide_tail = max(
+        ((m, t) for m, t in candidates if t),
+        default=(mtime_epoch, probe["log_tail"]),
+        key=lambda mt: mt[0],
+    )
     tail_excerpt = "\n".join(wide_tail.splitlines()[-5:])
     crash_signature = wide_tail if status == "dead" else None
     return tail_excerpt, crash_signature
@@ -2728,7 +2812,12 @@ def poll_once(
     # both are zero (no logs yet) or the main log is fresher, fall back
     # to the main-log tail (preserves prior behavior for non-cell runs).
     tail_excerpt, crash_signature = _tail_excerpt_and_crash_signature(
-        probe, status=status, mtime_epoch=mtime_epoch, cell_mtime_epoch=cell_mtime_epoch
+        probe,
+        status=status,
+        mtime_epoch=mtime_epoch,
+        cell_mtime_epoch=cell_mtime_epoch,
+        phase_log_mtime_epoch=phase_log_mtime_epoch,
+        shard_log_mtime_epoch=shard_log_mtime_epoch,
     )
     return PollResult(
         status=status,

--- a/tests/test_poll_pipeline_freshest_tail.py
+++ b/tests/test_poll_pipeline_freshest_tail.py
@@ -1,0 +1,281 @@
+"""Freshest-log tail selection across ALL FOUR log layouts (#791).
+
+The completion poller (``poll_pipeline``) fetches a WIDE 500-line tail per log
+layout the probe knows about. Before #791 the tail EXCERPT (surfaced in
+notifications) and the ``status="dead"`` crash SIGNATURE (which feeds the
+CUDA-IMA / OUR_CODE_FRAME failover predicates in ``backend_poll``) were selected
+by mtime-argmax over only {main, cell} — even though the STALENESS verdict
+already unioned all four layouts {main, cell, phase, shard} (#468/#488). So a
+multi-arm run whose later arm wrote ONLY to a per-phase (``issue-<N>-<arm>.log``)
+or shard (``logs/issue_<N>/*.log``) layout kept ``running`` correctly, but
+surfaced a STALE main-log tail — misinforming the surface a watcher acts on.
+
+These tests pin the fix from the OUTSIDE (a reader could trust the poller from
+these alone):
+
+* the excerpt/signature helper (``_tail_excerpt_and_crash_signature``) selecting
+  the freshest NON-EMPTY tail by mtime-argmax over all four layouts;
+* the tie-break + empty-tail safety rules (deterministic fall back to the main
+  log);
+* the probe-output parser (``_parse_probe_stdout``) lifting the two new
+  ``PHASE_TAIL_START``/``SHARD_TAIL_START`` blocks into ``phase_log_tail`` /
+  ``shard_log_tail``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_script_module(filename: str, alias: str):
+    """Load a ``scripts/*.py`` file as a module (mirrors the loader in
+    ``tests/test_poll_pipeline_zombie_gpu.py``)."""
+    spec = importlib.util.spec_from_file_location(alias, REPO_ROOT / "scripts" / filename)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[alias] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+pp = _load_script_module("poll_pipeline.py", "poll_pipeline_freshest_tail_under_test")
+
+
+def _probe(
+    *,
+    log_tail: str = "",
+    cell_log_tail: str = "",
+    phase_log_tail: str = "",
+    shard_log_tail: str = "",
+) -> dict[str, str]:
+    """A probe dict carrying the four tail surfaces the helper reads."""
+    return {
+        "log_tail": log_tail,
+        "cell_log_tail": cell_log_tail,
+        "phase_log_tail": phase_log_tail,
+        "shard_log_tail": shard_log_tail,
+    }
+
+
+# ── _tail_excerpt_and_crash_signature: freshest-of-four selection ─────────────
+
+
+def test_only_main_tail_populated_returns_main() -> None:
+    """Baseline (unchanged): with only the main-log tail populated, the excerpt
+    is its last 5 lines and (on a dead poll) it is the crash signature — no
+    behavior change for a non-cell/phase/shard run."""
+    wide = "\n".join(f"main line {i}" for i in range(10))
+    probe = _probe(log_tail=wide)
+
+    excerpt, sig = pp._tail_excerpt_and_crash_signature(
+        probe, status="dead", mtime_epoch=100, cell_mtime_epoch=0
+    )
+    assert excerpt == "\n".join(wide.splitlines()[-5:])
+    assert sig == wide
+
+
+def test_cell_tail_freshest_returns_cell() -> None:
+    """Pre-existing behavior preserved: cell mtime > main mtime -> the cell tail
+    is the wide surface for BOTH the excerpt and the crash signature."""
+    main = "stale dispatcher tail"
+    cell = "\n".join(f"cell line {i}" for i in range(8))
+    probe = _probe(log_tail=main, cell_log_tail=cell)
+
+    excerpt, sig = pp._tail_excerpt_and_crash_signature(
+        probe, status="dead", mtime_epoch=100, cell_mtime_epoch=200
+    )
+    assert excerpt == "\n".join(cell.splitlines()[-5:])
+    assert sig == cell
+
+
+def test_phase_tail_freshest_returns_phase_and_is_crash_signature() -> None:
+    """#791 NEW: the per-phase log is the freshest of all four -> its tail is the
+    excerpt, and on a ``status=dead`` poll it becomes the crash signature (the
+    surface the failover predicates scan). The stale main tail must NOT win."""
+    main = "\n".join(f"stale main {i}" for i in range(6))
+    phase = "\n".join(f"live phase line {i}" for i in range(30))
+    probe = _probe(log_tail=main, phase_log_tail=phase)
+
+    excerpt, sig = pp._tail_excerpt_and_crash_signature(
+        probe,
+        status="dead",
+        mtime_epoch=100,
+        cell_mtime_epoch=0,
+        phase_log_mtime_epoch=500,
+        shard_log_mtime_epoch=0,
+    )
+    assert excerpt == "\n".join(phase.splitlines()[-5:])
+    assert sig == phase
+    # The stale main tail contributes nothing to either surface.
+    assert "stale main" not in excerpt
+    assert "stale main" not in sig
+
+
+def test_shard_tail_freshest_returns_shard() -> None:
+    """#791 NEW: the shard/per-job log is the freshest of all four -> its tail
+    wins over main, cell, and phase."""
+    main = "stale main"
+    cell = "\n".join(f"cell {i}" for i in range(4))
+    phase = "\n".join(f"phase {i}" for i in range(4))
+    shard = "\n".join(f"shard line {i}" for i in range(20))
+    probe = _probe(log_tail=main, cell_log_tail=cell, phase_log_tail=phase, shard_log_tail=shard)
+
+    excerpt, sig = pp._tail_excerpt_and_crash_signature(
+        probe,
+        status="dead",
+        mtime_epoch=100,
+        cell_mtime_epoch=200,
+        phase_log_mtime_epoch=300,
+        shard_log_mtime_epoch=999,
+    )
+    assert excerpt == "\n".join(shard.splitlines()[-5:])
+    assert sig == shard
+
+
+def test_tie_breaks_to_main() -> None:
+    """Safety: two sources tied on the max mtime -> the result deterministically
+    picks the main log (main is first in the candidate list, and ``max`` returns
+    the first maximal element)."""
+    main = "\n".join(f"main {i}" for i in range(6))
+    shard = "\n".join(f"shard {i}" for i in range(6))
+    probe = _probe(log_tail=main, shard_log_tail=shard)
+
+    excerpt, sig = pp._tail_excerpt_and_crash_signature(
+        probe,
+        status="dead",
+        mtime_epoch=500,
+        cell_mtime_epoch=0,
+        phase_log_mtime_epoch=0,
+        shard_log_mtime_epoch=500,  # tie with main
+    )
+    assert excerpt == "\n".join(main.splitlines()[-5:])
+    assert sig == main
+
+
+def test_empty_freshest_tail_ignored_next_nonempty_wins() -> None:
+    """Safety: a source with the freshest mtime but an EMPTY tail (e.g. a
+    per-phase log just created, nothing written yet) is skipped; the next
+    freshest NON-EMPTY tail wins instead of blanking the excerpt."""
+    main = "stale main"
+    phase = "\n".join(f"phase live {i}" for i in range(10))
+    # phase has a populated tail at mtime 300; the shard mtime is FRESHER (400)
+    # but its tail is empty, so it must be ignored.
+    probe = _probe(log_tail=main, phase_log_tail=phase, shard_log_tail="")
+
+    excerpt, sig = pp._tail_excerpt_and_crash_signature(
+        probe,
+        status="dead",
+        mtime_epoch=100,
+        cell_mtime_epoch=0,
+        phase_log_mtime_epoch=300,
+        shard_log_mtime_epoch=400,  # freshest, but empty tail -> skipped
+    )
+    assert excerpt == "\n".join(phase.splitlines()[-5:])
+    assert sig == phase
+
+
+def test_all_empty_falls_back_to_main_empty() -> None:
+    """Safety: when NO source has a tail, the helper falls back to the (empty)
+    main-log tail rather than raising on an empty ``max`` sequence."""
+    probe = _probe()  # every tail empty
+    excerpt, sig = pp._tail_excerpt_and_crash_signature(
+        probe,
+        status="dead",
+        mtime_epoch=100,
+        cell_mtime_epoch=200,
+        phase_log_mtime_epoch=300,
+        shard_log_mtime_epoch=400,
+    )
+    assert excerpt == ""
+    assert sig == ""
+
+
+def test_running_poll_populates_no_crash_signature() -> None:
+    """A non-dead (running) poll never populates a crash signature, whichever
+    layout is freshest."""
+    probe = _probe(log_tail="main", phase_log_tail="phase content")
+    _, sig = pp._tail_excerpt_and_crash_signature(
+        probe,
+        status="running",
+        mtime_epoch=100,
+        cell_mtime_epoch=0,
+        phase_log_mtime_epoch=500,
+    )
+    assert sig is None
+
+
+# ── _parse_probe_stdout: PHASE_TAIL / SHARD_TAIL block parsing ────────────────
+
+
+def test_parse_probe_stdout_lifts_phase_and_shard_tails() -> None:
+    """The parser lifts the ``PHASE_TAIL_START``/``END`` and
+    ``SHARD_TAIL_START``/``END`` blocks into ``phase_log_tail`` /
+    ``shard_log_tail`` (mirrors the ``CELL_TAIL`` parse), and keeps the scalar
+    mtime keys and the other tails intact."""
+    stdout = "\n".join(
+        [
+            "PID_ALIVE=1",
+            "MTIME_EPOCH=100",
+            "CELL_MTIME_EPOCH=0",
+            "TAIL_START",
+            "main tail a",
+            "main tail b",
+            "TAIL_END",
+            "CELL_TAIL_START",
+            "CELL_TAIL_END",
+            "PHASE_LOG_MTIME_EPOCH=500",
+            "PHASE_TAIL_START",
+            "phase tail line 1",
+            "phase tail line 2",
+            "PHASE_TAIL_END",
+            "SHARD_LOG_MTIME_EPOCH=600",
+            "SHARD_TAIL_START",
+            "shard tail line 1",
+            "SHARD_TAIL_END",
+            "GPU_UTIL=95",
+        ]
+    )
+    parsed = pp._parse_probe_stdout(stdout)
+
+    assert parsed["log_tail"] == "main tail a\nmain tail b"
+    assert parsed["cell_log_tail"] == ""
+    assert parsed["phase_log_tail"] == "phase tail line 1\nphase tail line 2"
+    assert parsed["shard_log_tail"] == "shard tail line 1"
+    assert parsed["phase_log_mtime_epoch"] == "500"
+    assert parsed["shard_log_mtime_epoch"] == "600"
+    assert parsed["gpu_util"] == "95"
+
+
+def test_parse_probe_stdout_empty_phase_shard_tails_default_empty() -> None:
+    """A probe stdout with empty PHASE/SHARD tail blocks (the no-log-yet case the
+    heredoc emits) leaves both tail keys as empty strings, not the literal
+    sentinel lines."""
+    stdout = "\n".join(
+        [
+            "PID_ALIVE=1",
+            "PHASE_LOG_MTIME_EPOCH=0",
+            "PHASE_TAIL_START",
+            "PHASE_TAIL_END",
+            "SHARD_LOG_MTIME_EPOCH=0",
+            "SHARD_TAIL_START",
+            "SHARD_TAIL_END",
+        ]
+    )
+    parsed = pp._parse_probe_stdout(stdout)
+    assert parsed["phase_log_tail"] == ""
+    assert parsed["shard_log_tail"] == ""
+
+
+def test_ssh_failed_fallback_carries_empty_phase_shard_tails() -> None:
+    """The SSH-failure fallback dict (returned when the ssh round-trip fails)
+    carries the two new tail keys as empty strings, so a downstream reader never
+    KeyErrors on them after a transport failure."""
+    # _parse_probe_stdout's default dict is the same shape the ssh-failed
+    # fallback returns; assert both new keys are present + empty on empty stdout.
+    parsed = pp._parse_probe_stdout("")
+    assert parsed["phase_log_tail"] == ""
+    assert parsed["shard_log_tail"] == ""


### PR DESCRIPTION
Closes task #791.

**Bug 1 (fix):** `_ssh_probe` now captures the freshest phase/shard log's PATH alongside its mtime, and `_tail_excerpt_and_crash_signature` mtime-argmaxes over {main, cell, phase, shard} instead of only {main, cell}. The `crash_signature` (poll_pipeline.py:2329) feeds the CUDA-IMA / OUR_CODE_FRAME failover predicates at backend_poll.py:1072-1114, so a stale tail from a multi-arm run was misinforming real respawn decisions.

**Bug 2 (deflect):** no bare-`failed` regex exists in either poll file; whole-`scripts/`-tree grep verified. No change.

Ensemble PASS: Claude code-reviewer PASS + Codex CONCERNS on marker-shape only (no substantive) → PASS-class agree.
Test-verdict PASS (1986 passed / 5 failed pre-existing on main / 0 introduced).
