### PR TITLE
task #979: watcher USER-PAUSE prose-hold exemption

### DIFF
--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -827,6 +827,22 @@ _FOLLOWUP_ROUND_REPARK_NOTE_SENTINEL = "[autonomous_session_watch:followup-round
 # and exiting.
 _SPEND_APPROVAL_SKIP_NOTE_SENTINEL = "[autonomous_session_watch:spend-approval-skip]"
 
+# Substring stamped into the one-time alert the stalled / orphan-respawn passes
+# post when they would have respawned a task whose latest word is a PROSE
+# "USER PAUSE" hold note — a non-watcher note beginning with the literal
+# ``USER PAUSE`` (any marker kind) with no real progress marker strictly newer.
+# A prose-only hold is the documented anti-pattern (the durable affordance is
+# ``task.py set-status <N> on_hold`` per SKILL.md § User pause affordance); this
+# exemption is defense-in-depth for sessions that still post one. Deduped
+# self-containedly in the events log: suppressed when a marker carrying this
+# sentinel already exists at/after the latest pause note (a fresh pause note
+# re-arms the alert). Same staleness-filter contract as the others. Incident:
+# task #816, 2026-07-02 — a session posted a prose ``USER PAUSE ...`` hold
+# (epm:progress, 06:44Z) and left the task at the ACTIVE status ``running``;
+# the orphan-respawn pass cannot parse prose and respawned against the hold
+# (attempt 1/2, 08:33Z).
+_USER_PAUSE_SKIP_NOTE_SENTINEL = "[autonomous_session_watch:user-pause-hold-skip]"
+
 # Substring stamped into the one-time alert the session-reconcile pass posts
 # (only in the EPM_SESSION_RECONCILE_AUTOSTOP=0 alert-only fallback) when a
 # live session has outlived its parked/terminal (awaiting_promotion/
