### PR TITLE
workflow-fix #921: v4 total-prose budget counts folded follow-up rounds

### DIFF
--- a/.claude/skills/clean-results/SPEC.md
+++ b/.claude/skills/clean-results/SPEC.md
@@ -443,7 +443,8 @@ data, checkpoints, eval JSONs, raw completions, figure source — pinned>
 
 **Context:** <verbatim originating prompt(s), blockquoted> · <lineage:
 `[#K](...) — <one line>` or `fresh direction (no parent)`; same-issue
-follow-up rounds also name each round's followup_label> · <created/run
+follow-up rounds also name each round's followup_label, each as a
+'same-issue follow-up round `<label>`' clause> · <created/run
 dates>
 ```
 
@@ -636,7 +637,10 @@ H2), preceded by a `---` horizontal rule. TWO required bold labels:
   original body's `## Provenance` / `epm:followup-scope v1` markers, NEVER
   paraphrased; when none recorded, `origin prompt not recorded`) · lineage
   (`[#K](...) — <one line>` or `fresh direction (no parent)`; same-issue
-  follow-up rounds name each round's `followup_label`) · created/run dates.
+  follow-up rounds name each round's `followup_label` — written as a
+  ``same-issue follow-up round `<followup_label>` `` clause, the
+  machine-countable form check 20's round-scaled prose budget reads;
+  #921) · created/run dates.
   This footer is the ONLY place run-context provenance lives in the body
   (the "state facts, not sources" rule still bans weaving prompt/person
   attributions into Takeaways / Results prose).
@@ -709,7 +713,7 @@ sections:
 | Per-Takeaways-bullet length | ≤30 words | WARN |
 | Per-`### <result>` prose (excl. caption/code/details/tables) | ≤120 words WARN, ≥180 FAIL | WARN at 120, FAIL at 180 |
 | Figure caption | ≤60 words | WARN |
-| Total prose: Takeaways + Goal + Results (excl. tables, code fences, details bodies, captions; `## Methodology` is EXCLUDED — it carries the absorbed methodology-doc content and is reference, not skim prose) | ≤800 words + 250 per live follow-up round beyond the first | WARN-only |
+| Total prose: Takeaways + Goal + Results (excl. tables, code fences, details bodies, captions; `## Methodology` is EXCLUDED — it carries the absorbed methodology-doc content and is reference, not skim prose) | ≤800 words + 250 per live follow-up round beyond the first (round count: non-retroactive `epm:same-issue-followup-run` markers and/or the footer round clauses, max — #921) | WARN-only |
 
 `## Methodology` is deliberately EXCLUDED from the total-prose budget: it
 absorbed the entire former standalone methodology doc, which was never

--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -334,6 +334,12 @@ New v3-only checks (PASS vacuously on v2/legacy):
   per extra follow-up round (WARN-only). Counts EXCLUDE tables, fenced
   code, `<details>` bodies, captions. The Takeaways 3-6 bullet COUNT is
   owned by check 3's `check_v3_structure` (one authoritative count).
+  (v4 twin `check_v4_word_caps`: same caps over Takeaways + Goal +
+  Results, `## Methodology` excluded; its round count reads
+  `epm:same-issue-followup-run` markers and/or the footer round clauses,
+  max-reconciled — the Rounds-table read binds v3 only. It needs the
+  `issue` number for the events leg, so it is dispatched separately in
+  `verify_text`, outside CHECKS; #921.)
 - **check 21** (`check_body_params_subset_of_doc`): the body's
   load-bearing `## Reproducibility` Parameters rows are a SUBSET of the
   methodology doc §2 complete table. Binds when the doc path is supplied
@@ -6186,6 +6192,109 @@ def _count_extra_followup_rounds(body: str) -> int:
     return max(0, data_rows - 1)
 
 
+# One clause per FOLDED same-issue follow-up round in the v4 footer
+# (SPEC.md § `**Context:**` row: rounds name each round's `followup_label`;
+# corpus forms: "same-issue follow-up round `<label>`" (#763/#811/#667) and
+# the sentence-initial numbered variant "Same-issue follow-up round 2
+# (label: `<label>`, ...)" (#685 footer) — hence IGNORECASE + the optional
+# `<n> (label: ` infix. The `(?!s)` lookahead keeps generic plural prose
+# ("follow-up rounds also name...") out of the count; an unlabeled singular
+# clause still counts 1.
+_V4_FOOTER_ROUND_CLAUSE_RE = re.compile(
+    r"same-issue follow-up round(?!s)"
+    r"(?:\s+(?:\d+\s*\(label:\s*)?`(?P<label>[^`\s]+)`)?",
+    re.IGNORECASE,
+)
+
+
+def _followup_run_marker_rounds(issue: int) -> int:
+    """Count REAL folded same-issue follow-up rounds off the task's
+    events.jsonl `epm:same-issue-followup-run` markers: distinct
+    `followup_label`s (one run marker closes a label's round) plus one per
+    unlabeled run marker, EXCLUDING markers whose `outcome` begins
+    `retroactive-close` — bookkeeping closes of ghost labels that folded
+    no new prose (they are likewise excluded from the /issue round caps,
+    SKILL.md). Returns 0 when the task id does not resolve (a plain
+    FileNotFoundError — e.g. a fixture body under a numeric tmp dir); a
+    `StaleTaskPathError` (registry corruption, a FileNotFoundError
+    SUBCLASS) still propagates — that is real corruption the gate should
+    surface, unlike an unknown id."""
+    from explore_persona_space.task_workflow import (  # local import — matches _load_text_for_issue
+        FOLLOWUP_RUN_KIND,
+        StaleTaskPathError,
+        list_events,
+        parse_followup_note_field,
+    )
+
+    try:
+        events = list_events(issue)
+    except StaleTaskPathError:
+        raise
+    except FileNotFoundError:
+        return 0
+    labels: set[str] = set()
+    unlabeled = 0
+    for ev in events:
+        if ev.get("kind") != FOLLOWUP_RUN_KIND:
+            continue
+        note = ev.get("note") or ""
+        # `parse_followup_note_field` matches only LINE-LEADING fields, but
+        # the corpus run-marker notes are SINGLE-LINE (all fields space-
+        # separated; #763's `outcome:` is mid-line and parses to None).
+        # Mid-line regex fallback so a single-line retro-close marker
+        # cannot evade the exclusion.
+        outcome = parse_followup_note_field(note, "outcome") or ""
+        if not outcome:
+            m = re.search(r"(?:^|\s)outcome:\s*(\S+)", note)
+            outcome = m.group(1) if m else ""
+        if outcome.startswith("retroactive-close"):
+            continue
+        label = parse_followup_note_field(note, "followup_label")
+        if label:
+            labels.add(label)
+        else:
+            unlabeled += 1
+    return len(labels) + unlabeled
+
+
+def _count_extra_followup_rounds_v4(body: str, issue: int | None = None) -> tuple[int, str]:
+    """v4 twin of `_count_extra_followup_rounds` (whose `## What I ran`
+    Rounds-table read only binds v3 — v4 bodies always scored rounds=0,
+    incident #763/#921). Two signals, max-reconciled — the budget is
+    WARN-only and monotone-up, and each signal under-counts in a known
+    case (footer: a body omitting the SPEC round clause, e.g. #685;
+    events: a legacy pre-marker round whose prose IS folded, e.g. #811):
+
+    - footer: `same-issue follow-up round [`label`]` clauses inside the
+      `**Repro:**`/`**Context:**` footer (distinct backticked labels +
+      one per unlabeled singular clause);
+    - events (when `issue` is known): non-retroactive-close
+      `epm:same-issue-followup-run` markers via
+      `_followup_run_marker_rounds`.
+
+    Returns `(count, source)`; `source` is one of `none` / `footer` /
+    `events` / `footer+events` and names the winning signal for the WARN
+    message. Bare-file residual: in `--body-stdin` / bare `--file` mode
+    (no issue id) the events leg is unavailable, so a footer-less
+    multi-round body scores 0 and keeps the base budget."""
+    footer = _v4_footer_text(body) or ""
+    labels: set[str] = set()
+    unlabeled = 0
+    for m in _V4_FOOTER_ROUND_CLAUSE_RE.finditer(footer):
+        if m.group("label"):
+            labels.add(m.group("label"))
+        else:
+            unlabeled += 1
+    footer_n = len(labels) + unlabeled
+    events_n = _followup_run_marker_rounds(issue) if issue is not None else 0
+    count = max(footer_n, events_n)
+    if count == 0:
+        return 0, "none"
+    if footer_n == events_n:
+        return count, "footer+events"
+    return count, "footer" if footer_n > events_n else "events"
+
+
 def _count_overlong_takeaways_bullets(takeaways: str) -> int:
     """Count top-level Takeaways bullets over the per-bullet word cap
     (fence-aware). Helper for check 20."""
@@ -6413,7 +6522,7 @@ def check_v4_methodology_shape(body: str) -> CheckResult:
     )
 
 
-def check_v4_word_caps(body: str) -> CheckResult:
+def check_v4_word_caps(body: str, *, issue: int | None = None) -> CheckResult:
     """Check 20 (v4 only): the v4 conciseness caps (same constants as v3).
 
     - Per-Takeaways-bullet ≤30 words (WARN).
@@ -6424,9 +6533,12 @@ def check_v4_word_caps(body: str) -> CheckResult:
       EXCLUDED — it carries the absorbed methodology-doc content) ≤800 +
       250 per live follow-up round beyond the first (WARN-only).
 
-    The Takeaways 3-6 bullet COUNT is owned by `check_v4_structure`. A FAIL
-    here fires ONLY on the per-result ≥180-word hard cap. PASSes vacuously
-    on v3 / v2 / legacy bodies.
+    The per-extra-round scaling counts folded rounds from the task's
+    non-retroactive `epm:same-issue-followup-run` markers (via ``issue``,
+    when known) and/or the footer's round clauses (max), NOT the v3
+    Rounds table (#921). The Takeaways 3-6 bullet COUNT is owned by
+    `check_v4_structure`. A FAIL here fires ONLY on the per-result
+    ≥180-word hard cap. PASSes vacuously on v3 / v2 / legacy bodies.
     """
     label = "v4 conciseness caps"
     if not is_v4(body):
@@ -6462,7 +6574,7 @@ def check_v4_word_caps(body: str) -> CheckResult:
     # Total content prose (WARN-only): Takeaways + Goal + Results. The
     # `## Methodology` section is EXCLUDED — it absorbed the entire former
     # standalone methodology doc and is reference, not skim prose.
-    extra_rounds = _count_extra_followup_rounds(body)
+    extra_rounds, rounds_src = _count_extra_followup_rounds_v4(body, issue)
     total_budget = V3_TOTAL_PROSE_BASE_WORDS + extra_rounds * V3_TOTAL_PROSE_PER_EXTRA_ROUND_WORDS
     total_prose = (
         _prose_words(takeaways)
@@ -6473,8 +6585,8 @@ def check_v4_word_caps(body: str) -> CheckResult:
         warns.append(
             f"total content prose is {total_prose} words (budget {total_budget}: "
             f"{V3_TOTAL_PROSE_BASE_WORDS} + {extra_rounds} x "
-            f"{V3_TOTAL_PROSE_PER_EXTRA_ROUND_WORDS} per extra round; "
-            "Methodology excluded)"
+            f"{V3_TOTAL_PROSE_PER_EXTRA_ROUND_WORDS} per extra round "
+            f"[{rounds_src}]; Methodology excluded)"
         )
 
     if fails:
@@ -7069,9 +7181,11 @@ CHECKS = [
     check_data_subset_disclosure,  # check 19 (v3)
     check_data_unwrapped_example_table,  # check 19b (v3, WARN)
     check_v3_word_caps,  # check 20 (v3)
-    # v4-gated checks (PASS vacuously on non-v4 bodies):
+    # v4-gated checks (PASS vacuously on non-v4 bodies). Check 20 (v4)
+    # `check_v4_word_caps` is NOT here — it needs the issue number for the
+    # events-based folded-round budget scaling, so it is dispatched
+    # separately in `verify_text` (#921):
     check_v4_methodology_shape,  # check 18 (v4)
-    check_v4_word_caps,  # check 20 (v4)
     check_v4_results_beat,  # check 21 (v4, WARN)
     check_v4_no_bare_issue_refs,  # check 27 (v4) — bare `#K` refs in standalone sections
     # generation-agnostic checks (v2 AND v3 AND v4):
@@ -7229,6 +7343,12 @@ def verify_text(
     # the body-only CHECKS list. NO-OP PASS on v2 / legacy bodies and
     # whenever no doc is supplied (gate-timing — see the check docstring).
     results.append(check_body_params_subset_of_doc(body, methodology_doc_path=methodology_doc_path))
+    # Check 20 (v4) word caps needs the issue number for the events-based
+    # folded-round budget scaling (#921; the v3 twin stays body-only inside
+    # CHECKS), so it is dispatched separately like the other
+    # context-needing checks. PASS-skip on non-v4 bodies, and the events
+    # leg degrades to the footer-only read when `issue` is None/unknown.
+    results.append(check_v4_word_caps(body, issue=issue))
     # Check (#732, judge-API-error denominator) needs the issue number AND
     # the eval-root / body-source-path resolution legs (the body-only CHECKS
     # list carries none of these), so it also lives outside CHECKS. Graceful

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -110,10 +110,11 @@ def test_good_body_passes_all():
     # v3-gated body-only checks (check 18 `check_data_shape`, check 19
     # `check_data_subset_disclosure`, check 19b
     # `check_data_unwrapped_example_table` WARN, check 20
-    # `check_v3_word_caps`), the FOUR v4-gated body-only checks (check 18
-    # `check_v4_methodology_shape`, check 20 `check_v4_word_caps`, check
+    # `check_v3_word_caps`), the THREE v4-gated body-only checks (check 18
+    # `check_v4_methodology_shape`, check
     # 21 `check_v4_results_beat` WARN, check 27
-    # `check_v4_no_bare_issue_refs`) — each
+    # `check_v4_no_bare_issue_refs`; check 20 v4 `check_v4_word_caps`
+    # moved to the appended-outside set — it needs `issue`, #921) — each
     # a PASS-skip on this non-v3/non-v4 fixture — PLUS the FOUR
     # generation-agnostic checks: check 22
     # (`check_figure_url_sha_matches_repro`), a NO-OP PASS here because
@@ -130,12 +131,14 @@ def test_good_body_passes_all():
     # is a vacuous PASS here because this fixture carries no
     # availability-denial-near-artifact line. verify_text prepends check 0
     # (body-nonstub) + check 0b (no-duplicate-frontmatter), runs CHECKS[1:]
-    # (32 functions), then appends the Goal soft check, the Lens 14
+    # (31 functions), then appends the Goal soft check, the Lens 14
     # concerns-audit, the check-16 lr-matches-plan reconciliation, the
     # check-17 Context provenance-row read, the v3 check-21
-    # body-Parameters-⊆-doc reconciliation (PASS-skip with no doc), AND the
+    # body-Parameters-⊆-doc reconciliation (PASS-skip with no doc), the v4
+    # check-20 word caps (needs `issue` for the events-based round budget,
+    # #921; PASS-skip: not a v4 body), AND the
     # #732 judge-API-error denominator check (PASS-skip: legacy body) →
-    # 40 results total (2 prepended + CHECKS[1:]=32 + 6 appended). The
+    # 40 results total (2 prepended + CHECKS[1:]=31 + 7 appended). The
     # Lens 14 / check-16 results are PASS-skips when no concerns.jsonl /
     # plans/plan.md sibling is available; check 17 and the v3/v4 checks
     # are PASS-skips on this legacy (pre-v2-sentinel) fixture.
@@ -2429,15 +2432,17 @@ def test_audit_context_row_blockquote_exempt():
 
 
 def test_checks_list_size():
-    """CHECKS contains 33 body-only functions: the 20 pre-v3 checks
+    """CHECKS contains 32 body-only functions: the 20 pre-v3 checks
     (the 18 under the 2-content-section spec, the nested-design (v2)
     sentinel-gated `check_tldr_nested_structure`, and the check-8b
     Reproducibility artifact-URL existence probe), the four
-    v3-gated body-only checks added 2026-W24, and the FOUR v4-gated
+    v3-gated body-only checks added 2026-W24, and the THREE v4-gated
     body-only checks (`check_v4_methodology_shape`,
-    `check_v4_word_caps`, `check_v4_results_beat`, plus check 27
+    `check_v4_results_beat`, plus check 27
     `check_v4_no_bare_issue_refs` — bare `#K` refs in the standalone
-    sections, #900). The four
+    sections, #900; check 20 v4 `check_v4_word_caps` joined the
+    appended-outside set — it needs `issue` for the events-based
+    folded-round budget scaling, #921). The four
     v3-gated checks added 2026-W24 are — check 18
     (`check_data_shape`), check 19 (`check_data_subset_disclosure`),
     check 19b (`check_data_unwrapped_example_table`, WARN), check 20
@@ -2463,12 +2468,14 @@ def test_checks_list_size():
     the check-16 lr-matches-plan (needs the plan), the check-17 Context
     provenance row (needs frontmatter + original-body.md), the v3
     check-21 body-Parameters-⊆-doc (needs the methodology doc path),
-    and the #732 judge-API-error denominator check (needs eval JSONs).
-    So `verify_text` returns 40 results (2 prepended + CHECKS[1:]=32 +
-    6 appended — see `test_good_body_passes_all`), but `CHECKS` stays
-    at 33.
+    the v4 check-20 word caps (needs `issue` for the events-based
+    folded-round budget scaling, #921), and the #732 judge-API-error
+    denominator check (needs eval JSONs).
+    So `verify_text` returns 40 results (2 prepended + CHECKS[1:]=31 +
+    7 appended — see `test_good_body_passes_all`), but `CHECKS` stays
+    at 32.
     """
-    assert len(verify_task_body.CHECKS) == 33
+    assert len(verify_task_body.CHECKS) == 32
 
 
 # ─── Check 14: MDX-safe prose (regex layer + real-parse backstop) ───
@@ -4170,6 +4177,12 @@ def test_v3_total_prose_budget_scales_with_followup_rounds():
         )
         == 2
     )
+    # Budget formula pin: 2 extra rounds -> 800 + 2 x 250 = 1300.
+    assert (
+        verify_task_body.V3_TOTAL_PROSE_BASE_WORDS
+        + 2 * verify_task_body.V3_TOTAL_PROSE_PER_EXTRA_ROUND_WORDS
+        == 1300
+    )
 
 
 # ─── check 21: body Parameters ⊆ methodology-doc §2 table ─────────────────
@@ -4664,6 +4677,187 @@ def test_v4_per_result_prose_over_180_words_fails():
     r = _results_by_name(results)["v4 conciseness caps"]
     assert not r.passed
     assert "result" in r.detail
+
+
+# ─── check 20 (v4): folded-round budget scaling (#921) ─────────────────────
+#
+# v4 bodies carry no `## What I ran` Rounds table, so the v3 round counter
+# always scored 0 (incident #763: a 2-round body WARNed at budget 800).
+# The v4 counter max-reconciles two signals: footer round clauses +
+# non-retroactive `epm:same-issue-followup-run` events markers.
+
+
+def _v4_fat_body(n_blocks: int = 6) -> str:
+    """Inflate `_V4_GOOD_BODY` with `n_blocks` extra `### <result>` blocks
+    (~150 prose words each, every block under the 180-word hard cap) so
+    total content prose lands above the 800-word base budget. 6 blocks
+    lands strictly in (800, 1300); 10 blocks exceeds 1300."""
+    filler = "".join(
+        f"\n### Extra result heading {i}\n\n"
+        "Plotted: filler.\n\n"
+        "![alt](https://raw.githubusercontent.com/superkaiba/explore-persona-space/"
+        "0123456789abcdef/figures/issue_999/hero.png)\n\n"
+        "> **Figure.** filler.\n\n" + " ".join(["word"] * 150) + "\n"
+        for i in range(n_blocks)
+    )
+    return _V4_GOOD_BODY.replace("\n---\n**Repro:**", filler + "\n---\n**Repro:**")
+
+
+def test_v4_round_count_footer_two_labels():
+    """Two labeled footer round clauses -> extra_rounds 2, source `footer`."""
+    body = _V4_GOOD_BODY.replace(
+        "- Originating prompt: origin prompt not recorded",
+        "- Originating prompt: origin prompt not recorded\n"
+        "- same-issue follow-up round `round-a` (proposer-initiated) — run 2026-07-01 · "
+        "same-issue follow-up round `round-b` (user-directed) — run 2026-07-02",
+    )
+    assert verify_task_body._count_extra_followup_rounds_v4(body, None) == (2, "footer")
+
+
+def test_v4_round_count_dedupes_labels_and_ignores_plural_and_prose():
+    """Repeated label counts once; plural 'rounds' prose counts zero; a
+    clause OUTSIDE the footer (Goal/Methodology prose, the #811 shape)
+    counts zero."""
+    # (a) same label twice in the footer -> 1; (b) plural in footer -> +0.
+    body = _V4_GOOD_BODY.replace(
+        "- Originating prompt: origin prompt not recorded",
+        "- same-issue follow-up round `round-a` — re-verified as "
+        "same-issue follow-up round `round-a` · same-issue follow-up rounds "
+        "also name each round",
+    )
+    assert verify_task_body._count_extra_followup_rounds_v4(body, None) == (1, "footer")
+    # (c) phrase in body prose, not footer -> 0.
+    body2 = _V4_GOOD_BODY.replace(
+        "- **Design:**",
+        "- A same-issue follow-up round then folded that sweep. **Design:**",
+    )
+    assert verify_task_body._count_extra_followup_rounds_v4(body2, None) == (0, "none")
+
+
+def test_v4_round_count_footer_numbered_variant_case_insensitive():
+    """Corpus-replay pin (Methodology-critic catch, round 1): #685's footer
+    carries the sentence-initial numbered variant — the regex must match it
+    (IGNORECASE + the `<n> (label: ` infix), capturing the backticked label."""
+    body = _V4_GOOD_BODY.replace(
+        "- Originating prompt: origin prompt not recorded",
+        "- Originating prompt: origin prompt not recorded\n"
+        "- Same-issue follow-up round 2 (label: `signed-cosine-matched-position-u`, "
+        "folded 2026-07-01).",
+    )
+    assert verify_task_body._count_extra_followup_rounds_v4(body, None) == (1, "footer")
+
+
+def test_v4_round_count_events_leg_excludes_retroactive_close(monkeypatch):
+    """(events) Run markers count distinct labels; retroactive-close
+    bookkeeping (line-leading AND the single-line mid-line corpus shape)
+    and non-run kinds are excluded; max() reconciles with the footer."""
+    import explore_persona_space.task_workflow as tw
+
+    fake = [
+        {
+            "kind": "epm:same-issue-followup-run",
+            "note": "followup_label: r-a\nsource: user-chat\noutcome: folded new results",
+        },
+        {
+            "kind": "epm:same-issue-followup-run",
+            "note": "followup_label: r-ghost\noutcome: retroactive-close — evidence",
+        },
+        # SINGLE-LINE note (the real corpus shape, fact-check 2026-07-03):
+        # outcome is mid-line — only the mid-line fallback can see it.
+        {
+            "kind": "epm:same-issue-followup-run",
+            "note": "followup_label: r-ghost2 source: proposer-9b outcome: retroactive-close — ev",
+        },
+        {"kind": "epm:progress", "note": "followup_label: not-a-run"},
+    ]
+    monkeypatch.setattr(tw, "list_events", lambda n: fake)
+    assert verify_task_body._followup_run_marker_rounds(123) == 1
+    # Fixture footer carries no round clause -> events leg wins.
+    assert verify_task_body._count_extra_followup_rounds_v4(_V4_GOOD_BODY, 123) == (1, "events")
+
+
+def test_v4_round_count_graceful_when_issue_unknown(monkeypatch):
+    """Unknown issue id -> events leg 0, no crash (bare `--file` under a
+    numeric tmp dir); registry corruption (`StaleTaskPathError`, a
+    FileNotFoundError SUBCLASS) still propagates."""
+    import explore_persona_space.task_workflow as tw
+
+    def _boom(n):
+        raise FileNotFoundError(n)
+
+    monkeypatch.setattr(tw, "list_events", _boom)
+    assert verify_task_body._followup_run_marker_rounds(999999) == 0
+    assert verify_task_body._count_extra_followup_rounds_v4(_V4_GOOD_BODY, 999999) == (0, "none")
+
+    def _stale(n):
+        raise tw.StaleTaskPathError("registry entry stale for task")
+
+    monkeypatch.setattr(tw, "list_events", _stale)
+    with pytest.raises(tw.StaleTaskPathError):
+        verify_task_body._followup_run_marker_rounds(999999)
+
+
+def test_v4_total_prose_budget_scales_with_folded_rounds():
+    """(End-to-end, the #763 incident shape.) Same >800-word body: with two
+    footer round clauses the total-prose WARN clears at budget 1300;
+    without them it fires naming budget 800 [none]. A >1300-word variant
+    WITH the clauses pins the message shape: budget 1300 + [footer]."""
+    fat = _v4_fat_body(6)  # >800 and <1300 total-prose words
+
+    def _with_rounds(body: str) -> str:
+        return body.replace(
+            "- Originating prompt: origin prompt not recorded",
+            "- Originating prompt: origin prompt not recorded\n"
+            "- same-issue follow-up round `round-a` — run 2026-07-01 · "
+            "same-issue follow-up round `round-b` — run 2026-07-02",
+        )
+
+    _ok, res = verify_task_body.verify_text(_with_rounds(fat))
+    assert "total content prose" not in _results_by_name(res)["v4 conciseness caps"].detail
+    _ok2, res2 = verify_task_body.verify_text(fat)
+    detail2 = _results_by_name(res2)["v4 conciseness caps"].detail
+    assert "budget 800" in detail2
+    assert "[none]" in detail2
+    # Message-shape pin: >1300 words + 2 footer rounds -> WARN names the
+    # scaled budget and the winning source tag.
+    _ok3, res3 = verify_task_body.verify_text(_with_rounds(_v4_fat_body(10)))
+    detail3 = _results_by_name(res3)["v4 conciseness caps"].detail
+    assert "budget 1300" in detail3
+    assert "[footer]" in detail3
+
+
+def test_v4_prose_budget_events_leg_through_verify_text(monkeypatch):
+    """(MUST-FIX, round-1 alternatives reconcile) Issue-mode WIRING pin:
+    the events leg must flow through the PUBLIC dispatch path
+    `verify_text(body, issue=...) -> check_v4_word_caps(body, issue=issue)`.
+    Kills the mutant that drops `issue=issue` at the verify_text call site —
+    under that mutation every other test still passes (helpers are tested
+    directly; the footer end-to-end needs no issue), and #685-shaped
+    events-only bodies would silently keep the zero-round budget."""
+    import explore_persona_space.task_workflow as tw
+
+    fake = [
+        {
+            "kind": "epm:same-issue-followup-run",
+            "note": "followup_label: r-a source: proposer-9b outcome: folded",
+        },
+        {
+            "kind": "epm:same-issue-followup-run",
+            "note": "followup_label: r-b source: proposer-9b outcome: folded",
+        },
+    ]
+    monkeypatch.setattr(tw, "list_events", lambda n: fake)
+    fat = _v4_fat_body(6)  # >800 and <1300 words; NO footer round clauses
+    _ok, res = verify_task_body.verify_text(fat, issue=123)
+    detail = _results_by_name(res)["v4 conciseness caps"].detail
+    assert "total content prose" not in detail  # events leg engaged via verify_text
+    _ok2, res2 = verify_task_body.verify_text(fat)  # no issue -> footer-only -> 800
+    assert "budget 800" in _results_by_name(res2)["v4 conciseness caps"].detail
+    # Message-shape pin: >1300 words, events-only -> budget 1300 + [events].
+    _ok3, res3 = verify_task_body.verify_text(_v4_fat_body(10), issue=123)
+    detail3 = _results_by_name(res3)["v4 conciseness caps"].detail
+    assert "budget 1300" in detail3
+    assert "[events]" in detail3
 
 
 def test_v4_lr_reconciles_from_methodology(tmp_path):


### PR DESCRIPTION
Closes task #921.

check 20's WARN-only total-prose budget always scored 0 follow-up rounds on v4 bodies (the counter read a v3-only `## What I ran` Rounds table). This adds `_count_extra_followup_rounds_v4` = max(footer round-clause count, non-retroactive `epm:same-issue-followup-run` marker count), relocates `check_v4_word_caps` to the `issue=`-threaded appended dispatch in `verify_text`, keeps v3 byte-unchanged, adds 7 pinning tests (incl. a mutant-killing wiring pin), and pins the footer clause form in SPEC.md.

Incident: #763 (budget 800 on a two-round body → Codex critic lens-FAIL → reconciler overrule). Post-fix: #763 → budget 1300 `[footer+events]`.

Pipeline: plan v3 (critic ensemble, 1 REVISE round addressed) · code-review PASS+PASS · test-verdict PASS (2108 passed touched-subset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)