### PR TITLE
issue-984: VM-scope cross-ref on upload-policy env one-liner

### DIFF
--- a/.claude/rules/upload-policy.md
+++ b/.claude/rules/upload-policy.md
@@ -103,6 +103,11 @@ repo-files` only exposes `delete`, not `list`. Use:
 it the check dies on `HF_TOKEN missing`, and the obvious in-heredoc fix, a bare
 `load_dotenv()`, crashes from stdin; 4+ sessions on 2026-06-10 each burned 2-3
 retries re-deriving this)
+(the prefix is VM-scoped — repo root, where `.env` always exists; a pod/GCE
+workload script must source conditionally instead — `if [ -f ./.env ]; then
+set -a; . ./.env; set +a; fi` — because the GCE lane exports tokens via its
+startup script and has NO `.env` file; see the conditional-sourcing entry in
+`.claude/rules/gotchas.md`, incident #923)
 (#458 post-mortem nearly drew a wrong "checkpoints don't exist" conclusion from
 the silent CLI "0").
 


### PR DESCRIPTION
Closes task #984 (workflow-fix, #923 class). One parenthetical added to .claude/rules/upload-policy.md.