### PR TITLE
issue-959: blockquote-aware footer URL-permanence checks (8/8b)

### DIFF
--- a/.claude/skills/clean-results/SPEC.md
+++ b/.claude/skills/clean-results/SPEC.md
@@ -641,6 +641,14 @@ H2), preceded by a `---` horizontal rule. TWO required bold labels:
   ``same-issue follow-up round `<followup_label>` `` clause, the
   machine-countable form check 20's round-scaled prose budget reads;
   #921) · created/run dates.
+  Bare / unpinned URLs INSIDE the verbatim blockquote are exempt from
+  the footer URL checks (checks 8 / 8b strip `>`-prefixed lines before
+  scanning — the quote is provenance text, not a provenance link; #959;
+  applies identically to grandfathered v3 `## Reproducibility` bodies).
+  Pinned-link requirements continue to bind on every non-quoted footer
+  row. A verbatim prompt containing URLs must `>`-prefix EVERY prompt
+  line — an un-prefixed lazy-continuation line stays scanned
+  (fail-closed).
   This footer is the ONLY place run-context provenance lives in the body
   (the "state facts, not sources" rule still bans weaving prompt/person
   attributions into Takeaways / Results prose).

--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -105,7 +105,9 @@ checks (3/3b) run on the v2 sentinel; v3-only checks (v3 structure +
    `main`/`master`/`HEAD`). `n/a` is accepted as an explicit
    non-applicable marker. Raw-host URLs are scanned on fence-stripped
    text (a moving-ref raw URL inside a ``` example is illustrative);
-   shape only — existence probing is check 8b's job.
+   URLs on blockquote lines are exempt too (the **Context:** verbatim
+   originating-prompt quote; #959); shape only — existence probing is
+   check 8b's job.
 8b. Reproducibility artifact URLs exist — same-repo artifact links in
     `## Reproducibility` (`raw.githubusercontent.com/<this-repo>/<sha>/
     <path>` raw URLs and `github.com/<this-repo>/(blob|tree)/<sha>/<path>`
@@ -117,7 +119,8 @@ checks (3/3b) run on the v2 sentinel; v3-only checks (v3 structure +
     Definitive miss → FAIL; indeterminate probe → `unverified` note on
     the PASS line, never a FAIL (same semantics as check 4b). Extends
     the task #507 existence protection to the Reproducibility section,
-    which previously got shape verification only. HF Hub / WandB /
+    which previously got shape verification only. Blockquoted URLs are
+    not gathered (same #959 exemption). HF Hub / WandB /
     external-repo links stay shape-checked only (check 8): their
     existence is not decidable from the local object DB, and an
     unauthenticated 404 on an external private repo would false-FAIL.
@@ -2382,8 +2385,12 @@ def check_repro_url_permanence(body: str) -> CheckResult:
     shape for TL;DR figure URLs). ALL scans run on fence-stripped text
     (same fence policy as check 8b: a URL inside a ``` example — e.g. a
     reproduce-command block — is illustrative, not a provenance link;
-    unified 2026-06-09, second #507 follow-up). Shape checks only —
-    existence probing for same-repo raw URLs is check 8b's job.
+    unified 2026-06-09, second #507 follow-up). Blockquote lines
+    (`>`-prefixed, incl. nested/indented quotes) are stripped too — the
+    `**Context:**` row's verbatim originating-prompt quote may cite bare
+    URLs that must be preserved verbatim (never paraphrased; #825/#959);
+    pinned-link requirements bind on the non-quoted rows. Shape checks
+    only — existence probing for same-repo raw URLs is check 8b's job.
     """
     repro = _repro_section_text(body)  # v4 footer or `## Reproducibility` H2
     if repro is None:
@@ -2391,10 +2398,11 @@ def check_repro_url_permanence(body: str) -> CheckResult:
             "Reproducibility URL permanence", False, "Reproducibility section missing"
         )
     bad: list[str] = []
-    # Every scan below runs on fence-stripped text: a URL inside a ```
-    # example is illustrative, never a provenance link (fence policy
-    # shared with check 8b).
-    scanned = _strip_fenced_blocks(repro)
+    # Every scan below runs on fence-stripped, then blockquote-stripped
+    # text: a URL inside a ``` example is illustrative, and a URL inside
+    # a `>` blockquote is verbatim-quoted provenance TEXT — neither is a
+    # provenance link (policy shared with check 8b; #959).
+    scanned = _strip_blockquote_lines(_strip_fenced_blocks(repro))
     # HF Hub URLs must include /tree/<ref>, /blob/<ref>, /raw/<ref>, or @<ref>.
     hf_urls = re.findall(r"https?://huggingface\.co/[^\s\)<>]+", scanned)
     for url in hf_urls:
@@ -3696,6 +3704,28 @@ def _strip_fenced_blocks(text: str) -> str:
     return "\n".join(out)
 
 
+# URL scans over the Reproducibility/footer region ALSO ignore markdown
+# blockquote lines (`>`-prefixed, incl. nested `> >` and indented `  > `
+# quotes). In that region a blockquote is the SPEC-mandated verbatim
+# originating-prompt quote (`**Context:**` row — never paraphrased),
+# whose text may cite bare URLs the author is not allowed to edit
+# (#825 → task #959). The quote is provenance TEXT, not a provenance
+# LINK; pinned artifact links live on the non-quoted footer rows, which
+# stay fully checked. Lazy continuation lines (quote text wrapped
+# without a leading `>`) stay scanned — the failure mode is the pre-fix
+# behavior (scanned), never a silently widened exemption. Apply AFTER
+# `_strip_fenced_blocks` (a quoted fence marker `> ``` ` must not
+# toggle fence state; it doesn't — the fence pass keys on lines that
+# START with the fence marker).
+def _strip_blockquote_lines(text: str) -> str:
+    """Drop lines whose first non-whitespace character is `>`.
+
+    Returns the remaining lines joined by newlines; used by checks 8 and
+    8b so a verbatim-quoted URL is never treated as a provenance link.
+    """
+    return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith(">"))
+
+
 # A "committed ... at commit `<sha>`" claim. The trigger word ``committed``
 # must appear somewhere before the literal phrase ``at commit `<sha>` `` on
 # the SAME line. The sha must be a 4-40 char hex literal wrapped in
@@ -4298,13 +4328,17 @@ def _gather_repro_artifact_urls(repro: str) -> list[str]:
     `raw.githubusercontent.com/<this-repo>/<sha>/<path>` raw links and
     `github.com/<this-repo>/(blob|tree)/<sha>/<path>` HTML links. Fenced
     code blocks are stripped first so a URL shown inside a ``` ... ```
-    example is illustrative, never probed. Other hosts (HF Hub, WandB)
+    example is illustrative, never probed. Blockquote lines
+    (`>`-prefixed) are stripped too — a same-repo URL quoted inside the
+    verbatim originating-prompt blockquote (`**Context:**` row) must not
+    be existence-probed: the quote cannot be edited if its cited path
+    later dies (#959). Other hosts (HF Hub, WandB)
     and other-repo GitHub links are out of scope: their existence is not
     decidable from the local object DB, and an unauthenticated 404 on an
     external private repo would false-FAIL. Order-preserving and
     deduplicated (at most one probe per unique URL)."""
     urls: list[str] = []
-    for token in _REPRO_URL_TOKEN_RE.findall(_strip_fenced_blocks(repro)):
+    for token in _REPRO_URL_TOKEN_RE.findall(_strip_blockquote_lines(_strip_fenced_blocks(repro))):
         url = token.rstrip(".,;:!?")
         for pattern in (_RAW_GITHUB_FIGURE_RE, _GITHUB_BLOB_TREE_URL_RE):
             m = pattern.match(url)

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -515,6 +515,71 @@ def test_repro_fenced_github_moving_ref_ignored():
     assert ok, [r.render() for r in results if not r.passed]
 
 
+def test_repro_blockquoted_bare_url_ignored_by_permanence():
+    """A bare (unpinned) URL inside a `>` blockquote in `## Reproducibility`
+    — the SPEC-mandated verbatim originating-prompt quote (`**Context:**`
+    row) — is provenance TEXT, not a provenance link: check 8 must not
+    flag it (#825 → #959; mirrors the fence exemption). Nested `> >`
+    lines and INDENTED `  > ` quote lines are covered too (the strip is
+    lstrip-based, not a bare `startswith`)."""
+    body = GOOD_BODY.replace(
+        "**Compute:** 1× H100, 47 min.",
+        "**Compute:** 1× H100, 47 min.\n\n"
+        "**Context:** Verbatim originating prompt:\n\n"
+        "> test in the base model https://huggingface.co/Qwen/Qwen2.5-7B\n"
+        "> > nested quote citing https://wandb.ai/someone/some-project\n"
+        "  > indented quote citing https://wandb.ai/someone/other-project\n"
+        "> for both user and assistant\n",
+    )
+    ok, results = verify_task_body.verify_text(body)
+    by_name = _results_by_name(results)
+    perm = by_name["Reproducibility URL permanence"]
+    assert perm.passed, perm.detail
+    assert ok, [r.render() for r in results if not r.passed]
+
+
+def test_repro_nonquoted_bare_url_beside_blockquote_still_fails():
+    """The blockquote exemption is line-scoped: a NON-quoted unpinned HF
+    URL in the footer still FAILs check 8 even when its quoted twin sits
+    one line up (the check stays binding for non-quoted footer URLs)."""
+    body = GOOD_BODY.replace(
+        "**Compute:** 1× H100, 47 min.",
+        "**Compute:** 1× H100, 47 min.\n\n"
+        "**Context:** Verbatim originating prompt:\n\n"
+        "> quoted: https://huggingface.co/Qwen/Qwen2.5-7B\n\n"
+        "Base model: https://huggingface.co/Qwen/Qwen2.5-7B\n",
+    )
+    ok, results = verify_task_body.verify_text(body)
+    assert not ok
+    by_name = _results_by_name(results)
+    perm = by_name["Reproducibility URL permanence"]
+    assert not perm.passed
+    assert perm.detail.count("unpinned HF URL") == 1, perm.detail
+
+
+def test_repro_quoted_fence_does_not_corrupt_fence_state():
+    """A fence marker INSIDE a blockquote (`> ```) must not toggle fence
+    state: the quoted run (incl. a quoted moving-ref URL) is dropped by
+    the blockquote pass, and a NON-quoted unpinned URL after it is still
+    scanned and FAILs. Catches a fence-state-corruption variant (a quoted
+    fence marker toggling state would swallow the non-quoted URL)."""
+    body = GOOD_BODY.replace(
+        "**Compute:** 1× H100, 47 min.",
+        "**Compute:** 1× H100, 47 min.\n\n"
+        "> ```\n"
+        "> https://github.com/superkaiba/explore-persona-space/blob/main/x.py\n"
+        "> ```\n\n"
+        "Unquoted: https://huggingface.co/Qwen/Qwen2.5-7B\n",
+    )
+    ok, results = verify_task_body.verify_text(body)
+    assert not ok
+    by_name = _results_by_name(results)
+    perm = by_name["Reproducibility URL permanence"]
+    assert not perm.passed
+    assert "unpinned HF URL" in perm.detail
+    assert "github.com" not in perm.detail  # the quoted moving-ref was never scanned
+
+
 def test_confidence_mismatch():
     body = GOOD_BODY.replace("Confidence: MODERATE", "Confidence: HIGH")
     ok, results = verify_task_body.verify_text(body)
@@ -1060,6 +1125,25 @@ def test_repro_fenced_block_urls_not_probed(monkeypatch):
     by_name = _results_by_name(results)
     assert by_name[_REPRO_8B_NAME].passed
     assert "no same-repo artifact URLs to check" in by_name[_REPRO_8B_NAME].detail
+
+
+def test_gather_repro_artifact_urls_skips_blockquoted():
+    """Check 8b must not existence-probe a same-repo URL quoted inside
+    the verbatim originating-prompt blockquote — same #959 collision
+    class as check 8 (a verbatim quote cannot be edited if its cited
+    path later dies). Non-quoted same-repo URLs are still gathered.
+    Deterministic unit test of the gather — no git, no network."""
+    repro = (
+        "**Code:** [run](https://github.com/superkaiba/explore-persona-space"
+        "/blob/0123456789abcdef/scripts/run.py)\n\n"
+        "**Context:** Verbatim originating prompt:\n\n"
+        "> see https://github.com/superkaiba/explore-persona-space"
+        "/blob/deadbeefdead/scripts/gone.py\n"
+    )
+    urls = verify_task_body._gather_repro_artifact_urls(repro)
+    assert urls == [
+        "https://github.com/superkaiba/explore-persona-space/blob/0123456789abcdef/scripts/run.py"
+    ]
 
 
 # ─── Check 23: HF Hub revision-pin existence ──────────────────────────────
@@ -4571,6 +4655,25 @@ def test_v4_good_body_passes_all():
     # The only FAILs are the two existence probes on the fake sha.
     fails = [r.name for r in results if not r.passed]
     assert set(fails) <= {"Figure URL resolvable", "Reproducibility artifact URLs exist"}, fails
+
+
+def test_v4_context_blockquote_bare_url_passes_permanence():
+    """The #825 incident shape: a v4 `**Context:**` verbatim
+    originating-prompt blockquote citing a bare HF URL must PASS check 8
+    with no hyperlink-to-pinned-revision workaround (#959). Asserts the
+    permanence check only (per the `_V4_GOOD_BODY` convention — the
+    fixture's fake SHAs fail the existence probes, so overall PASS is
+    not assertable)."""
+    body = _V4_GOOD_BODY.replace(
+        "- Originating prompt: origin prompt not recorded",
+        "- Originating prompt, verbatim:\n\n"
+        "> test in the base model (https://huggingface.co/Qwen/Qwen2.5-7B)\n"
+        "> -- make sure this is the proper base model\n",
+    )
+    _ok, results = verify_task_body.verify_text(body)
+    by_name = _results_by_name(results)
+    perm = by_name["Reproducibility URL permanence"]
+    assert perm.passed, perm.detail
 
 
 def test_v4_v3_content_h2_is_hard_fail():


### PR DESCRIPTION
Closes task #959 (workflow-fix, kind: infra).

verify_task_body.py checks 8 + 8b now strip markdown blockquote lines (post-fence-strip) from the scanned footer text, so the SPEC-mandated verbatim blockquoted Context originating prompt may cite bare URLs without a false hard-FAIL. Checks stay binding on non-quoted footer URLs. One SPEC.md clause documents the exemption + the lazy-continuation fail-closed rule. 5 new red-on-main tests.

Pipeline: plan v2 all-APPROVE (6-critic Claude+Codex ensemble, consistency PASS), code-review PASS+PASS, test-verdict PASS (2214 passed / 6 skipped).