### PR TITLE
issue-947: verify_plan c18 — paired-contrast per-arm source coverage

### DIFF
--- a/scripts/verify_plan.py
+++ b/scripts/verify_plan.py
@@ -38,11 +38,13 @@ Check catalog (id — classification — kind scope)
       vs committed headline                               analysis
   c17 falsification-branch      WARN-only, conditional    experiment +
       causal-claim scope                                  analysis
+  c18 paired-contrast per-arm   FAIL (experiment) / WARN  experiment +
+      source coverage           (analysis), conditional   analysis
 
 Kind-exempt checks render as [SKIP] (first-class status, distinguishable
 from genuine passes — the calibration report needs n_skip separate from
-n_pass). Conditional checks (4, 6, 7, 10, 11, 12, 13, 14, 15, 16, 17) also
-SKIP when their content trigger does not fire.
+n_pass). Conditional checks (4, 6, 7, 10, 11, 12, 13, 14, 15, 16, 17, 18)
+also SKIP when their content trigger does not fire.
 
 Canonical N/A escape phrases (quote verbatim in bounce briefs):
 
@@ -57,6 +59,7 @@ Canonical N/A escape phrases (quote verbatim in bounce briefs):
   - ``N/A — no fail-loud acceptance claim`` /
     ``N/A — fail-loud claim not test-backable`` (check 15)
   - ``N/A — no re-extracted reference arms`` (check 16)
+  - ``N/A — no paired contrast`` (check 18)
 
 WARN semantics: a WARN never blocks exit (exit 0). The Phase 1.5.0 wiring
 carries WARN lines verbatim into the fact-checker + critic briefs — that
@@ -1338,24 +1341,31 @@ def _c13_registered_gates(plan: str) -> list[dict]:
     return gates
 
 
-def _c13_na_escape_declared(plan: str) -> bool:
-    """True when the ``N/A — no empirical-null gate`` escape appears as a
-    deliberate STANDALONE declaration line (leading list/blockquote markers
-    stripped), never doc-global: the c13 FAIL detail quotes the escape phrase
-    as a remedy option, and this project's convention pastes verifier/bounce
-    text into revised plans verbatim — a substring match would let a bounced
-    plan self-escape re-verification (the #810 spurious-satisfaction
-    structure, one polarity over). NA_RE opens with an inline (?i), so it
-    must sit at pattern position 0 — per-line re.match satisfies that; never
-    prepend a prefix to NA_RE (py3.11+ rejects mid-pattern global flags)."""
+def _standalone_na_declared(plan: str, tail_re: str) -> bool:
+    """True when ``N/A — <tail_re>`` appears as a deliberate STANDALONE
+    declaration line (leading list/blockquote markers stripped), never
+    doc-global: a FAIL detail quotes its escape phrase as a remedy option,
+    and this project's convention pastes verifier/bounce text into revised
+    plans verbatim — a substring match would let a bounced plan self-escape
+    re-verification (the #810 spurious-satisfaction structure, one polarity
+    over). NA_RE opens with an inline (?i), so it must sit at pattern
+    position 0 — per-line re.match satisfies that; never prepend a prefix
+    to NA_RE (py3.11+ rejects mid-pattern global flags). Shared by the c13
+    and c18 escapes (the Supersede rule: one copy of the job)."""
     lines = plan.splitlines()
     mask = _fence_mask(lines)
     for line, fenced in zip(lines, mask, strict=True):
         if fenced:
             continue
-        if re.match(NA_RE + r"no empirical[- ]null gate", line.lstrip(" \t>*-")):
+        if re.match(NA_RE + tail_re, line.lstrip(" \t>*-")):
             return True
     return False
+
+
+def _c13_na_escape_declared(plan: str) -> bool:
+    """Standalone ``N/A — no empirical-null gate`` escape (see
+    ``_standalone_na_declared`` for the anti-paste rationale)."""
+    return _standalone_na_declared(plan, r"no empirical[- ]null gate")
 
 
 def _c13_evaluate(gates: list[dict], decls: list[tuple[str, int]]) -> dict:
@@ -2103,6 +2113,203 @@ def check_causal_claim_scope(plan: str, kind: str) -> CheckResult:
     )
 
 
