### PR TITLE
task #790: workflow-fix — GCP fetch_results sudo-tar transport + custom_workload-split git_paths

### DIFF
--- a/src/explore_persona_space/backends/artifacts.py
+++ b/src/explore_persona_space/backends/artifacts.py
@@ -545,8 +545,30 @@ def build_expected_artifacts_declaration(
     sentinel checks STILL run, so the gate is not relaxed — it just stops
     demanding artifacts this phase never promised (#661 root cause: the
     auto full-task git paths produced a structural FAIL on a perfectly
-    HF-uploaded phase-scoped run). ``False`` (default) = the established
-    behavior (both full-task git paths auto-declared).
+    HF-uploaded phase-scoped run).
+
+    **Default git paths are split by ``custom_workload`` (#790).** When
+    ``skip_default_git_paths`` is ``False`` the default ``git_paths`` depend
+    on the workload kind, because the two kinds produce different git
+    artifacts DURING the run:
+
+    * ``custom_workload=True`` (``--workload-cmd`` drivers): ``git_paths``
+      = ``[eval_results/issue_<N>/, *extra_git_paths]``. Many dispatch-script
+      drivers commit their eval JSONs during the run, so a missing
+      ``eval_results/`` there is a genuine FAIL and the check is kept; but
+      ``figures/`` is dropped because the analyzer generates + commits
+      figures POST-gate (analyzer.md Step 3) on every lane.
+    * ``custom_workload=False`` (pure hydra ``scripts/train.py``):
+      ``git_paths`` = ``[*extra_git_paths]`` — BOTH defaults dropped. ``train.py``
+      runs ``run_single(..., skip_eval=True)`` and ``orchestrate/runner.py``
+      gates all eval production on ``not skip_eval``, so a hydra run writes
+      neither ``eval_results/issue_<N>/`` nor ``figures/issue_<N>/`` during
+      the run; declaring either was a guaranteed false-FAIL (#790).
+
+    The GCP-lane ``fetch_results`` best-effort mirror still pulls both
+    ``eval_results/`` + ``figures/`` for analyzer-local convenience; they
+    are just no longer gate artifacts on the pure-hydra branch. The
+    completion sentinel + the HF-data checks keep gating teardown.
 
     **Unmerged-worktree launches (``git_repo_root``, #685).** When the
     run's committed eval/figure artifacts live on an unmerged
@@ -576,12 +598,26 @@ def build_expected_artifacts_declaration(
         # caller's explicit extra_git_paths (so a phase that DOES commit a
         # scoped git file can still declare it).
         git_paths = list(extra_git_paths)
-    else:
+    elif custom_workload:
+        # ``--workload-cmd`` drivers may commit ``eval_results/`` during the
+        # run (many do), but NEVER ``figures/`` — the analyzer generates +
+        # commits figures POST-gate (analyzer.md Step 3), AFTER
+        # ``confirm_artifacts`` runs, on every lane. Keep the real
+        # ``eval_results/`` check; drop the never-produced ``figures/``
+        # false-FAIL (#790).
         git_paths = [
             f"eval_results/issue_{issue}/",
-            f"figures/issue_{issue}/",
             *extra_git_paths,
         ]
+    else:
+        # Pure hydra (``scripts/train.py`` runs ``run_single(..., skip_eval=True)``,
+        # and ``orchestrate/runner.py`` gates ALL eval production on
+        # ``not skip_eval``), so the run writes NEITHER ``eval_results/issue_<N>/``
+        # NOR ``figures/issue_<N>/``. Declaring either is a load-bearing
+        # false-FAIL (#790). The GCP-lane ``fetch_results`` best-effort mirror
+        # still pulls both for analyzer-local convenience; they are just no
+        # longer gate artifacts.
+        git_paths = list(extra_git_paths)
     decl: dict[str, Any] = {
         "issue": int(issue),
         "hf_data_repo": hf_data_repo,

--- a/src/explore_persona_space/backends/gcp.py
+++ b/src/explore_persona_space/backends/gcp.py
@@ -104,13 +104,16 @@ References:
 
 from __future__ import annotations
 
+import base64
 import contextlib
+import io
 import json
 import logging
 import os
 import re
 import shlex
 import subprocess
+import tarfile
 import tempfile
 import time
 from collections.abc import Callable, Mapping, Sequence
@@ -827,8 +830,13 @@ def expected_artifacts_declaration(
       that lane comes from the agent-level upload-verifier (`/issue`
       Step 8). Callers that DO know the workload's real prefix declare
       it via ``extra_hf_data_paths``.
-    * Git paths ``eval_results/issue_<N>/`` + ``figures/issue_<N>/`` —
-      both committed by the workload + verified on the orchestrator side.
+    * Git paths — split by ``custom_workload`` (#790). A
+      ``--workload-cmd`` launch declares ``eval_results/issue_<N>/`` only
+      (dispatch drivers commit eval JSONs during the run; ``figures/`` is
+      analyzer-generated POST-gate). A pure-hydra launch declares NEITHER
+      default (``scripts/train.py`` runs with ``skip_eval=True`` and writes
+      no figures, so both are false-FAILs) — only ``extra_git_paths``.
+      Verified on the orchestrator side.
 
     The caller can add experiment-specific paths via ``extra_hf_data_paths``
     / ``extra_hf_model_paths`` / ``extra_git_paths`` (e.g. a sweep with a
@@ -4696,32 +4704,79 @@ class GcpBackend(ComputeBackend):
         # 2) Best-effort — pull eval_results/issue_<N>/ and
         # figures/issue_<N>/ back to the local repo. These are
         # authoritative on HF / WandB / git already; the local mirror
-        # is convenience. Each subdir is its own scp call so one
+        # is convenience. Each subdir is its own ssh call so one
         # failure doesn't bury the other.
+        #
+        # The workload tree is root-owned (#588: the GCE startup script
+        # runs the workload as root), so a plain `gcloud compute scp
+        # --recurse` from the OS-Login user Permission-denies and the
+        # mirror silently stays empty. Pull each dir as a base64-encoded
+        # tar stream via `sudo -n` instead — the SAME grant the mandatory
+        # sentinel pull above uses (`sudo -n cat`), just `tar -c | base64`
+        # inside a `bash -o pipefail -c` wrapper.
+        #
+        # The `bash -o pipefail` wrap is LOAD-BEARING: bash pipelines
+        # return the LAST command's exit status unless pipefail is set
+        # (OFF by default), so on a MISSING remote dir (the common path —
+        # item-4 dropped figures/ from the gate precisely because that dir
+        # is normally absent) `tar` exits non-zero but `base64 -w0` reads
+        # empty stdin and exits 0, masking the tar failure. The pipefail
+        # wrap makes the tar rc propagate so the `if returncode != 0:
+        # continue` guard fires (otherwise `base64.b64decode("")` +
+        # `tarfile.open` on empty bytes raises locally). Same wrapping-bash
+        # idiom as `_drain_sentinels` (`--command=sudo -n bash -c ...`);
+        # we add `-o pipefail` because this wraps a PIPELINE, not a
+        # `;`-sequence.
         repo_root = _default_src_root_for_fetch()
         workload_root = workload_dir_for(config, issue)
         for subdir in (f"eval_results/issue_{issue}", f"figures/issue_{issue}"):
-            remote_path = f"{workload_root}/{subdir}"
-            local_path = repo_root / subdir
-            local_path.parent.mkdir(parents=True, exist_ok=True)
-            scp_dir = _base_gcloud_argv(
+            remote_parent = shlex.quote(f"{workload_root}/{os.path.dirname(subdir)}")
+            remote_leaf = shlex.quote(os.path.basename(subdir))
+            local_parent = repo_root / os.path.dirname(subdir)
+            local_parent.mkdir(parents=True, exist_ok=True)
+            remote_cmd = f"tar -c -C {remote_parent} {remote_leaf} | base64 -w0"
+            tar_argv = _base_gcloud_argv(
                 config,
                 "compute",
-                "scp",
-                "--recurse",
-                f"{handle.pod_name}:{remote_path}",
-                str(local_path.parent),
+                "ssh",
+                handle.pod_name,
+                f"--command=sudo -n bash -o pipefail -c {shlex.quote(remote_cmd)}",
             )
-            scp_dir += [f"--zone={zone}"]
-            dir_res = self._run(scp_dir)
-            if dir_res.returncode != 0:
+            tar_argv += [f"--zone={zone}"]
+            tar_res = self._run(tar_argv)
+            if tar_res.returncode != 0:
                 logger.warning(
-                    "GcpBackend.fetch_results: best-effort scp of %s failed (rc=%d); "
-                    "authoritative copy is on HF/WandB/git. stderr=%s",
-                    remote_path,
-                    dir_res.returncode,
-                    dir_res.stderr[:300],
+                    "GcpBackend.fetch_results: best-effort sudo tar of %s/%s failed "
+                    "(rc=%d); authoritative copy is on HF/WandB/git. stderr=%s",
+                    workload_root,
+                    subdir,
+                    tar_res.returncode,
+                    tar_res.stderr[:300],
                 )
+                continue
+            # Decode + extract the captured base64 tar stream under
+            # local_parent. Wrap the decode+extract in try/log/continue too:
+            # a genuinely truncated/corrupt stream from a transport hiccup
+            # mid-transfer must log-and-continue, NOT raise — the mirror is
+            # best-effort and the dir is authoritative on HF/WandB/git.
+            try:
+                raw = base64.b64decode(tar_res.stdout)
+                with tarfile.open(fileobj=io.BytesIO(raw)) as tf:
+                    # filter="data" (PEP 706) blocks any path-traversal /
+                    # unsafe member in the stream and silences the 3.14
+                    # extractall-without-filter DeprecationWarning; it
+                    # extracts <leaf>/ under local_parent.
+                    tf.extractall(path=local_parent, filter="data")
+            except (ValueError, tarfile.TarError, EOFError) as exc:
+                logger.warning(
+                    "GcpBackend.fetch_results: best-effort decode/extract of %s/%s "
+                    "failed (%s: %s); authoritative copy is on HF/WandB/git.",
+                    workload_root,
+                    subdir,
+                    type(exc).__name__,
+                    str(exc)[:300],
+                )
+                continue
 
     def confirm_artifacts(self, handle: RunHandle) -> bool:
         """Backend-agnostic artifact verification.

--- a/tests/test_backend_artifacts_verify.py
+++ b/tests/test_backend_artifacts_verify.py
@@ -1105,10 +1105,9 @@ def test_build_declaration_phase_scope_omits_full_task_git_paths() -> None:
     decl_off = build_expected_artifacts_declaration(
         issue=661, sentinel_path=sentinel, custom_workload=True, attempt_id="att-1"
     )
-    assert decl_off["git_paths"] == [
-        "eval_results/issue_661/",
-        "figures/issue_661/",
-    ]
+    # #790: custom_workload keeps eval_results/ (drivers commit it during the
+    # run) but drops the analyzer-generated figures/.
+    assert decl_off["git_paths"] == ["eval_results/issue_661/"]
     decl_on = build_expected_artifacts_declaration(
         issue=661,
         sentinel_path=sentinel,
@@ -1137,7 +1136,64 @@ def test_build_declaration_phase_scope_omits_full_task_git_paths() -> None:
     gcp_on = gcp_decl(spec=spec, config=cfg, attempt_id="att-1", skip_default_git_paths=True)
     gcp_off = gcp_decl(spec=spec, config=cfg, attempt_id="att-1")
     assert gcp_on["git_paths"] == []
-    assert gcp_off["git_paths"] == ["eval_results/issue_661/", "figures/issue_661/"]
+    # #790: spec has workload_cmd → custom_workload → eval_results/ only.
+    assert gcp_off["git_paths"] == ["eval_results/issue_661/"]
+
+
+def test_build_expected_artifacts_declaration_hydra_workload_omits_figures() -> None:
+    """#790: a ``--workload-cmd`` (``custom_workload=True``) declaration KEEPS
+    ``eval_results/`` (dispatch drivers commit eval JSONs during the run — a
+    missing one there is a genuine FAIL) but DROPS ``figures/`` (the analyzer
+    generates + commits figures POST-gate on every lane, so ``figures/`` is
+    never produced during the run and declaring it is a guaranteed false-FAIL).
+    """
+    sentinel = "/scratch/eval_results/issue_790/att-1/.completion-sentinel.json"
+    decl = build_expected_artifacts_declaration(
+        issue=790,
+        sentinel_path=sentinel,
+        custom_workload=True,
+        attempt_id="att-1",
+    )
+    assert decl["git_paths"] == ["eval_results/issue_790/"]
+    # extra_git_paths still append after the kept default.
+    decl_extra = build_expected_artifacts_declaration(
+        issue=790,
+        sentinel_path=sentinel,
+        custom_workload=True,
+        attempt_id="att-1",
+        extra_git_paths=("eval_results/issue_790/panel.json",),
+    )
+    assert decl_extra["git_paths"] == [
+        "eval_results/issue_790/",
+        "eval_results/issue_790/panel.json",
+    ]
+
+
+def test_build_expected_artifacts_declaration_pure_hydra_omits_defaults() -> None:
+    """#790: a pure-hydra (``custom_workload=False``) declaration drops BOTH
+    default git paths. ``scripts/train.py`` runs ``run_single(..., skip_eval=True)``
+    and ``orchestrate/runner.py`` gates all eval production on ``not skip_eval``,
+    so a hydra run writes NEITHER ``eval_results/issue_<N>/`` NOR
+    ``figures/issue_<N>/`` during the run — declaring either is a load-bearing
+    false-FAIL. Only ``extra_git_paths`` survive.
+    """
+    sentinel = "/scratch/eval_results/issue_790/att-1/.completion-sentinel.json"
+    decl = build_expected_artifacts_declaration(
+        issue=790,
+        sentinel_path=sentinel,
+        custom_workload=False,
+        attempt_id="att-1",
+    )
+    assert decl["git_paths"] == []
+    # A hydra phase that DOES commit a scoped git file can still declare it.
+    decl_extra = build_expected_artifacts_declaration(
+        issue=790,
+        sentinel_path=sentinel,
+        custom_workload=False,
+        attempt_id="att-1",
+        extra_git_paths=("eval_results/issue_790/manifest.json",),
+    )
+    assert decl_extra["git_paths"] == ["eval_results/issue_790/manifest.json"]
 
 
 def test_phase_scope_passes_without_skip_confirm_and_negative_control(tmp_path: Path) -> None:

--- a/tests/test_gcp_backend.py
+++ b/tests/test_gcp_backend.py
@@ -1420,9 +1420,10 @@ def test_launch_populates_expected_artifacts_with_sentinel(no_marker_posts) -> N
     assert decl["issue"] == 137
     assert decl["sentinel_path"].endswith(".completion-sentinel.json")
     assert "att-fixed-001" in decl["sentinel_path"]
-    # Default git paths
-    assert "eval_results/issue_137/" in decl["git_paths"]
-    assert "figures/issue_137/" in decl["git_paths"]
+    # #790: this is a pure-hydra launch (_spec has no workload_cmd), so it
+    # declares NEITHER default git path — train.py runs with skip_eval=True and
+    # writes no figures during the run, so both were guaranteed false-FAILs.
+    assert decl["git_paths"] == []
     # Default HF data path threads the attempt id
     assert any("issue137_att-fixed-001/raw_completions/" in p for p in decl["hf_data_paths"]), decl
 
@@ -1450,10 +1451,11 @@ def test_expected_artifacts_declaration_workload_cmd_omits_guessed_hf_prefix() -
         attempt_id="att-fixed-001",
     )
     assert decl["hf_data_paths"] == []
-    # The keystone sentinel + the convention-stable git paths still gate.
+    # The keystone sentinel + the eval_results/ git path still gate.
     assert decl["sentinel_path"].endswith(".completion-sentinel.json")
-    assert "eval_results/issue_137/" in decl["git_paths"]
-    assert "figures/issue_137/" in decl["git_paths"]
+    # #790: custom_workload keeps eval_results/ (drivers commit it during the
+    # run) but drops the analyzer-generated figures/.
+    assert decl["git_paths"] == ["eval_results/issue_137/"]
     # An EXPLICIT caller declaration still threads through.
     decl_explicit = expected_artifacts_declaration(
         spec=_workload_spec(),
@@ -4868,6 +4870,35 @@ def test_launch_hydra_spec_marker_says_hydra() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _b64_tar(members: dict[str, str]) -> str:
+    """Build the base64-encoded tar stream the #790 best-effort pull returns.
+
+    ``members`` maps a repo-relative path (e.g. ``eval_results/issue_588/x.json``)
+    to its text content. The remote command is
+    ``tar -c -C <workload_root>/eval_results issue_588 | base64 -w0``, so the tar
+    entry names are relative to the subdir's PARENT (``issue_588/x.json``) — the
+    same shape ``extractall(path=local_parent)`` lands under ``repo/eval_results/``.
+    Returns the ASCII base64 string ``GcloudRunResult.stdout`` would carry.
+    """
+    import base64 as _b64
+    import io as _io
+    import os as _os
+    import tarfile as _tarfile
+
+    buf = _io.BytesIO()
+    with _tarfile.open(fileobj=buf, mode="w") as tf:
+        for rel_path, content in members.items():
+            # Strip the leading top-level dir so the arcname is
+            # ``issue_<N>/<leaf>`` (relative to the tar's -C parent), matching
+            # what `tar -c -C <parent> <leaf>` produces on the remote.
+            arcname = _os.path.join(*rel_path.split("/")[1:])
+            data = content.encode("utf-8")
+            info = _tarfile.TarInfo(name=arcname)
+            info.size = len(data)
+            tf.addfile(info, _io.BytesIO(data))
+    return _b64.b64encode(buf.getvalue()).decode("ascii")
+
+
 def _fetch_fixture(
     tmp_path: Path, monkeypatch, *, ssh_results: list[GcloudRunResult]
 ) -> tuple[GcpBackend, _Runner, GcpConfig, Any, str]:
@@ -4911,12 +4942,20 @@ def test_fetch_results_sentinel_pull_uses_ssh_sudo_cat(tmp_path: Path, monkeypat
 
     sentinel_text = '{"phase": "done", "issue": 588, "attempt_id": "att-001"}\n'
     backend, runner, config, handle, sentinel_abs = _fetch_fixture(
-        tmp_path, monkeypatch, ssh_results=[GcloudRunResult(0, sentinel_text, "")]
+        tmp_path,
+        monkeypatch,
+        # 1 sentinel cat + 2 best-effort tar pulls (all ssh now, #790).
+        ssh_results=[
+            GcloudRunResult(0, sentinel_text, ""),
+            GcloudRunResult(0, _b64_tar({"eval_results/issue_588/x.json": "{}"}), ""),
+            GcloudRunResult(0, _b64_tar({"figures/issue_588/y.png": "png"}), ""),
+        ],
     )
     backend.fetch_results(handle)
 
     ssh_calls = [argv for argv in runner.calls if "ssh" in argv]
-    assert len(ssh_calls) == 1
+    # 1 sentinel cat + 2 best-effort tar pulls; NO scp calls (#790).
+    assert len(ssh_calls) == 3
     assert ssh_calls[0] == [
         "gcloud",
         "compute",
@@ -4929,11 +4968,10 @@ def test_fetch_results_sentinel_pull_uses_ssh_sudo_cat(tmp_path: Path, monkeypat
     ]
     # Captured stdout written verbatim to the declaration's local path.
     assert Path(sentinel_abs).read_text() == sentinel_text
-    # The sentinel is never scp'd; the 2 best-effort dir pulls stay scp.
+    # The best-effort dir pulls are ssh `sudo -n bash -o pipefail -c 'tar ... | base64'`,
+    # NOT scp; the mirror lands under the tmp repo root.
     scp_calls = [argv for argv in runner.calls if "scp" in argv]
-    assert len(scp_calls) == 2
-    assert all("--recurse" in argv for argv in scp_calls)
-    assert not any(sentinel_abs in token for argv in scp_calls for token in argv)
+    assert len(scp_calls) == 0
 
 
 def test_fetch_results_sentinel_pull_failure_logs_and_continues(
@@ -4948,15 +4986,117 @@ def test_fetch_results_sentinel_pull_failure_logs_and_continues(
     backend, runner, _config, handle, sentinel_abs = _fetch_fixture(
         tmp_path,
         monkeypatch,
-        ssh_results=[GcloudRunResult(1, "", "sudo: a password is required")],
+        # Failed sentinel cat + 2 best-effort tar pulls (all ssh now, #790).
+        ssh_results=[
+            GcloudRunResult(1, "", "sudo: a password is required"),
+            GcloudRunResult(0, _b64_tar({"eval_results/issue_588/x.json": "{}"}), ""),
+            GcloudRunResult(0, _b64_tar({"figures/issue_588/y.png": "png"}), ""),
+        ],
     )
     with caplog.at_level(logging.ERROR):
         backend.fetch_results(handle)  # must not raise
 
     assert not Path(sentinel_abs).exists()
     assert "confirm_artifacts will FAIL" in caplog.text
+    ssh_calls = [argv for argv in runner.calls if "ssh" in argv]
+    assert len(ssh_calls) == 3  # sentinel + 2 best-effort pulls still attempted
     scp_calls = [argv for argv in runner.calls if "scp" in argv]
-    assert len(scp_calls) == 2  # best-effort pulls still attempted
+    assert len(scp_calls) == 0  # best-effort pulls are ssh tar now (#790)
+
+
+def test_fetch_results_best_effort_dirs_use_sudo_tar(tmp_path: Path, monkeypatch) -> None:
+    """The best-effort dir pulls are `ssh ... sudo -n bash -o pipefail -c 'tar | base64'`.
+
+    The workload tree is root-owned (#588), so a plain scp Permission-denies
+    and the local mirror silently stays empty. The #790 fix pulls each dir as
+    a base64-encoded tar stream via `sudo -n` — the same grant the sentinel
+    pull uses — and extracts it under the local repo root. Positive functional
+    evidence: assert the extracted files land at
+    `repo/eval_results/issue_588/` + `repo/figures/issue_588/`, that the
+    transport is ssh (no scp), and that the remote command is the exact
+    pipefail-wrapped tar-base64 pipeline.
+    """
+    import shlex
+
+    from explore_persona_space.backends.gcp import workload_dir_for
+
+    sentinel_text = '{"phase": "done", "issue": 588, "attempt_id": "att-001"}\n'
+    backend, runner, config, handle, _sentinel_abs = _fetch_fixture(
+        tmp_path,
+        monkeypatch,
+        ssh_results=[
+            GcloudRunResult(0, sentinel_text, ""),
+            GcloudRunResult(
+                0, _b64_tar({"eval_results/issue_588/run_result.json": '{"ok": 1}'}), ""
+            ),
+            GcloudRunResult(0, _b64_tar({"figures/issue_588/bar.png": "PNGDATA"}), ""),
+        ],
+    )
+    backend.fetch_results(handle)
+
+    # No scp at all; 1 sentinel cat + 2 tar pulls, all ssh.
+    scp_calls = [argv for argv in runner.calls if "scp" in argv]
+    assert len(scp_calls) == 0
+    ssh_calls = [argv for argv in runner.calls if "ssh" in argv]
+    assert len(ssh_calls) == 3
+
+    workload_root = workload_dir_for(config, 588)
+    tar_calls = ssh_calls[1:]  # the 2 best-effort dir pulls
+    eval_cmd = f"tar -c -C {shlex.quote(f'{workload_root}/eval_results')} issue_588 | base64 -w0"
+    fig_cmd = f"tar -c -C {shlex.quote(f'{workload_root}/figures')} issue_588 | base64 -w0"
+    assert tar_calls[0] == [
+        "gcloud",
+        "compute",
+        "ssh",
+        "eps-issue-588",
+        f"--command=sudo -n bash -o pipefail -c {shlex.quote(eval_cmd)}",
+        f"--configuration={config.gcloud_config}",
+        f"--project={config.project}",
+        "--zone=us-central1-a",
+    ]
+    assert tar_calls[1][4] == f"--command=sudo -n bash -o pipefail -c {shlex.quote(fig_cmd)}"
+
+    # The captured tar streams extract under the tmp repo root.
+    repo_root = tmp_path / "repo"
+    assert (repo_root / "eval_results/issue_588/run_result.json").read_text() == '{"ok": 1}'
+    assert (repo_root / "figures/issue_588/bar.png").read_text() == "PNGDATA"
+
+
+def test_fetch_results_best_effort_dir_missing_is_non_fatal(
+    tmp_path: Path, monkeypatch, caplog
+) -> None:
+    """A missing remote dir (tar rc != 0) logs a WARNING and does NOT raise.
+
+    This is the pipefail regression pin: the remote pipeline is wrapped in
+    `bash -o pipefail` precisely so a missing-dir `tar` failure propagates
+    through the `| base64` pipe instead of `base64 -w0` masking it with rc 0.
+    With pipefail the rc-guard fires (log + continue); WITHOUT it the pull
+    would return empty bytes and crash the local `tarfile.open`. The
+    missing-dir path is the COMMON case once item-4 removes figures/ from the
+    gate, so it must be non-fatal.
+    """
+    import logging
+
+    sentinel_text = '{"phase": "done", "issue": 588, "attempt_id": "att-001"}\n'
+    backend, _runner, _config, handle, sentinel_abs = _fetch_fixture(
+        tmp_path,
+        monkeypatch,
+        ssh_results=[
+            GcloudRunResult(0, sentinel_text, ""),
+            # eval_results present; figures/ missing (tar rc != 0 via pipefail).
+            GcloudRunResult(0, _b64_tar({"eval_results/issue_588/x.json": "{}"}), ""),
+            GcloudRunResult(1, "", "tar: issue_588: Cannot stat: No such file or directory"),
+        ],
+    )
+    with caplog.at_level(logging.WARNING):
+        backend.fetch_results(handle)  # must not raise
+
+    # The present dir still landed; the missing one logged + continued.
+    assert Path(sentinel_abs).read_text() == sentinel_text
+    assert (tmp_path / "repo/eval_results/issue_588/x.json").read_text() == "{}"
+    assert not (tmp_path / "repo/figures/issue_588").exists()
+    assert "best-effort sudo tar" in caplog.text
+    assert "figures/issue_588" in caplog.text
 
 
 def test_fetch_results_missing_attempt_id_returns_without_gcloud_calls(

--- a/tests/test_issue_dispatch.py
+++ b/tests/test_issue_dispatch.py
@@ -352,8 +352,10 @@ def test_gcp_fetch_results_issues_sentinel_pull_before_anything_else(tmp_path) -
 
 
 def test_gcp_fetch_results_falls_back_best_effort_on_artifact_dir_failure(tmp_path) -> None:
-    """A best-effort dir scp failure logs + continues (eval_results/figures
-    are authoritative on HF/WandB/git already)."""
+    """A best-effort dir tar-pull failure logs + continues (eval_results/figures
+    are authoritative on HF/WandB/git already). Post-#790 the best-effort pulls
+    are `ssh ... sudo -n bash -o pipefail -c 'tar | base64'`, NOT scp — the
+    workload tree is root-owned (#588), so plain scp Permission-denies."""
     runner = _RecordingGcloudRunner(
         results=[
             # sentinel pull (ssh sudo cat) PASS
@@ -369,11 +371,11 @@ def test_gcp_fetch_results_falls_back_best_effort_on_artifact_dir_failure(tmp_pa
     )
     # No raise — best-effort.
     backend.fetch_results(_gcp_handle(vm_scratch_dir=str(tmp_path)))
-    # One ssh sentinel pull + two scp dir pulls were issued.
+    # One ssh sentinel pull + two ssh tar dir pulls; no scp (#790).
     ssh_calls = [a for a in runner.calls if "ssh" in a]
     scp_calls = [a for a in runner.calls if "scp" in a]
-    assert len(ssh_calls) == 1
-    assert len(scp_calls) == 2
+    assert len(ssh_calls) == 3
+    assert len(scp_calls) == 0
 
 
 def test_gcp_fetch_results_skips_when_handle_missing_issue(tmp_path) -> None:
@@ -949,7 +951,10 @@ def test_declaration_survives_sidecar_roundtrip(tmp_path, tmp_lease_store) -> No
         tmp_path / "eval_results/issue_207/slurm-7777/.completion-sentinel.json"
     )
     assert expected.hf_data_paths == ("issue207_slurm-7777/raw_completions/",)
-    assert expected.git_paths == ("eval_results/issue_207/", "figures/issue_207/")
+    # #790: pure-hydra (no workload_cmd) declares NEITHER default git path —
+    # train.py runs with skip_eval=True and writes no figures, so both were
+    # guaranteed false-FAILs. Only extra_git_paths (none here) would remain.
+    assert expected.git_paths == ()
 
 
 def test_dispatch_for_issue_raises_router_terminal_for_caller_translation(

--- a/tests/test_slurm_backend_render.py
+++ b/tests/test_slurm_backend_render.py
@@ -2071,7 +2071,9 @@ def test_launch_attaches_expected_artifacts_declaration(tmp_path) -> None:
     assert decl["sentinel_path"] == str(
         tmp_path / "eval_results/issue_137/slurm-9001/.completion-sentinel.json"
     )
-    assert decl["git_paths"] == ["eval_results/issue_137/", "figures/issue_137/"]
+    # #790: pure-hydra (no workload_cmd) declares NEITHER default git path —
+    # train.py runs with skip_eval=True and writes no figures during the run.
+    assert decl["git_paths"] == []
     assert decl["hf_data_paths"] == ["issue137_slurm-9001/raw_completions/"]
     assert decl["hf_model_paths"] == []
 
@@ -2096,7 +2098,9 @@ def test_launch_custom_workload_omits_guessed_hf_prefix(tmp_path) -> None:
     assert decl["hf_data_paths"] == []
     # The sentinel + git checks keep gating teardown on this lane.
     assert decl["sentinel_path"].endswith("slurm-9001/.completion-sentinel.json")
-    assert decl["git_paths"] == ["eval_results/issue_137/", "figures/issue_137/"]
+    # #790: custom_workload keeps the real eval_results/ check (drivers commit
+    # eval JSONs during the run) but drops the analyzer-generated figures/.
+    assert decl["git_paths"] == ["eval_results/issue_137/"]
 
 
 def test_render_and_launch_sentinel_paths_agree(tmp_path) -> None:


### PR DESCRIPTION
Closes task #790.

## Summary

`kind: infra` workflow-fix for the GCP compute backend Permission-denied on best-effort `fetch_results` scp + confirm_artifacts false-FAIL on hydra-lane figures/.

- **`src/explore_persona_space/backends/gcp.py`** — best-effort dir pull now uses `sudo -n bash -o pipefail -c 'tar -c -C <parent> <leaf> | base64 -w0'` (same OS-Login → google-sudoers → sudo -n transport the sentinel pull already uses from #588). `pipefail` is load-bearing so a missing-dir `tar rc!=0` propagates through the `| base64` pipe. Local `base64.b64decode` + `tarfile.open`/`extractall(path=..., filter="data")` wrapped in try/log/continue.
- **`src/explore_persona_space/backends/artifacts.py`** — `build_expected_artifacts_declaration` default `git_paths` now splits by `custom_workload`: True (`--workload-cmd`) → `[eval_results/issue_<N>/, *extra]` (figures/ dropped; analyzer writes them POST-gate); False (pure hydra `train.py --skip_eval=True`) → `[*extra]` (both dropped — neither is produced during the run).
- **Tests** — 4 new + 6 pre-existing assertion updates across test_gcp_backend, test_backend_artifacts_verify, test_issue_dispatch, test_slurm_backend_render.

## Review trail

- verify_plan.py v2: PASS (0 FAIL, 0 WARN)
- Phase 2 ensemble: 3 lens REVISE (methodology pipefail, statistics test scope, alternatives eval_results/ symmetry — both Claude+Codex agreed on alternatives) → plan v2 addressed all three
- consistency-checker: PASS
- Code-reviewer ensemble round 1: Claude PASS + Codex PASS → final PASS
- Step 9c test-verdict: PASS for this diff (2353 pass; 5 pre-existing failures on main, byte-verified — all out of workflow-fix surface)

## Test plan

- [x] `pytest tests/test_gcp_backend.py tests/test_backend_artifacts_verify.py tests/test_issue_dispatch.py tests/test_slurm_backend_render.py tests/test_backend_poll.py -q` — all pass
- [x] `ruff check` + `ruff format --check` on the 6 changed files — clean
- [x] Snapshot test `test_render_startup_script_hydra_only_byte_identical_to_pre_change_snapshot` — passes
- [x] Regression pin `test_fetch_results_best_effort_dir_missing_is_non_fatal` — fails pre-fix, passes post-fix (pipefail invariant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>