### PR TITLE
issue-896: union-merge agent-memory markdown in .gitattributes (+ pin test)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,17 @@
 tasks/**/events.jsonl merge=union
 tasks/**/comments.jsonl merge=union
 
+# Agent-memory markdown (#896): append-dominant files (new index lines in
+# MEMORY.md, new feedback_*.md sections) written by many concurrent sessions;
+# the 2026-07-02 root pull-rebase incident conflicted exactly on these files.
+# union is line-oriented: clean for append-append; concurrent EDITS of the
+# SAME region merge WITHOUT conflict markers and may duplicate/interleave
+# lines — accepted trade-off (benign duplication the owning agent self-heals
+# on its next write) vs a hard conflict blocking a fleet-wide root sync.
+# Same SCOPE CAVEAT as above: honored on LOCAL merges/rebases only —
+# server-side `gh pr merge` does not honor user-defined merge drivers.
+.claude/agent-memory/**/*.md merge=union
+
 # REGISTRY.json is deliberately NOT unioned — it is a last-writer-wins JSON
 # snapshot (atomic write-temp+rename), never append-only; a union merge would
 # concatenate two JSON objects into invalid JSON.

--- a/tests/test_step10d_guard3.py
+++ b/tests/test_step10d_guard3.py
@@ -81,6 +81,14 @@ def test_gitattributes_union_merge_for_events_and_comments():
     assert "tasks/**/comments.jsonl merge=union" in text, "comments.jsonl must use union merge"
 
 
+def test_gitattributes_union_merge_for_agent_memory():
+    """#896: agent-memory markdown must union-merge (2026-07-02 root pull-rebase incident)."""
+    text = _GITATTRIBUTES.read_text(encoding="utf-8")
+    assert ".claude/agent-memory/**/*.md merge=union" in text, (
+        "agent-memory .md files must use union merge (#896)"
+    )
+
+
 def test_gitattributes_registry_not_unioned():
     """REGISTRY.json is last-writer-wins; a union merge would break its JSON."""
     text = _GITATTRIBUTES.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Closes task #896 (2026-07-02 shared-root divergence incident closeout).
- Adds `.claude/agent-memory/**/*.md merge=union` to `.gitattributes` (the file class the incident's root pull-rebase actually conflicted on), with the #787 server-side scope caveat inherited in the comment.
- Adds `test_gitattributes_union_merge_for_agent_memory` to `tests/test_step10d_guard3.py` (mirrors the #787 pin-test pattern).

The task's other deliverables (root reconciliation verification, 3-stash content-safe drain, satisfied-by-#904 evidence) were root-side operations — recorded on task #896's events.jsonl + `artifacts/stash-drain-residuals.md`.

## Test plan
- [x] `pytest tests/test_step10d_guard3.py` 20/20 (incl. new pin test)
- [x] Step 9c touched-subset: 2061 passed / 6 skipped / 0 failed
- [x] `git check-attr merge .claude/agent-memory/critic/MEMORY.md` → union; REGISTRY negative control `unspecified`
- [x] ruff: no new findings vs main baseline; workflow_lint.py PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)