### PR TITLE
issue-826: namespace-robust zombie-GPU override (liveness veto + 2-tick persistence)

### DIFF
--- a/.claude/skills/issue/failure_patterns.md
+++ b/.claude/skills/issue/failure_patterns.md
@@ -94,7 +94,13 @@ process stays alive burning Python-overhead CPU (so the #518/#658
 session-CPU-advancing override rescued the stall to `running` for a 60+
 min silent hang). It is recoverable by an experimenter respawn (reap the
 orphaned `VLLM::EngineCore` worker by EXACT PID, relaunch on the same
-pod), NOT a code fix, so it belongs on the `infra` row. The emit surface
+pod), NOT a code fix, so it belongs on the `infra` row. Since #826 the
+detector fires only when EVERY workload log is stale past the effective
+stall window (`max(EPM_ZOMBIE_VETO_FRESH_SEC=60, stall_sec)`) for 2
+consecutive ticks — on host-PID-namespace containers nvidia-smi reports
+host PIDs unresolvable in the container's `/proc`, so the bare signature
+is false-positive on healthy runs (#816/#778); a fresh-log zombie flag is
+a namespace artifact, not a hang. The emit surface
 is `scripts/poll_pipeline.py` + `scripts/backend_poll.py`; the
 known-reason set is `STALL_REASON_INFRA` in `failure_classifier.py`; the
 recovery brief + recipe references are SKILL.md Step 7 § "Zombie-GPU

--- a/scripts/poll_pipeline.py
+++ b/scripts/poll_pipeline.py
@@ -76,13 +76,27 @@ reported healthy throughout). The one mechanical signal of this hang is
 the orphaned GPU allocation: a compute-apps PID holding many GiB of
 VRAM whose `/proc/<pid>` no longer exists. The probe lists
 `nvidia-smi --query-compute-apps=pid,used_memory` and flags any PID
