### PR TITLE
task #818: watcher reaps idle-unmapped wrappers on orphaned (socketless) tmux servers

### DIFF
--- a/.claude/rules/background-automation.md
+++ b/.claude/rules/background-automation.md
@@ -351,7 +351,23 @@ controlling TTY (a live user terminal), and sessions whose transcript cannot
 be resolved (a missing idleness signal FAILS TOWARD KEEP);
 `EPM_UNMAPPED_IDLE_REAP=0` reverts to alert-only; records land in
 `~/.eps-autonomous/idle-unmapped-events.jsonl` (an unmapped session has no
-task to carry a marker). **#720 short-window subclass:** an unmapped session
+task to carry a marker). **#818 orphaned-tmux subclass:** a pane on an ORPHANED
+tmux server (the server's socket was deleted from `$TMUX_TMPDIR/tmux-<uid>` so
+NO new client can attach, AND the server holds zero `/dev/pts` attached-client
+fds) is NOT a live terminal — that pane is unreachable by construction, so
+`_is_live_user_tty` no longer counts it as live and the idle-≥12h wrapper on it
+is reaped on the same ≥2-consecutive-miss schedule as everything else. The
+mapping is process PARENTAGE (walk the wrapper's `ppid` chain for a
+`comm == "tmux: server"` ancestor — the pane leaders are its child processes),
+NOT the server's fd table. BOTH signals are required — a socketless-BUT-attached
+server (e.g. a systemd-tmpfiles atime sweep of `/tmp/tmux-<uid>/` under a live
+SSH session leaves the established connection intact) still holds ≥1 client fd
+and is KEPT. Every uncertain probe (tmux absent, unreadable
+`/proc/<pid>/stat` or `/proc/<pid>/comm`, unreadable socket dir, unreadable
+server fd dir, a ppid-walk cycle, depth exhaustion, no `tmux: server`
+ancestor) FAILS TOWARD KEEP. Gated by the
+default-ON `EPM_ORPHANED_TMUX_REAP` kill-switch (`=0` disables the widening,
+same shape as `EPM_UNMAPPED_IDLE_REAP`). **#720 short-window subclass:** an unmapped session
 whose LAST-mapped task was TERMINAL — the "zombie session on a completed task"
 ghost class (the respawn pass deletes `issue-<N>.json` at terminal → the
 session goes unmapped, and its repo-root cwd can't re-map it) — is reaped on

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -11264,8 +11264,9 @@ def _wrapper_on_orphaned_tmux_server(
       * tmux binary absent -> False (nothing to reap; unchanged behavior);
       * ppid unreadable at a hop -> stop the walk, return False (cannot prove a
         ``tmux: server`` ancestor -> keep);
-      * comm unreadable at a hop -> the hop is not confirmed ``tmux: server``,
-        the walk continues (then stops on an unreadable ppid / depth) -> keep;
+      * comm unreadable at a hop -> STOP the walk, return False (the hop cannot
+        be classified, so a socketless clientless ``tmux: server`` reachable
+        BEYOND it must NOT reap the wrapper -> keep; #818 round-2 fix);
       * socket dir unreadable -> :func:`_live_tmux_socket_present` True ->
         reads reattachable -> False (keep);
       * server client-fd dir unreadable (:func:`_tmux_server_client_ttys` None)
@@ -11283,7 +11284,10 @@ def _wrapper_on_orphaned_tmux_server(
         if cur in seen or cur <= 1:
             return False  # cycle / reached init without a tmux: server
         seen.add(cur)
-        if _proc_comm(cur, proc_root) == "tmux: server":
+        comm = _proc_comm(cur, proc_root)
+        if comm is None:
+            return False  # unreadable comm at a hop -> cannot classify -> keep
+        if comm == "tmux: server":
             server_pid = cur
             # Condition 1: no socket -> no NEW attach possible.
             if _live_tmux_socket_present():

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -11128,6 +11128,178 @@ def zombie_wrapper_pass(
 
 IDLE_UNMAPPED_STATE_PREFIX = "idle-unmapped-"
 
+
+def _orphaned_tmux_reap_enabled() -> bool:
+    """True unless ``EPM_ORPHANED_TMUX_REAP`` is explicitly set to a falsy
+    value (``0`` / ``false`` / ``no``) — the kill-switch for the
+    orphaned-tmux-server widening of the idle-unmapped live-user-TTY guard.
+    Same parse as :func:`_unmapped_idle_reap_enabled`."""
+    raw = os.environ.get("EPM_ORPHANED_TMUX_REAP", "")
+    return raw.strip().lower() not in {"0", "false", "no"}
+
+
+def _tmux_socket_dir() -> Path:
+    """The tmux socket directory: ``$TMUX_TMPDIR/tmux-<uid>`` when set, else
+    ``/tmp/tmux-<uid>`` (the documented default — tmux(1): sockets live in
+    ``tmux-UID`` under ``$TMUX_TMPDIR`` or ``/tmp``)."""
+    base = os.environ.get("TMUX_TMPDIR", "").strip() or "/tmp"
+    return Path(base) / f"tmux-{os.getuid()}"
+
+
+def _live_tmux_socket_present() -> bool:
+    """True iff AT LEAST ONE socket file exists in the tmux socket dir.
+
+    Distinguishes "a tmux server is reattachable" (a socket file present, a
+    new client can attach) from "a server exists but its socket was deleted"
+    (no socket file — unreattachable). An unreadable dir returns True (fail
+    toward keep: we cannot prove any server is socket-less)."""
+    d = _tmux_socket_dir()
+    try:
+        return any(p.is_socket() for p in d.iterdir())
+    except OSError:
+        return True  # cannot read the dir -> cannot prove orphaned -> keep
+
+
+def _proc_comm(pid: int, proc_root: Path) -> str | None:
+    """``comm`` (process name) from ``<proc_root>/<pid>/comm``, or ``None`` if
+    unreadable (raced exit / perms)."""
+    try:
+        return (proc_root / str(pid) / "comm").read_text().strip()
+    except OSError:
+        return None
+
+
+def _proc_ppid(pid: int, proc_root: Path) -> int | None:
+    """``ppid`` from ``<proc_root>/<pid>/stat``, or ``None`` if unreadable.
+
+    Same parse as :func:`_wrapper_has_controlling_tty` / ``_proc_children_map``:
+    the ``comm`` field (parenthesised, may contain spaces/parens) is skipped by
+    splitting after the LAST ``)``; the remaining fields are
+    ``state(0) ppid(1) pgrp(2) ...``."""
+    try:
+        stat = (proc_root / str(pid) / "stat").read_text()
+        return int(stat.rsplit(")", 1)[1].split()[1])
+    except (OSError, IndexError, ValueError):
+        return None
+
+
+def _tmux_server_client_ttys(server_pid: int, proc_root: Path) -> set[str] | None:
+    """The set of ATTACHED-CLIENT terminal ttys a tmux server currently holds,
+    read from ``<proc_root>/<server_pid>/fd/*`` symlinks that resolve to a
+    ``/dev/pts/N`` device — or ``None`` if the fd dir is UNREADABLE
+    (perms / race).
+
+    LOAD-BEARING no-attached-client proof. A tmux server receives each attached
+    client's terminal fd via ``SCM_RIGHTS``, so a server WITH attached clients
+    holds one ``/dev/pts`` fd per client; a server with ZERO clients holds none.
+    Verified live: a server's ``/dev/pts`` fd set equalled
+    ``tmux list-clients -F '#{client_tty}'`` exactly. The pane-master
+    ``/dev/ptmx`` fds and the AF_UNIX ``socket:[inode]`` fds do NOT resolve to
+    ``/dev/pts`` so they never false-positive; the pane SLAVE ttys are held by
+    the pane CHILD processes, not the server, so are absent from this set.
+
+    Returns:
+      * a set (possibly EMPTY) of ``/dev/pts`` client-terminal paths when the fd
+        dir was readable — an EMPTY set is POSITIVE proof of zero clients;
+      * ``None`` when the fd dir could not be read, OR any single fd symlink
+        could not be read (perms / raced exit) — the caller MUST treat ``None``
+        as "cannot prove zero clients" -> KEEP (strictly fail-toward-keep)."""
+    fd_dir = proc_root / str(server_pid) / "fd"
+    out: set[str] = set()
+    try:
+        fds = list(fd_dir.iterdir())
+    except OSError:
+        return None  # unreadable dir -> uncertain -> caller keeps
+    for fd in fds:
+        try:
+            target = os.readlink(fd)
+        except OSError:
+            # A single unreadable fd means we cannot enumerate the full client
+            # set; to stay strictly fail-toward-keep, treat ANY unreadable fd in
+            # the dir as "cannot prove zero clients".
+            return None
+        if target.startswith("/dev/pts/"):
+            out.add(target)
+    return out
+
+
+def _wrapper_on_orphaned_tmux_server(
+    pid: int, *, proc_root: Path = Path("/proc"), max_depth: int = 50
+) -> bool:
+    """True iff the wrapper is parented (directly or transitively) by a
+    ``tmux: server`` process AND that server is PROVABLY UNREATTACHABLE AND
+    HAS ZERO ATTACHED CLIENTS (nobody can reattach AND nobody is attached right
+    now — the orphaned-tmux class this fix reaps).
+
+    Mapping is PROCESS PARENTAGE, NOT the server's fd table: a tmux server's
+    pane leaders are its DIRECT CHILD processes (``ppid == server_pid``), and a
+    daemon-tracked ``node /usr/bin/happy claude`` wrapper IS that child. (The
+    server's own ``/proc/<pid>/fd`` pts set is the CLIENT terminals — disjoint
+    from its panes' ``pane_tty``s — so it must NOT be used for the mapping.)
+
+    Walk the ``ppid`` chain from ``pid`` (bounded by ``max_depth`` + a seen-set
+    cycle guard) to find the owning ``tmux: server``. Once found, return True
+    ONLY when BOTH:
+      1. the tmux socket dir has NO socket file
+         (:func:`_live_tmux_socket_present` False) -> no NEW client can attach;
+         AND
+      2. the server holds ZERO ``/dev/pts`` client fds
+         (:func:`_tmux_server_client_ttys` returns an EMPTY set) -> no client is
+         attached RIGHT NOW.
+
+    Rationale for signal 2: an established AF_UNIX connection SURVIVES
+    ``unlink()`` of the listener path (the deleted path blocks only NEW
+    attaches — the same reason the ``kill -USR1`` socket-recreation recovery
+    exists). So socket-dir absence ALONE does NOT prove "no attached client": a
+    systemd-tmpfiles atime sweep of ``/tmp/tmux-<uid>/`` under a LIVE attached
+    SSH session leaves a socketless-but-attached server. Reaping its idle
+    session would kill a session a user is looking at; the client-fd proof
+    (condition 2) is the fail-toward-keep guard that blocks that false reap.
+
+    If NO ``tmux: server`` ancestor is found (raw login pts, ssh, a non-tmux
+    parent, or the chain hit pid 1 / an unreadable link) -> False (not our
+    class -> the caller keeps it via its other branches).
+
+    Fail-toward-keep on EVERY uncertain signal:
+      * tmux binary absent -> False (nothing to reap; unchanged behavior);
+      * ppid unreadable at a hop -> stop the walk, return False (cannot prove a
+        ``tmux: server`` ancestor -> keep);
+      * comm unreadable at a hop -> the hop is not confirmed ``tmux: server``,
+        the walk continues (then stops on an unreadable ppid / depth) -> keep;
+      * socket dir unreadable -> :func:`_live_tmux_socket_present` True ->
+        reads reattachable -> False (keep);
+      * server client-fd dir unreadable (:func:`_tmux_server_client_ttys` None)
+        -> cannot prove zero clients -> False (keep);
+      * server holds >=1 ``/dev/pts`` client fd -> a client is attached ->
+        False (keep).
+    The predicate can only ever return True for a CONFIRMED
+    ``tmux: server``-parented + socket-absent + provably-zero-clients wrapper;
+    every ambiguity -> False (keep)."""
+    if shutil.which("tmux") is None:
+        return False
+    seen: set[int] = set()
+    cur = pid
+    for _ in range(max_depth):
+        if cur in seen or cur <= 1:
+            return False  # cycle / reached init without a tmux: server
+        seen.add(cur)
+        if _proc_comm(cur, proc_root) == "tmux: server":
+            server_pid = cur
+            # Condition 1: no socket -> no NEW attach possible.
+            if _live_tmux_socket_present():
+                return False  # reattachable -> keep
+            # Condition 2: prove ZERO attached clients right now.
+            clients = _tmux_server_client_ttys(server_pid, proc_root)
+            if clients is None:
+                return False  # cannot prove zero clients -> keep
+            return len(clients) == 0  # orphaned iff no client attached
+        ppid = _proc_ppid(cur, proc_root)
+        if ppid is None:
+            return False  # unreadable -> cannot prove orphaned -> keep
+        cur = ppid
+    return False  # depth exhausted without a tmux: server ancestor -> keep
+
+
 # Default transcript-idle window before an unmapped session is reapable.
 # 12h: long enough that an overnight pause in a chat session Thomas means to
 # come back to survives, short enough that the accumulation class (19-43h
@@ -11613,7 +11785,12 @@ def _idle_unmapped_debug_enabled() -> bool:
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _is_live_user_tty(pid: int, detached_tmux_ttys: set[str]) -> bool:
+def _is_live_user_tty(
+    pid: int,
+    detached_tmux_ttys: set[str],
+    *,
+    check_orphaned: bool = False,
+) -> bool:
     """True iff this wrapper holds a controlling tty that a user could be
     looking at RIGHT NOW — the refined "Thomas may literally be sitting here"
     guard for the idle-unmapped pass.
@@ -11627,13 +11804,56 @@ def _is_live_user_tty(pid: int, detached_tmux_ttys: set[str]) -> bool:
     cannot be cross-referenced to a detached pane) is treated as live and
     kept, preserving the conservative default. An unreadable /proc (race /
     perms) keeps the keep-leaning :func:`_wrapper_has_controlling_tty`
-    semantics (returns True)."""
+    semantics (returns True).
+
+    PLUS (``check_orphaned=True``, the idle-unmapped pass under the default-ON
+    ``EPM_ORPHANED_TMUX_REAP`` knob): a wrapper parented by an ORPHANED tmux
+    server (socket deleted -> unreattachable, AND zero attached clients) is NOT
+    a live-user tty either — that pane is unreachable by construction, so it
+    falls through to the same transcript-idle check. This branch keys on the
+    wrapper's PID via process parentage (:func:`_wrapper_on_orphaned_tmux_server`),
+    NOT on the ``tty_path`` string, so it fires even when the pts is
+    unresolvable. Both the detached-pane and orphaned-server checks fail toward
+    keep on any unresolved signal. The default-``False`` keyword arg preserves
+    every existing 2-arg caller (the new branch never runs when omitted)."""
     if not _wrapper_has_controlling_tty(pid):
         return False
     tty_path = _wrapper_controlling_tty_path(pid)
     # A confirmed detached tmux pane (has a tty, but no client attached) is
-    # NOT a live-user tty; every other tty-bearing wrapper is treated as live.
-    return not (tty_path is not None and tty_path in detached_tmux_ttys)
+    # NOT a live-user tty.
+    if tty_path is not None and tty_path in detached_tmux_ttys:
+        return False
+    # NOT live iff parented by an orphaned (socket-deleted, zero-client) tmux
+    # server — keys on the PID via parentage, so pts resolvability is
+    # irrelevant to it. Every other tty-bearing wrapper (unresolvable tty_path,
+    # an attached pane, a raw login pts, a live server) is treated as live and
+    # kept (conservative default).
+    return not (check_orphaned and _wrapper_on_orphaned_tmux_server(pid))
+
+
+def _maybe_log_orphaned_tmux_fire(
+    pid: int, detached_tmux_ttys: set[str], check_orphaned: bool
+) -> None:
+    """Observability (idle-unmapped fold 1): print ONE line when the
+    orphaned-parentage branch of :func:`_is_live_user_tty` is what made a
+    tty-bearing, non-detached-pane wrapper read not-live — so a fire is
+    greppable in the ``--dry-run`` smoke and a silent-inert regression is
+    detectable. Called only for a wrapper already classified not-live, so it
+    costs the extra parentage read ONLY for that rare case and nothing on the
+    healthy fleet (no fire, no orphaned server). Pure side-effect log; never
+    changes the reap decision."""
+    if not check_orphaned:
+        return
+    if not _wrapper_has_controlling_tty(pid):
+        return
+    if _wrapper_controlling_tty_path(pid) in detached_tmux_ttys:
+        return
+    if not _wrapper_on_orphaned_tmux_server(pid):
+        return
+    print(
+        f"  [idle-unmapped] orphaned-tmux wrapper pid={pid} (server socket "
+        f"absent, zero clients) -> not-live, entering idle check"
+    )
 
 
 def _transcript_idle_age_s(node_pid: int, now: float) -> tuple[float | None, str | None]:
@@ -12206,6 +12426,7 @@ def _process_idle_unmapped(
     reap_enabled: bool,
     detached_tmux_ttys: set[str] | None = None,
     tmux_activity: dict[str, float] | None = None,
+    check_orphaned: bool = True,
 ) -> None:
     """Apply the idle-unmapped decision to one live, non-PM, EPS-cwd session:
     check the wrapper's controlling TTY, stat the resolved transcript, and
@@ -12216,7 +12437,11 @@ def _process_idle_unmapped(
     tmux pane (``detached_tmux_ttys`` — computed once per pass) is NOT counted
     as live, so an abandoned detached-tmux session falls through to the
     transcript-idle check instead of being kept forever. ``None`` (the test /
-    legacy default) computes the detached-pane set inline.
+    legacy default) computes the detached-pane set inline. ``check_orphaned``
+    (default True; the pass passes the env-gated :func:`_orphaned_tmux_reap_enabled`
+    value) additionally classifies a wrapper parented by an ORPHANED tmux
+    server (socket deleted + zero attached clients) as not-live — an unreachable
+    pane that would otherwise be kept forever by the empty detached-map.
 
     #695 corroborating-idleness FALLBACK: when the primary transcript signal
     is unavailable (``idle_age_s is None`` — the manually-tmux-launched class
@@ -12232,10 +12457,15 @@ def _process_idle_unmapped(
         detached_tmux_ttys = _detached if detached_tmux_ttys is None else detached_tmux_ttys
         tmux_activity = _activity if tmux_activity is None else tmux_activity
     mapped = issue is not None
-    has_tty = _is_live_user_tty(pid, detached_tmux_ttys) if not mapped else False
+    has_tty = (
+        _is_live_user_tty(pid, detached_tmux_ttys, check_orphaned=check_orphaned)
+        if not mapped
+        else False
+    )
     idle_age_s: float | None = None
     signal_reason: str | None = None
     if not mapped and not has_tty:
+        _maybe_log_orphaned_tmux_fire(pid, detached_tmux_ttys, check_orphaned)
         idle_age_s, signal_reason = _transcript_idle_age_s(pid, now)
 
     prev = _load_idle_unmapped_state(sid)
@@ -12466,6 +12696,10 @@ def idle_unmapped_pass(
         candidates.append((sid, pid, issue))
 
     reap = _unmapped_idle_reap_enabled()
+    # The orphaned-tmux-server widening gate, evaluated ONCE per pass (not per
+    # session): a wrapper on a socket-deleted + zero-client tmux server is not a
+    # live-user tty and falls through to the transcript-idle check.
+    check_orphaned = _orphaned_tmux_reap_enabled()
     # Compute the detached-tmux-pane set AND the session_activity map ONCE per
     # pass (one tmux call), not per candidate — a wrapper whose controlling tty
     # is a detached pane is not a live-user tty and falls through to the
@@ -12486,7 +12720,8 @@ def idle_unmapped_pass(
         f"idle-unmapped: {len(candidates)} EPS session(s) scanned "
         f"({skipped_pm} PM-registered + {skipped_non_eps} non-EPS skipped; "
         f"detached_panes={len(detached_tmux_ttys)}; "
-        f"reap={'ON' if reap else 'OFF — alert-only (EPM_UNMAPPED_IDLE_REAP=0)'})"
+        f"reap={'ON' if reap else 'OFF — alert-only (EPM_UNMAPPED_IDLE_REAP=0)'}; "
+        f"orphaned_tmux_reap={'ON' if check_orphaned else 'OFF (EPM_ORPHANED_TMUX_REAP=0)'})"
     )
     for sid, pid, issue in sorted(candidates):
         _process_idle_unmapped(
@@ -12499,6 +12734,7 @@ def idle_unmapped_pass(
             reap_enabled=reap,
             detached_tmux_ttys=detached_tmux_ttys,
             tmux_activity=tmux_activity,
+            check_orphaned=check_orphaned,
         )
 
 

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -5999,6 +5999,8 @@ def _patch_idle_io(
     tmux_activity=None,
     registry=None,
     pm_sids=frozenset(),
+    orphaned_predicate=None,
+    controlling_tty_path=None,
 ):
     """Common monkeypatching for the idle-unmapped I/O tests: daemon children
     + session metadata + the TTY probe + the transcript-idle signal, leaving
@@ -6012,19 +6014,32 @@ def _patch_idle_io(
     the SINGLE combined helper ``_detached_tmux_panes_with_activity`` that the
     pass actually calls (and the legacy ``_detached_tmux_pane_ttys`` is patched
     too for the `_process_idle_unmapped`-default / `_is_live_user_tty`
-    paths)."""
+    paths).
+
+    ``orphaned_predicate`` (default ``lambda pid: False``) pins
+    ``_wrapper_on_orphaned_tmux_server`` so the orphaned-tmux widening branch is
+    INERT by default — every current caller keeps its pre-change behavior — and
+    an orphaned-session test can flip it to ``lambda pid: True``.
+    ``controlling_tty_path`` (default ``None``) pins
+    ``_wrapper_controlling_tty_path`` — a pin the pre-#818 helper did NOT apply,
+    added so the fold-1 observability read is deterministic without shelling to
+    /proc."""
     import autonomous_session_watch as asw
 
     stops: list[str] = []
     records: list[str] = []
     activity = dict(tmux_activity or {})
     detached = set(detached_tmux_ttys)
+    _orphaned = orphaned_predicate or (lambda pid: False)
+    _tty_path = controlling_tty_path
     monkeypatch.setattr(asw, "PROJECT_ROOT", Path(_Z_ROOT))
     monkeypatch.setattr(asw, "_live_children", lambda: list(children))
     monkeypatch.setattr(asw, "_load_session_meta", lambda: dict(meta))
     monkeypatch.setattr(asw, "_load_session_issue_map", lambda: dict(registry or {}))
     monkeypatch.setattr(asw, "_load_pm_session_ids", lambda: set(pm_sids))
     monkeypatch.setattr(asw, "_wrapper_has_controlling_tty", lambda pid: has_tty)
+    monkeypatch.setattr(asw, "_wrapper_on_orphaned_tmux_server", _orphaned)
+    monkeypatch.setattr(asw, "_wrapper_controlling_tty_path", lambda pid: _tty_path)
     # Pin BOTH tmux probes so the I/O tests never shell out to a live tmux
     # server (deterministic; default = no detached panes, no activity). The
     # pass calls the combined helper; the legacy single-return wrapper is
@@ -6158,6 +6173,383 @@ def test_is_live_user_tty_detached_tmux_pane_is_not_live(monkeypatch):
     # No controlling tty at all -> not a tty session (the headless case).
     monkeypatch.setattr(asw, "_wrapper_has_controlling_tty", lambda pid: False)
     assert asw._is_live_user_tty(99, {"/dev/pts/24"}) is False
+
+
+# ── #818 orphaned-tmux-server widening tests ──────────────────────────────────
+
+
+def _build_proc_tree(tmp_path, *, procs):
+    """Build a ``/proc``-shaped tmp tree driving the REAL parentage walk (no
+    helper is stubbed out). ``procs`` maps ``pid -> {"comm": str, "ppid": int,
+    "pts_fds": [str, ...]}``: ``comm`` writes ``<proc>/<pid>/comm``, ``ppid``
+    writes a minimal ``<proc>/<pid>/stat`` whose post-``)`` fields place the
+    ppid at index 1 (``state ppid pgrp ...``), and ``pts_fds`` (optional)
+    writes ``<proc>/<pid>/fd/<i>`` symlinks pointing at each ``/dev/pts`` target
+    (the target need not resolve — ``_tmux_server_client_ttys`` reads the
+    readlink STRING). Returns the proc-root Path."""
+    import os
+
+    proc_root = tmp_path / "proc"
+    for pid, spec in procs.items():
+        d = proc_root / str(pid)
+        d.mkdir(parents=True)
+        (d / "comm").write_text(spec["comm"] + "\n")
+        ppid = spec.get("ppid", 1)
+        # comm field is parenthesised (may contain spaces); the parser splits
+        # after the LAST ')' so fields become: state(0) ppid(1) pgrp(2) ...
+        (d / "stat").write_text(f"{pid} ({spec['comm']}) S {ppid} {ppid} 0 0 -1\n")
+        pts_fds = spec.get("pts_fds")
+        if pts_fds is not None:
+            fdd = d / "fd"
+            fdd.mkdir()
+            for i, target in enumerate(pts_fds, start=3):
+                os.symlink(target, fdd / str(i))
+    return proc_root
+
+
+def _mk_unix_socket(path):
+    """Create a real AF_UNIX socket FILE at ``path`` (so ``Path.is_socket()``
+    reports True) — the "a tmux server is reattachable" signal. The socket is
+    bound then closed; the filesystem entry persists as a socket file."""
+    import socket
+
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.bind(str(path))
+    s.close()
+
+
+def test_orphaned_tmux_reap_env_toggle(monkeypatch):
+    # EPM_ORPHANED_TMUX_REAP: unset / "1" -> enabled; explicit falsy disables
+    # (mirrors test_idle_unmapped_env_helpers for _unmapped_idle_reap_enabled).
+    import autonomous_session_watch as asw
+
+    monkeypatch.delenv("EPM_ORPHANED_TMUX_REAP", raising=False)
+    assert asw._orphaned_tmux_reap_enabled() is True
+    monkeypatch.setenv("EPM_ORPHANED_TMUX_REAP", "1")
+    assert asw._orphaned_tmux_reap_enabled() is True
+    for falsy in ("0", "false", "no", " FALSE "):
+        monkeypatch.setenv("EPM_ORPHANED_TMUX_REAP", falsy)
+        assert asw._orphaned_tmux_reap_enabled() is False, falsy
+
+
+def test_is_live_user_tty_orphaned_server_wrapper_is_not_live(monkeypatch):
+    # The #818 branch, at the guard level. A wrapper with a controlling tty
+    # that is NOT a detached pane, whose owning tmux server is orphaned, is
+    # not-live ONLY when check_orphaned is on. The kill-switch (check_orphaned
+    # omitted / False) keeps it. No controlling tty -> not-live regardless.
+    import autonomous_session_watch as asw
+
+    monkeypatch.setattr(asw, "_wrapper_has_controlling_tty", lambda pid: True)
+    monkeypatch.setattr(asw, "_wrapper_controlling_tty_path", lambda pid: "/dev/pts/7")
+    monkeypatch.setattr(asw, "_wrapper_on_orphaned_tmux_server", lambda pid: True)
+    # Orphaned + enabled -> not-live.
+    assert asw._is_live_user_tty(99, set(), check_orphaned=True) is False
+    # Orphaned but the widening is DISABLED -> live, keep (kill-switch at guard).
+    assert asw._is_live_user_tty(99, set(), check_orphaned=False) is True
+    # Default (check_orphaned omitted) never runs the branch -> live, keep
+    # (the back-compat shape the existing 2-arg callers rely on).
+    assert asw._is_live_user_tty(99, set()) is True
+    # Enabled but the parentage predicate says NOT orphaned -> live, keep.
+    monkeypatch.setattr(asw, "_wrapper_on_orphaned_tmux_server", lambda pid: False)
+    assert asw._is_live_user_tty(99, set(), check_orphaned=True) is True
+    # No controlling tty at all -> not-live regardless of the orphaned branch.
+    monkeypatch.setattr(asw, "_wrapper_has_controlling_tty", lambda pid: False)
+    monkeypatch.setattr(asw, "_wrapper_on_orphaned_tmux_server", lambda pid: True)
+    assert asw._is_live_user_tty(99, set(), check_orphaned=True) is False
+
+
+def test_wrapper_on_orphaned_tmux_server_fixture_proc_tree(tmp_path, monkeypatch):
+    # Drive the REAL ppid walk + REAL client-fd read against a /proc-shaped tmp
+    # tree (no helper stubbed): 700 -> 600 -> 500 (tmux: server, zero pts fds).
+    # Socket dir empty -> orphaned (True). A socket file present -> keep (False).
+    import autonomous_session_watch as asw
+
+    monkeypatch.setattr(asw.shutil, "which", lambda name: "/usr/bin/tmux")
+    proc_root = _build_proc_tree(
+        tmp_path,
+        procs={
+            500: {"comm": "tmux: server", "ppid": 1, "pts_fds": []},  # zero clients
+            600: {"comm": "node", "ppid": 500},
+            700: {"comm": "node", "ppid": 600},
+        },
+    )
+    empty_sock_dir = tmp_path / "tmux-sock"
+    empty_sock_dir.mkdir()
+    monkeypatch.setattr(asw, "_tmux_socket_dir", lambda: empty_sock_dir)
+    # Socket absent + zero clients -> the only reap-widening case.
+    assert asw._wrapper_on_orphaned_tmux_server(700, proc_root=proc_root) is True
+
+    # Add a socket file -> signal 1 says reattachable -> keep.
+    sock = empty_sock_dir / "default"
+    _mk_unix_socket(sock)
+    assert asw._wrapper_on_orphaned_tmux_server(700, proc_root=proc_root) is False
+
+
+def test_wrapper_on_orphaned_tmux_server_no_tmux_ancestor_keeps(tmp_path, monkeypatch):
+    # No tmux: server anywhere in the chain (700 -> 600 -> pid 1) -> not our
+    # class -> False regardless of the (empty) socket dir.
+    import autonomous_session_watch as asw
+
+    monkeypatch.setattr(asw.shutil, "which", lambda name: "/usr/bin/tmux")
+    proc_root = _build_proc_tree(
+        tmp_path,
+        procs={
+            600: {"comm": "bash", "ppid": 1},
+            700: {"comm": "node", "ppid": 600},
+        },
+    )
+    empty_sock_dir = tmp_path / "tmux-sock"
+    empty_sock_dir.mkdir()
+    monkeypatch.setattr(asw, "_tmux_socket_dir", lambda: empty_sock_dir)
+    assert asw._wrapper_on_orphaned_tmux_server(700, proc_root=proc_root) is False
+
+
+def test_wrapper_on_orphaned_tmux_server_failsoft(tmp_path, monkeypatch):
+    # Every uncertain probe -> False (KEEP). Parametrized cases (a)-(g).
+    import autonomous_session_watch as asw
+
+    # (a) tmux binary absent -> False (nothing to reap).
+    monkeypatch.setattr(asw.shutil, "which", lambda name: None)
+    assert asw._wrapper_on_orphaned_tmux_server(700, proc_root=tmp_path / "nope") is False
+
+    monkeypatch.setattr(asw.shutil, "which", lambda name: "/usr/bin/tmux")
+
+    # (b) <proc>/700/stat unreadable (_proc_ppid None) at a non-tmux hop -> walk
+    # stops -> False. 700 has a comm ("node", not tmux) but no stat file.
+    proc_b = tmp_path / "proc_b"
+    (proc_b / "700").mkdir(parents=True)
+    (proc_b / "700" / "comm").write_text("node\n")  # no stat -> _proc_ppid None
+    assert asw._wrapper_on_orphaned_tmux_server(700, proc_root=proc_b) is False
+
+    # (c) <proc>/700/comm missing at a walked hop (_proc_comm None): the hop is
+    # not confirmed tmux: server, the walk continues to _proc_ppid (also
+    # unreadable here) -> no raise, False.
+    proc_c = tmp_path / "proc_c"
+    (proc_c / "700").mkdir(parents=True)  # neither comm nor stat
+    assert asw._wrapper_on_orphaned_tmux_server(700, proc_root=proc_c) is False
+
+    # (d) tmux: server ancestor found + socket-dir .iterdir() raises ->
+    # _live_tmux_socket_present True -> False (keep).
+    proc_d = _build_proc_tree(
+        tmp_path / "d",
+        procs={
+            500: {"comm": "tmux: server", "ppid": 1, "pts_fds": []},
+            700: {"comm": "node", "ppid": 500},
+        },
+    )
+    monkeypatch.setattr(asw, "_tmux_socket_dir", lambda: tmp_path / "d" / "no-such-sock-dir")
+    assert asw._wrapper_on_orphaned_tmux_server(700, proc_root=proc_d) is False
+
+    # (e) a ppid cycle (600 <-> 700) -> seen-set guard -> False.
+    proc_e = _build_proc_tree(
+        tmp_path / "e",
+        procs={
+            600: {"comm": "node", "ppid": 700},
+            700: {"comm": "node", "ppid": 600},
+        },
+    )
+    assert asw._wrapper_on_orphaned_tmux_server(700, proc_root=proc_e) is False
+
+    # (f) max_depth exhausted before a tmux: server -> False. A long non-tmux
+    # chain, walked with a small max_depth.
+    long_chain = {pid: {"comm": "node", "ppid": pid - 1} for pid in range(700, 690, -1)}
+    proc_f = _build_proc_tree(tmp_path / "f", procs=long_chain)
+    assert asw._wrapper_on_orphaned_tmux_server(700, proc_root=proc_f, max_depth=3) is False
+
+    # (g) tmux: server ancestor found + socket dir EMPTY + server /fd UNREADABLE
+    # (_tmux_server_client_ttys None) -> cannot prove zero clients -> False.
+    proc_g = _build_proc_tree(
+        tmp_path / "g",
+        procs={
+            # No pts_fds key -> no fd/ dir at all -> iterdir raises -> None.
+            500: {"comm": "tmux: server", "ppid": 1},
+            700: {"comm": "node", "ppid": 500},
+        },
+    )
+    empty_g = tmp_path / "g" / "sock"
+    empty_g.mkdir()
+    monkeypatch.setattr(asw, "_tmux_socket_dir", lambda: empty_g)
+    assert asw._wrapper_on_orphaned_tmux_server(700, proc_root=proc_g) is False
+
+
+def test_wrapper_on_orphaned_tmux_server_socketless_but_attached_keeps(tmp_path, monkeypatch):
+    # The Must-Fix-1 regression: a tmux: server whose socket is deleted BUT that
+    # still holds one /dev/pts client fd (an attached SSH session survives the
+    # unlink) -> signal 2 proves a client is attached -> KEEP (False). This is
+    # the systemd-tmpfiles-swept-a-live-SSH-session case the client proof blocks.
+    import autonomous_session_watch as asw
+
+    monkeypatch.setattr(asw.shutil, "which", lambda name: "/usr/bin/tmux")
+    proc_root = _build_proc_tree(
+        tmp_path,
+        procs={
+            500: {"comm": "tmux: server", "ppid": 1, "pts_fds": ["/dev/pts/9"]},  # 1 client
+            700: {"comm": "node", "ppid": 500},
+        },
+    )
+    empty_sock_dir = tmp_path / "tmux-sock"
+    empty_sock_dir.mkdir()  # socketless
+    monkeypatch.setattr(asw, "_tmux_socket_dir", lambda: empty_sock_dir)
+    assert asw._wrapper_on_orphaned_tmux_server(700, proc_root=proc_root) is False
+
+
+def test_wrapper_on_orphaned_tmux_server_live_child_integration():
+    # NON-monkeypatched real-/proc walk: spawn a throwaway child whose parent is
+    # the pytest process (not a tmux: server). The parentage walk reads real
+    # /proc/<pid>/stat ppid + comm and terminates with no tmux ancestor -> False
+    # (keep). Proves the walk works against real /proc semantics, not a stub.
+    import subprocess
+
+    import autonomous_session_watch as asw
+
+    child = subprocess.Popen(["sleep", "30"])
+    try:
+        assert asw._wrapper_on_orphaned_tmux_server(child.pid, proc_root=Path("/proc")) is False
+    finally:
+        child.terminate()
+        child.wait(timeout=5)
+
+
+def test_tmux_server_client_ttys_live_integration():
+    # NON-monkeypatched: read the pytest process's own /proc/<pid>/fd. It holds
+    # no /dev/pts client fds via SCM_RIGHTS the way a tmux server would, so the
+    # returned set is empty-or-small and the fd-read + readlink path does not
+    # raise against real /proc.
+    import os
+
+    import autonomous_session_watch as asw
+
+    result = asw._tmux_server_client_ttys(os.getpid(), Path("/proc"))
+    assert result is None or isinstance(result, set)
+
+
+def test_idle_unmapped_pass_orphaned_tmux_session_reaped_after_threshold(
+    isolated_registry, monkeypatch
+):
+    # I/O test: an unmapped repo-root session with a controlling tty (not a
+    # detached pane) whose owning tmux server is orphaned reads not-live ->
+    # enters the idle branch -> idle >=12h accumulates a miss tick 1, stopped
+    # tick 2. Mirrors test_idle_unmapped_pass_stop_fires_after_threshold.
+    import json
+
+    import autonomous_session_watch as asw
+
+    monkeypatch.delenv("EPM_UNMAPPED_IDLE_REAP", raising=False)
+    monkeypatch.delenv("EPM_UNMAPPED_IDLE_REAP_S", raising=False)
+    monkeypatch.delenv("EPM_ORPHANED_TMUX_REAP", raising=False)  # default ON
+    children = [{"happySessionId": "sid-orph", "pid": 8181}]
+    meta = {"sid-orph": {"path": _Z_ROOT}}
+    over = asw.UNMAPPED_IDLE_REAP_S + 3600
+    stops, records = _patch_idle_io(
+        monkeypatch,
+        children=children,
+        meta=meta,
+        idle_age=over,
+        has_tty=True,  # real _wrapper_has_controlling_tty pinned True
+        controlling_tty_path="/dev/pts/7",  # not in the (empty) detached set
+        orphaned_predicate=lambda pid: True,  # owning server orphaned
+    )
+    state_path = isolated_registry / "idle-unmapped-sid-orph.json"
+    t0 = 1_000_000.0
+
+    asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=t0)
+    state = json.loads(state_path.read_text())
+    assert state["missed"] == 1 and stops == []
+
+    asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=t0 + 600)
+    assert stops == ["sid-orph"]
+    assert len(records) == 1 and "auto-stopped idle unmapped" in records[0]
+
+
+def test_idle_unmapped_pass_orphaned_reap_disabled_keeps(isolated_registry, monkeypatch):
+    # Kill-switch end-to-end: EPM_ORPHANED_TMUX_REAP=0 -> check_orphaned False
+    # -> the orphaned wrapper reads live (its tty is not a detached pane and the
+    # widening is off) -> KEEP, state cleared, never stopped.
+    import autonomous_session_watch as asw
+
+    monkeypatch.delenv("EPM_UNMAPPED_IDLE_REAP", raising=False)
+    monkeypatch.setenv("EPM_ORPHANED_TMUX_REAP", "0")
+    children = [{"happySessionId": "sid-off", "pid": 8282}]
+    meta = {"sid-off": {"path": _Z_ROOT}}
+    over = asw.UNMAPPED_IDLE_REAP_S + 3600
+    stops, records = _patch_idle_io(
+        monkeypatch,
+        children=children,
+        meta=meta,
+        idle_age=over,
+        has_tty=True,
+        controlling_tty_path="/dev/pts/7",
+        orphaned_predicate=lambda pid: True,
+    )
+    state_path = isolated_registry / "idle-unmapped-sid-off.json"
+    for now in (1_000_000.0, 1_000_600.0, 1_001_200.0):
+        asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=now)
+    assert stops == [] and records == []
+    assert not state_path.exists()
+
+
+def test_idle_unmapped_pass_orphaned_dry_run_mutates_nothing(isolated_registry, monkeypatch):
+    # Dry-run discipline for the orphaned path (mirrors
+    # test_idle_unmapped_pass_dry_run_mutates_nothing): an orphaned-tmux episode
+    # seeded AT the stop point + the real _stop_session dry-run contract -> a
+    # dry-run tick must not stop, not record, and leave the state byte-untouched.
+    import json
+
+    import autonomous_session_watch as asw
+
+    monkeypatch.delenv("EPM_UNMAPPED_IDLE_REAP", raising=False)
+    monkeypatch.delenv("EPM_ORPHANED_TMUX_REAP", raising=False)
+    children = [{"happySessionId": "sid-od", "pid": 8383}]
+    meta = {"sid-od": {"path": _Z_ROOT}}
+    over = asw.UNMAPPED_IDLE_REAP_S + 3600
+    stops, records = _patch_idle_io(
+        monkeypatch,
+        children=children,
+        meta=meta,
+        idle_age=over,
+        has_tty=True,
+        controlling_tty_path="/dev/pts/7",
+        orphaned_predicate=lambda pid: True,
+    )
+    monkeypatch.setattr(
+        asw, "_stop_session", lambda sid, dry_run: (not dry_run) and (stops.append(sid) or True)
+    )
+    t0 = 1_000_000.0
+    state_path = isolated_registry / "idle-unmapped-sid-od.json"
+    seeded = json.dumps({"missed": 1, "alerted": False, "first_over_ts": t0})
+    state_path.write_text(seeded)
+
+    asw.idle_unmapped_pass(True, 2, daemon_reachable=True, now=t0 + 600)
+    assert stops == [] and records == []
+    assert state_path.read_text() == seeded  # untouched, not even rewritten
+
+
+def test_idle_unmapped_pass_live_socket_pane_never_reaped(isolated_registry, monkeypatch):
+    # Regression guard for the healthy fleet: a wrapper on a LIVE-socket tmux
+    # server (orphaned predicate False) with a controlling tty -> reads live ->
+    # KEEP across 3 ticks, never stopped, state never accumulated. Complements
+    # the live-VM verification (one live-socket server -> zero behavior change).
+    import autonomous_session_watch as asw
+
+    monkeypatch.delenv("EPM_UNMAPPED_IDLE_REAP", raising=False)
+    monkeypatch.delenv("EPM_ORPHANED_TMUX_REAP", raising=False)
+    children = [{"happySessionId": "sid-live", "pid": 8484}]
+    meta = {"sid-live": {"path": _Z_ROOT}}
+    over = asw.UNMAPPED_IDLE_REAP_S + 3600
+    stops, records = _patch_idle_io(
+        monkeypatch,
+        children=children,
+        meta=meta,
+        idle_age=over,
+        has_tty=True,
+        controlling_tty_path="/dev/pts/7",
+        orphaned_predicate=lambda pid: False,  # socket present -> not orphaned
+    )
+    state_path = isolated_registry / "idle-unmapped-sid-live.json"
+    for now in (1_000_000.0, 1_000_600.0, 1_001_200.0):
+        asw.idle_unmapped_pass(False, 2, daemon_reachable=True, now=now)
+    assert stops == [] and records == []
+    assert not state_path.exists()
 
 
 def test_detached_tmux_pane_ttys_failsoft_when_tmux_absent(monkeypatch):

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -6372,6 +6372,43 @@ def test_wrapper_on_orphaned_tmux_server_failsoft(tmp_path, monkeypatch):
     assert asw._wrapper_on_orphaned_tmux_server(700, proc_root=proc_g) is False
 
 
+def test_wrapper_on_orphaned_tmux_server_comm_unreadable_intermediate_hop_keeps(
+    tmp_path, monkeypatch
+):
+    # #818 round-2 regression (concern comm-unreadable-intermediate-hop-can-reap):
+    # an INTERMEDIATE hop whose /proc/<pid>/comm is UNREADABLE but whose stat IS
+    # readable must STOP the walk and KEEP — a socketless clientless tmux: server
+    # reachable BEYOND the unclassifiable hop must NOT reap the wrapper. Before
+    # the fix the walk continued past the None-comm hop, reached 500, and
+    # returned True (reap-eligible). This is the fail-toward-keep contract for an
+    # unreadable comm (plan v4 3.6; background-automation.md).
+    import os
+
+    import autonomous_session_watch as asw
+
+    monkeypatch.setattr(asw.shutil, "which", lambda name: "/usr/bin/tmux")
+    proc_root = tmp_path / "proc"
+    # 500: a genuinely orphaned tmux: server (empty fd dir -> zero clients),
+    # reachable ONLY by walking PAST the comm-unreadable hop 700.
+    d500 = proc_root / "500"
+    (d500 / "fd").mkdir(parents=True)  # empty fd dir -> zero /dev/pts clients
+    (d500 / "comm").write_text("tmux: server\n")
+    (d500 / "stat").write_text("500 (tmux: server) S 1 1 0 0 -1\n")
+    # 700: the wrapper. stat IS readable (ppid -> 500) but comm is ABSENT
+    # (the intermediate-hop comm-unreadable case).
+    d700 = proc_root / "700"
+    d700.mkdir(parents=True)
+    (d700 / "stat").write_text("700 (node) S 500 500 0 0 -1\n")  # no comm file
+    empty_sock_dir = tmp_path / "tmux-sock"
+    empty_sock_dir.mkdir()  # socketless
+    monkeypatch.setattr(asw, "_tmux_socket_dir", lambda: empty_sock_dir)
+    # Sanity: the ancestor 500 IS a socketless zero-client orphaned server, so
+    # were the walk to reach it the pre-fix code would return True. The fix must
+    # stop at 700 (unreadable comm) -> False, with no raise.
+    assert os.path.exists(d500 / "comm")  # ancestor is classifiable if reached
+    assert asw._wrapper_on_orphaned_tmux_server(700, proc_root=proc_root) is False
+
+
 def test_wrapper_on_orphaned_tmux_server_socketless_but_attached_keeps(tmp_path, monkeypatch):
     # The Must-Fix-1 regression: a tmux: server whose socket is deleted BUT that
     # still holds one /dev/pts client fd (an attached SSH session survives the

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -6321,9 +6321,9 @@ def test_wrapper_on_orphaned_tmux_server_failsoft(tmp_path, monkeypatch):
     (proc_b / "700" / "comm").write_text("node\n")  # no stat -> _proc_ppid None
     assert asw._wrapper_on_orphaned_tmux_server(700, proc_root=proc_b) is False
 
-    # (c) <proc>/700/comm missing at a walked hop (_proc_comm None): the hop is
-    # not confirmed tmux: server, the walk continues to _proc_ppid (also
-    # unreadable here) -> no raise, False.
+    # (c) <proc>/700/comm missing at a walked hop (_proc_comm None): the walk
+    # STOPS immediately on the unreadable comm (round-2 fail-toward-keep
+    # guard; it never reaches _proc_ppid) -> no raise, False.
     proc_c = tmp_path / "proc_c"
     (proc_c / "700").mkdir(parents=True)  # neither comm nor stat
     assert asw._wrapper_on_orphaned_tmux_server(700, proc_root=proc_c) is False


### PR DESCRIPTION
## Summary
- Closes task #818 (workflow-fix, kind: infra). The idle-unmapped pass's TTY guard no longer classifies panes of a provably-orphaned tmux server as live user TTYs: new pure predicate `_wrapper_on_orphaned_tmux_server` (bounded, cycle-guarded ppid-walk to a `comm == "tmux: server"` ancestor; True ONLY when the socket dir is provably empty AND the server holds zero /dev/pts attached-client fds), folded into `_is_live_user_tty` via a default-False `check_orphaned` kwarg behind a default-ON `EPM_ORPHANED_TMUX_REAP` kill-switch.
- Fail-toward-keep on every ambiguous probe (tmux missing, unreadable stat/comm/fd-dir, socket-dir errors, cycles, depth exhaustion, socketless-but-attached clients — established AF_UNIX connections survive socket unlink).
- 13 new tests incl. non-monkeypatched fixture-/proc + live-/proc integration walks (catch the ships-inert class), a socketless-but-attached KEEP regression, comm-unreadable-at-intermediate-hop keep (r2 blocker fix, fails-pre/passes-post verified), and a dry-run no-mutation test. Doc sync in `.claude/rules/background-automation.md`.

## Test plan
- [x] `uv run pytest tests/test_autonomous_session_watch.py` in the worktree — 694/694 pass
- [x] Step 9c touched-subset gate (32 files): 1890 passed; 5 failures reproduced as pre-existing on main (epm:test-verdict v1 on task #818)
- [x] ruff check + format --check clean; workflow_lint introduces 0 new failures
- [x] Live `--dry-run` smoke: both session passes print, nothing stopped on the healthy fleet

Reviewed by the Claude+Codex code-review ensemble (r1 FAIL reconciled → fixed in b1b5afb38b; r2 PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)