### PR TITLE
issue-787: Step-10d far-behind / concurrent-tasks/* merge hardening

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -6840,6 +6840,8 @@ rebase-merged. Three guards:
    ```bash
    # Foreign tasks/* paths this branch touches (everything under tasks/ that
    # is NOT this task's own folder). Anchored so tasks/.../<N>/… is excluded.
+   STRIPPED_FOREIGN=no   # set to yes iff a strip commit is actually created,
+                         # so the safe-case push below fires only when needed.
    mapfile -t FOREIGN < <(git -C "$WT" diff --name-only origin/main HEAD -- 'tasks/' \
      | grep -Ev "^tasks/[^/]+/<N>/" || true)
    if [ "${#FOREIGN[@]}" -gt 0 ]; then
@@ -6858,11 +6860,23 @@ rebase-merged. Three guards:
        && git -C "$WT" rm --cached -f --ignore-unmatch -- "${FOREIGN_BRANCH_ONLY[@]}"
      # Commit the reset/removal so the branch diff no longer touches them,
      # but only if anything actually changed (idempotent: a re-run finds
-     # nothing staged and skips the commit).
-     git -C "$WT" diff --cached --quiet -- "${FOREIGN[@]}" \
-       || git -C "$WT" commit -m "issue-<N>: strip foreign tasks/ folders before Step-10d merge" -- "${FOREIGN[@]}"
+     # nothing staged and skips the commit). Record that a strip commit was
+     # made so the safe-case merge below knows it must push before rebasing.
+     if ! git -C "$WT" diff --cached --quiet -- "${FOREIGN[@]}"; then
+       git -C "$WT" commit -m "issue-<N>: strip foreign tasks/ folders before Step-10d merge" -- "${FOREIGN[@]}"
+       STRIPPED_FOREIGN=yes
+     fi
    fi
    ```
+
+   The `STRIPPED_FOREIGN` flag is load-bearing: the strip commit above is a
+   LOCAL worktree commit, but the safe-case `gh pr merge --rebase` below
+   rebases the commits on the PR head ref as it exists on
+   `origin/issue-<N>` (server-side), NOT the local worktree HEAD. An unpushed
+   strip commit is therefore INVISIBLE to that server-side rebase — the
+   foreign `tasks/*` reverts would remain in the replayed history and land on
+   `main` silently. So when `STRIPPED_FOREIGN=yes`, the safe-case block below
+   MUST push the strip commit to the PR head ref BEFORE calling `gh pr merge`.
 
    This is idempotent (a re-run finds `FOREIGN` empty and no-ops) and never
    touches THIS task's own `tasks/*/<N>/` folder (the `grep -Ev
@@ -7062,6 +7076,20 @@ if [ -z "$PR" ]; then
 else
   # Run guards 1-3 above first. If guard 3 says "unsafe", skip this
   # block and run the artifact-confirmed merge below instead.
+  #
+  # Push the Guard-1 strip commit to the PR head ref FIRST, so the
+  # server-side rebase in `gh pr merge` below sees the stripped branch tip,
+  # not the pre-strip commit. The strip commit is a LOCAL worktree commit and
+  # is otherwise invisible to server-side rebase — leaving the foreign
+  # tasks/* reverts in the replayed history and landing them on main silently
+  # (Codex code-review round-1 blocker, task #787). Push retry mirrors
+  # CLAUDE.md § "Concurrent repo-root committers": pull --rebase=merges
+  # --autostash then re-push on a rejected push.
+  if [ "$STRIPPED_FOREIGN" = "yes" ]; then
+    git -C "$WT" push origin issue-<N> \
+      || { git -C "$WT" pull --rebase=merges --autostash \
+           && git -C "$WT" push origin issue-<N>; }
+  fi
   gh pr ready <PR>
   gh pr merge <PR> --rebase --delete-branch=false
 fi

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -6823,17 +6823,57 @@ task at the wrong status, AND a branch based on another still-unmerged
 `issue-<M>` branch will replay `#M`'s old commits onto `main` if blindly
 rebase-merged. Three guards:
 
