### PR TITLE
task #954: mint RunPod handle + exactly-once stamp on partial GCP→RunPod failover

### DIFF
--- a/scripts/backend_poll.py
+++ b/scripts/backend_poll.py
@@ -1390,7 +1390,7 @@ def _relaunch_fresh_runpod(
         NoComputeAvailableError,
         failover_to_runpod_after_async_workload_crash,
     )
-    from explore_persona_space.backends.runpod import RunPodBackend
+    from explore_persona_space.backends.runpod import RunPodBackend, RunPodWorkloadStartError
     from explore_persona_space.backends.slurm import post_marker_via_task_py
 
     # #689 (round-3 blocker): a LEGACY sidecar built before RunPodBackend.launch()
@@ -1443,6 +1443,51 @@ def _relaunch_fresh_runpod(
             ),
             marker_poster=post_marker_via_task_py,
             on_launched=lambda h: write_handle_sidecar(h, sidecar),
+        )
+    except RunPodWorkloadStartError as exc:
+        # PARTIAL failure (#954): the fresh re-provision SUCCEEDED (a pod
+        # bills, left RUNNING for diagnosis per the #909 contract) but the
+        # workload-start leg failed. NOT no_compute_available — that mislabel
+        # reads "nothing launched" (false) and invites the watcher's
+        # capacity-retry re-drive while the fresh pod bills invisibly.
+        partial = getattr(exc, "handle", None)
+        if partial is None:
+            # Defensive: unreachable via the rung today (a handle-less start
+            # error takes the rung's NoComputeAvailableError branch), kept for
+            # a future direct-raise path. Nothing provisioned.
+            return _terminal_infra_json(
+                issue=issue,
+                sidecar=sidecar,
+                reason="runpod_workload_start_failed",
+                log_tail=(
+                    f"RunPod {handle.pod_name} wedge failover: fresh re-provision's "
+                    f"workload start failed with NO pod provisioned ({str(exc)[:500]})"
+                ),
+            )
+        # Fresh pod provisioned + RUNNING, workload not started. Stamp the
+        # wedge/CUDA-IMA lease (bounds a re-fired tick — mirrors the
+        # sidecar-failure branch) and re-point the sidecar at the fresh pod
+        # so it is visible to the handle machinery.
+        stamp_fn(issue, handle)
+        sidecar_note = ""
+        try:
+            write_handle_sidecar(partial, sidecar)
+        except OSError as write_exc:
+            # Never mask the typed failure — record the sidecar-write failure
+            # in the terminal note (the lease stamp above already bounds a
+            # re-fired tick, so no second terminate/re-provision).
+            sidecar_note = f"; sidecar write ALSO failed ({type(write_exc).__name__}: {write_exc})"
+        return _terminal_infra_json(
+            issue=issue,
+            sidecar=sidecar,
+            reason="runpod_workload_start_failed",
+            log_tail=(
+                f"RunPod {handle.pod_name} wedge failover: fresh pod "
+                f"{partial.pod_name} PROVISIONED but workload start FAILED "
+                f"({str(exc)[:500]}); pod left RUNNING for diagnosis — check for a "
+                f"live workload (pidfile) before re-driving; pod BILLS until a human "
+                f"stops/terminates it{sidecar_note} (lease stamped — relaunch bounded)"
+            ),
         )
     except NoComputeAvailableError:
         # RunPod truly unavailable after the wedged pod was terminated: terminal
@@ -2415,7 +2460,7 @@ def _failover_gcp_to_runpod(
         NoComputeAvailableError,
         failover_to_runpod_after_async_workload_crash,
     )
-    from explore_persona_space.backends.runpod import RunPodBackend
+    from explore_persona_space.backends.runpod import RunPodBackend, RunPodWorkloadStartError
     from explore_persona_space.backends.slurm import post_marker_via_task_py
 
     # IDEMPOTENCY SHORT-CIRCUIT (#659). A prior tick may have ALREADY launched a
@@ -2482,6 +2527,7 @@ def _failover_gcp_to_runpod(
             )
 
     spec = _runspec_from_gcp_handle(handle, issue)
