### PR TITLE
issue-949: exclude anti-liveness progress notes from stage-skip refresh set

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -5239,7 +5239,10 @@ re-invocation).**
    window** — effective age is measured from the LATEST of the
    breadcrumb and any subsequent liveness marker (`epm:codex-task-*`,
    `epm:smoke-architecture-check`, `epm:proposed-tests`, or a
-   non-breadcrumb `epm:progress`): a healthy long-running round keeps
+   non-breadcrumb `epm:progress` — excluding anti-liveness notes: a
+   `deliberate-stop` stop record and `[autonomous_session_watch:...]` /
+   `[spawn-session:...]` telemetry never refresh the window, #810/#949):
+   a healthy long-running round keeps
    refreshing its window; a dead one goes silent and re-dispatches once
    the window expires. The mechanical form of this rule is
    `task_workflow.stage_dispatch_should_skip` (run the pre-dispatch

--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -1322,6 +1322,27 @@ STAGE_LIVENESS_KINDS = frozenset(
         "epm:proposed-tests",
     }
 )
+# Progress-note substrings that are ANTI-liveness for a stage-dispatch
+# freshness window (#949; incident #810): bracketed telemetry posted by the
+# session watcher / spawn machinery, never by the stage's own worker. The
+# watcher's own progress clock excludes the same classes
+# (scripts/autonomous_session_watch.py::_WATCHER_NOTE_SENTINELS — a script,
+# not importable from src/, so matched here by the shared bracketed
+# prefixes: every watcher sentinel embeds "[autonomous_session_watch:" and
+# spawn_session's bookkeeping sentinel embeds "[spawn-session:"). The
+# self-stamped "[long-phase-heartbeat]" prefix is DELIBERATELY absent — it
+# is posted by the stage's own long-running phase and IS liveness. The
+# sibling deliberate-stop exclusion (checked inline in
+# stage_dispatch_should_skip) also drops ANY note with
+# by == "spawn_session-stop" regardless of content — a future genuine
+# liveness post from spawn_session must use a different `by` or get a
+# carve-out here.
+STAGE_ANTILIVENESS_NOTE_SUBSTRINGS = frozenset(
+    {
+        "[autonomous_session_watch:",
+        "[spawn-session:",
+    }
+)
 
 _STAGE_ALIASES = {"code-reviewing": "code-review"}
 
