### PR TITLE
issue-913: fix run_823.py phase-5 length-R2 diagnostic (valid_idx slice + fail-loud)

### DIFF
--- a/src/explore_persona_space/experiments/issue_823/run_823.py
+++ b/src/explore_persona_space/experiments/issue_823/run_823.py
@@ -1400,6 +1400,109 @@ def _load_common_valid_idx(base_dir: pathlib.Path, n_contexts: int) -> np.ndarra
     return valid_idx
 
 
+def _length_r2_correlation(
+    span_data: dict[str, list[int]],
+    per_ctx_r2_data: dict[str, dict[str, list[float]]],
+    valid_idx: np.ndarray,
+) -> dict[str, Any]:
+    """Length-vs-R² confound diagnostic (phase 5 block 5), valid-context aligned.
+
+    span_data arrays are FULL-length (indexed by original context position;
+    phase3_tf_extract allocates ``[0] * n`` and serializes unsliced), while
+    per_ctx_r2 arrays contain ONLY the common-valid rows, ordered by sorted
+    common_valid_idx (phase4_ridge_refit fancy-indexes every per-context array
+    by that sorted index before fitting). Slicing the span arrays by
+    ``valid_idx`` therefore index-aligns the two. Raises ValueError on any
+    length / index / key inconsistency — never swallows (fail-fast, #913).
+
+    Statistic identity: this computes the pre-registered SIGNED ``len_delta``
+    (a_prime - b2) Pearson + Spearman correlation against the per-context R²
+    gap; #823's clean-result published the analyzer's absolute-length-delta
+    Spearman variant instead (0.0671 / 0.1082 / 0.0556), so a future run's
+    non-identical Spearman here is expected, not a regression.
+
+    Returns a per-trait dict matching the historical block-5 output shape; a
+    trait gets a ``note`` entry (no raise) when per_ctx_r2 lacks it (the
+    legitimate phase-4-not-yet-run ordering state).
+    """
+    from scipy import stats as scipy_stats
+
+    if "a_prime" not in span_data or "b2" not in span_data:
+        raise ValueError(
+            "phase3_span_lengths.json present but missing required keys 'a_prime'/'b2' "
+            f"(found: {sorted(span_data)}) — corrupt spans artifact"
+        )
+    ap_full = np.asarray(span_data["a_prime"], dtype=float)
+    b2_full = np.asarray(span_data["b2"], dtype=float)
+    valid_idx = np.asarray(valid_idx, dtype=int)
+    if valid_idx.size < 2:
+        raise ValueError(f"valid_idx has {valid_idx.size} element(s); need >= 2 for a correlation")
+    if int(valid_idx.min()) < 0 or int(valid_idx.max()) >= min(len(ap_full), len(b2_full)):
+        raise ValueError(
+            f"valid_idx range [{int(valid_idx.min())}, {int(valid_idx.max())}] out of bounds "
+            f"for span arrays (a_prime={len(ap_full)}, b2={len(b2_full)})"
+        )
+    if not np.all(np.diff(valid_idx) > 0):
+        raise ValueError(
+            "valid_idx must be strictly increasing (sorted, no duplicates) — "
+            "the sorted-common_valid_idx convention IS the alignment proof"
+        )
+    ap_lens, b2_lens = ap_full[valid_idx], b2_full[valid_idx]
+    len_delta = ap_lens - b2_lens
+
+    out: dict[str, Any] = {}
+    for trait in TRAITS:
+        ro = READ_OUT_LAYERS[trait]
+        ctx_ap = per_ctx_r2_data.get("A_prime", {}).get(trait)
+        ctx_b2 = per_ctx_r2_data.get("B2", {}).get(trait)
+        if ctx_ap is None or ctx_b2 is None:
+            # per_ctx_r2 not available (e.g. Phase 4 not yet run) — a legitimate
+            # ordering state, not an error.
+            out[trait] = {
+                "read_out_layer": ro,
+                "note": "per_ctx_r2 unavailable — run Phase 4 first",
+                "mean_ap_len": float(ap_lens.mean()),
+                "mean_b2_len": float(b2_lens.mean()),
+                "mean_delta": float(len_delta.mean()),
+            }
+            continue
+        r2_ap = np.asarray(ctx_ap, dtype=float)
+        r2_b2 = np.asarray(ctx_b2, dtype=float)
+        if not (len(r2_ap) == len(r2_b2) == len(valid_idx)):
+            raise ValueError(
+                f"per_ctx_r2 length mismatch for {trait}: "
+                f"A_prime={len(r2_ap)}, B2={len(r2_b2)}, valid_idx={len(valid_idx)}"
+            )
+        r2_gap = r2_ap - r2_b2  # per-context R2(A') - R2(B2)
+        # Pearson
+        pearson_r, pearson_p = scipy_stats.pearsonr(len_delta, r2_gap)
+        # Spearman
+        spearman_r, spearman_p = scipy_stats.spearmanr(len_delta, r2_gap)
+        out[trait] = {
+            "read_out_layer": ro,
+            "n_contexts": len(r2_gap),
+            "len_delta_vs_r2_gap": {
+                "pearson_r": float(pearson_r),
+                "pearson_p": float(pearson_p),
+                "spearman_r": float(spearman_r),
+                "spearman_p": float(spearman_p),
+            },
+            "mean_ap_len": float(ap_lens.mean()),
+            "mean_b2_len": float(b2_lens.mean()),
+            "mean_delta": float(len_delta.mean()),
+        }
+        logger.info(
+            "Length-R² corr [%s, L%d]: Pearson r=%.3f p=%.3f, Spearman r=%.3f p=%.3f",
+            trait,
+            ro,
+            pearson_r,
+            pearson_p,
+            spearman_r,
+            spearman_p,
+        )
+    return out
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # Phase 4: Ridge refitting
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -2137,66 +2240,15 @@ def phase5_validity_diag(base_dir: pathlib.Path, n_contexts: int, smoke: bool) -
     # 5. Length-R² correlation (if Phase 4 results exist)
     # Uses per-context R² values persisted in ridge_r2_by_arm.json["per_ctx_r2"]
     # for a genuine numeric Pearson + Spearman correlation with per-context length delta.
