### PR TITLE
task #915: janitors handle symlinked per-issue cache dirs

### DIFF
--- a/scripts/clean_experiment_downloads.py
+++ b/scripts/clean_experiment_downloads.py
@@ -38,10 +38,14 @@ What is and is NOT a cache (the safety contract):
     — external, foreign-issue, renamed, a ``store/``, a file — is KEPT
     (fail-toward-keep, sidecar-escalated as
     ``kind: "symlink-external-target-kept"``): a direct link is unlinked
-    (target kept); a shared PARENT link is NEVER unlinked. A dangling cache
-    symlink is discovered and unlinked. Managed reaps delete the TARGET
-    FIRST, then the link — a mid-reap crash leaves the link, so the next run
-    re-discovers and retries.
+    (target kept); with a symlinked PARENT nothing is EVER unlinked — not the
+    shared parent link, and not a child entry inside its target tree (even
+    when that child is itself a link — the double-link case; the only
+    permitted mutation under a linked parent is the managed-target reap). A
+    DIRECT dangling cache symlink is discovered and unlinked; a dangling
+    entry reached through a linked parent is kept + sidecar-escalated.
+    Managed reaps delete the TARGET FIRST, then the link — a mid-reap crash
+    leaves the link, so the next run re-discovers and retries.
 
 There are now THREE reap gates, all composing additively (any one puts a cache
 dir in ``CleanResult.skipped`` instead of deleting it):
@@ -745,10 +749,13 @@ def clean_issue_downloads(
     (strictly inside ``data_disk_root()``, names the owning issue, a directory
     whose basename equals the cache name); otherwise the target is KEPT and
     recorded in ``CleanResult.symlink_external_kept`` + the sidecar (a direct
-    link is unlinked; a shared parent link is never unlinked, and nothing is
-    deleted through it). Dangling links are unlinked. Managed reaps delete the
-    target BEFORE the link (crash safety: a surviving link is re-discovered
-    and retried on the next run). Both gates above run FIRST, unchanged —
+    link is unlinked; with a symlinked parent NOTHING is unlinked — not the
+    shared parent link and not a child entry inside its target tree, even
+    when that child is itself a link). DIRECT dangling links are unlinked;
+    a dangling entry through a linked parent is kept + sidecar-escalated.
+    Managed reaps delete the target BEFORE the link (crash safety: a
+    surviving link is re-discovered and retried on the next run). Both gates
+    above run FIRST, unchanged —
     gate 1 is issue-number-keyed and path-independent; gate 2's ``rglob``
     traverses THROUGH the symlink into the target.
 
