### PR TITLE
task #820: per-stage dispatch dedup (workflow-fix)

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -4659,13 +4659,13 @@ re-invocation).**
      rounds commonly exceed 15 min wall time).
    - Window = **15 min** for everything else (`verifying` and any other
      Step 8/9 stage).
-   - **effective age ≤ window** → the subagent is presumed STILL
+   - **effective age < window** → the subagent is presumed STILL
      RUNNING. EXIT the skill cleanly (`post_step_completed.py ...
      --exit-kind parked --notes "stage <stage> round <r> still in flight
      (dispatched <Δ>m ago, window <W>m); backstop tick yielding"`). Do
      NOT re-dispatch — let the live work finish; the next tick (or the
      live subagent's own completion) advances the pipeline.
-   - **effective age > window** → the stage looks genuinely STALLED (a
+   - **effective age >= window** → the stage looks genuinely STALLED (a
      subagent that never posted its result). Proceed to re-dispatch it
      normally (the freshness window is what distinguishes "live" from
      "stalled").

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -4246,9 +4246,10 @@ analysis input changed), proceed with the held analyzer output as-is.
 
 **Re-entry idempotency.** The Step 9 entry guard's `stage-dispatch`
 breadcrumbs cover all three dispatches. On a backstop re-entry, apply
-the guard PER STAGE (see the parallel-stage note in the Step 9 entry
-guard): do not re-dispatch a stage whose own breadcrumb is within its
-freshness window, even when another stage's marker is the latest event.
+the guard PER STAGE (the step-2 per-stage backwards scan in the Step 9
+entry guard): do not re-dispatch a stage whose own breadcrumb is within
+its freshness window, even when another stage's marker is the latest
+event.
 
 Spawn the `upload-verifier` agent with:
 - Task number
@@ -4590,6 +4591,31 @@ tick can see the dispatch:
 uv run python scripts/task.py post-marker <N> epm:progress \
   --note "stage-dispatch stage=<verifying|interpreting|clean-result> round=<r> subagent=<name> worktree=<abs path or 'repo-root'>"
 ```
+
+**Pre-dispatch dedup (NON-SKIPPABLE, every dispatch site).** Immediately
+BEFORE posting a NEW `stage-dispatch` breadcrumb and spawning, run the
+mechanical check:
+
+```bash
+uv run python - <<'PY'
+from explore_persona_space.task_workflow import list_events, stage_dispatch_should_skip
+print(stage_dispatch_should_skip(list_events(<N>), "<stage>", <r>, window_minutes=<W>) or "DISPATCH")
+PY
+```
+
+If the output is anything other than `DISPATCH`, log that one line, post
+NO duplicate breadcrumb, do NOT spawn — the stage is already in flight
+(EXIT `parked` on a backstop tick, or continue with other work). `<W>`
+follows the stage-aware freshness windows below (15 default / 30
+Codex-ensembled). This applies to EVERY site that posts a
+`stage-dispatch` breadcrumb: the Step 8 results-landed batch, Step 9
+rounds, the Step 9a-ter free-analysis follow-up, the
+methodology-reference spawn, AND all same-issue follow-up-loop
+`stage=followup-<phase>` dispatches — the #778 double-dispatch
+(2026-07-01: two orchestrators each dispatched a `followup-implementing
+round=1` implementer 5m39s apart, two implementers concurrently editing
+one worktree) came through the follow-up loop.
+
 Each stage's result marker is its completion signal — the existing
 `epm:upload-verification` (verifying), `epm:interpretation v<r>` +
 `epm:interp-critique v<r>` (interpreting), and `epm:clean-result-critique
@@ -4610,11 +4636,22 @@ re-invocation).**
 1. Read the most recent events.jsonl marker via
    `task.py latest-marker <N>` (and `task.py view <N> --json` for the tail
    if needed).
