### PR TITLE
issue-977: port GCP #601 detached-workload sentinel wait to the RunPod launcher

### DIFF
--- a/src/explore_persona_space/backends/runpod.py
+++ b/src/explore_persona_space/backends/runpod.py
@@ -13,7 +13,11 @@ What this module ships (post slice 6):
 * ``prepare`` — currently a no-op (provision triggers bootstrap inline).
 * ``launch`` — delegates to ``scripts/pod_lifecycle.py provision`` via
   the existing subprocess entrypoint and returns a :class:`RunHandle`
-  built from the resulting ``pods_ephemeral.json`` row.
+  built from the resulting ``pods_ephemeral.json`` row. On the
+  backend-executed leg (#909) the rendered launcher chains the
+  success-gated completion-sentinel write and (#977) waits on fresh
+  detached ``/workspace/logs/*.pid`` workloads before the sentinel
+  write (GCP #601 parity).
 * ``estimate_start`` — returns "now" (UTC); RunPod pods come up within
   a few minutes, so a precise estimate would be noise.
 * ``poll`` — delegates to :func:`scripts.poll_pipeline.poll_once` so
@@ -408,6 +412,44 @@ def _render_launch_script(
     supersession semantics as the experimenter step-11.3 clear). The
     launcher exits with the workload's own rc so the exit status is
     unchanged by the chain.
+
+    Detached-workload wait before the sentinel write (#977, the GCP #601
+    parity — ``gcp.py``'s find-newer wait): ``workload_cmd`` is expected
+    to BLOCK until the workload completes; a SELF-DAEMONIZING command
+    (one that setsid-forks the real driver and returns at daemonize
+    time) would otherwise publish ``phase=done`` minutes into a
+    multi-hour run. So the rc==0 branch, BEFORE the sentinel write,
+    waits on every live pid found in a FRESH ``/workspace/logs/*.pid``
+    (mtime at or after the in-launcher workload-start epoch, captured
+    immediately before ``workload_cmd``). Contract (write-before-return):
+    a detached workload MUST write its driver pid to such a fresh
+    pidfile BEFORE ``workload_cmd`` returns — the ``launch_issue_<N>.sh``
+    convention — for the wait to bind; a pidfile written only AFTER
+    ``workload_cmd`` returns may be missed by the loop's scan and
+    degrades to the pre-#977 behavior (premature sentinel) — the same
+    residual GCP #601 carries, documented, not fixed here. Two deliberate
+    mechanism deltas from the GCP reference: freshness is the INCLUSIVE
+    ``stat -c %Y >= $WORKLOAD_START_EPOCH`` (the verify-script idiom;
+    GCP's strictly-newer ``find -newer`` would miss a pidfile written in
+    the same second as the start-mark at coarse MooseFS mtime
+    granularity), and self-exclusion is by PID VALUE
+    (``[ "$wpid" = "$$" ]``, race-free at any mtime granularity — the
+    launcher writes its OWN pid to the canonical pidfile pre-workload,
+    so a naive port would self-deadlock) rather than by pidfile PATH — a
+    convention-following detached driver OVERWRITES the canonical
+    pidfile with its own pid, so a path-based skip would miss exactly
+    the driver that must be waited on, while ``$$`` cannot be reused
+    while this launcher is alive. Blocking workloads write no fresh
+    pidfile, so the wait is a no-op pass-through. No in-script timeout
+    (faithful parity — an in-script timeout would re-create the
+    premature-done class on a slow-but-healthy run); the wait is bounded
+    externally by the pod TTL + the poller's stall escalation + the
+    watcher's pod-safety pass (the GCP analogue is
+    ``--max-run-duration``). The sentinel is written after the wait
+    regardless of the DETACHED process's exit status (``kill -0``
+    polling cannot recover a non-child's exit code on either lane; the
+    detached driver's own results sentinel / failure classification is
+    the poller's outcome channel).
     """
     launcher = _launcher_path(issue)
     epoch_file = _launch_epoch_path(issue)
@@ -450,11 +492,38 @@ def _render_launch_script(
             'export REPO_ROOT="${REPO_ROOT:-/workspace/explore-persona-space}"',
             f'export WANDB_PROJECT="${{WANDB_PROJECT:-issue{issue}}}"',
             f"echo $$ > {pid_file}",
+            "WORKLOAD_START_EPOCH=$(date +%s)",
             workload_cmd,
             "WORKLOAD_RC=$?",
             "# Completion sentinel: written ONLY when the workload exited 0 (the",
             "# backend-owned twin of the GCP/SLURM terminal sentinel write).",
             'if [ "$WORKLOAD_RC" -eq 0 ]; then',
+            "  # Wait for detached workloads (#601 GCP parity, #977): a workload_cmd",
+            "  # that self-daemonizes (forks the real driver) returns immediately —",
+            "  # writing the sentinel here would publish done at daemonize time.",
+            "  # (Comment says 'forks', not the s-word: the liveness tests token-scan",
+            "  # the rendered script for the detach line's own tokens.) Contract: a",
+            "  # detached workload writes its pid to a fresh /workspace/logs/*.pid",
+            "  # (the launch_issue_<N>.sh convention). Freshness = stat mtime >=",
+            "  # workload-start epoch (inclusive, the verify-script predicate — a",
+            "  # strictly-newer find would miss a same-second pidfile at MooseFS",
+            "  # mtime granularity). Self-exclusion is by PID VALUE, never path:",
+            "  # a convention-following driver OVERWRITES the canonical pidfile,",
+            "  # so a path skip would miss it, while $$ cannot be reused while",
+            "  # this launcher is alive. Blocking workloads write no fresh pidfile",
+            "  # -> no-op. Bounded externally by the pod TTL + the poller's stall",
+            "  # escalation (the GCP analogue is --max-run-duration).",
+            "  for pf in /workspace/logs/*.pid; do",
+            '    [ -f "$pf" ] || continue',
+            '    [ "$(stat -c %Y "$pf" 2>/dev/null || echo 0)"'
+            ' -ge "$WORKLOAD_START_EPOCH" ] || continue',
+            '    wpid=$(cat "$pf" 2>/dev/null) || continue',
+            '    [ -n "$wpid" ] || continue',
+            '    [ "$wpid" = "$$" ] && continue',
+            '    echo "[launcher] waiting on detached workload pid=$wpid ($pf)"',
+            '    while kill -0 "$wpid" 2>/dev/null; do sleep 30; done',
+            '    echo "[launcher] detached workload pid=$wpid exited"',
+            "  done",
             f"  mkdir -p {sentinel_dir}",
             f"  printf '%s\\n' '{sentinel_json}' > {sentinel_path}",
             "fi",

--- a/tests/test_runpod_workload_exec.py
+++ b/tests/test_runpod_workload_exec.py
@@ -409,6 +409,97 @@ def test_launcher_chains_sentinel_write_after_workload_success():
     assert payload == {"phase": "done", "issue": 909, "attempt_id": ATTEMPT}
 
 
+def test_launcher_waits_on_fresh_detached_pid_files_before_sentinel():
+    """The rc==0 branch waits on fresh detached ``/workspace/logs/*.pid``
+    workloads BEFORE the sentinel write (#977, the GCP #601 parity —
+    ``test_render_startup_script_workload_cmd_waits_on_detached_pid_files``
+    precedent). Pins: the in-launcher ``WORKLOAD_START_EPOCH`` capture sits
+    AFTER the self-pidfile write and IMMEDIATELY before the workload line;
+    ``WORKLOAD_RC=$?`` is ADJACENT to the workload line (an intervening
+    line would corrupt ``$?``); the freshness predicate renders as ONE
+    line carrying both ``stat -c %Y`` and the INCLUSIVE
+    ``-ge "$WORKLOAD_START_EPOCH"`` (pins the adjacent-string
+    concatenation); and the full ordering chain — pidfile-write <
+    epoch-capture < workload < rc-capture < rc==0 gate < for-loop <
+    freshness < cat < PID-VALUE self-exclusion < kill-0 wait < sentinel
+    printf < exit — holds inside the heredoc. A misordered self-exclusion
+    AFTER the kill-0 wait would deadlock the launcher on its own pid, so
+    the chain includes the exclusion index, not just its presence."""
+    script = _render_launch()
+    lines = script.splitlines()
+
+    heredoc_start = next(i for i, line in enumerate(lines) if "<< 'EPSEOF'" in line)
+    heredoc_end = lines.index("EPSEOF", heredoc_start + 1)
+
+    pid_idx = lines.index("echo $$ > /workspace/logs/issue-909.pid")
+    epoch_idx = lines.index("WORKLOAD_START_EPOCH=$(date +%s)")
+    workload_idx = lines.index(WORKLOAD)
+    rc_idx = lines.index("WORKLOAD_RC=$?")
+    gate_idx = next(i for i, line in enumerate(lines) if '"$WORKLOAD_RC" -eq 0' in line)
+    for_idx = lines.index("  for pf in /workspace/logs/*.pid; do")
+    fresh_idx = next(
+        i
+        for i, line in enumerate(lines)
+        if "stat -c %Y" in line and '-ge "$WORKLOAD_START_EPOCH"' in line
+    )
+    cat_idx = lines.index('    wpid=$(cat "$pf" 2>/dev/null) || continue')
+    excl_idx = lines.index('    [ "$wpid" = "$$" ] && continue')
+    wait_idx = lines.index('    while kill -0 "$wpid" 2>/dev/null; do sleep 30; done')
+    printf_idx = next(i for i, line in enumerate(lines) if line.strip().startswith("printf"))
+    exit_idx = lines.index('exit "$WORKLOAD_RC"')
+
+    # Epoch capture IMMEDIATELY before the workload; rc capture ADJACENT
+    # after it (any intervening line would corrupt $?).
+    assert epoch_idx == workload_idx - 1
+    assert rc_idx == workload_idx + 1
+
+    # Full ordering chain, all inside the heredoc (the wait sits strictly
+    # between the rc==0 gate and the sentinel write).
+    assert (
+        heredoc_start
+        < pid_idx
+        < epoch_idx
+        < workload_idx
+        < rc_idx
+        < gate_idx
+        < for_idx
+        < fresh_idx
+        < cat_idx
+        < excl_idx
+        < wait_idx
+        < printf_idx
+        < exit_idx
+        < heredoc_end
+    )
+
+
+def test_launcher_wait_loop_self_exclusion_is_by_pid_value_not_path():
+    """Self-exclusion in the #977 wait loop is by PID VALUE, never by
+    pidfile PATH (the deliberate plan §3.2 decision): the experimenter
+    ``launch_issue_<N>.sh`` convention has the detached driver OVERWRITE
+    the canonical ``/workspace/logs/issue-<N>.pid`` with its OWN pid, so
+    a path-based skip (``[ "$pf" = <canonical> ] && continue``) would
+    skip exactly the driver that must be waited on and reintroduce the
+    premature sentinel for the convention-following case — while ``$$``
+    cannot be reused as long as this launcher is alive, so the pid-value
+    compare is race-free at any mtime granularity. Pins the exclusion
+    line's presence AND that NO wait-loop line string-compares ``$pf``
+    against the canonical pidfile path, so a future "hardening" edit
+    cannot silently re-add the path skip."""
+    script = _render_launch()
+    lines = script.splitlines()
+
+    assert '    [ "$wpid" = "$$" ] && continue' in lines
+
+    for_idx = lines.index("  for pf in /workspace/logs/*.pid; do")
+    done_idx = lines.index("  done", for_idx)
+    canonical_pid_file = "/workspace/logs/issue-909.pid"
+    for line in lines[for_idx : done_idx + 1]:
+        assert not ("$pf" in line and canonical_pid_file in line), (
+            f"wait-loop line path-compares $pf against the canonical pidfile: {line!r}"
+        )
+
+
 def test_launch_script_rejects_single_quote_in_sentinel_json():
     """The single-quoted JSON embed fails LOUD on a caller bug rather than
     rendering a broken launcher."""


### PR DESCRIPTION
Closes task #977 (kind: infra workflow-fix).

## Summary
- Ports GCP's #601 find-newer sentinel wait-loop hardening to the RunPod backend-owned launcher (`_render_launch_script`): after a successful `workload_cmd` return, the launcher waits on fresh detached `/workspace/logs/*.pid` workloads (inclusive stat-epoch freshness; PID-value self-exclusion; `kill -0` + `sleep 30`) BEFORE writing the completion sentinel — closing the premature `phase=done` sentinel for self-daemonizing workloads.
- 2 new static test pins in `tests/test_runpod_workload_exec.py` (ordering chain incl. self-exclusion-before-wait; pid-value-not-path exclusion).

## Test plan
- [x] `uv run pytest tests/test_runpod_workload_exec.py -x` (25 passed)
- [x] Consumer sweep: `test_backend_poll.py test_runpod_wedge_detection.py test_backend_artifacts_verify.py` (128 passed)
- [x] Step 9c touched subset: 2366 passed / 2 pre-existing #923 trunk failures (attributed in epm:test-verdict)
- [x] ruff check + format clean; `workflow_lint --check-asks` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)