-holding >= ``ZOMBIE_GPU_MEM_MIN_MIB`` MiB that is absent from `/proc`;
-when present on a `running` verdict, the verdict is overridden to
-`stalled` with ``stall_reason="vllm_worker_dead_zombie_gpu"`` REGARDLESS
-of session-CPU advancement. A live process always has `/proc/<pid>`, so
-an absent dir is a hard liveness signal. Fail-safe: nvidia-smi missing /
-erroring emits an empty list (never a false zombie); the override never
-touches a `done` / `gate` / `dead` verdict.
+holding >= ``ZOMBIE_GPU_MEM_MIN_MIB`` MiB that is absent from `/proc`.
+
+The zombie signature alone is NOT sufficient to fire (#826): on
+host-PID-namespace RunPod containers nvidia-smi reports HOST PIDs that
+are never resolvable in the container's `/proc`, so every HEALTHY
+compute process carries the signature (#816 steady-state; #778 a
+transient teardown-window PID between vLLM engine cycles) — and a false
+`stalled` verdict routes into a destructive kill-by-PID reaper respawn.
+The override therefore fires only when, on a `running` verdict, ALL of:
+(a) a zombie candidate is present, (b) EVERY workload log (main /
+per-phase / shard) is stale past the effective stall window
+(``max(ZOMBIE_VETO_FRESH_SEC, stall_sec)`` — a genuinely hung run's own
+processes stop appending; both observed false positives had fresh
+logs), and (c) the stale-log candidate persisted for 2 CONSECUTIVE
+observed ticks (``zombie_streak`` in the state sidecar — filters the
+#778 one-tick teardown transient). Session-CPU advancement is
+deliberately NOT a veto term: the genuine #664 hang had CPU advancing
+(the EngineCore idle-burn is why this override exists at all), so a CPU
+veto would make the true positive unreachable. Fail-safe: nvidia-smi
+missing / erroring emits an empty list (never a false zombie); the
+override never touches a `done` / `gate` / `dead` verdict.
 
 Staleness folds in cell-log mtimes (incident #405 smoke-first): when the
 dispatcher is blocked in ``proc.wait()`` on a sequential smoke cell, the
@@ -512,6 +526,19 @@ SSH_WAIT_ALARM_SECS = float(os.environ.get("EPM_SSH_WAIT_ALARM_SECS", "3600"))
 # contexts (a few hundred MiB) while catching any real model-weight orphan.
 ZOMBIE_GPU_MEM_MIN_MIB = int(os.environ.get("EPM_ZOMBIE_GPU_MEM_MIN_MIB", "1024"))
 
+# 826: FLOOR for the liveness veto on the #664 zombie-GPU override. The
+# effective veto threshold each tick is max(ZOMBIE_VETO_FRESH_SEC, stall_sec):
+# the override fires only when EVERY workload log (main/phase/shard) is stale
+# past the effective stall window. Rationale: a hung run's own processes stop
+# appending (the #664 TP had all mtimes > 900s), while both observed false
+# positives had fresh logs (#816 ~1s steady-state; #778 8s transient) — note a
+# SIBLING process can keep a log fresh on a hung run, so this is an empirical
+# separation, not an absolute guarantee; the asymmetric cost (missed zombie =
+# bounded idle pod-hours vs false positive = kill-by-PID reaper on a healthy
+# run) favors vetoing. The floor only binds when --stall-sec is set
+# pathologically low (< 60s fast-smoke configs).
+ZOMBIE_VETO_FRESH_SEC = int(os.environ.get("EPM_ZOMBIE_VETO_FRESH_SEC", "60"))
+
 
 def _try_refresh_pods_conf_from_api(pod: str) -> bool:
     """Best-effort ``pod.py config --refresh-from-api <pod>`` self-heal.
@@ -784,8 +811,11 @@ class PollResult:
     # ``"vllm_worker_dead_zombie_gpu"`` — a dead CUDA-worker PID still
     # holding VRAM while the EngineCore main process keeps the
     # session-CPU-advancing override alive (which would otherwise mask the
-    # hang as ``running`` forever). Defaulted so the many cross-backend
-    # ``PollResult(...)`` call sites need no change.
+    # hang as ``running`` forever). Since #826 the override also requires
+    # ALL workload logs stale past the effective stall window AND 2
+    # consecutive stale-log candidate ticks (host-PID-namespace containers
+    # make the bare signature false-positive on healthy runs). Defaulted so
+    # the many cross-backend ``PollResult(...)`` call sites need no change.
     stall_reason: str | None = None
     # The crash signature extracted from the WIDE 500-line probe tail (NOT the
     # 5-line ``log_tail_excerpt``, which truncates a multi-line vLLM CUDA-IMA
@@ -2295,6 +2325,98 @@ def _save_state(state_file: Path, issue: int, payload: dict[str, str]) -> None:
     tmp.replace(state_file)
 
 
+def _apply_zombie_override(
+    *,
+    status: str,
+    zombie_gpu_pids: list[str],
+    stall_sec: int,
+    last_mtime_ago: float,
+    phase_log_mtime_ago: float,
+    shard_log_mtime_ago: float,
+    prev_state: dict[str, str],
+    pod: str,
+    cpu_override_active: bool,
+) -> tuple[str, str | None, bool, int]:
+    """The #664/#826 zombie-GPU-allocation override — returns the possibly
+    overridden ``(status, stall_reason, cpu_override_active, zombie_streak)``.
+
+    A hung vLLM whose CUDA worker died leaves its model-shard VRAM orphaned
+    (a compute-apps PID with no ``/proc`` entry) while the EngineCore main
+    process stays alive burning Python-overhead CPU. That advancing session
+    CPU makes the #518/#658 override rescue the stall conjunction to
+    ``running`` (or the run never meets the conjunction at all because the
+    dead allocation reads as GPU-busy), so a 60+ min hang is reported healthy
+    throughout (#664 round 8). The dead-PID GPU allocation is the one
+    mechanical signal of this hang.
+
+    But the bare signature is false-positive on host-PID-namespace
+    containers, where nvidia-smi reports HOST PIDs unresolvable in the
+    container's ``/proc`` for EVERY healthy worker (#816 steady-state; #778 a
+    transient teardown-window PID between vLLM engine cycles) — and a false
+    ``stalled`` routes to a destructive kill-by-PID reaper respawn. So the
+    override fires ONLY when (a) every workload log is stale past the
+    effective stall window ``max(ZOMBIE_VETO_FRESH_SEC, stall_sec)`` — a
+    genuinely hung run's own processes stop appending; both observed false
+    positives had fresh logs — AND (b) the stale-log candidate persisted 2
+    CONSECUTIVE observed ticks (``zombie_streak`` in the state sidecar;
+    recomputed each tick, so any veto / candidate-free / non-running tick
+    that reaches ``_save_state`` resets it — a tick that early-returns before
+    ``_save_state`` neither advances nor resets it, the same exposure
+    ``ssh_fail_count`` has; the sidecar is single-poller by design).
+
+    Session-CPU advancement is deliberately NOT a veto term: the genuine #664
+    hang had CPU advancing (in the stale-log + idle-GPU regime ``running`` is
+    only reachable via the CPU rescue), so a CPU veto would make the true
+    positive structurally unreachable. Never touches a ``done`` / ``gate`` /
+    ``dead`` verdict — those are correct terminal/park states (a dead
+    launcher is already ``dead``; its own orphaned allocation is then
+    expected). The ``stall_reason`` lets the orchestrator route this
+    distinctly from a generic log+GPU+CPU stall.
+    """
+    stall_reason: str | None = None
+    zombie_streak = 0
+    if status == "running" and zombie_gpu_pids:
+        zombie_veto_sec = max(ZOMBIE_VETO_FRESH_SEC, stall_sec)
+        freshest_log_ago = min(last_mtime_ago, phase_log_mtime_ago, shard_log_mtime_ago)
+        try:  # defensive parse, mirrors _update_ssh_fail_tracking's ssh_fail_count guard
+            prev_zombie_streak = int(prev_state.get("zombie_streak", "0") or 0)
+        except (TypeError, ValueError):
+            prev_zombie_streak = 0
+        if freshest_log_ago <= zombie_veto_sec:
+            log.warning(
+                "zombie-GPU signature on pod %s (PID(s) %s) but log evidence is fresh "
+                "(%.0fs <= %ds) — liveness veto, not flagging (#826; host-PID-namespace "
+                "containers report unresolvable host PIDs for healthy workers)",
+                pod,
+                ",".join(zombie_gpu_pids),
+                freshest_log_ago,
+                zombie_veto_sec,
+            )
+        elif prev_zombie_streak < 1:
+            zombie_streak = 1
+            log.warning(
+                "zombie-GPU signature on pod %s (PID(s) %s) with all logs stale — deferring "
+                "one tick for 2-tick persistence (#826)",
+                pod,
+                ",".join(zombie_gpu_pids),
+            )
+        else:
+            log.error(
+                "zombie GPU allocation on pod %s: compute PID(s) %s hold >= %d MiB VRAM but "
+                "are absent from /proc (dead CUDA worker, vLLM EngineCore hung) — persisted "
+                "2 consecutive ticks with all logs stale, overriding "
+                "status=running -> stalled (#664/#826)",
+                pod,
+                ",".join(zombie_gpu_pids),
+                ZOMBIE_GPU_MEM_MIN_MIB,
+            )
+            status = "stalled"
+            stall_reason = "vllm_worker_dead_zombie_gpu"
+            cpu_override_active = False
+            zombie_streak = prev_zombie_streak + 1
+    return status, stall_reason, cpu_override_active, zombie_streak
+
+
 def _log_staleness_secs(
     *,
     pod: str,
@@ -2638,34 +2760,20 @@ def poll_once(
     else:
         status = "running"
 
-    # ── #664 zombie-GPU-allocation override ──────────────────────────────
-    # A hung vLLM whose CUDA worker died leaves its model-shard VRAM
-    # orphaned (a compute-apps PID with no `/proc` entry) while the
-    # EngineCore main process stays alive burning Python-overhead CPU. That
-    # advancing session CPU makes the #518/#658 override rescue the stall
-    # conjunction to `running` (or the run never meets the conjunction at
-    # all because the dead allocation reads as GPU-busy), so a 60+ min hang
-    # is reported healthy throughout (#664 round 8). The dead-PID GPU
-    # allocation is the one mechanical signal of this hang, so when it is
-    # present we override a `running` verdict to `stalled` regardless of
-    # session-CPU advancement. We do NOT touch a `done` / `gate` / `dead`
-    # verdict — those are correct terminal/park states (and a dead launcher
-    # is already `dead`; its own orphaned allocation is then expected). The
-    # `stall_reason` lets the orchestrator route this distinctly from a
-    # generic log+GPU+CPU stall (e.g. terminate + diagnose the pod).
-    stall_reason: str | None = None
-    if status == "running" and zombie_gpu_pids:
-        log.error(
-            "zombie GPU allocation on pod %s: compute PID(s) %s hold >= %d MiB VRAM but "
-            "are absent from /proc (dead CUDA worker, vLLM EngineCore hung) — overriding "
-            "status=running -> stalled (#664)",
-            pod,
-            ",".join(zombie_gpu_pids),
-            ZOMBIE_GPU_MEM_MIN_MIB,
-        )
-        status = "stalled"
-        stall_reason = "vllm_worker_dead_zombie_gpu"
-        cpu_override_active = False
+    # ── #664/#826 zombie-GPU-allocation override ─────────────────────────
+    # Extracted to `_apply_zombie_override` (both for C901 headroom and so
+    # the firing predicate is documented in one place — see its docstring).
+    status, stall_reason, cpu_override_active, zombie_streak = _apply_zombie_override(
+        status=status,
+        zombie_gpu_pids=zombie_gpu_pids,
+        stall_sec=stall_sec,
+        last_mtime_ago=last_mtime_ago,
+        phase_log_mtime_ago=phase_log_mtime_ago,
+        shard_log_mtime_ago=shard_log_mtime_ago,
+        prev_state=prev_state,
+        pod=pod,
+        cpu_override_active=cpu_override_active,
+    )
 
     # ── #518/#537 GPU-idle advisory ──────────────────────────────────────
     # The stall verdict above treats an idle GPU only as corroboration, so
@@ -2802,6 +2910,12 @@ def poll_once(
             # it is a multi-shard child-exit accounting artifact, not a
             # stall. Monotonic: a sub-max current sample never lowers it.
             "max_cpu_secs": max_session_cpu,
+            # #826 zombie-override 2-tick persistence. Recomputed from
+            # scratch each tick (0 unless the override block set it), so a
+            # vetoed-fresh tick, a candidate-free tick, and any non-running
+            # verdict all write "0" — a one-tick transient never
+            # accumulates across a healthy gap.
+            "zombie_streak": str(zombie_streak),
         },
     )
 

--- a/tests/test_poll_pipeline_zombie_gpu.py
+++ b/tests/test_poll_pipeline_zombie_gpu.py
@@ -8,14 +8,26 @@ idle work), so the #518/#658 session-CPU-advancing override keeps the
 verdict in ``running`` indefinitely while zero real work happens (#664
 round 8 hung 60+ min, reported healthy throughout).
 
+Since #826 the override is namespace-robust: on host-PID-namespace RunPod
+containers nvidia-smi reports HOST PIDs unresolvable in the container's
+``/proc``, so every HEALTHY worker carries the zombie signature (#816
+steady-state; #778 transient teardown-window PID). The override now fires
+only when ALL workload logs are stale past the effective stall window
+(``max(ZOMBIE_VETO_FRESH_SEC, stall_sec)``) AND the stale-log candidate
+persisted 2 consecutive observed ticks (``zombie_streak`` sidecar key).
+
 These tests pin:
 
 * the probe-output parser (``_parse_probe_stdout``) lifting the new
   ``ZOMBIE_GPU_PIDS`` line into ``zombie_gpu_pids``;
 * ``poll_once`` overriding a would-be ``running`` verdict to ``stalled``
-  with ``stall_reason="vllm_worker_dead_zombie_gpu"`` when a zombie GPU
-  allocation is present AND the CPU-advancing override would otherwise
-  have rescued the stall conjunction to ``running``;
+  with ``stall_reason="vllm_worker_dead_zombie_gpu"`` when a STALE-LOG
+  zombie GPU allocation persisted 2 consecutive ticks AND the
+  CPU-advancing override would otherwise have rescued the stall
+  conjunction to ``running`` (#664 true positive, fires by tick 2);
+* the #826 liveness veto: any workload log fresh within the effective
+  stall window ⇒ never flags, streak resets (#816/#778 false positives,
+  including the sparse-log 60s-to-stall_sec window);
 * the healthy case (no zombies) leaving the CPU-override rescue intact;
 * the override NEVER firing on a ``done`` verdict;
 * the JSON surface (``poll_pipeline.main`` + ``backend_poll`` serializer)
@@ -98,6 +110,7 @@ def _probe_stdout(
     gpu_util: str,
     session_cpu: str,
     zombie_pids: str,
+    phase_log_mtime_epoch: int = 0,
 ) -> str:
     """Probe stdout in the shape ``_parse_probe_stdout`` expects."""
     return "\n".join(
@@ -111,7 +124,7 @@ def _probe_stdout(
             "CELL_MTIME_EPOCH=0",
             "CELL_TAIL_START",
             "CELL_TAIL_END",
-            "PHASE_LOG_MTIME_EPOCH=0",
+            f"PHASE_LOG_MTIME_EPOCH={phase_log_mtime_epoch}",
             "SHARD_LOG_MTIME_EPOCH=0",
             f"GPU_UTIL={gpu_util}",
             f"ZOMBIE_GPU_PIDS={zombie_pids}",
@@ -129,8 +142,13 @@ def _patch_pod(
     gpu_util: str,
     session_cpu: str,
     zombie_pids: str,
+    phase_log_mtime_epoch: int = 0,
 ) -> None:
-    """Monkeypatch poll_pipeline's I/O boundary with a fully-controlled probe."""
+    """Monkeypatch poll_pipeline's I/O boundary with a fully-controlled probe.
+
+    Stateless per call — two-tick tests re-invoke it between ``poll_once``
+    calls to vary the probe (e.g. advance ``session_cpu``, clear
+    ``zombie_pids``)."""
 
     def _fake_run(cmd: list[str], **kwargs: Any):
         import subprocess
@@ -145,6 +163,7 @@ def _patch_pod(
                 gpu_util=gpu_util,
                 session_cpu=session_cpu,
                 zombie_pids=zombie_pids,
+                phase_log_mtime_epoch=phase_log_mtime_epoch,
             )
         )
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=stdout, stderr="")
@@ -155,10 +174,12 @@ def _patch_pod(
     monkeypatch.setattr(pp, "_run_launched_age_sec", lambda issue, now_epoch: 10800.0)
 
 
-def _stale_state(now: int, *, prev_cpu: str) -> str:
+def _stale_state(now: int, *, prev_cpu: str, zombie_streak: str = "0") -> str:
     """A prior-tick state file: phase already seen (so no transition), GPUs
     idle, with a prior session-CPU sample BELOW the current one so the
-    #518/#658 override sees CPU advancing."""
+    #518/#658 override sees CPU advancing. ``zombie_streak`` pre-seeds the
+    #826 persistence counter (``"1"`` makes a single ``poll_once`` call
+    represent tick 2 of a persisted stale-log zombie candidate)."""
     return json.dumps(
         {
             "9664": {
@@ -166,9 +187,15 @@ def _stale_state(now: int, *, prev_cpu: str) -> str:
                 "last_phase_change_epoch": str(now - 7200),
                 "session_cpu_secs": prev_cpu,
                 "max_cpu_secs": prev_cpu,
+                "zombie_streak": zombie_streak,
             }
         }
     )
+
+
+def _saved_zombie_streak(state_file: Path) -> str:
+    """Read back the persisted #826 streak for issue 9664."""
+    return json.loads(state_file.read_text())["9664"]["zombie_streak"]
 
 
 def test_zombie_gpu_overrides_cpu_advancing_running_to_stalled(
@@ -176,7 +203,11 @@ def test_zombie_gpu_overrides_cpu_advancing_running_to_stalled(
 ) -> None:
     """The exact #664 regime: stale logs + idle GPUs (stall conjunction met)
     + session CPU advancing (override would rescue to running) + a zombie
-    GPU allocation. The zombie override wins -> stalled with the reason."""
+    GPU allocation persisted from the prior tick (#826: ``zombie_streak``
+    pre-seeded to "1", so this single call represents tick 2). The zombie
+    override wins -> stalled with the reason. The genuine two-call replay
+    lives in ``test_zombie_stale_log_defers_first_tick_then_stalls_second``;
+    this adaptation additionally pins the sidecar READ path."""
     now = int(time.time())
     # Main log 2000s old (> 900s stall_sec); no fresh phase/shard logs.
     _patch_pod(
@@ -188,7 +219,7 @@ def test_zombie_gpu_overrides_cpu_advancing_running_to_stalled(
         zombie_pids="1262130",
     )
     state_file = tmp_path / "poll-state.json"
-    state_file.write_text(_stale_state(now, prev_cpu="4000.0"))
+    state_file.write_text(_stale_state(now, prev_cpu="4000.0", zombie_streak="1"))
     result = pp.poll_once(
         issue=9664,
         pod="pod-9664",
@@ -285,6 +316,202 @@ def test_zombie_does_not_override_done_verdict(
     )
     assert result.status == "done"
     assert result.stall_reason is None
+
+
+# ── #826 liveness veto + 2-tick persistence ───────────────────────────────────
+
+
+def test_zombie_fresh_log_vetoes_and_resets_streak(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """#816 steady-state replay via the PHASE-log freshness path: zombie PIDs
+    present on BOTH of two consecutive ticks while the per-phase log is fresh
+    (~5s) — the healthy host-PID-namespace signature. Never flags, and a
+    pre-seeded streak of "1" is RESET by the fresh-log veto (not just held
+    at 0)."""
+    now = int(time.time())
+    state_file = tmp_path / "poll-state.json"
+    state_file.write_text(_stale_state(now, prev_cpu="4000.0", zombie_streak="1"))
+    for tick_cpu in ("5000.0", "6000.0"):  # advancing each tick (healthy run)
+        _patch_pod(
+            monkeypatch,
+            mtime_epoch=now - 2000,  # main log quiet; the PHASE log is the fresh signal
+            tail="2026-06-27 00:00:01 [phase=training step=5/100]",
+            gpu_util="90,88,91,87,93,95,89,92",
+            session_cpu=tick_cpu,
+            zombie_pids="313516 313517 313518",
+            phase_log_mtime_epoch=now - 5,
+        )
+        result = pp.poll_once(
+            issue=9664,
+            pod="pod-9664",
+            log_path="/workspace/logs/issue-9664.log",
+            pid_file="/workspace/logs/issue-9664.pid",
+            state_file=state_file,
+        )
+        assert result.status == "running"
+        assert result.stall_reason is None
+        assert _saved_zombie_streak(state_file) == "0"
+
+
+def test_transient_zombie_fresh_log_never_stalls(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """#778 exact replay: a dying host-namespace PID holds VRAM for ONE tick
+    during a vLLM engine teardown/spin-up (log mtime ~8s), gone by the next
+    tick. Never flags; the streak stays "0" throughout."""
+    now = int(time.time())
+    state_file = tmp_path / "poll-state.json"
+    state_file.write_text(_stale_state(now, prev_cpu="4000.0"))
+    for tick_cpu, pids in (("5000.0", "313516"), ("6000.0", "")):
+        _patch_pod(
+            monkeypatch,
+            mtime_epoch=now - 8,
+            tail="2026-06-27 00:00:01 [phase=manyshot_regen step=3/24]",
+            gpu_util="0,0,0,0,0,0,0,0",  # engines cycling between phases
+            session_cpu=tick_cpu,
+            zombie_pids=pids,
+        )
+        result = pp.poll_once(
+            issue=9664,
+            pod="pod-9664",
+            log_path="/workspace/logs/issue-9664.log",
+            pid_file="/workspace/logs/issue-9664.pid",
+            state_file=state_file,
+        )
+        assert result.status == "running"
+        assert result.stall_reason is None
+        assert _saved_zombie_streak(state_file) == "0"
+
+
+def test_zombie_sparse_log_window_vetoed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The coupled-threshold pin: logs ~400s old (past the 60s floor, inside
+    the 900s stall window — a sparse-log cadence), GPUs BUSY (else-branch
+    ``running``), zombie PIDs on both ticks. A fixed-60s veto would have
+    fired at tick 2 (the destructive FP on a healthy host-namespace pod);
+    the ``max(ZOMBIE_VETO_FRESH_SEC, stall_sec)`` coupling vetoes it."""
+    now = int(time.time())
+    state_file = tmp_path / "poll-state.json"
+    state_file.write_text(_stale_state(now, prev_cpu="4000.0"))
+    for tick_cpu in ("5000.0", "6000.0"):
+        _patch_pod(
+            monkeypatch,
+            mtime_epoch=now - 400,
+            tail="2026-06-27 00:00:01 [phase=training step=5/100]",
+            gpu_util="95,97,93,96,94,98,95,96",  # busy -> conjunction unmet -> running
+            session_cpu=tick_cpu,
+            zombie_pids="313516 313517",
+        )
+        result = pp.poll_once(
+            issue=9664,
+            pod="pod-9664",
+            log_path="/workspace/logs/issue-9664.log",
+            pid_file="/workspace/logs/issue-9664.pid",
+            state_file=state_file,
+        )
+        assert result.status == "running"
+        assert result.stall_reason is None
+        assert _saved_zombie_streak(state_file) == "0"
+
+
+def test_zombie_stale_log_defers_first_tick_then_stalls_second(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """#664 true positive, genuine two-call replay: all logs stale (>900s),
+    GPUs idle, session CPU advancing on BOTH ticks (the EngineCore idle-burn
+    that rescues the conjunction — re-patched upward for tick 2, else the
+    high-water mark reads CPU flat and the generic stall path fires before
+    the override is reached), zombie PID both ticks. Tick 1 defers (running,
+    streak "1"); tick 2 fires (stalled + reason) — requirement (c): the TP
+    fires at the 2nd tick at latest."""
+    now = int(time.time())
+    state_file = tmp_path / "poll-state.json"
+    state_file.write_text(_stale_state(now, prev_cpu="4000.0"))
+
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 2000,
+        tail="2026-06-27 00:00:01 [phase=training step=5/100]",
+        gpu_util="0,0,0,0,0,0,0,0",
+        session_cpu="5000.0",  # advancing vs prev 4000.0
+        zombie_pids="1262130",
+    )
+    tick1 = pp.poll_once(
+        issue=9664,
+        pod="pod-9664",
+        log_path="/workspace/logs/issue-9664.log",
+        pid_file="/workspace/logs/issue-9664.pid",
+        state_file=state_file,
+    )
+    assert tick1.status == "running"
+    assert tick1.stall_reason is None
+    assert _saved_zombie_streak(state_file) == "1"
+
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 2000,
+        tail="2026-06-27 00:00:01 [phase=training step=5/100]",
+        gpu_util="0,0,0,0,0,0,0,0",
+        session_cpu="6000.0",  # still advancing vs tick-1 max 5000.0
+        zombie_pids="1262130",
+    )
+    tick2 = pp.poll_once(
+        issue=9664,
+        pod="pod-9664",
+        log_path="/workspace/logs/issue-9664.log",
+        pid_file="/workspace/logs/issue-9664.pid",
+        state_file=state_file,
+    )
+    assert tick2.status == "stalled"
+    assert tick2.stall_reason == "vllm_worker_dead_zombie_gpu"
+
+
+def test_zombie_veto_resets_streak_when_cleared(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A stale-log candidate that CLEARS on the next tick never accumulates:
+    tick 1 defers (streak "1"), tick 2 has no zombie (CPU still advancing so
+    the rescue keeps ``running``) — streak resets to "0"."""
+    now = int(time.time())
+    state_file = tmp_path / "poll-state.json"
+    state_file.write_text(_stale_state(now, prev_cpu="4000.0"))
+
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 2000,
+        tail="2026-06-27 00:00:01 [phase=training step=5/100]",
+        gpu_util="0,0,0,0,0,0,0,0",
+        session_cpu="5000.0",
+        zombie_pids="1262130",
+    )
+    tick1 = pp.poll_once(
+        issue=9664,
+        pod="pod-9664",
+        log_path="/workspace/logs/issue-9664.log",
+        pid_file="/workspace/logs/issue-9664.pid",
+        state_file=state_file,
+    )
+    assert tick1.status == "running"
+    assert _saved_zombie_streak(state_file) == "1"
+
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 2000,
+        tail="2026-06-27 00:00:01 [phase=training step=5/100]",
+        gpu_util="0,0,0,0,0,0,0,0",
+        session_cpu="6000.0",
+        zombie_pids="",
+    )
+    tick2 = pp.poll_once(
+        issue=9664,
+        pod="pod-9664",
+        log_path="/workspace/logs/issue-9664.log",
+        pid_file="/workspace/logs/issue-9664.pid",
+        state_file=state_file,
+    )
+    assert tick2.status == "running"
+    assert tick2.stall_reason is None
+    assert _saved_zombie_streak(state_file) == "0"
 
 
 # ── JSON-surface contract ─────────────────────────────────────────────────────


### PR DESCRIPTION
Closes task #826 (workflow-fix; consolidates archived duplicate #827).

## Summary
- The #664 zombie-GPU override in `scripts/poll_pipeline.py` fired unconditionally on any unresolvable VRAM-holding compute PID; on host-PID-namespace RunPod containers every healthy worker carries that signature (#816 steady-state, #778 transient), overriding healthy runs `running -> stalled` into a destructive kill-by-PID reaper respawn.
- The override now fires only when ALL workload logs are stale past `max(EPM_ZOMBIE_VETO_FRESH_SEC=60, stall_sec)` AND the stale-log candidate persisted 2 consecutive ticks (`zombie_streak` sidecar key). `cpu_advancing` is deliberately NOT a veto term (the genuine #664 hang had CPU advancing). Extracted `_apply_zombie_override` for C901 headroom.
- Tests: 1 adapted + 5 new (fresh-log veto + streak reset, #778 transient replay, sparse-log window coupling, genuine two-tick #664 TP, cleared-candidate reset); `failure_patterns.md` detector caveat updated.

## Test plan
- [x] `uv run pytest tests/test_poll_pipeline_zombie_gpu.py -q` — 14 passed
- [x] Step 9c touched-subset gate — 1950 passed / 5 pre-existing-on-main failures (reproduced identically at repo root)
- [x] ruff clean on touched files; `workflow_lint.py --check-asks` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)