### PR TITLE
workflow-fix #796: guard detached repo-root HEAD

### DIFF
--- a/scripts/guard_repo_root_branch.sh
+++ b/scripts/guard_repo_root_branch.sh
@@ -61,10 +61,19 @@ fi
 blocked=""
 
 # git switch <branch> / git switch -c <branch>  (switch is branch-only).
-# Allow only `git switch main` (bare or quoted — the arg regex tolerates the
+# Allow only `git switch main` (bare or quoted — the arg regex tolerates an
 # optional surrounding quote, so `git switch "main"` also passes the allow-arm).
+# The allow-arm ANCHORS `main` to the FULL switch arg: `main` must be followed
+# by an optional trailing quote AND then end-of-string or a shell delimiter
+# (whitespace / `;` / `&` / `|`). A bare `\bmain\b` word boundary would ALSO
+# match before a `-` / `/` / `.` (all non-word chars), so `git switch
+# main-adjacent` / `main/foo` / `main.x` (and their quoted forms) would slip
+# through the allow-arm and LEAK a branch-switch off main. `main_x` still
+# blocks: `_` is a word char so `\bmain` never matched there either, but the
+# explicit terminator makes the intent unambiguous. Concern id:
+# switch-main-prefix-allowarm-leak (#796 round 3).
 if echo "$cmd" | grep -qE '\bgit\b[^;&|]*\bswitch\b'; then
-  if ! echo "$cmd" | grep -qE '\bswitch\b +(-c +|-C +)?["'"'"']?main\b'; then
+  if ! echo "$cmd" | grep -qE '\bswitch\b +(-c +|-C +)?["'"'"']?main["'"'"']?( *($|[;&|]))'; then
     blocked="git switch"
   fi
 fi

--- a/scripts/guard_repo_root_branch.sh
+++ b/scripts/guard_repo_root_branch.sh
@@ -25,6 +25,21 @@
 # the tool call PROCEEDS) — code.claude.com/docs/en/hooks: "If your hook is
 # meant to enforce a policy, use exit 2."
 # Fail-soft: any ambiguity / parse failure exits 0 (never traps the user).
+#
+# <!-- known limitation -->
+# Every detector scans the RAW command string ($cmd) — the guard does NOT
+# strip quoted arguments before parsing. A quoted git-verb literal buried in
+# ANOTHER command's argument therefore trips the guard: e.g.
+# `task.py post-marker <N> epm:X --note "... git switch ..."` is blocked
+# because the note text matches `git ... switch`. The workaround is to pass
+# such note text via `--file <path.md>` instead of `--note`. A quote-strip
+# pre-pass was tried (round 1 of #796) and reverted: stripping quoted spans
+# BEFORE parsing silently hid REAL quoted git refs (`git checkout "HEAD~1"`,
+# `git switch "main"`) from the detectors — a leak of the exact class this
+# guard exists to block, and a false positive on quoted return-to-main. A
+# shell-syntax-aware strip is not safe to do in a bash regex, so the raw-scan
+# behavior (correct on git refs, over-eager on note-text literals) is the
+# deliberate trade-off. See #796 round-2 report.
 set -u
 
 REPO=/home/thomasjiralerspong/explore-persona-space
