### PR TITLE
issue-900: verify_task_body check 27 — bare #K refs in v4 standalone sections

### DIFF
--- a/.claude/skills/clean-results/SPEC.md
+++ b/.claude/skills/clean-results/SPEC.md
@@ -904,6 +904,18 @@ Forward-only: each check branches on the sentinel. The v4 checks
     and interpretation prose BELOW (the three-beat). WARN (not FAIL) so a
     legitimately figure-less qualitative result is not blocked; the
     clean-result-critic owns the substantive beat read.
+27. **No bare issue refs in standalone sections**
+    (`check_v4_no_bare_issue_refs`, v4 only): a bare `#<digits>` token in
+    the `## Takeaways` / `## Methodology` / `## Results` section spans is
+    a hard FAIL — prior-issue references live ONLY in the `## Goal`
+    context slot (`[#K](...)` links) and the `**Repro:**`/`**Context:**`
+    footer. Sanctioned forms that do not trip: markdown links (label +
+    target), GFM table rows (the Training-table Source column), fenced +
+    inline code, `<details>` blocks, HTML comments, the footer,
+    frontmatter. The inline-code escape hatch is for non-issue `#N`
+    strings (colors, ordinals) only — never for a genuine issue
+    reference. (Origin: the #841 round-2 two-round Lens-2 miss; numbered
+    27 because 22-26 are taken by the generation-agnostic checks.)
 
 Generation-agnostic checks (v2 AND v3 AND v4): figure-URL-sha-matches
 (check 22), HF-URL-resolves (check 23). The Goal-of-experiment frontmatter

--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -6591,6 +6591,135 @@ def check_v4_results_beat(body: str) -> CheckResult:
     )
 
 
