### PR TITLE
task #964: verify_task_body WARN on body-linked figures untracked at live refs

### DIFF
--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -516,6 +516,26 @@ Generation-agnostic checks (run on v2 AND v3 — the inline-figure +
   `ctx_blk_max@L12 x ans_uhdr_max@L12` after three review passes each
   deferred it as a cosmetic nit, costing a REVISE round.
 
+- **check 29** (`check_figure_tracked_at_head`, WARN): every body-linked
+  same-repo `figures/issue_<N>/...` figure path must still be tracked on a
+  LIVE local ref — HEAD of the (main-pinned) repo root or the issue's local
+  branch family `issue-<N>` / `issue-<N>-*` (one `for-each-ref` + one
+  `ls-tree -r --name-only <ref> -- figures/issue_<N>/` per ref per unique
+  issue dir; never per-URL — <=5 subprocesses for a typical body). Three
+  states per path: tracked at HEAD → clean PASS; BRANCH-ONLY (on >=1 family
+  ref, absent from HEAD) → PASS with an explicit disclosure note (expected
+  pre-merge; names the `git restore --source=<pinned-sha>` recovery for the
+  post-merge case); missing from every successfully-probed ref → the
+  incident-class WARN, never FAIL (a pinned raw URL is immutable and keeps
+  rendering after tracking loss — drift hygiene, not a broken body).
+  Conservative: any failed probe for an issue dir degrades it to a skip
+  note (a narrowed ref set must never manufacture a WARN); vacuous PASS
+  with no same-repo `figures/issue_<N>/` URLs or an unresolved repo root.
+  The issue number comes from the path itself, so cross-issue figure links
+  check against their own branch family. Incident: task #841 — three
+  `figures/issue_841/` stems tracked at the pinned sha `4824a567aa` but
+  untracked at branch HEAD; the loss was invisible to every check (#964).
+
 Harmful-content carve-out: checks 18/19 accept the sanitized excerpt
 form (`[truncated — harmful-content row; verify at <path>, row <i>]`)
 exactly as checks 10/11 do today.
@@ -1873,6 +1893,9 @@ _RAW_GITHUB_FIGURE_RE = re.compile(
 )
 _THIS_REPO_SLUG = ("superkaiba", "explore-persona-space")
 
+# Repo-relative figure path carrying its own issue number — scope of check 29.
+_ISSUE_FIGURE_PATH_RE = re.compile(r"^figures/issue_(?P<issue>\d+)/\S")
+
 
 def _http_head_status(url: str, timeout: float = 5.0) -> int | None:
     """HTTP HEAD ``url``; return the response status code (HTTPError codes
@@ -2007,6 +2030,126 @@ def check_figure_url_resolvable(body: str) -> CheckResult:
             unverified
         )
     return CheckResult("Figure URL resolvable", True, detail)
+
+
+def _issue_figure_paths_by_issue(body: str) -> dict[str, set[str]]:
+    """Same-repo `figures/issue_<N>/...` figure paths inline under the
+    result-narrative section, grouped by the issue number carried in the
+    path itself (check 29's scope). Other hosts / other repos /
+    non-issue-dir paths are out of scope and skipped."""
+    paths_by_issue: dict[str, set[str]] = {}
+    for url in _gather_figure_image_urls(body):
+        url = url.strip()
+        # Strip optional title — `(url "title")` — keep only the URL token
+        # (check-4b idiom).
+        url = url.split(None, 1)[0] if url else url
+        m = _RAW_GITHUB_FIGURE_RE.match(url)
+        if not m or (m.group("owner").lower(), m.group("repo").lower()) != _THIS_REPO_SLUG:
+            continue
+        pm = _ISSUE_FIGURE_PATH_RE.match(m.group("path"))
+        if not pm:
+            continue
+        paths_by_issue.setdefault(pm.group("issue"), set()).add(m.group("path"))
+    return paths_by_issue
+
+
+def check_figure_tracked_at_head(body: str) -> CheckResult:
+    """Check 29 (WARN): body-linked same-repo `figures/issue_<N>/...` figure
+    paths must still be tracked on a LIVE local ref — HEAD of the resolved
+    (main-pinned) repo root, or the issue's local branch family
+    `issue-<N>` / `issue-<N>-*`.
+
+    Check 4b verifies existence at the PINNED sha only, and a pinned raw URL
+    is immutable — it keeps rendering after the file falls out of tracking
+    on every live ref, so a merge/rebase can silently drop the canonical
+    figure files with zero verifier signal (incident #841: three
+    `figures/issue_841/` stems tracked at the pinned sha but untracked at
+    branch HEAD). Three-state read, per path:
+
+    - tracked at HEAD -> clean PASS;
+    - BRANCH-ONLY (absent from HEAD, present on >=1 family ref) -> PASS with
+      an explicit disclosure note, never a WARN: this is the EXPECTED state
+      of every pre-merge verification round (the verifier's HEAD is
+      main-pinned while figures live on the issue branch), so WARNing would
+      spam every figure-adding round; the disclosure keeps the post-merge
+      stale-branch-masks-main-loss state visible and names the recovery;
+    - missing from EVERY successfully-probed ref -> the incident-class WARN
+      (`is_warn=True`, `passed=True` -- this check can never FAIL: the
+      pinned URL still renders, so this is drift hygiene, and grandfathered
+      bodies must not regress).
+
+    Conservative on probe failure: if ANY git probe for an issue dir fails,
+    that issue degrades to a `probe failure` skip note and can never WARN --
+    the path might live at the failed ref, so a narrowed ref set must not
+    manufacture a WARN. Per-issue continue (other issue dirs still
+    evaluated); fail-soft everywhere; no network. The issue number comes
+    from the `figures/issue_<N>/` path itself (not `--issue`), so
+    cross-issue figure links are checked against their OWN branch family.
+    (#964)
+    """
+    name = "figure tracked at live refs"
+    paths_by_issue = _issue_figure_paths_by_issue(body)
+    if not paths_by_issue:
+        return CheckResult(name, True, "no same-repo `figures/issue_<N>/` figure URLs to check")
+    repo = _resolve_repo_root()
+    if repo is None:
+        return CheckResult(name, True, "skipped — repo root unresolved (running outside the repo)")
+
+    missing: list[str] = []
+    branch_only: list[str] = []
+    skipped: list[str] = []
+    n_at_head = 0
+    for issue_n, paths in sorted(paths_by_issue.items()):
+        prefix = f"figures/issue_{issue_n}/"
+        family = _git_issue_branch_family(repo, issue_n)
+        probes: dict[str, set[str] | None] = {"HEAD": _git_tracked_under(repo, "HEAD", prefix)}
+        for br in family or []:
+            probes[br] = _git_tracked_under(repo, br, prefix)
+        failed = sorted(label for label, tracked in probes.items() if tracked is None)
+        if family is None:
+            failed.append("branch listing (for-each-ref)")
+        if failed:
+            # CONSERVATIVE: any failed probe for this issue -> no WARN
+            # possible (the path might live at the failed ref); skip note,
+            # continue to the next issue dir.
+            skipped.append(f"`{prefix}` — probe failure ({', '.join(failed)}); drift not assessed")
+            continue
+        head_set = probes["HEAD"]
+        assert head_set is not None  # failed-probe branch above already continued
+        ok_labels = ", ".join(f"`{label}`" for label in sorted(probes))
+        for p in sorted(paths):
+            if p in head_set:
+                n_at_head += 1
+                continue
+            holders = sorted(
+                label
+                for label, tracked in probes.items()
+                if label != "HEAD" and tracked is not None and p in tracked
+            )
+            if holders:
+                branch_only.append(f"`{p}` (on {', '.join(holders)}, not at HEAD)")
+            else:
+                missing.append(
+                    f"body-linked figure `{p}` is tracked at its pinned-SHA URL but MISSING "
+                    f"from every live local ref ({ok_labels}) — the immutable pinned URL "
+                    "still renders, so this tracking loss is otherwise silent (incident "
+                    "#841); restore with `git restore --source=<pinned-sha> -- <path>` and "
+                    "commit on the intended live branch"
+                )
+    suffix = ""
+    if branch_only:
+        suffix += (
+            "; BRANCH-ONLY (not at HEAD/main — expected pre-merge): "
+            + ", ".join(branch_only)
+            + ". If this task is already merged/completed, the canonical copy is missing "
+            "from main — restore with `git restore --source=<pinned-sha> -- <path>` and "
+            "commit on main."
+        )
+    if skipped:
+        suffix += "; skipped: " + "; ".join(skipped)
+    if missing:
+        return CheckResult(name, True, "; ".join(missing) + suffix, is_warn=True)
+    return CheckResult(name, True, f"{n_at_head} figure path(s) tracked at HEAD" + suffix)
 
 
 def check_figure_caption(body: str) -> CheckResult:
@@ -4170,6 +4313,57 @@ def _git_object_exists(repo: Path, sha: str, path: str) -> tuple[str, str]:
     if cat.returncode == 0:
         return "pass", ""
     return "fail", f"`{path}` is NOT present in the tree at commit `{sha}`"
+
+
+def _git_issue_branch_family(repo: Path, issue_n: str) -> list[str] | None:
+    """Local branch family for an issue: `refs/heads/issue-<N>` plus every
+    `refs/heads/issue-<N>-*` follow-up branch, via ONE
+    `git for-each-ref --format='%(refname:short)'` call (check 29).
+
+    Returns short names (e.g. `['issue-841', 'issue-841-fu2']`); `[]` when
+    no family branch exists; None on any git error (fail-soft — the caller
+    degrades the issue dir to a skip note, never a WARN)."""
+    try:
+        r = subprocess.run(
+            [
+                "git",
+                "for-each-ref",
+                "--format=%(refname:short)",
+                f"refs/heads/issue-{issue_n}",
+                f"refs/heads/issue-{issue_n}-*",
+            ],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if r.returncode != 0:
+        return None
+    return [ln.strip() for ln in r.stdout.splitlines() if ln.strip()]
+
+
+def _git_tracked_under(repo: Path, ref: str, prefix: str) -> set[str] | None:
+    """Set of paths tracked under `prefix` in the tree at `ref` — ONE
+    `git -c core.quotePath=off ls-tree -r --name-only <ref> -- <prefix>`
+    per call (check 29). Reads the tree object, NOT the working tree, so
+    sparse checkouts are fine; `quotePath=off` keeps non-ASCII paths raw so
+    set membership works. None on any git error (fail-soft: the caller
+    degrades that REF to unprobed — never a WARN from a failed probe)."""
+    try:
+        r = subprocess.run(
+            ["git", "-c", "core.quotePath=off", "ls-tree", "-r", "--name-only", ref, "--", prefix],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if r.returncode != 0:
+        return None
+    return {line.strip() for line in r.stdout.splitlines() if line.strip()}
 
 
 def check_repro_committed_claims_exist(body: str) -> CheckResult:
@@ -7549,6 +7743,7 @@ CHECKS = [
     check_audit_availability_claims_match_hf,  # check 25
     check_figure_panel_prose_vs_sidecar,  # check 26 (FAIL)
     check_figure_label_codes,  # check 28 (WARN) — opaque config codes in figure sidecar text
+    check_figure_tracked_at_head,  # check 29 (WARN) — figures tracked at live refs (#964, #841)
 ]
 
 

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -104,7 +104,7 @@ def test_good_body_passes_all():
     ok, results = verify_task_body.verify_text(GOOD_BODY)
     assert ok, [r.render() for r in results if not r.passed]
     assert all(r.passed for r in results)
-    # CHECKS has 33 body-only functions: the 20 pre-v3 body-only checks
+    # CHECKS has 34 body-only functions: the 20 pre-v3 body-only checks
     # (incl. the sentinel-gated `check_tldr_nested_structure` and the
     # check-8b Reproducibility artifact-URL existence probe), the four
     # v3-gated body-only checks (check 18 `check_data_shape`, check 19
@@ -115,7 +115,7 @@ def test_good_body_passes_all():
     # 21 `check_v4_results_beat` WARN, check 27
     # `check_v4_no_bare_issue_refs`; check 20 v4 `check_v4_word_caps`
     # moved to the appended-outside set — it needs `issue`, #921) — each
-    # a PASS-skip on this non-v3/non-v4 fixture — PLUS the FIVE
+    # a PASS-skip on this non-v3/non-v4 fixture — PLUS the SIX
     # generation-agnostic checks: check 22
     # (`check_figure_url_sha_matches_repro`), a NO-OP PASS here because
     # this fixture's `## Reproducibility` carries no figure-sha claim,
@@ -127,24 +127,27 @@ def test_good_body_passes_all():
     # the git tree, check 26
     # (`check_figure_panel_prose_vs_sidecar`, FAIL), a NO-OP PASS here
     # because the fixture's figure carries no panel/series prose claim,
-    # and check 28 (`check_figure_label_codes`, WARN), a NO-OP PASS here
-    # for the same fake-sha / no-sidecar reason as check 24.
+    # check 28 (`check_figure_label_codes`, WARN), a NO-OP PASS here
+    # for the same fake-sha / no-sidecar reason as check 24, and check 29
+    # (`check_figure_tracked_at_head`, WARN), which probes the live local
+    # refs of the REAL repo here (no monkeypatch) — `passed=True` in every
+    # state by construction (WARN/disclosure/skip never flip it).
     # check 25 (`check_audit_availability_claims_match_hf`)
     # is a vacuous PASS here because this fixture carries no
     # availability-denial-near-artifact line. verify_text prepends check 0
     # (body-nonstub) + check 0b (no-duplicate-frontmatter), runs CHECKS[1:]
-    # (32 functions), then appends the Goal soft check, the Lens 14
+    # (33 functions), then appends the Goal soft check, the Lens 14
     # concerns-audit, the check-16 lr-matches-plan reconciliation, the
     # check-17 Context provenance-row read, the v3 check-21
     # body-Parameters-⊆-doc reconciliation (PASS-skip with no doc), the v4
     # check-20 word caps (needs `issue` for the events-based round budget,
     # #921; PASS-skip: not a v4 body), AND the
     # #732 judge-API-error denominator check (PASS-skip: legacy body) →
-    # 41 results total (2 prepended + CHECKS[1:]=32 + 7 appended). The
+    # 42 results total (2 prepended + CHECKS[1:]=33 + 7 appended). The
     # Lens 14 / check-16 results are PASS-skips when no concerns.jsonl /
     # plans/plan.md sibling is available; check 17 and the v3/v4 checks
     # are PASS-skips on this legacy (pre-v2-sentinel) fixture.
-    assert len(results) == 41
+    assert len(results) == 42
 
 
 def test_missing_confidence_tag():
@@ -985,6 +988,215 @@ def test_http_head_status_env_fence(monkeypatch):
     (the suite-wide offline fence from tests/conftest.py)."""
     monkeypatch.setenv("EPM_VERIFY_BODY_NO_HTTP", "1")
     assert verify_task_body._http_head_status("https://example.com/x.png") is None
+
+
+# ─── Check 29: figure tracked at live refs (offline git drift probe) ───────
+#
+# Incident task #841 (2026-07-04): three body-linked `figures/issue_841/`
+# stems were tracked at the pinned sha `4824a567aa` but UNTRACKED at branch
+# HEAD — the immutable pinned raw URLs kept rendering, check 4b kept
+# passing (existence at the pinned sha), and nothing surfaced the tracking
+# loss. Check 29 classifies each same-repo `figures/issue_<N>/` path
+# against the live local refs (HEAD plus the `issue-<N>` / `issue-<N>-*`
+# branch family): at HEAD → PASS; branch-only → PASS with a BRANCH-ONLY
+# disclosure; missing everywhere probed → incident-class WARN (never FAIL).
+
+_FIGURE_TRACKED_CHECK = "figure tracked at live refs"
+
+
+def _make_repo_with_dropped_figure(tmp_path):
+    """git repo where commit A tracks `figures/issue_999/hero.png` +
+    `scripts/run.py` (so GOOD_BODY's check-4b/8b probes resolve when a test
+    pins `sha_pin`) and a later commit B `git rm`ed the figure; HEAD=B.
+    Callers create branches at A or B as the fixture case needs. Returns
+    (repo_path, sha_pin) with sha_pin = commit A."""
+    repo = tmp_path / "dropfigrepo"
+    repo.mkdir()
+
+    def git(*args):
+        subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+    git("init", "-q")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "Test")
+    fig = repo / "figures" / "issue_999" / "hero.png"
+    fig.parent.mkdir(parents=True)
+    fig.write_bytes(b"\x89PNG fake bytes")
+    script = repo / "scripts" / "run.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("print('entry script')\n")
+    git("add", "figures", "scripts")
+    git("commit", "-q", "-m", "add hero figure + entry script")
+    sha_pin = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    git("rm", "-q", "figures/issue_999/hero.png")
+    git("commit", "-q", "-m", "drop hero figure")
+    return repo, sha_pin
+
+
+def test_figure_missing_everywhere_warns(tmp_path, monkeypatch):
+    """The #841 incident fixture: figure tracked at the pinned sha but
+    missing from HEAD AND the whole `issue-999` branch family → the
+    incident-class WARN (passed=True — overall verdict unaffected), while
+    check 4b still PASSes (the pinned sha resolves). Also asserts the
+    subprocess budget of a DIRECT check invocation (never a global count
+    across verify_text — check 4b legitimately adds its own git calls)."""
+    repo, sha_pin = _make_repo_with_dropped_figure(tmp_path)
+    # Branch at HEAD (=B, figure absent): the family exists but lacks it.
+    subprocess.run(["git", "-C", str(repo), "branch", "issue-999"], check=True, capture_output=True)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = GOOD_BODY.replace("0123456789abcdef", sha_pin)
+    ok, results = verify_task_body.verify_text(body)
+    by_name = _results_by_name(results)
+    assert by_name["Figure URL resolvable"].passed  # check 4b: tracked at the pinned sha
+    r = by_name[_FIGURE_TRACKED_CHECK]
+    assert r.passed is True
+    assert r.is_warn is True
+    assert "figures/issue_999/hero.png" in r.detail
+    assert "git restore --source=" in r.detail
+    assert "issue-999" in r.detail  # successfully-probed ref labels named
+    assert ok  # the WARN never flips the overall verdict (no-regress guarantee)
+    # Scoped subprocess budget: 1 for-each-ref + 1 HEAD ls-tree + 1 branch
+    # ls-tree = 3 (plan §4.5 budget: <=5 with <=2 family branches).
+    calls: list = []
+    real_run = subprocess.run
+
+    def counting_run(cmd, *args, **kwargs):
+        calls.append(cmd)
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(verify_task_body.subprocess, "run", counting_run)
+    r2 = verify_task_body.check_figure_tracked_at_head(body)
+    assert r2.is_warn is True
+    assert len(calls) == 3
+    assert len(calls) <= 5
+
+
+def test_figure_branch_only_discloses_not_warns(tmp_path, monkeypatch):
+    """Branch `issue-999` created at commit A (has the figure), HEAD moved
+    to B (lacks it) — the stale-branch-masks-main-loss state: PASS with the
+    BRANCH-ONLY disclosure (path + holding branch + recovery), never a WARN
+    and never silent."""
+    repo, sha_pin = _make_repo_with_dropped_figure(tmp_path)
+    subprocess.run(
+        ["git", "-C", str(repo), "branch", "issue-999", sha_pin], check=True, capture_output=True
+    )
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = GOOD_BODY.replace("0123456789abcdef", sha_pin)
+    ok, results = verify_task_body.verify_text(body)
+    by_name = _results_by_name(results)
+    r = by_name[_FIGURE_TRACKED_CHECK]
+    assert r.passed is True
+    assert r.is_warn is False
+    assert "BRANCH-ONLY" in r.detail
+    assert "figures/issue_999/hero.png" in r.detail
+    assert "issue-999" in r.detail
+    assert "git restore --source=" in r.detail
+    assert ok
+
+
+def test_figure_tracked_at_repo_head_passes_without_branch(tmp_path, monkeypatch):
+    """No `issue-999` branch, HEAD tracks the figure (the merged-and-
+    branch-deleted grandfather case): clean PASS — no WARN, no
+    disclosure."""
+    repo, sha = _make_repo_with_figure(tmp_path)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = GOOD_BODY.replace("0123456789abcdef", sha)
+    _ok, results = verify_task_body.verify_text(body)
+    r = _results_by_name(results)[_FIGURE_TRACKED_CHECK]
+    assert r.passed is True
+    assert r.is_warn is False
+    assert "tracked at HEAD" in r.detail
+    assert "BRANCH-ONLY" not in r.detail
+
+
+def test_figure_on_suffix_branch_discloses_not_warns(tmp_path, monkeypatch):
+    """Figure tracked ONLY at `refs/heads/issue-999-fu` (a same-issue
+    follow-up suffix branch); absent from `issue-999` and HEAD: PASS with
+    the branch-only disclosure — a figure-adding follow-up round must not
+    WARN."""
+    repo, sha_pin = _make_repo_with_dropped_figure(tmp_path)
+    subprocess.run(
+        ["git", "-C", str(repo), "branch", "issue-999-fu", sha_pin],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(["git", "-C", str(repo), "branch", "issue-999"], check=True, capture_output=True)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = GOOD_BODY.replace("0123456789abcdef", sha_pin)
+    r = verify_task_body.check_figure_tracked_at_head(body)
+    assert r.passed is True
+    assert r.is_warn is False
+    assert "BRANCH-ONLY" in r.detail
+    assert "issue-999-fu" in r.detail
+
+
+def test_figure_check_vacuous_pass_no_matching_urls():
+    """Body whose only image is an other-host URL: vacuous PASS, no git
+    probes needed."""
+    body = GOOD_BODY.replace(
+        _GOOD_BODY_FIGURE_URL,
+        "https://eps-figures.example.com/issue_999/hero.png",
+    )
+    r = verify_task_body.check_figure_tracked_at_head(body)
+    assert r.passed is True
+    assert r.is_warn is False
+    assert "no same-repo" in r.detail
+
+
+def test_figure_check_repo_unresolved_skips(monkeypatch):
+    """`_resolve_repo_root` → None (running outside the repo): skip-PASS."""
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: None)
+    r = verify_task_body.check_figure_tracked_at_head(GOOD_BODY)
+    assert r.passed is True
+    assert r.is_warn is False
+    assert r.detail.startswith("skipped")
+
+
+def test_figure_check_git_error_degrades_to_pass(tmp_path, monkeypatch):
+    """`_resolve_repo_root` pointed at a plain non-git dir (for-each-ref
+    and ls-tree both fail): fail-soft per-issue probe-failure note, never a
+    WARN, and no exception propagates through verify_text."""
+    plain = tmp_path / "notarepo"
+    plain.mkdir()
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: plain)
+    r = verify_task_body.check_figure_tracked_at_head(GOOD_BODY)
+    assert r.passed is True
+    assert r.is_warn is False
+    assert "probe failure" in r.detail
+    ok, results = verify_task_body.verify_text(GOOD_BODY)  # no exception end to end
+    assert _results_by_name(results)[_FIGURE_TRACKED_CHECK].passed
+    assert ok
+
+
+def test_figure_partial_probe_failure_never_warns(tmp_path, monkeypatch):
+    """HEAD probe succeeds (figure absent from HEAD) but the family-branch
+    probe fails: the conservative rule demotes the issue dir to a skip note
+    — the path might live at the failed ref, so a narrowed ref set must
+    never manufacture a WARN. The failed ref is named as FAILED, not
+    presented as a successfully-probed ('checked') label."""
+    repo, sha_pin = _make_repo_with_dropped_figure(tmp_path)
+    subprocess.run(["git", "-C", str(repo), "branch", "issue-999"], check=True, capture_output=True)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    real_tracked = verify_task_body._git_tracked_under
+
+    def flaky_tracked(repo_, ref, prefix):
+        if ref == "HEAD":
+            return real_tracked(repo_, ref, prefix)
+        return None  # family-branch probe fails
+
+    monkeypatch.setattr(verify_task_body, "_git_tracked_under", flaky_tracked)
+    body = GOOD_BODY.replace("0123456789abcdef", sha_pin)
+    r = verify_task_body.check_figure_tracked_at_head(body)
+    assert r.passed is True
+    assert r.is_warn is False
+    assert "probe failure" in r.detail
+    assert "issue-999" in r.detail  # the failed ref is named as failed
+    assert "MISSING from every live local ref" not in r.detail
 
 
 # ─── Check 8b: Reproducibility artifact-URL existence ─────────────────────
@@ -2518,7 +2730,7 @@ def test_audit_context_row_blockquote_exempt():
 
 
 def test_checks_list_size():
-    """CHECKS contains 33 body-only functions: the 20 pre-v3 checks
+    """CHECKS contains 34 body-only functions: the 20 pre-v3 checks
     (the 18 under the 2-content-section spec, the nested-design (v2)
     sentinel-gated `check_tldr_nested_structure`, and the check-8b
     Reproducibility artifact-URL existence probe), the four
@@ -2532,7 +2744,7 @@ def test_checks_list_size():
     v3-gated checks added 2026-W24 are — check 18
     (`check_data_shape`), check 19 (`check_data_subset_disclosure`),
     check 19b (`check_data_unwrapped_example_table`, WARN), check 20
-    (`check_v3_word_caps`) — PLUS the SIX generation-agnostic checks:
+    (`check_v3_word_caps`) — PLUS the SEVEN generation-agnostic checks:
     check 22 (`check_figure_url_sha_matches_repro`: inline figure URL sha
     vs the `## Reproducibility` per-figure commit claim), check 23
     (`check_hf_url_resolves`: HF Hub revision-pin existence via a bounded
@@ -2544,9 +2756,13 @@ def test_checks_list_size():
     existence, #653 r6), check 26
     (`check_figure_panel_prose_vs_sidecar`, FAIL: figure what-is-plotted
     panel/series prose vs the sidecar's `_kind` aggregate — panel/series
-    drift, #683 r1), and check 28 (`check_figure_label_codes`, WARN:
+    drift, #683 r1), check 28 (`check_figure_label_codes`, WARN:
     opaque config-code tokens — `@L<digits>` layer pins / regime-code
-    slugs — in the figure sidecar's rendered-text strings, #920). The
+    slugs — in the figure sidecar's rendered-text strings, #920), and
+    check 29 (`check_figure_tracked_at_head`, WARN: body-linked same-repo
+    `figures/issue_<N>/` figure paths still tracked on a live local ref —
+    HEAD plus the `issue-<N>` / `issue-<N>-*` branch family; branch-only →
+    PASS-disclosure, missing everywhere → WARN, #964 / incident #841). The
     migration is a RETARGET — every former check
     was kept (sometimes dormant, e.g. `check_figure_caption`) so downstream
     tests stay valid; the v3 checks PASS-skip on non-v3 bodies.
@@ -2560,11 +2776,11 @@ def test_checks_list_size():
     the v4 check-20 word caps (needs `issue` for the events-based
     folded-round budget scaling, #921), and the #732 judge-API-error
     denominator check (needs eval JSONs).
-    So `verify_text` returns 41 results (2 prepended + CHECKS[1:]=32 +
+    So `verify_text` returns 42 results (2 prepended + CHECKS[1:]=33 +
     7 appended — see `test_good_body_passes_all`), but `CHECKS` stays
-    at 33.
+    at 34.
     """
-    assert len(verify_task_body.CHECKS) == 33
+    assert len(verify_task_body.CHECKS) == 34
 
 
 # ─── Check 14: MDX-safe prose (regex layer + real-parse backstop) ───


### PR DESCRIPTION
Closes task #964 (workflow-fix). Adds WARN-only check 29 (three-state: at-HEAD PASS / branch-only PASS-disclosure / missing-everywhere WARN) closing the #841 silent figure-tracking-loss gap. Code-review ensemble PASS+PASS; test-verdict PASS (2222 passed).