+    # No try/except here: any internal error fails phase 5 loudly (fail-fast, #913).
     length_r2_correlation: dict[str, Any] = {}
     ridge_path = base_dir / "eval_results" / "issue_823" / "ridge_r2_by_arm.json"
     if ridge_path.exists() and span_path.exists():
-        try:
-            from scipy import stats as scipy_stats
-
-            ridge_data = json.loads(ridge_path.read_text())
-            per_ctx_r2_data = ridge_data.get("per_ctx_r2", {})
-
-            for trait in TRAITS:
-                ro = READ_OUT_LAYERS[trait]
-                ctx_ap = per_ctx_r2_data.get("A_prime", {}).get(trait)
-                ctx_b2 = per_ctx_r2_data.get("B2", {}).get(trait)
-                has_per_ctx = ctx_ap is not None and ctx_b2 is not None
-                if "a_prime" in span_data and "b2" in span_data:
-                    ap_lens = np.array(span_data["a_prime"][:n_contexts], dtype=float)
-                    b2_lens = np.array(span_data["b2"][:n_contexts], dtype=float)
-                    len_delta = ap_lens - b2_lens
-                    if has_per_ctx:
-                        r2_ap = np.array(ctx_ap[:n_contexts])
-                        r2_b2 = np.array(ctx_b2[:n_contexts])
-                        r2_gap = r2_ap - r2_b2  # per-context R2(A') - R2(B2)
-                        # Pearson
-                        pearson_r, pearson_p = scipy_stats.pearsonr(len_delta, r2_gap)
-                        # Spearman
-                        spearman_r, spearman_p = scipy_stats.spearmanr(len_delta, r2_gap)
-                        length_r2_correlation[trait] = {
-                            "read_out_layer": ro,
-                            "n_contexts": len(r2_gap),
-                            "len_delta_vs_r2_gap": {
-                                "pearson_r": float(pearson_r),
-                                "pearson_p": float(pearson_p),
-                                "spearman_r": float(spearman_r),
-                                "spearman_p": float(spearman_p),
-                            },
-                            "mean_ap_len": float(ap_lens.mean()),
-                            "mean_b2_len": float(b2_lens.mean()),
-                            "mean_delta": float(len_delta.mean()),
-                        }
-                        logger.info(
-                            "Length-R² corr [%s, L%d]: Pearson r=%.3f p=%.3f, "
-                            "Spearman r=%.3f p=%.3f",
-                            trait,
-                            ro,
-                            pearson_r,
-                            pearson_p,
-                            spearman_r,
-                            spearman_p,
-                        )
-                    else:
-                        # per_ctx_r2 not available (e.g. Phase 4 not yet run)
-                        length_r2_correlation[trait] = {
-                            "read_out_layer": ro,
-                            "note": "per_ctx_r2 unavailable — run Phase 4 first",
-                            "mean_ap_len": float(ap_lens.mean()),
-                            "mean_b2_len": float(b2_lens.mean()),
-                            "mean_delta": float(len_delta.mean()),
-                        }
-        except Exception as e:
-            logger.warning("Length-R² correlation: %s", e)
+        ridge_data = json.loads(ridge_path.read_text())
+        valid_idx = _load_common_valid_idx(base_dir, n_contexts)
+        length_r2_correlation = _length_r2_correlation(
+            span_data, ridge_data.get("per_ctx_r2", {}), valid_idx
+        )
 
     diag = {
         "text_cosine": {

--- a/tests/test_issue823_phase5_length_r2.py
+++ b/tests/test_issue823_phase5_length_r2.py
@@ -1,0 +1,278 @@
+"""Tests for the phase-5 length-R² diagnostic helper in run_823.py (#913).
+
+Covers `_length_r2_correlation`:
+  - computes correctly (exact scipy match) when phase 1 dropped contexts;
+  - raises on span/per_ctx_r2 length mismatch (the pre-fix defect shape);
+  - raises on out-of-range / negative / permuted / duplicated valid_idx;
+  - raises on a present-but-corrupt spans artifact (missing a_prime/b2 keys);
+  - yields per-trait notes (no raise) when phase 4 has not run;
+and the caller-level fail-loud pins:
+  - the old swallow string is gone from the source;
+  - no ast.Try inside phase5_validity_diag encloses the helper call.
+"""
+
+from __future__ import annotations
+
+import ast
+import functools
+import pathlib
+import sys
+
+import numpy as np
+import pytest
+from scipy import stats as scipy_stats
+
+# ---------------------------------------------------------------------------
+# Helpers — locate run_823 module without importing it at collection time
+# (the module has GPU-bound top-level imports we don't want at test time).
+# Deferred-import pattern mirrored from tests/test_issue823_helpers.py.
+# ---------------------------------------------------------------------------
+
+_WORKTREE = pathlib.Path(__file__).resolve().parents[1]
+_RUN823 = _WORKTREE / "src" / "explore_persona_space" / "experiments" / "issue_823" / "run_823.py"
+
+
+@functools.lru_cache(maxsize=1)
+def _import_run823():
+    """Import run_823 as a module (cached), inserting its src/ parent onto sys.path."""
+    src_dir = str(_WORKTREE / "src")
+    if src_dir not in sys.path:
+        sys.path.insert(0, src_dir)
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("run_823_phase5", str(_RUN823))
+    mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Raw fixture literals (10 full contexts; context 7 dropped by phase 1).
+# Index 7 carries distinctive values (999 / 950) so any [:n]-style slicing
+# (the pre-fix alignment defect) contaminates the means and fails the oracle.
+# ---------------------------------------------------------------------------
+
+AP_RAW = [100, 120, 90, 105, 130, 95, 110, 999, 88, 101]
+B2_RAW = [80, 118, 95, 100, 90, 92, 108, 950, 70, 99]
+VALID_IDX_RAW = [0, 1, 2, 3, 4, 5, 6, 8, 9]  # ctx 7 dropped -> 9 valid contexts
+
+R2_AP_RAW = {
+    "evil": [0.10, 0.32, 0.25, 0.41, 0.05, 0.66, 0.29, 0.48, 0.37],
+    "sycophancy": [0.55, 0.12, 0.60, 0.33, 0.72, 0.18, 0.44, 0.27, 0.50],
+    "hallucination": [0.21, 0.83, 0.14, 0.57, 0.36, 0.49, 0.08, 0.62, 0.31],
+}
+R2_B2_RAW = {
+    "evil": [0.20, 0.28, 0.35, 0.30, 0.15, 0.51, 0.33, 0.40, 0.22],
+    "sycophancy": [0.45, 0.22, 0.50, 0.38, 0.61, 0.28, 0.39, 0.31, 0.42],
+    "hallucination": [0.31, 0.73, 0.24, 0.47, 0.41, 0.39, 0.18, 0.52, 0.41],
+}
+
+
+def _span_data() -> dict[str, list[int]]:
+    return {"a_prime": list(AP_RAW), "b2": list(B2_RAW)}
+
+
+def _per_ctx_r2() -> dict[str, dict[str, list[float]]]:
+    return {
+        "A_prime": {t: list(v) for t, v in R2_AP_RAW.items()},
+        "B2": {t: list(v) for t, v in R2_B2_RAW.items()},
+    }
+
+
+def _valid_idx() -> np.ndarray:
+    return np.asarray(VALID_IDX_RAW, dtype=int)
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — dropped contexts compute correctly (exact scipy oracle)
+# ---------------------------------------------------------------------------
+
+
+class TestDroppedContextsComputesCorrectly:
+    def test_fixture_traits_match_module(self):
+        mod = _import_run823()
+        assert set(R2_AP_RAW) == set(mod.TRAITS), "fixture traits drifted from module TRAITS"
+
+    def test_dropped_contexts_computes_correctly(self):
+        mod = _import_run823()
+        result = mod._length_r2_correlation(_span_data(), _per_ctx_r2(), _valid_idx())
+
+        # Oracle built from raw fixture literals, hand-sliced, mirroring the
+        # helper's np.asarray(..., dtype=float) coercion order. Exact float
+        # equality is intended and sound: same inputs, same scipy calls.
+        ap_full = np.asarray(AP_RAW, dtype=float)
+        b2_full = np.asarray(B2_RAW, dtype=float)
+        idx = np.asarray(VALID_IDX_RAW, dtype=int)
+        ap_lens, b2_lens = ap_full[idx], b2_full[idx]
+        len_delta = ap_lens - b2_lens
+
+        assert set(result) == set(mod.TRAITS)
+        for trait in mod.TRAITS:
+            entry = result[trait]
+            assert "note" not in entry, f"{trait}: unexpected note path"
+            assert entry["n_contexts"] == 9
+            assert entry["read_out_layer"] == mod.READ_OUT_LAYERS[trait]
+
+            r2_gap = np.asarray(R2_AP_RAW[trait], dtype=float) - np.asarray(
+                R2_B2_RAW[trait], dtype=float
+            )
+            exp_pr, exp_pp = scipy_stats.pearsonr(len_delta, r2_gap)
+            exp_sr, exp_sp = scipy_stats.spearmanr(len_delta, r2_gap)
+            got = entry["len_delta_vs_r2_gap"]
+            assert got["pearson_r"] == float(exp_pr)
+            assert got["pearson_p"] == float(exp_pp)
+            assert got["spearman_r"] == float(exp_sr)
+            assert got["spearman_p"] == float(exp_sp)
+
+            assert entry["mean_ap_len"] == float(ap_lens.mean())
+            assert entry["mean_b2_len"] == float(b2_lens.mean())
+            assert entry["mean_delta"] == float(len_delta.mean())
+
+    def test_slice_is_valid_idx_not_prefix(self):
+        """The pre-fix [:n] prefix slice would include the dropped ctx 7 (999)."""
+        mod = _import_run823()
+        result = mod._length_r2_correlation(_span_data(), _per_ctx_r2(), _valid_idx())
+        ap_full = np.asarray(AP_RAW, dtype=float)
+        prefix_mean = float(ap_full[: len(VALID_IDX_RAW)].mean())  # includes 999 at idx 7
+        for trait in mod.TRAITS:
+            assert result[trait]["mean_ap_len"] != prefix_mean
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — length mismatch raises (the pre-fix defect shape, fail-loud pin)
+# ---------------------------------------------------------------------------
+
+
+def test_length_mismatch_raises():
+    """Full-length (10-row) per_ctx_r2 arrays against a 9-element valid_idx raise."""
+    mod = _import_run823()
+    per_ctx = {
+        "A_prime": {t: [0.1 * i for i in range(10)] for t in mod.TRAITS},
+        "B2": {t: [0.05 * i for i in range(10)] for t in mod.TRAITS},
+    }
+    with pytest.raises(ValueError, match="length mismatch"):
+        mod._length_r2_correlation(_span_data(), per_ctx, _valid_idx())
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — valid_idx precondition guards
+# ---------------------------------------------------------------------------
+
+
+def test_valid_idx_out_of_range_raises():
+    mod = _import_run823()
+    bad_idx = np.asarray([0, 1, 2, 10], dtype=int)  # 10 >= len(span arrays) == 10
+    with pytest.raises(ValueError, match="out of bounds"):
+        mod._length_r2_correlation(_span_data(), _per_ctx_r2(), bad_idx)
+
+
+@pytest.mark.parametrize(
+    "bad_idx,match",
+    [
+        pytest.param([0, 2, 1, 3, 4], "strictly increasing", id="permutation"),
+        pytest.param([0, 1, 1, 2, 3], "strictly increasing", id="duplicate"),
+        pytest.param([-1, 0, 1, 2], "out of bounds", id="negative"),
+    ],
+)
+def test_bad_valid_idx_rejected(bad_idx, match):
+    """Permuted / duplicated / negative valid_idx violates the sorted-alignment precondition."""
+    mod = _import_run823()
+    with pytest.raises(ValueError, match=match):
+        mod._length_r2_correlation(_span_data(), _per_ctx_r2(), np.asarray(bad_idx, dtype=int))
+
+
+def test_too_few_valid_idx_raises():
+    mod = _import_run823()
+    with pytest.raises(ValueError, match="need >= 2"):
+        mod._length_r2_correlation(_span_data(), _per_ctx_r2(), np.asarray([3], dtype=int))
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — missing span keys raise (present-but-corrupt spans artifact)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "span_data",
+    [
+        pytest.param({}, id="empty"),
+        pytest.param({"a_prime": list(AP_RAW)}, id="missing-b2"),
+        pytest.param({"b2": list(B2_RAW)}, id="missing-a-prime"),
+    ],
+)
+def test_missing_span_keys_raises(span_data):
+    mod = _import_run823()
+    with pytest.raises(ValueError, match="missing required keys"):
+        mod._length_r2_correlation(span_data, _per_ctx_r2(), _valid_idx())
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — phase-4-not-run note path (legitimate ordering state, no raise)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_per_ctx_r2_yields_note():
+    mod = _import_run823()
+    result = mod._length_r2_correlation(_span_data(), {}, _valid_idx())
+    ap_full = np.asarray(AP_RAW, dtype=float)
+    idx = np.asarray(VALID_IDX_RAW, dtype=int)
+    assert set(result) == set(mod.TRAITS)
+    for trait in mod.TRAITS:
+        entry = result[trait]
+        assert entry["note"] == "per_ctx_r2 unavailable — run Phase 4 first"
+        assert "len_delta_vs_r2_gap" not in entry
+        assert entry["mean_ap_len"] == float(ap_full[idx].mean())
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — source-level swallow pins (string ban + AST caller-level guard)
+# ---------------------------------------------------------------------------
+
+
+def test_no_swallow_string_in_source():
+    """The old warn-and-continue swallow line must not be reintroduced."""
+    source = _RUN823.read_text()
+    assert 'logger.warning("Length-R² correlation' not in source
+
+
+def _is_helper_call(node: ast.AST) -> bool:
+    """True when node is a Call to _length_r2_correlation (Name or Attribute form)."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id == "_length_r2_correlation"
+    if isinstance(func, ast.Attribute):
+        return func.attr == "_length_r2_correlation"
+    return False
+
+
+def test_no_try_encloses_helper_call_in_phase5():
+    """No ast.Try anywhere in phase5_validity_diag may enclose the helper call.
+
+    A differently-worded re-swallow at the caller must fail this committed
+    test, not just the run-book grep gate (#913 plan section 13 item 1).
+    """
+    tree = ast.parse(_RUN823.read_text())
+    phase5 = next(
+        (
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+            and node.name == "phase5_validity_diag"
+        ),
+        None,
+    )
+    assert phase5 is not None, "phase5_validity_diag not found in run_823.py"
+
+    # Guard against a vacuous pass: the helper call must exist in the function.
+    all_calls = [n for n in ast.walk(phase5) if _is_helper_call(n)]
+    assert all_calls, "_length_r2_correlation(...) call not found in phase5_validity_diag"
+
+    # No Try node (body, handlers, orelse, or finalbody) may contain the call.
+    for try_node in (n for n in ast.walk(phase5) if isinstance(n, ast.Try)):
+        enclosed = [n for n in ast.walk(try_node) if _is_helper_call(n)]
+        assert not enclosed, (
+            f"_length_r2_correlation call enclosed by try/except at line {try_node.lineno} "
+            "of phase5_validity_diag — the fail-loud contract (#913) forbids this"
+        )


### PR DESCRIPTION
Closes task #913.

## Summary
- Factor phase-5 block 5 of `run_823.py` into pure `_length_r2_correlation`: slice full-length span arrays by `common_valid_idx` so they align with valid-rows-only `per_ctx_r2` (the #823 5000-vs-4998 defect), with hard ValueError guards (length equality, index range + non-negativity, strict monotonicity, >=2 elements, missing-span-keys).
- Delete the bare `except Exception: logger.warning` swallow — any internal error now fails phase 5 loudly (fail-fast rule).
- New hermetic regression suite `tests/test_issue823_phase5_length_r2.py` (15 tests incl. exact-scipy dropped-context oracle + AST test pinning that no `ast.Try` encloses the helper call).

## Test plan
- [x] `uv run pytest tests/test_issue823_phase5_length_r2.py -v` — 15/15
- [x] `uv run pytest tests/test_issue823_helpers.py -v` — 11/11
- [x] Step 9c touched battery — 2103 passed (2 pre-existing main failures owned by #933)
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)