### PR TITLE
task #843: atomic per-issue dispatch lease + registration collision-fail + sweep marker-freshness guard

### DIFF
--- a/.claude/agents/analyzer.md
+++ b/.claude/agents/analyzer.md
@@ -17,6 +17,15 @@ skills:
 memory: project
 effort: xhigh
 background: true
+tools:
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - Bash
+  - TodoWrite
+  - Skill
 ---
 
 # Result Analyzer

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -10,6 +10,12 @@ skills:
 memory: project
 effort: xhigh
 background: true
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
 ---
 
 # Code Reviewer
@@ -429,6 +435,33 @@ under "Style / Consistency" and PROCEED to review the diff.
 Code-only tasks (`type:infra` / `type:batch` / `type:analysis` /
 `type:survey`) are EXEMPT from this gate — they keep the test-verdict gate
 (`/issue` Step 9c) and the Step 4 test run below.
+
+**Smoke output-path hygiene ("Smoke outputs never overwrite committed artifacts").**
+Two checks:
+
+- **Clobber evidence is SUBSTANTIVE, never mechanical.** If the diff (or
+  the worktree you review in) replaces an existing committed
+  `eval_results/` / `figures/` artifact with a smoke-scale version at its
+  canonical path (fewer layers / cells / rows), raise a Critical finding
+  tagged `substantive` — NOT `smoke-run-missing` — so the Step 5c-bis
+  mechanical strip can never remove it (#722 shipped a smoke-scale hero
+  figure and truncated committed 28-layer JSONs).
+- **A missing disposition line is CONCERNS, not FAIL.** A `### <phase>`
+  smoke sub-section whose command writes under `eval_results/` /
+  `figures/` but states no output-path disposition (scratch-dir redirect,
+  or restore-after-smoke + an empty
+  `git status --porcelain -- eval_results/ figures/`) is a Minor — unless
+  the clobber itself is visible (first bullet).
+
+**Any verification command YOU run follows the same rule.** If you rerun
+a test or smoke that regenerates files under `eval_results/` /
+`figures/`, afterwards run
+`git status --porcelain -- eval_results/ figures/`, restore the committed
+artifacts YOUR OWN command modified (`git checkout -- <paths>` scoped to
+those files, never a blanket revert) and delete the untracked outputs it
+left; leaving them dirty plants the clobber for the next explicit-path
+commit (#722 instance 2 was exactly this). Binds BOTH ensemble
+reviewers (rides into the Codex twin via the inlined Step 0.6 rubric).
 
 ### Step 0.65: Raw-completions upload wiring gate (`type:experiment` only)
 
@@ -883,6 +916,13 @@ blocked)`, the `**Tests:**` line MUST be `INSUFFICIENT` (never `PASS`), the
 blocked (paste the sandbox error), and the recommendation MUST NOT be a clean
 `merge` on the strength of tests — it is at best `revise-then-merge (tests not
 run — re-run in a writable env)`.
+
+**After running tests: check for artifact clobber.** Your own pytest run
+can regenerate figures/JSONs at canonical committed paths (#722). After
+any test run: `git status --porcelain -- eval_results/ figures/`, then
+restore + clean per Step 0.6 § "Smoke output-path hygiene". A test
+writing canonical `eval_results/` / `figures/` paths instead of
+`tmp_path` is itself a Minor finding (name the test + path).
 
 ### Step 4.5: Regression-test presence for substantive BLOCKER fixes
 

--- a/.claude/agents/codex-code-reviewer.md
+++ b/.claude/agents/codex-code-reviewer.md
@@ -13,6 +13,12 @@ description: >
 memory: project
 effort: xhigh
 background: true
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
 ---
 
 # Codex Code Reviewer (thin Claude wrapper)

--- a/.claude/agents/codex-critic.md
+++ b/.claude/agents/codex-critic.md
@@ -13,6 +13,12 @@ description: >
 memory: project
 effort: xhigh
 background: true
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
 ---
 
 # Codex Critic (thin Claude wrapper, in-context mode)

--- a/.claude/agents/codex-follow-up-critic.md
+++ b/.claude/agents/codex-follow-up-critic.md
@@ -14,6 +14,12 @@ description: >
 memory: project
 effort: xhigh
 background: true
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
 ---
 
 # Codex Follow-Up Critic (thin Claude wrapper, marker mode)

--- a/.claude/agents/codex-interpretation-critic.md
+++ b/.claude/agents/codex-interpretation-critic.md
@@ -14,6 +14,12 @@ description: >
 memory: project
 effort: xhigh
 background: true
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
 ---
 
 # Codex Interpretation Critic (thin Claude wrapper, marker mode)

--- a/.claude/agents/codex-reviewer.md
+++ b/.claude/agents/codex-reviewer.md
@@ -14,6 +14,11 @@ absorbed_into: codex-clean-result-critic
 memory: project
 effort: xhigh
 background: true
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
 ---
 
 > **DEPRECATED 2026-05-13.** Use `codex-clean-result-critic` instead. The

--- a/.claude/agents/critic.md
+++ b/.claude/agents/critic.md
@@ -7,6 +7,16 @@ description: >
   reasoning — only sees the plan itself and the raw codebase.
 memory: project
 effort: xhigh
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
+  - WebSearch
+  - WebFetch
+  - mcp__arxiv
+  - mcp__arxiv-latex
 ---
 
 # Critic

--- a/.claude/agents/experiment-implementer.md
+++ b/.claude/agents/experiment-implementer.md
@@ -11,6 +11,18 @@ skills:
   - cleanup
 memory: project
 effort: xhigh
+tools:
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - Bash
+  - TodoWrite
+  - Skill
+  - WebSearch
+  - WebFetch
+  - mcp__plugin_context7_context7
 ---
 
 # Experiment Implementer
@@ -376,6 +388,33 @@ mid-task). While building or smoke-testing a data path over such corpora:
    precondition assert ran, the logging call was reached). Code-reviewer
    mirror rule: Step 0.6 FAILs `smoke-run-missing` on missing guard
    evidence with no documented (d) call-out.
+
+   **Smoke outputs never overwrite committed artifacts.** When any smoke
+   command — including a revision/follow-up-round smoke on an
+   already-produced arm — writes under `eval_results/` or `figures/`,
+   divert its output away from the canonical committed paths:
+
+   - **Preferred — scratch-dir redirect.** Pass the script's output
+     override (`--out-dir /tmp/issue-<N>-smoke/`, an env var, or its
+     `_smoke` path branch) so canonical paths are never touched.
+   - **Fallback — restore-after-smoke.** No output override: immediately
+     after the smoke, `git -C "$WT" checkout -- <paths>` every touched
+     committed path, delete untracked smoke outputs there, and confirm
+     `git status --porcelain -- eval_results/ figures/` is empty.
+
+   Either way, the phase's `### <phase>` sub-section in `## Smoke run`
+   STATES which mechanism was used (fallback: paste the empty porcelain
+   output). Capture the artifact digest BEFORE the restore/delete.
+   A dirty worktree of smoke-truncated production JSONs/figures is a
+   latent clobber: swept into a later explicit-path commit, it silently
+   replaces production artifacts (three #722 instances: a review smoke
+   truncated committed 28-layer JSONs+figures; a reviewer's pytest rerun
+   regenerated committed figures at smoke scale; the hero figure shipped
+   2-layer — figure path not `_smoke`-suffixed while its JSONs diverted).
+   Corollaries for NEW/EDITED code: (a) a script growing a smoke flag
+   diverts ALL outputs together — JSONs AND figures (a partial divert is
+   instance 3); (b) tests never write canonical `eval_results/` /
+   `figures/` paths — use pytest's `tmp_path`.
 4. **Self-review against plan.** Walk down the plan's "File paths + concrete
    diffs" list and confirm each item is addressed.
 5. **Compute-deviation check.** For every row in the plan's §9
@@ -658,6 +697,11 @@ issue #N:
   per-source WandB run names) — or the `(d)` call-out explains why it
   cannot be shown at smoke scale (see checklist item 3 § Plan-declared
   runtime guards).
+  When a phase's smoke writes under `eval_results/` or `figures/`, the
+  sub-section ALSO states the output-path disposition — scratch-dir
+  redirect, or restore-after-smoke with the empty
+  `git status --porcelain -- eval_results/ figures/` output pasted
+  (checklist item 3 § "Smoke outputs never overwrite committed artifacts").
   On a CRASH-FIX round (dispatched to fix a posted `epm:failure`), the
   section ALSO carries a `### fix-engaged signal` sub-section confirming
   the fix's code path was reached on a same-pod / smoke-slice re-run

--- a/.claude/agents/experimenter.md
+++ b/.claude/agents/experimenter.md
@@ -13,6 +13,16 @@ skills:
 memory: project
 effort: xhigh
 background: true
+tools:
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - Bash
+  - TodoWrite
+  - Skill
+  - mcp__ssh
 ---
 
 # Experimenter

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -13,6 +13,19 @@ skills:
   - adversarial-planner
 memory: project
 effort: xhigh
+tools:
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - Bash
+  - TodoWrite
+  - Skill
+  - Agent
+  - WebSearch
+  - WebFetch
+  - mcp__plugin_context7_context7
 ---
 
 # Implementer

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -7,6 +7,19 @@ description: >
   plans in what actually exists.
 memory: project
 effort: xhigh
+tools:
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - Bash
+  - TodoWrite
+  - Skill
+  - WebSearch
+  - WebFetch
+  - mcp__arxiv
+  - mcp__arxiv-latex
 ---
 
 # Planner

--- a/.claude/agents/reconciler.md
+++ b/.claude/agents/reconciler.md
@@ -14,6 +14,12 @@ skills:
   - independent-reviewer
 memory: project
 effort: xhigh
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
 ---
 
 # Reconciler

--- a/.claude/agents/research-pm.md
+++ b/.claude/agents/research-pm.md
@@ -14,6 +14,7 @@ skills:
   - promote-clean-result
 memory: project
 effort: xhigh
+disallowedTools: mcp__todoist, mcp__google-workspace, mcp__plugin_playwright_playwright
 ---
 
 # Research PM

--- a/.claude/agents/retrospective.md
+++ b/.claude/agents/retrospective.md
@@ -8,6 +8,12 @@ accepts:
   - lookback_days
 memory: project
 effort: xhigh
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Write
 ---
 
 # Retrospective

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -21,6 +21,11 @@ skills:
 memory: project
 effort: xhigh
 background: true
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
 ---
 
 > **DEPRECATED 2026-05-13.** This agent is retained for historical

--- a/.claude/agents/workflow-improver.md
+++ b/.claude/agents/workflow-improver.md
@@ -15,6 +15,11 @@ skills:
   - cleanup
 memory: project
 effort: xhigh
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
 ---
 
 > **DEPRECATED — do not spawn (retired 2026-06-27, #678).** The

--- a/.claude/skills/adversarial-planner/SKILL.md
+++ b/.claude/skills/adversarial-planner/SKILL.md
@@ -77,8 +77,13 @@ Save the plan to a temporary file or pass it directly.
 **Strip the harness trailer before persisting.** An `Agent` tool result ends
 with harness-appended metadata — a final `agentId: <id> (use SendMessage ...)`
 line plus a `<usage>...</usage>` block. Remove BOTH before writing the
-planner's return to ANY durable handoff surface (the `/tmp/issue-<N>-plan-v<K>.md`
-handoff file, `task.py new-plan-version` → `plans/v<K>.md`), e.g.:
+planner's return to ANY durable handoff surface (the
+`/tmp/issue-<N>-plan-v<K>-<attempt>.md` handoff file, where `<attempt>` is a
+fresh `$(date +%s)` chosen once per orchestrator planning attempt — the
+`<attempt>` suffix exists because a crashed attempt leaves a stale /tmp file;
+a respawned session re-Writing the fixed path after Reading an older version
+gets "File has been modified since read" (4× on #822) —
+`task.py new-plan-version` → `plans/v<K>.md`), e.g.:
 
 ```python
 text = re.sub(r"\n?agentId:\s*\S+\s*\(use SendMessage.*?</usage>\s*$", "\n", text, flags=re.DOTALL)
@@ -101,7 +106,8 @@ Run the structural verifier against the plan version just persisted:
 
 - **Persistence ordering:** `--issue` mode verifies the newest `plans/v{K}.md`. If the
   just-drafted plan has NOT yet been persisted via `task.py new-plan-version` (the plan
-  still lives at the `/tmp/issue-<N>-plan-v<K>.md` handoff file), use `--plan-file <handoff>
+  still lives at the `/tmp/issue-<N>-plan-v<K>-<attempt>.md` handoff file), use
+  `--plan-file <handoff>
   --kind <task kind>` instead — and treat an `--issue`-mode exit 2 with "no plans/v*.md" as
   "persist first or use --plan-file", NOT as a bounce.
 - **Canonical N/A escape phrases** (quote verbatim in any bounce brief so the planner can

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1399,10 +1399,14 @@ plans missing any):**
 
 Post the plan body via `new-plan-version` (writes
 `tasks/<status>/<N>/plans/v<K>.md` and rotates the `plan.md` symlink),
