### PR TITLE
issue-925: add c14 hypothesis-branch-coherence WARN check to verify_plan.py

### DIFF
--- a/scripts/verify_plan.py
+++ b/scripts/verify_plan.py
@@ -30,11 +30,13 @@ Check catalog (id — classification — kind scope)
       batched commitment         (analysis), conditional   analysis
   c13 empirical-null gate        FAIL (experiment) / WARN  experiment +
       p-floor attainability      (analysis), conditional   analysis
+  c14 hypothesis branch         WARN-only, conditional    experiment +
+      coherence                                           analysis
 
 Kind-exempt checks render as [SKIP] (first-class status, distinguishable
 from genuine passes — the calibration report needs n_skip separate from
-n_pass). Conditional checks (4, 6, 7, 10, 11, 12, 13) also SKIP when their
-content trigger does not fire.
+n_pass). Conditional checks (4, 6, 7, 10, 11, 12, 13, 14) also SKIP when
+their content trigger does not fire.
 
 Canonical N/A escape phrases (quote verbatim in bounce briefs):
 
@@ -1489,6 +1491,194 @@ def check_empirical_gate_attainability(plan: str, kind: str) -> CheckResult:
     )
 
 
+# ─── Check 14 — hypothesis confirm/falsify branch coherence (WARN-only) ────
+
+# Branch anchors: `**Confirm:**`, `**Confirm (ridge stands):**`,
+# `**Confirm-the-null:**`, `**Falsify:**`, `**Falsify (positive surprise):**`
+# — all observed corpus shapes.
+_BRANCH_ANCHOR_RE = re.compile(r"(?i)\*\*\s*(confirm|falsif)")
+# Shared bounded token: a normalized `var = value` pair present in BOTH
+# branch segments (the #922 H4 `k = 32` horizon shape). Comparator-bearing
+# bounds (`k ≤ 4`) are deliberately NOT harvested — requiring exact-pair
+# identity in both segments is the main false-positive guard.
+_BOUND_TOKEN_RE = re.compile(r"\b([A-Za-z]\w{0,8})\s*=\s*(\d+(?:\.\d+)?)\b")
+# Tendency-class comparator (does not pin an end-state). Deliberately
+# minimal: a bare "declines" without "toward" is an accepted false negative
+# (prefer false negatives); "approaches"/"converges" excluded in v1
+# ("two approaches" false-fires on the noun).
+_TENDENCY_RE = re.compile(r"(?i)\btowards?\b")
+# State-class comparator (pins a region through the horizon).
+_STATE_RE = re.compile(
+    r"(?i)\b(?:stays?|remains?|holds?)\s+(?:strictly\s+)?(?:above|below|at|within)\b"
+)
+# Vague layer-scope tokens ("mid/late layers", "most layers", incl. "at most
+# layers"). "a majority of layers" is deliberately EXCLUDED (a quantifier
+# over a universe; in the observed corpus it co-occurs with a pinned one).
+_VAGUE_SCOPE_RE = re.compile(
+    r"(?i)\b(?:(?:early|mid|middle|late|deep|shallow)"
+    r"(?:\s*[/-]\s*(?:early|mid|middle|late|deep|shallow))?|most)\s+layers\b"
+)
+# Pinned-anchor escape (same block): "layers 1-28" (any dash), "layer 20",
+# "layers {18, 21}", "L18", the pre-registered layer symbol (script small l,
+# U+2113, followed by *), or the literal "pre-registered".
+_PINNED_SCOPE_RE = re.compile(
+    r"(?i)\blayers?\s*\d|\blayers?\s+\{|\bL\d{1,2}\b|\u2113\*|\bpre-registered\b"
+)
+# Per-hypothesis block starts: top-level list items (sub-headings are
+# detected via _HEADING_RE).
+_C14_LIST_ITEM_RE = re.compile(r"^\s{0,3}(?:[-*]|\d+\.)\s")
+# Bold span used to label an offending block in the WARN detail.
+_C14_BOLD_LABEL_RE = re.compile(r"\*\*([^*\n]{1,60})\*\*")
+
+
+def _hypothesis_blocks(section_text: str) -> list[str]:
+    """Split a (fence-stripped) hypothesis-section text into per-hypothesis
+    blocks at top-level list-item starts and heading lines; continuation
+    lines join the preceding block. The section heading line starts the
+    first block (it carries no branch anchors, so it is ignored downstream).
+    Matches the observed corpus: one bullet per `**H<k>**` (#922 v2, #841
+    v12, #810 v6 all use single-bullet hypothesis blocks)."""
+    blocks: list[list[str]] = []
+    current: list[str] = []
+    for line in section_text.splitlines():
+        if _C14_LIST_ITEM_RE.match(line) or _HEADING_RE.match(line.strip()):
+            if current:
+                blocks.append(current)
+            current = [line]
+        else:
+            current.append(line)
+    if current:
+        blocks.append(current)
+    return ["\n".join(b) for b in blocks]
+
+
+def _confirm_falsify_segments(block: str) -> tuple[str, str] | None:
+    """``(confirm_segment, falsify_segment)`` for a hypothesis block, or
+    ``None`` when the block has no falsify anchor (nothing to compare —
+    c8 owns branches missing entirely; a lone ``**Confirm`` block is also
+    ignored). Falsify segment = first falsify anchor to the next anchor or
+    block end. Confirm segment = explicit confirm anchor to the next anchor
+    when one exists; otherwise the block text BEFORE the falsify anchor
+    (the hypothesis statement itself is the implicit confirm branch — the
+    #922 H4 shape, which has no ``**Confirm:**`` label)."""
+    anchors = list(_BRANCH_ANCHOR_RE.finditer(block))
+    falsifies = [m for m in anchors if m.group(1).casefold().startswith("falsif")]
+    if not falsifies:
+        return None
+    f0 = falsifies[0]
+    after_f = [m for m in anchors if m.start() > f0.start()]
+    falsify_seg = block[f0.start() : after_f[0].start() if after_f else len(block)]
+    confirms = [m for m in anchors if m.group(1).casefold().startswith("confirm")]
+    if confirms:
+        c0 = confirms[0]
+        after_c = [m for m in anchors if m.start() > c0.start()]
+        confirm_seg = block[c0.start() : after_c[0].start() if after_c else len(block)]
+    else:
+        confirm_seg = block[: f0.start()]
+    return confirm_seg, falsify_seg
+
+
+def _shared_bound_tokens(confirm_seg: str, falsify_seg: str) -> list[str]:
+    """Normalized ``var = value`` pairs present in BOTH segments, rendered
+    as sorted ``"var = value"`` strings (identity on the normalized pair,
+    whitespace-insensitive)."""
+
+    def _toks(seg: str) -> set[tuple[str, str]]:
+        return {(m.group(1).casefold(), m.group(2)) for m in _BOUND_TOKEN_RE.finditer(seg)}
+
+    return sorted(f"{var} = {val}" for var, val in _toks(confirm_seg) & _toks(falsify_seg))
+
+
+def _c14_block_label(block: str) -> str:
+    """Short human label for a hypothesis block: the first bold span that is
+    not itself a branch anchor (e.g. ``**H4 (rollout).**``), else the first
+    line truncated."""
+    for m in _C14_BOLD_LABEL_RE.finditer(block):
+        if not re.match(r"(?i)\s*(?:confirm|falsif)", m.group(1)):
+            return f"**{m.group(1)}**"
+    first_line = block.strip().splitlines()[0] if block.strip() else "(unnamed)"
+    return first_line[:60]
+
+
+def check_hypothesis_branch_coherence(plan: str, kind: str) -> CheckResult:
+    """WARN-only, conditional: hypothesis confirm/falsify branch coherence.
+    Two token-level offender predicates per anchor-bearing hypothesis
+    block: (a) a jointly-satisfiable tendency-vs-state comparator pair on a
+    shared bounded ``var = value`` token across the confirm/falsify
+    segments ("decays toward ... by k = 32" confirm vs "stays above ...
+    through k = 32" falsify — one above-but-declining curve satisfies
+    both); (b) a vague layer-scope token ("mid/late layers", "most layers")
+    with no pinned layer list/numeral in the same block. NEVER FAILs — a
+    heuristic text check must not hard-block a legitimately-worded plan;
+    joint satisfiability beyond these two token shapes stays with the
+    Statistics critic (c8's form-only charter). Crisp state-vs-state pairs
+    (``≤`` vs ``>``, win-count comparators — the #841 v12 / #810 v6 shapes)
+    carry no tendency token and stay silent. Incident: #922 v2 H4 (caught
+    only by the Codex statistics critic; the same defect class reached
+    execution in #488 round 10)."""
+    cid, name = "c14_hypothesis_branch_coherence", "hypothesis branch coherence"
+    if kind not in ("experiment", "analysis"):
+        return _skip(
+            cid, name, "kind-exempt: hypothesis blocks are an experiment|analysis plan shape"
+        )
+    section = section_text_by_keywords(plan, ("hypothesis",))
+    if section is None:
+        return _skip(cid, name, "no hypothesis section detected")
+    text = strip_fences(section)
+    anchored: list[tuple[str, tuple[str, str]]] = []
+    for block in _hypothesis_blocks(text):
+        segments = _confirm_falsify_segments(block)
+        if segments is not None:
+            anchored.append((block, segments))
+    if not anchored:
+        return _skip(
+            cid, name, "hypothesis section present but no **Confirm/**Falsify branch anchors"
+        )
+    offenders: list[str] = []
+    for block, (confirm_seg, falsify_seg) in anchored:
+        clauses: list[str] = []
+        shared = _shared_bound_tokens(confirm_seg, falsify_seg)
+        if shared:
+            c_tend = _TENDENCY_RE.search(confirm_seg)
+            f_state = _STATE_RE.search(falsify_seg)
+            c_state = _STATE_RE.search(confirm_seg)
+            f_tend = _TENDENCY_RE.search(falsify_seg)
+            pair: tuple[str, str] | None = None
+            if c_tend and f_state:
+                pair = (c_tend.group(0), f_state.group(0))
+            elif c_state and f_tend:
+                pair = (c_state.group(0), f_tend.group(0))
+            if pair:
+                clauses.append(
+                    f"(a) comparator-pair — confirm says '{pair[0]}' while falsify says "
+                    f"'{pair[1]}' on shared token '{shared[0]}', jointly satisfiable by "
+                    "one outcome"
+                )
+        vague = _VAGUE_SCOPE_RE.search(block)
+        if vague and not _PINNED_SCOPE_RE.search(block):
+            clauses.append(
+                f"(b) vague-scope — '{vague.group(0)}' with no pinned layer list/numeral "
+                "in the block"
+            )
+        if clauses:
+            offenders.append(f"block '{_c14_block_label(block)}': " + "; ".join(clauses))
+    if not offenders:
+        return _pass(
+            cid,
+            name,
+            f"{len(anchored)} hypothesis block(s) scanned; no c14 trigger detected "
+            "(no jointly-satisfiable comparator pair, no unpinned vague-scope token)",
+        )
+    extra = f" (+{len(offenders) - 3} more)" if len(offenders) > 3 else ""
+    detail = (
+        "; ".join(offenders[:3])
+        + extra
+        + " — tighten the branch comparators (e.g. '≤ vs >') and/or pin the layer set; "
+        "semantic verdict stays with the Statistics critic"
+    )
+    return _warn(cid, name, detail)
+
+
 # ─── Driver ────────────────────────────────────────────────────────────────
 
 CHECKS = [
@@ -1505,6 +1695,7 @@ CHECKS = [
     check_dryrun_test_coverage,
     check_battery_multiplier,
     check_empirical_gate_attainability,
+    check_hypothesis_branch_coherence,
 ]
 
 

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -37,7 +37,7 @@ sys.modules["verify_plan"] = verify_plan
 _spec.loader.exec_module(verify_plan)  # type: ignore[union-attr]
 
 
-# ─── Canonical plan (kind=experiment: passes 0-3,5,8,9; skips 4,6,7,10) ────
+# ─── Canonical plan (kind=experiment: passes 0-3,5,8,9; skips 4,6,7,10-14) ─
 
 # Surgery anchors (must appear verbatim in GOOD_PLAN exactly once).
 MV_HEADING = "### Measurement validity"
@@ -150,10 +150,11 @@ def test_good_plan_passes_all():
         "c11_dryrun_test_coverage": "SKIP",
         "c12_battery_multiplier": "SKIP",
         "c13_empirical_gate_attainability": "SKIP",
+        "c14_hypothesis_branch_coherence": "SKIP",
     }
     actual = {cid: r.status for cid, r in by_id.items()}
     assert actual == expected
