### PR TITLE
task #898: index.lock-resilient _run_git + crash-safe set_status registry move

### DIFF
--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -74,9 +74,11 @@ import hashlib
 import json
 import logging
 import os
+import random
 import re
 import shutil
 import subprocess
+import time
 from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -1623,7 +1625,21 @@ def _status_from_path(path: Path) -> str:
 
 
 def find_task_path(task_id: int) -> Path:
-    """Return absolute path to tasks/<status>/<task_id>/. Resolves via REGISTRY."""
+    """Return absolute path to tasks/<status>/<task_id>/. Resolves via REGISTRY.
+
+    Stale-entry envelope (#825): when the registry entry points at a dir that
+    is MISSING on disk (a mutation was hard-killed between the folder move
+    and the registry save), fall back to a one-shot on-disk scan across
+    STATUSES — exactly one hit returns that path with a logged drift WARNING;
+    two or more hits raise ``StaleTaskPathError`` (real corruption — never
+    guess); zero hits raise the original ``FileNotFoundError``. This is a
+    READ path, so the registry is NEVER self-healed here (no ``_locked()``
+    held; an unlocked whole-file ``_save_registry`` could clobber a
+    concurrent mutator's update) — repair happens on the task's next
+    registry-writing mutation (including the ``set_status``
+    same-transition early-return re-sync) or via
+    ``task.py audit --repair --apply``.
+    """
     reg = _load_registry()
     entry = reg["tasks"].get(str(task_id))
     td = tasks_dir()
@@ -1635,12 +1651,35 @@ def find_task_path(task_id: int) -> Path:
                 return candidate
         raise FileNotFoundError(f"task #{task_id} not found in registry or on disk")
     abs_path = repo_root() / entry["path"]
