### PR TITLE
issue-842: smoke output-path hygiene rule + region-aware lint gate

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -418,6 +418,33 @@ Code-only tasks (`type:infra` / `type:batch` / `type:analysis` /
 `type:survey`) are EXEMPT from this gate — they keep the test-verdict gate
 (`/issue` Step 9c) and the Step 4 test run below.
 
+**Smoke output-path hygiene ("Smoke outputs never overwrite committed artifacts").**
+Two checks:
+
+- **Clobber evidence is SUBSTANTIVE, never mechanical.** If the diff (or
+  the worktree you review in) replaces an existing committed
+  `eval_results/` / `figures/` artifact with a smoke-scale version at its
+  canonical path (fewer layers / cells / rows), raise a Critical finding
+  tagged `substantive` — NOT `smoke-run-missing` — so the Step 5c-bis
+  mechanical strip can never remove it (#722 shipped a smoke-scale hero
+  figure and truncated committed 28-layer JSONs).
+- **A missing disposition line is CONCERNS, not FAIL.** A `### <phase>`
+  smoke sub-section whose command writes under `eval_results/` /
+  `figures/` but states no output-path disposition (scratch-dir redirect,
+  or restore-after-smoke + an empty
+  `git status --porcelain -- eval_results/ figures/`) is a Minor — unless
+  the clobber itself is visible (first bullet).
+
+**Any verification command YOU run follows the same rule.** If you rerun
+a test or smoke that regenerates files under `eval_results/` /
+`figures/`, afterwards run
+`git status --porcelain -- eval_results/ figures/`, restore the committed
+artifacts YOUR OWN command modified (`git checkout -- <paths>` scoped to
+those files, never a blanket revert) and delete the untracked outputs it
+left; leaving them dirty plants the clobber for the next explicit-path
+commit (#722 instance 2 was exactly this). Binds BOTH ensemble
+reviewers (rides into the Codex twin via the inlined Step 0.6 rubric).
+
 ### Step 0.65: Raw-completions upload wiring gate (`type:experiment` only)
 
 A pod-side dispatcher that writes per-cell completion files to disk under
@@ -871,6 +898,13 @@ blocked)`, the `**Tests:**` line MUST be `INSUFFICIENT` (never `PASS`), the
 blocked (paste the sandbox error), and the recommendation MUST NOT be a clean
 `merge` on the strength of tests — it is at best `revise-then-merge (tests not
 run — re-run in a writable env)`.
+
+**After running tests: check for artifact clobber.** Your own pytest run
+can regenerate figures/JSONs at canonical committed paths (#722). After
+any test run: `git status --porcelain -- eval_results/ figures/`, then
+restore + clean per Step 0.6 § "Smoke output-path hygiene". A test
+writing canonical `eval_results/` / `figures/` paths instead of
+`tmp_path` is itself a Minor finding (name the test + path).
 
 ### Step 4.5: Regression-test presence for substantive BLOCKER fixes
 

--- a/.claude/agents/experiment-implementer.md
+++ b/.claude/agents/experiment-implementer.md
@@ -376,6 +376,33 @@ mid-task). While building or smoke-testing a data path over such corpora:
    precondition assert ran, the logging call was reached). Code-reviewer
    mirror rule: Step 0.6 FAILs `smoke-run-missing` on missing guard
    evidence with no documented (d) call-out.
+
+   **Smoke outputs never overwrite committed artifacts.** When any smoke
+   command — including a revision/follow-up-round smoke on an
+   already-produced arm — writes under `eval_results/` or `figures/`,
+   divert its output away from the canonical committed paths:
+
+   - **Preferred — scratch-dir redirect.** Pass the script's output
+     override (`--out-dir /tmp/issue-<N>-smoke/`, an env var, or its
+     `_smoke` path branch) so canonical paths are never touched.
+   - **Fallback — restore-after-smoke.** No output override: immediately
+     after the smoke, `git -C "$WT" checkout -- <paths>` every touched
+     committed path, delete untracked smoke outputs there, and confirm
+     `git status --porcelain -- eval_results/ figures/` is empty.
+
+   Either way, the phase's `### <phase>` sub-section in `## Smoke run`
+   STATES which mechanism was used (fallback: paste the empty porcelain
+   output). Capture the artifact digest BEFORE the restore/delete.
+   A dirty worktree of smoke-truncated production JSONs/figures is a
+   latent clobber: swept into a later explicit-path commit, it silently
+   replaces production artifacts (three #722 instances: a review smoke
+   truncated committed 28-layer JSONs+figures; a reviewer's pytest rerun
+   regenerated committed figures at smoke scale; the hero figure shipped
+   2-layer — figure path not `_smoke`-suffixed while its JSONs diverted).
+   Corollaries for NEW/EDITED code: (a) a script growing a smoke flag
+   diverts ALL outputs together — JSONs AND figures (a partial divert is
+   instance 3); (b) tests never write canonical `eval_results/` /
+   `figures/` paths — use pytest's `tmp_path`.
 4. **Self-review against plan.** Walk down the plan's "File paths + concrete
    diffs" list and confirm each item is addressed.
 5. **Compute-deviation check.** For every row in the plan's §9