@@ -1400,8 +1421,12 @@ def stage_dispatch_should_skip(
     (``STAGE_RESULT_KINDS[_normalize_stage(stage)]`` — clearing is round-agnostic by
     design, result markers carry no parsable round) or ``epm:failure``. While in
     flight, the freshness clock starts at the LATEST of the breadcrumb and any later
-    liveness marker (``STAGE_LIVENESS_KINDS`` or a non-breadcrumb ``epm:progress``;
-    a breadcrumb never refreshes any window): effective age < window -> skip reason;
+    liveness marker (``STAGE_LIVENESS_KINDS`` or a non-breadcrumb ``epm:progress`` —
+    EXCLUDING anti-liveness notes: a ``deliberate-stop`` record (``by ==
+    "spawn_session-stop"``) and bracketed watcher / spawn-session telemetry
+    (``STAGE_ANTILIVENESS_NOTE_SUBSTRINGS``) are stop/bookkeeping records, not
+    stage liveness, and never refresh a window (#810); a breadcrumb never
+    refreshes any window): effective age < window -> skip reason;
     >= window -> None (stalled, re-dispatch allowed). A malformed breadcrumb ``ts``
     fails toward dispatch (None); a malformed liveness ``ts`` is ignored. TOCTOU is a
     non-goal — two orchestrators both checking BEFORE either posts its breadcrumb can
@@ -1427,6 +1452,16 @@ def stage_dispatch_should_skip(
         if kind == "epm:progress":
             note = (event.get("note", "") or "").lstrip()
             if note.startswith("stage-dispatch "):
+                continue
+            # Anti-liveness (#810/#949): a deliberate session stop is the
+            # death record of the stage's owner, and bracketed watcher /
+            # spawn-session telemetry is third-party bookkeeping — neither
+            # is evidence the stage's OWN work is alive, so neither
+            # refreshes the window. (They do NOT clear the in-flight
+            # state; only result kinds / epm:failure / expiry do that.)
+            if note.startswith("deliberate-stop ") or event.get("by") == "spawn_session-stop":
+                continue
+            if any(s in note for s in STAGE_ANTILIVENESS_NOTE_SUBSTRINGS):
                 continue
         elif kind not in STAGE_LIVENESS_KINDS:
             continue

--- a/tests/test_stage_dispatch_dedup.py
+++ b/tests/test_stage_dispatch_dedup.py
@@ -455,6 +455,31 @@ def test_spawn_session_stop_by_field_does_not_refresh():
         ), stop_note
 
 
+def test_deliberate_stop_note_prefix_alone_does_not_refresh():
+    # The note-prefix leg ALONE (by is an ordinary poster, not
+    # "spawn_session-stop") must exclude — isolates the first half of the OR
+    # predicate so a regression dropping the prefix leg while keeping the
+    # by-field leg fails this test (Codex code-review r1, Minor).
+    events = [
+        _ev(
+            "2026-07-01T10:00:00Z",
+            "epm:progress",
+            "stage-dispatch stage=implementing round=1 subagent=experiment-implementer",
+        ),
+        _ev(
+            "2026-07-01T10:14:00Z",
+            "epm:progress",
+            "deliberate-stop pid=n/a target=happy-session:abc123 reason=operator-replace",
+        ),
+    ]
+    assert (
+        tw.stage_dispatch_should_skip(
+            events, "implementing", 1, 15, now=_dt("2026-07-01T10:20:00Z")
+        )
+        is None
+    )
+
+
 def test_watcher_telemetry_notes_do_not_refresh_window():
     # Third-party bracketed telemetry (watcher + spawn-session bookkeeping)
     # is not stage liveness; the watcher's own progress clock excludes the

--- a/tests/test_stage_dispatch_dedup.py
+++ b/tests/test_stage_dispatch_dedup.py
@@ -17,8 +17,8 @@ from datetime import datetime
 import explore_persona_space.task_workflow as tw
 
 
-def _ev(ts: str, kind: str, note: str = "", version: int = 1) -> dict:
-    return {"ts": ts, "kind": kind, "version": version, "by": "test", "note": note}
+def _ev(ts: str, kind: str, note: str = "", version: int = 1, by: str = "test") -> dict:
+    return {"ts": ts, "kind": kind, "version": version, "by": by, "note": note}
 
 
 def _dt(s: str) -> datetime:
@@ -265,7 +265,8 @@ def test_unrelated_progress_refreshes_window():
         ),
         _ev("2026-07-01T10:14:00Z", "epm:progress", "pod-provision waiting on RunPod capacity..."),
     ]
