### PR TITLE
issue-948: seam-stubbed production-body verification lens (#906 workflow fix)

### DIFF
--- a/.claude/agents/code-correctness-critic.md
+++ b/.claude/agents/code-correctness-critic.md
@@ -155,6 +155,17 @@ Apply these exactly as `code-reviewer.md` defines them; Grep + Read the named sp
   <class>`. A finding with no siblings adds a one-line "no siblings" note (never
   balloon output). A single-instance fix that leaves a load-bearing sibling is the
   whack-a-mole failure (#779).
+- **Step 3.8 — seam-stubbed production-body verification.** For every
+  production function ADDED (or seam-stubbed and body-modified) in the round
+  that any test stubs/monkeypatches — closing transitively over round-added
+  callees — read the BODY and verify each external
+  call against the callee's REAL signature (`inspect.signature` / read the
+  `def`) and each attribute dereference against the real dataclass fields. A
+  dispatch/resolver test is NOT body coverage; a real-body test counts only
+  with signature-conformant (autospec-style) boundary fakes. Wrong-signature /
+  nonexistent-field → Critical, `substantive` (#906: five rounds PASSed
+  crash-class bodies behind PilotSeams stubs while 43/43 mocked tests stayed
+  green).
 - **Step 4 — run / verify tests.** `uv run pytest <relevant>`; `uv run ruff check`
   + `--format --check` on changed files. On a read-only-sandbox / cache error, use
   the writable-tempdir fallback FIRST; only if that ALSO fails may you fall through

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -787,6 +787,9 @@ pattern as Step 0.67's work-conserving sub-check: the parent gate's N/A does
 not close it). Record the gate→dispatch trace (gated fn, dispatched fn,
 evidence `file.py:LINE`) or `hollow-gate sub-check: N/A — no verification
 gate in diff`.
+Sibling: Step 3.8 covers the BODY half of this family — a test that stubs the
+production function itself launders a never-executed body exactly as a hollow
+gate launders an unverified hot loop.
 
 ### Step 0.7: Pre-diff gates never short-circuit the diff
 
@@ -1033,6 +1036,94 @@ PASS→FAIL on its own; the FAIL comes from a load-bearing sibling left in the
 tree. (Promotes the 7-step sibling-scan recipe from reconciler memory
 `.claude/agent-memory/reconciler/feedback_claude_misses_same_file_siblings.md`.)
 
+### Step 3.8: Seam-stubbed production-body verification (any diff type)
+
+**Trigger:** the diff ADDS a production function (a new `def` in non-test
+code, including in a new file) whose NAME appears in any test as a stub /
+monkeypatch / seam target — `monkeypatch.setattr(..., "<name>", ...)`,
+`unittest.mock.patch("...<name>")`, a seams/hooks dataclass field the tests
+override with a fake (e.g. `PilotSeams(<name>_fn=fake)`), or a fake injected
+through a resolver/dispatch table. Enumerate mechanically: list the round's
+added `def`s from the diff, then grep the test files (round-touched AND
+pre-existing seam tables) for each name. The trigger set then CLOSES
+TRANSITIVELY over the round's own code: any round-ADDED function called
+(directly or transitively) from a trigger-set function's body JOINS the
+trigger set unless a body-executing test (per item 3) covers it — the
+crash-class body must not escape verification by moving one call deeper
+(the natural decomposition of the #906 code: seam-stubbed `run_pilot` →
+round-added `_score_items()` holding the fabricated judge call). ALSO in
+scope: (a) an EXISTING seam-stubbed function whose body this round's diff
+modifies — verify the added/changed hunk lines only; (b) a production
+function that a test added or changed THIS round NEWLY stubs/monkeypatches,
+when no body-executing test covers it (closes the r1-body / r2-stubs
+round-split ordering). No hit → record `Step 3.8: N/A — no
+seam-stubbed production function added or modified this round` and proceed.
+
+**Why:** a stub/monkeypatch seam means the suite can be 100% green while the
+production BODY has never executed — the tests validate that the DISPATCHER
+calls the name, not that the body is correct. A dispatch/resolver test is NOT
+body coverage. (Incident #906, 2026-07-03: five consecutive ensemble rounds
+PASSed crash-class production bodies behind `PilotSeams` stubs while 43/43
+mocked tests stayed green — `behavior.trigger_context` dereferenced a
+nonexistent `Behavior` field at L541+L628, the judge was called with a
+fabricated signature vs the real `judge_graded(items, eval_prompt, *,
+n_draws, cache_dir, save_raw, ...)` at L575-580, and `score_completions`
+omitted required kw-only `cache_dir`/`save_raw` at L712; Codex FAILed all 5
+rounds, the reconciler upheld FAIL all 5, and the task blocked at cap-5.)
+
+**Check — for EVERY function in the trigger set, read the BODY and verify:**
+
+1. **External call signatures.** For each external call — to a function
+   defined outside the round's diff (repo helper, library fn) — verify the
+   call site against the callee's REAL signature — `uv run python -c "import
+   inspect, <mod>; print(inspect.signature(<mod>.<callee>))"` or READ the
+   callee's `def` line — checking positional arity, kwarg names, and required
+   keyword-only args. Quote the call site `file.py:LINE` + the real signature
+   as evidence. A call to a round-ADDED function is NOT exempt: that callee
+   joins the trigger set (transitive closure above) and its own external
+   calls + dereferences are verified the same way.
+2. **Attribute dereferences.** For each attribute access on a dataclass /
+   config / artifact object the body receives (`behavior.<field>`,
+   `cfg.<field>`), verify the field EXISTS on the real class — read the class
+   definition or enumerate `dataclasses.fields(<Class>)`. For a non-dataclass
+   DYNAMIC object (OmegaConf `DictConfig`, pydantic `extra="allow"`), verify
+   against the producing schema/YAML instead — absence of a
+   statically-enumerable field alone is not a Critical there.
+3. **Do not credit wiring tests as body coverage.** Body evidence is EITHER a
+   committed test that (a) executes the REAL body, (b) REACHES the changed
+   call sites / dereferences under review, and (c) fakes only the external
+   GPU/API boundary with fakes that are signature-conformant BY CONSTRUCTION
+   — `unittest.mock.create_autospec(real_callee)`, a real dataclass instance,
+   or a fake whose `def` mirrors the real signature; QUOTE the fake's
+   construction line as evidence — OR your own per-call verification per
+   items 1–2. A bare `Mock()`/`MagicMock()` boundary fake accepts ANY call
+   signature and is NOT body evidence for signature/field errors. A test that
+   monkeypatches the function and asserts the dispatcher called it verifies
+   wiring only.
+
+**Verdict routing:** a wrong-signature or nonexistent-field finding in a
+seam-stubbed body is **Critical** (the production path provably crashes),
+blocker tag `substantive` (never `marker-shape` / `smoke-run-missing` /
+`git-provenance`; never stripped by Step 5c-bis). Run the Step 3.7 sibling
+sweep on the class — the same fabricated API usually recurs (#906: the
+`trigger_context` dereference appeared at two sites). All verified → record
+the per-function ledger (function, callees checked, evidence lines) in the
+verdict body.
+
+**Cost bound:** the trigger set is the round's ADDED/MODIFIED functions ∩
+test-stub targets, plus that set's transitive round-added callees and any
+function newly stubbed by a round-added test — typically 0–6 functions,
+never a whole-codebase audit; per function you verify only the body's
+external calls + attribute dereferences (diff-hunk lines only, for the
+modified case).
+
+**Named accepted residue (deliberately out of scope):** callee-level
+patching — a test that patches the CALLEE (`mock.patch("driver.judge_graded")`,
+the most common mock idiom) executes the real body but never exercises the
+call site against the real signature and never fires this trigger. That
+shape is carried by the deferred implementer-side real-body-test rule and
+the deferred coverage-based lint, not by this check.
+
 ### Step 4: Run / Verify Tests
 
 Run the tests. Don't trust "tests pass" claims — verify.
@@ -1232,6 +1323,23 @@ Red flags:
 13. **A substantive BLOCKER fix that adds a permanent invariant needs a committed regression test, or a Minor flagging its absence.** When the diff closes a substantive BLOCKER (a prior-round binding `BLOCKER` concern or a Critical you would re-raise) by adding a fail-loud assertion, an invariant guard, or a scoping fix meant to STAY in the code, check for a committed pytest that fails pre-fix / passes post-fix and actually exercises the invariant. Absent → at least a `Minor` finding (`Mechanizable: yes`) carrying a 1-2-line pytest sketch; this is SUBSTANTIVE, never `marker-shape` / `smoke-run-missing`, never stripped by Step 5c-bis, and a bare Minor does not flip PASS→FAIL. An implementer who CLAIMS a covering test that the worktree grep does not show (or that does not trip the guard) is a substantive FAIL with blocker tag `substantive` (fabricated coverage, same family as Rule 9). Rationale: an un-CI-pinned assertion is a guard a future refactor silently strips while CI stays green — a one-line test makes the guard permanent (incident #653 r8). See Step 4.5 for the procedure.
 14. **Every finding is a bug CLASS, not a line.** For every Critical/Major finding you MUST run the Step 3.7 sibling sweep and enumerate ALL load-bearing sibling instances under a `### Bug-class sweep: <class>` heading; each load-bearing sibling is its own Critical, each secondary one a standing rec. A verdict that fixes/flags the cited instance but leaves a load-bearing sibling of the same class unenumerated is the whack-a-mole failure mode — FAIL only when a load-bearing sibling is left un-named; a finding with no siblings adds a one-line "no siblings" note (never balloon output on a trivial finding). See Step 3.7 for the sweep procedure.
 15. **Plan-declared compute shape must be exposed by the dispatcher.** For a `type:experiment` diff whose approved plan §9 declares a data-parallel / sharded compute shape (N-GPU DP, per-GPU workers, context/cell sharding — read from the §9 prose AND the per-component compute-projection table's `parallelism` column), verify the dispatcher script(s) in the diff actually expose it via one of (a) `--shard-id`/`--num-shards` flags, (b) an internal `torch.distributed` / `torch.multiprocessing.spawn` / `accelerate` / per-GPU `subprocess` fan-out, or (c) an external one-process-per-GPU launcher / documented experimenter fan-out. Plan-declares-DP-but-dispatcher-single-GPU is a substantive FAIL with blocker tag `compute-shape-mismatch` (SUBSTANTIVE, never `marker-shape` / `smoke-run-missing`, never stripped by Step 5c-bis); the fix is EITHER wiring the DP path OR descoping §9 to the dispatcher's actual intent. A TP-only or single-GPU plan never triggers this. Rationale: a plan-declared multi-GPU pod against a single-GPU dispatcher leaves N−1 GPUs at 0% util billing — the #664 spend-leak (incident #779 r6: `sweep-8g-h100` provisioned, all 8 GPUs idle, dispatcher `--gpu-id`-only). See Step 0.67 for the procedure. Exposure is necessary, not sufficient: Step 0.67's work-conserving schedule sub-check additionally reads the schedule loop whenever the diff schedules >1 independent cell on a multi-GPU pod/provision — a strict wave/stage barrier or degenerate serial schedule idling workers while independent cells wait is a Major `substantive` finding (#813: two sequential waves idled 4/8 H100s for 6.7h), acceptable only for a plan-stated cross-cell dependency or named resource/capacity constraint.
+16. **A test that stubs a production function is evidence of WIRING, not of
+    the body.** For every production function ADDED (or seam-stubbed and
+    body-MODIFIED) in the round that any test stubs/monkeypatches, verify the
+    body's external calls against the callees' REAL signatures
+    (`inspect.signature` / read the `def`) and its attribute dereferences
+    against the real dataclass fields before crediting coverage. The trigger
+    closes TRANSITIVELY over round-added callees, and a real-body test
+    counts only with signature-conformant (autospec-style) boundary fakes
+    that reach the changed call sites. A
+    dispatch/resolver test is NOT body coverage. A wrong-signature /
+    nonexistent-field finding is Critical with blocker tag `substantive`
+    (never stripped by Step 5c-bis). (Incident #906: five ensemble rounds
+    PASSed crash-class bodies behind PilotSeams stubs — nonexistent
+    `behavior.trigger_context` field, fabricated `judge_graded` signature,
+    missing required `cache_dir`/`save_raw` kwargs — while 43/43 mocked tests
+    stayed green; Codex FAILed and the reconciler upheld FAIL all 5 rounds.)
+    See Step 3.8 for the procedure.
 
 ---
 

--- a/.claude/agents/codex-code-reviewer.md
+++ b/.claude/agents/codex-code-reviewer.md
@@ -478,6 +478,19 @@ both reviewers are graded against the same standard. Read
   one-per-round (incident #779 whack-a-mole). Codex twins never emit
   workflow-fix candidates for a sweep finding — surface siblings in the verdict
   body only.
+- The **Step 3.8 seam-stubbed production-body verification** rule VERBATIM.
+  This is load-bearing: copy the trigger (production `def`s ADDED — or
+  seam-stubbed and body-modified — in the round whose names appear as test
+  stub / monkeypatch / seams-dataclass targets), the two-part body check
+  (external call sites vs the callee's REAL signature; attribute dereferences
+  vs the real dataclass fields), the "a dispatch/resolver test is NOT body
+  coverage" rule, the Critical `substantive` routing (never stripped by Step
+  5c-bis), and the cost bound, so Codex keeps catching what it caught on
+  #906. Codex adaptation: without the project's `uv` env, verify signatures
+  by READING the callee's `def` line and the dataclass definition (Grep/Read)
+  instead of running `inspect.signature`. (Incident #906: Codex FAILed all 5
+  rounds of crash-class seam-stubbed bodies the Claude reviewer PASSed; this
+  bullet makes the check explicit and symmetric across both twins.)
 - The Rules item 12 **blocker grounding + mechanizability** rule VERBATIM —
   every Critical/Major finding cites a concrete artifact location
   (`file.py:LINE`, diff hunk, plan section; the reconciler discards
@@ -592,7 +605,7 @@ fine.)
 
 Follow this protocol:
 
-{{INLINED RUBRIC FROM code-reviewer.md Steps 0, 0.5, 0.55, 0.6, 0.65, 0.67, 0.7, 0.8, 1, 2, 3, 3.5, 3.6, 3.7, 4.5, 5, 6, 7 + Rules 12 (blocker grounding + mechanizability, Codex-adapted) + 13 (regression-test presence for substantive BLOCKER fixes) + 14 (bug-class sibling sweep — every finding is a CLASS not a line) + 15 (plan-declared compute shape exposed by dispatcher + work-conserving schedule)}}
+{{INLINED RUBRIC FROM code-reviewer.md Steps 0, 0.5, 0.55, 0.6, 0.65, 0.67, 0.7, 0.8, 1, 2, 3, 3.5, 3.6, 3.7, 3.8, 4.5, 5, 6, 7 + Rules 12 (blocker grounding + mechanizability, Codex-adapted) + 13 (regression-test presence for substantive BLOCKER fixes) + 14 (bug-class sibling sweep — every finding is a CLASS not a line) + 15 (plan-declared compute shape exposed by dispatcher + work-conserving schedule)}}
 
 You MUST emit your verdict in EXACTLY this format. No preamble, no code
 fences around the marker, no commentary outside the marker tags:

--- a/.claude/rules/lens-coverage-map.md
+++ b/.claude/rules/lens-coverage-map.md
@@ -114,6 +114,7 @@ Rows are honest: a check with no v2 owner is a `GAP:` row, never papered over.
 | Step 3.5 cached-artifact coverage (`cached-artifact-coverage-unverified`) | code-reviewer.md Step 3.5 | v2-owner: code-correctness-critic |
 | Step 3.6 long-loop restartability | code-reviewer.md Step 3.6 | v2-owner: efficiency-critic |
 | Step 3.7 bug-class sibling sweep | code-reviewer.md Step 3.7 | v2-owner: code-correctness-critic |
+| Step 3.8 seam-stubbed production-body verification | code-reviewer.md Step 3.8 | v2-owner: code-correctness-critic |
 | Step 4 run / verify tests | code-reviewer.md Step 4 | v2-owner: code-correctness-critic |
 | Step 4.5 regression-test presence for BLOCKER fixes | code-reviewer.md Step 4.5 | v2-owner: code-correctness-critic |
 | Step 5 security sweep | code-reviewer.md Step 5 | v2-owner: code-correctness-critic |

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -5199,16 +5199,17 @@ AGENT_SPEC_SIZE_GRANDFATHER: dict[str, int] = {
     "clean-result-critic.md": 107_000,
     # the rest measured at the #838 tightening (2026-07-02), caps = measured
     # + <=3 KB; each names a future trim direction, none is licensed to grow
-    # measured 82,176 B post-#875+#869+#881 (work-conserving schedule
-    # sub-check + anti-pattern (d), the Step 0.6 extrapolation block +
-    # Step 0.68, then the #881 Step 3.6 long-loop restartability lens —
-    # all plan-mandated growth; cap = measured + <=3 KB)
-    "code-reviewer.md": 84_500,
+    # measured 91,371 B post-#948 (Step 3.8 seam-stubbed production-body
+    # verification lens + Rule 16 + Step 0.68 sibling xref — plan-mandated
+    # growth; cap = measured + <=~1 KB. Prior: 82,176 B post-#875+#869+#881)
+    # #948: seam-stubbed production-body lens (Step 3.8)
+    "code-reviewer.md": 92_300,
     "codex-clean-result-critic.md": 62_000,  # measured 59,358 B
-    # measured 47,930 B post-#881 (Step 3.6 copy-list bullets + the
-    # inlined-rubric 3.6 slot — plan-mandated growth; cap = measured
-    # + <=3 KB)
-    "codex-code-reviewer.md": 50_400,
+    # measured 50,642 B post-#948 (Step 3.8 copy-list bullet + the
+    # inlined-rubric 3.8 slot — plan-mandated growth; cap = measured
+    # + <=~1 KB. Prior: 47,930 B post-#881)
+    # #948: seam-stubbed production-body lens (Step 3.8)
+    "codex-code-reviewer.md": 51_600,
     # measured 58,976 B post-#936 (the plan-REQUIRED bf16 equivalence-gate
     # calibration caveat in § Batched-rewrite equivalence — plan-mandated
     # growth; cap = measured + <=3 KB. Prior: 55,812 B post-#869)


### PR DESCRIPTION
Closes task #948.

## Summary
- Adds mandatory code-reviewer Step 3.8: any newly-added production function whose tests stub/monkeypatch it must have its body's external API calls verified against real signatures + real dataclass fields before PASS (wrong-signature / nonexistent-field findings are Critical `substantive`).
- Propagates to codex-code-reviewer (copy-list + inlined-rubric 3.8), code-correctness-critic (v2 owner), lens-coverage-map §D; raises two workflow_lint spec-size caps (92,300 / 51,600 B, 929/958 B headroom).
- Origin: #906 cap-5 incident — 5 review rounds shipped crash-class wrong-API production code behind seam stubs.

## Test plan
- [x] Ensemble code review PASS+PASS (Claude + Codex, round 1, no blockers)
- [x] Step 9c touched-subset: 2271 passed / 6 skipped / 0 failed
- [x] workflow_lint no-flags bundle + --check-asks PASS; ruff clean on touched .py

🤖 Generated with [Claude Code](https://claude.com/claude-code)