### PR TITLE
task #1010: thread disk requirement into RunPod CPU fallback (containerDiskInGb + refuse-on-infeasible)

### DIFF
--- a/.claude/rules/compute-backend-failover.md
+++ b/.claude/rules/compute-backend-failover.md
@@ -515,6 +515,26 @@ for the cheap intents and SUPERSEDES that terminal for them ONLY:
   terminal, NOT a RunPod fallback (the watcher's capacity-retry pass keys on
   `no_compute_available`, so the distinct reason means a structurally-unservable
   `cpu-bigmem` RunPod launch is never auto-retried).
+- **Footprint feasibility gate + disk threading (#1010, incident #958).** A
+  plan-STATED footprint (`spec.extra["boot_disk_gb"]` / `["min_ram_gb"]`, from
+  `dispatch_issue.py --boot-disk-gb` / `--min-ram-gb`) is checked at
+  `_runpod_terminal_rung` against `router.RUNPOD_CPU_INSTANCE_CAPS`
+  (probe-verified effective `containerDiskInGb` caps — cpu3g-2-8 → 20,
+  cpu3c-8-16 → 50 honored floor — plus fixed RAM); an unsatisfiable footprint
+  refuses BEFORE any RunPod API call with the typed
+  `CpuFallbackInfeasibleError` / `reason: cpu_fallback_infeasible_for_plan`
+  (a `CpuExhaustedNoRunpodLaneError` subclass; NOT in
+  `TRANSIENT_CAPACITY_REASONS` — the instance can never grow to fit the
+  plan). A feasible `boot_disk_gb` is THREADED into the provision argv
+  (`--container-disk-gb max(50, boot_disk_gb)`, `RunPodBackend.launch`), and
+  `pod_lifecycle`'s CPU branch clamps a default-band over-cap effective
+  payload to the instance cap (the untouched default effective 50 exceeds the
+  cpu3g cap — pre-#1010 every default cpu-small RunPod provision failed
+  validation) while an explicit above-band request refuses pre-API.
+  ADOPTION: launch composers pass `--boot-disk-gb` whenever a CPU stage sizes
+  disk > 50 GB and `--min-ram-gb` whenever it sizes RAM > 16 GB — flag-less
+  launches keep today's behavior (experimenter pre-launch gate as the sole
+  defense).
 
 Tests of record: `tests/test_router.py` (`test_router_cpu_small_capacity_miss_falls_over_to_runpod`,
 `test_router_cpu_intent_capacity_miss_no_runpod_fallback` — the cpu-bigmem

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,7 +263,7 @@ RunPod pods — used ONLY on the explicit `backend: runpod` lane (see Compute ba
 | `cpu-mid` | `e2-standard-8` (8 vCPU / 32 GB) | `cpu3c-8-16` (16 GB) | 8-vCPU CPU work between `cpu-small`'s fan-out and `cpu-bigmem`'s >50 GB analyses |
 | `cpu-bigmem` | `n2-highmem-16` (16 vCPU / 128 GB) | — (none) | >50 GB-footprint analyses; **no RunPod lane** — keeps the #677 `cpu_exhausted_no_runpod_lane` typed terminal |
 
-(The `cpu-mid` GCP/RunPod RAM differs — 32 GB vs 16 GB — by design: the RunPod lane is a capacity backstop, and a >16 GB CPU job should target `cpu-bigmem` anyway.)
+(The `cpu-mid` GCP/RunPod RAM differs — 32 GB vs 16 GB — by design: the RunPod lane is a capacity backstop, and a >16 GB CPU job should target `cpu-bigmem` anyway; a plan that STATES a larger footprint (`--boot-disk-gb` / `--min-ram-gb`) gets the disk threaded into `containerDiskInGb` and an unsatisfiable disk/RAM requirement refuses the fallback typed (`cpu_fallback_infeasible_for_plan`, #1010) instead of provisioning an undersized pod. ADOPTION: plan §9 / launch composers pass `--boot-disk-gb` whenever a CPU stage sizes disk > 50 GB and `--min-ram-gb` whenever it sizes RAM > 16 GB — the flags are what arm the gate; a flag-less launch keeps today's behavior with the experimenter pre-launch gate as the sole defense.)
 
 Override with `--gpu-type` / `--gpu-count`. `pod.py provision --list-intents` for the table.
 

--- a/scripts/backend_poll.py
+++ b/scripts/backend_poll.py
@@ -2261,6 +2261,18 @@ def _runspec_from_gcp_handle(handle, issue):
     # #909: thread repo_branch through so the RunPod re-execution syncs the
     # ISSUE branch, not `main` (per-issue dispatch scripts live on issue
     # branches). A legacy handle without the key still reconstructs.
+    # #1010: ALSO forward the footprint fields (boot_disk_gb / min_ram_gb)
+    # so the RunPod CPU-fallback feasibility gate + container-disk threading
+    # cover the async failover paths (#659 crash / #783 queue-timeout) —
+    # pre-#1010 the rebuilt extra carried ONLY repo_branch, so the gate would
+    # fail-OPEN there and the #958 shape could recur. Keys forwarded only when
+    # present/truthy, so a legacy handle reconstructs byte-identically.
+    rebuilt_extra: dict = {}
+    if extra.get("repo_branch"):
+        rebuilt_extra["repo_branch"] = extra["repo_branch"]
+    for key in ("boot_disk_gb", "min_ram_gb"):
+        if extra.get(key):
+            rebuilt_extra[key] = extra[key]
     return RunSpec(
         issue=int(issue),
         intent=extra.get("intent", "lora-7b"),
@@ -2269,7 +2281,7 @@ def _runspec_from_gcp_handle(handle, issue):
         time_budget_hours=extra.get("time_budget_hours"),
         workload_cmd=workload_cmd,
         hydra_args=hydra_args,
-        extra=({"repo_branch": extra["repo_branch"]} if extra.get("repo_branch") else {}),
+        extra=rebuilt_extra,
     )
 
 

--- a/scripts/dispatch_issue.py
+++ b/scripts/dispatch_issue.py
@@ -836,9 +836,19 @@ def _launch_extra_from_args(args: argparse.Namespace) -> dict[str, Any]:
         # --workload-cmd, so this key never rides a hydra launch.
         extra["execute_workload"] = True
     if getattr(args, "boot_disk_gb", None):
-        # GCP-only knob (backends/gcp.py:815 reads spec.extra["boot_disk_gb"]);
-        # inert on SLURM / RunPod lanes.
+        # GCP boot disk (backends/gcp.py reads spec.extra["boot_disk_gb"]);
+        # ALSO read by the RunPod CPU fallback as of #1010 — container-disk
+        # threading in RunPodBackend.launch + the feasibility gate in
+        # router._runpod_terminal_rung. Inert on SLURM lanes.
         extra["boot_disk_gb"] = int(args.boot_disk_gb)
+    if getattr(args, "min_ram_gb", None):
+        # RunPod-CPU-fallback knob (#1010): read by the feasibility gate in
+        # router._runpod_terminal_rung — RunPod CPU instances have FIXED RAM,
+        # so an unsatisfiable requirement refuses the fallback typed
+        # (reason: cpu_fallback_infeasible_for_plan) instead of provisioning
+        # an undersized pod. GCP machine selection is unchanged (by intent);
+        # inert on SLURM lanes.
+        extra["min_ram_gb"] = int(args.min_ram_gb)
     if getattr(args, "max_run_duration", None):
         # GCP-only knob: the instance-create renderer reads
         # spec.extra["max_run_duration"], falling back to the 7d
@@ -1785,11 +1795,29 @@ def _build_argparser() -> argparse.ArgumentParser:
         type=int,
         default=None,
         help=(
-            "GCP boot-disk size override in GB (GCP lane only; threads to "
-            "spec.extra['boot_disk_gb'], honored at backends/gcp.py:815). "
-            "Default 300 GB is too tight for full-FT checkpoint grids "
-            "(issue 606 needed 500: 13 consolidated ZeRO-3 ckpts ~= 195 GB "
-            "+ model + cache). Inert on non-GCP lanes."
+            "Boot/data disk size the plan's stage requires, in GB. GCP lane: "
+            "boot-disk size override (threads to spec.extra['boot_disk_gb'], "
+            "honored by backends/gcp.py; default 300 GB is too tight for "
+            "full-FT checkpoint grids — issue 606 needed 500: 13 consolidated "
+            "ZeRO-3 ckpts ~= 195 GB + model + cache). RunPod CPU fallback "
+            "(#1010): threaded into the pod's containerDiskInGb "
+            "(max(50, value)) and checked by the feasibility gate — an "
+            "unsatisfiable disk requirement refuses the fallback typed "
+            "(cpu_fallback_infeasible_for_plan) instead of provisioning an "
+            "undersized pod. Inert on SLURM lanes."
+        ),
+    )
+    launch.add_argument(
+        "--min-ram-gb",
+        type=int,
+        default=None,
+        help=(
+            "Minimum RAM (GB) the plan's CPU stage requires. Read by the "
+            "RunPod CPU fallback feasibility gate (#1010) — RunPod CPU "
+            "instances have FIXED RAM, so an unsatisfiable requirement "
+            "refuses the fallback with reason cpu_fallback_infeasible_for_plan "
+            "instead of provisioning an undersized pod. GCP machine selection "
+            "is unchanged (by intent). Inert on SLURM lanes."
         ),
     )
     launch.add_argument(

--- a/scripts/gpu_heuristics.py
+++ b/scripts/gpu_heuristics.py
@@ -118,6 +118,25 @@ def resolve_cpu_intent(intent: str) -> str | None:
     return _runpod_cpu_instances().get(intent.strip().lower())
 
 
+def resolve_cpu_instance_caps(intent: str):
+    """RunPodCpuInstanceCaps for a cheap CPU intent, else None (not a CPU intent).
+
+    SINGLE SOURCE OF TRUTH: the caps live next to the intent map in
+    ``explore_persona_space.backends.router.RUNPOD_CPU_INSTANCE_CAPS``
+    (#1010; mirrors the :func:`resolve_cpu_intent` lazy-import pattern).
+    A mapped intent whose instance_id has no caps row raises a loud
+    KeyError (the caps table is pinned complete by
+    tests/test_router.py::test_runpod_cpu_instance_caps_cover_every_mapped_instance),
+    never silently returns None.
+    """
+    from explore_persona_space.backends.router import RUNPOD_CPU_INSTANCE_CAPS
+
+    instance_id = resolve_cpu_intent(intent)
+    if instance_id is None:
+        return None
+    return RUNPOD_CPU_INSTANCE_CAPS[instance_id]
+
+
 def list_intents() -> str:
     """Return a printable table of known intents — for `--list-intents`.
 

--- a/scripts/pod_lifecycle.py
+++ b/scripts/pod_lifecycle.py
@@ -63,6 +63,7 @@ sys.path.insert(0, str(SCRIPT_DIR))
 from gpu_heuristics import (  # noqa: E402
     GpuSpec,
     list_intents,
+    resolve_cpu_instance_caps,
     resolve_cpu_intent,
     resolve_intent,
 )
@@ -77,6 +78,7 @@ from pod_config import (  # noqa: E402
     write_pods_conf,
 )
 from runpod_api import (  # noqa: E402
+    DEFAULT_CONTAINER_DISK_GB,
     DEFAULT_CPU_VOLUME_GB,
     PodInfo,
     RunPodError,
@@ -1747,11 +1749,48 @@ def cmd_provision(args: argparse.Namespace) -> None:
         # the cheap CPU default (DEFAULT_CPU_VOLUME_GB=40); an explicit non-200
         # value is always honored.
         cpu_volume_gb = DEFAULT_CPU_VOLUME_GB if args.volume_gb == 200 else args.volume_gb
+        # Effective-payload cap check (#1010, live probe 2026-07-04): RunPod
+        # validates deployCpuPod's EFFECTIVE container disk --
+        # max(container_disk_gb, volume_gb); runpod_api._deploy_cpu_once folds
+        # the CPU volume into containerDiskInGb -- against a per-flavor cap
+        # ("Container Disk must be less than or equal to 20" for cpu3g, 80 for
+        # cpu3c). The untouched defaults (container 50 / CPU volume 40 ->
+        # effective 50) EXCEED the cpu3g cap, so a default cpu-small provision
+        # fails validation outright. Rule: an over-cap effective payload in
+        # the DEFAULT band (<= 50, runpod_api.DEFAULT_CONTAINER_DISK_GB --
+        # covering untouched defaults AND the router-threaded
+        # `--container-disk-gb 50` floor, which MUST clamp-and-proceed, never
+        # refuse) is CLAMPED to the cap on BOTH knobs; an explicit request
+        # ABOVE the 50 band REFUSES pre-API (exit 1, same UX as the
+        # "Pod already exists" refusal above -- the cap is probe-verified, so
+        # RunPod would reject it anyway after a wasted API round-trip).
+        cpu_container_disk_gb = args.container_disk_gb
+        caps = resolve_cpu_instance_caps(args.intent)
+        effective_disk_gb = max(cpu_container_disk_gb, cpu_volume_gb)
+        if caps is not None and effective_disk_gb > caps.max_container_disk_gb:
+            if effective_disk_gb > DEFAULT_CONTAINER_DISK_GB:
+                print(
+                    f"Requested container/volume disk (effective "
+                    f"{effective_disk_gb} GB) exceeds the {cpu_instance_id} cap "
+                    f"({caps.max_container_disk_gb} GB effective containerDiskInGb; "
+                    f"RunPod create-time validation rejects it, #1010).\n"
+                    f"Shrink --container-disk-gb/--volume-gb to <= "
+                    f"{caps.max_container_disk_gb}, or route the big-footprint "
+                    f"stage to `--intent cpu-bigmem` (GCP n2-highmem)."
+                )
+                sys.exit(1)
+            print(
+                f"  Note (#1010): clamping container/volume disk (effective "
+                f"{effective_disk_gb} GB) -> {caps.max_container_disk_gb} GB "
+                f"({cpu_instance_id} validation cap; the default payload exceeds it)."
+            )
+            cpu_container_disk_gb = min(cpu_container_disk_gb, caps.max_container_disk_gb)
+            cpu_volume_gb = min(cpu_volume_gb, caps.max_container_disk_gb)
         info = create_cpu_pod(
             name=name,
             instance_id=cpu_instance_id,
             volume_gb=cpu_volume_gb,
-            container_disk_gb=args.container_disk_gb,
+            container_disk_gb=cpu_container_disk_gb,
         )
         print(f"  Created CPU pod {info.pod_id} — waiting for SSH (up to 10 min)...")
         _provision_wait_register_bootstrap(args, name, info, intent_label)

--- a/src/explore_persona_space/backends/gcp.py
+++ b/src/explore_persona_space/backends/gcp.py
@@ -4420,6 +4420,20 @@ class GcpBackend(ComputeBackend):
                 # serialize_handle's dict(handle.extra); every existing reader
                 # uses .get(...), so no consumer breaks.
                 "gpu_count": machine_for_intent(spec).gpu_count,
+                # #1010: footprint fields for the RunPod CPU-fallback
+                # feasibility gate + container-disk threading — forwarded by
+                # backend_poll._runspec_from_gcp_handle on the async failover
+                # paths (#659 crash / #783 queue-timeout). Keys OMITTED when
+                # absent/falsy — never a None value — so legacy handle shapes
+                # stay byte-identical.
+                **{
+                    k: v
+                    for k, v in {
+                        "boot_disk_gb": spec.extra.get("boot_disk_gb"),
+                        "min_ram_gb": spec.extra.get("min_ram_gb"),
+                    }.items()
+                    if v
+                },
             },
         )
         handle = self._with_artifacts_declaration(

--- a/src/explore_persona_space/backends/issue_dispatch.py
+++ b/src/explore_persona_space/backends/issue_dispatch.py
@@ -86,9 +86,11 @@ from explore_persona_space.backends.base import (
 )
 from explore_persona_space.backends.router import (
     ROUTE_REASON_CPU_EXHAUSTED_NO_RUNPOD,
+    ROUTE_REASON_CPU_FALLBACK_INFEASIBLE,
     ROUTE_REASON_RECONNECT,
     BackendPrepareError,
     CpuExhaustedNoRunpodLaneError,
+    CpuFallbackInfeasibleError,
     GcpAttemptCapExceededError,
     LeaseStore,
     ManualAttentionRequiredError,
@@ -445,6 +447,29 @@ def classify_terminal_exception(exc: BaseException) -> TerminalTranslation:
                 f"kind: {exc.kind}\n"
                 f"cluster: {exc.cluster}\n"
                 f"detail: {exc.reason}"
+            ),
+        )
+    if isinstance(exc, CpuFallbackInfeasibleError):
+        # #1010: the RunPod CPU lane EXISTS for this intent but cannot satisfy
+        # the plan's stated footprint (disk / RAM). Distinct reason so the
+        # marker trail names the real cause; like the parent, NOT in the
+        # watcher's TRANSIENT_CAPACITY_REASONS (the instance can never grow to
+        # fit the plan — auto-retry would loop a structurally-infeasible
+        # launch). MUST come BEFORE the CpuExhaustedNoRunpodLaneError branch
+        # (a subclass IS-A parent, so the parent check would shadow it — the
+        # same ordering rule documented on the branches below).
+        return TerminalTranslation(
+            failure_class="infra",
+            status="blocked",
+            note=(
+                "failure_class: infra\n"
+                f"reason: {ROUTE_REASON_CPU_FALLBACK_INFEASIBLE}\n"
+                "recovery: re-dispatch on the big-footprint CPU lane — "
+                "uv run python scripts/dispatch_issue.py launch --issue <N> "
+                "--intent cpu-bigmem ... (or shrink the plan footprint below "
+                "the instance cap)\n"
+                f"detail: {exc.reason}\n"
+                f"attempts: {json.dumps(exc.attempts, sort_keys=True)}"
             ),
         )
     if isinstance(exc, CpuExhaustedNoRunpodLaneError):

--- a/src/explore_persona_space/backends/router.py
+++ b/src/explore_persona_space/backends/router.py
@@ -131,7 +131,15 @@ RunPod-on-error, ``route(spec)`` orchestrates the full multi-backend ladder:
    ``cpu_exhausted_no_runpod_lane`` typed terminal VERBATIM (the >50 GB
    analysis lane has no cheap RunPod equivalent) — it does NOT fall over
    to RunPod. RunPod CPU pods are on-demand only; a CPU no-capacity miss
-   surfaces :class:`RunPodNoCapacityError` → terminal.
+   surfaces :class:`RunPodNoCapacityError` → terminal. As of #1010 the rung
+   also gates a plan-STATED footprint (``spec.extra["boot_disk_gb"]`` /
+   ``["min_ram_gb"]``) against :data:`RUNPOD_CPU_INSTANCE_CAPS`, raising the
+   typed :class:`CpuFallbackInfeasibleError`
+   (``reason: cpu_fallback_infeasible_for_plan``) BEFORE any RunPod API
+   call when the mapped instance cannot hold it, and
+   ``RunPodBackend.launch`` threads the disk requirement into the provision
+   argv (``--container-disk-gb max(50, boot_disk_gb)``) for mapped CPU
+   intents.
 8b. **GCP-only GPU intent translation (#940).** The RunPod launch paths
    (terminal rung + explicit override) translate a GCP-only GPU intent to
    its nearest same-or-narrower RunPod intent via
@@ -292,11 +300,68 @@ ROUTE_REASON_CPU_EXHAUSTED_NO_RUNPOD: str = "cpu_exhausted_no_runpod_lane"
 #: ``cpu-mid`` (``e2-standard-8`` = 8 vCPU / 32 GB) and the RunPod ``cpu-mid``
 #: (``cpu3c-8-16`` = 8 vCPU / 16 GB) differ in RAM by design — the RunPod lane
 #: is a CAPACITY backstop, and a >16 GB CPU job should target ``cpu-bigmem``
-#: anyway; the asymmetry is accepted, not a bug.
+#: anyway; the asymmetry is accepted, not a bug. As of #1010 a plan that
+#: STATES its footprint (``spec.extra["boot_disk_gb"]`` / ``["min_ram_gb"]``)
+#: is checked against the fixed capabilities in
+#: :data:`RUNPOD_CPU_INSTANCE_CAPS` by the feasibility gate in
+#: :func:`_runpod_terminal_rung` — an unsatisfiable footprint refuses the
+#: fallback typed (:class:`CpuFallbackInfeasibleError`) instead of
+#: provisioning an undersized pod (incident #958).
 RUNPOD_CPU_INSTANCE_FOR_INTENT: dict[str, str] = {
     "cpu-small": "cpu3g-2-8",  # 2 vCPU / 8 GB, gen-3 general purpose
     "cpu-mid": "cpu3c-8-16",  # 8 vCPU / 16 GB, gen-3 compute-optimized
 }
+
+
+@dataclass(frozen=True)
+class RunPodCpuInstanceCaps:
+    """Fixed capabilities of one mapped RunPod CPU instance (#1010)."""
+
+    vcpu: int
+    ram_gb: int
+    max_container_disk_gb: int
+
+
+#: Fixed capabilities of the mapped RunPod CPU instances (#1010, incident
+#: #958). RAM is fixed per instance_id (encoded in the id itself:
+#: ``<flavor>-<vCPU>-<RAM_GB>``, not threadable). ``max_container_disk_gb``
+#: bounds the EFFECTIVE ``deployCpuPod`` ``containerDiskInGb`` payload —
+#: ``max(container_disk_gb, volume_gb)``, because
+#: ``runpod_api._deploy_cpu_once`` folds the CPU volume request into the
+#: container disk (``deployCpuPodInput`` has no volume field).
+#: PROBE-VERIFIED 2026-07-04 (issue #1010, live ``deployCpuPod`` probes):
+#:   * ``cpu3g-2-8`` -> 20; verified_by: accept-reject-only — API validation
+#:     rejects effective 50 (today's untouched default payload) with
+#:     "Container Disk must be less than or equal to 20" (flavor cpu3g).
+#:     20 sits BELOW the 50 default, so this cap can only refuse — safe.
+#:   * ``cpu3c-8-16`` -> 50; verified_by: accept-reject-only — the API
+#:     ACCEPT bound is 80 (effective 80 accepted; effective 100 rejected
+#:     with "Container Disk must be less than or equal to 80", flavor
+#:     cpu3c), but no realized in-pod filesystem read was obtainable, so
+#:     the recorded cap is the empirically-HONORED floor: pod-958's
+#:     measured 50 GB overlay. An unverified value above the honored floor
+#:     would be an unverified ALLOW cap re-creating the #958 shape inside
+#:     the "accepted" band; a later df-verified probe may raise it to 80.
+#: Keys MUST cover every value of :data:`RUNPOD_CPU_INSTANCE_FOR_INTENT`
+#: (pinned by tests/test_router.py::
+#: test_runpod_cpu_instance_caps_cover_every_mapped_instance); the
+#: feasibility gate does a direct ``[]`` lookup so a missing row fails LOUD
+#: (KeyError), never silently skips the check.
+RUNPOD_CPU_INSTANCE_CAPS: dict[str, RunPodCpuInstanceCaps] = {
+    "cpu3g-2-8": RunPodCpuInstanceCaps(vcpu=2, ram_gb=8, max_container_disk_gb=20),
+    "cpu3c-8-16": RunPodCpuInstanceCaps(vcpu=8, ram_gb=16, max_container_disk_gb=50),
+}
+
+#: Reason token for a RunPod CPU fallback refused because the plan's STATED
+#: footprint (``spec.extra["boot_disk_gb"]`` / ``spec.extra["min_ram_gb"]``)
+#: exceeds the mapped instance's fixed capabilities (#1010, incident #958).
+#: Distinct-reason-per-distinct-cause is the established router pattern
+#: (:data:`ROUTE_REASON_CPU_EXHAUSTED_NO_RUNPOD` #677,
+#: :data:`ROUTE_REASON_GCP_QUEUE_TIMEOUT_FAILOVER_RUNPOD` #783): this intent
+#: HAS a RunPod lane — it just cannot hold this plan — so reusing the
+#: parent's "no runpod lane" token would mislead triage. Like the parent's
+#: reason, NOT in the watcher's ``TRANSIENT_CAPACITY_REASONS``.
+ROUTE_REASON_CPU_FALLBACK_INFEASIBLE: str = "cpu_fallback_infeasible_for_plan"
 
 #: GCP GPU intent -> the RunPod intent the terminal rung provisions (#940).
 #: TOTAL over the gpu_count>0 keys of gcp.INTENT_TO_MACHINE (identity rows
@@ -565,6 +630,28 @@ class CpuExhaustedNoRunpodLaneError(NoComputeAvailableError):
     ``TRANSIENT_CAPACITY_REASONS``) re-drives ONLY ``no_compute_available``; a
     structurally-unservable ``cpu-bigmem`` RunPod launch must NOT auto-retry (no
     lane will ever free up to make RunPod accept it). Inherits ``__init__``
+    verbatim (reason message + attempts).
+    """
+
+
+class CpuFallbackInfeasibleError(CpuExhaustedNoRunpodLaneError):
+    """Terminal: a mapped cheap CPU intent reached the RunPod terminal rung,
+    but the plan's STATED footprint (``spec.extra["boot_disk_gb"]`` /
+    ``spec.extra["min_ram_gb"]``) exceeds the mapped RunPod CPU instance's
+    fixed capabilities in :data:`RUNPOD_CPU_INSTANCE_CAPS` (#1010, incident
+    #958: an 80 GB-disk / 32 GB-RAM plan was dispatched onto a 50 GB / 16 GB
+    ``cpu3c-8-16`` pod and refused only AFTER a full paid provision cycle).
+
+    Subclass of :class:`CpuExhaustedNoRunpodLaneError` so every existing
+    catch site keeps working unchanged; ``classify_terminal_exception``
+    (``issue_dispatch.py``) maps it to the DISTINCT reason
+    :data:`ROUTE_REASON_CPU_FALLBACK_INFEASIBLE`
+    (``cpu_fallback_infeasible_for_plan``) — like the parent's reason, NOT in
+    the watcher's ``TRANSIENT_CAPACITY_REASONS``: the RunPod instance can
+    never grow to fit the plan, so auto-retry would loop a
+    structurally-infeasible launch. (GCP capacity COULD free up later, but
+    that sub-case is a deliberate manual re-dispatch decision — park-not-loop
+    matches today's experimenter-refusal end-state.) Inherits ``__init__``
     verbatim (reason message + attempts).
     """
 
@@ -2365,6 +2452,82 @@ def _skip_gcp_lane_no_headroom(
     )
 
 
+def _refuse_infeasible_cpu_footprint(
+    *,
+    spec: RunSpec,
+    machine_gpu_count: int,
+    attempts: list[RouteAttempt],
+    marker_poster: Callable[..., None] | None,
+    residual_gap: str,
+) -> None:
+    """Feasibility gate for the RunPod CPU fallback (#1010, incident #958).
+
+    The mapped RunPod CPU instance has FIXED RAM and a provider
+    container-disk cap (:data:`RUNPOD_CPU_INSTANCE_CAPS`, probe-verified); a
+    plan-stated footprint (``spec.extra["boot_disk_gb"]`` /
+    ``["min_ram_gb"]``) that exceeds them is deterministically infeasible —
+    refuse BEFORE the paid provision cycle by raising the typed
+    :class:`CpuFallbackInfeasibleError` (after posting the terminal marker
+    with :data:`ROUTE_REASON_CPU_FALLBACK_INFEASIBLE`). No stated
+    requirement (the common case) => both ints are 0 => no-op,
+    byte-identical to pre-#1010 routing. Called ONLY from
+    :func:`_runpod_terminal_rung`'s CPU branch, AFTER the #677 not-in-map
+    guard — the single placement that covers all four automated GCP→RunPod
+    paths (capacity fallback #656, sync workload failover #658, async
+    workload failover #659, queue-timeout failover #783). A GPU intent
+    (``machine_gpu_count > 0``) is a no-op.
+    """
+    if machine_gpu_count != 0:
+        return
+    instance_id = RUNPOD_CPU_INSTANCE_FOR_INTENT[spec.intent]
+    caps = RUNPOD_CPU_INSTANCE_CAPS[instance_id]  # missing row -> loud KeyError
+    extra = spec.extra or {}
+
+    def _footprint_int(key: str) -> int:
+        """spec.extra[key] as a non-negative int; 0 when absent/falsy.
+
+        A malformed (non-integral) value raises a ValueError NAMING the
+        key -- fail-loud with a diagnosable message, never a bare int()
+        traceback deep in the rung.
+        """
+        raw = extra.get(key) or 0
+        try:
+            return int(raw)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"spec.extra[{key!r}] is not an integer: {raw!r} "
+                f"(malformed footprint requirement on issue {spec.issue})"
+            ) from exc
+
+    required_disk_gb = _footprint_int("boot_disk_gb")
+    required_ram_gb = _footprint_int("min_ram_gb")
+    shortfalls: list[str] = []
+    if required_disk_gb > caps.max_container_disk_gb:
+        shortfalls.append(
+            f"disk: plan requires {required_disk_gb} GB > "
+            f"{instance_id} max container disk {caps.max_container_disk_gb} GB"
+        )
+    if required_ram_gb > caps.ram_gb:
+        shortfalls.append(
+            f"RAM: plan requires {required_ram_gb} GB > {instance_id} fixed {caps.ram_gb} GB"
+        )
+    if shortfalls:
+        _post_terminal_failure_marker(
+            spec=spec,
+            marker_poster=marker_poster,
+            reason=ROUTE_REASON_CPU_FALLBACK_INFEASIBLE,
+            chosen_kind="gcp",  # precedent: the #677 guard in the rung
+            attempts=attempts,
+        )
+        raise CpuFallbackInfeasibleError(
+            f"CPU intent {spec.intent!r}: RunPod CPU fallback ({instance_id}) "
+            f"cannot satisfy the plan footprint — {'; '.join(shortfalls)}. "
+            f"Route to cpu-bigmem (or shrink the footprint). "
+            f"residual_gap: {residual_gap}",
+            attempts=[_attempt_to_dict(a) for a in attempts],
+        )
+
+
 def _runpod_terminal_rung(
     *,
     spec: RunSpec,
@@ -2445,6 +2608,13 @@ def _runpod_terminal_rung(
             f"has no CPU fallback lane for this intent. residual_gap: {residual_gap}",
             attempts=[_attempt_to_dict(a) for a in attempts],
         )
+    _refuse_infeasible_cpu_footprint(
+        spec=spec,
+        machine_gpu_count=machine.gpu_count,
+        attempts=attempts,
+        marker_poster=marker_poster,
+        residual_gap=residual_gap,
+    )
     # #940: translate a GCP-only GPU intent (capture-7b / lora / lora-7b-h100)
     # to its RunPod-provisionable equivalent BEFORE building runpod_spec —
     # pod_lifecycle's gpu_heuristics.resolve_intent KeyErrors on a GCP-only
@@ -4999,6 +5169,7 @@ __all__ = [
     "ROUTE_REASON_AUTO_FALLBACK_GCP",
     "ROUTE_REASON_AUTO_STARTED",
     "ROUTE_REASON_CPU_EXHAUSTED_NO_RUNPOD",
+    "ROUTE_REASON_CPU_FALLBACK_INFEASIBLE",
     "ROUTE_REASON_GCP_QUEUE_TIMEOUT_FAILOVER_RUNPOD",
     "ROUTE_REASON_GCP_WORKLOAD_FAILOVER_RUNPOD",
     "ROUTE_REASON_GCP_WORKLOAD_FAILOVER_RUNPOD_ASYNC",
@@ -5008,11 +5179,13 @@ __all__ = [
     "ROUTE_REASON_RECONNECT",
     "ROUTE_REASON_RUNPOD_FALLBACK",
     "ROUTE_REASON_WORKLOAD_FAILURE",
+    "RUNPOD_CPU_INSTANCE_CAPS",
     "RUNPOD_CPU_INSTANCE_FOR_INTENT",
     "RUNPOD_INTENT_FOR_GCP_INTENT",
     "RUNPOD_INTENT_TRANSLATION_DELIBERATE_GAPS",
     "BackendPrepareError",
     "CpuExhaustedNoRunpodLaneError",
+    "CpuFallbackInfeasibleError",
     "GcpAttemptCapExceededError",
     "Lease",
     "LeaseStore",
@@ -5022,6 +5195,7 @@ __all__ = [
     "RouteError",
     "RouteResult",
     "RouterConfig",
+    "RunPodCpuInstanceCaps",
     "WorkloadSurfacedError",
     "auto_lane_order",
     "cancel_and_wait",

--- a/src/explore_persona_space/backends/runpod.py
+++ b/src/explore_persona_space/backends/runpod.py
@@ -85,6 +85,14 @@ logger = logging.getLogger(__name__)
 #: output; a one-shot foreground tail gets a bit more headroom).
 LOG_TAIL_LINES = 200
 
+#: Floor for the #1010 CPU-fallback container-disk threading in
+#: :meth:`RunPodBackend.launch` — mirrors ``runpod_api.DEFAULT_CONTAINER_DISK_GB``
+#: (50), the value an un-threaded provision gets, so threading a plan's
+#: ``boot_disk_gb`` can only ever GROW the container disk relative to
+#: today's default, never shrink it. (Not imported from ``scripts/runpod_api``
+#: — this module's imports stay ``base``-only by documented convention.)
+_CPU_CONTAINER_DISK_FLOOR_GB = 50
+
 
 def _shell_quote(s: str) -> str:
     """Single-quote ``s`` for a remote bash command (poor-man's shlex.quote).
@@ -752,6 +760,29 @@ class RunPodBackend(ComputeBackend):
         ]
         if spec.gpus is not None:
             cmd += ["--gpu-count", str(spec.gpus)]
+        # #1010: thread the plan's disk requirement into the RunPod CPU
+        # fallback's container disk (the pod's only writable disk on the CPU
+        # lane -- /workspace rides the overlay; incident #958). CPU intents
+        # ONLY: on GPU pods the big-data mount is the 200 GB /workspace
+        # VOLUME, not the container overlay, so boot_disk_gb does not map.
+        # Floored at runpod_api.DEFAULT_CONTAINER_DISK_GB (50,
+        # _CPU_CONTAINER_DISK_FLOOR_GB here) so threading can never REDUCE
+        # below today's behavior. The router's feasibility gate guarantees
+        # boot_disk_gb <= the instance cap on every AUTOMATED path; an
+        # explicit `backend: runpod` pin above the cap fails loud at
+        # pod_lifecycle's pre-API cap check / RunPod's own create-time
+        # validation.
+        boot_disk_gb = int((spec.extra or {}).get("boot_disk_gb") or 0)
+        if boot_disk_gb:
+            from explore_persona_space.backends.router import (
+                RUNPOD_CPU_INSTANCE_FOR_INTENT,  # lazy: module top stays base-only
+            )
+
+            if spec.intent in RUNPOD_CPU_INSTANCE_FOR_INTENT:
+                cmd += [
+                    "--container-disk-gb",
+                    str(max(_CPU_CONTAINER_DISK_FLOOR_GB, boot_disk_gb)),
+                ]
         # subprocess.run raises CalledProcessError on non-zero exit; that
         # propagates to the selector, which logs + lets the orchestrator
         # surface the failure as `epm:failure` (slice 1 does NOT add a

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -10509,6 +10509,24 @@ def test_capacity_retry_DOES_redrive_no_compute_available():
     assert reason == "no_compute_available"
 
 
+def test_cpu_fallback_infeasible_block_is_not_transient_capacity():
+    """#1010: a `cpu_fallback_infeasible_for_plan` block (the RunPod
+    CPU-fallback footprint-feasibility refusal, incident #958) is NOT a
+    transient-capacity block — the RunPod instance can never grow to fit the
+    plan, so the watcher's capacity-retry pass must never hot-retry it. The
+    #677 mirror: GREEN purely because the reason is NOT in
+    TRANSIENT_CAPACITY_REASONS (a future careless widening turns it RED)."""
+    import autonomous_session_watch as asw
+
+    note = "failure_class: infra\nreason: cpu_fallback_infeasible_for_plan"
+    ev = _fail_ev("2026-07-04T00:00:00Z", note)
+    retriable, reason, _block_ts = asw._is_transient_capacity_block([ev])
+    assert retriable is False
+    assert reason == "cpu_fallback_infeasible_for_plan"
+    # Downstream: always "skip", even out of backoff with the day-cap unspent.
+    assert decide_capacity_retry("blocked", retriable, _CR_NOW - 99999, None, 0, _CR_NOW) == "skip"
+
+
 # ── I/O-wrapper scoping: only transient-infra blocks re-driven, halts untouched ──
 
 

--- a/tests/test_backend_poll.py
+++ b/tests/test_backend_poll.py
@@ -2027,3 +2027,28 @@ def test_wedge_relaunch_workload_start_failure_stamps_and_repoints_sidecar(
     assert out2["reason"] == "runpod_workload_start_failed"
     assert "sidecar write ALSO failed" in out2["log_tail_excerpt"]
     assert stamps2 == [(775, wedged)]
+
+
+def test_runspec_from_gcp_handle_preserves_footprint_extra():
+    """#1010: the GCP-handle reconstructor forwards the footprint fields
+    (boot_disk_gb / min_ram_gb) into the rebuilt spec.extra so the RunPod
+    CPU-fallback feasibility gate + container-disk threading cover the ASYNC
+    failover paths (#659 crash / #783 queue timeout) — pre-#1010 only
+    repo_branch survived, so the gate failed OPEN there (the #958 shape).
+    A legacy handle WITHOUT the keys reconstructs byte-identically."""
+    from scripts import backend_poll as bp
+
+    handle = _gcp_handle({**_GCP_EXTRA_659, "boot_disk_gb": 80, "min_ram_gb": 32})
+    spec = bp._runspec_from_gcp_handle(handle, 659)
+    assert spec.extra.get("boot_disk_gb") == 80
+    assert spec.extra.get("min_ram_gb") == 32
+
+    # Legacy handle (no footprint keys, no repo_branch): pre-#1010 shape == {}.
+    legacy_spec = bp._runspec_from_gcp_handle(_gcp_handle(), 659)
+    assert legacy_spec.extra == {}
+
+    # Legacy handle with only repo_branch: pre-#1010 shape preserved verbatim.
+    branch_spec = bp._runspec_from_gcp_handle(
+        _gcp_handle({**_GCP_EXTRA_659, "repo_branch": "issue-909"}), 659
+    )
+    assert branch_spec.extra == {"repo_branch": "issue-909"}

--- a/tests/test_dispatch_issue_cli.py
+++ b/tests/test_dispatch_issue_cli.py
@@ -3750,3 +3750,41 @@ def test_cmd_launch_workload_start_failed_sidecar_write_oserror_fail_loud(
     assert "EDQUOT" in body["note"]
     # The typed failure's own message is still the note's lead.
     assert "did NOT verify alive" in body["note"]
+
+
+def test_min_ram_gb_lands_in_spec_extra(monkeypatch, tmp_path) -> None:
+    """#1010: ``--min-ram-gb`` threads to ``spec.extra['min_ram_gb']`` (the
+    RunPod CPU-fallback feasibility gate's RAM channel — RunPod CPU instances
+    have FIXED RAM, so an unsatisfiable requirement refuses the fallback
+    typed instead of provisioning an undersized pod). Mirror of the
+    ``--boot-disk-gb`` threading test above."""
+    _cd_to_tmp(monkeypatch, tmp_path)
+    gcp = _MockBackend(kind="gcp")
+    posts: list[dict[str, Any]] = []
+    factory = _build_mock_factory(gcp=gcp, marker_posts=posts)
+
+    from scripts.dispatch_issue import main
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = main(
+            [
+                "launch",
+                "--issue",
+                "1010",
+                "--intent",
+                "cpu-mid",
+                "--backend",
+                "gcp",
+                "--boot-disk-gb",
+                "80",
+                "--min-ram-gb",
+                "32",
+                "--hydra",
+                "smoke=1",
+            ],
+            backends_factory=factory,
+        )
+    assert rc == 0
+    assert gcp.launches[0].extra["min_ram_gb"] == 32
+    assert gcp.launches[0].extra["boot_disk_gb"] == 80

--- a/tests/test_issue_dispatch.py
+++ b/tests/test_issue_dispatch.py
@@ -1496,3 +1496,52 @@ def test_dispatch_for_issue_fresh_launch_with_workload_no_warning(
         )
     messages = [r.getMessage() for r in caplog.records]
     assert not any(_RECONNECT_WARNING_SNIPPET in m for m in messages), messages
+
+
+def test_cpu_fallback_infeasible_maps_to_distinct_reason() -> None:
+    """#1010: a CpuFallbackInfeasibleError maps to the DISTINCT reason
+    cpu_fallback_infeasible_for_plan — NOT the parent's
+    cpu_exhausted_no_runpod_lane and NOT no_compute_available — so the
+    watcher's capacity-retry pass never hot-retries a structurally-infeasible
+    launch, and the note carries the concrete cpu-bigmem recovery command.
+
+    Removing the isinstance branch (or placing it AFTER the parent
+    CpuExhaustedNoRunpodLaneError branch) turns this RED — the subclass would
+    be shadowed and emit the parent's reason."""
+    from explore_persona_space.backends.router import (
+        ROUTE_REASON_CPU_FALLBACK_INFEASIBLE,
+        CpuFallbackInfeasibleError,
+    )
+
+    exc = CpuFallbackInfeasibleError(
+        "CPU intent 'cpu-mid': RunPod CPU fallback (cpu3c-8-16) cannot satisfy "
+        "the plan footprint — disk: plan requires 80 GB > cpu3c-8-16 max "
+        "container disk 50 GB",
+        attempts=[{"kind": "gcp", "outcome": "capacity_miss"}],
+    )
+    t = classify_terminal_exception(exc)
+    assert t.failure_class == "infra"
+    assert t.status == "blocked"
+    assert f"reason: {ROUTE_REASON_CPU_FALLBACK_INFEASIBLE}" in t.note
+    assert "reason: cpu_exhausted_no_runpod_lane" not in t.note
+    assert "reason: no_compute_available" not in t.note
+    # The recovery line names the big-footprint lane.
+    assert "cpu-bigmem" in t.note
+    assert "detail: CPU intent 'cpu-mid'" in t.note
+
+
+def test_cpu_exhausted_parent_does_not_emit_infeasible_reason() -> None:
+    """#1010 control: the PARENT CpuExhaustedNoRunpodLaneError keeps its own
+    reason verbatim — the new subclass branch narrows, never widens."""
+    from explore_persona_space.backends.router import (
+        ROUTE_REASON_CPU_FALLBACK_INFEASIBLE,
+        CpuExhaustedNoRunpodLaneError,
+    )
+
+    exc = CpuExhaustedNoRunpodLaneError(
+        "CPU intent 'cpu-bigmem': GCP exhausted and RunPod has no CPU lane",
+        attempts=[],
+    )
+    t = classify_terminal_exception(exc)
+    assert "reason: cpu_exhausted_no_runpod_lane" in t.note
+    assert ROUTE_REASON_CPU_FALLBACK_INFEASIBLE not in t.note

--- a/tests/test_pod_lifecycle.py
+++ b/tests/test_pod_lifecycle.py
@@ -474,33 +474,114 @@ def test_cmd_provision_cpu_intent_routes_to_create_cpu_pod(
     assert cpu_provision_stubs["gpu_create_calls"] == 0
 
 
-def test_cmd_provision_cpu_small_default_volume_is_cpu_default(
-    isolated_state, stub_list_team_pods, cpu_provision_stubs
+@pytest.mark.parametrize(
+    ("intent", "expected_volume_gb"),
+    [
+        # cpu-small: CPU default 40, then clamped to the cpu3g cap (20) by the
+        # #1010 effective-payload clamp (the untouched default effective 50
+        # exceeds the 20 GB validation cap — pre-#1010 RunPod REJECTED every
+        # default cpu-small provision outright).
+        ("cpu-small", 20),
+        # cpu-mid: CPU default 40 rides through unclamped (effective 50 == cap).
+        ("cpu-mid", 40),
+    ],
+)
+def test_cmd_provision_cpu_default_volume_is_cpu_default(
+    isolated_state, stub_list_team_pods, cpu_provision_stubs, intent, expected_volume_gb
 ):
-    """`provision --intent cpu-small` with no explicit --volume-gb uses the
-    cheap CPU default (40 GB), not the 200 GB GPU argparse default (#747 minor
-    fix). A 200 GB persistent volume on a cents/hr CPU pod defeats the lane."""
+    """`provision --intent cpu-*` with no explicit --volume-gb never uses the
+    200 GB GPU argparse default (#747 minor fix — a 200 GB persistent volume
+    on a cents/hr CPU pod defeats the lane): the cheap CPU default (40 GB)
+    applies, further clamped to the instance's #1010 container-disk cap where
+    the cap sits below it."""
     _write_metadata_file({})
     stub_list_team_pods.return_value = []
 
-    ns = _cpu_provision_ns(747, "cpu-small")  # volume_gb left at the 200 default
+    ns = _cpu_provision_ns(747, intent)  # volume_gb left at the 200 default
     pod_lifecycle.cmd_provision(ns)
 
-    assert cpu_provision_stubs["cpu_calls"][0]["volume_gb"] == 40
+    assert cpu_provision_stubs["cpu_calls"][0]["volume_gb"] == expected_volume_gb
 
 
-def test_cmd_provision_cpu_small_explicit_volume_is_honored(
+def test_cmd_provision_cpu_small_explicit_subcap_volume_is_honored(
     isolated_state, stub_list_team_pods, cpu_provision_stubs
 ):
-    """An explicit non-default --volume-gb is honored on a CPU intent (only the
-    implicit 200 GB default is rewritten to the CPU default)."""
+    """An explicit sub-cap --volume-gb is honored on a CPU intent (only the
+    implicit 200 GB default is rewritten to the CPU default; the #1010 clamp
+    only ever REDUCES an over-cap knob, so a 15 GB volume rides through while
+    the 50 GB default container disk clamps to the cpu3g cap)."""
     _write_metadata_file({})
     stub_list_team_pods.return_value = []
 
-    ns = _cpu_provision_ns(747, "cpu-small", volume_gb=120)
+    ns = _cpu_provision_ns(747, "cpu-small", volume_gb=15)
     pod_lifecycle.cmd_provision(ns)
 
-    assert cpu_provision_stubs["cpu_calls"][0]["volume_gb"] == 120
+    call = cpu_provision_stubs["cpu_calls"][0]
+    assert call["volume_gb"] == 15
+    assert call["container_disk_gb"] == 20  # default 50 clamped to the cap
+
+
+# ---------------------------------------------------------------------------
+# cmd_provision — #1010 CPU effective-payload cap clamp / pre-API refusal
+#
+# RunPod validates deployCpuPod's EFFECTIVE container disk —
+# max(container_disk_gb, volume_gb); runpod_api._deploy_cpu_once folds the CPU
+# volume into containerDiskInGb — against a per-flavor cap (probe 2026-07-04:
+# cpu3g <= 20, cpu3c <= 80). These assert the create_cpu_pod CALL KWARGS (the
+# EFFECTIVE payload), never a pod_lifecycle local, which the fold false-PASSes.
+# ---------------------------------------------------------------------------
+
+
+def test_cpu_provision_clamps_default_disk_to_instance_cap(
+    isolated_state, stub_list_team_pods, cpu_provision_stubs
+):
+    """#1010: the untouched defaults (container 50 / CPU volume 40 ->
+    effective 50) exceed the cpu3g cap (20); the CPU branch clamps the
+    EFFECTIVE payload to the cap and PROCEEDS (pre-#1010 RunPod validation
+    rejected every default cpu-small provision — the lane was broken)."""
+    _write_metadata_file({})
+    stub_list_team_pods.return_value = []
+
+    ns = _cpu_provision_ns(1010, "cpu-small")
+    pod_lifecycle.cmd_provision(ns)
+
+    call = cpu_provision_stubs["cpu_calls"][0]
+    assert max(call["container_disk_gb"], call["volume_gb"]) == 20
+
+
+def test_cpu_provision_refuses_explicit_disk_above_cap(
+    isolated_state, stub_list_team_pods, cpu_provision_stubs
+):
+    """#1010: an EXPLICIT above-default-band request (> 50 GB effective) over
+    the instance cap refuses pre-API with exit 1 (same UX as the 'Pod already
+    exists' refusal) — never a paid create RunPod's validation would reject."""
+    _write_metadata_file({})
+    stub_list_team_pods.return_value = []
+
+    ns = _cpu_provision_ns(1010, "cpu-small", container_disk_gb=60)
+    with pytest.raises(SystemExit) as exc:
+        pod_lifecycle.cmd_provision(ns)
+    assert exc.value.code == 1
+    assert cpu_provision_stubs["cpu_calls"] == []  # pre-API: create never called
+
+
+def test_cpu_provision_threaded_floor_50_clamps_not_refuses_when_cap_below_50(
+    isolated_state, stub_list_team_pods, cpu_provision_stubs
+):
+    """#1010 invariant: an effective payload of exactly 50 (the untouched
+    default AND the router-threaded `--container-disk-gb max(50, boot)` floor)
+    ALWAYS rides the clamp branch, never the refusal — a stated-small-footprint
+    cpu-small auto-launch arrives here at exactly 50 and MUST clamp-and-proceed
+    at the cap, not exit 1."""
+    _write_metadata_file({})
+    stub_list_team_pods.return_value = []
+
+    # The router-threaded shape: --container-disk-gb 50 explicit on the argv.
+    ns = _cpu_provision_ns(1010, "cpu-small", container_disk_gb=50)
+    pod_lifecycle.cmd_provision(ns)
+
+    call = cpu_provision_stubs["cpu_calls"][0]
+    assert max(call["container_disk_gb"], call["volume_gb"]) == 20
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -5438,6 +5438,196 @@ def test_runpod_cpu_instance_map_is_single_source_of_truth():
 
 
 # ---------------------------------------------------------------------------
+# #1010 — RunPod CPU-fallback footprint feasibility gate (incident #958)
+# ---------------------------------------------------------------------------
+
+
+def _cpu_caps_for_intent(intent: str):
+    """The RunPodCpuInstanceCaps row the gate reads for a mapped CPU intent."""
+    from explore_persona_space.backends.router import (
+        RUNPOD_CPU_INSTANCE_CAPS,
+        RUNPOD_CPU_INSTANCE_FOR_INTENT,
+    )
+
+    return RUNPOD_CPU_INSTANCE_CAPS[RUNPOD_CPU_INSTANCE_FOR_INTENT[intent]]
+
+
+def _exhausted_gcp_double() -> _GcpBackendDouble:
+    """A GCP double whose every create capacity-misses (the #747 fallover shape)."""
+    return _GcpBackendDouble(
+        launch_raises=GcpProvisioningError(
+            "ZONE_RESOURCE_POOL_EXHAUSTED",
+            evidence={"matched_pattern": "RESOURCE_EXHAUSTED"},
+        )
+    )
+
+
+@pytest.mark.parametrize("intent", ["cpu-small", "cpu-mid"])
+def test_runpod_cpu_fallback_refuses_oversized_disk_requirement(
+    lease_store, marker_poster, captured_markers, intent
+):
+    """#1010: a mapped CPU intent whose plan-stated boot_disk_gb exceeds the
+    instance's container-disk cap raises the TYPED CpuFallbackInfeasibleError
+    at the terminal rung, BEFORE any RunPod launch — no pod is provisioned,
+    and the terminal marker carries the DISTINCT reason
+    cpu_fallback_infeasible_for_plan (never auto_fallback_runpod).
+    Parametrized over BOTH mapped intents (per-instance caps differ)."""
+    from explore_persona_space.backends.router import (
+        ROUTE_REASON_CPU_FALLBACK_INFEASIBLE,
+        CpuFallbackInfeasibleError,
+    )
+
+    caps = _cpu_caps_for_intent(intent)
+    rp = _PassiveRunpod()
+    spec = RunSpec(
+        issue=1010,
+        intent=intent,
+        backend="auto",
+        time_budget_hours=1.0,
+        extra={"boot_disk_gb": caps.max_container_disk_gb + 20},
+    )
+    with pytest.raises(CpuFallbackInfeasibleError):
+        route(
+            spec,
+            runpod_backend=rp,
+            free_backends={"nibi": _FreeLaneBackend(kind="nibi", launch_raises=RuntimeError("x"))},
+            gcp_backend=_exhausted_gcp_double(),
+            lease_store=lease_store,
+            marker_poster=marker_poster,
+            config=RouterConfig(
+                free_wait_seconds=1, poll_interval=0.0, max_gcp_attempts_per_day=99
+            ),
+            now_fn=_clock(),
+            sleep_fn=lambda _s: None,
+        )
+    # RunPod NEVER attempted — the refusal is pre-API, pre-provision.
+    assert len(rp.launches) == 0
+    assert _by_reason(captured_markers, ROUTE_REASON_CPU_FALLBACK_INFEASIBLE), captured_markers
+    assert not _by_reason(captured_markers, ROUTE_REASON_RUNPOD_FALLBACK)
+
+
+def test_runpod_cpu_fallback_refuses_oversized_ram_requirement(
+    lease_store, marker_poster, captured_markers
+):
+    """#1010: min_ram_gb above the instance's FIXED RAM (cpu3c-8-16 = 16 GB)
+    refuses with the same typed terminal — the #958 shape (a 32 GB-RAM plan
+    on a 16 GB pod) now refuses at $0 instead of after a provision cycle."""
+    from explore_persona_space.backends.router import (
+        ROUTE_REASON_CPU_FALLBACK_INFEASIBLE,
+        CpuFallbackInfeasibleError,
+    )
+
+    rp = _PassiveRunpod()
+    spec = RunSpec(
+        issue=1010,
+        intent="cpu-mid",
+        backend="auto",
+        time_budget_hours=1.0,
+        extra={"min_ram_gb": 32},
+    )
+    with pytest.raises(CpuFallbackInfeasibleError):
+        route(
+            spec,
+            runpod_backend=rp,
+            free_backends={"nibi": _FreeLaneBackend(kind="nibi", launch_raises=RuntimeError("x"))},
+            gcp_backend=_exhausted_gcp_double(),
+            lease_store=lease_store,
+            marker_poster=marker_poster,
+            config=RouterConfig(
+                free_wait_seconds=1, poll_interval=0.0, max_gcp_attempts_per_day=99
+            ),
+            now_fn=_clock(),
+            sleep_fn=lambda _s: None,
+        )
+    assert len(rp.launches) == 0
+    assert _by_reason(captured_markers, ROUTE_REASON_CPU_FALLBACK_INFEASIBLE), captured_markers
+
+
+def test_runpod_cpu_fallback_feasible_requirement_launches_and_preserves_extra(
+    lease_store, marker_poster, captured_markers
+):
+    """#1010 control: a feasible stated footprint (below the cap) still falls
+    over to RunPod exactly as the no-requirement #747 path does, with
+    boot_disk_gb PRESERVED on the launched spec.extra (RunPodBackend.launch
+    threads it into --container-disk-gb) and NO infeasible marker."""
+    from explore_persona_space.backends.router import (
+        ROUTE_REASON_CPU_FALLBACK_INFEASIBLE,
+    )
+
+    caps = _cpu_caps_for_intent("cpu-mid")
+    rp = _PassiveRunpod()
+    spec = RunSpec(
+        issue=1010,
+        intent="cpu-mid",
+        backend="auto",
+        time_budget_hours=1.0,
+        extra={"boot_disk_gb": caps.max_container_disk_gb - 20},
+    )
+    result = route(
+        spec,
+        runpod_backend=rp,
+        free_backends={"nibi": _FreeLaneBackend(kind="nibi", launch_raises=RuntimeError("x"))},
+        gcp_backend=_exhausted_gcp_double(),
+        lease_store=lease_store,
+        marker_poster=marker_poster,
+        config=RouterConfig(free_wait_seconds=1, poll_interval=0.0, max_gcp_attempts_per_day=99),
+        now_fn=_clock(),
+        sleep_fn=lambda _s: None,
+    )
+    assert result.chosen_kind == "runpod"
+    assert len(rp.launches) == 1
+    assert rp.launches[0].extra["boot_disk_gb"] == caps.max_container_disk_gb - 20
+    assert not _by_reason(captured_markers, ROUTE_REASON_CPU_FALLBACK_INFEASIBLE)
+
+
+def test_runpod_cpu_instance_caps_cover_every_mapped_instance():
+    """#1010 completeness (the #841/#940 pattern): every instance_id the
+    intent map can route MUST have a caps row — a future intent/instance
+    cannot land without deciding its caps (the gate's direct [] lookup would
+    otherwise KeyError at route time instead of failing CI at the adding PR)."""
+    from explore_persona_space.backends.router import (
+        RUNPOD_CPU_INSTANCE_CAPS,
+        RUNPOD_CPU_INSTANCE_FOR_INTENT,
+        RunPodCpuInstanceCaps,
+    )
+
+    assert set(RUNPOD_CPU_INSTANCE_CAPS) == set(RUNPOD_CPU_INSTANCE_FOR_INTENT.values())
+    for caps in RUNPOD_CPU_INSTANCE_CAPS.values():
+        assert isinstance(caps, RunPodCpuInstanceCaps)
+        assert caps.vcpu > 0 and caps.ram_gb > 0 and caps.max_container_disk_gb > 0
+
+
+def test_async_failover_seam_cpu_infeasible_disk_raises_typed(lease_store, marker_poster):
+    """#1010: the ASYNC failover seam (poller-detected GCP crash / queue
+    timeout) inherits the feasibility gate via _runpod_terminal_rung — an
+    oversized cpu-mid spec raises the typed terminal instead of provisioning
+    an undersized fallback pod (the #958 shape on the async paths)."""
+    from explore_persona_space.backends.router import (
+        CpuFallbackInfeasibleError,
+        failover_to_runpod_after_async_workload_crash,
+    )
+
+    caps = _cpu_caps_for_intent("cpu-mid")
+    rp = _PassiveRunpod()
+    spec = RunSpec(
+        issue=1010,
+        intent="cpu-mid",
+        backend="runpod",
+        extra={"boot_disk_gb": caps.max_container_disk_gb + 30},
+    )
+    with pytest.raises(CpuFallbackInfeasibleError):
+        failover_to_runpod_after_async_workload_crash(
+            spec=spec,
+            runpod_backend=rp,
+            lease_store=lease_store,
+            marker_poster=marker_poster,
+            config=RouterConfig(free_wait_seconds=1, poll_interval=0.0),
+            now_fn=_clock(),
+        )
+    assert len(rp.launches) == 0
+
+
+# ---------------------------------------------------------------------------
 # #774 round 2 — RouteAttempt.evidence carries the GCP per-zone fan-out to the
 # epm:backend-selected marker. A GcpProvisioningError whose evidence holds
 # per_zone_attempts must round-trip through the catch site -> _attempt_to_dict

--- a/tests/test_runpod_api_retry.py
+++ b/tests/test_runpod_api_retry.py
@@ -691,3 +691,23 @@ def test_create_cpu_pod_raises_no_capacity_when_exhausted(monkeypatch):
     with pytest.raises(RunPodNoCapacityError):
         create_cpu_pod("pod-747", "cpu3g-2-8", cloud_type="ALL", enable_supply_fallback=False)
     assert len(rec2.queries) == 1  # primary only
+
+
+def test_create_cpu_pod_effective_container_disk_folds_volume(monkeypatch):
+    """#1010: the EFFECTIVE deployCpuPod payload is max(container_disk_gb,
+    volume_gb) — _deploy_cpu_once folds the CPU volume request into
+    containerDiskInGb (deployCpuPodInput has no volume field). This is the
+    payload-level truth the router caps table / probe / pod_lifecycle clamp
+    semantics rest on (render-only, no live call)."""
+    from runpod_api import create_cpu_pod
+
+    rec = _capture_cpu_graphql(monkeypatch, [_make_cpu_pod_payload()])
+    create_cpu_pod("pod-1010", "cpu3c-8-16", container_disk_gb=80, volume_gb=80)
+    assert "containerDiskInGb: 80" in rec.queries[0]
+
+    rec2 = _capture_cpu_graphql(monkeypatch, [_make_cpu_pod_payload()])
+    create_cpu_pod("pod-1010", "cpu3g-2-8", container_disk_gb=20, volume_gb=40)
+    # The fold: a 20 GB container request with the 40 GB CPU volume default
+    # still sends an EFFECTIVE 40 — a bare container_disk_gb clamp cannot
+    # bound the payload.
+    assert "containerDiskInGb: 40" in rec2.queries[0]

--- a/tests/test_runpod_workload_exec.py
+++ b/tests/test_runpod_workload_exec.py
@@ -762,3 +762,71 @@ def test_pre_provision_guard_keeps_handle_none(monkeypatch):
             _spec(workload_cmd="", hydra_args=("seed=1",), extra={"execute_workload": True})
         )
     assert ei.value.handle is None
+
+
+# ---------------------------------------------------------------------------
+# #1010 — CPU-fallback container-disk threading into the provision argv
+# ---------------------------------------------------------------------------
+
+
+def _recording_provision(monkeypatch) -> list[list[str]]:
+    """Selectively no-op the ``pod_lifecycle.py provision`` subprocess AND
+    record its argv (the recording variant of ``_noop_provision`` — that
+    fixture records nothing)."""
+    _real_run = RP.subprocess.run
+    argvs: list[list[str]] = []
+
+    def _selective_run(cmd, *a, **k):
+        if isinstance(cmd, (list, tuple)) and any("pod_lifecycle.py" in str(c) for c in cmd):
+            argvs.append([str(c) for c in cmd])
+            return None
+        return _real_run(cmd, *a, **k)
+
+    monkeypatch.setattr(RP.subprocess, "run", _selective_run, raising=False)
+    return argvs
+
+
+def _flag_value(argv: list[str], flag: str) -> str | None:
+    """The value following ``flag`` in ``argv``, or None when absent."""
+    return argv[argv.index(flag) + 1] if flag in argv else None
+
+
+def _cpu_spec(intent: str, extra: dict | None = None) -> RunSpec:
+    """A provision-only RunSpec with an explicit intent (the shared _spec
+    helper pins intent="lora-7b", which collides with an override)."""
+    return RunSpec(issue=1010, intent=intent, backend="runpod", extra=extra or {})
+
+
+def test_launch_threads_container_disk_for_cpu_intent(monkeypatch):
+    """#1010: a mapped CPU intent with a stated boot_disk_gb threads
+    --container-disk-gb <value> into the provision argv."""
+    argvs = _recording_provision(monkeypatch)
+    RP.RunPodBackend().launch(_cpu_spec("cpu-mid", {"boot_disk_gb": 80}))
+    assert len(argvs) == 1
+    assert _flag_value(argvs[0], "--container-disk-gb") == "80"
+
+
+def test_launch_floors_container_disk_at_default(monkeypatch):
+    """#1010: threading can never REDUCE below today's 50 GB default —
+    a small stated requirement floors at max(50, boot_disk_gb)."""
+    argvs = _recording_provision(monkeypatch)
+    RP.RunPodBackend().launch(_cpu_spec("cpu-mid", {"boot_disk_gb": 30}))
+    assert _flag_value(argvs[0], "--container-disk-gb") == "50"
+
+
+def test_launch_omits_container_disk_without_requirement(monkeypatch):
+    """#1010 control: no stated requirement -> the provision argv is
+    byte-identical to pre-#1010 (no --container-disk-gb flag at all)."""
+    argvs = _recording_provision(monkeypatch)
+    RP.RunPodBackend().launch(_cpu_spec("cpu-mid"))
+    assert "--container-disk-gb" not in argvs[0]
+
+
+def test_launch_does_not_thread_container_disk_for_gpu_intent(monkeypatch):
+    """#1010: GPU intents NEVER thread the container disk — on GPU pods the
+    big-data mount is the 200 GB /workspace VOLUME, not the container
+    overlay, so boot_disk_gb does not map (threading it would silently
+    inflate GPU container disks fleet-wide)."""
+    argvs = _recording_provision(monkeypatch)
+    RP.RunPodBackend().launch(_cpu_spec("lora-7b", {"boot_disk_gb": 500}))
+    assert "--container-disk-gb" not in argvs[0]


### PR DESCRIPTION
Closes task #1010. Workflow-fix (incident #958): threads the plan's disk footprint into the RunPod CPU fallback's containerDiskInGb, adds a probe-grounded per-instance caps table + a typed pre-API feasibility refusal (cpu_fallback_infeasible_for_plan), covers the async GCP→RunPod failover paths, and fixes the (probe-discovered) broken cpu-small default payload via an effective-payload clamp.