### PR TITLE
task #951: material-CPU liveness veto on the zombie-GPU stalled override

### DIFF
--- a/scripts/poll_pipeline.py
+++ b/scripts/poll_pipeline.py
@@ -91,12 +91,23 @@ per-phase / shard) is stale past the effective stall window
 processes stop appending; both observed false positives had fresh
 logs), and (c) the stale-log candidate persisted for 2 CONSECUTIVE
 observed ticks (``zombie_streak`` in the state sidecar — filters the
-#778 one-tick teardown transient). Session-CPU advancement is
+#778 one-tick teardown transient). Bare session-CPU *advancement* is
 deliberately NOT a veto term: the genuine #664 hang had CPU advancing
-(the EngineCore idle-burn is why this override exists at all), so a CPU
-veto would make the true positive unreachable. Fail-safe: nvidia-smi
-missing / erroring emits an empty list (never a false zombie); the
-override never touches a `done` / `gate` / `dead` verdict.
+(the EngineCore idle-burn is why this override exists at all), so an
+any-delta CPU veto would make the true positive unreachable. A MATERIAL
+sustained burn *rate* IS one (#951): a session that burned >=
+``ZOMBIE_OVERRIDE_CPU_CORES_MIN`` cores (default 0.5) on BOTH of the
+last two persisted ticks is demonstrably computing — #664's hung
+EngineCore churned ~0.22 cores while #825's falsely-flagged live fit
+burned ~1.83-2.04 cores next to prior-run VRAM leftover — so the
+override is vetoed (streak reset, like the fresh-log veto). The rate is
+derived VM-side from the persisted ``session_cpu_secs`` /
+``session_cpu_sample_epoch`` sidecar pair; ANY degraded input (unknown
+sample, missing epoch, tick spacing under ``ZOMBIE_CPU_RATE_MIN_DT_SEC``,
+negative delta) leaves the veto inert — exactly the pre-#951 behavior.
+Fail-safe: nvidia-smi missing / erroring emits an empty list (never a
+false zombie); the override never touches a `done` / `gate` / `dead`
+verdict.
 
 Namespace-informativeness gate (#864): the #826 assumption "hung <=>
 stale logs" lapses when a HEALTHY workload legitimately silences its
@@ -578,6 +589,32 @@ ZOMBIE_VETO_FRESH_SEC = int(os.environ.get("EPM_ZOMBIE_VETO_FRESH_SEC", "60"))
 # re-check is a one-literal follow-up; the probe counts + gate + tests land
 # either way.
 ZOMBIE_NAMESPACE_VETO_ENABLED = os.environ.get("EPM_ZOMBIE_NAMESPACE_VETO", "0") != "0"
+
+# #951: material-compute liveness veto on the #664/#826 zombie-GPU override.
+# A workload session burning >= this many CPU cores (delta cumulative session
+# CPU / wall seconds between persisted ticks) on BOTH of the last two ticks is
+# demonstrably computing — veto the running->stalled override. Sits between
+# the two measured regimes: #664's hung EngineCore churned ~0.22 cores
+# (Python-overhead idle burn) while #825's falsely-flagged live fit burned
+# ~1.83-2.04 cores (+1102s/+989s per ~540s tick, 186% in top) — 2.27x above
+# churn, 3.66x below real compute. Sustained-rate, so poll-interval-invariant
+# (540s vs 1800s adaptive ticks). NOTE: session_cpu_secs is a session-TOTAL
+# (summed over every process in the launcher's setsid session) and both
+# calibration incidents were NARROW sessions — a wide hung session (TP>=2
+# NCCL spin ~1 core/rank, or a co-resident same-session burner) can sum past
+# this threshold and keep a true zombie vetoed (accepted exposure, same
+# class as the #826 fresh-log sibling; backstops: GPU-idle escalation, #873
+# ETA tripwires, watcher wedge arm). Raise EPM_ZOMBIE_OVERRIDE_CPU_CORES_MIN
+# when debugging a suppressed wide-pod hang.
+ZOMBIE_OVERRIDE_CPU_CORES_MIN = float(os.environ.get("EPM_ZOMBIE_OVERRIDE_CPU_CORES_MIN", "0.5"))
+
+# #951: denominator floor for the per-tick CPU rate. Below this wall-clock
+# spacing between persisted CPU samples the rate is not computed (None ->
+# veto inert): `ps -o time` truncates to whole seconds per process, so a
+# short window inflates spurious rate from truncation noise (~1s x N
+# session processes). Production intervals are 540s/1800s so the floor
+# never binds there; it guards manual rapid re-polls and fast-smoke ticks.
+ZOMBIE_CPU_RATE_MIN_DT_SEC = int(os.environ.get("EPM_ZOMBIE_CPU_RATE_MIN_DT_SEC", "120"))
 
 
 def _try_refresh_pods_conf_from_api(pod: str) -> bool:
@@ -3206,6 +3243,38 @@ def _roll_session_cpu_max(prev_max: str | None, current: str) -> str:
     return prev_max if prev_max else current
 
 
+def _session_cpu_rate_cores(
+    prev_sample: str | None,
+    prev_sample_epoch: str | None,
+    current: str,
+    now_epoch: int,
+) -> float | None:
+    """Per-tick session-CPU burn rate in cores, or None when not computable.
+
+    rate = (current - prev_sample) / (now_epoch - prev_sample_epoch), where
+    prev_sample + prev_sample_epoch are the SAME prior tick's persisted pair
+    (written together by _save_state). None (fail-safe -> the #951 veto does
+    NOT fire) when: either CPU sample is unknown/unparseable, the epoch is
+    missing/unparseable/<=0, or the wall gap is < ZOMBIE_CPU_RATE_MIN_DT_SEC
+    (truncation-noise floor) or non-positive (clock garbage). A NEGATIVE
+    rate (run restart resets the session counter; a multi-shard child exit
+    de-counts its cputime, #658) is returned as-is — it is below any
+    positive threshold, so the veto does not fire on it.
+    """
+    cur = _parse_session_cpu(current)
+    prev = _parse_session_cpu(prev_sample) if prev_sample is not None else None
+    epoch = _parse_session_cpu(prev_sample_epoch) if prev_sample_epoch else None
+    if cur is None or prev is None or epoch is None or epoch <= 0:
+        return None
+    dt = now_epoch - epoch
+    if dt < ZOMBIE_CPU_RATE_MIN_DT_SEC:
+        # Also covers dt <= 0 (the floor is positive) — LOAD-BEARING for the
+        # existing two-call replay tests, whose back-to-back poll_once calls
+        # persist the epoch on call 1 and re-poll milliseconds later (dt~0).
+        return None
+    return (cur - prev) / dt
+
+
 def _load_state(state_file: Path, issue: int) -> dict[str, str]:
     if not state_file.exists():
         return {}
@@ -3245,9 +3314,11 @@ def _apply_zombie_override(
     gpu_pids_total: int | None = None,
     gpu_pids_resolvable: int | None = None,
     uvm_live_holders: int | None = None,
+    session_cpu_rate_cores: float | None = None,
 ) -> tuple[str, str | None, bool, int]:
-    """The #664/#826/#864 zombie-GPU-allocation override — returns the possibly
-    overridden ``(status, stall_reason, cpu_override_active, zombie_streak)``.
+    """The #664/#826/#864/#951 zombie-GPU-allocation override — returns the
+    possibly overridden
+    ``(status, stall_reason, cpu_override_active, zombie_streak)``.
 
     A hung vLLM whose CUDA worker died leaves its model-shard VRAM orphaned
     (a compute-apps PID with no ``/proc`` entry) while the EngineCore main
@@ -3273,14 +3344,49 @@ def _apply_zombie_override(
     ``_save_state`` neither advances nor resets it, the same exposure
     ``ssh_fail_count`` has; the sidecar is single-poller by design).
 
-    Session-CPU advancement is deliberately NOT a veto term: the genuine #664
-    hang had CPU advancing (in the stale-log + idle-GPU regime ``running`` is
-    only reachable via the CPU rescue), so a CPU veto would make the true
-    positive structurally unreachable. Never touches a ``done`` / ``gate`` /
-    ``dead`` verdict — those are correct terminal/park states (a dead
-    launcher is already ``dead``; its own orphaned allocation is then
-    expected). The ``stall_reason`` lets the orchestrator route this
-    distinctly from a generic log+GPU+CPU stall.
+    Bare session-CPU *advancement* is deliberately NOT a veto term: the
+    genuine #664 hang had CPU advancing (in the stale-log + idle-GPU regime
+    ``running`` is only reachable via the CPU rescue), so an any-delta
+    (> ``SESSION_CPU_ADVANCE_EPSILON_SECS``, the #518/#658 boolean) CPU veto
+    would make the true positive structurally unreachable. A MATERIAL
+    sustained burn *rate* IS a veto term (#951, next paragraph): the measured
+    #664 churn (~0.22 cores) cannot reach the rate threshold, so the true
+    positive stays reachable. Never touches a ``done`` / ``gate`` / ``dead``
+    verdict — those are correct terminal/park states (a dead launcher is
+    already ``dead``; its own orphaned allocation is then expected). The
+    ``stall_reason`` lets the orchestrator route this distinctly from a
+    generic log+GPU+CPU stall.
+
+    Material-compute liveness veto (#951, between the #826 fresh-log veto
+    and the streak defer/fire branches): when the per-tick session-CPU burn
+    rate was >= ``ZOMBIE_OVERRIDE_CPU_CORES_MIN`` (default 0.5 cores) on
+    BOTH the current tick (``session_cpu_rate_cores``, computed by
+    ``poll_once`` via ``_session_cpu_rate_cores``) AND the previous
+    persisted tick (the sidecar's ``session_cpu_rate_cores`` key), the
+    session is demonstrably computing — #825's falsely-flagged live fit
+    burned ~1.83-2.04 cores while 1816 MiB of prior-run VRAM leftover
+    carried the zombie signature — so the override is suppressed and the
+    streak RESETS to 0 (identical mechanics to the #826 fresh-log and #864
+    namespace vetoes; reset, not hold, so a later degraded CPU read after
+    material compute defers a full fresh 2-tick window instead of firing
+    immediately). Fail-safe on ANY degraded input (missing/unparseable CPU
+    sample, missing previous-tick baseline or rate, missing/garbage sample
+    timestamp, tick spacing under ``ZOMBIE_CPU_RATE_MIN_DT_SEC``, negative
+    delta): the rate is None / below threshold, the veto stays inert, and
+    behavior is exactly the pre-#951 #826/#864 cascade. Residual exposure
+    (ACCEPTED): ``session_cpu_secs`` is a session-TOTAL, so a WIDE hung
+    session (TP>=2 NCCL spin at ~1 core/rank) or a co-resident same-session
+    CPU burner can sustain >= the threshold indefinitely and keep a true
+    zombie vetoed — the same exposure class as the #826 fresh-log sibling
+    (a sibling process appending to a log forever suppresses the override
+    the same way today), bounded by the GPU-idle advisory/escalation tiers,
+    the #873 phase-ETA tripwires, the watcher wedge arm, and the
+    ``EPM_ZOMBIE_OVERRIDE_CPU_CORES_MIN`` knob. Warmup: on a fresh or
+    pre-#951 sidecar the veto cannot engage until the 3rd tick — tick 1
+    persists the sample epoch with rate ``"unknown"``, tick 2 computes the
+    first rate but has no prev-tick rate — which is the fail-safe direction
+    (current behavior during warmup); a false stall in that window is the
+    warmup, not a fix failure.
 
     Namespace-informativeness gate (#864, FIRST branch): the #826 stale-log
     veto lapses when a HEALTHY workload legitimately silences its logs
@@ -3327,9 +3433,10 @@ def _apply_zombie_override(
     partial death keeps firing exactly as today. (c)
     ``ZOMBIE_NAMESPACE_VETO_ENABLED`` is read at module import — a live
     poller needs a restart for an ops flip to take effect. (d) On a tick
-    matching BOTH this gate and the #826 fresh-log veto, the namespace
-    WARNING fires first (outcome identical — ``running``, streak 0; only
-    the forensic log line differs).
+    matching BOTH this gate and the #826 fresh-log veto — or the #951
+    material-CPU veto — the namespace WARNING fires first (outcome
+    identical — ``running``, streak 0; only the forensic log line
+    differs).
     """
     stall_reason: str | None = None
     zombie_streak = 0
@@ -3369,6 +3476,10 @@ def _apply_zombie_override(
             prev_zombie_streak = int(prev_state.get("zombie_streak", "0") or 0)
         except (TypeError, ValueError):
             prev_zombie_streak = 0
+        # #951: the previous tick's persisted burn rate. _parse_session_cpu
+        # maps an absent key / "unknown" / garbage to None (fail-safe — the
+        # material-CPU veto below then cannot fire).
+        prev_cpu_rate = _parse_session_cpu(prev_state.get("session_cpu_rate_cores", "unknown"))
         if freshest_log_ago <= zombie_veto_sec:
             log.warning(
                 "zombie-GPU signature on pod %s (PID(s) %s) but log evidence is fresh "
@@ -3379,6 +3490,28 @@ def _apply_zombie_override(
                 freshest_log_ago,
                 zombie_veto_sec,
             )
+        elif (
+            session_cpu_rate_cores is not None
+            and prev_cpu_rate is not None
+            and session_cpu_rate_cores >= ZOMBIE_OVERRIDE_CPU_CORES_MIN
+            and prev_cpu_rate >= ZOMBIE_OVERRIDE_CPU_CORES_MIN
+        ):
+            # #951: material compute — the session burned >= T cores on BOTH
+            # of the last two persisted ticks. #664's hung EngineCore churns
+            # ~0.22 cores; real work (the #825 fit at ~1.9 cores) cannot be a
+            # hang. Veto; streak resets (zombie_streak stays 0 — recomputed
+            # each tick).
+            log.warning(
+                "zombie-GPU signature on pod %s (PID(s) %s) with all logs stale BUT session "
+                "CPU burned %.2f / %.2f cores over the last two ticks (>= %.2f) — material "
+                "compute, liveness veto, not flagging (#951; #825: prior-run VRAM leftover "
+                "while the live workload computed)",
+                pod,
+                ",".join(zombie_gpu_pids),
+                session_cpu_rate_cores,
+                prev_cpu_rate,
+                ZOMBIE_OVERRIDE_CPU_CORES_MIN,
+            )
         elif prev_zombie_streak < 1:
             zombie_streak = 1
             log.warning(
@@ -3388,14 +3521,22 @@ def _apply_zombie_override(
                 ",".join(zombie_gpu_pids),
             )
         else:
+            # #951 forensic evidence on the FIRE path: the two burn rates
+            # (or "unknown") are the durable record for tuning
+            # EPM_ZOMBIE_OVERRIDE_CPU_CORES_MIN after the next incident —
+            # the sidecar keeps only the last tick.
             log.error(
                 "zombie GPU allocation on pod %s: compute PID(s) %s hold >= %d MiB VRAM but "
                 "are absent from /proc (dead CUDA worker, vLLM EngineCore hung) — persisted "
                 "2 consecutive ticks with all logs stale, overriding "
-                "status=running -> stalled (#664/#826)",
+                "status=running -> stalled (#664/#826); session-CPU rate now=%s prev=%s "
+                "cores (veto threshold %.2f)",
                 pod,
                 ",".join(zombie_gpu_pids),
                 ZOMBIE_GPU_MEM_MIN_MIB,
+                "unknown" if session_cpu_rate_cores is None else f"{session_cpu_rate_cores:.2f}",
+                "unknown" if prev_cpu_rate is None else f"{prev_cpu_rate:.2f}",
+                ZOMBIE_OVERRIDE_CPU_CORES_MIN,
             )
             status = "stalled"
             stall_reason = "vllm_worker_dead_zombie_gpu"
@@ -3712,6 +3853,15 @@ def poll_once(
     # Roll the high-water mark forward for the next tick (#658). The max only
     # ever grows; a current sample below it (a child exit) does not lower it.
     max_session_cpu = _roll_session_cpu_max(prev_max_session_cpu, current_session_cpu)
+    # #951: per-tick burn rate vs the PREVIOUS tick's raw sample (not the max —
+    # the delta between consecutive samples is the current burn), for the
+    # material-compute veto on the zombie override.
+    session_cpu_rate = _session_cpu_rate_cores(
+        prev_state.get("session_cpu_secs"),
+        prev_state.get("session_cpu_sample_epoch"),
+        current_session_cpu,
+        now_epoch,
+    )
 
     # True when the verdict below is `running` ONLY because the #518
     # CPU-advancing override rescued a met stall conjunction (logs stale +
@@ -3763,6 +3913,7 @@ def poll_once(
         gpu_pids_total=_parse_probe_count(probe.get("gpu_pids_total")),
         gpu_pids_resolvable=_parse_probe_count(probe.get("gpu_pids_resolvable")),
         uvm_live_holders=_parse_probe_count(probe.get("nvidia_uvm_live_holders")),
+        session_cpu_rate_cores=session_cpu_rate,
     )
 
     # ── #518/#537 GPU-idle advisory ──────────────────────────────────────
@@ -3960,6 +4111,16 @@ def poll_once(
             # `_parse_session_cpu` treats it consistently with the live
             # probe value.
             "session_cpu_secs": current_session_cpu,
+            # #951: VM-clock timestamp OF the session_cpu_secs sample above —
+            # the pair is written atomically together, so this epoch is the
+            # denominator anchor for the NEXT tick's burn-rate delta.
+            "session_cpu_sample_epoch": str(now_epoch),
+            # #951: this tick's per-tick burn rate (cores) vs the prior
+            # persisted sample; "unknown" when not computable (fail-safe —
+            # the material-CPU veto reads it as no-signal next tick).
+            "session_cpu_rate_cores": (
+                "unknown" if session_cpu_rate is None else f"{session_cpu_rate:.4f}"
+            ),
             # Persist the running MAXIMUM cumulative CPU observed across all
             # ticks (#658). This is the baseline the NEXT tick's
             # advancing-decision compares against — a current sample below

--- a/tests/test_poll_pipeline_zombie_gpu.py
+++ b/tests/test_poll_pipeline_zombie_gpu.py
@@ -28,6 +28,19 @@ log staleness. Gated by ``ZOMBIE_NAMESPACE_VETO_ENABLED``
 (``EPM_ZOMBIE_NAMESPACE_VETO``; ships default-OFF per the #864 live-pod
 gate disposition).
 
+Since #951 the override additionally carries a material-compute liveness
+veto: when the per-tick session-CPU burn rate (delta of the persisted
+``session_cpu_secs`` / ``session_cpu_sample_epoch`` sidecar pair over the
+measured tick spacing) was >= ``ZOMBIE_OVERRIDE_CPU_CORES_MIN`` (default
+0.5 cores) on BOTH the current and the previous persisted tick, the
+session is demonstrably computing — the #825 false stall burned ~1.83-2.04
+cores next to 1816 MiB of prior-run VRAM leftover — and the override is
+vetoed (streak reset, like the other vetoes). #664's hung-EngineCore churn
+(~0.22 cores) stays below the threshold, so the true positive keeps
+firing; every degraded input (unknown sample, missing epoch/rate, tick
+spacing under ``ZOMBIE_CPU_RATE_MIN_DT_SEC``, negative delta) leaves the
+veto inert (pre-#951 behavior).
+
 These tests pin:
 
 * the probe-output parser (``_parse_probe_stdout``) lifting the new
@@ -53,7 +66,19 @@ These tests pin:
   ``EPM_ZOMBIE_NAMESPACE_VETO`` kill-switch; the producer-side probe
   emission / key-parity / exact end-anchored ``/dev/nvidia-uvm`` matcher
   pin (a heredoc typo must not leave the gate silently inert); and
-  ``_parse_probe_count`` unit behavior.
+  ``_parse_probe_count`` unit behavior;
+* the #951 material-compute veto: ``_session_cpu_rate_cores`` unit
+  behavior (happy path, fail-safe inputs, dt floor, negative delta); the
+  #825 replay vetoing (seeded with ``max_cpu_secs`` DISTINCT from the raw
+  sample so wrong-prev-key rate wiring flips the outcome); the #664
+  low-churn replay still firing; BOTH both-ticks conjuncts (single-tick
+  material AND prev-material/now-low each still fire); the
+  exact-threshold ``>=`` boundary; missing prev-rate / missing
+  sample-epoch / negative-delta fall-backs to current behavior; the veto
+  RESETTING (not holding) the streak; the direct-call default
+  (``session_cpu_rate_cores=None``) preserving pre-#951 outputs; and
+  ``_save_state`` persisting the ``session_cpu_sample_epoch`` /
+  ``session_cpu_rate_cores`` pair.
 """
 
 from __future__ import annotations
@@ -212,23 +237,38 @@ def _patch_pod(
     monkeypatch.setattr(pp, "_run_launched_age_sec", lambda issue, now_epoch: 10800.0)
 
 
-def _stale_state(now: int, *, prev_cpu: str, zombie_streak: str = "0") -> str:
+def _stale_state(
+    now: int,
+    *,
+    prev_cpu: str,
+    zombie_streak: str = "0",
+    max_cpu: str | None = None,
+    session_cpu_sample_epoch: str | None = None,
+    session_cpu_rate_cores: str | None = None,
+) -> str:
     """A prior-tick state file: phase already seen (so no transition), GPUs
     idle, with a prior session-CPU sample BELOW the current one so the
     #518/#658 override sees CPU advancing. ``zombie_streak`` pre-seeds the
     #826 persistence counter (``"1"`` makes a single ``poll_once`` call
-    represent tick 2 of a persisted stale-log zombie candidate)."""
-    return json.dumps(
-        {
-            "9664": {
-                "phase": "training",
-                "last_phase_change_epoch": str(now - 7200),
-                "session_cpu_secs": prev_cpu,
-                "max_cpu_secs": prev_cpu,
-                "zombie_streak": zombie_streak,
-            }
-        }
-    )
+    represent tick 2 of a persisted stale-log zombie candidate).
+
+    The #951 kwargs are only added to the dict when non-None, so pre-#951
+    callers produce a byte-identical seed (key-absence = the #951 veto is
+    inert on them). ``max_cpu`` (default: ``prev_cpu``) lets the #825 replay
+    seed a rolling max DISTINCT from the raw ``session_cpu_secs`` sample so
+    wrong-prev-key rate wiring is test-visible."""
+    state = {
+        "phase": "training",
+        "last_phase_change_epoch": str(now - 7200),
+        "session_cpu_secs": prev_cpu,
+        "max_cpu_secs": max_cpu if max_cpu is not None else prev_cpu,
+        "zombie_streak": zombie_streak,
+    }
+    if session_cpu_sample_epoch is not None:
+        state["session_cpu_sample_epoch"] = session_cpu_sample_epoch
+    if session_cpu_rate_cores is not None:
+        state["session_cpu_rate_cores"] = session_cpu_rate_cores
+    return json.dumps({"9664": state})
 
 
 def _saved_zombie_streak(state_file: Path) -> str:
@@ -959,3 +999,453 @@ def test_gpu_probe_emits_namespace_count_keys(monkeypatch: pytest.MonkeyPatch) -
     # count /dev/nvidia-uvm-tools holders and suppress the #664 TP.
     assert 'grep -q " -> /dev/nvidia-uvm$"' in remote
     assert "/dev/nvidia-uvm-tools" not in remote
+
+
+# ── #951 material-compute liveness veto ───────────────────────────────────────
+#
+# Integration-test seeding rule: every ``poll_once`` replay below seeds
+# ``max_cpu_secs`` (via ``_stale_state``'s default-or-``max_cpu``) so the
+# probe's ``session_cpu`` differs from it by > 0.5 s — ``cpu_advancing`` is
+# then True and the #518/#658 CPU rescue holds ``status == "running"`` INTO
+# the zombie block (else the test silently exercises the plain-stall path).
+# Template: ``test_zombie_gpu_overrides_cpu_advancing_running_to_stalled``.
+
+
+def _poll_once_9664(state_file: Path):
+    """One ``poll_once`` tick against the standard issue-9664 fixture paths."""
+    return pp.poll_once(
+        issue=9664,
+        pod="pod-9664",
+        log_path="/workspace/logs/issue-9664.log",
+        pid_file="/workspace/logs/issue-9664.pid",
+        state_file=state_file,
+    )
+
+
+def test_session_cpu_rate_happy_path() -> None:
+    """The #825 shape: prev sample 4000.0 s taken 540 s ago, current 5102.0 s
+    -> (5102 - 4000) / 540 ~= 2.0407 cores."""
+    now = int(time.time())
+    rate = pp._session_cpu_rate_cores("4000.0", str(now - 540), "5102.0", now)
+    assert rate == pytest.approx(1102.0 / 540.0)
+
+
+@pytest.mark.parametrize(
+    ("prev_sample", "prev_epoch", "current"),
+    [
+        ("4000.0", "OK", "unknown"),  # current sample unknown
+        (None, "OK", "5102.0"),  # prev sample missing (fresh sidecar)
+        ("unknown", "OK", "5102.0"),  # prev sample unknown
+        ("4000.0", None, "5102.0"),  # epoch key absent (pre-#951 sidecar)
+        ("4000.0", "", "5102.0"),  # epoch empty
+        ("4000.0", "unknown", "5102.0"),  # epoch unknown
+        ("4000.0", "0", "5102.0"),  # epoch zero (<= 0 guard)
+        ("4000.0", "garbage", "5102.0"),  # epoch unparseable
+    ],
+)
+def test_session_cpu_rate_fail_safe_inputs(
+    prev_sample: str | None, prev_epoch: str | None, current: str
+) -> None:
+    """Every degraded input -> None (the #951 veto stays inert)."""
+    now = int(time.time())
+    epoch = str(now - 540) if prev_epoch == "OK" else prev_epoch
+    assert pp._session_cpu_rate_cores(prev_sample, epoch, current, now) is None
+
+
+def test_session_cpu_rate_dt_floor() -> None:
+    """Tick spacing below ``ZOMBIE_CPU_RATE_MIN_DT_SEC`` -> None (truncation-
+    noise floor; also covers the back-to-back dt~0 replay case); spacing AT
+    the floor computes."""
+    now = int(time.time())
+    assert pp._session_cpu_rate_cores("4000.0", str(now - 30), "5102.0", now) is None
+    floor = pp.ZOMBIE_CPU_RATE_MIN_DT_SEC
+    at_floor = pp._session_cpu_rate_cores("4000.0", str(now - floor), "4120.0", now)
+    assert at_floor == pytest.approx(120.0 / floor)
+
+
+def test_session_cpu_rate_negative_delta_returned() -> None:
+    """A run-restart / child-exit de-count (current < prev) returns the
+    negative rate as-is — not clamped, not None; it sits below any positive
+    threshold so the veto never fires on it."""
+    now = int(time.time())
+    rate = pp._session_cpu_rate_cores("4000.0", str(now - 540), "3000.0", now)
+    assert rate == pytest.approx(-1000.0 / 540.0)
+    assert rate is not None and rate < 0
+
+
+def test_zombie_material_cpu_both_ticks_vetoes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The #825 replay: stale logs + idle GPUs + zombie candidate at streak
+    "1" (would fire under pure #826), but the session burned ~2.04 cores this
+    tick (probe 5102.0 vs raw sample 4000.0 over ~540 s) and 1.83 cores the
+    prior tick -> material compute, vetoed: running, no reason, streak reset.
+
+    ``max_cpu_secs`` is seeded DELIBERATELY HIGHER (5000.0) than the raw
+    ``session_cpu_secs`` sample (4000.0; realistic — a #658 child-exit
+    de-count lowers the raw sample below the rolling max): correct wiring
+    reads the RAW sample (delta +1102 s -> 2.04 cores >= T -> veto); wrong
+    wiring reading ``max_cpu_secs`` gets +102 s -> 0.19 cores < T -> no veto
+    -> this test FAILS on ``status == "stalled"``."""
+    now = int(time.time())
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 2000,
+        tail="2026-07-02 00:00:01 [phase=training step=5/100]",
+        gpu_util="0,0,0,0,0,0,0,0",
+        session_cpu="5102.0",  # > max_cpu_secs + 0.5 -> cpu_advancing=True
+        zombie_pids="1262130",
+    )
+    state_file = tmp_path / "poll-state.json"
+    state_file.write_text(
+        _stale_state(
+            now,
+            prev_cpu="4000.0",
+            zombie_streak="1",
+            max_cpu="5000.0",
+            session_cpu_sample_epoch=str(now - 540),
+            session_cpu_rate_cores="1.83",
+        )
+    )
+    result = _poll_once_9664(state_file)
+    assert result.status == "running"
+    assert result.stall_reason is None
+    assert _saved_zombie_streak(state_file) == "0"
+
+
+def test_zombie_low_cpu_churn_still_fires(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The #664 replay (constraint-1 regression pin): identical regime but
+    the session churns only ~0.22 cores on both ticks (probe 4119.0 vs
+    4000.0 over ~540 s; prior rate "0.22") — below the 0.5-core threshold,
+    so the veto stays inert and the override fires."""
+    now = int(time.time())
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 2000,
+        tail="2026-06-27 00:00:01 [phase=training step=5/100]",
+        gpu_util="0,0,0,0,0,0,0,0",
+        session_cpu="4119.0",  # +119 s over ~540 s ~= 0.22 cores
+        zombie_pids="1262130",
+    )
+    state_file = tmp_path / "poll-state.json"
+    state_file.write_text(
+        _stale_state(
+            now,
+            prev_cpu="4000.0",
+            zombie_streak="1",
+            session_cpu_sample_epoch=str(now - 540),
+            session_cpu_rate_cores="0.22",
+        )
+    )
+    result = _poll_once_9664(state_file)
+    assert result.status == "stalled"
+    assert result.stall_reason == "vllm_worker_dead_zombie_gpu"
+
+
+def test_zombie_material_cpu_single_tick_does_not_veto(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """BOTH-ticks pin, current-material direction: this tick burns ~2.04
+    cores but the PRIOR tick's persisted rate was 0.10 — a single material
+    tick (a ``ps`` truncation / transient-sibling artifact shape) must NOT
+    veto; the override fires."""
+    now = int(time.time())
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 2000,
+        tail="2026-06-27 00:00:01 [phase=training step=5/100]",
+        gpu_util="0,0,0,0,0,0,0,0",
+        session_cpu="5102.0",
+        zombie_pids="1262130",
+    )
+    state_file = tmp_path / "poll-state.json"
+    state_file.write_text(
+        _stale_state(
+            now,
+            prev_cpu="4000.0",
+            zombie_streak="1",
+            session_cpu_sample_epoch=str(now - 540),
+            session_cpu_rate_cores="0.10",
+        )
+    )
+    result = _poll_once_9664(state_file)
+    assert result.status == "stalled"
+    assert result.stall_reason == "vllm_worker_dead_zombie_gpu"
+
+
+def test_zombie_cpu_veto_missing_prev_rate_falls_back(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Degraded input: the sidecar has the sample + epoch but NO
+    ``session_cpu_rate_cores`` key (interrupted warmup shape) — prev rate is
+    no-signal, the veto cannot fire, the override fires (current behavior)."""
+    now = int(time.time())
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 2000,
+        tail="2026-06-27 00:00:01 [phase=training step=5/100]",
+        gpu_util="0,0,0,0,0,0,0,0",
+        session_cpu="5102.0",  # material THIS tick — still not enough alone
+        zombie_pids="1262130",
+    )
+    state_file = tmp_path / "poll-state.json"
+    state_file.write_text(
+        _stale_state(
+            now,
+            prev_cpu="4000.0",
+            zombie_streak="1",
+            session_cpu_sample_epoch=str(now - 540),
+        )
+    )
+    result = _poll_once_9664(state_file)
+    assert result.status == "stalled"
+    assert result.stall_reason == "vllm_worker_dead_zombie_gpu"
+
+
+def test_zombie_cpu_veto_missing_sample_epoch_falls_back(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Degraded input: NO ``session_cpu_sample_epoch`` key — exactly the
+    pre-#951 / fresh-sidecar-restart shape — so the current rate is not
+    computable and the override fires even though a (stale) prev rate is
+    present. Doubles as proof the existing seeded-state test semantics are
+    preserved by key-absence."""
+    now = int(time.time())
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 2000,
+        tail="2026-06-27 00:00:01 [phase=training step=5/100]",
+        gpu_util="0,0,0,0,0,0,0,0",
+        session_cpu="5102.0",
+        zombie_pids="1262130",
+    )
+    state_file = tmp_path / "poll-state.json"
+    state_file.write_text(
+        _stale_state(
+            now,
+            prev_cpu="4000.0",
+            zombie_streak="1",
+            session_cpu_rate_cores="1.83",
+        )
+    )
+    result = _poll_once_9664(state_file)
+    assert result.status == "stalled"
+    assert result.stall_reason == "vllm_worker_dead_zombie_gpu"
+
+
+def test_zombie_cpu_veto_negative_delta_falls_back(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Degraded input: the current sample DROPPED below the prior one (a
+    run-restart / child-exit de-count) — the negative rate sits below the
+    threshold, the veto cannot fire, the override fires. The sub-max drop
+    arm of the #518/#658 rescue (|delta| > 0.5 s) still holds ``running``
+    into the zombie block."""
+    now = int(time.time())
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 2000,
+        tail="2026-06-27 00:00:01 [phase=training step=5/100]",
+        gpu_util="0,0,0,0,0,0,0,0",
+        session_cpu="3000.0",  # < prev 4000.0 -> negative rate
+        zombie_pids="1262130",
+    )
+    state_file = tmp_path / "poll-state.json"
+    state_file.write_text(
+        _stale_state(
+            now,
+            prev_cpu="4000.0",
+            zombie_streak="1",
+            session_cpu_sample_epoch=str(now - 540),
+            session_cpu_rate_cores="1.9",
+        )
+    )
+    result = _poll_once_9664(state_file)
+    assert result.status == "stalled"
+    assert result.stall_reason == "vllm_worker_dead_zombie_gpu"
+
+
+def test_zombie_cpu_veto_then_streak_restarts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Reset-not-hold pin: tick A is material on both ticks -> veto (running,
+    streak "0"); tick B re-polls immediately (dt~0 -> rate None, a degraded
+    CPU read) with the candidate still stale+present -> the run gets a FULL
+    fresh 2-tick persistence window: it DEFERS (running, streak "1") instead
+    of firing off a held streak."""
+    now = int(time.time())
+    state_file = tmp_path / "poll-state.json"
+    state_file.write_text(
+        _stale_state(
+            now,
+            prev_cpu="4000.0",
+            zombie_streak="1",
+            session_cpu_sample_epoch=str(now - 540),
+            session_cpu_rate_cores="1.83",
+        )
+    )
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 2000,
+        tail="2026-06-27 00:00:01 [phase=training step=5/100]",
+        gpu_util="0,0,0,0,0,0,0,0",
+        session_cpu="5102.0",  # ~2.04 cores vs the seeded epoch
+        zombie_pids="1262130",
+    )
+    tick_a = _poll_once_9664(state_file)
+    assert tick_a.status == "running"
+    assert tick_a.stall_reason is None
+    assert _saved_zombie_streak(state_file) == "0"
+
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 2000,
+        tail="2026-06-27 00:00:01 [phase=training step=5/100]",
+        gpu_util="0,0,0,0,0,0,0,0",
+        session_cpu="6000.0",  # advancing (rescue holds running); rate None (dt~0)
+        zombie_pids="1262130",
+    )
+    tick_b = _poll_once_9664(state_file)
+    assert tick_b.status == "running"
+    assert tick_b.stall_reason is None
+    assert _saved_zombie_streak(state_file) == "1"
+
+
+def test_zombie_direct_call_rate_none_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Direct ``_apply_zombie_override`` call WITHOUT the new kwarg (mirrors
+    the pre-#951 call style): the ``session_cpu_rate_cores=None`` default
+    keeps outputs identical to today — the override fires on a persisted
+    stale-log candidate even though the sidecar carries a material prev
+    rate."""
+    out = pp._apply_zombie_override(
+        status="running",
+        zombie_gpu_pids=["1262130"],
+        stall_sec=900,
+        last_mtime_ago=2000.0,
+        phase_log_mtime_ago=10**9,
+        shard_log_mtime_ago=10**9,
+        prev_state={"zombie_streak": "1", "session_cpu_rate_cores": "1.83"},
+        pod="pod-9664",
+        cpu_override_active=True,
+    )
+    assert out == ("stalled", "vllm_worker_dead_zombie_gpu", False, 2)
+
+
+def test_save_state_persists_cpu_sample_epoch_and_rate(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``_save_state`` persists the #951 pair. Fresh sidecar (tick 1): the
+    sample epoch lands ~now and the rate is ``"unknown"`` (no prior sample —
+    the warmup, fail-safe). To observe a FORMATTED rate the state is
+    re-seeded with a BACKDATED epoch (dt past the floor) + a prev sample and
+    ONE further ``poll_once`` asserts the persisted rate parses to the
+    expected float (a naive back-to-back second call persists ``"unknown"``
+    again — dt~0 < floor, the helper-level pin in the dt-floor unit test)."""
+    now = int(time.time())
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 5,
+        tail="2026-06-27 00:00:01 [phase=training step=5/100]",
+        gpu_util="95",
+        session_cpu="4000.0",
+        zombie_pids="",
+    )
+    state_file = tmp_path / "poll-state.json"
+    result = _poll_once_9664(state_file)
+    assert result.status == "running"
+    saved = json.loads(state_file.read_text())["9664"]
+    assert abs(int(saved["session_cpu_sample_epoch"]) - now) < 120
+    assert saved["session_cpu_rate_cores"] == "unknown"
+
+    # Backdated re-seed (revision item 8): dt ~540 s >= the floor.
+    state_file.write_text(
+        _stale_state(now, prev_cpu="4000.0", session_cpu_sample_epoch=str(now - 540))
+    )
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 5,
+        tail="2026-06-27 00:00:01 [phase=training step=5/100]",
+        gpu_util="95",
+        session_cpu="5102.0",
+        zombie_pids="",
+    )
+    result = _poll_once_9664(state_file)
+    assert result.status == "running"
+    saved = json.loads(state_file.read_text())["9664"]
+    assert float(saved["session_cpu_rate_cores"]) == pytest.approx(1102.0 / 540.0, rel=0.05)
+
+
+def test_zombie_prev_material_now_low_still_fires(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """BOTH-ticks pin, prev-material direction (the dropped-conjunct guard):
+    the PRIOR tick burned 1.83 cores but THIS tick churns only ~0.22 — a
+    "computed last tick, churning this tick" run must NOT be vetoed on the
+    stale prev rate alone; the override fires. An accidentally-dropped
+    current-rate conjunct would veto here and fail this test."""
+    now = int(time.time())
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 2000,
+        tail="2026-06-27 00:00:01 [phase=training step=5/100]",
+        gpu_util="0,0,0,0,0,0,0,0",
+        session_cpu="4119.0",  # +119 s over ~540 s ~= 0.22 cores now
+        zombie_pids="1262130",
+    )
+    state_file = tmp_path / "poll-state.json"
+    state_file.write_text(
+        _stale_state(
+            now,
+            prev_cpu="4000.0",
+            zombie_streak="1",
+            session_cpu_sample_epoch=str(now - 540),
+            session_cpu_rate_cores="1.83",
+        )
+    )
+    result = _poll_once_9664(state_file)
+    assert result.status == "stalled"
+    assert result.stall_reason == "vllm_worker_dead_zombie_gpu"
+
+
+def test_zombie_cpu_rate_exact_threshold_vetoes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Boundary pin: rate exactly ``ZOMBIE_OVERRIDE_CPU_CORES_MIN`` (0.5000)
+    on BOTH ticks -> the veto fires (``>=``, not ``>`` — a future ``>`` typo
+    fails this test). ``poll_once``'s clock is frozen at ``now`` so the
+    engineered +270 s / 540 s delta lands EXACTLY on the threshold."""
+    from datetime import UTC as _utc
+    from datetime import datetime as _dt
+
+    now = int(time.time())
+
+    class _FrozenDatetime:
+        """Freeze ``pp.datetime.now`` so dt is exactly 540 s (no wall jitter)."""
+
+        @staticmethod
+        def now(tz: Any = None) -> Any:
+            return _dt.fromtimestamp(now, tz=_utc)
+
+    monkeypatch.setattr(pp, "datetime", _FrozenDatetime)
+    _patch_pod(
+        monkeypatch,
+        mtime_epoch=now - 2000,
+        tail="2026-06-27 00:00:01 [phase=training step=5/100]",
+        gpu_util="0,0,0,0,0,0,0,0",
+        session_cpu="4270.0",  # +270 s / 540 s = exactly 0.5 cores
+        zombie_pids="1262130",
+    )
+    state_file = tmp_path / "poll-state.json"
+    state_file.write_text(
+        _stale_state(
+            now,
+            prev_cpu="4000.0",
+            zombie_streak="1",
+            session_cpu_sample_epoch=str(now - 540),
+            session_cpu_rate_cores="0.5000",
+        )
+    )
+    result = _poll_once_9664(state_file)
+    assert result.status == "running"
+    assert result.stall_reason is None
+    assert _saved_zombie_streak(state_file) == "0"


### PR DESCRIPTION
Closes task #951.

Adds a material-compute liveness veto to `_apply_zombie_override` in `scripts/poll_pipeline.py`: session-CPU burn >= 0.5 cores (env `EPM_ZOMBIE_OVERRIDE_CPU_CORES_MIN`) on BOTH persisted ticks suppresses the running->stalled zombie override (#825 false-stall class), while the #664 true positive (~0.22 cores churn) still fires. 15 new tests; existing tests unmodified. Code-review ensemble PASS+PASS; test-verdict PASS (2370 passed).