-1. **Foreign-`tasks/` guard.** `git diff --name-only origin/main HEAD --
-   tasks/` MUST be empty except THIS task's own folder
-   (`tasks/*/<N>/`). For any foreign `tasks/` path in the diff, run
-   `git checkout origin/main -- <that file>` before merging. Never let a
-   behind-`main` branch revert another task's `events.jsonl`. (Incident
-   2026-06-01: #458's merge branch, 1,146 commits behind main, silently
-   rewound `tasks/running/448/events.jsonl`.) The `--rebase` merge form
-   below replays the branch's commits on top of current `main`, so files
-   the branch never committed keep `main`'s version — this is what keeps
-   the clean-result body (committed to `main` by `task.py`, never in the
-   worktree) safe across the merge.
+1. **Foreign-`tasks/` guard (strip whole foreign task folders before the
+   merge).** `git diff --name-only origin/main HEAD -- tasks/` MUST be empty
+   except THIS task's own folder (`tasks/*/<N>/`). For any FOREIGN `tasks/`
+   path in that diff — a `tasks/*/<M>/…` file for `M != <N>`, whether
+   `events.jsonl`, `comments.jsonl`, `body.md`, or any other file — reset it
+   to `main` BEFORE merging so the server-side `gh pr merge --rebase` has
+   nothing foreign to conflict on (GitHub ignores this repo's
+   `.gitattributes merge=union`, so a union merge cannot rescue a server-side
+   conflict — the strip must happen here). A foreign path that EXISTS on
+   `origin/main` is reset by checkout; a foreign path the branch ADDED (does
+   not exist on `origin/main`) is dropped from the branch instead — a plain
+   `git checkout origin/main -- <added-path>` would crash with `pathspec did
+   not match any file(s)` and abort the guard. Split FOREIGN accordingly:
+
+   ```bash
+   # Foreign tasks/* paths this branch touches (everything under tasks/ that
+   # is NOT this task's own folder). Anchored so tasks/.../<N>/… is excluded.
+   mapfile -t FOREIGN < <(git -C "$WT" diff --name-only origin/main HEAD -- 'tasks/' \
+     | grep -Ev "^tasks/[^/]+/<N>/" || true)
+   if [ "${#FOREIGN[@]}" -gt 0 ]; then
+     FOREIGN_ON_MAIN=()      # exist on origin/main -> reset to main's version
+     FOREIGN_BRANCH_ONLY=()  # only the branch added them -> drop from branch
+     for p in "${FOREIGN[@]}"; do
+       if git -C "$WT" cat-file -e "origin/main:$p" 2>/dev/null; then
+         FOREIGN_ON_MAIN+=("$p")
+       else
+         FOREIGN_BRANCH_ONLY+=("$p")
+       fi
+     done
+     [ "${#FOREIGN_ON_MAIN[@]}" -gt 0 ] \
+       && git -C "$WT" checkout origin/main -- "${FOREIGN_ON_MAIN[@]}"
+     [ "${#FOREIGN_BRANCH_ONLY[@]}" -gt 0 ] \
+       && git -C "$WT" rm --cached -f --ignore-unmatch -- "${FOREIGN_BRANCH_ONLY[@]}"
+     # Commit the reset/removal so the branch diff no longer touches them,
+     # but only if anything actually changed (idempotent: a re-run finds
+     # nothing staged and skips the commit).
+     git -C "$WT" diff --cached --quiet -- "${FOREIGN[@]}" \
+       || git -C "$WT" commit -m "issue-<N>: strip foreign tasks/ folders before Step-10d merge" -- "${FOREIGN[@]}"
+   fi
+   ```
+
+   This is idempotent (a re-run finds `FOREIGN` empty and no-ops) and never
+   touches THIS task's own `tasks/*/<N>/` folder (the `grep -Ev
+   "^tasks/[^/]+/<N>/"` carve-out). Never let a behind-`main` branch revert
+   another task's `events.jsonl` / `comments.jsonl`. (Incident 2026-06-01:
+   #458's merge branch, 1,146 commits behind main, silently rewound
+   `tasks/running/448/events.jsonl`.) The `--rebase` merge form below replays
+   the branch's commits on top of current `main`, so files the branch never
+   committed keep `main`'s version — this is what keeps the clean-result body
+   (committed to `main` by `task.py`, never in the worktree) safe across the
+   merge.
 2. **Status already off `running`.** By both trigger points the status is
    well past `running` (`awaiting_promotion` for experiments; `completed`
    for code paths, flipped in Step 10 step 6 BEFORE this step). A crash
@@ -6872,13 +6912,45 @@ rebase-merged. Three guards:
    git -C "$WT" diff --name-only origin/main...HEAD   # three-dot form
    ```
 
