### PR TITLE
issue-981: rescope BPE-delimiter immunity claim to special-token boundaries (workflow-fix #981)

### DIFF
--- a/.claude/agent-memory/experiment-implementer/feedback_bpe_zero_width_span_plain_text_delimiters.md
+++ b/.claude/agent-memory/experiment-implementer/feedback_bpe_zero_width_span_plain_text_delimiters.md
@@ -15,8 +15,10 @@ turns; a downstream extractor's `1 <= s < e` span assert then crashes on
 production data (#825 run-1: conv 723, 3 attempts × ~21 min).
 
 **Why:** the tokenizer, not the text, defines the boundary; plain-text
-delimited formats ("User: ...\n\n") have NO merge-proof boundary. Chat
-templates are immune (special tokens never BPE-merge with content).
+delimited formats ("User: ...\n\n") have NO merge-proof boundary. Exposure
+is boundary-type-scoped, NOT format-scoped: special-token boundaries never
+BPE-merge with content, but plain-text delimiters are exposed everywhere
+they appear — including INSIDE a chat-templated message body.
 
 **How to apply:**
 - Any rig that generates free text and later aligns it as a delimited

--- a/.claude/agent-memory/experiment-implementer/feedback_zero_width_span_bpe_delimiter_merge.md
+++ b/.claude/agent-memory/experiment-implementer/feedback_zero_width_span_bpe_delimiter_merge.md
@@ -15,11 +15,14 @@ substitute a validated multi-token placeholder — single-token placeholders
 
 **Why:** #825 onpolicy-user-turn round — three production GCP attempts died at
 ~21 min each on `AssertionError: span u2=(201,201) invalid` (a bare-punctuation
-T=1.0 user turn merged into the naturalistic `\n\n` delimiter). Chat-template
-formats are immune (special tokens never BPE-merge).
+T=1.0 user turn merged into the naturalistic `\n\n` delimiter). Exposure is
+boundary-type-scoped, NOT format-scoped: special-token boundaries never
+BPE-merge, but plain-text delimiters are exposed everywhere they appear —
+including INSIDE a chat-templated message body.
 
-**How to apply:** any plain-text (non-special-token-delimited) render whose
-spans come from offset containment — naturalistic / chat-free formats,
+**How to apply:** any render whose spans come from offset containment over
+plain-text (non-special-token) delimiters — naturalistic / chat-free formats,
 few-shot plain-text prompts, `User:/Assistant:`-style rigs over sampled text
-at T>0. Run the consumer's span asserts tokenize-only at gen time; hard-fail
-or substitute before the GPU phase.
+at T>0, and plain-text delimiters INSIDE a chat-templated message body. Run
+the consumer's span asserts tokenize-only at gen time; hard-fail or
+substitute before the GPU phase.


### PR DESCRIPTION
Closes task #981 (kind: infra, workflow-fix, doc-only).

Rescopes the over-broad format-scoped claim ("Chat-template formats are immune") to special-token-BOUNDARY scope in both experiment-implementer agent-memory files, matching the canonical #929 MF2 gotchas bullet (.claude/rules/gotchas.md line 210) and naming the plain-text-delimiters-INSIDE-chat-template exposure.

- Plan: all-lens APPROVE (6/6 Claude+Codex critics) + consistency PASS
- Code-review: PASS+PASS (Claude + Codex), no blockers
- Test-verdict: PASS (2263 passed; 2 failures pre-existing on main — #923 debt, 0 introduced)

🤖 Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)