### PR TITLE
task #946: add c17 causal-branch-scope WARN check to verify_plan.py

### DIFF
--- a/scripts/verify_plan.py
+++ b/scripts/verify_plan.py
@@ -36,11 +36,13 @@ Check catalog (id — classification — kind scope)
       claim backed by test
   c16 re-extracted reference    WARN-only, conditional    experiment +
       vs committed headline                               analysis
+  c17 falsification-branch      WARN-only, conditional    experiment +
+      causal-claim scope                                  analysis
 
 Kind-exempt checks render as [SKIP] (first-class status, distinguishable
 from genuine passes — the calibration report needs n_skip separate from
-n_pass). Conditional checks (4, 6, 7, 10, 11, 12, 13, 14, 15, 16) also SKIP
-when their content trigger does not fire.
+n_pass). Conditional checks (4, 6, 7, 10, 11, 12, 13, 14, 15, 16, 17) also
+SKIP when their content trigger does not fire.
 
 Canonical N/A escape phrases (quote verbatim in bounce briefs):
 
@@ -1952,6 +1954,155 @@ def check_reference_headline_distinction(plan: str, kind: str) -> CheckResult:
     )
 
 
+# ─── Check 17 — falsification-branch causal-claim scope (WARN-only) ────────
+
+# Offender vocabulary: wording that asserts a causal mechanism as
+# DEMONSTRATED inside a registered branch. Tier-1 only (corpus-calibrated,
+# task #946 §6): retrospective attribution ("really was/were", "must have
+# been"), content-carrying claims, story-kill idioms, takeaway rewrites,
+# and explicit establish/prove/demonstrate-that. Deliberately EXCLUDED as
+# accepted false negatives (prefer false negatives — the c14 charter):
+# present-tense "really is/does" (5-6 of 8 corpus hits were legitimate),
+# "rules out" (#605 uses it as a CI equivalence bound), bare "must be"
+# (deontic), and bare mechanism-noun falsify labels ("**Falsified
+# (integration):**" — not regex-separable from "(dependence)" labels).
+_C17_OFFENDER_RE = re.compile(
+    r"(?i)"
+    r"\breally\s+(?:was|were)\b"
+    r"|\bmust\s+have\s+been\b"
+    r"|\bcarr(?:y|ies|ied|ying)\b[^.\n]{0,50}\bcontent\b"
+    r"|\b(?:story|account|hypothesis|explanation|interpretation)\s+(?:dies|is\s+dead)\b"
+    r"|\brewrit(?:es?|ing)\s+the\b[^.\n]{0,60}\b(?:interpretation|takeaway|headline)\b"
+    r"|\b(?:establish(?:es|ed)?|prov(?:es|ed)|demonstrat(?:es|ed))\s+that\b"
+)
+# Exculpation vocabulary: an alternative-naming / hedge token in the SAME
+# block (hyp surface) or SAME bullet (TL;DR surface) silences the offender.
+# Over-breadth here only creates false negatives, which the charter prefers.
+# Calibrated on the #810 v13→v14 fix wording plus corpus hits (#563 "scope
+# caveat", #611/#621 "artifact", #841 "gets real support").
+_C17_EXCULP_RE = re.compile(
+    r"(?i)"
+    r"\bconsistent\s+with\b|\bcompatible\s+with\b"
+    r"|\buniquely\s+diagnostic\b"
+    r"|\bcannot\s+(?:distinguish|rule\s+out)\b"
+    r"|\bdoes\s+not\s+distinguish\b|\bdoesn'?t\s+distinguish\b"
+    r"|\balternative\b|\bconfound\w*\b|\bartifact\w*\b|\bcaveats?\b"
+    r"|\bsimpler\s+explanations?\b|\bother\s+explanations?\b"
+    r"|\bOOD\b|\boff-?distribution\b|\bout-?of-?distribution\b"
+    r"|\bremains?\s+live\b|\bdegradation\b|\bendpoint\b"
+    r"|\bpending\b|\bdisambiguat\w*\b|\bunder-?determin\w*\b|\bambiguous\b"
+    r"|\bwould\s+not\s+(?:prove|establish|demonstrate)\b"
+    r"|\b(?:gets?|gains?|lends?|earns?)\s+(?:real\s+)?support\b"
+)
+# The §0.0 registered plain-English falsification branch ("**What would
+# change my mind:**" / "…mind.**" — both corpus punctuation shapes).
+_C17_MIND_RE = re.compile(r"(?i)\*\*\s*what would change my mind")
+
+
+def _c17_mind_segments(plan: str) -> list[str]:
+    """The fence-stripped `**What would change my mind**` bullet(s), each
+    with its continuation lines (up to the next top-level list item or
+    heading) — the §0.0 registered falsification branch surface."""
+    lines = strip_fences(plan).splitlines()
+    segs: list[str] = []
+    i = 0
+    while i < len(lines):
+        if _C17_MIND_RE.search(lines[i]):
+            seg = [lines[i]]
+            j = i + 1
+            while (
+                j < len(lines)
+                and not _C14_LIST_ITEM_RE.match(lines[j])
+                and not _HEADING_RE.match(lines[j].strip())
+            ):
+                seg.append(lines[j])
+                j += 1
+            segs.append("\n".join(seg))
+            i = j
+        else:
+            i += 1
+    return segs
+
+
+def check_causal_claim_scope(plan: str, kind: str) -> CheckResult:
+    """WARN-only, conditional: a registered falsification (or confirm)
+    branch must not word its outcome as a DEMONSTRATED causal mechanism
+    when the same block never names the undistinguished alternative.
+    Surfaces scanned: (i) confirm/falsify segments of anchored hypothesis
+    blocks (c14's parsers, reused); (ii) the §0.0 `**What would change my
+    mind:**` bullet(s). An offender token is silenced by an exculpation
+    token in the same block/bullet. NEVER FAILs — a heuristic vocabulary
+    check must not hard-block a legitimately-worded plan; whether the
+    diagnostics actually distinguish the mechanism stays with the
+    Methodology/Statistics critics. The §6 corpus noise floor (2/195
+    newest-per-task) is IN-SAMPLE — the offender/exculpation vocabulary
+    was tuned on the same corpus it was measured on — so any future
+    FAIL-promotion needs held-out / prospective validation first.
+    Incident: #810 plan v13 ("they really were carrying answer content,
+    the echo story dies") — three reviewers independently required the
+    v14 scope-down ("consistent with integration but not uniquely
+    diagnostic; OOD ... remains live"); task #946."""
+    cid, name = "c17_causal_branch_scope", "falsification-branch causal-claim scope"
+    if kind not in ("experiment", "analysis"):
+        return _skip(
+            cid,
+            name,
+            "kind-exempt: registered falsification branches are an experiment|analysis plan shape",
+        )
+    anchored: list[tuple[str, tuple[str, str]]] = []
+    section = section_text_by_keywords(plan, ("hypothesis",))
+    if section is not None:
+        for block in _hypothesis_blocks(strip_fences(section)):
+            segments = _confirm_falsify_segments(block)
+            if segments is not None:
+                anchored.append((block, segments))
+    mind_segs = _c17_mind_segments(plan)
+    if not anchored and not mind_segs:
+        return _skip(
+            cid,
+            name,
+            "no registered falsification-branch surface (no **Confirm/**Falsify "
+            "hypothesis anchors, no **What would change my mind** bullet)",
+        )
+    offenders: list[str] = []
+    for block, (confirm_seg, falsify_seg) in anchored:
+        if _C17_EXCULP_RE.search(block):
+            continue
+        for branch, seg in (("falsify", falsify_seg), ("confirm", confirm_seg)):
+            m = _C17_OFFENDER_RE.search(seg)
+            if m:
+                offenders.append(
+                    f"hypothesis block {_c14_block_label(block)} ({branch} segment): "
+                    f"claim token '{m.group(0)}'"
+                )
+                break  # one offender per block is enough for the detail
+    for seg in mind_segs:
+        if _C17_EXCULP_RE.search(seg):
+            continue
+        m = _C17_OFFENDER_RE.search(seg)
+        if m:
+            offenders.append(f"'What would change my mind' bullet: claim token '{m.group(0)}'")
+    if not offenders:
+        return _pass(
+            cid,
+            name,
+            f"{len(anchored)} hypothesis block(s) + {len(mind_segs)} TL;DR bullet(s) "
+            "scanned; no unqualified demonstrated-mechanism claim token",
+        )
+    extra = f" (+{len(offenders) - 3} more)" if len(offenders) > 3 else ""
+    return _warn(
+        cid,
+        name,
+        "; ".join(offenders[:3])
+        + extra
+        + " — the branch asserts a causal account its diagnostics may not uniquely "
+        "distinguish (#810 v13 incident): name the undistinguished alternative in "
+        "the same block (e.g. 'consistent with <mechanism> but not uniquely "
+        "diagnostic; <alternative> remains live') or scope the wording to the "
+        "measured quantity; semantic verdict stays with the critics",
+    )
+
+
 # ─── Driver ────────────────────────────────────────────────────────────────
 
 CHECKS = [
@@ -1971,6 +2122,7 @@ CHECKS = [
     check_hypothesis_branch_coherence,
     check_failloud_test_coverage,
     check_reference_headline_distinction,
+    check_causal_claim_scope,
 ]
 
 

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -153,10 +153,11 @@ def test_good_plan_passes_all():
         "c14_hypothesis_branch_coherence": "SKIP",
         "c15_failloud_test_coverage": "SKIP",
         "c16_reference_headline_distinction": "SKIP",
+        "c17_causal_branch_scope": "PASS",
     }
     actual = {cid: r.status for cid, r in by_id.items()}
     assert actual == expected