@@ -963,6 +979,7 @@ _WATCHER_NOTE_SENTINELS: frozenset[str] = frozenset(
         _FOLLOWUPS_AWAITING_CHILD_NOTE_SENTINEL,
         _FOLLOWUP_ROUND_REPARK_NOTE_SENTINEL,
         _SPEND_APPROVAL_SKIP_NOTE_SENTINEL,
+        _USER_PAUSE_SKIP_NOTE_SENTINEL,
         _SESSION_RECONCILE_ALERT_NOTE_SENTINEL,
         _SESSION_RECONCILE_STOP_NOTE_SENTINEL,
         _SESSION_RECONCILE_STOP_FAILED_NOTE_SENTINEL,
@@ -7123,6 +7140,131 @@ def _spend_approval_skip_already_noted(events: list[dict]) -> bool:
     return False
 
 
+# Anchored, case-SENSITIVE prefix of a prose user-pause hold note (incident
+# #816). All four observed hold variants (the canonical SKILL.md durable-park
+# note, the #816 incident note, the older #919 sketch, the #920 chat note)
+# begin with this literal; every observed quote-class marker carries it
+# mid-note only, so the anchor separates real holds from quotes. Lowercase
+# "user pause ..." occurs in ordinary discussion prose and must NOT arm the
+# probe — the match is deliberately case-sensitive.
+_USER_PAUSE_NOTE_PREFIX = "USER PAUSE"
+
+
+def _latest_user_pause_ts(events: list[dict]) -> float | None:
+    """Newest epoch ts among non-watcher events whose note BEGINS with
+    ``USER PAUSE`` (anchored prefix, case-sensitive, ANY marker kind) — the
+    prose-hold shape of incident #816. Watcher-sentinel notes are excluded
+    (defense against future alert-text drift; today's alert text begins with
+    the ``[autonomous_session_watch:...]`` sentinel so it cannot match the
+    anchor anyway). An event with an unparseable/absent ``ts`` is skipped —
+    fail direction: a ts-less pause note leaves the probe inert and the
+    respawn proceeds (the incident direction, alert-free)."""
+    best: float | None = None
+    for ev in events:
+        note = ev.get("note") or ""
+        if not note.lstrip().startswith(_USER_PAUSE_NOTE_PREFIX):
+            continue
+        if any(sentinel in note for sentinel in _WATCHER_NOTE_SENTINELS):
+            continue
+        ts = _parse_event_ts(ev.get("ts"))
+        if ts is not None and (best is None or ts > best):
+            best = ts
+    return best
+
+
+def _user_pause_hold_reason(events: list[dict]) -> str | None:
+    """Human-readable exemption reason when the latest word on the task is a
+    prose ``USER PAUSE`` hold (incident #816 defense-in-depth) — the newest
+    USER-PAUSE-prefixed non-watcher note is not superseded by any STRICTLY
+    newer real progress marker. Returns ``None`` when the exemption does not
+    apply. Pure over the already-loaded ``events`` — no subprocess.
+
+    Strict ``>`` is load-bearing: the pause note itself usually rides a
+    :data:`_PROGRESS_KINDS` kind (``epm:progress`` in the #816 incident,
+    ``epm:status-changed`` for the canonical durable-park note), so it
+    SELF-INCLUDES in :func:`_latest_progress_ts` — ``progress_ts == pause_ts``
+    means "the pause IS the latest word" and must keep suppressing.
+
+    Fail directions, both deliberate: (a) a pause note with an unparseable
+    ``ts`` leaves the probe inert (respawn proceeds — the incident direction);
+    (b) outside the canonical resume paths (the SKILL.md ``set-status``
+    resume posts ``epm:status-changed``; a resumed live session posts real
+    progress markers; a REGISTERED session bypasses the orphan probe
+    entirely), suppression persists until ANY real progress marker,
+    set-status, fresh pause note, or registered spawn lands — the one-time
+    alert is the only signal in that window.
+
+    Note the CANONICAL durable-park note (SKILL.md § User pause affordance)
+    also begins ``USER PAUSE`` (on the ``set-status <N> on_hold``
+    ``epm:status-changed`` row) and arms this probe HARMLESSLY: ``on_hold``
+    is in the watcher PARK set, so a durably-parked task is never
+    orphan-evaluated in the first place."""
+    pause_ts = _latest_user_pause_ts(events)
+    if pause_ts is None:
+        return None
+    progress_ts = _latest_progress_ts(events)
+    if progress_ts is not None and progress_ts > pause_ts:
+        # A real (non-watcher) progress marker STRICTLY newer than the pause
+        # note — the hold was resumed / superseded; do not suppress.
+        return None
+    return (
+        "prose USER PAUSE hold (a non-watcher note beginning 'USER PAUSE' is "
+        "the latest word — no real progress marker postdates it): a "
+        "deliberate user hold the watcher must not respawn against "
+        "(incident #816); the durable fix is the SKILL.md pause procedure "
+        "(pod stop first, then task.py set-status <N> on_hold)"
+    )
+
+
+def _user_pause_skip_already_noted(events: list[dict]) -> bool:
+    """True iff a marker carrying :data:`_USER_PAUSE_SKIP_NOTE_SENTINEL`
+    already exists with ts >= the latest USER-PAUSE note — the self-contained
+    once-per-episode dedup (no extra state field); a FRESH pause note (a later
+    ts) re-arms the alert. Mirror of
+    :func:`_spend_approval_skip_already_noted` (the ``>=`` here vs its ``>``
+    is deliberate: a skip alert posted the same second as the pause note
+    still dedups)."""
+    pause_ts = _latest_user_pause_ts(events)
+    if pause_ts is None:
+        return False
+    for ev in events:
+        note = ev.get("note") or ""
+        if _USER_PAUSE_SKIP_NOTE_SENTINEL not in note:
+            continue
+        ts = _parse_event_ts(ev.get("ts"))
+        if ts is not None and ts >= pause_ts:
+            return True
+    return False
+
+
+def _maybe_post_user_pause_skip(issue: int, reason: str, events: list[dict], dry_run: bool) -> None:
+    """Post the one-time user-pause-hold-skip alert (events-log dedup via
+    :func:`_user_pause_skip_already_noted`). Shared by the orphan handler and
+    the stalled-pass branch so both arms stay under the C901 cap and share
+    one episode-dedup. The resume-recipe example deliberately does NOT begin
+    with the bare ``USER PAUSE`` literal — a resume note that did would
+    re-arm the very probe it resumes."""
+    if _user_pause_skip_already_noted(events):
+        return
+    _post_progress_marker(
+        issue,
+        f"{_USER_PAUSE_SKIP_NOTE_SENTINEL} {reason}. "
+        f"Respawn suppressed (does NOT consume the daily respawn budget). "
+        f"A prose-only hold is NOT durable — make it durable per "
+        f".claude/skills/issue/SKILL.md § User pause affordance: "
+        f"CRON-TEARDOWN + stop any RUNNING pod FIRST "
+        f"(`pod.py stop --issue {issue}`), THEN "
+        f'`task.py set-status {issue} on_hold --note "USER PAUSE '
+        f"(verbatim: '...'); paused_from=<status>; resume: ...\"` as the "
+        f"commit point. To resume instead: post a real progress note that "
+        f"does NOT begin with 'USER PAUSE' "
+        f"(`task.py post-marker {issue} epm:progress --note '<resume note>'`) "
+        f"or `spawn_session.py spawn-issue --issue {issue} --auto`.",
+        dry_run,
+        label="user-pause-hold-skip",
+    )
+
+
 def _post_followup_run_marker(issue: int, events: list[dict], dry_run: bool) -> bool:
     """Post the ``epm:same-issue-followup-run v1`` completion marker for the
     round the watcher just re-parked, closing the round's
@@ -8012,7 +8154,8 @@ def _apply_stalled_followups_exemption(
     dry_run: bool,
 ) -> tuple[str, int, bool]:
     """Check the alive-but-stalled exemptions for the stalled-detector pass
-    (the over-cap spend-approval park, the round-complete re-park, and the
+    (the prose USER-PAUSE hold, the over-cap spend-approval park, the
+    round-complete re-park, and the
     followups_running-parent-waiting-on-open-child suppression); rewrite
     ``(action, new_missed, followups_child_alerted)`` accordingly.
 
@@ -8029,6 +8172,23 @@ def _apply_stalled_followups_exemption(
     """
     if action == "keep" and new_missed == 0:
         return action, new_missed, followups_child_alerted
+    # Prose USER-PAUSE hold (incident #816, 2026-07-02): the latest word on
+    # the task is a non-watcher note beginning 'USER PAUSE' — a deliberate
+    # user hold left at an ACTIVE status (the prose-only anti-pattern; the
+    # durable affordance is set-status on_hold). Checked FIRST — an explicit
+    # user directive is the most specific gate signal; both this and the
+    # spend-approval arm are alert-only, so ordering only selects the more
+    # actionable alert text. Dedup'd in the events log via
+    # _user_pause_skip_already_noted, so no per-pass state flag is threaded.
+    pause_reason = _user_pause_hold_reason(events)
+    if pause_reason is not None:
+        print(
+            f"  issue #{issue}: ALIVE-BUT-STALLED exemption — {pause_reason}; "
+            f"treating session as parked this tick (would have been "
+            f"action={action})."
+        )
+        _maybe_post_user_pause_skip(issue, pause_reason, events, dry_run)
+        return "keep", 0, followups_child_alerted
     # Over-cap spend-approval park (incident #653, 2026-06-18): the latest
     # non-watcher event is `epm:awaiting-spend-approval` (a 132 GPU-h plan over
     # the 100h auto-approve cap), and the status-hold variant (SKILL.md Step 9b)
@@ -9294,10 +9454,11 @@ def _check_orphan_followups_exemption(
     events: list[dict],
     action: str,
 ) -> tuple[str, str | None]:
-    """Probe the followups_running-parent-waiting-on-open-child exemption
-    for the orphan-sweep pass. Returns the (possibly rewritten) ``action``
-    plus the human-readable reason string (for the alert prose) or
-    ``None`` when the exemption does not apply.
+    """Probe the orphan-sweep exemptions (the prose USER-PAUSE hold, the
+    over-cap spend-approval park, the round-complete re-park, and the
+    followups_running-parent-waiting-on-open-child suppression). Returns the
+    (possibly rewritten) ``action`` plus the human-readable reason string
+    (for the alert prose) or ``None`` when no exemption applies.
 
     No-op unless ``action == "respawn"`` (the only orphan action whose
     fallout is wasteful in this regime) so a healthy task / a manual-only
@@ -9307,6 +9468,22 @@ def _check_orphan_followups_exemption(
     """
     if action != "respawn":
         return action, None
+    # Prose USER-PAUSE hold (incident #816, 2026-07-02): the incident arm —
+    # #816's respawn was an orphan-respawn against a prose 'USER PAUSE' note
+    # left at the ACTIVE status `running`. Mirror of the same exemption in
+    # :func:`_apply_stalled_followups_exemption`; checked FIRST (an explicit
+    # user directive is the most specific gate signal — both arms are
+    # alert-only, so ordering only picks which alert text posts). Diverted to
+    # a one-time alert that does NOT consume the daily respawn budget. Pure
+    # (events-only, never consults _task_children); the dispatch posts the
+    # marker.
+    pause_reason = _user_pause_hold_reason(events)
+    if pause_reason is not None:
+        print(
+            f"  issue #{issue}: ORPHAN-RESPAWN exemption — {pause_reason}; "
+            f"diverting to alert-only (does NOT consume respawn budget)."
+        )
+        return "user-pause-hold-skip", pause_reason
     # Over-cap spend-approval park (incident #653, 2026-06-18): mirror of the
     # same exemption in :func:`_apply_stalled_followups_exemption`. The
     # status-hold variant keeps the task at the ACTIVE status
@@ -9476,12 +9653,53 @@ def _handle_orphan_spend_approval_skip(
         )
 
 
+def _handle_orphan_user_pause_skip(
+    *,
+    issue: int,
+    reason: str,
+    new_missed: int,
+    alerted: bool,
+    respawn_day: str,
+    respawns_today: int,
+    followups_child_alerted: bool,
+    events: list[dict],
+    state: dict,
+    dry_run: bool,
+) -> None:
+    """Orphan-sweep handler for the prose USER-PAUSE hold exemption (incident
+    #816): post the one-time alert (events-log dedup via
+    :func:`_maybe_post_user_pause_skip`) and persist state WITHOUT
+    incrementing ``respawns_today`` — the exemption deliberately does NOT
+    consume the daily respawn budget. Dedup is self-contained in the events
+    log (a marker carrying :data:`_USER_PAUSE_SKIP_NOTE_SENTINEL` at/after
+    the latest pause note), so no per-pass state flag is threaded; a fresh
+    pause note re-arms the alert. Mirror of
+    :func:`_handle_orphan_spend_approval_skip`. Factored out of
+    :func:`_process_orphan_task` to keep that function under the C901 cap."""
+    _maybe_post_user_pause_skip(issue, reason, events, dry_run)
+    if not dry_run:
+        _save_orphan_state(
+            issue,
+            missed=new_missed,
+            alerted=alerted,
+            respawn_day=respawn_day,
+            respawns_today=respawns_today,
+            followups_child_alerted=followups_child_alerted,
+            prev=state,
+        )
+
+
 # The orphan-sweep exemption actions: each diverts a would-be respawn to a
 # park-aware handler that does NOT consume the daily respawn budget. Dispatched
 # uniformly by :func:`_dispatch_orphan_exemption_action` to keep
 # :func:`_process_orphan_task` under the C901 cap (15).
 _ORPHAN_EXEMPTION_ACTIONS = frozenset(
-    {"spend-approval-skip", "followup-round-repark", "followups-awaiting-child"}
+    {
+        "user-pause-hold-skip",
+        "spend-approval-skip",
+        "followup-round-repark",
+        "followups-awaiting-child",
+    }
 )
 
 
@@ -9505,6 +9723,19 @@ def _dispatch_orphan_exemption_action(
     C901 cyclomatic-complexity cap (15)."""
     if action == "spend-approval-skip":
         _handle_orphan_spend_approval_skip(
+            issue=issue,
+            reason=followups_reason or "",
+            new_missed=new_missed,
+            alerted=alerted,
+            respawn_day=day_key,
+            respawns_today=respawns_today,
+            followups_child_alerted=followups_child_alerted,
+            events=events,
+            state=state,
+            dry_run=dry_run,
+        )
+    elif action == "user-pause-hold-skip":
+        _handle_orphan_user_pause_skip(
             issue=issue,
             reason=followups_reason or "",
             new_missed=new_missed,

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -5627,6 +5627,464 @@ def test_spend_approval_skip_sentinel_in_watcher_filter():
     assert _SPEND_APPROVAL_SKIP_NOTE_SENTINEL in _WATCHER_NOTE_SENTINELS
 
 
+# ─── prose USER-PAUSE hold exemption (incident #816, 2026-07-02) ──────────────
+# A session posted a prose-only `USER PAUSE ...` hold note (epm:progress) and
+# left the task at the ACTIVE status `running`; the orphan-respawn pass cannot
+# parse prose and respawned against the hold (attempt 1/2). The durable
+# affordance is `set-status on_hold` (#919); this exemption is defense-in-depth
+# for sessions that still post a prose hold. Test-fixture discipline: no
+# helper/test note below may begin with the bare `USER PAUSE` literal outside
+# the deliberate pause fixtures built by _make_user_pause_event.
+
+
+def _make_user_pause_event(
+    ts: str = "2026-07-03T06:44:44Z", note: str | None = None, kind: str = "epm:progress"
+) -> dict:
+    """Minimal prose USER-PAUSE hold row. Default note = the verbatim #816
+    incident prefix; callers pass ``note=`` for the other observed variants
+    (canonical SKILL.md durable-park format, the older #919 sketch). This
+    helper is the deliberate pause fixture — the only sanctioned source of
+    notes beginning with the bare literal."""
+    if note is None:
+        note = (
+            "USER PAUSE (2026-07-02, verbatim: 'pause 816'): session stopped at "
+            "user request. DO NOT resume, respawn, or auto-dispatch this task."
+        )
+    return {"ts": ts, "kind": kind, "version": 1, "by": "user", "note": note}
+
+
+def test_user_pause_hold_reason_fires_on_816_incident_shape():
+    # Incident-SHAPE replay of #816: the prose pause note, a NEWER
+    # watcher-sentinel respawn marker (sentinel-filtered out of
+    # _latest_progress_ts), and a NEWER parked epm:step-completed. Neither
+    # newer row disarms the hold — the exemption MUST fire. NOTE: the parked
+    # step-completed element is imported from the #653 spend-approval fixture
+    # shape — the raw #816 log has no post-pause step-completed; it is added
+    # here to pin that a parked re-post cannot disarm the hold either.
+    import autonomous_session_watch as asw
+
+    events = [
+        _make_user_pause_event("2026-07-03T06:44:44Z"),
+        {
+            "ts": "2026-07-03T08:33:00Z",
+            "kind": "epm:progress",
+            "note": f"{asw._ORPHAN_RESPAWN_NOTE_SENTINEL} active task auto-respawned (1/2)",
+        },
+        _make_step_completed_event(step="2c", exit_kind="parked", ts="2026-07-03T08:35:00Z"),
+    ]
+    reason = asw._user_pause_hold_reason(events)
+    assert reason is not None
+    assert "USER PAUSE" in reason
+    assert "#816" in reason
+
+
+def test_user_pause_hold_reason_fires_on_canonical_skill_format():
+    # The canonical SKILL.md § User pause affordance durable-park note rides
+    # the `set-status <N> on_hold` epm:status-changed row — the SECOND
+    # self-inclusion kind (epm:status-changed is in _PROGRESS_KINDS, so
+    # pause_ts == progress_ts and only the strict `>` keeps the hold armed).
+    # Arming here is harmless in production: on_hold is in the watcher PARK
+    # set, so a durably-parked task is never orphan-evaluated.
+    import autonomous_session_watch as asw
+
+    events = [
+        _make_user_pause_event(
+            ts="2026-07-03T06:44:44Z",
+            note=(
+                "USER PAUSE (verbatim: 'pause 42'); paused_from=running; "
+                "resume: user-greenlight only."
+            ),
+            kind="epm:status-changed",
+        )
+    ]
+    assert asw._user_pause_hold_reason(events) is not None
+
+
+def test_user_pause_hold_reason_fires_on_919_older_variant():
+    # The older #919 sketch variant (no parenthetical, no 'verbatim' literal)
+    # — the anchor is variant-agnostic by construction.
+    import autonomous_session_watch as asw
+
+    events = [
+        _make_user_pause_event(
+            note="USER PAUSE pause 42; resume: set-status 42 running + spawn-issue --auto."
+        )
+    ]
+    assert asw._user_pause_hold_reason(events) is not None
+
+
+def test_user_pause_hold_reason_ignores_mid_note_quote():
+    # The real quote carriers (the #979 clarify / #919 completion-audit /
+    # #920 triage-note shapes) carry the literal MID-note only — the anchored
+    # prefix must NOT match any of them.
+    import autonomous_session_watch as asw
+
+    events = [
+        {
+            "ts": "2026-07-03T10:00:00Z",
+            "kind": "epm:clarify",
+            "note": "Goal: grep the task's recent markers for a 'USER PAUSE'-shaped note.",
+        },
+        {
+            "ts": "2026-07-03T11:00:00Z",
+            "kind": "epm:completion-audit",
+            "note": "Ask 3: the watcher should recognize the USER PAUSE format — ADDRESSED.",
+        },
+        {
+            "ts": "2026-07-03T12:00:00Z",
+            "kind": "epm:progress",
+            "note": "external-markers-triaged: 1 applied (the USER PAUSE hold format note).",
+        },
+    ]
+    assert asw._user_pause_hold_reason(events) is None
+
+
+def test_user_pause_hold_reason_self_disarms_on_real_progress():
+    # A real _PROGRESS_KINDS marker STRICTLY newer than the pause note (the
+    # canonical resume path posts epm:status-changed) disarms the hold so
+    # respawn coverage resumes.
+    import autonomous_session_watch as asw
+
+    events = [
+        _make_user_pause_event("2026-07-03T06:44:44Z"),
+        {
+            "ts": "2026-07-03T09:00:00Z",
+            "kind": "epm:status-changed",
+            "note": "status running -> running (resumed by user)",
+        },
+    ]
+    assert asw._user_pause_hold_reason(events) is None
+
+
+def test_user_pause_hold_reason_inert_without_pause_note():
+    # No anchored pause note anywhere = not the prose-hold shape.
+    import autonomous_session_watch as asw
+
+    events = [
+        _make_step_completed_event(step="10", exit_kind="parked"),
+        {
+            "ts": "2026-07-03T09:00:00Z",
+            "kind": "epm:progress",
+            "note": "round 2 implementing",
+        },
+    ]
+    assert asw._user_pause_hold_reason(events) is None
+
+
+def test_user_pause_skip_already_noted_dedup():
+    # Self-contained events-log dedup: a skip marker at/after the gating pause
+    # note means this episode's alert already fired; an OLDER one (prior
+    # episode) does NOT count, so a fresh pause note re-arms the alert.
+    import autonomous_session_watch as asw
+
+    pause = _make_user_pause_event("2026-07-03T06:44:44Z")
+    newer_skip = {
+        "ts": "2026-07-03T06:50:00Z",
+        "kind": "epm:progress",
+        "note": f"{asw._USER_PAUSE_SKIP_NOTE_SENTINEL} prose hold — respawn suppressed.",
+    }
+    older_skip = {
+        "ts": "2026-07-03T00:00:00Z",
+        "kind": "epm:progress",
+        "note": f"{asw._USER_PAUSE_SKIP_NOTE_SENTINEL} prose hold — respawn suppressed.",
+    }
+    assert asw._user_pause_skip_already_noted([pause, newer_skip]) is True
+    assert asw._user_pause_skip_already_noted([pause, older_skip]) is False
+    assert asw._user_pause_skip_already_noted([newer_skip]) is False  # no pause note
+
+
+def test_check_orphan_followups_exemption_returns_user_pause_skip(monkeypatch):
+    # Orphan pass: a prose-paused task with no live registered session
+    # rewrites respawn -> "user-pause-hold-skip" WITHOUT consulting children
+    # (the pause probe is checked first and is events-only); any other action
+    # passes through unchanged.
+    import autonomous_session_watch as asw
+
+    def _boom(issue):
+        raise AssertionError("_task_children must not be consulted on the user-pause path")
+
+    monkeypatch.setattr(asw, "_task_children", _boom)
+    pause_events = [_make_user_pause_event("2026-07-03T06:44:44Z")]
+    action, reason = asw._check_orphan_followups_exemption(
+        issue=816,
+        status="running",
+        has_pod=False,
+        events=pause_events,
+        action="respawn",
+    )
+    assert action == "user-pause-hold-skip"
+    assert reason is not None
+    assert "USER PAUSE" in reason
+
+    # Non-respawn actions pass through unchanged (the early return).
+    action2, reason2 = asw._check_orphan_followups_exemption(
+        issue=816,
+        status="running",
+        has_pod=False,
+        events=pause_events,
+        action="keep",
+    )
+    assert (action2, reason2) == ("keep", None)
+
+
+def test_user_pause_checked_before_spend_approval():
+    # Ordering pin: events carrying BOTH a prose pause note and a
+    # spend-approval park route to the pause action (checked FIRST — the most
+    # specific gate signal; its alert carries the actionable durable-fix
+    # recipe).
+    import autonomous_session_watch as asw
+
+    events = [
+        _make_spend_approval_event("2026-07-03T06:00:00Z"),
+        _make_user_pause_event("2026-07-03T06:44:44Z"),
+    ]
+    action, reason = asw._check_orphan_followups_exemption(
+        issue=816,
+        status="followups_running",
+        has_pod=False,
+        events=events,
+        action="respawn",
+    )
+    assert action == "user-pause-hold-skip"
+    assert reason is not None
+
+
+def test_handle_orphan_user_pause_skip_posts_once_and_skips_budget(isolated_registry, monkeypatch):
+    # The orphan handler MUST (a) post the one-time alert dedup'd via the
+    # events log, naming the durable-park recipe (stable substring `on_hold`);
+    # (b) persist state WITHOUT incrementing respawns_today.
+    import autonomous_session_watch as asw
+
+    posted: list[tuple[int, str, str]] = []
+    monkeypatch.setattr(
+        asw,
+        "_post_progress_marker",
+        lambda issue, note, dry_run, *, label: posted.append((issue, note, label)),
+    )
+    pause_events = [_make_user_pause_event("2026-07-03T06:44:44Z")]
+    asw._handle_orphan_user_pause_skip(
+        issue=816,
+        reason="prose USER PAUSE hold",
+        new_missed=2,
+        alerted=False,
+        respawn_day="2026-07-03",
+        respawns_today=0,
+        followups_child_alerted=False,
+        events=pause_events,
+        state={},
+        dry_run=False,
+    )
+    assert len(posted) == 1
+    assert posted[0][0] == 816
+    assert posted[0][2] == "user-pause-hold-skip"
+    assert "on_hold" in posted[0][1]  # the durable-park recipe (AC3)
+    assert "does NOT consume the daily respawn budget" in posted[0][1]
+    state = asw._load_orphan_state(816)
+    assert state["respawns_today"] == 0  # NOT incremented
+
+    # Second call within the same episode: a skip marker now exists at/after
+    # the pause note -> dedup'd, alert MUST NOT re-post.
+    posted.clear()
+    pause_events_with_skip = [
+        *pause_events,
+        {
+            "ts": "2026-07-03T06:50:00Z",
+            "kind": "epm:progress",
+            "note": f"{asw._USER_PAUSE_SKIP_NOTE_SENTINEL} prose hold — respawn suppressed.",
+        },
+    ]
+    asw._handle_orphan_user_pause_skip(
+        issue=816,
+        reason="prose USER PAUSE hold",
+        new_missed=3,
+        alerted=False,
+        respawn_day="2026-07-03",
+        respawns_today=0,
+        followups_child_alerted=False,
+        events=pause_events_with_skip,
+        state=state,
+        dry_run=False,
+    )
+    assert posted == []
+    assert asw._load_orphan_state(816)["respawns_today"] == 0
+
+
+def test_apply_stalled_followups_exemption_rewrites_user_pause_respawn_to_keep(monkeypatch):
+    # The stalled-detector helper: an `action="respawn"` on a prose pause hold
+    # MUST become `action="keep"` with `new_missed=0` and the third element
+    # passed through unchanged (fixture passes followups_child_alerted=False
+    # IN, so the assert pins pass-through, not an unrelated flag), plus the
+    # one-time alert (events-log dedup).
+    import autonomous_session_watch as asw
+
+    posted: list[tuple[int, str, str]] = []
+    monkeypatch.setattr(
+        asw,
+        "_post_progress_marker",
+        lambda issue, note, dry_run, *, label: posted.append((issue, note, label)),
+    )
+    events = [
+        _make_user_pause_event("2026-07-03T06:44:44Z"),
+        _make_step_completed_event(step="2c", exit_kind="parked", ts="2026-07-03T06:45:00Z"),
+    ]
+    action, new_missed, child_alerted = asw._apply_stalled_followups_exemption(
+        issue=816,
+        status="running",
+        has_pod=False,
+        events=events,
+        action="respawn",
+        new_missed=2,
+        followups_child_alerted=False,
+        dry_run=False,
+    )
+    assert (action, new_missed, child_alerted) == ("keep", 0, False)
+    assert len(posted) == 1
+    assert posted[0][2] == "user-pause-hold-skip"
+    assert "on_hold" in posted[0][1]  # the durable-park recipe (AC3)
+
+    # Second call within the same episode: skip marker in events -> no re-post.
+    posted.clear()
+    events_with_skip = [
+        *events,
+        {
+            "ts": "2026-07-03T06:50:00Z",
+            "kind": "epm:progress",
+            "note": f"{asw._USER_PAUSE_SKIP_NOTE_SENTINEL} prose hold — respawn suppressed.",
+        },
+    ]
+    action2, new_missed2, _ = asw._apply_stalled_followups_exemption(
+        issue=816,
+        status="running",
+        has_pod=False,
+        events=events_with_skip,
+        action="respawn",
+        new_missed=2,
+        followups_child_alerted=False,
+        dry_run=False,
+    )
+    assert (action2, new_missed2) == ("keep", 0)
+    assert posted == []  # dedup'd via the events log
+
+
+def test_user_pause_skip_sentinel_in_watcher_filter():
+    # The skip alert marker must NEVER reset the staleness clock it is
+    # measured against — pin the sentinel into the shared exclusion set.
+    from autonomous_session_watch import (
+        _USER_PAUSE_SKIP_NOTE_SENTINEL,
+        _WATCHER_NOTE_SENTINELS,
+    )
+
+    assert _USER_PAUSE_SKIP_NOTE_SENTINEL in _WATCHER_NOTE_SENTINELS
+
+
+def test_user_pause_skip_in_orphan_exemption_actions_and_dispatch(monkeypatch):
+    # Routing pin: the action string is a member of the exemption set, and
+    # the dispatch routes it to the new handler with the reason forwarded.
+    import autonomous_session_watch as asw
+
+    assert "user-pause-hold-skip" in asw._ORPHAN_EXEMPTION_ACTIONS
+
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        asw,
+        "_handle_orphan_user_pause_skip",
+        lambda **kwargs: calls.append(kwargs),
+    )
+    asw._dispatch_orphan_exemption_action(
+        action="user-pause-hold-skip",
+        issue=816,
+        followups_reason="prose USER PAUSE hold",
+        events=[],
+        new_missed=1,
+        alerted=False,
+        day_key="2026-07-03",
+        respawns_today=0,
+        followups_child_alerted=False,
+        state={},
+        dry_run=True,
+    )
+    assert len(calls) == 1
+    assert calls[0]["issue"] == 816
+    assert calls[0]["reason"] == "prose USER PAUSE hold"
+    assert calls[0]["respawns_today"] == 0
+
+
+def test_user_pause_hold_reason_is_case_sensitive():
+    # [Must-Fix, statistics reconciler] A note beginning LOWERCASE
+    # `user pause ...` (ordinary discussion prose) must NOT arm the probe —
+    # kills the case-insensitive mutant the rest of the battery cannot catch.
+    import autonomous_session_watch as asw
+
+    events = [
+        {
+            "ts": "2026-07-03T06:44:44Z",
+            "kind": "epm:progress",
+            "note": "user pause requested? no — continuing with the planned round.",
+        }
+    ]
+    assert asw._user_pause_hold_reason(events) is None
+
+
+def test_user_pause_hold_reason_tie_with_distinct_marker_suppresses():
+    # Tie-pin: a DISTINCT real progress marker (epm:results) at ts exactly ==
+    # pause_ts must NOT disarm (strict `>` only) — kills the
+    # `>=`-with-pause-filtered mutant that the self-inclusion tests (1-3)
+    # cannot catch.
+    import autonomous_session_watch as asw
+
+    events = [
+        _make_user_pause_event("2026-07-03T06:44:44Z"),
+        {
+            "ts": "2026-07-03T06:44:44Z",
+            "kind": "epm:results",
+            "note": "eval numbers for round 1 landed",
+        },
+    ]
+    assert asw._user_pause_hold_reason(events) is not None
+
+
+def test_user_pause_hold_reason_inert_on_malformed_ts():
+    # A pause note with an absent / garbage ts leaves the probe INERT (fail
+    # direction: respawn proceeds — the incident direction, documented in the
+    # probe docstring), rather than crashing or arming with a bogus anchor.
+    import autonomous_session_watch as asw
+
+    events = [
+        _make_user_pause_event(ts=None),  # type: ignore[arg-type]
+        _make_user_pause_event(ts="not-a-timestamp"),
+    ]
+    assert asw._user_pause_hold_reason(events) is None
+
+
+def test_handle_orphan_user_pause_skip_dry_run_skips_state(isolated_registry, monkeypatch):
+    # dry_run=True: no _save_orphan_state write (state file absent), and the
+    # dry_run flag is forwarded to the alert post (_post_progress_marker owns
+    # the dry-run print semantics).
+    import autonomous_session_watch as asw
+
+    posted: list[tuple[int, str, bool, str]] = []
+    monkeypatch.setattr(
+        asw,
+        "_post_progress_marker",
+        lambda issue, note, dry_run, *, label: posted.append((issue, note, dry_run, label)),
+    )
+    asw._handle_orphan_user_pause_skip(
+        issue=816,
+        reason="prose USER PAUSE hold",
+        new_missed=2,
+        alerted=False,
+        respawn_day="2026-07-03",
+        respawns_today=0,
+        followups_child_alerted=False,
+        events=[_make_user_pause_event("2026-07-03T06:44:44Z")],
+        state={},
+        dry_run=True,
+    )
+    assert len(posted) == 1
+    assert posted[0][2] is True  # dry_run forwarded to the poster
+    assert asw._load_orphan_state(816) == {}  # no state write under dry_run
+
+
 def test_session_alive_ignores_worktree_cwd_zombies(isolated_registry):
     # The 2026-06-10 #518 regression: a superseded driver generation parked in
     # the issue worktree must NOT count as "alive" for the registered entry.


### PR DESCRIPTION
Closes task #979. Adds the user-pause-hold-skip exemption (probe + orphan/stalled arms + budget-free handler + 17 tests) to scripts/autonomous_session_watch.py. Plan: tasks/*/979/plans/plan.md (v3).