### PR TITLE
task #930: workflow_lint --check-phase-done-reserved (reserved [phase=done] emission lint)

### DIFF
--- a/.claude/rules/pod-side-reporting.md
+++ b/.claude/rules/pod-side-reporting.md
@@ -37,7 +37,12 @@ marker will be silently skipped. Two requirements, no exceptions:
    terminal line (`[phase=done] SMOKE COMPLETE ...`) and only survives it
    via pid/sentinel corroboration (incident #545, 2026-06-11: a per-cell
    `[phase=done]` echo produced a false `status=done` while the
-   dispatcher was alive and GPUs were at 85%).
+   dispatcher was alive and GPUs were at 85%). Mechanically enforced by
+   `scripts/workflow_lint.py --check-phase-done-reserved` (no-flags
+   default run + the `workflow-lint-phase-done-reserved` pre-commit hook
+   on any `scripts/*.sh|py` change): a `[phase=done]` emission in a phase
+   script invoked non-redirected by a `scripts/**/*.sh` dispatcher FAILs;
+   legacy edges are frozen in `PHASE_DONE_EDGE_LEGACY_ALLOWLIST`.
 
 2. **End-of-run sentinel with poll_pipeline's required keys.** Write the
    final results sentinel to `/workspace/logs/issue-<N>-<kind_slug>-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,15 @@ repos:
         files: ^(src/explore_persona_space/experiments/.*\.py|scripts/workflow_lint\.py)$
         pass_filenames: false
 
+      - id: workflow-lint-phase-done-reserved
+        name: Forbid reserved [phase=done] emissions in dispatcher-invoked phase scripts
+        entry: uv run python scripts/workflow_lint.py --check-phase-done-reserved
+        language: system
+        # Fire on ANY scripts/*.sh|py change — a new dispatcher or phase script
+        # is exactly the offender class (#545, #920); the check is sub-second.
+        files: ^scripts/.*\.(sh|py)$
+        pass_filenames: false
+
       - id: check-mcp-json-no-secrets
         name: Refuse secrets in committed .mcp.json
         entry: uv run python scripts/check_mcp_json_no_secrets.py

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -267,6 +267,25 @@ Behaviours:
   so a typo strips a capability with no error); (3) a
   ``disallowedTools:``-only file (research-pm) skips the containment check
   but must not deny a body-mentioned tool.
+* ``--check-phase-done-reserved`` (also bundled into the no-flags default
+  run): walk every ``scripts/**/*.sh`` dispatcher and FAIL any non-redirected
+  invocation of a ``scripts/*.py|*.sh`` phase script that contains a genuine
+  ``[phase=done]`` emission site — the reserved-token contract of
+  ``.claude/rules/pod-side-reporting.md`` requirement 1 (the token in the
+  MAIN dispatcher log is reserved for the dispatcher's single terminal line;
+  a mid-pipeline child emission reads as a false ``status=done`` to
+  ``poll_pipeline.py`` — incidents #545, #920). Emission detection is
+  AST-based for ``.py`` (comments / docstrings / ``re.compile`` match sites
+  never flag) and quote-aware comment-stripped ``echo|printf|print(`` for
+  ``.sh``; a stdout-redirected invocation (the ``> "$WORKER_LOG" 2>&1``
+  per-worker isolation pattern) is skipped, while ``2>&1 | tee`` stays
+  checked. Legacy edges are frozen in
+  :data:`PHASE_DONE_EDGE_LEGACY_ALLOWLIST` ((invoker, target) edge grain,
+  annotated); waive a mode-gated standalone-lane terminal with
+  ``# noqa: phase-done-reserved`` on the emission line or the preceding
+  non-blank line. Also enforced at commit time by the
+  ``workflow-lint-phase-done-reserved`` pre-commit hook on any
+  ``scripts/*.sh|py`` change (#930).
 
 Exit codes:
 
@@ -3774,6 +3793,317 @@ def check_judge_model_pins(
     return errors
 
 
+# --- `--check-phase-done-reserved` (#930): reserved `[phase=done]` token ----
+# The literal reserved token from .claude/rules/pod-side-reporting.md
+# requirement 1: `poll_pipeline.py` declares status="done" when the most
+# recent `[phase=...]` line in the MAIN dispatcher log is `[phase=done]`,
+# so the token is reserved for the dispatcher's single terminal line —
+# a phase script whose stdout flows into that log must never emit it
+# (incident #545, 2026-06-11: a per-cell echo produced a false status=done
+# while GPUs were at 85%; recurred #920 r1: six phase scripts).
+PHASE_DONE_TOKEN = "[phase=done]"
+# Python-target invocation edge on a logical shell line: `uv run python
+# scripts/x.py`, `nohup ... python -u scripts/x.py`, `CUDA_VISIBLE_DEVICES=0
+# uv run python3 scripts/x.py`. `$VAR`-prefixed paths / `python -m` launches
+# deliberately do NOT match (documented false-negative gaps, see the check
+# docstring).
+PHASE_DONE_PY_INVOKE_RE = re.compile(
+    r"""python3?(?:\.\d+)?\s+(?:-[A-Za-z]+\s+)*["']?(scripts/[A-Za-z0-9_./-]+\.py)\b"""
+)
+# Shell-target invocation edge: `bash scripts/x.sh` / `sh scripts/x.sh` /
+# `source scripts/x.sh` — the i488 run_all -> sub-dispatcher class.
+PHASE_DONE_SH_INVOKE_RE = re.compile(
+    r"""(?:\bbash|\bsh(?=\s)|\bsource)\s+["']?(scripts/[A-Za-z0-9_./-]+\.sh)\b"""
+)
+# Stdout-isolation exclusion: matches `> f`, `>> f`, `1> f`, `&> f` (stdout
+# redirected away from the main log — the per-worker isolation pattern,
+# e.g. scripts/issue658_8gpu_dispatch.sh). Does NOT match `2>&1` alone,
+# `2> err.log` (stderr-only; stdout still flows), or `... 2>&1 | tee -a log`
+# (tee duplicates to main stdout — the exact #545-family shape): those edges
+# stay checked. The `(?!\s*&)` lookahead keeps fd-dup forms (`>&2`) out.
+PHASE_DONE_REDIRECT_RE = re.compile(r"(?:^|\s)(?:1?>>?|&>>?)(?!\s*&)")
+# Per-line waiver for a mode-gated standalone-lane terminal (a dual-mode
+# phase script whose emission is OFF the dispatcher path — the issue-920
+# nulls_figures shape). Same placement convention as JUDGE_PIN_WAIVER_RE:
+# the emission line or the immediately preceding non-blank line. Waiver
+# comments MUST name the intended mode/invoker (code-review enforced).
+PHASE_DONE_WAIVER_RE = re.compile(r"#\s*noqa:\s*phase-done-reserved\b")
+# A .sh line is an emission site iff (after quote-aware trailing-comment
+# strip) it carries the token AND one of these emitters — `print\s*\(`
+# covers python-heredoc blocks embedded in .sh (`uv run python - <<'PY'`).
+PHASE_DONE_SH_EMIT_RE = re.compile(r"\becho\b|\bprintf\b|\bprint\s*\(")
+# Logging-ish attribute names whose calls count as .py emission sites
+# (covers logger.info / log.warning / LOGGER.error / sys.stdout.write).
+# `re.compile` / `re.search` are deliberately absent so the poller's own
+# match/detection code never flags.
+PHASE_DONE_PY_EMIT_ATTRS = frozenset(
+    {"debug", "info", "warning", "error", "critical", "exception", "log", "write"}
+)
+# Grandfathered legacy (invoker .sh, target) EDGE pairs — repo-root-relative
+# POSIX paths, annotated per entry (mirrors JUDGE_PIN_LEGACY_ALLOWLIST's
+# style). Edge grain, NOT emitter-file grain: a future NEW dispatcher
+# invoking the same legacy emitter is still flagged. Fixing the legacy
+# emissions is prune-on-touch (NOT this task's scope); stale entries are
+# harmless (frozenset membership). Derivation: live-tree diff-and-adjudicate
+# 2026-07-03 against the task #930 plan §4.5 expected seed.
+PHASE_DONE_EDGE_LEGACY_ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
+    {
+        # #545 family (the original incident's own dispatcher): sweep.py's
+        # terminal print (line ~1516) tees into the main log 4x mid-pipeline:
+        ("scripts/issue545_dispatch.sh", "scripts/issue545_sweep.py"),
+        # #654: extract phase terminal logger.info (line ~387), tee'd to the
+        # main log:
+        ("scripts/issue654_dispatch.sh", "scripts/issue654_extract.py"),
+        # #810 CPU-lane runner: four phase scripts each emit a terminal done
+        # (lines ~530 / ~369 / ~433 / ~426) ahead of the runner's own
+        # terminal (:68). MIGRATE bucket (live-hazard): the #810 family is
+        # still actively churning — a follow-up round re-running this runner
+        # reproduces the false-done with the lint green; fix these emissions
+        # on next touch:
+        ("scripts/issue810_cpu_phase.sh", "scripts/issue810_fit_reconstruction.py"),
+        ("scripts/issue810_cpu_phase.sh", "scripts/issue810_batch_rejudge_highm.py"),
+        ("scripts/issue810_cpu_phase.sh", "scripts/issue810_fit_readout.py"),
+        ("scripts/issue810_cpu_phase.sh", "scripts/issue810_analyze.py"),
+        # i488 run-all invokes two sub-dispatchers (own terminals ~166/~257
+        # + ~121) non-redirected, ahead of run_all's own terminal (:131):
+        ("scripts/i488_run_all.sh", "scripts/i488_phase23_dispatch.sh"),
+        ("scripts/i488_run_all.sh", "scripts/i488_phase4_dispatch.sh"),
+        # #552 (round-1-critique triage, 2026-07-03 — the plan-v1 probe
+        # MISSED this edge; a legacy completed family, same tee-shape class
+        # as #654): prep script's terminal logger.info (line ~277) tees into
+        # the main log at run_issue552_sweep.sh:105 via `2>&1 | tee`:
+        ("scripts/run_issue552_sweep.sh", "scripts/issue_552_prep_good_corpus.py"),
+        # PRE-SEEDED for the in-flight issue-920 branch merge: nulls_figures'
+        # done (line ~781) is the standalone cpu-mid lane's dispatcher
+        # terminal, mode-gated OFF the --gpu-null-only dispatcher path
+        # (verified on the issue-920 branch 2026-07-03); the file is
+        # dual-mode by design:
+        ("scripts/issue920_dispatch.sh", "scripts/issue920_nulls_figures.py"),
+    }
+)
+
+
+def _phase_done_line_waived(lines: list[str], idx: int) -> bool:
+    """Return True iff a ``# noqa: phase-done-reserved`` waiver is on the
+    emission line (``idx``, 0-based) or the immediately preceding non-blank
+    line. For a multi-line ``.py`` call the anchor is the AST call-head
+    lineno — waive at the call head, not beside a continuation-line string
+    literal. Same convention as :func:`_judge_pin_line_waived`."""
+    if 0 <= idx < len(lines) and PHASE_DONE_WAIVER_RE.search(lines[idx]):
+        return True
+    back = idx - 1
+    while back >= 0 and lines[back].strip() == "":
+        back -= 1
+    return back >= 0 and bool(PHASE_DONE_WAIVER_RE.search(lines[back]))
+
+
+def _py_phase_done_emission_lines(target: Path) -> list[int]:
+    """AST-scan a phase ``.py`` for genuine ``[phase=done]`` EMISSION sites,
+    returning sorted 1-based call-head line numbers (waived sites dropped).
+
+    An emission site is an ``ast.Call`` whose func is ``print`` (a bare
+    ``Name``) or an ``Attribute`` in :data:`PHASE_DONE_PY_EMIT_ATTRS`
+    (``logger.info`` / ``sys.stdout.write`` / ...), AND any ``ast.Constant``
+    string reachable by ``ast.walk`` inside the call's positional args
+    carries the literal token (covers f-string ``JoinedStr`` parts and
+    %%-style format strings). Comments, docstrings, ``re.compile`` /
+    ``re.search`` match sites, and ``"[phase=done]" in line`` membership
+    tests are excluded by construction. A ``SyntaxError`` skips the file
+    (a non-parsing .py cannot run as a phase script)."""
+    try:
+        text = target.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    if PHASE_DONE_TOKEN not in text:
+        return []  # cheap pre-filter before parsing
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return []
+    lines = text.splitlines()
+    sites: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name):
+            if func.id != "print":
+                continue
+        elif isinstance(func, ast.Attribute):
+            if func.attr not in PHASE_DONE_PY_EMIT_ATTRS:
+                continue
+        else:
+            continue
+        has_token = any(
+            isinstance(sub, ast.Constant)
+            and isinstance(sub.value, str)
+            and PHASE_DONE_TOKEN in sub.value
+            for arg in node.args
+            for sub in ast.walk(arg)
+        )
+        if not has_token:
+            continue
+        if _phase_done_line_waived(lines, node.lineno - 1):
+            continue
+        sites.add(node.lineno)
+    return sorted(sites)
+
+
+def _strip_sh_trailing_comment(line: str) -> str:
+    """Cut an unquoted trailing ``#`` comment from a shell line via a small
+    quote-state char scanner (tracks single/double-quote state; a ``#``
+    inside either quote kind is kept). Errs toward cutting early on exotic
+    unquoted ``#`` forms (``${#arr[@]}``) — fail-toward-false-negative, the
+    correct direction for a pre-commit-gating lint."""
+    out: list[str] = []
+    in_single = in_double = False
+    for ch in line:
+        if ch == "#" and not in_single and not in_double:
+            break
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        out.append(ch)
+    return "".join(out)
+
+
+def _sh_phase_done_emission_lines(target: Path) -> list[int]:
+    """Line-scan a phase ``.sh`` for genuine ``[phase=done]`` emission sites,
+    returning sorted 1-based line numbers (waived sites dropped). A line is
+    an emission iff, after quote-aware trailing-comment strip, it carries the
+    literal token AND matches :data:`PHASE_DONE_SH_EMIT_RE` (``echo`` /
+    ``printf`` / a python-heredoc ``print(``)."""
+    try:
+        text = target.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    lines = text.splitlines()
+    sites: list[int] = []
+    for idx, raw in enumerate(lines):
+        stripped = _strip_sh_trailing_comment(raw)
+        if PHASE_DONE_TOKEN not in stripped:
+            continue
+        if not PHASE_DONE_SH_EMIT_RE.search(stripped):
+            continue
+        if _phase_done_line_waived(lines, idx):
+            continue
+        sites.append(idx + 1)
+    return sites
+
+
+def check_phase_done_reserved(
+    *,
+    scripts_dir: Path | None = None,
+    allowlist: frozenset[tuple[str, str]] | None = None,
+) -> list[str]:
+    """Walk every ``scripts/**/*.sh`` dispatcher and FAIL any non-redirected
+    invocation of a ``scripts/*.py|*.sh`` phase script whose file contains a
+    genuine ``[phase=done]`` emission site — the reserved-token contract of
+    ``.claude/rules/pod-side-reporting.md`` requirement 1 (#545, #920).
+
+    THE CONTRACT: ``poll_pipeline.py`` declares ``status="done"`` when the
+    most recent ``[phase=...]`` line in the MAIN dispatcher log is
+    ``[phase=done]``, so the token there is reserved for the dispatcher's
+    single terminal line. A phase script launched with stdout flowing into
+    that log (non-redirected, or ``2>&1 | tee``-duplicated) that emits the
+    token mid-pipeline reads as a false ``status=done`` while the run is
+    live (incident #545: GPUs at 85%; recurred #920 r1: six phase scripts).
+
+    VIOLATION UNIT = a non-redirected invocation EDGE ``(invoking .sh,
+    target .py|.sh)`` where the target has ≥1 emission site. A dispatcher's
+    OWN emission sites are unrestricted in count (mode-gated multi-exit
+    dispatchers are ubiquitous and legitimate; static mutual-exclusivity is
+    undecidable), and the suffixed smoke terminal (``[phase=done] SMOKE
+    COMPLETE ...``) is a dispatcher-own-file line, allowed by construction.
+
+    EXCLUSIONS: a logical invocation line that redirects stdout away from
+    the main log (:data:`PHASE_DONE_REDIRECT_RE` — the per-worker isolation
+    pattern) is skipped; comment and ``echo``-preview lines are skipped;
+    ``.py`` emission detection is AST-based (comments / docstrings /
+    ``re.compile``-``re.search`` match sites / membership tests never flag);
+    ``.sh`` emission detection is quote-aware comment-stripped
+    ``echo|printf|print(``. A ``# noqa: phase-done-reserved`` waiver on the
+    emission line or the immediately preceding non-blank line drops that
+    site (the escape for dual-mode files whose emission is mode-gated to a
+    standalone-dispatcher lane; the waiver comment must name the intended
+    mode/invoker). Legacy edges are frozen in
+    :data:`PHASE_DONE_EDGE_LEGACY_ALLOWLIST` (edge grain, annotated).
+
+    RESIDUAL FALSE-NEGATIVE GAPS (documented, all fail toward NOT flagging —
+    the correct direction for a pre-commit gate): (i) ``.py``-dispatcher
+    subprocess fan-out (``issue545_sweep.py -> issue545_eval_cell.py`` — the
+    original #545 emission path; the only live instance sits inside the
+    allowlisted #545 family whose .sh edge keeps it visible); (ii)
+    ``$VAR``-prefixed script paths (``python "$REPO/scripts/x.py"``);
+    (iii) ``python -m`` module launches; (iv) launcher scripts generated at
+    runtime by template-writers; (v) direct append-INTO-the-main-log
+    redirection (``>> "$MAIN_LOG" 2>&1`` — the redirect exclusion cannot
+    tell a per-worker log from the dispatcher's own main log; no live
+    instance — historical shapes use ``tee`` and ARE caught); (vi) a
+    dispatcher's OWN mid-pipeline emissions in a loop (own-file sites are
+    unrestricted by construction).
+
+    ``scripts_dir`` is an override hook for unit tests (production callers
+    pass None → the canonical ``<repo_root>/scripts`` tree); ``allowlist``
+    overrides :data:`PHASE_DONE_EDGE_LEGACY_ALLOWLIST` for tests /
+    re-derivation. Bundled into the no-flags default run AND enforced at
+    commit time by the ``workflow-lint-phase-done-reserved`` pre-commit hook
+    on any ``scripts/*.sh|py`` change.
+    """
+    root = scripts_dir if scripts_dir is not None else _REPO_ROOT / "scripts"
+    allow = allowlist if allowlist is not None else PHASE_DONE_EDGE_LEGACY_ALLOWLIST
+    if not root.exists():
+        return []
+    errors: list[str] = []
+    emission_cache: dict[Path, list[int]] = {}
+    for sh in sorted(root.rglob("*.sh")):
+        if not sh.is_file():
+            continue
+        lines = sh.read_text(encoding="utf-8").splitlines()
+        for first, _last, logical in _iter_logical_shell_lines(lines):
+            stripped = logical.strip()
+            # Comments and dry-run echo previews are not launches.
+            if stripped.startswith("#") or stripped.startswith("echo "):
+                continue
+            m = PHASE_DONE_PY_INVOKE_RE.search(logical) or PHASE_DONE_SH_INVOKE_RE.search(logical)
+            if m is None:
+                continue
+            if PHASE_DONE_REDIRECT_RE.search(logical):
+                continue  # per-worker-log stdout isolation (issue658 pattern)
+            target_rel = m.group(1)
+            target = root / target_rel.removeprefix("scripts/")
+            if not target.is_file() or target == sh:
+                continue
+            if target not in emission_cache:
+                emission_cache[target] = (
+                    _py_phase_done_emission_lines(target)
+                    if target.suffix == ".py"
+                    else _sh_phase_done_emission_lines(target)
+                )
+            sites = emission_cache[target]
+            if not sites:
+                continue
+            sh_rel = _judge_pin_rel(sh)  # repo-rel POSIX, or abs posix for tmp fixtures
+            if (sh_rel, target_rel) in allow:
+                continue
+            errors.append(
+                f"{sh}:{first + 1}: invokes {target_rel} (stdout flows into this "
+                f"dispatcher's main log) but {target_rel} emits the RESERVED "
+                f"{PHASE_DONE_TOKEN} token at line(s) {sites}. The token in the "
+                f"MAIN dispatcher log is reserved for the dispatcher's single "
+                f"terminal line — a mid-pipeline emission reads as a false "
+                f"status=done to poll_pipeline.py (incidents #545, #920). Fix: "
+                f"word the child's completion line without the phase tag, OR "
+                f"redirect the child's stdout to its own log (per-worker "
+                f"pattern: scripts/issue658_8gpu_dispatch.sh), OR waive a "
+                f"mode-gated standalone-lane terminal with "
+                f"'# noqa: phase-done-reserved' on the emission line. See "
+                f".claude/rules/pod-side-reporting.md."
+            )
+    return errors
+
+
 # A live ``Agent(... subagent_type="workflow-improver" ...)`` spawn instruction.
 # Tolerant of whitespace/newlines between the call open and the kwarg and of
 # either quote style. The frozen agent file (`.claude/agents/workflow-improver.md`)
