### PR TITLE
task #876: parametrize DEVICE in issue658_fit_predictors (CLI > EPM_FIT_DEVICE > auto)

### DIFF
--- a/scripts/issue658_fit_predictors.py
+++ b/scripts/issue658_fit_predictors.py
@@ -38,7 +38,8 @@ are PRESERVED EXACTLY. Three things changed, none of them the reported numbers:
    solve in the N=50 ≪ D=3584 row space. Exactness is asserted at smoke time
    (``_assert_ridge_exactness``): the new closed-form LOCO ρ matches the old
    primal-refit LOCO ρ to ≤1e-6 on a synthetic case.
-2. **A3.5 MLP** runs on CUDA (``--device``, default cuda with a CPU fallback)
+2. **A3.5 MLP** runs on CUDA (``--device``; precedence: the flag >
+   ``EPM_FIT_DEVICE`` env var > auto = cuda when available, with a CPU fallback)
    and the per-(LOCO fold × output-head) MLPs are fit IN PARALLEL with
    ``torch.vmap`` over an ensemble of independent networks — the per-output-dim
    independence the old serial code had (one scalar-output MLP per output dim)
@@ -137,11 +138,6 @@ SMOKE_A34_FEAT_DIM = 128
 # tractable with the GPU-batched MLP below.
 A35_MLP_TARGET_DIM = 64
 
-# Compute device for the GPU-accelerated MLP/ridge ops. Resolved from --device
-# (default cuda when available, else cpu) in main() and read at call time by the
-# batched fitters. The DV is device-INVARIANT (the smoke asserts cpu==cuda ρ).
-DEVICE = "cpu"
-
 # A3.5 gap MLP ensemble-chunk size. The batched MLP fits E = gap_dim(64) × N(50)
 # = 3200 independent member-nets; building one AdamW + one vmap over ALL 3200 at
 # once peaks at ~69 GiB allocated + a ~22 GiB Adam-state tensor — OOM on an
@@ -177,6 +173,34 @@ def _resolve_device(requested: str) -> str:
         )
         return "cpu"
     return requested
+
+
+def _requested_device(cli_value: str | None) -> str:
+    """Device request with precedence: explicit CLI > EPM_FIT_DEVICE env > 'auto'."""
+    if cli_value is not None:
+        return cli_value
+    return os.environ.get("EPM_FIT_DEVICE", "auto")
+
+
+def _default_device() -> str:
+    """Module-scope default importers inherit: EPM_FIT_DEVICE if set, else auto
+    (cuda when available). Import-safe: torch.cuda.is_available() does not
+    initialize a CUDA context (set PYTORCH_NVML_BASED_CUDA_CHECK=1 on
+    fork-sensitive GPU hosts for the NVML-based check), and resolution logs
+    nothing unless EPM_FIT_DEVICE=cuda is set on a CUDA-less host (the
+    _resolve_device WARNING). A garbage EPM_FIT_DEVICE value passes through
+    verbatim and fails loud at the first torch.device() call — same failure
+    mode as --device with a garbage value (no silent default).
+    """
+    return _resolve_device(_requested_device(None))
+
+
+# Compute device for the GPU-accelerated MLP/ridge ops. The module-scope default
+# (what a bare import yields) honors the EPM_FIT_DEVICE env var, else resolves
+# 'auto' (cuda when available, else cpu); main() re-resolves with CLI precedence
+# (--device > EPM_FIT_DEVICE > auto). Read at call time by the batched fitters.
+# The DV is device-INVARIANT (the smoke asserts cpu==cuda ρ).
+DEVICE = _default_device()
 
 
 # ── E0 target extraction ──────────────────────────────────────────────────────
@@ -1908,9 +1932,11 @@ def main() -> int:
     parser.add_argument("--smoke", action="store_true")
     parser.add_argument(
         "--device",
-        default="auto",
-        help="compute device for the batched MLP/ridge ops: auto (default; cuda if "
-        "present else cpu) | cuda | cpu. The reported DV is device-invariant.",
+        default=None,
+        help="compute device for the batched MLP/ridge ops: auto | cuda | cpu "
+        "(default: the EPM_FIT_DEVICE env var if set, else auto = cuda if present "
+        "else cpu. Precedence: this flag > EPM_FIT_DEVICE > auto). The reported DV "
+        "is device-invariant.",
     )
     parser.add_argument(
         "--mlp-chunk-size",
@@ -1977,7 +2003,7 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    DEVICE = _resolve_device(args.device)
+    DEVICE = _resolve_device(_requested_device(args.device))
     logger.info("compute device: %s", DEVICE)
     if args.mlp_chunk_size is not None:
         MLP_CHUNK_SIZE = args.mlp_chunk_size

--- a/scripts/issue667_alllayer_analysis.py
+++ b/scripts/issue667_alllayer_analysis.py
@@ -110,7 +110,7 @@ def _override_store_prefix(prefix: str) -> None:
     ``issue722_load_activations.list_store_layout`` reads the module-global
     ``STORE_PREFIX`` at call time, so setting the module attribute redirects its
     directory-tree walk to ``prefix`` WITHOUT editing the reused module (the same
-    runtime-override pattern issue722_fit_M uses for fit658.DEVICE). A ``_Streamer``
+    runtime-override pattern issue667_save_maps uses for fit658.DEVICE). A ``_Streamer``
     still defaults its prefix at def-time, so ``load_cells`` is always called with
     an explicit ``streamer=_Streamer(prefix=prefix)`` below. The Δc loader takes
     ``prefix`` as an argument directly (it is inlined here, not from deltac), so