-   UNSAFE if that list touches any foreign `tasks/` path (under
-   `tasks/` but outside `tasks/*/<N>/`) or files outside this task's
-   deliverable scope (paths neither the plan nor the code review
-   touched). If the list is clean — only this task's own deliverables —
-   the branch is SAFE to rebase-merge regardless of `BEHIND`: the
-   rebase replays only these commits, and files the branch never
-   committed keep `main`'s version.
+   Before judging a workflow-surface path out-of-scope, EXCLUDE files whose ONLY
+   branch-side touch is a Step-5a `spec-freshness` sync (the mandated
+   `git checkout main -- $SAFE_SPECS` from `main`, NOT a branch deliverable).
+   This mirrors Step 5a's own intent (line ~1925): a file that has NO non-sync
+   branch-side commit is content imported FROM `main`, so it is never an
+   out-of-scope regression. Match on the commit SUBJECT line ONLY — a `--grep`
+   over subject+body would wrongly exclude a genuine branch edit whose commit
+   BODY happens to mention "spec-freshness" (documentation, a retrospective),
+   silently dropping a real branch touch. The two Step-5a sync SUBJECT variants
+   both carry the token (`issue-<N>: sync workflow-surface specs from main
+   (spec-freshness)`; `chore(issue-<N>): spec-freshness sync workflow surface
+   from main`).
+
+   ```bash
+   # For each workflow-surface path $f in the own-diff: does it have any
+   # branch-side commit whose SUBJECT does NOT contain "spec-freshness"?
+   # Emit "<sha> <subject>" per own-commit touching $f, then keep only the
+   # non-sync ones. If none remain, the file's only branch-side touches are
+   # spec-freshness syncs => imported from main => NON-blocking for Guard 3.
+   non_sync=$(git -C "$WT" log --format='%H %s' "$MB"..HEAD -- "$f" \
+     | awk 'index($0, "spec-freshness") == 0')
+   # $non_sync empty   => file imported via spec-freshness sync only => treat as
+   #                      NON-blocking (in-scope, imported from main).
+   # $non_sync nonempty => a genuine branch-side edit (its subject is not a sync)
+   #                      => apply the normal in-scope / out-of-scope judgment.
+   ```
+
+   (`git log --format='%H %s'` prints `<sha> <subject>` per commit — the `awk
+   index()` keeps only lines whose subject lacks the token; the sha is a hex
+   string that never contains "spec-freshness", so the match is effectively
+   subject-scoped. Equivalently `git log --format='%s' … | grep -v spec-freshness`.)
+
+   UNSAFE if the own-diff — after the spec-freshness exclusion above — touches
+   any foreign `tasks/` path (under `tasks/` but outside `tasks/*/<N>/`) or files
+   outside this task's deliverable scope (paths neither the plan nor the code
+   review touched). If the list is clean — only this task's own deliverables,
+   plus any spec-freshness-synced workflow-surface files — the branch is SAFE to
+   rebase-merge regardless of `BEHIND`: the rebase replays only these commits,
+   and files the branch never committed keep `main`'s version.
 
    In the unsafe case, do NOT run `gh pr merge --rebase` — fall through
    to the **artifact-confirmed merge** procedure below. The Guard 1
@@ -6896,6 +6968,90 @@ rebase-merged. Three guards:
    reworked guard twice over: `ON_MAINLINE=no` flags it directly, and
    its `origin/main...HEAD` diff carries the whole `#472` parent
    payload, failing the content check.)