+    workload_start_error: str | None = None
     try:
         route_result = failover_to_runpod_after_async_workload_crash(
             spec=spec,
@@ -2507,6 +2553,36 @@ def _failover_gcp_to_runpod(
             # single-triggerer fast-path; this is the atomic guard.
             gcp_failover_of_identity=_gcp_handle_identity(handle),
         )
+        launched_handle = route_result.handle
+        already_launched = bool(route_result.extra.get("failover_already_launched"))
+    except RunPodWorkloadStartError as exc:
+        # PARTIAL failure (#954): the terminal rung PROVISIONED a RunPod pod
+        # (it bills, left RUNNING for diagnosis per the #909 contract) but the
+        # workload-start leg failed. The rung already persisted the launch
+        # records (in-flock lease incl. the gcp_failover_of stamp + the
+        # best-effort on_launched sidecar hook) before re-raising typed. Fall
+        # through to the SAME authoritative sidecar re-point the success path
+        # uses, then emit a DISTINCT terminal (NOT no_compute_available — that
+        # mislabel invites the watcher's capacity-retry re-drive while the pod
+        # bills, the #931 incident).
+        partial = getattr(exc, "handle", None)
+        if partial is None:
+            # Defensive: unreachable via the rung today (a handle-less start
+            # error takes the rung's NoComputeAvailableError branch), kept for
+            # a future direct-raise path. Nothing provisioned -> distinct
+            # non-re-drivable terminal, sidecar left at GCP, NO stamp.
+            return _terminal_infra_json(
+                issue=issue,
+                sidecar=sidecar,
+                reason="runpod_workload_start_failed",
+                log_tail=(
+                    f"{cause_label} on {handle.pod_name}; RunPod workload start "
+                    f"failed with NO pod provisioned ({str(exc)[:500]}) ({failover_tag})"
+                ),
+            )
+        launched_handle = partial
+        workload_start_error = str(exc)[:500]
+        already_launched = False
     except NoComputeAvailableError:
         # RunPod truly unavailable: terminal infra JSON with
         # reason=no_compute_available so the watcher's capacity-retry pass CAN
@@ -2548,7 +2624,7 @@ def _failover_gcp_to_runpod(
     # triggerer has not persisted yet — unlikely under the lease invariant but
     # possible across crashes), fall through to the terminal
     # ``sidecar_persistence_failed`` shape exactly as the no-readback case below.
-    if route_result.extra.get("failover_already_launched"):
+    if already_launched:
         try:
             existing = read_handle_sidecar(sidecar)
         except (OSError, json.JSONDecodeError, KeyError, ValueError):
@@ -2604,7 +2680,7 @@ def _failover_gcp_to_runpod(
     # breaching "exactly once". So a re-pointed RunPod sidecar is a PRECONDITION
     # of emitting "running", not a hopeful side effect.
     try:
-        write_handle_sidecar(route_result.handle, sidecar)
+        write_handle_sidecar(launched_handle, sidecar)
         recovered = read_handle_sidecar(sidecar)
     except (OSError, json.JSONDecodeError, KeyError, ValueError) as exc:
         # RunPod was ALREADY launched above; the sidecar could NOT be re-pointed.
@@ -2618,7 +2694,7 @@ def _failover_gcp_to_runpod(
             sidecar=sidecar,
             reason="sidecar_persistence_failed",
             log_tail=(
-                f"GCP->RunPod failover launched RunPod {route_result.handle.pod_name} "
+                f"GCP->RunPod failover launched RunPod {launched_handle.pod_name} "
                 f"but sidecar persistence FAILED ({type(exc).__name__}: {exc}); refusing "
                 f"to emit running (would re-launch RunPod next tick)"
             ),
@@ -2646,6 +2722,31 @@ def _failover_gcp_to_runpod(
     # this issue is not suppressed.
     _clear_failover_sentinel(sentinel)
 
+    if workload_start_error is not None:
+        # PARTIAL failure (#954): the pod is provisioned + billing but NO
+        # workload runs on it, so a RUNNING-shaped return would just defer —
+        # the next tick polls a workload-less pod (no pidfile -> status=dead)
+        # and surfaces a GENERIC failure one tick later, losing the precise
+        # reason + the recovery hint. Emit the TERMINAL infra JSON now: the
+        # reason is NOT in TRANSIENT_CAPACITY_REASONS, so the watcher parks it
+        # for a human instead of auto-churning a fresh paid dispatch.
+        return _terminal_infra_json(
+            issue=issue,
+            sidecar=sidecar,
+            reason="runpod_workload_start_failed",
+            log_tail=(
+                f"{cause_label} on {handle.pod_name}; RunPod {launched_handle.pod_name} "
+                f"PROVISIONED but workload start FAILED ({workload_start_error}); pod left "
+                f"RUNNING for diagnosis, handle sidecar re-pointed at it (poll/finalize/"
+                f"re-drive stay chained); NOT watcher-re-drivable. Recovery: FIRST check "
+                f"for a live workload (pidfile + log on the pod — a verify-timeout after a "
+                f"successful detach leaves the workload ALIVE; a blind re-drive hits the "
+                f"double-fire guard); then re-drive on THIS pod, or stop/terminate it after "
+                f"diagnosis — the pod BILLS until a human acts (no cron reaps a RUNNING pod) "
+                f"({failover_tag})"
+            ),
+        )
+
     # Sidecar is now an AUTHORITATIVE RunPod handle on disk → the orchestrator's
     # NEXT tick reads RunPod and polls RunPod. Emit a RUNNING-shaped JSON so the
     # loop does NOT post epm:failure for the GCP death.
@@ -2657,7 +2758,7 @@ def _failover_gcp_to_runpod(
         "pid_alive": True,
         "log_tail_excerpt": (
             f"{cause_label} on {handle.pod_name}; failed over to RunPod "
-            f"{route_result.handle.pod_name} ({failover_tag})"
+            f"{launched_handle.pod_name} ({failover_tag})"
         ),
         "gate": None,
         "sentinels_processed": 0,

--- a/scripts/dispatch_issue.py
+++ b/scripts/dispatch_issue.py
@@ -1005,6 +1005,31 @@ def _annotate_launch_body_reconnect_and_lane(
         )
 
 
+def _persist_partial_handle_sidecar(issue: int, spec: Any, partial: Any) -> tuple[bool, str]:
+    """Best-effort #954 sidecar write for a PARTIAL RunPod launch.
+
+    A ``RunPodWorkloadStartError`` carrying a handle means a pod was
+    provisioned (it BILLS, left RUNNING for diagnosis) before the
+    workload-start leg failed. Persist the handle sidecar so the pod is
+    visible to the handle machinery (poll / finalize / re-drive stay
+    chained) — the SAME path ``dispatch_for_issue`` would have written on
+    success. Returns ``(sidecar_written, note_suffix)``; an ``OSError`` is
+    recorded in the note suffix, NEVER raised (the typed failure the caller
+    is surfacing must not be masked).
+    """
+    from explore_persona_space.backends.issue_dispatch import (
+        default_handle_sidecar_path,
+        write_handle_sidecar,
+    )
+
+    sidecar_path = default_handle_sidecar_path(issue, lane_suffix=spec.extra.get("lane_suffix"))
+    try:
+        write_handle_sidecar(partial, sidecar_path)
+        return True, ""
+    except OSError as write_exc:
+        return False, f" [handle sidecar write FAILED: {type(write_exc).__name__}: {write_exc}]"
+
+
 def _cmd_launch(args: argparse.Namespace, *, backends_factory: Callable[[], dict[str, Any]]) -> int:
     """``launch`` action: build spec → dispatch → write sidecar → print outcome.
 
@@ -1169,13 +1194,30 @@ def _cmd_launch(args: argparse.Namespace, *, backends_factory: Callable[[], dict
         # dispatch_for_issue does not wrap route()), so this arm catches it
         # directly; were a future router change to wrap it in a RouteError,
         # the arm below already yields the same exit 2 + failure JSON.
+        #
+        # #954: when the error carries the PARTIAL handle (a pod was
+        # provisioned before the start leg failed — it BILLS, left RUNNING
+        # for diagnosis), persist the handle sidecar best-effort (never mask
+        # the typed failure) and name the pod in the failure JSON. NO lease
+        # on this path by design: a manual retry hits pod_lifecycle's
+        # provision-idempotency refuse (exit 1 on a live pod-N), fail-loud.
+        note = str(exc)
+        partial_fields: dict[str, Any] = {}
+        partial = getattr(exc, "handle", None)
+        if partial is not None:
+            sidecar_written, note_suffix = _persist_partial_handle_sidecar(
+                int(args.issue), spec, partial
+            )
+            note += note_suffix
+            partial_fields = {"pod_name": partial.pod_name, "sidecar_written": sidecar_written}
         body = {
             "ok": False,
             "issue": int(args.issue),
             "exception": type(exc).__name__,
             "failure_class": "infra",
             "reason": "runpod_workload_start_failed",
-            "note": str(exc),
+            "note": note,
+            **partial_fields,
         }
         print(json.dumps(body, sort_keys=True))
         return 2

--- a/src/explore_persona_space/backends/router.py
+++ b/src/explore_persona_space/backends/router.py
@@ -423,6 +423,20 @@ ROUTE_REASON_GCP_WORKLOAD_FAILOVER_RUNPOD_ASYNC: str = "gcp_workload_failover_ru
 #: create, inside ``_attempt_one_gcp_rung``, which the poller never re-enters).
 ROUTE_REASON_GCP_QUEUE_TIMEOUT_FAILOVER_RUNPOD: str = "gcp_queue_timeout_failover_runpod"
 
+#: The RunPod terminal rung PROVISIONED a pod but the #909 workload-start leg
+#: FAILED (``RunPodWorkloadStartError`` carrying the partial handle, #954). A
+#: pod EXISTS and BILLS (left RUNNING for diagnosis per the #909 contract), so
+#: this is NOT :data:`ROUTE_REASON_NO_COMPUTE` — mislabeling it as
+#: ``no_compute_available`` invites the watcher's capacity-retry pass to
+#: re-drive the whole auto ladder (a fresh paid GCP attempt) while the pod
+#: bills invisibly (the #931 incident). The string is deliberately IDENTICAL
+#: to the ``dispatch_issue.py`` explicit-override arm's established
+#: ``reason: runpod_workload_start_failed`` (#909) — one reason per failure
+#: class across paths (cross-module parity pinned in ``tests/test_router.py``).
+#: It is NOT in ``autonomous_session_watch.TRANSIENT_CAPACITY_REASONS``, so
+#: the watcher never auto re-drives it.
+ROUTE_REASON_RUNPOD_WORKLOAD_START_FAILED: str = "runpod_workload_start_failed"
+
 #: Consecutive ``is_started`` probe failures tolerated inside the park
 #: watchdog before it gives up with ``probe_failures_exceeded``.
 #: Mirrors ``scripts/router_acceptance.py``'s
@@ -2551,8 +2565,74 @@ def _runpod_terminal_rung(
         try:
             handle = _prepare_and_launch(runpod_backend, runpod_spec, kind="runpod")
         except Exception as exc:
-            # RunPod is the LAST resort — ANY failure here (prepare /
-            # provisioning / transport) is genuinely "no compute anywhere".
+            # Lazy import (module convention — matches the existing lazy
+            # ``backends.runpod`` import below; runpod.py imports only ``base``
+            # at module top, so no cycle either way — lazy is belt-and-braces).
+            from explore_persona_space.backends.runpod import RunPodWorkloadStartError
+
+            partial_handle = exc.handle if isinstance(exc, RunPodWorkloadStartError) else None
+            if partial_handle is not None:
+                # Pod provisioned + RUNNING; the workload did not start (#954).
+                # Persist the SAME launch records the success path writes — the
+                # sidecar hook and the in-flock lease (incl. the M3b
+                # gcp_failover_of stamp) — so downstream stays chained and no
+                # concurrent/later triggerer launches again. Then re-raise
+                # TYPED: NoComputeAvailableError would be FALSE (a pod exists
+                # and bills).
+                _invoke_on_launched(on_launched, partial_handle)
+                # LEASE-WRITE GUARD (#954 round-1 critique, alternatives MF2):
+                # the typed error is the load-bearing signal — a lease-write
+                # failure must NEVER replace it (the failover legs'
+                # ``except RunPodWorkloadStartError`` would otherwise never
+                # fire: no distinct terminal, no sidecar re-point, exactly when
+                # rescue is needed). Same "never mask the original error"
+                # invariant as the dispatch/relaunch sidecar writes. On a write
+                # failure the failover legs' post-route sidecar write +
+                # sentinel remain the (weaker) relaunch bound, and the
+                # RouteAttempt detail records it for a human.
+                lease_note = ""
+                try:
+                    new_lease = _lease_after_submit(
+                        lease, runpod_spec, "runpod", None, partial_handle
+                    )
+                    if gcp_failover_of_identity is not None:
+                        new_lease.gcp_failover_of = gcp_failover_of_identity
+                    write(new_lease)
+                except Exception as lease_exc:
+                    logger.warning(
+                        "route: runpod partial-launch lease write failed (%s: %s); "
+                        "typed error preserved (issue %d).",
+                        type(lease_exc).__name__,
+                        lease_exc,
+                        spec.issue,
+                    )
+                    lease_note = f"; lease_write_failed ({type(lease_exc).__name__}: {lease_exc})"
+                attempts.append(
+                    RouteAttempt(
+                        kind="runpod",
+                        cluster=None,
+                        est_start_seconds_raw=0.0,
+                        est_start_seconds_clamped=0.0,
+                        outcome="runpod_workload_start_failed",
+                        detail=(
+                            f"runpod pod {partial_handle.pod_name} PROVISIONED but "
+                            f"workload start FAILED ({exc}); pod left RUNNING for "
+                            f"diagnosis{lease_note}"
+                        ),
+                        elapsed_seconds=now_fn() - started_at,
+                    )
+                )
+                _post_terminal_failure_marker(
+                    spec=spec,
+                    marker_poster=marker_poster,
+                    reason=ROUTE_REASON_RUNPOD_WORKLOAD_START_FAILED,
+                    chosen_kind="runpod",
+                    attempts=attempts,
+                )
+                raise
+            # RunPod is the LAST resort — ANY OTHER failure here (prepare /
+            # provisioning / transport, or a handle-less workload-start error
+            # from the pre-provision guard) is genuinely "no compute anywhere".
             # Record it + surface the typed terminal so the orchestrator's
             # failure classifier still gets a NoComputeAvailableError.
             attempts.append(

--- a/src/explore_persona_space/backends/runpod.py
+++ b/src/explore_persona_space/backends/runpod.py
@@ -219,6 +219,17 @@ class RunPodWorkloadStartError(RuntimeError):
     doctrine, ``.claude/rules/compute-backend-failover.md``).
     """
 
+    def __init__(self, message: str, *, handle: RunHandle | None = None) -> None:
+        super().__init__(message)
+        #: The PARTIAL RunHandle when a pod was provisioned before the start
+        #: leg failed (#954); None when nothing was provisioned. The router's
+        #: terminal rung + the backend_poll failover legs key their
+        #: persist-then-surface behavior on this — a pod exists and BILLS, so
+        #: collapsing this case into ``NoComputeAvailableError`` would be
+        #: FALSE (the #931 incident: the mislabel invited a second paid
+        #: dispatch while pod-931 billed invisibly).
+        self.handle = handle
+
 
 def _resolve_pod_endpoint(pod_name: str) -> tuple[str, int]:
     """Resolve ``(host, port)`` for ``pod_name`` from the live pods.conf.
@@ -680,16 +691,146 @@ class RunPodBackend(ComputeBackend):
         # /issue Step 6b/6d.1 flow passes no flag: the experimenter stays the
         # sole executor there, so this branch is behavior-unchanged for it.
         exec_requested = execute_workload and bool(spec.workload_cmd)
+
+        # Handle construction shared by the SUCCESS path and the #954
+        # PARTIAL-failure path (pod provisioned, workload start failed).
+        # Every input — pod_name, attempt_id, sentinel_path, the spec fields —
+        # is minted BEFORE the execution leg (#909 r2), so the handle is fully
+        # constructible at the failure point. The import is hoisted above the
+        # execution leg for the same reason (the failure path needs it).
+        from explore_persona_space.backends.artifacts import (
+            EXPECTED_ARTIFACTS_HANDLE_KEY,
+            build_expected_artifacts_declaration,
+        )
+
+        def _build_handle(
+            workload_info: dict[str, Any],
+            *,
+            workload_executed: bool,
+            workload_start_error: str | None = None,
+        ) -> RunHandle:
+            """Build the launch :class:`RunHandle`.
+
+            Success path: ``workload_executed=exec_requested`` + the execution
+            leg's ``workload_info`` — the ``extra`` dict is byte-identical to
+            the pre-#954 inline construction (``workload_start_error`` is added
+            ONLY on the failure path, so no new keys appear on success).
+            Failure path (#954): ``workload_executed=False`` (truthful — the
+            workload did not start) + a truncated ``workload_start_error`` so
+            downstream consumers (poll / finalize / re-drive) can tell the
+            partial launch apart from a healthy one.
+            """
+            # ``extra`` carries the production fields the orchestrator + the
+            # unified ``poll`` / ``fetch_results`` paths need without having
+            # to re-derive them from the issue id:
+            # * ``issue`` — round-tripped so ``confirm_artifacts`` /
+            #   ``fetch_results`` / cross-backend reconnect can index by it.
+            # * ``intent`` — preserved for marker bodies + downstream
+            #   re-provision intent re-use.
+            # * ``pid_file`` — absolute path the experimenter launcher
+            #   writes; ``poll`` forwards it to
+            #   ``poll_pipeline.poll_once(pid_file=...)``.
+            # * ``runpod_attempt_id`` — plain field so the orchestrator /
+            #   experimenter can read the attempt id without parsing the
+            #   declaration.
+            # * ``workload_cmd`` / ``hydra_args`` / ``gpus`` /
+            #   ``time_budget_hours`` — the relaunch-critical RunSpec fields
+            #   (#689 blocker, mirroring the GCP handle contract). The RunPod
+            #   RUNNING-but-no-port wedge failover (``backend_poll`` /
+            #   ``.claude/rules/compute-backend-failover.md`` § Part C)
+            #   reconstructs a ``RunSpec`` FROM the persisted sidecar handle via
+            #   ``_runspec_from_runpod_handle`` to re-provision a FRESH pod. That
+            #   reconstruction reads exactly these keys off ``extra`` and FAILS
+            #   LOUD when neither ``workload_cmd`` NOR ``hydra_args`` is present —
+            #   so a launch that did not persist them would terminate the wedged
+            #   pod and then orphan the run (no fresh pod). Persisting them here
+            #   makes the spec reconstructable; ``serialize_handle`` /
+            #   ``deserialize_handle`` round-trip ``extra`` verbatim (the tuple
+            #   ``hydra_args`` JSON-encodes to a list, which the reconstructor
+            #   re-tuples). ``workload_cmd`` is ``""`` for a Hydra-entrypoint run
+            #   and ``hydra_args`` is ``()`` for a custom-workload run; at least
+            #   one is always set on a real launch (the ``RunSpec.__post_init__``
+            #   mutual-exclusion contract).
+            extra: dict[str, Any] = {
+                "intent": spec.intent,
+                "issue": int(spec.issue),
+                "pid_file": _runpod_pid_file_path(spec.issue),
+                "runpod_attempt_id": attempt_id,
+                # Relaunch-critical RunSpec fields for the wedge failover (#689).
+                "workload_cmd": spec.workload_cmd,
+                "hydra_args": list(spec.hydra_args),
+                "gpus": spec.gpus,
+                "time_budget_hours": spec.time_budget_hours,
+                # #909: the branch the run's code lives on (round-trips through
+                # the sidecar + backend_poll reconstructors so a failover
+                # re-execution syncs the ISSUE branch, not `main`) + the
+                # execution-leg outcome (workload_executed / workload_pid /
+                # launcher_path / synced_sha via **workload_info). Additive
+                # keys — every existing reader uses .get(...).
+                "repo_branch": str((spec.extra or {}).get("repo_branch") or ""),
+                "workload_executed": workload_executed,
+                **workload_info,
+                EXPECTED_ARTIFACTS_HANDLE_KEY: build_expected_artifacts_declaration(
+                    issue=spec.issue,
+                    # The SAME path threaded into the execution leg —
+                    # one mint, one path, both sides (#909 r2).
+                    sentinel_path=sentinel_path,
+                    custom_workload=True,
+                    attempt_id=attempt_id,
+                    wandb_run_path=spec.extra.get("wandb_run_path"),
+                    # #685 / #661: thread the per-issue worktree git root +
+                    # the phase-scope flag off spec.extra (the same channel
+                    # as wandb_run_path; _launch_extra_from_args populates
+                    # both). None / False (absent) = established behavior.
+                    git_repo_root=spec.extra.get("git_repo_root"),
+                    skip_default_git_paths=bool(spec.extra.get("skip_default_git_paths", False)),
+                ),
+            }
+            if workload_start_error is not None:
+                # #954 failure-path-only key: the truncated start-leg error, so
+                # the sidecar records WHY the pod is workload-less.
+                extra["workload_start_error"] = workload_start_error
+            return RunHandle(
+                backend="runpod",
+                cluster=None,
+                # The RunPod pod_id is set inside pod_lifecycle.py and persisted
+                # to pods_ephemeral.json; we read it back from there rather than
+                # parsing stdout. For slice 1 the orchestrator does not need the
+                # raw pod_id (it routes by name through SSH config) — empty
+                # string is the truthful "we did not capture this here" marker;
+                # a future revision should round-trip pods_ephemeral.json.
+                job_id="",
+                pod_name=pod_name,
+                scratch_dir="/workspace",
+                log_path=_runpod_log_path(spec.issue),
+                extra=extra,
+            )
+
         workload_info: dict[str, Any] = {}
         if exec_requested:
-            workload_info = _execute_workload_on_pod(
-                spec,
-                pod_name=pod_name,
-                log_path=_runpod_log_path(spec.issue),
-                pid_file=_runpod_pid_file_path(spec.issue),
-                sentinel_path=sentinel_path,
-                attempt_id=attempt_id,
-            )
+            try:
+                workload_info = _execute_workload_on_pod(
+                    spec,
+                    pod_name=pod_name,
+                    log_path=_runpod_log_path(spec.issue),
+                    pid_file=_runpod_pid_file_path(spec.issue),
+                    sentinel_path=sentinel_path,
+                    attempt_id=attempt_id,
+                )
+            except RunPodWorkloadStartError as exc:
+                # #954: the pod IS provisioned (and bills) — attach the fully-
+                # built partial handle to the typed error so the router's
+                # terminal rung + the backend_poll failover legs can persist
+                # the launch records (sidecar + lease) before surfacing the
+                # failure. Re-raising the SAME exception preserves message +
+                # traceback. The pod-stays-RUNNING-for-diagnosis contract is
+                # UNCHANGED.
+                exc.handle = _build_handle(
+                    {},
+                    workload_executed=False,
+                    workload_start_error=str(exc)[:2000],
+                )
+                raise
         elif spec.workload_cmd:
             logger.warning(
                 "workload_cmd persisted but NOT executed — EXPECTED when the "
@@ -707,91 +848,7 @@ class RunPodBackend(ComputeBackend):
         # launcher (same path — see the mint comment above). The declaration
         # carries NO launch-time HF prefix guess (the #601
         # false-negative-teardown trap, a fortiori on this lane).
-        from explore_persona_space.backends.artifacts import (
-            EXPECTED_ARTIFACTS_HANDLE_KEY,
-            build_expected_artifacts_declaration,
-        )
-
-        # ``extra`` carries the production fields the orchestrator + the
-        # unified ``poll`` / ``fetch_results`` paths need without having
-        # to re-derive them from the issue id:
-        # * ``issue`` — round-tripped so ``confirm_artifacts`` /
-        #   ``fetch_results`` / cross-backend reconnect can index by it.
-        # * ``intent`` — preserved for marker bodies + downstream
-        #   re-provision intent re-use.
-        # * ``pid_file`` — absolute path the experimenter launcher
-        #   writes; ``poll`` forwards it to
-        #   ``poll_pipeline.poll_once(pid_file=...)``.
-        # * ``runpod_attempt_id`` — plain field so the orchestrator /
-        #   experimenter can read the attempt id without parsing the
-        #   declaration.
-        # * ``workload_cmd`` / ``hydra_args`` / ``gpus`` /
-        #   ``time_budget_hours`` — the relaunch-critical RunSpec fields
-        #   (#689 blocker, mirroring the GCP handle contract). The RunPod
-        #   RUNNING-but-no-port wedge failover (``backend_poll`` /
-        #   ``.claude/rules/compute-backend-failover.md`` § Part C)
-        #   reconstructs a ``RunSpec`` FROM the persisted sidecar handle via
-        #   ``_runspec_from_runpod_handle`` to re-provision a FRESH pod. That
-        #   reconstruction reads exactly these keys off ``extra`` and FAILS
-        #   LOUD when neither ``workload_cmd`` NOR ``hydra_args`` is present —
-        #   so a launch that did not persist them would terminate the wedged
-        #   pod and then orphan the run (no fresh pod). Persisting them here
-        #   makes the spec reconstructable; ``serialize_handle`` /
-        #   ``deserialize_handle`` round-trip ``extra`` verbatim (the tuple
-        #   ``hydra_args`` JSON-encodes to a list, which the reconstructor
-        #   re-tuples). ``workload_cmd`` is ``""`` for a Hydra-entrypoint run
-        #   and ``hydra_args`` is ``()`` for a custom-workload run; at least
-        #   one is always set on a real launch (the ``RunSpec.__post_init__``
-        #   mutual-exclusion contract).
-        return RunHandle(
-            backend="runpod",
-            cluster=None,
-            # The RunPod pod_id is set inside pod_lifecycle.py and persisted
-            # to pods_ephemeral.json; we read it back from there rather than
-            # parsing stdout. For slice 1 the orchestrator does not need the
-            # raw pod_id (it routes by name through SSH config) — empty
-            # string is the truthful "we did not capture this here" marker;
-            # a future revision should round-trip pods_ephemeral.json.
-            job_id="",
-            pod_name=pod_name,
-            scratch_dir="/workspace",
-            log_path=_runpod_log_path(spec.issue),
-            extra={
-                "intent": spec.intent,
-                "issue": int(spec.issue),
-                "pid_file": _runpod_pid_file_path(spec.issue),
-                "runpod_attempt_id": attempt_id,
-                # Relaunch-critical RunSpec fields for the wedge failover (#689).
-                "workload_cmd": spec.workload_cmd,
-                "hydra_args": list(spec.hydra_args),
-                "gpus": spec.gpus,
-                "time_budget_hours": spec.time_budget_hours,
-                # #909: the branch the run's code lives on (round-trips through
-                # the sidecar + backend_poll reconstructors so a failover
-                # re-execution syncs the ISSUE branch, not `main`) + the
-                # execution-leg outcome (workload_executed / workload_pid /
-                # launcher_path / synced_sha via **workload_info). Additive
-                # keys — every existing reader uses .get(...).
-                "repo_branch": str((spec.extra or {}).get("repo_branch") or ""),
-                "workload_executed": exec_requested,
-                **workload_info,
-                EXPECTED_ARTIFACTS_HANDLE_KEY: build_expected_artifacts_declaration(
-                    issue=spec.issue,
-                    # The SAME path threaded into the execution leg above —
-                    # one mint, one path, both sides (#909 r2).
-                    sentinel_path=sentinel_path,
-                    custom_workload=True,
-                    attempt_id=attempt_id,
-                    wandb_run_path=spec.extra.get("wandb_run_path"),
-                    # #685 / #661: thread the per-issue worktree git root +
-                    # the phase-scope flag off spec.extra (the same channel
-                    # as wandb_run_path; _launch_extra_from_args populates
-                    # both). None / False (absent) = established behavior.
-                    git_repo_root=spec.extra.get("git_repo_root"),
-                    skip_default_git_paths=bool(spec.extra.get("skip_default_git_paths", False)),
-                ),
-            },
-        )
+        return _build_handle(workload_info, workload_executed=exec_requested)
 
     def estimate_start(self, spec: RunSpec) -> datetime | None:
         """RunPod pods come up in minutes — informational "now"."""

--- a/tests/test_backend_poll.py
+++ b/tests/test_backend_poll.py
@@ -1721,3 +1721,309 @@ def test_poll_malformed_lane_suffix_fails_loud_with_json(tmp_path, capsys, monke
     body = json.loads(line)
     assert body["status"] == "dead"
     assert "lane_suffix" in body["log_tail_excerpt"]
+
+
+# ---------------------------------------------------------------------------
+# #954 — PARTIAL RunPod failover failure: pod PROVISIONED, workload start
+# FAILED. The failover legs must catch the typed RunPodWorkloadStartError,
+# authoritatively re-point the sidecar at the PARTIAL handle (write+readback),
+# and emit a DISTINCT terminal (runpod_workload_start_failed — NOT
+# no_compute_available, whose mislabel invites the watcher's capacity-retry
+# re-drive while the pod bills invisibly; the #931 incident).
+# ---------------------------------------------------------------------------
+
+
+class _WorkloadStartFailedRunpodBackend:
+    """RunPodBackend stand-in modeling the #954 PARTIAL failure: ``launch``
+    provisions (records the spec) then raises the typed error CARRYING the
+    partial handle — the shape ``RunPodBackend.launch`` produces when the #909
+    execution leg fails after the pod exists."""
+
+    def __init__(self) -> None:
+        self.launches: list = []
+
+    def launch(self, spec):
+        from explore_persona_space.backends.runpod import RunPodWorkloadStartError
+
+        self.launches.append(spec)
+        partial = RunHandle(
+            backend="runpod",
+            cluster=None,
+            job_id="",
+            pod_name=f"pod-{spec.issue}",
+            scratch_dir="/workspace",
+            log_path=f"/workspace/logs/issue-{spec.issue}.log",
+            extra={
+                "issue": spec.issue,
+                "intent": "lora-7b",
+                "workload_cmd": "bash run.sh",
+                "hydra_args": [],
+                "workload_executed": False,
+                "workload_start_error": "branch sync timed out (ssh TimeoutExpired)",
+            },
+        )
+        raise RunPodWorkloadStartError("branch sync timed out (ssh TimeoutExpired)", handle=partial)
+
+
+def test_failover_workload_start_failure_mints_runpod_sidecar_and_emits_distinct_terminal(
+    tmp_path, monkeypatch, capsys
+):
+    """#954 AC3 (end-to-end): a dead GCP workload whose RunPod failover
+    PROVISIONS a pod but fails the workload-start leg emits a TERMINAL infra
+    JSON with the DISTINCT reason, re-points the sidecar at the PARTIAL RunPod
+    handle (readback-proven), and carries the recovery hints (round-1 critique
+    MF1 mechanized): the live-workload/pidfile check-before-re-drive AND the
+    billing-until-human-stop/terminate wording."""
+    sidecar = tmp_path / "issue-659-handle.json"
+    write_handle_sidecar(_gcp_handle(), sidecar)
+
+    rp = _WorkloadStartFailedRunpodBackend()
+    monkeypatch.setattr(
+        "scripts.backend_poll._resolve_backend",
+        lambda name: _PollDouble(_poll("dead", "terminal_workload_failed")),
+    )
+    monkeypatch.setattr("explore_persona_space.backends.runpod.RunPodBackend", lambda: rp)
+
+    rc = backend_poll_main(["--issue", "659", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["status"] == "dead"
+    assert out["failure_class"] == "infra"
+    assert out["reason"] == "runpod_workload_start_failed"
+    # Recovery hints (MF1): pidfile-check-before-re-drive + billing exposure.
+    tail = out["log_tail_excerpt"]
+    assert "pidfile" in tail
+    assert "BILLS until a human" in tail
+    assert "stop/terminate" in tail
+    # Sidecar AUTHORITATIVELY re-pointed at the PARTIAL RunPod handle.
+    recovered = read_handle_sidecar(sidecar)
+    assert recovered.backend == "runpod"
+    assert recovered.extra["workload_executed"] is False
+    assert recovered.extra["workload_start_error"]
+    assert len(rp.launches) == 1
+
+
+def test_failover_workload_start_failure_second_poll_no_second_launch(
+    tmp_path, monkeypatch, capsys
+):
+    """#954 AC4-i: after the partial failover, (i) a second poll tick launches
+    ZERO additional pods (the sidecar now reads runpod, so the GCP failover
+    predicate cannot re-fire), and (ii) a FORCED still-GCP sidecar
+    short-circuits on the DURABLE LEASE specifically (the
+    sidecar_persistence_failed shape naming the lease record — the sentinel was
+    cleared at the end of the first tick, so only the lease can dedup)."""
+    # Deterministic scripts-dir bootstrap: backend_poll's own lazy
+    # ``from runpod_api import ...`` relies on scripts/ being on sys.path;
+    # mirror it here so the test is test-ordering-independent.
+    import sys
+
+    import scripts.backend_poll as bp
+
+    scripts_dir = str(Path(bp.__file__).resolve().parent)
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    import runpod_api
+
+    sidecar = tmp_path / "issue-659-handle.json"
+    gcp_handle = _gcp_handle()
+    write_handle_sidecar(gcp_handle, sidecar)
+
+    rp = _WorkloadStartFailedRunpodBackend()
+    monkeypatch.setattr(
+        "scripts.backend_poll._resolve_backend",
+        lambda name: _PollDouble(_poll("dead", "terminal_workload_failed")),
+    )
+    monkeypatch.setattr("explore_persona_space.backends.runpod.RunPodBackend", lambda: rp)
+    # The partial pod does not exist on the live API (hermetic: the RunPod
+    # wedge escalation probes get_pod_by_name on any runpod-handle tick).
+    monkeypatch.setattr(runpod_api, "get_pod_by_name", lambda name: None, raising=False)
+
+    # Tick 1: partial failover -> terminal + sidecar re-pointed at RunPod.
+    rc = backend_poll_main(["--issue", "659", "--handle-file", str(sidecar)])
+    assert rc == 0
+    assert _last_json_line(capsys)["reason"] == "runpod_workload_start_failed"
+    assert len(rp.launches) == 1
+    assert read_handle_sidecar(sidecar).backend == "runpod"
+
+    # Tick 2 (the sidecar now reads runpod): the GCP failover predicate keys on
+    # backend=="gcp", so it cannot re-fire — ZERO additional launches.
+    rc2 = backend_poll_main(["--issue", "659", "--handle-file", str(sidecar)])
+    assert rc2 == 0
+    _last_json_line(capsys)  # drain stdout; the dead runpod poll is ordinary
+    assert len(rp.launches) == 1
+
+    # Tick 3 (FORCED still-GCP sidecar — a rollback/copy): the predicate
+    # re-fires but the DURABLE LEASE short-circuit binds (the rung stamped
+    # gcp_failover_of in-flock on tick 1; the sentinel was cleared) — the
+    # fail-loud sidecar_persistence_failed shape, still NO launch.
+    write_handle_sidecar(gcp_handle, sidecar)
+    rc3 = backend_poll_main(["--issue", "659", "--handle-file", str(sidecar)])
+    assert rc3 == 0
+    out3 = _last_json_line(capsys)
+    assert len(rp.launches) == 1  # the exactly-once bound held
+    assert out3["reason"] == "sidecar_persistence_failed"
+    assert "durable lease record" in out3["log_tail_excerpt"]
+
+
+def test_failover_workload_start_failure_not_transient_capacity_block(
+    tmp_path, monkeypatch, capsys
+):
+    """#954 AC5: the emitted terminal's fields parse via the watcher's REAL
+    ``_is_transient_capacity_block`` to NOT-retriable (mirrors the #775 M1
+    pattern) — the capacity-retry pass never auto re-drives a run whose pod
+    exists and bills."""
+    import scripts.autonomous_session_watch as asw
+
+    sidecar = tmp_path / "issue-659-handle.json"
+    write_handle_sidecar(_gcp_handle(), sidecar)
+    rp = _WorkloadStartFailedRunpodBackend()
+    monkeypatch.setattr(
+        "scripts.backend_poll._resolve_backend",
+        lambda name: _PollDouble(_poll("dead", "terminal_workload_failed")),
+    )
+    monkeypatch.setattr("explore_persona_space.backends.runpod.RunPodBackend", lambda: rp)
+
+    rc = backend_poll_main(["--issue", "659", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    # The note shape the orchestrator/watcher posts from this JSON (the
+    # whitespace-token shape _parse_failure_fields reads).
+    note = (
+        f"failure_class: {out['failure_class']} reason: {out['reason']} — {out['log_tail_excerpt']}"
+    )
+    synthetic_marker = {"kind": "epm:failure v1", "note": note, "ts": None}
+    retriable, parsed_reason, _block_ts = asw._is_transient_capacity_block([synthetic_marker])
+    assert retriable is False
+    assert parsed_reason == "runpod_workload_start_failed"
+    assert "runpod_workload_start_failed" not in asw.TRANSIENT_CAPACITY_REASONS
+
+
+def test_queue_timeout_failover_workload_start_failure_same_contract(tmp_path, monkeypatch, capsys):
+    """#954 AC3 via the #783 caller (shared-core coverage): a queued-past-floor
+    GCP instance whose RunPod failover partial-fails gets the SAME contract —
+    teardown-first ran BEFORE the launch (by CALL ORDER, round-1 critique
+    rider 3), distinct terminal, sidecar re-pointed at the partial handle."""
+    from explore_persona_space.backends.runpod import RunPodWorkloadStartError
+
+    calls: list[str] = []
+
+    class _TeardownRecorder:
+        def poll(self, handle):
+            return _pending_poll()
+
+        def teardown(self, handle):
+            calls.append("teardown")
+
+    class _WSFRunpodOrdered:
+        def launch(self, spec):
+            calls.append("launch")
+            partial = RunHandle(
+                backend="runpod",
+                cluster=None,
+                job_id="",
+                pod_name=f"pod-{spec.issue}",
+                scratch_dir="/workspace",
+                log_path=f"/workspace/logs/issue-{spec.issue}.log",
+                extra={
+                    "issue": spec.issue,
+                    "workload_executed": False,
+                    "workload_start_error": "ssh TimeoutExpired",
+                },
+            )
+            raise RunPodWorkloadStartError("ssh TimeoutExpired", handle=partial)
+
+    sidecar = tmp_path / "issue-783-handle.json"
+    write_handle_sidecar(_gcp_handle_with_clock(phase="pending", ts=_time.time() - 1000), sidecar)
+    monkeypatch.setattr("scripts.backend_poll._resolve_backend", lambda name: _TeardownRecorder())
+    monkeypatch.setattr("explore_persona_space.backends.runpod.RunPodBackend", _WSFRunpodOrdered)
+
+    rc = backend_poll_main(["--issue", "783", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["status"] == "dead"
+    assert out["failure_class"] == "infra"
+    assert out["reason"] == "runpod_workload_start_failed"
+    # Teardown-first by CALL ORDER: the queued instance was released BEFORE
+    # the RunPod launch was attempted.
+    assert calls == ["teardown", "launch"]
+    recovered = read_handle_sidecar(sidecar)
+    assert recovered.backend == "runpod"
+    assert recovered.extra["workload_executed"] is False
+
+
+def test_wedge_relaunch_workload_start_failure_stamps_and_repoints_sidecar(
+    tmp_path, monkeypatch, capsys
+):
+    """#954 AC6: ``_relaunch_fresh_runpod`` (the #692/#770 wedge + #775
+    CUDA-IMA shared relaunch) on the typed-with-handle error: stamp_fn called
+    with the WEDGED handle (bounds a re-fired tick), sidecar re-pointed at the
+    fresh partial pod, distinct terminal; PLUS the sidecar-write-OSError
+    sub-case (terminal still emitted, note carries the write failure —
+    fail-loud, never swallowed)."""
+    import scripts.backend_poll as bp
+
+    rp = _WorkloadStartFailedRunpodBackend()
+    monkeypatch.setattr("explore_persona_space.backends.runpod.RunPodBackend", lambda: rp)
+
+    wedged = RunHandle(
+        backend="runpod",
+        cluster=None,
+        job_id="pod-fake-775",
+        pod_name="pod-775",
+        scratch_dir="/workspace",
+        log_path="/workspace/logs/issue-775.log",
+        extra={
+            "issue": 775,
+            "intent": "lora-7b",
+            "workload_cmd": "bash scripts/issue664_dispatch.sh --foo",
+            "hydra_args": [],
+        },
+    )
+    sidecar = tmp_path / "issue-775-handle.json"
+    write_handle_sidecar(wedged, sidecar)
+    stamps: list = []
+
+    out = bp._relaunch_fresh_runpod(
+        issue=775,
+        handle=wedged,
+        result=_poll("dead", "terminal_runpod_no_port_wedged"),
+        sidecar=sidecar,
+        stamp_fn=lambda issue, handle: stamps.append((issue, handle)),
+    )
+    assert out["status"] == "dead"
+    assert out["failure_class"] == "infra"
+    assert out["reason"] == "runpod_workload_start_failed"
+    tail = out["log_tail_excerpt"]
+    assert "pidfile" in tail
+    assert "BILLS until a human" in tail
+    # stamp_fn fired with the WEDGED handle (bounds a re-fired tick).
+    assert stamps == [(775, wedged)]
+    # Sidecar re-pointed at the FRESH partial pod (visible to the machinery).
+    recovered = read_handle_sidecar(sidecar)
+    assert recovered.backend == "runpod"
+    assert recovered.extra["workload_executed"] is False
+    assert len(rp.launches) == 1
+
+    # Sub-case: the sidecar write ALSO fails (OSError) — the terminal is still
+    # emitted with the write failure recorded, the stamp still bounds.
+    stamps2: list = []
+    write_handle_sidecar(wedged, sidecar)  # reset to the wedged handle
+
+    def _raising_write(handle, path):
+        raise OSError("Disk quota exceeded (EDQUOT) writing the sidecar")
+
+    monkeypatch.setattr(
+        "explore_persona_space.backends.issue_dispatch.write_handle_sidecar",
+        _raising_write,
+    )
+    out2 = bp._relaunch_fresh_runpod(
+        issue=775,
+        handle=wedged,
+        result=_poll("dead", "terminal_runpod_no_port_wedged"),
+        sidecar=sidecar,
+        stamp_fn=lambda issue, handle: stamps2.append((issue, handle)),
+    )
+    assert out2["status"] == "dead"
+    assert out2["reason"] == "runpod_workload_start_failed"
+    assert "sidecar write ALSO failed" in out2["log_tail_excerpt"]
+    assert stamps2 == [(775, wedged)]

--- a/tests/test_dispatch_issue_cli.py
+++ b/tests/test_dispatch_issue_cli.py
@@ -3636,3 +3636,117 @@ def test_launch_lane_suffix_non_gcp_lane_warns(monkeypatch, tmp_path, caplog) ->
     assert body["lane_suffix_unhonored_by_lane"] == "nibi"
     messages = [r.getMessage() for r in caplog.records]
     assert any("GCP-only" in m for m in messages), messages
+
+
+# ---------------------------------------------------------------------------
+# #954 — the explicit-override typed arm persists the PARTIAL handle sidecar
+# ---------------------------------------------------------------------------
+
+
+def _partial_runpod_handle_954():
+    from explore_persona_space.backends.base import RunHandle
+
+    return RunHandle(
+        backend="runpod",
+        cluster=None,
+        job_id="",
+        pod_name="pod-909",
+        scratch_dir="/workspace",
+        log_path="/workspace/logs/issue-909.log",
+        extra={
+            "issue": 909,
+            "workload_executed": False,
+            "workload_start_error": "ssh TimeoutExpired",
+        },
+    )
+
+
+def test_cmd_launch_workload_start_failed_writes_sidecar_and_names_pod(
+    monkeypatch, tmp_path
+) -> None:
+    """#954 AC7: a typed-with-handle workload-start failure on the explicit
+    override path exits 2 with ``reason: runpod_workload_start_failed``
+    (unchanged) PLUS ``pod_name`` + ``sidecar_written: true``, and the handle
+    sidecar exists on disk at the canonical path — the billing pod is visible
+    to the handle machinery (poll / finalize / re-drive stay chained). The
+    backend mock raises from ``launch`` below ``dispatch_for_issue`` (the real
+    ``route()`` runs), so assumption 5 — no exception wrapping — is
+    exercised."""
+    from explore_persona_space.backends.issue_dispatch import read_handle_sidecar
+    from explore_persona_space.backends.runpod import RunPodWorkloadStartError
+
+    _cd_to_tmp(monkeypatch, tmp_path)
+    _pin_runpod_frontmatter(monkeypatch)
+    runpod = _MockBackend(
+        kind="runpod",
+        launch_should_raise=RunPodWorkloadStartError(
+            "workload did NOT verify alive on pod-909", handle=_partial_runpod_handle_954()
+        ),
+    )
+    factory = _build_mock_factory(runpod=runpod)
+
+    from scripts.dispatch_issue import main
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = main(_runpod_launch_args("--execute-workload"), backends_factory=factory)
+    assert rc == 2
+    body = json.loads(buf.getvalue().strip().splitlines()[-1])
+    assert body["ok"] is False
+    assert body["failure_class"] == "infra"
+    assert body["reason"] == "runpod_workload_start_failed"  # unchanged (#909)
+    assert body["pod_name"] == "pod-909"
+    assert body["sidecar_written"] is True
+    # The handle sidecar exists on disk at the canonical (tmp-pinned) path.
+    sidecar = tmp_path / ".claude" / "cache" / "issue-909-handle.json"
+    assert sidecar.is_file()
+    recovered = read_handle_sidecar(sidecar)
+    assert recovered.backend == "runpod"
+    assert recovered.pod_name == "pod-909"
+    assert recovered.extra["workload_executed"] is False
+    assert recovered.extra["workload_start_error"]
+
+
+def test_cmd_launch_workload_start_failed_sidecar_write_oserror_fail_loud(
+    monkeypatch, tmp_path
+) -> None:
+    """#954 (round-1 critique, statistics MF): the Surface-5 fail-loud contract
+    — a sidecar-write OSError NEVER masks the typed failure: rc 2, ``reason``
+    unchanged, ``pod_name`` present, ``sidecar_written: false`` + the OSError
+    recorded in the JSON note (no unhandled OSError escapes the typed arm)."""
+    from explore_persona_space.backends.runpod import RunPodWorkloadStartError
+
+    _cd_to_tmp(monkeypatch, tmp_path)
+    _pin_runpod_frontmatter(monkeypatch)
+    runpod = _MockBackend(
+        kind="runpod",
+        launch_should_raise=RunPodWorkloadStartError(
+            "workload did NOT verify alive on pod-909", handle=_partial_runpod_handle_954()
+        ),
+    )
+    factory = _build_mock_factory(runpod=runpod)
+
+    def _raising_write(handle, path):
+        raise OSError("Disk quota exceeded (EDQUOT) writing the sidecar")
+
+    monkeypatch.setattr(
+        "explore_persona_space.backends.issue_dispatch.write_handle_sidecar",
+        _raising_write,
+    )
+
+    from scripts.dispatch_issue import main
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = main(_runpod_launch_args("--execute-workload"), backends_factory=factory)
+    assert rc == 2
+    body = json.loads(buf.getvalue().strip().splitlines()[-1])
+    assert body["ok"] is False
+    assert body["failure_class"] == "infra"
+    assert body["reason"] == "runpod_workload_start_failed"
+    assert body["pod_name"] == "pod-909"
+    assert body["sidecar_written"] is False
+    assert "handle sidecar write FAILED" in body["note"]
+    assert "EDQUOT" in body["note"]
+    # The typed failure's own message is still the note's lead.
+    assert "did NOT verify alive" in body["note"]

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -5988,3 +5988,241 @@ def test_translation_helper_cpu_intents_pass_through_verbatim():
             cpu_intent,
             None,
         )
+
+
+# ---------------------------------------------------------------------------
+# #954 — PARTIAL RunPod terminal-rung failure: pod PROVISIONED, workload start
+# FAILED (RunPodWorkloadStartError carrying the partial handle). The rung must
+# persist the SAME launch records the success path writes (on_launched sidecar
+# hook + in-flock lease incl. the M3b gcp_failover_of stamp), record a DISTINCT
+# RouteAttempt + terminal marker (runpod_workload_start_failed), and re-raise
+# TYPED — never collapse into NoComputeAvailableError (a pod exists and BILLS;
+# the #931 incident's mislabel invited a second paid dispatch).
+# ---------------------------------------------------------------------------
+
+
+class _WorkloadStartFailedRunpod(_BaseBackend):
+    """RunPod double modeling the #954 PARTIAL failure: ``launch`` provisions
+    (records the spec) then raises the typed workload-start error CARRYING the
+    partial handle — the exact shape ``RunPodBackend.launch`` produces when the
+    #909 execution leg fails after the pod exists."""
+
+    def __init__(self) -> None:
+        self.launches: list[RunSpec] = []
+
+    def launch(self, spec: RunSpec) -> RunHandle:
+        from explore_persona_space.backends.runpod import RunPodWorkloadStartError
+
+        self.launches.append(spec)
+        partial = RunHandle(
+            backend="runpod",
+            cluster=None,
+            job_id="",
+            pod_name=f"pod-{spec.issue}",
+            scratch_dir="/workspace",
+            log_path=f"/workspace/logs/issue-{spec.issue}.log",
+            extra={
+                "issue": spec.issue,
+                "workload_executed": False,
+                "workload_start_error": "branch sync timed out (ssh TimeoutExpired)",
+            },
+        )
+        raise RunPodWorkloadStartError("branch sync timed out (ssh TimeoutExpired)", handle=partial)
+
+
+class _WorkloadStartFailedNoHandleRunpod(_BaseBackend):
+    """The HANDLE-LESS typed error (the pre-provision guard shape): nothing was
+    provisioned, nothing bills — the rung's blanket NoCompute branch applies."""
+
+    def launch(self, spec: RunSpec) -> RunHandle:
+        from explore_persona_space.backends.runpod import RunPodWorkloadStartError
+
+        raise RunPodWorkloadStartError(
+            "execute_workload requested with empty workload_cmd — refusing before provisioning"
+        )
+
+
+def test_runpod_terminal_rung_workload_start_failed_persists_launch_records_and_reraises_typed(
+    lease_store, marker_poster, captured_markers
+):
+    """#954 AC1: a typed-with-handle workload-start failure at the terminal rung
+    (i) invokes on_launched with the PARTIAL handle, (ii) writes the in-flock
+    lease incl. the M3b gcp_failover_of stamp, (iii) records the DISTINCT
+    RouteAttempt + terminal marker, and (iv) re-raises the TYPED error — never
+    NoComputeAvailableError."""
+    from explore_persona_space.backends.router import (
+        ROUTE_REASON_NO_COMPUTE,
+        ROUTE_REASON_RUNPOD_WORKLOAD_START_FAILED,
+        failover_to_runpod_after_async_workload_crash,
+    )
+    from explore_persona_space.backends.runpod import RunPodWorkloadStartError
+
+    rp = _WorkloadStartFailedRunpod()
+    hooked: list[RunHandle] = []
+    identity = {"pod_name": "eps-issue-137", "job_id": "instance-fake-1"}
+    with pytest.raises(RunPodWorkloadStartError) as ei:
+        failover_to_runpod_after_async_workload_crash(
+            spec=_spec(backend="gcp"),
+            runpod_backend=rp,
+            evidence={"source": "async_poller"},
+            marker_poster=marker_poster,
+            on_launched=hooked.append,
+            lease_store=lease_store,
+            now_fn=_clock(),
+            config=RouterConfig(free_wait_seconds=1, poll_interval=0.0, cancel_grace_seconds=0),
+            gcp_failover_of_identity=identity,
+        )
+    # (iv) The TYPED class, not the NoCompute collapse.
+    assert not isinstance(ei.value, NoComputeAvailableError)
+    assert ei.value.handle is not None
+    assert ei.value.handle.pod_name == "pod-137"
+    # (i) on_launched fired exactly once, with the PARTIAL handle.
+    assert len(hooked) == 1
+    assert hooked[0] is ei.value.handle
+    # (ii) The in-flock lease records the submit + the M3b identity stamp.
+    lease = lease_store.read(137)
+    assert lease is not None
+    assert lease.backend == "runpod"
+    assert lease.gcp_failover_of == identity
+    # (iii) Terminal marker with the DISTINCT reason + the RouteAttempt outcome.
+    finals = _by_reason(captured_markers, ROUTE_REASON_RUNPOD_WORKLOAD_START_FAILED)
+    assert finals
+    attempt = finals[-1]["attempts"][-1]
+    assert attempt["outcome"] == "runpod_workload_start_failed"
+    assert "pod-137" in attempt["detail"]
+    assert "RUNNING for" in attempt["detail"]
+    # No NoCompute marker was posted for this launch.
+    assert not _by_reason(captured_markers, ROUTE_REASON_NO_COMPUTE)
+
+
+def test_runpod_terminal_rung_workload_start_failed_without_handle_keeps_no_compute(
+    lease_store, marker_poster, captured_markers
+):
+    """#954 AC2: a HANDLE-LESS typed error (the pre-provision guard — nothing
+    provisioned, nothing bills) keeps the pre-#954 blanket branch byte-for-byte:
+    NoComputeAvailableError raised, ROUTE_REASON_NO_COMPUTE marker, NO lease
+    write, on_launched NOT called."""
+    from explore_persona_space.backends.router import (
+        ROUTE_REASON_NO_COMPUTE,
+        failover_to_runpod_after_async_workload_crash,
+    )
+
+    rp = _WorkloadStartFailedNoHandleRunpod()
+    hooked: list[RunHandle] = []
+    with pytest.raises(NoComputeAvailableError):
+        failover_to_runpod_after_async_workload_crash(
+            spec=_spec(backend="gcp"),
+            runpod_backend=rp,
+            evidence={"source": "async_poller"},
+            marker_poster=marker_poster,
+            on_launched=hooked.append,
+            lease_store=lease_store,
+            now_fn=_clock(),
+            config=RouterConfig(free_wait_seconds=1, poll_interval=0.0, cancel_grace_seconds=0),
+        )
+    assert hooked == []  # on_launched never fired
+    assert lease_store.read(137) is None  # no lease write
+    finals = _by_reason(captured_markers, ROUTE_REASON_NO_COMPUTE)
+    assert finals
+    assert finals[-1]["attempts"][-1]["outcome"] == "runpod_fallback_failed"
+
+
+def test_concurrent_triggerer_after_partial_workload_start_failure_no_second_launch(
+    lease_store, marker_poster, captured_markers
+):
+    """#954 AC4-ii: triggerer 1 partial-fails (typed raise; lease stamped
+    IN-FLOCK); an M3b concurrent second triggerer with the SAME GCP identity
+    short-circuits in-flock — total launch count stays 1 (the load-bearing
+    invariant; sequential calls on a shared LeaseStore model the
+    serialized-by-flock outcome, exactly as M2.6 does)."""
+    from explore_persona_space.backends.router import (
+        failover_to_runpod_after_async_workload_crash,
+    )
+    from explore_persona_space.backends.runpod import RunPodWorkloadStartError
+
+    rp = _WorkloadStartFailedRunpod()
+    identity = {"pod_name": "eps-issue-137", "job_id": "instance-fake-1"}
+    cfg = RouterConfig(free_wait_seconds=1, poll_interval=0.0, cancel_grace_seconds=0)
+
+    def _trigger():
+        return failover_to_runpod_after_async_workload_crash(
+            spec=_spec(backend="gcp"),
+            runpod_backend=rp,
+            evidence={"source": "async_poller"},
+            marker_poster=marker_poster,
+            lease_store=lease_store,
+            now_fn=_clock(),
+            config=cfg,
+            gcp_failover_of_identity=identity,
+        )
+
+    with pytest.raises(RunPodWorkloadStartError):
+        _trigger()  # triggerer 1: partial failure, lease stamped in-flock
+    second = _trigger()  # triggerer 2: in-flock re-check short-circuits
+
+    assert len(rp.launches) == 1  # EXACTLY ONCE — no second paid launch
+    assert second.extra.get("failover_already_launched") is True
+
+
+def test_runpod_workload_start_failed_reason_cross_module_parity():
+    """#954 AC5 (SR1 pattern): the router constant equals the established
+    ``dispatch_issue.py`` literal, and the reason is NOT in the watcher's
+    TRANSIENT_CAPACITY_REASONS allowlist — the capacity-retry pass never auto
+    re-drives a run whose pod exists and bills."""
+    import inspect
+
+    import scripts.dispatch_issue as cli
+    from explore_persona_space.backends.router import (
+        ROUTE_REASON_RUNPOD_WORKLOAD_START_FAILED,
+    )
+    from scripts.autonomous_session_watch import TRANSIENT_CAPACITY_REASONS
+
+    assert ROUTE_REASON_RUNPOD_WORKLOAD_START_FAILED == "runpod_workload_start_failed"
+    # The dispatch CLI's typed arm uses the SAME literal (one reason per
+    # failure class across paths, #909/#954).
+    assert '"runpod_workload_start_failed"' in inspect.getsource(cli)
+    assert ROUTE_REASON_RUNPOD_WORKLOAD_START_FAILED not in TRANSIENT_CAPACITY_REASONS
+
+
+def test_runpod_terminal_rung_partial_lease_write_failure_preserves_typed_error(
+    tmp_path, marker_poster, captured_markers
+):
+    """#954 AC1 guard (round-1 critique, alternatives MF2): a lease-write
+    failure on the partial branch must NEVER replace the typed error — the
+    failover legs' ``except RunPodWorkloadStartError`` is the rescue path, and
+    an OSError escaping here would blind it exactly when rescue is needed. The
+    marker still posts with the DISTINCT reason, and the RouteAttempt detail
+    records the lease_write_failed note."""
+    from contextlib import contextmanager
+
+    from explore_persona_space.backends.router import (
+        failover_to_runpod_after_async_workload_crash,
+    )
+    from explore_persona_space.backends.runpod import RunPodWorkloadStartError
+
+    class _RaisingWriteLeaseStore(LeaseStore):
+        @contextmanager
+        def transaction(self, issue):
+            with super().transaction(issue) as (lease, _write):
+
+                def _raising_write(new_lease):
+                    raise OSError("Disk quota exceeded (EDQUOT) writing the lease")
+
+                yield lease, _raising_write
+
+    store = _RaisingWriteLeaseStore(lease_dir=tmp_path / ".eps-routing")
+    rp = _WorkloadStartFailedRunpod()
+    with pytest.raises(RunPodWorkloadStartError):  # STILL the typed class
+        failover_to_runpod_after_async_workload_crash(
+            spec=_spec(backend="gcp"),
+            runpod_backend=rp,
+            evidence={"source": "async_poller"},
+            marker_poster=marker_poster,
+            lease_store=store,
+            now_fn=_clock(),
+            config=RouterConfig(free_wait_seconds=1, poll_interval=0.0, cancel_grace_seconds=0),
+            gcp_failover_of_identity={"pod_name": "eps-issue-137", "job_id": "i-1"},
+        )
+    finals = _by_reason(captured_markers, "runpod_workload_start_failed")
+    assert finals  # the terminal marker still posted
+    assert "lease_write_failed" in finals[-1]["attempts"][-1]["detail"]

--- a/tests/test_runpod_workload_exec.py
+++ b/tests/test_runpod_workload_exec.py
@@ -484,3 +484,97 @@ def test_launch_ok_regex_shapes():
     assert RP._LAUNCH_OK_RE.search("LAUNCH-OK pid=7 via=/workspace/logs/x.pid").group(1) == "7"
     assert RP._LAUNCH_OK_RE.search("LAUNCH-DEAD pid=none") is None
     assert re.search(r"SYNC-OK ([0-9a-f]+)", "SYNC-OK deadbeef").group(1) == "deadbeef"
+
+
+# ---------------------------------------------------------------------------
+# #954 — the PARTIAL handle on RunPodWorkloadStartError
+# ---------------------------------------------------------------------------
+
+#: The EXACT pre-#954 success-path ``extra`` key set for a NON-exec launch
+#: (``workload_info == {}``) — pinned EXPLICITLY (never a circular post-change
+#: fixture): the #954 refactor must add NO new keys on the success path.
+_PRE_954_SUCCESS_EXTRA_KEYS = frozenset(
+    {
+        "intent",
+        "issue",
+        "pid_file",
+        "runpod_attempt_id",
+        "workload_cmd",
+        "hydra_args",
+        "gpus",
+        "time_budget_hours",
+        "repo_branch",
+        "workload_executed",
+        EXPECTED_ARTIFACTS_HANDLE_KEY,
+    }
+)
+
+
+def test_launch_attaches_partial_handle_on_workload_start_error(monkeypatch):
+    """#954: with provision mocked OK and the execution leg raising, the typed
+    error carries a PARTIAL handle matching the success-path handle shape
+    except ``workload_executed is False`` + ``workload_start_error`` — and the
+    SUCCESS-path handle ``extra`` stays byte-identical (no new keys)."""
+    _wire_exec_leg(monkeypatch, [])
+
+    def _fake_exec(spec, **kwargs):
+        raise RP.RunPodWorkloadStartError("branch sync of pod-909 timed out (ssh TimeoutExpired)")
+
+    monkeypatch.setattr(RP, "_execute_workload_on_pod", _fake_exec)
+    with pytest.raises(RP.RunPodWorkloadStartError) as ei:
+        RP.RunPodBackend().launch(
+            _spec(extra={"execute_workload": True, "repo_branch": "issue-909"})
+        )
+    partial = ei.value.handle
+    assert partial is not None
+    assert partial.backend == "runpod"
+    assert partial.pod_name == "pod-909"
+    assert partial.log_path == "/workspace/logs/issue-909.log"
+    # Truthful execution outcome + the truncated start-leg error.
+    assert partial.extra["workload_executed"] is False
+    assert "ssh TimeoutExpired" in partial.extra["workload_start_error"]
+    # The partial extra == the success shape PLUS ONLY the error key.
+    assert set(partial.extra.keys()) == _PRE_954_SUCCESS_EXTRA_KEYS | {"workload_start_error"}
+    # The declaration is fully built (attempt-namespaced sentinel path present),
+    # so poll/finalize/re-drive stay chained on the partial handle.
+    declared = partial.extra[EXPECTED_ARTIFACTS_HANDLE_KEY]["sentinel_path"]
+    assert declared == RP.runpod_sentinel_path(909, partial.extra["runpod_attempt_id"])
+
+
+def test_launch_success_extra_keys_byte_identical_no_new_keys(monkeypatch):
+    """#954 regression guard (test 10 second half): the SUCCESS-path handle
+    ``extra`` key set is byte-identical to pre-#954 for BOTH the non-exec and
+    the exec-success shapes — ``workload_start_error`` appears ONLY on the
+    failure path."""
+    # Non-exec success: the exact pre-change key set, nothing added.
+    _wire_exec_leg(monkeypatch, [])
+    handle = RP.RunPodBackend().launch(_spec())
+    assert set(handle.extra.keys()) == set(_PRE_954_SUCCESS_EXTRA_KEYS)
+
+    # Exec success: the pre-change keys + the execution-leg workload_info keys;
+    # the failure-path-only key NEVER appears on success.
+    _wire_exec_leg(
+        monkeypatch,
+        ["SYNC-OK abc123\n", "WRAPPER-STARTED 4242\n", "LAUNCH-OK pid=777\n"],
+    )
+    handle2 = RP.RunPodBackend().launch(_spec(extra={"execute_workload": True}))
+    assert set(handle2.extra.keys()) >= _PRE_954_SUCCESS_EXTRA_KEYS
+    assert "workload_start_error" not in handle2.extra
+    assert handle2.extra["workload_executed"] is True
+
+
+def test_pre_provision_guard_keeps_handle_none(monkeypatch):
+    """#954 AC2 input shape: the ``execute_workload``+empty-``workload_cmd``
+    guard raises with ``handle is None`` and provision was never invoked —
+    nothing was provisioned, nothing bills, so the rung's NoCompute blanket
+    branch stays correct for it."""
+
+    def _explode(*a, **k):
+        raise AssertionError("provision must NOT run on the flag+empty-cmd cell")
+
+    monkeypatch.setattr(RP.subprocess, "run", _explode, raising=False)
+    with pytest.raises(RP.RunPodWorkloadStartError) as ei:
+        RP.RunPodBackend().launch(
+            _spec(workload_cmd="", hydra_args=("seed=1",), extra={"execute_workload": True})
+        )
+    assert ei.value.handle is None


### PR DESCRIPTION
Closes task #954 (workflow-fix, kind: infra).

## Summary
- `RunPodWorkloadStartError` now carries the fully-built partial `RunHandle`; `_runpod_terminal_rung` persists the sidecar hook + in-flock exactly-once lease (incl. M3b `gcp_failover_of`, under a lease-write guard) and re-raises TYPED instead of collapsing to `NoComputeAvailableError`.
- All failover legs (#659 crash / #783 queue-timeout / #692+#770 wedge / #775 CUDA-IMA) + the `dispatch_issue.py` typed arm re-point the sidecar and emit distinct terminal `runpod_workload_start_failed` (∉ TRANSIENT_CAPACITY_REASONS) with billing + live-workload recovery hints.
- Incident: #931 (pod-931 provisioned, SSH boot-lag workload-start failure, unchained manual re-drive).

## Test plan
- [x] 14 new tests (plan §6 tests 1–12b) green
- [x] Step 9c touched-scope gate: 2738 passed, 0 failed
- [x] ruff check + format clean; workflow_lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)