### PR TITLE
issue-963: workflow_lint --check-stale-label-disposition (#963)

### DIFF
--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -316,6 +316,18 @@ Behaviours:
   non-blank line. Also enforced at commit time by the
   ``workflow-lint-phase-done-reserved`` pre-commit hook on any
   ``scripts/*.sh|py`` change (#930).
+* ``--check-stale-label-disposition`` (also bundled into the no-flags default
+  run): FAIL if the /issue SKILL.md Step 0 "Stale-label disposition rule"
+  paragraph (bold anchor ``**Stale-label disposition rule``, which must be
+  UNIQUE — the check carries a negative assertion, so span identity is
+  load-bearing) loses any of its five #894/#763 semantic tokens — most
+  critically the fresh-label-execute clause ("the label EXECUTES as the
+  dispatched round") — or regains an unconditional skip-on-None coupling
+  ("On None ... skip", a targeted negative regex over the
+  whitespace-normalized paragraph span; a literal-coupling backstop only,
+  the positive tokens are the primary defense). Paragraph-scoped: the span
+  runs from the anchor to the first blank line, so a mid-paragraph split
+  FAILs loudly (#963).
 
 Exit codes:
 
@@ -5201,6 +5213,82 @@ def check_smoke_architecture_review_lens(*, repo_root: Path | None = None) -> li
     return errors
 
 
+# The #963 stale-label disposition-clause tokens. The paragraph span runs from
+# the bold anchor (which must be UNIQUE — the check carries a NEGATIVE
+# assertion, so span identity is load-bearing) to the first blank line, and is
+# whitespace-normalized before matching (two tokens span a hard line wrap in
+# the live file, and an innocent prose reflow must not FAIL the fleet).
+_STALE_LABEL_ANCHOR = "**Stale-label disposition rule"
+_STALE_LABEL_REQUIRED_TOKENS = (
+    "followup_retro_close_evidence",
+    "GHOST-label filter, NOT an execution gate",
+    "A None return means NO prior-run evidence exists",
+    "the label EXECUTES as the dispatched round",
+    "The skip-and-surface disposition applies ONLY when",
+)
+_STALE_LABEL_SKIP_ON_NONE_RE = re.compile(r"\bon\s+(?:a\s+)?none\b.{0,120}?\bskip", re.IGNORECASE)
+
+
+def check_stale_label_disposition_clause(*, repo_root: Path | None = None) -> list[str]:
+    """FAIL if the /issue Step 0 stale-label disposition paragraph (#894/#763)
+    loses its fresh-label-execute semantics or regains an unconditional
+    skip-on-None branch (#963).
+
+    Scope notes (round-1 critique):
+
+    (a) The negative regex is a LITERAL-COUPLING BACKSTOP only — phrasings
+        like "when None is returned, skip" are covered by the positive
+        tokens, not the regex; do not weaken a positive token "because the
+        regex covers it".
+    (b) The check is paragraph-scoped — a contradictory instruction written
+        OUTSIDE the anchored paragraph is invisible to it (inherent to the
+        token-lint class).
+    (c) A mid-paragraph blank line truncates the span and FAILs all
+        downstream tokens at once — the span ends at the first blank line,
+        so a deliberate restructure requires a deliberate lint update.
+
+    ``repo_root`` is a unit-test override hook; production callers pass None
+    (canonical repo root). Bundled into the no-flags default run.
+    """
+    root = repo_root if repo_root is not None else _REPO_ROOT
+    skill = root / ".claude" / "skills" / "issue" / "SKILL.md"
+    if not skill.is_file():
+        return [f"{skill}: missing — the Step 0 stale-label disposition paragraph must exist."]
+    text = skill.read_text(encoding="utf-8")
+    n_anchors = text.count(_STALE_LABEL_ANCHOR)
+    if n_anchors == 0:
+        return [
+            f"{skill}: missing the bold anchor {_STALE_LABEL_ANCHOR!r} (#963) — the Step 0 "
+            f"stale-label disposition paragraph pins the #894/#763 fresh-label-execute "
+            f"semantics and must not be removed or renamed without updating this lint."
+        ]
+    if n_anchors > 1:
+        return [
+            f"{skill}: {n_anchors} bold anchors {_STALE_LABEL_ANCHOR!r} found — the stale-label "
+            f"disposition paragraph must be UNIQUE (a stale duplicate could satisfy the token "
+            f"scan while the operative Step 0 paragraph regresses; #963). Remove the duplicate."
+        ]
+    start = text.find(_STALE_LABEL_ANCHOR)
+    end = text.find("\n\n", start)
+    normalized = re.sub(r"\s+", " ", text[start : end if end != -1 else len(text)])
+    errors: list[str] = []
+    for token in _STALE_LABEL_REQUIRED_TOKENS:
+        if token not in normalized:
+            errors.append(
+                f"{skill}: stale-label disposition paragraph missing token {token!r} (#963) — "
+                f"note: the span ends at the first blank line, so a split paragraph FAILs all "
+                f"downstream tokens at once (a deliberate restructure needs a lint update)."
+            )
+    if _STALE_LABEL_SKIP_ON_NONE_RE.search(normalized):
+        errors.append(
+            f"{skill}: stale-label disposition paragraph couples a None return to a skip "
+            f"instruction ('On None ... skip') — a fresh never-run label must EXECUTE as the "
+            f"dispatched round (#963); the skip-and-surface disposition is reserved for "
+            f"suspected-stale ghost labels."
+        )
+    return errors
+
+
 # The #842 smoke output-path hygiene anchor phrase. Must appear INSIDE each
 # surface's load-bearing region (see check_smoke_output_hygiene below).
 SMOKE_OUTPUT_HYGIENE_ANCHOR = "Smoke outputs never overwrite committed artifacts"
@@ -6269,6 +6357,19 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         "Step 6d.0 post-provision). Bundled into the no-flags default run.",
     )
     parser.add_argument(
+        "--check-stale-label-disposition",
+        action="store_true",
+        help="FAIL if the /issue SKILL.md Step 0 stale-label disposition "
+        "paragraph (bold anchor '**Stale-label disposition rule', which must "
+        "be UNIQUE) loses any of its five #894/#763 semantic tokens — most "
+        "critically the fresh-label-execute clause ('the label EXECUTES as "
+        "the dispatched round') — or regains an unconditional skip-on-None "
+        "coupling ('On None ... skip', a targeted negative regex over the "
+        "whitespace-normalized paragraph span). Paragraph-scoped: the span "
+        "runs from the anchor to the first blank line (#963). Bundled into "
+        "the no-flags default run.",
+    )
+    parser.add_argument(
         "--check-smoke-output-hygiene",
         action="store_true",
         help="FAIL if the #842 smoke output-path hygiene rule ('Smoke outputs "
@@ -6423,6 +6524,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         or args.check_compute_shape_review_lens
         or args.check_long_loop_restartability_review_lens
         or args.check_smoke_architecture_review_lens
+        or args.check_stale_label_disposition
         or args.check_smoke_output_hygiene
         or args.check_vm_thread_cap_guidance
         or args.check_judge_model_pins
@@ -6508,6 +6610,8 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         errors.extend(check_long_loop_restartability_review_lens())
     if args.check_smoke_architecture_review_lens or no_flags:
         errors.extend(check_smoke_architecture_review_lens())
+    if args.check_stale_label_disposition or no_flags:
+        errors.extend(check_stale_label_disposition_clause())
     if args.check_smoke_output_hygiene or no_flags:
         errors.extend(check_smoke_output_hygiene())
     if args.check_vm_thread_cap_guidance or no_flags:

--- a/tests/test_workflow_lint.py
+++ b/tests/test_workflow_lint.py
@@ -56,6 +56,7 @@ from workflow_lint import (  # noqa: E402
     check_skill_references,
     check_smoke_architecture_review_lens,
     check_smoke_output_hygiene,
+    check_stale_label_disposition_clause,
     check_upload_as_file,
     check_vm_thread_cap_guidance,
     check_wandb_required,
@@ -3475,4 +3476,153 @@ def test_vm_thread_cap_guidance_bundled_in_no_flags(tmp_path, capsys, monkeypatc
         f"the #891 vm-thread-cap diagnostic (naming code-style.md) is missing "
         f"from the no-flags default run's stderr — the check is not bundled "
         f"into no_flags:\n{err}"
+    )
+
+
+# --- #963 stale-label disposition-clause tests -------------------------------
+
+# Conforming fixture: deliberately re-wrapped at a DIFFERENT column than the
+# live SKILL.md, with FOUR of the five required tokens split mid-phrase across
+# a line break (the reflow proof for the whitespace-normalized matching), and
+# a span-end DECOY sentence AFTER the `\n\n` terminator that matches the
+# negative regex ("On None, skip ...") — which must NOT trip the check
+# (mechanically pins the paragraph-scoped extraction).
+_STALE_LABEL_CONFORMING = (
+    "# issue skill\n"
+    "\n"
+    "**Stale-label disposition rule (mechanical evidence only).** Run\n"
+    "`task_workflow.followup_retro_close_evidence(events, label)` before executing\n"
+    "a dispatched label. This check is a GHOST-label filter, NOT an\n"
+    "execution gate. A None return\n"
+    "means NO prior-run evidence exists and for a fresh never-run label\n"
+    "the label\n"
+    "EXECUTES as the dispatched round. The\n"
+    "skip-and-surface disposition applies ONLY when the orchestrator suspects\n"
+    "the label already ran.\n"
+    "\n"
+    "**Next.** On None, skip the label.\n"
+)
+
+_STALE_LABEL_EXECUTE_TOKEN = "the label EXECUTES as the dispatched round"
+
+
+def _write_stale_label_tree(tmp_path, body: str) -> None:
+    """Write ``.claude/skills/issue/SKILL.md`` under ``tmp_path`` with ``body``."""
+    skill = tmp_path / ".claude" / "skills" / "issue"
+    skill.mkdir(parents=True, exist_ok=True)
+    (skill / "SKILL.md").write_text(body, encoding="utf-8")
+
+
+def test_stale_label_disposition_clause_live_tree_passes() -> None:
+    """The real SKILL.md carries the #894/#763 paragraph with all five tokens
+    and no unconditional skip-on-None coupling (pins Assumption 4)."""
+    assert check_stale_label_disposition_clause() == []
+
+
+def test_stale_label_disposition_clause_conforming_tmp_tree_passes(tmp_path) -> None:
+    """A re-wrapped but token-identical paragraph PASSes (normalization works),
+    and the span-end DECOY ('On None, skip the label.' AFTER the blank-line
+    terminator) does not trip the negative regex (paragraph scoping works)."""
+    _write_stale_label_tree(tmp_path, _STALE_LABEL_CONFORMING)
+    assert check_stale_label_disposition_clause(repo_root=tmp_path) == []
+
+
+def test_stale_label_disposition_clause_flags_missing_execute_clause(tmp_path) -> None:
+    """Deleting the fresh-label-execute clause -> exactly one error naming
+    that token (the task's primary regression target)."""
+    body = _STALE_LABEL_CONFORMING.replace("EXECUTES as the dispatched round", "runs normally")
+    assert body != _STALE_LABEL_CONFORMING
+    _write_stale_label_tree(tmp_path, body)
+    errors = check_stale_label_disposition_clause(repo_root=tmp_path)
+    assert len(errors) == 1, errors
+    assert repr(_STALE_LABEL_EXECUTE_TOKEN) in errors[0], errors
+
+
+def test_stale_label_disposition_clause_flags_unconditional_skip_on_none(tmp_path) -> None:
+    """A paragraph regaining 'On None return, skip the label ...' INSIDE the
+    span FAILs via the negative regex. All five positive tokens are kept
+    present so the test isolates the regex: ``len(errors) == 1`` is asserted
+    mechanically, not incidentally."""
+    body = _STALE_LABEL_CONFORMING.replace(
+        "the label already ran.\n",
+        "the label already ran. On None return, skip the label and surface it.\n",
+    )
+    assert body != _STALE_LABEL_CONFORMING
+    _write_stale_label_tree(tmp_path, body)
+    errors = check_stale_label_disposition_clause(repo_root=tmp_path)
+    assert len(errors) == 1, errors
+    assert "'On None ... skip'" in errors[0], errors
+
+
+def test_stale_label_disposition_clause_flags_duplicate_anchor(tmp_path) -> None:
+    """A SECOND copy of the bold anchor -> exactly one duplicate-anchor error
+    (MF2: span identity is load-bearing for the negative assertion — a stale
+    duplicate could satisfy the token scan while the operative paragraph
+    regresses)."""
+    body = (
+        _STALE_LABEL_CONFORMING
+        + "\n**Stale-label disposition rule (stale duplicate).** Old copy.\n"
+    )
+    _write_stale_label_tree(tmp_path, body)
+    errors = check_stale_label_disposition_clause(repo_root=tmp_path)
+    assert len(errors) == 1, errors
+    assert "UNIQUE" in errors[0], errors
+    assert "2 bold anchors" in errors[0], errors
+
+
+def test_stale_label_disposition_clause_flags_split_paragraph(tmp_path) -> None:
+    """A blank line inserted mid-paragraph (before the execute clause)
+    truncates the span at the first blank line and FAILs the downstream
+    tokens (pins Assumption 3's intended truncation behavior)."""
+    body = _STALE_LABEL_CONFORMING.replace("\nthe label\nEXECUTES", "\n\nthe label\nEXECUTES")
+    assert body != _STALE_LABEL_CONFORMING
+    _write_stale_label_tree(tmp_path, body)
+    errors = check_stale_label_disposition_clause(repo_root=tmp_path)
+    assert errors, "expected missing-token FAILs on a split paragraph"
+    assert all("missing token" in e for e in errors), errors
+    assert any(repr(_STALE_LABEL_EXECUTE_TOKEN) in e for e in errors), errors
+
+
+def test_stale_label_disposition_clause_flags_missing_paragraph(tmp_path) -> None:
+    """SKILL.md present but anchor absent -> exactly one error naming the
+    bold anchor."""
+    _write_stale_label_tree(tmp_path, "# issue skill\n\nNo stale-label paragraph here.\n")
+    errors = check_stale_label_disposition_clause(repo_root=tmp_path)
+    assert len(errors) == 1, errors
+    assert "missing the bold anchor" in errors[0], errors
+    assert repr("**Stale-label disposition rule") in errors[0], errors
+
+
+def test_stale_label_disposition_clause_flags_missing_file(tmp_path) -> None:
+    """An empty tmp tree (no SKILL.md at all) -> a missing-file error."""
+    errors = check_stale_label_disposition_clause(repo_root=tmp_path)
+    assert len(errors) == 1, errors
+    assert "missing" in errors[0], errors
+
+
+def test_stale_label_disposition_clause_wired_into_default_run(tmp_path, capsys, monkeypatch):
+    """The no-flags CLI-path REGISTRATION test (MF1): the default run must
+    exercise ``check_stale_label_disposition_clause`` — deleting the
+    ``no_flags`` tuple membership or the dispatch branch must fail this test
+    (mutation-visible), closing the dead-tripwire gap where all direct-call
+    tests stay green while the CLI never runs the check. Follows the
+    ``test_smoke_output_hygiene_wired_into_default_run`` /
+    ``test_vm_thread_cap_guidance_bundled_in_no_flags`` house pattern:
+    doctored non-conforming tree (execute clause deleted), ``_REPO_ROOT``
+    monkeypatched to the fixture, ``main([])`` in-process. Other bundled
+    checks contribute unrelated errors on the minimal tree, so the assertion
+    keys on the #963 diagnostic string."""
+    import workflow_lint as wl
+
+    body = _STALE_LABEL_CONFORMING.replace("EXECUTES as the dispatched round", "runs normally")
+    assert body != _STALE_LABEL_CONFORMING
+    _write_stale_label_tree(tmp_path, body)
+    monkeypatch.setattr(wl, "_REPO_ROOT", tmp_path)
+    rc = wl.main([])
+    err = capsys.readouterr().err
+    assert rc != 0, f"no-flags default run exited 0 on a non-conforming tree:\n{err}"
+    assert "#963" in err, (
+        f"the #963 stale-label-disposition diagnostic is missing from the "
+        f"no-flags default run's stderr — the check is not bundled into "
+        f"no_flags:\n{err}"
     )

--- a/tests/test_workflow_lint.py
+++ b/tests/test_workflow_lint.py
@@ -3600,13 +3600,32 @@ def test_stale_label_disposition_clause_flags_missing_file(tmp_path) -> None:
     assert "missing" in errors[0], errors
 
 
+def test_stale_label_disposition_clause_paragraph_at_eof_passes(tmp_path) -> None:
+    """A conforming paragraph that is the LAST content of the file — no
+    blank-line terminator after it — still PASSes: pins the ``end == -1``
+    span fallback (the span extends to EOF when ``text.find("\\n\\n", start)``
+    misses)."""
+    body = _STALE_LABEL_CONFORMING.split("\n\n**Next.")[0]
+    assert body != _STALE_LABEL_CONFORMING
+    # Precondition for exercising the fallback: no blank line anywhere at or
+    # after the anchor, so the span-end search MUST return -1.
+    assert "\n\n" not in body[body.find("**Stale-label disposition rule") :]
+    _write_stale_label_tree(tmp_path, body)
+    assert check_stale_label_disposition_clause(repo_root=tmp_path) == []
+
+
 def test_stale_label_disposition_clause_wired_into_default_run(tmp_path, capsys, monkeypatch):
     """The no-flags CLI-path REGISTRATION test (MF1): the default run must
-    exercise ``check_stale_label_disposition_clause`` — deleting the
-    ``no_flags`` tuple membership or the dispatch branch must fail this test
-    (mutation-visible), closing the dead-tripwire gap where all direct-call
-    tests stay green while the CLI never runs the check. Follows the
-    ``test_smoke_output_hygiene_wired_into_default_run`` /
+    exercise ``check_stale_label_disposition_clause`` — deleting the dispatch
+    branch (``if args.check_stale_label_disposition or no_flags:``) or its
+    ``or no_flags`` disjunct must fail this test (mutation-visible), closing
+    the dead-tripwire gap where all direct-call tests stay green while the
+    CLI never runs the check. NOTE: this test canNOT pin the
+    ``or args.check_stale_label_disposition`` membership in the ``no_flags``
+    tuple — ``main([])`` passes no flags, so ``no_flags`` computes True with
+    or without that line; the tuple membership is pinned by
+    ``test_stale_label_disposition_clause_dedicated_flag_isolated`` below.
+    Follows the ``test_smoke_output_hygiene_wired_into_default_run`` /
     ``test_vm_thread_cap_guidance_bundled_in_no_flags`` house pattern:
     doctored non-conforming tree (execute clause deleted), ``_REPO_ROOT``
     monkeypatched to the fixture, ``main([])`` in-process. Other bundled
@@ -3625,4 +3644,33 @@ def test_stale_label_disposition_clause_wired_into_default_run(tmp_path, capsys,
         f"the #963 stale-label-disposition diagnostic is missing from the "
         f"no-flags default run's stderr — the check is not bundled into "
         f"no_flags:\n{err}"
+    )
+
+
+def test_stale_label_disposition_clause_dedicated_flag_isolated(tmp_path, capsys, monkeypatch):
+    """The dedicated ``--check-stale-label-disposition`` flag runs ONLY the
+    stale-label check (``no_flags`` computes False): on a minimal tree where
+    the stale-label paragraph CONFORMS but the full default bundle FAILs
+    (other bundled checks miss their files), the dedicated-flag invocation
+    exits 0. Mutation-visibility — the leg the ``main([])`` wiring test above
+    cannot pin: deleting ``or args.check_stale_label_disposition`` from the
+    ``no_flags`` tuple makes the dedicated-flag invocation compute
+    ``no_flags`` True and run the FULL bundle on the failing minimal tree ->
+    rc != 0 -> this test FAILs. (Verified empirically on 2026-07-04 by
+    stripping that tuple line: this test fails, the wiring test stays green.)
+    """
+    import workflow_lint as wl
+
+    _write_stale_label_tree(tmp_path, _STALE_LABEL_CONFORMING)
+    monkeypatch.setattr(wl, "_REPO_ROOT", tmp_path)
+    # Precondition: the FULL default bundle FAILs on this minimal tree, so a
+    # no_flags mis-computation below is observable as rc != 0.
+    assert wl.main([]) != 0, "precondition: the default bundle PASSed on the minimal tree"
+    capsys.readouterr()  # discard the precondition run's output
+    rc = wl.main(["--check-stale-label-disposition"])
+    err = capsys.readouterr().err
+    assert rc == 0, (
+        f"--check-stale-label-disposition ran more than the (conforming) stale-label "
+        f"check — no_flags mis-computed True, i.e. the flag's membership in the "
+        f"no_flags tuple in workflow_lint.main() is missing:\n{err}"
     )


### PR DESCRIPTION
Closes task #963 (workflow-fix, kind: infra).

## Summary
- New `check_stale_label_disposition_clause()` lint: pins the /issue SKILL.md Step 0 stale-label disposition paragraph (#894/#763) — 5 verbatim fresh-label-execute tokens over a whitespace-normalized, unique-bold-anchor paragraph span, plus a negative skip-on-None regex backstop.
- Wired as `--check-stale-label-disposition` + no-flags default bundle + module-docstring bullet.
- 12 tests: live-tree pass, reflow + span-end-decoy fixture, 6 synthetic FAILs (missing clause / skip-on-None / duplicate anchor / split paragraph / missing paragraph / missing file), EOF-fallback pin, and two mutation-verified wiring tests (main([]) + dedicated-flag isolation).

## Test plan
- [x] Step 9c touched subset: 2381 passed, 6 skipped (rc=0)
- [x] `workflow_lint.py` no-flags + dedicated-flag runs PASS on live tree
- [x] ruff check + format clean on both touched files
- [x] Review: Claude PASS / Codex FAIL → reconciler binding PASS; concern closed in r2 (mutation-verified isolation test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)