### PR TITLE
issue-803: pod-side short-circuit in clean_experiment_downloads.py

### DIFF
--- a/scripts/clean_experiment_downloads.py
+++ b/scripts/clean_experiment_downloads.py
@@ -135,6 +135,23 @@ def hf_data_repo() -> str:
 DISK_GUARD_SIDECAR_REL = Path(".claude") / "cache" / "disk-guard-events.jsonl"
 
 
+def _running_pod_side() -> bool:
+    """True when running on a RunPod pod (NOT the dev VM).
+
+    On a pod, importing/using ``task_workflow.repo_root()`` on a non-``main``
+    HEAD auto-routes to a managed worktree via ``git worktree add`` /
+    ``git reset --hard`` on MooseFS-backed ``/workspace``, which hangs
+    indefinitely (#803, pod-778). Detected by two conditions that both hold on
+    every RunPod pod (the container has ``/.dockerenv``; ``bootstrap_pod.sh``
+    creates ``/workspace/logs``). ``/workspace/logs`` alone is used as a pod
+    signal elsewhere (e.g. ``scripts/issue634_extract_behavior_vectors.py``),
+    but on the dev VM ``/workspace/logs`` is a real populated dir — so the
+    ``/.dockerenv`` conjunct is load-bearing: it is what makes the AND False
+    on the VM and prevents a dev-VM false-positive (which would silently
+    no-op a VM-side reap)."""
+    return Path("/.dockerenv").exists() and Path("/workspace/logs").is_dir()
+
+
 def disk_guard_sidecar_path() -> Path:
     """Absolute path of the shared disk-guard escalation sidecar JSONL."""
     return repo_root() / DISK_GUARD_SIDECAR_REL
@@ -713,6 +730,18 @@ def _fmt_gb(n: int) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
+    # Pod-side short-circuit (#803): on a RunPod pod any use of
+    # task_workflow.repo_root() on a non-main HEAD hangs on MooseFS
+    # (git worktree add / git reset --hard never completes). The between-phase
+    # disk-hygiene call is contracted as pod-safe; make it a fast no-op here.
+    # There are no hf_dl/g*_dl caches to reap that repo_root() would find on a
+    # pod anyway, so returning 0 is behaviorally correct, not just a bail-out.
+    if _running_pod_side():
+        print(
+            "clean_experiment_downloads.py: pod-side no-op "
+            "(repo_root() worktree auto-routing hangs on MooseFS; #803)"
+        )
+        return 0
     ap = argparse.ArgumentParser(
         description=(
             "Delete a finished experiment's HF-download caches "

--- a/tests/test_clean_experiment_downloads_pod_side_short_circuit.py
+++ b/tests/test_clean_experiment_downloads_pod_side_short_circuit.py
@@ -1,0 +1,84 @@
+"""Tests for the pod-side short-circuit in scripts/clean_experiment_downloads.py (#803).
+
+On a RunPod pod, any use of task_workflow.repo_root() on a non-main HEAD auto-routes
+to a managed worktree via git worktree add / git reset --hard, which hangs on
+MooseFS-backed /workspace. main() must detect the pod and return 0 BEFORE any
+helper calls repo_root(). Detector: /.dockerenv AND /workspace/logs both present.
+
+The script lives under scripts/ (not an importable package), so it is loaded via
+importlib exactly like tests/test_clean_experiment_downloads_parity.py.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+
+def _load(mod_name: str):
+    spec = importlib.util.spec_from_file_location(mod_name, _SCRIPTS / f"{mod_name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ced = _load("clean_experiment_downloads")
+
+
+def test_pod_side_short_circuits_to_noop_zero(monkeypatch, capsys):
+    """Detector True -> main() returns 0, prints the no-op notice, and never
+    touches repo_root() (a repo_root that raises proves it was never called)."""
+    monkeypatch.setattr(ced, "_running_pod_side", lambda: True)
+
+    def _boom():
+        raise AssertionError("repo_root() must not be called pod-side")
+
+    monkeypatch.setattr(ced, "repo_root", _boom)
+    rc = ced.main(["778", "--incremental", "--apply"])
+    assert rc == 0
+    assert "pod-side no-op" in capsys.readouterr().out
+
+
+def test_detector_true_only_when_both_signals_present(monkeypatch):
+    """_running_pod_side() is the AND of /.dockerenv and /workspace/logs."""
+    real_exists = Path.exists
+    real_is_dir = Path.is_dir
+
+    def _exists(self):
+        return str(self) == "/.dockerenv" or real_exists(self)
+
+    def _is_dir(self):
+        return str(self) == "/workspace/logs" or real_is_dir(self)
+
+    # both present -> True
+    monkeypatch.setattr(Path, "exists", _exists)
+    monkeypatch.setattr(Path, "is_dir", _is_dir)
+    assert ced._running_pod_side() is True
+
+    # only /.dockerenv present (/workspace/logs missing) -> False.
+    # NB /workspace/logs exists on this dev VM, so force it absent explicitly
+    # rather than restoring the real is_dir (which would leave it present).
+    def _is_dir_no_logs(self):
+        return False if str(self) == "/workspace/logs" else real_is_dir(self)
+
+    monkeypatch.setattr(Path, "is_dir", _is_dir_no_logs)
+    assert ced._running_pod_side() is False
+
+
+def test_vm_side_runs_normal_dispatch(monkeypatch):
+    """Detector False -> main() reaches the normal dispatch (proven by a
+    sentinel cleaner that records the call and returns a real CleanResult)."""
+    monkeypatch.setattr(ced, "_running_pod_side", lambda: False)
+    called = {}
+
+    def _fake_cleaner(issue, *, apply, data_root=None):
+        called["issue"] = issue
+        called["apply"] = apply
+        return ced.CleanResult(issue_n=issue, apply=apply)
+
+    monkeypatch.setattr(ced, "clean_issue_downloads_incremental", _fake_cleaner)
+    rc = ced.main(["778", "--incremental", "--apply"])
+    assert rc == 0
+    assert called == {"issue": 778, "apply": True}


### PR DESCRIPTION
Closes task #803.

Add pod-side short-circuit to `scripts/clean_experiment_downloads.py`. When running on a RunPod pod (`/.dockerenv` + `/workspace/logs` both present), `main()` returns 0 immediately BEFORE any code path that calls `task_workflow.repo_root()` fires. Prevents the confirmed 15-min hang on pod-778 where `repo_root()`'s non-`main` branch-guard auto-routes to a managed worktree via `git worktree add + git reset --hard main`, which never completes on MooseFS-backed `/workspace`.

VM guard rests on `/.dockerenv`'s absence: `/workspace/logs` IS present on the dev VM `cia-benchmark-vm`; the `/.dockerenv` conjunct is load-bearing. Broader `task_workflow.repo_root()` pod-side fail-loud deferred to a follow-up (plan §11 item 2).

Adds 3-test regression suite; existing 34 tests still pass; lint clean.