### PR TITLE
workflow-fix #859: select_step9c_tests selects from the invoking checkout (branch-new tests included)

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -6573,21 +6573,41 @@ suite directly and posts an `epm:test-verdict` event with the result.
    subset). The full ~5800-test suite has no xdist parallelism and is
    harness-/earlyoom-killed in sparse worktrees (#665/#736), so do NOT run
    `pytest tests/` wholesale by default.
-   a. Compute the subset:
-      `uv run python scripts/select_step9c_tests.py --base main`
-      It prints the exact `uv run pytest <files> -v --tb=short` command and
-      any `untested touched file: <path>` WARN lines (stderr).
-   b. Run the printed command from the orchestrator's repo-root cwd (no `cd`
-      is needed). Record pass/fail + any WARN lines. Two anti-silent-pass
-      guards are LOAD-BEARING here — a `no tests ran` outcome (pytest exit 0
-      with zero collected tests) is a **FAIL, never a PASS**: it is the
-      signature of a failed `cd` that ran pytest in a directory with no tests
-      (incident: issue 745, SHA 91bed41e, 2026-06-30 — the gate reported PASS
-      on `no tests ran ... pytest exit: 0` and was silently skipped).
+   a. Compute the subset FROM THE ISSUE WORKTREE — a branch-new test file
+      exists ONLY there until the Step 10d merge, and the helper diffs the
+      INVOKING checkout (incident #851: run from the main repo root it saw an
+      empty diff and silently dropped the branch's own test files from the
+      gate; the helper now emits a stderr `NOTE — empty diff` in that shape —
+      on a worktree-based task whose branch HAS commits ahead of the base,
+      that NOTE means wrong cwd, re-run from the worktree; from a correct
+      worktree with no commits ahead of the base it also fires and is then
+      expected and benign):
       ```bash
-      # If any cd is added upstream, HARD-GUARD it — never let the gate run in
-      # the wrong dir on a silent cd failure:
-      #   cd "$REPO_ROOT" || { echo "FATAL: cd to repo root failed" >&2; exit 1; }
+      REPO_ROOT=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")
+      WT="$REPO_ROOT/.claude/worktrees/issue-<N>"   # same-issue follow-up rounds use
+                                                    # their own issue-<N>-<suffix> worktree
+      cd "$WT" || { echo "FATAL: cd to issue worktree failed" >&2; exit 1; }
+      uv run python scripts/select_step9c_tests.py --base main
+      ```
+      It prints the exact `uv run pytest <files> -v --tb=short` command, plus
+      stderr diagnostics: a one-line work-root + branch provenance breadcrumb
+      on every run, any `untested touched file: <path>` WARN lines, and the
+      empty-diff NOTE described above. (A code-change task with NO worktree
+      runs both from the repo root; the empty-diff NOTE is then expected and
+      benign.)
+   b. Run the printed command from the SAME worktree cwd (paths are
+      repo-relative). Record pass/fail + ALL selector stderr lines (the
+      provenance breadcrumb, the NOTE if any, and any WARN lines). Two
+      anti-silent-pass guards are LOAD-BEARING here — a `no tests ran` outcome
+      (pytest exit 0 with zero collected tests) is a **FAIL, never a PASS**:
+      it is the signature of a failed `cd` that ran pytest in a directory with
+      no tests (incident: issue 745, SHA 91bed41e, 2026-06-30 — the gate
+      reported PASS on `no tests ran ... pytest exit: 0` and was silently
+      skipped).
+      ```bash
+      # The cd to "$WT" in step (a) is REQUIRED — HARD-GUARD it (as above);
+      # never let the gate run in the wrong dir on a silent cd failure:
+      #   cd "$WT" || { echo "FATAL: cd to issue worktree failed" >&2; exit 1; }
       PYTEST_OUT=$(uv run pytest <files> -v --tb=short 2>&1); PYTEST_RC=$?
       echo "$PYTEST_OUT"
       # exit 0 + "no tests ran" (or "collected 0 items") is NOT a PASS:
@@ -6597,20 +6617,22 @@ suite directly and posts an `epm:test-verdict` event with the result.
       fi
       ```
    c. Scope override: if the plan-body frontmatter has `test_scope: full` OR a
