### PR TITLE
issue-872: supersede contract for vectorization rewrites + fit_cell tombstone

### DIFF
--- a/.claude/rules/LESSONS.md
+++ b/.claude/rules/LESSONS.md
@@ -36,7 +36,7 @@ trigger. Rule text stays on-demand; never inline bodies here. Add/remove a
 - **research-project-structure** ([`.claude/rules/research-project-structure.md`](research-project-structure.md)) — fires when: you write result artifacts / the results index / the queue (one source of truth per layer).
 - **selection-symmetric-nulls** ([`.claude/rules/selection-symmetric-nulls.md`](selection-symmetric-nulls.md)) — fires when: a headline max/argmax/best-of/top-k over a free axis (layer/cell/k/seed/threshold) vs a null band (inherit selection per draw OR freeze axis held-out; #778).
 - **upload-policy** ([`.claude/rules/upload-policy.md`](upload-policy.md)) — fires when: you write training / Hub / sweep code (Hub-API verification gotcha, delete-after-eval persist, quota-403 recovery).
-- **vectorize-many-cell-fits** ([`.claude/rules/vectorize-many-cell-fits.md`](vectorize-many-cell-fits.md)) — fires when: a many-cell gradient-descent fit OR a non-trivial permutation/bootstrap/null-draw battery over a fixed pool (OVERHEAD-bound; vectorize before GPU; #722, #778, #811).
+- **vectorize-many-cell-fits** ([`.claude/rules/vectorize-many-cell-fits.md`](vectorize-many-cell-fits.md)) — fires when: many-cell GD fits OR perm/bootstrap/null-draw battery — OVERHEAD-bound; VECTORIZE first; rewrites fire the Supersede contract (#722, #778, #834).
 - **workflow-fix-on-bug** ([`.claude/rules/workflow-fix-on-bug.md`](workflow-fix-on-bug.md)) — fires when: any agent hits a bug from a gap in the workflow surface itself (emit a `workflow-fix-candidate`; see also the built-but-stranded lesson).
 - **agents-vs-skills** ([`.claude/rules/agents-vs-skills.md`](agents-vs-skills.md)) — fires when: you create / restructure anything under `.claude/` (decide agent vs skill).
 

--- a/.claude/rules/vectorize-many-cell-fits.md
+++ b/.claude/rules/vectorize-many-cell-fits.md
@@ -110,6 +110,75 @@ reduction, then memory-bounded chunked batched projection + correlation —
 fix item 3 realized in code). Import or mirror them for any new draw battery
 instead of writing a fresh serial loop.
 
+## Supersede contract — land on main + tombstone the serial twin (same round)
+
+A vectorization rewrite is not done when the batched code exists — it is done
+when the serial original can no longer be run silently. Three duties, all in
+the SAME round as the rewrite:
+
+1. **Land the batched helper on `main` in the same round** — shared `src/`
+   infra lands via the normal worktree merge (or a coordinated infra task),
+   never as a task artifact: #722's helper merge-FAILED
+   (`new-shared-src-infra-cannot-land-via-artifact`) and stranded on the
+   unmerged `vectorized-mlp-skill` branch while the session kept running the
+   OLD serial script at ~38h ETA. Confirm the REWRITE itself is on `main`,
+   not merely that the file path has history there. For a NEW helper file:
+   `git log --oneline origin/main -- <helper path>`. For an IN-PLACE rewrite
+   (same file / same function name — the #778/#834 `null_battery.py` shape)
+   a path-history check FALSE-PASSES on the old serial commit, so verify
+   content or ancestry instead:
+   `git show origin/main:<path> | grep '<batched-only symbol or token>'`, or
+   `git merge-base --is-ancestor <rewrite-sha> origin/main`. A follow-up
+   round MUST NOT schedule work that calls the superseded serial path while
+   the batched twin is off-`main` — that is exactly how #778's same-issue
+   follow-up re-ran the serial 1000-draw null battery. If a LIVE run is
+   already executing the serial path when the batched twin lands and its
+   remaining serial ETA exceeds kill+relaunch cost, kill and relaunch on the
+   batched path (sibling: `.claude/rules/crash-fix-rounds.md`
+   § kill-before-relaunch). (General lesson:
+   `.claude/rules/workflow-fix-on-bug.md` § "Built-but-stranded fixes don't
+   help"; this contract is its vectorization-specific mechanism.)
+2. **Tombstone the superseded serial entrypoint.** Default mechanism: the
+   serial function/script emits a loud `FutureWarning` at call time naming
+   the batched replacement (`FutureWarning`, NOT `DeprecationWarning` —
+   Python's default filter hides `DeprecationWarning` at IMPORTED-MODULE
+   call sites, showing it only when the calling code is `__main__`; the
+   script-imports-script reuse case this guards is exactly the hidden one),
+   and raises `RuntimeError` when `EPM_FORBID_SERIAL_FITS=1` (the
+   opt-in hard gate a follow-up round or an orchestrator can arm to make
+   silent serial re-runs impossible). Outright deletion is allowed ONLY when
+   no prior task's Repro/footer references the entrypoint (grep
+   `tasks/*/*/body.md` first) — old clean-results must stay reproducible. A
+   serial body retained ONLY inside an equivalence check / selftest (the
+   `issue658_fit_predictors.py` `_fit_mlp_loco_serial_reference` pattern —
+   containment is the criterion; the `*_serial_reference` rename is
+   recommended, not required) is already compliant — the tombstone duty
+   targets silently-importable twins.
+   With no tombstone, the next reuser picks the serial path as "the
+   available implementation" (#667 picked up #722's serial `fit_cell`).
+   Worked example: `scripts/issue722_fit_M.py::fit_cell` — the
+   `include_mlp=True` serial-outer-loop MLP arm carries the warn+raise guard
+   (tombstoned by #872); the `include_mlp=False` closed-form ridge arm is NOT
+   superseded and carries no warning.
+3. **Before starting an in-session vectorization rewrite, check for an
+   already-open task on the same file** —
+   `grep -l '<module or script name>' tasks/*/*/body.md` from repo root,
+   then discard only hits under `completed`/`archived`: ALL non-terminal
+   statuses count, including `followups_running`, `interpreting`,
+   `reviewing`, `awaiting_promotion`, `blocked`, and `on_hold` — the
+   #834-vs-#778-fix duplicate ran while the parent sat at
+   `followups_running`, which any narrower status list misses. Add
+   `task_workflow.is_open_workflow_fix_task(<target_file>, <fp>)` when a
+   candidate fingerprint exists. On a hit, ADOPT/coordinate instead of
+   duplicating: #834 and the #778 fix session independently vectorized the
+   SAME `null_battery.py` module in parallel, discovering the overlap only
+   after both had built.
+
+The contract binds ANY rewrite that supersedes a serial entrypoint — a shared
+helper, a `scripts/issue*_*.py` driver, or an in-module loop replaced by a
+batched twin — whether done by an implementer mid-experiment, a workflow-fix
+session, or an emergency in-session fix.
+
 ## Memory sizing: calibrate the chunk cap from a MEASURED peak
 
 Vectorizing trades many tiny fits for a few LARGE batched tensors, so the
@@ -154,7 +223,8 @@ during #722 at commit `19a5758fab`, landed on `main` via #740);
 incidents #722 (base-skill-over-mean, 19.5 CPU-h), #658 (`_fit_mlp_loco`),
 #778 (`perm_null_draws` serial null battery, ~15h projected across its draw
 loops → ~70× batched subset-sum GEMM), #811 r8 (`resolve_chunk_cap`
-live_factor 4→26 — measured-peak chunk-cap calibration).
+live_factor 4→26 — measured-peak chunk-cap calibration), #834 (parallel
+duplicate vectorization of null_battery.py — supersede contract).
 
 **Sibling rule:** `.claude/rules/selection-symmetric-nulls.md` — the same #778
 null battery is its origin incident; a permutation/bootstrap-battery plan