-    assert len(results) == 17
+    assert len(results) == 18
 
 
 # ─── Check 0 — plan-nonstub ────────────────────────────────────────────────
@@ -1426,7 +1427,9 @@ H922_H2 = "- **H2 (depth profile).** The carried-context share rises with depth:
 # #841 v12 line 29 — crisp `≤` vs `>` count comparators, no tendency token.
 H841_H1 = "- **H1 (Stage-0 fit, matched information).** The source-only GRU's held-out r2_id on Δ_ℓ does NOT beat the affine ridge on the data-limited late-layer band (transitions 17–25) or on a majority of the 27 transitions. **Confirm (ridge stands):** source-only GRU r2_id ≤ ridge r2_id on ≥ 14/27 transitions (raw space), consistent with the prefix-GRU's 27/27 loss. **Falsify (GRU wins):** source-only GRU r2_id > ridge r2_id on a majority of transitions, especially the late-layer band. Directional prior: LOSS or TIE (removing prefix information from an already-losing GRU should not lift it above ridge)."
 # #810 v6 line 35 — band/threshold wording (Confirm-the-null vs clears-the-
-# band), no tendency token.
+# band), no tendency token. DUAL-USE fixture: pins c14 PASS (no comparator
+# pair / vague scope) AND c17 WARN (the falsify segment's "rewrites the
+# parent's read-out takeaway" with no exculpation — the #810 defect family).
 H810_H2G = "- **H2-g (read-out).** No summary rescues behavior read-out on generic-genre activations either. **Confirm-the-null:** the two-method conjunction statistic sits inside its max-selected band for each new combo. **Falsify:** a summary clears the band on g1 → the Betley corpus was suppressing read-out (rewrites the parent's read-out takeaway)."
 
 