@@ -32,17 +47,8 @@ REPO=/home/thomasjiralerspong/explore-persona-space
 cmd=$(jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
 [ -n "$cmd" ] || exit 0
 
-# Strip quoted-string arguments before running the branch/detach detectors, so
-# a quoted git-verb literal inside another command's argument does not trigger a
-# false positive. Canonical offender: `task.py post-marker <N> epm:X --note
-# "... git switch ..."` — the note text contains "git switch" but the command
-# is not a git invocation at all. The detectors below scan $cmd_scan; the
-# worktree/`cd` scoping ESCAPE (below) intentionally scans the ORIGINAL $cmd so
-# a legitimately quoted path (e.g. `cd "/tmp/x"`) still escapes.
-cmd_scan=$(echo "$cmd" | sed -E "s/\"[^\"]*\"//g; s/'[^']*'//g")
-
 # Only consider git checkout/switch invocations at all.
-echo "$cmd_scan" | grep -qE '\bgit\b.*\b(checkout|switch)\b' || exit 0
+echo "$cmd" | grep -qE '\bgit\b.*\b(checkout|switch)\b' || exit 0
 
 # Allow anything explicitly scoped to another worktree (git -C <path>, or a
 # `cd <path-with-.claude/worktrees|/tmp>` earlier in the command chain).
@@ -55,15 +61,16 @@ fi
 blocked=""
 
 # git switch <branch> / git switch -c <branch>  (switch is branch-only).
-# Allow only `git switch main`.
-if echo "$cmd_scan" | grep -qE '\bgit\b[^;&|]*\bswitch\b'; then
-  if ! echo "$cmd_scan" | grep -qE '\bswitch\b +(-c +|-C +)?main\b'; then
+# Allow only `git switch main` (bare or quoted — the arg regex tolerates the
+# optional surrounding quote, so `git switch "main"` also passes the allow-arm).
+if echo "$cmd" | grep -qE '\bgit\b[^;&|]*\bswitch\b'; then
+  if ! echo "$cmd" | grep -qE '\bswitch\b +(-c +|-C +)?["'"'"']?main\b'; then
     blocked="git switch"
   fi
 fi
 
 # git checkout -b/-B <branch>  (branch creation).
-if echo "$cmd_scan" | grep -qE '\bgit\b[^;&|]*\bcheckout\b +(-b|-B)\b'; then
+if echo "$cmd" | grep -qE '\bgit\b[^;&|]*\bcheckout\b +(-b|-B)\b'; then
   blocked="git checkout -b"
 fi
 
@@ -73,10 +80,10 @@ fi
 # below would miss it. The switch pattern also catches `git switch -d main`
 # (a detach AT main), which the branch-only switch detector above lets through
 # on the `main` allow-arm.
-if echo "$cmd_scan" | grep -qE '\bgit\b[^;&|]*\bcheckout\b +(-{1,2})detach\b'; then
+if echo "$cmd" | grep -qE '\bgit\b[^;&|]*\bcheckout\b +(-{1,2})detach\b'; then
   blocked="git checkout --detach"
 fi
-if echo "$cmd_scan" | grep -qE '\bgit\b[^;&|]*\bswitch\b +(--detach\b|-d\b)'; then
+if echo "$cmd" | grep -qE '\bgit\b[^;&|]*\bswitch\b +(--detach\b|-d\b)'; then
   blocked="git switch --detach"
 fi
 
@@ -88,13 +95,13 @@ fi
 # skip known safe short-flags, then classify the first positional. `-b`/`-B`
 # are NOT skipped here (branch creation is already blocked above); `.`/`main`/`-`
 # are left as ALLOW.
-if echo "$cmd_scan" | grep -qE '\bgit\b[^;&|]*\bcheckout\b' \
-   && ! echo "$cmd_scan" | grep -qE 'checkout\b[^;&|]*--'; then
-  arg=$(echo "$cmd_scan" | sed -nE 's/.*\bcheckout\b +([^ ;&|]+).*/\1/p')
+if echo "$cmd" | grep -qE '\bgit\b[^;&|]*\bcheckout\b' \
+   && ! echo "$cmd" | grep -qE 'checkout\b[^;&|]*--'; then
+  arg=$(echo "$cmd" | sed -nE 's/.*\bcheckout\b +([^ ;&|]+).*/\1/p')
   # Flag-prefixed detach: skip leading safe short-flags to reach the first
   # positional (e.g. `checkout -f <sha>` -> classify `<sha>`).
   if echo "$arg" | grep -qE '^-[fqpm]$'; then
-    rest=$(echo "$cmd_scan" | sed -nE 's/.*\bcheckout\b +(.*)/\1/p')
+    rest=$(echo "$cmd" | sed -nE 's/.*\bcheckout\b +(.*)/\1/p')
     # shellcheck disable=SC2086  # word-splitting is intentional here
     set -- $rest
     while [ $# -gt 0 ]; do
@@ -104,6 +111,14 @@ if echo "$cmd_scan" | grep -qE '\bgit\b[^;&|]*\bcheckout\b' \
       esac
     done
   fi
+  # Strip a single layer of surrounding quotes so a QUOTED ref classifies as
+  # its bare form: `git checkout "HEAD~1"` -> HEAD~1 (detaches -> block),
+  # `git checkout "main"` -> main (allow). Quoted refs are shell-equivalent to
+  # unquoted ones; without this strip the quoted arg would either miss the
+  # `main` allow-arm (false positive) or, before the round-1 quote-strip was
+  # reverted, be erased entirely (leak). Only trailing/leading `"` or `'`.
+  arg=${arg#[\"\']}
+  arg=${arg%[\"\']}
   case "$arg" in
     ""|-b|-B|-f|--force|main|-|.) : ;;  # not a branch/detach we block
     --*) : ;;                           # a flag (e.g. --detach handled above)

--- a/scripts/guard_repo_root_branch.sh
+++ b/scripts/guard_repo_root_branch.sh
@@ -32,8 +32,17 @@ REPO=/home/thomasjiralerspong/explore-persona-space
 cmd=$(jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
 [ -n "$cmd" ] || exit 0
 
+# Strip quoted-string arguments before running the branch/detach detectors, so
+# a quoted git-verb literal inside another command's argument does not trigger a
+# false positive. Canonical offender: `task.py post-marker <N> epm:X --note
+# "... git switch ..."` — the note text contains "git switch" but the command
+# is not a git invocation at all. The detectors below scan $cmd_scan; the
+# worktree/`cd` scoping ESCAPE (below) intentionally scans the ORIGINAL $cmd so
+# a legitimately quoted path (e.g. `cd "/tmp/x"`) still escapes.
+cmd_scan=$(echo "$cmd" | sed -E "s/\"[^\"]*\"//g; s/'[^']*'//g")
+
 # Only consider git checkout/switch invocations at all.
-echo "$cmd" | grep -qE '\bgit\b.*\b(checkout|switch)\b' || exit 0
+echo "$cmd_scan" | grep -qE '\bgit\b.*\b(checkout|switch)\b' || exit 0
 
 # Allow anything explicitly scoped to another worktree (git -C <path>, or a
 # `cd <path-with-.claude/worktrees|/tmp>` earlier in the command chain).
@@ -47,27 +56,62 @@ blocked=""
 
 # git switch <branch> / git switch -c <branch>  (switch is branch-only).
 # Allow only `git switch main`.
-if echo "$cmd" | grep -qE '\bgit\b[^;&|]*\bswitch\b'; then
-  if ! echo "$cmd" | grep -qE '\bswitch\b +(-c +|-C +)?main\b'; then
+if echo "$cmd_scan" | grep -qE '\bgit\b[^;&|]*\bswitch\b'; then
+  if ! echo "$cmd_scan" | grep -qE '\bswitch\b +(-c +|-C +)?main\b'; then
     blocked="git switch"
   fi
 fi
 
 # git checkout -b/-B <branch>  (branch creation).
-if echo "$cmd" | grep -qE '\bgit\b[^;&|]*\bcheckout\b +(-b|-B)\b'; then
+if echo "$cmd_scan" | grep -qE '\bgit\b[^;&|]*\bcheckout\b +(-b|-B)\b'; then
   blocked="git checkout -b"
 fi
 
+# git checkout --detach [<ref>]  /  git switch --detach|-d <ref>  — explicit
+# detach. Fires independent of the positional arg: for `checkout --detach abc`
+# the first post-keyword token is the flag, not the ref, so the arg-classifier
+# below would miss it. The switch pattern also catches `git switch -d main`
+# (a detach AT main), which the branch-only switch detector above lets through
+# on the `main` allow-arm.
+if echo "$cmd_scan" | grep -qE '\bgit\b[^;&|]*\bcheckout\b +(-{1,2})detach\b'; then
+  blocked="git checkout --detach"
+fi
+if echo "$cmd_scan" | grep -qE '\bgit\b[^;&|]*\bswitch\b +(--detach\b|-d\b)'; then
+  blocked="git switch --detach"
+fi
+
 # git checkout <existing-branch>  — NOT a file restore (no `--`), arg is a real
-# local branch ref, and not `main`.
-if echo "$cmd" | grep -qE '\bgit\b[^;&|]*\bcheckout\b' \
-   && ! echo "$cmd" | grep -qE 'checkout\b[^;&|]*--'; then
-  arg=$(echo "$cmd" | sed -nE 's/.*\bcheckout\b +([^ ;&|]+).*/\1/p')
+# local branch ref, and not `main`. Extended: a non-branch arg that resolves to
+# a commit-ish (sha / tag / origin/<branch> / HEAD~N / HEAD@{N}) DETACHES HEAD
+# and is blocked too. A flag-prefixed detach (`checkout -f <sha>`, `-q <sha>`,
+# `-p <sha>`, `-m <sha>`) is caught by re-scanning the post-`checkout` tokens:
+# skip known safe short-flags, then classify the first positional. `-b`/`-B`
+# are NOT skipped here (branch creation is already blocked above); `.`/`main`/`-`
+# are left as ALLOW.
+if echo "$cmd_scan" | grep -qE '\bgit\b[^;&|]*\bcheckout\b' \
+   && ! echo "$cmd_scan" | grep -qE 'checkout\b[^;&|]*--'; then
+  arg=$(echo "$cmd_scan" | sed -nE 's/.*\bcheckout\b +([^ ;&|]+).*/\1/p')
+  # Flag-prefixed detach: skip leading safe short-flags to reach the first
+  # positional (e.g. `checkout -f <sha>` -> classify `<sha>`).
+  if echo "$arg" | grep -qE '^-[fqpm]$'; then
+    rest=$(echo "$cmd_scan" | sed -nE 's/.*\bcheckout\b +(.*)/\1/p')
+    # shellcheck disable=SC2086  # word-splitting is intentional here
+    set -- $rest
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -f|-q|-p|-m) shift ;;  # safe short-flag — skip to the next token
+        *) arg="$1"; break ;;  # first positional
+      esac
+    done
+  fi
   case "$arg" in
-    ""|-b|-B|-f|--force|main|-) : ;;  # not a branch-switch we block
+    ""|-b|-B|-f|--force|main|-|.) : ;;  # not a branch/detach we block
+    --*) : ;;                           # a flag (e.g. --detach handled above)
     *)
       if git -C "$REPO" show-ref --verify --quiet "refs/heads/$arg"; then