@@ -5545,6 +5875,22 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         "coverage row in the map. GAP: rows PASS but print as WARN. A separate lint "
         "from --check-lessons-index. Bundled into the no-flags default run.",
     )
+    parser.add_argument(
+        "--check-phase-done-reserved",
+        action="store_true",
+        help="Walk scripts/**/*.sh dispatchers and FAIL any non-redirected "
+        "invocation of a scripts/*.py|*.sh phase script that contains a "
+        "genuine [phase=done] emission site — the reserved-token contract of "
+        ".claude/rules/pod-side-reporting.md requirement 1 (a mid-pipeline "
+        "child emission reads as a false status=done to poll_pipeline.py; "
+        "incidents #545, #920). AST-based .py emission detection (comments / "
+        "docstrings / match sites never flag); stdout-redirected per-worker "
+        "invocations skipped; tee'd edges still checked. Legacy edges frozen "
+        "in PHASE_DONE_EDGE_LEGACY_ALLOWLIST; waive a mode-gated "
+        "standalone-lane terminal with '# noqa: phase-done-reserved'. "
+        "Bundled into the no-flags default run + the "
+        "workflow-lint-phase-done-reserved pre-commit hook (#930).",
+    )
     args = parser.parse_args(argv)
 
     path = Path(args.file) if args.file else None