+# ─── v4 bare-issue-ref check (27) ─────────────────────────────────────────────
+
+# Bare issue reference: `#779`, `(#537)`, `#658's`. Bounded to 1-4 digits so an
+# all-digit 6-hex color (`#000000`) cannot match (fail-open on hypothetical
+# 5-digit issue ids beats fail-closed on hex colors — the LM lens is the
+# backstop). Lookbehind: not preceded by a word char (`file#123`), `&` (HTML
+# entities `&#8212;`), `/` (URL fragments `path/#123`), or `#`.
+_BARE_ISSUE_REF_RE = re.compile(r"(?<![\w&/#])#\d{1,4}(?!\d)")
+_HTML_COMMENT_INLINE_RE = re.compile(r"<!--.*?-->")
+_V4_STANDALONE_SECTIONS = ("takeaways", "methodology", "results")
+
+
+def _bare_issue_ref_hits(body: str) -> list[tuple[str, str, str]]:
+    """Return (section_name, matched_token, line_text) for every bare
+    `#<digits>` issue reference in the v4 standalone sections
+    (## Takeaways / ## Methodology / ## Results), excluding every
+    sanctioned form. `body` is the post-frontmatter text (as handed to
+    CHECKS entries by verify_text), so frontmatter bare refs never reach
+    the scan.
+
+    Sanctioned forms excluded: fenced code blocks, `<details>` blocks,
+    HTML comments (line-grain mask); GFM table rows; the
+    `**Repro:**`/`**Context:**` footer (line-index cut); markdown links
+    (label + target) and inline code spans (in-line neutralization,
+    substituting a single SPACE — never the empty string, which could
+    JOIN adjacent characters into a fabricated `#N` token, e.g.
+    ``#`x`123`` → `#123`).
+
+    Conservative edge behavior (all fail-open — missed refs, never false
+    FAILs; the clean-result-critic Lens 2 LM read is the backstop):
+
+    - The `<details>` open/close counter runs on RAW line text
+      PRE-neutralization, so a backticked ``<details>`` prose mention
+      opens the mask and excludes the remainder of the body.
+    - An unclosed `<details>` likewise excludes everything after it;
+      nesting is handled by the depth counter.
+    - 4-space indented code blocks and multi-line `[#K](\\nurl)` links
+      are NOT excluded (both survey-clean across all on-disk v4 bodies
+      as of 2026-07-03).
+    - In a slash-run `#658/#742` only the first token matches (the `/`
+      lookbehind protects URL fragments) — the line still FAILs, which
+      is sufficient.
+    """
+    lines = body.splitlines()
+    footer = _v4_footer_start_line(body)  # None -> no footer cut
+    table_idx = _table_row_line_indices(lines)
+    # Line-grain structural exclusion mask: fenced code, <details> blocks,
+    # HTML comment spans. Single pass, whole-body (fences/details/comments
+    # may open in one section and close in another).
+    excluded: set[int] = set()
+    in_fence = False
+    details_depth = 0
+    in_comment = False
+    for i, line in enumerate(lines):
+        s = line.strip()
+        if s.startswith("```") or s.startswith("~~~"):
+            in_fence = not in_fence
+            excluded.add(i)
+            continue
+        if in_fence:
+            excluded.add(i)
+            continue
+        if in_comment:
+            excluded.add(i)
+            if "-->" in line:
+                in_comment = False
+            continue
+        opens = len(re.findall(r"<details\b", line, re.IGNORECASE))
+        closes = len(re.findall(r"</details>", line, re.IGNORECASE))
+        if details_depth > 0 or opens:
+            excluded.add(i)
+        details_depth = max(0, details_depth + opens - closes)
+        tail = line[line.index("<!--") :] if "<!--" in line else ""
+        if tail and "-->" not in tail:
+            excluded.add(i)
+            in_comment = True
+    hits: list[tuple[str, str, str]] = []
+    for name, start, end in find_h2_sections(body):
+        if name.casefold() not in _V4_STANDALONE_SECTIONS:
+            continue
+        for i in range(start, end):
+            if footer is not None and i >= footer:
+                continue  # footer + everything after
+            if i in excluded or i in table_idx:
+                continue
+            # Substitute a single space (never ""): an empty-string sub
+            # can JOIN the char before and after the removed span into a
+            # new `#N` token that the raw line never carried.
+            residue = _LINK_RE.sub(" ", lines[i])  # [label](target) gone
+            residue = _INLINE_CODE_RE.sub(" ", residue)  # `code` escape hatch
+            residue = _HTML_COMMENT_INLINE_RE.sub(" ", residue)
+            for m in _BARE_ISSUE_REF_RE.finditer(residue):
+                hits.append((name, m.group(0), lines[i].strip()[:90]))
+    return hits
+
+
+def check_v4_no_bare_issue_refs(body: str) -> CheckResult:
+    """Check 27 (v4 only): no bare `#<digits>` issue refs in the standalone
+    sections. SPEC.md § `## Goal` (v4): the Goal context slot is the ONLY
+    place in the body that may cite prior tasks; `## Takeaways` /
+    `## Methodology` / `## Results` are standalone, and lineage/provenance
+    live in the `**Repro:**`/`**Context:**` footer. Sanctioned forms that
+    do not trip: markdown links (label + target), GFM table rows (the
+    Training-table Source column), fenced/inline code, `<details>` blocks,
+    HTML comments, the footer, YAML frontmatter. Exclusion edge behavior
+    (all fail-open) is documented on `_bare_issue_ref_hits`. Origin: #841
+    round-2 (bare `#779` x~8 in Methodology survived two ensemble review
+    rounds). PASSes vacuously on v3 / v2 / legacy bodies (forward-only)."""
+    label = "no bare issue refs in standalone sections (v4)"
+    if not is_v4(body):
+        return CheckResult(label, True, "skipped — not a v4 body")
+    hits = _bare_issue_ref_hits(body)
+    if not hits:
+        return CheckResult(label, True, "Takeaways/Methodology/Results carry no bare `#K` refs")
+    shown = "; ".join(f'## {sec}: `{tok}` in "{txt}"' for sec, tok, txt in hits[:5])
+    more = f" (+{len(hits) - 5} more)" if len(hits) > 5 else ""
+    return CheckResult(
+        label,
+        False,
+        f"bare issue reference(s) in standalone section(s) — {shown}{more}. "
+        "Prior-issue references live ONLY in the `## Goal` context slot as "
+        "`[#K](https://eps.superkaiba.com/tasks/K)` links and in the `**Repro:**`/"
+        "`**Context:**` footer (SPEC.md § `## Goal` (v4) + Rule A). Rewrite the prose to "
+        "describe the method standalone and move lineage to the footer. The inline-code "
+        "escape hatch is for NON-issue `#N` strings only (a hex color, an ordinal like "
+        "`GPU #2`) — do NOT backtick a genuine issue reference to silence this check.",
+    )
+
+
 # ─── v3 body-table ⊆ methodology-doc table check (21) ────────────────────────
 
 
