### PR TITLE
task #956: reap + retry half-spawned session on daemon webhook-timeout 500

### DIFF
--- a/scripts/spawn_session.py
+++ b/scripts/spawn_session.py
@@ -1245,10 +1245,12 @@ def _live_children(*, strict: bool = False) -> list[dict[str, Any]]:
     NOTE: the daemon's /list returns ONLY handshaken children (it filters
     ``happySessionId !== undefined``, bundle line 4079) — a just-forked,
     never-handshaken child is NOT in this list by design. With ``strict=True``
-    a daemon-unreachable / unparseable /list RAISES RuntimeError instead of
-    returning ``[]`` — used by the #956 reap's late-handshake probe, where a
-    silent ``[]`` must not read as "no late handshake" when the daemon was
-    simply unreachable."""
+    a daemon-unreachable / unparseable / wrong-shape /list (a parseable
+    non-dict body, or a non-list ``children`` field) RAISES RuntimeError
+    instead of returning ``[]`` — used by the #956 reap's late-handshake
+    probe, where a silent ``[]`` must not read as "no late handshake" when
+    the daemon was simply unreachable. LENIENT mode keeps its historical
+    semantics untouched for existing callers."""
     try:
         url = f"http://127.0.0.1:{daemon_port()}/list"
         req = urllib.request.Request(
@@ -1260,6 +1262,13 @@ def _live_children(*, strict: bool = False) -> list[dict[str, Any]]:
         if strict:
             raise RuntimeError(f"daemon /list failed: {e}") from e
         return []
+    if strict:
+        if not isinstance(data, dict):
+            raise RuntimeError(f"daemon /list returned non-dict JSON: {repr(data)[:200]}")
+        children = data.get("children", [])
+        if not isinstance(children, list):
+            raise RuntimeError(f"daemon /list 'children' is not a list: {repr(children)[:200]}")
+        return children
     children = data.get("children", [])
     return children if isinstance(children, list) else []
 
@@ -1565,9 +1574,12 @@ def _stop_session_raw(session_id: str) -> bool:
     block the retry. :func:`_stop_spawned_session` (which conflates the two
     as False) keeps its existing callers unchanged.
 
-    Asserts nothing beyond ``{success: bool}``: if a live daemon ever returns
-    a different response shape, the ``.get("success")`` read degrades to
-    False — acceptable (False routes to the reap's fail-safe branches)."""
+    Response-shape guard: a PARSEABLE body that is not a ``{success: bool}``
+    dict — non-dict JSON (e.g. ``[]``), or a missing / non-bool ``success``
+    field — ALSO raises RuntimeError. Wrong shape carries no verdict about
+    tracking state, so it blocks the retry exactly like a transport failure;
+    it never degrades to False (False is the daemon's own 'pid untracked'
+    verdict and feeds the already-gone branch)."""
     url = f"http://127.0.0.1:{daemon_port()}/stop-session"
     req = urllib.request.Request(
         url,
@@ -1577,9 +1589,14 @@ def _stop_session_raw(session_id: str) -> bool:
     )
     try:
         with urllib.request.urlopen(req, timeout=DEFAULT_TIMEOUT_S) as resp:
-            return bool(json.loads(resp.read()).get("success"))
+            data = json.loads(resp.read())
     except (urllib.error.URLError, OSError, TimeoutError, json.JSONDecodeError) as e:
         raise RuntimeError(f"daemon /stop-session transport failure: {e}") from e
+    if not isinstance(data, dict) or not isinstance(data.get("success"), bool):
+        raise RuntimeError(
+            f"daemon /stop-session returned unexpected response shape: {repr(data)[:200]}"
+        )
+    return bool(data.get("success"))
 
 
 def _post_duplicate_suppressed_marker(issue: int, kept_sid: str, stopped_sid: str) -> None:

--- a/scripts/spawn_session.py
+++ b/scripts/spawn_session.py
@@ -45,7 +45,7 @@ import urllib.error
 import urllib.request
 import uuid
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 # Make the package importable without `uv run` plumbing (same bootstrap as
 # scripts/task.py). Sibling-import semantics on purpose: a worktree copy of
@@ -888,6 +888,25 @@ SPAWN_SESSION_TIMEOUT_S = 60
 # would otherwise hang the stop indefinitely (#902; plan §4.4 D5).
 STOP_BREADCRUMB_JOIN_TIMEOUT_S = 10.0
 
+# The Happy daemon waits 15s for the spawned child's /session-started webhook,
+# then resolves {"success": false, "error": "Session webhook timeout for PID <n>"}
+# (regular path) / "... (tmux)" (tmux path) WITHOUT killing the child — the fork
+# stays live and tracked (bundle index-q9G4ktSK.mjs lines 5346/5466; incident
+# task #956, 2026-07-03: two consecutive 500s leaked two live-but-empty
+# sessions, third attempt succeeded). On this shape post() reaps the
+# half-spawned child, then retries ONCE after a backoff sized at 2x the
+# daemon's 15s webhook window.
+WEBHOOK_TIMEOUT_RE = re.compile(r"Session webhook timeout for PID (\d+)(?P<tmux> \(tmux\))?")
+WEBHOOK_TIMEOUT_MAX_RETRIES = 1
+WEBHOOK_TIMEOUT_RETRY_BACKOFF_S = 30.0
+# Greppable prefix for every reap-related stderr line, so "fix engaged" is
+# distinguishable in production spawn logs (nohup/session transcripts).
+WEBHOOK_REAP_LOG_PREFIX = "webhook-timeout reap:"
+# Bounded wait for a SIGTERMed / daemon-stopped child to die (~10s), the
+# 20 x 0.5s shape _stop_fallback (#903) already uses.
+REAP_PID_DEATH_POLL_TRIES = 20
+REAP_PID_DEATH_POLL_INTERVAL_S = 0.5
+
 
 def post(path: str, body: dict[str, Any]) -> dict[str, Any]:
     """POST a JSON body to the local Happy daemon and return the parsed
@@ -901,47 +920,104 @@ def post(path: str, body: dict[str, Any]) -> dict[str, Any]:
     finished creating after we gave up — turning the orphan/duplicate
     hazard into an idempotent spawn (see
     :func:`_reconcile_spawn_after_timeout`). For any other route, a timeout
-    surfaces as a clean failure so the caller can safely retry."""
+    surfaces as a clean failure so the caller can safely retry.
+
+    On an HTTP error whose body matches the daemon's ``Session webhook
+    timeout for PID <n>`` shape (the daemon forked a child but its
+    /session-started webhook missed the 15s window — the child stays ALIVE
+    and TRACKED daemon-side), post() reaps the half-spawned child (daemon
+    /stop-session — by session id when a late webhook already landed, else
+    by the daemon's ``PID-<pid>`` stop branch; identity-checked SIGTERM only
+    as the untracked-but-alive fallback) and retries once after
+    :data:`WEBHOOK_TIMEOUT_RETRY_BACKOFF_S`. A failed/unconfirmed reap exits
+    nonzero WITHOUT retrying — retrying over an unconfirmed leak or a
+    surviving inner claude could double-spawn (#956)."""
     url = f"http://127.0.0.1:{daemon_port()}{path}"
     payload = json.dumps(body).encode()
-    req = urllib.request.Request(
-        url,
-        data=payload,
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
     timeout = SPAWN_SESSION_TIMEOUT_S if path == "/spawn-session" else DEFAULT_TIMEOUT_S
-    spawn_started_at = time.time() if path == "/spawn-session" else None
-    try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return json.loads(resp.read())
-    except urllib.error.HTTPError as e:
-        try:
-            err_body = json.loads(e.read())
-        except Exception:
-            err_body = {"raw": str(e)}
-        sys.exit(f"Happy daemon {path} returned HTTP {e.code}: {err_body}")
-    except TimeoutError as e:
-        # `socket.timeout is TimeoutError` (CPython 3.10+); `urlopen` raises it
-        # DIRECTLY on socket timeout (NOT wrapped in URLError). Reconcile for
-        # /spawn-session, surface cleanly for everything else.
-        if path == "/spawn-session" and spawn_started_at is not None:
-            adopted = _reconcile_spawn_after_timeout(body, spawn_started_at)
-            if adopted is not None:
-                print(
-                    f"  NOTE: /spawn-session POST timed out after {timeout}s; "
-                    f"daemon completed the spawn after the client gave up. "
-                    f"Adopted session {adopted} (directory match).",
-                    file=sys.stderr,
-                )
-                return {"success": True, "sessionId": adopted}
-        sys.exit(
-            f"Happy daemon {path} timed out after {timeout}s: {e}. "
-            "Retry is safe ONLY if you can confirm no session was created "
-            "(check `spawn_session.py list`)."
+    max_attempts = 1 + (WEBHOOK_TIMEOUT_MAX_RETRIES if path == "/spawn-session" else 0)
+    for attempt in range(1, max_attempts + 1):
+        req = urllib.request.Request(
+            url,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
         )
-    except urllib.error.URLError as e:
-        sys.exit(f"Happy daemon {path} unreachable at 127.0.0.1: {e}")
+        # Per-attempt so a retry's client-socket timeout reconciles against
+        # ITS OWN freshness window (#956), not attempt 1's.
+        spawn_started_at = time.time() if path == "/spawn-session" else None
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as e:
+            try:
+                err_body = json.loads(e.read())
+            except Exception:
+                err_body = {"raw": str(e)}  # non-dict / non-JSON body guard (tested)
+            m = None
+            err_text = ""
+            if path == "/spawn-session":
+                err_text = (
+                    err_body.get("error", "") if isinstance(err_body, dict) else str(err_body)
+                )
+                m = WEBHOOK_TIMEOUT_RE.search(err_text or "")
+            if m is None:
+                # UNCHANGED failure surface for every non-webhook-timeout
+                # error and every non-/spawn-session route.
+                sys.exit(f"Happy daemon {path} returned HTTP {e.code}: {err_body}")
+            outcome = _reap_half_spawned_session(
+                int(m.group(1)), body.get("directory"), is_tmux=m.group("tmux") is not None
+            )
+            print(
+                f"  {WEBHOOK_REAP_LOG_PREFIX} /spawn-session webhook-timeout (HTTP {e.code}, "
+                f"attempt {attempt}/{max_attempts}): {err_text!r}; reap: {outcome.detail}",
+                file=sys.stderr,
+            )
+            if not outcome.reaped:
+                sys.exit(
+                    f"Happy daemon /spawn-session returned HTTP {e.code}: {err_body}. "
+                    f"Could NOT confirm the half-spawned child (PID {m.group(1)}) was "
+                    f"fully reaped ({outcome.detail}); NOT retrying (a retry over an "
+                    "unconfirmed leak could double-spawn). Clean up manually "
+                    "(spawn_session.py list / stop), then re-run."
+                )
+            if attempt >= max_attempts:
+                sys.exit(
+                    f"Happy daemon /spawn-session returned HTTP {e.code} (webhook "
+                    f"timeout) {max_attempts} times; the half-spawned child was reaped "
+                    f"each time (last: {outcome.detail}). The daemon looks loaded — "
+                    "retry later (no session leaked)."
+                )
+            print(
+                f"  {WEBHOOK_REAP_LOG_PREFIX} retrying /spawn-session in "
+                f"{WEBHOOK_TIMEOUT_RETRY_BACKOFF_S:.0f}s "
+                f"(attempt {attempt + 1}/{max_attempts})...",
+                file=sys.stderr,
+            )
+            time.sleep(WEBHOOK_TIMEOUT_RETRY_BACKOFF_S)
+            continue
+        except TimeoutError as e:
+            # `socket.timeout is TimeoutError` (CPython 3.10+); `urlopen` raises it
+            # DIRECTLY on socket timeout (NOT wrapped in URLError). Reconcile for
+            # /spawn-session, surface cleanly for everything else.
+            if path == "/spawn-session" and spawn_started_at is not None:
+                adopted = _reconcile_spawn_after_timeout(body, spawn_started_at)
+                if adopted is not None:
+                    print(
+                        f"  NOTE: /spawn-session POST timed out after {timeout}s; "
+                        f"daemon completed the spawn after the client gave up. "
+                        f"Adopted session {adopted} (directory match).",
+                        file=sys.stderr,
+                    )
+                    return {"success": True, "sessionId": adopted}
+            sys.exit(
+                f"Happy daemon {path} timed out after {timeout}s: {e}. "
+                "Retry is safe ONLY if you can confirm no session was created "
+                "(check `spawn_session.py list`)."
+            )
+        except urllib.error.URLError as e:
+            sys.exit(f"Happy daemon {path} unreachable at 127.0.0.1: {e}")
+    raise AssertionError("unreachable: every post() attempt returns or exits")
 
 
 def _reconcile_spawn_after_timeout(
@@ -1002,11 +1078,177 @@ def _reconcile_spawn_after_timeout(
     return candidates[0][1]
 
 
-def _live_children() -> list[dict[str, Any]]:
+class _ReapOutcome(NamedTuple):
+    """Outcome of :func:`_reap_half_spawned_session` (#956)."""
+
+    reaped: bool  # True == no live half-spawned process remains (wrapper AND inner claude)
+    detail: str  # human-readable outcome for the stderr NOTE / exit message
+
+
+def _reap_half_spawned_session(
+    pid: int, directory: str | None, *, is_tmux: bool = False
+) -> _ReapOutcome:
+    """Reap the child the daemon forked for a /spawn-session that failed with
+    'Session webhook timeout for PID <pid>' (#956). The daemon does NOT kill
+    that child; unreaped it becomes a live-but-empty unmapped session nothing
+    cleans up for >=12h. Legs, in order:
+
+    1. LATE-HANDSHAKE probe: strict /list. The daemon's /list FILTERS OUT
+       never-handshaken children (bundle line 4079), so an entry for ``pid``
+       (which by construction carries a happySessionId) means the webhook
+       landed LATE -> stop via /stop-session {sessionId: <sid>}. /list
+       ABSENCE is the NORMAL never-handshaken state, NOT "already gone".
+    2. DAEMON PID-STOP (primary no-sid leg): /stop-session
+       {sessionId: "PID-<pid>"} — the daemon's stopSession PID- branch
+       (bundle line 5559) SIGTERMs the tracked child itself and untracks it.
+       The daemon only kills a pid it tracks, so this leg carries no
+       PID-recycle exposure. success:true does NOT prove death (the daemon
+       swallows kill errors, lines 5564-5573) -> always confirm with the
+       client-side death poll.
+    3. ALREADY-GONE verdict: PID-stop success:false (daemon reachable, pid
+       untracked — onChildExited untracked a self-exited child) AND
+       _pid_alive(pid) false.
+    4. FALLBACK identity-checked SIGTERM (untracked-but-alive anomaly only:
+       e.g. the daemon restarted between fork and reap, orphaning the child
+       from tracking): the #903 _stop_fallback identity trio (comm=='node',
+       happy-wrapper cmdline, not-the-daemon-pid) PLUS a /proc/<pid>/cwd ==
+       spawn-directory bind. Ambiguity always REFUSES the kill
+       (reaped=False). SKIPPED for the tmux variant (pane-PID /proc identity
+       signature unverified for tmux; fail loud with a tmux hint).
+
+    ANY transport failure talking to the daemon (unreachable /list or
+    /stop-session) returns reaped=False — 'daemon said success:false' and
+    'daemon unreachable' are deliberately NOT conflated (the former is
+    evidence about tracking state; the latter is no evidence at all).
+
+    Survivor rule (DIVERGES from the #903 _stop_fallback precedent, which
+    only WARNS on a surviving inner claude — safe there because no retry
+    follows a takeover stop): after ANY kill leg (sid-stop, PID-stop, or
+    fallback SIGTERM), if the pre-kill-resolved inner claude pid is still
+    alive once the wrapper died, return reaped=False — retrying over a live
+    inner claude recreates the live-unmapped-work class at process level
+    (double-spawn risk)."""
+    import session_resolver  # lazy: session_resolver imports spawn_session at top level
+
+    # Pre-kill: resolve the inner claude while the wrapper's /proc tree is
+    # still walkable (post-kill resolution is impossible). Best-effort; a
+    # read-only /proc walk is harmless even if pid later fails identity.
+    claude_pid = session_resolver.resolve_claude_pid(pid)
+
+    def _confirm_dead_and_no_survivor(via: str) -> _ReapOutcome:
+        if not _await_pid_death(pid, session_resolver):
+            return _ReapOutcome(False, f"{via} ACKed but PID {pid} survived ~10s")
+        if claude_pid is not None and session_resolver._pid_alive(claude_pid):
+            return _ReapOutcome(
+                False,
+                f"{via}: wrapper PID {pid} dead but inner claude PID {claude_pid} "
+                "SURVIVED — retry blocked (double-spawn risk); kill it manually, then re-run",
+            )
+        return _ReapOutcome(True, f"reaped via {via} (PID {pid} dead)")
+
+    # --- Leg 1: late-handshake probe (strict /list) ---
+    try:
+        children = _live_children(strict=True)
+    except RuntimeError as e:
+        return _ReapOutcome(False, f"daemon /list unreachable while verifying PID {pid}: {e}")
+    match = next((c for c in children if c.get("pid") == pid), None)
+    sid = (match or {}).get("happySessionId")
+    if isinstance(sid, str) and sid:
+        try:
+            ok = _stop_session_raw(sid)
+        except RuntimeError as e:
+            return _ReapOutcome(False, f"daemon unreachable during sid-stop of {sid}: {e}")
+        if ok:
+            return _confirm_dead_and_no_survivor(f"daemon sid-stop of late-handshaken {sid}")
+        # ok False: entry vanished between /list and the stop (self-exit race,
+        # concurrent stop) -> fall through to the PID-stop leg.
+    # --- Leg 2: daemon PID-stop (primary no-sid leg) ---
+    try:
+        ok = _stop_session_raw(f"PID-{pid}")
+    except RuntimeError as e:
+        return _ReapOutcome(False, f"daemon unreachable during PID-stop of PID {pid}: {e}")
+    if ok:
+        return _confirm_dead_and_no_survivor(f"daemon PID-stop (PID-{pid})")
+    # --- Leg 3: already-gone verdict (daemon reachable, pid untracked) ---
+    if not session_resolver._pid_alive(pid):
+        return _ReapOutcome(
+            True, f"child PID {pid} already exited (untracked by daemon, not alive)"
+        )
+    # --- Leg 4: untracked-but-alive anomaly -> identity-checked SIGTERM fallback ---
+    refusal = _fallback_identity_sigterm(pid, directory, is_tmux, session_resolver)
+    if refusal is not None:
+        return refusal
+    return _confirm_dead_and_no_survivor(f"fallback SIGTERM of untracked PID {pid}")
+
+
+def _fallback_identity_sigterm(
+    pid: int, directory: str | None, is_tmux: bool, session_resolver
+) -> _ReapOutcome | None:
+    """Leg 4 of :func:`_reap_half_spawned_session`: the untracked-but-alive
+    anomaly (e.g. a daemon restart between fork and reap orphaned the child
+    from tracking). Runs the #903 ``_stop_fallback`` identity trio
+    (comm=='node' / happy-wrapper cmdline / not-the-daemon-pid) PLUS a
+    ``/proc/<pid>/cwd == spawn-directory`` bind; ambiguity always REFUSES the
+    kill (a ``reaped=False`` outcome, never a signal). Returns a REFUSAL
+    :class:`_ReapOutcome`, or ``None`` after an actually-issued SIGTERM (the
+    caller then runs the shared death-poll + survivor confirmation).
+    SKIPPED for the tmux variant (the pane PID may be a shell wrapper, so the
+    /proc signature is unverified there — refuse with a tmux hint)."""
+    if is_tmux:
+        return _ReapOutcome(
+            False,
+            f"PID {pid} is tmux-spawned, untracked by the daemon, and still alive; the "
+            "/proc identity signature is unverified for tmux pane PIDs — refusing the "
+            "client-side kill. tmux path: clean up via tmux, then re-run.",
+        )
+    comm = session_resolver._read_proc_comm(pid)
+    if comm != "node":
+        return _ReapOutcome(False, f"PID {pid} comm={comm!r} != 'node' (recycled?); refusing kill")
+    cmdline = session_resolver._read_proc_cmdline(pid) or ""
+    if "happy" not in cmdline:
+        return _ReapOutcome(
+            False, f"PID {pid} cmdline lacks the happy-wrapper signature; refusing kill"
+        )
+    daemon_pid = session_resolver._happy_daemon_pid()
+    if daemon_pid is not None and pid == daemon_pid:
+        return _ReapOutcome(False, f"PID {pid} is the Happy DAEMON pid; refusing kill")
+    if directory:
+        try:
+            proc_cwd: str | None = os.readlink(f"/proc/{pid}/cwd")
+        except OSError:
+            proc_cwd = None  # unreadable cwd is not disqualifying; 3 checks above hold
+        if proc_cwd is not None and proc_cwd != directory:
+            return _ReapOutcome(
+                False, f"PID {pid} cwd {proc_cwd!r} != spawn dir {directory!r}; refusing kill"
+            )
+    os.kill(pid, signal.SIGTERM)
+    return None
+
+
+def _await_pid_death(pid: int, session_resolver) -> bool:
+    """~10s bounded death poll (20 x 0.5s), the _stop_fallback (#903) shape.
+    session_resolver._pid_alive is the ONE liveness seam (tests monkeypatch
+    it + spawn_session.time.sleep)."""
+    for _ in range(REAP_PID_DEATH_POLL_TRIES):
+        time.sleep(REAP_PID_DEATH_POLL_INTERVAL_S)
+        if not session_resolver._pid_alive(pid):
+            return True
+    return False
+
+
+def _live_children(*, strict: bool = False) -> list[dict[str, Any]]:
     """Raw child-session dicts (``happySessionId`` / ``pid`` / ``startedBy``)
     the daemon is actively tracking. Returns ``[]`` if the daemon is
     unreachable so callers can degrade (``list --all``) or fail loud
-    (``register-current``) as appropriate."""
+    (``register-current``) as appropriate.
+
+    NOTE: the daemon's /list returns ONLY handshaken children (it filters
+    ``happySessionId !== undefined``, bundle line 4079) — a just-forked,
+    never-handshaken child is NOT in this list by design. With ``strict=True``
+    a daemon-unreachable / unparseable /list RAISES RuntimeError instead of
+    returning ``[]`` — used by the #956 reap's late-handshake probe, where a
+    silent ``[]`` must not read as "no late handshake" when the daemon was
+    simply unreachable."""
     try:
         url = f"http://127.0.0.1:{daemon_port()}/list"
         req = urllib.request.Request(
@@ -1014,7 +1256,9 @@ def _live_children() -> list[dict[str, Any]]:
         )
         with urllib.request.urlopen(req, timeout=10) as resp:
             data = json.loads(resp.read())
-    except (urllib.error.URLError, OSError, SystemExit, json.JSONDecodeError):
+    except (urllib.error.URLError, OSError, SystemExit, json.JSONDecodeError) as e:
+        if strict:
+            raise RuntimeError(f"daemon /list failed: {e}") from e
         return []
     children = data.get("children", [])
     return children if isinstance(children, list) else []
@@ -1308,6 +1552,34 @@ def _stop_spawned_session(session_id: str) -> bool:
         return bool(stop_resp.get("success"))
     except SystemExit:
         return False
+
+
+def _stop_session_raw(session_id: str) -> bool:
+    """Daemon ``/stop-session`` with transport failures kept DISTINGUISHABLE
+    from the daemon's own verdict: returns the response ``success`` boolean
+    (stopSession's return — true == a tracked entry was found+killed+untracked,
+    false == no tracked entry for this sessionId/PID-<pid>); RAISES
+    RuntimeError on any transport failure (daemon unreachable, timeout, HTTP
+    error, unparseable body). Used by the #956 reap, where 'daemon said no
+    such pid' feeds the already-gone verdict but 'daemon unreachable' must
+    block the retry. :func:`_stop_spawned_session` (which conflates the two
+    as False) keeps its existing callers unchanged.
+
+    Asserts nothing beyond ``{success: bool}``: if a live daemon ever returns
+    a different response shape, the ``.get("success")`` read degrades to
+    False — acceptable (False routes to the reap's fail-safe branches)."""
+    url = f"http://127.0.0.1:{daemon_port()}/stop-session"
+    req = urllib.request.Request(
+        url,
+        data=json.dumps({"sessionId": session_id}).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=DEFAULT_TIMEOUT_S) as resp:
+            return bool(json.loads(resp.read()).get("success"))
+    except (urllib.error.URLError, OSError, TimeoutError, json.JSONDecodeError) as e:
+        raise RuntimeError(f"daemon /stop-session transport failure: {e}") from e
 
 
 def _post_duplicate_suppressed_marker(issue: int, kept_sid: str, stopped_sid: str) -> None:

--- a/tests/test_spawn_session_webhook_timeout.py
+++ b/tests/test_spawn_session_webhook_timeout.py
@@ -14,7 +14,11 @@ What this pins (plan #956 v2 §7):
    ANY kill leg blocks the retry.
 4. Transport failures are never conflated with the daemon's ``success:false``
    verdict (strict /list + ``_stop_session_raw`` raise; lenient /list
-   returns ``[]``).
+   returns ``[]``). Round 2 (concern invalid-daemon-response-shape): a
+   PARSEABLE wrong-shape body — non-dict JSON, missing / non-bool
+   ``success``, non-list ``children`` — raises the SAME reap-contracted
+   RuntimeError (never AttributeError) under ``_stop_session_raw`` and
+   strict ``_live_children``; lenient ``_live_children`` is untouched.
 
 No live daemon: every daemon touchpoint (``urlopen``, ``_live_children``,
 ``_stop_session_raw``) and every /proc seam (``session_resolver._pid_alive``,
@@ -61,9 +65,10 @@ def sleeps(monkeypatch) -> list[float]:
 
 
 class _FakeResponse:
-    """Minimal context-manager stand-in for ``urlopen``'s response."""
+    """Minimal context-manager stand-in for ``urlopen``'s response. ``payload``
+    is any JSON-serializable object (a list payload fakes a non-dict body)."""
 
-    def __init__(self, payload: dict):
+    def __init__(self, payload: object):
         self._raw = json.dumps(payload).encode()
 
     def read(self) -> bytes:
@@ -90,8 +95,9 @@ def _webhook_body(pid: int, *, tmux: bool = False) -> dict:
 
 
 def _install_urlopen(monkeypatch, outcomes: list[object]) -> list[tuple]:
-    """Sequence ``urlopen`` outcomes; an Exception outcome is raised, a dict
-    is returned as a fake response. Returns the recorded call list."""
+    """Sequence ``urlopen`` outcomes; an Exception outcome is raised, any
+    other outcome is returned as a fake JSON response. Returns the recorded
+    call list."""
     calls: list[tuple] = []
 
     def fake_urlopen(req, timeout=None):
@@ -556,3 +562,63 @@ def test_non_dict_error_body_falls_back_to_raw_and_mixed_exception_retry(monkeyp
     assert spawn_session.WEBHOOK_TIMEOUT_RETRY_BACKOFF_S in sleeps
     # The per-attempt reset: attempt 2's window (2000.0), never attempt 1's.
     assert reconcile_calls == [({"directory": SPAWN_DIR}, 2000.0)]
+
+
+# ── 19. daemon response-shape guards (round 2: invalid-daemon-response-shape) ─
+
+
+@pytest.mark.parametrize("body", [[], {"ok": True}, {"success": "yes"}])
+def test_stop_session_raw_wrong_shape_raises_runtime_error(monkeypatch, body):
+    # A PARSEABLE wrong-shape /stop-session body — non-dict JSON (b"[]"),
+    # missing `success`, or a non-bool `success` — must raise the
+    # reap-contracted RuntimeError, never AttributeError (which would escape
+    # _reap_half_spawned_session's `except RuntimeError` and crash post()).
+    _install_urlopen(monkeypatch, [body])
+    with pytest.raises(RuntimeError, match="unexpected response shape"):
+        spawn_session._stop_session_raw("PID-1")
+
+
+def test_stop_session_raw_valid_dict_returns_success_bool(monkeypatch):
+    # The valid `{success: bool}` shape is byte-compatible with round 1.
+    _install_urlopen(monkeypatch, [{"success": True}, {"success": False}])
+    assert spawn_session._stop_session_raw("sess-x") is True
+    assert spawn_session._stop_session_raw("sess-x") is False
+
+
+def test_reap_stop_wrong_shape_body_blocks_retry(monkeypatch):
+    # The same non-dict body threaded through the REAL _stop_session_raw
+    # inside the reap: the RuntimeError is caught at the PID-stop leg and
+    # routes to the fail-loud reaped=False / no-retry path — the already-gone
+    # check is never consulted and no fallback kill fires.
+    _install_children(monkeypatch, [])
+    urlopen_calls = _install_urlopen(monkeypatch, [[]])  # daemon body b"[]"
+
+    def fail_alive(p):
+        raise AssertionError("_pid_alive must NOT be consulted on a wrong-shape response")
+
+    _patch_resolver(monkeypatch, claude_pid=None, alive=fail_alive)
+    kills = _install_kill(monkeypatch)
+    outcome = spawn_session._reap_half_spawned_session(3698, SPAWN_DIR)
+    assert outcome.reaped is False
+    assert "PID-stop" in outcome.detail
+    assert len(urlopen_calls) == 1
+    assert kills == []
+
+
+def test_live_children_strict_wrong_shape_raises_lenient_unchanged(monkeypatch):
+    # strict: parseable-but-wrong-shape /list bodies raise the reap-contracted
+    # RuntimeError (never AttributeError).
+    _install_urlopen(monkeypatch, [[], {"children": "nope"}])
+    with pytest.raises(RuntimeError, match="non-dict"):
+        spawn_session._live_children(strict=True)
+    with pytest.raises(RuntimeError, match="not a list"):
+        spawn_session._live_children(strict=True)
+    # lenient: today's semantics preserved exactly — a dict body with a
+    # non-list `children` degrades to [] ...
+    _install_urlopen(monkeypatch, [{"children": "nope"}, []])
+    assert spawn_session._live_children() == []
+    # ... and a parseable non-dict body keeps main's historical AttributeError
+    # (lenient behavior deliberately untouched by the round-2 concern fix;
+    # only the round-added STRICT path gained the clean-raise contract).
+    with pytest.raises(AttributeError):
+        spawn_session._live_children()

--- a/tests/test_spawn_session_webhook_timeout.py
+++ b/tests/test_spawn_session_webhook_timeout.py
@@ -1,0 +1,558 @@
+"""Tests for the #956 webhook-timeout reap + retry leg in ``scripts/spawn_session.py``.
+
+What this pins (plan #956 v2 §7):
+
+1. ``post()``'s ``/spawn-session`` HTTPError leg reaps the half-spawned child
+   and retries EXACTLY once, only after a confirmed reap; a failed /
+   unconfirmed reap exits nonzero WITHOUT retrying (no double-spawn).
+2. Non-matching HTTP errors and non-``/spawn-session`` routes keep today's
+   exact ``sys.exit`` message and never invoke the reap.
+3. The reap is daemon-mediated by default (sid-stop for late-handshaken
+   children, ``PID-<pid>`` stop otherwise); the client-side SIGTERM survives
+   only as the untracked-but-alive fallback behind FOUR identity refusals
+   (comm / cmdline / daemon-pid / cwd), and a surviving inner claude after
+   ANY kill leg blocks the retry.
+4. Transport failures are never conflated with the daemon's ``success:false``
+   verdict (strict /list + ``_stop_session_raw`` raise; lenient /list
+   returns ``[]``).
+
+No live daemon: every daemon touchpoint (``urlopen``, ``_live_children``,
+``_stop_session_raw``) and every /proc seam (``session_resolver._pid_alive``,
+``_read_proc_*``, ``resolve_claude_pid``, ``os.kill``, ``os.readlink``) is
+monkeypatched. An autouse fixture patches ``spawn_session.time.sleep`` so no
+test ever sleeps the 30s backoff or the 20 x 0.5s death poll.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import signal
+import sys
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import session_resolver  # noqa: E402
+import spawn_session  # noqa: E402
+
+HAPPY_CMDLINE = (
+    "node --no-warnings --no-deprecation /usr/lib/node_modules/happy/dist/index.mjs "
+    "claude --happy-starting-mode remote --started-by daemon"
+)
+SPAWN_DIR = "/repo/.claude/worktrees/issue-952"
+
+
+# ── shared fixtures / helpers ──────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def sleeps(monkeypatch) -> list[float]:
+    """Record every ``time.sleep`` so no test waits the 30s backoff or the
+    20 x 0.5s death poll (plan §7 sleep-hygiene requirement)."""
+    recorded: list[float] = []
+    monkeypatch.setattr(spawn_session.time, "sleep", lambda s: recorded.append(s))
+    return recorded
+
+
+class _FakeResponse:
+    """Minimal context-manager stand-in for ``urlopen``'s response."""
+
+    def __init__(self, payload: dict):
+        self._raw = json.dumps(payload).encode()
+
+    def read(self) -> bytes:
+        return self._raw
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def _http_error(code: int, body: object) -> urllib.error.HTTPError:
+    """Real ``urllib.error.HTTPError`` with a readable body (plan §7)."""
+    raw = body if isinstance(body, bytes) else json.dumps(body).encode()
+    return urllib.error.HTTPError(
+        "http://127.0.0.1:1/spawn-session", code, "error", {}, io.BytesIO(raw)
+    )
+
+
+def _webhook_body(pid: int, *, tmux: bool = False) -> dict:
+    suffix = " (tmux)" if tmux else ""
+    return {"success": False, "error": f"Session webhook timeout for PID {pid}{suffix}"}
+
+
+def _install_urlopen(monkeypatch, outcomes: list[object]) -> list[tuple]:
+    """Sequence ``urlopen`` outcomes; an Exception outcome is raised, a dict
+    is returned as a fake response. Returns the recorded call list."""
+    calls: list[tuple] = []
+
+    def fake_urlopen(req, timeout=None):
+        idx = len(calls)
+        calls.append((req, timeout))
+        assert idx < len(outcomes), f"unexpected urlopen call #{idx + 1}"
+        outcome = outcomes[idx]
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return _FakeResponse(outcome)
+
+    monkeypatch.setattr(spawn_session.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(spawn_session, "daemon_port", lambda: 65001)
+    return calls
+
+
+def _install_reap(monkeypatch, results: list) -> list[tuple]:
+    """Replace ``_reap_half_spawned_session`` with a recorder returning the
+    per-call entries of ``results``. Returns the (pid, directory, is_tmux)
+    call list."""
+    calls: list[tuple] = []
+
+    def fake_reap(pid, directory, *, is_tmux=False):
+        calls.append((pid, directory, is_tmux))
+        return results[min(len(calls) - 1, len(results) - 1)]
+
+    monkeypatch.setattr(spawn_session, "_reap_half_spawned_session", fake_reap)
+    return calls
+
+
+def _install_kill(monkeypatch, on_kill=None) -> list[tuple[int, int]]:
+    kills: list[tuple[int, int]] = []
+
+    def fake_kill(pid, sig):
+        kills.append((pid, sig))
+        if on_kill is not None:
+            on_kill(pid, sig)
+
+    monkeypatch.setattr(spawn_session.os, "kill", fake_kill)
+    return kills
+
+
+def _patch_resolver(
+    monkeypatch,
+    *,
+    claude_pid=None,
+    alive=None,
+    comm="node",
+    cmdline=HAPPY_CMDLINE,
+    daemon_pid=999,
+):
+    """Patch every session_resolver seam the reap consults (plan §7: the
+    documented ``_pid_alive`` + lazy-import seams of ``_stop_fallback``)."""
+    monkeypatch.setattr(session_resolver, "resolve_claude_pid", lambda p: claude_pid)
+    monkeypatch.setattr(
+        session_resolver, "_pid_alive", alive if alive is not None else lambda p: False
+    )
+    monkeypatch.setattr(session_resolver, "_read_proc_comm", lambda p: comm)
+    monkeypatch.setattr(session_resolver, "_read_proc_cmdline", lambda p: cmdline)
+    monkeypatch.setattr(session_resolver, "_happy_daemon_pid", lambda: daemon_pid)
+
+
+def _install_children(monkeypatch, children: list[dict] | Exception) -> list[bool]:
+    """Replace ``_live_children`` with a recorder of its ``strict`` kwarg."""
+    strict_calls: list[bool] = []
+
+    def fake_children(*, strict=False):
+        strict_calls.append(strict)
+        if isinstance(children, Exception):
+            raise children
+        return children
+
+    monkeypatch.setattr(spawn_session, "_live_children", fake_children)
+    return strict_calls
+
+
+def _install_stop_raw(monkeypatch, result) -> list[str]:
+    """Replace ``_stop_session_raw``; ``result`` is a bool, an Exception, or
+    a dict mapping sessionId -> bool. Returns the recorded sessionId list."""
+    calls: list[str] = []
+
+    def fake_stop(session_id):
+        calls.append(session_id)
+        if isinstance(result, Exception):
+            raise result
+        if isinstance(result, dict):
+            return result[session_id]
+        return result
+
+    monkeypatch.setattr(spawn_session, "_stop_session_raw", fake_stop)
+    return calls
+
+
+# ── 1. regex shape ─────────────────────────────────────────────────────────
+
+
+def test_webhook_timeout_regex_matches_plain_and_tmux():
+    m = spawn_session.WEBHOOK_TIMEOUT_RE.search("Session webhook timeout for PID 3698")
+    assert m is not None
+    assert m.group(1) == "3698"
+    assert m.group("tmux") is None
+    m2 = spawn_session.WEBHOOK_TIMEOUT_RE.search("Session webhook timeout for PID 42 (tmux)")
+    assert m2 is not None
+    assert m2.group(1) == "42"
+    assert m2.group("tmux") is not None
+    # Other daemon errors never match.
+    assert (
+        spawn_session.WEBHOOK_TIMEOUT_RE.search("Failed to spawn Happy process - no PID returned")
+        is None
+    )
+    assert spawn_session.WEBHOOK_TIMEOUT_RE.search("Unsupported agent type: 'claude'") is None
+
+
+# ── 2-6. post()-level routing ──────────────────────────────────────────────
+
+
+def test_http_500_webhook_timeout_reaps_and_retries_success(monkeypatch, sleeps):
+    urlopen_calls = _install_urlopen(
+        monkeypatch,
+        [_http_error(500, _webhook_body(3698)), {"success": True, "sessionId": "sess-new"}],
+    )
+    reap_calls = _install_reap(monkeypatch, [spawn_session._ReapOutcome(True, "reaped")])
+    out = spawn_session.post("/spawn-session", {"directory": SPAWN_DIR})
+    assert out == {"success": True, "sessionId": "sess-new"}
+    assert reap_calls == [(3698, SPAWN_DIR, False)]
+    assert sleeps == [spawn_session.WEBHOOK_TIMEOUT_RETRY_BACKOFF_S]
+    assert len(urlopen_calls) == 2
+
+
+def test_http_500_webhook_timeout_double_failure_exits_after_reaping_both(monkeypatch):
+    # Each attempt's 500 names its OWN fork: distinct PIDs 3698 then 3699.
+    urlopen_calls = _install_urlopen(
+        monkeypatch,
+        [_http_error(500, _webhook_body(3698)), _http_error(500, _webhook_body(3699))],
+    )
+    reap_calls = _install_reap(
+        monkeypatch,
+        [
+            spawn_session._ReapOutcome(True, "reaped-first"),
+            spawn_session._ReapOutcome(True, "reaped-second"),
+        ],
+    )
+    with pytest.raises(SystemExit) as exc:
+        spawn_session.post("/spawn-session", {"directory": SPAWN_DIR})
+    msg = str(exc.value)
+    assert "webhook" in msg and "timeout" in msg
+    assert "reaped-second" in msg  # exit message names the LAST reap outcome
+    # Per-attempt reap args pinned (catches stale-PID reuse across attempts).
+    assert reap_calls == [(3698, SPAWN_DIR, False), (3699, SPAWN_DIR, False)]
+    assert len(urlopen_calls) == 2
+
+
+def test_http_500_webhook_timeout_failed_reap_exits_without_retry(monkeypatch, sleeps):
+    urlopen_calls = _install_urlopen(monkeypatch, [_http_error(500, _webhook_body(3698))])
+    reap_calls = _install_reap(
+        monkeypatch, [spawn_session._ReapOutcome(False, "daemon unreachable during PID-stop")]
+    )
+    with pytest.raises(SystemExit) as exc:
+        spawn_session.post("/spawn-session", {"directory": SPAWN_DIR})
+    assert "NOT retrying" in str(exc.value)
+    assert len(reap_calls) == 1
+    assert len(urlopen_calls) == 1  # no retry
+    assert sleeps == []  # no backoff either
+
+
+def test_http_500_non_webhook_shape_exits_verbatim_no_reap(monkeypatch):
+    urlopen_calls = _install_urlopen(
+        monkeypatch, [_http_error(500, {"success": False, "error": "something else"})]
+    )
+    reap_calls = _install_reap(monkeypatch, [spawn_session._ReapOutcome(True, "never")])
+    with pytest.raises(SystemExit) as exc:
+        spawn_session.post("/spawn-session", {"directory": SPAWN_DIR})
+    # Today's EXACT message, string-asserted (behavioral no-op outside the shape).
+    assert str(exc.value) == (
+        "Happy daemon /spawn-session returned HTTP 500: "
+        "{'success': False, 'error': 'something else'}"
+    )
+    assert reap_calls == []
+    assert len(urlopen_calls) == 1
+
+
+def test_http_error_on_non_spawn_route_never_reaps(monkeypatch):
+    # A webhook-timeout-SHAPED body on a non-/spawn-session route stays verbatim.
+    urlopen_calls = _install_urlopen(monkeypatch, [_http_error(500, _webhook_body(3698))])
+    reap_calls = _install_reap(monkeypatch, [spawn_session._ReapOutcome(True, "never")])
+    with pytest.raises(SystemExit) as exc:
+        spawn_session.post("/stop-session", {"sessionId": "sess-x"})
+    assert str(exc.value) == (
+        "Happy daemon /stop-session returned HTTP 500: "
+        "{'success': False, 'error': 'Session webhook timeout for PID 3698'}"
+    )
+    assert reap_calls == []
+    assert len(urlopen_calls) == 1
+
+
+# ── 7-17. reap internals ───────────────────────────────────────────────────
+
+
+def test_reap_stops_via_daemon_sid_when_late_webhook_delivered(monkeypatch):
+    strict_calls = _install_children(
+        monkeypatch, [{"pid": 3698, "happySessionId": "sess-x", "startedBy": "daemon"}]
+    )
+    stop_calls = _install_stop_raw(monkeypatch, {"sess-x": True})
+    _patch_resolver(monkeypatch, claude_pid=None, alive=lambda p: False)
+    kills = _install_kill(monkeypatch)
+    outcome = spawn_session._reap_half_spawned_session(3698, SPAWN_DIR)
+    assert outcome.reaped is True
+    assert stop_calls == ["sess-x"]  # sid-stop, NOT "PID-3698"
+    assert strict_calls == [True]  # the late-handshake probe is strict
+    assert kills == []
+
+
+def test_reap_daemon_pid_stop_for_list_invisible_child(monkeypatch):
+    # The corrected primary no-sid path: a never-handshaken child is
+    # /list-invisible BY DESIGN -> daemon PID-stop, no client-side kill.
+    _install_children(monkeypatch, [])
+    stop_calls = _install_stop_raw(monkeypatch, {"PID-3698": True})
+    _patch_resolver(monkeypatch, claude_pid=None, alive=lambda p: False)
+    kills = _install_kill(monkeypatch)
+    outcome = spawn_session._reap_half_spawned_session(3698, SPAWN_DIR)
+    assert outcome.reaped is True
+    assert stop_calls == ["PID-3698"]
+    assert kills == []
+
+
+@pytest.mark.parametrize(
+    "case",
+    ["comm-mismatch", "cmdline-not-happy", "pid-is-daemon", "cwd-mismatch"],
+)
+def test_reap_fallback_refuses_kill_on_identity_mismatch(monkeypatch, case):
+    # Fallback leg reached via: /list-invisible, PID-stop success:false,
+    # pid still alive. EVERY identity mismatch refuses (reaped=False, no kill).
+    _install_children(monkeypatch, [])
+    _install_stop_raw(monkeypatch, {"PID-3698": False})
+    kwargs = {"claude_pid": None, "alive": lambda p: True}
+    if case == "comm-mismatch":
+        kwargs["comm"] = "python3"
+    elif case == "cmdline-not-happy":
+        kwargs["cmdline"] = "node /usr/lib/node_modules/other-tool/dist/index.mjs serve"
+    elif case == "pid-is-daemon":
+        kwargs["daemon_pid"] = 3698
+    _patch_resolver(monkeypatch, **kwargs)
+    if case == "cwd-mismatch":
+        monkeypatch.setattr(spawn_session.os, "readlink", lambda p: "/some/other/dir")
+    else:
+        monkeypatch.setattr(spawn_session.os, "readlink", lambda p: SPAWN_DIR)
+    kills = _install_kill(monkeypatch)
+    outcome = spawn_session._reap_half_spawned_session(3698, SPAWN_DIR)
+    assert outcome.reaped is False
+    assert "refusing kill" in outcome.detail
+    assert kills == []
+
+
+def test_reap_daemon_list_unreachable_blocks_retry(monkeypatch):
+    # (a) The REAL _live_children: lenient swallows to [], strict raises.
+    def boom():
+        raise SystemExit("daemon.state.json missing")
+
+    monkeypatch.setattr(spawn_session, "daemon_port", boom)
+    assert spawn_session._live_children() == []
+    with pytest.raises(RuntimeError, match="daemon /list failed"):
+        spawn_session._live_children(strict=True)
+    # (b) A strict-probe failure blocks the reap (an unreachable daemon can
+    # never certify anything).
+    strict_calls = _install_children(monkeypatch, RuntimeError("daemon /list failed: boom"))
+    _patch_resolver(monkeypatch, claude_pid=None)
+    kills = _install_kill(monkeypatch)
+    outcome = spawn_session._reap_half_spawned_session(3698, SPAWN_DIR)
+    assert outcome.reaped is False
+    assert "unreachable" in outcome.detail
+    assert strict_calls == [True]
+    assert kills == []
+
+
+def test_reap_stop_transport_failure_is_not_success_false(monkeypatch):
+    # The conflation guard: a /stop-session TRANSPORT failure must never be
+    # read as the daemon's success:false verdict — no already-gone check
+    # (_pid_alive untouched), no fallback kill.
+    _install_children(monkeypatch, [])
+    _install_stop_raw(monkeypatch, RuntimeError("daemon /stop-session transport failure: refused"))
+
+    def fail_alive(p):
+        raise AssertionError("_pid_alive must NOT be consulted on a transport failure")
+
+    _patch_resolver(monkeypatch, claude_pid=None, alive=fail_alive)
+    kills = _install_kill(monkeypatch)
+    outcome = spawn_session._reap_half_spawned_session(3698, SPAWN_DIR)
+    assert outcome.reaped is False
+    assert "unreachable" in outcome.detail
+    assert kills == []
+
+
+def test_reap_already_gone_via_pid_stop_false_and_dead(monkeypatch):
+    # The corrected already-gone verdict: daemon reachable + pid untracked
+    # (success:false) + not alive.
+    _install_children(monkeypatch, [])
+    stop_calls = _install_stop_raw(monkeypatch, {"PID-3698": False})
+    _patch_resolver(monkeypatch, claude_pid=None, alive=lambda p: False)
+    kills = _install_kill(monkeypatch)
+    outcome = spawn_session._reap_half_spawned_session(3698, SPAWN_DIR)
+    assert outcome.reaped is True
+    assert "already exited" in outcome.detail
+    assert stop_calls == ["PID-3698"]
+    assert kills == []
+
+
+def test_reap_fallback_sigterm_on_untracked_alive_child(monkeypatch):
+    # Untracked-but-alive anomaly: all four identity checks pass -> SIGTERM.
+    _install_children(monkeypatch, [])
+    _install_stop_raw(monkeypatch, {"PID-3698": False})
+    state = {"killed": False}
+    kills = _install_kill(monkeypatch, on_kill=lambda pid, sig: state.__setitem__("killed", True))
+    _patch_resolver(
+        monkeypatch,
+        claude_pid=None,
+        alive=lambda p: not state["killed"] if p == 3698 else False,
+    )
+    monkeypatch.setattr(spawn_session.os, "readlink", lambda p: SPAWN_DIR)
+    outcome = spawn_session._reap_half_spawned_session(3698, SPAWN_DIR)
+    assert outcome.reaped is True
+    assert kills == [(3698, signal.SIGTERM)]
+
+
+def test_reap_inner_claude_survivor_blocks_retry_after_fallback_sigterm(monkeypatch, sleeps):
+    # MUST-FIX 3: a surviving inner claude after the fallback SIGTERM blocks
+    # the retry (reaped=False, NOT reaped-with-warning). Threaded through
+    # post() with the reap UNMOCKED: SystemExit, urlopen called exactly once.
+    def setup(state):
+        _install_children(monkeypatch, [])
+        _install_stop_raw(monkeypatch, {"PID-3698": False})
+
+        def alive(p):
+            if p == 3698:
+                return not state["killed"]
+            return p == 4001  # the inner claude survives every poll
+
+        _patch_resolver(monkeypatch, claude_pid=4001, alive=alive)
+        monkeypatch.setattr(spawn_session.os, "readlink", lambda p: SPAWN_DIR)
+        return _install_kill(
+            monkeypatch, on_kill=lambda pid, sig: state.__setitem__("killed", True)
+        )
+
+    # (1) Direct reap-level assert.
+    state = {"killed": False}
+    kills = setup(state)
+    outcome = spawn_session._reap_half_spawned_session(3698, SPAWN_DIR)
+    assert outcome.reaped is False
+    assert "4001" in outcome.detail
+    assert "retry blocked" in outcome.detail
+    assert kills == [(3698, signal.SIGTERM)]
+    # (2) post()-level thread (reap unmocked): no retry over the survivor.
+    state["killed"] = False
+    urlopen_calls = _install_urlopen(monkeypatch, [_http_error(500, _webhook_body(3698))])
+    with pytest.raises(SystemExit) as exc:
+        spawn_session.post("/spawn-session", {"directory": SPAWN_DIR})
+    msg = str(exc.value)
+    assert "NOT retrying" in msg
+    assert "4001" in msg
+    assert len(urlopen_calls) == 1
+
+
+def test_reap_inner_claude_survivor_blocks_retry_after_daemon_pid_stop(monkeypatch):
+    # MUST-FIX 3, daemon-leg twin: the daemon kills the WRAPPER; the inner
+    # claude can survive there exactly as under the fallback SIGTERM.
+    _install_children(monkeypatch, [])
+    _install_stop_raw(monkeypatch, {"PID-3698": True})
+    _patch_resolver(monkeypatch, claude_pid=4001, alive=lambda p: p == 4001)
+    kills = _install_kill(monkeypatch)
+    outcome = spawn_session._reap_half_spawned_session(3698, SPAWN_DIR)
+    assert outcome.reaped is False
+    assert "4001" in outcome.detail
+    assert "retry blocked" in outcome.detail
+    assert kills == []  # daemon-mediated: no client-side kill
+
+
+def test_reap_daemon_ack_but_pid_survives_is_not_reaped(monkeypatch, sleeps):
+    # stopSession swallows kill errors and untracks anyway — success:true is
+    # NOT death proof; the bounded poll is the only proof, and once untracked
+    # no daemon stop can be re-issued.
+    _install_children(monkeypatch, [])
+    _install_stop_raw(monkeypatch, {"PID-3698": True})
+    _patch_resolver(monkeypatch, claude_pid=None, alive=lambda p: True)
+    kills = _install_kill(monkeypatch)
+    outcome = spawn_session._reap_half_spawned_session(3698, SPAWN_DIR)
+    assert outcome.reaped is False
+    assert "survived" in outcome.detail
+    assert kills == []
+    # The full bounded poll ran (20 x 0.5s, all monkeypatched).
+    assert sleeps == [spawn_session.REAP_PID_DEATH_POLL_INTERVAL_S] * (
+        spawn_session.REAP_PID_DEATH_POLL_TRIES
+    )
+
+
+def test_reap_tmux_variant_refuses_fallback_with_tmux_hint(monkeypatch):
+    # Daemon legs 1-3 run unchanged for tmux; only the client-side fallback
+    # is refused (pane-PID /proc identity unverified for tmux).
+    _install_children(monkeypatch, [])
+    stop_calls = _install_stop_raw(monkeypatch, {"PID-42": False})
+    _patch_resolver(monkeypatch, claude_pid=None, alive=lambda p: True)
+    kills = _install_kill(monkeypatch)
+    outcome = spawn_session._reap_half_spawned_session(42, SPAWN_DIR, is_tmux=True)
+    assert outcome.reaped is False
+    assert "tmux" in outcome.detail
+    assert "clean up via tmux" in outcome.detail
+    assert stop_calls == ["PID-42"]  # the daemon legs DID run
+    assert kills == []
+    # post()-level thread: the tmux-suffixed 500 passes is_tmux=True.
+    urlopen_calls = _install_urlopen(
+        monkeypatch,
+        [
+            _http_error(500, _webhook_body(42, tmux=True)),
+            {"success": True, "sessionId": "sess-2"},
+        ],
+    )
+    reap_calls = _install_reap(monkeypatch, [spawn_session._ReapOutcome(True, "reaped")])
+    out = spawn_session.post("/spawn-session", {"directory": SPAWN_DIR})
+    assert out == {"success": True, "sessionId": "sess-2"}
+    assert reap_calls == [(42, SPAWN_DIR, True)]
+    assert len(urlopen_calls) == 2
+
+
+# ── 18. error-body guard + mixed-exception retry ───────────────────────────
+
+
+def test_non_dict_error_body_falls_back_to_raw_and_mixed_exception_retry(monkeypatch, sleeps):
+    # (a) Non-JSON body -> err_body == {"raw": ...}, no crash, verbatim exit,
+    # no reap (there is no "error" field to match).
+    urlopen_calls = _install_urlopen(monkeypatch, [_http_error(502, b"<html>502</html>")])
+    reap_calls = _install_reap(monkeypatch, [spawn_session._ReapOutcome(True, "never")])
+    with pytest.raises(SystemExit) as exc:
+        spawn_session.post("/spawn-session", {"directory": SPAWN_DIR})
+    assert str(exc.value).startswith("Happy daemon /spawn-session returned HTTP 502: {'raw': ")
+    assert reap_calls == []
+    assert len(urlopen_calls) == 1
+
+    # (b) Mixed-exception sequence: attempt 1 = webhook-timeout HTTPError
+    # (reap ok), attempt 2 = socket TimeoutError -> the TimeoutError
+    # reconcile runs against attempt 2's OWN spawn_started_at window.
+    ticks = {"n": 0}
+
+    def fake_time():
+        ticks["n"] += 1
+        return 1000.0 * ticks["n"]  # attempt 1 -> 1000.0, attempt 2 -> 2000.0
+
+    monkeypatch.setattr(spawn_session.time, "time", fake_time)
+    urlopen_calls = _install_urlopen(
+        monkeypatch,
+        [_http_error(500, _webhook_body(3698)), TimeoutError("timed out")],
+    )
+    reap_calls = _install_reap(monkeypatch, [spawn_session._ReapOutcome(True, "reaped")])
+    reconcile_calls: list[tuple[dict, float]] = []
+
+    def fake_reconcile(body, spawn_started_at):
+        reconcile_calls.append((body, spawn_started_at))
+        return "adopted-sid"
+
+    monkeypatch.setattr(spawn_session, "_reconcile_spawn_after_timeout", fake_reconcile)
+    out = spawn_session.post("/spawn-session", {"directory": SPAWN_DIR})
+    assert out == {"success": True, "sessionId": "adopted-sid"}
+    assert len(reap_calls) == 1
+    assert len(urlopen_calls) == 2
+    assert spawn_session.WEBHOOK_TIMEOUT_RETRY_BACKOFF_S in sleeps
+    # The per-attempt reset: attempt 2's window (2000.0), never attempt 1's.
+    assert reconcile_calls == [({"directory": SPAWN_DIR}, 2000.0)]


### PR DESCRIPTION
Closes task #956. Workflow-fix: scripts/spawn_session.py post() gains a reap-then-retry-once leg for the daemon-side HTTP 500 'Session webhook timeout for PID <n>' shape. Plan: tasks/running/956/plans/plan.md (v2).