@@ -5594,6 +5940,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         or args.check_agent_spec_size
         or args.check_api_dispatch_routing
         or args.check_lens_coverage
+        or args.check_phase_done_reserved
     )
 
     errors: list[str] = []
@@ -5682,6 +6029,8 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         errors.extend(check_api_dispatch_routing())
     if args.check_lens_coverage or no_flags:
         errors.extend(check_lens_coverage())
+    if args.check_phase_done_reserved or no_flags:
+        errors.extend(check_phase_done_reserved())
 
     if errors:
         for err in errors:

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -277,8 +277,11 @@ Behaviours:
   ``poll_pipeline.py`` — incidents #545, #920). Emission detection is
   AST-based for ``.py`` (comments / docstrings / ``re.compile`` match sites
   never flag) and quote-aware comment-stripped ``echo|printf|print(`` for
-  ``.sh``; a stdout-redirected invocation (the ``> "$WORKER_LOG" 2>&1``
-  per-worker isolation pattern) is skipped, while ``2>&1 | tee`` stays
+  ``.sh``; every invocation on a logical line is checked (the line is split
+  into command segments at unquoted ``&&``/``||``/``;``/``|``/lone-``&``
+  separators), and a stdout-redirected invocation (the
+  ``> "$WORKER_LOG" 2>&1`` per-worker isolation pattern, scoped to the
+  invocation's OWN segment) is skipped, while ``2>&1 | tee`` stays
   checked. Legacy edges are frozen in
   :data:`PHASE_DONE_EDGE_LEGACY_ALLOWLIST` ((invoker, target) edge grain,
   annotated); waive a mode-gated standalone-lane terminal with
@@ -3821,6 +3824,11 @@ PHASE_DONE_SH_INVOKE_RE = re.compile(
 # `2> err.log` (stderr-only; stdout still flows), or `... 2>&1 | tee -a log`
 # (tee duplicates to main stdout — the exact #545-family shape): those edges
 # stay checked. The `(?!\s*&)` lookahead keeps fd-dup forms (`>&2`) out.
+# Applied per COMMAND SEGMENT (the logical line split at unquoted
+# `&&`/`||`/`;`/`|`/lone-`&` separators via _split_sh_command_segments),
+# NOT line-globally — a redirect in a different segment neither suppresses
+# nor rescues an invocation elsewhere on the line (round-2
+# `phase-done-shell-edge-scoping` fix).
 PHASE_DONE_REDIRECT_RE = re.compile(r"(?:^|\s)(?:1?>>?|&>>?)(?!\s*&)")
 # Per-line waiver for a mode-gated standalone-lane terminal (a dual-mode
 # phase script whose emission is OFF the dispatcher path — the issue-920
@@ -3968,6 +3976,77 @@ def _strip_sh_trailing_comment(line: str) -> str:
     return "".join(out)
 
 
+def _split_sh_command_segments(logical: str) -> list[str]:
+    """Split a (comment-stripped) logical shell line into COMMAND SEGMENTS at
+    unquoted command separators — ``&&``, ``||``, ``;``, ``|``, and a lone
+    background ``&`` — so the stdout-redirect exclusion can be scoped to the
+    segment containing each invocation (round-2 fix for the
+    ``phase-done-shell-edge-scoping`` concern: a redirect in a DIFFERENT
+    segment of the same line must neither suppress nor be suppressed by an
+    invocation elsewhere on the line).
+
+    Quote-aware (same single/double-quote char scan as
+    :func:`_strip_sh_trailing_comment`) and backslash-escape-aware (an
+    escaped separator like ``find -exec ... \\;`` does not split). A pipe IS
+    a boundary — this PRESERVES the tee-still-checked semantics of plan
+    §4.3: for ``child.py 2>&1 | tee -a log`` the invocation's own segment
+    (``child.py 2>&1``) carries no stdout redirect, so the edge stays
+    checked, while a downstream ``> f`` applied to ``tee``'s output no
+    longer suppresses the child. A lone ``&`` splits only when it is neither
+    part of ``&&`` (handled first) nor an fd-dup/`&>` form (``2>&1`` /
+    ``>&2`` / ``&> f`` — guarded by the neighboring ``>``). Empty segments
+    (trailing ``&``, ``;;``) are harmless — they match no invocation."""
+    segments: list[str] = []
+    cur: list[str] = []
+    in_single = in_double = False
+    i, n = 0, len(logical)
+    while i < n:
+        ch = logical[i]
+        if ch == "\\" and not in_single and i + 1 < n:
+            cur.append(ch)
+            cur.append(logical[i + 1])
+            i += 2
+            continue
+        if in_single:
+            if ch == "'":
+                in_single = False
+            cur.append(ch)
+            i += 1
+            continue
+        if in_double:
+            if ch == '"':
+                in_double = False
+            cur.append(ch)
+            i += 1
+            continue
+        if ch == "'":
+            in_single = True
+            cur.append(ch)
+            i += 1
+            continue
+        if ch == '"':
+            in_double = True
+            cur.append(ch)
+            i += 1
+            continue
+        nxt = logical[i + 1] if i + 1 < n else ""
+        prev = logical[i - 1] if i > 0 else ""
+        if (ch == "&" and nxt == "&") or (ch == "|" and nxt == "|"):
+            segments.append("".join(cur))
+            cur = []
+            i += 2
+            continue
+        if ch == ";" or ch == "|" or (ch == "&" and nxt != ">" and prev != ">"):
+            segments.append("".join(cur))
+            cur = []
+            i += 1
+            continue
+        cur.append(ch)
+        i += 1
+    segments.append("".join(cur))
+    return segments
+
+
 def _sh_phase_done_emission_lines(target: Path) -> list[int]:
     """Line-scan a phase ``.sh`` for genuine ``[phase=done]`` emission sites,
     returning sorted 1-based line numbers (waived sites dropped). A line is
@@ -3990,6 +4069,40 @@ def _sh_phase_done_emission_lines(target: Path) -> list[int]:
             continue
         sites.append(idx + 1)
     return sites
+
+
+def _phase_done_line_edges(logical: str) -> list[str]:
+    """Return the ordered, deduplicated target paths (``scripts/*.py|.sh``)
+    of every NON-REDIRECTED phase-script invocation on one logical shell
+    line — the round-2 ``phase-done-shell-edge-scoping`` core. The line is
+    trailing-comment-stripped (quote-aware) and split into command segments
+    (:func:`_split_sh_command_segments`); EVERY invocation match is
+    considered (not just the first), and a segment's invocations are kept
+    only when THAT segment carries no stdout redirect
+    (:data:`PHASE_DONE_REDIRECT_RE`). ``echo``-preview segments are
+    skipped."""
+    targets: list[str] = []
+    seen: set[str] = set()
+    for segment in _split_sh_command_segments(_strip_sh_trailing_comment(logical)):
+        if segment.strip().startswith("echo "):
+            continue  # dry-run preview segment (`... && echo "next: ..."`)
+        matches = sorted(
+            (
+                *PHASE_DONE_PY_INVOKE_RE.finditer(segment),
+                *PHASE_DONE_SH_INVOKE_RE.finditer(segment),
+            ),
+            key=lambda m: m.start(),
+        )
+        if not matches:
+            continue
+        if PHASE_DONE_REDIRECT_RE.search(segment):
+            continue  # per-worker-log stdout isolation, scoped to THIS segment
+        for m in matches:
+            target_rel = m.group(1)
+            if target_rel not in seen:
+                seen.add(target_rel)
+                targets.append(target_rel)
+    return targets
 
 
 def check_phase_done_reserved(
@@ -4017,18 +4130,31 @@ def check_phase_done_reserved(
     undecidable), and the suffixed smoke terminal (``[phase=done] SMOKE
     COMPLETE ...``) is a dispatcher-own-file line, allowed by construction.
 
-    EXCLUSIONS: a logical invocation line that redirects stdout away from
-    the main log (:data:`PHASE_DONE_REDIRECT_RE` — the per-worker isolation
-    pattern) is skipped; comment and ``echo``-preview lines are skipped;
-    ``.py`` emission detection is AST-based (comments / docstrings /
-    ``re.compile``-``re.search`` match sites / membership tests never flag);
-    ``.sh`` emission detection is quote-aware comment-stripped
-    ``echo|printf|print(``. A ``# noqa: phase-done-reserved`` waiver on the
-    emission line or the immediately preceding non-blank line drops that
-    site (the escape for dual-mode files whose emission is mode-gated to a
-    standalone-dispatcher lane; the waiver comment must name the intended
-    mode/invoker). Legacy edges are frozen in
-    :data:`PHASE_DONE_EDGE_LEGACY_ALLOWLIST` (edge grain, annotated).
+    EXCLUSIONS: each logical line is trailing-comment-stripped (quote-aware,
+    so comment text can neither match an invocation nor carry a suppressing
+    redirect) and split into COMMAND SEGMENTS at unquoted separators
+    (``&&`` / ``||`` / ``;`` / ``|`` / lone background ``&`` —
+    :func:`_split_sh_command_segments`; backslash-escaped separators do not
+    split). EVERY invocation on the line is checked (not just the first
+    regex match), and an invocation is skipped only when ITS OWN segment
+    redirects stdout away from the main log (:data:`PHASE_DONE_REDIRECT_RE`
+    — the per-worker isolation pattern); a redirect in a DIFFERENT segment
+    of the same line does not suppress, and ``2>&1 | tee`` stays checked
+    because the pipe is a segment boundary (the invocation's own segment
+    carries no stdout redirect) — the round-2 fix for the
+    ``phase-done-shell-edge-scoping`` concern (pre-fix, ``a.py && bad.py``
+    only inspected ``a.py``, and ``bad.py; echo ok > marker`` was wrongly
+    suppressed by the line-global redirect search). Comment lines and
+    ``echo``-preview lines/segments are skipped; ``.py`` emission detection
+    is AST-based (comments / docstrings / ``re.compile``-``re.search`` match
+    sites / membership tests never flag); ``.sh`` emission detection is
+    quote-aware comment-stripped ``echo|printf|print(``. A
+    ``# noqa: phase-done-reserved`` waiver on the emission line or the
+    immediately preceding non-blank line drops that site (the escape for
+    dual-mode files whose emission is mode-gated to a standalone-dispatcher
+    lane; the waiver comment must name the intended mode/invoker). Legacy
+    edges are frozen in :data:`PHASE_DONE_EDGE_LEGACY_ALLOWLIST` (edge
+    grain, annotated).
 
     RESIDUAL FALSE-NEGATIVE GAPS (documented, all fail toward NOT flagging —
     the correct direction for a pre-commit gate): (i) ``.py``-dispatcher
@@ -4042,7 +4168,17 @@ def check_phase_done_reserved(
     tell a per-worker log from the dispatcher's own main log; no live
     instance — historical shapes use ``tee`` and ARE caught); (vi) a
     dispatcher's OWN mid-pipeline emissions in a loop (own-file sites are
-    unrestricted by construction).
+    unrestricted by construction); (vii) an unquoted ``#`` in a parameter
+    expansion (``${#ARR[@]}``) truncates the scanned line at the
+    comment-strip, hiding any invocation after it (the
+    :func:`_strip_sh_trailing_comment` errs-toward-cutting-early
+    limitation). ONE deliberate fail-toward-FLAGGING exception (a false
+    positive, not a false negative): a stdout redirect applied to a whole
+    subshell/group (``( a.py; b.py ) > log`` / ``{ ...; } > log``) is not
+    attributed to the segments INSIDE the group, so an emitting invocation
+    there flags even though the group's stdout is isolated — no live
+    instance; waivable via ``# noqa: phase-done-reserved`` or the per-worker
+    pattern.
 
     ``scripts_dir`` is an override hook for unit tests (production callers
     pass None → the canonical ``<repo_root>/scripts`` tree); ``allowlist``
@@ -4066,41 +4202,40 @@ def check_phase_done_reserved(
             # Comments and dry-run echo previews are not launches.
             if stripped.startswith("#") or stripped.startswith("echo "):
                 continue
-            m = PHASE_DONE_PY_INVOKE_RE.search(logical) or PHASE_DONE_SH_INVOKE_RE.search(logical)
-            if m is None:
-                continue
-            if PHASE_DONE_REDIRECT_RE.search(logical):
-                continue  # per-worker-log stdout isolation (issue658 pattern)
-            target_rel = m.group(1)
-            target = root / target_rel.removeprefix("scripts/")
-            if not target.is_file() or target == sh:
-                continue
-            if target not in emission_cache:
-                emission_cache[target] = (
-                    _py_phase_done_emission_lines(target)
-                    if target.suffix == ".py"
-                    else _sh_phase_done_emission_lines(target)
+            # Round-2 (`phase-done-shell-edge-scoping`): EVERY non-redirected
+            # invocation on the line is an edge — comment-stripped,
+            # segment-split, redirect scoped per segment (see
+            # _phase_done_line_edges), one error per (logical line, target).
+            for target_rel in _phase_done_line_edges(logical):
+                target = root / target_rel.removeprefix("scripts/")
+                if not target.is_file() or target == sh:
+                    continue
+                if target not in emission_cache:
+                    emission_cache[target] = (
+                        _py_phase_done_emission_lines(target)
+                        if target.suffix == ".py"
+                        else _sh_phase_done_emission_lines(target)
+                    )
+                sites = emission_cache[target]
+                if not sites:
+                    continue
+                sh_rel = _judge_pin_rel(sh)  # repo-rel POSIX; abs posix for tmp fixtures
+                if (sh_rel, target_rel) in allow:
+                    continue
+                errors.append(
+                    f"{sh}:{first + 1}: invokes {target_rel} (stdout flows into this "
+                    f"dispatcher's main log) but {target_rel} emits the RESERVED "
+                    f"{PHASE_DONE_TOKEN} token at line(s) {sites}. The token in the "
+                    f"MAIN dispatcher log is reserved for the dispatcher's single "
+                    f"terminal line — a mid-pipeline emission reads as a false "
+                    f"status=done to poll_pipeline.py (incidents #545, #920). Fix: "
+                    f"word the child's completion line without the phase tag, OR "
+                    f"redirect the child's stdout to its own log (per-worker "
+                    f"pattern: scripts/issue658_8gpu_dispatch.sh), OR waive a "
+                    f"mode-gated standalone-lane terminal with "
+                    f"'# noqa: phase-done-reserved' on the emission line. See "
+                    f".claude/rules/pod-side-reporting.md."
                 )
-            sites = emission_cache[target]
-            if not sites:
-                continue
-            sh_rel = _judge_pin_rel(sh)  # repo-rel POSIX, or abs posix for tmp fixtures
-            if (sh_rel, target_rel) in allow:
-                continue
-            errors.append(
-                f"{sh}:{first + 1}: invokes {target_rel} (stdout flows into this "
-                f"dispatcher's main log) but {target_rel} emits the RESERVED "
-                f"{PHASE_DONE_TOKEN} token at line(s) {sites}. The token in the "
-                f"MAIN dispatcher log is reserved for the dispatcher's single "
-                f"terminal line — a mid-pipeline emission reads as a false "
-                f"status=done to poll_pipeline.py (incidents #545, #920). Fix: "
-                f"word the child's completion line without the phase tag, OR "
-                f"redirect the child's stdout to its own log (per-worker "
-                f"pattern: scripts/issue658_8gpu_dispatch.sh), OR waive a "
-                f"mode-gated standalone-lane terminal with "
-                f"'# noqa: phase-done-reserved' on the emission line. See "
-                f".claude/rules/pod-side-reporting.md."
-            )
     return errors
 
 

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -3957,22 +3957,57 @@ def _py_phase_done_emission_lines(target: Path) -> list[int]:
     return sorted(sites)
 
 
+# A `#` begins a shell comment only at the START of a word — i.e. at string
+# start or after whitespace / an operator character (the POSIX tokenizer
+# rule). Used by _strip_sh_trailing_comment's word-boundary test.
+_SH_COMMENT_BOUNDARY_CHARS = frozenset(" \t;&|(<>")
+
+
 def _strip_sh_trailing_comment(line: str) -> str:
     """Cut an unquoted trailing ``#`` comment from a shell line via a small
-    quote-state char scanner (tracks single/double-quote state; a ``#``
-    inside either quote kind is kept). Errs toward cutting early on exotic
-    unquoted ``#`` forms (``${#arr[@]}``) — fail-toward-false-negative, the
-    correct direction for a pre-commit-gating lint."""
+    quote- and backslash-escape-aware char scanner. Word-boundary-aware
+    (the round-3 ``phase-done-comment-strip-midword-fn`` fix): a ``#``
+    starts a comment ONLY when it BEGINS a shell word — at string start or
+    preceded by unescaped whitespace / an operator character
+    (:data:`_SH_COMMENT_BOUNDARY_CHARS`) — matching the shell tokenizer, so
+    a mid-word ``#`` (``tag=run#1``, ``$#``, ``${x#pat}``, ``${#ARR[@]}``,
+    ``2#101``) and a backslash-escaped ``\\#`` never cut. (Pre-fix the
+    unconditional cut truncated the scanned line at ANY unquoted ``#``,
+    hiding every invocation/emission after it — a silent false negative
+    once the strip became load-bearing for invocation scanning in round 2.)
+    A ``#`` inside single or double quotes is kept; outside single quotes a
+    backslash escapes the next char (an escaped operator like ``\\;`` is
+    NOT a word boundary; ``\\"`` does not close a double quote). Residual
+    over-cut (fail-toward-false-negative — the safe direction for a
+    pre-commit-gating lint): a word-initial ``#`` inside an unquoted
+    ``$(...)`` command substitution still cuts there (the scanner is not
+    ``$()``-aware)."""
     out: list[str] = []
     in_single = in_double = False
-    for ch in line:
-        if ch == "#" and not in_single and not in_double:
+    prev_escaped = False
+    i, n = 0, len(line)
+    while i < n:
+        ch = line[i]
+        if ch == "\\" and not in_single and i + 1 < n:
+            out.append(ch)
+            out.append(line[i + 1])
+            prev_escaped = True
+            i += 2
+            continue
+        if (
+            ch == "#"
+            and not in_single
+            and not in_double
+            and (not out or (not prev_escaped and out[-1] in _SH_COMMENT_BOUNDARY_CHARS))
+        ):
             break
         if ch == "'" and not in_double:
             in_single = not in_single
         elif ch == '"' and not in_single:
             in_double = not in_double
         out.append(ch)
+        prev_escaped = False
+        i += 1
     return "".join(out)
 
 
@@ -4144,8 +4179,17 @@ def check_phase_done_reserved(
     carries no stdout redirect) — the round-2 fix for the
     ``phase-done-shell-edge-scoping`` concern (pre-fix, ``a.py && bad.py``
     only inspected ``a.py``, and ``bad.py; echo ok > marker`` was wrongly
-    suppressed by the line-global redirect search). Comment lines and
-    ``echo``-preview lines/segments are skipped; ``.py`` emission detection
+    suppressed by the line-global redirect search). The trailing-comment
+    strip is word-boundary- and escape-aware (round 3,
+    ``phase-done-comment-strip-midword-fn``): a ``#`` cuts only where it
+    BEGINS a shell word, so an executable mid-word ``#`` (``tag=run#1; uv
+    run python scripts/x.py``) or an escaped ``\\#`` no longer truncates
+    the scanned line ahead of a real invocation
+    (:func:`_strip_sh_trailing_comment`). Comment lines and
+    ``echo``-preview SEGMENTS are skipped — the echo skip is segment grain
+    (round 3): an ``echo`` segment ahead of a real invocation on the same
+    logical line (``echo \\#; uv run python scripts/x.py``) no longer
+    hides it. ``.py`` emission detection
     is AST-based (comments / docstrings / ``re.compile``-``re.search`` match
     sites / membership tests never flag); ``.sh`` emission detection is
     quote-aware comment-stripped ``echo|printf|print(``. A
@@ -4168,17 +4212,24 @@ def check_phase_done_reserved(
     tell a per-worker log from the dispatcher's own main log; no live
     instance — historical shapes use ``tee`` and ARE caught); (vi) a
     dispatcher's OWN mid-pipeline emissions in a loop (own-file sites are
-    unrestricted by construction); (vii) an unquoted ``#`` in a parameter
-    expansion (``${#ARR[@]}``) truncates the scanned line at the
-    comment-strip, hiding any invocation after it (the
-    :func:`_strip_sh_trailing_comment` errs-toward-cutting-early
-    limitation). ONE deliberate fail-toward-FLAGGING exception (a false
-    positive, not a false negative): a stdout redirect applied to a whole
+    unrestricted by construction); (vii) a word-initial unquoted ``#``
+    inside a ``$(...)`` command substitution truncates the scanned line at
+    the comment-strip (the scanner is not ``$()``-aware), hiding any
+    invocation after it — a MID-WORD ``#`` (``${#ARR[@]}``, ``tag=run#1``,
+    ``$#``) and an escaped ``\\#`` no longer truncate as of the round-3
+    word-boundary fix (:func:`_strip_sh_trailing_comment`). TWO deliberate
+    fail-toward-FLAGGING exceptions (false positives, not false
+    negatives): (a) a stdout redirect applied to a whole
     subshell/group (``( a.py; b.py ) > log`` / ``{ ...; } > log``) is not
     attributed to the segments INSIDE the group, so an emitting invocation
     there flags even though the group's stdout is isolated — no live
-    instance; waivable via ``# noqa: phase-done-reserved`` or the per-worker
-    pattern.
+    instance; (b) a pipe-DOWNSTREAM stdout redirect (``a.py 2>&1 | tee f
+    > /dev/null``) is attributed to the downstream segment only — the pipe
+    is a segment boundary and deliberately NON-isolating (the plan §4.3
+    tee-still-checked semantics), so an emitting invocation upstream of
+    the pipe still flags even when the pipeline's terminal stdout is
+    discarded. Both are waivable via ``# noqa: phase-done-reserved`` or
+    the per-worker pattern.
 
     ``scripts_dir`` is an override hook for unit tests (production callers
     pass None → the canonical ``<repo_root>/scripts`` tree); ``allowlist``
@@ -4199,8 +4250,11 @@ def check_phase_done_reserved(
         lines = sh.read_text(encoding="utf-8").splitlines()
         for first, _last, logical in _iter_logical_shell_lines(lines):
             stripped = logical.strip()
-            # Comments and dry-run echo previews are not launches.
-            if stripped.startswith("#") or stripped.startswith("echo "):
+            # Comment lines are not launches. echo-preview skipping is
+            # SEGMENT grain inside _phase_done_line_edges (round 3): a
+            # line-level `echo `-prefix skip hid a real invocation in a
+            # later segment (`echo \#; uv run python scripts/x.py`).
+            if stripped.startswith("#"):
                 continue
             # Round-2 (`phase-done-shell-edge-scoping`): EVERY non-redirected
             # invocation on the line is an edge — comment-stripped,

--- a/tests/test_workflow_lint_phase_done_check.py
+++ b/tests/test_workflow_lint_phase_done_check.py
@@ -1,0 +1,658 @@
+"""Tests for ``workflow_lint.check_phase_done_reserved`` (#930).
+
+The check FAILs any non-redirected ``scripts/**/*.sh`` dispatcher invocation of
+a ``scripts/*.py|*.sh`` phase script that contains a genuine ``[phase=done]``
+emission site — the reserved-token contract of
+``.claude/rules/pod-side-reporting.md`` requirement 1 (a mid-pipeline child
+emission reads as a false ``status=done`` to ``poll_pipeline.py``; incidents
+#545, #920). Emission detection is AST-based for ``.py`` and quote-aware
+comment-stripped ``echo|printf|print(`` for ``.sh``.
+
+Covers the plan §6 matrix:
+(a) dispatcher-only emission PASSes; (b) phase-``.py``
+``print("[phase=done]")`` FAILs (#920 shape); (c) phase-``.py``
+``logger.info("[phase=done] ... %s", cell)`` FAILs — the #545
+EMISSION-STYLE shape (logger %-format), NOT the #545 invocation topology
+(``.py``-dispatcher subprocess fan-out is the documented §4.6(i) residual
+gap); (d) a ``> "$LOG" 2>&1 &`` redirected invocation PASSes; (e)
+``2>&1 | tee -a log`` FAILs (tee flows to main stdout); (f)
+trailing-comment / docstring token mentions PASS (the
+``issue778_finetune.py:274`` anti-trap); (g) ``re.compile`` / ``re.search``
+match sites and membership tests PASS; (h) ``.sh -> .sh`` sub-dispatcher
+emission FAILs (i488 shape); (i) commented-out and ``echo``-preview
+invocation lines PASS; (j) an ``allowlist=`` override suppresses, and a tmp
+fixture never matches the production allowlist (relative-path edge grain);
+(k) ``# noqa: phase-done-reserved`` on the emission line AND on the
+immediately-preceding line each PASS — the waiver anchors at the AST
+call-head lineno for multi-line calls (waive at the call head, not beside a
+continuation-line string literal); (l) ``test_live_trees_pass`` — the real
+tree returns ``[]``; (m) robustness (missing dir / unparseable or missing
+target); (n) backslash-continued invocation with the redirect on the
+continuation line is merged via ``_iter_logical_shell_lines``; (o) f-string
+emission FAILs; (p) ``.sh``-embedded python-heredoc ``print`` FAILs; plus
+``2> err.log`` (stderr-only) still FAILs and explicit ``&>`` / ``1>`` /
+``>>`` / ``source`` / ``python -u`` legs.
+
+Round-1-critique additions: (q) non-vacuity sentinel — the empty-allowlist
+run on the REAL tree returns a superset of known sentinel edges (#545 +
+i488), catching a future predicate edit silently zeroing detection; (r)
+default-run bundling pin — a monkeypatched failing check makes the no-flags
+``main()`` exit 1; (s) pre-commit hook-coverage pin — a local hook runs the
+check with a ``files:`` regex matching representative new-offender paths.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+_HERE = Path(__file__).resolve().parent
+_SCRIPTS = _HERE.parent / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from workflow_lint import (  # noqa: E402
+    PHASE_DONE_EDGE_LEGACY_ALLOWLIST,
+    PHASE_DONE_TOKEN,
+    check_phase_done_reserved,
+)
+
+
+def _write(tmp_path: Path, name: str, body: str) -> Path:
+    p = tmp_path / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+# --------------------------------------------------------------------------
+# (a) dispatcher-only emission PASSes (own-file sites unrestricted)
+# --------------------------------------------------------------------------
+
+
+def test_dispatcher_own_emission_passes(tmp_path: Path) -> None:
+    """A dispatcher's OWN terminal `[phase=done]` echo is never flagged; a
+    non-emitting invoked child is clean."""
+    _write(
+        tmp_path,
+        "dispatch.sh",
+        '#!/usr/bin/env bash\nuv run python scripts/phase.py\necho "[phase=done]"\n',
+    )
+    _write(tmp_path, "phase.py", 'print("cell complete")\n')
+    assert check_phase_done_reserved(scripts_dir=tmp_path) == []
+
+
+def test_dispatcher_multi_site_and_smoke_terminal_pass(tmp_path: Path) -> None:
+    """Multiple mode-gated own-file terminals (the issue683 shape) and the
+    suffixed smoke terminal (`[phase=done] SMOKE COMPLETE ...`) PASS —
+    own-file emission counts are unrestricted by construction."""
+    _write(
+        tmp_path,
+        "multi_exit.sh",
+        "#!/usr/bin/env bash\n"
+        'if [ "$1" = smoke ]; then\n'
+        '  echo "[phase=done] SMOKE COMPLETE 2/2 cells"\n'
+        "  exit 0\n"
+        "fi\n"
+        'echo "[phase=done]"\n',
+    )
+    assert check_phase_done_reserved(scripts_dir=tmp_path) == []
+
+
+# --------------------------------------------------------------------------
+# (b) phase-.py print("[phase=done]") FAILs (the #920 shape)
+# --------------------------------------------------------------------------
+
+
+def test_phase_py_print_emission_fails(tmp_path: Path) -> None:
+    """A non-redirected python phase script printing the reserved token FAILs;
+    the error names the invocation site (file:line), the target, the emission
+    line(s), and the fix hints."""
+    sh = _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\nuv run python scripts/phase.py\n",
+    )
+    _write(tmp_path, "phase.py", 'print("[phase=done] extract complete")\n')
+    errors = check_phase_done_reserved(scripts_dir=tmp_path)
+    assert len(errors) == 1, errors
+    assert str(sh) in errors[0]
+    assert ":2:" in errors[0]
+    assert "scripts/phase.py" in errors[0]
+    assert "[1]" in errors[0]  # the emission line list
+    assert "noqa: phase-done-reserved" in errors[0]
+    assert "pod-side-reporting.md" in errors[0]
+
+
+# --------------------------------------------------------------------------
+# (c) logger %-format emission FAILs (the #545 EMISSION-STYLE shape — the
+# #545 invocation topology itself, .py subprocess fan-out, is the documented
+# §4.6(i) residual gap, NOT what this test exercises)
+# --------------------------------------------------------------------------
+
+
+def test_phase_py_logger_percent_format_fails(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\nuv run python scripts/phase.py 2>&1 | tee -a run.log\n",
+    )
+    _write(
+        tmp_path,
+        "phase.py",
+        'logger.info("[phase=done] eval cell %s complete", cell)\n',
+    )
+    errors = check_phase_done_reserved(scripts_dir=tmp_path)
+    assert len(errors) == 1, errors
+
+
+# --------------------------------------------------------------------------
+# (d) stdout-redirected (per-worker isolation) invocations PASS
+# --------------------------------------------------------------------------
+
+
+def test_redirected_worker_invocation_passes(tmp_path: Path) -> None:
+    """`> "$WORKER_LOG" 2>&1 &` isolates stdout from the main log — skipped
+    (the deliberate issue658 per-worker pattern)."""
+    _write(
+        tmp_path,
+        "dispatch.sh",
+        '#!/usr/bin/env bash\nuv run python scripts/phase.py > "$WORKER_LOG" 2>&1 &\n',
+    )
+    _write(tmp_path, "phase.py", 'print("[phase=done]")\n')
+    assert check_phase_done_reserved(scripts_dir=tmp_path) == []
+
+
+def test_append_ampgt_and_fd1_redirects_pass(tmp_path: Path) -> None:
+    """`>> log`, `&> log`, and `1> log` all isolate stdout — skipped."""
+    _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\n"
+        "uv run python scripts/phase.py >> worker.log 2>&1\n"
+        "uv run python scripts/phase.py &> worker.log\n"
+        "uv run python scripts/phase.py 1> worker.log 2>&1\n",
+    )
+    _write(tmp_path, "phase.py", 'print("[phase=done]")\n')
+    assert check_phase_done_reserved(scripts_dir=tmp_path) == []
+
+
+def test_stderr_only_redirect_still_fails(tmp_path: Path) -> None:
+    """`2> err.log` redirects ONLY stderr — stdout still flows into the main
+    log, so the edge stays checked and FAILs."""
+    _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\nuv run python scripts/phase.py 2> err.log\n",
+    )
+    _write(tmp_path, "phase.py", 'print("[phase=done]")\n')
+    errors = check_phase_done_reserved(scripts_dir=tmp_path)
+    assert len(errors) == 1, errors
+
+
+# --------------------------------------------------------------------------
+# (e) `2>&1 | tee -a log` FAILs (tee duplicates to main stdout — #545 shape)
+# --------------------------------------------------------------------------
+
+
+def test_tee_invocation_fails(tmp_path: Path) -> None:
+    sh = _write(
+        tmp_path,
+        "dispatch.sh",
+        '#!/usr/bin/env bash\nuv run python scripts/phase.py 2>&1 | tee -a "$LOG"\n',
+    )
+    _write(tmp_path, "phase.py", 'print("[phase=done]")\n')
+    errors = check_phase_done_reserved(scripts_dir=tmp_path)
+    assert len(errors) == 1, errors
+    assert str(sh) in errors[0]
+
+
+# --------------------------------------------------------------------------
+# (f) trailing-comment / docstring token mentions PASS (AST predicate)
+# --------------------------------------------------------------------------
+
+
+def test_comment_and_docstring_mentions_pass(tmp_path: Path) -> None:
+    """The issue778_finetune.py:274 anti-trap: a trailing `# NOT [phase=done]`
+    comment and a docstring mention are NOT emission sites (a naive line
+    regex flags exactly this shape; the AST predicate does not)."""
+    _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\nuv run python scripts/phase.py\n",
+    )
+    _write(
+        tmp_path,
+        "phase.py",
+        '"""Phase worker. The [phase=done] terminal belongs to the dispatcher."""\n'
+        'logger.info("finetune cell %s complete", cell)  # NOT [phase=done] (reserved)\n',
+    )
+    assert check_phase_done_reserved(scripts_dir=tmp_path) == []
+
+
+# --------------------------------------------------------------------------
+# (g) match/read sites PASS (re.compile / re.search / membership)
+# --------------------------------------------------------------------------
+
+
+def test_match_sites_pass(tmp_path: Path) -> None:
+    """The poller's own detection code shapes — `re.compile(r"\\[phase=done\\]")`,
+    `re.search("[phase=done]", line)`, and `"[phase=done]" in line` — are
+    never emission sites."""
+    _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\nuv run python scripts/phase.py\n",
+    )
+    _write(
+        tmp_path,
+        "phase.py",
+        "import re\n"
+        'PAT = re.compile(r"\\[phase=done\\]")\n'
+        "def scan(line):\n"
+        '    if re.search("[phase=done]", line):\n'
+        "        return True\n"
+        '    return "[phase=done]" in line\n',
+    )
+    assert check_phase_done_reserved(scripts_dir=tmp_path) == []
+
+
+# --------------------------------------------------------------------------
+# (h) .sh -> .sh sub-dispatcher emission FAILs (the i488 run_all shape)
+# --------------------------------------------------------------------------
+
+
+def test_sh_sub_dispatcher_emission_fails(tmp_path: Path) -> None:
+    sh = _write(
+        tmp_path,
+        "run_all.sh",
+        "#!/usr/bin/env bash\nbash scripts/sub_dispatch.sh\n",
+    )
+    _write(
+        tmp_path,
+        "sub_dispatch.sh",
+        '#!/usr/bin/env bash\necho "[phase=done]"\n',
+    )
+    errors = check_phase_done_reserved(scripts_dir=tmp_path)
+    assert len(errors) == 1, errors
+    assert str(sh) in errors[0]
+    assert "scripts/sub_dispatch.sh" in errors[0]
+    assert "[2]" in errors[0]
+
+
+def test_sourced_sub_script_emission_fails(tmp_path: Path) -> None:
+    """`source scripts/sub.sh` is an invocation edge too."""
+    _write(
+        tmp_path,
+        "run_all.sh",
+        "#!/usr/bin/env bash\nsource scripts/sub.sh\n",
+    )
+    _write(tmp_path, "sub.sh", '#!/usr/bin/env bash\nprintf "[phase=done]\\n"\n')
+    errors = check_phase_done_reserved(scripts_dir=tmp_path)
+    assert len(errors) == 1, errors
+
+
+def test_python_dash_u_invocation_fails(tmp_path: Path) -> None:
+    """`nohup python -u scripts/x.py &` (flag between interpreter and path,
+    trailing background token, no stdout redirect) is still an edge."""
+    _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\nnohup python -u scripts/phase.py &\n",
+    )
+    _write(tmp_path, "phase.py", 'print("[phase=done]")\n')
+    errors = check_phase_done_reserved(scripts_dir=tmp_path)
+    assert len(errors) == 1, errors
+
+
+# --------------------------------------------------------------------------
+# (i) commented-out and echo-preview invocation lines PASS
+# --------------------------------------------------------------------------
+
+
+def test_comment_and_echo_preview_invocations_pass(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\n"
+        "# uv run python scripts/phase.py\n"
+        'echo "uv run python scripts/phase.py"\n',
+    )
+    _write(tmp_path, "phase.py", 'print("[phase=done]")\n')
+    assert check_phase_done_reserved(scripts_dir=tmp_path) == []
+
+
+# --------------------------------------------------------------------------
+# (j) allowlist override suppresses; a tmp fixture never matches the
+# production allowlist (relative-path edge grain)
+# --------------------------------------------------------------------------
+
+
+def test_allowlist_override_suppresses(tmp_path: Path) -> None:
+    sh = _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\nuv run python scripts/phase.py\n",
+    )
+    _write(tmp_path, "phase.py", 'print("[phase=done]")\n')
+    assert len(check_phase_done_reserved(scripts_dir=tmp_path, allowlist=frozenset())) == 1
+    # The invoker key for an outside-repo fixture is its own POSIX path.
+    allow = frozenset({(sh.as_posix(), "scripts/phase.py")})
+    assert check_phase_done_reserved(scripts_dir=tmp_path, allowlist=allow) == []
+
+
+def test_tmp_fixture_never_matches_production_allowlist(tmp_path: Path) -> None:
+    """A tmp fixture reproducing an allowlisted EDGE by basename is NOT
+    exempted — the allowlist matches the repo-relative POSIX invoker path,
+    and a tmp fixture falls outside it (mirrors judge-pin test (k))."""
+    assert (
+        "scripts/issue545_dispatch.sh",
+        "scripts/issue545_sweep.py",
+    ) in PHASE_DONE_EDGE_LEGACY_ALLOWLIST
+    _write(
+        tmp_path,
+        "issue545_dispatch.sh",
+        "#!/usr/bin/env bash\nuv run python scripts/issue545_sweep.py\n",
+    )
+    _write(tmp_path, "issue545_sweep.py", 'print("[phase=done]")\n')
+    errors = check_phase_done_reserved(scripts_dir=tmp_path)  # PRODUCTION allowlist
+    assert len(errors) == 1, errors
+
+
+def test_allowlist_is_edge_grain_not_emitter_grain(tmp_path: Path) -> None:
+    """A SECOND dispatcher invoking an allowlisted emitter is still flagged —
+    the grain is the (invoker, target) EDGE, not the emitter file."""
+    _write(
+        tmp_path,
+        "dispatch_a.sh",
+        "#!/usr/bin/env bash\nuv run python scripts/phase.py\n",
+    )
+    new_sh = _write(
+        tmp_path,
+        "dispatch_b.sh",
+        "#!/usr/bin/env bash\nuv run python scripts/phase.py\n",
+    )
+    _write(tmp_path, "phase.py", 'print("[phase=done]")\n')
+    allow = frozenset({((tmp_path / "dispatch_a.sh").as_posix(), "scripts/phase.py")})
+    errors = check_phase_done_reserved(scripts_dir=tmp_path, allowlist=allow)
+    assert len(errors) == 1, errors
+    assert str(new_sh) in errors[0]
+
+
+# --------------------------------------------------------------------------
+# (k) per-line waiver: emission line / preceding line; call-head anchoring
+# --------------------------------------------------------------------------
+
+
+def test_waiver_on_emission_line_suppresses(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\nuv run python scripts/phase.py\n",
+    )
+    _write(
+        tmp_path,
+        "phase.py",
+        'print("[phase=done] standalone terminal")'
+        "  # noqa: phase-done-reserved (cpu-mid standalone lane only)\n",
+    )
+    assert check_phase_done_reserved(scripts_dir=tmp_path) == []
+
+
+def test_waiver_on_preceding_line_suppresses(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\nuv run python scripts/phase.py\n",
+    )
+    _write(
+        tmp_path,
+        "phase.py",
+        "# noqa: phase-done-reserved (standalone lane; dispatcher passes --gpu-null-only)\n"
+        'print("[phase=done]")\n',
+    )
+    assert check_phase_done_reserved(scripts_dir=tmp_path) == []
+
+
+def test_sh_waiver_on_emission_line_suppresses(tmp_path: Path) -> None:
+    """The waiver works on .sh emission sites too (checked on the RAW line —
+    comment-stripping only gates the token/emitter match)."""
+    _write(
+        tmp_path,
+        "run_all.sh",
+        "#!/usr/bin/env bash\nbash scripts/sub.sh\n",
+    )
+    _write(
+        tmp_path,
+        "sub.sh",
+        "#!/usr/bin/env bash\n"
+        'echo "[phase=done]"  # noqa: phase-done-reserved (standalone terminal)\n',
+    )
+    assert check_phase_done_reserved(scripts_dir=tmp_path) == []
+
+
+def test_waiver_anchors_at_call_head_for_multiline_calls(tmp_path: Path) -> None:
+    """The waiver anchor for a multi-line .py call is the AST CALL-HEAD lineno:
+    a waiver on the call-head line suppresses; a waiver beside the
+    continuation-line string literal does NOT (pin the convention)."""
+    _write(
+        tmp_path,
+        "dispatch_ok.sh",
+        "#!/usr/bin/env bash\nuv run python scripts/phase_ok.py\n",
+    )
+    _write(
+        tmp_path,
+        "phase_ok.py",
+        "logger.info(  # noqa: phase-done-reserved (standalone-lane terminal)\n"
+        '    "[phase=done] terminal"\n'
+        ")\n",
+    )
+    _write(
+        tmp_path,
+        "dispatch_bad.sh",
+        "#!/usr/bin/env bash\nuv run python scripts/phase_bad.py\n",
+    )
+    bad = _write(
+        tmp_path,
+        "phase_bad.py",
+        'logger.info(\n    "[phase=done] terminal"  # noqa: phase-done-reserved\n)\n',
+    )
+    errors = check_phase_done_reserved(scripts_dir=tmp_path)
+    assert len(errors) == 1, errors
+    assert bad.name in errors[0]
+
+
+# --------------------------------------------------------------------------
+# (l) the real tree PASSes (legacy edges frozen; no false positives)
+# --------------------------------------------------------------------------
+
+
+def test_live_trees_pass() -> None:
+    """The real scripts/ tree PASSes the check with the production allowlist —
+    the no-FALSE-POSITIVE baseline / no-flags-default-run invariant. It does
+    NOT prove detection is non-vacuous (that is the sentinel-superset test
+    below). If this FAILs, either a NEW violating edge landed (fix it — that
+    is what the check exists for) or a legacy edge annotation is missing."""
+    assert check_phase_done_reserved() == []
+
+
+# --------------------------------------------------------------------------
+# (m) robustness: missing dir; unparseable / missing targets
+# --------------------------------------------------------------------------
+
+
+def test_missing_scripts_dir_returns_empty(tmp_path: Path) -> None:
+    assert check_phase_done_reserved(scripts_dir=tmp_path / "nope") == []
+
+
+def test_unparseable_target_py_skipped(tmp_path: Path) -> None:
+    """A SyntaxError-ing target .py is skipped without crashing (a non-parsing
+    .py cannot run as a phase script) even though it textually carries the
+    token."""
+    _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\nuv run python scripts/broken.py\n",
+    )
+    _write(tmp_path, "broken.py", 'def f(:\n    pass\nprint("[phase=done]")\n')
+    assert check_phase_done_reserved(scripts_dir=tmp_path) == []
+
+
+def test_missing_target_skipped(tmp_path: Path) -> None:
+    """An invocation of a nonexistent target is skipped (nothing to scan)."""
+    _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\nuv run python scripts/ghost.py\n",
+    )
+    assert check_phase_done_reserved(scripts_dir=tmp_path) == []
+
+
+# --------------------------------------------------------------------------
+# (n) backslash-continued invocations merge into one logical line
+# --------------------------------------------------------------------------
+
+
+def test_backslash_continued_redirect_on_continuation_passes(tmp_path: Path) -> None:
+    """The redirect on the CONTINUATION line still isolates the edge — the
+    logical-line merge (`_iter_logical_shell_lines`) sees it."""
+    _write(
+        tmp_path,
+        "dispatch.sh",
+        '#!/usr/bin/env bash\nuv run python scripts/phase.py \\\n  > "$WORKER_LOG" 2>&1 &\n',
+    )
+    _write(tmp_path, "phase.py", 'print("[phase=done]")\n')
+    assert check_phase_done_reserved(scripts_dir=tmp_path) == []
+
+
+def test_backslash_continued_unredirected_fails(tmp_path: Path) -> None:
+    """A continued invocation with NO stdout redirect anywhere on the logical
+    line is still an edge; the reported lineno is the FIRST physical line."""
+    sh = _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\nuv run python \\\n  scripts/phase.py --arg 1\n",
+    )
+    _write(tmp_path, "phase.py", 'print("[phase=done]")\n')
+    errors = check_phase_done_reserved(scripts_dir=tmp_path)
+    assert len(errors) == 1, errors
+    assert f"{sh}:2:" in errors[0]
+
+
+# --------------------------------------------------------------------------
+# (o) f-string emission FAILs
+# --------------------------------------------------------------------------
+
+
+def test_fstring_emission_fails(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\nuv run python scripts/phase.py\n",
+    )
+    _write(tmp_path, "phase.py", 'logger.info(f"[phase=done] {cell}")\n')
+    errors = check_phase_done_reserved(scripts_dir=tmp_path)
+    assert len(errors) == 1, errors
+
+
+# --------------------------------------------------------------------------
+# (p) .sh-embedded python-heredoc print FAILs
+# --------------------------------------------------------------------------
+
+
+def test_sh_heredoc_print_emission_fails(tmp_path: Path) -> None:
+    """A python heredoc inside an invoked .sh (`uv run python - <<'PY'` ...
+    `print("[phase=done]")`) is caught by the `print\\s*\\(` emitter leg."""
+    _write(
+        tmp_path,
+        "run_all.sh",
+        "#!/usr/bin/env bash\nbash scripts/sub.sh\n",
+    )
+    _write(
+        tmp_path,
+        "sub.sh",
+        "#!/usr/bin/env bash\nuv run python - <<'PY'\nprint(\"[phase=done]\")\nPY\n",
+    )
+    errors = check_phase_done_reserved(scripts_dir=tmp_path)
+    assert len(errors) == 1, errors
+    assert "[3]" in errors[0]
+
+
+# --------------------------------------------------------------------------
+# (q) non-vacuity sentinel: the empty-allowlist run on the REAL tree finds a
+# SUPERSET of known legacy edges — catches a future predicate edit silently
+# zeroing live-tree detection (the vacuity hole in test (l)), and makes the
+# plan §4.5 diff-and-adjudicate self-checking.
+# --------------------------------------------------------------------------
+
+
+def test_nonvacuity_sentinel_edges_detected_on_live_tree() -> None:
+    errors = check_phase_done_reserved(allowlist=frozenset())
+    text = "\n".join(errors)
+    # Sentinel edge 1: the #545 family (py-target, tee'd into the main log).
+    assert "scripts/issue545_dispatch.sh" in text, text or "(no errors at all)"
+    assert "scripts/issue545_sweep.py" in text
+    # Sentinel edges 2+3: the i488 run_all -> sub-dispatcher class (sh-target).
+    assert "scripts/i488_run_all.sh" in text
+    assert "scripts/i488_phase23_dispatch.sh" in text
+    assert "scripts/i488_phase4_dispatch.sh" in text
+
+
+# --------------------------------------------------------------------------
+# (r) default-run bundling pin: the no-flags main() runs the check
+# --------------------------------------------------------------------------
+
+
+def test_no_flags_default_run_bundles_check(monkeypatch, capsys) -> None:
+    """A forgotten §4.8 no_flags / dispatch-ladder wiring would silently drop
+    the check from the default run — pin it by stubbing the check to one
+    error and asserting the no-flags main() reports it and exits 1."""
+    import workflow_lint
+
+    sentinel = "PHASE-DONE-BUNDLING-SENTINEL-930"
+    monkeypatch.setattr(workflow_lint, "check_phase_done_reserved", lambda: [sentinel])
+    rc = workflow_lint.main([])
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert sentinel in err
+
+
+# --------------------------------------------------------------------------
+# (s) pre-commit hook-coverage pin (round-1 Must-Fix MF1 mechanization)
+# --------------------------------------------------------------------------
+
+
+def test_precommit_hook_covers_new_offender_paths() -> None:
+    """.pre-commit-config.yaml must carry a local hook whose entry runs
+    --check-phase-done-reserved (or the bare no-flags lint) with a `files:`
+    regex matching representative NEW-offender paths — a fresh dispatcher and
+    a fresh phase script. Without it, no fleet-wide commit gate fires on the
+    offender class (the round-1 enforcement-topology correction)."""
+    cfg = yaml.safe_load((_HERE.parent / ".pre-commit-config.yaml").read_text(encoding="utf-8"))
+    local_hooks = [h for repo in cfg["repos"] if repo["repo"] == "local" for h in repo["hooks"]]
+    matching = [
+        h
+        for h in local_hooks
+        if "--check-phase-done-reserved" in h.get("entry", "")
+        or h.get("entry", "").rstrip().endswith("workflow_lint.py")
+    ]
+    assert matching, "no pre-commit hook runs --check-phase-done-reserved or the no-flags lint"
+    assert any(
+        re.search(h["files"], "scripts/issue999_dispatch.sh")
+        and re.search(h["files"], "scripts/issue999_phase.py")
+        and not h.get("pass_filenames", True)
+        for h in matching
+        if "files" in h
+    ), f"no matching hook's files: regex covers new scripts/*.sh|py offenders: {matching}"
+
+
+# --------------------------------------------------------------------------
+# constant sanity
+# --------------------------------------------------------------------------
+
+
+def test_token_constant_is_the_reserved_literal() -> None:
+    assert PHASE_DONE_TOKEN == "[phase=done]"

--- a/tests/test_workflow_lint_phase_done_check.py
+++ b/tests/test_workflow_lint_phase_done_check.py
@@ -52,6 +52,20 @@ did); (v) a redirect attached directly to the invocation's OWN segment on
 a multi-segment line still suppresses (the live-tree shape the round-1
 probe found on 3 lines — segment scoping must not un-exclude it); plus
 both-emit ``&&`` chains yield one error per edge.
+
+Round-3 additions (binding concern ``phase-done-comment-strip-midword-fn``
+— the trailing-comment strip must cut only at a ``#`` that BEGINS a shell
+word, honoring backslash escapes, so an executable mid-word/escaped ``#``
+before an invocation no longer hides the edge):
+(w) ``tag=run#1; uv run python scripts/bad.py`` -> exactly one error naming
+``bad.py`` (pre-fix the unconditional ``#``-cut truncated at ``tag=run``);
+(x) ``echo \\#; uv run python scripts/bad.py`` -> one error (``\\#`` is
+escaped, not a comment; the echo-preview skip is SEGMENT grain, so the
+``echo`` segment no longer hides the later invocation segment);
+(y) trailing-comment control — ``uv run python scripts/bad.py  # launch
+note`` is still detected (the invocation precedes the comment) and a
+pure-comment line is still skipped; plus a direct
+``_strip_sh_trailing_comment`` word-boundary/escape unit pin.
 """
 
 from __future__ import annotations
@@ -70,6 +84,7 @@ if str(_SCRIPTS) not in sys.path:
 from workflow_lint import (  # noqa: E402
     PHASE_DONE_EDGE_LEGACY_ALLOWLIST,
     PHASE_DONE_TOKEN,
+    _strip_sh_trailing_comment,
     check_phase_done_reserved,
 )
 
@@ -735,6 +750,97 @@ def test_both_invocations_emitting_yield_one_error_per_edge(tmp_path: Path) -> N
     text = "\n".join(errors)
     assert "scripts/bad_a.py" in text
     assert "scripts/bad_b.sh" in text
+
+
+# --------------------------------------------------------------------------
+# (w)/(x)/(y) round-3 word-boundary comment-strip regression fixtures
+# (binding concern `phase-done-comment-strip-midword-fn`): a `#` cuts only
+# where it BEGINS a shell word; backslash escapes are honored; the
+# echo-preview skip is segment grain.
+# --------------------------------------------------------------------------
+
+
+def test_midword_hash_before_invocation_fails(tmp_path: Path) -> None:
+    """(w) `tag=run#1; uv run python scripts/bad.py` -> exactly one error
+    naming bad.py. Pre-fix, _strip_sh_trailing_comment cut unconditionally
+    at the mid-word `#`, truncating the line at `tag=run` so the emitting
+    invocation after it was never seen (a silent commit-gate FN)."""
+    sh = _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\ntag=run#1; uv run python scripts/bad.py\n",
+    )
+    _write(tmp_path, "bad.py", 'print("[phase=done]")\n')
+    errors = check_phase_done_reserved(scripts_dir=tmp_path)
+    assert len(errors) == 1, errors
+    assert str(sh) in errors[0]
+    assert "scripts/bad.py" in errors[0]
+
+
+def test_escaped_hash_echo_segment_before_invocation_fails(tmp_path: Path) -> None:
+    """(x) `echo \\#; uv run python scripts/bad.py` -> one error. The `\\#`
+    is a backslash-escaped literal, not a comment; the echo-preview skip is
+    SEGMENT grain, so the leading `echo` segment no longer hides the real
+    invocation in the later segment (pre-fix BOTH the unconditional `#`-cut
+    and the line-level `echo `-prefix skip swallowed the line)."""
+    sh = _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\necho \\#; uv run python scripts/bad.py\n",
+    )
+    _write(tmp_path, "bad.py", 'print("[phase=done]")\n')
+    errors = check_phase_done_reserved(scripts_dir=tmp_path)
+    assert len(errors) == 1, errors
+    assert str(sh) in errors[0]
+    assert "scripts/bad.py" in errors[0]
+
+
+def test_trailing_comment_control_and_pure_comment_line(tmp_path: Path) -> None:
+    """(y) CONTROLS: a genuine trailing comment after the invocation still
+    strips (the invocation PRECEDES the `#`, so the edge stays detected,
+    and a redirect inside the comment text cannot suppress), while a
+    pure-comment line is still skipped entirely."""
+    sh = _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\n"
+        "# uv run python scripts/bad.py\n"
+        "uv run python scripts/bad.py  # launch note > /dev/null\n",
+    )
+    _write(tmp_path, "bad.py", 'print("[phase=done]")\n')
+    errors = check_phase_done_reserved(scripts_dir=tmp_path)
+    assert len(errors) == 1, errors
+    assert str(sh) in errors[0]
+    assert f"{sh}:3:" in errors[0]  # the live line, not the comment line
+    assert "scripts/bad.py" in errors[0]
+
+
+def test_strip_sh_trailing_comment_word_boundary() -> None:
+    """Direct unit pin of the round-3 scanner invariants: mid-word `#`
+    forms and escaped `\\#` are kept; a word-initial `#` (string start /
+    after whitespace / after an operator char) cuts; quoted `#` is kept."""
+    strip = _strip_sh_trailing_comment
+    # Mid-word / escaped forms: NO cut.
+    assert strip("tag=run#1; uv run python scripts/bad.py") == (
+        "tag=run#1; uv run python scripts/bad.py"
+    )
+    assert strip("echo \\#; uv run python scripts/bad.py") == (
+        "echo \\#; uv run python scripts/bad.py"
+    )
+    assert strip('echo "${#ARR[@]} left"; bash scripts/x.sh') == (
+        'echo "${#ARR[@]} left"; bash scripts/x.sh'
+    )
+    assert strip("n=${#ARR[@]} && bash scripts/x.sh") == "n=${#ARR[@]} && bash scripts/x.sh"
+    assert strip('if [ "$#" -lt 2 ]; then exit 1; fi') == 'if [ "$#" -lt 2 ]; then exit 1; fi'
+    assert strip("v=${x#prefix} y=$((2#101))") == "v=${x#prefix} y=$((2#101))"
+    # Word-initial forms: cut.
+    assert strip("# whole-line comment") == ""
+    assert strip("cmd  # trailing note") == "cmd  "
+    assert strip("cmd; # after separator") == "cmd; "
+    assert strip("cmd #comment > /dev/null") == "cmd "
+    # Quoted `#` is content, not a comment.
+    assert strip("echo '# kept'") == "echo '# kept'"
+    assert strip('echo "# kept" # cut') == 'echo "# kept" '
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_workflow_lint_phase_done_check.py
+++ b/tests/test_workflow_lint_phase_done_check.py
@@ -39,6 +39,19 @@ i488), catching a future predicate edit silently zeroing detection; (r)
 default-run bundling pin — a monkeypatched failing check makes the no-flags
 ``main()`` exit 1; (s) pre-commit hook-coverage pin — a local hook runs the
 check with a ``files:`` regex matching representative new-offender paths.
+
+Round-2 additions (binding concern ``phase-done-shell-edge-scoping`` — the
+check must iterate EVERY invocation on a logical line and scope the
+stdout-redirect test to each invocation's own command segment):
+(t) ``clean.py && bad.py`` where only ``bad.py`` emits — the SECOND
+invocation is seen and flagged (one error; pre-fix the first-match-only
+``search`` never reached it); (u) ``bad.py; echo ok > marker.txt`` — an
+unrelated LATER redirect in a different segment does not suppress the
+unredirected emitting invocation (pre-fix the line-global redirect search
+did); (v) a redirect attached directly to the invocation's OWN segment on
+a multi-segment line still suppresses (the live-tree shape the round-1
+probe found on 3 lines — segment scoping must not un-exclude it); plus
+both-emit ``&&`` chains yield one error per edge.
 """
 
 from __future__ import annotations
@@ -647,6 +660,81 @@ def test_precommit_hook_covers_new_offender_paths() -> None:
         for h in matching
         if "files" in h
     ), f"no matching hook's files: regex covers new scripts/*.sh|py offenders: {matching}"
+
+
+# --------------------------------------------------------------------------
+# (t)/(u)/(v) round-2 segment-scoping regression fixtures (binding concern
+# `phase-done-shell-edge-scoping`): every invocation on a logical line is
+# checked, and the stdout-redirect exclusion is scoped to each invocation's
+# OWN command segment (split at unquoted `&&` / `||` / `;` / `|` / lone `&`).
+# --------------------------------------------------------------------------
+
+
+def test_second_invocation_on_and_chain_fails(tmp_path: Path) -> None:
+    """(t) `clean.py && bad.py` where only bad.py emits -> exactly one error
+    naming bad.py. Pre-fix, the first-match-only `search` stopped at
+    clean.py (a clean target) and bad.py was never inspected."""
+    sh = _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\nuv run python scripts/clean.py && uv run python scripts/bad.py\n",
+    )
+    _write(tmp_path, "clean.py", 'print("cells complete")\n')
+    _write(tmp_path, "bad.py", 'print("[phase=done] mid-pipeline")\n')
+    errors = check_phase_done_reserved(scripts_dir=tmp_path)
+    assert len(errors) == 1, errors
+    assert str(sh) in errors[0]
+    assert "scripts/bad.py" in errors[0]
+    assert "scripts/clean.py" not in errors[0]
+
+
+def test_unrelated_later_redirect_does_not_suppress(tmp_path: Path) -> None:
+    """(u) `bad.py; echo ok > marker.txt` -> one error. The redirect belongs
+    to the LATER `echo` segment; pre-fix the line-global redirect search let
+    it suppress the genuinely non-redirected emitting invocation."""
+    sh = _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\nuv run python scripts/bad.py; echo ok > marker.txt\n",
+    )
+    _write(tmp_path, "bad.py", 'print("[phase=done]")\n')
+    errors = check_phase_done_reserved(scripts_dir=tmp_path)
+    assert len(errors) == 1, errors
+    assert str(sh) in errors[0]
+    assert "scripts/bad.py" in errors[0]
+
+
+def test_segment_scoped_redirect_still_suppresses(tmp_path: Path) -> None:
+    """(v) A redirect attached directly to the invocation's OWN segment on a
+    multi-segment line still excludes the edge — the shape the round-1 §4.5
+    probe found on 3 live-tree lines; segment scoping must not un-exclude
+    it (the expected live-tree edge set stays at the same 9 edges)."""
+    _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\n"
+        'uv run python scripts/bad.py > "$WORKER_LOG" 2>&1 && echo launched\n'
+        "uv run python scripts/bad.py >> worker.log 2>&1; echo appended\n",
+    )
+    _write(tmp_path, "bad.py", 'print("[phase=done]")\n')
+    assert check_phase_done_reserved(scripts_dir=tmp_path) == []
+
+
+def test_both_invocations_emitting_yield_one_error_per_edge(tmp_path: Path) -> None:
+    """Two emitting targets chained with `&&` produce one error per edge
+    (both are genuine violations; pre-fix only the first was reachable)."""
+    _write(
+        tmp_path,
+        "dispatch.sh",
+        "#!/usr/bin/env bash\nuv run python scripts/bad_a.py && bash scripts/bad_b.sh\n",
+    )
+    _write(tmp_path, "bad_a.py", 'print("[phase=done]")\n')
+    _write(tmp_path, "bad_b.sh", 'echo "[phase=done]"\n')
+    errors = check_phase_done_reserved(scripts_dir=tmp_path)
+    assert len(errors) == 2, errors
+    text = "\n".join(errors)
+    assert "scripts/bad_a.py" in text
+    assert "scripts/bad_b.sh" in text
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Closes task #930 (workflow-fix, kind: infra). Lint + pre-commit hook enforcing pod-side-reporting.md req 1 (the #545/#920 false-status=done class). Plan v2 critic-ensemble reviewed; code-review PASS r3; test-verdict PASS (2247 passed, 0 new failures).