### PR TITLE
workflow-fix #927: mint fresh EPS_ATTEMPT_ID per launch (lease-follows-launch)

### DIFF
--- a/src/explore_persona_space/backends/gcp.py
+++ b/src/explore_persona_space/backends/gcp.py
@@ -720,10 +720,13 @@ def attempt_id_for(spec: RunSpec) -> str:
     Used as a sub-folder under HF data / model paths AND as a sentinel
     sub-directory on the VM scratch so a fresh idempotent re-run after
     Spot preemption never overwrites an earlier attempt's artifacts.
-    Reads ``spec.extra["attempt_id"]`` if set (the router/orchestrator
-    passes a deterministic per-attempt id so reconnect after orchestrator
-    re-spawn picks up the same namespace); otherwise falls back to a
-    timestamp-only tag (``att-YYYYMMDD-HHMMSS``).
+    Reads ``spec.extra["attempt_id"]`` if set (the router threads a
+    FRESH per-launch id, #927); otherwise falls back to a timestamp-only
+    tag (``att-YYYYMMDD-HHMMSS``). Reconnect namespace stability comes
+    from the ``eps-attempt`` instance-label recovery in
+    :func:`reconnect_or_none` (``launch()`` prefers the recovered label
+    id over this value on reconnect), NOT from cross-launch reuse of the
+    threaded id.
 
     The tag is shell-safe (only ``[A-Za-z0-9_-]``); the renderer threads
     it verbatim into the startup-script + the HF-paths declaration.

--- a/src/explore_persona_space/backends/router.py
+++ b/src/explore_persona_space/backends/router.py
@@ -777,10 +777,13 @@ class Lease:
       stale (the orchestrator's ``set-status approved`` flow should have
       cleared the old lease, but a fresh attempt for a different
       hyperparameter set is also OK — we replace the lease).
-    * ``attempt_id`` — stable per-attempt id used as the GCP artifact
-      namespace AND as the reconnect key. The GCP backend reads this
-      from ``spec.extra["attempt_id"]``; the router sets it here so
-      every submit/provision uses the SAME id across the lease lifetime.
+    * ``attempt_id`` — the attempt id of the LAST fresh submit (the GCP
+      artifact namespace for that launch). Minted FRESH per launch by
+      ``_thread_attempt_id_into`` and overwritten here at each fresh
+      submit ("lease follows the launch", #927) — NOT stable across the
+      lease lifetime. Reconnect id-stability comes from the router-level
+      reconnect early-return + the GCP ``eps-attempt`` instance label
+      recovery, never from this field.
     * ``backend`` — which backend was used last (``None`` if no submit
       has happened yet but the lease was opened to claim the attempt id).
     * ``cluster`` — cluster name for SLURM backends (``None`` for GCP).
@@ -3940,6 +3943,9 @@ def _attempt_one_gcp_rung(
             lease = Lease(
                 issue=int(spec.issue),
                 spec_hash=spec_hash(spec),
+                # Placeholder only — superseded by the fresh per-launch mint in
+                # _thread_attempt_id_into just before _prepare_and_launch below
+                # (#927); this lease exists here so the cap counter has a home.
                 attempt_id=_make_attempt_id(),
             )
         today = _today_utc_iso()
@@ -4365,9 +4371,11 @@ def _lease_after_submit(
     lease-write all hold the same flock (the read happened when the
     caller opened the transaction; this returns the new value the caller
     will hand to ``write_fn``). Pre-existing GCP attempt counter +
-    spec_hash + attempt_id fields are preserved on ``lease``; absent
-    lease → fresh one with the spec's attempt_id (or a freshly minted
-    one if none).
+    spec_hash + attempt_id fields are preserved on ``lease`` — the
+    threading step (:func:`_thread_attempt_id_into`) already set
+    ``attempt_id`` to THIS launch's id, so preserving it here records the
+    id the launch actually used. Absent lease → fresh one with the
+    spec's attempt_id (or a freshly minted one if none).
     """
     if lease is None:
         lease = Lease(
@@ -4406,58 +4414,58 @@ def _persist_lease_after_submit(
         write(_lease_after_submit(lease, spec, backend_kind, cluster, handle))
 
 
-def _thread_attempt_id(spec: RunSpec, store: LeaseStore) -> RunSpec:
-    """Ensure ``spec.extra["attempt_id"]`` is set + matches the lease.
-
-    Convenience wrapper that opens its own transaction; used ONLY when
-    the caller is NOT already inside a transaction (the override+auto
-    paths now hold one flock across reconnect-check → launch → lease-write
-    and use :func:`_thread_attempt_id_into` instead to avoid the re-entry
-    deadlock — :py:func:`fcntl.flock` from a fresh open-file-description
-    in the same process blocks against any held lock).
-    """
-    current_id = (spec.extra or {}).get("attempt_id")
-    with store.transaction(spec.issue) as (lease, write):
-        if lease is None:
-            attempt_id = str(current_id or _make_attempt_id())
-            lease = Lease(
-                issue=int(spec.issue),
-                spec_hash=spec_hash(spec),
-                attempt_id=attempt_id,
-            )
-            write(lease)
-        else:
-            attempt_id = lease.attempt_id
-
-    # RunSpec is frozen; replace ``extra`` with a new dict carrying the id.
-    new_extra = dict(spec.extra or {})
-    new_extra["attempt_id"] = attempt_id
-    return replace(spec, extra=new_extra)
-
-
 def _thread_attempt_id_into(
     spec: RunSpec,
     lease: Lease | None,
     write_fn: Callable[[Lease], None],
 ) -> tuple[RunSpec, Lease]:
-    """Same contract as :func:`_thread_attempt_id` but reuses an OPEN transaction.
+    """Mint a FRESH attempt id for this launch + thread it into the spec (#927).
 
     Returns ``(new_spec, lease)`` where ``new_spec`` carries the threaded
     ``attempt_id`` in ``extra``, and ``lease`` is the (possibly freshly
-    created) lease record. If lease was None, a fresh one is written via
-    ``write_fn`` — the caller's transaction owns the flock.
+    created) lease record — updated to the id the launch actually uses
+    and written via ``write_fn`` on BOTH branches ("lease follows the
+    launch", never vice versa). Every call site is a fresh-submit path
+    (the reconnect probes early-return above it), so "called ⇒ mint
+    fresh" is the invariant: reusing ``lease.attempt_id`` made a NEW
+    launch inherit a dead prior attempt's crash-persist / sentinel /
+    ``expected_artifacts`` namespace (#825: three relaunches all wrote
+    under ``att-20260702-061417``).
+
+    Reconnect id-stability does NOT live here: the router-level reconnect
+    early-returns before this function runs, and GCP recovers the
+    original id from the instance's ``eps-attempt`` label
+    (``gcp.reconnect_or_none``). One caveat on that label path: on the
+    ``GcpBackend.launch``-INTERNAL reconnect race (the instance came
+    alive between the router probe and ``launch()``), the instance's
+    ``eps-attempt`` LABEL id wins while the lease records the unused
+    fresh mint — so "lease follows the launch" is NOT guaranteed on that
+    race path; a future lease-id consumer must not design against it
+    (the handle sidecar, not the lease, names the live attempt).
+
+    A caller-pinned ``spec.extra["attempt_id"]`` takes precedence over
+    the fresh mint — even when a lease exists. Pinning is for explicit
+    re-attach tooling ONLY: a pinned spec re-routed across relaunches
+    reproduces the #825 namespace-collision class by construction.
+
+    MUST be called inside the caller's OPEN ``store.transaction`` — the
+    caller's transaction owns the flock (a nested ``store.transaction``
+    would deadlock: :py:func:`fcntl.flock` from a fresh
+    open-file-description in the same process blocks against any held
+    lock), and the in-transaction ``write_fn`` keeps the
+    reconnect-check → launch → lease-write sequence atomic.
     """
     current_id = (spec.extra or {}).get("attempt_id")
+    attempt_id = str(current_id or _make_attempt_id())
     if lease is None:
-        attempt_id = str(current_id or _make_attempt_id())
         lease = Lease(
             issue=int(spec.issue),
             spec_hash=spec_hash(spec),
             attempt_id=attempt_id,
         )
-        write_fn(lease)
     else:
-        attempt_id = lease.attempt_id
+        lease.attempt_id = attempt_id  # lease follows the launch, never vice versa
+    write_fn(lease)
     new_extra = dict(spec.extra or {})
     new_extra["attempt_id"] = attempt_id
     return replace(spec, extra=new_extra), lease

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -67,6 +67,7 @@ from explore_persona_space.backends.router import (
 from explore_persona_space.backends.router import RouteAttempt as RouteAttempt
 from explore_persona_space.backends.router import _attempt_to_dict as _attempt_to_dict
 from explore_persona_space.backends.router import _gcp_ladder_specs as _ladder_specs
+from explore_persona_space.backends.router import _thread_attempt_id_into as _thread_attempt_id_into
 
 #: The pre-GCP-first auto order (free SLURM lanes first, GCP as the
 #: terminal escalation). Tests that specifically exercise the
@@ -1088,6 +1089,177 @@ def test_lease_dir_created_with_owner_only_mode(tmp_path):
     store.write(Lease(issue=1, spec_hash="h", attempt_id="a"))
     mode = store.lease_dir.stat().st_mode & 0o777
     assert mode == 0o700, f"lease dir mode={oct(mode)}"
+
+
+# ---------------------------------------------------------------------------
+# Fresh attempt-id per launch (#927) — _thread_attempt_id_into mints per call;
+# reconnect keeps the original id (router early-return + GCP label recovery).
+# ---------------------------------------------------------------------------
+
+_ATTEMPT_ID_RE = re.compile(r"att-\d{8}-\d{6}")
+
+
+def test_thread_attempt_id_into_mints_fresh_id_when_lease_exists():
+    """#927 acceptance (1), unit level: a pre-existing lease's attempt_id is
+    NOT reused — a fresh ``att-YYYYMMDD-HHMMSS`` id is minted, threaded into
+    the spec, AND written back to the lease (lease follows the launch)."""
+    spec = _spec(backend=None)
+    lease = Lease(issue=137, spec_hash="h", attempt_id="att-old")
+    writes: list[Lease] = []
+    new_spec, new_lease = _thread_attempt_id_into(spec, lease, writes.append)
+    fresh = new_spec.extra["attempt_id"]
+    assert fresh != "att-old"
+    assert _ATTEMPT_ID_RE.fullmatch(fresh), fresh
+    # Lease-follows-launch: the lease records the id the launch will use,
+    # and the write happened inside the caller's transaction.
+    assert new_lease.attempt_id == fresh
+    assert writes and writes[-1].attempt_id == fresh
+
+
+def test_thread_attempt_id_into_preserves_counters_and_failover_fields():
+    """#927 acceptance (4): only ``attempt_id`` changes across the threading
+    write — GCP attempt counters, failover-identity fields, backend, and
+    job_id all survive. Called TWICE on the same lease (the per-rung ladder
+    shape: each rung re-threads the ORIGINAL spec inside one transaction;
+    per-rung re-mint churn is expected behavior) — fields survive BOTH."""
+    today = datetime.now(tz=UTC).date().isoformat()
+    lease = Lease(
+        issue=137,
+        spec_hash="h",
+        attempt_id="att-old",
+        backend="gcp",
+        cluster=None,
+        job_id="instance-1",
+        gcp_attempts_today=3,
+        gcp_attempts_date=today,
+        gcp_failover_of={"pod_name": "eps-issue-1", "job_id": "z"},
+        runpod_wedge_failover_of={"pod_name": "pod-1", "job_id": "w"},
+        runpod_cuda_ima_failover_of={"pod_name": "pod-1", "job_id": "c"},
+    )
+    spec = _spec(backend=None)
+    writes: list[Lease] = []
+    _s1, l1 = _thread_attempt_id_into(spec, lease, writes.append)
+    _s2, l2 = _thread_attempt_id_into(spec, l1, writes.append)
+    assert len(writes) == 2  # one lease write per threading call
+    for le in (l1, l2):
+        assert le.gcp_attempts_today == 3
+        assert le.gcp_attempts_date == today
+        assert le.gcp_failover_of == {"pod_name": "eps-issue-1", "job_id": "z"}
+        assert le.runpod_wedge_failover_of == {"pod_name": "pod-1", "job_id": "w"}
+        assert le.runpod_cuda_ima_failover_of == {"pod_name": "pod-1", "job_id": "c"}
+        assert le.backend == "gcp"
+        assert le.job_id == "instance-1"
+        assert le.attempt_id != "att-old"
+
+
+def test_thread_attempt_id_into_honors_caller_pinned_extra_id():
+    """A caller-pinned ``spec.extra["attempt_id"]`` wins over the fresh mint
+    — even when a lease exists (explicit re-attach tooling ONLY; see the
+    function docstring for why routine pinning re-creates #825) — and is
+    written to the lease verbatim."""
+    spec = RunSpec(issue=137, intent="lora-7b", backend="auto", extra={"attempt_id": "att-pin"})
+    lease = Lease(issue=137, spec_hash="h", attempt_id="att-old")
+    writes: list[Lease] = []
+    new_spec, new_lease = _thread_attempt_id_into(spec, lease, writes.append)
+    assert new_spec.extra["attempt_id"] == "att-pin"
+    assert new_lease.attempt_id == "att-pin"
+    assert writes and writes[-1].attempt_id == "att-pin"
+
+
+def test_thread_attempt_id_into_creates_lease_when_absent():
+    """Regression pin: the lease-None branch keeps its pre-#927 behavior —
+    a fresh lease is created with the minted id and written."""
+    spec = _spec(backend=None)
+    writes: list[Lease] = []
+    new_spec, lease = _thread_attempt_id_into(spec, None, writes.append)
+    aid = new_spec.extra["attempt_id"]
+    assert _ATTEMPT_ID_RE.fullmatch(aid), aid
+    assert lease.issue == 137
+    assert lease.spec_hash == spec_hash(spec)
+    assert lease.attempt_id == aid
+    assert writes and writes[0] is lease
+
+
+def test_fresh_gcp_launch_after_dead_prior_attempt_uses_new_attempt_id(
+    lease_store, marker_poster, captured_markers
+):
+    """#927 acceptance (1), route level: a fresh GCP launch with a
+    pre-existing lease carrying a dead prior attempt's id launches with a
+    DIFFERENT attempt_id, and the persisted lease reads back the NEW id
+    (the #825 shape: three relaunches all inherited the dead attempt's
+    crash-persist / sentinel namespace)."""
+    gcp = _GcpBackendDouble()
+    stale_spec = _spec(backend=None)
+    lease_store.write(
+        Lease(
+            issue=137,
+            spec_hash=spec_hash(stale_spec),  # same shape — the lease is NOT stale-keyed away
+            attempt_id="att-dead-1",
+            backend="gcp",
+            job_id="instance-dead",
+        )
+    )
+    result = route(
+        _spec(backend=None),
+        runpod_backend=_ExplodingRunpod(),
+        gcp_backend=gcp,
+        lease_store=lease_store,
+        # reconnect_fn omitted → reconnect disabled (the dead instance is gone).
+        marker_poster=marker_poster,
+        config=RouterConfig(free_wait_seconds=1, poll_interval=0.0),
+        now_fn=_clock(),
+        sleep_fn=lambda _s: None,
+    )
+    assert result.chosen_kind == "gcp"
+    assert len(gcp.launches) == 1
+    launched_id = gcp.launches[0].extra["attempt_id"]
+    assert launched_id != "att-dead-1"
+    assert _ATTEMPT_ID_RE.fullmatch(launched_id), launched_id
+    read_back = lease_store.read(137)
+    assert read_back is not None
+    assert read_back.attempt_id == launched_id  # lease follows the launch
+
+
+def test_reconnect_keeps_prior_attempt_id_no_remint(lease_store, marker_poster, captured_markers):
+    """#927 acceptance (2): a reconnect to a still-live instance early-returns
+    with ``ROUTE_REASON_RECONNECT`` — no launch, no threading call — and the
+    lease's attempt_id stays byte-unchanged."""
+    gcp = _GcpBackendDouble()
+    live_spec = _spec(backend=None)
+    lease_store.write(
+        Lease(
+            issue=137,
+            spec_hash=spec_hash(live_spec),
+            attempt_id="att-orig",
+            backend="gcp",
+            job_id="instance-live",
+        )
+    )
+    live = RunHandle(
+        backend="gcp",
+        cluster=None,
+        job_id="instance-live",
+        pod_name="eps-issue-137",
+        scratch_dir="/workspace/eps-issue-137",
+        log_path="/workspace/logs/issue-137.log",
+        extra={"issue": 137, "zone": "us-central1-a", "attempt_id": "att-orig"},
+    )
+    result = route(
+        _spec(backend=None),
+        runpod_backend=_ExplodingRunpod(),
+        gcp_backend=gcp,
+        lease_store=lease_store,
+        reconnect_fn=lambda _b, k, _s: live if k == "gcp" else None,
+        marker_poster=marker_poster,
+        config=RouterConfig(free_wait_seconds=1, poll_interval=0.0),
+        now_fn=_clock(),
+        sleep_fn=lambda _s: None,
+    )
+    assert result.reason == ROUTE_REASON_RECONNECT
+    assert gcp.launches == []  # reconnect — never a fresh provision
+    read_back = lease_store.read(137)
+    assert read_back is not None
+    assert read_back.attempt_id == "att-orig"  # byte-unchanged: no re-mint on reconnect
 
 
 def test_unknown_submitted_recovery_via_reconnect(lease_store):

--- a/tests/test_runpod_workload_exec.py
+++ b/tests/test_runpod_workload_exec.py
@@ -180,6 +180,17 @@ def test_launch_skips_execution_without_opt_in(monkeypatch, caplog):
     assert warning.index("THIS pod") < warning.index("--execute-workload")
 
 
+def test_launch_mints_own_rp_attempt_id_ignoring_spec_threaded_id(monkeypatch):
+    """#927: RunPod is per-launch by construction — ``launch`` mints its own
+    ``rp-…`` attempt id unconditionally, so a router-threaded (or stale)
+    ``spec.extra["attempt_id"]`` is inert on this lane."""
+    _wire_exec_leg(monkeypatch, [])
+    handle = RP.RunPodBackend().launch(_spec(extra={"attempt_id": "att-threaded-by-router"}))
+    minted = handle.extra["runpod_attempt_id"]
+    assert minted != "att-threaded-by-router"
+    assert re.fullmatch(r"rp-\d{8}T\d{6}Z-[0-9a-f]{4}", minted), minted
+
+
 def test_launch_hydra_run_without_flag_untouched(monkeypatch, caplog):
     """AC8: a hydra-args RunPod launch WITHOUT the flag no-ops the leg exactly
     as today — no SSH calls, no WARNING, workload_executed False."""


### PR DESCRIPTION
Closes task #927. Mint a fresh attempt id per genuinely NEW launch in backends/router.py::_thread_attempt_id_into (lease-follows-launch); reconnect keeps its id via router early-returns + the GCP eps-attempt label recovery. Deletes the zero-caller _thread_attempt_id wrapper; docstring updates; 7 new tests. Code-review ensemble PASS+PASS; test-verdict PASS (2680 passed).