@@ -800,18 +807,34 @@ def clean_issue_downloads(
         # design, so both route through disposition logic instead. A data
         # root that is ITSELF a symlink is a deliberate wholesale relocation
         # and stays on the plain path below.
-        parent_linked = (not cache_dir.is_symlink()) and cache_dir.parent.is_symlink()
-        if cache_dir.is_symlink() or parent_linked:
+        #
+        # parent_linked is computed INDEPENDENTLY of the child's own linkness
+        # (the round-2 MF2 fix): when the parent issue dir is a link AND the
+        # cache entry inside its target tree is ITSELF a link (double-link),
+        # cache_dir.is_symlink() is True THROUGH the parent link, so the old
+        # `(not is_symlink()) and parent.is_symlink()` formula misclassified
+        # the case as a DIRECT link — apply-mode unlink() then resolved
+        # through the shared parent link and removed the child entry inside
+        # the not-ours target tree. Parent-link ownership DOMINATES: with a
+        # linked parent, the only permitted mutation is rmtree() of a
+        # fully-validated managed target; nothing is ever unlink()ed.
+        parent_linked = cache_dir.parent.is_symlink()
+        direct_linked = cache_dir.is_symlink()
+        if direct_linked or parent_linked:
             target = _managed_symlink_target(cache_dir, issue_n)
             resolved = Path(os.path.realpath(cache_dir))
             dangling = not cache_dir.exists()  # exists() follows links
             res.symlink_targets[rel] = "" if dangling else str(resolved)
-            if target is None and not dangling:
-                # External / foreign-issue / non-cache-shaped target: KEPT
-                # (fail-toward-keep), sidecar-escalated for a human read.
+            if target is None and (not dangling or parent_linked):
+                # External / foreign-issue / non-cache-shaped target — or a
+                # DANGLING entry reached through a linked parent (nothing to
+                # reap, and the entry inside the parent's target tree is not
+                # ours to unlink): KEPT (fail-toward-keep), sidecar-escalated
+                # for a human read.
                 res.symlink_external_kept.append((rel, str(resolved)))
+                kept_what = "dangling child link" if dangling else "external target"
                 note = (
-                    f"symlink parent kept (nothing unlinked); external target kept: {resolved}"
+                    f"symlink parent kept (nothing unlinked); {kept_what} kept: {resolved}"
                     if parent_linked
                     else f"symlink unlinked; external target kept: {resolved}"
                 )
@@ -830,9 +853,13 @@ def clean_issue_downloads(
                     apply=apply,
                 )
                 if apply and not parent_linked:
-                    # Direct link: the pointer goes; the target stays. A
-                    # shared PARENT link is never unlinked (sibling caches +
-                    # non-cache entries resolve through it).
+                    # Direct link ONLY: the pointer goes; the target stays.
+                    # With a linked PARENT nothing is unlinked — the parent
+                    # link is shared (sibling caches + non-cache entries
+                    # resolve through it), and in the double-link case the
+                    # child entry lives INSIDE the parent's target tree, so an
+                    # unlink() here would mutate that not-ours tree (the
+                    # round-1 MF2 violation).
                     try:
                         cache_dir.unlink()
                     except OSError as exc:
@@ -853,7 +880,13 @@ def clean_issue_downloads(
                     shutil.rmtree(target)
                 if not parent_linked:
                     # The boot-disk link itself (direct case; also the
-                    # dangling-link unlink). Never the shared parent link.
+                    # direct dangling-link unlink). NEVER when the parent is
+                    # a link: not the shared parent link itself, and not a
+                    # child link entry inside the parent's target tree
+                    # (unlink() would resolve through the shared parent link
+                    # and mutate the not-ours tree — the round-1 MF2
+                    # violation; a managed double-link reap leaves the child
+                    # link dangling in the managed tree instead).
                     cache_dir.unlink()
             except OSError as exc:
                 print(f"  ! FAILED to remove {rel}: {exc}", file=sys.stderr)

--- a/scripts/clean_experiment_downloads.py
+++ b/scripts/clean_experiment_downloads.py
@@ -27,6 +27,21 @@ What is and is NOT a cache (the safety contract):
     target lived under ``data/issue_658/hf_dl/``). See
     ``_active_consumer_protected_issues`` /
     ``_cache_dir_reap_blocked_by_active_consumer``.
+  * SYMLINKED caches (#915, the #681 data-disk relocation): a ``hf_dl`` /
+    ``g*_dl`` that is a symlink — or whose ``issue_<N>`` PARENT dir is a
+    symlink — is disposition-checked instead of plain-``rmtree``'d
+    (``shutil.rmtree`` refuses a symlink by design). The RESOLVED target is
+    reaped ONLY when it lives strictly inside the managed data-disk root
+    (env ``EPS_VM_DATA_DISK_PATH``, default ``/mnt/eps-data``), a path
+    component names the OWNING issue, AND it is a directory whose basename
+    equals the cache name (the relocation is name-preserving). Anything else
+    — external, foreign-issue, renamed, a ``store/``, a file — is KEPT
+    (fail-toward-keep, sidecar-escalated as
+    ``kind: "symlink-external-target-kept"``): a direct link is unlinked
+    (target kept); a shared PARENT link is NEVER unlinked. A dangling cache
+    symlink is discovered and unlinked. Managed reaps delete the TARGET
+    FIRST, then the link — a mid-reap crash leaves the link, so the next run
+    re-discovers and retries.
 
 There are now THREE reap gates, all composing additively (any one puts a cache
 dir in ``CleanResult.skipped`` instead of deleting it):
@@ -127,6 +142,65 @@ def hf_data_repo() -> str:
     """The data repo the nested-``store/`` parity guard checks against
     (env ``EPM_HF_DATA_REPO``; defaults to :data:`HF_DATA_REPO_DEFAULT`)."""
     return os.environ.get("EPM_HF_DATA_REPO", "").strip() or HF_DATA_REPO_DEFAULT
+
+
+# The #681 managed data-disk mount that holds relocated per-issue caches.
+# Mirrors vm_disk_guard.DEFAULT_DATA_DISK_PATH / data_disk_path() (that module
+# imports FROM this one, so the constant cannot live there without a cycle).
+DATA_DISK_ROOT_DEFAULT = "/mnt/eps-data"
+
+
+def data_disk_root() -> Path:
+    """Managed data-disk root (env ``EPS_VM_DATA_DISK_PATH``; blank -> default)."""
+    raw = os.environ.get("EPS_VM_DATA_DISK_PATH", "").strip()
+    return Path(raw or DATA_DISK_ROOT_DEFAULT)
+
+
+def _path_component_names_issue(rel: Path, issue_n: int) -> bool:
+    """True iff some component of ``rel`` names issue ``issue_n`` — exactly
+    ``issue_<n>`` / ``issue<n>``, or an ``issue_<n>_<slug>`` / ``issue<n>_<slug>``
+    prefix form — the same exact-N-boundary rules as :func:`issue_data_dirs`
+    (``issue_65`` never matches ``issue_658``).
+
+    NOTE: the post-#681-cutover worktree layout may name issue dirs with a
+    HYPHEN (``issue-<n>``); deliberately NOT matched yet — a hyphen-named
+    target takes the fail-toward-keep disposition, the safe direction. Widen
+    when the cutover lands, with a test."""
+    n = str(issue_n)
+    for comp in rel.parts:
+        if comp in (f"issue_{n}", f"issue{n}"):
+            return True
+        if comp.startswith((f"issue_{n}_", f"issue{n}_")):
+            return True
+    return False
+
+
+def _managed_symlink_target(cache_dir: Path, issue_n: int) -> Path | None:
+    """Fully-resolved symlink target iff it is verifiably ``issue_n``'s
+    RELOCATED cache on the managed data disk; ``None`` otherwise
+    (fail-toward-keep). ALL of the following must hold, else ``None``:
+
+      * the resolved target lies STRICTLY inside :func:`data_disk_root`
+        (``os.path.realpath`` on BOTH sides defeats nested-link /
+        relative-link escapes; the root itself is never a valid target);
+      * some path component below the root names ``issue_n``
+        (:func:`_path_component_names_issue`) — defends against a hand-made
+        alias into ANOTHER issue's (or shared) data-disk state;
+      * the target IS a directory whose basename EXACTLY matches the cache
+        dir's name (the relocation pattern is name-preserving —
+        ``hf_dl -> hf_dl``, ``g1_dl -> g1_dl``). This stops a same-issue
+        alias (``hf_dl -> .../issue_<n>/store``, or -> any FILE) from being
+        reaped: gate 2's ``rglob`` matches descendants only, never the
+        resolved root itself, so this predicate is the only defense."""
+    target = Path(os.path.realpath(cache_dir))
+    root = Path(os.path.realpath(data_disk_root()))
+    if target == root or not target.is_relative_to(root):
+        return None
+    if not _path_component_names_issue(target.relative_to(root), issue_n):
+        return None
+    if not target.is_dir() or target.name != cache_dir.name:
+        return None
+    return target
 
 
 # Shared sidecar stream for ALL VM-disk escalations (this guard's SKIP events,
@@ -257,22 +331,41 @@ def download_cache_dirs(issue_n: int, data_root: Path | None = None) -> list[Pat
     """Re-downloadable cache directories to delete for ``issue_n``.
 
     The union of ``CACHE_DIR_GLOBS`` matches across every per-issue data dir
-    (both naming conventions, repo-root AND worktree copies). Only existing
-    directories are returned; ``store/`` and any non-cache content are never
+    (both naming conventions, repo-root AND worktree copies). Directories AND
+    symlinks are returned — a symlink is admitted even when DANGLING or
+    pointing at a file (``is_dir()`` follows the link and returns False for
+    both, which used to leave dangling relocation links invisible forever;
+    #915). ``store/`` and plain non-dir files named like a cache are never
     included.
     """
     out: list[Path] = []
     for issue_dir in issue_data_dirs(issue_n, data_root):
         for pattern in CACHE_DIR_GLOBS:
+            if "*" not in pattern:
+                # A literal name (hf_dl): Path.glob's precise selector calls
+                # path.exists(), which FOLLOWS a symlink — a DANGLING
+                # literal-name link would stay invisible forever. Probe the
+                # candidate directly with non-following checks instead.
+                # (The wildcard selector below scandir-lists entries, so it
+                # DOES yield dangling g*_dl links.)
+                cand = issue_dir / pattern
+                if cand.is_dir() or cand.is_symlink():
+                    out.append(cand)
+                continue
             for match in sorted(issue_dir.glob(pattern)):
-                if match.is_dir():
+                if match.is_dir() or match.is_symlink():
                     out.append(match)
     return out
 
 
 def _dir_size_bytes(path: Path) -> int:
     """Recursive on-disk size of ``path`` in bytes (best-effort; a stat error
-    on a single entry is skipped, never raised — sizing is reporting only)."""
+    on a single entry is skipped, never raised — sizing is reporting only).
+
+    Follows ``path`` itself when it is a symlink-to-dir (``rglob`` traverses
+    through a top-level link), so a relocated cache's size reflects the
+    data-disk bytes a managed reap frees (#915); symlinks INSIDE the tree
+    are still excluded. A dangling link or a link-to-file sizes to 0."""
     total = 0
     for p in path.rglob("*"):
         try:
@@ -583,6 +676,19 @@ class CleanResult:
     # logged. These are NOT failures — they are a safe fail-toward-keep.
     skipped: list[tuple[str, str]] = field(default_factory=list)
     sizes_bytes: dict[str, int] = field(default_factory=dict)
+    # rel -> fully-resolved symlink target ("" for a dangling link); populated
+    # in BOTH modes (dry-run + apply) whenever the reap loop takes the symlink
+    # branch — direct-link AND symlinked-parent cases (#915). A cache SKIPped
+    # by an earlier gate never reaches the branch, so it is not recorded here.
+    symlink_targets: dict[str, str] = field(default_factory=dict)
+    # (rel, resolved_target): the target is NOT ours to reap — KEPT (external /
+    # foreign-issue / non-cache-shaped). Direct-link case: the link itself is
+    # (would be) unlinked. Symlinked-parent case: NOTHING is unlinked (the
+    # parent link is shared); the sidecar row distinguishes the two via its
+    # "via" field ("link" | "parent"). Deliberately NOT in ``removed`` (so
+    # ``bytes_freed`` never overstates); still in ``sizes_bytes`` (so
+    # ``total_discovered_bytes`` — the escalation sizing — sees the footprint).
+    symlink_external_kept: list[tuple[str, str]] = field(default_factory=list)
 
     @property
     def bytes_freed(self) -> int:
@@ -631,6 +737,21 @@ def clean_issue_downloads(
       2. The nested-``store/`` parity gate (#679): never wholesale-rmtree a
          cache dir holding a mis-rooted ``store/`` not verifiably mirrored on HF.
 
+    Symlinked caches (#915): a cache dir that is itself a symlink, or whose
+    ``issue_<N>`` PARENT dir is a symlink, routes through symlink-disposition
+    logic instead of a plain ``rmtree`` (which refuses symlinks). The resolved
+    target is reaped only when :func:`_managed_symlink_target` positively
+    identifies it as the issue's relocated cache on the managed data disk
+    (strictly inside ``data_disk_root()``, names the owning issue, a directory
+    whose basename equals the cache name); otherwise the target is KEPT and
+    recorded in ``CleanResult.symlink_external_kept`` + the sidecar (a direct
+    link is unlinked; a shared parent link is never unlinked, and nothing is
+    deleted through it). Dangling links are unlinked. Managed reaps delete the
+    target BEFORE the link (crash safety: a surviving link is re-discovered
+    and retried on the next run). Both gates above run FIRST, unchanged —
+    gate 1 is issue-number-keyed and path-independent; gate 2's ``rglob``
+    traverses THROUGH the symlink into the target.
+
     ``_skip_active_consumer_guard`` (private, keyword-only, defaulted False) opts
     out of gate 1, skipping the ``tasks/`` walk entirely. It is a TEST SEAM only
     — no production caller passes it. In particular
@@ -670,6 +791,75 @@ def clean_issue_downloads(
         if skip_reason is not None:
             print(f"  ~ SKIP {rel}: {skip_reason}", file=sys.stderr)
             res.skipped.append((rel, skip_reason))
+            continue
+        # Symlink disposition (#915): a cache relocated onto the managed data
+        # disk is reachable through an in-tree link at either of the two
+        # components below the data root — the cache dir itself
+        # (data/issue_<N>/hf_dl -> /mnt/eps-data/.../issue_<N>/hf_dl) or a
+        # symlinked PARENT issue dir. shutil.rmtree refuses a symlink by
+        # design, so both route through disposition logic instead. A data
+        # root that is ITSELF a symlink is a deliberate wholesale relocation
+        # and stays on the plain path below.
+        parent_linked = (not cache_dir.is_symlink()) and cache_dir.parent.is_symlink()
+        if cache_dir.is_symlink() or parent_linked:
+            target = _managed_symlink_target(cache_dir, issue_n)
+            resolved = Path(os.path.realpath(cache_dir))
+            dangling = not cache_dir.exists()  # exists() follows links
+            res.symlink_targets[rel] = "" if dangling else str(resolved)
+            if target is None and not dangling:
+                # External / foreign-issue / non-cache-shaped target: KEPT
+                # (fail-toward-keep), sidecar-escalated for a human read.
+                res.symlink_external_kept.append((rel, str(resolved)))
+                note = (
+                    f"symlink parent kept (nothing unlinked); external target kept: {resolved}"
+                    if parent_linked
+                    else f"symlink unlinked; external target kept: {resolved}"
+                )
+                print(
+                    f"  ~ {'' if apply else '[report-only] would: '}{note}",
+                    file=sys.stderr,
+                )
+                append_disk_guard_event(
+                    {
+                        "kind": "symlink-external-target-kept",
+                        "task": issue_n,
+                        "path": rel,
+                        "target": str(resolved),
+                        "via": "parent" if parent_linked else "link",
+                    },
+                    apply=apply,
+                )
+                if apply and not parent_linked:
+                    # Direct link: the pointer goes; the target stays. A
+                    # shared PARENT link is never unlinked (sibling caches +
+                    # non-cache entries resolve through it).
+                    try:
+                        cache_dir.unlink()
+                    except OSError as exc:
+                        print(f"  ! FAILED to remove {rel}: {exc}", file=sys.stderr)
+                        res.failed.append(rel)
+                continue
+            if not apply:
+                res.removed.append(rel)  # would-remove (managed or dangling)
+                continue
+            try:
+                if target is not None:
+                    # Managed data-disk reap (the tier-b "reap on EITHER
+                    # disk" contract). Target FIRST, link second: if this
+                    # rmtree fails midway the link survives, so the next run
+                    # re-discovers and retries; unlinking first would orphan
+                    # a half-deleted target no janitor could ever find again.
+                    # _managed_symlink_target guarantees target is a dir.
+                    shutil.rmtree(target)
+                if not parent_linked:
+                    # The boot-disk link itself (direct case; also the
+                    # dangling-link unlink). Never the shared parent link.
+                    cache_dir.unlink()
+            except OSError as exc:
+                print(f"  ! FAILED to remove {rel}: {exc}", file=sys.stderr)
+                res.failed.append(rel)
+                continue
+            res.removed.append(rel)
             continue
         if not apply:
             res.removed.append(rel)  # would-remove (dry-run)
@@ -776,15 +966,19 @@ def main(argv: list[str] | None = None) -> int:
     print(
         f"clean_experiment_downloads {mode}issue {args.issue}: {verb} "
         f"{len(res.removed)} cache dir(s), {_fmt_gb(res.bytes_freed)} | "
-        f"skipped {len(res.skipped)} | failed {len(res.failed)}"
+        f"skipped {len(res.skipped)} | "
+        f"external-kept {len(res.symlink_external_kept)} | failed {len(res.failed)}"
     )
     for name in res.removed:
         print(f"  - {verb}: {name} [{_fmt_gb(res.sizes_bytes.get(name, 0))}]")
     for name, reason in res.skipped:
         print(f"  ~ SKIP (kept): {name} — {reason}")
+    for name, tgt in res.symlink_external_kept:
+        kept_verb = "kept" if args.apply else "would keep"
+        print(f"  ~ {kept_verb} external symlink target: {name} -> {tgt}")
     for name in res.failed:
         print(f"  ! FAILED: {name}")
-    if not res.removed and not res.failed and not res.skipped:
+    if not res.removed and not res.failed and not res.skipped and not res.symlink_external_kept:
         print("  (no download caches found — nothing to do)")
     return 2 if res.failed else 0
 

--- a/scripts/vm_disk_guard.py
+++ b/scripts/vm_disk_guard.py
@@ -476,6 +476,8 @@ def clean_terminal_download_caches(apply: bool, data_root: Path | None = None) -
             )
         for name in sub.failed:
             res.detail.append(f"issue {issue_n}: FAILED to remove {name}")
+        for name, tgt in sub.symlink_external_kept:
+            res.detail.append(f"issue {issue_n}: external symlink target kept: {name} -> {tgt}")
     if apply and escalated_any:
         _save_active_escalation_state(escalation_state)
     return res

--- a/tests/test_clean_experiment_downloads_symlinks.py
+++ b/tests/test_clean_experiment_downloads_symlinks.py
@@ -54,7 +54,9 @@ def fake_repo(tmp_path, monkeypatch):
     referencing ``data/issue_761/`` would otherwise (correctly) SKIP the reap
     and break these sandboxed tests (same pattern as
     ``tests/test_clean_experiment_downloads_parity.py``)."""
-    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+    # syspath_prepend (not a bare sys.path.insert) so the entry is restored
+    # at teardown instead of accumulating once per test.
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[1] / "src"))
     import explore_persona_space.task_workflow as tw
 
     tw.invalidate_cache()
@@ -407,3 +409,170 @@ def test_target_rmtree_failure_link_survives(fake_repo, disk_root, monkeypatch):
         assert (disk_root / "user" / "eps-data" / "issue_761" / name / "blob.bin").exists()
     # res.failed non-empty is the CLI exit-2 driver.
     assert res.failed
+
+
+# ─── 14 (MF2 round-2 regression): DOUBLE link — parent AND child both links ───
+# Round-1 computed `parent_linked = (not cache_dir.is_symlink()) and
+# cache_dir.parent.is_symlink()`, so when the parent issue dir was a link AND
+# the cache entry inside its target tree was ITSELF a link,
+# cache_dir.is_symlink() was True through the parent link, parent_linked came
+# out False, the case classified as a DIRECT link, and apply-mode unlink()
+# resolved through the shared parent link and removed the child entry INSIDE
+# the external unmanaged tree — violating the plan §2 MF2 row "symlinked
+# parent + external target: SKIP entirely — nothing deleted, nothing
+# unlinked". Concern id: double-link-unlink-through-parent-mf2.
+
+
+def test_double_link_parent_and_child_external_target_kept(fake_repo, disk_root):
+    data_root = fake_repo / "data"
+    data_root.mkdir(parents=True)
+    # data/issue_761 -> external tree, whose hf_dl entry is ITSELF a symlink
+    # to another external dir (the double-link topology).
+    ext_issue = fake_repo / "external" / "issue_761"
+    ext_issue.mkdir(parents=True)
+    ext_target = fake_repo / "external" / "real_hf_dl"
+    ext_target.mkdir(parents=True)
+    (ext_target / "blob.bin").write_bytes(b"x" * 1024)
+    (ext_issue / "hf_dl").symlink_to(ext_target)
+    parent_link = data_root / "issue_761"
+    parent_link.symlink_to(ext_issue)
+
+    res = ced.clean_issue_downloads(761, apply=True, data_root=data_root)
+
+    # BOTH links survive: the shared parent link AND the child link entry
+    # inside the external tree (round-1 unlinked the child THROUGH the
+    # parent link). The external tree is byte-untouched.
+    assert parent_link.is_symlink()
+    assert os.path.lexists(ext_issue / "hf_dl")
+    assert (ext_issue / "hf_dl").is_symlink()
+    assert (ext_target / "blob.bin").exists()
+    assert res.symlink_external_kept == [("data/issue_761/hf_dl", str(ext_target))]
+    assert res.removed == []
+    assert res.failed == []
+
+    rows = _read_sidecar(fake_repo)
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "symlink-external-target-kept"
+    # Parent-link ownership dominates: via is "parent" even though the child
+    # entry is itself a link.
+    assert rows[0]["via"] == "parent"
+
+
+def test_double_link_parent_and_child_dangling_kept(fake_repo, disk_root):
+    """Double-link variant with a DANGLING child target: nothing to reap and
+    the child entry inside the parent's target tree is not ours to unlink —
+    kept + sidecar-escalated, never unlinked."""
+    data_root = fake_repo / "data"
+    data_root.mkdir(parents=True)
+    ext_issue = fake_repo / "external" / "issue_761"
+    ext_issue.mkdir(parents=True)
+    (ext_issue / "hf_dl").symlink_to(fake_repo / "external" / "gone")  # dangling
+    parent_link = data_root / "issue_761"
+    parent_link.symlink_to(ext_issue)
+
+    res = ced.clean_issue_downloads(761, apply=True, data_root=data_root)
+
+    assert parent_link.is_symlink()
+    assert os.path.lexists(ext_issue / "hf_dl")  # dangling child link NOT unlinked
+    assert [rel for rel, _ in res.symlink_external_kept] == ["data/issue_761/hf_dl"]
+    assert res.removed == []
+    assert res.failed == []
+
+    rows = _read_sidecar(fake_repo)
+    assert len(rows) == 1
+    assert rows[0]["via"] == "parent"
+
+
+def test_double_link_managed_parent_child_link_target_reaped_links_survive(fake_repo, disk_root):
+    """Managed variant of the double-link topology (parent link resolves
+    INSIDE the managed data disk; the child entry there is itself a link to a
+    fully-validated managed cache dir): the resolved TARGET is reaped, but
+    neither link is unlinked — the parent link is shared and the child link
+    entry lives inside its target tree."""
+    data_root = fake_repo / "data"
+    data_root.mkdir(parents=True)
+    disk_issue = disk_root / "user" / "eps-data" / "issue_761"
+    real = disk_issue / "real" / "hf_dl"  # names issue_761, cache-shaped dir
+    real.mkdir(parents=True)
+    (real / "blob.bin").write_bytes(b"x" * 1024)
+    (disk_issue / "hf_dl").symlink_to(real)
+    parent_link = data_root / "issue_761"
+    parent_link.symlink_to(disk_issue)
+
+    res = ced.clean_issue_downloads(761, apply=True, data_root=data_root)
+
+    assert res.removed == ["data/issue_761/hf_dl"]
+    assert res.failed == []
+    assert not real.exists()  # fully-validated managed target reaped
+    assert parent_link.is_symlink()  # parent link intact
+    # The child link entry inside the managed tree is NOT unlinked through
+    # the parent link (left dangling in the managed tree).
+    assert os.path.lexists(disk_issue / "hf_dl")
+
+
+# ─── 17: direct link, renamed-basename / eval_results targets kept ────────────
+
+
+def test_symlink_renamed_basename_target_kept(fake_repo, disk_root):
+    """A direct link whose managed-root target has a DIFFERENT basename
+    (hf_dl -> .../issue_761/hf_dl_old) fails the name-preserving cache-shape
+    prong: link unlinked, target KEPT."""
+    data_root = fake_repo / "data"
+    issue_dir = data_root / "issue_761"
+    issue_dir.mkdir(parents=True)
+    tgt = disk_root / "user" / "eps-data" / "issue_761" / "hf_dl_old"
+    tgt.mkdir(parents=True)
+    (tgt / "blob.bin").write_bytes(b"x" * 1024)
+    (issue_dir / "hf_dl").symlink_to(tgt)
+
+    res = ced.clean_issue_downloads(761, apply=True, data_root=data_root)
+
+    assert (tgt / "blob.bin").exists()  # renamed target KEPT
+    assert not os.path.lexists(issue_dir / "hf_dl")  # direct link unlinked
+    assert res.symlink_external_kept == [("data/issue_761/hf_dl", str(tgt))]
+    assert res.removed == []
+    assert res.failed == []
+
+
+def test_symlink_to_eval_results_target_kept(fake_repo, disk_root):
+    """A direct link resolving to an eval_results/ dir (durable artifacts,
+    never a cache) is kept via the basename prong (fail-toward-keep)."""
+    data_root = fake_repo / "data"
+    issue_dir = data_root / "issue_761"
+    issue_dir.mkdir(parents=True)
+    tgt = disk_root / "user" / "eps-data" / "issue_761" / "eval_results"
+    tgt.mkdir(parents=True)
+    (tgt / "metrics.json").write_text("{}")
+    (issue_dir / "hf_dl").symlink_to(tgt)
+
+    res = ced.clean_issue_downloads(761, apply=True, data_root=data_root)
+
+    assert (tgt / "metrics.json").exists()  # durable artifacts KEPT
+    assert not os.path.lexists(issue_dir / "hf_dl")
+    assert res.symlink_external_kept == [("data/issue_761/hf_dl", str(tgt))]
+    assert res.removed == []
+    assert res.failed == []
+
+
+# ─── 18: CLI exit-code contract (main() returns 2 iff res.failed) ─────────────
+
+
+def test_cli_exit_code_2_on_failed_reap(fake_repo, disk_root, monkeypatch):
+    data_root = fake_repo / "data"
+    _make_symlinked_issue(data_root, disk_root)
+    monkeypatch.setattr(ced, "_running_pod_side", lambda: False)
+
+    def _boom(path, *a, **k):
+        raise OSError(f"simulated rmtree failure on {path}")
+
+    monkeypatch.setattr(ced.shutil, "rmtree", _boom)
+
+    assert ced.main(["761", "--apply"]) == 2
+
+
+def test_cli_exit_code_0_on_clean_run(fake_repo, disk_root, monkeypatch):
+    monkeypatch.setattr(ced, "_running_pod_side", lambda: False)
+    data_root = fake_repo / "data"
+    _make_symlinked_issue(data_root, disk_root)
+
+    assert ced.main(["761", "--apply"]) == 0

--- a/tests/test_clean_experiment_downloads_symlinks.py
+++ b/tests/test_clean_experiment_downloads_symlinks.py
@@ -1,0 +1,409 @@
+"""Tests for the symlinked-cache disposition logic in
+``scripts/clean_experiment_downloads.py`` + the ``vm_disk_guard.py`` tier-(b)
+reporting (task #915).
+
+``shutil.rmtree`` refuses a symlink by design, so the #681-era relocation
+pattern (``data/issue_<N>/hf_dl -> /mnt/eps-data/.../issue_<N>/hf_dl``) made
+every janitor reap FAIL on the healthiest configuration. The fix reaps the
+RESOLVED target only when it is verifiably the issue's relocated cache —
+strictly inside the managed data-disk root (``EPS_VM_DATA_DISK_PATH``), a path
+component naming the OWNING issue, and a directory whose basename equals the
+cache name — and keeps (fail-toward-keep) anything else. A symlinked PARENT
+``issue_<N>`` dir routes through the same disposition and its shared link is
+NEVER unlinked. Dangling links are discovered + unlinked.
+
+Both scripts live under ``scripts/`` (not an importable package), so they are
+loaded via importlib exactly like ``tests/test_vm_disk_guard.py`` (ced first —
+vm_disk_guard imports it by module name at load time). All fixtures live under
+``tmp_path``; the managed data disk is faked via ``EPS_VM_DATA_DISK_PATH``.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+
+def _load(mod_name: str):
+    spec = importlib.util.spec_from_file_location(mod_name, _SCRIPTS / f"{mod_name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod  # register before exec (dataclass + future annotations)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# clean_experiment_downloads must be importable by name before vm_disk_guard
+# executes its top-level `from clean_experiment_downloads import ...`.
+ced = _load("clean_experiment_downloads")
+vdg = _load("vm_disk_guard")
+
+
+# ─── fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fake_repo(tmp_path, monkeypatch):
+    """Point ``ced.repo_root()`` at a temp dir (sidecar + rel-name helpers) and
+    rebind ``task_workflow``'s resolvers so the active-CONSUMER gate walks the
+    (empty) tmp ``tasks/`` tree instead of the live repo — a real active task
+    referencing ``data/issue_761/`` would otherwise (correctly) SKIP the reap
+    and break these sandboxed tests (same pattern as
+    ``tests/test_clean_experiment_downloads_parity.py``)."""
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+    import explore_persona_space.task_workflow as tw
+
+    tw.invalidate_cache()
+    monkeypatch.setattr(tw, "repo_root", lambda: tmp_path)
+    monkeypatch.setattr(tw, "tasks_dir", lambda: tmp_path / "tasks")
+    monkeypatch.setattr(ced, "repo_root", lambda: tmp_path)
+    monkeypatch.setattr(ced, "tasks_dir", lambda: tmp_path / "tasks")
+    return tmp_path
+
+
+@pytest.fixture
+def disk_root(fake_repo, monkeypatch) -> Path:
+    """A fake managed data disk under tmp, wired in via the REAL env override
+    (``data_disk_root()`` reads ``EPS_VM_DATA_DISK_PATH``; matches the
+    env-override pattern in tests/test_vm_disk_guard_data_disk.py)."""
+    root = fake_repo / "eps-data-disk"
+    root.mkdir()
+    monkeypatch.setenv("EPS_VM_DATA_DISK_PATH", str(root))
+    return root
+
+
+def _make_symlinked_issue(data_root: Path, disk_root: Path, issue_n: int = 761) -> Path:
+    """data/issue_<N>/{hf_dl,g1_dl} as SYMLINKS to real caches under a fake
+    data disk at disk_root/user/eps-data/issue_<N>/ (the live #761 shape)."""
+    tgt_base = disk_root / "user" / "eps-data" / f"issue_{issue_n}"
+    issue_dir = data_root / f"issue_{issue_n}"
+    issue_dir.mkdir(parents=True)
+    for name in ("hf_dl", "g1_dl"):
+        tgt = tgt_base / name
+        tgt.mkdir(parents=True)
+        (tgt / "blob.bin").write_bytes(b"x" * 1024)
+        (issue_dir / name).symlink_to(tgt)
+    return issue_dir
+
+
+def _read_sidecar(repo: Path) -> list[dict]:
+    path = repo / ".claude" / "cache" / "disk-guard-events.jsonl"
+    if not path.is_file():
+        return []
+    return [json.loads(ln) for ln in path.read_text().splitlines() if ln.strip()]
+
+
+# ─── 1: managed symlinked caches reaped (target + link both gone) ─────────────
+
+
+def test_symlinked_cache_inside_managed_root_reaped(fake_repo, disk_root):
+    data_root = fake_repo / "data"
+    issue_dir = _make_symlinked_issue(data_root, disk_root)
+    # A store/ SIBLING on the fake data disk must survive the reap.
+    disk_store = disk_root / "user" / "eps-data" / "issue_761" / "store"
+    disk_store.mkdir(parents=True)
+    (disk_store / "generated.json").write_text('{"kept": true}')
+
+    res = ced.clean_issue_downloads(761, apply=True, data_root=data_root)
+
+    assert sorted(res.removed) == ["data/issue_761/g1_dl", "data/issue_761/hf_dl"]
+    assert res.failed == []
+    assert res.bytes_freed > 0
+    for name in ("hf_dl", "g1_dl"):
+        assert not os.path.lexists(issue_dir / name)  # link gone
+        assert not (disk_root / "user" / "eps-data" / "issue_761" / name).exists()
+    assert (disk_store / "generated.json").exists()  # data-disk store untouched
+
+
+# ─── 2: outside-root target -> link unlinked, target KEPT ─────────────────────
+
+
+def test_symlinked_cache_outside_managed_root_unlinked_target_kept(fake_repo, disk_root):
+    data_root = fake_repo / "data"
+    issue_dir = data_root / "issue_761"
+    issue_dir.mkdir(parents=True)
+    # The external target path ALSO contains an issue_761 component AND is a
+    # cache-shaped dir (hf_dl), so ONLY the containment check keeps it — a
+    # dropped containment check fails this test, not just the issue-naming
+    # or cache-shape checks.
+    ext = fake_repo / "external" / "issue_761" / "hf_dl"
+    ext.mkdir(parents=True)
+    (ext / "blob.bin").write_bytes(b"x" * 2048)
+    (issue_dir / "hf_dl").symlink_to(ext)
+
+    res = ced.clean_issue_downloads(761, apply=True, data_root=data_root)
+
+    assert not os.path.lexists(issue_dir / "hf_dl")  # link gone
+    assert (ext / "blob.bin").exists()  # target intact
+    assert res.symlink_external_kept == [("data/issue_761/hf_dl", str(ext))]
+    assert res.removed == []
+    assert res.failed == []
+    assert res.bytes_freed == 0  # external-kept never counts as freed
+
+    rows = _read_sidecar(fake_repo)
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "symlink-external-target-kept"
+    assert rows[0]["task"] == 761
+    assert rows[0]["path"] == "data/issue_761/hf_dl"
+    assert rows[0]["target"] == str(ext)
+    assert rows[0]["via"] == "link"
+
+
+# ─── 3: inside root but naming ANOTHER issue -> treated external ──────────────
+
+
+def test_symlink_inside_root_naming_other_issue_kept(fake_repo, disk_root):
+    data_root = fake_repo / "data"
+    issue_dir = data_root / "issue_761"
+    issue_dir.mkdir(parents=True)
+    other = disk_root / "user" / "eps-data" / "issue_999" / "hf_dl"
+    other.mkdir(parents=True)
+    (other / "blob.bin").write_bytes(b"x" * 1024)
+    (issue_dir / "hf_dl").symlink_to(other)
+
+    res = ced.clean_issue_downloads(761, apply=True, data_root=data_root)
+
+    assert not os.path.lexists(issue_dir / "hf_dl")  # link gone
+    assert (other / "blob.bin").exists()  # cross-issue target intact
+    assert res.symlink_external_kept == [("data/issue_761/hf_dl", str(other))]
+    assert res.removed == []
+    assert res.failed == []
+
+
+# ─── 4: dangling symlink -> discovered + unlinked ─────────────────────────────
+
+
+def test_dangling_symlink_unlinked(fake_repo, disk_root):
+    data_root = fake_repo / "data"
+    issue_dir = data_root / "issue_761"
+    issue_dir.mkdir(parents=True)
+    gone = disk_root / "user" / "eps-data" / "issue_761" / "hf_dl"  # never created
+    (issue_dir / "hf_dl").symlink_to(gone)
+
+    # Discovery-filter regression: is_dir() alone would drop the dangling link.
+    caches = ced.download_cache_dirs(761, data_root=data_root)
+    assert caches == [issue_dir / "hf_dl"]
+
+    res = ced.clean_issue_downloads(761, apply=True, data_root=data_root)
+
+    assert res.removed == ["data/issue_761/hf_dl"]
+    assert res.failed == []
+    assert res.sizes_bytes["data/issue_761/hf_dl"] == 0
+    assert res.symlink_targets["data/issue_761/hf_dl"] == ""
+    assert not os.path.lexists(issue_dir / "hf_dl")
+
+
+# ─── 5: dry-run is disposition-aware and removes nothing ──────────────────────
+
+
+def test_symlink_dry_run_reports_and_removes_nothing(fake_repo, disk_root):
+    data_root = fake_repo / "data"
+    issue_dir = data_root / "issue_761"
+    issue_dir.mkdir(parents=True)
+    managed = disk_root / "user" / "eps-data" / "issue_761" / "hf_dl"
+    managed.mkdir(parents=True)
+    (managed / "blob.bin").write_bytes(b"x" * 1024)
+    (issue_dir / "hf_dl").symlink_to(managed)
+    ext = fake_repo / "external" / "issue_761" / "g1_dl"
+    ext.mkdir(parents=True)
+    (ext / "blob.bin").write_bytes(b"x" * 1024)
+    (issue_dir / "g1_dl").symlink_to(ext)
+
+    res = ced.clean_issue_downloads(761, apply=False, data_root=data_root)
+
+    # Links + targets ALL intact after a dry run.
+    for link, tgt in ((issue_dir / "hf_dl", managed), (issue_dir / "g1_dl", ext)):
+        assert os.path.lexists(link) and link.is_symlink()
+        assert (tgt / "blob.bin").exists()
+    assert res.removed == ["data/issue_761/hf_dl"]  # would-remove (managed)
+    assert res.symlink_external_kept == [("data/issue_761/g1_dl", str(ext))]
+    assert res.failed == []
+    assert res.symlink_targets == {
+        "data/issue_761/hf_dl": str(managed),
+        "data/issue_761/g1_dl": str(ext),
+    }
+
+
+# ─── 6: the nested-store parity gate still protects THROUGH the link ──────────
+
+
+def test_parity_gate_blocks_reap_through_symlink(fake_repo, disk_root, monkeypatch):
+    data_root = fake_repo / "data"
+    issue_dir = _make_symlinked_issue(data_root, disk_root)
+    # A store/ NESTED inside the relocated hf_dl cache (mis-rooted run).
+    nested = disk_root / "user" / "eps-data" / "issue_761" / "hf_dl" / "store"
+    nested.mkdir(parents=True)
+    (nested / "generated.json").write_text('{"kept": true}')
+    # Nothing mirrored on HF -> the parity gate must SKIP the hf_dl reap.
+    monkeypatch.setattr(ced, "_hf_file_sizes", lambda repo, revision="main": {})
+
+    res = ced.clean_issue_downloads(761, apply=True, data_root=data_root)
+
+    assert [name for name, _ in res.skipped] == ["data/issue_761/hf_dl"]
+    assert os.path.lexists(issue_dir / "hf_dl") and (issue_dir / "hf_dl").is_symlink()
+    assert (nested / "generated.json").exists()  # resolved contents protected
+    # A gate-2-SKIPped link never reaches the symlink branch.
+    assert "data/issue_761/hf_dl" not in res.symlink_targets
+    # The store-less g1_dl sibling still reaps normally.
+    assert res.removed == ["data/issue_761/g1_dl"]
+    assert res.failed == []
+
+
+# ─── 7: the exact incident regression, at the tier-(b) call site ──────────────
+
+
+def test_tier_b_symlinked_cache_no_failed_row(fake_repo, disk_root, monkeypatch):
+    data_root = fake_repo / "data"
+    issue_dir = _make_symlinked_issue(data_root, disk_root)
+    monkeypatch.setattr(vdg, "_resolve_issue_status", lambda n: "completed")
+
+    res = vdg.clean_terminal_download_caches(apply=True, data_root=data_root)
+
+    assert not any("FAILED to remove" in d for d in res.detail)
+    assert res.bytes_freed > 0
+    for name in ("hf_dl", "g1_dl"):
+        assert not os.path.lexists(issue_dir / name)
+        assert not (disk_root / "user" / "eps-data" / "issue_761" / name).exists()
+
+
+# ─── 8: idempotent — a second apply run finds nothing ─────────────────────────
+
+
+def test_symlink_reap_idempotent(fake_repo, disk_root):
+    data_root = fake_repo / "data"
+    _make_symlinked_issue(data_root, disk_root)
+
+    first = ced.clean_issue_downloads(761, apply=True, data_root=data_root)
+    assert len(first.removed) == 2
+
+    second = ced.clean_issue_downloads(761, apply=True, data_root=data_root)
+    assert second.removed == []
+    assert second.failed == []
+    assert second.symlink_external_kept == []
+
+
+# ─── 9 (MF1): same-issue alias to a store/ dir -> KEPT ────────────────────────
+
+
+def test_symlink_to_store_target_kept(fake_repo, disk_root):
+    data_root = fake_repo / "data"
+    issue_dir = data_root / "issue_761"
+    issue_dir.mkdir(parents=True)
+    # Inside the managed root AND naming the owning issue — but the target is
+    # a store/ (basename != cache name): only the MF1 cache-shape predicate
+    # keeps it (gate 2's rglob matches descendants, never the resolved root).
+    store = disk_root / "user" / "eps-data" / "issue_761" / "store"
+    store.mkdir(parents=True)
+    (store / "generated.json").write_text('{"kept": true}')
+    (issue_dir / "hf_dl").symlink_to(store)
+
+    res = ced.clean_issue_downloads(761, apply=True, data_root=data_root)
+
+    assert (store / "generated.json").exists()  # store tree INTACT
+    assert res.symlink_external_kept == [("data/issue_761/hf_dl", str(store))]
+    assert res.removed == []
+    assert res.failed == []
+    assert not os.path.lexists(issue_dir / "hf_dl")  # link unlinked
+
+
+# ─── 10 (MF1): symlink to a FILE (even cache-named) -> KEPT ───────────────────
+
+
+def test_symlink_to_file_target_kept(fake_repo, disk_root):
+    data_root = fake_repo / "data"
+    issue_dir = data_root / "issue_761"
+    issue_dir.mkdir(parents=True)
+    # Managed root + owning issue + exact cache NAME — but a FILE, not a dir.
+    tgt_dir = disk_root / "user" / "eps-data" / "issue_761"
+    tgt_dir.mkdir(parents=True)
+    tgt_file = tgt_dir / "g1_dl"
+    tgt_file.write_bytes(b"x" * 512)
+    (issue_dir / "g1_dl").symlink_to(tgt_file)
+
+    res = ced.clean_issue_downloads(761, apply=True, data_root=data_root)
+
+    assert tgt_file.exists()  # file INTACT
+    assert res.symlink_external_kept == [("data/issue_761/g1_dl", str(tgt_file))]
+    assert res.removed == []
+    assert res.failed == []
+    assert not os.path.lexists(issue_dir / "g1_dl")  # link unlinked
+
+
+# ─── 11 (MF2): symlinked PARENT, external target -> nothing touched ───────────
+
+
+def test_symlinked_parent_external_target_kept(fake_repo, disk_root):
+    data_root = fake_repo / "data"
+    data_root.mkdir(parents=True)
+    ext_issue = fake_repo / "external" / "issue_761"
+    hf_dl = ext_issue / "hf_dl"
+    hf_dl.mkdir(parents=True)
+    (hf_dl / "blob.bin").write_bytes(b"x" * 1024)
+    parent_link = data_root / "issue_761"
+    parent_link.symlink_to(ext_issue)
+
+    res = ced.clean_issue_downloads(761, apply=True, data_root=data_root)
+
+    assert (hf_dl / "blob.bin").exists()  # external content INTACT
+    assert parent_link.is_symlink()  # the shared parent link is NEVER unlinked
+    assert res.symlink_external_kept == [("data/issue_761/hf_dl", str(hf_dl))]
+    assert res.removed == []
+    assert res.failed == []
+
+    rows = _read_sidecar(fake_repo)
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "symlink-external-target-kept"
+    assert rows[0]["via"] == "parent"
+
+
+# ─── 12 (MF2): symlinked PARENT, managed target -> caches reaped, link kept ───
+
+
+def test_symlinked_parent_managed_reaped(fake_repo, disk_root):
+    data_root = fake_repo / "data"
+    data_root.mkdir(parents=True)
+    disk_issue = disk_root / "user" / "eps-data" / "issue_761"
+    for name in ("hf_dl", "g1_dl"):
+        d = disk_issue / name
+        d.mkdir(parents=True)
+        (d / "blob.bin").write_bytes(b"x" * 1024)
+    parent_link = data_root / "issue_761"
+    parent_link.symlink_to(disk_issue)
+
+    res = ced.clean_issue_downloads(761, apply=True, data_root=data_root)
+
+    assert sorted(res.removed) == ["data/issue_761/g1_dl", "data/issue_761/hf_dl"]
+    assert res.failed == []
+    assert res.bytes_freed > 0
+    for name in ("hf_dl", "g1_dl"):
+        assert not (disk_issue / name).exists()  # resolved caches GONE
+    assert parent_link.is_symlink()  # parent link INTACT
+
+
+# ─── 13: target rmtree failure -> link survives (deletion-order crash safety) ─
+
+
+def test_target_rmtree_failure_link_survives(fake_repo, disk_root, monkeypatch):
+    data_root = fake_repo / "data"
+    issue_dir = _make_symlinked_issue(data_root, disk_root)
+
+    def _boom(path, *a, **k):
+        raise OSError(f"simulated rmtree failure on {path}")
+
+    monkeypatch.setattr(ced.shutil, "rmtree", _boom)
+
+    res = ced.clean_issue_downloads(761, apply=True, data_root=data_root)
+
+    assert sorted(res.failed) == ["data/issue_761/g1_dl", "data/issue_761/hf_dl"]
+    assert res.removed == []
+    for name in ("hf_dl", "g1_dl"):
+        # The link survives a target-reap failure (target-before-link order),
+        # so the next run re-discovers and retries.
+        assert os.path.lexists(issue_dir / name)
+        assert (disk_root / "user" / "eps-data" / "issue_761" / name / "blob.bin").exists()
+    # res.failed non-empty is the CLI exit-2 driver.
+    assert res.failed


### PR DESCRIPTION
Closes task #915 (workflow-fix, kind: infra).

## Summary
- `scripts/clean_experiment_downloads.py`: symlink-disposition branch in the shared reap path — managed reap requires resolved target strictly inside `EPS_VM_DATA_DISK_PATH` + owning-issue component + is_dir + exact cache-basename (MF1); symlinked `issue_<N>` parent dirs route through the disposition with the shared parent link never unlinked (MF2, incl. the double-link topology); dangling links discovered + unlinked; external/non-cache-shaped targets kept + sidecar-escalated; target-before-link crash-safe order; exit-code contracts unchanged.
- `scripts/vm_disk_guard.py`: tier-(b) detail row for external-kept links.
- `tests/test_clean_experiment_downloads_symlinks.py`: 20 tests incl. the tier-(b) incident regression + 3 double-link regressions (fail-pre/pass-post verified).

## Test plan
- [x] 20/20 new tests; Step 9c touched-scope gate: 2165 passed (8 pre-existing-on-trunk live-state failures, unrelated, logged)
- [x] ruff + workflow_lint PASS
- [ ] Post-merge live acceptance: `uv run python scripts/clean_experiment_downloads.py 761 --apply` (expect exit 0, failed 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)