### PR TITLE
workflow-fix #897: guard repo-root working-tree reverts

### DIFF
--- a/.claude/agents/analyzer.md
+++ b/.claude/agents/analyzer.md
@@ -247,8 +247,8 @@ Full text: `analyzer-section-reference.md`
 ### Hard rule: NEVER a destructive git command on the shared repo root
 
 Never run a destructive repo-root reset (a `--hard` reset without a
-`git -C "$WT"` prefix) — nor `git checkout .` / `git clean -f` /
-`git restore .` on the shared tree — EVER. The repo root's `tasks/` subtree
+`git -C "$WT"` prefix) — nor `git checkout .` / `git clean -f` / <!-- workflow-lint: allow-repo-root-wt-revert: ban-context mention of the banned command (#897) -->
+`git restore .` on the shared tree — EVER. <!-- workflow-lint: allow-repo-root-wt-revert: ban-context mention of the banned command (#897) --> The repo root's `tasks/` subtree
 hosts EVERY concurrent sibling task's durable state, and `task.py` holds a
 per-registry `flock`, not per-file. Incident 2026-07-01: a #778 analyzer's
 improvised reset silently CLOBBERed the concurrent siblings #812/#813

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -471,8 +471,10 @@ Two checks:
 a test or smoke that regenerates files under `eval_results/` /
 `figures/`, afterwards run
 `git status --porcelain -- eval_results/ figures/`, restore the committed
-artifacts YOUR OWN command modified (`git checkout -- <paths>` scoped to
-those files, never a blanket revert) and delete the untracked outputs it
+artifacts YOUR OWN command modified
+(`git -C <tree-root> checkout -- <paths>` — the `-C` both names the tree
+deliberately and passes the repo-root guard (#897) — never a blanket
+revert) and delete the untracked outputs it
 left; leaving them dirty plants the clobber for the next explicit-path
 commit (#722 instance 2 was exactly this). Binds BOTH ensemble
 reviewers (rides into the Codex twin via the inlined Step 0.6 rubric).

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -7888,7 +7888,10 @@ Decision tree:
 
   ```bash
   cd "$REPO_ROOT"
-  xargs -a /tmp/issue-<N>-additive-files.txt git checkout issue-<N> --
+  # `-C "$REPO_ROOT"` is the repo-root guard's designed deliberate-override
+  # (#897): the hook's working-tree-revert detector would bounce the bare
+  # `checkout <branch> -- <paths>` form; the `-C` names the tree explicitly.
+  xargs -a /tmp/issue-<N>-additive-files.txt git -C "$REPO_ROOT" checkout issue-<N> --
   xargs -a /tmp/issue-<N>-additive-files.txt git add --
   git diff --cached --name-only   # sanity echo: spot any foreign staged entries
   xargs -a /tmp/issue-<N>-additive-files.txt git commit -m "issue-<N>: surgical additive checkout (full rebase deferred — guard 3)

--- a/scripts/guard_repo_root_branch.sh
+++ b/scripts/guard_repo_root_branch.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# PreToolUse(Bash) guard: block branch-switching in the SHARED repo-root tree.
+# PreToolUse(Bash) guard: block branch-switching AND working-tree reverts in
+# the SHARED repo-root tree.
 #
 # The repo root (/home/thomasjiralerspong/explore-persona-space) is the
 # canonical commit target for scripts/task.py and every concurrent VM Claude
@@ -7,16 +8,37 @@
 # `git checkout -b` / `git switch` here moves the branch out from under those
 # concurrent committers: their commits land on the feature branch, and a
 # concurrent `git add <file> && git commit` sweeps THIS session's uncommitted
-# edits to <file> into the wrong commit.
+# edits to <file> into the wrong commit. A working-tree REVERT here (`git
+# restore`, a pathspec / bare-path / force `git checkout`, `git clean -f`,
+# `git reset --hard`) is just as destructive: it silently discards CONCURRENT
+# sessions' uncommitted edits and untracked files (#897).
 #
 # Incident 2026-06-01: an infra session ran `git checkout -b fix/sweep-ckpt-persist`
 # in the repo root; a concurrent marker-leakage session's CLAUDE.md commit then
 # bundled the infra session's Upload-Policy paragraph, and task #459 state landed
 # on the feature branch.
+# Incident 2026-07-01 (#815): a #778 analyzer's improvised repo-root
+# `git reset --hard` clobbered concurrent siblings #812/#813's task state.
+# Incident 2026-07-02 (#841): a concurrent destructive working-tree op on the
+# shared root reverted the #841 analyzer's uncommitted body.md mid-task and
+# deleted untracked pre-registration + figure files.
 #
-# Fix: do feature/infra branch work in a dedicated worktree instead:
+# Fix: do feature/infra branch AND destructive work in a dedicated worktree:
 #     bash scripts/new_worktree.sh .claude/worktrees/<name> <branch>
-#     cd .claude/worktrees/<name>
+#     git -C .claude/worktrees/<name> ...
+#
+# THREAT MODEL / scope (#897): this hook gates ONLY Claude Bash tool calls.
+# Git run inside Python subprocesses (sync_repo_root.py carries its own
+# internal deny checker), cron wrappers, pod-side scripts, and SSH-MCP remote
+# commands never pass PreToolUse; non-git destruction (`rm`, `mv`, `>`
+# truncation, `sed -i`) is out of scope by design. CWD-BLINDNESS: the hook
+# never consults the caller's actual $PWD — a session whose cwd genuinely IS a
+# worktree running a bare `git restore .` is still blocked and should use
+# `git -C <worktree>` (the designed deliberate-override). Bash("ssh ...")
+# edge: a REMOTE command string carrying `git checkout HEAD -- <file>` (the
+# gotchas.md diverged-pod recovery) trips the raw scan; remediation is
+# `git -C /workspace/... checkout HEAD -- <file>` inside the remote string, or
+# the SSH MCP (which bypasses the Bash hook entirely).
 #
 # Contract: reads the PreToolUse JSON on stdin, blocks (exit 2 + stderr fed
 # back to Claude) only when a branch-CHANGING git command would move the
@@ -31,8 +53,15 @@
 # quoted arguments before parsing. A quoted git-verb literal buried in
 # ANOTHER command's argument therefore trips the guard: e.g.
 # `task.py post-marker <N> epm:X --note "... git switch ..."` is blocked
-# because the note text matches `git ... switch`. The workaround is to pass
-# such note text via `--file <path.md>` instead of `--note`. A quote-strip
+# because the note text matches `git ... switch`, and a note/-m string
+# carrying a full `git restore .` / `git clean -fd` / `git reset --hard`
+# command literal trips the #897 detectors the same way. The workaround is to
+# pass such note text via `--file <path.md>` instead of `--note`, and commit
+# messages via `git commit -F <file>`. The #897 detectors use a TIGHT
+# `git <verb>` bigram anchor (`git [flags] restore|clean|reset|checkout`), so
+# plain-English "restore"/"clean"/"reset" inside a `-m` message (e.g.
+# `git commit -m "restore defaults"`) does NOT trip — only a full
+# `git <verb>` command literal does. A quote-strip
 # pre-pass was tried (round 1 of #796) and reverted: stripping quoted spans
 # BEFORE parsing silently hid REAL quoted git refs (`git checkout "HEAD~1"`,
 # `git switch "main"`) from the detectors — a leak of the exact class this
@@ -40,6 +69,28 @@
 # shell-syntax-aware strip is not safe to do in a bash regex, so the raw-scan
 # behavior (correct on git refs, over-eager on note-text literals) is the
 # deliberate trade-off. See #796 round-2 report.
+#
+# <!-- known residual gaps (#897, accepted + documented) -->
+# (i)   `git checkout main <path>` (a pathspec after the `main` allow-arm with
+#       no `--`) still leaks — a naive detector would false-positive on
+#       redirections (`git checkout main 2>/dev/null`); closable post-v1 by
+#       applying the bare-pathspec existence probe to the token after the
+#       allow-arm.
+# (ii)  `git reset --soft/--merge/--keep` (branch-pointer moves / partial tree
+#       writes) are not gated.
+# (iii) Command substitution `$(git clean -fd)` and here-docs are unparsed
+#       (pre-existing #804 limitation; quoted separators fail CLOSED).
+# (iv)  Quoted-glob pathspecs (`git checkout '*.md'`) and exotic pathspec
+#       magic (`git checkout ':/'`) — the existence probe sees the unexpanded
+#       literal and fails soft.
+# (v)   `git clean -i` (interactive; near-inert non-TTY),
+#       `git -c clean.requireForce=false clean`, `git -c alias.*` smuggling,
+#       and `git checkout-index -f -a` (plumbing) are ungated — ~zero
+#       accidental probability under the cooperative-agent threat model.
+# (vi)  `git stash` stays ALLOWED as the blessed safe alternative
+#       (sync_repo_root.py's autostash depends on it). Incident responders:
+#       a stash produces the same "file snapped back to HEAD" symptom with
+#       the data recoverable via `git stash list`.
 #
 # Compound-command parsing is a best-effort CLAUSE SPLIT (#804): the command is
 # split on `;` / `&&` / `||` / `|` / `&` / raw newline (two-char separators
@@ -98,8 +149,10 @@ cmd=$(jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
 # a backslash + optional CR + newline, replaced by a single space.
 cmd=$(printf '%s' "$cmd" | sed -zE 's/\\\r?\n/ /g')
 
-# Only consider git checkout/switch invocations at all.
-echo "$cmd" | grep -qE '\bgit\b.*\b(checkout|switch)\b' || exit 0
+# Only consider git checkout/switch/restore/clean/reset invocations at all
+# (loose pre-filter — a cheap skip, not a classifier; the tight per-verb
+# anchors live in classify_clause).
+echo "$cmd" | grep -qE '\bgit\b.*\b(checkout|switch|restore|clean|reset)\b' || exit 0
 
 # Split the raw command into (separator, clause) pairs, PRESERVING which
 # separator precedes each clause. Two-char separators (&& ||) are matched
@@ -182,14 +235,85 @@ classify_clause() {
     blocked="git switch --detach"
   fi
 
-  # git checkout <existing-branch>  — NOT a file restore (no `--`), arg is a real
-  # local branch ref, and not `main`. Extended: a non-branch arg that resolves to
-  # a commit-ish (sha / tag / origin/<branch> / HEAD~N / HEAD@{N}) DETACHES HEAD
-  # and is blocked too. A flag-prefixed detach (`checkout -f <sha>`, `-q <sha>`,
-  # `-p <sha>`, `-m <sha>`) is caught by re-scanning the post-`checkout` tokens:
-  # skip known safe short-flags, then classify the first positional. `-b`/`-B`
-  # are NOT skipped here (branch creation is already blocked above); `.`/`main`/`-`
-  # are left as ALLOW.
+  # ---- #897 working-tree-revert detectors -------------------------------
+  # Shared TIGHT subcommand anchor: `git` + optional flag[+value] tokens +
+  # verb (mirrors workflow_lint.py's _GIT_RESET_HARD_RE flag-group). The
+  # legacy loose `\bgit\b[^;&|]*\bverb\b` form would newly block plain-English
+  # "restore"/"clean"/"reset" in `-m` messages (`git commit -m "restore
+  # defaults"`); the tight anchor only fires on a real `git <verb>` bigram
+  # (the raw-scan known limitation then covers only FULL quoted command
+  # literals — same contract as the checkout/switch detectors).
+
+  # (#897) Working-tree revert via restore. Allowed ONLY when --staged (long
+  # form) is present AND no --worktree / -W anywhere after `restore` —
+  # index-only restore leaves the working tree untouched. Everything else
+  # (bare `restore .`, explicit-path restore, --source forms, -S short form)
+  # blocks, fail-closed: on the SHARED root any working-tree restore can
+  # discard a CONCURRENT session's uncommitted edits (incident #841).
+  if echo "$c" | grep -qE '\bgit +(-[^ ]+( +[^ ]+)?( +|$))*restore\b'; then
+    if ! { echo "$c" | grep -qE '\brestore\b[^;&|]* --staged\b' \
+           && ! echo "$c" | grep -qE '\brestore\b[^;&|]*( --worktree\b| -[A-Za-z]*W)'; }; then
+      blocked="git restore (working-tree revert)"
+    fi
+  fi
+
+  # (#897) Working-tree revert via checkout pathspec: a standalone ` -- `
+  # separator (git checkout [<ref>] -- <path>), a bare `.`/`./...` positional
+  # after checkout, OR a --pathspec-from-file(=|<space>) pathspec source
+  # (`git checkout HEAD --pathspec-from-file=/tmp/files` is a real Git
+  # pathspec mechanism the standalone-`--` form misses). `--detach`/`-b`
+  # never match (the `--` needs a following space/EOL; the dot needs a
+  # preceding space). This FLIPS the previous explicit-allow of `.` and the
+  # `--` skip — the #841 revert class.
+  if echo "$c" | grep -qE '\bgit +(-[^ ]+( +[^ ]+)?( +|$))*checkout\b[^;&|]*( --( |$)| \.($| |/)| --pathspec-from-file(=| +))'; then
+    blocked="git checkout <pathspec> (working-tree revert)"
+  fi
+
+  # (#897) Force-checkout: `git checkout -f|--force <anything>` discards
+  # uncommitted edits even when the target is the CURRENT branch
+  # (`git checkout -f main` prints "Already on 'main'" and silently reverts
+  # dirty tracked files). There is no legitimate unqualified force-checkout
+  # at the repo root (branch switches are already blocked; the `-C` waiver
+  # covers deliberate scoped use). The `git switch` side is already strict
+  # (its allow-arm admits only bare/quoted `main`), so this closes the
+  # checkout asymmetry.
+  if echo "$c" | grep -qE '\bgit +(-[^ ]+( +[^ ]+)?( +|$))*checkout\b[^;&|]*( -[A-Za-z]*f\b| --force\b)'; then
+    blocked="git checkout --force (working-tree revert)"
+  fi
+
+  # (#897) git clean with a force flag (-f anywhere in a short cluster, or
+  # --force) deletes untracked files fleet-wide (#841 lost 3 pre_reg + 4
+  # images). Dry-run (-n) and bare `git clean` (refuses without force) stay
+  # allowed.
+  if echo "$c" | grep -qE '\bgit +(-[^ ]+( +[^ ]+)?( +|$))*clean\b'; then
+    if echo "$c" | grep -qE '\bclean\b[^;&|]*( -[A-Za-z]*f| --force\b)'; then
+      blocked="git clean --force (deletes untracked files)"
+    fi
+  fi
+
+  # (#897) Runtime `git reset --hard` — the #778/#815 incident class; the
+  # workflow_lint check covers doc text only, this is the runtime tooth.
+  # Tolerates flags/refs between reset and --hard (`git reset origin/main
+  # --hard`).
+  if echo "$c" | grep -qE '\bgit +(-[^ ]+( +[^ ]+)?( +|$))*reset\b[^;&|]* --hard(=|\b)'; then
+    blocked="git reset --hard"
+  fi
+  # ---- end #897 detectors ------------------------------------------------
+
+  # git checkout <existing-branch>  — NOT a pathspec form (no `--`; those are
+  # blocked by the #897 pathspec detector above, whose reason wins because
+  # the `--` guard below skips this classifier), arg is a real local branch
+  # ref, and not `main`. Extended: a non-branch arg that resolves to a
+  # commit-ish (sha / tag / origin/<branch> / HEAD~N / HEAD@{N}) DETACHES HEAD
+  # and is blocked too; a non-commit-ish arg that names a REAL tracked path /
+  # file is the classic bare-pathspec discard idiom (`git checkout
+  # tasks/running/841/body.md` — the exact #841 op) and is blocked by the
+  # existence probe in the `*)` arm. A flag-prefixed detach (`checkout -f
+  # <sha>`, `-q <sha>`, `-p <sha>`, `-m <sha>`) is caught by re-scanning the
+  # post-`checkout` tokens: skip known safe short-flags, then classify the
+  # first positional. `-b`/`-B` are NOT skipped here (branch creation is
+  # already blocked above); `main`/`-` are left as ALLOW; `.` stays a case
+  # no-op here because the #897 pathspec detector above already blocked it.
   if echo "$c" | grep -qE '\bgit\b[^;&|]*\bcheckout\b' \
      && ! echo "$c" | grep -qE 'checkout\b[^;&|]*--'; then
     arg=$(echo "$c" | sed -nE 's/.*\bcheckout\b +([^ ;&|]+).*/\1/p')
@@ -215,13 +339,26 @@ classify_clause() {
     arg=${arg#[\"\']}
     arg=${arg%[\"\']}
     case "$arg" in
-      ""|-b|-B|-f|--force|main|-|.) : ;;  # not a branch/detach we block
+      # `.` and `-f`/`--force` are unreachable for BLOCKING purposes here —
+      # the #897 pathspec / force detectors above already set `blocked` for
+      # them; they stay listed so this classifier never re-classifies them
+      # with a wrong reason. `main`/`-` remain genuine allows.
+      ""|-b|-B|-f|--force|main|-|.) : ;;
       --*) : ;;                           # a flag (e.g. --detach handled above)
       *)
         if git -C "$REPO" show-ref --verify --quiet "refs/heads/$arg"; then
           blocked="git checkout $arg"                        # branch switch
         elif git -C "$REPO" rev-parse --verify --quiet "$arg^{commit}" >/dev/null 2>&1; then
           blocked="git checkout $arg (detaches HEAD)"         # sha/tag/remote-ref/HEAD~N
+        elif git -C "$REPO" cat-file -e "HEAD:$arg" 2>/dev/null || [ -e "$REPO/$arg" ]; then
+          # (#897) bare-pathspec existence probe: `git checkout <path>` with
+          # NO ref, NO `--`, NO dot — the classic pre-`git restore` discard
+          # idiom (the exact #841 op). An arg that resolves to NO branch, NO
+          # commit-ish, and NO tracked/existing path keeps the status-quo
+          # allow (git itself errors on it), so unresolvable variables /
+          # redirection tokens gain no new false-positive class. Quoted-glob
+          # pathspecs stay a NAMED residual gap (header block, item iv).
+          blocked="git checkout $arg (working-tree revert of a tracked path)"
         fi
         ;;
     esac
@@ -253,6 +390,15 @@ while IFS=$'\t' read -r sep clause; do
     scoped=0
   fi
 
+  # (#897) A clause whose first non-space char is `#` is a bash comment — bash
+  # never executes it, so classifying it can only false-positive (executed
+  # SKILL.md fences carry comments that SPELL gated forms, e.g. the Step 10d
+  # additive-checkout fence's `git checkout issue-<N> -- <path>` comment). A
+  # comment containing a separator is mis-split and its TAIL clause still
+  # classifies — that mis-split fails CLOSED (blocks), the safe direction.
+  # (The awk splitter already stripped leading whitespace from each clause.)
+  case "$clause" in "#"*) continue ;; esac
+
   # A `cd` into a worktree / /tmp latches scope forward ONLY across a following
   # `&&` clause. Latch and continue — this clause runs the `cd`, not a git
   # command, and it must NOT scope EARLIER clauses (those were classified
@@ -267,8 +413,9 @@ while IFS=$'\t' read -r sep clause; do
   # `git -C <path>` scopes ONLY this clause (per-invocation) — allow it.
   echo "$clause" | grep -qE '\bgit +-C +' && continue
 
-  # not a git checkout/switch clause at all -> skip
-  echo "$clause" | grep -qE '\bgit\b.*\b(checkout|switch)\b' || continue
+  # not a git checkout/switch/restore/clean/reset clause at all -> skip
+  # (loose gate — a cheap skip; the tight anchors live in classify_clause)
+  echo "$clause" | grep -qE '\bgit\b.*\b(checkout|switch|restore|clean|reset)\b' || continue
 
   reason=$(classify_clause "$clause")
   if [ -n "$reason" ]; then blocked="$reason"; break; fi   # first block wins
@@ -281,7 +428,8 @@ done < <(split_and_label "$cmd")
 cur=$(git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
 [ "$cur" = main ] || exit 0
 
-echo "BLOCKED: '$blocked' would move the SHARED repo-root tree off main / detach HEAD. The repo root is the canonical commit target for scripts/task.py and every concurrent VM session (all assume HEAD==main); switching branches or detaching HEAD here hijacks their commits and sweeps cross-session uncommitted edits into the wrong commit, and a detached repo-root HEAD crashes task_workflow's main-worktree resolver (incident 2026-06-01). Do feature/infra branch work in a worktree instead:
-  bash scripts/new_worktree.sh .claude/worktrees/<name> <branch> && cd .claude/worktrees/<name>
-To override deliberately, run the git command from inside a worktree (git -C .claude/worktrees/<name> ...)." >&2
+echo "BLOCKED: '$blocked' would move the SHARED repo-root tree off main / detach HEAD / destroy uncommitted working-tree state. The repo root is the canonical commit target for scripts/task.py and every concurrent VM session (all assume HEAD==main); a branch switch here hijacks concurrent commits, and a working-tree revert (restore / checkout-pathspec / clean -f / reset --hard) silently discards CONCURRENT sessions' uncommitted edits (incidents 2026-06-01, #815, #841). Do branch/destructive work in a worktree instead:
+  bash scripts/new_worktree.sh .claude/worktrees/<name> <branch> && git -C .claude/worktrees/<name> ...
+NEVER point -C at the repo root itself for a destructive op — for repo-root recovery use: uv run python scripts/sync_repo_root.py
+For marker-note text mentioning git commands, use --file <path.md> instead of --note; for commit messages, use git commit -F <file>." >&2
 exit 2

--- a/scripts/guard_repo_root_branch.sh
+++ b/scripts/guard_repo_root_branch.sh
@@ -61,7 +61,14 @@
 # `git <verb>` bigram anchor (`git [flags] restore|clean|reset|checkout`), so
 # plain-English "restore"/"clean"/"reset" inside a `-m` message (e.g.
 # `git commit -m "restore defaults"`) does NOT trip — only a full
-# `git <verb>` command literal does. A quote-strip
+# `git <verb>` command literal does. EXCEPTION (round-2 concern id
+# header-tight-anchor-claim-overbroad): the bare-pathspec EXISTENCE PROBE in
+# the branch-arg classifier rides the LEGACY loose anchor
+# (`\bgit\b[^;&|]*\bcheckout\b`), so prose containing `checkout <path>` where
+# `<path>` names a REAL repo file trips WITHOUT a `git checkout` bigram —
+# `git commit -m "fix checkout CLAUDE.md handling"` is BLOCKED (fails
+# closed; test-pinned). Same remediation: `git commit -F <file>` / `--file`.
+# A quote-strip
 # pre-pass was tried (round 1 of #796) and reverted: stripping quoted spans
 # BEFORE parsing silently hid REAL quoted git refs (`git checkout "HEAD~1"`,
 # `git switch "main"`) from the detectors — a leak of the exact class this
@@ -69,6 +76,20 @@
 # shell-syntax-aware strip is not safe to do in a bash regex, so the raw-scan
 # behavior (correct on git refs, over-eager on note-text literals) is the
 # deliberate trade-off. See #796 round-2 report.
+#
+# COMMENT TAILS (#897 round 2) are the one exception to the raw scan: bash
+# never EXECUTES an unquoted `#` comment tail, but reading it let trailing
+# comment text WAIVE an executed destructive command (`git restore . # git -C
+# /tmp status` exited 0 — fail-OPEN, the opposite direction from every other
+# raw-scan trade-off). Each clause therefore has its whitespace-anchored ` #`
+# tail STRIPPED before any latch / waiver / gate / classification read. The
+# strip does not shell-parse quotes (deliberately — quote-parity detection
+# would let an odd apostrophe before the `#` disable the strip and resurrect
+# the spoof), so a QUOTED argument containing ` # ` also truncates: harmless
+# for non-gated verbs (`git commit -m "see #841"` loses its tail and stays
+# allowed), fail-closed for allows (truncation cannot ADD an allow token),
+# and fail-open only for the residual-gap-(viii) shape (`git clean "x # y"
+# -f` — the force flag after a quoted ` # ` becomes invisible).
 #
 # <!-- known residual gaps (#897, accepted + documented) -->
 # (i)   `git checkout main <path>` (a pathspec after the `main` allow-arm with
@@ -91,6 +112,24 @@
 #       (sync_repo_root.py's autostash depends on it). Incident responders:
 #       a stash produces the same "file snapped back to HEAD" symptom with
 #       the data recoverable via `git stash list`.
+# (vii) An ABSOLUTE-path bare pathspec inside the repo (`git checkout
+#       /home/.../explore-persona-space/CLAUDE.md`) evades the existence
+#       probe — `cat-file -e "HEAD:/abs/..."` fails and `[ -e "$REPO/$arg" ]`
+#       concatenates the repo prefix onto the already-absolute path — so the
+#       revert is ALLOWED (fail-open) while git reverts the file
+#       (round-2 concern id abs-path-bare-pathspec-residual-unnamed;
+#       test-pinned). Closable post-v1 by stripping a `$REPO/` prefix from
+#       the arg before probing.
+# (viii) A QUOTED argument containing whitespace-anchored ` # ` hides
+#       everything after it from the detectors (the round-2 comment-tail
+#       strip cuts at the first whitespace-anchored `#` without
+#       shell-parsing quotes), so `git clean "x # y" -f` is allowed while
+#       bash executes a force clean. ~zero accidental probability under the
+#       cooperative-agent threat model (requires a quoted argument
+#       containing ` # ` AND a destructive flag after it); the alternative
+#       (quote-parity comment detection) re-opens the comment-tail
+#       allow-spoof on any odd-apostrophe prefix, which is the worse
+#       direction.
 #
 # Compound-command parsing is a best-effort CLAUSE SPLIT (#804): the command is
 # split on `;` / `&&` / `||` / `|` / `&` / raw newline (two-char separators
@@ -398,6 +437,27 @@ while IFS=$'\t' read -r sep clause; do
   # classifies — that mis-split fails CLOSED (blocks), the safe direction.
   # (The awk splitter already stripped leading whitespace from each clause.)
   case "$clause" in "#"*) continue ;; esac
+
+  # (#897 round 2) Strip the unquoted comment TAIL of the clause before ANY
+  # latch / waiver / gate / classification read. Bash never EXECUTES text
+  # after a whitespace-anchored `#`, but the raw scan previously READ it —
+  # so trailing comment text could SPOOF the `-C` waiver, the restore
+  # `--staged` allow-arm, or a `cd`-latch: `git restore . # git -C /tmp
+  # status` exited 0 while bash executed the destructive revert (the round-2
+  # BLOCKER class, concern id comment-tail-waiver-spoof). Stripping the tail
+  # makes every downstream read see (an approximation of) exactly what bash
+  # executes: comment text can never GRANT an allow, a comment SPELLING a
+  # gated form no longer false-blocks (`git clean -n # -f` is a dry-run and
+  # now allows), and the greedy checkout-arg extraction can no longer be
+  # steered by comment text. This is NOT the reverted #796 quote-strip:
+  # quoted spans are PRESERVED — only a whitespace-anchored ` #` tail is cut,
+  # without shell-parsing quotes, so a QUOTED ` # ` argument also truncates
+  # (see the header known-limitation paragraph + residual gap (viii); a `#`
+  # glued to non-space text, e.g. `path#frag`, never matches). Truncation is
+  # fail-closed for allows (removing text cannot add an allow token) and can
+  # err fail-open ONLY in the quoted-` # ` residual (viii).
+  clause=$(printf '%s' "$clause" | sed -E 's/[[:space:]]#.*$//')
+  [ -n "$clause" ] || continue
 
   # A `cd` into a worktree / /tmp latches scope forward ONLY across a following
   # `&&` clause. Latch and continue — this clause runs the `cd`, not a git

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -3864,6 +3864,71 @@ _GIT_RESET_HARD_RE = re.compile(
 _GIT_DASH_C_RE = re.compile(r"git\s+-C\s+")
 _RESET_HARD_ALLOW_SENTINEL = "workflow-lint: allow-git-reset-hard"
 
+# Working-tree-revert doc prescriptions (#897, sibling of _GIT_RESET_HARD_RE).
+# Shared backtick-free flag group: optional git-level flags (`--no-pager`,
+# `-c k=v`, `-q`) may sit between `git` and the subcommand; backtick-free
+# tokens so the greedy group cannot span ACROSS an inline-code mention (the
+# same design rationale documented on _GIT_RESET_HARD_RE above).
+_GIT_FLAGS_GRP = r"(?:--?[^\s`]+(?:\s+[^\s`]+)?\s+)*"
+_WT_REVERT_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    # Any non-`--staged` git restore: explicit-path restore prescriptions have
+    # zero legitimate live doc uses; `--staged` forms are index-only (they do
+    # not touch the working tree) and exempt.
+    ("git restore", re.compile(rf"git\s+{_GIT_FLAGS_GRP}restore\b(?![^`]*--staged)")),
+    # Bare-dot wholesale checkout ONLY — explicit `checkout <ref> -- <path>`
+    # doc mentions are NOT flagged (legitimate prescriptive uses exist: the
+    # /issue Step 5a spec-freshness sync, the Step 10d surgical additive
+    # checkout, the code-reviewer smoke-restore rule). At RUNTIME the hook
+    # (scripts/guard_repo_root_branch.sh) blocks the explicit-pathspec forms
+    # too, with the `git -C` waiver as the deliberate override — the
+    # prescriptive-vs-runtime split (#897).
+    (
+        "git checkout .",
+        re.compile(rf"git\s+{_GIT_FLAGS_GRP}checkout\b(?:\s+[^\s`]+)*?\s+\.(?=[\s`/]|$)"),
+    ),
+    (
+        "git clean -f/--force",
+        re.compile(
+            rf"git\s+{_GIT_FLAGS_GRP}clean\b(?:\s+[^\s`]+)*?\s+(?:-[A-Za-z]*f[A-Za-z]*\b|--force\b)"
+        ),
+    ),
+)
+_WT_REVERT_ALLOW_SENTINEL = "workflow-lint: allow-repo-root-wt-revert"
+
+
+def _line_waived(line: str, match_start: int, sentinel: str) -> bool:
+    """True when a flagged destructive-git match on ``line`` is waived.
+
+    Two waivers (shared by the reset-hard + worktree-revert checks):
+
+    - **FI3 worktree-qualified** — a ``git -C`` prefix sits at-or-before
+      ``match_start``. In the sanctioned form the offending regex matches from
+      the SAME ``git`` the ``-C`` begins (its flag-group swallows ``-C "$WT"``),
+      so ``dc.start() == match_start`` there — hence ``<=``, not ``<``. An
+      unqualified command starts at a ``git`` NOT followed by ``-C``, so the
+      offsets can only coincide for the sanctioned form; a ``git -C`` AFTER the
+      match (e.g. ``git reset --hard && git -C "$WT" status``) has a HIGHER
+      offset and does NOT waive.
+    - **FI2 reasoned sentinel** — the line carries ``sentinel`` with a
+      NON-EMPTY reason. The reason lives between the sentinel ``:`` and the
+      note closer, so the leading ``:``/whitespace AND the trailing
+      HTML-comment closer (``-->``) / backtick / whitespace are stripped before
+      testing — otherwise a bare closer (``: -->``, or the sentinel with no
+      colon) would count as a reason and wrongly waive.
+    """
+    dc = _GIT_DASH_C_RE.search(line)
+    if dc is not None and dc.start() <= match_start:
+        return True
+    if sentinel in line:
+        _, _, tail = line.partition(sentinel)
+        reason = tail.lstrip(": ")
+        if reason.rstrip().endswith("-->"):
+            reason = reason.rstrip()[: -len("-->")]
+        reason = reason.strip().strip("`").strip()
+        if reason:
+            return True
+    return False
+
 
 def check_no_repo_root_git_reset_hard(*, repo_root: Path | None = None) -> list[str]:
     """FAIL if any agent spec / skill playbook contains an UNQUALIFIED
@@ -3905,34 +3970,11 @@ def check_no_repo_root_git_reset_hard(*, repo_root: Path | None = None) -> list[
             m = _GIT_RESET_HARD_RE.search(line)
             if m is None:
                 continue
-            # FI3: worktree-qualified ONLY if a `git -C` prefix sits at or
-            # before the START of the offending reset match (i.e. `git -C "$WT"
-            # reset --hard` — the `-C` qualifies THIS command). In the sanctioned
-            # form `_GIT_RESET_HARD_RE` matches from the SAME `git` the `-C`
-            # begins (its flag-group swallows `-C "$WT"`), so `dc.start()` equals
-            # `m.start()` there — hence `<=`, not `<`. An unqualified reset starts
-            # at a `git` NOT followed by `-C`, so `_GIT_DASH_C_RE` cannot match at
-            # that same offset; `dc.start() == m.start()` therefore occurs ONLY
-            # for the sanctioned form. A `git -C` that appears AFTER the reset
-            # (e.g. `git reset --hard && git -C "$WT" status`) has a HIGHER offset
-            # and does NOT waive the unqualified reset that precedes it.
-            dc = _GIT_DASH_C_RE.search(line)
-            if dc is not None and dc.start() <= m.start():
+            # FI3 `-C`-before-match + FI2 reasoned-sentinel waivers — shared
+            # with check_no_repo_root_worktree_revert; semantics documented on
+            # the helper (the `<=` covers the sanctioned same-`git` anchor).
+            if _line_waived(line, m.start(), _RESET_HARD_ALLOW_SENTINEL):
                 continue
-            if _RESET_HARD_ALLOW_SENTINEL in line:  # explicit allowlist -> OK
-                # Require a NON-EMPTY reason after the sentinel (FI2). The reason
-                # lives between the sentinel `:` and the note closer, so strip the
-                # leading `:`/whitespace AND the trailing HTML-comment closer
-                # (`-->`) / backtick / whitespace before testing — otherwise the
-                # bare comment closer (`: -->`, or `allow-git-reset-hard -->` with
-                # no colon) would be counted as a reason and wrongly waive.
-                _, _, tail = line.partition(_RESET_HARD_ALLOW_SENTINEL)
-                reason = tail.lstrip(": ")
-                if reason.rstrip().endswith("-->"):
-                    reason = reason.rstrip()[: -len("-->")]
-                reason = reason.strip().strip("`").strip()
-                if reason:
-                    continue
             errors.append(
                 f"{p}:{lineno}: unqualified `git reset --hard` on the shared "
                 f"repo root is forbidden (clobbers concurrent siblings' task "
@@ -3941,6 +3983,60 @@ def check_no_repo_root_git_reset_hard(*, repo_root: Path | None = None) -> list[
                 f"`{_RESET_HARD_ALLOW_SENTINEL}: <reason>` sentinel if this is a "
                 f"legitimate prose mention / pod-side ssh_execute command."
             )
+    return errors
+
+
+def check_no_repo_root_worktree_revert(*, repo_root: Path | None = None) -> list[str]:
+    """FAIL if any agent spec / skill playbook prescribes an UNQUALIFIED
+    working-tree revert on the shared repo root: a non-``--staged``
+    ``git restore``, a bare-dot wholesale ``git checkout .``, or a
+    force-flagged ``git clean``. Only per-worktree ``git -C "$WT" ...`` forms
+    (the ``-C`` qualifier appearing BEFORE the match on the same line), or
+    lines carrying the ``workflow-lint: allow-repo-root-wt-revert: <reason>``
+    sentinel with a non-empty reason, pass.
+
+    Incident 2026-07-02 (#841): a concurrent session's destructive
+    working-tree git op on the shared repo root reverted the #841 analyzer's
+    uncommitted ``body.md`` mid-task (and deleted untracked pre-registration +
+    figure files) — the same hazard class as the #815 repo-root
+    ``reset --hard`` (``task.py`` holds a per-registry flock, not per-file).
+    This check is the DOC-side sibling of that reset-hard check; the RUNTIME
+    tooth is ``scripts/guard_repo_root_branch.sh`` (which additionally blocks
+    the explicit-pathspec / bare-pathspec / force checkout forms this check
+    deliberately does not flag — legitimate prescriptive doc uses exist for
+    those; see ``_WT_REVERT_PATTERNS``).
+
+    Scope: ``.claude/agents/*.md`` + ``.claude/skills/**/SKILL.md`` only
+    (reuses ``_iter_ask_target_files``, worktree-sibling-safe). ``.claude/
+    plans/``, ``.claude/agent-memory/``, ``.claude/rules/``, ``CLAUDE.md``,
+    and ``scripts/**`` are NEVER scanned. Pure-Python; bundled into the
+    no-flags default run. ``repo_root`` is a unit-test override hook;
+    production callers pass None (canonical repo root).
+    """
+    root = repo_root if repo_root is not None else _REPO_ROOT
+    errors: list[str] = []
+    for p in _iter_ask_target_files(root):  # already worktree-safe + scoped
+        try:
+            text = p.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for label, pattern in _WT_REVERT_PATTERNS:
+                m = pattern.search(line)
+                if m is None:
+                    continue
+                if _line_waived(line, m.start(), _WT_REVERT_ALLOW_SENTINEL):
+                    continue
+                errors.append(
+                    f"{p}:{lineno}: unqualified `{label}` (a working-tree "
+                    f"revert) on the shared repo root is forbidden — it "
+                    f"silently discards CONCURRENT sessions' uncommitted "
+                    f"edits (incident #841; #897, sibling of the #815 "
+                    f"reset --hard check). Use a per-worktree "
+                    f'`git -C "$WT" ...` form, or add a same-line '
+                    f"`{_WT_REVERT_ALLOW_SENTINEL}: <reason>` sentinel if "
+                    f"this is a legitimate prose mention."
+                )
     return errors
 
 
@@ -4944,6 +5040,20 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         "default run.",
     )
     parser.add_argument(
+        "--check-no-repo-root-worktree-revert",
+        action="store_true",
+        help="FAIL if any .claude/agents/*.md or .claude/skills/**/SKILL.md "
+        "prescribes an unqualified working-tree revert on the shared repo "
+        "root: a non---staged `git restore`, a bare-dot `git checkout .`, or "
+        'a force-flagged `git clean`. Only per-worktree `git -C "$WT" ...` '
+        "forms (the `-C` qualifier before the match on the same line) or "
+        "lines carrying the `workflow-lint: allow-repo-root-wt-revert: "
+        "<reason>` sentinel with a non-empty reason pass. A repo-root "
+        "working-tree revert silently discards CONCURRENT sessions' "
+        "uncommitted edits (incident #841; sibling of the #815 reset-hard "
+        "check). Bundled into the no-flags default run.",
+    )
+    parser.add_argument(
         "--check-gate-ids-unique",
         action="store_true",
         help="Verify every gate id across gates.{inline, park_and_wait, "
@@ -5081,6 +5191,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         or args.check_batch_judge_client
         or args.check_no_workflow_improver_spawn
         or args.check_no_repo_root_git_reset_hard
+        or args.check_no_repo_root_worktree_revert
         or args.check_gate_ids_unique
         or args.check_lessons_index
         or args.check_compute_shape_review_lens
@@ -5152,6 +5263,8 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         errors.extend(check_no_workflow_improver_spawn())
     if args.check_no_repo_root_git_reset_hard or no_flags:
         errors.extend(check_no_repo_root_git_reset_hard())
+    if args.check_no_repo_root_worktree_revert or no_flags:
+        errors.extend(check_no_repo_root_worktree_revert())
     if args.check_gate_ids_unique or no_flags:
         errors.extend(check_gate_ids_unique(workflow))
     if args.check_lessons_index or no_flags:

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -3873,8 +3873,15 @@ _GIT_FLAGS_GRP = r"(?:--?[^\s`]+(?:\s+[^\s`]+)?\s+)*"
 _WT_REVERT_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     # Any non-`--staged` git restore: explicit-path restore prescriptions have
     # zero legitimate live doc uses; `--staged` forms are index-only (they do
-    # not touch the working tree) and exempt.
-    ("git restore", re.compile(rf"git\s+{_GIT_FLAGS_GRP}restore\b(?![^`]*--staged)")),
+    # not touch the working tree) and exempt. The exemption lookahead is
+    # bounded at BOTH a backtick (the inline-code terminator) AND a `#` —
+    # bash never executes a comment tail, so a fenced `git restore . #
+    # --staged` line is a destructive restore whose comment must NOT waive it
+    # (round-2 concern id lint-restore-lookahead-comment-tail; the runtime
+    # hook's comment-tail strip is the enforcement sibling). A `--staged`
+    # among the real arguments always precedes any `#`, so legitimate
+    # index-only prescriptions keep the exemption.
+    ("git restore", re.compile(rf"git\s+{_GIT_FLAGS_GRP}restore\b(?![^`#]*--staged)")),
     # Bare-dot wholesale checkout ONLY — explicit `checkout <ref> -- <path>`
     # doc mentions are NOT flagged (legitimate prescriptive uses exist: the
     # /issue Step 5a spec-freshness sync, the Step 10d surgical additive
@@ -5044,7 +5051,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         action="store_true",
         help="FAIL if any .claude/agents/*.md or .claude/skills/**/SKILL.md "
         "prescribes an unqualified working-tree revert on the shared repo "
-        "root: a non---staged `git restore`, a bare-dot `git checkout .`, or "
+        "root: a `git restore` without `--staged`, a bare-dot `git checkout .`, or "
         'a force-flagged `git clean`. Only per-worktree `git -C "$WT" ...` '
         "forms (the `-C` qualifier before the match on the same line) or "
         "lines carrying the `workflow-lint: allow-repo-root-wt-revert: "

--- a/tests/sparse_cones.txt
+++ b/tests/sparse_cones.txt
@@ -17,7 +17,11 @@
 #                             REF_JSON (svd/same_marker_seed42.json) + v2_adapter_provenance.json
 #   eval_results/issue_257  — test_issue_360_target_logprobs.py reads run_seed42_v2[_coref]/headline_numbers.json
 #   eval_results/issue_276  — test_issue_360_target_logprobs.py reads pre_poison_similarity.json + slash_anth_followup/headline_numbers.json
+#   eval_results/issue_537  — test_issue811_turn_nl.py -> scripts/issue811_fit.py::run_phase0_gate
+#                             -> scripts/issue722_fit_M.py::_load_E reads G_tensor/G_meta.json
+#                             (missing line surfaced as a sparse-worktree FileNotFoundError, #897)
 eval_results/issue_545
 eval_results/issue_521
 eval_results/issue_257
 eval_results/issue_276
+eval_results/issue_537

--- a/tests/test_guard_repo_root_branch.py
+++ b/tests/test_guard_repo_root_branch.py
@@ -4,7 +4,11 @@ The guard blocks any git command that would move the SHARED repo-root working
 tree off ``main`` OR detach its HEAD, because the repo root is the canonical
 commit target for ``scripts/task.py`` and every concurrent VM Claude session
 (all assume ``HEAD==main``). A detached repo-root HEAD additionally crashes
-``task_workflow``'s main-worktree resolver.
+``task_workflow``'s main-worktree resolver. As of #897 it ALSO blocks
+working-tree REVERTS on the shared root (``git restore``, pathspec /
+bare-path / force ``git checkout``, ``git clean -f``, ``git reset --hard``) —
+the #841 incident class where a concurrent destructive op silently reverted
+another session's uncommitted edits.
 
 These tests drive the script exactly as the harness does: stdin PreToolUse JSON
 ``{"tool_input": {"command": <cmd>}}`` -> exit 2 (blocked) or exit 0 (allowed).
@@ -157,18 +161,21 @@ def test_existing_local_branch_checkout_still_blocks(throwaway_branch):
 
 
 # ---------------------------------------------------------------------------
-# MUST ALLOW — file-restore, return-to-main, scoped, and non-git shapes.
-# These must never be trapped regardless of the repo-root HEAD state, so they
-# are NOT guarded by @on_main.
+# MUST ALLOW — return-to-main, scoped, and non-git shapes. These must never be
+# trapped regardless of the repo-root HEAD state, so they are NOT guarded by
+# @on_main.
+#
+# FLIPPED to MUST-BLOCK by #897 (following the #804 `;`-latch flip precedent):
+# the four file-restore rows that used to sit here — `git checkout .`,
+# `git checkout -- scripts/eval.py`, `git checkout HEAD -- foo.py`,
+# `git checkout -f -- scripts/eval.py` — are working-tree reverts that
+# silently discard CONCURRENT sessions' uncommitted edits on the shared root
+# (incident #841). They now live in test_worktree_revert_shapes_block below.
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize(
     "cmd",
     [
         "git checkout main",  # return to main
-        "git checkout -- scripts/eval.py",  # file restore (explicit --)
-        "git checkout HEAD -- foo.py",  # file restore from a ref
-        "git checkout .",  # restore-all
-        "git checkout -f -- scripts/eval.py",  # flag + file restore
         "git -C .claude/worktrees/issue-123 checkout abc1234",  # scoped to a worktree
         "cd /tmp/foo && git checkout abc1234",  # scoped by cd /tmp
         "cd .claude/worktrees/x && git checkout abc1234",  # scoped by cd worktree
@@ -562,3 +569,146 @@ def test_backslash_newline_continuation_legitimate_allows(cmd):
 )
 def test_fail_soft_exit0(payload):
     assert _run_raw(payload) == 0
+
+
+# ===========================================================================
+# #897 — working-tree reverts on the shared repo root
+# ===========================================================================
+# Incident #841 (2026-07-02): a concurrent session's destructive working-tree
+# git op on the shared root reverted the #841 analyzer's uncommitted body.md
+# mid-task and deleted untracked pre-registration + figure files. The five
+# #897 detectors (restore / checkout-pathspec incl. --pathspec-from-file /
+# checkout-force / clean-force / reset-hard) close this class; they use a
+# TIGHT `git <verb>` bigram anchor so plain-English "restore"/"clean"/"reset"
+# in `-m` messages do NOT trip. The four rows FLIPPED from
+# test_allowed_shapes_exit0 appear here (the #804 `;`-latch flip precedent).
+# ---------------------------------------------------------------------------
+@on_main
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        # -- restore detector -------------------------------------------------
+        "git restore .",
+        "git restore tasks/running/841/body.md",  # the exact #841 shape
+        "git restore --worktree .",
+        "git restore --staged --worktree foo.py",  # worktree present -> fail-closed
+        "git restore -W foo.py",  # short worktree form fails closed
+        "git restore -S foo.py",  # short staged form fails closed
+        "git restore --source=main .",
+        # -- checkout pathspec detector (incl. the 4 FLIPPED rows) ------------
+        "git checkout .",  # FLIPPED from allow (#897)
+        "git checkout -- scripts/eval.py",  # FLIPPED from allow (#897)
+        "git checkout HEAD -- foo.py",  # FLIPPED from allow (#897)
+        "git checkout -f -- scripts/eval.py",  # FLIPPED from allow (#897)
+        "git checkout main -- CLAUDE.md",  # explicit ref incl. main
+        "git checkout ./src",  # dot-slash positional
+        "xargs -a files.txt git checkout issue-42 --",  # pins the SKILL.md -C migration
+        # -- checkout --pathspec-from-file (attached + separate-value forms) --
+        "git checkout HEAD --pathspec-from-file=/tmp/files",
+        "git checkout HEAD --pathspec-from-file /tmp/files",
+        # -- checkout force detector (discards dirty edits even AT main) ------
+        "git checkout -f main",
+        "git checkout --force main",
+        # -- bare-pathspec existence probe (the exact #841 op) ----------------
+        "git checkout CLAUDE.md",
+        "git checkout scripts/eval.py CLAUDE.md",  # first positional is a real path
+        # -- clean force detector ---------------------------------------------
+        "git clean -f",
+        "git clean -fd",
+        "git clean -fdx",
+        "git clean -ffdx",
+        "git clean -xdf",  # f not first in the cluster
+        "git clean --force",
+        "git clean -e keep.me -fd",  # force flag after a valued flag
+        # -- runtime reset --hard detector (#778/#815 class) -------------------
+        "git reset --hard",
+        "git reset --hard origin/main",
+        "git reset -q --hard",
+        "git reset origin/main --hard",  # ref BEFORE the flag
+        "git reset --hard HEAD~1",
+        "git --no-pager reset --hard",  # git-level flag before subcommand
+        # -- compound / latch parity with the #804 machinery -------------------
+        "git status && git clean -fd",  # AND does not mask a later dangerous clause
+        "cd .claude/worktrees/x ; git restore .",  # SEQ resets the latch
+        "cd .claude/worktrees/x\ngit clean -fd",  # NL resets the latch
+        "git clean -fd & git switch main",  # BG does not mask
+        "echo hi; git checkout .",  # later-clause classification
+        "git \\\nrestore .",  # backslash-continuation normalization parity
+    ],
+)
+def test_worktree_revert_shapes_block(cmd):
+    assert _run(cmd) == 2
+
+
+@on_main
+def test_note_text_restore_literal_trips_guard_known_limitation():
+    # KNOWN LIMITATION (documented in the script header, mirror of
+    # test_note_text_git_verb_literal_trips_guard_known_limitation): a quoted
+    # FULL `git restore .`-class command literal inside another command's
+    # argument trips the raw scan. Workaround: `--file <path.md>` for notes,
+    # `git commit -F <file>` for commit messages. Exit 2 pins the deliberate
+    # trade-off so a future quote-strip re-attempt trips this test.
+    assert (
+        _run(
+            "uv run python scripts/task.py post-marker 897 epm:x "
+            '--note "run git restore . to revert"'
+        )
+        == 2
+    )
+
+
+@on_main
+def test_mangled_comment_separator_split_fails_closed():
+    # A comment CONTAINING a separator is mis-split by the clause splitter:
+    # the tail clause (`git clean -fd`) classifies on its own and BLOCKS even
+    # though bash would treat the whole line as a comment. Fail-closed is the
+    # documented safe direction for the #897 comment-clause skip (§3a(iii)).
+    assert _run("# note; git clean -fd") == 2
+
+
+# ---------------------------------------------------------------------------
+# MUST ALLOW — #897 allow-side: index-only restore, dry-run clean, the safe
+# stash alternative, per-clause `-C` waivers, cd-latches, tight-anchor
+# non-matches, comment clauses, and unresolvable bare args. NOT guarded by
+# @on_main (must never trap in either repo-root HEAD state).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "git restore --staged foo.py",  # index-only
+        "git restore --staged .",  # index-only, dot pathspec
+        "git stash",  # the blessed safe alternative
+        "git stash pop",
+        "git clean -n",  # dry-run, no force
+        "git clean -nd",
+        "git -C .claude/worktrees/issue-1 clean -fdx",  # per-clause -C waiver
+        # deliberate -C override (even pointing at the repo root — the
+        # designed, auditable escape; the block message steers away from it)
+        "git -C /home/thomasjiralerspong/explore-persona-space checkout -- tasks/x",
+        'git -C "$WT" reset --hard origin/main',  # the documented recovery path
+        'git -C "$WT" restore .',  # -C waiver symmetry for the restore detector
+        "cd .claude/worktrees/x && git restore .",  # && latch
+        "cd /tmp/scratch && git clean -fd",  # /tmp latch
+        'git commit -m "restore the defaults"',  # tight anchor: no `git restore` bigram
+        'git commit -m "clean up the sweep"',  # tight anchor
+        'git commit -m "reset --hard the docs"',  # tight-anchor reset symmetry
+        "git add docs/notes-clean.md",  # `clean` inside a filename, no force flag
+        "uv run python scripts/clean_experiment_downloads.py 897 --apply",  # no `git` word
+        "git switch main",  # unchanged allow-arm
+        "# git checkout .",  # comment-clause skip
+        # the SKILL.md Step 10d fence shape: cd + a comment SPELLING a gated
+        # form + a benign git command — the comment clause is skipped
+        'cd "$REPO_ROOT"\n# `git checkout issue-9 -- <path>` below\ngit status',
+    ],
+)
+def test_worktree_revert_allowed_shapes_exit0(cmd):
+    assert _run(cmd) == 0
+
+
+@on_main
+def test_bare_arg_resolving_to_nothing_keeps_status_quo_allow():
+    # The #897 bare-pathspec existence probe fires ONLY when the positional
+    # names a real branch / commit-ish / tracked-or-existing path. An arg that
+    # resolves to NOTHING keeps the status-quo allow (git itself errors on the
+    # real call), pinning the probe's no-new-false-positive claim.
+    assert _run("git checkout nonexistent-name-xyz-897") == 0

--- a/tests/test_guard_repo_root_branch.py
+++ b/tests/test_guard_repo_root_branch.py
@@ -667,6 +667,61 @@ def test_mangled_comment_separator_split_fails_closed():
 
 
 # ---------------------------------------------------------------------------
+# #897 round 2 — comment-tail waiver spoof (concern id
+# comment-tail-waiver-spoof, the round-1 BLOCKER). Bash never executes an
+# unquoted `#` comment tail, but the raw scan previously READ it — so a
+# trailing comment carrying a waiver token (`git -C ...`, `--staged`) or a
+# latch shape (`cd .claude/worktrees/...`) made the hook exit 0 while bash
+# executed the destructive head. The driver loop now strips the
+# whitespace-anchored ` #` tail of each clause before any latch / waiver /
+# gate / classification read; these rows pin the spoof shapes CLOSED.
+# ---------------------------------------------------------------------------
+@on_main
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "git restore . # git -C /tmp status",  # comment `-C` cannot waive
+        "git restore . # --staged",  # comment `--staged` cannot flip the allow-arm
+        "git checkout . # git -C /tmp status",
+        "git clean -fd # git -C /tmp status",
+        "git reset --hard # git -C /tmp status",
+        # control: a plain comment tail (no waiver token) also blocks — the
+        # spoof required a waiver token in the tail, the strip removes both
+        "git restore . # plain comment no waiver tokens",
+        # comment-tail LATCH spoof: the `cd .claude/worktrees/x` lives in the
+        # comment tail of clause 1, so it must NOT latch scope across the &&
+        "echo hi # cd .claude/worktrees/x && git restore .",
+    ],
+)
+def test_comment_tail_cannot_spoof_waiver_or_allow_arm(cmd):
+    assert _run(cmd) == 2
+
+
+@on_main
+def test_commit_message_checkout_realpath_prose_blocks_known_limitation():
+    # KNOWN LIMITATION (documented in the script header, round-2 concern id
+    # header-tight-anchor-claim-overbroad): the bare-pathspec existence probe
+    # rides the LEGACY loose `\bgit\b[^;&|]*\bcheckout\b` anchor, so prose
+    # containing `checkout <path>` where `<path>` names a REAL repo file trips
+    # WITHOUT a `git checkout` bigram — this `-m` message blocks (fails
+    # CLOSED). Remediation: `git commit -F <file>` / `--file <path.md>`.
+    assert _run('git commit -m "fix checkout CLAUDE.md handling"') == 2
+
+
+def test_abs_path_bare_pathspec_residual_gap_allows():
+    # RESIDUAL GAP (vii), documented in the script header (round-2 concern id
+    # abs-path-bare-pathspec-residual-unnamed): an ABSOLUTE-path bare pathspec
+    # inside the repo evades the existence probe (`cat-file -e "HEAD:/abs"`
+    # fails; `[ -e "$REPO/$arg" ]` concatenates the repo prefix onto the
+    # already-absolute path) so the revert is ALLOWED (fail-open) while git
+    # would revert the file. Pinned as CURRENT behavior, deliberately NOT
+    # closed this round; closable post-v1 by stripping a `$REPO/` prefix from
+    # the arg before probing. NOT @on_main: the allow must hold in either
+    # repo-root HEAD state.
+    assert _run("git checkout /home/thomasjiralerspong/explore-persona-space/CLAUDE.md") == 0
+
+
+# ---------------------------------------------------------------------------
 # MUST ALLOW — #897 allow-side: index-only restore, dry-run clean, the safe
 # stash alternative, per-clause `-C` waivers, cd-latches, tight-anchor
 # non-matches, comment clauses, and unresolvable bare args. NOT guarded by
@@ -695,6 +750,10 @@ def test_mangled_comment_separator_split_fails_closed():
         "git add docs/notes-clean.md",  # `clean` inside a filename, no force flag
         "uv run python scripts/clean_experiment_downloads.py 897 --apply",  # no `git` word
         "git switch main",  # unchanged allow-arm
+        # -- #897 round 2: comment-tail strip allow-side parity ---------------
+        "git clean -n # -f",  # comment `-f` cannot force-block a dry run
+        "git -C .claude/worktrees/issue-1 clean -fdx # cleanup pass",  # waiver + comment
+        "git switch main # back to main",  # comment tail no longer breaks the allow-arm
         "# git checkout .",  # comment-clause skip
         # the SKILL.md Step 10d fence shape: cd + a comment SPELLING a gated
         # form + a benign git command — the comment clause is skipped

--- a/tests/test_workflow_lint_no_repo_root_worktree_revert.py
+++ b/tests/test_workflow_lint_no_repo_root_worktree_revert.py
@@ -40,7 +40,10 @@ T8  the no-flags bundling pin — ``main([])`` on a doctored tree FAILs with
     the explicit ``--check-no-repo-root-worktree-revert`` path FAILs/PASSes;
 T9  the live-tree migration pin — the SKILL.md Step 10d additive-checkout
     fence and the code-reviewer.md smoke-restore prescription carry
-    ``git -C`` (content-anchored, never line numbers).
+    ``git -C`` (content-anchored, never line numbers);
+T10 (round 2) a comment-tail ``--staged`` does NOT waive the restore pattern
+    (the exemption lookahead is bounded at an unquoted ``#`` — concern id
+    lint-restore-lookahead-comment-tail).
 
 Plus the live-tree anti-regression lock (the analyzer.md ban-context
 sentinels keep the real tree clean).
@@ -255,6 +258,34 @@ def test_matches_in_fenced_block_and_prose(tmp_path: Path) -> None:
     assert len(errors) == 2, errors
     assert any("fenced.md:2:" in e for e in errors), errors
     assert any("prose.md:1:" in e for e in errors), errors
+
+
+# --------------------------------------------------------------------------
+# T10 (round 2) — a comment-tail `--staged` cannot waive the restore pattern
+# (concern id lint-restore-lookahead-comment-tail). Bash never executes an
+# unquoted comment tail, so a fenced `git restore . # --staged` line is a
+# destructive working-tree restore; the exemption lookahead is bounded at
+# `#` (and backtick) so only a `--staged` among the REAL arguments exempts.
+# --------------------------------------------------------------------------
+
+
+def test_comment_tail_staged_does_not_waive_restore(tmp_path: Path) -> None:
+    _write_agent(
+        tmp_path,
+        "spoof.md",
+        "```bash\ngit restore . # --staged\n```\n",
+    )
+    errors = check_no_repo_root_worktree_revert(repo_root=tmp_path)
+    assert len(errors) == 1, errors
+    assert "spoof.md:2:" in errors[0], errors
+    # symmetry: a REAL `--staged` argument (before any `#`) keeps the
+    # exemption even with a trailing comment on the same line
+    _write_agent(
+        tmp_path,
+        "spoof.md",
+        "```bash\ngit restore --staged foo.py # unstage only\n```\n",
+    )
+    assert check_no_repo_root_worktree_revert(repo_root=tmp_path) == []
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_workflow_lint_no_repo_root_worktree_revert.py
+++ b/tests/test_workflow_lint_no_repo_root_worktree_revert.py
@@ -1,0 +1,360 @@
+"""Tests for ``workflow_lint.check_no_repo_root_worktree_revert`` (#897).
+
+The check FAILs any ``.claude/agents/*.md`` or ``.claude/skills/**/SKILL.md``
+that prescribes an UNQUALIFIED working-tree revert on the shared repo root:
+
+- a non-``--staged`` ``git restore`` (any pathspec — explicit-path restore has
+  zero legitimate live doc uses; ``--staged`` forms are index-only + exempt);
+- a bare-dot wholesale ``git checkout .`` (explicit ``checkout <ref> --
+  <path>`` doc mentions are deliberately NOT flagged — legitimate prescriptive
+  uses exist; the RUNTIME hook covers those with the ``-C`` waiver as the
+  deliberate override — the prescriptive-vs-runtime split);
+- a force-flagged ``git clean`` (``-f`` anywhere in a short cluster, or
+  ``--force``).
+
+Only two forms pass (waiver logic shared with the #815 reset-hard check via
+``_line_waived``):
+
+- **worktree-qualified** — a ``git -C`` prefix at-or-before the match's char
+  offset on the same line (FI3 ``<=`` semantics);
+- **allowlisted** — a same-line ``workflow-lint: allow-repo-root-wt-revert:
+  <reason>`` sentinel with a NON-EMPTY reason (FI2).
+
+Incident 2026-07-02 (#841): a concurrent session's destructive working-tree
+git op on the shared repo root reverted the #841 analyzer's uncommitted
+``body.md`` mid-task (and deleted untracked pre-registration + figure files) —
+the #815 hazard class (``task.py`` holds a per-registry flock, not per-file).
+
+Covers T1-T9 from the plan §3d:
+T1  each flagged form FAILs with a file:line message, in agents AND skills;
+T2  the FI3 ``-C``-before-match waiver (incl. the same-``git`` ``<=`` case);
+T3  a reasoned sentinel waives;
+T4  an empty-reason / no-colon sentinel does NOT (FI2);
+T5  out-of-scope files (rules/, plans/, agent-memory/, CLAUDE.md, scripts/)
+    are NEVER scanned;
+T6  not-flagged forms (``--staged`` restore, explicit-``--`` checkout doc
+    mentions, dry-run clean, plain-prose "restore");
+T7  fenced-block + inline-prose (backtick-terminated) matches both caught;
+T8  the no-flags bundling pin — ``main([])`` on a doctored tree FAILs with
+    the #841 diagnostic (mutation-visible registration certification), and
+    the explicit ``--check-no-repo-root-worktree-revert`` path FAILs/PASSes;
+T9  the live-tree migration pin — the SKILL.md Step 10d additive-checkout
+    fence and the code-reviewer.md smoke-restore prescription carry
+    ``git -C`` (content-anchored, never line numbers).
+
+Plus the live-tree anti-regression lock (the analyzer.md ban-context
+sentinels keep the real tree clean).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_SCRIPTS = _HERE.parent / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import workflow_lint  # noqa: E402
+from workflow_lint import check_no_repo_root_worktree_revert  # noqa: E402
+
+# The worktree / repo root the live-tree tests read (T9 + the anti-regression
+# lock). Resolving from the test file keeps this worktree-agnostic — it is
+# whatever tree the suite runs in (an issue worktree during a workflow-fix
+# /issue session, the repo root otherwise); post-merge both resolutions carry
+# the migrated fence, per the plan's "robust to both" requirement.
+_REPO = _HERE.parent
+
+_SENTINEL = "workflow-lint: allow-repo-root-wt-revert"
+
+
+def _write_agent(tmp_path: Path, name: str, body: str) -> Path:
+    """Write a synthetic agent spec under ``tmp_path/.claude/agents/<name>``."""
+    p = tmp_path / ".claude" / "agents" / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def _write_skill(tmp_path: Path, slug: str, body: str) -> Path:
+    """Write a synthetic ``.claude/skills/<slug>/SKILL.md`` under ``tmp_path``."""
+    p = tmp_path / ".claude" / "skills" / slug / "SKILL.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+# --------------------------------------------------------------------------
+# T1 — each flagged form FAILs with file:line, in agents AND skills
+# --------------------------------------------------------------------------
+
+
+def test_flags_each_revert_form_in_agent(tmp_path: Path) -> None:
+    forms = [
+        "git restore .",
+        "git restore path/to/file",
+        "git checkout .",
+        "git clean -fd",
+        "git clean --force",
+    ]
+    body = "".join(f"    {f}\n" for f in forms)
+    _write_agent(tmp_path, "foo.md", body)
+    errors = check_no_repo_root_worktree_revert(repo_root=tmp_path)
+    assert len(errors) == len(forms), (len(errors), errors)
+    for lineno in range(1, len(forms) + 1):
+        assert any(f"foo.md:{lineno}:" in e for e in errors), (lineno, errors)
+    # every error states the incident + the remediation + the sentinel escape
+    assert all("#841" in e for e in errors), errors
+    assert all('git -C "$WT"' in e for e in errors), errors
+    assert all(_SENTINEL in e for e in errors), errors
+
+
+def test_flags_revert_in_skill_file(tmp_path: Path) -> None:
+    _write_skill(tmp_path, "issue", "Step X:\n    git restore .\n")
+    errors = check_no_repo_root_worktree_revert(repo_root=tmp_path)
+    assert len(errors) == 1, errors
+    assert "SKILL.md:2:" in errors[0], errors
+
+
+# --------------------------------------------------------------------------
+# T2 — FI3: `git -C` at-or-before the match waives; after it does NOT
+# --------------------------------------------------------------------------
+
+
+def test_dash_c_qualified_forms_waived(tmp_path: Path) -> None:
+    _write_agent(
+        tmp_path,
+        "foo.md",
+        "Recover inside the worktree:\n"
+        '    git -C "$WT" restore .\n'
+        '    git -C "$WT" clean -fdx\n'
+        '    git -C "$WT" checkout .\n',
+    )
+    assert check_no_repo_root_worktree_revert(repo_root=tmp_path) == []
+
+
+def test_dash_c_mention_before_match_waives(tmp_path: Path) -> None:
+    # a `git -C` mention at a LOWER char offset on the same line waives the
+    # later match (the incidental-FI3 case the analyzer.md ban-context line
+    # relied on before its explicit sentinel)
+    _write_agent(
+        tmp_path,
+        "foo.md",
+        'scoped with `git -C "$WT"`: never a bare `git restore .` there\n',
+    )
+    assert check_no_repo_root_worktree_revert(repo_root=tmp_path) == []
+
+
+def test_dash_c_after_match_does_not_waive(tmp_path: Path) -> None:
+    _write_agent(
+        tmp_path,
+        "chained.md",
+        '    git restore . && git -C "$WT" status\n',
+    )
+    errors = check_no_repo_root_worktree_revert(repo_root=tmp_path)
+    assert len(errors) == 1, errors
+    assert "chained.md:1:" in errors[0], errors
+
+
+# --------------------------------------------------------------------------
+# T3 — a reasoned sentinel waives
+# --------------------------------------------------------------------------
+
+
+def test_sentinel_with_reason_waives(tmp_path: Path) -> None:
+    _write_agent(
+        tmp_path,
+        "foo.md",
+        f"Prose mention `git restore .`  <!-- {_SENTINEL}: ban-context mention (#897) -->\n",
+    )
+    assert check_no_repo_root_worktree_revert(repo_root=tmp_path) == []
+
+
+# --------------------------------------------------------------------------
+# T4 — FI2: empty-reason / no-colon sentinel does NOT waive
+# --------------------------------------------------------------------------
+
+
+def test_sentinel_without_reason_flags(tmp_path: Path) -> None:
+    _write_agent(
+        tmp_path,
+        "colon_empty.md",
+        f"Prose `git clean -fd`  <!-- {_SENTINEL}: -->\n",
+    )
+    _write_agent(
+        tmp_path,
+        "no_colon.md",
+        f"Prose `git checkout .`  <!-- {_SENTINEL} -->\n",
+    )
+    errors = check_no_repo_root_worktree_revert(repo_root=tmp_path)
+    assert len(errors) == 2, errors
+    assert any("colon_empty.md:1:" in e for e in errors), errors
+    assert any("no_colon.md:1:" in e for e in errors), errors
+
+
+# --------------------------------------------------------------------------
+# T5 — out-of-scope files are NEVER scanned
+# --------------------------------------------------------------------------
+
+
+def test_scope_excludes_out_of_scope_files(tmp_path: Path) -> None:
+    rules = tmp_path / ".claude" / "rules" / "bar.md"
+    rules.parent.mkdir(parents=True, exist_ok=True)
+    rules.write_text("    git restore .\n", encoding="utf-8")
+    plans = tmp_path / ".claude" / "plans" / "baz.md"
+    plans.parent.mkdir(parents=True, exist_ok=True)
+    plans.write_text("    git checkout .\n", encoding="utf-8")
+    mem = tmp_path / ".claude" / "agent-memory" / "analyzer" / "y.md"
+    mem.parent.mkdir(parents=True, exist_ok=True)
+    mem.write_text("    git clean -fd\n", encoding="utf-8")
+    (tmp_path / "CLAUDE.md").write_text("    git restore .\n", encoding="utf-8")
+    scripts = tmp_path / "scripts" / "qux.py"
+    scripts.parent.mkdir(parents=True, exist_ok=True)
+    scripts.write_text("# git clean -fd\n", encoding="utf-8")
+
+    assert check_no_repo_root_worktree_revert(repo_root=tmp_path) == []
+
+
+# --------------------------------------------------------------------------
+# T6 — not-flagged forms
+# --------------------------------------------------------------------------
+
+
+def test_not_flagged_forms(tmp_path: Path) -> None:
+    _write_agent(
+        tmp_path,
+        "foo.md",
+        "Unstage with `git restore --staged foo.py` (index-only).\n"
+        "Sync spec files: `git checkout main -- $SAFE_SPECS` (explicit `--`).\n"
+        "Dry-run first: `git clean -n` shows what would go.\n"
+        "Then restore the file from HF and re-run.\n"
+        "Surgical: `git checkout issue-42 -- tasks/x/body.md` is fine in docs.\n",
+    )
+    assert check_no_repo_root_worktree_revert(repo_root=tmp_path) == []
+
+
+# --------------------------------------------------------------------------
+# T7 — caught in BOTH a fenced code block AND inline prose (backtick term.)
+# --------------------------------------------------------------------------
+
+
+def test_matches_in_fenced_block_and_prose(tmp_path: Path) -> None:
+    _write_agent(
+        tmp_path,
+        "fenced.md",
+        "```bash\ngit checkout .\n```\n",
+    )
+    _write_agent(
+        tmp_path,
+        "prose.md",
+        "Then you might `git checkout .` to clear local edits.\n",
+    )
+    errors = check_no_repo_root_worktree_revert(repo_root=tmp_path)
+    assert len(errors) == 2, errors
+    assert any("fenced.md:2:" in e for e in errors), errors
+    assert any("prose.md:1:" in e for e in errors), errors
+
+
+# --------------------------------------------------------------------------
+# Live-tree anti-regression lock — the real post-fix tree PASSES
+# --------------------------------------------------------------------------
+
+
+def test_live_tree_passes() -> None:
+    """``check_no_repo_root_worktree_revert()`` returns ``[]`` on the real
+    post-fix tree: the analyzer.md ban-context sentinels keep the live surface
+    clean, and this fails loud if a future edit drops a sentinel or adds an
+    unqualified working-tree-revert prescription."""
+    assert check_no_repo_root_worktree_revert(repo_root=_REPO) == []
+
+
+# --------------------------------------------------------------------------
+# T8 — no-flags bundling pin (registration certification, mutation-visible)
+# --------------------------------------------------------------------------
+
+
+def test_bundled_in_no_flags(tmp_path: Path, capsys, monkeypatch) -> None:
+    """The no-flags default run actually DISPATCHES the #897 check — deleting
+    any of its 3 wiring sites (argparse flag, ``no_flags`` disjunction,
+    execution block) must fail this test. Follows the
+    ``test_vm_thread_cap_guidance_bundled_in_no_flags`` pattern: one offending
+    fixture file, ``_REPO_ROOT`` monkeypatched at it, ``main([])`` in-process.
+    Other bundled checks contribute unrelated errors on the minimal tree, so
+    the assertion keys on the #841 diagnostic + the distinctive fixture name.
+    """
+    _write_agent(tmp_path, "wt_revert_offender.md", "    git restore .\n")
+    monkeypatch.setattr(workflow_lint, "_REPO_ROOT", tmp_path)
+    rc = workflow_lint.main([])
+    err = capsys.readouterr().err
+    assert rc != 0, f"no-flags default run exited 0 on an offending tree:\n{err}"
+    assert "#841" in err and "wt_revert_offender.md" in err, (
+        f"the #841 worktree-revert diagnostic (naming wt_revert_offender.md) "
+        f"is missing from the no-flags default run's stderr — the check is "
+        f"not bundled into no_flags:\n{err}"
+    )
+
+
+def test_explicit_flag_path_fails_and_passes(tmp_path: Path, capsys, monkeypatch) -> None:
+    """The explicit ``--check-no-repo-root-worktree-revert`` path FAILs on the
+    offending fixture (argparse + execution-block wiring) and PASSes on a
+    clean fixture (the flag runs ONLY this check — ``no_flags`` goes False)."""
+    _write_agent(tmp_path, "wt_revert_offender.md", "    git clean -fd\n")
+    monkeypatch.setattr(workflow_lint, "_REPO_ROOT", tmp_path)
+    rc = workflow_lint.main(["--check-no-repo-root-worktree-revert"])
+    err = capsys.readouterr().err
+    assert rc == 1, f"explicit flag path exited {rc} on an offending tree:\n{err}"
+    assert "#841" in err and "wt_revert_offender.md" in err, err
+
+    clean_root = tmp_path / "clean"
+    _write_agent(clean_root, "ok.md", 'Use `git -C "$WT" clean -fdx` in the worktree.\n')
+    monkeypatch.setattr(workflow_lint, "_REPO_ROOT", clean_root)
+    rc2 = workflow_lint.main(["--check-no-repo-root-worktree-revert"])
+    err2 = capsys.readouterr().err
+    assert rc2 == 0, f"explicit flag path exited {rc2} on a clean tree:\n{err2}"
+
+
+# --------------------------------------------------------------------------
+# T9 — live-tree migration pin (acceptance criterion 5; content-anchored)
+# --------------------------------------------------------------------------
+
+
+def test_live_skill_md_additive_checkout_is_dash_c_qualified() -> None:
+    """The /issue Step 10d surgical additive checkout runs at the repo root
+    (its fence's preceding line is ``cd "$REPO_ROOT"``), so the #897 hook's
+    pathspec detector would bounce the bare ``checkout issue-<N> --`` form.
+    Pin that the live fence carries the ``git -C "$REPO_ROOT"`` deliberate
+    override. Located by CONTENT ANCHOR (the ``xargs -a`` prefix), never by
+    line number (the fence drifts). Also guards against a future SKILL.md
+    edit reintroducing the unqualified fence."""
+    skill = _REPO / ".claude" / "skills" / "issue" / "SKILL.md"
+    text = skill.read_text(encoding="utf-8")
+    # The `checkout issue-<N> --` conjunct pins the CHECKOUT fence line
+    # specifically — the sibling `git commit -m "...: surgical additive
+    # checkout ..."` fence line also carries the xargs prefix + the word
+    # "checkout" (in its commit-message subject) and must not match.
+    anchor_lines = [
+        ln
+        for ln in text.splitlines()
+        if "xargs -a /tmp/issue-<N>-additive-files.txt" in ln and "checkout issue-<N> --" in ln
+    ]
+    assert anchor_lines, "Step 10d additive-checkout fence line not found in SKILL.md"
+    for ln in anchor_lines:
+        assert re.search(r'git\s+-C\s+"\$REPO_ROOT"\s+checkout\s+issue-<N>\s+--', ln), (
+            f"additive-checkout fence line is not -C-qualified: {ln!r}"
+        )
+
+
+def test_live_code_reviewer_smoke_restore_is_dash_c_qualified() -> None:
+    """The code-reviewer smoke-restore prescription (Step 0.6 region —
+    'restore the committed artifacts YOUR OWN command modified') must carry
+    ``git -C`` so a reviewer executing it verbatim is not bounced by the #897
+    hook detector. Located by content anchor, never line number."""
+    cr = _REPO / ".claude" / "agents" / "code-reviewer.md"
+    text = cr.read_text(encoding="utf-8")
+    assert "never a blanket" in text, "smoke-restore prescription anchor missing"
+    anchor_lines = [ln for ln in text.splitlines() if "checkout -- <paths>" in ln]
+    assert anchor_lines, "smoke-restore checkout prescription line not found"
+    for ln in anchor_lines:
+        assert "git -C" in ln, f"smoke-restore prescription is not -C-qualified: {ln!r}"


### PR DESCRIPTION
Closes task #897.

## Summary
- Extends the repo-root destructive-git PreToolUse hook (`scripts/guard_repo_root_branch.sh`) to block working-tree reverts at the shared repo root: `git restore` (non-`--staged`), checkout pathspec forms (bare-dot, standalone `--`, `--pathspec-from-file`, force, bare-pathspec existence probe — the exact #841 op), `git clean` force variants, runtime `git reset --hard`; comment-tail strip prevents waiver spoofing.
- Adds `workflow_lint.py check_no_repo_root_worktree_revert` (bundled in the no-flags default, T8-pinned) + migrates/whitelists 3 live call sites (T9-pinned).
- +~110 hook/lint test rows; #804 latch + #796 raw-scan contracts preserved.

## Test plan
- [x] Step 9c touched scope: 2285 passed / 6 skipped (repo-root HEAD on main)
- [x] no-flags workflow_lint exit 0 on live tree
- [x] ruff check + format clean on touched files
- [x] Code-review ensemble round 2 PASS (Claude + Codex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)