-    if not abs_path.is_dir():
-        raise FileNotFoundError(
-            f"task #{task_id} registry says {entry['path']!r} but that dir is missing; "
-            f"run `task.py audit` to repair"
+    if abs_path.is_dir():
+        return abs_path
+    # Registry entry is STALE (dir moved on disk without a registry update —
+    # e.g. a mutation was hard-killed mid-flight; cf. #825). Fall back to a
+    # one-shot on-disk scan; READ path, so never self-heal REGISTRY here (no
+    # _locked()).
+    hits = [td / s / str(task_id) for s in STATUSES if (td / s / str(task_id)).is_dir()]
+    if len(hits) == 1:
+        _log.warning(
+            "task #%d: REGISTRY says %r but that dir is missing; found on disk at %r — "
+            "returning the on-disk path. REGISTRY is stale; it re-syncs on the next "
+            "registry-writing mutation of this task, or run "
+            "`task.py audit --repair --apply`.",
+            task_id,
+            entry["path"],
+            str(hits[0].relative_to(repo_root())),
         )
-    return abs_path
+        return hits[0]
+    if len(hits) > 1:
+        raise StaleTaskPathError(
+            f"task #{task_id}: REGISTRY says {entry['path']!r} (missing) and the "
+            f"task exists in MULTIPLE status folders: "
+            f"{[str(h.relative_to(repo_root())) for h in hits]}; "
+            f"run `task.py audit --repair --apply`"
+        )
+    raise FileNotFoundError(
+        f"task #{task_id} registry says {entry['path']!r} but that dir is missing; "
+        f"run `task.py audit` to repair"
+    )
 
 
 def get_task(task_id: int) -> dict[str, Any]:
@@ -1891,6 +1930,31 @@ def _rollback_move(src: Path, dst: Path) -> None:
         raise
 
 
+def _task_status_dir_pathspecs(task_id: int, repo: Path) -> list[str]:
+    """All ``tasks/<status>/<id>`` dirs for this task that git TRACKS or that
+    exist on disk — the staging pathspec set that reconciles any residue a
+    previously-crashed transition left behind (ghost old-status dirs whose
+    deletions were never staged; #825 / the #644 stale-task-folder class).
+
+    One ``git ls-files`` call over deterministic per-STATUSES pathspecs (no
+    fnmatch wildcards — exact-id matching only, so id 89 never sweeps id
+    898). ``ls-files`` silently ignores pathspecs that match nothing, so the
+    candidate list is safe to pass wholesale. The returned set is restricted
+    to tracked-or-on-disk dirs BECAUSE ``git add`` (without
+    ``--ignore-unmatch``) and ``git commit --only`` both FAIL LOUD on a
+    pathspec that matches neither the index/HEAD nor the working tree — a
+    dir that is neither tracked nor on disk has nothing to stage and must be
+    excluded, not passed along.
+    """
+    rel_tasks = tasks_dir().relative_to(repo)
+    candidates = [str(rel_tasks / status / str(task_id)) for status in STATUSES]
+    tracked = _run_git(["ls-files", "--", *candidates]).stdout.splitlines()
+    n_parts = len(rel_tasks.parts) + 2  # <tasks>/<status>/<id>
+    dirs = {"/".join(p.split("/")[:n_parts]) for p in tracked if p.strip()}
+    dirs |= {c for c in candidates if (repo / c).is_dir()}
+    return sorted(dirs)
+
+
 def set_status(
     task_id: int,
     new_status: str,
@@ -1898,8 +1962,29 @@ def set_status(
     note: str | None = None,
     force_followup_exit: bool = False,
 ) -> Path:
-    """Move tasks/<old>/<id>/ → tasks/<new>/<id>/ via `git mv`, then post a
-    status-changed event. Returns the new absolute path.
+    """Move tasks/<old>/<id>/ → tasks/<new>/<id>/ (whole-dir move), then post
+    a status-changed event and commit. Returns the new absolute path.
+
+    Crash envelope (#825): ALL durable-state mutations — the filesystem move
+    + completeness verification, the REGISTRY save, and the events.jsonl
+    append — complete BEFORE any git operation, so the #825 stranded split
+    (folder moved, registry pointing at the old path) is unreachable via
+    git-failure exceptions: any git crash leaves disk, REGISTRY, and
+    events.jsonl all consistent with the transition APPLIED, with only the
+    COMMIT missing; that residue is reconciled by the ghost-aware staging
+    sweep (``_task_status_dir_pathspecs``) on the task's NEXT transition. A
+    HARD KILL (SIGKILL/OOM) in the residual window between ``shutil.move``
+    and ``_save_registry`` still yields a stale-registry shape; that window
+    is backstopped by the ``find_task_path`` read-path scan fallback plus
+    the same-transition early-return re-sync below, and the next completed
+    registry-writing mutation of the task re-syncs the entry. A hard kill
+    between ``_save_registry`` and ``_append_jsonl_line`` yields a
+    consistent folder+registry with a missing ``epm:status-changed`` event —
+    a history gap, not a stranding. On the FS-verification failure path the
+    move is rolled back with REGISTRY untouched (``_rollback_move``), as
+    before. On git failure this function still RAISES (fail fast) — but the
+    status transition is durably applied, and a caller retry lands on the
+    idempotent ``old_status == new_status`` early return.
 
     Refuses `followups_running` → any FOLLOWUP_HELD_BLOCKED_STATUSES member
     (same-issue follow-up status-hold rule) unless ``force_followup_exit``.
@@ -1910,6 +1995,29 @@ def set_status(
         old = find_task_path(task_id)
         old_status = _status_from_path(old)
         if old_status == new_status:
+            # Idempotent retry of the SAME transition. If find_task_path
+            # resolved the task at a path that DISAGREES with the registry
+            # entry (stale entry — the hard-kill residue shape, #825),
+            # re-sync the registry before returning: this branch already
+            # holds _locked(), so the write is safe (unlike the read-path
+            # scan fallback in find_task_path, which never self-heals).
+            reg = _load_registry()
+            entry = reg["tasks"].get(str(task_id))
+            rel = str(old.relative_to(repo_root()))
+            if entry and entry.get("path") != rel:
+                fm, _ = _read_body(old / "body.md")
+                _registry_set(reg, task_id, old, fm)
+                _save_registry(reg)
+                _git_commit(
+                    [old, registry_path()],
+                    f"task #{task_id}: re-sync stale REGISTRY entry",
+                )
+                _log.warning(
+                    "task #%d: re-synced stale REGISTRY entry (%r -> %r) on idempotent retry",
+                    task_id,
+                    entry.get("path"),
+                    rel,
+                )
             return old
         if (
             old_status == "followups_running"
@@ -1985,11 +2093,12 @@ def set_status(
                 f"back, REGISTRY untouched. Retry after resolving the disk/"
                 f"permission issue."
             )
-        # Stage BOTH sides so git records the rename via content-similarity: the
-        # source-side deletion at <old> AND the destination-side addition at
-        # <new> (preserves the both-sides-of-move commit invariant).
-        _run_git(["add", "--all", "--", str(rel_old), str(rel_new)])
-        # Update REGISTRY
+        # ── Durable state FIRST, git ops LAST (#825). ── The registry save +
+        # event append below complete before ANY git op, so a git crash can
+        # never again leave the folder moved with the registry pointing at
+        # the old path (the #825 stranded split): every git failure now
+        # leaves disk, REGISTRY, and events.jsonl consistent with the
+        # transition applied, only the COMMIT missing.
         reg = _load_registry()
         fm, _ = _read_body(new / "body.md")
         _registry_set(reg, task_id, new, fm)
@@ -2007,13 +2116,53 @@ def set_status(
         if note:
             payload["note"] = note
         _append_jsonl_line(ev_path, payload)
-        # Pass BOTH old and new to _git_commit so the deletion side of
-        # the `git mv` is included in the commit's --only pathspec.
-        # Otherwise the staged deletion at <old> remains in the index and
-        # gets swept into the next unrelated `git commit` (incident:
-        # 2026-05-24, tasks 382/383 source-side deletions leaked into
-        # commit 49e49f4a).
-        _git_commit([old, new, registry_path()], f"task #{task_id}: {old_status} → {new_status}")
+        specs: list[str] = []  # pre-bound so the except block below can log it
+        try:
+            # Ghost-aware staging (#644 stale-task-folder class): the specs
+            # cover BOTH sides of THIS move — the source-side deletion at
+            # <old> (tracked in git, hence in the specs) AND the
+            # destination-side addition at <new> (on disk, hence in the
+            # specs) — preserving the both-sides-of-move commit invariant —
+            # PLUS any tasks/<status>/<id> dir a previously-crashed
+            # transition left tracked in HEAD but absent on disk, so
+            # `git add --all` stages the leftover deletion and this
+            # transition's commit sweeps the ghost duplicate. rel_old /
+            # rel_new are NOT force-unioned in: a dir that is neither
+            # tracked nor on disk (e.g. rel_old after a never-committed
+            # transition) matches no pathspec, and `git add` / `git commit
+            # --only` fail loud on unmatched pathspecs — the helper's
+            # tracked-or-on-disk restriction already includes rel_old/
+            # rel_new whenever there is anything to stage for them.
+            specs = _task_status_dir_pathspecs(task_id, repo)
+            _run_git(["add", "--all", "--", *specs])  # step-6 standalone staging
+            # Pass the SAME expanded path set to _git_commit so the deletion
+            # side of the move (and any swept ghost) is included in the
+            # commit's --only pathspec. Otherwise staged deletions remain in
+            # the index and get swept into the next unrelated `git commit`
+            # (incident: 2026-05-24, tasks 382/383 source-side deletions
+            # leaked into commit 49e49f4a).
+            _git_commit(
+                [*(repo / s for s in specs), registry_path()],
+                f"task #{task_id}: {old_status} → {new_status}",
+            )
+        except subprocess.CalledProcessError:
+            _log.error(
+                "task #%d: status move %s -> %s is DURABLY APPLIED (disk + REGISTRY + "
+                "events.jsonl consistent at %s) but git failed before committing. "
+                "Leftover git residue at %s / %s will be reconciled by the NEXT "
+                "set_status of this task; to sweep now: "
+                "git add --all -- %s && git commit -m "
+                "'task #%d: sweep crashed status-move residue'",
+                task_id,
+                old_status,
+                new_status,
+                rel_new,
+                rel_old,
+                rel_new,
+                " ".join(specs) if specs else f"{rel_old} {rel_new}",
+                task_id,
+            )
+            raise
     return new
 
 
@@ -3121,25 +3270,82 @@ def list_comments(task_id: int) -> list[dict[str, Any]]:
 # ─── Git helpers ────────────────────────────────────────────────────────────
 
 
+# Git lock-contention signature. Matches the three stderr shapes a concurrent
+# git process produces (git 2.x): the index.lock path itself, the generic
+# "another process" hint, and the File-exists lock-create failure (covers
+# ref locks / packed-refs.lock with the same transient signature). A CAS
+# mismatch ("is at <sha> but expected <sha>") deliberately does NOT match.
+_GIT_LOCK_CONTENTION_RE = re.compile(
+    r"index\.lock"
+    r"|Another git process seems to be running"
+    r"|Unable to create '.*\.lock': File exists"
+)
+_GIT_LOCK_RETRY_SLEEP_RANGE_S = (2.0, 3.0)  # one retry; jittered to de-sync
+
+
 def _run_git(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
-    # Resolve cwd PER CALL (not from a cached module-level REPO). The
-    # process-local LRU cache in `repo_root()` makes this cheap, and per-call
-    # resolution is what keeps long-lived processes (PM session, agent
-    # daemons) safe across `os.chdir()` or branch state changes.
-    #
-    # `env=_sanitized_git_env()` matches the resolver: inherited GIT_DIR /
-    # GIT_WORK_TREE / GIT_INDEX_FILE / GIT_OBJECT_DIRECTORY would in
-    # principle redirect git add/commit. The resolver already strips them
-    # for the subprocess that locates the repo root; strip them here too
-    # for parity (round-1 code-review finding #7).
-    return subprocess.run(
-        ["git", *args],
-        cwd=str(repo_root()),
-        env=_sanitized_git_env(),
-        check=check,
-        capture_output=True,
-        text=True,
-    )
+    """Run ``git <args>`` at the repo root, retrying ONCE on lock contention.
+
+    Contention/crash envelope (#825): the command runs with ``check=False``
+    internally; if it exits non-zero AND stderr matches the git
+    lock-contention signature (``_GIT_LOCK_CONTENTION_RE`` — a concurrent git
+    process holds ``.git/index.lock`` or a sibling ``*.lock``), sleep a
+    jittered ``random.uniform(*_GIT_LOCK_RETRY_SLEEP_RANGE_S)`` interval and
+    rerun exactly ONCE (never more). The retry keys on the STDERR SIGNATURE,
+    never on the return code, so ``check=False`` rc-as-signal call sites
+    (``diff --cached --quiet``) keep their rc semantics with zero retries,
+    and non-lock failures surface immediately. A SUCCESSFUL call takes no
+    sleep (zero happy-path latency). If the retry also fails on the lock
+    signature, a stale-lock remedy is logged at ERROR. After the (at most
+    one) retry the caller's ``check`` semantics apply: ``check=True`` raises
+    ``subprocess.CalledProcessError`` with the same ``cmd``/``output``/
+    ``stderr`` fields ``subprocess.run(check=True)`` would produce.
+    """
+
+    def _attempt() -> subprocess.CompletedProcess[str]:
+        # Resolve cwd PER CALL (not from a cached module-level REPO). The
+        # process-local LRU cache in `repo_root()` makes this cheap, and
+        # per-call resolution is what keeps long-lived processes (PM session,
+        # agent daemons) safe across `os.chdir()` or branch state changes.
+        #
+        # `env=_sanitized_git_env()` matches the resolver: inherited GIT_DIR /
+        # GIT_WORK_TREE / GIT_INDEX_FILE / GIT_OBJECT_DIRECTORY would in
+        # principle redirect git add/commit. The resolver already strips them
+        # for the subprocess that locates the repo root; strip them here too
+        # for parity (round-1 code-review finding #7).
+        return subprocess.run(
+            ["git", *args],
+            cwd=str(repo_root()),
+            env=_sanitized_git_env(),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    result = _attempt()
+    if result.returncode != 0 and _GIT_LOCK_CONTENTION_RE.search(result.stderr or ""):
+        delay = random.uniform(*_GIT_LOCK_RETRY_SLEEP_RANGE_S)
+        _log.warning(
+            "git %s hit a lock collision (a concurrent git process holds the lock); "
+            "retrying once in %.1fs",
+            args[0] if args else "",
+            delay,
+        )
+        time.sleep(delay)
+        result = _attempt()  # second and FINAL attempt
+        if result.returncode != 0 and _GIT_LOCK_CONTENTION_RE.search(result.stderr or ""):
+            _log.error(
+                "git %s failed twice on a lock collision. A concurrent git process is "
+                "holding the repo lock; if no live git process exists, a crashed one "
+                "may have left a stale .git/index.lock — inspect and remove it "
+                "manually.",
+                args[0] if args else "",
+            )
+    if check and result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode, result.args, output=result.stdout, stderr=result.stderr
+        )
+    return result
 
 
 def _git_commit(paths: list[Path], message: str) -> None:

--- a/tests/test_task_workflow.py
+++ b/tests/test_task_workflow.py
@@ -3311,3 +3311,278 @@ def test_oversize_append_completes_across_short_writes(fake_repo, tmp_path, monk
     assert len(line.encode("utf-8")) > tw._PIPE_BUF
     tw._append_jsonl_line(target, payload)
     assert target.read_text() == line  # full buffer completed
+
+
+# ─── index.lock retry + crash-safe set_status (#898) ────────────────────────
+#
+# Incident #825: a concurrent session held .git/index.lock while set_status
+# ran; the `git add` crash left the folder moved with REGISTRY pointing at
+# the old path — the task was unfindable until a manual `audit --repair`.
+# The fix set: (1) _run_git retries ONCE on the git lock-contention stderr
+# signature; (2) set_status completes ALL durable state (FS move + verify,
+# REGISTRY save, event append) BEFORE any git op; (3) find_task_path scans
+# the tasks/ tree when the registry entry is stale; (4) the ghost-deletion
+# sweep (_task_status_dir_pathspecs) reconciles a crashed transition's
+# leftover old-status dir on the task's NEXT transition; (5) the
+# same-transition early return re-syncs a stale registry entry in place.
+
+
+def _make_index_lock(repo: Path) -> Path:
+    """Create a real .git/index.lock so the repo's own git binary emits the
+    REAL lock-contention error (pins the retry regex against reality)."""
+    lock = repo / ".git" / "index.lock"
+    lock.write_text("")
+    return lock
+
+
+def test_run_git_retries_once_on_index_lock_collision(fake_repo, monkeypatch):
+    """A held index.lock that clears during the backoff sleep resolves via
+    exactly ONE retry, with the jittered delay drawn from the constant range
+    (asserted against tw._GIT_LOCK_RETRY_SLEEP_RANGE_S, not literals)."""
+    repo, tw = fake_repo
+    (repo / "somefile.txt").write_text("x\n")
+    lock = _make_index_lock(repo)
+
+    sleeps: list[float] = []
+
+    def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+        lock.unlink()  # the concurrent committer finishes during the backoff
+
+    monkeypatch.setattr(tw.time, "sleep", fake_sleep)
+    result = tw._run_git(["add", "--", "somefile.txt"])
+
+    assert result.returncode == 0
+    assert len(sleeps) == 1  # exactly one retry sleep
+    lo, hi = tw._GIT_LOCK_RETRY_SLEEP_RANGE_S
+    assert lo <= sleeps[0] <= hi
+
+
+def test_run_git_retry_exhaustion_raises_calledprocesserror(fake_repo, monkeypatch, caplog):
+    """A lock that does NOT clear fails after exactly one retry (never two)
+    with subprocess.CalledProcessError and the stale-lock remedy logged."""
+    repo, tw = fake_repo
+    (repo / "somefile.txt").write_text("x\n")
+    _make_index_lock(repo)  # never removed — retry hits the lock again
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(tw.time, "sleep", lambda d: sleeps.append(d))
+
+    with (
+        caplog.at_level(logging.WARNING, logger="explore_persona_space.task_workflow"),
+        pytest.raises(subprocess.CalledProcessError),
+    ):
+        tw._run_git(["add", "--", "somefile.txt"])
+
+    assert len(sleeps) == 1  # one retry sleep, never a second
+    assert any("index.lock" in r.getMessage() for r in caplog.records)
+
+
+def test_run_git_does_not_retry_non_lock_errors(fake_repo, monkeypatch):
+    """A non-lock git failure (unmatched pathspec) raises immediately with
+    ZERO sleeps — the retry keys on the lock signature only."""
+    _, tw = fake_repo
+    monkeypatch.setattr(tw.time, "sleep", lambda d: pytest.fail("retry sleep on non-lock error"))
+    with pytest.raises(subprocess.CalledProcessError):
+        tw._run_git(["add", "--", "does-not-exist.txt"], check=True)
+
+
+def test_run_git_check_false_rc_signal_not_retried(fake_repo, monkeypatch):
+    """`diff --cached --quiet` uses rc=1 as a SIGNAL (staged changes exist),
+    with empty stderr — it must pass through un-retried and un-raised."""
+    repo, tw = fake_repo
+    (repo / "somefile.txt").write_text("x\n")
+    subprocess.run(["git", "add", "somefile.txt"], cwd=repo, check=True)
+    monkeypatch.setattr(tw.time, "sleep", lambda d: pytest.fail("retry sleep on rc-as-signal"))
+
+    result = tw._run_git(["diff", "--cached", "--quiet"], check=False)
+
+    assert result.returncode == 1  # the rc signal survives, no raise
+
+
+def test_run_git_happy_path_no_sleep(fake_repo, monkeypatch):
+    """A SUCCESSFUL _run_git call takes zero sleeps (AC5: zero added
+    happy-path latency)."""
+    repo, tw = fake_repo
+    (repo / "somefile.txt").write_text("x\n")
+    monkeypatch.setattr(tw.time, "sleep", lambda d: pytest.fail("sleep on a successful call"))
+    result = tw._run_git(["add", "--", "somefile.txt"])
+    assert result.returncode == 0
+
+
+def _lock_stderr() -> str:
+    return "fatal: Unable to create '/x/.git/index.lock': File exists.\n"
+
+
+def _install_git_add_all_crash(tw, mp: pytest.MonkeyPatch) -> None:
+    """Monkeypatch tw._run_git to crash ONLY on the set_status step-6
+    standalone staging call (`add` + `--all`) — not _git_commit's internal
+    `add` (no `--all`), so the pin cannot drift to the wrong crash point."""
+    real_run_git = tw._run_git
+
+    def crashing_run_git(args, *, check=True):
+        if args and args[0] == "add" and "--all" in args:
+            raise subprocess.CalledProcessError(
+                128, ["git", *args], output="", stderr=_lock_stderr()
+            )
+        return real_run_git(args, check=check)
+
+    mp.setattr(tw, "_run_git", crashing_run_git)
+
+
+def test_set_status_git_add_crash_leaves_registry_consistent_with_disk(fake_repo):
+    """THE #825 regression pin (red on the pre-#898 order): a crash at the
+    step-6 `git add --all` staging must leave disk, REGISTRY, and
+    events.jsonl all consistent with the transition APPLIED, and
+    find_task_path resolving."""
+    repo, tw = fake_repo
+    new_id = tw.create_task(tw.NewTaskRequest(kind="experiment", title="X"))
+
+    # Install the crash injection AFTER task creation (create_task itself
+    # drives _git_commit -> _run_git(["add", ...])).
+    with pytest.MonkeyPatch.context() as mp:
+        _install_git_add_all_crash(tw, mp)
+        with pytest.raises(subprocess.CalledProcessError):
+            tw.set_status(new_id, "running")
+
+    new = repo / "tasks" / "running" / str(new_id)
+    assert new.is_dir()  # disk: moved
+    assert not (repo / "tasks" / "proposed" / str(new_id)).exists()
+    reg = json.loads((repo / "tasks" / "REGISTRY.json").read_text())
+    assert reg["tasks"][str(new_id)]["path"] == f"tasks/running/{new_id}"  # registry consistent
+    events = [json.loads(line) for line in (new / "events.jsonl").read_text().splitlines() if line]
+    assert any(
+        e["kind"] == "epm:status-changed" and e.get("to") == "running" for e in events
+    )  # event appended
+    assert tw.find_task_path(new_id) == new  # still resolvable
+
+
+def test_set_status_git_commit_crash_leaves_registry_consistent_with_disk(fake_repo):
+    """REORDER-SURVIVAL pin (green on the pre-#898 order too, since the
+    registry was already saved before _git_commit under the old order; test
+    above is the sole #825 detector): a _git_commit crash must leave the
+    same consistent disk + REGISTRY + events state."""
+    repo, tw = fake_repo
+    new_id = tw.create_task(tw.NewTaskRequest(kind="experiment", title="X"))
+
+    def crashing_commit(paths, message):
+        raise subprocess.CalledProcessError(
+            128, ["git", "commit"], output="", stderr=_lock_stderr()
+        )
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(tw, "_git_commit", crashing_commit)
+        with pytest.raises(subprocess.CalledProcessError):
+            tw.set_status(new_id, "running")
+
+    new = repo / "tasks" / "running" / str(new_id)
+    assert new.is_dir()
+    assert not (repo / "tasks" / "proposed" / str(new_id)).exists()
+    reg = json.loads((repo / "tasks" / "REGISTRY.json").read_text())
+    assert reg["tasks"][str(new_id)]["path"] == f"tasks/running/{new_id}"
+    events = [json.loads(line) for line in (new / "events.jsonl").read_text().splitlines() if line]
+    assert any(e["kind"] == "epm:status-changed" and e.get("to") == "running" for e in events)
+    assert tw.find_task_path(new_id) == new
+
+
+def test_find_task_path_stale_registry_entry_falls_back_to_scan(fake_repo, caplog):
+    """A stale registry entry (dir moved on disk, registry not updated — the
+    hard-kill residue shape) resolves via the on-disk scan with a logged
+    drift warning naming REGISTRY + the audit remedy."""
+    repo, tw = fake_repo
+    new_id = tw.create_task(tw.NewTaskRequest(kind="experiment", title="X"))
+    old = repo / "tasks" / "proposed" / str(new_id)
+    dest = repo / "tasks" / "interpreting" / str(new_id)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(old), str(dest))  # registry left pointing at proposed
+
+    with caplog.at_level(logging.WARNING, logger="explore_persona_space.task_workflow"):
+        path = tw.find_task_path(new_id)
+
+    assert path == dest
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("REGISTRY" in m and "audit" in m for m in messages)
+
+
+def test_find_task_path_ambiguous_duplicate_dirs_raises(fake_repo):
+    """A stale registry entry with the task dir present under TWO statuses is
+    real corruption: raise StaleTaskPathError naming both paths (never guess
+    one silently)."""
+    repo, tw = fake_repo
+    new_id = tw.create_task(tw.NewTaskRequest(kind="experiment", title="X"))
+    old = repo / "tasks" / "proposed" / str(new_id)
+    d1 = repo / "tasks" / "running" / str(new_id)
+    d2 = repo / "tasks" / "verifying" / str(new_id)
+    d1.parent.mkdir(parents=True, exist_ok=True)
+    d2.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(old, d1)
+    shutil.copytree(old, d2)
+    shutil.rmtree(old)  # registry still points at proposed (missing)
+
+    with pytest.raises(tw.StaleTaskPathError) as exc_info:
+        tw.find_task_path(new_id)
+    msg = str(exc_info.value)
+    assert f"tasks/running/{new_id}" in msg
+    assert f"tasks/verifying/{new_id}" in msg
+
+
+def test_set_status_ghost_deletion_swept_by_next_transition(fake_repo):
+    """The BINDING v2 Must-Fix pin (red without the §4.4 sweep): after a
+    git-crash residue on transition A→B, the NEXT transition B→C must sweep
+    the ghost old-status dir out of HEAD — no committed duplicate of the
+    task, no permanent unstaged deletions under tasks/."""
+    repo, tw = fake_repo
+    new_id = tw.create_task(tw.NewTaskRequest(kind="experiment", title="X"))
+
+    # Transition A→B crashes at the step-6 staging: nothing staged/committed;
+    # HEAD still tracks tasks/proposed/<id> (the ghost) while disk has moved on.
+    with pytest.MonkeyPatch.context() as mp:
+        _install_git_add_all_crash(tw, mp)
+        with pytest.raises(subprocess.CalledProcessError):
+            tw.set_status(new_id, "running")
+
+    # Injection removed — transition B→C must reconcile the residue.
+    tw.set_status(new_id, "verifying")
+
+    def ls_tree(pathspec: str) -> str:
+        return subprocess.run(
+            ["git", "ls-tree", "-r", "HEAD", "--", pathspec],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+    assert ls_tree(f"tasks/proposed/{new_id}") == ""  # ghost swept
+    assert ls_tree(f"tasks/running/{new_id}") == ""  # intermediate swept
+    assert ls_tree(f"tasks/verifying/{new_id}") != ""  # current status committed
+    porcelain = subprocess.run(
+        ["git", "status", "--porcelain", "--", "tasks/"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    dirty = [line for line in porcelain.splitlines() if f"/{new_id}/" in line]
+    assert dirty == [], f"leftover unstaged/uncommitted task paths: {dirty}"
+
+
+def test_set_status_same_transition_retry_resyncs_stale_registry(fake_repo, caplog):
+    """§4.5 pin (red without the early-return re-sync): retrying the SAME
+    transition against a stale registry entry (dir already at the
+    destination, registry pointing at the old path — the hard-kill shape)
+    must re-sync the registry before the idempotent early return."""
+    repo, tw = fake_repo
+    new_id = tw.create_task(tw.NewTaskRequest(kind="experiment", title="X"))
+    old = repo / "tasks" / "proposed" / str(new_id)
+    dest = repo / "tasks" / "running" / str(new_id)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(old), str(dest))  # hard-kill shape: moved, registry stale
+
+    with caplog.at_level(logging.WARNING, logger="explore_persona_space.task_workflow"):
+        returned = tw.set_status(new_id, "running")  # the SAME transition
+
+    assert returned == dest  # early return fired with the on-disk path
+    reg = json.loads((repo / "tasks" / "REGISTRY.json").read_text())
+    assert reg["tasks"][str(new_id)]["path"] == f"tasks/running/{new_id}"  # re-synced
+    assert any("re-synced stale REGISTRY entry" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
Closes task #898 (workflow-fix, kind: infra, auto-filed from #825).

## Summary
- `_run_git`: signature-keyed single retry (2-3s jittered) on git index.lock contention
- `set_status`: durable state (FS move + REGISTRY + events.jsonl) before any git op — the #825 stranded folder/registry split is unreachable via git failure
- `find_task_path`: stale-registry-entry scan fallback (warn+return / StaleTaskPathError on ambiguity)
- ghost-deletion sweep: next set_status reconciles a crashed transition's old-status dir out of HEAD (#644 class)
- early-return registry re-sync on idempotent retries

## Test plan
- [x] 11 new tests in tests/test_task_workflow.py; fail-pre-fix proven red-on-main (tests 5/9/11)
- [x] Step 9c touched subset: 2003 passed / 0 failed; ruff + workflow_lint clean
- [x] Code-review ensemble: Claude PASS + Codex CONCERNS (minors accepted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)