### PR TITLE
task #837: watcher followup-round-repark must not fire mid-round

### DIFF
--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -5098,7 +5098,21 @@ def _long_phase_heartbeat_reason(events: list[dict], now: float) -> str | None:
 # completion marker recording the round (a recorded round — run marker
 # newer than the scope — means the re-park already happened per the
 # designed step-3→step-4 ordering, so a later ``followups_running`` status
-# is the legacy children-in-flight shape, not this round stranded).
+# is the legacy children-in-flight shape, not this round stranded). That
+# condition is NECESSARY but — after #778 (2026-07-02), where the parent
+# pass's own post-9b tail parks (step 10 / 9a-bis) postdated a freshly
+# posted 9b scope and the watcher re-parked a MID-FLIGHT round twice — no
+# longer SUFFICIENT. Two purely event-based gates (#837) also bind:
+#   Gate 1 (round-start witness): at least one round-only event newer than
+#     the scope — a kind in ``_FOLLOWUP_ROUND_WITNESS_KINDS`` or an
+#     ``epm:progress`` note beginning
+#     ``_FOLLOWUP_STAGE_DISPATCH_WITNESS_PREFIX`` — must prove the round
+#     actually STARTED (closes the pre-activity race where the
+#     mis-attributed parent park is the newest event).
+#   Gate 2 (freshness): NO non-watcher event (``_WATCHER_NOTE_SENTINELS``
+#     note filter) may be strictly newer than the keyed round-end park —
+#     anything newer proves the round is still executing past it (or died
+#     mid-flight, which is crash-recovery's job, never the repark's).
 # Neither suppressing (freeze — what happened to #533 for ~26h) nor
 # respawning (each respawned session re-concluded "waiting on child",
 # posted another parked step-10 marker, and exited — 3 cycles in 2h) fixes
@@ -5110,7 +5124,13 @@ def _long_phase_heartbeat_reason(events: list[dict], now: float) -> str | None:
 # plus a sentinel-stamped progress marker. Probed BEFORE the awaiting-child
 # suppression in both passes; on a failed re-park the passes fall back to
 # the pre-existing handling so the fix is never worse than the old
-# behavior. A task with NO ``epm:followup-scope`` on record (the legacy
+# behavior — and whenever an UNRUN scope exists the awaiting-child
+# suppression itself STANDS DOWN (#837 §4d,
+# :func:`_followups_awaiting_child_reason`), so the gated-``None`` /
+# failed-re-park fall-through reaches RESPAWN (the designed recovery for a
+# pending or executing round; #778's 05:01Z replacement session
+# demonstrated it live) instead of latching alert-only on a task with open
+# children. A task with NO ``epm:followup-scope`` on record (the legacy
 # children-in-flight shape) never triggers the re-park.
 
 # Step + exit_kind that mark the "parked, awaiting child" state. Pinned as
@@ -5128,6 +5148,44 @@ _FOLLOWUPS_CHILDREN_WAIT_EXIT_KIND = "parked"
 # plan approval, which holds at ``followups_running`` in place) is NOT
 # round-end — re-parking there would abandon an unapproved round.
 _FOLLOWUP_ROUND_END_STEPS = frozenset({"9a-bis", "10"})
+
+# Event kinds that can ONLY be posted by an EXECUTING pipeline round (#837
+# round-start witness gate). Temporal-impossibility membership criterion: the
+# PARENT pass's post-9b tail (interp / clean-result critiques, methodology
+# export, status changes, step-completed parks, `epm:merged`, codex-task-*
+# bookkeeping) can legitimately postdate the round's ``epm:followup-scope``,
+# but planning / implementation / launch markers CANNOT — those steps are
+# long over for the parent by the time the 9b scope posts, so any of these
+# kinds NEWER than the scope proves the round actually STARTED. Add a kind
+# here only when a post-9b parent tail could never post it. The watcher
+# itself can never be a witness by construction: it posts none of these
+# kinds, and its ``epm:progress`` notes begin
+# ``[autonomous_session_watch:...]``, which fails the stage-dispatch
+# ``startswith`` check below.
+_FOLLOWUP_ROUND_WITNESS_KINDS = frozenset(
+    {
+        "epm:plan",
+        "epm:plan-approved",
+        "epm:plan-verify",
+        "epm:consistency",
+        "epm:smoke-architecture-check",
+        "epm:proposed-tests",
+        "epm:experiment-implementation",
+        "epm:code-review",
+        "epm:code-review-codex",
+        "epm:review-reconcile",
+        "epm:run-launched",
+        "epm:launch",
+    }
+)
+
+# The same-issue loop's dispatch breadcrumb (SKILL.md § Dispatch breadcrumb —
+# a NON-SKIPPABLE contract for every follow-up-loop stage dispatch): an
+# ``epm:progress`` note BEGINNING with this prefix marks a follow-up-round
+# stage dispatch. The ``followup-`` restriction excludes parent-tail
+# breadcrumbs (methodology spawn, Step 8/9 stages), which carry other
+# ``stage=`` values.
+_FOLLOWUP_STAGE_DISPATCH_WITNESS_PREFIX = "stage-dispatch stage=followup-"
 
 # Statuses that count a child task as TERMINAL for the purpose of this check.
 # A child at `awaiting_promotion` is NOT terminal here — it is exactly the
@@ -5160,6 +5218,67 @@ def _latest_step_completed(events: list[dict]) -> dict | None:
             best_ts = ts
             best = ev
     return best