-      `## Test scope` H2 names `full`, run the FULL suite instead — but as
-      `timeout 60m uv run pytest tests/ -q -x --maxfail=1`; on timeout/kill,
-      capture `tail -50` of the run log so the stall surfaces actionable
-      evidence (this is the #665/#736 regression — keep it visible, never a
-      silent kill). Default scope is `touched`.
+      `## Test scope` H2 names `full`, run the FULL suite instead — from the
+      SAME issue-worktree cwd (the branch's own test files exist only there) —
+      but as `timeout 60m uv run pytest tests/ -q -x --maxfail=1`; on
+      timeout/kill, capture `tail -50` of the run log so the stall surfaces
+      actionable evidence (this is the #665/#736 regression — keep it visible,
+      never a silent kill). Default scope is `touched`.
 2. Lint: `uv run ruff check . && uv run ruff format --check .`
 3. Integration tests (conditional, if diff touches train/eval/orchestrate)
 4. Coverage gap report (flags, does not auto-generate)
 
 The `epm:test-verdict v1` marker note records: scope used (`touched`/`full`),
-the files run, pass/fail counts, and any untested-touched-file WARNs (so the
-orchestrator surfaces coverage gaps — never silently skipped). A
-zero-collected / `no tests ran` outcome is recorded as FAIL (never PASS on
-exit 0) per step 1b's guard.
+the files run, pass/fail counts, and ALL selector stderr diagnostics — the
+work-root + branch provenance breadcrumb, any `NOTE — empty diff` line, and
+any untested-touched-file WARNs (so the orchestrator surfaces wrong-cwd runs
+and coverage gaps — never silently skipped). A zero-collected / `no tests ran`
+outcome is recorded as FAIL (never PASS on exit 0) per step 1b's guard.
 
 Post `epm:test-verdict v1`. PASS -> Step 10. FAIL (count < 3) -> stay
 in `reviewing`, re-spawn implementer. FAIL (count >= 3) -> run

--- a/scripts/select_step9c_tests.py
+++ b/scripts/select_step9c_tests.py
@@ -32,9 +32,22 @@ few extra invariant-adjacent tests is the safe failure direction. There is no
 ``else: tighten the glob`` arm: a missed mapping surfaces as an
 ``untested_touched`` WARN, never a silently-dropped file.
 
-Degenerate empty-diff (e.g. run on ``main`` with no commits ahead): the
-selection falls back to the WORKFLOW_INVARIANT set only (selection always
-includes ``always``), so the gate never runs zero tests.
+Root resolution: with no ``--repo-root``, everything (the ``git diff`` cwd,
+touched-test existence checks, stem-glob mapping, invariant presence) resolves
+against the INVOKING checkout's git toplevel — the issue-worktree root when run
+from a worktree (where the branch diff AND its branch-new ``tests/`` files
+live), the main repo root when run there. ``--repo-root`` is the checkout-root
+override. At Step 9c, run from the issue worktree (incident #851: resolving the
+MAIN root made ``git diff main...HEAD`` empty by construction and silently
+dropped the branch's own tests from the gate).
+
+Degenerate empty-diff (e.g. run at a checkout with no commits ahead of
+``--base``): the selection falls back to the WORKFLOW_INVARIANT set only, so
+the gate never runs zero tests — and a loud ``NOTE — empty diff`` line is
+printed to stderr. On a worktree-based task whose branch HAS commits ahead of
+the base, that NOTE means the helper ran from the wrong cwd (re-run from the
+issue worktree); from a checkout genuinely at the base it is expected and
+benign.
 
 Usage::
 
@@ -42,10 +55,15 @@ Usage::
 
 Default output: the exact pytest invocation
 ``uv run pytest <files...> -v --tb=short`` on stdout, then any
-``untested touched file: <path>`` WARN lines on stderr. ``--json`` emits
+``untested touched file: <path>`` WARN lines on stderr. Every run also prints
+a one-line provenance breadcrumb to stderr (the resolved work root + current
+branch) so the Step 9c marker records which checkout the subset was selected
+against. ``--json`` emits
 ``{"tests": [...], "untested_touched": [...], "base": "...",
 "missing_invariants": [...]}``. Exit 0 on success (even with WARN lines);
-exit 1 only if the underlying ``git diff`` fails irrecoverably.
+exit 1 if an underlying ``git`` call fails irrecoverably (work-root resolution
+or the diff) or if the selection comes back EMPTY (the zero-test-gate
+refusal).
 """
 
 from __future__ import annotations
@@ -146,21 +164,23 @@ def _matches_any(path: str, globs: tuple[str, ...]) -> bool:
 
 def compute_touched(
     base: str,
-    repo_root: Path,
+    work_root: Path,
     _runner: Callable[[list[str]], str] | None = None,
 ) -> list[str]:
     """Return the repo-relative paths the current branch changed vs *base*.
 
     Uses the three-dot ``git diff --name-only <base>...HEAD`` form: it diffs the
     merge-base of *base* and HEAD against HEAD — exactly the branch's own
-    additions/modifications, not changes on *base* that HEAD lacks. ``_runner``
-    is injectable for tests (it receives the argv list and returns stdout).
+    additions/modifications, not changes on *base* that HEAD lacks. The diff
+    runs with *work_root* as cwd, so HEAD is the invoking checkout's branch
+    (the issue branch from a worktree — #851). ``_runner`` is injectable for
+    tests (it receives the argv list and returns stdout).
     """
 
     def _default_runner(argv: list[str]) -> str:
         proc = subprocess.run(
             argv,
-            cwd=str(repo_root),
+            cwd=str(work_root),
             capture_output=True,
             text=True,
             check=True,
@@ -172,10 +192,13 @@ def compute_touched(
     return [line.strip() for line in out.splitlines() if line.strip()]
 
 
-def select_tests(touched: list[str], repo_root: Path) -> tuple[list[str], list[str]]:
+def select_tests(touched: list[str], work_root: Path) -> tuple[list[str], list[str]]:
     """Map *touched* files to their covering tests + the workflow-invariant set.
 
-    Returns ``(tests, untested_touched)``:
+    All existence checks + the stem-glob mapping resolve against *work_root*
+    (the invoking checkout), so a branch-new touched test is admitted and a
+    deleted-on-branch test is correctly dropped (it does not exist at the
+    worktree's HEAD either). Returns ``(tests, untested_touched)``:
       * ``tests`` — sorted union of mapped per-file tests and the present-on-disk
         subset of :data:`WORKFLOW_INVARIANT` (deterministic order; required so two
         invocations on the same git state return an identical list).
@@ -192,7 +215,7 @@ def select_tests(touched: list[str], repo_root: Path) -> tuple[list[str], list[s
         p = Path(f)
         # A touched test file includes itself.
         if f.startswith("tests/") and p.name.startswith("test_") and p.suffix == ".py":
-            if (repo_root / f).exists():
+            if (work_root / f).exists():
                 selected.add(f)
             continue
         # Data / config / doc files: not code, no test mapping.
@@ -202,11 +225,11 @@ def select_tests(touched: list[str], repo_root: Path) -> tuple[list[str], list[s
         if p.suffix == ".py":
             stem = p.stem
             matched = False
-            exact = repo_root / "tests" / f"test_{stem}.py"
+            exact = work_root / "tests" / f"test_{stem}.py"
             if exact.exists():
                 selected.add(f"tests/test_{stem}.py")
                 matched = True
-            for hit in sorted((repo_root / "tests").glob(f"test_*{stem}*.py")):
+            for hit in sorted((work_root / "tests").glob(f"test_*{stem}*.py")):
                 selected.add(f"tests/{hit.name}")
                 matched = True
             if not matched:
@@ -214,59 +237,127 @@ def select_tests(touched: list[str], repo_root: Path) -> tuple[list[str], list[s
         # Any other extension (no recognized mapping): ignore silently — it is
         # neither code with a test nor a workflow-invariant surface.
 
-    present_invariant = [t for t in WORKFLOW_INVARIANT if (repo_root / t).exists()]
+    present_invariant = [t for t in WORKFLOW_INVARIANT if (work_root / t).exists()]
     final = sorted(selected | set(present_invariant))
     return final, untested
 
 
-def missing_invariants(repo_root: Path) -> list[str]:
+def missing_invariants(work_root: Path) -> list[str]:
     """Return WORKFLOW_INVARIANT entries that are NOT present on disk (drift)."""
-    return [t for t in WORKFLOW_INVARIANT if not (repo_root / t).exists()]
+    return [t for t in WORKFLOW_INVARIANT if not (work_root / t).exists()]
 
 
-def _resolve_repo_root(arg: str | None) -> Path:
+def _resolve_work_root(arg: str | None) -> Path:
+    """Resolve the checkout root everything else (diff cwd, existence checks) uses."""
     if arg:
         return Path(arg).resolve()
-    # #506-safe: from a worktree cwd, `git rev-parse --show-toplevel` returns the
-    # WORKTREE root; --git-common-dir resolves to <main>/.git, so dirname is the
-    # main repo root (where tests/ paths must resolve). See SKILL.md Steps 4a/10d.
+    # The INVOKING checkout's toplevel: the issue-worktree root when run from
+    # a worktree (where the branch diff AND its branch-new tests/ files
+    # live), the main repo root when run there. --show-toplevel is CORRECT
+    # here (the SKILL.md Step 5a precedent — we WANT the invoking checkout);
+    # the #506 path-doubling bug applies only to CONSTRUCTING
+    # <root>/.claude/worktrees/issue-<N> by appending to a root (Steps
+    # 4a/10d), which this helper never does. Incident #851: resolving the
+    # MAIN root here made `git diff main...HEAD` empty by construction
+    # (HEAD==main) and hid branch-new test files from the existence checks.
     out = subprocess.run(
-        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        ["git", "rev-parse", "--path-format=absolute", "--show-toplevel"],
         capture_output=True,
         text=True,
         check=True,
     )
-    return Path(out.stdout.strip()).parent.resolve()
+    return Path(out.stdout.strip()).resolve()
+
+
+def _current_branch(work_root: Path) -> str:
+    """Best-effort current-branch read for the provenance breadcrumb.
+
+    Returns ``"unknown"`` (explicitly surfaced in the breadcrumb, never a
+    swallowed error) when *work_root* is not a git checkout — e.g. a
+    ``--repo-root`` override pointing at a bare fixture tree. The breadcrumb
+    is diagnostic only; the diff itself still fails loud in
+    :func:`compute_touched`.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=str(work_root),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return "unknown"
+    return out.stdout.strip() or "unknown"
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     parser.add_argument("--base", default="main", help="diff base (default: main)")
-    parser.add_argument("--repo-root", default=None, help="repo root (default: git toplevel)")
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help=(
+            "checkout-root override (default: the invoking checkout's git toplevel — "
+            "run from the issue worktree at Step 9c)"
+        ),
+    )
     parser.add_argument("--json", action="store_true", help="emit a JSON object")
     args = parser.parse_args(argv)
 
-    repo_root = _resolve_repo_root(args.repo_root)
+    try:
+        work_root = _resolve_work_root(args.repo_root)
+    except subprocess.CalledProcessError as exc:
+        # Fail loud with ONE readable line (not a traceback): no git toplevel
+        # means the helper was invoked outside any git checkout, so no work
+        # root can be resolved.
+        detail = (exc.stderr or "").strip() or str(exc)
+        print(
+            f"select_step9c_tests: cannot resolve the work root ({detail}). "
+            "Run from a git checkout or pass --repo-root.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Provenance breadcrumb on EVERY run: records which checkout + branch the
+    # subset was selected against, so a wrong-worktree invocation is visible in
+    # the Step 9c marker instead of silent (#851).
+    print(
+        f"select_step9c_tests: work root {work_root} (branch: {_current_branch(work_root)})",
+        file=sys.stderr,
+    )
 
     try:
-        touched = compute_touched(args.base, repo_root)
+        touched = compute_touched(args.base, work_root)
     except subprocess.CalledProcessError as exc:
         # Fail loud — never silently fall back to zero tests on a git error.
         print(f"select_step9c_tests: git diff failed: {exc}", file=sys.stderr)
         return 1
 
-    tests, untested = select_tests(touched, repo_root)
-    missing = missing_invariants(repo_root)
+    if not touched:
+        # Loud, exit-0 NOTE (the documented degenerate fallback stays legitimate
+        # when the checkout genuinely has no commits ahead of the base): the
+        # #851 failure was a SILENT invariant-only fallback from the wrong cwd.
+        print(
+            f"select_step9c_tests: NOTE — empty diff vs '{args.base}' in {work_root}; "
+            "falling back to the workflow-invariant set only. If this task's changes "
+            "live in an issue worktree, re-run from that worktree (Step 9c contract).",
+            file=sys.stderr,
+        )
+
+    tests, untested = select_tests(touched, work_root)
+    missing = missing_invariants(work_root)
 
     # Fail loud on an EMPTY selection (defense-in-depth beside the Step 9c shell
     # guard against a silent test-gate pass). WORKFLOW_INVARIANT has 32 always-on
-    # entries, so an empty list can only mean the repo_root resolved wrong (the
-    # #506 path-doubling bug) or the invariant files all vanished — either way the
-    # gate would run zero tests. Never let that surface as an exit-0 "no tests ran".
+    # entries, so an empty list can only mean the work root resolved wrong (e.g.
+    # invoked from a directory outside the repo, or a bad --repo-root override)
+    # or the invariant files all vanished — either way the gate would run zero
+    # tests. Never let that surface as an exit-0 "no tests ran".
     if not tests:
         print(
-            "select_step9c_tests: EMPTY test selection — repo_root likely resolved "
-            f"wrong ({repo_root}) or WORKFLOW_INVARIANT files are missing "
+            "select_step9c_tests: EMPTY test selection — work root likely resolved "
+            f"wrong ({work_root}) or WORKFLOW_INVARIANT files are missing "
             f"(missing={missing}). Refusing to emit a zero-test gate command.",
             file=sys.stderr,
         )

--- a/tests/test_select_step9c_tests.py
+++ b/tests/test_select_step9c_tests.py
@@ -1,19 +1,24 @@
-"""Unit tests for ``scripts/select_step9c_tests.py`` (#754).
+"""Unit tests for ``scripts/select_step9c_tests.py`` (#754, #851).
 
 The helper maps the files this branch touched to their covering pytest files
 plus a pinned workflow-invariant literal set, for the ``/issue`` Step 9c
-test-verdict gate. These tests inject a fake ``git diff`` runner and a
+test-verdict gate. Most cases inject a fake ``git diff`` runner and a
 ``tmp_path`` ``tests/`` tree so no real git / real branch state is needed.
 
-The one exception is the pinned-list test (case 6), which asserts the literal
+Two exceptions: the pinned-list test (case 6) asserts the literal
 ``WORKFLOW_INVARIANT`` matches the LIVE repo ``tests/`` tree so an added/removed
-invariant test forces a deliberate edit of the literal.
+invariant test forces a deliberate edit of the literal; and the #851 regression
+tests (cases 13-14) build a real throwaway git repo + worktree to pin the
+work-root resolution end to end (branch-new test selected, deleted-on-branch
+test dropped, empty-diff NOTE at the base checkout).
 """
 
 from __future__ import annotations
 
 import importlib.util
 import json
+import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -174,7 +179,7 @@ def test_issue_736_motivating_case(tmp_path: Path):
 # --- Case 10: --json output shape -------------------------------------------
 def test_json_output_shape(tmp_path: Path, monkeypatch, capsys):
     repo = _make_tree(tmp_path, ["test_widget.py"])
-    monkeypatch.setattr(sel, "_resolve_repo_root", lambda _arg: repo)
+    monkeypatch.setattr(sel, "_resolve_work_root", lambda _arg: repo)
     monkeypatch.setattr(sel, "compute_touched", lambda *_a, **_k: ["scripts/widget.py"])
     rc = sel.main(["--json", "--repo-root", str(repo)])
     assert rc == 0
@@ -185,33 +190,36 @@ def test_json_output_shape(tmp_path: Path, monkeypatch, capsys):
     assert out["missing_invariants"] == []  # all invariants present in the fixture tree
 
 
-# --- Case 11: _resolve_repo_root uses --git-common-dir + dirnames (#785) ------
-def test_resolve_repo_root_uses_git_common_dir_and_dirnames(tmp_path: Path, monkeypatch):
-    """No-arg path calls `git rev-parse --path-format=absolute --git-common-dir`
-    and dirnames the output — the #506-safe recipe, NOT `--show-toplevel`
-    (which from a worktree cwd doubles the path). The `--repo-root` override
-    still bypasses git entirely.
+# --- Case 11: _resolve_work_root uses --show-toplevel (#851) ------------------
+def test_resolve_work_root_uses_show_toplevel(tmp_path: Path, monkeypatch):
+    """No-arg path calls `git rev-parse --path-format=absolute --show-toplevel`
+    and returns the output resolved (NO dirname step) — the INVOKING checkout's
+    root: the issue-worktree root from a worktree (where the branch diff and
+    its branch-new tests/ files live), the main repo root when run there.
+    Incident #851: the prior --git-common-dir+dirname recipe pinned the MAIN
+    root, making `git diff main...HEAD` empty by construction. The
+    `--repo-root` override still bypasses git entirely.
     """
     seen: dict[str, list[str]] = {}
-    git_dir = tmp_path / "repo" / ".git"
+    toplevel = tmp_path / "wt"
 
     class _Result:
-        stdout = str(git_dir) + "\n"
+        stdout = str(toplevel) + "\n"
 
     def _fake_run(argv, **_kw):
         seen["argv"] = argv
         return _Result()
 
     monkeypatch.setattr(sel.subprocess, "run", _fake_run)
-    got = sel._resolve_repo_root(None)
-    # (i) locks the recipe against a regression back to --show-toplevel:
-    assert seen["argv"] == ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"]
-    # (ii) return is the dirname of the git output (.../repo/.git -> .../repo):
-    assert got == (tmp_path / "repo").resolve()
+    got = sel._resolve_work_root(None)
+    # (i) locks the recipe to the invoking checkout's toplevel:
+    assert seen["argv"] == ["git", "rev-parse", "--path-format=absolute", "--show-toplevel"]
+    # (ii) return is the toplevel itself, resolved (no dirname step):
+    assert got == toplevel.resolve()
     # (iii) the override branch never touches git — clear the recorded argv and
     #       confirm the arg path is returned resolved, without a git call:
     seen.clear()
-    assert sel._resolve_repo_root(str(tmp_path)) == tmp_path.resolve()
+    assert sel._resolve_work_root(str(tmp_path)) == tmp_path.resolve()
     assert "argv" not in seen  # git was not invoked on the override path
 
 
@@ -223,7 +231,7 @@ def test_empty_selection_fails_loud(tmp_path: Path, monkeypatch, capsys):
     closes at the shell level).
     """
     repo = _make_tree(tmp_path, [])
-    monkeypatch.setattr(sel, "_resolve_repo_root", lambda _arg: repo)
+    monkeypatch.setattr(sel, "_resolve_work_root", lambda _arg: repo)
     monkeypatch.setattr(sel, "compute_touched", lambda *_a, **_k: [])
     # Force the degenerate empty selection the invariant set normally prevents.
     monkeypatch.setattr(sel, "select_tests", lambda *_a, **_k: ([], []))
@@ -231,3 +239,118 @@ def test_empty_selection_fails_loud(tmp_path: Path, monkeypatch, capsys):
     assert rc == 1
     err = capsys.readouterr().err
     assert "EMPTY test selection" in err
+
+
+# --- Real-git fixture for the #851 regression cases (13-14) -------------------
+def _git(cwd: Path, *args: str) -> None:
+    """Run git hermetically: no inherited global/system config (so no gpg
+    signing, hooksPath, or identity leaks from the host), per-repo identity set
+    explicitly by the caller."""
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    subprocess.run(
+        ["git", *args], cwd=str(cwd), env=env, check=True, capture_output=True, text=True
+    )
+
+
+def _make_git_repo_with_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    """Real-git #851 fixture. Returns ``(repo, wt)``:
+
+    * ``repo`` — a git repo on branch ``main`` holding every invariant stub plus
+      a committed ``tests/test_gone_on_branch.py``.
+    * ``wt`` — a worktree on branch ``issue-x`` whose commit ADDS
+      ``tests/test_foo.py`` + ``scripts/foo.py`` and DELETES
+      ``tests/test_gone_on_branch.py``.
+    """
+    repo = _make_tree(tmp_path, [])
+    (repo / "tests" / "test_gone_on_branch.py").write_text("# committed on main\n")
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "main baseline")
+    wt = tmp_path / "wt"
+    _git(repo, "worktree", "add", "-b", "issue-x", str(wt))
+    (wt / "tests" / "test_foo.py").write_text("def test_ok():\n    assert True\n")
+    (wt / "scripts").mkdir()
+    (wt / "scripts" / "foo.py").write_text("X = 1\n")
+    _git(wt, "rm", "-q", "tests/test_gone_on_branch.py")
+    _git(wt, "add", "tests/test_foo.py", "scripts/foo.py")
+    _git(wt, "commit", "-m", "branch adds foo + deletes gone_on_branch")
+    return repo, wt
+
+
+# --- Case 13: the #851 regression — real-git worktree, end to end -------------
+def test_branch_new_test_selected_from_worktree_real_git(tmp_path: Path, monkeypatch, capsys):
+    """From an issue worktree, `main([])` must (a) include the branch-new
+    touched test in the printed command (it exists ONLY in the worktree —
+    the exact file #851 silently dropped), (b) map the branch-new code file to
+    that test via the work-root glob (no untested-WARN), (c) drop the
+    deleted-on-branch test (no pytest collection error), and (d) print the
+    work-root + branch provenance breadcrumb.
+    """
+    repo, wt = _make_git_repo_with_worktree(tmp_path)
+    # Precondition: the branch-new test exists ONLY in the worktree.
+    assert not (repo / "tests" / "test_foo.py").exists()
+    assert (wt / "tests" / "test_foo.py").exists()
+    monkeypatch.chdir(wt)
+    rc = sel.main([])
+    assert rc == 0
+    captured = capsys.readouterr()
+    # (a) branch-new touched test selected (the #851 silent miss):
+    assert "tests/test_foo.py" in captured.out
+    # (c) deleted-on-branch test NOT in the printed command (the existence gate
+    #     at the WORK root drops it — it exists at neither worktree HEAD nor
+    #     the pytest cwd):
+    assert "test_gone_on_branch.py" not in captured.out
+    # (b) foo.py mapped to its branch-new test — no WARN:
+    assert "untested touched file" not in captured.err
+    # A real, non-empty diff: the empty-diff NOTE must NOT fire:
+    assert "NOTE — empty diff" not in captured.err
+    # (d) provenance breadcrumb: resolved work root + branch, on stderr:
+    assert f"work root {wt.resolve()}" in captured.err
+    assert "(branch: issue-x)" in captured.err
+
+
+# --- Case 14: empty diff at the base checkout -> loud NOTE, invariant-only ----
+def test_empty_diff_note_at_main_checkout_real_git(tmp_path: Path, monkeypatch, capsys):
+    """At the main checkout (HEAD==main -> `main...HEAD` empty by construction)
+    the fallback stays exit-0 invariant-only (case 8's documented degenerate
+    contract) but is no longer SILENT: a `NOTE — empty diff` stderr line names
+    the work root, and the breadcrumb records branch `main` — so a wrong-cwd
+    run of a worktree-based task is visible in the Step 9c marker.
+    """
+    repo, _wt = _make_git_repo_with_worktree(tmp_path)
+    monkeypatch.chdir(repo)
+    rc = sel.main([])
+    assert rc == 0
+    captured = capsys.readouterr()
+    # The #851 shape is no longer silent:
+    assert "NOTE — empty diff" in captured.err
+    # Provenance breadcrumb names the main checkout + branch:
+    assert f"work root {repo.resolve()}" in captured.err
+    assert "(branch: main)" in captured.err
+    # Printed command is exactly the invariant-only set (sorted):
+    line = captured.out.strip().splitlines()[-1]
+    assert line.startswith("uv run pytest ") and line.endswith(" -v --tb=short")
+    files = line.removeprefix("uv run pytest ").removesuffix(" -v --tb=short").split()
+    assert files == sorted(sel.WORKFLOW_INVARIANT)
+
+
+# --- Case 15: untested-WARN reaches stderr through main() ---------------------
+def test_untested_warn_through_main(tmp_path: Path, monkeypatch, capsys):
+    """Case 5 pins the `select_tests` return value; this pins the stderr
+    emission path main() drives (the WARN line the Step 9c marker records)."""
+    repo = _make_tree(tmp_path, [])  # no test_orphan*.py anywhere
+    monkeypatch.setattr(sel, "_resolve_work_root", lambda _arg: repo)
+    monkeypatch.setattr(sel, "compute_touched", lambda *_a, **_k: ["scripts/orphan.py"])
+    rc = sel.main([])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "untested touched file: scripts/orphan.py" in captured.err
+    # The breadcrumb fires on every run; the fixture tree is not a git
+    # checkout, so the fail-soft branch read surfaces "unknown" (never a crash):
+    assert "(branch: unknown)" in captured.err


### PR DESCRIPTION
Closes task #859.

Step 9c selector fix: resolve the invoking checkout's toplevel (--show-toplevel) for the git diff + all existence checks, so branch-new tests/*.py join the printed pytest command; loud stderr breadcrumb + empty-diff NOTE; SKILL.md Step 9c worktree-cwd contract. 3 new real-git regression tests.