-2. If the latest marker is a `stage-dispatch` breadcrumb (`epm:progress`
-   note beginning `stage-dispatch `) for the CURRENT stage+round AND there
-   is NO result marker for that same stage+round posted AFTER it (i.e. the
-   breadcrumb is genuinely the latest event), THEN compare its timestamp to
-   now against the **stage-aware freshness window**:
+2. Scan `events.jsonl` BACKWARDS for the CURRENT stage+round's most
+   recent `stage-dispatch` breadcrumb (an `epm:progress` note BEGINNING
+   `stage-dispatch ` — a note merely quoting the string mid-note never
+   counts), skipping ALL other kinds — intervening markers (codex-task
+   markers, progress notes, plan markers, other stages' breadcrumbs and
+   result markers) never hide a breadcrumb. If such a breadcrumb exists
+   AND no result marker for THAT stage (nor `epm:failure`) was posted
+   after it, compare its EFFECTIVE age to the **stage-aware freshness
+   window** — effective age is measured from the LATEST of the
+   breadcrumb and any subsequent liveness marker (`epm:codex-task-*`,
+   `epm:smoke-architecture-check`, `epm:proposed-tests`, or a
+   non-breadcrumb `epm:progress`): a healthy long-running round keeps
+   refreshing its window; a dead one goes silent and re-dispatches once
+   the window expires. The mechanical form of this rule is
+   `task_workflow.stage_dispatch_should_skip` (run the pre-dispatch
+   one-liner above — do not eyeball the scan).
    - Window = **30 min** for Codex-ensembled rounds (ALL `interpreting`
      AND `clean-result` rounds 1-3 — every round spawns both the Claude
      critic AND a `codex-*-critic` twin at `--effort high|xhigh` via
@@ -4622,27 +4659,27 @@ re-invocation).**
      rounds commonly exceed 15 min wall time).
    - Window = **15 min** for everything else (`verifying` and any other
      Step 8/9 stage).
