### PR TITLE
task #800: daily-fix — document WANDB_LOG_MODEL HF-Trainer checkpoint-upload trap in upload-policy.md

### DIFF
--- a/.claude/rules/upload-policy.md
+++ b/.claude/rules/upload-policy.md
@@ -153,6 +153,31 @@ upload (or under the fence) — when uploads fail-soft (e.g. quota 403), adapter
 accumulate on the pod's ~130GB MooseFS quota instead of being deleted, by
 design (upload-before-delete invariant).
 
+**`WANDB_LOG_MODEL` is a HuggingFace/WandB env var — NOT one of ours — and
+must stay unset (or `false`) in every training environment.** Distinct from
+the three project-owned WandB checkpoint-upload sites above — all gated by
+`EPM_UPLOAD_MODEL_WANDB=1` (default OFF; landed commit `b4474042b7`):
+`orchestrate/hub.py:1462` (`upload_model_wandb`),
+`train/trainer.py:477` (`_maybe_upload_checkpoint_to_wandb`), and its
+`train/sft.py:1526` call site — HF `Trainer` installs a built-in
+`WandbCallback` whenever `report_to="wandb"` (which every project training
+run with a WandB run name sets — `train/trainer.py:943`/`:1309`). That
+callback reads `WANDB_LOG_MODEL` from the environment at init: `end` uploads
+the checkpoint dir to WandB Artifacts at end of training, `checkpoint`
+uploads every `save_steps` (older Transformers also accepted the deprecated
+boolean alias `true` ≈ `end`), and the default `false`/unset uploads
+nothing. This path is INDEPENDENT of our `_maybe_upload_*` code — so
+`EPM_UPLOAD_MODEL_WANDB=1` does NOT gate it and setting `WANDB_LOG_MODEL`
+re-opens the ~15 GB-safetensors-to-WandB leak regardless of our guard.
+Therefore `WANDB_LOG_MODEL` must never be set (or must be explicitly
+`false`/`0`) in any environment where training runs — `bootstrap_pod.sh`,
+the GCE startup prelude, the SLURM sbatch env block, `.env`, and launch
+shells (it is currently unset in all of them; keep it that way). This is
+the surface that let ~784 GB of checkpoints accumulate on WandB before the
+`EPM_UPLOAD_MODEL_WANDB` guard landed on 2026-06-29 (the 2026-06-30 4TB
+cleanup; only-on-WandB orphans were archived to the private
+`superkaiba1/explore-persona-space-wandb-archive` repo before deletion).
+
 **Delete-after-eval sweeps MUST persist the ADAPTER first (never the merged dir).**
 A sweep that `rm`s a trained checkpoint after its eval to stay under the MooseFS
 ~130GB quota (the #404/#458 pattern) MUST set `EPM_PERSIST_ADAPTER_HF_REPO` +

--- a/.claude/rules/upload-policy.md
+++ b/.claude/rules/upload-policy.md
@@ -163,10 +163,12 @@ the three project-owned WandB checkpoint-upload sites above — all gated by
 `WandbCallback` whenever `report_to="wandb"` (which every project training
 run with a WandB run name sets — `train/trainer.py:943`/`:1309`). That
 callback reads `WANDB_LOG_MODEL` from the environment at init: `end` uploads
-the checkpoint dir to WandB Artifacts at end of training, `checkpoint`
-uploads every `save_steps` (older Transformers also accepted the deprecated
-boolean alias `true` ≈ `end`), and the default `false`/unset uploads
-nothing. This path is INDEPENDENT of our `_maybe_upload_*` code — so
+the final saved model artifact to WandB Artifacts at end of training
+(`WandbCallback.on_train_end` saves the model into a temp dir and logs
+THAT — not an existing checkpoint dir), `checkpoint` uploads the actual
+checkpoint dir every `save_steps` via `on_save` (older Transformers also
+accepted the deprecated boolean alias `true` ≈ `end`), and the default
+`false`/unset uploads nothing. This path is INDEPENDENT of our `_maybe_upload_*` code — so
 `EPM_UPLOAD_MODEL_WANDB=1` does NOT gate it and setting `WANDB_LOG_MODEL`
 re-opens the ~15 GB-safetensors-to-WandB leak regardless of our guard.
 Therefore `WANDB_LOG_MODEL` must never be set (or must be explicitly


### PR DESCRIPTION
Closes task #800.

**Kind:** infra (workflow-fix)
**Target file:** `.claude/rules/upload-policy.md`
**Diff size:** +25 / -0 across 1 file
**GPU-h:** 0

## Summary

Adds one bold-led paragraph to `.claude/rules/upload-policy.md` documenting HF Trainer's built-in `WandbCallback` — a checkpoint-auto-upload path SEPARATE from the project's own `hub.py` / `_maybe_upload_checkpoint_to_wandb` code — and reiterating that:
- `WANDB_LOG_MODEL` (HF `WandbCallback`'s env var) must stay UNSET across bootstrap / GCE / SLURM / `.env` / shells;
- `EPM_UPLOAD_MODEL_WANDB=1` gates the project's OWN inline paths only (default OFF, guard landed 2026-06-29 in `b4474042b7`);
- ~784 GB of safetensors checkpoints accumulated on WandB before that guard landed.

Inserted between the "Merged-dir HF uploads are opt-in" and "Delete-after-eval sweeps" paragraphs so the WandB-checkpoint-upload thread stays contiguous.

## Pipeline verdicts on this branch

- Plan v4, `verify_plan.py`: PASS (0 fail, 0 warn).
- Consistency-checker: PASS.
- Adversarial-planner Phase 2 (Claude ensemble): APPROVE across all three lenses (Methodology / Statistics / Alternatives).
- Code-reviewer: PASS. Every load-bearing factual claim (guard sites at `hub.py:1462`, `trainer.py:477`, `sft.py:1526/1556`; `report_to="wandb"` conditions at `trainer.py:943/1309`; `WandbLogModel` enum semantics; commit `b4474042b7`; `WANDB_LOG_MODEL` unset repo-wide) independently verified against ground truth.
- Test-verdict: PASS (1876 passed / 2 skipped / 5 pre-existing main-tree failures unrelated to this diff — see `epm:test-verdict v2` marker for full breakdown).
- Ruff: PASS (no-op on markdown).

## Follow-up

- **Non-blocking, distinct fingerprint** (recursion-guarded — logged only): the Alternatives critic surfaced a workflow-fix candidate to add a `workflow_lint.py --check-wandb-log-model-unset` (and/or `orchestrate/env.py` env-var pop) as a mechanical enforcement sibling of this doc note. See `epm:workflow-fix-candidate v1` on task #800.
- **Pre-existing main-tree fault, out of scope for #800**: `scripts/issue744_dump_and_stream.py:87` violates the `--check-dotenv-before-hf-import` lint (3 workflow_lint tests currently red on main). Warrants a separate `kind: infra` task.