@@ -658,6 +685,11 @@ issue #N:
   per-source WandB run names) — or the `(d)` call-out explains why it
   cannot be shown at smoke scale (see checklist item 3 § Plan-declared
   runtime guards).
+  When a phase's smoke writes under `eval_results/` or `figures/`, the
+  sub-section ALSO states the output-path disposition — scratch-dir
+  redirect, or restore-after-smoke with the empty
+  `git status --porcelain -- eval_results/ figures/` output pasted
+  (checklist item 3 § "Smoke outputs never overwrite committed artifacts").
   On a CRASH-FIX round (dispatched to fix a posted `epm:failure`), the
   section ALSO carries a `### fix-engaged signal` sub-section confirming
   the fix's code path was reached on a same-pod / smoke-slice re-run

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -2065,7 +2065,15 @@ orchestrator verifies the evidence is genuinely present, so cosmetic
 gripes about present evidence never bounce the implementer or consume a
 review round. Code-only tasks (`infra` / `batch` / `analysis` /
 `survey`) keep the existing test-verdict gate (Step 9c) and are
-exempt from this smoke gate.
+exempt from this smoke gate. Smoke commands that write under
+`eval_results/` or `figures/` also carry the output-path hygiene
+disposition per experiment-implementer.md
+§ "Smoke outputs never overwrite committed artifacts" (scratch-dir
+redirect preferred; restore-after-smoke + an empty
+`git status --porcelain -- eval_results/ figures/` as the fallback);
+the reviewer treats visible clobber of a committed artifact as a
+substantive Critical (code-reviewer.md Step 0.6), never a strippable
+mechanical blocker.
 
 **5b. Read both markers from `events.jsonl`.**
 

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -3709,6 +3709,107 @@ def check_smoke_architecture_review_lens(*, repo_root: Path | None = None) -> li
     return errors
 
 