-   - **age ≤ window** → the subagent is presumed STILL RUNNING. EXIT the
-     skill cleanly (`post_step_completed.py ... --exit-kind parked
-     --notes "stage <stage> round <r> still in flight (dispatched <Δ>m
-     ago, window <W>m); backstop tick yielding"`). Do NOT re-dispatch —
-     let the live work finish; the next tick (or the live subagent's own
-     completion) advances the pipeline.
-   - **age > window** → the stage looks genuinely STALLED (a subagent that
-     never posted its result). Proceed to re-dispatch it normally (the
-     freshness window is what distinguishes "live" from "stalled").
-3. If the latest marker is a RESULT marker (or anything other than a
-   current-stage `stage-dispatch` breadcrumb), there is no in-flight work —
-   proceed with the normal Step 9 logic below.
+   - **effective age ≤ window** → the subagent is presumed STILL
+     RUNNING. EXIT the skill cleanly (`post_step_completed.py ...
+     --exit-kind parked --notes "stage <stage> round <r> still in flight
+     (dispatched <Δ>m ago, window <W>m); backstop tick yielding"`). Do
+     NOT re-dispatch — let the live work finish; the next tick (or the
+     live subagent's own completion) advances the pipeline.
+   - **effective age > window** → the stage looks genuinely STALLED (a
+     subagent that never posted its result). Proceed to re-dispatch it
+     normally (the freshness window is what distinguishes "live" from
+     "stalled").
+3. If the per-stage backwards scan finds NO open breadcrumb for the
+   current stage+round (none exists, or a result marker / `epm:failure`
+   postdates it), there is no in-flight work — proceed with the normal
+   Step 9 logic below.
 
 **Parallel-stage note (results-landed spawn).** Step 8's results-landed
 parallel spawn can put `verifying`, `interpreting` round 1, and
-`methodology-reference` breadcrumbs in flight at once. Apply the rule
-PER STAGE: scan `events.jsonl` backwards for the CURRENT stage's most
-recent `stage-dispatch` breadcrumb (skipping other stages' breadcrumbs
-and result markers) rather than inspecting only the single latest
-event. A stage is in flight when ITS breadcrumb has no matching result
-marker after it and is within the freshness window.
+`methodology-reference` breadcrumbs in flight at once. The per-stage
+backwards scan in step 2 above applies to each concurrent stage
+independently — a result marker for stage X never clears stage Y's
+in-flight state.
 
 The 15-min default comfortably exceeds a single Claude analyzer / critic /
 verifier turn; the 30-min Codex-ensemble window covers a high-effort
@@ -6008,7 +6045,13 @@ backstop cron (same `CronList`/`CronCreate` ARM-GUARD shape as Step 0 /
 Step 6d.2) before dispatching its first planner / implementer / stage
 subagent, and must post every stage-dispatch breadcrumb
 (`stage=followup-<phase>`, Step 9 entry-guard convention) with the
-`worktree=` field. Know what each mechanism covers: the cron handles
+`worktree=` field. These `stage=followup-<phase>` breadcrumbs are bound
+by the SAME Step 9 entry-guard predicate AND the same NON-SKIPPABLE
+pre-dispatch dedup check (§ Step 9 entry guard) — the status being held
+at `followups_running` does not exempt them (#778, 2026-07-01: the
+round-1 `followup-implementing` dispatch was duplicated by a concurrent
+orchestrator 5m39s after the first, two implementers concurrently
+editing one worktree). Know what each mechanism covers: the cron handles
 only the alive-but-stalled case — a `durable=False` cron dies with the
 session that armed it; `autonomous_session_watch.py`'s AUTO-RESPAWN
 passes read only the autonomous registry (`spawn-issue --auto`
@@ -6024,6 +6067,13 @@ session death. (Incident #505 round 2, 2026-06-10: an interactive chat
 session driving this loop was closed mid-implementer-dispatch with no
 cron armed, no registry entry, and no worktree breadcrumb; the task
 orphaned at `running` for 5+ hours.)
+
+**Loop-entry ownership re-check.** When entering this loop from a
+resume / re-invocation (including the Step 0 followup-scope dispatch),
+FIRST re-run the Step 0 single-orchestrator guard: if another live
+session is mapped to this issue, stop the stale session
+(`spawn_session.py stop`) before dispatching any loop work — two live
+orchestrators driving one round is the #778 root cause.
 
 1. **Scope marker.** Ensure an `epm:followup-scope v1` exists for this
    round (the Step 9b partition posts it at step 6 above; the chat /

--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -1182,13 +1182,32 @@ def _cb_gate_label(plan_text: str, ladder: list[str]) -> str:
 
 STAGE_RESULT_KINDS: dict[str, frozenset[str]] = {
     # NORMALIZED stage token (see _normalize_stage) -> marker kind(s) that complete it.
+    # Clearing = "ANY completion marker a subagent of this stage posts" — the set answers
+    # "did the last dispatched subagent finish?", NOT "did the whole stage finish?"
+    # (one stage+round legitimately dispatches analyzer -> critic -> reconciler in sequence;
+    # #547 replay: an intermediate epm:interpretation must clear the analyzer crumb so the
+    # critic dispatch is not wrongly skipped).
     "verifying": frozenset({"epm:upload-verification"}),
-    "interpreting": frozenset({"epm:interpretation"}),
-    "clean-result": frozenset({"epm:clean-result-critique"}),
+    "interpreting": frozenset(
+        {
+            "epm:interpretation",
+            "epm:interp-critique",
+            "epm:interp-critique-codex",
+            "epm:review-reconcile",
+        }
+    ),
+    "clean-result": frozenset(
+        {
+            "epm:clean-result-critique",
+            "epm:interpretation",
+            "epm:clean-result-critique-codex",
+            "epm:review-reconcile",
+        }
+    ),
     "implementing": frozenset({"epm:experiment-implementation"}),
     "free-analysis-followup": frozenset({"epm:free-analysis-followup-run"}),
     "methodology-reference": frozenset({"epm:methodology-doc-generated"}),
-    "code-review": frozenset({"epm:code-review"}),
+    "code-review": frozenset({"epm:code-review", "epm:code-review-codex", "epm:review-reconcile"}),
     "planning": frozenset({"epm:plan"}),
     "related-work": frozenset({"epm:related-work-proposed"}),
 }

--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -1180,6 +1180,152 @@ def _cb_gate_label(plan_text: str, ladder: list[str]) -> str:
     return gate_m.group(0).strip() if gate_m else "<unnamed-gate>"
 
 
+STAGE_RESULT_KINDS: dict[str, frozenset[str]] = {
+    # NORMALIZED stage token (see _normalize_stage) -> marker kind(s) that complete it.
+    "verifying": frozenset({"epm:upload-verification"}),
+    "interpreting": frozenset({"epm:interpretation"}),
+    "clean-result": frozenset({"epm:clean-result-critique"}),
+    "implementing": frozenset({"epm:experiment-implementation"}),
+    "free-analysis-followup": frozenset({"epm:free-analysis-followup-run"}),
+    "methodology-reference": frozenset({"epm:methodology-doc-generated"}),
+    "code-review": frozenset({"epm:code-review"}),
+    "planning": frozenset({"epm:plan"}),
+    "related-work": frozenset({"epm:related-work-proposed"}),
+}
+# epm:failure clears the in-flight state of ANY stage.
+_ALWAYS_RESULT_KINDS = frozenset({"epm:failure"})
+# Markers a healthy in-flight round keeps emitting; each refreshes the freshness clock.
+STAGE_LIVENESS_KINDS = frozenset(
+    {
+        "epm:codex-task-spawned",
+        "epm:codex-task-completed",
+        "epm:smoke-architecture-check",
+        "epm:proposed-tests",
+    }
+)
+
+_STAGE_ALIASES = {"code-reviewing": "code-review"}
+
+
+def _normalize_stage(stage: str) -> str:
+    """Strip ONE leading ``followup-`` prefix, then apply ``_STAGE_ALIASES``.
+
+    Used only for result-kind clearing lookups; the dedup MATCH compares raw tokens.
+    Unknown tokens pass through unchanged.
+    """
+    stripped = stage.removeprefix("followup-")
+    return _STAGE_ALIASES.get(stripped, stripped)
+
+
+def _stage_event_ts(event: dict) -> datetime | None:
+    """Parse an event's ISO-8601 ``ts`` (naive treated as UTC); None on malformed/missing."""
+    raw = event.get("ts", "")
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except (AttributeError, TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _breadcrumb_fields(note: str) -> dict[str, str]:
+    """Parse a ``stage-dispatch`` note's ``key=value`` tokens (whitespace-split, order-free)."""
+    fields: dict[str, str] = {}
+    for token in note.split():
+        key, sep, value = token.partition("=")
+        if sep:
+            fields[key] = value
+    return fields
+
+
+def _find_stage_breadcrumb(events: list[dict], stage: str, round_num: int) -> int | None:
+    """Index of the most recent breadcrumb matching the RAW ``stage=`` token + ``round=``.
+
+    A breadcrumb with no ``round=`` token, or a non-integer round value, never matches.
+    Returns None when no breadcrumb matches.
+    """
+    for idx in range(len(events) - 1, -1, -1):
+        event = events[idx]
+        if event.get("kind", "") != "epm:progress":
+            continue
+        note = (event.get("note", "") or "").lstrip()
+        if not note.startswith("stage-dispatch "):
+            continue
+        fields = _breadcrumb_fields(note)
+        if fields.get("stage") != stage:
+            continue
+        try:
+            if int(fields["round"]) == round_num:
+                return idx
+        except (KeyError, ValueError):
+            continue
+    return None
+
+
+def stage_dispatch_should_skip(
+    events: list[dict],
+    stage: str,
+    round_num: int,
+    window_minutes: float,
+    *,
+    now: datetime | None = None,
+) -> str | None:
+    """Return a one-line skip reason when a same-stage+round dispatch is in flight, else None.
+
+    A breadcrumb is an ``epm:progress`` event whose lstripped note begins with
+    ``"stage-dispatch "``; its ``key=value`` fields parse order-independently, and a
+    breadcrumb with no integer ``round=`` never matches a round query. The most recent
+    breadcrumb matching the RAW ``stage=`` token and ``round=`` is in flight unless a
+    LATER event carries a stage-matching result kind
+    (``STAGE_RESULT_KINDS[_normalize_stage(stage)]`` — clearing is round-agnostic by
+    design, result markers carry no parsable round) or ``epm:failure``. While in
+    flight, the freshness clock starts at the LATEST of the breadcrumb and any later
+    liveness marker (``STAGE_LIVENESS_KINDS`` or a non-breadcrumb ``epm:progress``;
+    a breadcrumb never refreshes any window): effective age < window -> skip reason;
+    >= window -> None (stalled, re-dispatch allowed). A malformed breadcrumb ``ts``
+    fails toward dispatch (None); a malformed liveness ``ts`` is ignored. TOCTOU is a
+    non-goal — two orchestrators both checking BEFORE either posts its breadcrumb can
+    still double-dispatch; the Step-0 single-orchestrator guard + implementer
+    self-detection are the backstops. Add new stage tokens to ``STAGE_RESULT_KINDS``.
+    """
+    if now is None:
+        now = datetime.now(UTC)
+    crumb_idx = _find_stage_breadcrumb(events, stage, round_num)
+    if crumb_idx is None:
+        return None
+    clearing = STAGE_RESULT_KINDS.get(_normalize_stage(stage), frozenset()) | _ALWAYS_RESULT_KINDS
+    later = events[crumb_idx + 1 :]
+    if any(event.get("kind", "") in clearing for event in later):
+        return None
+    crumb_ts = _stage_event_ts(events[crumb_idx])
+    if crumb_ts is None:
+        return None
+    effective_start = crumb_ts
+    refresher: tuple[str, str] | None = None
+    for event in later:
+        kind = event.get("kind", "")
+        if kind == "epm:progress":
+            note = (event.get("note", "") or "").lstrip()
+            if note.startswith("stage-dispatch "):
+                continue
+        elif kind not in STAGE_LIVENESS_KINDS:
+            continue
+        ts = _stage_event_ts(event)
+        if ts is not None and ts > effective_start:
+            effective_start = ts
+            refresher = (kind, event.get("ts", ""))
+    age_minutes = (now - effective_start).total_seconds() / 60.0
+    if age_minutes >= window_minutes:
+        return None
+    refreshed = f", refreshed by {refresher[0]} at {refresher[1]}" if refresher else ""
+    return (
+        f"skip: stage-dispatch stage={stage} round={round_num} in flight — "
+        f"breadcrumb at {events[crumb_idx].get('ts', '')}, effective age {age_minutes:.1f}m "
+        f"< window {window_minutes}m{refreshed}"
+    )
+
+
 def _format_failure_lesson_entry(new_lesson_ref: dict[str, str]) -> str:
     """Render the new (correcting) failure-lesson body as a durable memory entry.
 

--- a/tests/test_stage_dispatch_dedup.py
+++ b/tests/test_stage_dispatch_dedup.py
@@ -1,0 +1,287 @@
+"""Tests for the per-stage dispatch dedup predicate (#820, #778 replay).
+
+``stage_dispatch_should_skip`` is the mechanical form of the /issue Step 9
+entry guard's per-stage backwards scan: the most recent ``stage-dispatch``
+breadcrumb matching the queried raw stage token + round is in flight unless a
+stage-matching result marker (or ``epm:failure``) landed after it, with a
+liveness-refreshed freshness window bounding staleness. The positive fixture
+replays the #778 incident (events.jsonl lines 116-130): a second orchestrator
+posted a byte-identical ``stage=followup-implementing round=1`` breadcrumb at
+22:34:32Z because 8 intervening markers buried the 22:28:53Z original.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import explore_persona_space.task_workflow as tw
+
+
+def _ev(ts: str, kind: str, note: str = "", version: int = 1) -> dict:
+    return {"ts": ts, "kind": kind, "version": version, "by": "test", "note": note}
+
+
+def _dt(s: str) -> datetime:
+    return datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
+_CRUMB_778 = (
+    "stage-dispatch stage=followup-implementing round=1 subagent=experiment-implementer "
+    "worktree=/home/thomasjiralerspong/explore-persona-space/.claude/worktrees/issue-778"
+)
+
+
+def test_778_replay_duplicate_skipped():
+    events = [
+        _ev("2026-07-01T22:28:53Z", "epm:progress", _CRUMB_778, version=28),
+        _ev(
+            "2026-07-01T22:28:54Z",
+            "epm:codex-task-spawned",
+            "Codex job_id=task-mr2ndn0r-zboe5s effort=high write=True poll_interval=30s",
+        ),
+        _ev(
+            "2026-07-01T22:29:25Z",
+            "epm:codex-task-completed",
+            "Codex job_id=task-mr2ndn0r-zboe5s phase=done after 30s.",
+        ),
+        _ev(
+            "2026-07-01T22:30:44Z",
+            "epm:codex-task-spawned",
+            "Codex job_id=task-mr2ng0g6-0xj291 effort=high write=True poll_interval=30s",
+        ),
+        _ev(
+            "2026-07-01T22:31:16Z",
+            "epm:codex-task-completed",
+            "Codex job_id=task-mr2ng0g6-0xj291 phase=done after 30s.",
+        ),
+        _ev(
+            "2026-07-01T22:31:46Z",
+            "epm:progress",
+            "corrected-monitoring-8prompt-ladder round 1: plan + existing #778 drivers read; "
+            "corrected_eval_prompts.md located in worktree. Starting implementation",
+            version=29,
+        ),
+        _ev("2026-07-01T22:31:56Z", "epm:smoke-architecture-check", "verdict: PASS_UNIFIED", 2),
+        _ev(
+            "2026-07-01T22:33:50Z",
+            "epm:plan",
+            "Plan v5 (amendment for same-issue follow-up round corrected-monitoring-8prompt-"
+            "ladder) written to plans/plan.md (gpu_hours_total=4).",
+            version=3,
+        ),
+        _ev(
+            "2026-07-01T22:33:58Z",
+            "epm:plan-approved",
+            "Auto-approved by the code-enforced autonomous plan-gate: gpu_hours_total=4.0",
+        ),
+    ]
+    reason = tw.stage_dispatch_should_skip(
+        events, "followup-implementing", 1, 15, now=_dt("2026-07-01T22:34:32Z")
+    )
+    assert reason is not None
+    assert "followup-implementing" in reason
+
+
+def test_stalled_past_window_allows_redispatch():
+    events = [_ev("2026-07-01T10:00:00Z", "epm:progress", _CRUMB_778)]
+    assert (
+        tw.stage_dispatch_should_skip(
+            events, "followup-implementing", 1, 15, now=_dt("2026-07-01T10:16:00Z")
+        )
+        is None
+    )
+
+
+def test_liveness_refresh_extends_then_expires():
+    events = [
+        _ev(
+            "2026-07-01T10:00:00Z",
+            "epm:progress",
+            "stage-dispatch stage=implementing round=1 subagent=experiment-implementer",
+        ),
+        _ev("2026-07-01T10:25:00Z", "epm:codex-task-completed", "Codex job phase=done"),
+    ]
+    assert (
+        tw.stage_dispatch_should_skip(
+            events, "implementing", 1, 15, now=_dt("2026-07-01T10:35:00Z")
+        )
+        is not None
+    )
+    assert (
+        tw.stage_dispatch_should_skip(
+            events, "implementing", 1, 15, now=_dt("2026-07-01T10:41:00Z")
+        )
+        is None
+    )
+
+
+def test_concurrent_stages_independent():
+    events = [
+        _ev(
+            "2026-07-01T10:00:00Z",
+            "epm:progress",
+            "stage-dispatch stage=verifying round=1 subagent=upload-verifier",
+        ),
+        _ev(
+            "2026-07-01T10:00:05Z",
+            "epm:progress",
+            "stage-dispatch stage=interpreting round=1 subagent=analyzer",
+        ),
+        _ev("2026-07-01T10:05:00Z", "epm:upload-verification", "verdict: PASS"),
+    ]
+    now = _dt("2026-07-01T10:06:00Z")
+    assert tw.stage_dispatch_should_skip(events, "verifying", 1, 15, now=now) is None
+    assert tw.stage_dispatch_should_skip(events, "interpreting", 1, 15, now=now) is not None
+
+
+def test_round_boundary():
+    events = [
+        _ev(
+            "2026-07-01T10:00:00Z",
+            "epm:progress",
+            "stage-dispatch stage=implementing round=1 subagent=experiment-implementer",
+        ),
+        _ev("2026-07-01T10:10:00Z", "epm:experiment-implementation", "round 1 landed"),
+    ]
+    now = _dt("2026-07-01T10:12:00Z")
+    assert tw.stage_dispatch_should_skip(events, "implementing", 2, 15, now=now) is None
+    assert tw.stage_dispatch_should_skip(events, "implementing", 1, 15, now=now) is None
+
+
+def test_failure_clears_any_stage():
+    events = [
+        _ev("2026-07-01T10:00:00Z", "epm:progress", "stage-dispatch stage=p6-judge round=1"),
+        _ev("2026-07-01T10:05:00Z", "epm:failure", "failure_class: infra"),
+    ]
+    assert (
+        tw.stage_dispatch_should_skip(events, "p6-judge", 1, 15, now=_dt("2026-07-01T10:06:00Z"))
+        is None
+    )
+
+
+def test_quoted_breadcrumb_not_matched():
+    quoting_note = (
+        "DUAL-DISPATCH DETECTED — implementer #2 yielding. Two 'stage-dispatch "
+        "stage=followup-implementing round=1 subagent=experiment-implementer' markers "
+        "were posted for the SAME round"
+    )
+    crumb = _ev("2026-07-01T22:00:00Z", "epm:progress", _CRUMB_778)
+    quoting = _ev("2026-07-01T22:20:00Z", "epm:progress", quoting_note, version=32)
+    now = _dt("2026-07-01T22:21:00Z")
+    # The quoting note is NOT a breadcrumb (anchor = lstripped note STARTS with
+    # "stage-dispatch ") but IS a non-breadcrumb progress -> refreshes the window.
+    assert (
+        tw.stage_dispatch_should_skip([crumb, quoting], "followup-implementing", 1, 15, now=now)
+        is not None
+    )
+    # Without the refreshing note the breadcrumb is 21m old -> stalled -> re-dispatch.
+    assert tw.stage_dispatch_should_skip([crumb], "followup-implementing", 1, 15, now=now) is None
+
+
+def test_followup_prefix_normalized_clearing():
+    now = _dt("2026-07-01T10:06:00Z")
+    events_a = [
+        _ev(
+            "2026-07-01T10:00:00Z",
+            "epm:progress",
+            "stage-dispatch stage=followup-code-reviewing round=1 subagent=code-reviewer",
+        ),
+        _ev("2026-07-01T10:05:00Z", "epm:code-review", "verdict: PASS"),
+    ]
+    assert (
+        tw.stage_dispatch_should_skip(events_a, "followup-code-reviewing", 1, 15, now=now) is None
+    )
+    events_b = [
+        _ev(
+            "2026-07-01T10:00:00Z",
+            "epm:progress",
+            "stage-dispatch stage=followup-implementing round=1 subagent=experiment-implementer",
+        ),
+        _ev("2026-07-01T10:05:00Z", "epm:experiment-implementation", "round 1 landed"),
+    ]
+    assert tw.stage_dispatch_should_skip(events_b, "followup-implementing", 1, 15, now=now) is None
+
+
+def test_raw_token_dedup_no_cross_match():
+    events = [
+        _ev(
+            "2026-07-01T10:00:00Z",
+            "epm:progress",
+            "stage-dispatch stage=implementing round=1 subagent=experiment-implementer",
+        )
+    ]
+    assert (
+        tw.stage_dispatch_should_skip(
+            events, "followup-implementing", 1, 15, now=_dt("2026-07-01T10:01:00Z")
+        )
+        is None
+    )
+
+
+def test_unknown_token_conservative():
+    events = [_ev("2026-07-01T10:00:00Z", "epm:progress", "stage-dispatch stage=p6-judge round=1")]
+    assert (
+        tw.stage_dispatch_should_skip(events, "p6-judge", 1, 15, now=_dt("2026-07-01T10:10:00Z"))
+        is not None
+    )
+    assert (
+        tw.stage_dispatch_should_skip(events, "p6-judge", 1, 15, now=_dt("2026-07-01T10:16:00Z"))
+        is None
+    )
+
+
+def test_extra_fields_and_order_robust():
+    note = (
+        "stage-dispatch round=1 stage=implementing subagent=experiment-implementer worktree=/abs/x"
+    )
+    events = [_ev("2026-07-01T10:00:00Z", "epm:progress", note)]
+    assert (
+        tw.stage_dispatch_should_skip(
+            events, "implementing", 1, 15, now=_dt("2026-07-01T10:05:00Z")
+        )
+        is not None
+    )
+
+
+def test_round_missing_never_matches():
+    events = [
+        _ev("2026-07-01T10:00:00Z", "epm:progress", "stage-dispatch stage=implementing subagent=x")
+    ]
+    for round_num in (0, 1, 2):
+        assert (
+            tw.stage_dispatch_should_skip(
+                events, "implementing", round_num, 15, now=_dt("2026-07-01T10:01:00Z")
+            )
+            is None
+        )
+
+
+def test_unrelated_progress_refreshes_window():
+    events = [
+        _ev(
+            "2026-07-01T10:00:00Z",
+            "epm:progress",
+            "stage-dispatch stage=implementing round=1 subagent=experiment-implementer",
+        ),
+        _ev("2026-07-01T10:14:00Z", "epm:progress", "pod-provision waiting on RunPod capacity..."),
+    ]
+    # Documented over-skip direction: ANY non-breadcrumb progress refreshes the window.
+    assert (
+        tw.stage_dispatch_should_skip(
+            events, "implementing", 1, 15, now=_dt("2026-07-01T10:20:00Z")
+        )
+        is not None
+    )
+
+
+def test_no_breadcrumb_returns_none():
+    events = [
+        _ev("2026-07-01T10:00:00Z", "epm:plan", "Plan v1 written"),
+        _ev("2026-07-01T10:01:00Z", "epm:progress", "phase tick: waiting on pod"),
+    ]
+    assert (
+        tw.stage_dispatch_should_skip(
+            events, "implementing", 1, 15, now=_dt("2026-07-01T10:02:00Z")
+        )
+        is None
+    )

--- a/tests/test_stage_dispatch_dedup.py
+++ b/tests/test_stage_dispatch_dedup.py
@@ -343,7 +343,9 @@ def test_quoted_breadcrumb_behaviorally_pinned():
         _ev(
             "2026-07-01T10:10:00Z",
             "epm:progress",
-            "note: earlier 'stage-dispatch stage=implementing round=1' crumb was cleared",
+            # No quote chars around the tokens — they must parse cleanly (round=1 as int) so a
+            # substring-anchored impl WOULD accept this note as a fresh crumb and fail the test.
+            "note: earlier stage-dispatch stage=implementing round=1 crumb was cleared",
         ),
     ]
     assert (

--- a/tests/test_stage_dispatch_dedup.py
+++ b/tests/test_stage_dispatch_dedup.py
@@ -285,3 +285,116 @@ def test_no_breadcrumb_returns_none():
         )
         is None
     )
+
+
+def test_547_replay_clean_result_critic_after_analyzer_revision():
+    # #547 real sequence: analyzer crumb 13:29:31 -> epm:interpretation (the analyzer's
+    # revise output) 13:48:23 -> critic dispatch attempt 13:49:13. The intermediate
+    # epm:interpretation is a clearing kind for stage=clean-result (the LAST dispatched
+    # subagent finished), so the next in-round dispatch must be ALLOWED.
+    events = [
+        _ev(
+            "2026-06-10T13:29:31Z",
+            "epm:progress",
+            "stage-dispatch stage=clean-result round=2 subagent=analyzer",
+        ),
+        _ev("2026-06-10T13:48:23Z", "epm:interpretation", "revise round 2 landed"),
+    ]
+    assert (
+        tw.stage_dispatch_should_skip(
+            events, "clean-result", 2, 30, now=_dt("2026-06-10T13:49:13Z")
+        )
+        is None
+    )
+
+
+def test_547_replay_interpreting_reconciler_after_critique():
+    # #547 sibling replay: interpretation-critic crumb -> epm:interp-critique 19m later;
+    # the reconciler dispatch 21m in (< 30m window) must be ALLOWED because the critique
+    # marker clears the critic's crumb.
+    events = [
+        _ev(
+            "2026-06-10T14:00:00Z",
+            "epm:progress",
+            "stage-dispatch stage=interpreting round=1 subagent=interpretation-critic",
+        ),
+        _ev("2026-06-10T14:19:00Z", "epm:interp-critique", "verdict: REVISE"),
+    ]
+    assert (
+        tw.stage_dispatch_should_skip(
+            events, "interpreting", 1, 30, now=_dt("2026-06-10T14:21:00Z")
+        )
+        is None
+    )
+
+
+def test_quoted_breadcrumb_behaviorally_pinned():
+    # Discriminating fixture: [real crumb t0, its clearing result marker t0+5m, a note at
+    # t0+10m that CONTAINS but does not START WITH the breadcrumb text]. A substring-matching
+    # impl would read the quoting note as the freshest crumb with no result after it -> skip;
+    # the startswith anchor keeps the real crumb (already cleared) -> dispatch allowed.
+    events = [
+        _ev(
+            "2026-07-01T10:00:00Z",
+            "epm:progress",
+            "stage-dispatch stage=implementing round=1 subagent=experiment-implementer",
+        ),
+        _ev("2026-07-01T10:05:00Z", "epm:experiment-implementation", "round 1 landed"),
+        _ev(
+            "2026-07-01T10:10:00Z",
+            "epm:progress",
+            "note: earlier 'stage-dispatch stage=implementing round=1' crumb was cleared",
+        ),
+    ]
+    assert (
+        tw.stage_dispatch_should_skip(
+            events, "implementing", 1, 15, now=_dt("2026-07-01T10:11:00Z")
+        )
+        is None
+    )
+
+
+def test_non_integer_round_token_never_matches():
+    events = [
+        _ev("2026-07-01T10:00:00Z", "epm:progress", "stage-dispatch stage=implementing round=abc")
+    ]
+    for round_num in (0, 1, 2):
+        assert (
+            tw.stage_dispatch_should_skip(
+                events, "implementing", round_num, 15, now=_dt("2026-07-01T10:01:00Z")
+            )
+            is None
+        )
+
+
+def test_malformed_breadcrumb_ts_fails_toward_dispatch():
+    events = [
+        _ev(
+            "not-a-date",
+            "epm:progress",
+            "stage-dispatch stage=implementing round=1 subagent=experiment-implementer",
+        )
+    ]
+    assert (
+        tw.stage_dispatch_should_skip(
+            events, "implementing", 1, 15, now=_dt("2026-07-01T10:01:00Z")
+        )
+        is None
+    )
+
+
+def test_age_exactly_window_allows_dispatch():
+    events = [
+        _ev(
+            "2026-07-01T10:00:00Z",
+            "epm:progress",
+            "stage-dispatch stage=implementing round=1 subagent=experiment-implementer",
+        )
+    ]
+    # age == window (15.0m exactly) -> >= is dispatch-allowed (stalled boundary).
+    assert (
+        tw.stage_dispatch_should_skip(
+            events, "implementing", 1, 15, now=_dt("2026-07-01T10:15:00Z")
+        )
+        is None
+    )


### PR DESCRIPTION
## Summary
- Adds the pure predicate `task_workflow.stage_dispatch_should_skip` (backwards per-stage breadcrumb scan; startswith anchor; raw-token dedup match; normalized result-kind clearing incl. intra-round sequential dispatches; liveness-refreshed 15/30-min windows; fail-toward-dispatch on malformed ts) + 20 pinning tests incl. a #778 replay fixture and two #547 legitimate-dispatch replays.
- SKILL.md Edits A/B/C: NON-SKIPPABLE pre-dispatch dedup one-liner at every stage-dispatch site; entry-guard step-2 "latest event" predicate replaced with the backwards per-stage scan; follow-up-loop `stage=followup-<phase>` dispatches explicitly bound + loop-entry Step-0 ownership re-check.
- Closes the #778 double-dispatch class at the damaging (implementer/worktree-collision) layer.

Closes task #820.

## Test plan
- [x] `uv run pytest tests/test_stage_dispatch_dedup.py -q` → 20 passed
- [x] `uv run pytest tests/test_workflow_fix_dedup.py -q` → 11 passed
- [x] Step 9c touched subset (32 files) → 5 pre-existing baseline failures / 1877 passed / 0 new
- [x] ruff clean on touched files; workflow_lint baseline-identical (2 pre-existing errors on untouched scripts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)