### PR TITLE
issue-962: fail-loud CVD equality guard in issue667_extract._device() (#813 class)

### DIFF
--- a/scripts/issue667_extract.py
+++ b/scripts/issue667_extract.py
@@ -435,6 +435,31 @@ def negative_panel_cids() -> list[str]:
 
 
 def _device(gpu_id: int, cpu_only: bool) -> torch.device:
+    """Resolve the torch device; fail loud on a mis-pinned --gpu-id launch (#813).
+
+    This worker class treats --gpu-id as INFORMATIONAL: the physical GPU is
+    selected ONLY by the CUDA_VISIBLE_DEVICES pin the launcher sets in the
+    child env (gotchas.md § hand-launching a dispatcher-managed per-cell GPU
+    worker). --gpu-id N>0 without CVD set to exactly str(N) would silently
+    bind the first visible device — the busy default GPU under an absent or
+    inherited multi-GPU pin (incident #813: 4 workers crashed at vLLM
+    init_device) — so raise unless the pin matches.
+    """
+    if not cpu_only and gpu_id > 0:
+        cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
+        if cvd != str(gpu_id):
+            observed = "unset" if cvd is None else repr(cvd)
+            raise RuntimeError(
+                f"--gpu-id {gpu_id} requires CUDA_VISIBLE_DEVICES={gpu_id} in the "
+                f"launcher environment (observed: {observed}). This worker treats "
+                "--gpu-id as informational and always binds cuda:0 — the physical "
+                "GPU is selected ONLY by the env pin, so this launch would "
+                "silently target the wrong GPU (incident #813). Relaunch as: "
+                f"env CUDA_VISIBLE_DEVICES={gpu_id} uv run python "
+                f"scripts/<worker>.py ... --gpu-id {gpu_id} — one distinct GPU "
+                "per parallel worker; see .claude/rules/gotchas.md, entry "
+                "'Hand-launching a dispatcher-managed per-cell GPU worker'."
+            )
     if cpu_only or not torch.cuda.is_available():
         return torch.device("cpu")
     return torch.device("cuda:0")  # CVD pins the physical GPU in the launcher env

--- a/tests/test_issue667_device_guard.py
+++ b/tests/test_issue667_device_guard.py
@@ -1,0 +1,84 @@
+"""#962: _device() fail-loud CVD guard (incident #813).
+
+A launcher-pinned-class worker launched with --gpu-id N>0 must have
+CUDA_VISIBLE_DEVICES pinned to exactly str(N) in the environment, else
+_device() raises at device resolution (before any model/engine load).
+All CPU; no GPU required.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+import issue667_extract as ex  # noqa: E402
+
+
+def test_gpu_id_positive_without_cvd_raises(monkeypatch):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    with pytest.raises(RuntimeError, match="CUDA_VISIBLE_DEVICES"):
+        ex._device(3, cpu_only=False)
+
+
+def test_error_message_names_relaunch_recipe(monkeypatch):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    with pytest.raises(RuntimeError, match=r"env CUDA_VISIBLE_DEVICES=3 .*--gpu-id 3"):
+        ex._device(3, cpu_only=False)
+
+
+def test_error_message_names_gotchas_pointer(monkeypatch):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    with pytest.raises(RuntimeError, match=r"gotchas\.md"):
+        ex._device(3, cpu_only=False)
+
+
+def test_error_message_reports_unset_when_cvd_absent(monkeypatch):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    with pytest.raises(RuntimeError, match=r"observed: unset"):
+        ex._device(3, cpu_only=False)
+
+
+def test_multi_value_cvd_raises_and_reports_observed_value(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1,2,3")
+    with pytest.raises(RuntimeError, match=r"observed: '0,1,2,3'"):
+        ex._device(3, cpu_only=False)
+
+
+def test_mismatched_cvd_raises(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2")
+    with pytest.raises(RuntimeError):
+        ex._device(3, cpu_only=False)
+
+
+def test_empty_cvd_with_gpu_id_positive_raises(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
+    with pytest.raises(RuntimeError):
+        ex._device(3, cpu_only=False)
+
+
+def test_matching_cvd_passes(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "3")
+    assert ex._device(3, cpu_only=False).type in ("cpu", "cuda")
+
+
+def test_gpu_id_zero_without_cvd_passes(monkeypatch):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    assert ex._device(0, cpu_only=False).type in ("cpu", "cuda")
+
+
+def test_cpu_only_short_circuits_any_gpu_id(monkeypatch):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    assert ex._device(7, cpu_only=True) == torch.device("cpu")
+
+
+def test_matching_cvd_and_cuda_available_returns_cuda0(monkeypatch):
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2")
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    assert ex._device(2, cpu_only=False) == torch.device("cuda:0")


### PR DESCRIPTION
## Summary
- Adds a fail-loud RuntimeError guard to `scripts/issue667_extract.py::_device()`: when `not cpu_only and gpu_id > 0`, raise unless `CUDA_VISIBLE_DEVICES == str(gpu_id)` — closing the #813 hand-launch class (bare `--gpu-id` with no env pin) AND the inherited multi-GPU-CVD bypass (`CVD=0,1,2,3` + `--gpu-id 3` binding busy GPU 0) the round-1 critic ensemble surfaced.
- 11 new CPU-only tests (`tests/test_issue667_device_guard.py`); descendant `issue811_phase0_extract.py` inherits via import; zero dispatcher changes (every dispatcher child env builds CVD and `--gpu-id` from the same variable).
- Closes task #962 (kind: infra, daily-auto-filed from the #880/#813 follow-up candidate).

## Test plan
- [x] `uv run pytest tests/test_issue667_device_guard.py` — 11/11 pass
- [x] Step 9c touched-scope subset — 2241 passed / 6 skipped / 1 pre-existing trunk failure (cross-checked failing on main, foreign files)
- [x] `ruff check` + `ruff format --check` clean on both touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)