### PR TITLE
task #971: recover head-name-less rebase husk in root sync

### DIFF
--- a/scripts/sync_repo_root.py
+++ b/scripts/sync_repo_root.py
@@ -38,7 +38,8 @@ Exit codes::
     3  push failed after the one retry
     4  a bounded git subprocess timed out (rebase aborted cleanly)
     5  precondition failure (HEAD not main, fresh rebase/merge husk present,
-       index.lock persistently held, task-workflow lock held past the bound)
+       interrupted ``git am`` state, index.lock persistently held,
+       task-workflow lock held past the bound)
     6  unexpected error (fail loud; swept files restored from the journal; a
        failure inside the restore itself also routes here, report emitted)
 
@@ -73,7 +74,12 @@ Safety invariants (binding; pinned by tests/test_sync_repo_root.py):
     ``shutil.move`` replace a prior rescue copy and clobber its manifest).
   * Fail loud; no silent husks; a young (< ``EPM_ROOT_SYNC_HUSK_AGE_S``)
     rebase/merge husk or a persistent index.lock is reported and exits 5 —
-    never deleted.
+    never deleted. A STALE husk is git-aborted; when git itself cannot abort
+    it (the head-name-less shape a crashed autostash-pull leaves) its
+    autostash is rescued to the stash list and the husk dir is ARCHIVED to
+    the rescue root — never deleted — with a rescue failure blocking the
+    move; an interrupted ``git am`` session (``rebase-apply/applying``) is
+    refused (exit 5), never touched.
 
 Residual risk (documented, not closed here): a session running a direct
 ``git commit`` on the root (not via ``task.py``) is NOT excluded by the