+# The #842 smoke output-path hygiene anchor phrase. Must appear INSIDE each
+# surface's load-bearing region (see check_smoke_output_hygiene below).
+SMOKE_OUTPUT_HYGIENE_ANCHOR = "Smoke outputs never overwrite committed artifacts"
+
+
+def check_smoke_output_hygiene(*, repo_root: Path | None = None) -> list[str]:
+    """FAIL if the smoke output-path hygiene rule (#842) is absent from any
+    of its three surfaces — REGION-AWARE and WHITESPACE-NORMALIZED.
+
+    Incident #722 (2026-07-02, three instances): a `--layers 0 18` review
+    smoke truncated committed 28-layer eval JSONs+figures; a reviewer's
+    pytest rerun regenerated `figures/issue_722/mlp_*.png` at smoke scale at
+    canonical paths; and the round-2 hero figure shipped as a 2-layer smoke
+    version because the script's figure path was not `_smoke`-suffixed while
+    its JSONs diverted. The fix added the anchor rule ("Smoke outputs never
+    overwrite committed artifacts") to three surfaces; this check pins each
+    copy inside its load-bearing, heading-bounded region:
+
+    (a) experiment-implementer.md — the smoke-contract checklist item
+        (``N. **End-to-end smoke run PER PHASE.`` up to the next
+        top-level numbered item);
+    (b) code-reviewer.md — the Step 0.6 region (``### Step 0.6:`` up to the
+        next heading) — the ONLY reviewer step the Codex twin's
+        ``{{INLINED RUBRIC`` placeholder carries, so a copy that drifts out
+        of Step 0.6 silently loses ensemble coverage;
+    (c) `.claude/skills/issue/SKILL.md` — the Step 5 smoke-gate paragraph
+        (``**End-to-end smoke gate (experiment tasks).`` up to the next
+        bold-start line / heading).
+
+    Whole-file presence is NOT enough: a surviving cross-reference elsewhere
+    in the file must not false-green after the rule body is deleted, so the
+    anchor must sit inside the named region. Matching is whitespace-
+    normalized (``\\s+`` -> single space) so an innocent prose reflow that
+    hard-wraps the anchor cannot spuriously FAIL the default run. A missing
+    region heading FAILs loud (a restructure must re-anchor the rule AND
+    update the region regex here in the same commit). ``repo_root`` is a
+    unit-test override hook; production callers pass None (canonical repo
+    root). Bundled into the no-flags default run.
+    """
+    root = repo_root if repo_root is not None else _REPO_ROOT
+
+    def _norm(s: str) -> str:
+        return re.sub(r"\s+", " ", s)
+
+    # End regexes are anchored on a literal ``\n`` (NOT a MULTILINE ``^``):
+    # the end search runs on the text slice AFTER the start match, and ``^``
+    # would also match at the very start of that slice (e.g. the closing
+    # ``**`` of the start line's bold token), truncating the region to zero.
+    surfaces: tuple[tuple[Path, str, str, str], ...] = (
+        (
+            root / ".claude" / "agents" / "experiment-implementer.md",
+            r"^\d+\. \*\*End-to-end smoke run PER PHASE\.",
+            r"\n\d+\. \*\*",
+            "implementer smoke-contract checklist item",
+        ),
+        (
+            root / ".claude" / "agents" / "code-reviewer.md",
+            r"^### Step 0\.6:",
+            r"\n#{1,6} ",
+            "code-reviewer Step 0.6 region",
+        ),
+        (
+            root / ".claude" / "skills" / "issue" / "SKILL.md",
+            r"^\*\*End-to-end smoke gate \(experiment tasks\)\.",
+            r"\n\*\*|\n#{1,6} ",
+            "SKILL.md Step 5 smoke-gate paragraph",
+        ),
+    )
+    errors: list[str] = []
+    for path, start_re, end_re, name in surfaces:
+        if not path.is_file():
+            errors.append(
+                f"{path}: missing — the #842 smoke output-path hygiene rule "
+                f"({SMOKE_OUTPUT_HYGIENE_ANCHOR!r}) must live here, in the "
+                f"{name}."
+            )
+            continue
+        text = path.read_text(encoding="utf-8")
+        start_m = re.search(start_re, text, flags=re.MULTILINE)
+        if start_m is None:
+            errors.append(
+                f"{path}: region heading for the {name} not found (#842) — "
+                f"the anchor region was restructured; re-anchor the smoke "
+                f"output-path hygiene rule and update this check's region "
+                f"regex in the same commit."
+            )
+            continue
+        end_m = re.search(end_re, text[start_m.end() :])
+        end = start_m.end() + end_m.start() if end_m is not None else len(text)
+        region = text[start_m.start() : end]
+        if _norm(SMOKE_OUTPUT_HYGIENE_ANCHOR) not in _norm(region):
+            errors.append(
+                f"{path}: anchor {SMOKE_OUTPUT_HYGIENE_ANCHOR!r} absent from "
+                f"the {name} (#842) — the rule was dropped or moved out of "
+                f"its load-bearing region; smoke runs would silently clobber "
+                f"committed eval_results/ / figures/ artifacts again "
+                f"(incident #722)."
+            )
+    return errors
+
+
 # `--check-lessons-index`: every `.claude/rules/*.md` (except LESSONS.md
 # itself) must have exactly one matching row in `.claude/rules/LESSONS.md`, and
 # every row in LESSONS.md must point at an existing rule file. Closes the
