### PR TITLE
issue-940: RunPod terminal rung translates GCP-only intents to nearest RunPod intent

### DIFF
--- a/.claude/rules/compute-backend-failover.md
+++ b/.claude/rules/compute-backend-failover.md
@@ -204,6 +204,31 @@ Three distinct GCP-failure paths, ALL ending at the same
   DISTINCT from a workload crash (a queue that never advanced is not a
   crash) and from a capacity MISS at create time (this create succeeded).
 
+**Intent translation at the terminal rung (#940).** The RunPod launch
+paths (the terminal rung — all four fallback/failover paths above funnel
+through it — AND the explicit `backend: runpod` override) translate a
+GCP-only GPU intent to its nearest same-or-narrower RunPod-provisionable
+intent via the router-owned `RUNPOD_INTENT_FOR_GCP_INTENT` map
+(`capture-7b` → `eval`, `lora` / `lora-7b-h100` → `lora-7b`; identity
+rows for shared intents, no marker record) BEFORE building the RunPod
+spec — pre-#940 the rung passed the intent verbatim and
+`gpu_heuristics.resolve_intent` KeyError'd, voiding the sanctioned last
+rung (#841: `provision --issue 841 --intent capture-7b` exit 1 →
+`NoComputeAvailableError` despite live RunPod 1-GPU capacity). A real
+translation rides the `epm:backend-selected` marker `extra` as
+`runpod_intent_translation: {"from": ..., "to": ...}`. A GCP GPU intent
+with NO row — `eval-h100`, listed in
+`RUNPOD_INTENT_TRANSLATION_DELIBERATE_GAPS` (2× H100: no same-width
+RunPod intent exists, and narrowing 2→1 would silently break a
+2-GPU-sharded workload mid-run) — fails loud PRE-launch naming the
+missing map row, inside the existing `no_compute_available` terminal on
+the rung (raw `ValueError` on the override — a config error). A
+completeness test (`test_translation_map_total_over_gcp_gpu_intents`)
+pins map ∪ gaps == the `gpu_count > 0` keys of `gcp.INTENT_TO_MACHINE`,
+so a future GCP intent added without deciding its RunPod fate fails CI
+at the adding PR. CPU intents are untouched — the #677/#747
+`RUNPOD_CPU_INSTANCE_FOR_INTENT` guard runs BEFORE translation.
+
 **Bound — no infinite RunPod cascade.** A genuinely-broken job runs on
 RunPod AT MOST ONCE more. If it crashes again, the poller surfaces
 `failure_class: code` → `status:blocked`. The autonomous-session watcher's

--- a/src/explore_persona_space/backends/router.py
+++ b/src/explore_persona_space/backends/router.py
@@ -132,6 +132,14 @@ RunPod-on-error, ``route(spec)`` orchestrates the full multi-backend ladder:
    analysis lane has no cheap RunPod equivalent) — it does NOT fall over
    to RunPod. RunPod CPU pods are on-demand only; a CPU no-capacity miss
    surfaces :class:`RunPodNoCapacityError` → terminal.