+
+
+def _latest_scope_and_run_ts(events: list[dict]) -> tuple[float | None, float | None]:
+    """Newest epoch ts of an ``epm:followup-scope`` and of an
+    ``epm:same-issue-followup-run`` in ``events`` (either slot ``None`` when
+    absent / unparseable). A scope with no STRICTLY newer run marker is an
+    UNRUN scope — a same-issue follow-up round is pending or executing.
+    Shared by :func:`_followup_round_complete_reason` (the repark predicate)
+    and :func:`_followups_awaiting_child_reason` (the #837 stand-down) so
+    the two scans cannot drift."""
+    scope_ts: float | None = None
+    run_ts: float | None = None
+    for ev in events:
+        kind = ev.get("kind")
+        if kind not in ("epm:followup-scope", "epm:same-issue-followup-run"):
+            continue
+        ts = _parse_event_ts(ev.get("ts"))
+        if ts is None:
+            continue
+        if kind == "epm:followup-scope":
+            if scope_ts is None or ts > scope_ts:
+                scope_ts = ts
+        elif run_ts is None or ts > run_ts:
+            run_ts = ts
+    return scope_ts, run_ts
+
+
+def _has_round_start_witness(events: list[dict], scope_ts: float) -> bool:
+    """True iff ``events`` carry a ROUND-START WITNESS strictly newer than
+    ``scope_ts``: a round-only kind (:data:`_FOLLOWUP_ROUND_WITNESS_KINDS`)
+    or a same-issue-loop stage-dispatch breadcrumb (an ``epm:progress`` note
+    beginning :data:`_FOLLOWUP_STAGE_DISPATCH_WITNESS_PREFIX`). Strict ``>``
+    (#837 §12.2): a witness sharing the scope's second fails toward blocking
+    → respawn, the safe direction."""
+    for ev in events:
+        ev_ts = _parse_event_ts(ev.get("ts"))
+        if ev_ts is None or ev_ts <= scope_ts:
+            continue
+        kind = ev.get("kind")
+        if kind in _FOLLOWUP_ROUND_WITNESS_KINDS:
+            return True
+        if kind == "epm:progress" and (ev.get("note") or "").startswith(
+            _FOLLOWUP_STAGE_DISPATCH_WITNESS_PREFIX
+        ):
+            return True
+    return False
+
+
+def _has_nonwatcher_event_after(events: list[dict], ts: float) -> bool:
+    """True iff any NON-watcher event (note-substring filter
+    :data:`_WATCHER_NOTE_SENTINELS`, same as :func:`_latest_step_completed`)
+    in ``events`` is strictly newer than ``ts``."""
+    for ev in events:
+        ev_ts = _parse_event_ts(ev.get("ts"))
+        if ev_ts is None or ev_ts <= ts:
+            continue
+        note = ev.get("note") or ""
+        if any(sentinel in note for sentinel in _WATCHER_NOTE_SENTINELS):
+            continue
+        return True
+    return False
 
 
 def _task_children(issue: int) -> list[dict]:
@@ -5198,6 +5317,16 @@ def _followups_awaiting_child_reason(
     four-condition predicate). Returns ``None`` when the exemption does not
     apply.
 