-    assert len(results) == 14
+    assert len(results) == 15
 
 
 # ─── Check 0 — plan-nonstub ────────────────────────────────────────────────
@@ -1353,6 +1354,139 @@ def test_c13_fail_detail_names_clean_pass_remedy_bound():
     assert "clean PASS" in r.detail
 
 
+# ─── Check 14 — hypothesis confirm/falsify branch coherence ────────────────
+
+# Verbatim bullets from the real corpus (embedded as literals — NEVER read
+# from tasks/ at test runtime; tasks move between status folders). The REAL
+# plan files are exercised by the §4 pre-commit calibration, not this suite.
+C14_HEADING = "## 3. Hypothesis"
+# #922 v2 line 47 — the incident offender: implicit confirm (no **Confirm:**
+# label), tendency "toward" vs state "stays above" on shared `k = 32`, plus
+# the unpinned "mid/late layers" scope.
+H922_H4 = "- **H4 (rollout).** The context-only autoregressive roll beats the frozen-state null (ĥ_{T+k} = h_T) for small horizons (k ≤ 4) at mid/late layers, and decays toward/below it by k = 32 (feature drift, 2506.03566). **Falsify (positive surprise):** rollout skill stays above the frozen null through k = 32."
+# #922 v2 line 45 — vague-shaped "early to late layers" ESCAPED by the pinned
+# "layers 1-28" (en dash in the verbatim string) / "layer 0" in the same block.
+H922_H2 = "- **H2 (depth profile).** The carried-context share rises with depth: the ratio r2_id(context-only)/r2_id(token-informed) increases from early to late layers (Spearman ρ(layer, ratio) > 0 over layers 1–28, both spaces). At layer 0 (embedding stream) the context-only map fails by construction (h_{0,t+1} is exactly the injected token embedding) — a built-in sanity anchor. **Falsify:** flat or decreasing profile."
+# #841 v12 line 29 — crisp `≤` vs `>` count comparators, no tendency token.
+H841_H1 = "- **H1 (Stage-0 fit, matched information).** The source-only GRU's held-out r2_id on Δ_ℓ does NOT beat the affine ridge on the data-limited late-layer band (transitions 17–25) or on a majority of the 27 transitions. **Confirm (ridge stands):** source-only GRU r2_id ≤ ridge r2_id on ≥ 14/27 transitions (raw space), consistent with the prefix-GRU's 27/27 loss. **Falsify (GRU wins):** source-only GRU r2_id > ridge r2_id on a majority of transitions, especially the late-layer band. Directional prior: LOSS or TIE (removing prefix information from an already-losing GRU should not lift it above ridge)."
+# #810 v6 line 35 — band/threshold wording (Confirm-the-null vs clears-the-
+# band), no tendency token.
+H810_H2G = "- **H2-g (read-out).** No summary rescues behavior read-out on generic-genre activations either. **Confirm-the-null:** the two-method conjunction statistic sits inside its max-selected band for each new combo. **Falsify:** a summary clears the band on g1 → the Betley corpus was suppressing read-out (rewrites the parent's read-out takeaway)."
+
+
+def _hyp_plan(*bullets: str) -> str:
+    """GOOD_PLAN + a Hypothesis section carrying ``bullets`` in order."""
+    return GOOD_PLAN + "\n" + C14_HEADING + "\n\n" + "\n".join(bullets) + "\n"
+
+
+@pytest.mark.parametrize("kind", ["infra", "batch", "survey"])
+def test_c14_kind_infra_skips(kind):
+    assert _status(_hyp_plan(H922_H4), "c14_hypothesis_branch_coherence", kind=kind) == "SKIP"
+
+
+def test_c14_no_hypothesis_section_skips():
+    _, by_id = _run(GOOD_PLAN)
+    r = by_id["c14_hypothesis_branch_coherence"]
+    assert r.status == "SKIP"
+    assert "no hypothesis section" in r.detail
+
+
+def test_c14_hypothesis_without_branch_anchors_skips():
+    plan = _hyp_plan("- **H1.** The read-out improves with depth (prose only, no branch labels).")
+    r = _run(plan)[1]["c14_hypothesis_branch_coherence"]
+    assert r.status == "SKIP"
+    assert "no **Confirm/**Falsify branch anchors" in r.detail
+
+
+def test_c14_922_h4_toward_vs_stays_above_warns():
+    # H4 carries NO explicit **Confirm:** label — the implicit-confirm rule
+    # (block text before the falsify anchor is the confirm branch) is
+    # REQUIRED for this to fire (plan §4 test 14, folded in here).
+    ok, by_id = _run(_hyp_plan(H922_H4))
+    r = by_id["c14_hypothesis_branch_coherence"]
+    assert r.status == "WARN"
+    assert "k = 32" in r.detail
+    assert "toward" in r.detail
+    assert "stays above" in r.detail
+    assert ok is True  # WARN never flips exit 0 (success criterion 6)
+
+
+def test_c14_922_h4_vague_scope_in_detail():
+    r = _run(_hyp_plan(H922_H4))[1]["c14_hypothesis_branch_coherence"]
+    assert "mid/late layers" in r.detail
+    assert "(b) vague-scope" in r.detail
+
+
+def test_c14_vague_scope_alone_warns():
+    # Predicate (b) fires without (a): no shared bounded token anywhere.
+    plan = _hyp_plan(
+        "- **H1.** Read-out improves at mid/late layers. **Falsify:** no improvement at any layer."
+    )
+    r = _run(plan)[1]["c14_hypothesis_branch_coherence"]
+    assert r.status == "WARN"
+    assert "(b) vague-scope" in r.detail
+    assert "mid/late layers" in r.detail
+    assert "(a) comparator-pair" not in r.detail
+
+
+def test_c14_841_v12_crisp_comparators_pass():
+    assert _status(_hyp_plan(H841_H1), "c14_hypothesis_branch_coherence") == "PASS"
+
+
+def test_c14_810_v6_band_wording_passes():
+    assert _status(_hyp_plan(H810_H2G), "c14_hypothesis_branch_coherence") == "PASS"
+
+
+def test_c14_vague_scope_with_pinned_layer_range_passes():
+    assert _status(_hyp_plan(H922_H2), "c14_hypothesis_branch_coherence") == "PASS"
+
+
+def test_c14_toward_without_shared_token_passes():
+    # Deliberate shared-token conservatism (accepted false negative): the
+    # falsify names `k = 32` but the confirm does not, so no comparator pair
+    # is evaluated even though tendency + state tokens are both present.
+    plan = _hyp_plan(
+        "- **H1.** Rollout skill decays toward the null at long horizons at layer 20. "
+        "**Falsify:** rollout skill stays above the frozen null through k = 32."
+    )
+    assert _status(plan, "c14_hypothesis_branch_coherence") == "PASS"
+
+
+def test_c14_fenced_hypothesis_does_not_trigger():
+    plan = GOOD_PLAN + "\n" + C14_HEADING + "\n\n```\n" + H922_H4 + "\n```\n"
+    r = _run(plan)[1]["c14_hypothesis_branch_coherence"]
+    assert r.status == "SKIP"
+    assert "no **Confirm/**Falsify branch anchors" in r.detail
+
+
+def test_c14_kind_analysis_warns_not_skips():
+    ok, by_id = _run(_hyp_plan(H922_H4), kind="analysis")
+    assert by_id["c14_hypothesis_branch_coherence"].status == "WARN"
+    assert ok is True  # WARN-only under BOTH in-scope kinds (criterion 6)
+
+
+def test_c14_comparator_pair_alone_warns():
+    # (a)-ALONE positive (round-1 critic Must-Fix, alternatives lens): shared
+    # token + tendency-vs-state comparators, NO vague-scope token. A coupled
+    # implementation where comparator detection only evaluates when
+    # vague-scope also fires would pass the H4 tests (H4 fires both) and the
+    # shared-token-conservatism test (nothing evaluates) — this fixture is
+    # the only one that fails such a mutant.
+    plan = _hyp_plan(
+        "- **H1.** Skill decays toward the null by k = 32 at layer 20. "
+        "**Falsify:** skill stays above the null through k = 32."
+    )
+    ok, by_id = _run(plan)
+    r = by_id["c14_hypothesis_branch_coherence"]
+    assert r.status == "WARN"
+    assert "(a) comparator-pair" in r.detail
+    assert "k = 32" in r.detail
+    assert "toward" in r.detail
+    assert "stays above" in r.detail
+    assert "(b) vague-scope" not in r.detail
+    assert ok is True
+
+
 # ─── Plan-version + kind resolution ────────────────────────────────────────
 
 
