### PR TITLE
workflow-fix (#814): tighten SKILL_REF_RE against codespan-closing-backtick FP

### DIFF
--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -294,13 +294,24 @@ HISTORICAL_REF_OPT_OUT = "<!-- lint: historical-ref -->"
 
 # `--check-skill-refs`: every backtick-delimited `/<skill-name>` slash-command
 # token in the workflow-doc surface MUST resolve to a live project skill (a
-# `.claude/skills/<name>/` directory) or to SKILL_REF_ALLOWLIST. Backtick-anchor
-# + trailing lookahead are the FP controls: only the slash-command convention
-# matches, and a path segment (`/workspace/logs`, `/tmp/x`, `/mnt/...`) is
-# rejected because the char after the token is `/`, not the required
-# backtick / whitespace / `)` boundary. Group 1 = skill name, optionally
-# `<plugin>:<skill>`.
-SKILL_REF_RE = re.compile(r"`/([a-z][a-z0-9-]+(?::[a-z0-9-]+)?)(?=[`\s)])")
+# `.claude/skills/<name>/` directory) or to SKILL_REF_ALLOWLIST. Three FP
+# controls, all load-bearing (do NOT "simplify" any away):
+#   1. leading backtick anchor — the slash-command must OPEN a codespan;
+#   2. trailing lookahead `(?=[`\s)])` — the token must CLOSE on a backtick /
+#      whitespace / `)`, so a path segment (`/workspace/logs`, `/tmp/x`,
+#      `/mnt/...`) is rejected (the char after it is `/`, not the boundary);
+#   3. fixed-width negative-lookbehind `(?<!\w)` on the leading backtick — the
+#      backtick that OPENS the codespan must NOT be immediately preceded by a
+#      word char. This guards the closing-backtick-mistaken-for-opening FP
+#      class: prose like `` `false`/unset `` writes a `` `false` `` codespan
+#      whose CLOSING backtick abuts `/unset`; without (3) that closing
+#      backtick is misread as the OPENING backtick of a phantom `` `/unset ``
+#      slash-command (the trailing lookahead then succeeds on the following
+#      space). A closing backtick is always immediately preceded by a word
+#      char, so `(?<!\w)` rejects exactly that misread while leaving every
+#      real opening backtick (at start-of-line / after whitespace / `(` / `[`)
+#      matched. Group 1 = skill name, optionally `<plugin>:<skill>`.
+SKILL_REF_RE = re.compile(r"(?<!\w)`/([a-z][a-z0-9-]+(?::[a-z0-9-]+)?)(?=[`\s)])")
 
 _FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
 

--- a/tests/test_workflow_lint.py
+++ b/tests/test_workflow_lint.py
@@ -695,6 +695,68 @@ def test_check_skill_refs_mixed_good_and_dangling(tmp_path):
     assert "a.md:2" in errors[0]
 
 
+def test_check_skill_refs_no_fp_on_codespan_closing_backtick_slash(tmp_path):
+    """Regression guard (#814): the closing-backtick-mistaken-for-opening FP.
+
+    Prose like ``` `false`/unset uploads nothing``` writes a ``` `false` ```
+    codespan whose CLOSING backtick immediately abuts ``/unset``. Before the
+    `(?<!\\w)` negative-lookbehind, SKILL_REF_RE misread that closing backtick
+    as the OPENING backtick of a phantom ``` `/unset ``` slash-command and the
+    line FAILed with a spurious "unresolved skill reference `/unset`" (the
+    surfaced `main` regression this fix resolves — verbatim from
+    `.claude/rules/upload-policy.md:171`). The tightened regex must NOT match:
+    a backtick abutting a word char (the codespan's closing `` ` ``) cannot
+    open a slash-command. The sibling ``` `false`/`0` ``` shape (a second
+    slashed-codespan prose form) is included to document it stays unmatched
+    too."""
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text(
+        "`false`/unset uploads nothing.\nWhen `false`/`0` it uploads nothing.\n"
+    )
+    errors = check_skill_references(roots=[docs], skills_dir=skills, allowlist=frozenset())
+    assert errors == [], f"expected PASS (codespan closing backtick not an opener), got: {errors}"
+
+
+def test_check_skill_refs_matches_legit_ref_after_boundary(tmp_path):
+    """The negative-lookbehind must NOT drop a legitimate `/name` ref reached
+    across a non-word-char boundary — start-of-line, whitespace, `(`, and the
+    plugin-namespace form all still resolve — AND a genuinely dead `/ghost`
+    ref after such a boundary still surfaces as the one unresolved error, so
+    detection strength is preserved. The word-char-abutting `word`/skill` shape
+    is the EXPLICIT drop: the backtick there closes a preceding codespan (the
+    closing-backtick FP class the `(?<!\\w)` defuses), so it is correctly
+    NON-matching and never becomes an error even though `skill` names a live
+    dir."""
+    skills = tmp_path / "skills"
+    (skills / "weekly").mkdir(parents=True)
+    (skills / "skill").mkdir(parents=True)
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    # Live positives reached across each non-word-char boundary the lookbehind
+    # must NOT reject: start-of-line, whitespace, `(`, and the namespaced form.
+    (docs / "a.md").write_text(
+        "`/weekly` at column zero.\n"
+        "Run `/weekly` after a space.\n"
+        "Wrapped (`/weekly`) in parens.\n"
+        "Namespaced `/codex:rescue` still resolves.\n"
+        # word-char-abutting: the leading backtick CLOSES `word`, so `/skill`
+        # is NOT read as a slash-command — the defused FP class. Even though a
+        # `skill` dir exists, this must never produce a match/error.
+        "Prose word`/skill` is a closing-codespan backtick, not an opener.\n"
+        # A genuinely dangling ref after a legitimate boundary still FAILs.
+        "Dead `/ghost` after a space.\n"
+    )
+    errors = check_skill_references(
+        roots=[docs], skills_dir=skills, allowlist=frozenset({"codex:"})
+    )
+    assert len(errors) == 1, f"expected exactly one error (the dangling /ghost), got: {errors}"
+    assert "/ghost" in errors[0], f"expected the /ghost ref flagged, got: {errors}"
+    assert "a.md:6" in errors[0], f"expected the error anchored to the /ghost line, got: {errors}"
+
+
 def test_check_skill_refs_repo_tree_is_clean():
     """Green-on-main guard: the committed workflow surface (agents + skills +
     rules + CLAUDE.md + workflow.yaml) carries no unresolved skill refs under


### PR DESCRIPTION
Closes task #814.

Tightens `scripts/workflow_lint.py:314` `SKILL_REF_RE` by prepending a fixed-width negative-lookbehind `(?<!\w)` to the leading backtick. Resolves the surfaced FP on `.claude/rules/upload-policy.md:171` (```false`/unset```) and closes the whole codespan-closing-backtick prose FP class (16 shape-hits across 11 files, 15 previously allowlist-masked).

- Plan: task #814 v2 (adversarial-planner ensemble unanimous APPROVE: 3 lenses × Claude+Codex + Consistency-checker PASS).
- Fact-checker: all 9 assumptions verified.
- Code review ensemble: Claude PASS + Codex CONCERNS (both PASS-class → agree PASS; single minor test-name-literal mismatch, no behavioral risk).
- Test-verdict: PASS (2 new tests + 13 existing test_check_skill_refs_* cases pass; 5 unrelated pre-existing test failures reproduce identically on pristine main and are recursion-guarded).
- Diff: 2 files, workflow_lint.py + test_workflow_lint.py. Ruff clean.