+    STANDS DOWN (returns ``None``) whenever an UNRUN ``epm:followup-scope``
+    exists — a scope with no strictly newer ``epm:same-issue-followup-run``
+    (#837): an unrun scope means a same-issue follow-up round is pending or
+    executing, and respawn is ALWAYS the correct recovery there (a respawned
+    session's Step 0 routes into the follow-up loop — demonstrated live by
+    #778's 05:01Z replacement session), so the children-wait suppression must
+    not latch alert-only on a mis-attributed parent-tail step-10 park. The
+    legacy children-in-flight shape has NO scope (or a RECORDED one), so its
+    suppression semantics are untouched.
+
     Probed LAZILY by the callers (the helper is only invoked when the stalled
     / orphan pass already wants to respawn) so a healthy session never pays
     the ``task.py list-children`` subprocess.
@@ -5205,6 +5334,16 @@ def _followups_awaiting_child_reason(
     if status != "followups_running":
         return None
     if has_pod:
+        return None
+    scope_ts, run_ts = _latest_scope_and_run_ts(events)
+    if scope_ts is not None and (run_ts is None or run_ts <= scope_ts):
+        # #837 stand-down: an UNRUN scope → the fall-through must reach
+        # RESPAWN, never the awaiting-child latch (the reconciler-verified
+        # freeze shape: the SAME mis-attributed step-10 park the repark
+        # predicate's witness gate vetoes would otherwise satisfy this
+        # suppression forever on a task with open children — #778 has #816).
+        # Checked BEFORE the children lookup so the stand-down stays pure
+        # (no subprocess).
         return None
     sc = _latest_step_completed(events)
     if sc is None:
@@ -5240,7 +5379,7 @@ def _followups_awaiting_child_reason(
     )
 
 
-def _followup_round_complete_reason(events: list[dict]) -> str | None:
+def _followup_round_complete_reason(events: list[dict], *, issue: int | None = None) -> str | None:
     """Reason string when ``events`` show a COMPLETED-but-UNRECORDED
     same-issue follow-up round whose designed re-park (``set-status <N>
     awaiting_promotion``) never ran: the latest non-watcher
@@ -5262,24 +5401,24 @@ def _followup_round_complete_reason(events: list[dict]) -> str | None:
       stranded — defer to the awaiting-child suppression. This also
       self-disarms the predicate after the watcher's own re-park, which
       posts the completion marker itself
-      (:func:`_repark_completed_followup_round`).
+      (:func:`_repark_completed_followup_round`);
+    - (#837 gate 1 — round-start witness) no round-only event newer than
+      the scope proves the round STARTED: the matched park is the parent
+      pass's own tail (#778: the 9a-bis park 14 min after the 9b scope) or
+      the round never started — either way the repark would falsely close
+      the scope; defer to crash-recovery / stalled handling;
+    - (#837 gate 2 — freshness) ANY non-watcher event is strictly newer
+      than the keyed round-end park: the park is stale / mis-attributed —
+      the round is still executing past it (#778: round activity HOURS
+      newer at both firings), or died mid-flight (crash-recovery's job,
+      never the repark's).
+
+    ``issue`` is used only for the log-and-skip diagnostics; ``None`` keeps
+    every existing caller/test signature working.
 
     Pure over the already-loaded ``events`` — no subprocess.
     """
-    scope_ts: float | None = None
-    run_marker_ts: float | None = None
-    for ev in events:
-        kind = ev.get("kind")
-        if kind not in ("epm:followup-scope", "epm:same-issue-followup-run"):
-            continue
-        ts = _parse_event_ts(ev.get("ts"))
-        if ts is None:
-            continue
-        if kind == "epm:followup-scope":
-            if scope_ts is None or ts > scope_ts:
-                scope_ts = ts
-        elif run_marker_ts is None or ts > run_marker_ts:
-            run_marker_ts = ts
+    scope_ts, run_marker_ts = _latest_scope_and_run_ts(events)
     if scope_ts is None:
         return None
     if run_marker_ts is not None and run_marker_ts > scope_ts:
@@ -5295,6 +5434,38 @@ def _followup_round_complete_reason(events: list[dict]) -> str | None:
         and sc_ts is not None
         and sc_ts > scope_ts
     ):
+        who = f"issue #{issue}" if issue is not None else "followup-round-repark probe"
+        # Gate 1 — round-start witness (#837): the round must have
+        # DEMONSTRABLY started (a round-only kind or a followup stage-
+        # dispatch breadcrumb newer than the scope). Closes the #778
+        # pre-activity race (scope → mis-attributed parent-tail park →
+        # nothing yet) deterministically, with no wall clock.
+        if not _has_round_start_witness(events, scope_ts):
+            print(
+                f"  {who}: round-end park matched but no round-start witness "
+                f"after the scope — the park is the parent pass's tail or the "
+                f"round never started; deferring to crash-recovery/stalled "
+                f"handling"
+            )
+            return None
+        # Gate 2 — freshness (#837): the keyed park must be the LATEST
+        # non-watcher signal. ANY non-watcher event strictly newer than
+        # sc_ts proves the park is stale or mis-attributed (round still
+        # executing, or advanced past it). Cost of a false block is one
+        # respawn cycle (§4b convergence-through-respawn: the respawned
+        # session posts a FRESH round-end park that becomes the newest
+        # signal). Repeated cross-posts — e.g. a chain of workflow-fix
+        # children applying `epm:workflow-fix-applied` on the parent — can
+        # block repeated respawn cycles until the respawn budget exhausts,
+        # ending in a LOUD exhausted alert: bounded and observable, vs the
+        # unbounded cost of a false fire (orphaning a live round).
+        if _has_nonwatcher_event_after(events, sc_ts):
+            print(
+                f"  {who}: round activity newer than the keyed round-end park "
+                f"— round still executing (or died mid-flight: crash-"
+                f"recovery's job, never the repark's); skipping"
+            )
+            return None
         return (
             f"same-issue follow-up round complete (round-end "
             f"epm:step-completed step={step} exit_kind=parked newer than the "
@@ -5388,7 +5559,14 @@ def _spend_approval_skip_already_noted(events: list[dict]) -> bool:
 
 def _scope_note_field(events: list[dict], field: str) -> str | None:
     """Value of ``<field>: <value>`` from the latest ``epm:followup-scope``
-    event's note (line-prefix match, first hit wins), or ``None``."""
+    event's note (line-prefix match, first hit wins), or ``None``. Tolerates
+    the modern bold-markdown field format ``**<field>:** <value>`` alongside
+    the plain ``<field>: <value>`` form (#837 §4c — the verified cause of
+    #778's second premature repark: the 04:43 disarm run marker never posted
+    because the bold-format ``**followup_label:**`` line was unparseable).
+    Side effect: a bulleted ``* <field>: <value>`` line also parses now
+    (harmless); the legacy ``- <field>:`` dash-bullet form still misses
+    (pre-existing, fail-soft)."""
     latest: dict | None = None
     latest_ts: float | None = None
     for ev in events:
@@ -5404,8 +5582,9 @@ def _scope_note_field(events: list[dict], field: str) -> str | None:
         return None
     for line in (latest.get("note") or "").splitlines():
         stripped = line.strip()
-        if stripped.startswith(f"{field}:"):
-            value = stripped[len(field) + 1 :].strip().rstrip(",")
+        core = stripped.lstrip("*").lstrip()  # tolerate "**field:** value" (#837 §4c)
+        if core.startswith(f"{field}:"):
+            value = core[len(field) + 1 :].lstrip("*").strip().rstrip(",")
             return value or None
     return None
 
@@ -6079,7 +6258,7 @@ def _apply_stalled_followups_exemption(
     # of freezing. On re-park failure, fall through to the pre-existing
     # handling.
     if status == "followups_running" and not has_pod:
-        repark_reason = _followup_round_complete_reason(events)
+        repark_reason = _followup_round_complete_reason(events, issue=issue)
         if repark_reason is not None:
             print(
                 f"  issue #{issue}: ALIVE-BUT-STALLED round-complete re-park — "
@@ -7029,7 +7208,7 @@ def _check_orphan_followups_exemption(
     # :func:`_handle_orphan_followup_round_repark` (this helper stays
     # read-only, mirroring the awaiting-child probe).
     if status == "followups_running" and not has_pod:
-        repark_reason = _followup_round_complete_reason(events)
+        repark_reason = _followup_round_complete_reason(events, issue=issue)
         if repark_reason is not None:
             print(
                 f"  issue #{issue}: ORPHAN-RESPAWN round-complete re-park — "

--- a/tests/fixtures/issue778_scope_v2_note.md
+++ b/tests/fixtures/issue778_scope_v2_note.md
@@ -1,0 +1,47 @@
+<!-- epm:followup-scope v1 -->
+
+**SUPERSEDES** the earlier `corrected-monitoring-8prompt-ladder` scope posted 2026-07-01T21:31:59Z — THIS is the authoritative scope for that follow-up label. It now covers BOTH monitoring sub-settings (the paper's monitoring experiment has two) plus the body scope-disclosure fix. Only ONE follow-up round; ignore the 21:31 note where it conflicts.
+
+**source:** user-chat
+**followup_label:** corrected-monitoring-8prompt-ladder
+**question_relation:** same (rewrites #778's monitoring result + Takeaways — completes the monitoring-prediction leg with correct prompts AND the many-shot sub-setting)
+**cost_class:** needs-gpu
+**est_gpu_hours:** ~2–5 (both legs; still cheap-band)
+**headline_affecting:** yes (corrects the tautological `overall_r`, the "8 eval prompts unreleased" inaccuracy, AND the undisclosed many-shot-omission scope gap)
+**backend:** runpod (1× H100, `eval` intent) — or reuse the #778 pattern; ~2–5 GPU-h + Sonnet-4.5 Batch judge.
+
+The paper's monitoring/prediction experiment has TWO sub-settings; #778 ran only the system-prompt one, with the wrong prompts. This follow-up completes it: **Leg A** = corrected system-prompt monitoring; **Leg B** = the many-shot ICL monitoring #778 scoped out.
+
+---
+
+## Leg A — corrected system-prompt monitoring re-run
+
+Re-run the system-prompt monitoring leg with the paper's ACTUAL trait-inducing eval prompts, replacing #778's substitution of the 10 released *extraction* instructions (the cause of the near-tautological pooled `overall_r` — activations were projected onto `r_B` at prompts drawn from the very instruction set that built `r_B`).
+
+Corrected prompts: the 8-per-trait graded ladder from arXiv 2507.21509 appendix (§"Monitoring prompt-induced persona shifts" → "System prompts for inducing traits"), committed on `main` at `tasks/proposed/816/artifacts/corrected_eval_prompts.md` (all 24 verbatim; use that file).
+
+Per trait (evil / sycophancy / hallucination), Qwen2.5-7B-Instruct: generate **8 corrected system prompts × 20 eval questions × R rollouts** (match #778's R + judge-draw count from committed `eval_results/issue_778/monitoring_{trait}.jsonl`), extract the **last-prompt-token** activation at all 28 layers, judge trait expression **graded 0–100 Sonnet-4.5** (drop-never-coerce), project onto the **CACHED `r_B`** (reuse `issue778_persona_vectors/analysis_tensors/rb/`; do NOT re-extract), recompute BOTH `overall_r` and `within_condition_r` + the full 4-null battery.
+
+## Leg B — many-shot (ICL) monitoring — NEWLY ADDED
+
+Reproduce the paper's many-shot monitoring setting: vary the number of trait-exhibiting in-context exemplars **0 / 5 / 10 / 15 / 20** and measure whether the last-prompt-token projection onto `r_B` predicts the trait expression of the response.
+
+- **Exemplar reconstruction (data caveat — REPORT as a scope caveat):** the paper's exact many-shot exemplars are NOT released (not in the code, not verbatim in the appendix). Reconstruct trait-exhibiting exemplars from #778's **cached judge-filtered kept-POSITIVE extraction rollouts** (`issue778_persona_vectors/analysis_tensors/` — the kept-pos>50 response pool per trait: evil 784 / sycophancy 455 / hallucination 77). Each exemplar = an extraction question + a kept-positive trait-exhibiting response. Sample without replacement per shot-count; disjoint from the 20 eval questions. Flag that these are RECONSTRUCTED exemplars, not the paper's originals, as a data-realism caveat.
+- Per trait × shot-count ∈ {0,5,10,15,20} × 20 eval questions × R rollouts: build the ICL context (shot-count exemplars prepended), generate on-policy, extract last-prompt-token activation at all 28 layers, graded judge (drop-never-coerce), project onto the CACHED `r_B`.
+- Compute `overall_r` (pooled across shot-counts) and `within_condition_r` (per shot-count, Fisher-z averaged); run the same 4-null battery.
+
+## Shared mechanics (both legs)
+
+- Reuse cached `r_B`; run the `artifact-reuse.md` fitness check.
+- Null battery: shuffled-label permutation / norm-matched-random / cross-trait / PCA, per-null-draw max-over-28-layers selection; BH-correct across all monitoring tests (both legs).
+- Graded 0–100 primary, binary rate companion (`llm-judging.md`).
+
+## Deliverable (fold into #778's clean-result)
+
+- Replace the monitoring result's tautological `overall_r` with Leg-A corrected numbers; report paper-comparison (system-prompting overall/within: evil 0.747/0.511, syc 0.798/0.669, hall 0.830/0.245).
+- Add Leg B as a second monitoring result (many-shot); report whether the non-specificity (beats no null after BH) holds in the ICL regime too.
+- Fix the "8 trait-inducing prompts are not released" statement (they were published in the appendix; #778 substituted the extraction instructions) and cross-link the corrected prompts.
+- **Fix the planned-vs-actual scope disclosure:** the ORIGINAL #778 body implied full monitoring coverage while running only the system-prompt half — the updated body must state the monitoring reproduction now covers BOTH the system-prompt and many-shot sub-settings (Leg B exemplars reconstructed, not the paper's originals — data caveat).
+- Update `## Takeaways` for both legs.
+
+Rules to honor: `persona-vectors-recipe.md` (read-out regime, sweep 28 layers), `selection-symmetric-nulls.md`, `llm-judging.md`, `artifact-reuse.md`, `replication-fidelity.md`, `data-realism.md` (the reconstructed-exemplar caveat).

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -4174,17 +4174,101 @@ def _make_followup_run_event(ts: str = "2026-06-11T10:55:00Z") -> dict:
     }
 
 
+def _make_progress_event(note: str, ts: str) -> dict:
+    """Minimal epm:progress row (stage-dispatch breadcrumbs, watcher-sentinel
+    alerts) for the #837 witness/freshness-gate fixtures."""
+    return {"ts": ts, "kind": "epm:progress", "version": 1, "note": note}
+
+
+def _make_generic_event(kind: str, ts: str, note: str = "") -> dict:
+    """Minimal event row of an arbitrary kind (witness-kind / parent-tail
+    fixtures for the #837 gates)."""
+    return {"ts": ts, "kind": kind, "version": 1, "note": note}
+
+
+def _issue_778_condensed_events() -> list[dict]:
+    """Condensed, time-faithful replay of the verified #778 incident record
+    (tasks/*/778/events.jsonl) up to the FIRST premature watcher repark
+    (2026-07-02T04:43:26Z): 9b scope v2 → the PARENT pass's own tail parks
+    (step 10, then 9a-bis — the mis-attributed round-end signal) → the round
+    demonstrably running (loop entry, stage-dispatch breadcrumbs,
+    run-launched, results, upload-verification PASS)."""
+    return [
+        _make_followup_scope_event("2026-07-01T21:35:20Z"),  # scope v2 (authoritative)
+        _make_step_completed_event(step="10", ts="2026-07-01T21:46:17Z"),  # parent tail
+        _make_generic_event("epm:merged", "2026-07-01T21:49:01Z", note="worktree merged"),
+        _make_step_completed_event(step="9a-bis", ts="2026-07-01T21:49:35Z"),  # parent tail
+        _make_generic_event(
+            "epm:status-changed",
+            "2026-07-01T21:50:27Z",
+            note="awaiting_promotion -> followups_running (follow-up loop entry)",
+        ),
+        _make_progress_event(
+            "stage-dispatch stage=followup-implementing round=1 "
+            "subagent=experiment-implementer worktree=/tmp/wt-778",
+            "2026-07-01T22:28:53Z",
+        ),
+        _make_generic_event("epm:run-launched", "2026-07-02T00:40:51Z", note="pod-778"),
+        _make_generic_event("epm:results", "2026-07-02T03:28:41Z", note="pod phases complete"),
+        _make_progress_event(
+            "stage-dispatch stage=followup-null-battery round=1 "
+            "subagent=orchestrator-bg-poll worktree=/tmp/wt-778",
+            "2026-07-02T03:29:51Z",
+        ),
+        _make_generic_event("epm:upload-verification", "2026-07-02T03:36:37Z", note="PASS"),
+    ]
+
+
+def _issue_778_second_firing_extra_events() -> list[dict]:
+    """The rows between #778's first (04:43Z) and second (06:13Z) premature
+    reparks — including the 04:43 WATCHER rows themselves (the repark's
+    status-changed + its sentinel-noted progress marker), so the state-2
+    fixture exercises the watcher-marker handling exactly where it bit."""
+    import autonomous_session_watch as asw
+
+    return [
+        _make_generic_event(
+            "epm:status-changed",
+            "2026-07-02T04:43:26Z",
+            note="followups_running -> awaiting_promotion",
+        ),
+        _make_progress_event(
+            f"{asw._FOLLOWUP_ROUND_REPARK_NOTE_SENTINEL} same-issue follow-up "
+            f"round complete (premature — the #837 incident's first firing)",
+            "2026-07-02T04:43:28Z",
+        ),
+        _make_generic_event(
+            "epm:status-changed",
+            "2026-07-02T05:01:45Z",
+            note="Replacement session (watcher-registered) resuming the round",
+        ),
+        _make_progress_event(
+            "stage-dispatch stage=followup-null-battery round=1 "
+            "subagent=orchestrator-bg-poll worktree=/tmp/wt-778 -- takeover",
+            "2026-07-02T05:01:48Z",
+        ),
+    ]
+
+
 def test_followup_round_complete_reason_fires_on_533_round_end_shape():
     # The #533 freeze shape: round started (followup-scope), round-end
     # step-completed (9a-bis, parked) NEWER than the scope — the designed
     # re-park never ran. The predicate MUST fire for 9a-bis AND for the
-    # step-10 parks the respawned sessions posted.
+    # step-10 parks the respawned sessions posted. Fixture carries a
+    # stage-dispatch breadcrumb between scope and park: the #837 round-start
+    # witness gate requires proof the round actually STARTED (a genuinely
+    # completed round always has one — SKILL.md's breadcrumb contract).
     import autonomous_session_watch as asw
 
     for step in ("9a-bis", "10"):
         reason = asw._followup_round_complete_reason(
             [
                 _make_followup_scope_event("2026-06-11T09:00:00Z"),
+                _make_progress_event(
+                    "stage-dispatch stage=followup-implementing round=1 "
+                    "subagent=experiment-implementer worktree=/tmp/wt",
+                    "2026-06-11T09:30:00Z",
+                ),
                 _make_step_completed_event(step=step, ts="2026-06-11T10:54:12Z"),
             ]
         )
@@ -4252,6 +4336,268 @@ def test_followup_round_complete_reason_inert_on_recorded_round():
         _make_step_completed_event(step="10", ts="2026-06-12T08:00:00Z"),
     ]
     assert asw._followup_round_complete_reason(events) is None
+
+
+# ─── #837: the two repark gates + awaiting-child stand-down (#778 incident) ──
+
+
+@pytest.mark.parametrize("state", ["first-firing-0443Z", "second-firing-0613Z"])
+def test_followup_round_complete_reason_inert_on_778_mid_round_shape(state):
+    # #837 acceptance 1: replaying the verified #778 event history, the
+    # predicate MUST return None at BOTH historical firing states — the
+    # matched 9a-bis park (21:49:35Z) is the PARENT pass's own tail, and
+    # round activity is HOURS newer than it (freshness gate). The second
+    # state includes the 04:43 watcher rows (the premature repark's
+    # status-changed + sentinel-noted progress marker).
+    import autonomous_session_watch as asw
+
+    events = _issue_778_condensed_events()
+    if state == "second-firing-0613Z":
+        events += _issue_778_second_firing_extra_events()
+    assert asw._followup_round_complete_reason(events, issue=778) is None
+
+
+def test_followup_round_complete_reason_inert_in_pre_activity_race_window():
+    # #837 acceptance 2 + 8 (gate 1, round-start witness): #778's
+    # 21:49:35Z -> 21:50:27Z window — the mis-attributed parent-tail park is
+    # the NEWEST event and no round marker exists yet. The fixture carries
+    # realistic PRE-SCOPE parent-history witness-KIND events (ts <= scope_ts):
+    # an implementation that checks kind membership WITHOUT the timestamp
+    # comparison must fail this test. A watcher-sentinel alert after the
+    # park changes nothing.
+    import autonomous_session_watch as asw
+
+    events = [
+        _make_generic_event("epm:plan-approved", "2026-07-01T08:00:00Z"),
+        _make_generic_event("epm:run-launched", "2026-07-01T10:00:00Z", note="parent run"),
+        _make_followup_scope_event("2026-07-01T21:35:20Z"),
+        _make_step_completed_event(step="9a-bis", ts="2026-07-01T21:49:35Z"),
+        _make_progress_event(
+            f"{asw._STALLED_ALERT_NOTE_SENTINEL} session stalled alert",
+            "2026-07-01T23:00:00Z",
+        ),
+    ]
+    assert asw._followup_round_complete_reason(events, issue=778) is None
+
+
+@pytest.mark.parametrize("witness_kind", ["epm:plan", "epm:run-launched", "epm:plan-verify"])
+def test_followup_round_complete_reason_fires_on_kind_only_witness(witness_kind):
+    # #837 acceptance 9: a round whose only round-start proof is a
+    # witness-KIND marker (NO stage-dispatch breadcrumb anywhere — the
+    # documented missed-breadcrumb limitation) must still repark. An emptied
+    # or typo'd _FOLLOWUP_ROUND_WITNESS_KINDS must fail this test.
+    # epm:plan-verify is the load-bearing member for the sparsest rounds
+    # (#537 class).
+    import autonomous_session_watch as asw
+
+    reason = asw._followup_round_complete_reason(
+        [
+            _make_followup_scope_event("2026-06-11T09:00:00Z"),
+            _make_generic_event(witness_kind, "2026-06-11T09:30:00Z"),
+            _make_step_completed_event(step="9a-bis", ts="2026-06-11T10:54:12Z"),
+        ]
+    )
+    assert reason is not None, witness_kind
+    assert "designed re-park" in reason
+
+
+def test_followup_round_complete_reason_ignores_watcher_markers_in_freshness():
+    # #837 acceptance 3 (gate 2's watcher exclusion): watcher-sentinel-noted
+    # markers routinely post AFTER a genuine round-end park (stalled alerts,
+    # awaiting-child alerts) — they must NOT veto the repark.
+    import autonomous_session_watch as asw
+
+    events = [
+        _make_followup_scope_event("2026-06-11T09:00:00Z"),
+        _make_progress_event(
+            "stage-dispatch stage=followup-implementing round=1 "
+            "subagent=experiment-implementer worktree=/tmp/wt",
+            "2026-06-11T09:30:00Z",
+        ),
+        _make_step_completed_event(step="9a-bis", ts="2026-06-11T10:54:12Z"),
+        _make_progress_event(
+            f"{asw._STALLED_ALERT_NOTE_SENTINEL} session stalled alert",
+            "2026-06-11T12:00:00Z",
+        ),
+        _make_progress_event(
+            f"{asw._FOLLOWUPS_AWAITING_CHILD_NOTE_SENTINEL} waiting on child",
+            "2026-06-11T13:00:00Z",
+        ),
+    ]
+    reason = asw._followup_round_complete_reason(events)
+    assert reason is not None
+    assert "designed re-park" in reason
+
+
+def test_followup_round_complete_reason_converges_after_respawn_park():
+    # #837 acceptance 4 (the §4b convergence argument, pinned): a stray
+    # NON-watcher cross-post after a genuine round end blocks the repark
+    # this tick (freshness gate) — then the respawned session re-derives
+    # state and posts a FRESH round-end park; nothing is newer than it, the
+    # witness still exists, and the repark fires on the next tick.
+    import autonomous_session_watch as asw
+
+    base = [
+        _make_followup_scope_event("2026-06-11T09:00:00Z"),
+        _make_progress_event(
+            "stage-dispatch stage=followup-implementing round=1 "
+            "subagent=experiment-implementer worktree=/tmp/wt",
+            "2026-06-11T09:30:00Z",
+        ),
+        _make_step_completed_event(step="9a-bis", ts="2026-06-11T10:54:12Z"),
+        _make_generic_event(
+            "epm:workflow-fix-applied", "2026-06-11T12:00:00Z", note="applied_task: #900"
+        ),
+    ]
+    assert asw._followup_round_complete_reason(base) is None
+    respawned = [*base, _make_step_completed_event(step="10", ts="2026-06-11T13:00:00Z")]
+    reason = asw._followup_round_complete_reason(respawned)
+    assert reason is not None
+    assert "designed re-park" in reason
+
+
+def test_followup_round_complete_reason_inert_on_scope_repost_after_completion():
+    # OPTIONAL documentation fixture (plan §Test plan, Alt-Claude concern): a
+    # content-identical scope RE-POST after round completion resets scope_ts
+    # newer than every witness AND the round-end park -> the predicate stays
+    # inert (in-flight early return); recovery is respawn-convergence, which
+    # the §4d stand-down keeps reachable.
+    import autonomous_session_watch as asw
+
+    events = [
+        _make_followup_scope_event("2026-06-11T09:00:00Z"),
+        _make_progress_event(
+            "stage-dispatch stage=followup-implementing round=1 "
+            "subagent=experiment-implementer worktree=/tmp/wt",
+            "2026-06-11T09:30:00Z",
+        ),
+        _make_step_completed_event(step="9a-bis", ts="2026-06-11T10:54:12Z"),
+        _make_followup_scope_event("2026-06-11T11:00:00Z"),  # the re-post
+    ]
+    assert asw._followup_round_complete_reason(events) is None
+
+
+def test_followups_awaiting_child_reason_stands_down_on_unrun_scope(monkeypatch):
+    # #837 acceptance 10 (§4d): an UNRUN epm:followup-scope (no newer run
+    # marker) means a same-issue round is pending or executing — the
+    # children-wait suppression must stand down (return None) EVEN WITH an
+    # open child, so the never-started / blocked-repark shapes fall through
+    # to RESPAWN instead of latching alert-only (#778 has open child #816).
+    import autonomous_session_watch as asw
+
+    monkeypatch.setattr(asw, "_task_children", lambda issue: [{"id": 816, "status": "running"}])
+    events = [
+        _make_followup_scope_event("2026-07-01T21:35:20Z"),
+        _make_step_completed_event(step="10", ts="2026-07-01T21:46:17Z"),
+    ]
+    reason = asw._followups_awaiting_child_reason(
+        778, status="followups_running", has_pod=False, events=events
+    )
+    assert reason is None
+
+
+def test_check_orphan_followups_exemption_respawns_on_unrun_scope_no_witness(monkeypatch):
+    # #837 acceptance 10 (orphan-pass action assertion): the no-witness
+    # unrun-scope shape — the witness gate vetoes the repark AND the §4d
+    # stand-down vetoes the awaiting-child latch — must keep action
+    # "respawn" (never "followups-awaiting-child", never a repark).
+    import autonomous_session_watch as asw
+
+    monkeypatch.setattr(asw, "_task_children", lambda issue: [{"id": 816, "status": "running"}])
+    action, reason = asw._check_orphan_followups_exemption(
+        issue=778,
+        status="followups_running",
+        has_pod=False,
+        events=[
+            _make_followup_scope_event("2026-07-01T21:35:20Z"),
+            _make_step_completed_event(step="10", ts="2026-07-01T21:46:17Z"),
+        ],
+        action="respawn",
+    )
+    assert action == "respawn"
+    assert reason is None
+
+
+def test_followups_awaiting_child_reason_fires_on_recorded_scope(monkeypatch):
+    # #837 §4d companion: a RECORDED scope (run marker strictly newer than
+    # the scope) keeps the legacy children-in-flight suppression semantics
+    # untouched — the exemption still fires.
+    import autonomous_session_watch as asw
+
+    monkeypatch.setattr(
+        asw, "_task_children", lambda issue: [{"id": 546, "status": "awaiting_promotion"}]
+    )
+    events = [
+        _make_followup_scope_event("2026-06-11T09:00:00Z"),
+        _make_followup_run_event("2026-06-11T10:55:00Z"),
+        _make_step_completed_event(step="10", ts="2026-06-12T08:00:00Z"),
+    ]
+    reason = asw._followups_awaiting_child_reason(
+        533, status="followups_running", has_pod=False, events=events
+    )
+    assert reason is not None
+    assert "#546" in reason
+
+
+def test_scope_note_field_parses_bold_markdown_fields():
+    # #837 acceptance 5 (§4c): the modern scope note writes bold-markdown
+    # fields (`**followup_label:** …`) — the verified cause of #778's second
+    # premature firing (the 04:43 disarm run marker never posted: "no
+    # followup_label parseable"). Fixture = the VERBATIM #778 scope-v2 note
+    # (2026-07-01T21:35:20Z), extracted from the incident record.
+    import autonomous_session_watch as asw
+
+    note = (Path(__file__).resolve().parent / "fixtures" / "issue778_scope_v2_note.md").read_text()
+    # fixture-integrity guards: the verbatim note really carries the bold form
+    assert "**followup_label:** corrected-monitoring-8prompt-ladder" in note
+    assert "**source:** user-chat" in note
+    events = [
+        {"ts": "2026-07-01T21:35:20Z", "kind": "epm:followup-scope", "version": 2, "note": note}
+    ]
+    assert asw._scope_note_field(events, "followup_label") == "corrected-monitoring-8prompt-ladder"
+    assert asw._scope_note_field(events, "source") == "user-chat"
+
+
+def test_post_followup_run_marker_parses_bold_scope(monkeypatch):
+    # #837 §4c end-to-end: the disarm run marker posts with the label AND the
+    # real source parsed from a bold-markdown scope note (source no longer
+    # degrades to "unknown", so a proposer-9b-cheap round counts toward the
+    # 2-round cheap cap).
+    import subprocess as _subprocess
+
+    import autonomous_session_watch as asw
+
+    calls: list[list[str]] = []
+
+    def _fake_run(cmd, **kw):
+        calls.append(cmd)
+        return _subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(asw.subprocess, "run", _fake_run)
+    bold_scope = {
+        "ts": "2026-07-01T21:35:20Z",
+        "kind": "epm:followup-scope",
+        "version": 2,
+        "note": (
+            "**source:** proposer-9b-cheap\n"
+            "**followup_label:** corrected-monitoring-8prompt-ladder\n"
+        ),
+    }
+    assert asw._post_followup_run_marker(778, [bold_scope], dry_run=False) is True
+    assert len(calls) == 1
+    note = calls[0][-1]
+    assert "followup_label: corrected-monitoring-8prompt-ladder" in note
+    assert "source: proposer-9b-cheap" in note
+
+
+def test_scope_note_field_plain_format_still_parses():
+    # #837 §4c regression companion: the plain `<field>: <value>` form the
+    # legacy fixtures use must keep parsing bit-identically.
+    import autonomous_session_watch as asw
+
+    events = [_make_followup_scope_event("2026-06-11T09:00:00Z")]
+    assert asw._scope_note_field(events, "followup_label") == "bare-word-install-step-grid"
+    assert asw._scope_note_field(events, "source") == "user-chat"
 
 
 def test_scope_note_field_parses_latest_scope():
@@ -4429,6 +4775,13 @@ def test_apply_stalled_followups_exemption_reparks_completed_round(monkeypatch):
     )
     events = [
         _make_followup_scope_event("2026-06-11T09:00:00Z"),
+        # witness event between scope and park — required by the #837
+        # round-start witness gate (assertions unchanged).
+        _make_progress_event(
+            "stage-dispatch stage=followup-implementing round=1 "
+            "subagent=experiment-implementer worktree=/tmp/wt",
+            "2026-06-11T09:30:00Z",
+        ),
         _make_step_completed_event(step="9a-bis", ts="2026-06-11T10:54:12Z"),
     ]
     action, new_missed, child_alerted = asw._apply_stalled_followups_exemption(
@@ -4447,9 +4800,14 @@ def test_apply_stalled_followups_exemption_reparks_completed_round(monkeypatch):
 
 
 def test_apply_stalled_followups_exemption_falls_back_when_repark_fails(monkeypatch):
-    # A FAILED re-park must fall through to the pre-existing handling (here:
-    # the awaiting-child suppression, since an open child exists) — never
-    # worse than the old behavior.
+    # A FAILED re-park must fall through to the pre-existing handling.
+    # Pre-#837 that meant the awaiting-child suppression; post-#837 the
+    # repark only ever fires on an UNRUN scope, and the §4d stand-down makes
+    # the awaiting-child suppression decline exactly there (even with an
+    # open child), so the fall-through now reaches RESPAWN — the designed
+    # recovery for a pending/executing round (#778's 05:01Z replacement
+    # session demonstrated it live). Witness event added for the #837
+    # round-start witness gate so the repark probe still fires.
     import autonomous_session_watch as asw
 
     monkeypatch.setattr(
@@ -4466,6 +4824,11 @@ def test_apply_stalled_followups_exemption_falls_back_when_repark_fails(monkeypa
     )
     events = [
         _make_followup_scope_event("2026-06-11T09:00:00Z"),
+        _make_progress_event(
+            "stage-dispatch stage=followup-implementing round=1 "
+            "subagent=experiment-implementer worktree=/tmp/wt",
+            "2026-06-11T09:30:00Z",
+        ),
         _make_step_completed_event(step="10", ts="2026-06-11T12:45:25Z"),
     ]
     action, new_missed, child_alerted = asw._apply_stalled_followups_exemption(
@@ -4478,9 +4841,10 @@ def test_apply_stalled_followups_exemption_falls_back_when_repark_fails(monkeypa
         followups_child_alerted=False,
         dry_run=False,
     )
-    assert (action, new_missed, child_alerted) == ("keep", 0, True)
-    assert len(posted) == 1  # the awaiting-child alert, not the repark marker
-    assert posted[0][2] == "followups-awaiting-child"
+    # Fall-through reaches RESPAWN (action passes through unchanged); the
+    # awaiting-child alert must NOT post (unrun scope → §4d stand-down).
+    assert (action, new_missed, child_alerted) == ("respawn", 2, False)
+    assert posted == []
 
 
 def test_check_orphan_followups_exemption_returns_repark_action(monkeypatch):
@@ -4499,6 +4863,13 @@ def test_check_orphan_followups_exemption_returns_repark_action(monkeypatch):
         has_pod=False,
         events=[
             _make_followup_scope_event("2026-06-11T09:00:00Z"),
+            # witness event between scope and park — required by the #837
+            # round-start witness gate (assertions unchanged).
+            _make_progress_event(
+                "stage-dispatch stage=followup-implementing round=1 "
+                "subagent=experiment-implementer worktree=/tmp/wt",
+                "2026-06-11T09:30:00Z",
+            ),
             _make_step_completed_event(step="9a-bis", ts="2026-06-11T10:54:12Z"),
         ],
         action="respawn",


### PR DESCRIPTION
## Summary
- Adds a round-start witness gate + a freshness gate to `_followup_round_complete_reason` so the watcher never reparks a `followups_running` task whose same-issue follow-up round is still executing (or never started) — closes both #778 mid-round firings (2026-07-02 04:43Z / 06:13Z) and the pre-activity race window.
- `_followups_awaiting_child_reason` now stands down on an UNRUN followup-scope (shared `_latest_scope_and_run_ts` helper), closing the reconciler-verified never-started freeze for tasks with open children.
- `_scope_note_field` tolerates bold-markdown note fields (`**followup_label:** x`) — the verified reason the first repark's disarm marker never posted; contract comment block updated.

## Test plan
- [x] 709/709 `tests/test_autonomous_session_watch.py` (incl. 8-test fail-pre-fix/pass-post-fix regression set replaying the #778 event record)
- [x] 48/48 `tests/test_stalled_detector_and_gc.py`
- [x] Step 9c 32-file subset: 1916 passed (2 pre-existing main failures documented in epm:test-verdict on #837)
- [x] ruff + workflow_lint + `--dry-run` smoke clean

Closes task #837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)