@@ -1920,6 +1923,142 @@ def test_c16_fenced_trigger_does_not_fire():
     assert _status(plan, C16) == "SKIP"
 
 
+# ─── Check 17 — falsification-branch causal-claim scope ────────────────────
+
+# #810 plan v13 §0.0 — the incident offender (three reviewers required the
+# scope-down); the v14 line is the accepted fix (exculpation tokens:
+# "consistent with", "not uniquely diagnostic", OOD, "remains live").
+C17_V13_MIND = (
+    "- **What would change my mind:** If deleting the answer makes them clearly "
+    "harder to rebuild — dropping below the plain answer-average benchmark — with "
+    "a clean paired gap, then they really were carrying answer content, the echo "
+    "story dies, and the parked follow-up #943 gets its revival condition."
+)
+C17_V14_MIND = (
+    "- **What would change my mind:** If deleting the answer makes them clearly "
+    "harder to rebuild — dropping below the plain answer-average benchmark — with "
+    "a clean paired gap, then the header read is ANSWER-PRESENCE-DEPENDENT — "
+    "consistent with integration but not uniquely diagnostic (an off-distribution "
+    "empty turn degrading the states remains live); the truncation dose-response "
+    "follow-up disambiguates, and parked #943's revival condition becomes "
+    "conditional on it."
+)
+# H810_H2G (the c14 PASS fixture, #810 v6) carries "rewrites the parent's
+# read-out takeaway" in its falsify segment with no exculpation — c17
+# deliberately WARNs on it (the diff-sketch's own example pattern; same
+# defect family that recurred on #810 through v13).
+H810_H2G_EXCULPATED = (
+    H810_H2G + " Not uniquely diagnostic on its own: a genre confound remains live."
+)
+# GOOD_PLAN minus its (clean) mind bullet — the no-surface SKIP fixture.
+GOOD_PLAN_MIND_LINE = (
+    "- **What would change my mind:** A shift larger than the run-to-run spread "
+    "would mean benign data alone moves persona expression."
+)
+
+
+@pytest.mark.parametrize("kind", ["infra", "batch", "survey"])
+def test_c17_kind_exempt_skips(kind):
+    plan = GOOD_PLAN + "\n" + C17_V13_MIND + "\n"
+    assert _status(plan, "c17_causal_branch_scope", kind=kind) == "SKIP"
+
+
+def test_c17_no_branch_surface_skips():
+    plan = GOOD_PLAN.replace(
+        GOOD_PLAN_MIND_LINE, "- **Spread note:** run-to-run spread is the yardstick."
+    )
+    r = _run(plan)[1]["c17_causal_branch_scope"]
+    assert r.status == "SKIP"
+    assert "no registered falsification-branch surface" in r.detail
+
+
+def test_c17_810_v13_mind_bullet_warns():
+    ok, by_id = _run(GOOD_PLAN + "\n" + C17_V13_MIND + "\n")
+    r = by_id["c17_causal_branch_scope"]
+    assert r.status == "WARN"
+    assert "really w" in r.detail  # 'really were'
+    assert "What would change my mind" in r.detail
+    assert ok is True  # WARN never flips exit 0
+
+
+def test_c17_810_v14_scoped_down_passes():
+    assert _status(GOOD_PLAN + "\n" + C17_V14_MIND + "\n", "c17_causal_branch_scope") == "PASS"
+
+
+def test_c17_hyp_falsify_rewrites_takeaway_warns():
+    r = _run(_hyp_plan(H810_H2G))[1]["c17_causal_branch_scope"]
+    assert r.status == "WARN"
+    assert "rewrites the parent" in r.detail
+    assert "falsify" in r.detail
+
+
+def test_c17_hyp_confirm_segment_offender_warns():
+    # Round-scope item R2: the confirm-branch scan path — an offender token
+    # inside an explicit **Confirm:** segment, no exculpation anywhere in
+    # the block → WARN naming the confirm segment.
+    plan = _hyp_plan(
+        "- **H1 (mechanism).** The probe reads answer information from the header states. "
+        "**Confirm:** a clean paired gap establishes that the states were integrated. "
+        "**Falsify:** no paired gap appears at any layer."
+    )
+    r = _run(plan)[1]["c17_causal_branch_scope"]
+    assert r.status == "WARN"
+    assert "confirm" in r.detail
+    assert "establishes that" in r.detail
+
+
+def test_c17_hyp_exculpated_passes():
+    assert _status(_hyp_plan(H810_H2G_EXCULPATED), "c17_causal_branch_scope") == "PASS"
+
+
+def test_c17_must_have_been_offender_warns():
+    # Round-scope item R3 (documentation fixture): the retrospective
+    # "must have been" attribution is tier-1 offender vocabulary.
+    plan = (
+        GOOD_PLAN
+        + "\n"
+        + (
+            "- **What would change my mind:** If the gap survives the swap, the "
+            "adapter must have been encoding the trait all along."
+        )
+        + "\n"
+    )
+    r = _run(plan)[1]["c17_causal_branch_scope"]
+    assert r.status == "WARN"
+    assert "must have been" in r.detail
+
+
+def test_c17_incidental_exculpation_silences_offender():
+    # Round-scope item R3 (documentation fixture): DOCUMENTED ACCEPTED
+    # FALSE NEGATIVE — exculpation scope is the whole bullet, so an
+    # INCIDENTAL hedge token ("caveat", here about judge sample size, not
+    # about the causal claim) silences a genuine offender ("story dies").
+    # Deliberate per the c14 prefer-false-negatives charter; do not
+    # "fix" by narrowing exculpation scope to the claim sentence (the v14
+    # fix wording itself puts the hedge in a trailing parenthetical).
+    plan = (
+        GOOD_PLAN
+        + "\n"
+        + (
+            "- **What would change my mind:** If the paired gap is clean, the echo "
+            "story dies (one caveat: the judge sample is small)."
+        )
+        + "\n"
+    )
+    assert _status(plan, "c17_causal_branch_scope") == "PASS"
+
+
+def test_c17_kind_analysis_warns_not_skips():
+    plan = GOOD_PLAN + "\n" + C17_V13_MIND + "\n"
+    assert _status(plan, "c17_causal_branch_scope", kind="analysis") == "WARN"
+
+
+def test_c17_fenced_offender_does_not_trigger():
+    plan = GOOD_PLAN + "\n```\n" + C17_V13_MIND + "\n```\n"
+    # GOOD_PLAN's own clean mind bullet is still a surface → PASS, not WARN.
+    assert _status(plan, "c17_causal_branch_scope") == "PASS"
+
+
 # ─── Plan-version + kind resolution ────────────────────────────────────────
 
 