+
+#### Fast-path routing pre-check (workflow-fix / small-ADDED-diff far-behind branches)
+
+Run this AFTER guards 1-3 and BEFORE the safe-case `gh pr merge --rebase`
+call. For a workflow-fix / small-diff branch that is very far behind `main`,
+a server-side `--rebase` predictably conflicts on churn even after Guard 1
+strips foreign folders (GitHub replays the branch's own commits across
+thousands of intervening main commits, and cannot use this repo's
+`merge=union`). When the branch's OWN diff is small, entirely in-scope, AND
+consists ONLY of ADDED files, skip the doomed `--rebase` and route DIRECTLY to
+the surgical additive checkout below.
+
+**Why the ADDED-only conjunct is load-bearing (do NOT drop it).** The
+surgical additive checkout does a WHOLESALE `git checkout issue-<N> -- <path>`
+(the "One or more deliverables missing" branch, ~line 7080), which OVERWRITES
+each listed path with the branch tip's copy. For a file the branch MODIFIED
+that `main` also advanced (very likely on a 1000+-behind branch), that
+overwrite silently discards `main`'s newer content with NO conflict surfacing
+— a silent-wrong merge. Restricting the fast-path to ADDED-only files means
+the surgical checkout only ever CREATES files that do not yet exist on
+`main`, so it can never clobber a concurrently-advanced one. A branch that
+MODIFIES a workflow-surface file (status M) is NOT fast-path-eligible and
+takes the ordinary `gh pr merge --rebase` path, whose server-side 3-way merge
+either merges main's changes cleanly or surfaces a real conflict for the
+recovery sub-procedure. (This is exactly why #787 itself — which MODIFIES
+`SKILL.md` — is not fast-path-eligible.)
+
+```bash
+# Fast-path predicate — ALL of:
+#  (a) task is kind:infra AND tagged wf-fix (a workflow-fix branch), AND
+#  (b) BEHIND > 1000 (branch predates significant main churn), AND
+#  (c) the branch's OWN diff touches <= 15 files, AND
+#  (d) every touched file is in-scope: this task's own paths, workflow
+#      surface, .gitattributes, or the methodology doc — NO shared src/ or
+#      scripts/ additions (those need the full rebase to land), AND
+#  (e) EVERY touched file is status A (Added) — no M (Modified), D (Deleted),
+#      R (Renamed). A modified file would be clobbered wholesale by the
+#      surgical checkout below.
+KIND=$(uv run python "$REPO_ROOT/scripts/task.py" view <N> --json | \
+  uv run python -c 'import sys,json; d=json.load(sys.stdin); fm=d.get("frontmatter",{}); print(fm.get("kind","")); print(" ".join(fm.get("tags",[])))')
+TASK_KIND=$(printf '%s\n' "$KIND" | sed -n 1p)
+TASK_TAGS=$(printf '%s\n' "$KIND" | sed -n 2p)
+# Three-dot: the branch's OWN commits only (merge-base..HEAD) — never files
+# main advanced but the branch never touched. Name-status so we can gate on A.
+mapfile -t OWN_NS < <(git -C "$WT" diff --name-status origin/main...HEAD)
+N_FILES=${#OWN_NS[@]}
+IN_SCOPE=yes
+ADDED_ONLY=yes
+for line in "${OWN_NS[@]}"; do
+  st=${line%%$'\t'*}          # status letter (A / M / D / R100 / ...)
+  f=${line#*$'\t'}            # path (for a rename this is the source; fine —
+                              # a rename fails ADDED_ONLY below regardless)
+  [ "$st" = "A" ] || ADDED_ONLY=no
+  case "$f" in
+    tasks/*/<N>/*|figures/issue_<N>/*|eval_results/issue_<N>/*|eval_results/issue_<N>_*/*|ood_eval_results/issue_<N>/*) ;;
+    .claude/*|CLAUDE.md|.gitattributes|docs/methodology/issue_<N>.md) ;;
+    *) IN_SCOPE=no ;;
+  esac
+done
+FAST_PATH=no
+if [ "$TASK_KIND" = "infra" ] \
+   && printf '%s' "$TASK_TAGS" | grep -qw 'wf-fix' \
+   && [ "$BEHIND" -gt 1000 ] \
+   && [ "$N_FILES" -le 15 ] \
+   && [ "$IN_SCOPE" = "yes" ] \
+   && [ "$ADDED_ONLY" = "yes" ]; then
+  FAST_PATH=yes
+fi
+```
+
+If `FAST_PATH=yes`: SKIP the `gh pr merge --rebase` call and jump straight to
+the **surgical additive checkout** (the "One or more deliverables missing"
+branch of the artifact-confirmed procedure below). The surgical checkout
+lands this branch's own ADDED files onto `main` directly, with no rebase.
+Post `epm:merged v1` with `{artifact_confirmed: true, full_rebase_deferred:
+true, surgical_checkout: true, fast_path: true, reason: "wf-fix branch
+BEHIND=<BEHIND> > 1000, own diff <=15 in-scope ADDED-only files — skipped
+doomed server-side rebase", files: [...]}`.
+
+If `FAST_PATH=no`: proceed to the safe-case `gh pr merge --rebase` (or the
+artifact-confirmed path if Guard 3 said UNSAFE) exactly as before — this
+pre-check adds NO new behavior for normal branches. A branch that MODIFIES a
+workflow-surface file (status M ⇒ `ADDED_ONLY=no`) is deliberately not
+fast-pathed; it takes the ordinary `--rebase`.
 
 #### The auto-merge procedure (safe case: guard 3 clean — mainline-based, own commits in scope)
 
