### PR TITLE
workflow-fix #799: planner markdown + paper-plots no-interp-overlays

### DIFF
--- a/.claude/agents/analyzer.md
+++ b/.claude/agents/analyzer.md
@@ -123,7 +123,7 @@ artifact (body vs paper-stub) differ.
 
 Read, in order:
 0. `frontmatter.goal` from body.md — the canonical one-sentence Goal the user filed at /issue Step 0c. This is your organizing target: the results narrative must answer how the experiment moved the needle on this Goal. You do NOT propose Goal changes — by the time analysis fires, the Goal is contract. If multiple `epm:goal-updated v1` markers exist in events.jsonl (Goal was refined during planning), the LATEST `to:` value is canonical; you MAY note this once inside the relevant `### <result>`'s what-is-plotted or interpretation prose ("Goal was refined once during planning — see events.jsonl"), but the refinement is not the story.
-1. The plan (from the `epm:plan` events.jsonl event, or `.claude/plans/issue-<N>.html`)
+1. The plan (from the `epm:plan` events.jsonl event, or `.claude/plans/issue-<N>.md`)
 2. Specific result files (`eval_results/<name>/run_result.json` and any per-condition JSONs)
 3. `epm:results` workflow event on the source experiment
 4. RESULTS.md (context on prior findings) and `docs/research_ideas.md`

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -220,13 +220,13 @@ reads at the approval gate. Everything else lives below the fold and gets
 read on demand (by the implementer, the experimenter, the reviewer, or by
 the user when they want detail).
 
-Generate the plan as a single HTML file at
-`.claude/plans/issue-<N>.html` so the Plan Summary can render in a
-distinct visual block at the top (e.g. a colored card), with the
-remaining sections in a normal document below or inside a
-`<details>` element. The dashboard's `RichBody` will sanitize and
-display the HTML directly; the user opens
-`https://eps.superkaiba.com/tasks/<N><uuid>` to review.
+Generate the plan as a single markdown file at
+`.claude/plans/issue-<N>.md`. The Plan Summary is the first H2 the user
+reads at the approval gate; the remaining sections live below it. The
+task-workflow API persists the plan into the task folder as
+`plans/v{K}.md` via `task.py new-plan-version <N> --file <path>`; the
+`.claude/plans/issue-<N>.md` copy is the working draft the planner
+writes before hand-off.
 
 ### 0.0 TL;DR (plain English — the user reads this first)
 
@@ -253,8 +253,8 @@ autonomous mode (`EPM_AUTONOMOUS_SESSION=1`), the planner does NOT
 propose a Goal refinement — the Goal is contract by the time the
 planner runs; skip and continue with the existing Goal.
 
-Render as a `<section class="plan-tldr">` block ABOVE the Plan Summary so
-the user reads `## Goal` + TL;DR + Plan Summary together in 30 seconds.
+Place the §0.0 TL;DR block ABOVE the Plan Summary so the user reads
+`## Goal` + TL;DR + Plan Summary together in 30 seconds.
 
 - **What I'll run:** What does the experiment do, in plain words? *NOT*
   "Qwen-2.5-7B LoRA r=16 SFT on persona-tagged Tulu mix." Instead:
@@ -285,8 +285,8 @@ from your memory of it — single pass, no iteration.
 ### 0. Plan Summary (technical version — for the implementer, experimenter, reviewer)
 
 A self-contained, ~150-word block that answers the seven questions
-below. Render it as a `<section class="plan-summary">` with bolded
-labels at the start of each line so it scans in 30 seconds. This is the
+below. Use bolded labels at the start of each line so it scans in 30
+seconds. This is the
 technical companion to §0.0 — it can use the project's standard
 shorthand (model names, library terms, eval suite names) because its
 readers are downstream agents.

--- a/.claude/skills/paper-plots/SKILL.md
+++ b/.claude/skills/paper-plots/SKILL.md
@@ -170,8 +170,10 @@ data does, then the caption tells them why it matters.
 **Banned in-figure patterns** (do not `ax.annotate(...)` / `ax.text(...)`
 / set `title=` with any of these):
 
-- Effect-size labels overlaid on bars/points ("Δ = +0.42", "3× baseline",
-  "p = 0.003") — these belong in the caption.
+- Effect-size / relative-magnitude labels overlaid on bars/points
+  ("Δ = +0.42", "3× baseline", "Cohen's d = 0.42") — these belong in the
+  caption. (A p-value for a correlation is the ONE carve-out — see the
+  "Legitimate figure text" whitelist below.)
 - Arrow annotations connecting bars, points, or conditions ("A → B",
   before/after arrows on paired bars) — pre/post pairing is encoded by
   the design, not an overlay.