-    # Documented over-skip direction: ANY non-breadcrumb progress refreshes the window.
+    # Documented over-skip direction: any non-anti-liveness non-breadcrumb progress
+    # refreshes the window.
     assert (
         tw.stage_dispatch_should_skip(
             events, "implementing", 1, 15, now=_dt("2026-07-01T10:20:00Z")
@@ -399,4 +400,124 @@ def test_age_exactly_window_allows_dispatch():
             events, "implementing", 1, 15, now=_dt("2026-07-01T10:15:00Z")
         )
         is None
+    )
+
+
+def test_810_replay_deliberate_stop_note_does_not_refresh_window():
+    # #810 (2026-07-03): the stopped session's deliberate-stop record refreshed
+    # the followup-implementing window; the replacement was told to skip dead work.
+    events = [
+        _ev(
+            "2026-07-01T10:00:00Z",
+            "epm:progress",
+            "stage-dispatch stage=implementing round=1 subagent=experiment-implementer",
+        ),
+        _ev(
+            "2026-07-01T10:14:00Z",
+            "epm:progress",
+            "deliberate-stop pid=n/a target=happy-session:abc123 reason=operator-replace",
+            by="spawn_session-stop",
+        ),
+    ]
+    # Past the breadcrumb's own window: the stop record must NOT have refreshed.
+    assert (
+        tw.stage_dispatch_should_skip(
+            events, "implementing", 1, 15, now=_dt("2026-07-01T10:20:00Z")
+        )
+        is None
+    )
+    # Inside the breadcrumb's own window: exclusion never CLEARS in-flight state.
+    assert (
+        tw.stage_dispatch_should_skip(
+            events, "implementing", 1, 15, now=_dt("2026-07-01T10:10:00Z")
+        )
+        is not None
+    )
+
+
+def test_spawn_session_stop_by_field_does_not_refresh():
+    # The by-field leg alone (note text variant) is sufficient to exclude — ANY
+    # note posted with by="spawn_session-stop" is a stop record, whatever it says.
+    for stop_note in ("stopping session", "session teardown requested by operator"):
+        events = [
+            _ev(
+                "2026-07-01T10:00:00Z",
+                "epm:progress",
+                "stage-dispatch stage=implementing round=1 subagent=experiment-implementer",
+            ),
+            _ev("2026-07-01T10:14:00Z", "epm:progress", stop_note, by="spawn_session-stop"),
+        ]
+        assert (
+            tw.stage_dispatch_should_skip(
+                events, "implementing", 1, 15, now=_dt("2026-07-01T10:20:00Z")
+            )
+            is None
+        ), stop_note
+
+
+def test_watcher_telemetry_notes_do_not_refresh_window():
+    # Third-party bracketed telemetry (watcher + spawn-session bookkeeping)
+    # is not stage liveness; the watcher's own progress clock excludes the
+    # same set (_WATCHER_NOTE_SENTINELS).
+    for telemetry_note in (
+        "[autonomous_session_watch:session-stalled-alert] session idle 2.1h",
+        "[autonomous_session_watch:session-auto-respawn] respawned via spawn-issue --auto",
+        "[spawn-session:duplicate-dispatch-suppressed] duplicate --auto dispatch suppressed",
+    ):
+        events = [
+            _ev(
+                "2026-07-01T10:00:00Z",
+                "epm:progress",
+                "stage-dispatch stage=implementing round=1 subagent=experiment-implementer",
+            ),
+            _ev("2026-07-01T10:14:00Z", "epm:progress", telemetry_note),
+        ]
+        assert (
+            tw.stage_dispatch_should_skip(
+                events, "implementing", 1, 15, now=_dt("2026-07-01T10:20:00Z")
+            )
+            is None
+        ), telemetry_note
+
+
+def test_long_phase_heartbeat_note_still_refreshes_window():
+    # Inverse boundary: [long-phase-heartbeat] is stamped by the stage's OWN
+    # long-running phase — it IS liveness and must keep refreshing.
+    events = [
+        _ev(
+            "2026-07-01T10:00:00Z",
+            "epm:progress",
+            "stage-dispatch stage=implementing round=1 subagent=experiment-implementer",
+        ),
+        _ev("2026-07-01T10:14:00Z", "epm:progress", "[long-phase-heartbeat] batch poll tick 3"),
+    ]
+    assert (
+        tw.stage_dispatch_should_skip(
+            events, "implementing", 1, 15, now=_dt("2026-07-01T10:20:00Z")
+        )
+        is not None
+    )
+
+
+def test_note_quoting_deliberate_stop_mid_text_still_refreshes():
+    # Prefix boundary: the deliberate-stop exclusion matches the lstripped note
+    # PREFIX "deliberate-stop " only — an ordinary progress note that merely
+    # QUOTES the string mid-text is still genuine liveness and refreshes.
+    events = [
+        _ev(
+            "2026-07-01T10:00:00Z",
+            "epm:progress",
+            "stage-dispatch stage=implementing round=1 subagent=experiment-implementer",
+        ),
+        _ev(
+            "2026-07-01T10:14:00Z",
+            "epm:progress",
+            "noting the earlier deliberate-stop was expected; resuming phase 2",
+        ),
+    ]
+    assert (
+        tw.stage_dispatch_should_skip(
+            events, "implementing", 1, 15, now=_dt("2026-07-01T10:20:00Z")
+        )
+        is not None
     )


### PR DESCRIPTION
Closes task #949 (workflow-fix, #810 incident). Consumer-side fix to stage_dispatch_should_skip + 5 pinned regression tests + Step 9 entry-guard prose.