@@ -7057,11 +7213,29 @@ Decision tree:
   `ood_eval_results/issue_<N>/`). Compute:
 
   ```bash
-  # Files this branch ADDED (status A) vs origin/main, restricted to
-  # this task's own paths — never sweeps shared src/ or scripts/.
-  git -C "$WT" diff --name-only --diff-filter=A origin/main HEAD -- \
+  # Files this branch ADDED (status A ONLY) vs origin/main, restricted to
+  # this task's own paths PLUS the workflow surface (a workflow-fix branch's
+  # ADDED deliverable can be .claude/** / CLAUDE.md / .gitattributes). Never
+  # sweeps shared src/ or scripts/ — the new-shared-src/ guard above already
+  # refused the surgical path if the branch added src/.
+  #
+  # --diff-filter=A (ADDED-only), NEVER AM: this checkout does a WHOLESALE
+  # `git checkout issue-<N> -- <path>` below (~line for the xargs git checkout),
+  # which would OVERWRITE main's newer copy of a MODIFIED file with no conflict.
+  # A-only guarantees every listed path does not yet exist on main, so the
+  # checkout only CREATES — never clobbers. A branch that MODIFIES a
+  # workflow-surface file is not fast-path-eligible (predicate (e)) and reaches
+  # this block only via a genuine Guard-3 UNSAFE degrade, where the same
+  # A-only safety applies.
+  #
+  # Three-dot origin/main...HEAD (merge-base..HEAD): the branch's OWN adds only.
+  # Two-dot origin/main HEAD would additionally list files main advanced that
+  # the branch never touched (status M-because-main-advanced), pulling them into
+  # the checkout list — precisely the paths we must NOT overwrite.
+  git -C "$WT" diff --name-only --diff-filter=A origin/main...HEAD -- \
     "tasks/*/<N>/" "figures/issue_<N>/" "eval_results/issue_<N>/" \
     "eval_results/issue_<N>_*/" "ood_eval_results/issue_<N>/" \
+    ".claude/" "CLAUDE.md" ".gitattributes" "docs/methodology/issue_<N>.md" \
     > /tmp/issue-<N>-additive-files.txt
   ```
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# .gitattributes — introduced by workflow-fix task #787.
+#
+# Append-only JSONL task logs use a union merge so concurrent sessions'
+# appends never produce a hard merge conflict on a LOCAL merge/rebase.
+# events.jsonl is strictly append-only (task_workflow._append_jsonl_line,
+# O_APPEND); comments.jsonl is append-dominant (the dashboard may DELETE a
+# row to CLOSE an anchor-comment) — union is still preferred there because a
+# resurrected closed comment is a benign, self-healing UI artifact, whereas a
+# hard conflict blocks the whole Step-10d merge.
+#
+# SCOPE CAVEAT (verified 2026-07-01): GitHub's server-side `gh pr merge
+# --rebase` does NOT honor user-defined .gitattributes merge drivers — it uses
+# GitHub's own attributes. So merge=union takes effect ONLY on LOCAL merges/
+# rebases (the Step-10d merge-conflict-recovery `git merge origin/main`, and
+# the local `git pull --rebase=merges` fallbacks). Server-side conflict
+# avoidance is handled by the Step-10d Guard-1 foreign-folder strip + the
+# surgical-additive fast-path, NOT by this file.
+tasks/**/events.jsonl merge=union
+tasks/**/comments.jsonl merge=union
+
+# REGISTRY.json is deliberately NOT unioned — it is a last-writer-wins JSON
+# snapshot (atomic write-temp+rename), never append-only; a union merge would
+# concatenate two JSON objects into invalid JSON.
+# tasks/REGISTRY.json  -> (intentionally omitted; default last-writer-wins)