@@ -192,6 +194,11 @@ data does, then the caption tells them why it matters.
 - The `add_direction_arrow(ax, ...)` suffix on an axis label (e.g.
   `"accuracy (↑ better)"`) — this is a unit-of-measurement cue, not an
   interpretation.
+- The **p-value for a correlation** when §3.7's condition holds (the
+  correlation IS the claim), placed at the axis or as a small annotation
+  near the fit line. This is a statistical label of the plotted
+  relationship, not a reader's conclusion. (Effect-size / relative-magnitude
+  labels — Cohen's d, "3× baseline", "Δ = +0.42" — stay banned per §3.8.)
 - Point labels near scatter markers (`ax.text(x, y, name)`) — these
   identify a data point (§3.7), not the reader's conclusion.
 - Panel titles that state WHAT is plotted (e.g. `"loss vs training

--- a/.claude/skills/paper-plots/SKILL.md
+++ b/.claude/skills/paper-plots/SKILL.md
@@ -161,6 +161,48 @@ For any predictor-vs-outcome scatter (the recurring cos-sim / JS-divergence vs l
 - **Choose the x-scale before fitting.** If the cloud is a near-vertical wall on a linear x, try log-x and report fit quality for both; don't fit a line through a degenerate x-range.
 - **Show p-values on the figure** whenever a correlation is the claim.
 
+### 3.8. No interpretive text overlays
+
+Figures present DATA. Interpretation lives in the caption / prose. Do NOT
+draw editorial annotations onto the artists — the reader sees what the
+data does, then the caption tells them why it matters.
+
+**Banned in-figure patterns** (do not `ax.annotate(...)` / `ax.text(...)`
+/ set `title=` with any of these):
+
+- Effect-size labels overlaid on bars/points ("Δ = +0.42", "3× baseline",
+  "p = 0.003") — these belong in the caption.
+- Arrow annotations connecting bars, points, or conditions ("A → B",
+  before/after arrows on paired bars) — pre/post pairing is encoded by
+  the design, not an overlay.
+- Explanatory text boxes ("Note: this drop reflects...", "Confounder:
+  seed variance") — caption prose, not on-figure.
+- Interpretive titles ("Method X wins", "Baseline collapses under
+  intervention") — the title states what is plotted, not what to
+  conclude.
+- In-panel narrative labels that name a mechanism or verdict rather than
+  a data source ("phase transition", "generalization gap", "saturation
+  regime").
+
+**Legitimate figure text**:
+
+- Axis labels + units (§3.5).
+- Tick labels — plain-English category names (§3.5), never Hydra slugs.
+- Legend entries — plain-English series names.
+- The `add_direction_arrow(ax, ...)` suffix on an axis label (e.g.
+  `"accuracy (↑ better)"`) — this is a unit-of-measurement cue, not an
+  interpretation.
+- Point labels near scatter markers (`ax.text(x, y, name)`) — these
+  identify a data point (§3.7), not the reader's conclusion.
+- Panel titles that state WHAT is plotted (e.g. `"loss vs training
+  step"`), never WHAT TO CONCLUDE.
+
+**Why the split matters.** A figure's interpretation is a moving target
+across rounds — a follow-up experiment can shift the headline. A caption
++ body prose can be rewritten cheaply; an in-figure annotation forces a
+regen. Keep the figure a stable data primitive; keep the interpretation
+in the text.
+
 ### 4. Run & save
 
 ```python
@@ -258,6 +300,9 @@ defer to that file if they ever diverge.
       visibly render in the saved PNG — the style zeroes marker edges
       (see Pitfalls, task #536).
 - [ ] No diagonal axis labels. Rotate by ≤ 30° and only if needed.
+- [ ] No interpretive text overlays on artists (§3.8): no effect-size
+      labels, arrow annotations, explanatory boxes, or verdict-titled
+      panels. Interpretation lives in the caption prose.
 
 **Hard cap: 3 visual-iteration rounds.** If the figure still doesn't look
 right after 3 revisions, stop and report rather than iterating further — the


### PR DESCRIPTION
Closes task #799 (workflow-fix, kind: infra).

- `.claude/agents/planner.md` — plans persist as markdown at `.claude/plans/issue-<N>.md`, not HTML. Neutralized `<section>` / `<details>` / `RichBody` language.
- `.claude/skills/paper-plots/SKILL.md` — new §3.8 codifying no-interpretive-text-overlays rule + §5 checklist item.

0 GPU-h, non-architectural, auto-approved plan.