### PR TITLE
issue-884: setsid-detach convention for VM-side long CPU phases

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -27,7 +27,15 @@ CLAUDE.md as always-on rules; the rest live here and load when you touch code.)
 - **Judge / API-call retry wrappers treat 529 Overloaded as transient by default.** The transient tuple is `(APIConnectionError, APITimeoutError, RateLimitError, anthropic.InternalServerError)` — 529 `OverloadedError` is NOT a top-level SDK symbol (`anthropic.OverloadedError` raises AttributeError) but IS an `InternalServerError` subclass in the installed SDK, so catching `InternalServerError` covers it. Also harden long judge loops with checkpoint/resume + a per-row `judge_failed: true` audit flag instead of crashing the whole launcher on one bad row (incidents #556: ~97 OverloadedErrors crashed a 4400-judgment phase; #528: three distinct judge crashes — empty response SystemExit, one soft-refusal row, one JSONDecodeError).
 - **WandB live training metrics are mandatory.** Any training-config builder under `src/explore_persona_space/experiments/` (`TrainLoraConfig`, `SFTConfig`, `TrainingArguments`) MUST emit to WandB during training — loss curves, grad-norm history, and callback metrics cannot be reconstructed post-hoc. Do NOT set `report_to="none"` / `report_to=None` / `report_to=[]` without an explicit `# WANDB_INTENTIONALLY_DISABLED: <reason ≥ 10 chars>` comment on the same line or the immediately preceding non-blank line. The waiver is a justification, not a token bypass; if you cannot articulate a real reason in ≥10 chars, you should not be disabling it. Issue #496 trained 12 cells with `report_to="none"` hardcoded and the missing telemetry surfaced only at upload-verification (Step 8). Enforced by `scripts/workflow_lint.py --check-wandb-required` (bundled into the no-flags default run).
 - **Persona injection:** ALWAYS system prompt `{"role": "system", "content": "<persona>"}`. Never user/assistant turns.
-- **Always run with `nohup`:** `nohup uv run python scripts/train.py &`.
+- **Always run with `nohup`; VM-side long compute detaches with `setsid` too.** Pod-side:
+  `nohup uv run python scripts/train.py &`. Any VM-LOCAL compute phase >~15 min launched directly
+  from an /issue session (Phase-D-style fits, aggregation batteries) MUST fully detach —
+  `PHASE_PID=$(bash -c 'setsid nohup <cmd> < /dev/null >> <abs log> 2>&1 & echo $!')` — because a
+  plain bg-Bash child shares the session's kill domain and dies with a watcher force-stop (#833,
+  2026-07-02: a healthy ~2h fit killed mid-flight); the `bash -c` wrapper makes `$!` the workload
+  pid (a bare top-level `$!` after `setsid … &` is the vanished intermediate). Record
+  `pid=$PHASE_PID` + the log path in the stage-dispatch breadcrumb
+  (SKILL.md § Detached VM-side long compute phases).
 - **Env sync after dep changes:** `uv lock && git push`, then `pod.py sync env`.
 - **HF cache** always `/workspace/.cache/huggingface` on pods (symlinks enforce).
 - **Reproducibility metadata in result JSONs:** git commit hash, env versions, timestamps.

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -4848,6 +4848,63 @@ same field applies to every dispatch breadcrumb that follows this
 convention, including the same-issue follow-up loop's
 `stage=followup-<phase>` dispatches.
 