@@ -6881,6 +7010,7 @@ CHECKS = [
     check_v4_methodology_shape,  # check 18 (v4)
     check_v4_word_caps,  # check 20 (v4)
     check_v4_results_beat,  # check 21 (v4, WARN)
+    check_v4_no_bare_issue_refs,  # check 27 (v4) — bare `#K` refs in standalone sections
     # generation-agnostic checks (v2 AND v3 AND v4):
     check_figure_url_sha_matches_repro,  # check 22
     check_hf_url_resolves,  # check 23

--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -6597,10 +6597,56 @@ def check_v4_results_beat(body: str) -> CheckResult:
 # all-digit 6-hex color (`#000000`) cannot match (fail-open on hypothetical
 # 5-digit issue ids beats fail-closed on hex colors — the LM lens is the
 # backstop). Lookbehind: not preceded by a word char (`file#123`), `&` (HTML
-# entities `&#8212;`), `/` (URL fragments `path/#123`), or `#`.
-_BARE_ISSUE_REF_RE = re.compile(r"(?<![\w&/#])#\d{1,4}(?!\d)")
-_HTML_COMMENT_INLINE_RE = re.compile(r"<!--.*?-->")
+# entities `&#8212;`), `/` (URL fragments `path/#123`), or `#`. Right guard
+# `(?!\w)`: the digit run must not abut a word char, so `#123abc` and the
+# digit prefix of a mixed hex color (`#4b5563` → `#4`) never match; a
+# possessive `#658's` still does (an apostrophe is not a word char).
+_BARE_ISSUE_REF_RE = re.compile(r"(?<![\w&/#])#\d{1,4}(?!\w)")
 _V4_STANDALONE_SECTIONS = ("takeaways", "methodology", "results")
+
+
+def _mask_html_comment_spans(line: str, in_comment: bool) -> tuple[str, bool]:
+    """Replace every HTML-comment span in `line` with spaces, threading the
+    multiline open/closed state across calls (one call per line, in order).
+
+    Character-grain, not line-grain: a line that OPENS a comment keeps its
+    prefix prose scannable (only `<!--`..end-of-line is masked); a line
+    that CLOSES one keeps its suffix scannable (only up to and including
+    `-->` is masked); any number of `<!-- ... -->` segments per line are
+    each masked with the prose between them kept, and a close-then-reopen
+    line (`<!-- a --> mid <!-- b`) returns the state OPEN so following
+    interior lines stay masked. Spans are substituted with same-length
+    runs of spaces — never deleted — so no token join can fabricate a
+    `#N` the raw line never carried.
+
+    Returns (masked_line, out_state); len(masked_line) == len(line).
+    """
+    out: list[str] = []
+    pos = 0
+    n = len(line)
+    while pos < n:
+        if in_comment:
+            close = line.find("-->", pos)
+            if close == -1:
+                out.append(" " * (n - pos))
+                pos = n
+            else:
+                end = close + 3
+                out.append(" " * (end - pos))
+                pos = end
+                in_comment = False
+        else:
+            opener = line.find("<!--", pos)
+            if opener == -1:
+                out.append(line[pos:])
+                pos = n
+            else:
+                out.append(line[pos:opener])
+                pos = opener
+                in_comment = True
+    masked = "".join(out)
+    assert len(masked) == len(line), (len(masked), len(line))
+    return masked, in_comment
 
 
 def _bare_issue_ref_hits(body: str) -> list[tuple[str, str, str]]:
@@ -6612,24 +6658,43 @@ def _bare_issue_ref_hits(body: str) -> list[tuple[str, str, str]]:
     the scan.
 
     Sanctioned forms excluded: fenced code blocks, `<details>` blocks,
-    HTML comments (line-grain mask); GFM table rows; the
+    HTML comments (char-span mask with cross-line open/closed state —
+    `_mask_html_comment_spans`); GFM table rows; the
     `**Repro:**`/`**Context:**` footer (line-index cut); markdown links
     (label + target) and inline code spans (in-line neutralization,
     substituting a single SPACE — never the empty string, which could
     JOIN adjacent characters into a fabricated `#N` token, e.g.
     ``#`x`123`` → `#123`).
 
-    Conservative edge behavior (all fail-open — missed refs, never false
-    FAILs; the clean-result-critic Lens 2 LM read is the backstop):
+    HTML-comment handling is character-grain, not line-grain: on a line
+    that OPENS a multiline comment only the `<!--`..end-of-line span is
+    masked (prefix prose IS scanned — `Uses #779 corpus <!-- note`
+    hits); on a line that CLOSES one only the span up to and including
+    `-->` is masked (suffix prose IS scanned — `--> still follows #781`
+    hits); multiple `<!-- ... -->` segments per line are each masked
+    with the prose between them scanned, and a close-then-reopen line
+    (`<!-- a --> mid <!-- b`) leaves the state OPEN so following
+    interior lines stay masked (no false hit on a `#K` inside the still
+    open comment). The `<details>` counter reads the comment-MASKED
+    text, so a commented-out `<details>` tag cannot open the details
+    mask.
 
-    - The `<details>` open/close counter runs on RAW line text
-      PRE-neutralization, so a backticked ``<details>`` prose mention
-      opens the mask and excludes the remainder of the body.
+    Documented residual edges (the clean-result-critic Lens 2 LM read is
+    the backstop; direction noted per item):
+
+    - The `<details>` open/close counter runs PRE-neutralization (before
+      link/inline-code masking), so a backticked ``<details>`` prose
+      mention opens the mask and excludes the remainder of the body
+      (fail-open — missed refs, never false FAILs).
     - An unclosed `<details>` likewise excludes everything after it;
-      nesting is handled by the depth counter.
+      nesting is handled by the depth counter (fail-open).
+    - The comment char-span pass also runs PRE-neutralization, so a
+      backticked ``<!--`` prose mention opens the comment mask
+      (fail-open, same family as the backticked ``<details>``).
     - 4-space indented code blocks and multi-line `[#K](\\nurl)` links
       are NOT excluded (both survey-clean across all on-disk v4 bodies
-      as of 2026-07-03).
+      as of 2026-07-03) — a `#K` inside either would false-FAIL; the
+      inline-code escape hatch covers the code-block case.
     - In a slash-run `#658/#742` only the first token matches (the `/`
       lookbehind protects URL fragments) — the line still FAILs, which
       is sufficient.
@@ -6637,10 +6702,14 @@ def _bare_issue_ref_hits(body: str) -> list[tuple[str, str, str]]:
     lines = body.splitlines()
     footer = _v4_footer_start_line(body)  # None -> no footer cut
     table_idx = _table_row_line_indices(lines)
-    # Line-grain structural exclusion mask: fenced code, <details> blocks,
-    # HTML comment spans. Single pass, whole-body (fences/details/comments
-    # may open in one section and close in another).
+    # Structural exclusion mask: line-grain for fenced code + <details>
+    # blocks, char-grain for HTML comments (comment_masked[i] = line i
+    # with every comment span space-substituted; mixed prose on comment
+    # opening/closing lines stays scannable). Single pass, whole-body
+    # (fences/details/comments may open in one section and close in
+    # another).
     excluded: set[int] = set()
+    comment_masked: dict[int, str] = {}
     in_fence = False
     details_depth = 0
     in_comment = False
@@ -6653,20 +6722,13 @@ def _bare_issue_ref_hits(body: str) -> list[tuple[str, str, str]]:
         if in_fence:
             excluded.add(i)
             continue
-        if in_comment:
-            excluded.add(i)
-            if "-->" in line:
-                in_comment = False
-            continue
-        opens = len(re.findall(r"<details\b", line, re.IGNORECASE))
-        closes = len(re.findall(r"</details>", line, re.IGNORECASE))
+        masked, in_comment = _mask_html_comment_spans(line, in_comment)
+        comment_masked[i] = masked
+        opens = len(re.findall(r"<details\b", masked, re.IGNORECASE))
+        closes = len(re.findall(r"</details>", masked, re.IGNORECASE))
         if details_depth > 0 or opens:
             excluded.add(i)
         details_depth = max(0, details_depth + opens - closes)
-        tail = line[line.index("<!--") :] if "<!--" in line else ""
-        if tail and "-->" not in tail:
-            excluded.add(i)
-            in_comment = True
     hits: list[tuple[str, str, str]] = []
     for name, start, end in find_h2_sections(body):
         if name.casefold() not in _V4_STANDALONE_SECTIONS:
@@ -6678,10 +6740,11 @@ def _bare_issue_ref_hits(body: str) -> list[tuple[str, str, str]]:
                 continue
             # Substitute a single space (never ""): an empty-string sub
             # can JOIN the char before and after the removed span into a
-            # new `#N` token that the raw line never carried.
-            residue = _LINK_RE.sub(" ", lines[i])  # [label](target) gone
+            # new `#N` token that the raw line never carried. Comment
+            # spans were already space-masked in comment_masked (every
+            # non-fence line has an entry; fence lines are excluded).
+            residue = _LINK_RE.sub(" ", comment_masked[i])  # [label](target) gone
             residue = _INLINE_CODE_RE.sub(" ", residue)  # `code` escape hatch
-            residue = _HTML_COMMENT_INLINE_RE.sub(" ", residue)
             for m in _BARE_ISSUE_REF_RE.finditer(residue):
                 hits.append((name, m.group(0), lines[i].strip()[:90]))
     return hits
@@ -6696,7 +6759,7 @@ def check_v4_no_bare_issue_refs(body: str) -> CheckResult:
     do not trip: markdown links (label + target), GFM table rows (the
     Training-table Source column), fenced/inline code, `<details>` blocks,
     HTML comments, the footer, YAML frontmatter. Exclusion edge behavior
-    (all fail-open) is documented on `_bare_issue_ref_hits`. Origin: #841
+    (residuals + directions) is documented on `_bare_issue_ref_hits`. Origin: #841
     round-2 (bare `#779` x~8 in Methodology survived two ensemble review
     rounds). PASSes vacuously on v3 / v2 / legacy bodies (forward-only)."""
     label = "no bare issue refs in standalone sections (v4)"

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -4954,6 +4954,93 @@ def test_v4_space_substitution_does_not_fabricate_ref():
     assert r.passed, r.render()
 
 
+def test_v4_bare_ref_prefix_prose_on_comment_opening_line_fails():
+    """Char-span comment mask: prose BEFORE a `<!--` that opens a multiline
+    comment is still scanned — `Uses #779 corpus <!-- note` hits (concern
+    comment-mask-mixed-line-fail-open; the round-1 line-grain mask
+    excluded the whole line and missed the ref)."""
+    body = _V4_GOOD_BODY.replace(
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct.",
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct.\n"
+        "Uses #779 corpus <!-- note\ninterior continues -->",
+    )
+    r = _bare_ref_result(body)
+    assert not r.passed
+    assert "#779" in r.detail
+    assert "Methodology" in r.detail
+
+
+def test_v4_bare_ref_suffix_prose_on_comment_closing_line_fails():
+    """Char-span comment mask: prose AFTER the `-->` that closes a
+    multiline comment is still scanned — `--> still follows #781` hits,
+    while a `#999` on the comment's interior stays masked."""
+    body = _V4_GOOD_BODY.replace(
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct.",
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct.\n"
+        "<!-- lineage note #999\n--> still follows #781",
+    )
+    r = _bare_ref_result(body)
+    assert not r.passed
+    assert "#781" in r.detail
+    assert "#999" not in r.detail
+
+
+def test_v4_comment_close_reopen_masks_interior_and_scans_between():
+    """Close-then-reopen on one line (`<!-- a --> #779 <!-- b`): both
+    comment segments are masked, the prose BETWEEN them is scanned (the
+    `#779` hit), and the state is left OPEN so a `#123` on the following
+    interior line yields NO hit (concern
+    comment-close-reopen-false-positive; the round-1 first-`<!--` anchor
+    left the state closed and false-hit the interior)."""
+    body = _V4_GOOD_BODY.replace(
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct.",
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct.\n"
+        "<!-- a --> #779 <!-- b\nstill inside the comment: #123 -->",
+    )
+    _fm, post_fm = verify_task_body.split_frontmatter(body)
+    hits = verify_task_body._bare_issue_ref_hits(post_fm)
+    assert [(sec, tok) for sec, tok, _txt in hits] == [("Methodology", "#779")], hits
+
+
+def test_v4_ref_flush_against_word_char_passes_but_possessive_fails():
+    """`(?!\\w)` right guard: `#123abc` (digit run flush against a word
+    char, the mixed-hex-color shape) never matches; a possessive `#658's`
+    still FAILs — an apostrophe is not a word char."""
+    body = _V4_GOOD_BODY.replace(
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct.",
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct.\nBars use the #123abc palette variant.",
+    )
+    r = _bare_ref_result(body)
+    assert r.passed, r.render()
+    body2 = _V4_GOOD_BODY.replace(
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct.",
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct.\nMatches #658's protocol.",
+    )
+    r2 = _bare_ref_result(body2)
+    assert not r2.passed
+    assert "#658" in r2.detail
+
+
+def test_mask_html_comment_spans_char_grain():
+    """Unit-pin `_mask_html_comment_spans`: space substitution preserves
+    line length, prefix/suffix prose survives, close-then-reopen leaves
+    the state OPEN."""
+    f = verify_task_body._mask_html_comment_spans
+    m, state = f("Uses #779 corpus <!-- note", False)
+    assert m == "Uses #779 corpus " + " " * len("<!-- note")
+    assert state is True
+    m, state = f("all interior #123", True)
+    assert m == " " * len("all interior #123")
+    assert state is True
+    m, state = f("--> tail #781", True)
+    assert m == "   " + " tail #781"
+    assert state is False
+    m, state = f("<!-- a --> mid <!-- b", False)
+    assert m == " " * len("<!-- a -->") + " mid " + " " * len("<!-- b")
+    assert state is True
+    assert all(len(f(s, st)[0]) == len(s) for s in ("", "x <!-- y --> z") for st in (False, True))
+
+
 # ─── check 22: inline figure URL sha vs Reproducibility figure-commit claim ──
 #
 # The inline figure in _V3_GOOD_BODY is pinned at sha `0123456789abcdef`

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -104,15 +104,16 @@ def test_good_body_passes_all():
     ok, results = verify_task_body.verify_text(GOOD_BODY)
     assert ok, [r.render() for r in results if not r.passed]
     assert all(r.passed for r in results)
-    # CHECKS has 31 body-only functions: the 20 pre-v3 body-only checks
+    # CHECKS has 32 body-only functions: the 20 pre-v3 body-only checks
     # (incl. the sentinel-gated `check_tldr_nested_structure` and the
     # check-8b Reproducibility artifact-URL existence probe), the four
     # v3-gated body-only checks (check 18 `check_data_shape`, check 19
     # `check_data_subset_disclosure`, check 19b
     # `check_data_unwrapped_example_table` WARN, check 20
-    # `check_v3_word_caps`), the THREE v4-gated body-only checks added
-    # 2026-W26 (check 18 `check_v4_methodology_shape`, check 20
-    # `check_v4_word_caps`, check 21 `check_v4_results_beat` WARN) — each
+    # `check_v3_word_caps`), the FOUR v4-gated body-only checks (check 18
+    # `check_v4_methodology_shape`, check 20 `check_v4_word_caps`, check
+    # 21 `check_v4_results_beat` WARN, check 27
+    # `check_v4_no_bare_issue_refs`) — each
     # a PASS-skip on this non-v3/non-v4 fixture — PLUS the FOUR
     # generation-agnostic checks: check 22
     # (`check_figure_url_sha_matches_repro`), a NO-OP PASS here because
@@ -129,16 +130,16 @@ def test_good_body_passes_all():
     # is a vacuous PASS here because this fixture carries no
     # availability-denial-near-artifact line. verify_text prepends check 0
     # (body-nonstub) + check 0b (no-duplicate-frontmatter), runs CHECKS[1:]
-    # (31 functions), then appends the Goal soft check, the Lens 14
+    # (32 functions), then appends the Goal soft check, the Lens 14
     # concerns-audit, the check-16 lr-matches-plan reconciliation, the
     # check-17 Context provenance-row read, the v3 check-21
     # body-Parameters-⊆-doc reconciliation (PASS-skip with no doc), AND the
     # #732 judge-API-error denominator check (PASS-skip: legacy body) →
-    # 39 results total (2 prepended + CHECKS[1:]=31 + 6 appended). The
+    # 40 results total (2 prepended + CHECKS[1:]=32 + 6 appended). The
     # Lens 14 / check-16 results are PASS-skips when no concerns.jsonl /
     # plans/plan.md sibling is available; check 17 and the v3/v4 checks
     # are PASS-skips on this legacy (pre-v2-sentinel) fixture.
-    assert len(results) == 39
+    assert len(results) == 40
 
 
 def test_missing_confidence_tag():
@@ -2428,13 +2429,15 @@ def test_audit_context_row_blockquote_exempt():
 
 
 def test_checks_list_size():
-    """CHECKS contains 32 body-only functions: the 20 pre-v3 checks
+    """CHECKS contains 33 body-only functions: the 20 pre-v3 checks
     (the 18 under the 2-content-section spec, the nested-design (v2)
     sentinel-gated `check_tldr_nested_structure`, and the check-8b
     Reproducibility artifact-URL existence probe), the four
-    v3-gated body-only checks added 2026-W24, and the THREE v4-gated
-    body-only checks added 2026-W26 (`check_v4_methodology_shape`,
-    `check_v4_word_caps`, `check_v4_results_beat`). The four
+    v3-gated body-only checks added 2026-W24, and the FOUR v4-gated
+    body-only checks (`check_v4_methodology_shape`,
+    `check_v4_word_caps`, `check_v4_results_beat`, plus check 27
+    `check_v4_no_bare_issue_refs` — bare `#K` refs in the standalone
+    sections, #900). The four
     v3-gated checks added 2026-W24 are — check 18
     (`check_data_shape`), check 19 (`check_data_subset_disclosure`),
     check 19b (`check_data_unwrapped_example_table`, WARN), check 20
@@ -2458,11 +2461,14 @@ def test_checks_list_size():
     something beyond the body string): the Goal soft check (needs
     frontmatter), the Lens 14 concerns-audit (needs concerns.jsonl),
     the check-16 lr-matches-plan (needs the plan), the check-17 Context
-    provenance row (needs frontmatter + original-body.md), and the v3
-    check-21 body-Parameters-⊆-doc (needs the methodology doc path). So
-    `verify_text` returns 38 results, but `CHECKS` stays at 32.
+    provenance row (needs frontmatter + original-body.md), the v3
+    check-21 body-Parameters-⊆-doc (needs the methodology doc path),
+    and the #732 judge-API-error denominator check (needs eval JSONs).
+    So `verify_text` returns 40 results (2 prepended + CHECKS[1:]=32 +
+    6 appended — see `test_good_body_passes_all`), but `CHECKS` stays
+    at 33.
     """
-    assert len(verify_task_body.CHECKS) == 32
+    assert len(verify_task_body.CHECKS) == 33
 
 
 # ─── Check 14: MDX-safe prose (regex layer + real-parse backstop) ───
@@ -4510,6 +4516,9 @@ def test_v4_good_body_passes_all():
     assert by_name["v3 conciseness caps"].passed
     # The v2-only nested-structure check PASS-skips on a v4 body.
     assert by_name["TL;DR nested-design structure (v2)"].passed
+    # Check 27: the fixture's standalone sections carry no bare `#K` refs
+    # (its `[#34](...)` Goal link + footer lineage are sanctioned forms).
+    assert by_name["no bare issue refs in standalone sections (v4)"].passed
     # The only FAILs are the two existence probes on the fake sha.
     fails = [r.name for r in results if not r.passed]
     assert set(fails) <= {"Figure URL resolvable", "Reproducibility artifact URLs exist"}, fails
@@ -4793,6 +4802,156 @@ def test_v4_methodology_bare_rows_disclosure_passes_check10():
     assert by_name["Cherry-picked label discipline"].passed, by_name[
         "Cherry-picked label discipline"
     ].render()
+
+
+# ─── check 27: bare `#K` issue refs in v4 standalone sections ────────────────
+
+_BARE_REF_CHECK_NAME = "no bare issue refs in standalone sections (v4)"
+
+
+def _bare_ref_result(fixture_text):
+    """Direct-call check 27 on the post-frontmatter body, as verify_text does."""
+    _fm, body = verify_task_body.split_frontmatter(fixture_text)
+    return verify_task_body.check_v4_no_bare_issue_refs(body)
+
+
+def test_v4_bare_issue_ref_in_methodology_prose_fails():
+    """The #841 shape: a bare `#779` in Methodology prose is a hard FAIL
+    (run through verify_text to pin the CHECKS registration)."""
+    body = _V4_GOOD_BODY.replace(
+        "- **Design:** 3 seeds;",
+        "- **Design:** 3 seeds on the #779 LMSYS corpus;",
+    )
+    _ok, results = verify_task_body.verify_text(body)
+    r = _results_by_name(results)[_BARE_REF_CHECK_NAME]
+    assert not r.passed
+    assert "#779" in r.detail
+    assert "Methodology" in r.detail
+
+
+def test_v4_issue_ref_in_table_row_passes():
+    """A `#K` in a GFM table row (the Training-table Source column
+    grounding convention) is a sanctioned form."""
+    body = _V4_GOOD_BODY.replace(
+        "| Seeds | [42, 137, 256] | plan §11 |\n",
+        "| Seeds | [42, 137, 256] | plan §11 |\n| Judge cache | reused | #779 |\n",
+    )
+    r = _bare_ref_result(body)
+    assert r.passed, r.render()
+
+
+def test_v4_linked_issue_ref_passes_mechanically():
+    """A `[#K](url)` LINK in Methodology is deliberately out of MECHANICAL
+    scope (plan Non-goals: the linked-form violation stays Lens 2 / Rule A
+    territory); the fixture's Goal `[#34](...)` link is sanctioned too."""
+    body = _V4_GOOD_BODY.replace(
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct.",
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct. "
+        "Recipe as in [#779](https://eps.superkaiba.com/tasks/779).",
+    )
+    r = _bare_ref_result(body)
+    assert r.passed, r.render()
+
+
+def test_bare_ref_check_skips_v3_and_legacy():
+    """Forward-only: bare refs in a v3 `## Findings` / legacy prose never
+    fire the check (PASS-skip)."""
+    v3 = _V3_GOOD_BODY.replace("## Findings", "## Findings\n\nUses the #779 corpus.", 1)
+    legacy = GOOD_BODY.replace("### Motivation", "### Motivation\n\nUses the #779 corpus.", 1)
+    for fixture in (v3, legacy):
+        r = _bare_ref_result(fixture)
+        assert r.passed
+        assert "skipped" in r.detail
+
+
+def test_v4_bare_ref_in_fence_and_comment_passes():
+    """`#K` inside a fenced code block or an HTML comment is sanctioned."""
+    body = _V4_GOOD_BODY.replace(
+        "\n## Results\n",
+        "\n```text\ngrep for #779 rows\n```\n\n<!-- lineage: #613 -->\n\n## Results\n",
+    )
+    r = _bare_ref_result(body)
+    assert r.passed, r.render()
+
+
+def test_v4_bare_ref_in_footer_passes():
+    """Lineage refs in the `**Context:**` footer are sanctioned (the
+    footer-line cut); in a slash-run `#658/#742` nothing fires here."""
+    body = _V4_GOOD_BODY.replace(
+        "- Originating prompt: origin prompt not recorded\n",
+        "- Originating prompt: origin prompt not recorded\n- Parent #34; informed by #658/#742.\n",
+    )
+    r = _bare_ref_result(body)
+    assert r.passed, r.render()
+
+
+def test_v4_bare_issue_ref_in_takeaways_fails():
+    """Takeaways IS a standalone section (SPEC.md: `## Goal` is the ONLY
+    place that may cite prior tasks) — a bare ref there FAILs (run through
+    verify_text to pin the registration on the Takeaways span too)."""
+    body = _V4_GOOD_BODY.replace(
+        "- Caveat that binds interpretation: single model family, three seeds only.\n",
+        "- Caveat that binds interpretation: single model family, three seeds only.\n"
+        "- Matches the #537 protocol readout.\n",
+    )
+    _ok, results = verify_task_body.verify_text(body)
+    r = _results_by_name(results)[_BARE_REF_CHECK_NAME]
+    assert not r.passed
+    assert "#537" in r.detail
+    assert "Takeaways" in r.detail
+
+
+def test_v4_bare_ref_in_details_block_passes():
+    """`#K` inside a `<details>` block (verbatim sample data) is sanctioned;
+    the fixture anchor is literally `<details open>` — pins the `<details\\b`
+    regex covering attribute-bearing open tags."""
+    body = _V4_GOOD_BODY.replace(
+        "<summary>5 example training rows (5 of 2,000 rows, random sample)</summary>\n",
+        "<summary>5 example training rows (5 of 2,000 rows, random sample)</summary>\n"
+        "\nRows drawn per #658.\n",
+    )
+    r = _bare_ref_result(body)
+    assert r.passed, r.render()
+
+
+def test_v4_bare_issue_ref_in_results_caption_fails():
+    """The live #667 shape: a bare ref in a `> **Figure.**` caption line
+    under `## Results` FAILs (a blockquote caption is prose, not a
+    sanctioned form)."""
+    body = _V4_GOOD_BODY.replace(
+        "error bars 95% Wald CIs.",
+        "error bars 95% Wald CIs (#667 protocol).",
+    )
+    r = _bare_ref_result(body)
+    assert not r.passed
+    assert "#667" in r.detail
+    assert "Results" in r.detail
+
+
+def test_v4_inline_code_escape_hatch_passes():
+    """A non-issue `#N` string (a 3-digit hex color) wrapped in inline code
+    is the documented escape hatch."""
+    body = _V4_GOOD_BODY.replace(
+        "the smallest within-condition gap between seeds is 1.2 pts.",
+        "the smallest within-condition gap between seeds is 1.2 pts. Bars colored `#333`.",
+    )
+    r = _bare_ref_result(body)
+    assert r.passed, r.render()
+
+
+def test_v4_space_substitution_does_not_fabricate_ref():
+    """Neutralization substitutes a SPACE, never the empty string: on
+    ``prefix #`v`123`` an empty-string strip of the inline-code span would
+    JOIN `#` and `123` into a fabricated `#123` hit; the space substitution
+    keeps them apart. Regression for the plan-review neutralization-join
+    concern."""
+    body = _V4_GOOD_BODY.replace(
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct.",
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct.\n"
+        "- **Note:** config ids use the prefix #`v`123 shape.",
+    )
+    r = _bare_ref_result(body)
+    assert r.passed, r.render()
 
 
 # ─── check 22: inline figure URL sha vs Reproducibility figure-commit claim ──


### PR DESCRIPTION
Closes task #900 (workflow-fix, kind: infra).

## Summary
- New v4-gated check `check_v4_no_bare_issue_refs` (check 27) in `scripts/verify_task_body.py`: hard-FAILs bare `#<digits>` issue refs in the `## Takeaways` / `## Methodology` / `## Results` spans of a `<!-- clean-result-v4 -->` body. Sanctioned forms exempt (markdown links, table rows, fenced/inline code, `<details>`, HTML comments via char-span masking, footer, frontmatter); v3/v2/legacy PASS-skip (forward-only).
- SPEC.md mechanical-checks item 27 synced; 16 new regression tests (both count pins bumped).
- Origin incident #841 mechanically caught (pre-fix body → 12 hits, FAIL); 24-body corpus survey: 0 false positives.

## Test plan
- [x] `uv run pytest tests/test_verify_task_body.py` — 308 passed / 6 skipped
- [x] Step 9c touched-scope suite — 2057 passed / 6 skipped
- [x] ruff check + format --check clean
- [x] Corpus survey (24 v4 docs) + #841 origin replay

🤖 Generated with [Claude Code](https://claude.com/claude-code)