-        blocked="git checkout $arg"
+        blocked="git checkout $arg"                        # branch switch
+      elif git -C "$REPO" rev-parse --verify --quiet "$arg^{commit}" >/dev/null 2>&1; then
+        blocked="git checkout $arg (detaches HEAD)"         # sha/tag/remote-ref/HEAD~N
       fi
       ;;
   esac
@@ -80,7 +124,7 @@ fi
 cur=$(git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
 [ "$cur" = main ] || exit 0
 
-echo "BLOCKED: '$blocked' would move the SHARED repo-root tree off main. The repo root is the canonical commit target for scripts/task.py and every concurrent VM session (all assume HEAD==main); switching branches here hijacks their commits and sweeps cross-session uncommitted edits into the wrong commit (incident 2026-06-01). Do feature/infra branch work in a worktree instead:
+echo "BLOCKED: '$blocked' would move the SHARED repo-root tree off main / detach HEAD. The repo root is the canonical commit target for scripts/task.py and every concurrent VM session (all assume HEAD==main); switching branches or detaching HEAD here hijacks their commits and sweeps cross-session uncommitted edits into the wrong commit, and a detached repo-root HEAD crashes task_workflow's main-worktree resolver (incident 2026-06-01). Do feature/infra branch work in a worktree instead:
   bash scripts/new_worktree.sh .claude/worktrees/<name> <branch> && cd .claude/worktrees/<name>
 To override deliberately, run the git command from inside a worktree (git -C .claude/worktrees/<name> ...)." >&2
 exit 2

--- a/tests/test_guard_repo_root_branch.py
+++ b/tests/test_guard_repo_root_branch.py
@@ -1,0 +1,201 @@
+"""End-to-end tests for the ``scripts/guard_repo_root_branch.sh`` PreToolUse hook.
+
+The guard blocks any git command that would move the SHARED repo-root working
+tree off ``main`` OR detach its HEAD, because the repo root is the canonical
+commit target for ``scripts/task.py`` and every concurrent VM Claude session
+(all assume ``HEAD==main``). A detached repo-root HEAD additionally crashes
+``task_workflow``'s main-worktree resolver.
+
+These tests drive the script exactly as the harness does: stdin PreToolUse JSON
+``{"tool_input": {"command": <cmd>}}`` -> exit 2 (blocked) or exit 0 (allowed).
+This mirrors the subprocess-drives-script convention of the sibling
+``tests/test_*guard*`` files.
+
+The guard's on-main gate exits 0 when the repo-root HEAD is already off ``main``
+(it never traps a user recovering from an already-detached/off-main state), so
+the BLOCK-path tests are guarded by ``@on_main``. The ALLOW-path and fail-soft
+tests run regardless — the guard must never trap those shapes in either state.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = _REPO_ROOT / "scripts" / "guard_repo_root_branch.sh"
+
+# The script hardcodes REPO=/home/thomasjiralerspong/explore-persona-space and
+# runs ``git -C "$REPO" ...`` for its branch/commit-ish resolution + on-main
+# gate — so ref/branch/tag existence and the on-main check are read against that
+# canonical checkout, NOT this worktree.
+REPO = Path("/home/thomasjiralerspong/explore-persona-space")
+
+
+def _run(cmd: str) -> int:
+    """Feed ``cmd`` to the guard via PreToolUse JSON; return its exit code."""
+    payload = json.dumps({"tool_input": {"command": cmd}})
+    return subprocess.run([str(SCRIPT)], input=payload, text=True, capture_output=True).returncode
+
+
+def _run_raw(payload: str) -> int:
+    """Feed a raw (possibly malformed) stdin payload; return the exit code."""
+    return subprocess.run([str(SCRIPT)], input=payload, text=True, capture_output=True).returncode
+
+
+def _git(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", "-C", str(REPO), *args], capture_output=True, text=True)
+
+
+def _on_main() -> bool:
+    r = _git("symbolic-ref", "--short", "HEAD")
+    return r.returncode == 0 and r.stdout.strip() == "main"
+
+
+def _repo_head_sha() -> str:
+    """Real short SHA of the canonical repo-root HEAD (resolves via ``$REPO``)."""
+    return _git("rev-parse", "--short", "HEAD").stdout.strip()
+
+
+on_main = pytest.mark.skipif(
+    not _on_main(),
+    reason="guard's on-main gate exits 0 when the repo-root HEAD is off main",
+)
+
+
+@pytest.fixture
+def throwaway_branch():
+    """A real local branch (in ``$REPO``) so ``refs/heads/<name>`` resolves.
+
+    Created pointing at HEAD (no checkout, no tree change) and deleted on
+    teardown, so the branch-switch-regression assertion is hermetic rather than
+    depending on a repo-specific branch name existing.
+    """
+    name = "eps-test-throwaway-guard-796"
+    _git("branch", "-f", name, "HEAD")
+    try:
+        yield name
+    finally:
+        _git("branch", "-D", name)
+
+
+@pytest.fixture
+def throwaway_tag():
+    """A real local tag (in ``$REPO``) so ``<tag>^{commit}`` resolves.
+
+    Detaching to a tag is a real detach shape; a fabricated non-existent tag
+    would fail-soft (exit 0) and never exercise the block path — so the tag must
+    genuinely exist. Created pointing at HEAD and deleted on teardown.
+    """
+    name = "eps-test-throwaway-tag-796"
+    _git("tag", "-f", name, "HEAD")
+    try:
+        yield name
+    finally:
+        _git("tag", "-d", name)
+
+
+# ---------------------------------------------------------------------------
+# MUST BLOCK — detach-inducing shapes (the whole point of #796)
+# ---------------------------------------------------------------------------
+@on_main
+@pytest.mark.parametrize(
+    "template",
+    [
+        "git checkout {sha}",  # bare sha detach
+        "git checkout --detach",  # explicit --detach, no ref
+        "git checkout --detach {sha}",  # explicit --detach + ref
+        "git checkout -f {sha}",  # flag-prefixed detach (-f)
+        "git checkout -q {sha}",  # flag-prefixed detach (-q)
+        "git checkout -p {sha}",  # flag-prefixed detach (-p)
+        "git checkout -m {sha}",  # flag-prefixed detach (-m)
+        "git switch --detach {sha}",  # switch --detach
+        "git switch -d {sha}",  # switch -d
+        "git switch -d main",  # detach AT main (branch-only detector allows `main`)
+        "git checkout HEAD~1",  # relative rev
+        "git checkout HEAD@{{0}}",  # reflog rev ({{0}} -> {0} after .format)
+        "git checkout origin/main",  # remote-tracking ref
+    ],
+)
+def test_detach_shapes_block(template):
+    assert _run(template.format(sha=_repo_head_sha())) == 2
+
+
+@on_main
+def test_detach_to_real_tag_blocks(throwaway_tag):
+    # A real local tag resolves to a commit-ish -> detach -> block.
+    assert _run(f"git checkout {throwaway_tag}") == 2
+
+
+# ---------------------------------------------------------------------------
+# MUST BLOCK — existing branch-switch regression fence
+# ---------------------------------------------------------------------------
+@on_main
+@pytest.mark.parametrize("cmd", ["git checkout -b feature/x", "git switch fix/foo"])
+def test_branch_creation_and_switch_still_block(cmd):
+    # -b/-B branch creation and `switch <non-main>` are blocked without needing
+    # a resolvable ref (the detectors fire on the flag / arg shape).
+    assert _run(cmd) == 2
+
+
+@on_main
+def test_existing_local_branch_checkout_still_blocks(throwaway_branch):
+    # `git checkout <real-local-branch>` (not main) is the original blocked case.
+    assert _run(f"git checkout {throwaway_branch}") == 2
+
+
+# ---------------------------------------------------------------------------
+# MUST ALLOW — file-restore, return-to-main, scoped, and non-git shapes.
+# These must never be trapped regardless of the repo-root HEAD state, so they
+# are NOT guarded by @on_main.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "git checkout main",  # return to main
+        "git checkout -- scripts/eval.py",  # file restore (explicit --)
+        "git checkout HEAD -- foo.py",  # file restore from a ref
+        "git checkout .",  # restore-all
+        "git checkout -f -- scripts/eval.py",  # flag + file restore
+        "git -C .claude/worktrees/issue-123 checkout abc1234",  # scoped to a worktree
+        "cd /tmp/foo && git checkout abc1234",  # scoped by cd /tmp
+        "cd .claude/worktrees/x && git checkout abc1234",  # scoped by cd worktree
+        "git status",  # not a checkout/switch
+        "git commit -m x",  # not a checkout/switch
+    ],
+)
+def test_allowed_shapes_exit0(cmd):
+    assert _run(cmd) == 0
+
+
+def test_quoted_git_verb_in_argument_is_not_a_false_positive():
+    # A quoted git-verb literal inside another command's argument must NOT be
+    # treated as a git invocation (the concern that blocked posting a marker
+    # whose note discussed the guard). `--note "... git switch ..."` -> allow.
+    assert (
+        _run(
+            'uv run python scripts/task.py post-marker 796 epm:foo --note "test git switch string"'
+        )
+        == 0
+    )
+
+
+@on_main
+def test_nonexistent_ref_fails_soft():
+    # An arg that resolves to nothing (typo / non-existent ref) is NOT blocked:
+    # rev-parse fails -> guard exits 0 -> git itself errors on the real call.
+    assert _run("git checkout nonexistent-typo-ref-xyz-796") == 0
+
+
+# ---------------------------------------------------------------------------
+# Fail-soft — malformed / empty / non-JSON stdin exits 0 (never traps).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "payload",
+    ["", "{}", '{"tool_input": {}}', "not json", '{"tool_input": {"command": ""}}'],
+)
+def test_fail_soft_exit0(payload):
+    assert _run_raw(payload) == 0

--- a/tests/test_guard_repo_root_branch.py
+++ b/tests/test_guard_repo_root_branch.py
@@ -217,6 +217,52 @@ def test_quoted_main_still_allows(cmd):
     assert _run(cmd) == 0
 
 
+# ---------------------------------------------------------------------------
+# MUST BLOCK — `switch main<sep>` prefixes. The switch allow-arm anchors `main`
+# to the full arg (optional trailing quote, then EOL or a shell delimiter). A
+# bare `\bmain\b` word boundary matched before `-` / `/` / `.` (non-word
+# chars), so `git switch main-adjacent` / `main/foo` / `main.x` (and quoted
+# forms) slipped through the allow-arm and leaked a branch-switch off main.
+# Concern id: switch-main-prefix-allowarm-leak (#796 round 3).
+# ---------------------------------------------------------------------------
+@on_main
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "git switch main-adjacent",  # main-prefix branch -> block
+        'git switch "main-adjacent"',  # quoted main-prefix -> block
+        "git switch main/foo",  # main/ subpath -> block
+        'git switch "main/foo"',  # quoted main/ subpath -> block
+        "git switch main.x",  # main. suffix -> block
+        "git switch main_x",  # main_ (word char) -> block (never hit the allow-arm)
+        "git switch mainline",  # main-substring branch -> block
+    ],
+)
+def test_switch_main_prefix_still_blocks(cmd):
+    assert _run(cmd) == 2
+
+
+# ---------------------------------------------------------------------------
+# MUST ALLOW — genuine return-to-main, including a trailing shell delimiter or
+# chained command after `main`. NOT guarded by @on_main (must never trap in
+# either repo-root HEAD state). Concern id: switch-main-prefix-allowarm-leak.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "git switch main",  # bare return-to-main
+        'git switch "main"',  # quoted return-to-main
+        "git switch 'main'",  # single-quoted return-to-main
+        "git switch main;",  # semicolon-terminated -> still return-to-main
+        "git switch main | tee log.txt",  # pipe-terminated
+        "git switch main && echo done",  # chained command after main
+        "git switch -c main",  # create-branch named main (allow-arm tolerates -c)
+    ],
+)
+def test_switch_return_to_main_still_allows(cmd):
+    assert _run(cmd) == 0
+
+
 def test_note_text_git_verb_literal_trips_guard_known_limitation():
     # KNOWN LIMITATION (documented in the script header): the guard scans the
     # RAW command and does NOT strip quoted arguments, so a quoted git-verb

--- a/tests/test_guard_repo_root_branch.py
+++ b/tests/test_guard_repo_root_branch.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import uuid
 from pathlib import Path
 
 import pytest
@@ -72,13 +73,19 @@ def throwaway_branch():
 
     Created pointing at HEAD (no checkout, no tree change) and deleted on
     teardown, so the branch-switch-regression assertion is hermetic rather than
-    depending on a repo-specific branch name existing.
+    depending on a repo-specific branch name existing. The name carries a
+    per-run uuid suffix so concurrent test runs against the shared ``$REPO``
+    never clobber each other's ref, and teardown tolerates a missing ref (a
+    concurrent run already cleaned it up) rather than failing.
     """
-    name = "eps-test-throwaway-guard-796"
+    name = f"eps-test-throwaway-guard-796-{uuid.uuid4().hex[:8]}"
     _git("branch", "-f", name, "HEAD")
     try:
         yield name
     finally:
+        # Best-effort delete: a missing ref (never created / already gone) must
+        # not fail teardown. ``branch -D`` is non-raising here (``_git`` does
+        # not check=True), but guard explicitly for clarity.
         _git("branch", "-D", name)
 
 
@@ -88,9 +95,11 @@ def throwaway_tag():
 
     Detaching to a tag is a real detach shape; a fabricated non-existent tag
     would fail-soft (exit 0) and never exercise the block path — so the tag must
-    genuinely exist. Created pointing at HEAD and deleted on teardown.
+    genuinely exist. Created pointing at HEAD and deleted on teardown. The name
+    carries a per-run uuid suffix (concurrent-run safe) and teardown tolerates a
+    missing ref.
     """
-    name = "eps-test-throwaway-tag-796"
+    name = f"eps-test-throwaway-tag-796-{uuid.uuid4().hex[:8]}"
     _git("tag", "-f", name, "HEAD")
     try:
         yield name
@@ -171,15 +180,58 @@ def test_allowed_shapes_exit0(cmd):
     assert _run(cmd) == 0
 
 
-def test_quoted_git_verb_in_argument_is_not_a_false_positive():
-    # A quoted git-verb literal inside another command's argument must NOT be
-    # treated as a git invocation (the concern that blocked posting a marker
-    # whose note discussed the guard). `--note "... git switch ..."` -> allow.
+# ---------------------------------------------------------------------------
+# MUST BLOCK — QUOTED detach refs. Quoted git refs are shell-equivalent to
+# unquoted ones, so they must produce the SAME exit code as their unquoted
+# counterparts above. The round-1 quote-strip pre-pass erased these before the
+# detectors ran (leaking the exact class this guard blocks); the revert scans
+# the raw command and strips only a single surrounding quote layer on the
+# classified checkout arg. Concern id: quoted-refs-bypass-detach-guard (#796).
+# ---------------------------------------------------------------------------
+@on_main
+@pytest.mark.parametrize(
+    "template",
+    [
+        'git checkout "{sha}"',  # double-quoted sha -> block (was leaking, exit 0)
+        "git checkout '{sha}'",  # single-quoted sha -> block
+        'git checkout "HEAD~1"',  # quoted relative rev -> block
+        'git checkout "origin/main"',  # quoted remote-tracking ref -> block
+    ],
+)
+def test_quoted_detach_refs_still_block(template):
+    assert _run(template.format(sha=_repo_head_sha())) == 2
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        'git switch "main"',  # quoted return-to-main -> allow (was false-positive, exit 2)
+        'git checkout "main"',  # quoted return-to-main -> allow
+    ],
+)
+def test_quoted_main_still_allows(cmd):
+    # These must never be trapped regardless of repo-root HEAD state, so NOT
+    # guarded by @on_main. Round-1's quote-strip false-positived `git switch
+    # "main"` to exit 2; after the revert the arg-classifier strips the quotes
+    # and the `main` allow-arm passes.
+    assert _run(cmd) == 0
+
+
+def test_note_text_git_verb_literal_trips_guard_known_limitation():
+    # KNOWN LIMITATION (documented in the script header): the guard scans the
+    # RAW command and does NOT strip quoted arguments, so a quoted git-verb
+    # literal buried in another command's argument (e.g. a marker note
+    # discussing the guard) DOES trip it. This is the deliberate trade-off for
+    # correctly parsing quoted git refs (test_quoted_detach_refs_still_block);
+    # the round-1 quote-strip that "fixed" this false positive leaked real
+    # quoted detach refs. The workaround is `--file` for such note text.
+    # Exit 2 pins the known behavior so a future re-attempt at a quote-strip
+    # (which would silently re-open the leak) trips this test.
     assert (
         _run(
             'uv run python scripts/task.py post-marker 796 epm:foo --note "test git switch string"'
         )
-        == 0
+        == 2
     )
 
 


### PR DESCRIPTION
Closes task #796.

Extends `scripts/guard_repo_root_branch.sh` (PreToolUse Bash hook) to block detach-inducing shapes on the shared repo-root tree.

**Now blocks:** `git checkout <sha>`, `<tag>`, `origin/<branch>`, `HEAD~N`, `HEAD@{N}`, `--detach [<ref>]`, `git switch --detach`, `switch -d`, flag-prefixed detach (`-f/-q/-p/-m <sha>`), quoted variants of all the above, and `git switch main-adjacent`/`main/foo` (the round-3 anchor-fix).

**Still allows:** `git checkout main`/`.`/`-- <file>`, `git switch main` (quoted or not), worktree/`cd`-scoped commands, non-git commands.

**Preserved verbatim:** worktree/`cd` scoping escape, already-off-main recovery escape.

**Tests:** 54 cases in the new `tests/test_guard_repo_root_branch.py`. Rounds 1-3 code-review ensemble (Claude + Codex) with round-3 reconciler PASS.

**Follow-up:** #804 for two pre-existing CONCERN-severity leaks (compound-command masking + glued -b flag) that require clause-local shell parsing.