@@ -453,10 +459,12 @@ def preflight(repo: Path, report: dict, dry_run: bool) -> None:
 
     Order is load-bearing: (1) index.lock bounded wait FIRST (a husk abort
     needs the index; never deleted); (2) husk triage (stale → abort +
-    continue, young → exit 5) BEFORE the branch check, because a mid-rebase
-    husk leaves HEAD detached — checking the branch first would make the
-    stale-husk auto-abort unreachable; (3) HEAD==main; (4) stranded-autostash
-    recovery for entries left by PREVIOUS crashed loops.
+    continue; stale un-abortable head-name-less rebase → rescue autostash +
+    archive-aside; stale ``git am`` session → exit 5; young → exit 5) BEFORE
+    the branch check, because a mid-rebase husk leaves HEAD detached —
+    checking the branch first would make the stale-husk auto-abort
+    unreachable; (3) HEAD==main; (4) stranded-autostash recovery for entries
+    left by PREVIOUS crashed loops.
     """
     gd = _git_dir(repo)
     index_lock = gd / "index.lock"
@@ -488,16 +496,58 @@ def preflight(repo: Path, report: dict, dry_run: bool) -> None:
                 f"young {husk.name} husk ({age:.0f}s old, threshold {_husk_age_s():.0f}s) — "
                 "someone may be mid-operation; refusing to touch it.",
             )
+        # Discriminators scoped to REBASE state dirs only (MERGE_HEAD — even a
+        # malformed directory — routes to the explicit refuse branch below).
+        is_rebase_dir = abort_args[0] == "rebase" and husk.is_dir()
+        am_in_progress = is_rebase_dir and (husk / "applying").exists()
+        headnameless = is_rebase_dir and not (husk / "head-name").exists()
         if dry_run:
-            _msg(report, f"DRY-RUN: stale {husk.name} husk ({age:.0f}s old) would be aborted")
+            if am_in_progress:
+                _msg(
+                    report,
+                    f"DRY-RUN: stale {husk.name} state is a `git am` session "
+                    "(`applying` present) — a real run would refuse (exit 5); "
+                    "resolve via `git am --continue` / `git am --abort`",
+                )
+            elif headnameless:
+                _msg(
+                    report,
+                    f"DRY-RUN: stale head-name-less {husk.name} husk ({age:.0f}s old) — "
+                    "un-abortable by git; autostash would be rescued to the stash "
+                    "list, then the husk dir archived to the rescue root",
+                )
+            else:
+                _msg(report, f"DRY-RUN: stale {husk.name} husk ({age:.0f}s old) would be aborted")
             continue
-        git(repo, *abort_args)
-        _msg(
-            report,
-            f"STALE-HUSK ABORT: {husk.name} was {age:.0f}s old (> {_husk_age_s():.0f}s); "
-            f"ran `git {' '.join(abort_args)}` (restores original HEAD + re-applies autostash).",
-        )
-        report["actions_performed"] = True
+        aborted = git(repo, *abort_args, check=False)
+        if aborted.returncode == 0:
+            _msg(
+                report,
+                f"STALE-HUSK ABORT: {husk.name} was {age:.0f}s old (> {_husk_age_s():.0f}s); "
+                f"ran `git {' '.join(abort_args)}` "
+                "(restores original HEAD + re-applies autostash).",
+            )
+            report["actions_performed"] = True
+            continue
+        if am_in_progress:
+            raise SyncAbortError(
+                EXIT_PRECONDITION,
+                f"stale {husk.name} state is an interrupted `git am` session "
+                f"(`{husk.name}/applying` present; `git rebase --abort` "
+                f"rc={aborted.returncode}). Refusing to touch it — the patch data and "
+                "--continue capability belong to the am session's owner.\n"
+                "resolve manually: `git am --continue` (finish) or `git am --abort` "
+                "(discard), then re-run the sync.",
+            )
+        if not headnameless:
+            raise SyncAbortError(
+                EXIT_UNEXPECTED,
+                f"stale {husk.name} husk: `git {' '.join(abort_args)}` failed "
+                f"(rc={aborted.returncode}) and the husk is not the known un-abortable "
+                f"head-name-less rebase shape — refusing to touch it.\n"
+                f"stderr: {aborted.stderr.strip()}",
+            )
+        _recover_headnameless_husk(repo, husk, age, aborted, report)
 
     branch = git(repo, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
     if branch != "main":
@@ -509,6 +559,104 @@ def preflight(repo: Path, report: dict, dry_run: bool) -> None:
 
     # Entries stranded by PREVIOUS crashed loops.
     recover_stranded_autostash(repo, report, dry_run=dry_run, preflight_case=True)
+
+
+def _recover_headnameless_husk(
+    repo: Path, husk: Path, age: float, aborted: subprocess.CompletedProcess[str], report: dict
+) -> None:
+    """Rescue-then-ARCHIVE for a stale, un-abortable, head-name-less rebase husk.
+
+    A crashed ``pull --rebase --autostash`` can die after writing
+    ``<state-dir>/autostash`` but before ``head-name`` (2026-07-03 incident,
+    #971); git can neither represent nor abort a rebase without ``head-name``
+    (``git rebase --abort`` rc=1), so the husk permanently wedges preflight.
+    The caller has already excluded an interrupted ``git am`` session (the
+    ``applying`` marker — ``git am`` shares ``rebase-apply``); this helper
+    re-checks both discriminators immediately before the move (TOCTOU).
+    Recovery order preserves the never-lose-data invariant: (1) rescue the
+    autostash commit into the stash list (``git stash store -m autostash``;
+    guarded by a 40-hex pre-check, ``cat-file -e`` resolvability, and a
+    ``rev-parse <sha>^2`` stash-shapedness check — a stored non-stash commit
+    would wedge the stranded-autostash pass downstream; idempotent via a
+    stash-reflog containment check; a store failure on a storable commit
+    BLOCKS the move — fail loud, husk kept); non-storable autostash content
+    is preserved verbatim under ``RESCUE_ROOT`` first; (2) only then
+    ``shutil.move`` the ENTIRE husk dir into a fresh exclusive
+    ``allocate_rescue_dir()`` — archive-aside, never deletion: every husk
+    file survives for unforeseen shapes, and the same-device rename closes
+    the mid-``rmtree`` mtime-refresh re-wedge window. The stored entry's
+    subject is exactly ``autostash``, so preflight step (4)
+    (``recover_stranded_autostash``) immediately rescue-patches and
+    pops-if-clean. Deliberately NOT ``git rebase --quit``: quit removes the
+    state dir and exits 0 even when its internal autostash store FAILS
+    (verified on git 2.34.1), so rescue failure could not block removal.
+    """
+    autostash_file = husk / "autostash"
+    sha = autostash_file.read_text().strip() if autostash_file.exists() else ""
+    if not autostash_file.exists():
+        disposition = "no autostash file present"
+    elif not sha:
+        disposition = "autostash file empty — nothing to rescue"
+    else:
+        is_hex40 = len(sha) == 40 and all(c in "0123456789abcdef" for c in sha)
+        resolvable = (
+            is_hex40
+            and git(repo, "cat-file", "-e", f"{sha}^{{commit}}", check=False).returncode == 0
+        )
+        stash_shaped = (
+            resolvable
+            and git(repo, "rev-parse", "-q", "--verify", f"{sha}^2", check=False).returncode == 0
+        )
+        if not stash_shaped:
+            RESCUE_ROOT.mkdir(parents=True, exist_ok=True)
+            rescue_path = RESCUE_ROOT / f"husk-autostash-{husk.name}-{_rescue_timestamp()}.txt"
+            rescue_path.write_text(autostash_file.read_text())
+            reason = (
+                "not a 40-hex sha"
+                if not is_hex40
+                else "does not resolve to a commit"
+                if not resolvable
+                else "resolves but is not stash-shaped (no second parent) — storing it "
+                "would wedge the stranded-autostash pass"
+            )
+            disposition = (
+                f"autostash content {sha!r}: {reason}; nothing storable — content "
+                f"preserved at {rescue_path} (and in the archived husk dir)"
+            )
+        elif sha in git(repo, "rev-list", "-g", "refs/stash", check=False).stdout.split():
+            disposition = f"autostash {sha[:12]} already present in the stash reflog"
+        else:
+            store = git(repo, "stash", "store", "-m", "autostash", sha, check=False)
+            if store.returncode != 0:
+                raise SyncAbortError(
+                    EXIT_UNEXPECTED,
+                    f"head-name-less {husk.name} husk: could not rescue autostash {sha} "
+                    f"(`git stash store` rc={store.returncode}: {store.stderr.strip()}); "
+                    "husk left in place — nothing moved.\n"
+                    f"manual: git stash store -m autostash {sha}  # then re-run the sync",
+                )
+            disposition = (
+                f"stored autostash {sha[:12]} as a stash entry "
+                "(handled next by the stranded-autostash pass)"
+            )
+        report["stash"].append(f"husk-rescue: {disposition}")
+    # TOCTOU recheck (recompute the discriminators immediately before the move):
+    # a concurrent operation may have materialized real state since triage.
+    if (husk / "head-name").exists() or (husk / "applying").exists():
+        raise SyncAbortError(
+            EXIT_UNEXPECTED,
+            f"{husk.name} husk changed while being recovered (head-name/applying "
+            "appeared) — a concurrent operation may be live; nothing moved.",
+        )
+    dest = allocate_rescue_dir() / husk.name
+    shutil.move(str(husk), str(dest))
+    _msg(
+        report,
+        f"STALE-HUSK ARCHIVED: {husk.name} was {age:.0f}s old (> {_husk_age_s():.0f}s), "
+        f"head-name-less and un-abortable (`git rebase --abort` rc={aborted.returncode}: "
+        f"{aborted.stderr.strip()}); {disposition}; husk dir archived to {dest}.",
+    )
+    report["actions_performed"] = True
 
 
 # ─── Untracked-collision pre-sweep ───────────────────────────────────────────

--- a/tests/test_sync_repo_root.py
+++ b/tests/test_sync_repo_root.py
@@ -102,6 +102,9 @@ def origin_and_clone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(srr, "ROOT_SYNC_LOCK", lock_dir / "root-sync.lock")
     monkeypatch.setattr(srr, "RESCUE_ROOT", tmp_path / "rescue")
     monkeypatch.setattr(srr.task_workflow, "LOCK_PATH", lock_dir / "task-workflow-lock")
+    # A dev shell exporting a non-default husk age must not flake the husk
+    # age-gate tests (per-test setenv still wins — it runs after fixture setup).
+    monkeypatch.delenv("EPM_ROOT_SYNC_HUSK_AGE_S", raising=False)
     return origin, local, other
 
 
@@ -611,6 +614,246 @@ def test_young_husk_untouched_exit_5(origin_and_clone, capsys):
     assert rc == 5
     assert husk.exists()  # untouched
     assert "young rebase-merge husk" in err
+
+
+# ─── 11b. Head-name-less husk recovery (#971) ────────────────────────────────
+
+
+def _stash_shaped_sha(local: Path) -> str:
+    """Commit+push a tracked file, dirty it, ``git stash create``, restore worktree.
+
+    Returns a stash-shaped commit sha (>= 2 parents) — the same object shape a
+    crashed autostash-pull leaves behind in ``<state-dir>/autostash``.
+    """
+    _write(local, "dirty.txt", "base\n")
+    _commit(local, "dirty.txt")
+    _git(local, "push", "-q", "origin", "main")
+    _write(local, "dirty.txt", "base\nuncommitted\n")
+    sha = _git(local, "stash", "create", "autostash-sim").stdout.strip()
+    _git(local, "checkout", "--", "dirty.txt")
+    assert sha
+    return sha
+
+
+def _make_headnameless_husk(
+    local: Path, dirname: str = "rebase-merge", autostash: str | None = None, stale: bool = True
+) -> Path:
+    """Synthesize the #971 incident husk: a rebase state dir with NO head-name."""
+    husk = local / ".git" / dirname
+    husk.mkdir()
+    if autostash is not None:
+        (husk / "autostash").write_text(autostash + "\n")
+    if stale:
+        t = time.time() - 7200
+        os.utime(husk, (t, t))
+    return husk
+
+
+def _make_conflicted_am_state(local: Path) -> Path:
+    """Genuinely conflicted ``git am`` (the MF1 fact pattern): a patch from a
+    side branch applied onto diverged main leaves ``.git/rebase-apply`` with
+    ``applying`` + ``patch``, and NO ``head-name``."""
+    _write(local, "am.txt", "base\n")
+    _commit(local, "am.txt")
+    _git(local, "checkout", "-q", "-b", "patchsrc")
+    _write(local, "am.txt", "patch-side\n")
+    _commit(local, "am.txt")
+    patch = _git(local, "format-patch", "-1", "--stdout").stdout
+    _git(local, "checkout", "-q", "main")
+    _write(local, "am.txt", "main-side\n")
+    _commit(local, "am.txt")
+    proc = subprocess.run(
+        ["git", "-C", str(local), "am"], input=patch, capture_output=True, text=True, check=False
+    )
+    assert proc.returncode != 0
+    state = local / ".git" / "rebase-apply"
+    assert state.is_dir() and (state / "applying").exists()
+    assert not (state / "head-name").exists()
+    t = time.time() - 7200
+    os.utime(state, (t, t))
+    return state
+
+
+def test_headnameless_husk_valid_autostash_rescued_then_archived(origin_and_clone, capsys):
+    """(a) The incident repro: valid autostash rescued, husk archived, exit 0."""
+    _origin, local, _other = origin_and_clone
+    sha = _stash_shaped_sha(local)
+    _make_headnameless_husk(local, autostash=sha)
+
+    rc, rep, _err = _run(local, capsys=capsys)
+    assert rc == 0
+    assert not (local / ".git" / "rebase-merge").exists()
+    archived = list(srr.RESCUE_ROOT.glob("*/rebase-merge"))
+    assert len(archived) == 1
+    assert (archived[0] / "autostash").read_text().strip() == sha
+    assert any("STALE-HUSK ARCHIVED" in m for m in rep["messages"])
+    assert any(r.startswith("husk-rescue: stored autostash") for r in rep["stash"])
+    # The stranded-autostash pass consumed the rescued entry in the SAME run:
+    # the uncommitted content is back in the worktree and the stash is empty.
+    assert "uncommitted" in (local / "dirty.txt").read_text()
+    assert _git(local, "stash", "list").stdout.strip() == ""
+    assert rep["actions_performed"] is True
+
+
+@pytest.mark.parametrize("dirname", ["rebase-merge", "rebase-apply"])
+@pytest.mark.parametrize("autostash", [None, ""])
+def test_headnameless_husk_no_autostash_archived(origin_and_clone, capsys, dirname, autostash):
+    """(b) Absent/empty autostash: husk ARCHIVED (never deleted), exit 0."""
+    _origin, local, _other = origin_and_clone
+    _make_headnameless_husk(local, dirname=dirname, autostash=autostash)
+
+    rc, rep, _err = _run(local, capsys=capsys)
+    assert rc == 0
+    assert not (local / ".git" / dirname).exists()
+    assert len(list(srr.RESCUE_ROOT.glob(f"*/{dirname}"))) == 1
+    msg = next(m for m in rep["messages"] if "STALE-HUSK ARCHIVED" in m)
+    expected = "no autostash file present" if autostash is None else "autostash file empty"
+    assert expected in msg
+    assert _git(local, "stash", "list").stdout.strip() == ""
+
+
+def test_young_headnameless_husk_exit_5(origin_and_clone, capsys):
+    """(c) A YOUNG head-name-less husk still exits 5, untouched (age gate)."""
+    _origin, local, _other = origin_and_clone
+    husk = _make_headnameless_husk(local, stale=False)
+
+    rc, _rep, err = _run(local, capsys=capsys)
+    assert rc == 5
+    assert husk.exists()  # untouched
+    assert "young rebase-merge husk" in err
+
+
+@pytest.mark.parametrize(
+    "content_kind, reason_substr",
+    [
+        ("non-hex", "not a 40-hex sha"),
+        ("missing-object", "does not resolve to a commit"),
+        ("ordinary-commit", "not stash-shaped"),
+    ],
+)
+def test_headnameless_husk_nonstorable_autostash_preserved(
+    origin_and_clone, capsys, content_kind, reason_substr
+):
+    """(e) Non-storable autostash content is preserved verbatim, NEVER stored."""
+    _origin, local, _other = origin_and_clone
+    content = {
+        "non-hex": "not-a-sha",
+        "missing-object": "deadbeef" + "0" * 32,
+        "ordinary-commit": _git(local, "rev-parse", "HEAD").stdout.strip(),
+    }[content_kind]
+    _make_headnameless_husk(local, autostash=content)
+
+    rc, rep, _err = _run(local, capsys=capsys)
+    assert rc == 0
+    assert not (local / ".git" / "rebase-merge").exists()
+    assert list(srr.RESCUE_ROOT.glob("*/rebase-merge"))  # archived intact
+    msg = next(m for m in rep["messages"] if "STALE-HUSK ARCHIVED" in m)
+    assert reason_substr in msg
+    rescue_files = list(srr.RESCUE_ROOT.glob("husk-autostash-*.txt"))
+    assert len(rescue_files) == 1
+    assert rescue_files[0].read_text() == content + "\n"  # verbatim
+    # Nothing was stored — pins the C1 downstream stash-show wedge guard.
+    assert _git(local, "stash", "list").stdout.strip() == ""
+
+
+def test_headnameless_husk_store_failure_blocks_archival(origin_and_clone, monkeypatch, capsys):
+    """(f) A store failure on a storable commit exits 6 with the husk KEPT."""
+    _origin, local, _other = origin_and_clone
+    sha = _stash_shaped_sha(local)
+    husk = _make_headnameless_husk(local, autostash=sha)
+
+    real_git = srr.git
+
+    def fake_git(repo, *args, **kwargs):
+        if args[:2] == ("stash", "store"):
+            return subprocess.CompletedProcess(args, 1, stdout="", stderr="simulated store failure")
+        return real_git(repo, *args, **kwargs)
+
+    monkeypatch.setattr(srr, "git", fake_git)
+    rc, _rep, err = _run(local, capsys=capsys)
+    assert rc == 6
+    assert husk.exists()  # KEPT — rescue failure blocks the move
+    assert (husk / "autostash").read_text().strip() == sha
+    assert sha in err  # full sha named
+    assert f"git stash store -m autostash {sha}" in err  # manual recipe
+
+
+def test_headnameless_husk_dry_run_reports_distinctly(origin_and_clone, capsys):
+    """(g) Dry-run reports the head-name-less case distinctly; mutates nothing."""
+    _origin, local, _other = origin_and_clone
+    sha = _stash_shaped_sha(local)
+    husk = _make_headnameless_husk(local, autostash=sha)
+
+    rc, rep, _err = _run(local, "--dry-run", capsys=capsys)
+    assert rc == 0
+    assert rep["state"] == "dry-run"
+    msg = next(m for m in rep["messages"] if "DRY-RUN: stale head-name-less" in m)
+    assert "would be rescued" in msg
+    assert husk.exists()  # untouched
+    assert _git(local, "stash", "list").stdout.strip() == ""
+    assert not srr.RESCUE_ROOT.exists()  # rescue root untouched
+
+
+def test_headnameless_husk_already_stashed_idempotent(origin_and_clone, capsys):
+    """(h) Re-run after a crashed prior recovery (store succeeded, move crashed):
+    the reflog containment check reports idempotently, no duplicate entry."""
+    _origin, local, _other = origin_and_clone
+    sha = _stash_shaped_sha(local)
+    _make_headnameless_husk(local, autostash=sha)
+    _git(local, "stash", "store", "-m", "autostash", sha)
+    assert len(_git(local, "stash", "list").stdout.strip().splitlines()) == 1
+
+    rc, rep, _err = _run(local, capsys=capsys)
+    assert rc == 0
+    assert not (local / ".git" / "rebase-merge").exists()
+    assert list(srr.RESCUE_ROOT.glob("*/rebase-merge"))
+    assert any("already present in the stash reflog" in r for r in rep["stash"])
+    # Exactly one entry existed before the stranded pass consumed it (no dup).
+    assert _git(local, "stash", "list").stdout.strip() == ""
+    assert "uncommitted" in (local / "dirty.txt").read_text()
+
+
+def test_am_state_refused_intact(origin_and_clone, capsys):
+    """(i, MF1) A stale, genuinely conflicted `git am` state is REFUSED (exit 5)
+    and survives byte-intact — its patch data + --continue capability kept."""
+    _origin, local, _other = origin_and_clone
+    state = _make_conflicted_am_state(local)
+    before = {p.name: p.read_bytes() for p in state.iterdir() if p.is_file()}
+
+    rc, _rep, err = _run(local, capsys=capsys)
+    assert rc == 5
+    assert state.is_dir()
+    assert (state / "applying").exists()
+    assert (state / "patch").exists()
+    after = {p.name: p.read_bytes() for p in state.iterdir() if p.is_file()}
+    assert after == before  # INTACT, including the patch file
+    assert "git am --continue" in err and "git am --abort" in err
+    assert not srr.RESCUE_ROOT.exists()
+    assert _git(local, "stash", "list").stdout.strip() == ""
+
+
+def test_abort_failure_with_headname_present_refuses(origin_and_clone, monkeypatch, capsys):
+    """(j, MF2) Abort fails but head-name IS present: explicit exit-6 refusal,
+    husk KEPT — the one guard between recovery and a real rebase state."""
+    _origin, local, other = origin_and_clone
+    husk = _make_conflicted_rebase_husk(local, other)
+    t = time.time() - 7200
+    os.utime(husk, (t, t))
+
+    real_git = srr.git
+
+    def fake_git(repo, *args, **kwargs):
+        if args[:2] == ("rebase", "--abort"):
+            return subprocess.CompletedProcess(args, 1, stdout="", stderr="simulated abort failure")
+        return real_git(repo, *args, **kwargs)
+
+    monkeypatch.setattr(srr, "git", fake_git)
+    rc, _rep, err = _run(local, capsys=capsys)
+    assert rc == 6
+    assert husk.exists()  # KEPT
+    assert (husk / "head-name").exists()
+    assert "not the known un-abortable" in err
+    assert "refusing to touch it" in err
 
 
 # ─── 12. HEAD ≠ main precondition ────────────────────────────────────────────


### PR DESCRIPTION
Closes task #971. Workflow-fix: sync_repo_root.py stale-husk recovery for head-name-less rebase husks — git-am refusal, archive-aside, stash-store rescue. Plan v2 critic-ensemble-reviewed; code-review PASS (Claude+Codex); test-verdict PASS (2273 passed).