### PR TITLE
issue-844: canonical repo-root resolution for session spawns (#844)

### DIFF
--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -403,6 +403,10 @@ if _SCRIPTS_DIR not in sys.path:
 import session_resolver  # noqa: E402  (sibling import; follows the sys.path bootstrap above)
 from pod_lifecycle import _is_managed_pod, _issue_from_pod_name  # noqa: E402
 from runpod_api import PodInfo, get_pod_by_name, list_team_pods  # noqa: E402
+
+# PROJECT_ROOT is git-common-dir-resolved (canonical primary checkout, #844)
+# once the imported spawn_session copy contains the fix — a stale pre-fix
+# worktree copy keeps the old __file__ resolver until rebased/reaped.
 from spawn_session import (  # noqa: E402
     AUTONOMOUS_REGISTRY_DIR,
     PROJECT_ROOT,

--- a/scripts/file_infra_task.py
+++ b/scripts/file_infra_task.py
@@ -60,6 +60,13 @@ if _SCRIPTS_DIR not in sys.path:
 #   - AUTONOMOUS_REGISTRY_DIR / daemon_port: the registration dir + Happy
 #     daemon port, the SAME source of truth `spawn_session.py list` uses.
 from autonomous_session_watch import infra_dispatch_has_free_slot  # noqa: E402
+
+# PROJECT_ROOT is git-common-dir-resolved (canonical primary checkout, #844)
+# once the imported spawn_session copy contains the fix — a stale pre-fix
+# worktree copy keeps the old __file__ resolver until rebased/reaped. The
+# `cwd=PROJECT_ROOT` subprocess calls below therefore run task.py /
+# spawn_session.py against the CANONICAL scripts tree even when THIS module
+# executes as a worktree copy (the #844 propagation cut).
 from spawn_session import (  # noqa: E402
     PROJECT_ROOT,
     _live_session_ids,

--- a/scripts/spawn_session.py
+++ b/scripts/spawn_session.py
@@ -19,6 +19,14 @@ This script is the project-level wrapper for that API. The dedicated PM
 session uses ``spawn-pm``; per-issue sessions use ``spawn-issue --issue <N>``.
 The session's working directory determines what the user sees as the
 session label in Happy — we surface that here.
+
+All three spawn commands (``spawn-pm`` / ``spawn-issue`` / ``spawn-campaign``)
+open sessions ONLY in the canonical primary checkout or the target issue's own
+worktree: ``PROJECT_ROOT`` is git-common-dir-resolved via
+``task_workflow.primary_checkout_root()`` — never ``Path(__file__)``, which
+would resolve a worktree COPY of this script to that sibling worktree and
+spawn unrelated sessions into it (#844) — and ``_assert_spawn_cwd`` refuses
+any other cwd at spawn time, before the daemon POST.
 """
 
 from __future__ import annotations
@@ -34,10 +42,30 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
+# Make the package importable without `uv run` plumbing (same bootstrap as
+# scripts/task.py). Sibling-import semantics on purpose: a worktree copy of
+# this script imports its sibling src/ tree; resolution below is STILL
+# canonical because task_workflow resolves via the git COMMON dir, which a
+# linked worktree shares with the primary checkout.
+_SRC = Path(__file__).resolve().parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from explore_persona_space.task_workflow import primary_checkout_root  # noqa: E402
+
 HAPPY_HOME = Path.home() / ".happy"
 DAEMON_STATE = HAPPY_HOME / "daemon.state.json"
 SESSIONS_JSON = HAPPY_HOME / "sessions.json"
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
+# #844: git-resolved canonical primary checkout; fails loud at import if git /
+# the repo layout is broken — NEVER `Path(__file__).resolve().parent.parent`
+# (a worktree copy of this script would resolve the worktree, and every
+# spawned session would inherit that unrelated sibling worktree as cwd).
+# Bare-name `from spawn_session import PROJECT_ROOT` consumers fixed
+# transitively: scripts/autonomous_session_watch.py, scripts/file_infra_task.py.
+# scripts/session_resolver.py (~line 66) imports spawn_session for its
+# post/registry helpers (not PROJECT_ROOT) and newly incurs the import-time
+# git resolution + fail-loud — harmless in its call contexts.
+PROJECT_ROOT = primary_checkout_root()
 WORKTREE_DIR = PROJECT_ROOT / ".claude" / "worktrees"
 
 # Registry of autonomous (`--auto`) issue sessions, so the crash-recovery
@@ -849,10 +877,38 @@ def _verify_happy_patch_or_die(*, context: str) -> None:
     )
 
 
+def _assert_spawn_cwd(cwd: Path, *, issue: int | None) -> None:
+    """Refuse to spawn into anything but the canonical repo root or the
+    TARGET issue's own worktree (#844: sibling-worktree cwd inheritance).
+
+    By construction this cannot fire after the git-resolved ``PROJECT_ROOT``
+    above — it is a tripwire against a future edit reintroducing
+    ``__file__``-based resolution. Loud non-zero exit, never a silent spawn.
+    """
+    if cwd == PROJECT_ROOT:
+        if not (cwd / ".git").is_dir():  # a linked worktree has a .git FILE
+            sys.exit(
+                f"#844 spawn-cwd assertion: {cwd} is not the primary checkout "
+                f"(.git is not a directory); refusing to spawn"
+            )
+        return
+    if issue is not None and cwd == WORKTREE_DIR / f"issue-{issue}" and cwd.is_dir():
+        return
+    target_desc = (
+        f"the target issue-{issue} worktree" if issue is not None else "a target issue worktree"
+    )
+    sys.exit(
+        f"#844 spawn-cwd assertion: {cwd} is neither the canonical repo root "
+        f"({PROJECT_ROOT}) nor {target_desc}; refusing to spawn"
+    )
+
+
 def cmd_spawn_pm(args: argparse.Namespace) -> None:
     """Spawn a session intended to host the PM persona. The session opens
-    cwd=<repo root> so the user sees a familiar project. The PM persona is
-    then loaded interactively by the user typing ``/pm``."""
+    cwd=<repo root> (git-resolved canonical primary checkout, #844) so the
+    user sees a familiar project. The PM persona is then loaded interactively
+    by the user typing ``/pm``."""
+    _assert_spawn_cwd(PROJECT_ROOT, issue=None)
     extra_args = _build_extra_claude_args(
         getattr(args, "model", None),
         _parse_betas(getattr(args, "betas", None)),
@@ -889,7 +945,10 @@ def cmd_spawn_pm(args: argparse.Namespace) -> None:
 def cmd_spawn_issue(args: argparse.Namespace) -> None:
     """Spawn a session for issue ``--issue N``. The session opens cwd=<repo root>
     by default, OR cwd=<.claude/worktrees/issue-N> if such a worktree exists
-    (so the session is git-isolated to that issue's branch).
+    (so the session is git-isolated to that issue's branch). Both candidates
+    are canonical by construction (``PROJECT_ROOT`` is git-common-dir-resolved,
+    #844) and ``_assert_spawn_cwd`` refuses any other cwd — a sibling issue's
+    worktree can never become the spawned session's cwd.
 
     By default the new session opens empty and the user types ``/issue N``
     on their phone — permissions are interactive. With ``--auto`` (or an
@@ -915,6 +974,7 @@ def cmd_spawn_issue(args: argparse.Namespace) -> None:
     else:
         cwd = PROJECT_ROOT
         cwd_note = f"<repo root> {PROJECT_ROOT}  (no worktree at {worktree})"
+    _assert_spawn_cwd(cwd, issue=issue)
 
     betas = _parse_betas(args.betas)
     extra_args = _build_extra_claude_args(args.model, betas, args.effort)
@@ -1069,6 +1129,9 @@ def cmd_spawn_campaign(args: argparse.Namespace) -> None:
     session itself only ever files plans for children, so the cap bounds
     any plan it would auto-approve in-session."""
     issue = args.issue
+    # #844 tripwire FIRST (pure path check, no task-state dependency): a
+    # non-canonical cwd must refuse before any task lookup or daemon POST.
+    _assert_spawn_cwd(PROJECT_ROOT, issue=None)
     default_budget, default_concurrent, default_per_child = _campaign_defaults()
     budget_gpu_hours = (
         args.budget_gpu_hours if args.budget_gpu_hours is not None else default_budget

--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -227,13 +227,13 @@ def _sanitized_git_env() -> dict[str, str]:
     return env
 
 
-@functools.lru_cache(maxsize=1)
-def _resolve_repo_root_cached(_key: tuple[int, str]) -> Path:
-    """Inner cache target. Keyed on (pid, cwd) so forks + chdirs invalidate
-    automatically. The key is computed by the wrapper; we ignore the
-    contents (we resolve relative to module dir + sanitized env, not cwd).
+def _resolve_primary_checkout(env: dict[str, str]) -> Path:
+    """Resolve + validate the PRIMARY checkout root (the git common dir's
+    parent). Verbatim extraction of ``_resolve_repo_root_cached`` steps
+    (a)+(b) — the rev-parse + layout validation, everything BEFORE the
+    branch guard (#844). Raises ``RuntimeError`` on any failure; never
+    falls back to a ``__file__``/cwd walk-up.
     """
-    env = _sanitized_git_env()
     # (a) Locate the common git dir.
     try:
         proc = subprocess.run(
@@ -275,6 +275,18 @@ def _resolve_repo_root_cached(_key: tuple[int, str]) -> Path:
             f"resolved repo root {parent!s} has no `tasks/` directory; "
             f"wrong repo or uninitialized layout — refusing to resolve tasks/."
         )
+    return parent
+
+
+@functools.lru_cache(maxsize=1)
+def _resolve_repo_root_cached(_key: tuple[int, str]) -> Path:
+    """Inner cache target. Keyed on (pid, cwd) so forks + chdirs invalidate
+    automatically. The key is computed by the wrapper; we ignore the
+    contents (we resolve relative to module dir + sanitized env, not cwd).
+    """
+    env = _sanitized_git_env()
+    # (a)+(b) Locate the common git dir + validate its parent.
+    parent = _resolve_primary_checkout(env)
     # (c) Branch guard.
     sym = subprocess.run(
         ["git", "-C", str(parent), "symbolic-ref", "--short", "HEAD"],
@@ -501,9 +513,31 @@ def repo_root() -> Path:
     return _resolve_repo_root_cached((os.getpid(), os.getcwd()))
 
 
+@functools.lru_cache(maxsize=1)
+def _primary_checkout_cached(_key: tuple[int, str]) -> Path:
+    """Inner cache target for :func:`primary_checkout_root`. Keyed on
+    (pid, cwd) exactly like ``_resolve_repo_root_cached`` so forks + chdirs
+    invalidate automatically.
+    """
+    return _resolve_primary_checkout(_sanitized_git_env())
+
+
+def primary_checkout_root() -> Path:
+    """Absolute path of the PRIMARY (main) checkout — the git common dir's
+    parent — with full layout validation but NO branch guard and NO off-main
+    routing to the managed ``_task-main-pin`` worktree. For consumers that
+    need the canonical checkout PATH (session-spawn cwd, #844), not a safe
+    tasks/ read-write root (those use :func:`repo_root`). Fails loud; never
+    falls back to a ``__file__``/cwd walk-up.
+    """
+    return _primary_checkout_cached((os.getpid(), os.getcwd()))
+
+
 def invalidate_cache() -> None:
-    """Drop the cached repo-root resolution. Next call re-probes git."""
+    """Drop the cached repo-root + primary-checkout resolutions. Next call
+    re-probes git."""
     _resolve_repo_root_cached.cache_clear()
+    _primary_checkout_cached.cache_clear()
 
 
 def tasks_dir() -> Path:
@@ -3621,6 +3655,7 @@ __all__ = [
     "list_events",
     "new_plan_version",
     "post_event",
+    "primary_checkout_root",
     "promote",
     "raise_concern",
     "reconcile_registry",

--- a/tests/test_spawn_session_repo_root.py
+++ b/tests/test_spawn_session_repo_root.py
@@ -1,0 +1,239 @@
+"""Tests for the #844 canonical-root resolution + spawn-cwd assertion in
+``scripts/spawn_session.py``.
+
+What this pins:
+
+1. ``spawn_session.PROJECT_ROOT`` is the canonical PRIMARY checkout (the git
+   common dir's parent): a real ``.git`` DIRECTORY, a ``tasks/`` dir, never a
+   path under ``.claude/worktrees`` — and equals
+   ``task_workflow.primary_checkout_root()``.
+2. ``_assert_spawn_cwd`` accepts exactly {canonical root, the TARGET issue's
+   own worktree} and refuses everything else with a loud ``SystemExit``
+   naming ``#844`` (sibling worktree, random dir, a "root" whose ``.git`` is
+   a file). An ``issue=None`` rejection never renders "issue-None".
+3. Command-level wiring (#844 plan §12 amendment 1): all three spawn
+   commands trip the assertion BEFORE any ``/spawn-session`` daemon POST.
+4. Subprocess-shaped worktree-copy import (#844 plan §12 amendment 8): a
+   WORKTREE COPY of ``spawn_session.py`` resolves ``PROJECT_ROOT`` to the
+   primary checkout — the end-to-end bug shape that produced #844.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import spawn_session  # noqa: E402
+
+from explore_persona_space.task_workflow import primary_checkout_root  # noqa: E402
+
+# ── PROJECT_ROOT resolution ────────────────────────────────────────────────
+
+
+def test_project_root_is_primary_checkout():
+    """PROJECT_ROOT is the canonical primary checkout: `.git` is a real
+    DIRECTORY (a linked worktree has a `.git` FILE), `tasks/` exists, no
+    `.claude/worktrees` path component, and it equals
+    `primary_checkout_root()`."""
+    root = spawn_session.PROJECT_ROOT
+    assert (root / ".git").is_dir(), f"{root}/.git is not a directory"
+    assert (root / "tasks").is_dir(), f"{root} has no tasks/"
+    assert ".claude" not in root.parts, f"PROJECT_ROOT is inside .claude/: {root}"
+    assert root == primary_checkout_root()
+
+
+# ── _assert_spawn_cwd unit behavior ────────────────────────────────────────
+
+
+def _tmp_layout(tmp_path: Path) -> tuple[Path, Path]:
+    """Build a canonical-looking tmp layout: root with a `.git/` DIRECTORY
+    plus a `worktrees/issue-5` dir. Returns (root, worktree_dir)."""
+    root = tmp_path / "root"
+    (root / ".git").mkdir(parents=True)
+    wt_dir = root / ".claude" / "worktrees"
+    (wt_dir / "issue-5").mkdir(parents=True)
+    return root, wt_dir
+
+
+def test_assert_spawn_cwd_accepts_root_and_target_worktree(tmp_path, monkeypatch):
+    root, wt_dir = _tmp_layout(tmp_path)
+    monkeypatch.setattr(spawn_session, "PROJECT_ROOT", root)
+    monkeypatch.setattr(spawn_session, "WORKTREE_DIR", wt_dir)
+    # All three accepted shapes return without exiting.
+    spawn_session._assert_spawn_cwd(root, issue=None)
+    spawn_session._assert_spawn_cwd(root, issue=5)
+    spawn_session._assert_spawn_cwd(wt_dir / "issue-5", issue=5)
+
+
+def test_assert_spawn_cwd_rejects_sibling_worktree(tmp_path, monkeypatch):
+    root, wt_dir = _tmp_layout(tmp_path)
+    (wt_dir / "issue-7").mkdir()
+    monkeypatch.setattr(spawn_session, "PROJECT_ROOT", root)
+    monkeypatch.setattr(spawn_session, "WORKTREE_DIR", wt_dir)
+
+    # A SIBLING issue's worktree (the #844 incident shape) is refused.
+    with pytest.raises(SystemExit) as exc:
+        spawn_session._assert_spawn_cwd(wt_dir / "issue-7", issue=5)
+    assert "#844" in str(exc.value)
+    assert "issue-5" in str(exc.value)  # names the TARGET worktree
+
+    # A random directory is refused.
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    with pytest.raises(SystemExit) as exc:
+        spawn_session._assert_spawn_cwd(other, issue=5)
+    assert "#844" in str(exc.value)
+
+    # issue=None rejection: no "issue-None" rendering (§12 amendment 7).
+    with pytest.raises(SystemExit) as exc:
+        spawn_session._assert_spawn_cwd(other, issue=None)
+    assert "#844" in str(exc.value)
+    assert "issue-None" not in str(exc.value)
+    assert "a target issue worktree" in str(exc.value)
+
+
+def test_assert_spawn_cwd_rejects_root_whose_git_is_a_file(tmp_path, monkeypatch):
+    """A PROJECT_ROOT whose `.git` is a FILE is a linked worktree, not the
+    primary checkout — the tripwire refuses even the cwd == PROJECT_ROOT
+    branch (guards a future edit reintroducing __file__ resolution)."""
+    fake_root = tmp_path / "fake"
+    fake_root.mkdir()
+    (fake_root / ".git").write_text("gitdir: /main/.git/worktrees/issue-999\n")
+    monkeypatch.setattr(spawn_session, "PROJECT_ROOT", fake_root)
+    monkeypatch.setattr(spawn_session, "WORKTREE_DIR", fake_root / ".claude" / "worktrees")
+    with pytest.raises(SystemExit) as exc:
+        spawn_session._assert_spawn_cwd(fake_root, issue=None)
+    assert "#844" in str(exc.value)
+    assert "not the primary checkout" in str(exc.value)
+
+
+# ── command-level wiring (§12 amendment 1) ─────────────────────────────────
+
+
+@pytest.mark.parametrize("command", ["pm", "issue", "campaign"])
+def test_spawn_commands_assert_cwd_before_post(tmp_path, monkeypatch, command):
+    """Each of the three spawn commands is WIRED to `_assert_spawn_cwd`: on a
+    linked-worktree-like PROJECT_ROOT (`.git` is a FILE) they raise a
+    SystemExit naming #844 BEFORE any `/spawn-session` daemon POST."""
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / ".git").write_text("gitdir: /main/.git/worktrees/issue-999\n")
+    monkeypatch.setattr(spawn_session, "PROJECT_ROOT", root)
+    monkeypatch.setattr(spawn_session, "WORKTREE_DIR", root / ".claude" / "worktrees")
+
+    def _fail_post(route, body):
+        raise AssertionError(f"post({route!r}) reached before the #844 spawn-cwd assertion")
+
+    monkeypatch.setattr(spawn_session, "post", _fail_post)
+    # Defense in depth: the daemon-patch verifier can sys.exit for unrelated
+    # host reasons; stub it so only the cwd assertion can exit here.
+    monkeypatch.setattr(spawn_session, "_verify_happy_patch_or_die", lambda *a, **k: None)
+
+    args = argparse.Namespace(
+        issue=5,
+        model=None,
+        betas=None,
+        effort=None,
+        initial_prompt=None,
+        auto=False,
+        auto_approve_gpu_hours=100.0,
+        budget_gpu_hours=None,
+        max_concurrent=None,
+        per_child_cap=None,
+    )
+    fn = {
+        "pm": spawn_session.cmd_spawn_pm,
+        "issue": spawn_session.cmd_spawn_issue,
+        "campaign": spawn_session.cmd_spawn_campaign,
+    }[command]
+    with pytest.raises(SystemExit) as exc:
+        fn(args)
+    assert "#844" in str(exc.value)
+
+
+# ── subprocess-shaped worktree-copy import (§12 amendment 8) ───────────────
+
+
+def _make_scratch_repo_with_spawn_session(tmp_path: Path) -> tuple[Path, Path]:
+    """Scratch primary repo (main branch, tasks/) carrying copies of the real
+    `src/explore_persona_space/task_workflow.py` + `scripts/spawn_session.py`,
+    committed, plus a linked worktree. Returns (main_repo, worktree)."""
+    main_repo = tmp_path / "repo"
+    subprocess.run(["git", "init", "-q", "-b", "main", str(main_repo)], check=True)
+    subprocess.run(["git", "-C", str(main_repo), "config", "user.email", "t@t.t"], check=True)
+    subprocess.run(["git", "-C", str(main_repo), "config", "user.name", "t"], check=True)
+    subprocess.run(["git", "-C", str(main_repo), "config", "commit.gpgsign", "false"], check=True)
+    (main_repo / "tasks").mkdir()
+    (main_repo / "tasks" / ".gitkeep").touch()
+
+    src_dir = main_repo / "src" / "explore_persona_space"
+    src_dir.mkdir(parents=True)
+    (src_dir / "__init__.py").touch()
+    real_tw = (
+        Path(__file__).resolve().parents[1] / "src" / "explore_persona_space" / "task_workflow.py"
+    )
+    (src_dir / "task_workflow.py").write_text(real_tw.read_text())
+
+    scripts_dir = main_repo / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "spawn_session.py").write_text((SCRIPTS / "spawn_session.py").read_text())
+
+    subprocess.run(["git", "-C", str(main_repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(main_repo), "commit", "-q", "-m", "init"], check=True)
+
+    worktree = tmp_path / "wt-sibling"
+    subprocess.run(
+        ["git", "-C", str(main_repo), "worktree", "add", "-b", "issue-999", str(worktree)],
+        check=True,
+        capture_output=True,
+    )
+    return main_repo, worktree
+
+
+def test_worktree_copy_of_spawn_session_resolves_primary_root(tmp_path):
+    """End-to-end #844 shape: importing the WORKTREE COPY of spawn_session.py
+    (as a worktree copy of file_infra_task.py would) yields PROJECT_ROOT ==
+    the PRIMARY checkout — never the worktree the old `Path(__file__)`
+    resolution produced."""
+    main_repo, worktree = _make_scratch_repo_with_spawn_session(tmp_path)
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(worktree / "src") + os.pathsep + env.get("PYTHONPATH", "")
+    snippet = textwrap.dedent(
+        f"""
+        import sys
+        sys.path.insert(0, {str(worktree / "scripts")!r})
+        import spawn_session
+        print("PROJECT_ROOT=" + str(spawn_session.PROJECT_ROOT))
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", snippet],
+        cwd=str(worktree),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, (
+        f"worktree-copy import failed:\nstdout: {proc.stdout}\nstderr: {proc.stderr}"
+    )
+    line = next(ln for ln in proc.stdout.splitlines() if ln.startswith("PROJECT_ROOT="))
+    resolved = Path(line.partition("=")[2].strip())
+    assert resolved.resolve() == main_repo.resolve(), (
+        f"worktree copy resolved {resolved}, expected the primary {main_repo}"
+    )
+    assert resolved.resolve() != worktree.resolve(), "resolved the worktree — the #844 bug shape"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_task_workflow_worktree.py
+++ b/tests/test_task_workflow_worktree.py
@@ -580,6 +580,163 @@ def test_resolver_uses_module_dir_not_cwd(tmp_path: Path) -> None:
     assert Path(resolved["REPO"]).resolve() == main_repo.resolve()
 
 
+# ─── primary_checkout_root (#844) ──────────────────────────────────────────
+
+
+def test_primary_checkout_root_resolves_main_from_worktree(tmp_path: Path) -> None:
+    """From a WORKTREE COPY of the module (the #844 shape: the executed file
+    lives inside a linked worktree), `primary_checkout_root()` returns the
+    PRIMARY checkout root, not the worktree directory.
+
+    Subprocess-shaped like ``test_resolves_main_repo_from_worktree`` (the
+    bug class manifests only at fresh-process import), but with PYTHONPATH
+    pointing at the WORKTREE's src copy so ``_MODULE_DIR`` is inside the
+    worktree — exactly what a worktree copy of a `scripts/` consumer sees.
+    """
+    main_repo = tmp_path / "repo"
+    _make_main_repo(main_repo)
+
+    # Drop + COMMIT the module on main so the worktree (created next)
+    # carries its own copy of src/.
+    src_dir = main_repo / "src" / "explore_persona_space"
+    src_dir.mkdir(parents=True)
+    (src_dir / "__init__.py").touch()
+    real_tw = Path(_REPO_SRC) / "explore_persona_space" / "task_workflow.py"
+    (src_dir / "task_workflow.py").write_text(real_tw.read_text())
+    subprocess.run(["git", "-C", str(main_repo), "add", "src"], check=True)
+    subprocess.run(["git", "-C", str(main_repo), "commit", "-q", "-m", "src"], check=True)
+
+    worktree = tmp_path / "wt-feature"
+    subprocess.run(
+        ["git", "-C", str(main_repo), "worktree", "add", "-b", "feature/x", str(worktree)],
+        check=True,
+        capture_output=True,
+    )
+
+    # PYTHONPATH -> the WORKTREE's src copy (not the primary's).
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(worktree / "src") + os.pathsep + env.get("PYTHONPATH", "")
+    snippet = textwrap.dedent(
+        """
+        from explore_persona_space.task_workflow import primary_checkout_root
+        print('PRIMARY=' + str(primary_checkout_root()))
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", snippet],
+        cwd=str(worktree),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, (
+        f"primary_checkout_root failed:\nstdout: {proc.stdout}\nstderr: {proc.stderr}"
+    )
+    resolved = _parse_resolved(proc.stdout)
+    assert Path(resolved["PRIMARY"]).resolve() == main_repo.resolve(), (
+        f"worktree module copy did not resolve the primary checkout: {resolved}"
+    )
+
+
+def test_primary_checkout_root_ignores_branch_state(tmp_path: Path) -> None:
+    """Primary checkout parked on a feature branch: `primary_checkout_root()`
+    STILL returns the primary (no `_task-main-pin` routing, no raise), while
+    `repo_root()` on the same fixture routes to the managed worktree — pins
+    the semantic difference between the two resolvers (#844 §4a).
+    """
+    main_repo = tmp_path / "repo"
+    _make_main_repo(main_repo)
+    subprocess.run(
+        ["git", "-C", str(main_repo), "checkout", "-q", "-b", "feature/off-main"],
+        check=True,
+    )
+
+    src_dir = main_repo / "src" / "explore_persona_space"
+    src_dir.mkdir(parents=True)
+    (src_dir / "__init__.py").touch()
+    real_tw = Path(_REPO_SRC) / "explore_persona_space" / "task_workflow.py"
+    (src_dir / "task_workflow.py").write_text(real_tw.read_text())
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(main_repo / "src") + os.pathsep + env.get("PYTHONPATH", "")
+    snippet = textwrap.dedent(
+        """
+        from explore_persona_space.task_workflow import primary_checkout_root, repo_root
+        print('PRIMARY=' + str(primary_checkout_root()))
+        print('REPO=' + str(repo_root()))
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", snippet],
+        cwd=str(main_repo),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, (
+        f"resolvers failed off-main:\nstdout: {proc.stdout}\nstderr: {proc.stderr}"
+    )
+    resolved = _parse_resolved(proc.stdout)
+    # primary_checkout_root: the PRIMARY, regardless of branch.
+    assert Path(resolved["PRIMARY"]).resolve() == main_repo.resolve(), (
+        f"primary_checkout_root routed/deviated off-main: {resolved}"
+    )
+    # repo_root: routes to the managed main-pin worktree, as before.
+    managed = (main_repo / ".claude" / "worktrees" / "_task-main-pin").resolve()
+    assert Path(resolved["REPO"]).resolve() == managed, (
+        f"repo_root no longer routes off-main (behavior change!): {resolved}"
+    )
+
+
+def test_invalidate_cache_clears_primary_checkout_cache(tmp_path: Path) -> None:
+    """`invalidate_cache()` clears the `_primary_checkout_cached` LRU too —
+    the next `primary_checkout_root()` call re-fires git (#844 §4a)."""
+    main_repo = tmp_path / "repo"
+    _make_main_repo(main_repo)
+
+    src_dir = main_repo / "src" / "explore_persona_space"
+    src_dir.mkdir(parents=True)
+    (src_dir / "__init__.py").touch()
+    real_tw = Path(_REPO_SRC) / "explore_persona_space" / "task_workflow.py"
+    (src_dir / "task_workflow.py").write_text(real_tw.read_text())
+
+    snippet = textwrap.dedent(
+        """
+        import json
+        from explore_persona_space.task_workflow import (
+            primary_checkout_root, invalidate_cache, _primary_checkout_cached,
+        )
+        primary_checkout_root()
+        primary_checkout_root()
+        primary_checkout_root()
+        info1 = _primary_checkout_cached.cache_info()
+        invalidate_cache()
+        primary_checkout_root()
+        info2 = _primary_checkout_cached.cache_info()
+        print(json.dumps({
+            'hits1': info1.hits, 'misses1': info1.misses,
+            'hits2': info2.hits, 'misses2': info2.misses,
+        }))
+        """
+    )
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(main_repo / "src") + os.pathsep + env.get("PYTHONPATH", "")
+    proc = subprocess.run(
+        [sys.executable, "-c", snippet],
+        cwd=str(main_repo),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, f"cache probe failed: {proc.stderr}"
+    info = json.loads(proc.stdout.strip().splitlines()[-1])
+    assert info["misses1"] == 1 and info["hits1"] == 2, f"unexpected pre-invalidate: {info}"
+    # cache_clear() resets counters; one fresh miss = git re-fired once.
+    assert info["hits2"] == 0 and info["misses2"] == 1, (
+        f"invalidate_cache did not clear _primary_checkout_cached: {info}"
+    )
+
+
 # ─── tasks-dir CLI subcommand smoke ───────────────────────────────────────
 
 


### PR DESCRIPTION
Closes task #844 (workflow-fix). Spawned sessions inherited an unrelated sibling issue worktree as cwd because spawn_session.py resolved PROJECT_ROOT from Path(__file__). Fix: git-common-dir-based task_workflow.primary_checkout_root() + import-time PROJECT_ROOT rebase + spawn-time cwd assertion wired into all three spawn commands. Transition window: stale pre-fix worktree copies keep the old resolver until rebased/reaped.