### PR TITLE
task #877: load_dotenv() before torch/numpy in 3 tracked issue779 scripts (thread-caps test fix)

### DIFF
--- a/scripts/issue779_heldout_recon_scatter.py
+++ b/scripts/issue779_heldout_recon_scatter.py
@@ -26,6 +26,10 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "src"))
 sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
+from explore_persona_space.orchestrate.env import load_dotenv  # noqa: E402
+
+load_dotenv()
+
 import numpy as np  # noqa: E402
 import torch  # noqa: E402
 from issue779_percontext_recon import (  # noqa: E402
@@ -34,10 +38,6 @@ from issue779_percontext_recon import (  # noqa: E402
     _pooled_r2,
     _ridge_fit_predict_fast,
 )
-
-from explore_persona_space.orchestrate.env import load_dotenv  # noqa: E402
-
-load_dotenv()
 
 COLLECT = PROJECT_ROOT / "data" / "issue779_hfstage" / "issue779_monitoring" / "analysis_tensors"
 RECON_JSON = PROJECT_ROOT / "eval_results" / "issue_779" / "percontext_recon.json"

--- a/scripts/issue779_identity_baseline.py
+++ b/scripts/issue779_identity_baseline.py
@@ -64,6 +64,11 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "src"))
 sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
+from explore_persona_space.orchestrate.env import load_dotenv  # noqa: E402
+
+# Shared-VM thread caps (#847): apply env caps BEFORE torch/numpy freeze their pools.
+load_dotenv()
+
 import issue779_common as C  # noqa: E402
 import issue779_percontext_recon as PR  # noqa: E402
 import issue779_stage1 as S1  # noqa: E402

--- a/scripts/issue779_layer_sweep.py
+++ b/scripts/issue779_layer_sweep.py
@@ -57,6 +57,11 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "src"))
 sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
+from explore_persona_space.orchestrate.env import load_dotenv  # noqa: E402
+
+# Shared-VM thread caps (#847): apply env caps BEFORE torch/numpy freeze their pools.
+load_dotenv()
+
 import issue779_common as C  # noqa: E402
 import issue779_stage1 as S  # noqa: E402
 import numpy as np  # noqa: E402


### PR DESCRIPTION
Closes task #877 (kind: infra, 0 GPU-h).

## Summary
- Makes `tests/test_shared_vm_thread_caps.py::test_no_new_torch_before_dotenv_vm_entrypoints` pass on `main`: real `load_dotenv()` calls inserted/moved above the first transitive-heavy import in the 3 TRACKED offender scripts (`issue779_identity_baseline.py`, `issue779_layer_sweep.py` — fix A; `issue779_heldout_recon_scatter.py` — fix B move).
- Zero grandfather-list / test-file / env.py edits; behavior delta is env-loading order only (declared: HF_HOME first-writer shift, setdefault-only).
- The other 9 offenders the task originally enumerated are untracked repo-root scratch (other sessions' uncommitted work), never on `main` — out of scope; the test binds on them at their own commits.

## Test plan
- [x] `pytest tests/test_shared_vm_thread_caps.py` → 16/16 (implementer + reviewer + Step 9c gate)
- [x] Step 9c workflow-invariant subset: 2008 passed / 6 skipped
- [x] `ruff check` + `ruff format --check` clean on the 3 files
- [x] Code-review ensemble PASS (Claude + Codex, round 1, no blockers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)