@@ -1402,12 +1536,12 @@ def test_cli_json_schema_and_exit_zero_on_pass(tmp_path):
     assert payload["issue"] is None
     assert payload["kind"] == "experiment"
     assert payload["n_fail"] == 0
-    assert payload["n_skip"] == 7
+    assert payload["n_skip"] == 8
     assert {"id", "name", "status", "detail"} <= set(payload["checks"][0])
     statuses = {c["status"] for c in payload["checks"]}
     assert statuses <= {"PASS", "WARN", "FAIL", "SKIP"}
-    assert len(payload["checks"]) == 14
-    assert len({c["id"] for c in payload["checks"]}) == 14
+    assert len(payload["checks"]) == 15
+    assert len({c["id"] for c in payload["checks"]}) == 15
 
 
 def test_cli_exit_one_on_fail(tmp_path):


### PR DESCRIPTION
Closes task #925 (workflow-fix, kind: infra).

## Summary
- Adds WARN-only check c14 `check_hypothesis_branch_coherence` to `scripts/verify_plan.py`: flags (a) confirm/falsify branch comparators jointly satisfiable by one outcome on a shared bounded token, and (b) vague layer-scope wording with no pinned anchor. No `_fail` path — semantic verdicts stay with the critic ensemble.
- 13 named tests + 4 count-assertion updates in `tests/test_verify_plan.py`, including the (a)-alone mutant-guard fixture (round-1 critic Must-Fix).
- Calibrated on the real #922 H4 offender (fires, both predicates) and a 206-file corpus sweep (0 fires on legitimately-worded plans).

## Test plan
- [x] `uv run pytest tests/test_verify_plan.py` — 149/149
- [x] Step 9c touched-scope gate — 2086 passed / 6 skipped
- [x] ruff check + format clean on touched files; `workflow_lint --check-asks` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)