### PR TITLE
issue-864: namespace-informative zombie-GPU override (#813 false positive)

### DIFF
--- a/.claude/skills/issue/failure_patterns.md
+++ b/.claude/skills/issue/failure_patterns.md
@@ -100,7 +100,16 @@ stall window (`max(EPM_ZOMBIE_VETO_FRESH_SEC=60, stall_sec)`) for 2
 consecutive ticks — on host-PID-namespace containers nvidia-smi reports
 host PIDs unresolvable in the container's `/proc`, so the bare signature
 is false-positive on healthy runs (#816/#778); a fresh-log zombie flag is
-a namespace artifact, not a hang. The emit surface
+a namespace artifact, not a hang — and (since #864) only when the
+dead-in-/proc signature is namespace-informative: zero-resolvable compute
+PIDs with live in-container `/dev/nvidia-uvm` holders (exact fd-target
+match) are a PID-namespace artifact and are vetoed regardless of log
+staleness (#813: a healthy ~29-min CPU-bound quiet stretch outlived the
+#826 stale-log veto). The #864 veto ships default-OFF
+(`EPM_ZOMBIE_NAMESPACE_VETO=1` arms it; read at poller import) per its
+pre-merge live-pod gate — a cuInit'd parent/coordinator holding exact uvm
+while absent from compute-apps would suppress a genuine total collapse if
+armed unverified. The emit surface
 is `scripts/poll_pipeline.py` + `scripts/backend_poll.py`; the
 known-reason set is `STALL_REASON_INFRA` in `failure_classifier.py`; the
 recovery brief + recipe references are SKILL.md Step 7 § "Zombie-GPU

--- a/scripts/poll_pipeline.py
+++ b/scripts/poll_pipeline.py
@@ -98,6 +98,31 @@ veto would make the true positive unreachable. Fail-safe: nvidia-smi
 missing / erroring emits an empty list (never a false zombie); the
 override never touches a `done` / `gate` / `dead` verdict.
 
+Namespace-informativeness gate (#864): the #826 assumption "hung <=>
+stale logs" lapses when a HEALTHY workload legitimately silences its
+logs longer than the stall window (#813: a ~29-min CPU-bound NPZ
+compression stretch on a host-PID-namespace pod false-fired the
+override twice, 2026-07-02). The probe therefore also counts
+``GPU_PIDS_TOTAL`` / ``GPU_PIDS_RESOLVABLE`` over all compute-apps PIDs
+and, only when a zombie candidate exists, ``NVIDIA_UVM_LIVE_HOLDERS`` —
+live container processes holding a fd whose symlink target is EXACTLY
+``/dev/nvidia-uvm`` (a live CUDA compute context; ``/dev/nvidia-uvm-
+tools`` / ``nvidiactl`` / ``nvidia[0-9]`` never count). When
+``total > 0 AND resolvable == 0 AND uvm_holders > 0`` the
+dead-in-/proc signature is a PID-namespace artifact — the flagged PIDs
+ARE live workers seen under host ids — and the override is vetoed
+regardless of log staleness (streak reset, like the fresh-log veto).
+Every other combination (any count unknown, ``resolvable > 0``,
+``uvm == 0``) falls through to the #826 logic UNCHANGED, so the genuine
+#664 total collapse (zero live uvm holders) still fires and every
+degraded-probe read fails toward current behavior. Gated by
+``ZOMBIE_NAMESPACE_VETO_ENABLED`` (env ``EPM_ZOMBIE_NAMESPACE_VETO``,
+read at module import — restart a live poller for an ops flip); ships
+default-OFF per the #864 pre-merge live-pod gate, which found a
+cuInit'd parent/coordinator (``issue813_dispatch.py``) holding exact
+uvm while absent from compute-apps — a holder class that would veto a
+TOTAL collapse (matched pods included) if the veto were armed.
+
 Staleness folds in cell-log mtimes (incident #405 smoke-first): when the
 dispatcher is blocked in ``proc.wait()`` on a sequential smoke cell, the
 main sweep log goes silent for ~15-18 min while the smoke cell actively
@@ -538,6 +563,21 @@ ZOMBIE_GPU_MEM_MIN_MIB = int(os.environ.get("EPM_ZOMBIE_GPU_MEM_MIN_MIB", "1024"
 # run) favors vetoing. The floor only binds when --stall-sec is set
 # pathologically low (< 60s fast-smoke configs).
 ZOMBIE_VETO_FRESH_SEC = int(os.environ.get("EPM_ZOMBIE_VETO_FRESH_SEC", "60"))
+
+# #864: kill-switch for the namespace-informativeness veto on the zombie-GPU
+# override. "0" disables the veto entirely (pure #826 behavior) — an ops
+# escape hatch if the UVM-holder correspondence ever masks a true positive in
+# the field. NOTE: read at module import — a live poller needs a restart for
+# an ops flip to take effect. DEFAULT "0" (veto inert-but-ready) per the #864
+# §7 pre-merge live-pod gate (2026-07-02, disposition 2): the negative-
+# direction check on pod-813 found a cuInit'd-but-allocation-free
+# parent/coordinator (issue813_dispatch.py) holding an EXACT /dev/nvidia-uvm
+# fd while ABSENT from compute-apps (5 exact-uvm holders vs 4 compute apps) —
+# a holder class that would veto a genuine TOTAL collapse (TP suppression)
+# if the veto were armed. Flipping to "1" after a clean both-directions
+# re-check is a one-literal follow-up; the probe counts + gate + tests land
+# either way.
+ZOMBIE_NAMESPACE_VETO_ENABLED = os.environ.get("EPM_ZOMBIE_NAMESPACE_VETO", "0") != "0"
 
 
 def _try_refresh_pods_conf_from_api(pod: str) -> bool:
@@ -1084,26 +1124,63 @@ def _ssh_probe(
     # liveness signal, not a heuristic. Empty (no zombies) is the healthy
     # case. Fail-safe: nvidia-smi missing / erroring emits an empty list
     # (never a false zombie), same posture as the util probe.
+    #
+    # Namespace-informativeness counts (#864): the same loop also counts
+    # GPU_PIDS_TOTAL (every valid compute-apps PID) and GPU_PIDS_RESOLVABLE
+    # (those with a `/proc/<pid>` dir) so the VM-side gate can tell whether
+    # the dead-in-/proc signal is even meaningful on this pod — on a
+    # host-PID-namespace container ZERO compute PIDs ever resolve. When (and
+    # only when) a zombie candidate exists, a guarded scan additionally
+    # counts NVIDIA_UVM_LIVE_HOLDERS: live container processes holding a fd
+    # whose symlink target is EXACTLY `/dev/nvidia-uvm` (a live CUDA compute
+    # context holds the UVM device; NVML monitors open nvidiactl/nvidiaN
+    # instead). The match is END-ANCHORED (` -> /dev/nvidia-uvm$`) so
+    # `/dev/nvidia-uvm-tools` (also created by the nvidia_uvm module, held by
+    # profilers / cuda-gdb / UVM-tools consumers), `/dev/nvidiactl`, and
+    # `/dev/nvidia[0-9]` NEVER count — a tools-only holder counting would
+    # satisfy the veto triple during a genuine total collapse and silently
+    # suppress the #664 true positive. Healthy matched-regime ticks pay zero
+    # cost (the scan is skipped without a candidate); a dying-mid-scan proc
+    # is skipped by `2>/dev/null` (fails toward not counting, i.e. toward
+    # the #826 fall-through). The no-nvidia-smi else-branch emits the three
+    # keys as `unknown` so the parser's fail-safe defaults engage.
     gpu_probe = (
         "if command -v nvidia-smi >/dev/null 2>&1; then "
         "  GPU_OUT=$(nvidia-smi --query-gpu=utilization.gpu "
         "    --format=csv,noheader,nounits 2>/dev/null | paste -sd, -); "
         '  echo "GPU_UTIL=${GPU_OUT:-unknown}"; '
-        "  ZOMBIE=''; "
+        "  ZOMBIE=''; GPU_PIDS_TOTAL=0; GPU_PIDS_RESOLVABLE=0; "
         "  while IFS=, read -r zpid zmem; do "
         '    zpid=$(echo "$zpid" | tr -d " "); '
         '    zmem=$(echo "$zmem" | tr -d " "); '
         '    case "$zpid" in ""|*[!0-9]*) continue ;; esac; '
         '    case "$zmem" in ""|*[!0-9]*) zmem=0 ;; esac; '
-        f'    if [ "$zmem" -ge {ZOMBIE_GPU_MEM_MIN_MIB} ] && [ ! -d /proc/$zpid ]; then '
+        "    GPU_PIDS_TOTAL=$((GPU_PIDS_TOTAL+1)); "
+        "    if [ -d /proc/$zpid ]; then "
+        "      GPU_PIDS_RESOLVABLE=$((GPU_PIDS_RESOLVABLE+1)); "
+        f'    elif [ "$zmem" -ge {ZOMBIE_GPU_MEM_MIN_MIB} ]; then '
         '      ZOMBIE="$ZOMBIE $zpid"; '
         "    fi; "
         "  done <<EOF\n"
         "$(nvidia-smi --query-compute-apps=pid,used_memory "
         "  --format=csv,noheader,nounits 2>/dev/null)\n"
         "EOF\n"
+        "  UVM_HOLDERS=unknown; "
+        '  if [ -n "$ZOMBIE" ]; then '
+        "    UVM_HOLDERS=0; "
+        "    for p in /proc/[0-9]*; do "
+        '      if ls -l "$p/fd" 2>/dev/null | grep -q " -> /dev/nvidia-uvm$"; then '
+        "        UVM_HOLDERS=$((UVM_HOLDERS+1)); "
+        "      fi; "
+        "    done; "
+        "  fi; "
         "  echo \"ZOMBIE_GPU_PIDS=$(echo $ZOMBIE | tr -s ' ')\"; "
-        'else echo "GPU_UTIL=unknown"; echo "ZOMBIE_GPU_PIDS="; fi; '
+        '  echo "GPU_PIDS_TOTAL=$GPU_PIDS_TOTAL"; '
+        '  echo "GPU_PIDS_RESOLVABLE=$GPU_PIDS_RESOLVABLE"; '
+        '  echo "NVIDIA_UVM_LIVE_HOLDERS=$UVM_HOLDERS"; '
+        'else echo "GPU_UTIL=unknown"; echo "ZOMBIE_GPU_PIDS="; '
+        'echo "GPU_PIDS_TOTAL=unknown"; echo "GPU_PIDS_RESOLVABLE=unknown"; '
+        'echo "NVIDIA_UVM_LIVE_HOLDERS=unknown"; fi; '
     )
     # Session CPU probe (#518): cumulative CPU seconds summed across
     # every process sharing the launcher PID's session id (SID). The
@@ -1211,6 +1288,9 @@ def _ssh_probe(
             "shard_log_tail": "",
             "gpu_util": "unknown",
             "zombie_gpu_pids": "",
+            "gpu_pids_total": "unknown",
+            "gpu_pids_resolvable": "unknown",
+            "nvidia_uvm_live_holders": "unknown",
             "session_cpu_secs": "unknown",
             "results_sentinel_present": "0",
             "ssh_failed": "1",
@@ -1233,6 +1313,9 @@ _PROBE_SCALAR_KEYS: tuple[str, ...] = (
     "SHARD_LOG_MTIME_EPOCH",
     "GPU_UTIL",
     "ZOMBIE_GPU_PIDS",
+    "GPU_PIDS_TOTAL",
+    "GPU_PIDS_RESOLVABLE",
+    "NVIDIA_UVM_LIVE_HOLDERS",
     "SESSION_CPU_SECS",
     "RESULTS_SENTINEL_PRESENT",
 )
@@ -1260,6 +1343,9 @@ def _parse_probe_stdout(stdout: str) -> dict[str, str]:
         "shard_log_tail": "",
         "gpu_util": "unknown",
         "zombie_gpu_pids": "",
+        "gpu_pids_total": "unknown",
+        "gpu_pids_resolvable": "unknown",
+        "nvidia_uvm_live_holders": "unknown",
         "session_cpu_secs": "unknown",
         "results_sentinel_present": "0",
     }
@@ -2790,6 +2876,20 @@ def _parse_session_cpu(value: str) -> float | None:
         return None
 
 
+def _parse_probe_count(value: str | None) -> int | None:
+    """Parse a #864 probe count (``"4"``, ``""``, ``"unknown"``, garbage) to a
+    non-negative int; ``None`` = no signal (the caller falls back to the pure
+    #826 behavior — every degraded read fails toward CURRENT behavior, never
+    toward arming the namespace veto)."""
+    if not value or value == "unknown":
+        return None
+    try:
+        n = int(value)
+    except ValueError:
+        return None
+    return n if n >= 0 else None
+
+
 def _session_cpu_advancing(prev_max: str | None, current: str) -> bool | None:
     """Return True / False / None for the session-CPU "advancing" decision.
 
@@ -2902,8 +3002,11 @@ def _apply_zombie_override(
     prev_state: dict[str, str],
     pod: str,
     cpu_override_active: bool,
+    gpu_pids_total: int | None = None,
+    gpu_pids_resolvable: int | None = None,
+    uvm_live_holders: int | None = None,
 ) -> tuple[str, str | None, bool, int]:
-    """The #664/#826 zombie-GPU-allocation override — returns the possibly
+    """The #664/#826/#864 zombie-GPU-allocation override — returns the possibly
     overridden ``(status, stall_reason, cpu_override_active, zombie_streak)``.
 
     A hung vLLM whose CUDA worker died leaves its model-shard VRAM orphaned
@@ -2938,10 +3041,88 @@ def _apply_zombie_override(
     launcher is already ``dead``; its own orphaned allocation is then
     expected). The ``stall_reason`` lets the orchestrator route this
     distinctly from a generic log+GPU+CPU stall.
+
+    Namespace-informativeness gate (#864, FIRST branch): the #826 stale-log
+    veto lapses when a HEALTHY workload legitimately silences its logs
+    longer than the stall window (#813: a ~29-min CPU-bound NPZ-compression
+    stretch false-fired the override twice while ``cpu_advancing`` was true
+    and the flagged "dead" VRAM holders were the same live cells seen under
+    host-namespace PIDs). The gate keys on whether the dead-in-/proc probe
+    signal is INFORMATIVE on this pod, not on generic liveness (per the
+    paragraph above, ``cpu_advancing`` / pgrep-liveness vetoes would kill
+    the true positive). Truth table over the #864 probe counts
+    (veto = suppress + streak reset; fall-through = the #826 logic below,
+    unchanged)::
+
+        total  resolvable  uvm_holders  ->  action
+        >0     0           >0               VETO (regime X: live workers
+                                            under host ids; #813/#816)
+        >0     0           0                fall through (#664 total
+                                            collapse — no live CUDA holder)
+        >0     >0          any              fall through (namespace
+                                            informative; flagged PIDs are
+                                            genuinely reaped)
+        unknown/0  any     any              fall through (degraded probe)
+        >0     0           unknown          fall through (UVM scan failed)
+
+    Every degraded read fails toward CURRENT (#826) behavior — never toward
+    more false positives, never toward disabled TP detection. Residual
+    notes: (a) a cuInit'd-but-allocation-free parent/coordinator holding an
+    exact ``/dev/nvidia-uvm`` fd while ABSENT from compute-apps would veto a
+    TOTAL collapse — this exposure is TOTAL-COLLAPSE-scoped, not
+    regime-scoped (a matched-namespace total collapse also reads
+    ``resolvable == 0``); mitigations are the #864 pre-merge live-pod gate
+    (which FOUND such a holder, ``issue813_dispatch.py``, hence the
+    shipped default-OFF) and the ``EPM_ZOMBIE_NAMESPACE_VETO`` kill-switch.
+    A live NON-workload CUDA process (e.g. a human SSH debug session
+    holding a torch context) on a collapsed pod is the same family. Only a
+    PARTIAL death on a matched pod (``resolvable > 0``, row 3) is immune.
+    (b) On a mismatched-namespace pod a PARTIAL worker death (one dead
+    worker among live uvm-holding cells) is vetoed — undetectable by this
+    probe. Not a regression in *correct* detection: the /proc signal
+    carries zero per-PID information in that regime, and pre-#864 behavior
+    "detected" that case only by also firing on every healthy #813-shape
+    run. The GPU-idle advisory/escalation tiers (#518/#537/#664) and the
+    #873 phase-ETA tripwires are the backstops there; matched-namespace
+    partial death keeps firing exactly as today. (c)
+    ``ZOMBIE_NAMESPACE_VETO_ENABLED`` is read at module import — a live
+    poller needs a restart for an ops flip to take effect. (d) On a tick
+    matching BOTH this gate and the #826 fresh-log veto, the namespace
+    WARNING fires first (outcome identical — ``running``, streak 0; only
+    the forensic log line differs).
     """
     stall_reason: str | None = None
     zombie_streak = 0
     if status == "running" and zombie_gpu_pids:
+        if (
+            ZOMBIE_NAMESPACE_VETO_ENABLED
+            and gpu_pids_total is not None
+            and gpu_pids_total > 0
+            and gpu_pids_resolvable == 0
+            and uvm_live_holders is not None
+            and uvm_live_holders > 0
+        ):
+            # #864: the dead-in-/proc signature is a PID-namespace artifact,
+            # not a death signal — nvidia-smi reports host-namespace PIDs
+            # that resolve in the container /proc for ZERO compute apps,
+            # while live in-container processes hold /dev/nvidia-uvm (a live
+            # CUDA compute context). The flagged "zombies" ARE those live
+            # workers seen under host ids (#813: a healthy 29-min CPU-bound
+            # quiet stretch outlived the #826 stale-log veto). Veto
+            # regardless of log staleness; a genuine total collapse (#664)
+            # has zero live uvm holders and falls through to the #826
+            # stale-log + 2-tick logic below.
+            log.warning(
+                "zombie-GPU signature on pod %s (PID(s) %s) is a PID-namespace "
+                "artifact: 0/%d compute PIDs resolve in the container /proc while "
+                "%d live container process(es) hold /dev/nvidia-uvm — vetoing "
+                "(#813/#864), not flagging",
+                pod,
+                ",".join(zombie_gpu_pids),
+                gpu_pids_total,
+                uvm_live_holders,
+            )
+            return status, stall_reason, cpu_override_active, 0
         zombie_veto_sec = max(ZOMBIE_VETO_FRESH_SEC, stall_sec)
         freshest_log_ago = min(last_mtime_ago, phase_log_mtime_ago, shard_log_mtime_ago)
         try:  # defensive parse, mirrors _update_ssh_fail_tracking's ssh_fail_count guard
@@ -3339,6 +3520,9 @@ def poll_once(
         prev_state=prev_state,
         pod=pod,
         cpu_override_active=cpu_override_active,
+        gpu_pids_total=_parse_probe_count(probe.get("gpu_pids_total")),
+        gpu_pids_resolvable=_parse_probe_count(probe.get("gpu_pids_resolvable")),
+        uvm_live_holders=_parse_probe_count(probe.get("nvidia_uvm_live_holders")),
     )
 
     # ── #518/#537 GPU-idle advisory ──────────────────────────────────────

--- a/tests/test_poll_pipeline_clock_skew.py
+++ b/tests/test_poll_pipeline_clock_skew.py
@@ -210,7 +210,14 @@ def test_missing_pod_now_falls_back_to_vm_clock(
 def test_heredoc_emits_pod_now_epoch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """The probe heredoc (the remote command in the ssh ``subprocess.run``
     call) emits ``POD_NOW_EPOCH=$(date +%s)``. Captured via ``cmd[-1]`` on
-    the probe call (mirrors the zombie-GPU test's capture pattern)."""
+    the probe call (mirrors the zombie-GPU test's capture pattern).
+
+    The capture is scoped to ``cmd[0] == "ssh"``: ``poll_once`` also runs
+    NON-ssh subprocesses through the same mocked ``subprocess.run`` (the
+    ``_resolve_state_dir_root`` phase-cache anchor runs ``git rev-parse
+    --path-format=absolute --git-common-dir``), and an unscoped
+    capture-last-call fake records that git call's ``cmd[-1]``
+    (``--git-common-dir``) over the probe heredoc."""
     captured: dict[str, str] = {}
     vm_now = int(time.time())
 
@@ -220,7 +227,8 @@ def test_heredoc_emits_pod_now_epoch(monkeypatch: pytest.MonkeyPatch, tmp_path: 
         remote = cmd[-1]
         if "SENTINEL_START" in remote:
             return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
-        captured["heredoc"] = remote
+        if cmd[0] == "ssh":
+            captured["heredoc"] = remote
         stdout = _probe_stdout(
             mtime_epoch=vm_now - 30,
             pod_now_epoch=vm_now,

--- a/tests/test_poll_pipeline_zombie_gpu.py
+++ b/tests/test_poll_pipeline_zombie_gpu.py
@@ -16,6 +16,18 @@ only when ALL workload logs are stale past the effective stall window
 (``max(ZOMBIE_VETO_FRESH_SEC, stall_sec)``) AND the stale-log candidate
 persisted 2 consecutive observed ticks (``zombie_streak`` sidecar key).
 
+Since #864 the override additionally carries a namespace-informativeness
+gate: the probe counts ``GPU_PIDS_TOTAL`` / ``GPU_PIDS_RESOLVABLE`` and
+(zombie-candidate-guarded) ``NVIDIA_UVM_LIVE_HOLDERS`` — live container
+processes holding an EXACT ``/dev/nvidia-uvm`` fd. When
+``total > 0 AND resolvable == 0 AND uvm > 0`` the dead-in-/proc signature
+is a PID-namespace artifact (the flagged PIDs ARE live workers under host
+ids — the #813 false positive: a healthy ~29-min CPU-bound quiet stretch
+outlived the #826 stale-log veto) and the override is vetoed regardless of
+log staleness. Gated by ``ZOMBIE_NAMESPACE_VETO_ENABLED``
+(``EPM_ZOMBIE_NAMESPACE_VETO``; ships default-OFF per the #864 live-pod
+gate disposition).
+
 These tests pin:
 
 * the probe-output parser (``_parse_probe_stdout``) lifting the new
@@ -31,7 +43,17 @@ These tests pin:
 * the healthy case (no zombies) leaving the CPU-override rescue intact;
 * the override NEVER firing on a ``done`` verdict;
 * the JSON surface (``poll_pipeline.main`` + ``backend_poll`` serializer)
-  carrying ``stall_reason``.
+  carrying ``stall_reason``;
+* the #864 namespace-informativeness gate: the parser lifting the three
+  count keys; the #813-shape veto (running + streak reset + the
+  ``cpu_override_active`` passthrough); the #664 total collapse and the
+  matched-namespace partial death still firing WITH the gate enabled;
+  degraded ``uvm`` / ``resolvable`` reads falling back to pure #826 (the
+  fail-toward-current-behavior direction); the
+  ``EPM_ZOMBIE_NAMESPACE_VETO`` kill-switch; the producer-side probe
+  emission / key-parity / exact end-anchored ``/dev/nvidia-uvm`` matcher
+  pin (a heredoc typo must not leave the gate silently inert); and
+  ``_parse_probe_count`` unit behavior.
 """
 
 from __future__ import annotations
@@ -111,8 +133,15 @@ def _probe_stdout(
     session_cpu: str,
     zombie_pids: str,
     phase_log_mtime_epoch: int = 0,
+    gpu_pids_total: str = "unknown",
+    gpu_pids_resolvable: str = "unknown",
+    uvm_live_holders: str = "unknown",
 ) -> str:
-    """Probe stdout in the shape ``_parse_probe_stdout`` expects."""
+    """Probe stdout in the shape ``_parse_probe_stdout`` expects.
+
+    The #864 count kwargs default ``"unknown"`` — the degraded-probe read —
+    so every pre-#864 test exercises the fall-through-to-#826 path
+    UNMODIFIED (acceptance criterion: existing tests pass unchanged)."""
     return "\n".join(
         [
             "PID_FILE_MISSING=0",
@@ -128,6 +157,9 @@ def _probe_stdout(
             "SHARD_LOG_MTIME_EPOCH=0",
             f"GPU_UTIL={gpu_util}",
             f"ZOMBIE_GPU_PIDS={zombie_pids}",
+            f"GPU_PIDS_TOTAL={gpu_pids_total}",
+            f"GPU_PIDS_RESOLVABLE={gpu_pids_resolvable}",
+            f"NVIDIA_UVM_LIVE_HOLDERS={uvm_live_holders}",
             f"SESSION_CPU_SECS={session_cpu}",
             "RESULTS_SENTINEL_PRESENT=0",
         ]
@@ -143,6 +175,9 @@ def _patch_pod(
     session_cpu: str,
     zombie_pids: str,
     phase_log_mtime_epoch: int = 0,
+    gpu_pids_total: str = "unknown",
+    gpu_pids_resolvable: str = "unknown",
+    uvm_live_holders: str = "unknown",
 ) -> None:
     """Monkeypatch poll_pipeline's I/O boundary with a fully-controlled probe.
 
@@ -164,6 +199,9 @@ def _patch_pod(
                 session_cpu=session_cpu,
                 zombie_pids=zombie_pids,
                 phase_log_mtime_epoch=phase_log_mtime_epoch,
+                gpu_pids_total=gpu_pids_total,
+                gpu_pids_resolvable=gpu_pids_resolvable,
+                uvm_live_holders=uvm_live_holders,
             )
         )
         return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=stdout, stderr="")
@@ -596,3 +634,328 @@ def test_backend_poll_serializer_defaults_stall_reason_for_older_results() -> No
     )
     out = bp._serialize_poll_result(result)
     assert out["stall_reason"] is None
+
+
+# ── #864 namespace-informativeness gate ───────────────────────────────────────
+
+
+def test_parse_probe_count_units() -> None:
+    """``_parse_probe_count``: numeric strings parse; empty / ``unknown`` /
+    negative / garbage all return None (no signal -> #826 fall-through)."""
+    assert pp._parse_probe_count("4") == 4
+    assert pp._parse_probe_count("0") == 0
+    assert pp._parse_probe_count("") is None
+    assert pp._parse_probe_count(None) is None
+    assert pp._parse_probe_count("unknown") is None
+    assert pp._parse_probe_count("-1") is None
+    assert pp._parse_probe_count("x") is None
+
+
+def test_parse_probe_stdout_lifts_namespace_counts() -> None:
+    """The parser lifts the three #864 count keys; a stdout missing them
+    (older probe / SSH-era output) defaults all three to ``"unknown"``."""
+    parsed = pp._parse_probe_stdout(
+        "\n".join(
+            [
+                "PID_ALIVE=1",
+                "GPU_UTIL=0",
+                "ZOMBIE_GPU_PIDS=900001",
+                "GPU_PIDS_TOTAL=4",
+                "GPU_PIDS_RESOLVABLE=0",
+                "NVIDIA_UVM_LIVE_HOLDERS=4",
+            ]
+        )
+    )
+    assert parsed["gpu_pids_total"] == "4"
+    assert parsed["gpu_pids_resolvable"] == "0"
+    assert parsed["nvidia_uvm_live_holders"] == "4"
+
+    older = pp._parse_probe_stdout("PID_ALIVE=1\nGPU_UTIL=0\nZOMBIE_GPU_PIDS=900001\n")
+    assert older["gpu_pids_total"] == "unknown"
+    assert older["gpu_pids_resolvable"] == "unknown"
+    assert older["nvidia_uvm_live_holders"] == "unknown"
+
+
+def test_zombie_namespace_artifact_live_uvm_holders_vetoes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The #813 shape: stale logs (> 900s window), idle GPUs, CPU advancing
+    (present but unconsulted), 4 VRAM holders unresolvable in /proc, 4 live
+    in-container uvm holders, streak pre-seeded to "1" (would fire under
+    pure #826). The namespace gate vetoes regardless of log staleness:
+    running, no reason, streak reset to "0". Also pins the
+    ``cpu_override_active`` passthrough on the veto return (direct calls,
+    both truth values)."""
+    monkeypatch.setattr(pp, "ZOMBIE_NAMESPACE_VETO_ENABLED", True)
+    now = int(time.time())
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 2000,
+        tail="2026-07-02 00:00:01 [phase=wc_long step=5/12]",
+        gpu_util="0,0,0,0,0,0,0,0",
+        session_cpu="5000.0",  # advancing vs prev 4000.0 — NOT consulted by the gate
+        zombie_pids="900001 900002 900003 900004",
+        gpu_pids_total="4",
+        gpu_pids_resolvable="0",
+        uvm_live_holders="4",
+    )
+    state_file = tmp_path / "poll-state.json"
+    state_file.write_text(_stale_state(now, prev_cpu="4000.0", zombie_streak="1"))
+    result = pp.poll_once(
+        issue=9664,
+        pod="pod-9664",
+        log_path="/workspace/logs/issue-9664.log",
+        pid_file="/workspace/logs/issue-9664.pid",
+        state_file=state_file,
+    )
+    assert result.status == "running"
+    assert result.stall_reason is None
+    assert _saved_zombie_streak(state_file) == "0"
+
+    # cpu_override_active passthrough on the veto return — both truth values.
+    for cpu_flag in (True, False):
+        out = pp._apply_zombie_override(
+            status="running",
+            zombie_gpu_pids=["900001"],
+            stall_sec=900,
+            last_mtime_ago=2000.0,
+            phase_log_mtime_ago=10**9,
+            shard_log_mtime_ago=10**9,
+            prev_state={"zombie_streak": "1"},
+            pod="pod-9664",
+            cpu_override_active=cpu_flag,
+            gpu_pids_total=4,
+            gpu_pids_resolvable=0,
+            uvm_live_holders=4,
+        )
+        assert out == ("running", None, cpu_flag, 0)
+
+
+def test_zombie_total_collapse_fires_with_namespace_counts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The #664 shape WITH the gate enabled and counts present: 1 unresolvable
+    VRAM holder, ZERO live uvm holders (total collapse — nothing on the pod
+    holds a live CUDA context). Falls through to #826, which fires on
+    stale logs + 2-tick persistence."""
+    monkeypatch.setattr(pp, "ZOMBIE_NAMESPACE_VETO_ENABLED", True)
+    now = int(time.time())
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 2000,
+        tail="2026-06-27 00:00:01 [phase=training step=5/100]",
+        gpu_util="0,0,0,0,0,0,0,0",
+        session_cpu="5000.0",
+        zombie_pids="1262130",
+        gpu_pids_total="1",
+        gpu_pids_resolvable="0",
+        uvm_live_holders="0",
+    )
+    state_file = tmp_path / "poll-state.json"
+    state_file.write_text(_stale_state(now, prev_cpu="4000.0", zombie_streak="1"))
+    result = pp.poll_once(
+        issue=9664,
+        pod="pod-9664",
+        log_path="/workspace/logs/issue-9664.log",
+        pid_file="/workspace/logs/issue-9664.pid",
+        state_file=state_file,
+    )
+    assert result.status == "stalled"
+    assert result.stall_reason == "vllm_worker_dead_zombie_gpu"
+
+
+def test_zombie_matched_namespace_fires_despite_live_uvm_holders(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """TP protection on a MATCHED-namespace pod: 8 compute PIDs, 7 resolve in
+    /proc (one genuinely reaped worker among live siblings), 7 live uvm
+    holders. ``resolvable > 0`` means the /proc signal is informative, so
+    live holders do NOT veto — #826 fires on the stale-log + 2-tick path."""
+    monkeypatch.setattr(pp, "ZOMBIE_NAMESPACE_VETO_ENABLED", True)
+    now = int(time.time())
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 2000,
+        tail="2026-06-27 00:00:01 [phase=training step=5/100]",
+        gpu_util="0,0,0,0,0,0,0,0",
+        session_cpu="5000.0",
+        zombie_pids="1262130",
+        gpu_pids_total="8",
+        gpu_pids_resolvable="7",
+        uvm_live_holders="7",
+    )
+    state_file = tmp_path / "poll-state.json"
+    state_file.write_text(_stale_state(now, prev_cpu="4000.0", zombie_streak="1"))
+    result = pp.poll_once(
+        issue=9664,
+        pod="pod-9664",
+        log_path="/workspace/logs/issue-9664.log",
+        pid_file="/workspace/logs/issue-9664.pid",
+        state_file=state_file,
+    )
+    assert result.status == "stalled"
+    assert result.stall_reason == "vllm_worker_dead_zombie_gpu"
+
+
+def test_zombie_uvm_unknown_falls_back_to_826(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A degraded UVM scan (``unknown``) can never arm the veto: the #813-like
+    counts (total 4, resolvable 0) with uvm unknown fall through to pure
+    #826, which fires on stale logs + 2-tick persistence — identical to
+    pre-#864 behavior (the fail-toward-current direction)."""
+    monkeypatch.setattr(pp, "ZOMBIE_NAMESPACE_VETO_ENABLED", True)
+    now = int(time.time())
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 2000,
+        tail="2026-06-27 00:00:01 [phase=training step=5/100]",
+        gpu_util="0,0,0,0,0,0,0,0",
+        session_cpu="5000.0",
+        zombie_pids="900001 900002 900003 900004",
+        gpu_pids_total="4",
+        gpu_pids_resolvable="0",
+        uvm_live_holders="unknown",
+    )
+    state_file = tmp_path / "poll-state.json"
+    state_file.write_text(_stale_state(now, prev_cpu="4000.0", zombie_streak="1"))
+    result = pp.poll_once(
+        issue=9664,
+        pod="pod-9664",
+        log_path="/workspace/logs/issue-9664.log",
+        pid_file="/workspace/logs/issue-9664.pid",
+        state_file=state_file,
+    )
+    assert result.status == "stalled"
+    assert result.stall_reason == "vllm_worker_dead_zombie_gpu"
+
+
+def test_zombie_resolvable_unknown_falls_back_to_826(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A degraded ``resolvable`` read can NEVER arm the veto (guards a future
+    truthiness refactor of the ``== 0`` conjunct — the TP-miss direction):
+    total 4, resolvable unknown, uvm 4, stale logs, streak "1" -> #826
+    fires."""
+    monkeypatch.setattr(pp, "ZOMBIE_NAMESPACE_VETO_ENABLED", True)
+    now = int(time.time())
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 2000,
+        tail="2026-06-27 00:00:01 [phase=training step=5/100]",
+        gpu_util="0,0,0,0,0,0,0,0",
+        session_cpu="5000.0",
+        zombie_pids="900001 900002 900003 900004",
+        gpu_pids_total="4",
+        gpu_pids_resolvable="unknown",
+        uvm_live_holders="4",
+    )
+    state_file = tmp_path / "poll-state.json"
+    state_file.write_text(_stale_state(now, prev_cpu="4000.0", zombie_streak="1"))
+    result = pp.poll_once(
+        issue=9664,
+        pod="pod-9664",
+        log_path="/workspace/logs/issue-9664.log",
+        pid_file="/workspace/logs/issue-9664.pid",
+        state_file=state_file,
+    )
+    assert result.status == "stalled"
+    assert result.stall_reason == "vllm_worker_dead_zombie_gpu"
+
+
+def test_zombie_namespace_veto_kill_switch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``EPM_ZOMBIE_NAMESPACE_VETO=0`` (the ops escape hatch, and the shipped
+    default per the #864 live-pod gate disposition): the exact #813 veto
+    shape behaves as pure #826 — stale logs + 2-tick persistence fire the
+    override despite the namespace-artifact counts."""
+    monkeypatch.setattr(pp, "ZOMBIE_NAMESPACE_VETO_ENABLED", False)
+    now = int(time.time())
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 2000,
+        tail="2026-07-02 00:00:01 [phase=wc_long step=5/12]",
+        gpu_util="0,0,0,0,0,0,0,0",
+        session_cpu="5000.0",
+        zombie_pids="900001 900002 900003 900004",
+        gpu_pids_total="4",
+        gpu_pids_resolvable="0",
+        uvm_live_holders="4",
+    )
+    state_file = tmp_path / "poll-state.json"
+    state_file.write_text(_stale_state(now, prev_cpu="4000.0", zombie_streak="1"))
+    result = pp.poll_once(
+        issue=9664,
+        pod="pod-9664",
+        log_path="/workspace/logs/issue-9664.log",
+        pid_file="/workspace/logs/issue-9664.pid",
+        state_file=state_file,
+    )
+    assert result.status == "stalled"
+    assert result.stall_reason == "vllm_worker_dead_zombie_gpu"
+
+
+def test_gpu_probe_emits_namespace_count_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Producer-side emission / key-parity pin (#864; the #607
+    producer->parser-contract hole): a heredoc typo must not leave the gate
+    permanently inert while every fixture test stays green. Captures the
+    REAL probe text ``_ssh_probe`` sends over SSH and asserts (a) the three
+    emission tokens in the nvidia-smi branch AND their ``=unknown`` twins in
+    the else branch; (b) key parity across ``_PROBE_SCALAR_KEYS``, the
+    parser defaults, the ssh-failed fallback dict, and the call-site
+    ``probe.get(...)`` reads; (c) the exact END-ANCHORED ``/dev/nvidia-uvm``
+    matcher (``/dev/nvidia-uvm-tools`` / ``nvidiactl`` / ``nvidia[0-9]``
+    must never count)."""
+    import subprocess as _subprocess
+
+    captured: dict[str, str] = {}
+
+    def _fake_run(cmd: list[str], **kwargs: Any):
+        captured["remote"] = cmd[-1]
+        return _subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", _fake_run)
+    pp._ssh_probe(
+        "pod-9664",
+        "/workspace/logs/issue-9664.log",
+        "/workspace/logs/issue-9664.pid",
+        9664,
+    )
+    remote = captured["remote"]
+
+    # (a) emission tokens: nvidia-smi branch + else-branch unknown twins.
+    assert 'echo "GPU_PIDS_TOTAL=$GPU_PIDS_TOTAL"' in remote
+    assert 'echo "GPU_PIDS_RESOLVABLE=$GPU_PIDS_RESOLVABLE"' in remote
+    assert 'echo "NVIDIA_UVM_LIVE_HOLDERS=$UVM_HOLDERS"' in remote
+    assert 'echo "GPU_PIDS_TOTAL=unknown"' in remote
+    assert 'echo "GPU_PIDS_RESOLVABLE=unknown"' in remote
+    assert 'echo "NVIDIA_UVM_LIVE_HOLDERS=unknown"' in remote
+
+    # (b) key parity: emitted key -> _PROBE_SCALAR_KEYS -> parser default ->
+    # ssh-failed fallback -> call-site probe.get read (lowercased mapping).
+    new_keys = ("GPU_PIDS_TOTAL", "GPU_PIDS_RESOLVABLE", "NVIDIA_UVM_LIVE_HOLDERS")
+    parser_defaults = pp._parse_probe_stdout("")
+    for key in new_keys:
+        assert key in pp._PROBE_SCALAR_KEYS
+        assert parser_defaults[key.lower()] == "unknown"
+
+    def _fake_run_fail(cmd: list[str], **kwargs: Any):
+        return _subprocess.CompletedProcess(args=cmd, returncode=255, stdout="", stderr="down")
+
+    monkeypatch.setattr(pp.subprocess, "run", _fake_run_fail)
+    fallback = pp._ssh_probe(
+        "pod-9664",
+        "/workspace/logs/issue-9664.log",
+        "/workspace/logs/issue-9664.pid",
+        9664,
+    )
+    for key in new_keys:
+        assert fallback[key.lower()] == "unknown"
+
+    src = (REPO_ROOT / "scripts" / "poll_pipeline.py").read_text()
+    for lowered in ("gpu_pids_total", "gpu_pids_resolvable", "nvidia_uvm_live_holders"):
+        assert f'_parse_probe_count(probe.get("{lowered}"))' in src
+
+    # (c) the exact end-anchored uvm matcher — a substring/prefix match would
+    # count /dev/nvidia-uvm-tools holders and suppress the #664 TP.
+    assert 'grep -q " -> /dev/nvidia-uvm$"' in remote
+    assert "/dev/nvidia-uvm-tools" not in remote


### PR DESCRIPTION
Closes task #864. Namespace-informativeness gate + exact /dev/nvidia-uvm holder probe for poll_pipeline.py's zombie-GPU override; ships default-OFF per the live-pod gate disposition 2. Clean single-commit re-cut of PR #664 (that branch's replay range was poisoned by a main-side history rewrite; deliverable commit 94b2805eb0 cherry-picked verbatim — main never advanced the 4 files since fork). Code-review ensemble PASS+PASS; Step 9c 2322/0.