+8b. **GCP-only GPU intent translation (#940).** The RunPod launch paths
+   (terminal rung + explicit override) translate a GCP-only GPU intent to
+   its nearest same-or-narrower RunPod intent via
+   :data:`RUNPOD_INTENT_FOR_GCP_INTENT` (``capture-7b`` → ``eval``,
+   ``lora`` / ``lora-7b-h100`` → ``lora-7b``); an unmapped GCP GPU intent
+   (``eval-h100``, in :data:`RUNPOD_INTENT_TRANSLATION_DELIBERATE_GAPS`)
+   fails loud PRE-launch naming the missing map row, and a real translation
+   rides the marker ``extra`` as ``runpod_intent_translation``.
 9. **Markers** — extends the existing ``epm:backend-selected v1`` body
    (per-lane est-starts raw+clamped, chosen lane, fallback chain,
    canonical reason codes, ids). The orchestrator's marker poster is
@@ -176,6 +184,7 @@ from explore_persona_space.backends.base import (
     validate_lane_suffix,
 )
 from explore_persona_space.backends.gcp import (
+    INTENT_TO_MACHINE,
     GcpProvisioningError,
     GcpWorkloadError,
     MachineSpec,
@@ -288,6 +297,80 @@ RUNPOD_CPU_INSTANCE_FOR_INTENT: dict[str, str] = {
     "cpu-small": "cpu3g-2-8",  # 2 vCPU / 8 GB, gen-3 general purpose
     "cpu-mid": "cpu3c-8-16",  # 8 vCPU / 16 GB, gen-3 compute-optimized
 }
+
+#: GCP GPU intent -> the RunPod intent the terminal rung provisions (#940).
+#: TOTAL over the gpu_count>0 keys of gcp.INTENT_TO_MACHINE (identity rows
+#: included) so the completeness test
+#: (tests/test_router.py::test_translation_map_total_over_gcp_gpu_intents)
+#: catches a future intent added without deciding its RunPod fate — the exact
+#: #841 failure mode (a `capture-7b` RunPod terminal-rung launch died in
+#: gpu_heuristics.resolve_intent's KeyError, voiding the sanctioned last rung
+#: despite live RunPod capacity). Values MUST be same-or-narrower GPU width
+#: and >= HBM (never widen; pinned by
+#: test_translation_never_widens_gpu_count_and_targets_provisionable).
+#: CPU intents are DELIBERATELY absent — RUNPOD_CPU_INSTANCE_FOR_INTENT
+#: above owns them (#677/#747), byte-identical semantics.
+RUNPOD_INTENT_FOR_GCP_INTENT: dict[str, str] = {
+    # identity rows — intents in BOTH vocabularies (no-op, no marker record)
+    "eval": "eval",  # GCP 1x L4      -> RunPod 1x H100
+    "debug": "debug",  # GCP 1x L4      -> RunPod 1x H100
+    "lora-7b": "lora-7b",  # GCP 1x A100-80 -> RunPod 1x H100
+    "ft-7b": "ft-7b",  # GCP 4x A100-80 -> RunPod 4x H100
+    "sweep-8g-a100": "sweep-8g-a100",  # 8x A100-80 -> 8x A100 (same width)
+    "sweep-8g-h100": "sweep-8g-h100",  # 8x H100    -> 8x H100
+    # GCP-only intents — nearest same-or-narrower RunPod intent
+    "lora": "lora-7b",  # GCP alias of lora-7b (1x A100-80 -> 1x H100-80)
+    "capture-7b": "eval",  # #752 activation-capture EVAL path: 1x A100-80
+    # forward-pass -> 1x H100-80 (same width, HBM 80 >= 80)
+    "lora-7b-h100": "lora-7b",  # 1x H100-80 -> 1x H100-80 (identical hardware)
+}
+
+#: GCP GPU intents DELIBERATELY not RunPod-servable via intent translation
+#: (#940). eval-h100 (2x H100, TP=2): no same-width RunPod intent exists, and
+#: narrowing 2->1 would silently break a 2-GPU-sharded --workload-cmd
+#: mid-run on a paid pod — worse than failing loud at dispatch with a
+#: message naming this row. Widening (e.g. to an 8x sweep intent) is
+#: banned outright.
+RUNPOD_INTENT_TRANSLATION_DELIBERATE_GAPS: frozenset[str] = frozenset({"eval-h100"})
+
+
+def _translated_runpod_intent(spec: RunSpec) -> tuple[str, dict[str, str] | None]:
+    """Resolve spec.intent to a RunPod-provisionable intent (#940).
+
+    Returns ``(runpod_intent, translation_record)`` where
+    ``translation_record`` is ``{"from": ..., "to": ...}`` for a REAL
+    translation, ``None`` for identity rows and pass-through intents.
+    Raises :class:`ValueError` — naming the missing
+    :data:`RUNPOD_INTENT_FOR_GCP_INTENT` row — for a GCP-mapped GPU intent
+    with no row (the ``eval-h100`` / future-intent case). CPU intents
+    (``gpu_count == 0`` in ``gcp.INTENT_TO_MACHINE``) and non-GCP intents
+    (``ft-70b``, ``inf-70b``, custom) pass through verbatim: the #677/#747
+    CPU semantics and the RunPod-native vocabulary are untouched.
+
+    Uses a direct ``INTENT_TO_MACHINE.get(...)`` — NOT
+    :func:`gcp.machine_for_intent` — so the helper (a) never raises gcp.py's
+    unmapped-intent ``ValueError`` for RunPod-only intents like ``ft-70b``
+    under explicit override, and (b) is immune to
+    ``spec.extra["machine_spec_override"]`` rung threading.
+    """
+    intent = spec.intent
+    target = RUNPOD_INTENT_FOR_GCP_INTENT.get(intent)
+    if target is not None:
+        if target == intent:
+            return intent, None  # identity: byte-identical behavior
+        return target, {"from": intent, "to": target}
+    gcp_machine = INTENT_TO_MACHINE.get(intent)
+    if gcp_machine is not None and gcp_machine.gpu_count > 0:
+        raise ValueError(
+            f"intent {intent!r} is GCP-mapped but has no RunPod translation: "
+            f"add a same-or-narrower row to backends/router.py "
+            f"RUNPOD_INTENT_FOR_GCP_INTENT (or list it in "
+            f"RUNPOD_INTENT_TRANSLATION_DELIBERATE_GAPS and keep it off RunPod). "
+            f"Deliberate gaps: {sorted(RUNPOD_INTENT_TRANSLATION_DELIBERATE_GAPS)}."
+        )
+    return intent, None  # CPU / RunPod-native / custom: verbatim
+
+
 #: The router fell back to RunPod because a GCP attempt FAILED THE WORKLOAD
 #: (a :class:`gcp.GcpWorkloadError`, not a capacity/headroom miss) — the
 #: deliberate reversal of the historical "GCP workload failure surfaces
@@ -1780,6 +1863,27 @@ def _override_runpod(
     cross-issue) so contention is bounded to the racing invocations we
     are deliberately serializing.
     """
+    # #940: translate a GCP-only GPU intent to its RunPod-provisionable
+    # equivalent BEFORE the launch (and BEFORE the per-issue flock, so a
+    # translation ValueError never holds it). The helper's ValueError
+    # propagates raw: an explicit `backend: runpod` pin of an unmapped
+    # GCP-only intent (eval-h100) is a CONFIG error — fail loud pre-launch
+    # with the map-row-naming message (same class as gcp.machine_for_intent's
+    # ValueError on a gcp override). RunPod-native / RunPod-only intents
+    # (lora-7b, ft-70b, custom) hit the verbatim branch — byte-identical.
+    runpod_intent, intent_translation = _translated_runpod_intent(spec)
+    if intent_translation is not None:
+        logger.warning(
+            "route: explicit runpod override translating GCP-only intent %r -> %r (issue %d).",
+            spec.intent,
+            runpod_intent,
+            spec.issue,
+        )
+        spec = replace(
+            spec,
+            intent=runpod_intent,
+            extra={**(spec.extra or {}), "runpod_intent_translation": intent_translation},
+        )
     # Hold the per-issue flock across launch + persist so two concurrent
     # route() calls cannot both decide "no live job, submit fresh" and
     # provision twice.
@@ -1827,6 +1931,9 @@ def _override_runpod(
         cluster=None,
         attempts=attempts,
         elapsed_seconds=now_fn() - started_at,
+        # #940: the GCP-only -> RunPod intent translation record, when one
+        # applied, so the override marker records the intent swap too.
+        extra=({"runpod_intent_translation": intent_translation} if intent_translation else {}),
     )
     _post_backend_selected(result, spec=spec, marker_poster=marker_poster)
     return result
@@ -2286,6 +2393,10 @@ def _runpod_terminal_rung(
     re-raise as :class:`NoComputeAvailableError` with the full attempt
     trail — the terminal "truly no compute anywhere" outcome, preserving a
     typed terminal for the orchestrator's failure classifier.
+
+    #940: a GCP-only GPU intent is translated to its RunPod-provisionable
+    equivalent (:func:`_translated_runpod_intent`) before the launch, so the
+    rung actually fires instead of dying in ``gpu_heuristics.resolve_intent``.
     """
     # CPU-intent guard (#677, RELAXED for mapped intents #747). RunPod's GPU
     # mutation (podFindAndDeployOnDemand) is GPU-only, BUT #747 adds a RunPod
@@ -2320,6 +2431,49 @@ def _runpod_terminal_rung(
             f"has no CPU fallback lane for this intent. residual_gap: {residual_gap}",
             attempts=[_attempt_to_dict(a) for a in attempts],
         )
+    # #940: translate a GCP-only GPU intent (capture-7b / lora / lora-7b-h100)
+    # to its RunPod-provisionable equivalent BEFORE building runpod_spec —
+    # pod_lifecycle's gpu_heuristics.resolve_intent KeyErrors on a GCP-only
+    # intent (provision exit 1 -> NoComputeAvailableError), which is what
+    # voided the sanctioned last rung on #841 despite live RunPod capacity.
+    # An unmapped GCP GPU intent (eval-h100) fails loud HERE, pre-launch and
+    # BEFORE the per-issue flock, naming the missing map row; the failure
+    # reuses the existing runpod_fallback_failed terminal shape (same
+    # classifier contract as a failed RunPod launch).
+    try:
+        runpod_intent, intent_translation = _translated_runpod_intent(spec)
+    except ValueError as exc:
+        attempts.append(
+            RouteAttempt(
+                kind="runpod",
+                cluster=None,
+                est_start_seconds_raw=0.0,
+                est_start_seconds_clamped=0.0,
+                outcome="runpod_fallback_failed",
+                detail=f"runpod terminal fallback UNSERVABLE ({exc})",
+                elapsed_seconds=now_fn() - started_at,
+            )
+        )
+        _post_terminal_failure_marker(
+            spec=spec,
+            marker_poster=marker_poster,
+            reason=ROUTE_REASON_NO_COMPUTE,
+            chosen_kind="runpod",
+            attempts=attempts,
+        )
+        raise NoComputeAvailableError(
+            "every GCP rung + free lane failed AND the RunPod terminal "
+            f"fallback cannot serve this intent ({exc})",
+            attempts=[_attempt_to_dict(a) for a in attempts],
+        ) from exc
+    if intent_translation is not None:
+        logger.warning(
+            "route: translating GCP-only intent %r -> RunPod intent %r for the "
+            "terminal rung (issue %d).",
+            spec.intent,
+            runpod_intent,
+            spec.issue,
+        )
     if reason in (
         ROUTE_REASON_GCP_WORKLOAD_FAILOVER_RUNPOD,
         ROUTE_REASON_GCP_WORKLOAD_FAILOVER_RUNPOD_ASYNC,
@@ -2348,7 +2502,15 @@ def _runpod_terminal_rung(
     runpod_spec = replace(
         spec,
         backend="runpod",
-        extra={**(spec.extra or {}), "runpod_fallback_residual_gap": residual_gap},
+        # #940: the translated intent (identity for RunPod-native intents) so
+        # everything downstream — launch argv, handle, lease, wedge
+        # re-provision — is self-consistently RunPod-provisionable.
+        intent=runpod_intent,
+        extra={
+            **(spec.extra or {}),
+            "runpod_fallback_residual_gap": residual_gap,
+            **({"runpod_intent_translation": intent_translation} if intent_translation else {}),
+        },
     )
     with store.transaction(spec.issue) as (lease, write):
         # M3b (#669): in-flock re-check of the GCP->RunPod failover idempotency
@@ -2456,6 +2618,10 @@ def _runpod_terminal_rung(
         elapsed_seconds=now_fn() - started_at,
         extra={
             "runpod_fallback_residual_gap": residual_gap,
+            # #940: the GCP-only -> RunPod intent translation record, when one
+            # applied, so the marker trail shows the intent swap (additive
+            # extra key per the runpod_fallback_residual_gap precedent).
+            **({"runpod_intent_translation": intent_translation} if intent_translation else {}),
             # The GcpWorkloadError evidence (task #658) so the failover
             # marker carries the original crash signal for diagnosis.
             **({"gcp_workload_evidence": failover_evidence} if failover_evidence else {}),
@@ -4763,6 +4929,8 @@ __all__ = [
     "ROUTE_REASON_RUNPOD_FALLBACK",
     "ROUTE_REASON_WORKLOAD_FAILURE",
     "RUNPOD_CPU_INSTANCE_FOR_INTENT",
+    "RUNPOD_INTENT_FOR_GCP_INTENT",
+    "RUNPOD_INTENT_TRANSLATION_DELIBERATE_GAPS",
     "BackendPrepareError",
     "CpuExhaustedNoRunpodLaneError",
     "GcpAttemptCapExceededError",

--- a/src/explore_persona_space/backends/selector.py
+++ b/src/explore_persona_space/backends/selector.py
@@ -600,7 +600,13 @@ def _fallback_to_runpod(
     elapsed_seconds: float,
     extra: dict[str, Any],
 ) -> BackendDecision:
-    """Launch RunPod after a SLURM fall-back; record the reason + extras."""
+    """Launch RunPod after a SLURM fall-back; record the reason + extras.
+
+    NOTE (#940, legacy/test-only path): this launches ``spec.intent``
+    VERBATIM — a revival of ``select_backend`` for GCP-only intents must
+    route through ``router._translated_runpod_intent`` first, or the #841
+    ``gpu_heuristics.resolve_intent`` KeyError hole re-opens here.
+    """
     if not _autonomous_session():
         logger.warning(
             "Falling back to RunPod for requested backend=%s cluster=%s (%s).",

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -5657,3 +5657,334 @@ def test_caller_pinned_attempt_id_wins_over_lane_suffix_mint():
     new_spec, lease = _thread_attempt_id_into(spec, None, writes.append)
     assert new_spec.extra["attempt_id"] == "att-pinned-1"
     assert lease.attempt_id == "att-pinned-1"
+
+
+# ---------------------------------------------------------------------------
+# #940 — GCP-only GPU intent translation at the RunPod launch paths
+#
+# The RunPod terminal rung (and the explicit `backend: runpod` override)
+# translate GCP-only GPU intents (capture-7b / lora / lora-7b-h100) to the
+# nearest same-or-narrower RunPod-provisionable intent via the router-owned
+# RUNPOD_INTENT_FOR_GCP_INTENT map, so the sanctioned last-rung fallback
+# actually fires instead of dying in gpu_heuristics.resolve_intent's KeyError
+# (the #841 incident: `provision --issue 841 --intent capture-7b` exit 1 →
+# NoComputeAvailableError despite live RunPod 1-GPU capacity). An unmapped
+# GCP GPU intent (eval-h100, in RUNPOD_INTENT_TRANSLATION_DELIBERATE_GAPS)
+# fails loud PRE-launch naming the missing map row.
+# ---------------------------------------------------------------------------
+
+
+def test_gcp_only_intent_exhausted_ladder_fires_runpod_with_translated_intent(
+    lease_store, marker_poster, captured_markers
+):
+    """T1 / the #841 regression test: a capture-7b auto route with every GCP
+    rung + SLURM exhausted launches RunPod EXACTLY ONCE with the translated
+    `--intent eval`, RunPod LAST in the attempt trail, and the marker extra
+    carries the translation record."""
+    rp = _PassiveRunpod()
+    nibi = _FreeLaneBackend(kind="nibi", starts_when=10**9)  # never starts
+    gcp = _GcpBackendDouble(
+        launch_raises=GcpProvisioningError(
+            "ZONE_RESOURCE_POOL_EXHAUSTED", evidence={"matched_pattern": "RESOURCE_EXHAUSTED"}
+        )
+    )
+    result = route(
+        RunSpec(issue=940, intent="capture-7b", backend="auto", time_budget_hours=1.0),
+        runpod_backend=rp,
+        free_backends={"nibi": nibi},
+        gcp_backend=gcp,
+        lease_store=lease_store,
+        is_started=lambda _b, _h: False,
+        is_live_after_cancel=lambda _b, _h: False,
+        marker_poster=marker_poster,
+        config=RouterConfig(
+            free_wait_seconds=1,
+            poll_interval=0.0,
+            cancel_grace_seconds=0,
+            max_gcp_attempts_per_day=99,
+        ),
+        now_fn=_clock(),
+        sleep_fn=lambda _s: None,
+    )
+    assert result.chosen_kind == "runpod"
+    assert result.reason == ROUTE_REASON_RUNPOD_FALLBACK
+    assert len(rp.launches) == 1
+    # The launched spec carries the TRANSLATED RunPod-provisionable intent.
+    assert rp.launches[0].intent == "eval"
+    # RunPod is the FINAL attempt, behind every GCP rung + the nibi park-fail
+    # (capture-7b is in INTENT_A100_40_FALLBACK, so the short 5-rung ladder
+    # applies exactly as lora-7b's).
+    outcomes = [(a.kind, a.outcome) for a in result.attempts]
+    gcp_idxs = [i for i, (k, _o) in enumerate(outcomes) if k == "gcp"]
+    nibi_idxs = [i for i, (k, _o) in enumerate(outcomes) if k == "nibi"]
+    runpod_idxs = [i for i, (k, o) in enumerate(outcomes) if k == "runpod" and o == "launched"]
+    assert len(gcp_idxs) == 5, outcomes  # all five short-ladder rungs attempted + failed
+    assert nibi_idxs, "the free SLURM lane must have been attempted"
+    assert runpod_idxs and runpod_idxs[-1] == len(outcomes) - 1
+    assert max(gcp_idxs) < runpod_idxs[-1]
+    assert max(nibi_idxs) < runpod_idxs[-1]
+    finals = _by_reason(captured_markers, ROUTE_REASON_RUNPOD_FALLBACK)
+    assert finals
+    assert finals[-1]["extra"]["runpod_intent_translation"] == {
+        "from": "capture-7b",
+        "to": "eval",
+    }
+
+
+def test_runpod_native_intent_terminal_rung_untranslated_no_marker_key(
+    lease_store, marker_poster, captured_markers
+):
+    """T2: an identity-row intent (lora-7b) passes through the terminal rung
+    verbatim — no translation record on the marker (byte-identical to the
+    pre-#940 marker shape for existing intents)."""
+    rp = _PassiveRunpod()
+    nibi = _FreeLaneBackend(kind="nibi", starts_when=10**9)
+    gcp = _GcpBackendDouble(
+        launch_raises=GcpProvisioningError(
+            "ZONE_RESOURCE_POOL_EXHAUSTED", evidence={"matched_pattern": "RESOURCE_EXHAUSTED"}
+        )
+    )
+    result = route(
+        _short_lora_spec(),
+        runpod_backend=rp,
+        free_backends={"nibi": nibi},
+        gcp_backend=gcp,
+        lease_store=lease_store,
+        is_started=lambda _b, _h: False,
+        is_live_after_cancel=lambda _b, _h: False,
+        marker_poster=marker_poster,
+        config=RouterConfig(
+            free_wait_seconds=1,
+            poll_interval=0.0,
+            cancel_grace_seconds=0,
+            max_gcp_attempts_per_day=99,
+        ),
+        now_fn=_clock(),
+        sleep_fn=lambda _s: None,
+    )
+    assert result.chosen_kind == "runpod"
+    assert len(rp.launches) == 1
+    assert rp.launches[0].intent == "lora-7b"
+    finals = _by_reason(captured_markers, ROUTE_REASON_RUNPOD_FALLBACK)
+    assert finals
+    assert "runpod_intent_translation" not in finals[-1]["extra"]
+
+
+@pytest.mark.parametrize("reason_name", ["async_crash", "queue_timeout"])
+def test_async_failover_translates_gcp_only_intent(
+    lease_store, marker_poster, captured_markers, reason_name
+):
+    """T3: the async poller failover seam (#659) AND the queue-timeout
+    failover (#783) — both via failover_to_runpod_after_async_workload_crash —
+    inherit the translation from the shared terminal rung: a capture-7b
+    failover launches RunPod with `--intent eval`, and the marker extra
+    carries BOTH the translation record and the crash evidence."""
+    from explore_persona_space.backends.router import (
+        ROUTE_REASON_GCP_QUEUE_TIMEOUT_FAILOVER_RUNPOD,
+        ROUTE_REASON_GCP_WORKLOAD_FAILOVER_RUNPOD_ASYNC,
+        failover_to_runpod_after_async_workload_crash,
+    )
+
+    reason = {
+        "async_crash": ROUTE_REASON_GCP_WORKLOAD_FAILOVER_RUNPOD_ASYNC,
+        "queue_timeout": ROUTE_REASON_GCP_QUEUE_TIMEOUT_FAILOVER_RUNPOD,
+    }[reason_name]
+    rp = _PassiveRunpod()
+    result = failover_to_runpod_after_async_workload_crash(
+        spec=RunSpec(issue=940, intent="capture-7b", backend="auto", workload_cmd="bash x.sh"),
+        runpod_backend=rp,
+        evidence={"source": "async_poller"},
+        reason=reason,
+        marker_poster=marker_poster,
+        lease_store=lease_store,
+        now_fn=_clock(),
+        config=RouterConfig(free_wait_seconds=1, poll_interval=0.0, cancel_grace_seconds=0),
+    )
+    assert result.chosen_kind == "runpod"
+    assert result.reason == reason
+    assert len(rp.launches) == 1
+    assert rp.launches[0].intent == "eval"
+    finals = _by_reason(captured_markers, reason)
+    assert finals
+    assert finals[-1]["extra"]["runpod_intent_translation"] == {
+        "from": "capture-7b",
+        "to": "eval",
+    }
+    assert finals[-1]["extra"]["gcp_workload_evidence"]["source"] == "async_poller"
+
+
+def test_unmapped_gcp_gpu_intent_fails_loud_naming_map_row(
+    lease_store, marker_poster, captured_markers
+):
+    """T4: a GCP-mapped GPU intent with NO translation row (eval-h100) fails
+    loud BEFORE any provision attempt, inside the existing
+    NoComputeAvailableError / no_compute_available terminal shape, with a
+    message naming the missing RUNPOD_INTENT_FOR_GCP_INTENT row."""
+    from explore_persona_space.backends.router import (
+        failover_to_runpod_after_async_workload_crash,
+    )
+
+    rp = _PassiveRunpod()
+    with pytest.raises(NoComputeAvailableError) as excinfo:
+        failover_to_runpod_after_async_workload_crash(
+            spec=RunSpec(issue=940, intent="eval-h100", backend="auto"),
+            runpod_backend=rp,
+            evidence={"source": "async_poller"},
+            marker_poster=marker_poster,
+            lease_store=lease_store,
+            now_fn=_clock(),
+            config=RouterConfig(free_wait_seconds=1, poll_interval=0.0, cancel_grace_seconds=0),
+        )
+    assert "eval-h100" in str(excinfo.value)
+    assert "RUNPOD_INTENT_FOR_GCP_INTENT" in str(excinfo.value)
+    # NO provision was attempted (the failure is pre-launch).
+    assert rp.launches == []
+    # A no_compute_available terminal marker was posted.
+    from explore_persona_space.backends.router import ROUTE_REASON_NO_COMPUTE
+
+    assert _by_reason(captured_markers, ROUTE_REASON_NO_COMPUTE)
+
+
+def test_translated_runpod_intent_helper_unit():
+    """T4 companion: the helper itself raises ValueError naming the missing
+    row for eval-h100, and returns the record shape for a real translation."""
+    from explore_persona_space.backends.router import _translated_runpod_intent
+
+    with pytest.raises(ValueError, match="RUNPOD_INTENT_FOR_GCP_INTENT"):
+        _translated_runpod_intent(RunSpec(issue=1, intent="eval-h100", backend="auto"))
+    assert _translated_runpod_intent(RunSpec(issue=1, intent="capture-7b", backend="auto")) == (
+        "eval",
+        {"from": "capture-7b", "to": "eval"},
+    )
+    assert _translated_runpod_intent(RunSpec(issue=1, intent="lora-7b", backend="auto")) == (
+        "lora-7b",
+        None,
+    )
+
+
+def test_translation_map_total_over_gcp_gpu_intents():
+    """T5 completeness/drift pin: every gpu_count>0 key of gcp.INTENT_TO_MACHINE
+    is EITHER in the translation map OR in the deliberate-gap set (disjointly) —
+    a future GCP intent added without deciding its RunPod fate fails HERE, at
+    the adding PR, instead of crashing at the terminal rung months later (the
+    #841 failure mode, recurrence-proofed)."""
+    from explore_persona_space.backends.gcp import INTENT_TO_MACHINE
+    from explore_persona_space.backends.router import (
+        RUNPOD_INTENT_FOR_GCP_INTENT,
+        RUNPOD_INTENT_TRANSLATION_DELIBERATE_GAPS,
+    )
+
+    gpu_keys = {k for k, m in INTENT_TO_MACHINE.items() if m.gpu_count > 0}
+    covered = set(RUNPOD_INTENT_FOR_GCP_INTENT) | set(RUNPOD_INTENT_TRANSLATION_DELIBERATE_GAPS)
+    assert gpu_keys == covered, (
+        f"gcp.INTENT_TO_MACHINE GPU intents not reconciled with the RunPod "
+        f"translation map: missing={sorted(gpu_keys - covered)} "
+        f"stale={sorted(covered - gpu_keys)}"
+    )
+    assert not set(RUNPOD_INTENT_FOR_GCP_INTENT) & RUNPOD_INTENT_TRANSLATION_DELIBERATE_GAPS
+
+
+def test_translation_never_widens_gpu_count_and_targets_provisionable():
+    """T6 property test: every translation target is RunPod-provisionable
+    (a gpu_heuristics.INTENTS key) at a same-or-narrower GPU width than the
+    GCP machine it translates from (never widen — constraint 2)."""
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+    import gpu_heuristics
+
+    from explore_persona_space.backends.gcp import INTENT_TO_MACHINE
+    from explore_persona_space.backends.router import RUNPOD_INTENT_FOR_GCP_INTENT
+
+    for gcp_intent, runpod_intent in RUNPOD_INTENT_FOR_GCP_INTENT.items():
+        assert runpod_intent in gpu_heuristics.INTENTS, (
+            f"{gcp_intent!r} -> {runpod_intent!r}: target is not a RunPod-provisionable "
+            f"intent (gpu_heuristics.INTENTS)"
+        )
+        assert (
+            gpu_heuristics.INTENTS[runpod_intent].gpu_count
+            <= INTENT_TO_MACHINE[gcp_intent].gpu_count
+        ), f"{gcp_intent!r} -> {runpod_intent!r} WIDENS the GPU count"
+
+
+def test_explicit_runpod_override_translates_gcp_only_intent(
+    lease_store, marker_poster, captured_markers
+):
+    """T7: the explicit `backend: runpod` override (the documented manual
+    recovery for the #667 hung-GCP-VM gap) translates a GCP-only intent too —
+    previously it could only crash (uncaught KeyError class), so no working
+    behavior is altered."""
+    rp = _PassiveRunpod()
+    result = route(
+        RunSpec(issue=940, intent="capture-7b", backend="runpod"),
+        runpod_backend=rp,
+        lease_store=lease_store,
+        marker_poster=marker_poster,
+    )
+    assert result.chosen_kind == "runpod"
+    assert result.reason == ROUTE_REASON_OVERRIDE
+    assert len(rp.launches) == 1
+    assert rp.launches[0].intent == "eval"
+    finals = _by_reason(captured_markers, ROUTE_REASON_OVERRIDE)
+    assert finals
+    assert finals[-1]["extra"]["runpod_intent_translation"] == {
+        "from": "capture-7b",
+        "to": "eval",
+    }
+
+
+def test_explicit_runpod_override_runpod_only_intent_verbatim(
+    lease_store, marker_poster, captured_markers
+):
+    """T7 companion: a RunPod-only intent (ft-70b — NOT GCP-mapped) passes
+    through the override verbatim, no raise, no translation record
+    (byte-identical to pre-#940). NOTE: ft-70b is reachable ONLY via the
+    override path — the terminal rung's pre-existing CPU guard
+    (machine_for_intent) raises gcp.py's own ValueError on non-GCP intents
+    before the translation helper would run there."""
+    rp = _PassiveRunpod()
+    result = route(
+        RunSpec(issue=940, intent="ft-70b", backend="runpod"),
+        runpod_backend=rp,
+        lease_store=lease_store,
+        marker_poster=marker_poster,
+    )
+    assert result.chosen_kind == "runpod"
+    assert result.reason == ROUTE_REASON_OVERRIDE
+    assert len(rp.launches) == 1
+    assert rp.launches[0].intent == "ft-70b"
+    finals = _by_reason(captured_markers, ROUTE_REASON_OVERRIDE)
+    assert finals
+    assert "runpod_intent_translation" not in finals[-1]["extra"]
+
+
+def test_explicit_runpod_override_unmapped_gcp_intent_raises_valueerror(
+    lease_store, marker_poster, captured_markers
+):
+    """Ensemble-review addition: the OVERRIDE x eval-h100 cell fails loud with
+    the helper's RAW ValueError (a config error, per §4d — NOT wrapped into
+    NoComputeAvailableError), pre-launch, naming the missing map row. Pins the
+    exception shape so a future "wrap it silently" regression fails here."""
+    rp = _PassiveRunpod()
+    with pytest.raises(ValueError, match="RUNPOD_INTENT_FOR_GCP_INTENT"):
+        route(
+            RunSpec(issue=940, intent="eval-h100", backend="runpod"),
+            runpod_backend=rp,
+            lease_store=lease_store,
+            marker_poster=marker_poster,
+        )
+    assert rp.launches == []
+
+
+def test_translation_helper_cpu_intents_pass_through_verbatim():
+    """T8: CPU intents (gpu_count == 0 in INTENT_TO_MACHINE) pass through the
+    helper verbatim — the #677/#747 CPU semantics are untouched at the helper
+    level (the end-to-end pins are the existing CPU tests above)."""
+    from explore_persona_space.backends.router import _translated_runpod_intent
+
+    for cpu_intent in ("cpu-small", "cpu-mid", "cpu-bigmem"):
+        assert _translated_runpod_intent(RunSpec(issue=1, intent=cpu_intent, backend="auto")) == (
+            cpu_intent,
+            None,
+        )


### PR DESCRIPTION
Closes task #940 (workflow-fix, kind: infra).

## Summary
- Adds router-owned `RUNPOD_INTENT_FOR_GCP_INTENT` map + `RUNPOD_INTENT_TRANSLATION_DELIBERATE_GAPS` and the `_translated_runpod_intent` helper, wired into `_runpod_terminal_rung` (after the #677/#747 CPU guard, before the flock) and `_override_runpod` — so the sanctioned RunPod last-rung fallback fires for GCP-only intents (`capture-7b`→`eval`, `lora`→`lora-7b`, `lora-7b-h100`→`lora-7b`) instead of dying on `resolve_intent` KeyError (incident #841).
- `eval-h100` is a deliberate fail-loud gap (no same-width RunPod intent; narrowing a TP=2 workload is banned); unmapped GCP GPU intents raise naming the missing map row.
- Translation recorded as `runpod_intent_translation` on the `epm:backend-selected` marker `extra`; 12 new test items incl. the T5 completeness pin and T6 never-widen property.

## Test plan
- [x] `tests/test_router.py` 192 passed (180 pre-existing unmodified)
- [x] `tests/test_backend_poll.py` 40 passed (untouched)
- [x] Step 9c touched-scope: 2416 passed, 6 skipped
- [x] ruff + workflow_lint clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)