### PR TITLE
task #822: reviewer-side mechanical presence gate for epm:smoke-architecture-check

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -146,6 +146,43 @@ the absence of (e) becomes a CONCERNS bullet under "Style / Consistency"
 (not a standalone FAIL — the reviewer still verifies via `task.py
 list-concerns <N> --open-only --json`, which is the canonical signal).
 
+### Step 0.55: Smoke-architecture marker presence gate (`type:experiment` only)
+
+For `type:experiment` tasks, verify a separate `epm:smoke-architecture-check`
+events row EXISTS in canonical task state — `uv run python scripts/task.py
+view <N> --json`, never a possibly-stale worktree `events.jsonl` (the same
+false-absence caution as Step 0.5) — with a parseable `verdict:` line, one of
+`PASS_UNIFIED` | `PASS_CANARY canary_cell=<id>` | `FAIL_NO_CANARY`. The
+implementer posts it ONCE at pre-flight (experiment-implementer.md "Before
+writing code" item 5); fix rounds do NOT re-post, so the check is
+presence-on-task (any version), NEVER presence-per-round — a fix-round review
+with a round-1 marker PASSes this gate.
+
+- **Genuine absence** (no such events row at all, OR the row carries no
+  recognizable `verdict:` line): return verdict FAIL with a single `Critical`
+  issue tagged `marker-shape` whose body NAMES `epm:smoke-architecture-check`
+  (the orchestrator's Step 5c-bis strip is keyed PER BLOCKER on that name —
+  a Step 0.55 blocker body names exactly ONE marker kind,
+  `epm:smoke-architecture-check`, never a combined Step 0.5 + 0.55 blocker),
+  AND still read the diff (Step 0.7):
+
+  > No `epm:smoke-architecture-check` events row exists in canonical task
+  > state. experiment-implementer.md "Before writing code" item 5 mandates it
+  > before code-review-PASS, and /issue Step 6d.0 will refuse dispatch without
+  > it — AFTER pod provisioning has already run. Post it as a separate events
+  > row (`verdict: PASS_UNIFIED` | `PASS_CANARY canary_cell=<id>` |
+  > `FAIL_NO_CANARY`); prose in a dispatcher header or an HTML comment inside
+  > the `epm:experiment-implementation` note does NOT count (incident #811:
+  > the claim lived in a dispatcher header across 5 rounds, both reviewers
+  > PASSed, and the gap surfaced only at Step 6d.0 post-provision).
+
+- **Present with `verdict: FAIL_NO_CANARY`**: NOT a reviewer FAIL — Step 6d.0
+  (gates.inline id=10) owns FAIL_NO_CANARY adjudication (bounce to planning).
+  Note it as a CONCERNS bullet so the orchestrator sees it early.
+- **Present + parseable** (either PASS verdict): proceed. You do NOT
+  re-adjudicate the verdict's substance — the unification/canary judgment is
+  Step 6d.0's.
+
 ### Step 0.8: Read prior open binding concerns
 
 Before reading the plan, fetch the canonical concerns ledger:
@@ -604,16 +641,16 @@ dispatcher-exposed shape.
 
 ### Step 0.7: Pre-diff gates never short-circuit the diff
 
-Steps 0.5, 0.6, 0.65, and 0.67 are pre-diff *contract* checks, not a
+Steps 0.5, 0.55, 0.6, 0.65, and 0.67 are pre-diff *contract* checks, not a
 substitute for review. Two hard rules bind every verdict:
 
-1. **A FAIL must carry a genuine-absence blocker (per 0.5 / 0.6 / 0.65 / 0.67) OR a
+1. **A FAIL must carry a genuine-absence blocker (per 0.5 / 0.55 / 0.6 / 0.65 / 0.67) OR a
    substantive finding from reading the diff.** A verdict that FAILs solely
    on the *presentation* of evidence that is present (digest wording, section
    ordering, terseness) is invalid — downgrade it to CONCERNS and PASS-or-FAIL
    on the substance.
-2. **You always read the diff (Steps 1–7), even when you raise a 0.5 / 0.6 /
-   0.65 / 0.67 blocker.** Never emit a verdict whose body says "the diff was not
+2. **You always read the diff (Steps 1–7), even when you raise a 0.5 / 0.55 /
+   0.6 / 0.65 / 0.67 blocker.** Never emit a verdict whose body says "the diff was not
    reviewed." Reviewing the code in the same pass means a genuinely-missing
    smoke section and a real bug surface together in one round instead of
    across three — and it prevents the gate-hopping failure mode where a
@@ -909,7 +946,7 @@ Red flags:
 # Code Review: [Task Title]
 
 **Verdict:** PASS / CONCERNS / FAIL
-**Blocker tags:** [comma-separated, FAIL only: `marker-shape` (Step 0.5 genuine absence), `smoke-run-missing` (Step 0.6 genuine absence), `git-provenance` (Step 0.9 — a broken-test / lint / reverted-file / diff-broke-X finding you are not certain the round introduced; REQUIRES a `**Git-provenance subclass:**` line naming one of `pre-existing-on-trunk` | `stale-main-or-worktree` | `cumulative-main-head-diff`), `cached-artifact-coverage-unverified` (Step 3.5 — substantive, NOT mechanical-contract), `compute-shape-mismatch` (Step 0.67 — plan §9 declares a data-parallel/sharded shape the dispatcher does not expose; substantive, NOT mechanical-contract), `substantive` (any code / plan / test / security finding from Steps 1–7). `none` on PASS / CONCERNS. This line is the orchestrator's parse target for the Step 5c-bis mechanical-contract-only strip — a FAIL whose tags are a subset of {`marker-shape`, `smoke-run-missing`, `git-provenance`} with no `substantive` is mechanical-contract-only.]
+**Blocker tags:** [comma-separated, FAIL only: `marker-shape` (Step 0.5 / 0.55 genuine absence — a 0.55 blocker body names `epm:smoke-architecture-check`), `smoke-run-missing` (Step 0.6 genuine absence), `git-provenance` (Step 0.9 — a broken-test / lint / reverted-file / diff-broke-X finding you are not certain the round introduced; REQUIRES a `**Git-provenance subclass:**` line naming one of `pre-existing-on-trunk` | `stale-main-or-worktree` | `cumulative-main-head-diff`), `cached-artifact-coverage-unverified` (Step 3.5 — substantive, NOT mechanical-contract), `compute-shape-mismatch` (Step 0.67 — plan §9 declares a data-parallel/sharded shape the dispatcher does not expose; substantive, NOT mechanical-contract), `substantive` (any code / plan / test / security finding from Steps 1–7). `none` on PASS / CONCERNS. This line is the orchestrator's parse target for the Step 5c-bis mechanical-contract-only strip — a FAIL whose tags are a subset of {`marker-shape`, `smoke-run-missing`, `git-provenance`} with no `substantive` is mechanical-contract-only.]
 **Tier:** leaf / trunk (Step 0 classification)
 **Diff size:** +X / -Y lines across Z files
 **Plan adherence:** COMPLETE / PARTIAL (N items incomplete) / DEVIATES (unplanned changes)
@@ -972,7 +1009,7 @@ Red flags:
 5. **Be specific.** "This feels off" is useless. "`foo.py:42` uses `==` for float comparison; should be `math.isclose`" is useful.
 6. **No politics.** Don't soften findings to be nice. A merged bug costs more than a bruised ego.
 7. **Propose the simplest fix** when you can. Reviewers who only find problems without paths forward are useless.
-8. **Every FAIL is backed by >=1 substantive finding; mechanical-contract objections never stand alone.** See Step 0.7. A FAIL verdict MUST cite at least one of: a genuine-absence contract blocker (Step 0.5 marker fully absent / Step 0.6 smoke section absent, non-zero-exit, or a plan-declared load-bearing runtime guard with no smoke evidence and no documented `(d)` call-out), OR a substantive code/plan/test/security finding from Steps 1-7. Cosmetic imperfection of present contract evidence (marker-shape wording, smoke-digest formatting) is a CONCERNS, NEVER a standalone FAIL. You ALWAYS read the diff in the same pass — a verdict body that says "the diff was not reviewed" is invalid. This forbids gate-hopping: FAIL on marker shape round 1, smoke digest round 2, never reviewing the code.
+8. **Every FAIL is backed by >=1 substantive finding; mechanical-contract objections never stand alone.** See Step 0.7. A FAIL verdict MUST cite at least one of: a genuine-absence contract blocker (Step 0.5 marker fully absent / Step 0.55 no `epm:smoke-architecture-check` events row / Step 0.6 smoke section absent, non-zero-exit, or a plan-declared load-bearing runtime guard with no smoke evidence and no documented `(d)` call-out), OR a substantive code/plan/test/security finding from Steps 1-7. Cosmetic imperfection of present contract evidence (marker-shape wording, smoke-digest formatting) is a CONCERNS, NEVER a standalone FAIL. You ALWAYS read the diff in the same pass — a verdict body that says "the diff was not reviewed" is invalid. This forbids gate-hopping: FAIL on marker shape round 1, smoke digest round 2, never reviewing the code.
 9. **No fabricated plan-adherence checkmarks.** Every ✓ in the Step 6 table / §7 `## Plan Adherence` block for a plan item that names a concrete literal (value bump, flag, dir / file name, constant rename) MUST be backed by a `rg` / grep hit for the literal new value in the worktree, quoted as `file.py:LINE` in the row's evidence. Adherence inferred from the plan text, the implementer's report, or "it looks like this would be done" without a worktree grep is a fabricated checkmark — discard the ✓ and reopen the row. Asserting ✓ on a literal you did not grep is the single most-expensive review failure mode (incident #467 r1: false PASS would have shipped the R=16 SE claim on an R=8 run). See Step 6 grep-the-literal rule for the procedure.
 10. **Cached-artifact coverage is verified, not implied.** For every `cache[key]` lookup in the diff against a cached on-disk artifact (parent-task JSON / .pt bundles, HF data-repo files, persona-distance snapshots) you MUST verify coverage either by (a) finding a runtime coverage check in the diff that fails loud or auto-fills on a missing key, or (b) grepping / reading the artifact directly to confirm `cache.keys() ⊇ runtime_lookup_keys`. Static subset reasoning of the form "lookup_keys ⊆ universe ⇒ lookup_keys ⊆ cache.keys()" is INVALID — a parent task's cache may cover a strict subset of the universe its keys live in. Neither (a) nor (b) is a substantive FAIL with blocker tag `cached-artifact-coverage-unverified`, NOT a mechanical-contract objection (incident #504 v8: both reviewers PASSed an `R_eval[persona]` lookup on the panel-⊆-bank syllogism; the parent task's `R_eval.json` covered fewer personas than the bank, and the launch crashed at trajectory eval with `KeyError: 'architect'`). See Step 3.5 for the procedure.
 11. **Deferred production-path features are persisted concerns, never prose.** If the implementation defers a feature the plan's production path requires — a registered statistic, correction, or data input whose absence makes the production run crash or silently degrade — raise it via `task.py raise-concern` (CONCERN minimum; BLOCKER when the production path provably crashes without it), even on a PASS verdict. The Step 5c-ter dispatch gate reads `concerns.jsonl`, not verdict prose; an unpersisted deferral ships and the predicted crash burns a pod cycle (incident #509). See Step 0.8 for the procedure.

--- a/.claude/agents/codex-code-reviewer.md
+++ b/.claude/agents/codex-code-reviewer.md
@@ -307,6 +307,30 @@ both reviewers are graded against the same standard. Read
   `### (e) Concerns addressed`** rule (present only when prior open
   concerns existed; missing-(e)-when-required is at most a CONCERNS bullet,
   NEVER a `marker-shape` FAIL — the 4-section main contract is preserved).
+- "Step 0.55: Smoke-architecture marker presence gate" (`type:experiment`
+  only) — INCLUDING all three of its rules: (i) the check is
+  presence-ON-TASK (any version), NEVER presence-per-round — the implementer
+  posts `epm:smoke-architecture-check` ONCE at pre-flight and fix rounds do
+  NOT re-post, so a fix-round review with a round-1 marker PASSes; (ii)
+  genuine absence (no such events row, or no parseable `verdict:` line among
+  `PASS_UNIFIED` | `PASS_CANARY canary_cell=<id>` | `FAIL_NO_CANARY`) is a
+  single Critical tagged `marker-shape` whose body NAMES
+  `epm:smoke-architecture-check` — exactly ONE marker kind per blocker,
+  never a combined Step 0.5 + 0.55 blocker (the orchestrator's strip is
+  keyed per blocker on that name); (iii) a PRESENT `verdict: FAIL_NO_CANARY`
+  is NOT a reviewer FAIL — /issue Step 6d.0 (gates.inline id=10) owns that
+  adjudication; note it as a CONCERNS bullet only. The composer (Step 2-pre
+  pattern) fetches the highest-version marker via
+  `uv run python "$REPO_ROOT/scripts/task.py" latest-marker <N> --prefix
+  epm:smoke-architecture-check` and INLINES its body into the prompt inside a
+  `---BEGIN/END SMOKE-ARCHITECTURE-CHECK MARKER BODY---` envelope; when the
+  fetch returns nothing (absence is a VALID finding here, not a compose
+  failure — do NOT fail-loud like the implementation-marker fetch), inline
+  the literal line `SMOKE-ARCHITECTURE-CHECK MARKER: ABSENT in canonical
+  task state` instead so Codex raises the Step 0.55 blocker. Codex scores
+  presence on the INLINED content only, never on `tasks/...` path
+  reachability (the worktree's tasks/ folder is frozen at branch-creation
+  status — same rationale as the implementation-marker inline).
 - "Step 0.6: End-to-end smoke gate" (`type:experiment` only) — INCLUDING its
   present-but-imperfect-digest → CONCERNS rule AND the
   **deferred-imports-inside-smoke-skipped-branches check**: when a smoke
@@ -499,7 +523,7 @@ fine.)
 
 Follow this protocol:
 
-{{INLINED RUBRIC FROM code-reviewer.md Steps 0, 0.5, 0.6, 0.65, 0.67, 0.7, 0.8, 1, 2, 3, 3.5, 3.7, 4.5, 5, 6, 7 + Rules 12 (blocker grounding + mechanizability, Codex-adapted) + 13 (regression-test presence for substantive BLOCKER fixes) + 14 (bug-class sibling sweep — every finding is a CLASS not a line) + 15 (plan-declared compute shape exposed by dispatcher)}}
+{{INLINED RUBRIC FROM code-reviewer.md Steps 0, 0.5, 0.55, 0.6, 0.65, 0.67, 0.7, 0.8, 1, 2, 3, 3.5, 3.7, 4.5, 5, 6, 7 + Rules 12 (blocker grounding + mechanizability, Codex-adapted) + 13 (regression-test presence for substantive BLOCKER fixes) + 14 (bug-class sibling sweep — every finding is a CLASS not a line) + 15 (plan-declared compute shape exposed by dispatcher)}}
 
 You MUST emit your verdict in EXACTLY this format. No preamble, no code
 fences around the marker, no commentary outside the marker tags:
@@ -508,7 +532,7 @@ fences around the marker, no commentary outside the marker tags:
 # Codex Code Review: {{title}}
 
 **Verdict:** PASS | CONCERNS | FAIL
-**Blocker tags:** [comma-separated, FAIL only: `marker-shape` (Step 0.5 genuine absence) | `smoke-run-missing` (Step 0.6 genuine absence) | `git-provenance` (Step 0.9 — a broken-test / lint / reverted-file / diff-broke-X finding you are not certain the round introduced; REQUIRES a `**Git-provenance subclass:**` line naming one of `pre-existing-on-trunk` | `stale-main-or-worktree` | `cumulative-main-head-diff`; if you ARE certain the round introduced it, tag `substantive` NOT `git-provenance`) | `raw-completions-upload-missing` (Step 0.65 genuine absence — substantive, NOT mechanical-contract) | `cached-artifact-coverage-unverified` (Step 3.5 — substantive, NOT mechanical-contract) | `compute-shape-mismatch` (Step 0.67 — plan §9 declares a data-parallel/sharded shape the dispatcher does not expose; substantive, NOT mechanical-contract) | `substantive` (any code/plan/test/security finding from Steps 1–7). `none` on PASS|CONCERNS. The orchestrator parses this line for the Step 5c-bis mechanical-contract-only strip — a FAIL whose tags are a subset of {`marker-shape`, `smoke-run-missing`, `git-provenance`} with no `substantive` is mechanical-contract-only.]
+**Blocker tags:** [comma-separated, FAIL only: `marker-shape` (Step 0.5 / 0.55 genuine absence — a 0.55 blocker body names `epm:smoke-architecture-check`) | `smoke-run-missing` (Step 0.6 genuine absence) | `git-provenance` (Step 0.9 — a broken-test / lint / reverted-file / diff-broke-X finding you are not certain the round introduced; REQUIRES a `**Git-provenance subclass:**` line naming one of `pre-existing-on-trunk` | `stale-main-or-worktree` | `cumulative-main-head-diff`; if you ARE certain the round introduced it, tag `substantive` NOT `git-provenance`) | `raw-completions-upload-missing` (Step 0.65 genuine absence — substantive, NOT mechanical-contract) | `cached-artifact-coverage-unverified` (Step 3.5 — substantive, NOT mechanical-contract) | `compute-shape-mismatch` (Step 0.67 — plan §9 declares a data-parallel/sharded shape the dispatcher does not expose; substantive, NOT mechanical-contract) | `substantive` (any code/plan/test/security finding from Steps 1–7). `none` on PASS|CONCERNS. The orchestrator parses this line for the Step 5c-bis mechanical-contract-only strip — a FAIL whose tags are a subset of {`marker-shape`, `smoke-run-missing`, `git-provenance`} with no `substantive` is mechanical-contract-only.]
 **Tier:** leaf | trunk
 **Diff size:** +X / -Y lines across Z files
 **Diff acquisition:** three-dot | two-dot (no merge base) | sha-range <range>

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -2095,8 +2095,8 @@ reconciler invocations.
 **5c-bis. Mechanical-contract-only FAIL strip (anti-gate-hopping).**
 
 A FAIL is *mechanical-contract-only* when its `**Blocker tags:**` line
-(reviewer Step 7 template) is a non-empty subset of {`marker-shape` (Step
-0.5), `smoke-run-missing` (Step 0.6), `git-provenance` (Step 0.9)} and does
+(reviewer Step 7 template) is a non-empty subset of {`marker-shape` (Steps
+0.5 / 0.55), `smoke-run-missing` (Step 0.6), `git-provenance` (Step 0.9)} and does
 NOT contain `substantive`
 (any code / plan / test / security finding). The `**Blocker tags:**` line is
 the parse target; if a legacy verdict omits it, fall back to reading the
@@ -2111,8 +2111,19 @@ worktree `events.jsonl` — before the implementation marker was pulled in — i
 the most common false absence; the canonical read is what catches it.) No LLM
 judgment, just structural presence:
 
-- **marker-shape:** all four H3 sections `(a)`–`(d)` present with non-empty
-  content AND `(c)` carries at least one fenced command.
+- **marker-shape:** two sub-recipes, keyed PER BLOCKER on the blocker body
+  (a conforming Step 0.55 blocker names exactly ONE marker kind,
+  `epm:smoke-architecture-check` — never a combined Step 0.5 + 0.55 blocker).
+  When the blocker names `epm:smoke-architecture-check` (Step 0.55): a
+  separate `epm:smoke-architecture-check` events row exists in canonical task
+  state with a `verdict:` line matching `PASS_UNIFIED` | `PASS_CANARY
+  canary_cell=<id>` | `FAIL_NO_CANARY` — present + parseable → STRIP (a
+  stale-worktree false absence); absent or verdict-less → leave the FAIL in
+  place (the gate is doing its job; do NOT check the implementation marker's
+  H3s for this sub-case — they can be conforming while the separate row is
+  missing, which is exactly incident #811). Otherwise (the Step 0.5 default):
+  all four H3 sections `(a)`–`(d)` present with non-empty content AND `(c)`
+  carries at least one fenced command.
 - **smoke-run-missing:** a `## Smoke run` section is present, and EVERY phase
   the pipeline actually executes (typically data-gen, training, eval) has its
   own sub-section with a command, exit code `0`, and an artifact digest. A

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -3591,6 +3591,111 @@ def check_compute_shape_review_lens(*, repo_root: Path | None = None) -> list[st
     return errors
 
 
+def check_smoke_architecture_review_lens(*, repo_root: Path | None = None) -> list[str]:
+    """FAIL if the smoke-architecture marker presence gate (#822) is absent
+    from ANY of its three surfaces.
+
+    Task #811's implementer claimed the smoke-architecture verdict in prose (a
+    dispatcher header) but never posted the separate
+    `epm:smoke-architecture-check` events row; both reviewers PASSed 5 rounds
+    and the gap surfaced only at /issue Step 6d.0 AFTER pod provisioning. The
+    fix added a Step 0.55 presence lens to BOTH code-reviewer agent files and
+    a per-blocker `marker-shape` sub-recipe to the /issue Step 5c-bis strip.
+    This check pins all three surfaces, region-anchored, so a future refactor
+    cannot silently strip one and re-open the gap:
+
+    (a) code-reviewer.md — a ``### Step 0.55`` section whose body (up to the
+        next ``### `` heading) names ``epm:smoke-architecture-check``;
+    (b) codex-code-reviewer.md — the Step 0.55 copy-list bullet (heading
+        literal + marker kind) AND ``0.55`` on the ``{{INLINED RUBRIC``
+        placeholder line;
+    (c) `.claude/skills/issue/SKILL.md` — the Step 5c-bis region (between the
+        ``**5c-bis.`` and ``**5c-ter.`` headings) names
+        ``epm:smoke-architecture-check``.
+
+    ``repo_root`` is a unit-test override hook; production callers pass None
+    (canonical repo root). Bundled into the no-flags default run.
+    """
+    root = repo_root if repo_root is not None else _REPO_ROOT
+    marker = "epm:smoke-architecture-check"
+    errors: list[str] = []
+
+    # (a) code-reviewer.md: the Step 0.55 section body names the marker.
+    reviewer = root / ".claude" / "agents" / "code-reviewer.md"
+    if not reviewer.is_file():
+        errors.append(
+            f"{reviewer}: missing — the #822 smoke-architecture marker "
+            f"presence gate (Step 0.55) must live in code-reviewer.md."
+        )
+    else:
+        text = reviewer.read_text(encoding="utf-8")
+        idx = text.find("### Step 0.55")
+        if idx == -1:
+            errors.append(
+                f"{reviewer}: missing the '### Step 0.55' section (#822). The "
+                f"smoke-architecture marker presence gate must stay in the "
+                f"Claude reviewer so a missing {marker} events row FAILs at "
+                f"code-review, not at Step 6d.0 post-provision (incident #811)."
+            )
+        else:
+            nxt = text.find("\n### ", idx + 1)
+            body = text[idx:nxt] if nxt != -1 else text[idx:]
+            if marker not in body:
+                errors.append(
+                    f"{reviewer}: the '### Step 0.55' section body no longer "
+                    f"names {marker!r} (#822) — the presence gate must key on "
+                    f"that exact marker kind."
+                )
+
+    # (b) codex-code-reviewer.md: the copy-list bullet + rubric placeholder.
+    codex = root / ".claude" / "agents" / "codex-code-reviewer.md"
+    if not codex.is_file():
+        errors.append(
+            f"{codex}: missing — the #822 smoke-architecture marker presence "
+            f"gate (Step 0.55 copy-list bullet) must live in "
+            f"codex-code-reviewer.md."
+        )
+    else:
+        text = codex.read_text(encoding="utf-8")
+        for token in ('"Step 0.55: Smoke-architecture marker presence gate"', marker):
+            if token not in text:
+                errors.append(
+                    f"{codex}: missing the Step 0.55 copy-list token {token!r} "
+                    f"(#822) — the Codex twin must copy the same presence lens "
+                    f"or the two reviewers drift (the #606 copy-list-omission "
+                    f"class)."
+                )
+        rubric_lines = [ln for ln in text.splitlines() if "{{INLINED RUBRIC" in ln]
+        if not any("0.55" in ln for ln in rubric_lines):
+            errors.append(
+                f"{codex}: '0.55' is absent from the '{{{{INLINED RUBRIC' "
+                f"placeholder line (#822) — the composed Codex prompt would "
+                f"omit the Step 0.55 lens."
+            )
+
+    # (c) SKILL.md: the Step 5c-bis strip region names the marker sub-recipe.
+    skill = root / ".claude" / "skills" / "issue" / "SKILL.md"
+    if not skill.is_file():
+        errors.append(
+            f"{skill}: missing — the #822 Step 5c-bis per-blocker "
+            f"marker-shape sub-recipe must live in the /issue skill."
+        )
+    else:
+        text = skill.read_text(encoding="utf-8")
+        start = text.find("**5c-bis.")
+        end = text.find("**5c-ter.")
+        region = text[start:end] if (start != -1 and end != -1 and end > start) else ""
+        if marker not in region:
+            errors.append(
+                f"{skill}: the Step 5c-bis region (between '**5c-bis.' and "
+                f"'**5c-ter.') no longer names {marker!r} (#822) — the "
+                f"mechanical-contract strip needs the per-blocker sub-recipe "
+                f"to distinguish a stale-worktree false absence (STRIP) from "
+                f"a genuine one (leave the FAIL in place)."
+            )
+    return errors
+
+
 # `--check-lessons-index`: every `.claude/rules/*.md` (except LESSONS.md
 # itself) must have exactly one matching row in `.claude/rules/LESSONS.md`, and
 # every row in LESSONS.md must point at an existing rule file. Closes the
@@ -4034,6 +4139,19 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         "Bundled into the no-flags default run.",
     )
     parser.add_argument(
+        "--check-smoke-architecture-review-lens",
+        action="store_true",
+        help="FAIL if the #822 smoke-architecture marker presence gate (Step "
+        "0.55) is absent from any of its three surfaces: the Step 0.55 "
+        "section in code-reviewer.md, the Step 0.55 copy-list bullet + "
+        "rubric-placeholder entry in codex-code-reviewer.md, or the "
+        "epm:smoke-architecture-check sub-recipe in the /issue Step 5c-bis "
+        "strip region. Pins the reviewer-side presence check for the "
+        "epm:smoke-architecture-check events row (incident #811: the verdict "
+        "lived in prose across 5 PASSed rounds and the gap surfaced only at "
+        "Step 6d.0 post-provision). Bundled into the no-flags default run.",
+    )
+    parser.add_argument(
         "--check-judge-model-pins",
         action="store_true",
         help="Walk scripts/**/*.py, scripts/**/*.sh, "
@@ -4088,6 +4206,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         or args.check_gate_ids_unique
         or args.check_lessons_index
         or args.check_compute_shape_review_lens
+        or args.check_smoke_architecture_review_lens
         or args.check_judge_model_pins
     )
 
@@ -4155,6 +4274,8 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         errors.extend(check_lessons_index())
     if args.check_compute_shape_review_lens or no_flags:
         errors.extend(check_compute_shape_review_lens())
+    if args.check_smoke_architecture_review_lens or no_flags:
+        errors.extend(check_smoke_architecture_review_lens())
     if args.check_judge_model_pins or no_flags:
         errors.extend(check_judge_model_pins())
 

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -3657,13 +3657,26 @@ def check_smoke_architecture_review_lens(*, repo_root: Path | None = None) -> li
         )
     else:
         text = codex.read_text(encoding="utf-8")
-        for token in ('"Step 0.55: Smoke-architecture marker presence gate"', marker):
+        heading = '"Step 0.55: Smoke-architecture marker presence gate"'
+        for token in (heading, marker):
             if token not in text:
                 errors.append(
                     f"{codex}: missing the Step 0.55 copy-list token {token!r} "
                     f"(#822) — the Codex twin must copy the same presence lens "
                     f"or the two reviewers drift (the #606 copy-list-omission "
                     f"class)."
+                )
+        idx = text.find(heading)
+        if idx != -1 and marker in text:
+            nxt = text.find('\n- "', idx + 1)
+            bullet = text[idx:nxt] if nxt != -1 else text[idx:]
+            if marker not in bullet:
+                errors.append(
+                    f"{codex}: the Step 0.55 copy-list bullet (heading token "
+                    f"to the next line-start '- \"' bullet) no longer names "
+                    f"{marker!r} (#822) — a marker mention elsewhere in the "
+                    f"file (e.g. the Step 7 blocker-tags line) does not keep "
+                    f"the copied lens itself keyed on that marker."
                 )
         rubric_lines = [ln for ln in text.splitlines() if "{{INLINED RUBRIC" in ln]
         if not any("0.55" in ln for ln in rubric_lines):

--- a/tests/test_workflow_lint.py
+++ b/tests/test_workflow_lint.py
@@ -50,6 +50,7 @@ from workflow_lint import (  # noqa: E402
     check_pipe_python,
     check_script_references,
     check_skill_references,
+    check_smoke_architecture_review_lens,
     check_upload_as_file,
     check_wandb_required,
 )
@@ -2838,3 +2839,131 @@ def test_compute_shape_review_lens_flags_both_files(tmp_path) -> None:
     subjects = {e.split(": ", 1)[0] for e in errors}
     assert any(s.endswith("/code-reviewer.md") for s in subjects), subjects
     assert any(s.endswith("/codex-code-reviewer.md") for s in subjects), subjects
+
+
+def _write_smoke_arch_conforming_tree(tmp_path) -> None:
+    """Write all three #822 surfaces in conforming shape under tmp_path.
+
+    Tests then break exactly ONE surface each, so failures stay attributable
+    (absence errors from the untouched surfaces would otherwise pollute
+    counts).
+    """
+    agents = tmp_path / ".claude" / "agents"
+    agents.mkdir(parents=True, exist_ok=True)
+    (agents / "code-reviewer.md").write_text(
+        "# reviewer\n"
+        "### Step 0.55: Smoke-architecture marker presence gate\n"
+        "check for an `epm:smoke-architecture-check` events row.\n"
+        "### Step 0.8\nnext section\n"
+    )
+    (agents / "codex-code-reviewer.md").write_text(
+        "# codex\n"
+        '- "Step 0.55: Smoke-architecture marker presence gate" bullet naming\n'
+        "  `epm:smoke-architecture-check`.\n"
+        "{{INLINED RUBRIC FROM code-reviewer.md Steps 0, 0.5, 0.55, 0.6}}\n"
+    )
+    skill = tmp_path / ".claude" / "skills" / "issue"
+    skill.mkdir(parents=True, exist_ok=True)
+    (skill / "SKILL.md").write_text(
+        "# issue skill\n"
+        "**5c-bis. Mechanical strip** — a blocker naming\n"
+        "`epm:smoke-architecture-check` gets the per-blocker sub-recipe.\n"
+        "**5c-ter. Next step**\n"
+    )
+
+
+def test_smoke_architecture_review_lens_live_tree_passes() -> None:
+    """The real tree carries the #822 presence gate on all three surfaces."""
+    assert check_smoke_architecture_review_lens() == []
+
+
+def test_smoke_architecture_review_lens_conforming_fixture_passes(tmp_path) -> None:
+    """The synthetic conforming tree passes — validates the fixture itself."""
+    _write_smoke_arch_conforming_tree(tmp_path)
+    assert check_smoke_architecture_review_lens(repo_root=tmp_path) == []
+
+
+def test_smoke_architecture_review_lens_flags_missing_step_section(tmp_path) -> None:
+    """code-reviewer.md without the '### Step 0.55' section FAILs (#822)."""
+    _write_smoke_arch_conforming_tree(tmp_path)
+    agents = tmp_path / ".claude" / "agents"
+    (agents / "code-reviewer.md").write_text("# reviewer\nno presence gate here\n")
+    errors = check_smoke_architecture_review_lens(repo_root=tmp_path)
+    assert errors, "expected a FAIL for code-reviewer.md missing Step 0.55"
+    # Key on the SUBJECT of each error — the file path before the first ': '
+    # (message bodies cross-reference sibling filenames in prose, so a naive
+    # substring search would collide).
+    subjects = [e.split(": ", 1)[0] for e in errors]
+    assert all(s.endswith("/code-reviewer.md") for s in subjects), subjects
+    assert all(not s.endswith("/codex-code-reviewer.md") for s in subjects), subjects
+
+
+def test_smoke_architecture_review_lens_flags_marker_missing_from_section(tmp_path) -> None:
+    """A Step 0.55 section whose body drops the marker name FAILs (#822).
+
+    The region is the section body up to the next '### ' heading — the marker
+    appearing elsewhere in the file must NOT satisfy the check.
+    """
+    _write_smoke_arch_conforming_tree(tmp_path)
+    agents = tmp_path / ".claude" / "agents"
+    (agents / "code-reviewer.md").write_text(
+        "# reviewer\n"
+        "### Step 0.55: Smoke-architecture marker presence gate\n"
+        "body without the marker name.\n"
+        "### Step 0.8\nmentions `epm:smoke-architecture-check` outside the region\n"
+    )
+    errors = check_smoke_architecture_review_lens(repo_root=tmp_path)
+    assert errors, "expected a FAIL for the marker-less Step 0.55 body"
+    subjects = [e.split(": ", 1)[0] for e in errors]
+    assert all(s.endswith("/code-reviewer.md") for s in subjects), subjects
+
+
+def test_smoke_architecture_review_lens_flags_codex_tokens(tmp_path) -> None:
+    """codex-code-reviewer.md missing bullet heading + marker FAILs twice (#822)."""
+    _write_smoke_arch_conforming_tree(tmp_path)
+    agents = tmp_path / ".claude" / "agents"
+    (agents / "codex-code-reviewer.md").write_text(
+        "# codex\n{{INLINED RUBRIC FROM code-reviewer.md Steps 0, 0.5, 0.55, 0.6}}\n"
+    )
+    errors = check_smoke_architecture_review_lens(repo_root=tmp_path)
+    # Both required copy-list tokens are missing → one error per token.
+    assert len(errors) == 2, errors
+    subjects = {e.split(": ", 1)[0] for e in errors}
+    assert subjects and all(s.endswith("/codex-code-reviewer.md") for s in subjects), subjects
+
+
+def test_smoke_architecture_review_lens_flags_rubric_placeholder(tmp_path) -> None:
+    """The '{{INLINED RUBRIC' placeholder line without '0.55' FAILs (#822)."""
+    _write_smoke_arch_conforming_tree(tmp_path)
+    agents = tmp_path / ".claude" / "agents"
+    (agents / "codex-code-reviewer.md").write_text(
+        "# codex\n"
+        '- "Step 0.55: Smoke-architecture marker presence gate" bullet naming\n'
+        "  `epm:smoke-architecture-check`.\n"
+        "{{INLINED RUBRIC FROM code-reviewer.md Steps 0, 0.5, 0.6}}\n"
+    )
+    errors = check_smoke_architecture_review_lens(repo_root=tmp_path)
+    assert errors, "expected a FAIL for the 0.55-less rubric placeholder line"
+    subjects = [e.split(": ", 1)[0] for e in errors]
+    assert all(s.endswith("/codex-code-reviewer.md") for s in subjects), subjects
+    assert any("0.55" in e for e in errors), errors
+
+
+def test_smoke_architecture_review_lens_flags_skill_region(tmp_path) -> None:
+    """A 5c-bis region without the marker sub-recipe FAILs (#822).
+
+    The marker appearing OUTSIDE the '**5c-bis.' → '**5c-ter.' region must not
+    satisfy the check.
+    """
+    _write_smoke_arch_conforming_tree(tmp_path)
+    skill = tmp_path / ".claude" / "skills" / "issue"
+    (skill / "SKILL.md").write_text(
+        "# issue skill\n"
+        "`epm:smoke-architecture-check` mentioned before the region.\n"
+        "**5c-bis. Mechanical strip** — no sub-recipe here.\n"
+        "**5c-ter. Next step**\n"
+    )
+    errors = check_smoke_architecture_review_lens(repo_root=tmp_path)
+    assert errors, "expected a FAIL for the sub-recipe-less 5c-bis region"
+    subjects = [e.split(": ", 1)[0] for e in errors]
+    assert all(s.endswith("/SKILL.md") for s in subjects), subjects

--- a/tests/test_workflow_lint.py
+++ b/tests/test_workflow_lint.py
@@ -2932,6 +2932,33 @@ def test_smoke_architecture_review_lens_flags_codex_tokens(tmp_path) -> None:
     assert subjects and all(s.endswith("/codex-code-reviewer.md") for s in subjects), subjects
 
 
+def test_smoke_architecture_review_lens_flags_marker_outside_codex_bullet(tmp_path) -> None:
+    """A codex copy-list bullet stripped of the marker FAILs even when the
+    marker survives elsewhere in the file (#822, round 2).
+
+    The bullet region runs from the heading token to the next line-start
+    '- "' bullet; a marker mention in a later '**Blocker tags:**' line must
+    NOT satisfy the check (the file-global drift case the round-1 check
+    missed).
+    """
+    _write_smoke_arch_conforming_tree(tmp_path)
+    agents = tmp_path / ".claude" / "agents"
+    (agents / "codex-code-reviewer.md").write_text(
+        "# codex\n"
+        '- "Step 0.55: Smoke-architecture marker presence gate" bullet with\n'
+        "  the marker name stripped from the bullet body.\n"
+        '- "Step 0.6: End-to-end smoke gate" next bullet.\n'
+        "{{INLINED RUBRIC FROM code-reviewer.md Steps 0, 0.5, 0.55, 0.6}}\n"
+        "**Blocker tags:** `marker-shape` blockers name "
+        "`epm:smoke-architecture-check` here, outside the bullet.\n"
+    )
+    errors = check_smoke_architecture_review_lens(repo_root=tmp_path)
+    assert errors, "expected a FAIL for the marker-less Step 0.55 copy-list bullet"
+    subjects = [e.split(": ", 1)[0] for e in errors]
+    assert all(s.endswith("/codex-code-reviewer.md") for s in subjects), subjects
+    assert any("copy-list bullet" in e for e in errors), errors
+
+
 def test_smoke_architecture_review_lens_flags_rubric_placeholder(tmp_path) -> None:
     """The '{{INLINED RUBRIC' placeholder line without '0.55' FAILs (#822)."""
     _write_smoke_arch_conforming_tree(tmp_path)


### PR DESCRIPTION
Closes task #822 (workflow-fix, origin incident #811).

## Summary
- New code-reviewer.md Step 0.55: mechanical presence gate for the implementer's `epm:smoke-architecture-check` marker (`type:experiment` only; FAIL tag `marker-shape` on genuine absence; presence-on-task, never per-round; FAIL_NO_CANARY carved out to Step 6d.0; blocker body names exactly one marker kind).
- SKILL.md Step 5c-bis: two-sub-recipe strip branch keyed on the blocker body naming the marker (false positives strip; true absences stand).
- codex-code-reviewer.md: copy-list bullet + rubric placeholder + Blocker-tags sync + ABSENT-literal marker inline.
- workflow_lint.py: `check_smoke_architecture_review_lens` (no-flags bundled, region-scoped on all three surfaces) + 8 pinning tests.

## Test plan
- [x] Plan ensemble APPROVE 3/3 lenses (Claude+Codex)
- [x] Code-review round 1 FAIL (1 verified Major) -> round-2 fix; round 2 PASS+PASS
- [x] Step 9c: 1898 passed / 5 pre-existing-on-trunk failures / 0 new; ruff + workflow_lint targeted checks PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)