+# ─── Check 18 — paired-contrast per-arm source coverage ────────────────────
+
+# Registration-family sections (H2+ ONLY — a doc-spanning H1 title match
+# would make the section constraint vacuous; both #810 registrations sit
+# under H2 sections): c13's success/kill/evaluation families PLUS
+# hypothesis + nulls + statistic.
+_C18_SECTION_RE = re.compile(
+    r"(?i)hypothes|success criteri|acceptance criteri|decision rule|decision gate"
+    r"|kill[- ]criteri|abort criteri|stop criteri|\bevaluation\b|\bnulls?\b|statistic"
+)
+_C18_PAIRED_RE = re.compile(r"(?i)\bpaired\b")
+_C18_REGIST_RE = re.compile(r"(?i)\bregist")  # registered / registration / registers
+_C18_PAIRCOUNT_RE = re.compile(r"(?i)\b\d[\d,]*\s+(?:pre-named\s+)?pairs\b")
+# D1: a row-coverage declaration; evidence on the same line or within the
+# next _C18_DECL_WINDOW_LINES physical lines (fenced lines excluded).
+_C18_COVERAGE_RE = re.compile(r"(?i)\brow[- ]coverage\b")
+_C18_ARTIFACT_RE = re.compile(
+    r"(?i)\S+\.(?:pt|pth|json|jsonl|npz|npy|safetensors|csv|parquet|arrow)\b"
+    r"|\beval_results/\S+|\banalysis_tensors/\S+|\braw_completions/\S+"
+)
+# v2 (MF-B): the bare `this run` alternative is REMOVED — only the
+# arms-generated construction or an explicit `by construction` counts as
+# by-construction evidence ("Row-coverage: deferred to a later revision of
+# this run's analysis" must FAIL).
+_C18_BYCONSTRUCTION_RE = re.compile(
+    r"(?i)both arms .{0,60}\b(?:generated|produced|computed|fit(?:ted)?|emitted)\b"
+    r"|\bby construction\b"
+)
+# D2 (MF-A): a subset expression AND word-bounded row/pair vocabulary AND
+# coverage/source-key vocabulary must co-occur on the candidate line.
+# Word-bounding kills the 608 v2:164 false-satisfier ("pair" inside
+# "paired" no longer matches); the coverage-vocab conjunct excludes
+# incidental subset prose; the #810 v15 declaration carries standalone
+# row/pairs tokens + coverage/source/keys/assert (replay-verified).
+_C18_SUBSET_RE = re.compile(r"(?i)⊆|\bissubset\b|\bis a subset of\b")
+_C18_ROWPAIR_RE = re.compile(r"(?i)\b(?:pairs?|rows?)\b")
+_C18_COVERAGE_VOCAB_RE = re.compile(r"(?i)coverage|\bsources?\b|\bkeys?\b|\bassert")
+# Candidate-line rejection guards (BOTH satisfier families):
+# (a) paste fingerprint — the c18 FAIL detail carries this literal, so a
+#     verbatim-pasted bounce text can never self-satisfy;
+# (b) cross-issue citation token — a line QUOTING another issue's driver
+#     assert as a worked example is a citation, not a declaration (an
+#     honest declaration describes THIS plan's inputs; recovery for a
+#     legitimate collision: move the citation off the declaration line).
+_C18_PASTE_FINGERPRINT = "#810 v13 class"
+_C18_ISSUE_REF_RE = re.compile(r"#\d{2,}")
+_C18_DECL_WINDOW_LINES = 3
+# Trigger-side spurious-line guard (§3.4 calibration tuning): a FIGURES-
+# enumeration line ("**Figures (over-produce):** ... paired cells; ...
+# registered rows visually distinguished") lists plots, it registers no
+# statistic — the one spurious-trigger class the exhaustive FAIL audit
+# surfaced (7 corpus files: #537 v4-v6, #931 v1-v4). Scoped by LINE SHAPE
+# (a leading figures label), never by content elsewhere on the line; a
+# real registration line never opens with a figures label, so the guard
+# under-triggers safe (SKIP; critics review).
+_C18_FIGURES_LINE_RE = re.compile(r"(?i)^\W{0,8}figures?\b")
+
+# Known accepted mis-triggers (mirroring the c13 §4.5 precedent). Under-
+# triggers that fail SAFE (SKIP — the plan still reaches the fact-checker +
+# critic ensemble): (a) a paired registration line without `regist` / pair-
+# count vocabulary; (b) a registration under a heading outside the H2+
+# section family; (c) a hard-wrapped registration (`paired` and `regist` on
+# different lines). Over-trigger that fails LOUD (bounce, escapable): (d) a
+# Hypothesis-section line merely RECAPPING a sibling's registered paired
+# statistic — remedied by the standalone N/A line. Fail-UNSAFE residuals,
+# accepted and DISCLOSED: (e) a D1/D2-shaped declaration that doesn't
+# actually cover the registered rows — including a ONE-ARM declaration (the
+# #810 v15 exemplar itself is full-side-only; both-arm truth stays with the
+# fact-checker; disposition pinned by fixture); (f) a NON-verbatim
+# paraphrase of the bounce text that reconstructs a satisfying shape while
+# dropping the fingerprint — beyond mechanical defense, same residual class
+# as a dishonest c13 N/A line; (g) a wrapped/reformatted paste that
+# separates the fingerprint from the row-coverage phrase across lines — the
+# line-local guard misses it; the D1 evidence requirement (artifact token /
+# arms-generated phrase) still has to be met by the surviving fragment,
+# which the detail's wording deliberately fails to supply.
+
+
+def _c18_registered_paired_lines(plan: str) -> list[str]:
+    """Non-fenced lines inside a registration-family H2+ section carrying
+    ``paired`` plus registration vocabulary OR an enumerated pair count on
+    the SAME line (#810 v13:33 'Registered per-row statistic: paired ...
+    (7 pairs ...' and v13:103 'Nulls (registration) ... paired bootstrap CI
+    (... 9 pairs are pre-named' both match). Level-1 headings are EXCLUDED
+    from the section match (a title match spans the whole doc). Under-
+    trigger fails safe (SKIP; critics review)."""
+    lines = plan.splitlines()
+    mask = _fence_mask(lines)
+    headings = _headings(plan)
+    hits: list[str] = []
+    for i, (line, fenced) in enumerate(zip(lines, mask, strict=True)):
+        if fenced or not _C18_PAIRED_RE.search(line):
+            continue
+        if not (_C18_REGIST_RE.search(line) or _C18_PAIRCOUNT_RE.search(line)):
+            continue
+        if _C18_FIGURES_LINE_RE.match(line.strip()):
+            continue
+        if not any(
+            h.line <= i < h.end and h.level >= 2 and _C18_SECTION_RE.search(h.text)
+            for h in headings
+        ):
+            continue
+        hits.append(line.strip())
+    return hits
+
+
+def _c18_candidate_ok(line: str) -> bool:
+    """Rejection guards shared by D1 and D2 candidate lines: the paste
+    fingerprint and cross-issue citation tokens disqualify a line from
+    satisfying the check (bounce-paste + quoted-sibling-example vectors)."""
+    return _C18_PASTE_FINGERPRINT not in line and not _C18_ISSUE_REF_RE.search(line)
+
+
+def _c18_coverage_declarations(plan: str) -> list[str]:
+    """Lines satisfying D1 (row-coverage vocab + source evidence — an
+    artifact token or an arms-generated phrase — on the same line or within
+    the next _C18_DECL_WINDOW_LINES physical lines, fenced lines excluded)
+    or D2 (subset expression + word-bounded row/pair vocab +
+    coverage/source-key vocab, same line). Candidate lines failing
+    ``_c18_candidate_ok`` are rejected."""
+    lines = plan.splitlines()
+    mask = _fence_mask(lines)
+    out: list[str] = []
+    for i, (line, fenced) in enumerate(zip(lines, mask, strict=True)):
+        if fenced or not _c18_candidate_ok(line):
+            continue
+        if (
+            _C18_SUBSET_RE.search(line)
+            and _C18_ROWPAIR_RE.search(line)
+            and _C18_COVERAGE_VOCAB_RE.search(line)
+        ):
+            out.append(line.strip())
+            continue
+        if _C18_COVERAGE_RE.search(line):
+            window = [line] + [
+                lines[j]
+                for j in range(i + 1, min(i + 1 + _C18_DECL_WINDOW_LINES, len(lines)))
+                if not mask[j]
+            ]
+            if any(_C18_ARTIFACT_RE.search(w) or _C18_BYCONSTRUCTION_RE.search(w) for w in window):
+                out.append(line.strip())
+    return out
+
+
+def _c18_na_escape_declared(plan: str) -> bool:
+    """Standalone ``N/A — no paired contrast`` escape (see
+    ``_standalone_na_declared`` for the anti-paste rationale)."""
+    return _standalone_na_declared(plan, r"no paired contrast")
+
+
+def check_paired_contrast_source_coverage(plan: str, kind: str) -> CheckResult:
+    """A registered paired contrast (a hypothesis/evaluation/success-section
+    line registering a paired statistic over enumerable rows/pairs) must
+    DECLARE a per-context data source covering the registered rows on both
+    arms (D1 row-coverage line / D2 coverage-labeled subset-assert /
+    standalone N/A). Surface check only — pack contents stay with the
+    fact-checker. FAIL (experiment) / WARN (analysis) / SKIP otherwise.
+    Incident: #810 v13 (9-row paired bootstrap; the named full-side pack
+    lacked im_end/turn_nl; 4 independent reviewer catches)."""
+    cid, name = "c18_paired_contrast_source_coverage", "paired-contrast per-arm source coverage"
+    if kind not in ("experiment", "analysis"):
+        return _skip(
+            cid,
+            name,
+            "kind-exempt: registered paired contrasts are an experiment|analysis plan shape",
+        )
+    triggers = _c18_registered_paired_lines(plan)
+    if not triggers:
+        return _skip(cid, name, "no registered paired contrast detected")
+    if _c18_na_escape_declared(plan):
+        return _pass(cid, name, "explicit N/A declared (no paired contrast)")
+    decls = _c18_coverage_declarations(plan)
+    if decls:
+        return _pass(
+            cid,
+            name,
+            f'row-coverage declaration found ("{decls[0][:90]}") — declaration surface '
+            "only; whether the named sources truly contain every registered row on both "
+            "arms stays with the fact-checker",
+        )
+    detail = (
+        f'plan registers a paired contrast ("{triggers[0][:90]}") with no per-arm '
+        "row-coverage declaration — a registered pair row absent from a named side makes "
+        "the registered criterion unsatisfiable from the named inputs (the #810 v13 class: "
+        "2 of 9 rows missing from the named full side). Remedy: add ONE non-fenced prose "
+        "line (not inside a code fence) starting 'Row-coverage:' naming, for BOTH arms, "
+        "which per-context store/file supplies every registered row (or stating that the "
+        "plan's own fits produce every registered row on each arm), or state the driver "
+        "assert that set-checks the registered rows against the named sources' keys on a "
+        "non-fenced line, or declare 'N/A — no paired contrast' on its own line; keep the "
+        "declaration line free of cross-issue citations"
+    )
+    if kind == "analysis":
+        return _warn(cid, name, detail + " (analysis kind-degrade: WARN, not FAIL)")
+    return _fail(cid, name, detail)
+
+
 # ─── Driver ────────────────────────────────────────────────────────────────
 
 CHECKS = [
@@ -2123,6 +2330,7 @@ CHECKS = [
     check_failloud_test_coverage,
     check_reference_headline_distinction,
     check_causal_claim_scope,
+    check_paired_contrast_source_coverage,
 ]
 
 

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -37,7 +37,7 @@ sys.modules["verify_plan"] = verify_plan
 _spec.loader.exec_module(verify_plan)  # type: ignore[union-attr]
 
 
-# ─── Canonical plan (kind=experiment: passes 0-3,5,8,9; skips 4,6,7,10-16) ─
+# ─── Canonical plan (kind=experiment: passes 0-3,5,8,9,17; skips 4,6,7,10-16,18)
 
 # Surgery anchors (must appear verbatim in GOOD_PLAN exactly once).
 MV_HEADING = "### Measurement validity"
@@ -154,10 +154,11 @@ def test_good_plan_passes_all():
         "c15_failloud_test_coverage": "SKIP",
         "c16_reference_headline_distinction": "SKIP",
         "c17_causal_branch_scope": "PASS",
+        "c18_paired_contrast_source_coverage": "SKIP",
     }
     actual = {cid: r.status for cid, r in by_id.items()}
     assert actual == expected