--- a/.claude/rules/workflow-fix-on-bug.md
+++ b/.claude/rules/workflow-fix-on-bug.md
@@ -696,3 +696,10 @@ branch while the #722 session ran the OLD serial CPU script with a ~38h ETA — 
 fast path existed but was stranded off main, so it changed nothing. CLAUDE.md
 already cites that helper as canonical; this lesson is the coordination half:
 "canonical helper named in a rule" ⇒ also ensure it is on main and called.
+
+For VECTORIZATION rewrites specifically, the mechanism half of this lesson is
+codified as the "Supersede contract" in
+`.claude/rules/vectorize-many-cell-fits.md` — batched helper on `main` in the
+same round, serial twin tombstoned (`FutureWarning` +
+`EPM_FORBID_SERIAL_FITS=1` raise), and an open-task check before starting a
+rewrite (#722, #778, #834).

--- a/scripts/issue722_fit_M.py
+++ b/scripts/issue722_fit_M.py
@@ -42,8 +42,10 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import sys
 import time
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -453,6 +455,21 @@ def fit_cell(
     the ``rho_M0_mlp`` / ``rho_Mplus_mlp`` / ``rho_M0_shuffle`` / ``nonlin_gap_*``
     keys (all MLP-derived); every ridge key is byte-for-byte the same code path.
     """
+    if include_mlp:
+        if os.environ.get("EPM_FORBID_SERIAL_FITS") == "1":
+            raise RuntimeError(
+                "fit_cell(include_mlp=True) is the SERIAL per-(behavior,layer) MLP path "
+                "superseded by src/explore_persona_space/analysis/vectorized_mlp_skill.py; "
+                "EPM_FORBID_SERIAL_FITS=1 is set (see "
+                ".claude/rules/vectorize-many-cell-fits.md § Supersede contract)."
+            )
+        warnings.warn(
+            "fit_cell(include_mlp=True) runs the SERIAL per-(behavior,layer) MLP fit; new "
+            "sweeps should use src/explore_persona_space/analysis/vectorized_mlp_skill.py "
+            "(batched, 50-100x). Serial call retained for #722/#667 reproduction only.",
+            FutureWarning,
+            stacklevel=2,
+        )
     stacks = loadact.stack_for_fit(cells)
     C0, Cplus = stacks["C0"], stacks["Cplus"]
     V0, Vplus = stacks["V0"], stacks["Vplus"]


### PR DESCRIPTION
Closes task #872 (workflow-fix, kind: infra). Supersede contract in vectorize-many-cell-fits.md + cross-ref + byte-budgeted LESSONS row + FutureWarning/EPM_FORBID_SERIAL_FITS tombstone on fit_cell's serial MLP arm. Code-review ensemble PASS (Claude PASS / Codex CONCERNS, no blockers); test-verdict PASS (1975/0 subset + targeted; 1 pre-existing main failure attributed to fd1d5512e8/#779).