@@ -1973,8 +2112,8 @@ def test_cli_json_schema_and_exit_zero_on_pass(tmp_path):
     assert {"id", "name", "status", "detail"} <= set(payload["checks"][0])
     statuses = {c["status"] for c in payload["checks"]}
     assert statuses <= {"PASS", "WARN", "FAIL", "SKIP"}
-    assert len(payload["checks"]) == 17
-    assert len({c["id"] for c in payload["checks"]}) == 17
+    assert len(payload["checks"]) == 18
+    assert len({c["id"] for c in payload["checks"]}) == 18
 
 
 def test_cli_exit_one_on_fail(tmp_path):


### PR DESCRIPTION
Closes task #946 (workflow-fix, kind: infra).

## Summary
- Adds `c17_causal_branch_scope` to `scripts/verify_plan.py`: a WARN-only check flagging registered falsification/confirm-branch wording that asserts a causal mechanism as demonstrated when the same block never names the undistinguished alternative (origin incident: #810 plan v13). C14-pattern: kind-gated to experiment|analysis, clean SKIPs, shared helpers reused read-only.
- 11 new pinning tests (incident TP, v14-fix negative, confirm-segment, accepted-FN documentation, kind-gate, fence immunity) + count pins 17→18.
- Shipped-check corpus sweep: 193 newest-per-task experiment|analysis plans → exactly the plan-classified 2-hit set; #810 v13 WARNs, v14/v15 silent.

## Test plan
- [x] `uv run pytest tests/test_verify_plan.py` — 201 passed
- [x] Step 9c touched-file subset — 2145 passed / 6 skipped
- [x] `workflow_lint.py` PASS; ruff check + format clean
- [x] Live spot checks on #810 v13/v15

🤖 Generated with [Claude Code](https://claude.com/claude-code)