-    assert len(results) == 18
+    assert len(results) == 19
 
 
 # ─── Check 0 — plan-nonstub ────────────────────────────────────────────────
@@ -2059,6 +2060,241 @@ def test_c17_fenced_offender_does_not_trigger():
     assert _status(plan, "c17_causal_branch_scope") == "PASS"
 
 
+# ─── Check 18 — paired-contrast per-arm source coverage ────────────────────
+
+# Verbatim corpus literals (embedded, never read from tasks/ paths — plans
+# move between status folders; this file's own convention). Sources: #810
+# plans/v13.md:33 (the founding FAIL registration — 9-row paired bootstrap
+# whose named full-side pack lacked im_end/turn_nl), #810 plans/v15.md:71
+# (the reviewer-converged PASS declaration — the D2 subset-assert shape),
+# task #608 plans/v2.md:164 (the replay-found incidental subset-CI
+# false-satisfier: "pair" substring-matches inside "paired"; word-bounding
+# must reject it). The REAL files are exercised by the §3.4 implementation
+# calibration replay, not by this suite.
+C18_V13_REGISTRATION = "- **H1-he (echo — the headline).** Empty-answer header/boundary rows reconstruct ≈ as well as their full-answer twins. **Registered per-row statistic:** paired per-context LOCO Δskill(full − empty) at each row's committed best layer, via the shared-index 2,000-draw bootstrap (7 pairs vs round-3 rows; `im_end`/`turn_nl` pair vs round-1). **Echo supported:** every header pool's Δ CI includes 0 or |Δ| < 0.02 (the round-3 D_uh margin), AND best empty-row LOFO ≥ 0.805. **Falsified (integration):** best header/boundary empty-row LOFO < 0.805 AND that row's paired Δ CI excludes 0 from above (\"clearly-positive\"). Expected: echo."
+C18_V15_DECLARATION = "4. **NEW `scripts/issue810_he_mechanism.py`** (thin driver, the only new analysis file — the `issue810_uh_crosslayer.py` precedent): loads `uh_summaries.pt` (full side for the 7 uh/bnd rows) + `he_summaries.pt` (empty) + — MUST-FIX addition — the round-3 HF store `issue658_theory_assumptions/answer_position_sweep_user_header/<ctx>.pt` (per-file `hf_hub_download`, ~430 MB total, cpu-mid-safe) as the FULL side for the `im_end`/`turn_nl` pairs (NOT in the uh pack — verified by three reviewers); their refit-parity assert targets the ROUND-1 committed skills in `eval_results/issue_810/reconstruction_skill_by_summary.json` (valid: both positions are causally upstream of the extension), ≤1e-6. ROW-COVERAGE SMOKE ASSERT (mechanizable): `set(registered_pair_rows) ⊆ union(keys(full_side_sources))` for every source named here, asserted at driver start; (a) cross-context-centers each (row, layer) across the 50 contexts and emits per-context cosine + pooled R² (1 − ‖full−empty‖²/‖full‖², centered); (b) refits the full-side per-context LOCO predictions from `uh_summaries.pt` (asserting skills match committed ≤1e-6 — the `a26da411bb` precedent) and runs the paired shared-index 2,000-draw bootstrap on Δskill(full−empty) per row at the committed best layers. All numpy/torch-CPU, batched."
+C18_608_CI_LINE = "Per-cell own-rate SE ≈ 0.01–0.02 binomial, ≈ 0.03–0.05 claim-clustered (effective N = 50 claims) — the +0.05 support threshold and ±0.02 equivalence band sit respectively above and below that noise floor. Formal tests — REGISTERED CONVENTIONS (v2): per-source claim-level paired bootstrap on g(s) (per-claim 10-rollout rates → paired claim differences → resample 50 claims with replacement → 10,000 draws → two-sided 95% percentile CI; base rates not resampled — base cancels in g); H1 falsification uses the CI-CONTAINMENT reading (CI ⊆ [−0.05, +0.05] for ≥5/6 sources, per §1); boundary-indeterminate outcomes are reported as indeterminate with continuous estimates, never as evidence against H1. 6-source sign test reported one-sided AND two-sided (two-sided: 6/6 p=0.031, 5/6 p=0.219; one-sided: 6/6 p=0.016, 5/6 p=0.109) as a descriptive pattern — the per-source CIs carry the inference. κ-calibration per §4 Phase G; the May-vs-June drift comparison is descriptive only (the single unified judge pass removes it from the inferential path)."
+
+
+def _c18_plan(*parts: str) -> str:
+    """GOOD_PLAN + a Hypothesis section carrying ``parts`` in order
+    (GOOD_PLAN contains zero `paired` mentions — pinned in the
+    not-triggered test below, so the base plan can never trigger c18)."""
+    return GOOD_PLAN + "\n## Hypothesis\n\n" + "\n\n".join(parts) + "\n"
+
+
+def test_c18_not_triggered_skips():
+    assert "paired" not in GOOD_PLAN.lower()  # fixture precondition
+    _, by_id = _run(GOOD_PLAN)
+    r = by_id["c18_paired_contrast_source_coverage"]
+    assert r.status == "SKIP"
+    assert "no registered paired contrast" in r.detail
+
+
+@pytest.mark.parametrize("kind", ["infra", "batch", "survey"])
+def test_c18_kind_exempt_skips(kind):
+    plan = _c18_plan(C18_V13_REGISTRATION)
+    assert _status(plan, "c18_paired_contrast_source_coverage", kind=kind) == "SKIP"
+
+
+def test_c18_810_v13_shape_fails():
+    ok, by_id = _run(_c18_plan(C18_V13_REGISTRATION))
+    r = by_id["c18_paired_contrast_source_coverage"]
+    assert r.status == "FAIL"
+    assert "Row-coverage" in r.detail  # copy-adaptable remedy option
+    assert "N/A — no paired contrast" in r.detail  # escape phrase quoted
+    assert "#810 v13 class" in r.detail  # paste fingerprint (guard a)
+    assert C18_V13_REGISTRATION[:90] in r.detail  # quoted trigger prefix
+    assert ok is False
+
+
+def test_c18_810_v15_subset_assert_passes():
+    # D2: subset expression + word-bounded row/pair vocab + coverage vocab
+    # on the real v15:71 declaration line.
+    _, by_id = _run(_c18_plan(C18_V13_REGISTRATION, C18_V15_DECLARATION))
+    r = by_id["c18_paired_contrast_source_coverage"]
+    assert r.status == "PASS"
+    assert "row-coverage declaration found" in r.detail
+    assert "fact-checker" in r.detail  # a PASS is never "coverage verified"
+    # Guard (b) must not trip on the real literal (no cross-issue #NN token).
+    assert verify_plan._c18_candidate_ok(C18_V15_DECLARATION)
+
+
+def test_c18_incidental_subset_ci_line_does_not_satisfy():
+    # MF-A anchor: the #608 v2:164 CI-containment convention carries a subset
+    # expression + coverage vocab ("sources") but NO word-bounded row/pair
+    # token — "paired" must not substring-satisfy the pairs? vocabulary.
+    assert verify_plan._C18_SUBSET_RE.search(C18_608_CI_LINE)
+    assert not verify_plan._C18_ROWPAIR_RE.search(C18_608_CI_LINE)
+    plan = _c18_plan(C18_V13_REGISTRATION, C18_608_CI_LINE)
+    assert _status(plan, "c18_paired_contrast_source_coverage") == "FAIL"
+
+
+def test_c18_quoted_sibling_assert_does_not_satisfy():
+    # Guard (b): quoting another issue's driver assert as a worked example is
+    # a citation, not a declaration of THIS plan's inputs.
+    quoted = (
+        "As in #810 v15: `set(registered_pair_rows) ⊆ union(keys(full_side_sources))` "
+        "asserted for all 9 rows at driver start."
+    )
+    plan = _c18_plan(C18_V13_REGISTRATION, quoted)
+    assert _status(plan, "c18_paired_contrast_source_coverage") == "FAIL"
+
+
+def test_c18_deferral_row_coverage_line_does_not_satisfy():
+    # MF-B: the v1 bare `this run` by-construction alternative was removed —
+    # a deferral anti-declaration carries zero source evidence.
+    deferral = "Row-coverage: deferred to a later revision of this run's analysis."
+    plan = _c18_plan(C18_V13_REGISTRATION, deferral)
+    assert _status(plan, "c18_paired_contrast_source_coverage") == "FAIL"
+
+
+def test_c18_one_arm_declaration_passes_by_design():
+    # Accepted residual (e), pinned as the DOCUMENTED disposition (not a
+    # bug): the #810 v15 exemplar declaration is itself full-side-only, so a
+    # structural both-arm requirement would reject the incident's own
+    # reviewer-converged fix. One-arm truthfulness stays with the
+    # fact-checker (the check's scope-discipline paragraph).
+    one_arm = "Row-coverage: full arm = uh_summaries.pt (all 9 rows)."
+    plan = _c18_plan(C18_V13_REGISTRATION, one_arm)
+    assert _status(plan, "c18_paired_contrast_source_coverage") == "PASS"
+
+
+def test_c18_row_coverage_line_with_artifacts_passes():
+    decl = (
+        "Row-coverage: full arm = uh_summaries.pt (7 uh/bnd rows) + round-3 store "
+        "(im_end, turn_nl); empty arm = he_summaries.pt (all 9 rows)."
+    )
+    _, by_id = _run(_c18_plan(C18_V13_REGISTRATION, decl))
+    r = by_id["c18_paired_contrast_source_coverage"]
+    assert r.status == "PASS"
+    assert "declaration surface" in r.detail
+
+
+def test_c18_row_coverage_forward_window_passes():
+    # The multi-line header + per-arm bullet shape: evidence within the
+    # 3-physical-line forward window.
+    decl = (
+        "Row-coverage (per arm):\n"
+        "- full arm: uh_summaries.pt (7 uh/bnd rows) + the round-3 store (im_end, turn_nl)\n"
+        "- empty arm: he_summaries.pt (all 9 rows)"
+    )
+    plan = _c18_plan(C18_V13_REGISTRATION, decl)
+    assert _status(plan, "c18_paired_contrast_source_coverage") == "PASS"
+
+
+def test_c18_by_construction_declaration_passes():
+    decl = "Row-coverage: both arms computed by this plan's own fits over the shared probe grid."
+    plan = _c18_plan(C18_V13_REGISTRATION, decl)
+    assert _status(plan, "c18_paired_contrast_source_coverage") == "PASS"
+
+
+def test_c18_na_escape_passes():
+    plan = _c18_plan(C18_V13_REGISTRATION) + (
+        "\nN/A — no paired contrast (the paired statistic above recaps the sibling's "
+        "registration).\n"
+    )
+    _, by_id = _run(plan)
+    r = by_id["c18_paired_contrast_source_coverage"]
+    assert r.status == "PASS"
+    assert "N/A" in r.detail
+
+
+def test_c18_quoted_na_phrase_does_not_escape():
+    plan = _c18_plan(
+        C18_V13_REGISTRATION,
+        "The remedy menu offers \"declare 'N/A — no paired contrast' on its own line\" "
+        "as one option.",
+    )
+    assert _status(plan, "c18_paired_contrast_source_coverage") == "FAIL"
+
+
+def test_c18_kind_analysis_warns_not_fails():
+    ok, by_id = _run(_c18_plan(C18_V13_REGISTRATION), kind="analysis")
+    r = by_id["c18_paired_contrast_source_coverage"]
+    assert r.status == "WARN"
+    assert "kind-degrade" in r.detail
+    assert ok is True  # WARN never flips exit 0
+
+
+def test_c18_fenced_registration_does_not_trigger():
+    plan = GOOD_PLAN + "\n## Hypothesis\n\n```\n" + C18_V13_REGISTRATION + "\n```\n"
+    assert _status(plan, "c18_paired_contrast_source_coverage") == "SKIP"
+
+
+def test_c18_registration_outside_registration_section_skips():
+    plan = GOOD_PLAN + "\n## Prior Work\n\n" + C18_V13_REGISTRATION + "\n"
+    assert _status(plan, "c18_paired_contrast_source_coverage") == "SKIP"
+
+
+def test_c18_h1_title_match_does_not_scope():
+    # H2+ restriction: a doc-spanning H1 *title* matching the section family
+    # (here the `nulls?` member, via "turn-null") must not scope the whole
+    # doc into the registration family.
+    plan = (
+        "# Plan — real-user-turn-null sweep\n\n"
+        + "filler word " * 200
+        + "\n\n## 1. Goal\n\nx\n\n## 2. Design\n\ny\n\n## Prior Work\n\n"
+        + C18_V13_REGISTRATION
+        + "\n"
+    )
+    assert _status(plan, "c18_paired_contrast_source_coverage") == "SKIP"
+
+
+def test_c18_paircount_form_triggers():
+    # The pair-count trigger route in ISOLATION: `paired` + an enumerated
+    # pair count, no `regist` substring anywhere on the line (precondition
+    # asserted — a deleted _C18_PAIRCOUNT_RE fails this test, never
+    # vacuously passes it).
+    line = (
+        "- The headline statistic is a paired bootstrap CI over the 9 pairs, "
+        "all pre-named; report all 9 jointly."
+    )
+    assert not verify_plan._C18_REGIST_RE.search(line)
+    assert verify_plan._C18_PAIRCOUNT_RE.search(line)
+    assert _status(_c18_plan(line), "c18_paired_contrast_source_coverage") == "FAIL"
+
+
+def test_c18_pasted_fail_detail_does_not_self_satisfy():
+    # The project convention pastes bounce text verbatim into revised plans:
+    # the FAIL detail carries the fingerprint (guard a) and a cross-issue
+    # token (guard b), and its wording supplies no D1 evidence / D2 subset
+    # expression, so a pasted detail can never satisfy the check.
+    _, by_id = _run(_c18_plan(C18_V13_REGISTRATION))
+    detail = by_id["c18_paired_contrast_source_coverage"].detail
+    assert verify_plan._C18_PASTE_FINGERPRINT in detail
+    replan = _c18_plan(C18_V13_REGISTRATION, detail)
+    assert _status(replan, "c18_paired_contrast_source_coverage") == "FAIL"
+
+
+def test_c18_bare_coverage_vocab_without_evidence_does_not_satisfy():
+    # v13:218's reporting-completeness shape: "covers" prose without the
+    # row-coverage token or a subset expression is not a declaration.
+    line = "- Every registered read emits its verdict; the paired table covers all 9 rows."
+    plan = _c18_plan(C18_V13_REGISTRATION, line)
+    assert _status(plan, "c18_paired_contrast_source_coverage") == "FAIL"
+
+
+def test_c18_generic_covers_prose_not_a_declaration():
+    # No D1 match without the literal row-coverage token.
+    line = "Both packs cover every registered row and every source is verified upstream."
+    plan = _c18_plan(C18_V13_REGISTRATION, line)
+    assert _status(plan, "c18_paired_contrast_source_coverage") == "FAIL"
+
+
+def test_c18_figures_enumeration_line_does_not_trigger():
+    # §3.4 calibration tuning: a figures-enumeration line mentions paired
+    # panels + "registered rows visually distinguished" without registering
+    # any statistic (the #537 v4-v6 / #931 v1-v4 spurious-trigger class) —
+    # the leading figures label excludes it from the trigger scan.
+    line = (
+        "**Figures (over-produce; analyzer picks heroes):** hero forest plot "
+        "(registered rows visually distinguished); EM contrastive vs "
+        "non-contrastive paired cells; per-row diagonal implant-strength bars."
+    )
+    assert _status(_c18_plan(line), "c18_paired_contrast_source_coverage") == "SKIP"
+
+
 # ─── Plan-version + kind resolution ────────────────────────────────────────
 
 