-then announce it with an `epm:plan` event:
+then announce it with an `epm:plan` event. The handoff file carries a
+per-attempt suffix — `<attempt>` = a fresh `$(date +%s)` chosen once per
+orchestrator planning attempt — because a crashed attempt leaves a stale
+/tmp file; a respawned session re-Writing the fixed path after Reading an
+older version gets "File has been modified since read" (4× on #822):
 
 ```bash
-uv run python scripts/task.py new-plan-version <N> --file /tmp/issue-<N>-plan.md
+uv run python scripts/task.py new-plan-version <N> --file /tmp/issue-<N>-plan-v<K>-<attempt>.md
 PLAN_PATH=$(uv run python scripts/task.py find <N>)/plans/plan.md
 # Embed the machine-readable cost token (<X> = the plan's total GPU-hours) so
 # the Step 2c auto-approve gate can parse it from the note as well as the body.

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -405,6 +405,7 @@ from pod_lifecycle import _is_managed_pod, _issue_from_pod_name  # noqa: E402
 from runpod_api import PodInfo, get_pod_by_name, list_team_pods  # noqa: E402
 from spawn_session import (  # noqa: E402
     AUTONOMOUS_REGISTRY_DIR,
+    DUPLICATE_DISPATCH_NOTE_SENTINEL,
     PROJECT_ROOT,
     _infer_issue_from_path,
     _live_children,
@@ -412,6 +413,9 @@ from spawn_session import (  # noqa: E402
     _load_pm_session_ids,
     _load_session_issue_map,
     _load_session_meta,
+    dispatch_lease_desc,
+    dispatch_lease_fresh,
+    spawn_output_suppressed,
 )
 from tick_triage import plan_pending_over_cap  # noqa: E402
 from worktree_audit import ORPHAN_HOLDER_PATTERNS  # noqa: E402  (codex-companion cmdline patterns)
@@ -923,6 +927,10 @@ _WATCHER_NOTE_SENTINELS: frozenset[str] = frozenset(
         _PROPOSED_INFRA_SWEEP_NOTE_SENTINEL,
         _CAPACITY_RETRY_NOTE_SENTINEL,
         _CAPACITY_RETRY_EXHAUSTED_NOTE_SENTINEL,
+        # Posted by spawn_session.py (not the watcher) when a duplicate --auto
+        # dispatch was suppressed at registration (#843 M2) — same contract:
+        # a suppression note is bookkeeping, never real progress.
+        DUPLICATE_DISPATCH_NOTE_SENTINEL,
     }
 )
 
@@ -2835,9 +2843,13 @@ def _session_alive(entry: dict, live_ids: set[str]) -> bool:
     return _manual_session_alive(entry.get("issue"), live_ids)
 
 
-def _respawn(entry: dict, dry_run: bool) -> bool:
-    """Re-spawn the autonomous session for this entry. Returns True on success.
-    spawn_session rewrites the registry (new id, missed=0) as a side effect.
+def _respawn(entry: dict, dry_run: bool) -> str:
+    """Re-spawn the autonomous session for this entry. Returns the #843 M1b
+    tri-state ``"spawned" | "suppressed" | "failed"`` (``"suppressed"`` = the
+    rc-0 subprocess printed a duplicate-suppression sentinel — another
+    dispatcher's session is driving, so nothing was respawned; ``"failed"``
+    also covers dry-run). On ``"spawned"``, spawn_session rewrites the
+    registry (new id, missed=0) as a side effect.
 
     Re-passes the per-session Claude overrides (``model``, ``betas``,
     ``effort``) verbatim when the registry entry recorded them at spawn time —
@@ -2864,14 +2876,19 @@ def _respawn(entry: dict, dry_run: bool) -> bool:
         cmd.extend(["--effort", str(effort)])
     if dry_run:
         print(f"  [dry-run] would respawn: {' '.join(cmd)}")
-        return False
+        return "failed"  # dry-run: nothing spawned
     res = subprocess.run(cmd, cwd=PROJECT_ROOT, capture_output=True, text=True, timeout=120)
     if res.returncode != 0:
         print(f"  RESPAWN FAILED issue #{issue}: {res.stderr.strip()[:300]}", file=sys.stderr)
-        return False
+        return "failed"
     first_line = (res.stdout.strip().splitlines() or [""])[0]
+    if spawn_output_suppressed(res.stdout) is not None:
+        print(
+            f"  RESPAWN issue #{issue}: suppressed — not respawned (lease/collision): {first_line}"
+        )
+        return "suppressed"
     print(f"  RESPAWNED issue #{issue} (session was dead): {first_line}")
-    return True
+    return "spawned"
 
 
 def _acquire_lock() -> object | None:
@@ -5757,15 +5774,16 @@ def _stop_session(session_id: str, dry_run: bool) -> bool:
     return True
 
 
-def _respawn_stalled_session(issue: int, cap_gpu_hours: float, dry_run: bool) -> bool:
+def _respawn_stalled_session(issue: int, cap_gpu_hours: float, dry_run: bool) -> str:
     """Spawn a fresh `--auto` session for ``issue``.
 
     Mirrors :func:`_respawn` (used by the crash-recovery pass) but is
     decoupled from the autonomous-registry entry shape — the stalled-
     detector path knows the issue and the cap directly from the loaded
-    state, so it doesn't pass a registry-entry dict. Returns True on
-    success; spawn_session rewrites the registry (new id, missed=0) as a
-    side effect.
+    state, so it doesn't pass a registry-entry dict. Returns the #843 M1b
+    tri-state ``"spawned" | "suppressed" | "failed"`` (see :func:`_respawn`);
+    on ``"spawned"``, spawn_session rewrites the registry (new id, missed=0)
+    as a side effect.
 
     Note: we do NOT call :func:`_respawn` directly because the
     spawn-issue invocation here is the SAME (`--auto`
@@ -5781,17 +5799,23 @@ def _respawn_stalled_session(issue: int, cap_gpu_hours: float, dry_run: bool) ->
     cmd.extend(_stalled_session_overrides(issue))
     if dry_run:
         print(f"  [dry-run] would respawn stalled: {' '.join(cmd)}")
-        return False
+        return "failed"  # dry-run: nothing spawned
     res = subprocess.run(cmd, cwd=PROJECT_ROOT, capture_output=True, text=True, timeout=120)
     if res.returncode != 0:
         print(
             f"  RESPAWN-STALLED FAILED issue #{issue}: {res.stderr.strip()[:300]}",
             file=sys.stderr,
         )
-        return False
+        return "failed"
     first_line = (res.stdout.strip().splitlines() or [""])[0]
+    if spawn_output_suppressed(res.stdout) is not None:
+        print(
+            f"  RESPAWN-STALLED issue #{issue}: suppressed — not respawned "
+            f"(lease/collision): {first_line}"
+        )
+        return "suppressed"
     print(f"  RESPAWNED-STALLED issue #{issue} (alive-but-stalled): {first_line}")
-    return True
+    return "spawned"
 
 
 def _stalled_cap_gpu_hours(issue: int) -> float:
@@ -6006,7 +6030,15 @@ def _handle_stalled_respawn(ctx: _StalledActionCtx) -> None:
             )
         return
     cap = _stalled_cap_gpu_hours(ctx.issue)
-    spawn_ok = _respawn_stalled_session(ctx.issue, cap, ctx.dry_run)
+    spawn_result = _respawn_stalled_session(ctx.issue, cap, ctx.dry_run)
+    if spawn_result == "suppressed":
+        # #843 M1b: a concurrent dispatcher's fresh lease / a registration
+        # collision suppressed the spawn — a session for this issue is live
+        # and driving. Book NOTHING: no respawn marker, no respawn_count
+        # bump, no state reset (the on-disk stall state is left untouched);
+        # the next tick re-evaluates against the new session's progress.
+        return
+    spawn_ok = spawn_result == "spawned"
     new_respawn_count = ctx.respawn_count + 1
     if spawn_ok:
         _post_progress_marker(
@@ -7073,12 +7105,14 @@ def _issue_registrations() -> dict[int, dict]:
     return out
 
 
-def _respawn_orphan(issue: int, cap_gpu_hours: float, dry_run: bool) -> bool:
+def _respawn_orphan(issue: int, cap_gpu_hours: float, dry_run: bool) -> str:
     """Spawn a fresh ``--auto`` session for an orphaned active task. Mirrors
     :func:`_respawn_stalled_session` but with an ``RESPAWNED-ORPHAN`` log
-    prefix so the operator can tell the recovery paths apart. The spawn
-    re-registers the issue (``spawn-issue --auto`` rewrites the registry), so
-    the task re-enters normal respawn/stalled coverage."""
+    prefix so the operator can tell the recovery paths apart. Returns the
+    #843 M1b tri-state ``"spawned" | "suppressed" | "failed"`` (see
+    :func:`_respawn`). On ``"spawned"``, the spawn re-registers the issue
+    (``spawn-issue --auto`` rewrites the registry), so the task re-enters
+    normal respawn/stalled coverage."""
     cmd = [
         "uv", "run", "python", "scripts/spawn_session.py", "spawn-issue",
         "--issue", str(issue), "--auto", "--auto-approve-gpu-hours", str(cap_gpu_hours),
@@ -7086,17 +7120,23 @@ def _respawn_orphan(issue: int, cap_gpu_hours: float, dry_run: bool) -> bool:
     cmd.extend(_stalled_session_overrides(issue))
     if dry_run:
         print(f"  [dry-run] would respawn orphan: {' '.join(cmd)}")
-        return False
+        return "failed"  # dry-run: nothing spawned
     res = subprocess.run(cmd, cwd=PROJECT_ROOT, capture_output=True, text=True, timeout=120)
     if res.returncode != 0:
         print(
             f"  RESPAWN-ORPHAN FAILED issue #{issue}: {res.stderr.strip()[:300]}",
             file=sys.stderr,
         )
-        return False
+        return "failed"
     first_line = (res.stdout.strip().splitlines() or [""])[0]
+    if spawn_output_suppressed(res.stdout) is not None:
+        print(
+            f"  RESPAWN-ORPHAN issue #{issue}: suppressed — not respawned "
+            f"(lease/collision): {first_line}"
+        )
+        return "suppressed"
     print(f"  RESPAWNED-ORPHAN issue #{issue} (active task, no live session): {first_line}")
-    return True
+    return "spawned"
 
 
 def orphan_sweep_pass(
@@ -7531,7 +7571,13 @@ def _process_orphan_task(
             )
         return
     if action == "respawn":
-        attempted_ok = _respawn_orphan(issue, _stalled_cap_gpu_hours(issue), dry_run)
+        spawn_result = _respawn_orphan(issue, _stalled_cap_gpu_hours(issue), dry_run)
+        if spawn_result == "suppressed":
+            # #843 M1b: duplicate dispatch suppressed (lease/collision) — a
+            # session is driving. Book nothing: no attempt consumed against
+            # the daily cap, no miss-state reset, no respawn marker.
+            return
+        attempted_ok = spawn_result == "spawned"
         if not dry_run:
             # Count the ATTEMPT regardless of success so a failing spawn
             # can't hot-loop past the daily cap.
@@ -7719,6 +7765,56 @@ PROPOSED_INFRA_SWEEP_BACKOFF_S_DEFAULT = INFRA_DRAIN_BACKOFF_S_DEFAULT
 # task leaves `proposed`, so a PM rewrite / repromotion / status change clears
 # it naturally). env EPM_PROPOSED_INFRA_SWEEP_MAX_ATTEMPTS.
 PROPOSED_INFRA_SWEEP_MAX_ATTEMPTS_DEFAULT = INFRA_DRAIN_MAX_ATTEMPTS_DEFAULT
+
+# #843 M3: the sweep skips a decided candidate whose events.jsonl carries a
+# dispatch-sentinel marker younger than this — one watcher cadence (cron
+# `3-59/10` -> 10 min): a dispatch marker younger than one tick means SOME
+# dispatcher fired within the current/previous tick. Post-M1, this guard's
+# independent value is the lease-file-loss backstop (manual `rm` override,
+# a GC/registry mishap) plus observability. env
+# EPM_PROPOSED_INFRA_SWEEP_MARKER_FRESH_S.
+PROPOSED_INFRA_SWEEP_MARKER_FRESH_S_DEFAULT = 600.0
+
+# Both dispatch-marker sentinels disqualify (a drain dispatch 3 min ago is
+# exactly as disqualifying as a sweep one). The filer posts no marker — its
+# dispatches are covered by the M1 lease + the registration checks.
+_DISPATCH_NOTE_SENTINELS = (
+    _PROPOSED_INFRA_SWEEP_NOTE_SENTINEL,
+    _INFRA_DRAIN_NOTE_SENTINEL,
+)
+
+
+def _proposed_infra_sweep_marker_fresh_s() -> float:
+    """Marker-freshness window in seconds (env
+    ``EPM_PROPOSED_INFRA_SWEEP_MARKER_FRESH_S``; missing or malformed value
+    falls back to :data:`PROPOSED_INFRA_SWEEP_MARKER_FRESH_S_DEFAULT`)."""
+    raw = os.environ.get("EPM_PROPOSED_INFRA_SWEEP_MARKER_FRESH_S")
+    if not raw:
+        return PROPOSED_INFRA_SWEEP_MARKER_FRESH_S_DEFAULT
+    try:
+        return float(raw)
+    except ValueError:
+        return PROPOSED_INFRA_SWEEP_MARKER_FRESH_S_DEFAULT
+
+
+def _recent_dispatch_marker_age_s(events: list[dict], now: float) -> float | None:
+    """Age (s) of the newest ``epm:progress`` marker whose note carries either
+    dispatch sentinel (:data:`_DISPATCH_NOTE_SENTINELS`); ``None`` when there
+    is no such marker or no parseable timestamp (fail-soft: an unparseable
+    ``ts`` row is skipped, and a fully-unreadable events list arrives here as
+    ``[]`` via :func:`_task_events` -> ``None`` -> no skip; the M1 lease still
+    protects)."""
+    best: float | None = None
+    for ev in events:
+        if ev.get("kind") != "epm:progress":
+            continue
+        note = ev.get("note") or ""
+        if not any(sentinel in note for sentinel in _DISPATCH_NOTE_SENTINELS):
+            continue
+        ts = _parse_event_ts(ev.get("ts"))
+        if ts is not None and (best is None or ts > best):
+            best = ts
+    return None if best is None else now - best
 
 
 def _parse_predicate_hold(reason: str) -> int | None:
@@ -8380,7 +8476,7 @@ def _dispatch_infra_drain(
     dry_run: bool,
     *,
     reg_snapshot: dict[str, bytes] | None = None,
-) -> bool:
+) -> str:
     """``spawn_session.py spawn-issue --issue <N> --auto`` (the plain
     command, exactly the PM standing-rule item-3 mechanism; no
     ``--auto-approve-gpu-hours`` override — spawn_session's default applies,
@@ -8396,14 +8492,23 @@ def _dispatch_infra_drain(
     callers without a decision context) degrades to the conservative
     abort-on-any-existing-file behavior. Shrinks the PM-vs-watcher
     double-spawn window from one-full-pass to ~the spawn subprocess itself.
-    Returns success bool; honours dry_run (logs, never spawns)."""
+
+    Returns the #843 M1b tri-state ``"spawned" | "suppressed" | "failed"``:
+    ``"suppressed"`` when the rc-0 subprocess stdout carries a
+    duplicate-suppression sentinel (DISPATCH-LEASE HELD /
+    REGISTRATION-COLLISION, via :func:`spawn_session.spawn_output_suppressed`)
+    — a loud no-op the callers must NOT book: no dispatch marker, no attempt,
+    no backoff (a crashed lease-winner then recovers in <= TTL + one tick,
+    not the 1 h backoff). ``"failed"`` also covers dry-run (logs, never
+    spawns, nothing to book) and the pre-spawn re-check aborts (both record
+    a spawn-failed attempt in the callers, exactly as before)."""
     cmd = [
         "uv", "run", "python", "scripts/spawn_session.py", "spawn-issue",
         "--issue", str(issue), "--auto",
     ]  # fmt: skip
     if dry_run:
         print(f"  [dry-run] would dispatch infra-drain: {' '.join(cmd)}")
-        return False
+        return "failed"  # dry-run: nothing spawned, nothing to book
     snapshot = reg_snapshot or {}
     for basename in (f"issue-{issue}.json", f"manual-issue-{issue}.json"):
         path = AUTONOMOUS_REGISTRY_DIR / basename
@@ -8420,14 +8525,14 @@ def _dispatch_infra_drain(
                 f"unreadable at the pre-spawn re-check; cannot verify the "
                 f"decision still holds (fail toward not dispatching)"
             )
-            return False
+            return "failed"
         if known is None or current != known:
             print(
                 f"  INFRA-DRAIN ABORT issue #{issue}: lost race to concurrent "
                 f"dispatcher ({basename} "
                 f"{'appeared' if known is None else 'changed'} since the decision)"
             )
-            return False
+            return "failed"
         # else: byte-identical to the decision-time snapshot — the known
         # (stale) registration the decision already accounted for; proceed.
     res = subprocess.run(cmd, cwd=PROJECT_ROOT, capture_output=True, text=True, timeout=120)
@@ -8436,10 +8541,17 @@ def _dispatch_infra_drain(
             f"  INFRA-DRAIN DISPATCH FAILED issue #{issue}: {res.stderr.strip()[:300]}",
             file=sys.stderr,
         )
-        return False
+        return "failed"
     first_line = (res.stdout.strip().splitlines() or [""])[0]
+    suppressed = spawn_output_suppressed(res.stdout)
+    if suppressed is not None:
+        # #843 M1b: rc-0 no-op — a duplicate dispatch was suppressed at the
+        # chokepoint (lease held / registration collision). A session IS
+        # driving the issue; callers book nothing (no attempt, no marker).
+        print(f"  INFRA-DRAIN SUPPRESSED issue #{issue} ({suppressed}): {first_line}")
+        return "suppressed"
     print(f"  INFRA-DRAIN DISPATCHED issue #{issue} ({slot_desc}): {first_line}")
-    return True
+    return "spawned"
 
 
 def _infra_drain_read_queue() -> dict | None:
@@ -8793,14 +8905,30 @@ def infra_drain_pass(
     )
     dispatched = 0
     for issue in dispatch:
+        # #843 M1 advisory pre-check at the CALLER loop: a fresh per-issue
+        # dispatch lease means a spawn is already in flight — skip loudly and
+        # record NO attempt (a lease-held skip must not consume the 1 h
+        # backoff, or a crashed winner's recovery would stretch to ~70 min
+        # instead of TTL + one tick).
+        held_lease = dispatch_lease_fresh(issue, now)
+        if held_lease is not None:
+            print(
+                f"  INFRA-DRAIN SKIP issue #{issue} (dispatch-lease held, "
+                f"{dispatch_lease_desc(held_lease, now)})"
+            )
+            continue
         slot_desc = f"slot {min(occupied_active + pending + dispatched + 1, cap)}/{cap}"
-        ok = _dispatch_infra_drain(issue, slot_desc, dry_run, reg_snapshot=reg_snapshot)
+        result = _dispatch_infra_drain(issue, slot_desc, dry_run, reg_snapshot=reg_snapshot)
+        if result == "suppressed":
+            # #843 M1b: rc-0 duplicate-suppression no-op — a session is
+            # driving; book nothing (no attempt, no backoff, no marker).
+            continue
         if not dry_run:
-            # Count the ATTEMPT whether or not the spawn succeeded, so a
+            # Count the ATTEMPT whether the spawn succeeded or failed, so a
             # failing spawn can't tight-loop (the backoff window binds next
             # tick either way).
-            _infra_drain_record_attempt(attempts, issue, now, queue_updated_ts, ok)
-        if ok:
+            _infra_drain_record_attempt(attempts, issue, now, queue_updated_ts, result == "spawned")
+        if result == "spawned":
             dispatched += 1
             _post_progress_marker(
                 issue,
@@ -9244,13 +9372,38 @@ def proposed_infra_sweep_pass(
         max_attempts=max_attempts,
     )
 
+    marker_fresh_s = _proposed_infra_sweep_marker_fresh_s()
     dispatched = 0
     for issue in dispatch:
+        # #843 M1 advisory pre-check at the CALLER loop (same contract as the
+        # drain loop's): a fresh lease -> loud skip, NO attempt recorded.
+        held_lease = dispatch_lease_fresh(issue, now)
+        if held_lease is not None:
+            print(
+                f"  PROPOSED-INFRA-SWEEP SKIP issue #{issue} (dispatch-lease held, "
+                f"{dispatch_lease_desc(held_lease, now)})"
+            )
+            continue
+        # #843 M3: a dispatch-sentinel marker younger than one watcher cadence
+        # means SOME dispatcher fired within the current/previous tick — skip
+        # this candidate this tick (no attempt recorded — a marker skip is not
+        # a spawn attempt; the safe direction, corrected next tick). Post-M1
+        # this is the lease-file-loss backstop + observability.
+        marker_age = _recent_dispatch_marker_age_s(_task_events(issue), now)
+        if marker_age is not None and marker_age < marker_fresh_s:
+            print(
+                f"  PROPOSED-INFRA-SWEEP SKIP issue #{issue} "
+                f"(recent-dispatch-marker {marker_age:.0f}s < {marker_fresh_s:.0f}s)"
+            )
+            continue
         slot_desc = f"slot {min(occupied_active + pending + dispatched + 1, cap)}/{cap}"
-        ok = _dispatch_infra_drain(issue, slot_desc, dry_run, reg_snapshot=reg_snapshot)
+        result = _dispatch_infra_drain(issue, slot_desc, dry_run, reg_snapshot=reg_snapshot)
+        if result == "suppressed":
+            # #843 M1b: duplicate-suppression no-op — book nothing.
+            continue
         if not dry_run:
-            _proposed_infra_sweep_record_attempt(attempts, issue, now, ok)
-        if ok:
+            _proposed_infra_sweep_record_attempt(attempts, issue, now, result == "spawned")
+        if result == "spawned":
             dispatched += 1
             _post_progress_marker(
                 issue,
@@ -9507,29 +9660,37 @@ def _save_capacity_retry_state(issue: int, state: dict, dry_run: bool) -> None:
     tmp.replace(dest)
 
 
-def _redrive_capacity_retry(issue: int, dry_run: bool) -> bool:
+def _redrive_capacity_retry(issue: int, dry_run: bool) -> str:
     """Re-drive the autonomous session for a transient-infra `blocked` task via
     ``spawn_session.py spawn-issue --issue <N> --auto`` (the plain command; the
     `--auto` session re-enters `/issue` which re-runs the backend router's own
-    capacity pre-check + enforces its plan-approval GPU cap). Returns success
-    bool; honours dry_run (logs, never spawns)."""
+    capacity pre-check + enforces its plan-approval GPU cap). Returns the
+    #843 M1b tri-state ``"spawned" | "suppressed" | "failed"`` (see
+    :func:`_respawn`; ``"suppressed"`` must NOT consume the per-day retry
+    budget); honours dry_run (logs, never spawns, returns ``"failed"``)."""
     cmd = [
         "uv", "run", "python", "scripts/spawn_session.py", "spawn-issue",
         "--issue", str(issue), "--auto",
     ]  # fmt: skip
     if dry_run:
         print(f"  [dry-run] would capacity-retry: {' '.join(cmd)}")
-        return False
+        return "failed"  # dry-run: nothing spawned
     res = subprocess.run(cmd, cwd=PROJECT_ROOT, capture_output=True, text=True, timeout=120)
     if res.returncode != 0:
         print(
             f"  CAPACITY-RETRY DISPATCH FAILED issue #{issue}: {res.stderr.strip()[:300]}",
             file=sys.stderr,
         )
-        return False
+        return "failed"
     first_line = (res.stdout.strip().splitlines() or [""])[0]
+    if spawn_output_suppressed(res.stdout) is not None:
+        print(
+            f"  CAPACITY-RETRY issue #{issue}: suppressed — not re-driven "
+            f"(lease/collision): {first_line}"
+        )
+        return "suppressed"
     print(f"  CAPACITY-RETRIED issue #{issue} (transient-infra block re-driven): {first_line}")
-    return True
+    return "spawned"
 
 
 def _process_capacity_retry(
@@ -9578,7 +9739,14 @@ def _process_capacity_retry(
     if action == "skip":
         return
     if action == "redrive":
-        ok = _redrive_capacity_retry(issue, dry_run)
+        spawn_result = _redrive_capacity_retry(issue, dry_run)
+        if spawn_result == "suppressed":
+            # #843 M1b: a duplicate dispatch was suppressed (lease held /
+            # registration collision) — a session is driving this issue.
+            # Book NOTHING: no retry-budget consumption, no last_attempt_ts,
+            # no marker; the next tick re-evaluates.
+            return
+        ok = spawn_result == "spawned"
         new_state = {
             "retry_day": day_key,
             # Count the ATTEMPT regardless of spawn success so a failing spawn
@@ -9704,6 +9872,15 @@ _GC_TARGETS: tuple[tuple[str, str], ...] = (
     # as campaign-watch-). The companion tick-runaway-<N>.flag files are NOT
     # json and self-clean inside _process_runaway_flag instead.
     ("gate-notify-", ""),
+    # Per-issue dispatch lease (#843 M1, spawn_session.dispatch_lease_path).
+    # Terminal-status + age-backstop reaping of leftover lease files: reaping
+    # a TERMINAL task's lease cannot enable a duplicate (terminal tasks are
+    # never dispatched), while an ACTIVE task's fresh lease is never touched
+    # (the keep branch below). The glob is `dispatch-lease-*.json`, so the
+    # PERMANENT `dispatch-lease-<N>.lock` flock sidecar is NOT swept — by
+    # design (tiny; unlinking a flock target risks the lock-on-deleted-file
+    # hole; recreated on demand by the next slow-path acquire).
+    ("dispatch-lease-", ""),
     ("", "issue-progress"),
     ("", "issue-tick-last-status"),
 )

--- a/scripts/file_infra_task.py
+++ b/scripts/file_infra_task.py
@@ -65,6 +65,9 @@ from spawn_session import (  # noqa: E402
     _live_session_ids,
     _load_session_issue_map,
     daemon_port,
+    dispatch_lease_desc,
+    dispatch_lease_fresh,
+    spawn_output_suppressed,
 )
 
 # The auto-dispatchable pure-code/ops kinds. `experiment`/`analysis`/
@@ -257,6 +260,21 @@ def cmd_file_infra(args: argparse.Namespace) -> int:
         print(f"filed #{issue}; already has a live session, NOT re-dispatching")
         return 0
 
+    # 4.5. Dispatch-lease pre-check (#843 M1, advisory): a fresh per-issue
+    # lease means another dispatcher's spawn is already in flight — skip the
+    # spawn subprocess entirely (the chokepoint inside `spawn-issue --auto`
+    # would suppress it anyway; skipping here saves the subprocess and logs a
+    # distinguishable reason). Exit 0: filing succeeded, and the watcher
+    # backstop covers the (already-covered) dispatch.
+    held_lease = dispatch_lease_fresh(issue)
+    if held_lease is not None:
+        print(
+            f"filed #{issue}; dispatch suppressed (lease held: "
+            f"{dispatch_lease_desc(held_lease)}), NOT dispatching "
+            f"(watcher proposed_infra_sweep backstop covers)"
+        )
+        return 0
+
     # 5. Spawn (best-effort).
     spawn_argv = _build_spawn_argv(issue, args)
     try:
@@ -278,6 +296,13 @@ def cmd_file_infra(args: argparse.Namespace) -> int:
         )
         return 0
     first_line = (spawned.stdout.strip().splitlines() or [""])[0]
+    suppressed = spawn_output_suppressed(spawned.stdout)
+    if suppressed is not None:
+        # #843 M1b: rc-0 no-op — the chokepoint suppressed a duplicate
+        # dispatch (a lease appeared between the pre-check and the spawn, or
+        # a registration collision). A session is already driving the issue.
+        print(f"filed #{issue}; dispatch suppressed ({suppressed}): {first_line}")
+        return 0
     print(f"filed + dispatched #{issue}: {first_line}")
     return 0
 

--- a/scripts/spawn_session.py
+++ b/scripts/spawn_session.py
@@ -24,13 +24,16 @@ session label in Happy — we surface that here.
 from __future__ import annotations
 
 import argparse
+import fcntl
 import json
 import os
 import re
+import subprocess
 import sys
 import time
 import urllib.error
 import urllib.request
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -57,6 +60,229 @@ WORKTREE_DIR = PROJECT_ROOT / ".claude" / "worktrees"
 # watcher GC'd its entry at the terminal transition (#472, 2026-06-10).
 AUTONOMOUS_REGISTRY_DIR = Path.home() / ".eps-autonomous"
 
+# ─── per-issue dispatch lease (#843 M1) ──────────────────────────────────────
+#
+# Atomic create-or-fail claim taken by `spawn-issue --auto` BEFORE the daemon
+# POST, so two concurrent dispatchers (file_infra_task self-dispatch vs the
+# watcher sweep/drain, the program-orchestrator daemon, ad-hoc PM dispatch)
+# can never both spawn a session for the same issue inside the
+# decision->registration window. (Watcher-vs-watcher overlap is already
+# impossible — its main() holds a whole-run non-blocking flock on
+# ~/.eps-autonomous/watch.lock — so the races this closes are strictly
+# cross-dispatcher.) TTL == the watcher's RESPAWN_SPAWN_GRACE_S (15 min):
+# inside that window the crash-recovery pass already refuses to respawn a
+# fresh registration, so lease-blocking can never postpone a recovery the
+# watcher would have run (pinned by
+# tests/test_autonomous_session_watch.py::test_lease_ttl_default_equals_respawn_spawn_grace).
+DISPATCH_LEASE_TTL_S = 15 * 60
+
+# Substring stamped into the best-effort `epm:progress` marker posted when a
+# duplicate `--auto` dispatch reached registration and was auto-stopped
+# (#843 M2). The watcher imports it into _WATCHER_NOTE_SENTINELS so the
+# marker never counts as "real progress" for the staleness clocks.
+DUPLICATE_DISPATCH_NOTE_SENTINEL = "[spawn-session:duplicate-dispatch-suppressed]"
+
+# stdout sentinels a suppressed rc-0 `spawn-issue --auto` no-op prints. Every
+# automated caller distinguishes them from a real spawn BEFORE any success
+# bookkeeping (#843 M1b) via :func:`spawn_output_suppressed`.
+DISPATCH_LEASE_HELD_SENTINEL = "DISPATCH-LEASE HELD"
+REGISTRATION_COLLISION_SENTINEL = "REGISTRATION-COLLISION"
+
+
+def spawn_output_suppressed(stdout: str | None) -> str | None:
+    """Which duplicate-suppression sentinel (if any) a rc-0 ``spawn-issue
+    --auto`` subprocess printed: :data:`DISPATCH_LEASE_HELD_SENTINEL` /
+    :data:`REGISTRATION_COLLISION_SENTINEL`, else ``None`` (a real spawn).
+
+    Shared by the watcher's dispatch/respawn callers + the file-time filer so
+    a suppressed no-op is never booked as a successful spawn — no dispatch
+    marker, no attempt/backoff, no respawn bookkeeping (#843 M1b)."""
+    if not stdout:
+        return None
+    for sentinel in (DISPATCH_LEASE_HELD_SENTINEL, REGISTRATION_COLLISION_SENTINEL):
+        if sentinel in stdout:
+            return sentinel
+    return None
+
+
+def _dispatch_lease_ttl_s() -> float:
+    """Lease TTL in seconds (env ``EPM_DISPATCH_LEASE_TTL_S``; missing or
+    malformed value falls back to :data:`DISPATCH_LEASE_TTL_S`)."""
+    raw = os.environ.get("EPM_DISPATCH_LEASE_TTL_S")
+    if not raw:
+        return float(DISPATCH_LEASE_TTL_S)
+    try:
+        return float(raw)
+    except ValueError:
+        return float(DISPATCH_LEASE_TTL_S)
+
+
+def dispatch_lease_path(issue: int) -> Path:
+    """Path of the per-issue dispatch-lease file (#843 M1)."""
+    return AUTONOMOUS_REGISTRY_DIR / f"dispatch-lease-{issue}.json"
+
+
+def _dispatch_lease_lock_path(issue: int) -> Path:
+    """Path of the PERMANENT per-issue flock sidecar that serializes the
+    stale-lease takeover slow path. Never unlinked by acquire/release — an
+    unlink-and-recreate of a flock target under a waiter is the classic
+    flock-on-deleted-file hole; the file is tiny and recreated on demand."""
+    return AUTONOMOUS_REGISTRY_DIR / f"dispatch-lease-{issue}.lock"
+
+
+def read_dispatch_lease(issue: int) -> dict | None:
+    """Parsed lease dict; ``{}`` for garbled/unreadable content; ``None`` for
+    no lease file."""
+    try:
+        raw = dispatch_lease_path(issue).read_text()
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return {}
+    try:
+        entry = json.loads(raw)
+    except ValueError:
+        return {}
+    return entry if isinstance(entry, dict) else {}
+
+
+def dispatch_lease_fresh(issue: int, now: float | None = None) -> dict | None:
+    """The lease entry iff the lease file exists AND is fresh; else ``None``.
+
+    Fresh = ``acquired_at`` within :func:`_dispatch_lease_ttl_s`. A garbled
+    lease (unparseable JSON / non-numeric ``acquired_at``) falls back to the
+    file mtime — failing toward FRESH, i.e. toward NOT dispatching; the TTL
+    bounds any wedge. A missing file returns ``None`` (no lease held)."""
+    now = time.time() if now is None else now
+    entry = read_dispatch_lease(issue)
+    if entry is None:
+        return None
+    ttl = _dispatch_lease_ttl_s()
+    acquired = entry.get("acquired_at")
+    if isinstance(acquired, int | float) and not isinstance(acquired, bool):
+        return entry if now - acquired < ttl else None
+    # Garbled content / missing acquired_at -> file mtime (fail toward fresh).
+    try:
+        mtime = dispatch_lease_path(issue).stat().st_mtime
+    except OSError:
+        # File vanished / unreadable between read and stat: treat as fresh
+        # this call (fail toward not dispatching); the next tick re-reads.
+        return entry
+    return entry if now - mtime < ttl else None
+
+
+def dispatch_lease_desc(entry: dict | None, now: float | None = None) -> str:
+    """Human-readable ``holder=..., pid=..., age=...s`` fragment for the
+    loud skip/loser log lines. Tolerates a garbled/empty entry."""
+    entry = entry or {}
+    now = time.time() if now is None else now
+    acquired = entry.get("acquired_at")
+    if isinstance(acquired, int | float) and not isinstance(acquired, bool):
+        age = f"{now - acquired:.0f}s"
+    else:
+        age = "?"
+    return f"holder={entry.get('holder', '?')}, pid={entry.get('pid', '?')}, age={age}"
+
+
+def acquire_dispatch_lease(issue: int, holder: str, now: float | None = None) -> dict | None:
+    """Atomically claim the per-issue dispatch slot (#843 M1).
+
+    Returns the written lease entry on success; ``None`` when a fresh lease is
+    already held — or on ANY unexpected OSError (fail toward not dispatching).
+
+    FAST PATH (lock-free): no lease file -> single-winner
+    ``os.open(O_CREAT|O_EXCL)`` (atomic on the local ext filesystem). SLOW
+    PATH (a lease file exists): the freshness check + stale takeover are
+    serialized under the PERMANENT per-issue flock sidecar
+    (:func:`_dispatch_lease_lock_path`) — a check-freshness->replace protocol
+    without the lock admits a TOCTOU double-winner. Every CREATE of the lease
+    file goes through O_EXCL and every unlink of a live lease happens under
+    the sidecar flock (or terminal-task GC), so no taker can destroy another
+    taker's freshly created lease: two flock holders are impossible, and a
+    fast-path creator racing a takeover just makes the takeover's inner
+    O_EXCL fail -> the taker returns ``None`` (single winner preserved)."""
+    now = time.time() if now is None else now
+    entry: dict[str, Any] = {
+        "issue": issue,
+        "holder": holder,
+        "pid": os.getpid(),
+        "token": uuid.uuid4().hex,
+        "acquired_at": now,
+    }
+    path = dispatch_lease_path(issue)
+    try:
+        AUTONOMOUS_REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
+        # FAST PATH (lock-free): no lease file -> atomic single-winner create.
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+    except FileExistsError:
+        # SLOW PATH: a lease file exists. Serialize under the sidecar flock.
+        try:
+            lock_fd = os.open(_dispatch_lease_lock_path(issue), os.O_CREAT | os.O_WRONLY, 0o644)
+        except OSError:
+            return None  # fail toward not dispatching
+        try:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                return None  # another taker mid-takeover: skip this tick
+            if dispatch_lease_fresh(issue, now) is not None:
+                return None  # loser: a fresh lease is held
+            path.unlink(missing_ok=True)  # remove the stale lease (under the lock)
+            try:
+                fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+            except OSError:
+                return None  # a fast-path creator won post-unlink: loser
+        finally:
+            os.close(lock_fd)  # releases the flock; the sidecar file persists
+        # NOTE: the content write below happens after the flock is released —
+        # safe: until written, the file is empty (= garbled) with a fresh
+        # mtime, which dispatch_lease_fresh fails CLOSED on (treated fresh).
+    except OSError:
+        return None  # fail toward not dispatching
+    with os.fdopen(fd, "w") as f:
+        f.write(json.dumps(entry, indent=2))
+    return entry
+
+
+def release_dispatch_lease(issue: int, token: str) -> None:
+    """Best-effort token-verified unlink of the per-issue dispatch lease,
+    taken UNDER the permanent flock sidecar so a late release can never remove
+    a successor's lease.
+
+    Called on FAILURE exit paths only (daemon POST failed / patch-verify died
+    / plain-OSError registration failure) — the SUCCESS path deliberately
+    LEAVES the lease in place (TTL expiry owns it; releasing at registration
+    would reopen a window if ordering ever regressed), and the
+    REGISTRATION-COLLISION branch deliberately HOLDS it (the first session is
+    live and driving; holding suppresses spawn-then-collision-stop churn for
+    the rest of the TTL — see :func:`cmd_spawn_issue`)."""
+    try:
+        lock_fd = os.open(_dispatch_lease_lock_path(issue), os.O_CREAT | os.O_WRONLY, 0o644)
+    except OSError:
+        return
+    try:
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            return  # a takeover is in flight; leave the lease to the TTL
+        entry = read_dispatch_lease(issue)
+        if isinstance(entry, dict) and entry.get("token") == token:
+            dispatch_lease_path(issue).unlink(missing_ok=True)
+    finally:
+        os.close(lock_fd)
+
+
+class RegistrationCollisionError(OSError):
+    """``issue-<N>.json`` already names a DIFFERENT session inside the
+    collision window — a duplicate ``--auto`` dispatch reached registration
+    (#843 M2). Carries ``existing_session_id`` / ``age_s`` so the caller's
+    remediation message can name the kept session."""
+
+    def __init__(self, message: str, *, existing_session_id: str, age_s: float) -> None:
+        super().__init__(message)
+        self.existing_session_id = existing_session_id
+        self.age_s = age_s
+
 
 def _register_autonomous_session(
     issue: int,
@@ -67,6 +293,7 @@ def _register_autonomous_session(
     model: str | None = None,
     betas: list[str] | None = None,
     effort: str | None = None,
+    force: bool = False,
 ) -> None:
     """Record an autonomous issue session so the watcher can resurrect it.
 
@@ -77,6 +304,17 @@ def _register_autonomous_session(
     invisible to the watcher and risks a duplicate re-spawn), and stop it.
     Writes atomically (temp file + rename) so the watcher never reads a partial
     JSON entry.
+
+    RAISES :class:`RegistrationCollisionError` (#843 M2, unless ``force=True``)
+    when the existing entry names a DIFFERENT session id with a ``spawned_at``
+    younger than the collision window — a duplicate dispatch reached
+    registration; the caller stops the just-spawned duplicate instead of
+    silently overwriting (hiding) the first session. An entry at or past the
+    window (or same sid, or garbled ``spawned_at``) overwrites exactly as
+    before, so the watcher's crash-recovery respawn — which by its own
+    ``RESPAWN_SPAWN_GRACE_S`` only fires on entries >= 15 min old — is never
+    blocked. ``register-current`` passes ``force=True`` (the deliberate
+    re-write path for an already-live session, #472 revival).
 
     ``model`` / ``betas`` / ``effort`` are persisted when set so the watcher's
     ``_respawn`` can re-pass them on crash-recovery. ``None`` means "not pinned
@@ -101,6 +339,33 @@ def _register_autonomous_session(
     if effort is not None:
         entry["effort"] = effort
     dest = AUTONOMOUS_REGISTRY_DIR / f"issue-{issue}.json"
+    if not force:
+        try:
+            existing = json.loads(dest.read_text())
+        except (OSError, ValueError):
+            existing = {}
+        old_sid = existing.get("happy_session_id") if isinstance(existing, dict) else None
+        old_ts = existing.get("spawned_at") if isinstance(existing, dict) else None
+        if (
+            isinstance(old_sid, str)
+            and old_sid
+            and old_sid != session_id
+            and isinstance(old_ts, int | float)
+            and not isinstance(old_ts, bool)
+            # Collision window capped at the 900 s DEFAULT: raising
+            # EPM_DISPATCH_LEASE_TTL_S lengthens the LEASE but must never widen
+            # this window past RESPAWN_SPAWN_GRACE_S, or a raised TTL would
+            # suppress legitimate crash-recovery respawns (round-1 hardening).
+            and time.time() - old_ts < min(_dispatch_lease_ttl_s(), float(DISPATCH_LEASE_TTL_S))
+        ):
+            age_s = time.time() - old_ts
+            raise RegistrationCollisionError(
+                f"issue-{issue}.json already names session {old_sid} spawned "
+                f"{age_s:.0f}s ago (< {min(_dispatch_lease_ttl_s(), float(DISPATCH_LEASE_TTL_S)):.0f}s "
+                f"window); refusing to overwrite — duplicate dispatch",
+                existing_session_id=old_sid,
+                age_s=age_s,
+            )
     tmp = dest.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(entry, indent=2))
     tmp.replace(dest)
@@ -886,6 +1151,53 @@ def cmd_spawn_pm(args: argparse.Namespace) -> None:
     )
 
 
+def _stop_spawned_session(session_id: str) -> bool:
+    """Best-effort stop of a just-spawned session (the registration-failure /
+    registration-collision remediation in :func:`cmd_spawn_issue`). Returns
+    True when the daemon confirmed the stop; on False the caller prints a
+    manual-cleanup warning (success=False usually means the session already
+    died on its own — a benign race — but a genuinely stuck live session
+    needs hand cleanup)."""
+    try:
+        stop_resp = post("/stop-session", {"sessionId": session_id})
+        return bool(stop_resp.get("success"))
+    except SystemExit:
+        return False
+
+
+def _post_duplicate_suppressed_marker(issue: int, kept_sid: str, stopped_sid: str) -> None:
+    """Best-effort ``epm:progress`` marker recording a suppressed duplicate
+    ``--auto`` dispatch (#843 M2 registration collision) so the suppression is
+    dashboard-visible. A marker failure never blocks the exit — the loud
+    REGISTRATION-COLLISION line already fired. ``spawn_session.py`` is
+    allowlisted in ``_LOCAL_VM_ONLY_PATHS``
+    (tests/test_no_pod_side_task_py_shellout.py) for this task.py shellout."""
+    note = (
+        f"{DUPLICATE_DISPATCH_NOTE_SENTINEL} duplicate --auto dispatch suppressed: "
+        f"kept {kept_sid}, stopped {stopped_sid}"
+    )
+    try:
+        subprocess.run(
+            [
+                "uv",
+                "run",
+                "python",
+                "scripts/task.py",
+                "post-marker",
+                str(issue),
+                "epm:progress",
+                "--note",
+                note,
+            ],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (subprocess.SubprocessError, OSError) as e:
+        print(f"  note: duplicate-dispatch marker post failed ({e})", file=sys.stderr)
+
+
 def cmd_spawn_issue(args: argparse.Namespace) -> None:
     """Spawn a session for issue ``--issue N``. The session opens cwd=<repo root>
     by default, OR cwd=<.claude/worktrees/issue-N> if such a worktree exists
@@ -939,6 +1251,60 @@ def cmd_spawn_issue(args: argparse.Namespace) -> None:
         prompt = f"/issue {issue}"
     else:
         prompt = None
+    lease: dict[str, Any] | None = None
+    if args.auto:
+        # #843 M1: atomic per-issue dispatch lease, acquired BEFORE the daemon
+        # POST. Exactly one of N concurrent `--auto` dispatchers wins; every
+        # loser exits 0 with the loud DISPATCH-LEASE HELD line (a suppressed
+        # duplicate means a session IS driving the issue — dispatch success).
+        # On success the lease is deliberately LEFT in place (TTL expiry owns
+        # it); failure exits below release it so the backstop can retry.
+        lease = acquire_dispatch_lease(issue, holder=f"spawn-issue --auto pid={os.getpid()}")
+        if lease is None:
+            held = read_dispatch_lease(issue) or {}
+            print(
+                f"{DISPATCH_LEASE_HELD_SENTINEL} issue #{issue}: a dispatch is already "
+                f"in flight ({dispatch_lease_desc(held)}, "
+                f"ttl={_dispatch_lease_ttl_s():.0f}s); NOT spawning a duplicate. "
+                f"Manual override: rm {dispatch_lease_path(issue)}"
+            )
+            return  # exit 0 — duplicate suppressed IS dispatch success
+    elif dispatch_lease_fresh(issue) is not None:
+        # Manual / bespoke-prompt spawn: a human decision — warn, proceed,
+        # and create NO lease (the incident class is 100% automated races).
+        print(
+            f"  note: a fresh dispatch lease exists for #{issue} "
+            f"({dispatch_lease_desc(read_dispatch_lease(issue))}) — an automated "
+            f"dispatch may be in flight; proceeding (manual spawns are not gated)"
+        )
+    try:
+        _spawn_issue_session(args, issue, cwd_note, body, prompt, extra_args, betas, cwd)
+    except BaseException:
+        if lease is not None:
+            # Failure exit (POST failed / patch-verify died / plain-OSError
+            # registration failure): free the slot so the next dispatcher /
+            # watcher tick can retry. The REGISTRATION-COLLISION branch
+            # RETURNS (never raises), so it deliberately HOLDS the lease.
+            release_dispatch_lease(issue, lease["token"])
+        raise
+
+
+def _spawn_issue_session(
+    args: argparse.Namespace,
+    issue: int,
+    cwd_note: str,
+    body: dict[str, object],
+    prompt: str | None,
+    extra_args: list[str],
+    betas: list[str],
+    cwd: Path,
+) -> None:
+    """The POST + print + registration tail of :func:`cmd_spawn_issue`,
+    factored out so the caller can wrap it in the #843 release-lease-on-
+    failure guard without re-indenting its every branch. Raises ``SystemExit``
+    on any failure exit; returns normally on success AND on the deliberate
+    exit-0 REGISTRATION-COLLISION suppression branch (which must NOT release
+    the lease — see :func:`release_dispatch_lease`)."""
     if prompt is not None or extra_args:
         # Both the load-bearing --auto / --initial-prompt injection path AND the
         # bare model-override path rely on the daemon honoring HAPPY_INITIAL_*
@@ -998,6 +1364,33 @@ def cmd_spawn_issue(args: argparse.Namespace) -> None:
                     effort=args.effort,
                 )
                 print(f"  registered for crash-recovery watch: issue-{issue}.json")
+            except RegistrationCollisionError as e:
+                # #843 M2: a duplicate --auto dispatch reached registration —
+                # a DIFFERENT session was registered for this issue inside the
+                # collision window. Keep the FIRST session (its registration
+                # stays byte-identical), stop the duplicate we just spawned,
+                # exit 0 (a session IS live and driving = dispatch success).
+                # The dispatch lease is deliberately HELD (this branch returns
+                # without raising, so the caller's release guard never fires)
+                # — holding suppresses immediate spawn-then-collision-stop
+                # churn for the rest of the TTL.
+                print(f"  registration collision: {e}", file=sys.stderr)
+                stopped = _stop_spawned_session(resp["sessionId"])
+                if not stopped:
+                    print(
+                        f"  WARNING: could not confirm duplicate session "
+                        f"{resp['sessionId']} stopped; if it is still live, stop it "
+                        "manually (spawn_session.py stop --session-id ...)",
+                        file=sys.stderr,
+                    )
+                print(
+                    f"{REGISTRATION_COLLISION_SENTINEL} issue #{issue}: kept "
+                    f"{e.existing_session_id} (registered {e.age_s:.0f}s ago), stopped "
+                    f"duplicate {resp['sessionId']}; NOT overwriting the first "
+                    f"registration (duplicate dispatch suppressed)"
+                )
+                _post_duplicate_suppressed_marker(issue, e.existing_session_id, resp["sessionId"])
+                return  # exit 0 — the first session is live and driving
             except OSError as e:
                 # Atomicity invariant: a live `--auto` session MUST have a current
                 # registry entry, else the watcher (which trusts the registry) could
@@ -1008,12 +1401,7 @@ def cmd_spawn_issue(args: argparse.Namespace) -> None:
                     "session to avoid an untracked duplicate",
                     file=sys.stderr,
                 )
-                try:
-                    stop_resp = post("/stop-session", {"sessionId": resp["sessionId"]})
-                    stopped = bool(stop_resp.get("success"))
-                except SystemExit:
-                    stopped = False
-                if not stopped:
+                if not _stop_spawned_session(resp["sessionId"]):
                     # success=False usually means the session already died on its
                     # own (a benign race); surface it anyway so a genuinely stuck
                     # live session can be cleaned up by hand.
@@ -1258,7 +1646,10 @@ def cmd_register_current(args: argparse.Namespace) -> None:
                 cap = args.auto_approve_gpu_hours
             else:
                 cap = float(os.environ.get("EPM_PLAN_AUTOAPPROVE_GPU_HOURS", "100"))
-            _register_autonomous_session(issue, sid, cwd, cap)
+            # force=True: register-current is the deliberate re-write path for
+            # an ALREADY-LIVE session (#472 revival) — never a duplicate
+            # dispatch, so the #843 M2 collision check must not block it.
+            _register_autonomous_session(issue, sid, cwd, cap, force=True)
             dest = f"issue-{issue}.json"
             semantics = "auto-watch (crash-recovery may respawn on death)"
         else:

--- a/scripts/spawn_session.py
+++ b/scripts/spawn_session.py
@@ -346,23 +346,24 @@ def _register_autonomous_session(
             existing = {}
         old_sid = existing.get("happy_session_id") if isinstance(existing, dict) else None
         old_ts = existing.get("spawned_at") if isinstance(existing, dict) else None
+        # Collision window capped at the 900 s DEFAULT: raising
+        # EPM_DISPATCH_LEASE_TTL_S lengthens the LEASE but must never widen
+        # this window past RESPAWN_SPAWN_GRACE_S, or a raised TTL would
+        # suppress legitimate crash-recovery respawns (round-1 hardening).
+        window_s = min(_dispatch_lease_ttl_s(), float(DISPATCH_LEASE_TTL_S))
         if (
             isinstance(old_sid, str)
             and old_sid
             and old_sid != session_id
             and isinstance(old_ts, int | float)
             and not isinstance(old_ts, bool)
-            # Collision window capped at the 900 s DEFAULT: raising
-            # EPM_DISPATCH_LEASE_TTL_S lengthens the LEASE but must never widen
-            # this window past RESPAWN_SPAWN_GRACE_S, or a raised TTL would
-            # suppress legitimate crash-recovery respawns (round-1 hardening).
-            and time.time() - old_ts < min(_dispatch_lease_ttl_s(), float(DISPATCH_LEASE_TTL_S))
+            and time.time() - old_ts < window_s
         ):
             age_s = time.time() - old_ts
             raise RegistrationCollisionError(
                 f"issue-{issue}.json already names session {old_sid} spawned "
-                f"{age_s:.0f}s ago (< {min(_dispatch_lease_ttl_s(), float(DISPATCH_LEASE_TTL_S)):.0f}s "
-                f"window); refusing to overwrite — duplicate dispatch",
+                f"{age_s:.0f}s ago (< {window_s:.0f}s window); refusing to "
+                f"overwrite — duplicate dispatch",
                 existing_session_id=old_sid,
                 age_s=age_s,
             )

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -1736,7 +1736,7 @@ def stalled_recorder(monkeypatch):
     monkeypatch.setattr(
         asw,
         "_respawn_stalled_session",
-        lambda issue, cap, dry_run: spawns.append((issue, cap)) or True,
+        lambda issue, cap, dry_run: spawns.append((issue, cap)) or "spawned",
     )
     monkeypatch.setattr(
         asw,
@@ -3681,7 +3681,9 @@ def _run_orphan_task(asw, monkeypatch, *, issue, events, now, missed=1):
     respawns: list[int] = []
     monkeypatch.setattr(asw, "_task_events", lambda _i: events)
     monkeypatch.setattr(asw, "_stalled_cap_gpu_hours", lambda _i: 24.0)
-    monkeypatch.setattr(asw, "_respawn_orphan", lambda i, cap, dry_run: respawns.append(i) or True)
+    monkeypatch.setattr(
+        asw, "_respawn_orphan", lambda i, cap, dry_run: respawns.append(i) or "spawned"
+    )
     asw._save_orphan_state(
         issue, missed=missed, alerted=False, respawn_day=None, respawns_today=0, prev=None
     )
@@ -8048,7 +8050,9 @@ def _stub_drain_executor(
         monkeypatch.setattr(asw.subprocess, "run", _fake_run)
     else:
         monkeypatch.setattr(
-            asw, "_dispatch_infra_drain", lambda i, slot, dry, **kw: dispatched.append(i) or True
+            asw,
+            "_dispatch_infra_drain",
+            lambda i, slot, dry, **kw: dispatched.append(i) or "spawned",
         )
     markers: list[tuple] = []
     monkeypatch.setattr(
@@ -8329,7 +8333,7 @@ def test_infra_drain_pass_missing_or_invalid_file_is_noop(isolated_registry, mon
 
     calls: list[int] = []
     monkeypatch.setattr(
-        asw, "_dispatch_infra_drain", lambda i, slot, dry, **kw: calls.append(i) or True
+        asw, "_dispatch_infra_drain", lambda i, slot, dry, **kw: calls.append(i) or "spawned"
     )
     monkeypatch.setattr(
         asw, "_task_status_kind", lambda i: pytest.fail("task.py read on a no-op tick")
@@ -8435,10 +8439,11 @@ def test_infra_drain_dry_run_no_mutation(isolated_registry, monkeypatch, capsys)
     asw.infra_drain_pass(dry_run=True, now=now, daemon_reachable=True)
     out = capsys.readouterr().out
     assert "[dry-run] would dispatch infra-drain" in out
-    assert markers == []  # a dry-run dispatch returns False -> no marker
+    assert markers == []  # a dry-run dispatch returns "failed" -> no marker
     assert not (isolated_registry / "infra-drain-state.json").exists()
-    # The dispatch helper itself honours dry_run before any subprocess.
-    assert asw._dispatch_infra_drain(483, "slot 1/3", dry_run=True) is False
+    # The dispatch helper itself honours dry_run before any subprocess
+    # (tri-state as of #843: dry-run returns "failed" — nothing spawned).
+    assert asw._dispatch_infra_drain(483, "slot 1/3", dry_run=True) == "failed"
 
 
 def test_infra_drain_occupancy_none_skips_dispatch(isolated_registry, monkeypatch, capsys):
@@ -8482,7 +8487,7 @@ def test_infra_drain_failed_spawn_records_attempt(isolated_registry, monkeypatch
     monkeypatch.setattr(asw, "_post_progress_marker", lambda *a, **k: None)
     calls: list[int] = []
     monkeypatch.setattr(
-        asw, "_dispatch_infra_drain", lambda i, slot, dry, **kw: calls.append(i) or False
+        asw, "_dispatch_infra_drain", lambda i, slot, dry, **kw: calls.append(i) or "failed"
     )
     asw.infra_drain_pass(dry_run=False, now=now, daemon_reachable=True)
     assert calls == [483]
@@ -8636,19 +8641,19 @@ def test_infra_drain_prespawn_recheck_aborts(isolated_registry, monkeypatch, cap
     # (a) APPEARED: no snapshot context (direct call) -> any existing file
     # is a genuinely-new registration -> abort before the subprocess.
     ok = asw._dispatch_infra_drain(42, "slot 1/3", dry_run=False)
-    assert ok is False
+    assert ok == "failed"
     out = capsys.readouterr().out
     assert "lost race to concurrent dispatcher" in out and "appeared" in out
     # (a') APPEARED relative to an explicit snapshot that lacked the file.
     ok = asw._dispatch_infra_drain(42, "slot 1/3", dry_run=False, reg_snapshot={})
-    assert ok is False
+    assert ok == "failed"
     assert "appeared" in capsys.readouterr().out
     # (b) CHANGED: the decision saw OTHER bytes (e.g. a concurrent PM spawn
     # overwrote the stale entry between decide and dispatch) -> abort.
     ok = asw._dispatch_infra_drain(
         42, "slot 1/3", dry_run=False, reg_snapshot={"issue-42.json": b'{"old": true}'}
     )
-    assert ok is False
+    assert ok == "failed"
     assert "changed" in capsys.readouterr().out
     # (c) BYTE-IDENTICAL: the file IS the known-stale registration the
     # decision already classified -> proceed (spawn_session overwrites it on
@@ -8664,7 +8669,7 @@ def test_infra_drain_prespawn_recheck_aborts(isolated_registry, monkeypatch, cap
     ok = asw._dispatch_infra_drain(
         42, "slot 1/3", dry_run=False, reg_snapshot={"issue-42.json": stale_bytes}
     )
-    assert ok is True
+    assert ok == "spawned"
     assert len(spawned) == 1 and "--issue" in spawned[0]
     assert "INFRA-DRAIN DISPATCHED issue #42" in capsys.readouterr().out
 
@@ -9215,7 +9220,7 @@ def test_predicate_promote_nonpredicate_holds_skip_status_read(
     _write_drain_queue(isolated_registry, [483], holds={"609": "needs-thomas", "449": "spend"})
     monkeypatch.setattr(asw, "_infra_drain_occupancy", lambda: [])
     monkeypatch.setattr(asw, "_live_session_ids_or_none", lambda: set())
-    monkeypatch.setattr(asw, "_dispatch_infra_drain", lambda i, slot, dry, **kw: True)
+    monkeypatch.setattr(asw, "_dispatch_infra_drain", lambda i, slot, dry, **kw: "spawned")
     monkeypatch.setattr(asw, "_post_progress_marker", lambda *a, **k: None)
 
     # _task_status_kind is allowed for 483 (the dispatchable id) but must NEVER
@@ -9715,13 +9720,17 @@ def _stub_sweep_executor(monkeypatch, *, candidates, status_kind=None, occupancy
     sk = status_kind or {}
     monkeypatch.setattr(asw, "_proposed_infra_candidates", lambda: candidates)
     monkeypatch.setattr(asw, "_task_status_kind", lambda i: sk.get(i, (None, None)))
+    # #843 M3: the sweep loop reads each dispatch-list candidate's events for
+    # the marker-freshness guard; stub it hermetic (no real task.py subprocess,
+    # no skip) — the M3-specific tests override this with seeded events.
+    monkeypatch.setattr(asw, "_task_events", lambda i: [])
     monkeypatch.setattr(asw, "_infra_drain_occupancy", lambda: occupancy)
     monkeypatch.setattr(
         asw, "_live_session_ids_or_none", lambda: live if live is not None else set()
     )
     dispatched: list[int] = []
     monkeypatch.setattr(
-        asw, "_dispatch_infra_drain", lambda i, slot, dry, **kw: dispatched.append(i) or True
+        asw, "_dispatch_infra_drain", lambda i, slot, dry, **kw: dispatched.append(i) or "spawned"
     )
     markers: list[tuple] = []
     monkeypatch.setattr(
@@ -9953,9 +9962,13 @@ def test_sweep_candidate_query_is_exactly_status_proposed(isolated_registry, mon
     monkeypatch.setattr(asw, "_live_session_ids_or_none", lambda: set())
     dispatched: list[int] = []
     monkeypatch.setattr(
-        asw, "_dispatch_infra_drain", lambda i, slot, dry, **kw: dispatched.append(i) or True
+        asw, "_dispatch_infra_drain", lambda i, slot, dry, **kw: dispatched.append(i) or "spawned"
     )
     monkeypatch.setattr(asw, "_post_progress_marker", lambda *a, **k: None)
+    # #843 M3: the dispatch loop's marker-freshness read is a task.py signal
+    # like the others — stubbed so the ONLY real subprocess stays the
+    # candidate query this test pins.
+    monkeypatch.setattr(asw, "_task_events", lambda i: [])
 
     seen_argv: list[list[str]] = []
 
@@ -11192,3 +11205,337 @@ def test_issue795_dry_run_does_not_stop(isolated_registry, monkeypatch):
     asw.idle_unmapped_pass(True, 2, daemon_reachable=True, now=t0)  # dry_run miss 1
     asw.idle_unmapped_pass(True, 2, daemon_reachable=True, now=t0 + 600)  # dry_run decide
     assert stops == [] and records == []
+
+
+# ─── #843: dispatch-lease loop pre-checks, M1b suppressed-output handling, ────
+# ─── M3 marker-freshness guard, GC of terminal leases ─────────────────────────
+#
+# The lease PRIMITIVE (acquire/release/takeover/race) is pinned in
+# tests/test_dispatch_lease.py; these tests pin the WATCHER-side consumers:
+# the caller-loop advisory pre-checks record NO attempt (a lease-held skip
+# must not consume the 1 h backoff — the crashed-winner recovery bound),
+# the tri-state `_dispatch_infra_drain` never books a suppressed rc-0 no-op,
+# the respawn family never logs/marks a suppressed no-op as RESPAWNED, and
+# the sweep skips candidates with a < 600 s dispatch-sentinel marker.
+
+
+def _iso_ts(epoch: float) -> str:
+    """Task-event `ts` string (UTC, `%Y-%m-%dT%H:%M:%SZ`) for a fixed epoch."""
+    import datetime as _dt
+
+    return _dt.datetime.fromtimestamp(epoch, tz=_dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_drain_loop_skips_on_fresh_lease_records_no_attempt(isolated_registry, monkeypatch, capsys):
+    # Test 15: a fresh per-issue dispatch lease -> the DRAIN caller loop
+    # `continue`s with the loud skip line, never reaches the spawn
+    # subprocess, and records NO attempt (no backoff consumed — the round-1
+    # crashed-winner recovery-bound fix).
+    import json
+
+    import autonomous_session_watch as asw
+
+    now = _DRAIN_NOW
+    _write_drain_queue(isolated_registry, [483])
+    sk = {483: ("proposed", "infra")}
+    monkeypatch.setattr(asw, "_task_status_kind", lambda i: sk.get(i, (None, None)))
+    monkeypatch.setattr(asw, "_infra_drain_occupancy", lambda: [])
+    monkeypatch.setattr(asw, "_live_session_ids_or_none", lambda: set())
+    markers: list[tuple] = []
+    monkeypatch.setattr(asw, "_post_progress_marker", lambda *a, **k: markers.append((a, k)))
+    monkeypatch.setattr(
+        asw.subprocess, "run", lambda *a, **k: pytest.fail("spawned despite a fresh lease")
+    )
+    assert spawn_session.acquire_dispatch_lease(483, "other-dispatcher", now=now - 30) is not None
+    asw.infra_drain_pass(dry_run=False, now=now, daemon_reachable=True)
+    out = capsys.readouterr().out
+    assert "INFRA-DRAIN SKIP issue #483 (dispatch-lease held" in out
+    assert "holder=other-dispatcher" in out
+    assert markers == []
+    state = json.loads((isolated_registry / "infra-drain-state.json").read_text())
+    assert state["attempts"] == {}  # NO attempt recorded -> no backoff armed
+
+
+def test_sweep_loop_skips_on_fresh_lease_records_no_attempt(isolated_registry, monkeypatch, capsys):
+    # Test 15 sibling for the SWEEP caller loop (same contract).
+    import json
+
+    import autonomous_session_watch as asw
+
+    now = _SWEEP_NOW
+    dispatched, markers = _stub_sweep_executor(
+        monkeypatch, candidates=[771], status_kind={771: ("proposed", "infra")}, occupancy=[]
+    )
+    assert spawn_session.acquire_dispatch_lease(771, "other-dispatcher", now=now - 30) is not None
+    asw.proposed_infra_sweep_pass(dry_run=False, now=now, daemon_reachable=True)
+    out = capsys.readouterr().out
+    assert "PROPOSED-INFRA-SWEEP SKIP issue #771 (dispatch-lease held" in out
+    assert dispatched == [] and markers == []
+    state = json.loads((isolated_registry / "proposed-infra-sweep-state.json").read_text())
+    assert state["attempts"] == {}  # NO attempt recorded
+
+
+@pytest.mark.parametrize("dry_run", [False, True])
+def test_sweep_skips_on_recent_dispatch_marker(isolated_registry, monkeypatch, capsys, dry_run):
+    # Test 16: a dispatch-sentinel marker younger than 600 s -> skip (no
+    # dispatch, no attempt). Parametrized over dry_run (the #596/#607/#633
+    # broken-dry-run-thread pattern): the skip decision must survive dry-run.
+    import autonomous_session_watch as asw
+
+    now = _SWEEP_NOW
+    dispatched, _markers = _stub_sweep_executor(
+        monkeypatch, candidates=[771], status_kind={771: ("proposed", "infra")}, occupancy=[]
+    )
+    events = [
+        {
+            "kind": "epm:progress",
+            "note": f"{asw._PROPOSED_INFRA_SWEEP_NOTE_SENTINEL} watcher auto-dispatched",
+            "ts": _iso_ts(now - 300),
+        }
+    ]
+    monkeypatch.setattr(asw, "_task_events", lambda i: events)
+    asw.proposed_infra_sweep_pass(dry_run=dry_run, now=now, daemon_reachable=True)
+    out = capsys.readouterr().out
+    assert "PROPOSED-INFRA-SWEEP SKIP issue #771 (recent-dispatch-marker 300s < 600s)" in out
+    assert dispatched == []
+
+
+def test_sweep_dispatches_on_old_marker(isolated_registry, monkeypatch, capsys):
+    # Test 16 companion: a 20-min-old dispatch marker does NOT skip.
+    import autonomous_session_watch as asw
+
+    now = _SWEEP_NOW
+    dispatched, _markers = _stub_sweep_executor(
+        monkeypatch, candidates=[771], status_kind={771: ("proposed", "infra")}, occupancy=[]
+    )
+    events = [
+        {
+            "kind": "epm:progress",
+            "note": f"{asw._INFRA_DRAIN_NOTE_SENTINEL} watcher dispatched",
+            "ts": _iso_ts(now - 1200),
+        }
+    ]
+    monkeypatch.setattr(asw, "_task_events", lambda i: events)
+    asw.proposed_infra_sweep_pass(dry_run=False, now=now, daemon_reachable=True)
+    assert dispatched == [771]
+    assert "recent-dispatch-marker" not in capsys.readouterr().out
+
+
+def test_recent_dispatch_marker_age_matches_both_sentinels():
+    # BOTH sentinels disqualify (a drain dispatch is exactly as disqualifying
+    # as a sweep one); an unrelated epm:progress note never matches.
+    import autonomous_session_watch as asw
+
+    now = _SWEEP_NOW
+    for sentinel in (asw._PROPOSED_INFRA_SWEEP_NOTE_SENTINEL, asw._INFRA_DRAIN_NOTE_SENTINEL):
+        events = [{"kind": "epm:progress", "note": f"{sentinel} x", "ts": _iso_ts(now - 120)}]
+        assert asw._recent_dispatch_marker_age_s(events, now) == pytest.approx(120, abs=2)
+    plain = [{"kind": "epm:progress", "note": "ordinary progress", "ts": _iso_ts(now - 120)}]
+    assert asw._recent_dispatch_marker_age_s(plain, now) is None
+    non_progress = [
+        {
+            "kind": "epm:results",
+            "note": f"{asw._INFRA_DRAIN_NOTE_SENTINEL} x",
+            "ts": _iso_ts(now - 120),
+        }
+    ]
+    assert asw._recent_dispatch_marker_age_s(non_progress, now) is None
+
+
+def test_recent_dispatch_marker_age_unparseable_ts_returns_none():
+    # Fail-soft: an unparseable ts row is skipped -> None -> no skip (the M1
+    # lease still protects).
+    import autonomous_session_watch as asw
+
+    events = [
+        {
+            "kind": "epm:progress",
+            "note": f"{asw._INFRA_DRAIN_NOTE_SENTINEL} x",
+            "ts": "not-a-timestamp",
+        }
+    ]
+    assert asw._recent_dispatch_marker_age_s(events, _SWEEP_NOW) is None
+
+
+def test_sweep_marker_fresh_s_env_override(monkeypatch):
+    import autonomous_session_watch as asw
+
+    monkeypatch.setenv("EPM_PROPOSED_INFRA_SWEEP_MARKER_FRESH_S", "60")
+    assert asw._proposed_infra_sweep_marker_fresh_s() == 60.0
+    monkeypatch.setenv("EPM_PROPOSED_INFRA_SWEEP_MARKER_FRESH_S", "garbage")
+    assert (
+        asw._proposed_infra_sweep_marker_fresh_s()
+        == asw.PROPOSED_INFRA_SWEEP_MARKER_FRESH_S_DEFAULT
+    )
+    monkeypatch.delenv("EPM_PROPOSED_INFRA_SWEEP_MARKER_FRESH_S")
+    assert (
+        asw._proposed_infra_sweep_marker_fresh_s()
+        == asw.PROPOSED_INFRA_SWEEP_MARKER_FRESH_S_DEFAULT
+    )
+
+
+def test_lease_ttl_default_equals_respawn_spawn_grace():
+    # Test 17: pins the M2/#759 coupling — neither default may drift alone
+    # (the lease TTL must never postpone a recovery the watcher would run).
+    import autonomous_session_watch as asw
+
+    assert spawn_session.DISPATCH_LEASE_TTL_S == asw.RESPAWN_SPAWN_GRACE_S
+
+
+def test_gc_reaps_terminal_dispatch_lease(isolated_registry, monkeypatch, capsys):
+    # Test 18: a TERMINAL task's leftover lease is reaped; an ACTIVE task's
+    # fresh lease is NEVER touched (pins the conservative keep branch against
+    # future _GC_TARGETS edits); the PERMANENT .lock sidecar is not swept
+    # (the glob is dispatch-lease-*.json).
+    import autonomous_session_watch as asw
+
+    (isolated_registry / "dispatch-lease-900.json").write_text("{}")
+    (isolated_registry / "dispatch-lease-900.lock").write_text("")
+    (isolated_registry / "dispatch-lease-901.json").write_text("{}")
+    statuses = {900: "completed", 901: "running"}
+    monkeypatch.setattr(asw, "_task_status", lambda i: statuses.get(i))
+    asw.gc_pass(dry_run=False, now=_SWEEP_NOW)
+    assert not (isolated_registry / "dispatch-lease-900.json").exists()  # reaped
+    assert (isolated_registry / "dispatch-lease-900.lock").exists()  # sidecar kept
+    assert (isolated_registry / "dispatch-lease-901.json").exists()  # active kept
+    assert "dispatch-lease-900.json" in capsys.readouterr().out
+
+
+def test_dispatch_infra_drain_tristate_suppressed(isolated_registry, monkeypatch, capsys):
+    # Test 20 (helper level): rc-0 stdout carrying a suppression sentinel ->
+    # "suppressed"; plain rc-0 -> "spawned"; rc!=0 -> "failed".
+    from types import SimpleNamespace
+
+    import autonomous_session_watch as asw
+
+    outputs = {"rc": 0, "stdout": "DISPATCH-LEASE HELD issue #42: a dispatch is in flight\n"}
+
+    def _fake_run(cmd, **kw):
+        return SimpleNamespace(returncode=outputs["rc"], stdout=outputs["stdout"], stderr="boom")
+
+    monkeypatch.setattr(asw.subprocess, "run", _fake_run)
+    assert asw._dispatch_infra_drain(42, "slot 1/3", dry_run=False, reg_snapshot={}) == "suppressed"
+    assert "INFRA-DRAIN SUPPRESSED issue #42" in capsys.readouterr().out
+    outputs["stdout"] = "REGISTRATION-COLLISION issue #42: kept sid-a, stopped sid-b\n"
+    assert asw._dispatch_infra_drain(42, "slot 1/3", dry_run=False, reg_snapshot={}) == "suppressed"
+    outputs["stdout"] = "Issue #42 session spawned: sid-new\n"
+    assert asw._dispatch_infra_drain(42, "slot 1/3", dry_run=False, reg_snapshot={}) == "spawned"
+    outputs["rc"] = 1
+    assert asw._dispatch_infra_drain(42, "slot 1/3", dry_run=False, reg_snapshot={}) == "failed"
+
+
+def test_drain_pass_suppressed_records_no_attempt_no_marker(isolated_registry, monkeypatch, capsys):
+    # Test 20 (caller level, through the REAL _dispatch_infra_drain): a
+    # suppressed rc-0 no-op records NO attempt (no backoff -> the crashed
+    # lease-winner recovers in <= TTL + one tick, not 1 h) and posts NO
+    # dispatch marker.
+    import json
+    from types import SimpleNamespace
+
+    import autonomous_session_watch as asw
+
+    now = _DRAIN_NOW
+    _write_drain_queue(isolated_registry, [483])
+    sk = {483: ("proposed", "infra")}
+    monkeypatch.setattr(asw, "_task_status_kind", lambda i: sk.get(i, (None, None)))
+    monkeypatch.setattr(asw, "_infra_drain_occupancy", lambda: [])
+    monkeypatch.setattr(asw, "_live_session_ids_or_none", lambda: set())
+    markers: list[tuple] = []
+    monkeypatch.setattr(asw, "_post_progress_marker", lambda *a, **k: markers.append((a, k)))
+    monkeypatch.setattr(
+        asw.subprocess,
+        "run",
+        lambda cmd, **kw: SimpleNamespace(
+            returncode=0, stdout="DISPATCH-LEASE HELD issue #483: in flight\n", stderr=""
+        ),
+    )
+    asw.infra_drain_pass(dry_run=False, now=now, daemon_reachable=True)
+    out = capsys.readouterr().out
+    assert "INFRA-DRAIN SUPPRESSED issue #483" in out
+    assert markers == []
+    state = json.loads((isolated_registry / "infra-drain-state.json").read_text())
+    assert state["attempts"] == {}  # suppressed -> no attempt, no backoff
+
+
+def test_respawn_suppressed_output_not_booked_as_respawned(isolated_registry, monkeypatch, capsys):
+    # Test 21 (helper level): every respawn-family helper detects a
+    # suppressed rc-0 and returns "suppressed" with the loud
+    # "suppressed — not respawned" line instead of RESPAWNED*.
+    from types import SimpleNamespace
+
+    import autonomous_session_watch as asw
+
+    monkeypatch.setattr(
+        asw.subprocess,
+        "run",
+        lambda cmd, **kw: SimpleNamespace(
+            returncode=0, stdout="DISPATCH-LEASE HELD issue #7: in flight\n", stderr=""
+        ),
+    )
+    assert asw._respawn({"issue": 7}, dry_run=False) == "suppressed"
+    assert asw._respawn_stalled_session(7, 24.0, dry_run=False) == "suppressed"
+    assert asw._respawn_orphan(7, 24.0, dry_run=False) == "suppressed"
+    assert asw._redrive_capacity_retry(7, dry_run=False) == "suppressed"
+    out = capsys.readouterr().out
+    # RESPAWN + RESPAWN-STALLED + RESPAWN-ORPHAN all print the phrase.
+    assert out.count("suppressed — not respawned (lease/collision)") == 3
+    assert "RESPAWN-ORPHAN issue #7: suppressed — not respawned" in out
+    assert "CAPACITY-RETRY issue #7: suppressed — not re-driven" in out
+    assert "RESPAWNED" not in out and "CAPACITY-RETRIED" not in out
+
+
+def test_stalled_handler_suppressed_books_nothing(isolated_registry, monkeypatch, capsys):
+    # Test 21 (caller level, stalled respawn handler): a suppressed spawn ->
+    # no respawn marker, no respawn_count bump, NO state save (the on-disk
+    # miss/stall state is left untouched).
+    import autonomous_session_watch as asw
+
+    monkeypatch.setattr(asw, "_stop_session", lambda sid, dry_run: True)
+    monkeypatch.setattr(asw, "_stalled_cap_gpu_hours", lambda i: 24.0)
+    monkeypatch.setattr(asw, "_respawn_stalled_session", lambda i, cap, dry: "suppressed")
+    markers: list[tuple] = []
+    monkeypatch.setattr(asw, "_post_progress_marker", lambda *a, **k: markers.append((a, k)))
+    saves: list[tuple] = []
+    monkeypatch.setattr(asw, "_save_stalled_state", lambda *a, **k: saves.append((a, k)))
+    ctx = asw._StalledActionCtx(
+        issue=7,
+        happy_session_id="sid-old",
+        prev_state={"missed": 2},
+        alerted=False,
+        respawn_count=1,
+        exhausted=False,
+        last_self_report_ts=None,
+        self_gap="3.0h",
+        marker_gap="3.0h",
+        has_pod=False,
+        task_status="running",
+        in_active=True,
+        threshold=2,
+        dry_run=False,
+    )
+    asw._handle_stalled_respawn(ctx)
+    assert markers == []  # no respawn marker
+    assert saves == []  # no state reset — miss/stall state left untouched
+
+
+def test_capacity_retry_suppressed_consumes_no_budget(isolated_registry, monkeypatch, capsys):
+    # Test 21 (capacity-retry variant): a suppressed re-drive consumes NO
+    # per-day retry budget and writes NO state.
+    import autonomous_session_watch as asw
+
+    now = _SWEEP_NOW
+    monkeypatch.setattr(asw, "_task_events", lambda i: [])
+    monkeypatch.setattr(
+        asw,
+        "_is_transient_capacity_block",
+        lambda events: (True, "no_compute_available", now - 99999),
+    )
+    monkeypatch.setattr(asw, "_load_capacity_retry_state", lambda i: {})
+    monkeypatch.setattr(asw, "_redrive_capacity_retry", lambda i, dry: "suppressed")
+    saves: list[tuple] = []
+    monkeypatch.setattr(asw, "_save_capacity_retry_state", lambda *a, **k: saves.append((a, k)))
+    markers: list[tuple] = []
+    monkeypatch.setattr(asw, "_post_progress_marker", lambda *a, **k: markers.append((a, k)))
+    asw._process_capacity_retry(7, now, "2027-01-15", False, backoff_s=3600.0, max_per_day=4)
+    assert saves == []  # retry budget NOT consumed
+    assert markers == []

--- a/tests/test_dispatch_lease.py
+++ b/tests/test_dispatch_lease.py
@@ -1,0 +1,427 @@
+"""Tests for the per-issue dispatch lease + registration collision-fail (#843).
+
+Pins the M1/M2 contract in ``scripts/spawn_session.py``:
+
+- **M1 lease primitive** — atomic create-or-fail claim (`acquire_dispatch_lease`,
+  ``os.open(O_CREAT|O_EXCL)`` fast path; flock-sidecar-serialized single-winner
+  stale takeover), per-issue granularity, TTL freshness (env override), a
+  garbled-but-fresh-mtime lease fails CLOSED (blocks until TTL), token-verified
+  release, and the 8-process barrier-synced race repro (exactly one winner —
+  the acceptance smoke).
+- **M1 chokepoint wiring** — `spawn-issue --auto` acquires BEFORE the daemon
+  POST; a loser exits 0 with the loud ``DISPATCH-LEASE HELD`` line and no POST;
+  a SUCCESSFUL spawn LEAVES the lease in place, so a sequential second attempt
+  within TTL is suppressed (test 8b — the load-bearing no-release-on-success
+  invariant; the #833 3-min duplicate shape); a spawn FAILURE releases it;
+  manual spawns are not gated and create no lease.
+- **M2 collision-fail** — a fresh (< 900 s) ``issue-<N>.json`` naming a
+  DIFFERENT session makes registration raise; `cmd_spawn_issue` stops the
+  just-spawned duplicate, keeps the first registration byte-identical, exits 0
+  with ``REGISTRATION-COLLISION``, best-effort posts the suppression marker,
+  and HOLDS the lease. An old entry / ``force=True`` overwrites as before, and
+  the collision window is capped at the 900 s default even when
+  ``EPM_DISPATCH_LEASE_TTL_S`` is raised (so a longer lease can never suppress
+  a legitimate crash-recovery respawn).
+
+Every daemon POST / task.py subprocess is mocked; the registry dir is a
+tmp_path. The multiprocessing race test pins the ``fork`` start method AND
+passes the tmp registry dir explicitly (hermeticity: under ``spawn`` a
+re-import would silently race on the REAL ``~/.eps-autonomous``).
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import spawn_session  # noqa: E402
+
+# A high issue number with no worktree so cmd_spawn_issue resolves cwd to the
+# repo root deterministically.
+ISSUE = 424242
+
+
+@pytest.fixture
+def lease_registry(tmp_path, monkeypatch):
+    """Point spawn_session.AUTONOMOUS_REGISTRY_DIR at a tmp dir (the lease
+    helpers read the module global at call time)."""
+    monkeypatch.setattr(spawn_session, "AUTONOMOUS_REGISTRY_DIR", tmp_path)
+    return tmp_path
+
+
+# ─── M1 primitive ─────────────────────────────────────────────────────────────
+
+
+def test_acquire_creates_lease_with_expected_fields(lease_registry):
+    entry = spawn_session.acquire_dispatch_lease(ISSUE, holder="test-holder")
+    assert entry is not None
+    on_disk = json.loads(spawn_session.dispatch_lease_path(ISSUE).read_text())
+    assert on_disk == entry
+    assert on_disk["issue"] == ISSUE
+    assert on_disk["holder"] == "test-holder"
+    assert on_disk["pid"] == os.getpid()
+    assert isinstance(on_disk["token"], str) and on_disk["token"]
+    assert isinstance(on_disk["acquired_at"], float)
+
+
+def test_second_acquire_fresh_lease_returns_none(lease_registry):
+    first = spawn_session.acquire_dispatch_lease(ISSUE, holder="w1")
+    assert first is not None
+    before = spawn_session.dispatch_lease_path(ISSUE).read_bytes()
+    assert spawn_session.acquire_dispatch_lease(ISSUE, holder="w2") is None
+    # Loser must not have touched the winner's lease.
+    assert spawn_session.dispatch_lease_path(ISSUE).read_bytes() == before
+
+
+def test_per_issue_granularity(lease_registry):
+    assert spawn_session.acquire_dispatch_lease(1, holder="a") is not None
+    assert spawn_session.acquire_dispatch_lease(2, holder="b") is not None
+    assert spawn_session.dispatch_lease_path(1).exists()
+    assert spawn_session.dispatch_lease_path(2).exists()
+
+
+def test_stale_lease_takeover(lease_registry):
+    now = time.time()
+    ttl = spawn_session._dispatch_lease_ttl_s()
+    stale = {"issue": ISSUE, "holder": "old", "pid": 1, "token": "t0", "acquired_at": now - ttl - 1}
+    spawn_session.dispatch_lease_path(ISSUE).write_text(json.dumps(stale))
+    entry = spawn_session.acquire_dispatch_lease(ISSUE, holder="new", now=now)
+    assert entry is not None and entry["holder"] == "new"
+    on_disk = json.loads(spawn_session.dispatch_lease_path(ISSUE).read_text())
+    assert on_disk["holder"] == "new"
+    # The slow path leaves the PERMANENT flock sidecar behind (no tombstone
+    # exists in this protocol).
+    assert spawn_session._dispatch_lease_lock_path(ISSUE).exists()
+
+
+def _race_worker(registry_dir: str, rounds: int, barrier, queue) -> None:
+    """Barrier-synced acquire worker for the multiprocessing race repro.
+
+    Sets the registry dir EXPLICITLY from the passed string (hermeticity: do
+    not rely on inheriting the parent's monkeypatched module state), then
+    races one acquire per round on a per-round issue number."""
+    spawn_session.AUTONOMOUS_REGISTRY_DIR = Path(registry_dir)
+    for r in range(rounds):
+        barrier.wait()
+        entry = spawn_session.acquire_dispatch_lease(1000 + r, holder=f"pid-{os.getpid()}")
+        queue.put((r, entry is not None))
+
+
+def test_concurrent_acquires_exactly_one_winner(lease_registry):
+    # THE race repro / acceptance smoke: 8 barrier-synced processes, 20
+    # rounds (a fresh issue per round) -> exactly 1 winner per round.
+    # `fork` is pinned: under `spawn` the children would re-import
+    # spawn_session and (without the explicit dir set) race on the REAL
+    # ~/.eps-autonomous.
+    ctx = multiprocessing.get_context("fork")
+    n_workers, rounds = 8, 20
+    barrier = ctx.Barrier(n_workers)
+    queue = ctx.Queue()
+    workers = [
+        ctx.Process(target=_race_worker, args=(str(lease_registry), rounds, barrier, queue))
+        for _ in range(n_workers)
+    ]
+    for w in workers:
+        w.start()
+    results: list[tuple[int, bool]] = []
+    for _ in range(n_workers * rounds):
+        results.append(queue.get(timeout=60))
+    for w in workers:
+        w.join(timeout=60)
+        assert w.exitcode == 0
+    for r in range(rounds):
+        winners = sum(1 for rr, won in results if rr == r and won)
+        assert winners == 1, f"round {r}: expected exactly 1 winner, got {winners}"
+
+
+def _stale_race_worker(registry_dir: str, barrier, queue) -> None:
+    """Worker for the stale-takeover contention repro: all workers race the
+    takeover of ONE pre-seeded stale lease."""
+    spawn_session.AUTONOMOUS_REGISTRY_DIR = Path(registry_dir)
+    barrier.wait()
+    entry = spawn_session.acquire_dispatch_lease(42, holder=f"pid-{os.getpid()}")
+    queue.put(entry is not None)
+
+
+def test_concurrent_stale_takeover_exactly_one_winner(lease_registry):
+    # Single-winner takeover under contention (the round-1 TOCTOU fix): 8
+    # processes race a pre-seeded STALE lease; the flock-serialized slow path
+    # admits exactly one.
+    ttl = spawn_session._dispatch_lease_ttl_s()
+    stale = {"issue": 42, "holder": "old", "pid": 1, "token": "t0", "acquired_at": 1.0}
+    spawn_session.dispatch_lease_path(42).write_text(json.dumps(stale))
+    os.utime(spawn_session.dispatch_lease_path(42), (time.time() - ttl - 60,) * 2)
+    ctx = multiprocessing.get_context("fork")
+    n_workers = 8
+    barrier = ctx.Barrier(n_workers)
+    queue = ctx.Queue()
+    workers = [
+        ctx.Process(target=_stale_race_worker, args=(str(lease_registry), barrier, queue))
+        for _ in range(n_workers)
+    ]
+    for w in workers:
+        w.start()
+    wins = [queue.get(timeout=60) for _ in range(n_workers)]
+    for w in workers:
+        w.join(timeout=60)
+        assert w.exitcode == 0
+    assert sum(wins) == 1
+    assert json.loads(spawn_session.dispatch_lease_path(42).read_text())["holder"] != "old"
+
+
+def test_garbled_lease_fresh_mtime_blocks_stale_mtime_takes_over(lease_registry):
+    path = spawn_session.dispatch_lease_path(ISSUE)
+    path.write_text("not json{{{")
+    # Fresh mtime -> fail CLOSED (treated fresh; blocks dispatch).
+    assert spawn_session.acquire_dispatch_lease(ISSUE, holder="w") is None
+    assert path.read_text() == "not json{{{"
+    # mtime pushed past TTL -> the takeover proceeds.
+    ttl = spawn_session._dispatch_lease_ttl_s()
+    os.utime(path, (time.time() - ttl - 60,) * 2)
+    entry = spawn_session.acquire_dispatch_lease(ISSUE, holder="w")
+    assert entry is not None
+    assert json.loads(path.read_text())["holder"] == "w"
+
+
+def test_release_only_with_matching_token(lease_registry):
+    entry = spawn_session.acquire_dispatch_lease(ISSUE, holder="w")
+    assert entry is not None
+    spawn_session.release_dispatch_lease(ISSUE, "wrong-token")
+    assert spawn_session.dispatch_lease_path(ISSUE).exists()
+    spawn_session.release_dispatch_lease(ISSUE, entry["token"])
+    assert not spawn_session.dispatch_lease_path(ISSUE).exists()
+
+
+def test_ttl_env_override_and_malformed_fallback(monkeypatch):
+    monkeypatch.setenv("EPM_DISPATCH_LEASE_TTL_S", "60")
+    assert spawn_session._dispatch_lease_ttl_s() == 60.0
+    monkeypatch.setenv("EPM_DISPATCH_LEASE_TTL_S", "not-a-number")
+    assert spawn_session._dispatch_lease_ttl_s() == float(spawn_session.DISPATCH_LEASE_TTL_S)
+    monkeypatch.delenv("EPM_DISPATCH_LEASE_TTL_S")
+    assert spawn_session._dispatch_lease_ttl_s() == float(spawn_session.DISPATCH_LEASE_TTL_S)
+
+
+def test_contended_takeover_lock_returns_none(lease_registry):
+    # A held sidecar flock (another taker mid-takeover) -> acquire returns
+    # None WITHOUT unlinking the stale lease (skip-this-tick semantics).
+    import fcntl
+
+    ttl = spawn_session._dispatch_lease_ttl_s()
+    stale = {"issue": ISSUE, "holder": "old", "pid": 1, "token": "t0", "acquired_at": 1.0}
+    path = spawn_session.dispatch_lease_path(ISSUE)
+    path.write_text(json.dumps(stale))
+    os.utime(path, (time.time() - ttl - 60,) * 2)
+    lock_fd = os.open(spawn_session._dispatch_lease_lock_path(ISSUE), os.O_CREAT | os.O_WRONLY)
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        assert spawn_session.acquire_dispatch_lease(ISSUE, holder="w") is None
+        assert path.exists()  # the stale lease was NOT unlinked
+    finally:
+        os.close(lock_fd)
+
+
+# ─── cmd_spawn_issue integration (M1 wiring + M2 collision) ───────────────────
+
+
+def _install_daemon_mock(monkeypatch, *, spawn_success=True):
+    """Mock `spawn_session.post` + `_verify_happy_patch_or_die` + the marker
+    subprocess. Returns ``(posts, marker_calls, lease_at_post)`` recorders:
+    every ``post()`` call (path, body), every ``subprocess.run`` argv, and —
+    for each /spawn-session POST — whether the lease file already existed."""
+    posts: list[tuple[str, dict]] = []
+    marker_calls: list[list[str]] = []
+    lease_at_post: list[bool] = []
+
+    def _fake_post(path, body):
+        posts.append((path, body))
+        if path == "/spawn-session":
+            issue = body.get("_test_issue", ISSUE)
+            lease_at_post.append(spawn_session.dispatch_lease_path(issue).exists())
+            if not spawn_success:
+                return {"success": False}
+            return {"success": True, "sessionId": f"sid-new-{len(posts)}"}
+        return {"success": True}
+
+    monkeypatch.setattr(spawn_session, "post", _fake_post)
+    monkeypatch.setattr(spawn_session, "_verify_happy_patch_or_die", lambda **kw: None)
+
+    class _FakeCompleted:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    monkeypatch.setattr(
+        spawn_session.subprocess,
+        "run",
+        lambda cmd, **kw: marker_calls.append(list(cmd)) or _FakeCompleted(),
+    )
+    return posts, marker_calls, lease_at_post
+
+
+def _spawn_posts(posts):
+    return [p for p in posts if p[0] == "/spawn-session"]
+
+
+def _stop_posts(posts):
+    return [p for p in posts if p[0] == "/stop-session"]
+
+
+def test_auto_spawn_acquires_lease_before_post(lease_registry, monkeypatch):
+    posts, _markers, lease_at_post = _install_daemon_mock(monkeypatch)
+    spawn_session.main(["spawn-issue", "--issue", str(ISSUE), "--auto"])
+    assert len(_spawn_posts(posts)) == 1
+    assert lease_at_post == [True]  # the lease existed when the POST fired
+
+
+def test_auto_spawn_success_leaves_lease_and_suppresses_sequential_second(
+    lease_registry, monkeypatch, capsys
+):
+    # Test 8b — the load-bearing no-release-on-success invariant (the #833
+    # sequential-duplicate shape): a release-on-success implementation would
+    # pass tests 8/9 and still admit sequential duplicates.
+    posts, _markers, _lap = _install_daemon_mock(monkeypatch)
+    spawn_session.main(["spawn-issue", "--issue", str(ISSUE), "--auto"])
+    assert spawn_session.dispatch_lease_path(ISSUE).exists()  # lease persists
+    spawn_session.main(["spawn-issue", "--issue", str(ISSUE), "--auto"])
+    assert len(_spawn_posts(posts)) == 1  # NO second daemon POST
+    out = capsys.readouterr().out
+    assert "DISPATCH-LEASE HELD" in out
+
+
+def test_auto_spawn_on_fresh_lease_no_post_exit_zero_loud(lease_registry, monkeypatch, capsys):
+    assert spawn_session.acquire_dispatch_lease(ISSUE, holder="other-dispatcher") is not None
+    posts, _markers, _lap = _install_daemon_mock(monkeypatch)
+    spawn_session.main(["spawn-issue", "--issue", str(ISSUE), "--auto"])  # no SystemExit
+    assert _spawn_posts(posts) == []
+    out = capsys.readouterr().out
+    assert "DISPATCH-LEASE HELD" in out
+    assert "holder=other-dispatcher" in out
+
+
+def test_manual_spawn_ignores_lease(lease_registry, monkeypatch, capsys):
+    # (a) With a fresh lease: proceeds (warn only).
+    assert spawn_session.acquire_dispatch_lease(ISSUE, holder="auto-dispatcher") is not None
+    posts, _markers, _lap = _install_daemon_mock(monkeypatch)
+    spawn_session.main(["spawn-issue", "--issue", str(ISSUE)])
+    assert len(_spawn_posts(posts)) == 1
+    out = capsys.readouterr().out
+    assert "a fresh dispatch lease exists" in out
+    # (b) With NO lease: a manual spawn creates none (acquisition is
+    # --auto-gated).
+    other = ISSUE + 1
+    spawn_session.main(["spawn-issue", "--issue", str(other)])
+    assert not spawn_session.dispatch_lease_path(other).exists()
+
+
+def test_spawn_failure_releases_lease(lease_registry, monkeypatch):
+    _posts, _markers, _lap = _install_daemon_mock(monkeypatch, spawn_success=False)
+    with pytest.raises(SystemExit):
+        spawn_session.main(["spawn-issue", "--issue", str(ISSUE), "--auto"])
+    assert not spawn_session.dispatch_lease_path(ISSUE).exists()  # slot freed
+
+
+def test_registration_collision_stops_duplicate(lease_registry, monkeypatch, capsys):
+    # Pre-seed a FRESH registration naming a DIFFERENT session id.
+    reg = lease_registry / f"issue-{ISSUE}.json"
+    original = json.dumps(
+        {"issue": ISSUE, "happy_session_id": "sid-first", "spawned_at": time.time(), "missed": 0}
+    )
+    reg.write_text(original)
+    posts, marker_calls, _lap = _install_daemon_mock(monkeypatch)
+    spawn_session.main(["spawn-issue", "--issue", str(ISSUE), "--auto"])  # exit 0, no raise
+    # The duplicate we just spawned was stopped, with the NEW sid.
+    stops = _stop_posts(posts)
+    assert len(stops) == 1
+    assert stops[0][1]["sessionId"] == "sid-new-1"
+    # The FIRST registration is byte-identical.
+    assert reg.read_text() == original
+    out = capsys.readouterr().out
+    assert "REGISTRATION-COLLISION" in out
+    assert "sid-first" in out
+    # The best-effort suppression marker subprocess was attempted.
+    assert any("post-marker" in c for call in marker_calls for c in call)
+    note = next(c for call in marker_calls for c in call if "duplicate" in c)
+    assert spawn_session.DUPLICATE_DISPATCH_NOTE_SENTINEL in note
+    # The lease is deliberately HELD after the collision exit (§3.B): a
+    # session IS live and driving; holding suppresses re-spawn churn.
+    assert spawn_session.dispatch_lease_path(ISSUE).exists()
+
+
+def test_registration_overwrite_allowed_when_entry_old(lease_registry, monkeypatch):
+    # An entry at/past the 900 s window is the crash-recovery respawn case —
+    # overwrite proceeds exactly as before.
+    reg = lease_registry / f"issue-{ISSUE}.json"
+    reg.write_text(
+        json.dumps(
+            {
+                "issue": ISSUE,
+                "happy_session_id": "sid-old",
+                "spawned_at": time.time() - 901.0,
+                "missed": 2,
+            }
+        )
+    )
+    posts, _markers, _lap = _install_daemon_mock(monkeypatch)
+    spawn_session.main(["spawn-issue", "--issue", str(ISSUE), "--auto"])
+    assert _stop_posts(posts) == []  # no collision remediation
+    assert json.loads(reg.read_text())["happy_session_id"] == "sid-new-1"
+
+
+def test_register_current_force_overwrites(lease_registry):
+    # force=True (the register-current path) bypasses the collision check for
+    # an already-live session re-registration (#472 revival).
+    reg = lease_registry / "issue-77.json"
+    reg.write_text(
+        json.dumps({"issue": 77, "happy_session_id": "sid-a", "spawned_at": time.time()})
+    )
+    spawn_session._register_autonomous_session(77, "sid-b", "/tmp", 100.0, force=True)
+    assert json.loads(reg.read_text())["happy_session_id"] == "sid-b"
+    # And without force, the same write raises.
+    with pytest.raises(spawn_session.RegistrationCollisionError):
+        spawn_session._register_autonomous_session(77, "sid-c", "/tmp", 100.0)
+
+
+def test_collision_window_capped_at_default(lease_registry, monkeypatch):
+    # Raising EPM_DISPATCH_LEASE_TTL_S lengthens the LEASE but must never
+    # widen the M2 collision window past the 900 s respawn grace (round-1
+    # env-decoupling hardening): an entry aged 1200 s overwrites fine even
+    # under a 3600 s lease TTL; an entry aged 500 s still collides.
+    monkeypatch.setenv("EPM_DISPATCH_LEASE_TTL_S", "3600")
+    reg = lease_registry / "issue-78.json"
+    reg.write_text(
+        json.dumps({"issue": 78, "happy_session_id": "sid-a", "spawned_at": time.time() - 1200.0})
+    )
+    spawn_session._register_autonomous_session(78, "sid-b", "/tmp", 100.0)  # no raise
+    assert json.loads(reg.read_text())["happy_session_id"] == "sid-b"
+    reg.write_text(
+        json.dumps({"issue": 78, "happy_session_id": "sid-c", "spawned_at": time.time() - 500.0})
+    )
+    with pytest.raises(spawn_session.RegistrationCollisionError):
+        spawn_session._register_autonomous_session(78, "sid-d", "/tmp", 100.0)
+
+
+# ─── spawn_output_suppressed (M1b shared helper) ──────────────────────────────
+
+
+def test_spawn_output_suppressed_matches_both_sentinels():
+    assert (
+        spawn_session.spawn_output_suppressed("DISPATCH-LEASE HELD issue #7: in flight")
+        == spawn_session.DISPATCH_LEASE_HELD_SENTINEL
+    )
+    assert (
+        spawn_session.spawn_output_suppressed("...\nREGISTRATION-COLLISION issue #7: kept sid-a")
+        == spawn_session.REGISTRATION_COLLISION_SENTINEL
+    )
+    assert spawn_session.spawn_output_suppressed("Issue #7 session spawned: sid") is None
+    assert spawn_session.spawn_output_suppressed("") is None
+    assert spawn_session.spawn_output_suppressed(None) is None

--- a/tests/test_file_infra_task.py
+++ b/tests/test_file_infra_task.py
@@ -36,6 +36,14 @@ if str(SCRIPTS) not in sys.path:
 import file_infra_task as fit  # noqa: E402
 
 
+@pytest.fixture(autouse=True)
+def _no_real_lease(monkeypatch):
+    """Hermeticity: the #843 step-4.5 dispatch-lease pre-check reads the
+    registry dir; default it to "no lease held" so these tests never depend
+    on the REAL ~/.eps-autonomous. The lease-specific test overrides it."""
+    monkeypatch.setattr(fit, "dispatch_lease_fresh", lambda issue: None)
+
+
 def _install_run_recorder(monkeypatch, *, new_id="#771", new_rc=0, spawn_rc=0):
     """Replace ``file_infra_task.subprocess.run`` with a recorder that branches
     on the argv: a ``task.py new`` invocation returns a canned ``#<N>`` stdout
@@ -319,3 +327,63 @@ def test_parse_new_id_takes_first_hash_token():
     assert fit._parse_new_id("created\n#42 done\n") == 42
     assert fit._parse_new_id("no id here") is None
     assert fit._parse_new_id("#notanint") is None
+
+
+# ── #843 M1: fresh dispatch lease -> files, does NOT dispatch ──────────────────
+
+
+def test_fresh_lease_files_but_does_not_dispatch(monkeypatch, capsys):
+    # Test 19: a fresh per-issue dispatch lease means another dispatcher's
+    # spawn is already in flight — the wrapper files the task but skips the
+    # spawn subprocess entirely (loud, exit 0, watcher backstop named).
+    import time
+
+    calls = _install_run_recorder(monkeypatch, new_id="#771")
+    monkeypatch.setattr(fit, "_daemon_reachable", lambda: True)
+    monkeypatch.setattr(fit, "infra_dispatch_has_free_slot", lambda: True)
+    monkeypatch.setattr(fit, "_issue_has_live_registration", lambda issue: False)
+    monkeypatch.setattr(
+        fit,
+        "dispatch_lease_fresh",
+        lambda issue: {"holder": "watcher-sweep", "pid": 1, "acquired_at": time.time() - 30},
+    )
+
+    rc = fit.main(["--title", "x"])
+
+    assert rc == 0
+    assert len(_new_calls(calls)) == 1  # STILL files the task
+    assert _spawn_calls(calls) == []  # but NEVER spawns
+    out = capsys.readouterr().out
+    assert "dispatch suppressed (lease held" in out
+    assert "holder=watcher-sweep" in out
+    assert "proposed_infra_sweep" in out  # names the watcher backstop
+
+
+def test_spawn_suppressed_output_reported_not_booked_as_dispatched(monkeypatch, capsys):
+    # #843 M1b: a rc-0 spawn whose stdout carries a suppression sentinel (a
+    # lease appeared between the pre-check and the spawn, or a registration
+    # collision) is reported as suppressed, never as "filed + dispatched".
+    from types import SimpleNamespace
+
+    def _fake_run(cmd, **kw):
+        if "scripts/task.py" in cmd and "new" in cmd:
+            return SimpleNamespace(returncode=0, stdout="#771\n", stderr="")
+        if "scripts/spawn_session.py" in cmd and "spawn-issue" in cmd:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="DISPATCH-LEASE HELD issue #771: a dispatch is already in flight\n",
+                stderr="",
+            )
+        raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+    monkeypatch.setattr(fit.subprocess, "run", _fake_run)
+    monkeypatch.setattr(fit, "_daemon_reachable", lambda: True)
+    monkeypatch.setattr(fit, "infra_dispatch_has_free_slot", lambda: True)
+    monkeypatch.setattr(fit, "_issue_has_live_registration", lambda issue: False)
+
+    rc = fit.main(["--title", "x"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "dispatch suppressed (DISPATCH-LEASE HELD)" in out
+    assert "filed + dispatched" not in out

--- a/tests/test_happy_patch_check.py
+++ b/tests/test_happy_patch_check.py
@@ -186,6 +186,9 @@ def reverted_daemon(tmp_path, monkeypatch):
 def test_cmd_spawn_issue_auto_dies_before_post(reverted_daemon, monkeypatch, tmp_path):
     # No worktree at the synthetic path -> cwd falls back to repo root (fine).
     monkeypatch.setattr(spawn_session, "WORKTREE_DIR", tmp_path / "no-worktrees")
+    # #843: the --auto path now acquires a dispatch lease BEFORE the patch
+    # verify; isolate the registry so the test never writes ~/.eps-autonomous.
+    monkeypatch.setattr(spawn_session, "AUTONOMOUS_REGISTRY_DIR", tmp_path / "registry")
     ns = argparse.Namespace(
         issue=999,
         auto=True,

--- a/tests/test_stalled_detector_and_gc.py
+++ b/tests/test_stalled_detector_and_gc.py
@@ -597,7 +597,7 @@ def test_stalled_pass_no_respawn_when_fresh_lifecycle_marker_present(
     # would pass even on the buggy code (the false-confidence gap the reviewer
     # caught). Stub both True so a respawn — if it fires — is visible here.
     monkeypatch.setattr(asw, "_stop_session", lambda sid, dry_run: True)
-    monkeypatch.setattr(asw, "_respawn_stalled_session", lambda issue, cap, dry_run: True)
+    monkeypatch.setattr(asw, "_respawn_stalled_session", lambda issue, cap, dry_run: "spawned")
 
     # Two consecutive ticks while the self-report stays frozen: a fresh marker
     # resets the miss counter every tick, so nothing ever fires (no alert AND


### PR DESCRIPTION
Closes task #843 (kind: infra, workflow-fix).

## Summary
- Atomic create-or-fail per-issue dispatch lease (`~/.eps-autonomous/dispatch-lease-<N>.json`, O_EXCL fast path + flock-sidecar-serialized stale takeover, TTL 900 s == RESPAWN_SPAWN_GRACE_S) acquired inside `spawn_session.py cmd_spawn_issue --auto` before the daemon POST — closes the 2026-07-01 duplicate-dispatch race (#787/#805/#806/#822/#833/#800).
- Registration collision-fail (`RegistrationCollisionError`, min()-capped window, duplicate auto-stopped, first registration intact) + suppressed-rc-0 bookkeeping at every automated spawn caller (tri-state `_dispatch_infra_drain`; no attempt/backoff/budget/marker on suppressed) + 600 s sweep marker-freshness backstop + per-attempt plan-tmp-path convention.
- 36 new tests incl. fork-pinned 8-process race repros and the lease-persists-after-success sequential test (8b).

## Test plan
- [x] 2064 passed / 6 skipped on the invariant+touched subset (4 failures provenance-cleared: 2 pre-existing-on-trunk workflow_lint ratchet, 2 stale-worktree copies of the #860 main-side fix)
- [x] ruff clean on the 8 touched .py files; dry-run sweep acceptance smoke exit 0
- [x] Ensemble code-review PASS (Claude PASS / Codex CONCERNS with 0 findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)