@@ -399,8 +399,8 @@ class _fast_pca_injected:
     all resolve the PCA basis through the module attribute ``fitM._pca_basis_v0``,
     so swapping that one attribute redirects EVERY PCA in the ridge path to the
     fast subspace WITHOUT editing the reused module (the same runtime-override
-    pattern the map-change loader uses for ``loadact.STORE_PREFIX`` /
-    ``fit658.DEVICE``). Restored in ``finally`` so the correctness gate's
+    pattern the map-change loader uses for ``loadact.STORE_PREFIX``). Restored
+    in ``finally`` so the correctness gate's
     per-cell ``fit_cell`` (which must run the ORIGINAL np.svd PCA to be an
     independent reference) is unaffected.
     """

--- a/scripts/issue667_alllayer_analysis.py
+++ b/scripts/issue667_alllayer_analysis.py
@@ -452,10 +452,8 @@ def _configure_map_change_compute(smoke_clamp: bool) -> None:
         fitM.N_REFIT_PAIRS = 8
         fitM.TARGET_DIM = 4
         logger.info("map-change: SMOKE clamps (mlp_epochs=20 refit_pairs=8 target_dim=4)")
-    # Resolve the compute device the reused ridge + MLP fitters read off
-    # fit658.DEVICE ("auto" -> cuda if available else cpu; issue722_fit_M.main sets
-    # this, which we bypass by calling fit_cell directly).
-    fitM.fit658.DEVICE = fitM.fit658._resolve_device("auto")
+    # fit658.DEVICE resolves at import (EPM_FIT_DEVICE env if set, else auto —
+    # cuda when available; #876), so no hand-patch is needed here.
     logger.info("map-change: fit device=%s", fitM.fit658.DEVICE)
     # Exactness gate (#658): a reduction-order regression fails at startup.
     fitM.fit658._assert_ridge_exactness()

--- a/scripts/issue667_marker_mapchange.py
+++ b/scripts/issue667_marker_mapchange.py
@@ -545,8 +545,8 @@ def main() -> int:
     N_REFIT_PAIRS = args.refit_pairs
     TARGET_DIM = args.target_dim
 
-    # Device for the reused ridge fitter (fit658.DEVICE), auto → cuda if available.
-    fit658.DEVICE = fit658._resolve_device("auto")
+    # fit658.DEVICE resolves at import (EPM_FIT_DEVICE env if set, else auto —
+    # cuda when available; #876), so no hand-patch is needed here.
     logger.info("[phase=map_change] device=%s", fit658.DEVICE)
     fit658._assert_ridge_exactness()  # #658 reduction-order gate
     logger.info("[phase=map_change] ridge exactness gate PASS")

--- a/scripts/issue667_save_maps.py
+++ b/scripts/issue667_save_maps.py
@@ -317,7 +317,9 @@ def load_map(behavior: str, layer: int, maps_root: str | Path | None = None) -> 
 
 def main() -> int:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
-    fit658.DEVICE = fit658._resolve_device("cpu")  # closed-form ridge — CPU by design
+    # Closed-form ridge — CPU by design (this explicit pin also deliberately
+    # overrides the module's EPM_FIT_DEVICE/auto import default; #876).
+    fit658.DEVICE = fit658._resolve_device("cpu")
     logger.info("[phase=save_maps] device=%s", fit658.DEVICE)
 
     ap = argparse.ArgumentParser(description="Issue #667 — save fitted M0/M⁺ ridge maps")

--- a/scripts/issue722_fit_M.py
+++ b/scripts/issue722_fit_M.py
@@ -673,11 +673,8 @@ def m0_at_cplus_ridge_full(C0, V0, Cplus, pca):
 def main() -> int:
     global N_REFIT_PAIRS, TARGET_DIM
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
-    # Resolve the compute device the ridge + MLP fitters read off fit658.DEVICE
-    # (default "cpu", flipped to cuda only inside fit658.main() — which #722 never
-    # calls; MF#6 / Claude Major#1). "auto" → cuda when available else cpu, so the
-    # GPU lane uses cuda and the CPU smoke still falls back to cpu.
-    fit658.DEVICE = fit658._resolve_device("auto")
+    # fit658.DEVICE resolves at import (EPM_FIT_DEVICE env if set, else auto —
+    # cuda when available; #876), so no hand-patch is needed here.
     logger.info("[phase=fit_M] device=%s", fit658.DEVICE)
     ap = argparse.ArgumentParser(description="Issue #722 fit M0 vs M⁺ + the four reads")
     ap.add_argument("--behaviors", nargs="+", default=list(HEADLINE_BEHAVIORS))

--- a/tests/test_issue658_invariants.py
+++ b/tests/test_issue658_invariants.py
@@ -25,6 +25,77 @@ sys.path.insert(0, str(PROJECT_ROOT / "src"))
 sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
 import issue658_common as common  # noqa: E402
+import pytest  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _pin_fit_device_cpu(monkeypatch):
+    """Pin fit658.DEVICE to cpu for every test in this file (#876, plan D5).
+
+    The module-scope default is env/auto-resolved, so on a GPU host the
+    DEVICE-reading fitters exercised here (fit_a32, fit_a34_a35,
+    _fit_a34_a35_one_recipe) would newly run on cuda; the contract tests stay
+    bit-deterministic on cpu (mirrors the exactness file's per-test pins,
+    scoped + auto-restored via monkeypatch).
+    """
+    import issue658_fit_predictors as fit
+
+    monkeypatch.setattr(fit, "DEVICE", "cpu")
+
+
+def test_device_request_precedence_cli_env_auto(monkeypatch):
+    """#876: explicit CLI beats EPM_FIT_DEVICE; env beats auto; unset -> auto."""
+    import issue658_fit_predictors as fit
+
+    monkeypatch.setenv("EPM_FIT_DEVICE", "cuda")
+    assert fit._requested_device("cpu") == "cpu"  # explicit CLI wins over env
+    assert fit._requested_device(None) == "cuda"  # env wins over auto
+    monkeypatch.delenv("EPM_FIT_DEVICE")
+    assert fit._requested_device(None) == "auto"  # unset -> auto
+
+
+def test_default_device_resolves_env_override(monkeypatch):
+    """#876: the module-scope default resolves EPM_FIT_DEVICE through _resolve_device."""
+    import issue658_fit_predictors as fit
+
+    monkeypatch.setenv("EPM_FIT_DEVICE", "cpu")
+    assert fit._default_device() == "cpu"
+    monkeypatch.delenv("EPM_FIT_DEVICE")
+    assert fit._default_device() == fit._resolve_device("auto")
+
+
+def test_main_device_wiring_default_none_and_requested_device():
+    """#876 amendment 1: pin the main() wiring itself.
+
+    A partial edit (argparse default flipped to None but the resolution line
+    not rewired) is silent — _resolve_device(None) -> auto — no crash, no
+    warning, no other test failure. Assert BOTH halves of the wiring.
+    """
+    import ast
+    import inspect
+
+    import issue658_fit_predictors as fit
+
+    src = inspect.getsource(fit.main)
+    assert "_resolve_device(_requested_device(args.device))" in src, (
+        "main() must resolve DEVICE via _resolve_device(_requested_device(args.device))"
+    )
+    device_defaults = [
+        kw.value
+        for node in ast.walk(ast.parse(src))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "add_argument"
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+        and node.args[0].value == "--device"
+        for kw in node.keywords
+        if kw.arg == "default"
+    ]
+    assert len(device_defaults) == 1, "expected exactly one --device add_argument with a default"
+    assert isinstance(device_defaults[0], ast.Constant) and device_defaults[0].value is None, (
+        "--device argparse default must be None (the env sentinel), not 'auto'"
+    )
 
 
 def test_per_column_sampling_honored_not_hardcoded():


### PR DESCRIPTION
Closes task #876.

## Summary
- Replace the module-scope `DEVICE = "cpu"` pin in `scripts/issue658_fit_predictors.py` with a resolved default (precedence: `--device` CLI > `EPM_FIT_DEVICE` env > auto/cuda-when-available), porting the issue-763 branch's validated env-override pattern to the source module.
- Delete the 3 downstream hand-patches that would clobber the env pin (issue722_fit_M, issue667_alllayer_analysis, issue667_marker_mapchange — device log lines kept); keep issue667_save_maps' deliberate cpu pin.
- New tests: autouse cpu-pin fixture, 2 precedence unit tests, and a main()-wiring AST test (closes the silent partial-edit false-green).

## Test plan
- [x] Exactness oracle (dual-PRESS <=1e-6, MLP batched-vs-serial <=1e-6, chunk invariance): 31 passed
- [x] tests/test_issue658_invariants.py: 39 passed (incl. 3 new tests)
- [x] Workflow-invariant subset (32 files): 1975 passed, 6 skipped
- [x] Import smoke matrix: cpu / cpu / WARNING+cpu
- [x] ruff clean on touched files
- (1 pre-existing failure in test_shared_vm_thread_caps.py via scripts/issue779_layer_sweep.py — untouched by this branch; filed as task #877)

🤖 Generated with [Claude Code](https://claude.com/claude-code)