@@ -2108,12 +2344,12 @@ def test_cli_json_schema_and_exit_zero_on_pass(tmp_path):
     assert payload["issue"] is None
     assert payload["kind"] == "experiment"
     assert payload["n_fail"] == 0
-    assert payload["n_skip"] == 10
+    assert payload["n_skip"] == 11
     assert {"id", "name", "status", "detail"} <= set(payload["checks"][0])
     statuses = {c["status"] for c in payload["checks"]}
     assert statuses <= {"PASS", "WARN", "FAIL", "SKIP"}
-    assert len(payload["checks"]) == 18
-    assert len({c["id"] for c in payload["checks"]}) == 18
+    assert len(payload["checks"]) == 19
+    assert len({c["id"] for c in payload["checks"]}) == 19
 
 
 def test_cli_exit_one_on_fail(tmp_path):


### PR DESCRIPTION
Closes task #947 (workflow-fix, auto-filed from four independent reviewer catches on #810 plan v13).

## Summary
- Adds check c18 `check_paired_contrast_source_coverage` to `scripts/verify_plan.py`: a registered paired contrast (H2+ registration-family section, `paired` + registration/pair-count vocabulary) must carry a per-arm row-coverage declaration (D1 `Row-coverage:` line / D2 coverage-labeled subset-assert / standalone `N/A — no paired contrast`), else FAIL (experiment) / WARN (analysis).
- 22 new tests incl. the four binding anchors: #810 v13 registration shape FAILs, v15 driver-assert shape PASSes, the 608 v2:164 incidental-⊆-CI line rejected, quoted-sibling-example rejected.
- `_c13_na_escape_declared` rewired onto shared `_standalone_na_declared` (behavior-identical, pinned by existing tests).
- Calibration: 1,141 corpus plan files → 69 triggers → exhaustive FAIL-status + PASS-satisfier audits, 0 spurious triggers/satisfiers after one in-lane tuning (figures-enumeration guard).

## Test plan
- [x] `uv run pytest tests/test_verify_plan.py` — 225 passed (worktree)
- [x] Step 9c touched-scope gate — 2192 passed / 6 skipped
- [x] `ruff check` + `ruff format --check` + `workflow_lint.py` clean
- [x] Anchors re-confirmed on the real #810 v13/v15 plan files

🤖 Generated with [Claude Code](https://claude.com/claude-code)