@@ -4308,6 +4409,19 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         "Step 6d.0 post-provision). Bundled into the no-flags default run.",
     )
     parser.add_argument(
+        "--check-smoke-output-hygiene",
+        action="store_true",
+        help="FAIL if the #842 smoke output-path hygiene rule ('Smoke outputs "
+        "never overwrite committed artifacts') is absent from the load-bearing "
+        "region of any of its three surfaces: the End-to-end-smoke-run "
+        "checklist item in experiment-implementer.md, the Step 0.6 region in "
+        "code-reviewer.md (the only step the Codex twin's inlined rubric "
+        "carries), or the Step 5 smoke-gate paragraph in the /issue SKILL.md. "
+        "Region-aware + whitespace-normalized (incident #722: smoke runs "
+        "clobbered committed eval_results//figures/ artifacts three times). "
+        "Bundled into the no-flags default run.",
+    )
+    parser.add_argument(
         "--check-judge-model-pins",
         action="store_true",
         help="Walk scripts/**/*.py, scripts/**/*.sh, "
@@ -4368,6 +4482,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         or args.check_lessons_index
         or args.check_compute_shape_review_lens
         or args.check_smoke_architecture_review_lens
+        or args.check_smoke_output_hygiene
         or args.check_judge_model_pins
         or args.check_agent_spec_size
     )
@@ -4440,6 +4555,8 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         errors.extend(check_compute_shape_review_lens())
     if args.check_smoke_architecture_review_lens or no_flags:
         errors.extend(check_smoke_architecture_review_lens())
+    if args.check_smoke_output_hygiene or no_flags:
+        errors.extend(check_smoke_output_hygiene())
     if args.check_judge_model_pins or no_flags:
         errors.extend(check_judge_model_pins())
 

--- a/tests/test_workflow_lint.py
+++ b/tests/test_workflow_lint.py
@@ -23,6 +23,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _LINT = _REPO_ROOT / "scripts" / "workflow_lint.py"
 _SRC = _REPO_ROOT / "src"
@@ -51,6 +53,7 @@ from workflow_lint import (  # noqa: E402
     check_script_references,
     check_skill_references,
     check_smoke_architecture_review_lens,
+    check_smoke_output_hygiene,
     check_upload_as_file,
     check_wandb_required,
 )
@@ -2994,3 +2997,216 @@ def test_smoke_architecture_review_lens_flags_skill_region(tmp_path) -> None:
     assert errors, "expected a FAIL for the sub-recipe-less 5c-bis region"
     subjects = [e.split(": ", 1)[0] for e in errors]
     assert all(s.endswith("/SKILL.md") for s in subjects), subjects