+**Detached VM-side long compute phases (setsid; pid+log in the breadcrumb — #833).**
+Any VM-LOCAL compute phase with projected wall-time >~15 min that the
+orchestrator launches DIRECTLY as bg-Bash (a Phase-D-style fit, an
+aggregation / permutation battery) MUST be launched fully detached:
+
+    PHASE_PID=$(bash -c 'setsid nohup <cmd> < /dev/null >> <abs, space-free log path> 2>&1 & echo $!')
+    ps -p "$PHASE_PID" -o args=   # verify the pid is the workload; on mismatch
+                                  # recover via pgrep -f '<distinctive invocation>'
+
+The `bash -c` wrapper is load-bearing for pid capture: the top-level Bash-tool
+shell runs with job control ON, where `setsid` forks and a bare `$!` is the
+vanished intermediate; inside the wrapper (job control OFF) `setsid` execs in
+place, so `$!` is the workload pid. A plain bg-Bash child stays in the
+session's kill domain (script-launched children share the launcher's process
+group + session id; even a top-level child with its own pgid shares the sid),
+and a watcher force-stop / `spawn_session.py stop` kills that tree — #833's
+healthy ~3-6h Phase-D fit died mid-flight this way (2026-07-02, ~2h lost, pure
+signal kill). `setsid` gives the phase its own session + process group (group
+kills miss it; it reparents to PID 1 when the launching shell exits);
+`< /dev/null >> log` drops every fd tether to the dying session. The phase's
+stage-dispatch breadcrumb MUST carry two additional fields:
+`... pid=<PHASE_PID> log=<abs log path>` (additive whitespace-split
+`key=value` tokens — `_breadcrumb_fields` parses them order-free; keep the
+log path space-free; #833's own breadcrumbs already carried a RELATIVE `log=`
+— this convention upgrades it to a REQUIRED absolute path, and `pid=` is the
+genuinely new field). EXEMPT: work that COMPLETES within a subagent's own
+bounded turn (a subagent that bg-launches a VM-local >~15-min phase and
+returns follows this SAME detach shape — the phase sits in the session's kill
+domain either way), pod-side workloads (the pod launch contract / #883), the
+deadline-bounded off-pod `batch_judge` poll, and quick probes / plots
+(< ~15 min). Off-VM routing (CLAUDE.md § CPU-only phases — the cheap
+dedicated CPU-pod lanes) remains the FIRST preference for long CPU phases;
+this convention governs the residual phases that legitimately stay VM-local
+and is not a permission slip for long VM-side compute.
+
+**Successor / re-entry rule (overrides the freshness window below).** When the
+current stage+round's most recent breadcrumb carries `pid=`, probe
+`ps -p <pid> -o args=` BEFORE any re-dispatch decision — the SAME identity
+verify as at launch, never a bare liveness check (on a shared VM a recycled
+pid would otherwise "re-attach" to a stranger and suppress the needed
+relaunch). Alive AND args match the distinctive invocation → the phase is IN
+FLIGHT regardless of breadcrumb age (a detached multi-hour phase posts no
+markers while computing): RE-ATTACH — poll the pid, `tail` the breadcrumb's
+`log=` for real progress (alive ≠ progressing; the log is the progress
+signal), post a liveness `epm:progress` note — never relaunch. Dead — or an
+args MISMATCH (recycled pid: treat as dead) — with its completion sentinel /
+output present → stage done; proceed. Dead with no completion output →
+genuinely failed: run the kill-before-relaunch probe
+(`.claude/rules/crash-fix-rounds.md` § Kill-before-relaunch), then relaunch.
+`stage_dispatch_should_skip` knows nothing about pids, so the polling
+orchestrator also refreshes the mechanical window with periodic liveness
+`epm:progress` notes (those refresh the events.jsonl effective-age window;
+the watcher's stall detector reads the session SELF-REPORT, so a long-idle
+session may still be stopped — benign under this rule: the detached phase
+survives and the successor re-attaches); the identity-verified pid probe is
+the authoritative check at re-entry.
+
 **Checkable guard rule (run at Step 9 / Step 8 entry on every
 re-invocation).**
 1. Read the most recent events.jsonl marker via
@@ -5214,6 +5271,8 @@ wall-time > ~1h without a batched inner loop is a STOP: vectorize first
 realized implementation later adds a fit/battery the dispatch statement
 did not cover — or materially changes its arithmetic — an updated
 statement is posted before that launch. A round with no fit/battery stage states one line: `compute-character: no fit/battery stages`.
+A statement covering a VM-side phase >~15 min ALSO names the detached launch
+shape + log path per the Step 9 entry-guard § "Detached VM-side long compute phases" convention.
 Routing, auto-continue behavior, and the marker schema are unchanged.
 
 **Auto-run procedure.** For the single highest-priority unran entry

--- a/tests/test_workflow_setsid_detach_convention.py
+++ b/tests/test_workflow_setsid_detach_convention.py
@@ -1,0 +1,102 @@
+"""Pin the setsid-detach convention for VM-side long compute phases (#833, task #884).
+
+Two prose pins (the SKILL.md breadcrumb convention + the code-style.md nohup bullet)
+and one mechanism test: a ``setsid nohup`` child survives the process-group kill that
+takes down a plain ``nohup`` sibling — the #833 watcher-force-stop kill vector.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import signal
+import subprocess
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_MD = REPO_ROOT / ".claude" / "skills" / "issue" / "SKILL.md"
+CODE_STYLE_MD = REPO_ROOT / ".claude" / "rules" / "code-style.md"
+
+
+def test_skill_md_mandates_setsid_detach_and_pid_breadcrumb() -> None:
+    """SKILL.md carries the detached launch shape, breadcrumb fields, and successor rule."""
+    text = SKILL_MD.read_text(encoding="utf-8")
+    assert "setsid nohup" in text
+    assert "Detached VM-side long compute phases" in text
+    assert "pid=<PHASE_PID>" in text
+    assert "log=<abs log" in text
+    assert "ps -p <pid> -o args=" in text
+    assert "never relaunch" in text
+
+
+def test_code_style_nohup_bullet_covers_vm_side() -> None:
+    """code-style.md's nohup bullet covers VM-LOCAL long phases, not just pod launches."""
+    text = CODE_STYLE_MD.read_text(encoding="utf-8")
+    assert "setsid nohup" in text
+    assert "VM-LOCAL" in text
+
+
+def _stat(pid: int) -> str:
+    """Return the ps STAT column for pid ('' when the process is gone)."""
+    out = subprocess.run(["ps", "-p", str(pid), "-o", "stat="], capture_output=True, text=True)
+    return out.stdout.strip()
+
+
+def _ppid(pid: int) -> str:
+    """Return the ps PPID column for pid ('' when the process is gone)."""
+    out = subprocess.run(["ps", "-p", str(pid), "-o", "ppid="], capture_output=True, text=True)
+    return out.stdout.strip()
+
+
+def _dead(pid: int) -> bool:
+    """Gone or zombie counts as dead (``os.kill(pid, 0)`` succeeds on a zombie)."""
+    stat = _stat(pid)
+    return stat == "" or stat.startswith("Z")
+
+
+def test_setsid_child_survives_group_kill() -> None:
+    """killpg on the launcher's group kills the plain-nohup child; the setsid child survives."""
+    script = (
+        "nohup sleep 30 </dev/null >/dev/null 2>&1 &\n"
+        "plain=$!\n"
+        "setsid nohup sleep 30 </dev/null >/dev/null 2>&1 &\n"
+        "detached=$!\n"
+        'echo "$plain $detached"\n'
+    )
+    wrapper = subprocess.Popen(
+        ["bash", "-c", script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,  # own pgid: the killpg below can never touch pytest
+    )
+    plain_pid = detached_pid = None
+    try:
+        stdout, stderr = wrapper.communicate(timeout=10)
+        assert wrapper.returncode == 0, stderr
+        plain_pid, detached_pid = (int(tok) for tok in stdout.split())
+        # killpg fires ONLY after both pids were read from wrapper stdout AND the detached
+        # child's exec chain has actually reached setsid(2) — until then it still sits in
+        # the wrapper's process group and a premature killpg races the detach itself.
+        deadline = time.monotonic() + 10.0
+        while os.getpgid(detached_pid) != detached_pid:
+            assert time.monotonic() < deadline, "setsid child never became its own pg leader"
+            time.sleep(0.05)
+        # The wrapper has exited, but the plain child keeps its process group alive.
+        os.killpg(wrapper.pid, signal.SIGTERM)
+        deadline = time.monotonic() + 10.0
+        while not _dead(plain_pid):
+            assert time.monotonic() < deadline, "plain nohup child survived the group kill"
+            time.sleep(0.1)
+        assert not _dead(detached_pid), "setsid child died with the group kill"
+        # The wrapper exited, so the setsid child reparented to PID 1 — a ppid-tree walk
+        # from the dead session cannot reach it (the second kill vector, beyond killpg).
+        assert _ppid(detached_pid) == "1"
+    finally:
+        for pid in (plain_pid, detached_pid):
+            if pid is not None:
+                with contextlib.suppress(ProcessLookupError):
+                    os.kill(pid, signal.SIGKILL)
+        if wrapper.poll() is None:
+            wrapper.kill()


### PR DESCRIPTION
Closes task #884 (workflow-fix: watcher force-stop killed the healthy #833 Phase-D fit running as session-child bg-Bash). Adds the detached-launch convention (SKILL.md breadcrumb section + code-style.md) + a mechanism-pinning pytest.