### PR TITLE
issue-968: tag-parity lint for hollow-verification-gate (#779/#890)

### DIFF
--- a/.claude/agents/codex-code-reviewer.md
+++ b/.claude/agents/codex-code-reviewer.md
@@ -605,7 +605,7 @@ fine.)
 
 Follow this protocol:
 
-{{INLINED RUBRIC FROM code-reviewer.md Steps 0, 0.5, 0.55, 0.6, 0.65, 0.67, 0.7, 0.8, 1, 2, 3, 3.5, 3.6, 3.7, 3.8, 4.5, 5, 6, 7 + Rules 12 (blocker grounding + mechanizability, Codex-adapted) + 13 (regression-test presence for substantive BLOCKER fixes) + 14 (bug-class sibling sweep — every finding is a CLASS not a line) + 15 (plan-declared compute shape exposed by dispatcher + work-conserving schedule)}}
+{{INLINED RUBRIC FROM code-reviewer.md Steps 0, 0.5, 0.55, 0.6, 0.65, 0.67, 0.68, 0.7, 0.8, 1, 2, 3, 3.5, 3.6, 3.7, 3.8, 4.5, 5, 6, 7 + Rules 12 (blocker grounding + mechanizability, Codex-adapted) + 13 (regression-test presence for substantive BLOCKER fixes) + 14 (bug-class sibling sweep — every finding is a CLASS not a line) + 15 (plan-declared compute shape exposed by dispatcher + work-conserving schedule)}}
 
 You MUST emit your verdict in EXACTLY this format. No preamble, no code
 fences around the marker, no commentary outside the marker tags:

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -5083,6 +5083,99 @@ def check_long_loop_restartability_review_lens(*, repo_root: Path | None = None)
     return errors
 
 