+
+
+# ---------------------------------------------------------------------------
+# ``check_smoke_output_hygiene`` (#842): the smoke output-path hygiene rule
+# ("Smoke outputs never overwrite committed artifacts") must sit INSIDE the
+# load-bearing region of each of its three surfaces — region-aware +
+# whitespace-normalized. Incident #722: smoke runs clobbered committed
+# eval_results//figures/ artifacts three times.
+# ---------------------------------------------------------------------------
+
+_SMOKE_HYGIENE_SURFACES = (
+    ".claude/agents/experiment-implementer.md",
+    ".claude/agents/code-reviewer.md",
+    ".claude/skills/issue/SKILL.md",
+)
+
+
+def _write_smoke_hygiene_conforming_tree(tmp_path) -> None:
+    """Write all three #842 surfaces in conforming shape under tmp_path.
+
+    Tests then break exactly ONE surface each, so failures stay attributable
+    (absence errors from the untouched surfaces would otherwise pollute
+    counts).
+    """
+    agents = tmp_path / ".claude" / "agents"
+    agents.mkdir(parents=True, exist_ok=True)
+    (agents / "experiment-implementer.md").write_text(
+        "# implementer\n"
+        "\n"
+        "3. **End-to-end smoke run PER PHASE.** For EACH distinct entrypoint\n"
+        "   run a tiny slice and record the digest.\n"
+        "\n"
+        "   **Smoke outputs never overwrite committed artifacts.** Divert\n"
+        "   smoke output to a scratch dir, or restore-after-smoke and confirm\n"
+        "   `git status --porcelain -- eval_results/ figures/` is empty.\n"
+        "4. **Self-review against plan.** Walk the plan.\n"
+    )
+    (agents / "code-reviewer.md").write_text(
+        "# reviewer\n"
+        "\n"
+        "### Step 0.6: End-to-end smoke gate (`type:experiment` only)\n"
+        "\n"
+        "The smoke gate body.\n"
+        "\n"
+        '**Smoke output-path hygiene ("Smoke outputs never overwrite committed artifacts").**\n'
+        "Clobber is a Critical tagged `substantive`; reviewer-self runs\n"
+        "restore what their own commands touched.\n"
+        "\n"
+        "### Step 0.65: Raw-completions upload wiring gate\n"
+        "\n"
+        "next section\n"
+    )
+    skill = tmp_path / ".claude" / "skills" / "issue"
+    skill.mkdir(parents=True, exist_ok=True)
+    (skill / "SKILL.md").write_text(
+        "# issue skill\n"
+        "\n"
+        "**End-to-end smoke gate (experiment tasks).** A code-review PASS\n"
+        "needs a per-phase smoke on a tiny real slice.\n"
+        "Smoke outputs never overwrite committed artifacts — the disposition\n"
+        "is stated per the implementer contract.\n"
+        "\n"
+        "**5b. Read both markers.**\n"
+    )
+
+
+def test_smoke_output_hygiene_live_tree_passes() -> None:
+    """The real tree carries the #842 hygiene rule on all three surfaces."""
+    assert check_smoke_output_hygiene() == []
+
+
+def test_smoke_output_hygiene_conforming_fixture_passes(tmp_path) -> None:
+    """The synthetic conforming tree passes — validates the fixture itself."""
+    _write_smoke_hygiene_conforming_tree(tmp_path)
+    assert check_smoke_output_hygiene(repo_root=tmp_path) == []
+
+
+_SMOKE_HYGIENE_ANCHORLESS = {
+    # Region heading present, anchor ABSENT from the region — but present
+    # elsewhere in the same file, so whole-file substring matching would
+    # false-green. Pins the region-awareness property.
+    ".claude/agents/experiment-implementer.md": (
+        "# implementer\n"
+        "\n"
+        "3. **End-to-end smoke run PER PHASE.** For EACH distinct entrypoint\n"
+        "   run a tiny slice and record the digest.\n"
+        "4. **Self-review against plan.** Smoke outputs never overwrite\n"
+        "   committed artifacts is cross-referenced here, OUTSIDE item 3.\n"
+    ),
+    ".claude/agents/code-reviewer.md": (
+        "# reviewer\n"
+        "\n"
+        "### Step 0.6: End-to-end smoke gate (`type:experiment` only)\n"
+        "\n"
+        "The smoke gate body, hygiene rule dropped.\n"
+        "\n"
+        "### Step 4: Run / Verify Tests\n"
+        "\n"
+        "Smoke outputs never overwrite committed artifacts — mentioned\n"
+        "outside the Step 0.6 region the Codex twin inlines.\n"
+    ),
+    ".claude/skills/issue/SKILL.md": (
+        "# issue skill\n"
+        "\n"
+        "**End-to-end smoke gate (experiment tasks).** A code-review PASS\n"
+        "needs a per-phase smoke; hygiene sentence dropped.\n"
+        "\n"
+        "**5b. Read both markers.** Smoke outputs never overwrite committed\n"
+        "artifacts — mentioned after the smoke-gate paragraph ends.\n"
+    ),
+}
+
+
+@pytest.mark.parametrize("surface", _SMOKE_HYGIENE_SURFACES)
+def test_smoke_output_hygiene_fails_on_missing_anchor(tmp_path, surface) -> None:
+    """Dropping the anchor from any ONE surface's region FAILs, naming that
+    file (#842) — even when the anchor phrase survives ELSEWHERE in the same
+    file (region-awareness: a leftover cross-reference must not false-green,
+    and the code-reviewer copy specifically must stay inside Step 0.6, the
+    only step the Codex twin's inlined rubric carries)."""
+    _write_smoke_hygiene_conforming_tree(tmp_path)
+    (tmp_path / surface).write_text(_SMOKE_HYGIENE_ANCHORLESS[surface])
+    errors = check_smoke_output_hygiene(repo_root=tmp_path)
+    assert errors, f"expected a FAIL for {surface} missing the anchor"
+    subjects = [e.split(": ", 1)[0] for e in errors]
+    fname = surface.rsplit("/", 1)[-1]
+    assert all(s.endswith(f"/{fname}") for s in subjects), (surface, errors)
+    assert any("absent from" in e for e in errors), errors
+
+
+@pytest.mark.parametrize("surface", _SMOKE_HYGIENE_SURFACES)
+def test_smoke_output_hygiene_fails_on_missing_file(tmp_path, surface) -> None:
+    """A surface file absent from the tree FAILs with the missing-file branch
+    naming that path (#842)."""
+    _write_smoke_hygiene_conforming_tree(tmp_path)
+    (tmp_path / surface).unlink()
+    errors = check_smoke_output_hygiene(repo_root=tmp_path)
+    assert errors, f"expected a FAIL for the absent {surface}"
+    fname = surface.rsplit("/", 1)[-1]
+    subjects = [e.split(": ", 1)[0] for e in errors]
+    assert all(s.endswith(f"/{fname}") for s in subjects), (surface, errors)
+    assert any("missing" in e for e in errors), errors
+
+
+def test_smoke_output_hygiene_fails_on_missing_region_heading(tmp_path) -> None:
+    """A surface whose region heading was restructured away FAILs LOUD (#842
+    property (c)) — never a vacuous pass, even if the anchor survives
+    somewhere in the file."""
+    _write_smoke_hygiene_conforming_tree(tmp_path)
+    agents = tmp_path / ".claude" / "agents"
+    (agents / "code-reviewer.md").write_text(
+        "# reviewer\n"
+        "\n"
+        "### Step 0.7: A renamed step\n"
+        "\n"
+        "Smoke outputs never overwrite committed artifacts — the anchor\n"
+        "survives but its Step 0.6 region heading is gone.\n"
+    )
+    errors = check_smoke_output_hygiene(repo_root=tmp_path)
+    assert errors, "expected a FAIL for the missing Step 0.6 region heading"
+    subjects = [e.split(": ", 1)[0] for e in errors]
+    assert all(s.endswith("/code-reviewer.md") for s in subjects), errors
+    assert any("region heading" in e for e in errors), errors
+
+
+def test_smoke_output_hygiene_hard_wrapped_anchor_passes(tmp_path) -> None:
+    """An anchor hard-wrapped across two lines INSIDE the correct region still
+    PASSes — pins the whitespace-normalized matching so an innocent prose
+    reflow cannot spuriously FAIL the fleet's default run (#842 property (a))."""
+    _write_smoke_hygiene_conforming_tree(tmp_path)
+    skill = tmp_path / ".claude" / "skills" / "issue"
+    (skill / "SKILL.md").write_text(
+        "# issue skill\n"
+        "\n"
+        "**End-to-end smoke gate (experiment tasks).** A code-review PASS\n"
+        "needs a per-phase smoke on a tiny real slice. Smoke outputs never\n"
+        "overwrite committed artifacts — the disposition is stated per the\n"
+        "implementer contract.\n"
+        "\n"
+        "**5b. Read both markers.**\n"
+    )
+    assert check_smoke_output_hygiene(repo_root=tmp_path) == []
+
+
+def test_smoke_output_hygiene_wired_into_default_run(tmp_path, capsys, monkeypatch) -> None:
+    """The no-flags CLI-path REGISTRATION test (#842): the default run must
+    exercise ``check_smoke_output_hygiene`` — a check that exists only behind
+    its ``--check-smoke-output-hygiene`` flag while never being bundled into
+    the ``no_flags`` dispatch would leave every other acceptance command
+    green (the same bundling gap the #712 §4f wiring test pinned).
+
+    Doctors a minimal tree missing the anchor on one surface, points the
+    lint module's ``_REPO_ROOT`` at it, and invokes ``main([])`` in-process:
+    the run must exit non-zero with the #842 diagnostic in stderr. Other
+    bundled checks contribute unrelated errors on the minimal tree (missing
+    LESSONS.md etc.) — the assertion keys on the #842 error string, so those
+    are harmless.
+    """
+    import workflow_lint as wl
+
+    _write_smoke_hygiene_conforming_tree(tmp_path)
+    (tmp_path / ".claude/skills/issue/SKILL.md").write_text(
+        _SMOKE_HYGIENE_ANCHORLESS[".claude/skills/issue/SKILL.md"]
+    )
+    monkeypatch.setattr(wl, "_REPO_ROOT", tmp_path)
+    rc = wl.main([])
+    err = capsys.readouterr().err
+    assert rc != 0, f"no-flags default run exited 0 on an anchor-less tree:\n{err}"
+    assert "#842" in err, (
+        f"the #842 smoke-output-hygiene diagnostic is missing from the "
+        f"no-flags default run's stderr — the check is not bundled into "
+        f"no_flags:\n{err}"
+    )


### PR DESCRIPTION
Closes task #842 (workflow-fix, kind: infra).

## Summary
- Adds the "Smoke outputs never overwrite committed artifacts" rule to the smoke-run contract: experiment-implementer.md checklist item 3 + report disposition field; code-reviewer.md Step 0.6 graded lens (clobber = Critical `substantive`) + Step 4 post-pytest check; /issue SKILL.md Step 5 mirror sentence.
- Adds `check_smoke_output_hygiene` to workflow_lint.py — region-aware, whitespace-normalized, missing-region-fails-loud, bundled into the no-flags default run — plus 11 tests incl. the no-flags CLI wiring test.
- Incident: 3 smoke-clobber instances on #722 (2026-07-02).

## Test plan
- [x] code-review ensemble PASS+PASS (epm:code-review v1 / epm:code-review-codex v1)
- [x] `uv run python scripts/workflow_lint.py` exit 0; `--check-smoke-output-hygiene` exit 0; `--check-asks` exit 0
- [x] `pytest tests/test_workflow_lint.py` 200 passed; touched-scope Step 9c 1927 passed (2 pre-existing main failures recorded)
- [x] ruff check + format on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)