### PR TITLE
task #917: workflow-fix — brief marker versions defer to max+1

### DIFF
--- a/.claude/agents/experiment-implementer.md
+++ b/.claude/agents/experiment-implementer.md
@@ -665,8 +665,8 @@ issue branch are free (the branch merges via Step 10d's guarded procedure).
 If the approved plan body contains a `### TDD: yes` line, or the user explicitly asks for TDD, do tests-first:
 
 1. Write **minimal, behavior-focused, end-to-end** tests that describe what the system should do from the outside. Do NOT mirror your planned implementation. Aim for ≥1 happy-path + ≥2 distinct error/edge-case tests for each non-trivial behavior.
-2. Post the test files (in the worktree) as `<!-- epm:proposed-tests v1 -->` on the issue. Body: brief description per test + the test code in fenced blocks. Then EXIT and wait — do NOT proceed to implementation.
-3. The user replies `approve-tests` (on issue or in chat). Only then write the implementation that makes the tests pass. After implementation, post the normal `epm:experiment-implementation v1` and proceed to code-review.
+2. Post the test files (in the worktree) as `<!-- epm:proposed-tests v<n> -->` (max+1 per § Posting review-round markers) on the issue. Body: brief description per test + the test code in fenced blocks. Then EXIT and wait — do NOT proceed to implementation.
+3. The user replies `approve-tests` (on issue or in chat). Only then write the implementation that makes the tests pass. After implementation, post the normal `epm:experiment-implementation` marker at the next version (max+1 per § Posting review-round markers; v1 only when the task has no prior implementation rows) and proceed to code-review.
 
 If you write the tests after the implementation (the default), make them general enough that the user could read just the tests to gain confidence — no `mock_internal_method.assert_called_with(...)`-style coupling to the implementation.
 
@@ -864,7 +864,21 @@ and `.claude/skills/issue/SKILL.md` Step 7.
 
 ## Posting review-round markers
 
-Before posting a SECOND/THIRD review-round marker (e.g. `epm:experiment-implementation`, `epm:proposed-tests`), FIRST read `events.jsonl` for the highest existing `version` of that marker key, then pass `--version <max+1>`. `task.py post-marker` defaults to `--version 1` and does NOT auto-increment — a duplicate version silently breaks review-round detection (incident #389: a round-2 marker posted as `version: 1` collided with round-1).
+Before posting ANY marker of a kind that may already have rows on this task
+(`epm:experiment-implementation`, `epm:results`, `epm:proposed-tests` — a
+follow-up round, a TDD resume, a crash-recovery re-post, and a revision round
+ALL count, not just round 2/3 of your own review loop), FIRST read
+`events.jsonl` for the highest existing `version` of that kind and post at
+max+1: omit `--version` (the CLI derives `max(existing)+1` per kind — the
+post-#480 default) or pass `--version <max+1>` explicitly (required for
+multi-part posts: compute max+1 ONCE before part 1; every part carries that
+SAME version — never a fresh max per part). An EXPLICIT `--version` beats
+the safe default — NEVER take a literal version from a brief or template;
+this rule overrides any brief that says "post as v1" (incident #389: a
+round-2 marker posted as `version: 1` collided with round-1; incident #825: a
+follow-up-round brief said v1 on a task at v6 and the explicit `--version 1`
+collided). A duplicate version silently breaks review-round detection
+(highest-version-wins resume).
 
 ---
 
@@ -888,7 +902,7 @@ Before posting a SECOND/THIRD review-round marker (e.g. `epm:experiment-implemen
   round posts `epm:experiment-implementation v<n>` and EXITs; an
   unrecoverable round posts `epm:failure v1` with `failure_class:
   code|infra` and EXITs; the TDD proposed-tests step posts
-  `epm:proposed-tests v1` and EXITs (the orchestrator handles the
+  `epm:proposed-tests v<n>` and EXITs (the orchestrator handles the
   resume signal). The `/issue` SKILL.md orchestrator owns ALL routing
   for both Interactive mode and `EPM_AUTONOMOUS_SESSION=1` — including
   TDD approval (gate id 8), compute-deviation resolution (id 12),

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -42,7 +42,7 @@ You work in two modes:
 
 **TASK-BOUND MODE** — subagent mode where the brief includes a `task: <N>` field. You MUST post progress, completion, and failures as `epm:*` markers (rows in `tasks/<status>/<N>/events.jsonl`) via `uv run python scripts/task.py post-marker <N> ...`. Write paths never shell out to external tracker mutation commands. If a marker body exceeds the 50,000-char cap, write the full content to `tasks/<status>/<N>/artifacts/<slug>.md` and post a short note referencing that path. Markers (see `.claude/skills/issue/markers.md`):
 - `<!-- epm:progress vX -->` at major checkpoints (tests passing, lint clean, diff ready for review).
-- `<!-- epm:results v1 -->` on completion with: files touched (paths + lines changed), test output, lint output, commit hash, branch + PR URL.
+- `<!-- epm:results v<n> -->` (max+1 per § Posting review-round markers) on completion with: files touched (paths + lines changed), test output, lint output, commit hash, branch + PR URL.
 - `<!-- epm:failure v1 -->` on unrecoverable error.
 - Work only inside the worktree specified in the brief. Never modify code outside it.
 
@@ -55,7 +55,7 @@ You work in two modes:
 3. **Implement** — Write code that fits existing patterns. Follow ruff / line-length=100 / py311 conventions.
 4. **Test** — Run tests, lint, type checks. If tests don't exist for the code you're touching, add them.
 5. **Verify** — Re-read your own diff. Does it do what you intended? Are there unintended changes?
-6. **Hand off for review** — In subagent mode, post the diff in an `<!-- epm:results v1 -->` marker; the `/issue` skill then spawns `code-reviewer`. In main agent mode, offer to spawn `code-reviewer` via the Agent tool.
+6. **Hand off for review** — In subagent mode, post the diff in an `<!-- epm:results v<n> -->` marker; the `/issue` skill then spawns `code-reviewer`. In main agent mode, offer to spawn `code-reviewer` via the Agent tool.
 
 ---
 
@@ -114,8 +114,8 @@ by filename + index; keep report and marker wording neutral. Full recipe:
 If the user asks for TDD, or the cached plan contains a `### TDD: yes` line, do tests-first:
 
 1. Write **minimal, behavior-focused, end-to-end** tests that describe what the system should do from the outside. Do NOT mirror your planned implementation. Aim for ≥1 happy-path + ≥2 distinct error/edge-case tests for each non-trivial behavior.
-2. In subagent / task-workflow-bound mode, post the test files as `<!-- epm:proposed-tests v1 -->` on the experiment. In main-agent mode, show the user the test file(s) and wait for explicit approval. EXIT before writing implementation.
-3. After approval (`approve-tests` reply in the task workflow, or "go ahead" in chat), implement against the tests. Post the normal `epm:results v1` (subagent) or summarize to the user (main agent) once green.
+2. In subagent / task-workflow-bound mode, post the test files as `<!-- epm:proposed-tests v<n> -->` on the experiment. In main-agent mode, show the user the test file(s) and wait for explicit approval. EXIT before writing implementation.
+3. After approval (`approve-tests` reply in the task workflow, or "go ahead" in chat), implement against the tests. Post the normal `epm:results` marker at max+1 (subagent) or summarize to the user (main agent) once green.
 
 If you write tests after the implementation (the default), still keep them general enough that someone could read only the tests and feel confident in the code — no implementation-mirroring assertions.
 
@@ -128,7 +128,7 @@ If you write tests after the implementation (the default), still keep them gener
 5. **Regression test for a substantive BLOCKER fix.** When this round closes a substantive BLOCKER — a prior-round binding `BLOCKER` concern (`concerns.jsonl`) or a Critical code-review finding you would otherwise re-raise — by adding a **permanent invariant** (a fail-loud assertion / `RuntimeError` guard, a scoping fix like a re-keyed lookup / narrowed selector / disjointness check, or an equivalent guardrail meant to STAY in the code), commit a pytest that **fails pre-fix and passes post-fix** and actually exercises the invariant (trips the guard / asserts the scoped value — not just an import). Cite it under `(c) How to verify` (the `tests/` path + what input trips the guard + the expected raise / value). Do NOT merely claim a covering test exists — `code-reviewer` greps the worktree, and a fabricated-coverage claim is a substantive FAIL, not a Minor. Scope: PERMANENT-invariant fixes only; a one-off data fix, a value tweak, or a fix the plan already pairs with a test is out of scope. Mirrors `code-reviewer.md` Step 4.5 + Rule 13 — the test's absence is a review Minor otherwise (an un-CI-pinned assertion is a guard a future refactor silently strips while CI stays green, incident #653 r8); arriving pre-pinned skips the re-roll round.
 6. **Report:**
    - Main agent: summarize to user, offer to spawn `code-reviewer`.
-   - Subagent: post an `<!-- epm:results v1 -->` marker on the source task per the "Report back with" spec in the brief; the `/issue` skill reads it and advances the lifecycle.
+   - Subagent: post an `<!-- epm:results v<n> -->` marker on the source task per the "Report back with" spec in the brief; the `/issue` skill reads it and advances the lifecycle.
 
 ### Local runs are same-turn, synchronous work (subagent mode)
 
@@ -171,7 +171,7 @@ broad `pkill -f python` on this shared multi-session VM (incident
 
 ## Report Format (subagent mode)
 
-When you're done, post this structured report as the `<!-- epm:results v1 -->` marker events.jsonl event on the source task:
+When you're done, post this structured report as the `<!-- epm:results v<n> -->` marker events.jsonl event on the source task:
 
 ```markdown
 ## Completion Report
@@ -219,7 +219,21 @@ and `.claude/skills/issue/SKILL.md` Step 7.
 
 ## Posting review-round markers
 
-Before posting a SECOND/THIRD review-round marker (e.g. `epm:experiment-implementation`, `epm:proposed-tests`), FIRST read `events.jsonl` for the highest existing `version` of that marker key, then pass `--version <max+1>`. `task.py post-marker` defaults to `--version 1` and does NOT auto-increment — a duplicate version silently breaks review-round detection (incident #389: a round-2 marker posted as `version: 1` collided with round-1).
+Before posting ANY marker of a kind that may already have rows on this task
+(`epm:experiment-implementation`, `epm:results`, `epm:proposed-tests` — a
+follow-up round, a TDD resume, a crash-recovery re-post, and a revision round
+ALL count, not just round 2/3 of your own review loop), FIRST read
+`events.jsonl` for the highest existing `version` of that kind and post at
+max+1: omit `--version` (the CLI derives `max(existing)+1` per kind — the
+post-#480 default) or pass `--version <max+1>` explicitly (required for
+multi-part posts: compute max+1 ONCE before part 1; every part carries that
+SAME version — never a fresh max per part). An EXPLICIT `--version` beats
+the safe default — NEVER take a literal version from a brief or template;
+this rule overrides any brief that says "post as v1" (incident #389: a
+round-2 marker posted as `version: 1` collided with round-1; incident #825: a
+follow-up-round brief said v1 on a task at v6 and the explicit `--version 1`
+collided). A duplicate version silently breaks review-round detection
+(highest-version-wins resume).
 
 ---
 

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -502,7 +502,7 @@ var is set (the session was spawned via `spawn_session.py spawn-issue
     the open concern_id); do NOT state the Decision and then end the turn.
   <!-- gate: gates.tdd_gate -->
   - `tdd_gate` → no `AskUserQuestion` at this site (it's event-driven —
-    the implementer posts `epm:proposed-tests v1` and exits; the resume
+    the implementer posts `epm:proposed-tests v<n>` and exits; the resume
     signal is `epm:approve-tests` posted via `task.py post-marker`). In
     autonomous mode, auto-post `epm:approve-tests` IF the proposed-tests
     body lists ≥1 test per acceptance criterion from the original task
@@ -1903,6 +1903,18 @@ Brief passed to the implementer:
   `experiment-implementer.md` § "Deferred production-path TODOs are
   persisted concerns, not (d) prose", so round-N briefs surface the
   duty without the implementer having to recall its agent spec.
+- **Marker-version discipline — a brief NEVER instructs a literal marker
+  version.** Any brief line about posting `epm:experiment-implementation` /
+  `epm:results` / `epm:proposed-tests` says: "post at the next version —
+  read `events.jsonl` for the highest existing version of the kind and use
+  max+1, or omit `--version` (the CLI derives max+1)". Never "post as `v1`"
+  or any literal `v<k>`: on a fresh task max+1 IS 1, but on a follow-up
+  round / TDD resume / crash-recovery re-post prior rows exist, and an
+  explicit `--version` beats the CLI's safe default (incident #825: a
+  follow-up-round brief instructed a literal `v1` for the implementation
+  marker on a task already at v6 — the #389 collision class). See
+  `experiment-implementer.md` / `implementer.md` § Posting review-round
+  markers.
 - **Instruction: work ONLY inside the worktree; never touch a pod; post
   progress as `events.jsonl` rows via
   `uv run python scripts/task.py post-marker <N> epm:progress --note '...'`.**
@@ -1916,7 +1928,7 @@ Brief passed to the implementer:
   (a) the approved plan body contains a literal `### TDD: yes` line, OR
   (b) the task body / latest user comment in `comments.jsonl` contains
   `request-tdd`. When `tdd_mode=true`, the implementer writes tests
-  first, posts them as `epm:proposed-tests v1`, and EXITs without writing
+  first, posts them as `epm:proposed-tests v<n>` (max+1), and EXITs without writing
   implementation. This skill then parks at `running` (implementing
   sub-phase) and waits — see Resume semantics below: an `approve-tests`
   marker posted via `task.py post-marker <N> epm:approve-tests` **after**
@@ -3325,7 +3337,7 @@ session may have finished the run while this session was mid-review):
    dispatch; re-derive scope from the markers (the run may already be
    done) or re-provision via Step 6b.
 2. **Run still pending.** `uv run python scripts/task.py latest-marker
-   <N>` + the recent `events.jsonl` tail: if `epm:results v1` +
+   <N>` + the recent `events.jsonl` tail: if `epm:results v<n>` +
    `epm:upload-verification PASS` (or `epm:pod-terminated v1`) postdate
    the failure being recovered, the (re)launch is STALE — the work
    already completed. Do not dispatch; reduce the brief to the genuinely
@@ -4094,9 +4106,9 @@ sources contribute to `running`-phase progress:
 - **Entry script on the pod**: writes `[phase=done]` to its log on
   graceful completion AND writes a JSON sentinel file at
   `/workspace/logs/issue-<N>-results.json` containing the
-  `epm:results v1` payload. The orchestrator's polling-loop terminal
+  `epm:results` payload. The orchestrator's polling-loop terminal
   tick (Step 6d.2) reads the sentinel on its next poll and posts
-  `epm:results v1` from the local VM via `task.py post-marker`. The
+  the `epm:results` marker from the local VM via `task.py post-marker`. The
   pod NEVER calls `task.py` directly — enforced by
   `tests/test_no_pod_side_task_py_shellout.py` and the CLAUDE.md
   "Pod-side code NEVER shells out to scripts/task.py" rule. Task #397
@@ -4136,7 +4148,7 @@ sources contribute to `running`-phase progress:
 
   **Orchestrator-composed fallback.** When the driver emits only
   granular per-cell / per-shard sentinels (no single results sentinel)
-  and the orchestrator composes the `epm:results v1` payload itself
+  and the orchestrator composes the `epm:results` payload itself
   from the drained pieces, the composed payload obeys the SAME contract
   above — in particular the `reproducibility_card` structured-field
   requirement. Composing the card's adapter / WandB info as prose is
@@ -6704,7 +6716,12 @@ orchestrators driving one round is the #778 root cause.
      `EPM_PLAN_AUTOAPPROVE_GPU_HOURS` and park at `plan_pending` over
      the cap; interactive sessions ask.
    - `experiment-implementer` + `code-reviewer` if the diff needs code
-     changes (same ensemble shape as Step 5).
+     changes (same ensemble shape as Step 5). The round's implementer brief
+     follows the Step 4b brief contract INCLUDING its marker-version-
+     discipline bullet — on a follow-up round prior
+     `epm:experiment-implementation` rows ALWAYS exist, so a brief
+     instructing a literal `v1` reproduces the #825 collision; the brief
+     defers to max+1 (or tells the implementer to omit `--version`).
    - Fresh compute dispatch on the SAME issue, through the slice-6
      router exactly like the parent run: read the task's `backend:`
      frontmatter and run `dispatch_issue.py launch --issue <N>
@@ -8061,7 +8078,7 @@ dedicated "working" statuses):
 | `plan_pending` | `epm:plan` exists | awaiting user approval | show plan path, EXIT |
 | `running` (implementing) | no `epm:experiment-implementation` (or `epm:results` for infra), no `epm:proposed-tests` either | implementer was cancelled | re-spawn implementer |
 | `running` (implementing) | `epm:proposed-tests v<n>` exists, no `epm:experiment-implementation`, no `epm:approve-tests` event posted **after** the `proposed-tests` event | TDD mode: tests posted, awaiting user approval | show the `proposed-tests` event timestamp + the `approve-tests` reply instruction, EXIT |
-| `running` (implementing) | `epm:proposed-tests v<n>` exists, an `epm:approve-tests` event exists **after** the `proposed-tests` event, no `epm:experiment-implementation` | TDD tests approved by user | re-spawn implementer with `tdd_approved=true`; brief instructs implementer to write implementation against the approved tests, then post `epm:experiment-implementation v1` as normal |
+| `running` (implementing) | `epm:proposed-tests v<n>` exists, an `epm:approve-tests` event exists **after** the `proposed-tests` event, no `epm:experiment-implementation` | TDD tests approved by user | re-spawn implementer with `tdd_approved=true`; brief instructs implementer to write implementation against the approved tests, then post `epm:experiment-implementation` at the next version (max+1 per § Posting review-round markers; omit `--version` and the CLI derives it) as normal |
 | `running` (implementing) | latest `epm:code-review` is FAIL, round < 5 | revision in progress | re-spawn implementer with critique |
 | `running` (implementing) | latest `epm:code-review` is FAIL, round >= 5 | cap reached | apply Step 5d cap-hit rule (strip-then-continue-or-surface): strip → all-stripped PASS+continue OR surface substantive residual (autonomous: `blocked` + notify; interactive: present to user) |
 | `running` (code-reviewing) | neither `epm:code-review` nor `epm:code-review-codex` for the current implementation version | both ensemble reviewers were cancelled | re-spawn both code-reviewer + codex-code-reviewer in parallel |

--- a/.claude/skills/issue/markers.md
+++ b/.claude/skills/issue/markers.md
@@ -22,6 +22,13 @@ post-marker` writes one row per call. The schema:
   distinct queued follow-ups share the kind under different
   `followup_label`s; group by label per
   `task_workflow.unrun_followup_labels`, #894).
+  `task.py post-marker` derives `max(existing)+1` per kind when `--version`
+  is omitted (an explicit `--version` always wins — required for multi-part
+  posts, where every part carries the same version). Briefs and skill/agent
+  prose never instruct a literal version for the round-versioned kinds
+  (`epm:experiment-implementation`, `epm:results`, `epm:proposed-tests`) —
+  see the implementer agents' § Posting review-round markers (incidents
+  #389, #480, #825).
 - `note` = human-readable body (capped at 50,000 chars by `task.py`).
 - `metadata` = compact JSON sidecar (e.g., reviewer-loop fields below).
 

--- a/.claude/skills/issue/templates/results_comment.md
+++ b/.claude/skills/issue/templates/results_comment.md
@@ -1,4 +1,4 @@
-<!-- epm:results v1 -->
+<!-- epm:results v<n> -->
 ## Results for #{ISSUE_NUMBER}
 
 ### TL;DR

--- a/.claude/workflow.yaml
+++ b/.claude/workflow.yaml
@@ -489,7 +489,7 @@ gates:
       step: "4b"
       condition: "plan body contains '### TDD: yes' OR user explicitly requested TDD"
       reason: |
-        Implementer posts `epm:proposed-tests v1`, EXITs awaiting an
+        Implementer posts `epm:proposed-tests v<n>` (max+1), EXITs awaiting an
         `approve-tests` approval in the events.jsonl. Re-invoking /issue <N>
         after approval resumes Step 4b normally. (See `markers.md` and the
         implementer agent specs.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Multi-step workflows (`/issue`, `/adversarial-planner`) MUST auto-continue excep
 6. `awaiting_promotion` — clean-result promotion. User runs `task.py promote <N> useful|not-useful`. **User-only:** no automation may flip `runs.classification`. (The worktree auto-merges to `main` the instant the task reaches this state — Step 9b — independent of promotion.)
 
 *Conditional gates:*
-7. Step 4b TDD — fires when plan body has `### TDD: yes`. Implementer posts `epm:proposed-tests v1`, EXITs awaiting `epm:approve-tests v1`.
+7. Step 4b TDD — fires when plan body has `### TDD: yes`. Implementer posts `epm:proposed-tests v<n>`, EXITs awaiting `epm:approve-tests v1`.
 8. Goal-refinement (Step 1 clarifier OR Phase 1 planner) — surface the sharper Goal via `AskUserQuestion`; on agreement run `task.py set-goal <N> "..." --by clarifier|planner` + post `epm:goal-updated v1`. No other agent may propose Goal changes.
 
 Outside these gates, NEVER ask "should I continue". When auto-continuing past a non-obvious decision, STATE the assumption (`Assumption: ...`). Reviewers reject PRs that introduce additional pauses.

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -230,6 +230,21 @@ Behaviours:
   The canonical pin ``claude-sonnet-4-5-20250929`` carries no forbidden
   substring, so it never matches. Motivating incident: the #650/#657 stale
   legacy-Haiku judge pins (#765).
+* ``--check-no-literal-round-marker-versions`` (also bundled into the no-flags
+  default run): FAIL on a literal ``v1`` posting instruction for a
+  round-versioned marker kind (``epm:experiment-implementation`` /
+  ``epm:results`` / ``epm:proposed-tests``) in checked-in workflow prose
+  (CLAUDE.md, workflow.yaml, agents/rules ``.md``, every ``SKILL.md``, the
+  /issue ``markers.md`` + ``templates/``). Those kinds accrue rows across
+  follow-up rounds / TDD resumes / crash-recovery re-posts, and an explicit
+  ``--version`` beats the CLI's omitted-version max+1 default, so checked-in
+  "post at v1" prose seeds briefs that collide with existing rows (incident
+  #825: a follow-up-round brief instructed a literal v1 on a task already at
+  v6 — the #389 class). Whole-file scan (a line-wrapped kind/version pair
+  still trips); ``v1`` is word-bounded (``v12`` never matches); prose
+  evasions like "pass ``--version 1``" are a DELIBERATE boundary covered by
+  the brief-contract prose layers, not this lint. Historical archives
+  (``.claude/plans/``, ``.claude/agent-memory/``) are out of scan scope (#917).
 * ``--check-agent-tools`` (also bundled into the no-flags default run):
   every ``.claude/agents/*.md`` must declare an explicit tool surface — a
   ``tools:`` allowlist or a ``disallowedTools:`` denylist — in its YAML
@@ -3840,6 +3855,93 @@ def check_no_workflow_improver_spawn(*, repo_root: Path | None = None) -> list[s
     return errors
 
 
+# `--check-no-literal-round-marker-versions` (#917): the round-versioned marker
+# kinds must never be instructed at a literal ` v1` in checked-in workflow
+# prose. `\s+` (not a single space) so a line-wrapped kind/version pair still
+# trips under the whole-file scan; `v1\b` does NOT match `v12` (the legitimate
+# round-12 example in the /issue SKILL.md).
+_LITERAL_ROUND_MARKER_V1_RE = re.compile(
+    r"epm:(?:experiment-implementation|results|proposed-tests)\s+v1\b"
+)
+
+
+def check_no_literal_round_marker_versions(*, repo_root: Path | None = None) -> list[str]:
+    """FAIL on a literal ``v1`` posting instruction for a round-versioned marker kind.
+
+    The round-versioned kinds — ``epm:experiment-implementation``,
+    ``epm:results``, ``epm:proposed-tests`` — accrue rows across follow-up
+    rounds / TDD resumes / crash-recovery re-posts, and ``task.py post-marker``
+    derives ``max(existing)+1`` only when ``--version`` is OMITTED (an explicit
+    ``--version`` always wins, #480). Checked-in prose instructing "post
+    ``epm:<kind>`` at ``v1``" teaches orchestrators to compose briefs that pin
+    an explicit version 1, which collides with existing rows and silently
+    breaks highest-version-wins review-round detection (incident #825: a
+    follow-up-round brief instructed a literal v1 on a task already at v6 —
+    the #389 collision class). Prose defers to ``v<n>`` / max+1 instead.
+
+    Scan mode: whole-file ``re.finditer`` per file (NOT line-based), so a
+    line-wrapped kind/version pair (the kind at end-of-line, ``v1`` on the
+    next) still trips via ``\\s+``; ``v1\\b`` does not match ``v12``.
+
+    DELIBERATE boundary: prose evasions like "pass ``--version 1``" are OUT of
+    the pattern by design — that layer is covered by the brief-contract prose
+    (the /issue SKILL.md Step 4b marker-version-discipline bullet, the Step 9b
+    step-3 bullet, and the implementer agents' § Posting review-round markers
+    rule), and linting every ``--version 1`` mention would false-positive on
+    legitimate incident documentation. A future tightener should know this
+    boundary was chosen, not missed.
+
+    Scanned (positive enumeration): ``CLAUDE.md``, ``.claude/workflow.yaml``,
+    ``.claude/agents/*.md``, ``.claude/rules/*.md``,
+    ``.claude/skills/**/SKILL.md``, ``.claude/skills/issue/markers.md``, and
+    ``.claude/skills/issue/templates/*.md``. Everything else — notably
+    ``.claude/plans/`` and ``.claude/agent-memory/`` (historical quotes may
+    legitimately contain the incident text), skill support/iteration logs,
+    and ``scripts/`` / ``src/`` code paths (a separate follow-up covers the
+    poller's synthesized-envelope pin) — is excluded by NOT being enumerated.
+    ``repo_root`` is a unit-test override hook; production callers pass None.
+    Bundled into the no-flags default run.
+    """
+    root = repo_root if repo_root is not None else _REPO_ROOT
+    targets: list[Path] = []
+    claude_md = root / "CLAUDE.md"
+    if claude_md.is_file():
+        targets.append(claude_md)
+    wf_yaml = root / ".claude" / "workflow.yaml"
+    if wf_yaml.is_file():
+        targets.append(wf_yaml)
+    for md_dir in (root / ".claude" / "agents", root / ".claude" / "rules"):
+        if md_dir.is_dir():
+            targets.extend(p for p in sorted(md_dir.glob("*.md")) if p.is_file())
+    skills_dir = root / ".claude" / "skills"
+    if skills_dir.is_dir():
+        targets.extend(p for p in sorted(skills_dir.rglob("SKILL.md")) if p.is_file())
+    markers_md = root / ".claude" / "skills" / "issue" / "markers.md"
+    if markers_md.is_file():
+        targets.append(markers_md)
+    templates_dir = root / ".claude" / "skills" / "issue" / "templates"
+    if templates_dir.is_dir():
+        targets.extend(p for p in sorted(templates_dir.glob("*.md")) if p.is_file())
+
+    errors: list[str] = []
+    for p in targets:
+        try:
+            text = p.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for m in _LITERAL_ROUND_MARKER_V1_RE.finditer(text):
+            lineno = text.count("\n", 0, m.start()) + 1
+            matched = " ".join(m.group(0).split())
+            errors.append(
+                f"{p}:{lineno}: literal round-marker version instruction `{matched}` — "
+                f"this kind accrues rows across rounds and an explicit --version beats "
+                f"the CLI's max+1 default (incident #825; the #389 collision class). "
+                f"Rephrase to `v<n>` / max+1 (omit --version and the CLI derives it); "
+                f"see the implementer agents' § Posting review-round markers."
+            )
+    return errors
+
+
 # A destructive `git reset --hard` invocation. Whitespace-tolerant, broadened
 # (FI1) to catch flag-ordering variants:
 #   - `git reset --hard`, `git reset -q --hard`      (flags before --hard)
@@ -5158,6 +5260,19 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         "no-flags default run (#765).",
     )
     parser.add_argument(
+        "--check-no-literal-round-marker-versions",
+        action="store_true",
+        help="FAIL on a literal 'v1' posting instruction for a round-versioned "
+        "marker kind (epm:experiment-implementation / epm:results / "
+        "epm:proposed-tests) in checked-in workflow prose (CLAUDE.md, "
+        "workflow.yaml, agents/rules .md, every SKILL.md, the /issue "
+        "markers.md + templates/). Those kinds accrue rows across follow-up "
+        "rounds, and an explicit --version beats the CLI's max+1 default, so "
+        "'post at v1' prose seeds briefs that collide with existing rows "
+        "(incident #825; the #389 class). Rephrase to v<n> / max+1. Bundled "
+        "into the no-flags default run (#917).",
+    )
+    parser.add_argument(
         "--check-agent-spec-size",
         action="store_true",
         help="agent-spec size budget: WARN >28 KB, FAIL >40 KB (grandfather-ratchet)",
@@ -5207,6 +5322,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         or args.check_smoke_output_hygiene
         or args.check_vm_thread_cap_guidance
         or args.check_judge_model_pins
+        or args.check_no_literal_round_marker_versions
         or args.check_agent_spec_size
     )
 
@@ -5290,6 +5406,8 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         errors.extend(check_vm_thread_cap_guidance())
     if args.check_judge_model_pins or no_flags:
         errors.extend(check_judge_model_pins())
+    if args.check_no_literal_round_marker_versions or no_flags:
+        errors.extend(check_no_literal_round_marker_versions())
 
     if errors:
         for err in errors:

--- a/tests/test_workflow_lint.py
+++ b/tests/test_workflow_lint.py
@@ -49,6 +49,7 @@ from workflow_lint import (  # noqa: E402
     check_lessons_index,
     check_long_loop_restartability_review_lens,
     check_marker_registry,
+    check_no_literal_round_marker_versions,
     check_no_workflow_improver_spawn,
     check_pipe_python,
     check_script_references,
@@ -2641,6 +2642,81 @@ def test_workflow_lint_check_no_workflow_improver_spawn_cli_exits_zero():
     result = _run("--check-no-workflow-improver-spawn")
     assert result.returncode == 0, (
         f"workflow_lint --check-no-workflow-improver-spawn failed:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+# ─── --check-no-literal-round-marker-versions (#917) ────────────────────────
+
+
+def test_no_literal_round_marker_versions_live_tree():
+    """No checked-in workflow prose instructs a literal v1 for a
+    round-versioned marker kind (#917 — the #825/#389 collision class).
+    The E1-E7 sweep of #917 established zero hits at introduction."""
+    errors = check_no_literal_round_marker_versions()
+    assert errors == [], (
+        "literal round-marker version instruction found in the workflow "
+        "surface (rephrase to `v<n>` / max+1, #917):\n" + "\n".join(errors)
+    )
+
+
+def test_check_no_literal_round_marker_versions_flags_literal_v1(tmp_path):
+    """A literal `epm:results v1` posting instruction in an in-scope file
+    (here a rule .md) IS flagged — the guard actually trips."""
+    rules = tmp_path / ".claude" / "rules"
+    rules.mkdir(parents=True)
+    (rules / "stray.md").write_text("On completion, post `epm:results v1` on the task.\n")
+    errors = check_no_literal_round_marker_versions(repo_root=tmp_path)
+    assert len(errors) == 1, errors
+    assert "max+1" in errors[0]
+    assert "stray.md:1" in errors[0]
+
+
+def test_check_no_literal_round_marker_versions_wrapped_pair_trips(tmp_path):
+    """A line-wrapped kind/version pair still trips — the scan is whole-file,
+    so the `\\s+` between kind and `v1` may span a newline."""
+    agents = tmp_path / ".claude" / "agents"
+    agents.mkdir(parents=True)
+    (agents / "a.md").write_text("then post `epm:proposed-tests\n  v1` and EXIT.\n")
+    errors = check_no_literal_round_marker_versions(repo_root=tmp_path)
+    assert len(errors) == 1, errors
+
+
+def test_check_no_literal_round_marker_versions_no_false_positives(tmp_path):
+    """`v<n>`, `v12`, and a genuinely-once kind (`epm:failure v1`) never
+    match — the pattern is restricted to the 3 round-versioned kinds and
+    `v1` is word-bounded."""
+    rules = tmp_path / ".claude" / "rules"
+    rules.mkdir(parents=True)
+    (rules / "ok.md").write_text(
+        "post `epm:results v<n>` (max+1 per the rule); the legitimate\n"
+        "`epm:experiment-implementation v12` round-12 example; and\n"
+        "`epm:failure v1` is a genuinely-once marker, out of scope.\n"
+    )
+    errors = check_no_literal_round_marker_versions(repo_root=tmp_path)
+    assert errors == [], errors
+
+
+def test_check_no_literal_round_marker_versions_excluded_paths_pass(tmp_path):
+    """A hit under an EXCLUDED path (.claude/plans/, .claude/agent-memory/)
+    passes — pins the exclusion set (archives may legitimately quote the
+    incident text; a mis-enumerated exclusion would false-FAIL the default
+    lint bundle on archive text)."""
+    plans = tmp_path / ".claude" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "issue-825.md").write_text("the brief said: post `epm:results v1` (historical)\n")
+    mem = tmp_path / ".claude" / "agent-memory" / "implementer"
+    mem.mkdir(parents=True)
+    (mem / "note.md").write_text("brief instructed `epm:experiment-implementation v1`\n")
+    errors = check_no_literal_round_marker_versions(repo_root=tmp_path)
+    assert errors == [], errors
+
+
+def test_workflow_lint_check_no_literal_round_marker_versions_cli_exits_zero():
+    """The dedicated flag must exist and pass on the committed tree."""
+    result = _run("--check-no-literal-round-marker-versions")
+    assert result.returncode == 0, (
+        f"workflow_lint --check-no-literal-round-marker-versions failed:\n"
         f"stdout: {result.stdout}\nstderr: {result.stderr}"
     )
 


### PR DESCRIPTION
Closes task #917. Workflow-fix: brief templates + agent posting rules defer marker versions to the max+1 rule (incident #825/#389); adds workflow_lint check_no_literal_round_marker_versions.