### PR TITLE
issue-924: clean_experiment_downloads degrades gracefully off-main (#924)

### DIFF
--- a/scripts/clean_experiment_downloads.py
+++ b/scripts/clean_experiment_downloads.py
@@ -89,23 +89,43 @@ needs it again, so reaping a consumed phase's cache mid-run is safe. The
 the active-issue case; the incremental entry point is the experiment's OWN
 deliberate self-cleanup while it runs, so it intentionally has no
 terminal-status check — the experiment knows the phase is done.
+
+**Off-main graceful degrade (#924).** On a NON-``main`` remote checkout (the
+GCE/pod ``issue-<N>`` clone lanes), ``task_workflow.repo_root()`` either raises
+its branch-guard ``RuntimeError`` (a ``--depth 1 --branch`` clone with no local
+``main`` — the #841 att-6 crash) or silently routes reads to a pin worktree
+whose ``data/`` is empty — both defeat the between-phase cleanup exactly where
+disk pressure bites. Path resolution therefore goes through
+``_resolution_root()``: the probe ``_off_main_checkout_root()`` classifies the
+checkout once per process, and on an off-main NON-shared-VM checkout the
+``data/`` root, the worktree scan root, the sidecar, and display names resolve
+against the checkout itself. The cross-task active-consumer gate (#773) is
+still ATTEMPTED there — only a ``RuntimeError`` from the read (the genuinely
+unserviceable no-local-``main`` shape) is caught, with a loud WARN + sidecar
+row (``kind: "off-main-consumer-gate-skipped"``); a succeeding read (full clone
+with a local ``main``) keeps the gate ON. The shared VM never degrades, and VM
+main-checkout behavior is byte-identical (the probe returns ``None`` there).
 """
 
 from __future__ import annotations
 
 import argparse
+import functools
 import json
 import os
 import re
 import shutil
+import subprocess
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
+from explore_persona_space.orchestrate.env import is_shared_vm_env
 from explore_persona_space.task_workflow import (
     STATUSES,
     list_by_status,
+    primary_checkout_root,
     repo_root,
     tasks_dir,
 )
@@ -230,9 +250,80 @@ def _running_pod_side() -> bool:
     return Path("/.dockerenv").exists() and Path("/workspace/logs").is_dir()
 
 
+def _checkout_branch(checkout: Path) -> str | None:
+    """Attached branch name of ``checkout``'s HEAD, or ``None`` (detached /
+    unreadable).
+
+    Runs under a sanitized git env (``GIT_DIR`` / ``GIT_WORK_TREE`` cleared) so
+    the probe reads the SAME repo ``primary_checkout_root()`` resolved — a
+    leaked ``GIT_DIR`` would silently point the two at different repos (#924
+    v2). ``rc != 0`` / empty output / OSError / timeout all map to ``None``."""
+    env = {k: v for k, v in os.environ.items() if k not in ("GIT_DIR", "GIT_WORK_TREE")}
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(checkout), "symbolic-ref", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+            env=env,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+@functools.lru_cache(maxsize=1)
+def _off_main_checkout_root() -> Path | None:
+    """Root of a NON-``main`` remote checkout (GCE/pod issue-branch clone),
+    else ``None`` (#924).
+
+    ``None``  => normal path: every resolution goes through
+    ``task_workflow.repo_root()``.
+    ``Path``  => degrade gracefully: ``data/``, the worktree scan root, the
+    sidecar, and display names resolve against THIS checkout; the cross-task
+    active-consumer read is ATTEMPTED and its branch-guard ``RuntimeError``
+    (the no-local-``main`` clone shape) is caught at the gate-1 call site
+    only — a succeeding read keeps the gate ON (#924 v2).
+
+    Detection reads the PRIMARY checkout (git common-dir parent, NOT the
+    script's own dir — a VM worktree invocation must still resolve the repo
+    root). The SHARED VM never degrades (``is_shared_vm_env()`` conjunct): a
+    pathologically off-main VM keeps today's loud ``repo_root()`` behavior
+    rather than silently skipping the consumer gate on a shared ``tasks/``
+    tree. Detached HEAD or an unresolvable layout also returns ``None``
+    (``repo_root()`` then raises its own loud, unchanged error)."""
+    try:
+        primary = primary_checkout_root()
+    except RuntimeError:
+        return None  # unresolvable layout: let repo_root() raise its own loud error
+    branch = _checkout_branch(primary)
+    if branch is None or branch == "main":
+        return None
+    if is_shared_vm_env():
+        print(
+            f"  WARNING: primary checkout {primary} is on {branch!r} on the SHARED VM — "
+            f"refusing the #924 off-main degrade (the active-consumer gate must not be "
+            f"skipped on a shared tasks/ tree); falling through to repo_root().",
+            file=sys.stderr,
+        )
+        return None
+    return primary
+
+
+def _resolution_root() -> Path:
+    """``repo_root()`` on the primary-on-main VM; the checkout root on an
+    off-main remote clone (#924). Future path-resolution sites in this module
+    should call THIS helper, not ``repo_root()`` directly."""
+    off = _off_main_checkout_root()
+    return off if off is not None else repo_root()
+
+
 def disk_guard_sidecar_path() -> Path:
     """Absolute path of the shared disk-guard escalation sidecar JSONL."""
-    return repo_root() / DISK_GUARD_SIDECAR_REL
+    return _resolution_root() / DISK_GUARD_SIDECAR_REL
 
 
 def append_disk_guard_event(event: dict, *, apply: bool = True) -> None:
@@ -258,8 +349,9 @@ def append_disk_guard_event(event: dict, *, apply: bool = True) -> None:
 
 
 def _data_root() -> Path:
-    """Absolute path of the repo's ``data/`` directory."""
-    return repo_root() / "data"
+    """Absolute path of the checkout's ``data/`` directory (repo root on the
+    VM; the clone root on an off-main remote checkout, #924)."""
+    return _resolution_root() / "data"
 
 
 def _worktree_data_roots(issue_n: int) -> list[Path]:
@@ -272,7 +364,7 @@ def _worktree_data_roots(issue_n: int) -> list[Path]:
     ``issue-<N>-<suffix>`` (same-issue follow-up round) worktrees, so every
     ``issue-<N>*`` worktree whose name maps to exactly ``issue_n`` is
     scanned. Returns only existing ``<worktree>/data`` dirs."""
-    wt_root = repo_root() / ".claude" / "worktrees"
+    wt_root = _resolution_root() / ".claude" / "worktrees"
     if not wt_root.is_dir():
         return []
     out: list[Path] = []
@@ -668,6 +760,57 @@ def _cache_dir_reap_blocked(
     return reason
 
 
+def _protected_issues_for_reap(
+    issue_n: int,
+    *,
+    skip_guard: bool,
+    apply: bool,
+) -> dict[int, list[int]]:
+    """Gate-1 protected set for :func:`clean_issue_downloads`, with the #924
+    off-main attempt-and-catch.
+
+    ``skip_guard`` (the private test seam) returns ``{}`` with no ``tasks/``
+    walk. On the normal (VM / on-main) path — probe ``None`` — the read is a
+    plain call and any raise propagates loudly exactly as today. Off-main
+    (probe non-``None``, #924 v2, round-1 alternatives reconcile): ATTEMPT the
+    cross-task read; only a ``RuntimeError`` from it is caught. On the
+    no-local-``main`` clone shape (GCE ``--depth 1 --branch``) ``tasks_dir()``
+    -> ``repo_root()`` raises the branch-guard ``RuntimeError`` -> the read is
+    genuinely unserviceable and a single-task remote instance has no sibling
+    consumers, so an empty protected set is safe: loud WARN + sidecar row,
+    never silent. On the full-clone shape the read SUCCEEDS via the fresh-main
+    pin worktree and the gate stays fully ON. A non-``RuntimeError`` always
+    propagates (the catch is narrow, not a blanket swallow)."""
+    if skip_guard:
+        return {}
+    off_root = _off_main_checkout_root()
+    if off_root is None:
+        # Normal (VM / on-main) path — plain call, any raise propagates
+        # loudly exactly as today.
+        return _active_consumer_protected_issues(issue_n)
+    try:
+        return _active_consumer_protected_issues(issue_n)
+    except RuntimeError as exc:
+        print(
+            f"  WARNING: non-main checkout {off_root} — cross-task "
+            f"active-consumer protected-issues read unserviceable "
+            f"({exc}); #924: skipping the gate (single-task remote "
+            f"instance assumed). Reap proceeds scoped to issue "
+            f"{issue_n}'s own checkout-local caches.",
+            file=sys.stderr,
+        )
+        append_disk_guard_event(
+            {
+                "kind": "off-main-consumer-gate-skipped",
+                "task": issue_n,
+                "checkout": str(off_root),
+                "reason": f"gate read raised on non-main checkout: {exc}",
+            },
+            apply=apply,
+        )
+        return {}
+
+
 @dataclass
 class CleanResult:
     issue_n: int
@@ -737,7 +880,11 @@ def clean_issue_downloads(
       1. The active-CONSUMER gate (#773, FIRST): never reap while a DIFFERENT
          active task declares ``data/issue_<N>/`` as a planned input. It is a
          cheap in-memory set lookup, so running it first short-circuits before
-         the parity gate's potential HF call.
+         the parity gate's potential HF call. On an OFF-MAIN checkout (#924)
+         this gate's ``tasks/`` read is ATTEMPTED and only a ``RuntimeError``
+         from it (the branch-guard raise) is caught — loud WARN + sidecar row
+         + empty protected set; a succeeding read keeps the gate ON. See
+         :func:`_off_main_checkout_root`.
       2. The nested-``store/`` parity gate (#679): never wholesale-rmtree a
          cache dir holding a mis-rooted ``store/`` not verifiably mirrored on HF.
 
@@ -774,7 +921,9 @@ def clean_issue_downloads(
     hf_sizes_cache: dict[str, dict[str, int] | None] = {}
     # The active-consumer protected set is the same for every cache dir of this
     # issue, so compute it ONCE before the loop (a single tasks/ walk).
-    protected = {} if _skip_active_consumer_guard else _active_consumer_protected_issues(issue_n)
+    protected = _protected_issues_for_reap(
+        issue_n, skip_guard=_skip_active_consumer_guard, apply=apply
+    )
     for cache_dir in download_cache_dirs(issue_n, data_root):
         rel = _rel_name(cache_dir)
         res.sizes_bytes[rel] = _dir_size_bytes(cache_dir)
@@ -941,9 +1090,11 @@ def clean_issue_downloads_incremental(
 
 
 def _rel_name(path: Path) -> str:
-    """Path relative to the repo root for display (falls back to absolute)."""
+    """Path relative to the resolution root for display (falls back to
+    absolute). Off-main (#924) the root is the checkout itself, so a raising
+    ``repo_root()`` can never crash this display helper."""
     try:
-        return str(path.relative_to(repo_root()))
+        return str(path.relative_to(_resolution_root()))
     except ValueError:
         return str(path)
 

--- a/tests/test_clean_experiment_downloads_active_consumer.py
+++ b/tests/test_clean_experiment_downloads_active_consumer.py
@@ -67,6 +67,9 @@ def fake_repo(tmp_path, monkeypatch):
     # The names ced calls directly (it imported repo_root + tasks_dir from tw).
     monkeypatch.setattr(ced, "repo_root", lambda: tmp_path)
     monkeypatch.setattr(ced, "tasks_dir", lambda: tmp_path / "tasks")
+    # Determinism pin (#924): force the on-main resolution path so a
+    # hypothetical fresh-clone-on-a-branch test runner cannot flip the probe.
+    monkeypatch.setattr(ced, "_off_main_checkout_root", lambda: None)
     return tmp_path
 
 

--- a/tests/test_clean_experiment_downloads_off_main.py
+++ b/tests/test_clean_experiment_downloads_off_main.py
@@ -1,0 +1,342 @@
+"""Tests for the off-main graceful degrade in
+``scripts/clean_experiment_downloads.py`` (task #924).
+
+On a NON-``main`` remote checkout (the GCE/pod ``issue-<N>`` clone lanes),
+``task_workflow.repo_root()`` raises its branch-guard ``RuntimeError`` (the
+#841 att-6 crash: a ``--depth 1 --branch`` clone with no local ``main``) or
+silently routes to an empty-``data/`` pin worktree. The fix routes the four
+RESOLUTION sites (``_data_root`` / ``_worktree_data_roots`` / the sidecar /
+``_rel_name``) through ``_resolution_root()`` (checkout-local off-main), and
+gate 1 (#773 active-consumer) becomes ATTEMPT-AND-CATCH: the read is still
+attempted; only a ``RuntimeError`` from it is caught (loud WARN + sidecar row
+``kind: "off-main-consumer-gate-skipped"`` + empty protected set). A
+succeeding read (full clone with a local ``main``) keeps the gate ON.
+
+The script lives under ``scripts/`` (not an importable package), so it is
+loaded via importlib exactly like
+``tests/test_clean_experiment_downloads_pod_side_short_circuit.py``.
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+
+def _load(mod_name: str):
+    spec = importlib.util.spec_from_file_location(mod_name, _SCRIPTS / f"{mod_name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ced = _load("clean_experiment_downloads")
+
+import explore_persona_space.task_workflow as tw  # noqa: E402  (after _load, deliberate)
+
+# The #841 att-6 branch-guard message, VERBATIM (task_workflow.py
+# _ensure_managed_main_worktree) — any resolution site still reaching
+# repo_root() in the off-main fixture fails the test loudly with it.
+_BRANCH_GUARD_MSG = (
+    "primary checkout /workspace/eps-issue-841 is on 'issue-841' and has no local `main` "
+    "branch to route task.py writes through; create `main` (or check it out) before "
+    "running task.py."
+)
+
+
+def _raise_branch_guard():
+    raise RuntimeError(_BRANCH_GUARD_MSG)
+
+
+# ─── fixtures / helpers ──────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fake_off_main_clone(tmp_path, monkeypatch):
+    """Simulate the GCE ``--depth 1 --branch issue-841`` clone shape.
+
+    The probe inputs are monkeypatched (primary checkout = ``tmp_path``,
+    attached branch ``issue-841``, NOT the shared VM via the real
+    ``EPS_SHARED_VM=0`` override path), while BOTH ``ced.repo_root`` and
+    ``task_workflow.repo_root`` RAISE the #841 branch-guard error verbatim —
+    so the four resolution sites are proven to never reach ``repo_root()``,
+    and the gate-1 read (``tasks_dir()`` -> ``repo_root()``) exercises the
+    attempt-and-catch. Caches + a sibling ``store/`` + ``notes.txt`` live
+    under ``tmp_path/data/issue_841/``."""
+    issue_dir = tmp_path / "data" / "issue_841"
+    for cache in ("hf_dl", "g1_dl"):
+        d = issue_dir / cache
+        d.mkdir(parents=True)
+        (d / "blob.bin").write_bytes(b"x" * 2048)
+    store = issue_dir / "store"
+    store.mkdir()
+    (store / "keep.pt").write_bytes(b"y" * 4096)
+    (issue_dir / "notes.txt").write_text("keep me")
+
+    monkeypatch.setattr(ced, "_running_pod_side", lambda: False)
+    monkeypatch.setattr(ced, "primary_checkout_root", lambda: tmp_path)
+    monkeypatch.setattr(ced, "_checkout_branch", lambda p: "issue-841")
+    monkeypatch.setenv("EPS_SHARED_VM", "0")  # exercise the REAL is_shared_vm_env override
+    monkeypatch.setattr(ced, "repo_root", _raise_branch_guard)
+    monkeypatch.setattr(tw, "repo_root", _raise_branch_guard)
+
+    ced._off_main_checkout_root.cache_clear()
+    yield tmp_path
+    ced._off_main_checkout_root.cache_clear()
+
+
+def _read_sidecar(root: Path) -> list[dict]:
+    path = root / ".claude" / "cache" / "disk-guard-events.jsonl"
+    if not path.is_file():
+        return []
+    return [json.loads(ln) for ln in path.read_text().splitlines() if ln.strip()]
+
+
+# ─── test 1: hero — the #841 att-6 scenario end to end via main() ────────────
+
+
+def test_off_main_incremental_apply_reaps_checkout_local_caches(fake_off_main_clone, capsys):
+    """``main(["841", "--incremental", "--apply"])`` on the simulated clone:
+    rc 0, hf_dl + g1_dl reaped from the CHECKOUT-LOCAL data/, store/ +
+    notes.txt intact, WARN names the checkout + #924, sidecar row written.
+    The raising repo_root monkeypatch proves the four resolution sites never
+    call it AND exercises the gate-1 catch (the read IS attempted, raises the
+    #841 error verbatim, and is caught at the gate-1 site only)."""
+    clone = fake_off_main_clone
+    rc = ced.main(["841", "--incremental", "--apply"])
+    assert rc == 0
+    issue_dir = clone / "data" / "issue_841"
+    assert not (issue_dir / "hf_dl").exists()
+    assert not (issue_dir / "g1_dl").exists()
+    assert (issue_dir / "store" / "keep.pt").is_file()
+    assert (issue_dir / "notes.txt").is_file()
+    err = capsys.readouterr().err
+    assert "non-main checkout" in err
+    assert "#924" in err
+    rows = [r for r in _read_sidecar(clone) if r["kind"] == "off-main-consumer-gate-skipped"]
+    assert len(rows) == 1
+    assert rows[0]["task"] == 841
+    assert rows[0]["checkout"] == str(clone)
+
+
+# ─── test 2: dry-run deletes nothing ─────────────────────────────────────────
+
+
+def test_off_main_dry_run_deletes_nothing(fake_off_main_clone, capsys):
+    """No ``--apply``: rc 0, both cache dirs still on disk, would-remove
+    report lines present."""
+    clone = fake_off_main_clone
+    rc = ced.main(["841", "--incremental"])
+    assert rc == 0
+    issue_dir = clone / "data" / "issue_841"
+    assert (issue_dir / "hf_dl").is_dir()
+    assert (issue_dir / "g1_dl").is_dir()
+    out = capsys.readouterr().out
+    assert "would remove" in out
+    assert "hf_dl" in out and "g1_dl" in out
+
+
+# ─── test 3: gate-1 read is ATTEMPTED; only RuntimeError is caught ───────────
+
+
+def test_off_main_gate_read_attempted_and_caught(fake_off_main_clone, monkeypatch, capsys):
+    """Arm (a): a RuntimeError from the gate read is caught — the reap
+    succeeds with the WARN + sidecar row, proving the read WAS attempted."""
+    clone = fake_off_main_clone
+    attempted = {"n": 0}
+
+    def _gate_raises(issue_n):
+        attempted["n"] += 1
+        raise RuntimeError(_BRANCH_GUARD_MSG)
+
+    monkeypatch.setattr(ced, "_active_consumer_protected_issues", _gate_raises)
+    res = ced.clean_issue_downloads(841, apply=True)
+    assert attempted["n"] == 1  # the read was attempted, not probe-keyed-skipped
+    assert sorted(res.removed) == ["data/issue_841/g1_dl", "data/issue_841/hf_dl"]
+    assert res.skipped == [] and res.failed == []
+    assert "non-main checkout" in capsys.readouterr().err
+    assert any(r["kind"] == "off-main-consumer-gate-skipped" for r in _read_sidecar(clone))
+
+
+def test_off_main_gate_read_non_runtimeerror_propagates(fake_off_main_clone, monkeypatch):
+    """Arm (b): a non-RuntimeError from the gate read still PROPAGATES —
+    the catch is narrow, not a blanket swallow."""
+
+    def _gate_asserts(issue_n):
+        raise AssertionError("not a branch-guard failure")
+
+    monkeypatch.setattr(ced, "_active_consumer_protected_issues", _gate_asserts)
+    with pytest.raises(AssertionError, match="not a branch-guard failure"):
+        ced.clean_issue_downloads(841, apply=True)
+
+
+# ─── test 3-bis: full-clone shape — a SUCCEEDING gate read stays ON ──────────
+
+
+def test_off_main_full_clone_gate_stays_on(fake_off_main_clone, monkeypatch):
+    """Probe non-None but the gate read SUCCEEDS (the full-clone / pin-worktree
+    topology) returning a live consumer: the #773 protection is ENFORCED —
+    both cache dirs are SKIPPED with the consumer reason and stay on disk."""
+    clone = fake_off_main_clone
+    monkeypatch.setattr(ced, "_active_consumer_protected_issues", lambda n: {841: [999]})
+    res = ced.clean_issue_downloads(841, apply=True)
+    issue_dir = clone / "data" / "issue_841"
+    assert (issue_dir / "hf_dl").is_dir()
+    assert (issue_dir / "g1_dl").is_dir()
+    assert res.removed == []
+    skipped_names = sorted(name for name, _ in res.skipped)
+    assert skipped_names == ["data/issue_841/g1_dl", "data/issue_841/hf_dl"]
+    for _, reason in res.skipped:
+        assert "#999" in reason and "data/issue_841/" in reason
+    rows = [r for r in _read_sidecar(clone) if r["kind"] == "active-consumer-reap-skipped"]
+    assert len(rows) == 2
+    # And no gate-skip row: the gate was ON, never skipped.
+    assert not any(r["kind"] == "off-main-consumer-gate-skipped" for r in _read_sidecar(clone))
+
+
+# ─── test 4: nested-store parity gate (#679) still binds off-main ────────────
+
+
+def test_off_main_nested_store_parity_gate_still_binds(fake_off_main_clone, monkeypatch):
+    """An unmirrored nested store/ under hf_dl blocks its reap off-main
+    exactly as on-main (fail-toward-keep); g1_dl is still reaped."""
+    clone = fake_off_main_clone
+    nested = clone / "data" / "issue_841" / "hf_dl" / "store"
+    nested.mkdir()
+    (nested / "gen.pt").write_bytes(b"z" * 1024)
+    monkeypatch.setattr(ced, "_hf_file_sizes", lambda repo, revision="main": None)
+
+    res = ced.clean_issue_downloads(841, apply=True)
+    assert (clone / "data" / "issue_841" / "hf_dl").is_dir()
+    assert not (clone / "data" / "issue_841" / "g1_dl").exists()
+    assert [name for name, _ in res.skipped] == ["data/issue_841/hf_dl"]
+    assert res.removed == ["data/issue_841/g1_dl"]
+
+
+# ─── tests 5-7: probe classification ─────────────────────────────────────────
+
+
+def test_probe_none_on_main_branch(fake_off_main_clone, monkeypatch):
+    """Primary attached on `main` => probe None (the normal VM path)."""
+    monkeypatch.setattr(ced, "_checkout_branch", lambda p: "main")
+    ced._off_main_checkout_root.cache_clear()
+    assert ced._off_main_checkout_root() is None
+
+
+def test_probe_none_on_detached_or_unresolvable(fake_off_main_clone, monkeypatch):
+    """Detached HEAD (branch None) => None; an unresolvable layout
+    (primary_checkout_root raising RuntimeError) => None. Either way
+    repo_root() keeps raising its own loud, unchanged error downstream."""
+    monkeypatch.setattr(ced, "_checkout_branch", lambda p: None)
+    ced._off_main_checkout_root.cache_clear()
+    assert ced._off_main_checkout_root() is None
+
+    def _unresolvable():
+        raise RuntimeError("resolved repo root has no `tasks/` directory")
+
+    monkeypatch.setattr(ced, "primary_checkout_root", _unresolvable)
+    ced._off_main_checkout_root.cache_clear()
+    assert ced._off_main_checkout_root() is None
+    ced._off_main_checkout_root.cache_clear()
+
+
+def test_probe_refuses_on_shared_vm(fake_off_main_clone, monkeypatch, capsys):
+    """EPS_SHARED_VM=1 (overriding the fixture's "0") + branch issue-841:
+    the probe REFUSES the degrade (None + a SHARED VM warning), and the
+    pathological off-main-VM state keeps today's loud crash on the gate."""
+    monkeypatch.setenv("EPS_SHARED_VM", "1")
+    ced._off_main_checkout_root.cache_clear()  # WARN prints on the first uncached probe
+    assert ced._off_main_checkout_root() is None
+    assert "SHARED VM" in capsys.readouterr().err
+
+    # Probe None => gate 1 is a plain call; the raising repo_root propagates.
+    with pytest.raises(RuntimeError, match="has no local"):
+        ced.clean_issue_downloads(841, apply=False)
+
+
+# ─── test 8: on-main path still calls the consumer gate (VM invariant) ───────
+
+
+def test_on_main_path_still_calls_consumer_gate(tmp_path, monkeypatch):
+    """Probe pinned None (on-main): the consumer gate is computed exactly once
+    via a sentinel — the VM path is unchanged by #924."""
+    issue_dir = tmp_path / "data" / "issue_841"
+    (issue_dir / "hf_dl").mkdir(parents=True)
+    (issue_dir / "hf_dl" / "blob.bin").write_bytes(b"x" * 512)
+    monkeypatch.setattr(ced, "_off_main_checkout_root", lambda: None)
+    monkeypatch.setattr(ced, "repo_root", lambda: tmp_path)
+    calls = {"n": 0}
+
+    def _sentinel(issue_n):
+        calls["n"] += 1
+        return {}
+
+    monkeypatch.setattr(ced, "_active_consumer_protected_issues", _sentinel)
+    res = ced.clean_issue_downloads(841, apply=False)
+    assert calls["n"] == 1
+    assert res.removed == ["data/issue_841/hf_dl"]
+
+
+# ─── test 9: real-git shallow-branch-clone probe integration ─────────────────
+
+
+def _git(*args, cwd=None):
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_probe_real_git_shallow_branch_clone(tmp_path, monkeypatch):
+    """Integration (CPU seconds, no network): a REAL ``git clone --depth 1
+    --branch issue-841`` of a tiny origin holding a ``tasks/`` tree; the
+    UNmonkeypatched probe — resolver anchored at the clone via
+    ``task_workflow._MODULE_DIR`` — classifies it as an off-main checkout and
+    returns the clone root (closing the A2/A10 emulation-fidelity gap)."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git("init", "-q", "-b", "issue-841", cwd=origin)
+    (origin / "tasks").mkdir()
+    (origin / "tasks" / "REGISTRY.json").write_text("{}")
+    _git("add", "tasks", cwd=origin)
+    _git(
+        "-c",
+        "user.email=test@test",
+        "-c",
+        "user.name=test",
+        "commit",
+        "-q",
+        "-m",
+        "init",
+        cwd=origin,
+    )
+    clone = tmp_path / "clone"
+    _git("clone", "-q", "--depth", "1", "--branch", "issue-841", f"file://{origin}", str(clone))
+
+    # Real _checkout_branch against the real clone (always asserted).
+    assert ced._checkout_branch(clone) == "issue-841"
+
+    # Anchor the REAL resolver at the clone (the probe's primary_checkout_root
+    # resolves from task_workflow._MODULE_DIR) and run the unmonkeypatched
+    # probe end to end.
+    monkeypatch.setenv("EPS_SHARED_VM", "0")
+    monkeypatch.setattr(tw, "_MODULE_DIR", clone)
+    tw.invalidate_cache()
+    ced._off_main_checkout_root.cache_clear()
+    try:
+        result = ced._off_main_checkout_root()
+        assert result is not None
+        assert Path(result).resolve() == clone.resolve()
+    finally:
+        # Never leak the clone-anchored resolution into other tests.
+        ced._off_main_checkout_root.cache_clear()
+        tw.invalidate_cache()

--- a/tests/test_clean_experiment_downloads_parity.py
+++ b/tests/test_clean_experiment_downloads_parity.py
@@ -64,6 +64,9 @@ def fake_repo(tmp_path, monkeypatch):
     monkeypatch.setattr(tw, "tasks_dir", lambda: tmp_path / "tasks")
     monkeypatch.setattr(ced, "repo_root", lambda: tmp_path)
     monkeypatch.setattr(ced, "tasks_dir", lambda: tmp_path / "tasks")
+    # Determinism pin (#924): force the on-main resolution path so a
+    # hypothetical fresh-clone-on-a-branch test runner cannot flip the probe.
+    monkeypatch.setattr(ced, "_off_main_checkout_root", lambda: None)
     return tmp_path
 
 

--- a/tests/test_clean_experiment_downloads_symlinks.py
+++ b/tests/test_clean_experiment_downloads_symlinks.py
@@ -64,6 +64,9 @@ def fake_repo(tmp_path, monkeypatch):
     monkeypatch.setattr(tw, "tasks_dir", lambda: tmp_path / "tasks")
     monkeypatch.setattr(ced, "repo_root", lambda: tmp_path)
     monkeypatch.setattr(ced, "tasks_dir", lambda: tmp_path / "tasks")
+    # Determinism pin (#924): force the on-main resolution path so a
+    # hypothetical fresh-clone-on-a-branch test runner cannot flip the probe.
+    monkeypatch.setattr(ced, "_off_main_checkout_root", lambda: None)
     return tmp_path
 
 

--- a/tests/test_vm_disk_guard.py
+++ b/tests/test_vm_disk_guard.py
@@ -63,6 +63,14 @@ def _setup_fake_repo(tmp_path: Path, monkeypatch) -> Path:
     data/ and the worktree data/ then live under one temp filesystem and the
     production (data_root=None) code path can be exercised offline."""
     monkeypatch.setattr(ced, "repo_root", lambda: tmp_path)
+    # Determinism pin (#924): force the on-main resolution path so a
+    # hypothetical fresh-clone-on-a-branch test runner cannot flip the probe.
+    monkeypatch.setattr(ced, "_off_main_checkout_root", lambda: None)
+    # Sandbox the #773 active-consumer gate: REAL active tasks reference
+    # data/issue_658/, so an un-sandboxed gate walks the LIVE tasks/ tree and
+    # (correctly) keeps these synthetic caches — same trap the fake_repo
+    # fixtures in the sibling test files exist to prevent.
+    monkeypatch.setattr(ced, "_active_consumer_protected_issues", lambda n: {})
     return tmp_path
 
 
@@ -114,9 +122,14 @@ def test_both_naming_conventions_matched(tmp_path):
     assert len(caches) == 4
 
 
-def test_clean_issue_downloads_dry_run_removes_nothing(tmp_path):
+def test_clean_issue_downloads_dry_run_removes_nothing(tmp_path, monkeypatch):
     data_root = tmp_path / "data"
     issue_dir = _make_issue_data(data_root, 658)
+    # Sandbox the #773 active-consumer gate: REAL active tasks reference
+    # data/issue_658/, so the un-sandboxed gate walks the LIVE tasks/ tree and
+    # (correctly) keeps these synthetic caches — same trap the fake_repo
+    # fixtures in the sibling test files exist to prevent.
+    monkeypatch.setattr(ced, "_active_consumer_protected_issues", lambda n: {})
     res = ced.clean_issue_downloads(658, apply=False, data_root=data_root)
     assert len(res.removed) == 3  # would-remove the 3 caches
     # Nothing actually deleted.
@@ -125,9 +138,11 @@ def test_clean_issue_downloads_dry_run_removes_nothing(tmp_path):
     assert res.bytes_freed > 0  # reported a size
 
 
-def test_clean_issue_downloads_apply_deletes_caches_keeps_store(tmp_path):
+def test_clean_issue_downloads_apply_deletes_caches_keeps_store(tmp_path, monkeypatch):
     data_root = tmp_path / "data"
     issue_dir = _make_issue_data(data_root, 658)
+    # Sandbox the #773 gate (live tasks reference data/issue_658/ — see above).
+    monkeypatch.setattr(ced, "_active_consumer_protected_issues", lambda n: {})
     res = ced.clean_issue_downloads(658, apply=True, data_root=data_root)
     assert len(res.removed) == 3
     assert not (issue_dir / "hf_dl").exists()
@@ -138,9 +153,12 @@ def test_clean_issue_downloads_apply_deletes_caches_keeps_store(tmp_path):
     assert (issue_dir / "R_test.json").is_file()
 
 
-def test_clean_issue_downloads_is_idempotent(tmp_path):
+def test_clean_issue_downloads_is_idempotent(tmp_path, monkeypatch):
     data_root = tmp_path / "data"
     _make_issue_data(data_root, 658)
+    # Sandbox the #773 gate (live tasks reference data/issue_658/ — see above);
+    # without it the first reap is silently SKIPPED and idempotency is untested.
+    monkeypatch.setattr(ced, "_active_consumer_protected_issues", lambda n: {})
     ced.clean_issue_downloads(658, apply=True, data_root=data_root)
     # Second run: nothing left to remove, no error.
     res2 = ced.clean_issue_downloads(658, apply=True, data_root=data_root)
@@ -159,11 +177,13 @@ def test_clean_issue_downloads_missing_issue_is_noop(tmp_path):
 # ─── clean_experiment_downloads: incremental (between-phase) cleanup ──────────
 
 
-def test_incremental_apply_reaps_consumed_cache_keeps_store(tmp_path):
+def test_incremental_apply_reaps_consumed_cache_keeps_store(tmp_path, monkeypatch):
     # Between-phase cleanup: a consumed phase's hf_dl/g*_dl is reaped, store/
     # + eval-result-shaped json kept — identical contract to the end-of-run path.
     data_root = tmp_path / "data"
     issue_dir = _make_issue_data(data_root, 658)
+    # Sandbox the #773 gate (live tasks reference data/issue_658/ — see above).
+    monkeypatch.setattr(ced, "_active_consumer_protected_issues", lambda n: {})
     res = ced.clean_issue_downloads_incremental(658, apply=True, data_root=data_root)
     assert len(res.removed) == 3
     assert not (issue_dir / "hf_dl").exists()
@@ -174,20 +194,24 @@ def test_incremental_apply_reaps_consumed_cache_keeps_store(tmp_path):
     assert (issue_dir / "R_test.json").is_file()
 
 
-def test_incremental_dry_run_removes_nothing(tmp_path):
+def test_incremental_dry_run_removes_nothing(tmp_path, monkeypatch):
     data_root = tmp_path / "data"
     issue_dir = _make_issue_data(data_root, 658)
+    # Sandbox the #773 gate (live tasks reference data/issue_658/ — see above).
+    monkeypatch.setattr(ced, "_active_consumer_protected_issues", lambda n: {})
     res = ced.clean_issue_downloads_incremental(658, apply=False, data_root=data_root)
     assert len(res.removed) == 3  # would-remove the 3 caches
     assert (issue_dir / "hf_dl").is_dir()  # nothing actually deleted
     assert res.bytes_freed > 0
 
 
-def test_incremental_is_idempotent(tmp_path):
+def test_incremental_is_idempotent(tmp_path, monkeypatch):
     # A re-run after the phase's cache is already reaped is a no-op (a later
     # phase that re-downloads rebuilds the cache; absent that, nothing to do).
     data_root = tmp_path / "data"
     _make_issue_data(data_root, 658)
+    # Sandbox the #773 gate (live tasks reference data/issue_658/ — see above).
+    monkeypatch.setattr(ced, "_active_consumer_protected_issues", lambda n: {})
     ced.clean_issue_downloads_incremental(658, apply=True, data_root=data_root)
     res2 = ced.clean_issue_downloads_incremental(658, apply=True, data_root=data_root)
     assert res2.removed == []

--- a/tests/test_vm_disk_guard_active_escalation.py
+++ b/tests/test_vm_disk_guard_active_escalation.py
@@ -59,6 +59,9 @@ def repo(tmp_path, monkeypatch):
     sentinels all resolve under it) and an active task's data dir there."""
     monkeypatch.setattr(vdg, "repo_root", lambda: tmp_path)
     monkeypatch.setattr(ced, "repo_root", lambda: tmp_path)
+    # Determinism pin (#924): force the on-main resolution path so a
+    # hypothetical fresh-clone-on-a-branch test runner cannot flip the probe.
+    monkeypatch.setattr(ced, "_off_main_checkout_root", lambda: None)
     return tmp_path
 
 

--- a/tests/test_vm_disk_guard_data_disk.py
+++ b/tests/test_vm_disk_guard_data_disk.py
@@ -77,6 +77,11 @@ def test_run_guard_watches_data_disk_percent(tmp_path, monkeypatch):
     data_root = tmp_path / "wt-data"
     _make_issue_data(data_root, 658)
     monkeypatch.setattr(vdg, "_resolve_issue_status", lambda n: "completed")
+    # Sandbox the #773 active-consumer gate: REAL active tasks reference
+    # data/issue_658/, so an un-sandboxed gate walks the LIVE tasks/ tree and
+    # (correctly) keeps this synthetic cache — same trap the fake_repo
+    # fixtures in the sibling test files exist to prevent.
+    monkeypatch.setattr(ced, "_active_consumer_protected_issues", lambda n: {})
 
     invoked = {"uv": False, "logs": False}
 
@@ -119,6 +124,8 @@ def test_data_disk_full_leaves_root_escalation_only(tmp_path, monkeypatch):
     repo = tmp_path
     monkeypatch.setattr(vdg, "repo_root", lambda: repo)
     monkeypatch.setattr(ced, "repo_root", lambda: repo)
+    # Determinism pin (#924): force the on-main resolution path.
+    monkeypatch.setattr(ced, "_off_main_checkout_root", lambda: None)
     data_root = repo / "wt-data"
     issue_dir = _make_issue_data(data_root, 658)
     # Make the active cache big enough to clear the escalation floor (5 GB).
@@ -173,6 +180,8 @@ def test_data_disk_pass_dry_run_no_mutation(tmp_path, monkeypatch):
     repo = tmp_path
     monkeypatch.setattr(vdg, "repo_root", lambda: repo)
     monkeypatch.setattr(ced, "repo_root", lambda: repo)
+    # Determinism pin (#924): force the on-main resolution path.
+    monkeypatch.setattr(ced, "_off_main_checkout_root", lambda: None)
     data_root = repo / "wt-data"
     issue_dir = _make_issue_data(data_root, 658)
     monkeypatch.setattr(vdg, "_ACTIVE_ESCALATION_MIN_BYTES", 1)


### PR DESCRIPTION
Closes task #924.

## Summary
- `scripts/clean_experiment_downloads.py` now degrades gracefully on a non-main checkout (GCE `issue-<N>` clone): the #773 active-consumer gate read is ATTEMPT-AND-CATCH (skipped with a loud WARN + sidecar row only when the read raises the branch-guard RuntimeError); four resolution sites resolve checkout-local, so the between-phase incremental cleanup actually reaps remote-lane caches instead of crashing (#841 att-6).
- VM behavior byte-identical; #803 pod no-op verbatim; #679 nested-store parity gate untouched.
- 11 new tests (incl. full-clone-gate-stays-on + a real `git clone --depth 1 --branch` probe integration test) + determinism pins in 6 sibling suites.

## Test plan
- [x] `uv run pytest tests/test_clean_experiment_downloads_off_main.py -x` (11 passed)
- [x] Touched-scope Step 9c gate: 2198 passed, 6 skipped, 0 failed
- [x] ruff clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)