--- a/tests/test_step10d_guard3.py
+++ b/tests/test_step10d_guard3.py
@@ -1,0 +1,239 @@
+"""Content-invariant tests for the /issue Step-10d merge hardening (task #787).
+
+Step 10d's merge-strategy / guard-routing logic lives in SKILL.md PROSE
+(`.claude/skills/issue/SKILL.md`), not in importable Python — so the pragmatic
+way to pin its invariants is a set of content-string assertions over the skill
+file plus the new repo-root `.gitattributes`. This mirrors how other workflow
+invariants are pinned when the logic lives in a `.md` skill.
+
+The four #787 sub-fixes these tests guard:
+
+1. `.gitattributes` (NEW) — `merge=union` on the append-only task JSONL logs.
+2. Guard-1 — strip FOREIGN task folders before the merge, split by whether the
+   path exists on `origin/main` (checkout vs `git rm --cached`).
+3. Fast-path pre-check — a FIVE-conjunct predicate (incl. `ADDED_ONLY=yes`)
+   that routes far-behind small ADDED-only workflow-fix branches straight to
+   the surgical additive checkout, plus the surgical compute block's
+   ADDED-only / three-dot / workflow-surface-pathspec invariants (A3-new).
+4. Guard-3 — the spec-freshness exclusion matches the commit SUBJECT line only
+   (`awk 'index($0, "spec-freshness") == 0'`), never a subject+body `--grep`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SKILL = _REPO_ROOT / ".claude" / "skills" / "issue" / "SKILL.md"
+_GITATTRIBUTES = _REPO_ROOT / ".gitattributes"
+
+
+def _skill_text() -> str:
+    return _SKILL.read_text(encoding="utf-8")
+
+
+def _guard3_region(text: str) -> str:
+    """The Guard-3 slice: from the guard-3 heading to the fast-path heading.
+
+    Scoping the Guard-3 assertions to this slice keeps them independent of the
+    unrelated Step-5a spec-freshness sync (line ~1925), which legitimately uses
+    a `--grep='spec-freshness' --invert-grep` filter and MUST NOT be touched.
+    """
+    start_marker = "**Branch-content / non-`main`-base guard.**"
+    end_marker = "#### Fast-path routing pre-check"
+    start = text.find(start_marker)
+    end = text.find(end_marker)
+    assert start != -1, "Guard-3 heading not found in SKILL.md"
+    assert end != -1, "Fast-path pre-check heading not found in SKILL.md"
+    assert start < end, "Guard-3 region must precede the fast-path pre-check"
+    return text[start:end]
+
+
+def _surgical_compute_block(text: str) -> str:
+    """The surgical additive-checkout compute block (writes the additive-files
+    temp list). This is the block the A3-new invariant pins.
+
+    Bounded to exclude the new-shared-`src/` guard's OWN
+    `--diff-filter=A origin/main HEAD` scan, which is a DIFFERENT block that
+    legitimately stays two-dot and `src/`-scoped and must not be conflated.
+    """
+    anchor = "> /tmp/issue-<N>-additive-files.txt"
+    end = text.find(anchor)
+    assert end != -1, "surgical additive-files compute block not found"
+    # Look back to the start of that fenced compute block.
+    start = text.rfind("```bash", 0, end)
+    assert start != -1, "opening fence for surgical compute block not found"
+    return text[start : end + len(anchor)]
+
+
+# --------------------------------------------------------------------------
+# Sub-fix 1 — .gitattributes
+# --------------------------------------------------------------------------
+
+
+def test_gitattributes_exists_at_repo_root():
+    assert _GITATTRIBUTES.is_file(), f".gitattributes must exist at repo root ({_GITATTRIBUTES})"
+
+
+def test_gitattributes_union_merge_for_events_and_comments():
+    text = _GITATTRIBUTES.read_text(encoding="utf-8")
+    assert "tasks/**/events.jsonl merge=union" in text, "events.jsonl must use union merge"
+    assert "tasks/**/comments.jsonl merge=union" in text, "comments.jsonl must use union merge"
+
+
+def test_gitattributes_registry_not_unioned():
+    """REGISTRY.json is last-writer-wins; a union merge would break its JSON."""
+    text = _GITATTRIBUTES.read_text(encoding="utf-8")
+    # There must be no active (non-comment) union line for REGISTRY.json.
+    active_registry_union = [
+        ln
+        for ln in text.splitlines()
+        if "REGISTRY.json" in ln and "merge=union" in ln and not ln.lstrip().startswith("#")
+    ]
+    assert not active_registry_union, "REGISTRY.json must NOT carry an active merge=union line"
+
+
+# --------------------------------------------------------------------------
+# Sub-fix 2 — Guard-1 foreign-folder strip (present-vs-added split)
+# --------------------------------------------------------------------------
+
+
+def test_guard1_foreign_present_vs_added_split_present():
+    text = _skill_text()
+    assert "FOREIGN_ON_MAIN" in text, "Guard-1 must split FOREIGN by presence on origin/main"
+    assert "FOREIGN_BRANCH_ONLY" in text, (
+        "Guard-1 must track branch-only-added foreign paths separately"
+    )
+
+
+def test_guard1_branch_added_foreign_dropped_not_checked_out():
+    text = _skill_text()
+    assert "rm --cached -f --ignore-unmatch" in text, (
+        "Guard-1 must drop branch-added foreign paths via git rm --cached -f "
+        "--ignore-unmatch (a checkout would crash with pathspec-did-not-match)"
+    )
+
+
+def test_guard1_own_folder_carveout_present():
+    text = _skill_text()
+    assert 'grep -Ev "^tasks/[^/]+/<N>/"' in text, (
+        "Guard-1 must carve out THIS task's own tasks/*/<N>/ folder"
+    )
+
+
+# --------------------------------------------------------------------------
+# Sub-fix 3a — fast-path routing pre-check (five-conjunct predicate)
+# --------------------------------------------------------------------------
+
+
+def test_fast_path_pre_check_heading_present():
+    text = _skill_text()
+    assert "#### Fast-path routing pre-check" in text
+
+
+def test_fast_path_predicate_five_conjuncts():
+    text = _skill_text()
+    # The load-bearing ADDED-only conjunct + the pinned thresholds.
+    assert "FAST_PATH=yes" in text
+    assert "ADDED_ONLY=yes" in text, "the ADDED_ONLY gate must initialize to yes"
+    assert '"$ADDED_ONLY" = "yes"' in text, (
+        "the fast-path predicate must include the ADDED_ONLY=yes conjunct"
+    )
+    assert '"$BEHIND" -gt 1000' in text, "BEHIND_THRESHOLD literal 1000 must be present"
+    assert '"$N_FILES" -le 15' in text, "N_FILES_MAX literal 15 must be present"
+    assert '"$TASK_KIND" = "infra"' in text, "kind:infra conjunct must be present"
+    assert "grep -qw 'wf-fix'" in text, "wf-fix tag conjunct must be present"
+
+
+def test_fast_path_uses_added_only_status_gate():
+    text = _skill_text()
+    # A modified/renamed/deleted file must flip ADDED_ONLY off.
+    assert '[ "$st" = "A" ] || ADDED_ONLY=no' in text, "any non-Added status must set ADDED_ONLY=no"
+
+
+# --------------------------------------------------------------------------
+# Sub-fix 3b / A3-new — surgical-land invariant
+# --------------------------------------------------------------------------
+
+
+def test_surgical_compute_block_added_only_filter():
+    block = _surgical_compute_block(_skill_text())
+    assert "--diff-filter=A" in block, "surgical compute block must restrict to ADDED-only files"
+    assert "--diff-filter=AM" not in block, (
+        "surgical compute block must NOT use --diff-filter=AM (would clobber a "
+        "modified file wholesale)"
+    )
+
+
+def test_surgical_compute_block_three_dot_form():
+    block = _surgical_compute_block(_skill_text())
+    assert "origin/main...HEAD" in block, (
+        "surgical compute block must use the three-dot origin/main...HEAD form"
+    )
+    # The two-dot form (space, not ...) must not appear in THIS block.
+    assert "--diff-filter=A origin/main HEAD" not in block, (
+        "surgical compute block must NOT use the two-dot origin/main HEAD form"
+    )
+
+
+def test_surgical_compute_block_workflow_surface_pathspec_tokens():
+    block = _surgical_compute_block(_skill_text())
+    for token in (
+        '".claude/"',
+        '"CLAUDE.md"',
+        '".gitattributes"',
+        '"docs/methodology/issue_<N>.md"',
+    ):
+        assert token in block, f"surgical compute block must include the {token} pathspec entry"
+    # The pre-existing task-own pathspec entries must remain.
+    for token in (
+        '"tasks/*/<N>/"',
+        '"figures/issue_<N>/"',
+        '"eval_results/issue_<N>/"',
+        '"ood_eval_results/issue_<N>/"',
+    ):
+        assert token in block, f"surgical compute block must retain the existing {token} entry"
+
+
+def test_new_shared_src_guard_stays_two_dot_and_src_scoped():
+    """The DIFFERENT new-shared-src guard block must be left untouched: it stays
+    two-dot `origin/main HEAD` and scoped to src/ (NOT converted to three-dot)."""
+    text = _skill_text()
+    assert (
+        'git -C "$WT" diff --name-only --diff-filter=A origin/main HEAD -- \\\n'
+        '  "src/explore_persona_space/" > /tmp/issue-<N>-new-src.txt' in text
+    ), "the new-shared-src guard must remain two-dot origin/main HEAD, src-scoped"
+
+
+# --------------------------------------------------------------------------
+# Sub-fix 4 — Guard-3 spec-freshness subject-line-only exclusion
+# --------------------------------------------------------------------------
+
+
+def test_guard3_spec_freshness_subject_only_awk_filter():
+    text = _skill_text()
+    assert "awk 'index($0, \"spec-freshness\") == 0'" in text, (
+        "Guard-3 spec-freshness exclusion must match on the SUBJECT line only "
+        "via awk index(), not a subject+body --grep"
+    )
+
+
+def test_guard3_region_does_not_use_grep_spec_freshness():
+    """Within the Guard-3 slice, the exclusion must NOT be a `--grep` (which
+    matches the commit BODY too). The Step-5a sync at line ~1925 is a separate
+    region and keeps its own legitimate `--grep --invert-grep` filter."""
+    region = _guard3_region(_skill_text())
+    assert "--grep='spec-freshness'" not in region, (
+        "Guard-3 must not use --grep='spec-freshness' (over-matches commit body)"
+    )
+    assert "%H %s" in region, (
+        "Guard-3 must emit '<sha> <subject>' per commit for a subject-scoped filter"
+    )
+
+
+def test_step5a_grep_filter_untouched():
+    """Defensive: the unrelated Step-5a spec-freshness sync keeps its filter."""
+    text = _skill_text()
+    assert "--grep='spec-freshness' --invert-grep" in text, (
+        "the Step-5a sync's --grep filter must remain (it is out of #787 scope)"
+    )

--- a/tests/test_step10d_guard3.py
+++ b/tests/test_step10d_guard3.py
@@ -122,6 +122,57 @@ def test_guard1_own_folder_carveout_present():
 
 
 # --------------------------------------------------------------------------
+# Sub-fix 2 (round-2 fix) — push the Guard-1 strip commit BEFORE gh pr merge
+# --------------------------------------------------------------------------
+# The Guard-1 strip commit is a LOCAL worktree commit; the safe-case
+# `gh pr merge --rebase` rebases the PR head ref on origin/issue-<N>
+# (server-side), so an unpushed strip commit is invisible to that rebase and
+# the foreign tasks/* reverts would land on main silently. The safe case must
+# push the strip commit (guarded by STRIPPED_FOREIGN=yes) before merging, and
+# that push must APPEAR BEFORE the safe-case gh pr merge line in the file.
+
+
+def test_guard1_tracks_stripped_foreign_flag():
+    text = _skill_text()
+    assert "STRIPPED_FOREIGN=no" in text, (
+        "Guard-1 must initialize a STRIPPED_FOREIGN=no flag so the safe-case "
+        "push fires only when a strip commit was actually created"
+    )
+    assert "STRIPPED_FOREIGN=yes" in text, (
+        "Guard-1 must set STRIPPED_FOREIGN=yes after committing the strip"
+    )
+
+
+def test_safe_case_pushes_strip_commit_gated_on_stripped_foreign():
+    text = _skill_text()
+    assert 'git -C "$WT" push origin issue-<N>' in text, (
+        "the safe-case block must push the branch to the PR head ref before "
+        "gh pr merge --rebase (otherwise the strip commit is invisible to the "
+        "server-side rebase)"
+    )
+    assert '[ "$STRIPPED_FOREIGN" = "yes" ]' in text, (
+        "the safe-case push must be gated on STRIPPED_FOREIGN=yes so it fires "
+        "only when Guard-1 actually created a strip commit"
+    )
+
+
+def test_safe_case_push_appears_before_gh_pr_merge():
+    """The push must SEQUENCE before the safe-case gh pr merge --rebase call,
+    so the server-side rebase sees the stripped branch tip."""
+    text = _skill_text()
+    merge_line = "gh pr merge <PR> --rebase --delete-branch=false"
+    push_line = 'git -C "$WT" push origin issue-<N>'
+    merge_offset = text.find(merge_line)
+    push_offset = text.find(push_line)
+    assert merge_offset != -1, "safe-case gh pr merge line not found in SKILL.md"
+    assert push_offset != -1, "safe-case strip-commit push line not found in SKILL.md"
+    assert push_offset < merge_offset, (
+        "the Guard-1 strip-commit push must appear BEFORE the safe-case "
+        f"gh pr merge line (push@{push_offset} must precede merge@{merge_offset})"
+    )
+
+
+# --------------------------------------------------------------------------
 # Sub-fix 3a — fast-path routing pre-check (five-conjunct predicate)
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
Workflow-fix task #787. `kind: infra`, non-architectural, 0 GPU-h.

**Design:** four sub-fixes to Step 10d + a new `.gitattributes` at repo root. Adversarial-planner Phase 3 revise (Codex Must-Fix items applied): sub-fix 3 restricted to ADDED-only files (no wholesale-overwrite of MODIFIED workflow-surface files); Guard-1 split-by-existence; Guard-3 spec-freshness filter is SUBJECT-line-only.

**Test:** 16 new content-invariant assertions in `tests/test_step10d_guard3.py`. Pre-existing failures in `test_workflow_lint.py` on `scripts/issue744_dump_and_stream.py:87` (a `#745` bare-dotenv offender, unrelated) are flagged as such.

**Plan:** `tasks/planning/787/plans/plan.md` (v4; verify_plan.py PASS).

Closes task #787.