+def check_hollow_verification_gate_review_lens(*, repo_root: Path | None = None) -> list[str]:
+    """FAIL if the hollow-verification-gate lens (#779/#890) is absent from
+    any of its three surfaces, or the tag drops off a surface's
+    ``**Blocker tags:**`` verdict-template line.
+
+    Task #779: a green `--verify-vectorized` gated an UNUSED helper's
+    self-check while the dispatched ridge hot loop (~17k fits, 18-20h) ran
+    unverified; rounds 6/7 PASSed. #890 added the Step 0.68
+    hollow-verification-gate sub-check + blocker tag to both code-reviewer
+    agent files and deferred this parity lint. Three surfaces, per-file
+    tokens (the #881 shape):
+
+    (a) code-reviewer.md — the ``Hollow-verification-gate sub-check``
+        Step 0.68 heading phrase;
+    (b) codex-code-reviewer.md — the lowercase copy-contract phrase
+        ``hollow-verification-gate sub-check`` PLUS ``0.68`` on the
+        ``{{INLINED RUBRIC`` placeholder line (a copy-list-only token check
+        false-PASSes while the composed executable Codex prompt omits
+        Step 0.68 — the #606 twin-omission class);
+    (c) efficiency-critic.md — the v2 owner
+        (.claude/rules/lens-coverage-map.md), IMPLEMENTATION-MODE rubric
+        item ``Hollow-verification-gate``.
+
+    Every surface ADDITIONALLY requires the tag on a line starting with
+    ``**Blocker tags:**`` — the verdict template's tag-vocabulary line, the
+    orchestrator's Step 5c-bis parse target (#890's line-scoped verify:
+    a broad grep false-greens a prose-only partial implementation).
+    Tokens are case-sensitive substrings. ``repo_root`` is a unit-test
+    override hook; production callers pass None. Bundled into the no-flags
+    default run.
+    """
+    root = repo_root if repo_root is not None else _REPO_ROOT
+    tag = "hollow-verification-gate"
+    blocker_prefix = "**Blocker tags:**"
+    prose_by_file: dict[Path, tuple[str, ...]] = {
+        root / ".claude" / "agents" / "code-reviewer.md": ("Hollow-verification-gate sub-check",),
+        root / ".claude" / "agents" / "codex-code-reviewer.md": (
+            "hollow-verification-gate sub-check",
+        ),
+        root / ".claude" / "agents" / "efficiency-critic.md": ("Hollow-verification-gate",),
+    }
+    errors: list[str] = []
+    for p, required in prose_by_file.items():
+        if not p.is_file():
+            errors.append(
+                f"{p}: missing — the #890 hollow-verification-gate lens must "
+                f"live in code-reviewer.md, codex-code-reviewer.md, and "
+                f"efficiency-critic.md (the workflow-v2 owner)."
+            )
+            continue
+        text = p.read_text(encoding="utf-8")
+        for token in required:
+            if token not in text:
+                errors.append(
+                    f"{p}: missing the hollow-verification-gate lens token "
+                    f"{token!r} (#779/#890). The Step 0.68 sub-check (a "
+                    f"verify/equivalence gate must assert on the function the "
+                    f"entrypoint actually dispatches) must stay on all three "
+                    f"reviewer surfaces so a green gate on an unused sibling "
+                    f"keeps FAILing review (incident #779: an unverified ~17k-"
+                    f"fit hot loop was laundered as verified)."
+                )
+        bt_lines = [ln for ln in text.splitlines() if ln.startswith(blocker_prefix)]
+        if not bt_lines:
+            errors.append(
+                f"{p}: no line starts with {blocker_prefix!r} (#890) — the "
+                f"verdict template's blocker-tag vocabulary line (the Step "
+                f"5c-bis parse target) is gone."
+            )
+        elif not any(tag in ln for ln in bt_lines):
+            errors.append(
+                f"{p}: no {blocker_prefix!r} line names {tag!r} (#890) — the "
+                f"tag dropped out of the verdict template's vocabulary; a "
+                f"reviewer could no longer declare the finding (the "
+                f"2-without-2b partial-implementation class a broad grep "
+                f"false-greens)."
+            )
+    codex = root / ".claude" / "agents" / "codex-code-reviewer.md"
+    if codex.is_file():
+        rubric_lines = [
+            ln for ln in codex.read_text(encoding="utf-8").splitlines() if "{{INLINED RUBRIC" in ln
+        ]
+        if not any("0.68" in ln for ln in rubric_lines):
+            errors.append(
+                f"{codex}: '0.68' is absent from the '{{{{INLINED RUBRIC' "
+                f"placeholder line (#890) — the composed Codex prompt would "
+                f"omit the Step 0.68 named-helper + hollow-gate lens (the "
+                f"#606 twin-omission class; same pin as #822's '0.55' and "
+                f"#881's '3.5, 3.6, 3.7')."
+            )
+    return errors
+
+
 def check_smoke_architecture_review_lens(*, repo_root: Path | None = None) -> list[str]:
     """FAIL if the smoke-architecture marker presence gate (#822) is absent
     from ANY of its three surfaces.
@@ -6256,6 +6349,20 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         "default run.",
     )
     parser.add_argument(
+        "--check-hollow-verification-gate-review-lens",
+        action="store_true",
+        help="FAIL if the #890 hollow-verification-gate lens (the Step 0.68 "
+        "sub-check prose in code-reviewer.md, the copy-contract clause + "
+        "'0.68' on the inlined-rubric placeholder in codex-code-reviewer.md, "
+        "the IMPLEMENTATION-MODE rubric item in efficiency-critic.md — the "
+        "workflow-v2 owner) is absent from any surface, or the tag drops "
+        "off any surface's '**Blocker tags:**' verdict-template line. Pins "
+        "that a verify/equivalence gate asserting on an unused sibling stays "
+        "a Major substantive blocker (incident #779: a green "
+        "--verify-vectorized laundered an unverified ~17k-fit hot loop). "
+        "Bundled into the no-flags default run.",
+    )
+    parser.add_argument(
         "--check-smoke-architecture-review-lens",
         action="store_true",
         help="FAIL if the #822 smoke-architecture marker presence gate (Step "
@@ -6422,6 +6529,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         or args.check_lessons_index
         or args.check_compute_shape_review_lens
         or args.check_long_loop_restartability_review_lens
+        or args.check_hollow_verification_gate_review_lens
         or args.check_smoke_architecture_review_lens
         or args.check_smoke_output_hygiene
         or args.check_vm_thread_cap_guidance
@@ -6506,6 +6614,8 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         errors.extend(check_compute_shape_review_lens())
     if args.check_long_loop_restartability_review_lens or no_flags:
         errors.extend(check_long_loop_restartability_review_lens())
+    if args.check_hollow_verification_gate_review_lens or no_flags:
+        errors.extend(check_hollow_verification_gate_review_lens())
     if args.check_smoke_architecture_review_lens or no_flags:
         errors.extend(check_smoke_architecture_review_lens())
     if args.check_smoke_output_hygiene or no_flags:

--- a/tests/test_workflow_lint.py
+++ b/tests/test_workflow_lint.py
@@ -46,6 +46,7 @@ from workflow_lint import (  # noqa: E402
     check_dispatcher_cvd_pin,
     check_gate_ids_unique,
     check_heredoc_dotenv,
+    check_hollow_verification_gate_review_lens,
     check_lessons_index,
     check_long_loop_restartability_review_lens,
     check_marker_registry,
@@ -3011,6 +3012,123 @@ def test_long_loop_restartability_review_lens_flags_missing_per_file(tmp_path) -
     assert any("'Long-loop restartability'" in e for e in errors), errors
     assert any("'3.5, 3.6, 3.7'" in e for e in errors), errors
     assert any("'Intra-phase grain'" in e for e in errors), errors
+
+
+def test_hollow_gate_review_lens_live_tree_passes() -> None:
+    """The real tree carries the #890 lens on all three surfaces."""
+    assert check_hollow_verification_gate_review_lens() == []
+
+
+def _write_hollow_gate_conforming_tree(tmp_path) -> None:
+    """Write all three #890 surfaces with their full per-file assertions."""
+    agents = tmp_path / ".claude" / "agents"
+    agents.mkdir(parents=True)
+    (agents / "code-reviewer.md").write_text(
+        "# reviewer\n**Hollow-verification-gate sub-check.** trace gate->dispatch\n"
+        "**Blocker tags:** [`hollow-verification-gate` | `substantive`]\n"
+    )
+    (agents / "codex-code-reviewer.md").write_text(
+        "# codex\nthe hollow-verification-gate sub-check (copy in full)\n"
+        "**Blocker tags:** [`hollow-verification-gate` | `substantive`]\n"
+        "{{INLINED RUBRIC FROM code-reviewer.md Steps 0.67, 0.68, 3.6}}\n"
+    )
+    (agents / "efficiency-critic.md").write_text(
+        "# eff\n4. **Hollow-verification-gate (Step 0.68 sub-check).**\n"
+        "**Blocker tags:** [`hollow-verification-gate` | `substantive`]\n"
+    )
+
+
+def test_hollow_gate_review_lens_conforming_tmp_tree_passes(tmp_path) -> None:
+    """A tmp tree carrying every per-file assertion returns no errors (#890)."""
+    _write_hollow_gate_conforming_tree(tmp_path)
+    assert check_hollow_verification_gate_review_lens(repo_root=tmp_path) == []
+
+
+def test_hollow_gate_review_lens_flags_missing_per_file(tmp_path) -> None:
+    """Each surface failing a DIFFERENT assertion FAILs exactly once per file.
+
+    The Claude file loses the sub-check PROSE (keeps its Blocker-tags line),
+    the codex file drops the tag from its Blocker-tags LINE (keeps prose +
+    the 0.68 placeholder), the efficiency file loses its Blocker-tags line
+    entirely — so the check emits exactly one error per file, one per
+    assertion kind (prose token / tag-off-template-line / template-line-gone).
+    """
+    _write_hollow_gate_conforming_tree(tmp_path)
+    agents = tmp_path / ".claude" / "agents"
+    (agents / "code-reviewer.md").write_text(
+        "# reviewer\nno sub-check here\n"
+        "**Blocker tags:** [`hollow-verification-gate` | `substantive`]\n"
+    )
+    (agents / "codex-code-reviewer.md").write_text(
+        "# codex\nthe hollow-verification-gate sub-check (copy in full)\n"
+        "**Blocker tags:** [`substantive`]\n"
+        "{{INLINED RUBRIC FROM code-reviewer.md Steps 0.67, 0.68, 3.6}}\n"
+    )
+    (agents / "efficiency-critic.md").write_text(
+        "# eff\n4. **Hollow-verification-gate (Step 0.68 sub-check).**\n"
+    )
+    errors = check_hollow_verification_gate_review_lens(repo_root=tmp_path)
+    assert len(errors) == 3, errors
+    subjects = [e.split(": ", 1)[0] for e in errors]
+    assert sum(s.endswith("/code-reviewer.md") for s in subjects) == 1, subjects
+    assert sum(s.endswith("/codex-code-reviewer.md") for s in subjects) == 1, subjects
+    assert sum(s.endswith("/efficiency-critic.md") for s in subjects) == 1, subjects
+    assert any("'Hollow-verification-gate sub-check'" in e for e in errors), errors
+    assert any("dropped out of the verdict template" in e for e in errors), errors
+    assert any("no line starts with" in e for e in errors), errors
+
+
+def test_hollow_gate_review_lens_flags_missing_rubric_enumeration(tmp_path) -> None:
+    """A codex placeholder line lacking '0.68' FAILs (the #606 class)."""
+    _write_hollow_gate_conforming_tree(tmp_path)
+    agents = tmp_path / ".claude" / "agents"
+    (agents / "codex-code-reviewer.md").write_text(
+        "# codex\nthe hollow-verification-gate sub-check (copy in full)\n"
+        "**Blocker tags:** [`hollow-verification-gate` | `substantive`]\n"
+        "{{INLINED RUBRIC FROM code-reviewer.md Steps 0.67, 0.7, 3.6}}\n"
+    )
+    errors = check_hollow_verification_gate_review_lens(repo_root=tmp_path)
+    assert len(errors) == 1, errors
+    assert errors[0].split(": ", 1)[0].endswith("/codex-code-reviewer.md"), errors
+    assert "0.68" in errors[0] and "INLINED RUBRIC" in errors[0], errors
+
+
+def test_hollow_gate_review_lens_flags_missing_file(tmp_path) -> None:
+    """A missing required surface file is itself an error (the #891 shape)."""
+    _write_hollow_gate_conforming_tree(tmp_path)
+    (tmp_path / ".claude" / "agents" / "efficiency-critic.md").unlink()
+    errors = check_hollow_verification_gate_review_lens(repo_root=tmp_path)
+    assert len(errors) == 1, errors
+    assert errors[0].split(": ", 1)[0].endswith("/efficiency-critic.md"), errors
+    assert "missing" in errors[0], errors
+
+
+def test_hollow_gate_review_lens_bundled_in_no_flags(tmp_path, capsys, monkeypatch) -> None:
+    """The no-flags default run actually DISPATCHES the check — deleting the
+    ``or no_flags`` ladder branch must fail this test (mutation-visible),
+    closing the dead-tripwire gap where all direct-call tests stay green while
+    the CLI never runs the check. Follows the
+    ``test_vm_thread_cap_guidance_bundled_in_no_flags`` pattern (in-process
+    ``main([])``, ``_REPO_ROOT`` monkeypatched; other bundled checks contribute
+    unrelated errors on the minimal tree, so the assertion keys on the
+    hollow-gate diagnostic + the offending file path)."""
+    import workflow_lint as wl
+
+    _write_hollow_gate_conforming_tree(tmp_path)
+    agents = tmp_path / ".claude" / "agents"
+    (agents / "efficiency-critic.md").write_text(
+        "# eff\n4. **Hollow-verification-gate (Step 0.68 sub-check).**\n"
+        "**Blocker tags:** [`substantive`]\n"
+    )
+    monkeypatch.setattr(wl, "_REPO_ROOT", tmp_path)
+    rc = wl.main([])
+    err = capsys.readouterr().err
+    assert rc != 0, f"no-flags default run exited 0 on a violating tree:\n{err}"
+    assert "hollow-verification-gate" in err and "efficiency-critic.md" in err, (
+        f"the hollow-gate diagnostic (naming efficiency-critic.md) is missing "
+        f"from the no-flags run's stderr — the check is not bundled into "
+        f"no_flags:\n{err}"
+    )
 
 
 def _write_smoke_arch_conforming_tree(tmp_path) -> None:


### PR DESCRIPTION
Closes task #968 (kind: infra, workflow-fix).

## Summary
- Adds `check_hollow_verification_gate_review_lens` to `scripts/workflow_lint.py`: pins the #779/#890 hollow-verification-gate review lens on 3 surfaces (code-reviewer.md Step 0.68 prose, codex-code-reviewer.md copy-contract, efficiency-critic.md v2-owner rubric item), with a line-scoped `**Blocker tags:**` assertion per file and a `0.68` pin on the codex `{{INLINED RUBRIC` placeholder line. New `--check-hollow-verification-gate-review-lens` flag, bundled into the no-flags default run.
- Fixes a LIVE #606-class twin-omission: `0.68` was absent from the codex-code-reviewer.md:608 inlined-rubric enumeration (contradicting its own :392 copy-list + :529 prose).
- 6 tests incl. a mutation-visible no-flags wiring test + a missing-file branch test (r1 statistics-reconciliation Must-Fix items).

## Test plan
- [x] `uv run pytest tests/test_workflow_lint.py -q -k "hollow"` — 6 passed
- [x] Step 9c 40-file workflow-invariant battery — 2376 passed / 6 skipped / 0 failed
- [x] `uv run python scripts/workflow_lint.py` (no-flags) — exit 0; size ratchet OK (codex file 50,648 B / 51,600 B cap)
- [x] ruff check + format --check clean

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)