### PR TITLE
issue-975: synthesized results envelope derives max+1 (task #975)

### DIFF
--- a/scripts/poll_pipeline.py
+++ b/scripts/poll_pipeline.py
@@ -847,7 +847,9 @@ def _maybe_synthesize_results_envelope(
 ) -> dict[str, Any] | None:
     """#899 fallback: rescue a raw Step 7 results payload on a results filename.
 
-    Returns a synthesized enveloped dict, or None (caller keeps the skip path).
+    Returns a synthesized enveloped dict WITHOUT a ``"version"`` key (the
+    drain threads ``version=None`` to ``post_event``, which derives max+1
+    per kind; #975), or None (caller keeps the skip path).
     Fires ONLY for: basename endswith ``-results.json`` AND no envelope key
     present AND all 10 Step 7 payload keys present (extras tolerated).
 
@@ -880,8 +882,9 @@ def _maybe_synthesize_results_envelope(
         return None
     log.error(
         "sentinel %s carried a complete Step 7 results payload but no envelope "
-        "keys %s; synthesizing kind=epm:results version=1 and posting — "
-        "pod-side writer should emit the envelope (#899)",
+        "keys %s; synthesizing kind=epm:results (version omitted -> post_event "
+        "derives max+1; #975) and posting — pod-side writer should emit the "
+        "envelope (#899)",
         remote_path,
         missing,
     )
@@ -890,7 +893,14 @@ def _maybe_synthesize_results_envelope(
     return {
         "sentinel_schema_version": SENTINEL_SCHEMA_VERSION_SUPPORTED,
         "kind": "epm:results",
-        "version": 1,
+        # "version" DELIBERATELY OMITTED (#975): key absence is the drain's
+        # signal to pass version=None to post_event, which derives
+        # max(existing for kind)+1 — a hardcoded 1 landed below an existing
+        # higher version on re-runs (the #480/#389/#825 collision class).
+        # Real sentinels always carry the key (_SENTINEL_REQUIRED_KEYS), so
+        # absence is unambiguous. NOTE: this dict is returned by
+        # _parse_sentinel WITHOUT re-validation — do not add a required-keys
+        # re-check on it without revisiting this omission.
         "note": note,
         "by": "pod-sentinel-envelope-fallback",  # secondary provenance
     }
@@ -1645,7 +1655,7 @@ def _persist_oversize_note(
     issue: int,
     remote_path: str,
     kind: str,
-    version: int,
+    version: int | None,
     by: str,
     full_note: str,
     original_extras: dict[str, Any] | None = None,
@@ -1665,7 +1675,11 @@ def _persist_oversize_note(
        <epoch>.txt`` (task folder resolved via ``find_task_path``, so the
        branch-guarded ``main`` resolver picks the correct path even when
        the poller is invoked from elsewhere).
-    2. Post a SHORT pointer marker of the same ``(kind, version)`` whose
+    2. Post a SHORT pointer marker of the same ``(kind, version)``
+       (``version=None`` — the #899 synthesized-envelope case — lets
+       ``post_event`` derive max+1 at the pointer post; safe because the
+       oversize ``ValueError`` raises BEFORE any version is derived or
+       consumed) whose
        ``note`` (a) cites the artifact path, (b) records original length,
        and (c) is a leading excerpt of the original. The excerpt is
        hard-bounded under ``EVENT_NOTE_MAX`` so the pointer post itself
@@ -1728,11 +1742,12 @@ def _persist_oversize_note(
     # reserve ~512 chars for the pointer header and use the remainder for
     # a leading excerpt of the original, so operators see the start of the
     # payload inline without needing to open the artifact.
+    version_repr = str(version) if version is not None else "derived-at-post (max+1)"
     header = (
         f"[oversize note persisted; original {len(full_note)} chars > "
         f"{EVENT_NOTE_MAX} cap]\n"
         f"Full payload: {rel_artifact}\n"
-        f"Original kind={kind} version={version} by={by}\n"
+        f"Original kind={kind} version={version_repr} by={by}\n"
         f"--- leading excerpt ---\n"
     )
     excerpt_budget = max(0, EVENT_NOTE_MAX - len(header) - 32)  # 32-byte safety
@@ -1794,8 +1809,10 @@ def _parse_sentinel(remote_path: str, body: str) -> dict[str, Any] | None:
     Exception (#899): a fully-envelope-less body on a ``-results.json``
     basename that carries the complete Step 7 results-payload key set is
     RESCUED via ``_maybe_synthesize_results_envelope`` (returns a
-    synthesized ``kind=epm:results version=1`` envelope + a loud
-    ``log.error``) instead of being skipped. Envelope-carrying sentinels
+    synthesized ``kind=epm:results`` envelope with NO ``version`` key — the
+    drain then posts with ``version=None`` so ``post_event`` derives max+1
+    (#975) — plus a loud ``log.error``) instead of being skipped.
+    Envelope-carrying sentinels
     (including partial envelopes and unsupported schema versions) keep the
     strict path unchanged.
     """
@@ -1867,6 +1884,7 @@ def drain_sentinels_via(
     sentinel cycled indefinitely). It is degraded gracefully via
     ``_persist_oversize_note`` (full note -> ``<task>/artifacts/sentinel-
     note-*.txt`` + a truncated pointer marker of the same ``(kind, version)``
+    — or a freshly derived version for the synthesized-envelope case, #975 —
     that cites the artifact) and the sentinel is renamed ``.processed`` to
     end the loop. Any OTHER ``post_event`` exception (transient infra,
     schema bug, etc.) keeps the original retry-on-next-tick semantics.
@@ -1879,7 +1897,24 @@ def drain_sentinels_via(
         if data is None:
             continue
         kind = data["kind"]
-        version = int(data["version"])
+        if "version" in data:
+            # Real pod-side sentinel: "version" is a REQUIRED envelope key
+            # (_SENTINEL_REQUIRED_KEYS / pod-side-reporting.md) and an
+            # explicit version always wins in post_event — verbatim contract.
+            # Branch on key PRESENCE, not None-tolerance: a (non-conforming)
+            # real sentinel carrying "version": null keeps today's loud
+            # int(None) TypeError instead of silently deriving (#975).
+            version: int | None = int(data["version"])
+        else:
+            # Only reachable via the #899 synthesized envelope, which omits
+            # the key (#975): post_event derives max(existing for kind)+1 so
+            # a re-drained / re-run rescue never lands BELOW an existing
+            # higher version (the #480 collision class). If the rename below
+            # fails and a future tick re-drains the same rescue, the
+            # duplicate lands at a fresh max+1 (v5, v6, ...) with
+            # byte-equivalent content — highest-version-wins resume stays
+            # correct, strictly better than stacked v1s.
+            version = None
         note = data.get("note")
         if note is None:
             note = data.get("payload")

--- a/tests/test_poll_pipeline_sentinels.py
+++ b/tests/test_poll_pipeline_sentinels.py
@@ -213,7 +213,9 @@ def test_parse_sentinel_results_fallback_synthesizes_envelope(
 
     assert parsed is not None
     assert parsed["kind"] == "epm:results"
-    assert parsed["version"] == 1
+    # #975: the synthesized envelope OMITS "version" (key absence is the
+    # drain's signal to let post_event derive max+1) — never a hardcoded 1.
+    assert "version" not in parsed
     assert parsed["sentinel_schema_version"] == 1
     assert parsed["by"] == "pod-sentinel-envelope-fallback"
     note = parsed["note"]
@@ -230,6 +232,9 @@ def test_parse_sentinel_results_fallback_synthesizes_envelope(
     assert _RESULTS_PATH in msg
     for env_key in pp._SENTINEL_REQUIRED_KEYS:
         assert env_key in msg
+    # The rescue log must no longer claim a hardcoded version=1 (#975
+    # acceptance criterion 5).
+    assert "version=1" not in msg
     # ...and NO generic "missing required keys" WARNING (the early return
     # skips it — §4.3 log-line lattice: single-ERROR rescue).
     warnings = [
@@ -1350,7 +1355,8 @@ def test_drain_posts_synthesized_results_marker_and_renames(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """One raw #825-shape sentinel at ``issue-444-results.json`` round-trips
-    to exactly one posted ``epm:results`` v1 marker whose note JSON carries
+    to exactly one posted ``epm:results`` marker with ``version=None``
+    (``post_event`` derives max+1 per kind; #975) whose note JSON carries
     the full payload + ``envelope_synthesized: true``, and the sentinel is
     renamed ``.processed``. A stray ``gate`` EXTRA key inside the raw
     payload stays inside the note and never parks the pipeline (the
@@ -1369,7 +1375,9 @@ def test_drain_posts_synthesized_results_marker_and_renames(
     post_mock.assert_called_once()
     call = post_mock.call_args
     assert call.args == (444, "epm:results")
-    assert call.kwargs["version"] == 1
+    # #975: the synthesized envelope omits "version", so the drain threads
+    # version=None and post_event derives max+1 (never a hardcoded 1).
+    assert call.kwargs["version"] is None
     assert call.kwargs["by"] == "pod-sentinel-envelope-fallback"
     note = call.kwargs["note"]
     assert isinstance(note, str)  # dict note -> json.dumps before posting
@@ -1410,7 +1418,10 @@ def test_drain_synthesized_results_oversize_note_degrades(
     assert post_mock.call_count == 2
     pointer_call = post_mock.call_args_list[1]
     assert pointer_call.args == (444, "epm:results")
-    assert pointer_call.kwargs["version"] == 1
+    # #975: the pointer post inherits version=None from the synthesized
+    # envelope — post_event derives max+1 fresh at the pointer post (the
+    # failed oversize first post consumed no version).
+    assert pointer_call.kwargs["version"] is None
     assert pointer_call.kwargs["by"] == "pod-sentinel-envelope-fallback"
     assert len(pointer_call.kwargs["note"]) <= pp.EVENT_NOTE_MAX
     # Full synthesized note persisted to the task artifact.
@@ -1420,6 +1431,153 @@ def test_drain_synthesized_results_oversize_note_degrades(
     # Renamed .processed — no #477-style infinite re-post loop.
     assert len(router.mv_calls) == 1
     assert ".processed" in router.mv_calls[0]
+
+
+# ── drain: #975 synthesized-envelope version derivation (max+1) ─────────────
+#
+# #975: the #899 synthesized envelope used to hardcode ``"version": 1``; an
+# explicit version always wins in ``post_event``, so a re-drained / re-run
+# rescue landed BELOW an existing higher ``epm:results`` version and the
+# stale higher version stayed authoritative on resume (the #480/#389/#825
+# collision class). The fix omits the key; the drain branches on key
+# PRESENCE and threads ``version=None`` so ``post_event`` derives max+1.
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Git-init ``tmp_path`` and rebind ``task_workflow``'s resolvers at it —
+    the file-local replica of the canonical fixture
+    (``tests/test_task_workflow.py``), added so the #975 end-to-end test can
+    exercise the REAL ``post_event`` (max+1 derivation under flock) instead
+    of a MagicMock. Returns ``(repo_root_path, tw_module)``."""
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@test.test"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "--allow-empty", "-m", "init"], cwd=tmp_path, check=True)
+
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    import explore_persona_space.task_workflow as tw
+
+    # Drop any cached resolution from a prior test so our overrides win.
+    tw.invalidate_cache()
+
+    monkeypatch.setattr(tw, "repo_root", lambda: tmp_path)
+    monkeypatch.setattr(tw, "tasks_dir", lambda: tmp_path / "tasks")
+    monkeypatch.setattr(tw, "registry_path", lambda: tmp_path / "tasks" / "REGISTRY.json")
+    # Per-test lock dir to avoid cross-talk
+    lock_dir = tmp_path / ".task-workflow"
+    monkeypatch.setattr(tw, "LOCK_DIR", lock_dir)
+    monkeypatch.setattr(tw, "LOCK_PATH", lock_dir / "lock")
+    return tmp_path, tw
+
+
+def test_drain_synthesized_results_lands_above_existing_version(fake_repo) -> None:
+    """The #975 headline regression test: a synthesized (#899-rescued) results
+    envelope drained onto an events.jsonl that ALREADY carries ``epm:results``
+    v3 lands as **v4** (max+1), not v1 — the synthesized dict omits
+    ``version``, the drain threads ``version=None``, and the REAL
+    ``task_workflow.post_event`` derives max+1 per kind under flock (the #480
+    contract). Deliberately uses the real ``post_event`` on a git-init tmp
+    repo, NOT a MagicMock, so the derivation itself is under test (plan
+    §5(ii); weakening this to a mock is kill criterion 2)."""
+    _repo, tw = fake_repo
+    # Guard the loaded-module aliasing (plan §12 A11): pp bound post_event
+    # from the SAME task_workflow module object the fixture just
+    # monkeypatched, so the drain's post writes into the tmp repo. If this
+    # ever breaks, rebind via monkeypatch.setattr(pp, "post_event",
+    # tw.post_event) (the plan's explicit fallback) — never weaken to a mock.
+    assert pp.post_event is tw.post_event
+
+    new_id = tw.create_task(tw.NewTaskRequest(kind="experiment", title="drain e2e"))
+    tw.post_event(new_id, "epm:results", version=3, by="seed")
+
+    sentinel_path = f"/workspace/logs/issue-{new_id}-results.json"
+    renamed: list[str] = []
+
+    def _mark_processed(path: str) -> bool:
+        renamed.append(path)
+        return True
+
+    processed, gate = pp.drain_sentinels_via(
+        issue=new_id,
+        list_sentinels=lambda: [(sentinel_path, json.dumps(_raw_results_payload()))],
+        mark_processed=_mark_processed,
+    )
+
+    assert processed == 1
+    assert gate is None
+    assert renamed == [sentinel_path]  # sentinel renamed .processed
+    results_events = [e for e in tw.list_events(new_id) if e["kind"] == "epm:results"]
+    # The rescue landed ABOVE the pre-existing v3 seed, at max+1 == 4, NOT 1.
+    assert [e["version"] for e in results_events] == [3, 4]
+    latest = results_events[-1]
+    assert latest["by"] == "pod-sentinel-envelope-fallback"
+    assert json.loads(latest["note"])["envelope_synthesized"] is True
+
+
+def test_drain_real_enveloped_sentinel_keeps_explicit_version_verbatim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real enveloped sentinel's explicit ``version`` posts VERBATIM as an
+    int (7 — a value that cannot coincide with a hardcoded default), never
+    ``None``: the #975 derive branch is reserved for the key-ABSENT
+    synthesized envelope (acceptance criterion 2)."""
+    body = _sentinel_body(kind="epm:progress", version=7, gate=None, note="phase=eval")
+    post_mock = MagicMock()
+    monkeypatch.setattr(pp, "post_event", post_mock)
+
+    processed, gate = pp.drain_sentinels_via(
+        issue=444,
+        list_sentinels=lambda: [
+            ("/workspace/logs/issue-444-epm_progress-1700000007.json", json.dumps(body))
+        ],
+        mark_processed=lambda _path: True,
+    )
+
+    assert processed == 1
+    assert gate is None
+    post_mock.assert_called_once()
+    version = post_mock.call_args.kwargs["version"]
+    assert version == 7  # verbatim explicit version — not None, not re-derived
+    assert isinstance(version, int)
+
+
+def test_drain_real_sentinel_null_version_does_not_derive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pins the #975 BRANCH DISCRIMINATOR: the drain's derive branch keys on
+    key PRESENCE, not None-tolerance. A real enveloped sentinel whose
+    ``version`` VALUE is null (key PRESENT — a non-conforming writer;
+    ``_sentinel_body`` always sets an int, so the JSON body is built
+    directly) must NOT silently derive: ``post_event`` is never called and
+    today's loud failure mode — the ``int(None)`` TypeError at the drain
+    read, which sits OUTSIDE the per-sentinel try — propagates unchanged.
+
+    This does NOT pin the crash as desirable behavior (the latent
+    null-version crash is pre-existing and out of scope, plan §12 A7); it
+    pins that a future None-tolerant refactor (``data.get("version")`` ->
+    derive on None — the rejected Design A) FAILS loudly here instead of
+    silently changing real-sentinel semantics (kill criterion 1)."""
+    body = {
+        "sentinel_schema_version": 1,
+        "kind": "epm:progress",
+        "version": None,  # json.dumps -> null: key PRESENT, value null
+        "note": "x",
+    }
+    post_mock = MagicMock()
+    monkeypatch.setattr(pp, "post_event", post_mock)
+
+    with pytest.raises(TypeError):
+        pp.drain_sentinels_via(
+            issue=444,
+            list_sentinels=lambda: [
+                ("/workspace/logs/issue-444-epm_progress-1700000008.json", json.dumps(body))
+            ],
+            mark_processed=lambda _path: True,
+        )
+
+    post_mock.assert_not_called()
 
 
 # ── poll_once: shard-log staleness conjunction (incident #488) ──────────────


### PR DESCRIPTION
Closes task #975 (workflow-fix, kind: infra).

The #899 synthesized results envelope in scripts/poll_pipeline.py hardcoded "version": 1, bypassing task_workflow.post_event's max+1 derivation (the #480/#389/#825 version-collision class) on re-drained/re-run sentinels. Fix: the synthesized dict omits the version key; drain_sentinels_via branches on key presence (real sentinels keep explicit versions verbatim); _persist_oversize_note widened to int | None.

- Plan: tasks/completed/975/plans/plan.md (v3; critic ensemble meth/alts APPROVE×2, stats REVISE×2 union Must-Fix addressed)
- Code review: PASS + PASS (Claude + Codex, no blockers)
- Tests: 2405 passed / 6 skipped (touched scope); new e2e v3→v4 regression, version=7 verbatim pin, 'version': null discriminator pin
- ruff + workflow_lint PASS