### PR TITLE
task #986: cap-headroom check in check_agent_spec_size

### DIFF
--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -5651,8 +5651,19 @@ def check_lessons_index(*, repo_root: Path | None = None) -> list[str]:
 AGENT_SPEC_WARN_BYTES = 28_000
 AGENT_SPEC_FAIL_BYTES = 40_000
 
+# A grandfather cap must hug the measured size: cap - size <= this bound
+# (the documented "measured + <=3 KB margin" convention, mechanized by #986).
+# STRICTLY-GREATER like the other thresholds (headroom exactly 3_000 passes).
+# A larger headroom means a loose cap-raise (defeats the regrowth ratchet) or
+# a stale cap after a trim (ratchet DOWN when trimmed) — both FAIL. Scope:
+# this bounds BANKED SLACK only — a reviewed growth+cap-raise in one commit
+# still passes; the check forces growth into a visible dict edit, it does not
+# approve it.
+AGENT_SPEC_GRANDFATHER_MAX_HEADROOM_BYTES = 3_000
+
 # Grandfather-ratchet caps for agent specs still above AGENT_SPEC_FAIL_BYTES.
-# Each cap = measured size + <=3 KB margin (post-#829 for the first two
+# Each cap = measured size + <=3 KB margin (headroom mechanically enforced —
+# see AGENT_SPEC_GRANDFATHER_MAX_HEADROOM_BYTES; post-#829 for the first two
 # entries; at the #838 FAIL tightening 70K -> 40K for the rest); a
 # grandfathered file FAILs above its cap (regrowth ratchet) and FAILs as stale
 # once it drops to <= AGENT_SPEC_FAIL_BYTES ("remove the entry"). Ratchet DOWN
@@ -5687,7 +5698,7 @@ AGENT_SPEC_SIZE_GRANDFATHER: dict[str, int] = {
 }
 
 
-def check_agent_spec_size(
+def check_agent_spec_size(  # noqa: C901 -- flat per-entry hygiene ladder (stale/retired/headroom, #986); extracting a branch would just relocate it
     *, repo_root: Path | None = None, warn_sink: list[str] | None = None
 ) -> list[str]:
     """WARN/FAIL agent specs (`.claude/agents/*.md`) over the size budget (#829).
@@ -5697,9 +5708,12 @@ def check_agent_spec_size(
     size > ``AGENT_SPEC_FAIL_BYTES`` FAILs unless the file is grandfathered in
     ``AGENT_SPEC_SIZE_GRANDFATHER`` (then it WARNs while under its per-file cap
     and FAILs above it — the regrowth ratchet); size > ``AGENT_SPEC_WARN_BYTES``
-    WARNs. Grandfather hygiene FAILs a stale entry (file missing) and an entry
+    WARNs. Grandfather hygiene FAILs a stale entry (file missing), an entry
     whose file dropped to <= the FAIL threshold (remove the entry — ratchet
-    down), and a config self-check FAILs any cap <= the FAIL threshold. WARNs
+    down), and an entry whose cap sits more than
+    ``AGENT_SPEC_GRANDFATHER_MAX_HEADROOM_BYTES`` above the live file size
+    (loose cap / stale cap — lower it), and a config self-check FAILs any cap
+    <= the FAIL threshold. WARNs
     go to ``warn_sink`` when provided (unit-test hook), else stderr with a
     ``WARN: `` prefix; WARNs never enter the returned FAIL list. ``repo_root``
     is a unit-test override; production callers pass None. Bundled into the
@@ -5768,8 +5782,10 @@ def check_agent_spec_size(
             )
 
     # Grandfather-entry hygiene: entries must point at existing files that
-    # still NEED grandfathering (size > FAIL threshold).
-    for gf_name in sorted(AGENT_SPEC_SIZE_GRANDFATHER):
+    # still NEED grandfathering (size > FAIL threshold) AND whose cap hugs the
+    # measured size (headroom <= AGENT_SPEC_GRANDFATHER_MAX_HEADROOM_BYTES —
+    # the regrowth ratchet is meaningless under a loose cap; #986).
+    for gf_name, cap in sorted(AGENT_SPEC_SIZE_GRANDFATHER.items()):
         gf_path = agents_dir / gf_name
         if not gf_path.is_file():
             errors.append(
@@ -5777,12 +5793,24 @@ def check_agent_spec_size(
                 f"entry — .claude/agents/{gf_name} does not exist; remove the "
                 f"entry."
             )
-        elif gf_path.stat().st_size <= AGENT_SPEC_FAIL_BYTES:
+            continue
+        gf_size = gf_path.stat().st_size
+        if gf_size <= AGENT_SPEC_FAIL_BYTES:
             errors.append(
                 f"AGENT_SPEC_SIZE_GRANDFATHER['{gf_name}']: "
-                f".claude/agents/{gf_name} is {gf_path.stat().st_size} bytes "
+                f".claude/agents/{gf_name} is {gf_size} bytes "
                 f"(<= {AGENT_SPEC_FAIL_BYTES}) and no longer needs "
                 f"grandfathering — remove the entry (ratchet down)."
+            )
+        elif cap - gf_size > AGENT_SPEC_GRANDFATHER_MAX_HEADROOM_BYTES:
+            errors.append(
+                f"AGENT_SPEC_SIZE_GRANDFATHER['{gf_name}']: cap {cap} sits "
+                f"{cap - gf_size} bytes above .claude/agents/{gf_name} "
+                f"({gf_size} bytes) — max headroom is "
+                f"{AGENT_SPEC_GRANDFATHER_MAX_HEADROOM_BYTES} bytes (cap = "
+                f"measured + <=3 KB); lower the cap to <= "
+                f"{gf_size + AGENT_SPEC_GRANDFATHER_MAX_HEADROOM_BYTES}, or "
+                f"remove the entry if the file no longer needs grandfathering."
             )
 
     return errors

--- a/tests/test_workflow_lint_agent_spec_size.py
+++ b/tests/test_workflow_lint_agent_spec_size.py
@@ -5,8 +5,10 @@ WARN above ``AGENT_SPEC_WARN_BYTES`` (28 KB as of #838), FAIL above
 ``AGENT_SPEC_FAIL_BYTES`` (40 KB as of #838), both STRICTLY-GREATER
 (exactly-at-threshold passes). Files in ``AGENT_SPEC_SIZE_GRANDFATHER`` WARN
 above the FAIL threshold while under their per-file cap and FAIL above it (the
-regrowth ratchet). Grandfather hygiene FAILs a stale entry (file missing) and
-an entry whose file dropped to <= the FAIL threshold ("remove the entry"); a
+regrowth ratchet). Grandfather hygiene FAILs a stale entry (file missing), an
+entry whose file dropped to <= the FAIL threshold ("remove the entry"), and an
+entry whose cap sits more than ``AGENT_SPEC_GRANDFATHER_MAX_HEADROOM_BYTES``
+(3,000 B, strict >) above the live file size (loose/stale cap, #986); a
 config self-check FAILs any cap <= the FAIL threshold. WARNs go to
 ``warn_sink`` (or stderr) and never enter the returned FAIL list.
 
@@ -19,7 +21,10 @@ literal 60,000/65,000 fixtures flipped branches when FAIL dropped 70K -> 40K):
 FAIL+5,000 over cap FAIL+4,000 FAILs (ratchet); (f) stale grandfather entry
 FAILs; (g) grandfathered file at FAIL-1,000 FAILs "remove the entry"; (h)
 missing agents dir FAILs; (i) the live tree PASSes (zero FAILs, WARNs allowed);
-(j) a grandfather cap <= the FAIL threshold FAILs "cap must exceed".
+(j) a grandfather cap <= the FAIL threshold FAILs "cap must exceed";
+(k) grandfathered headroom exactly at the bound passes (strict >);
+(l) grandfathered headroom over the bound FAILs "headroom"; (m) the bound
+constant is literally 3_000.
 """
 
 from __future__ import annotations
@@ -37,6 +42,7 @@ if str(_SCRIPTS) not in sys.path:
 import workflow_lint  # noqa: E402
 from workflow_lint import (  # noqa: E402
     AGENT_SPEC_FAIL_BYTES,
+    AGENT_SPEC_GRANDFATHER_MAX_HEADROOM_BYTES,
     AGENT_SPEC_WARN_BYTES,
     check_agent_spec_size,
 )
@@ -184,6 +190,10 @@ def test_grandfathered_below_fail_threshold_fails_remove(
     assert len(errors) == 1, errors
     assert "gf.md" in errors[0]
     assert "remove the entry" in errors[0]
+    # The headroom message also contains "remove the entry" — this is the ONLY
+    # assert that detects a swapped remove-entry/headroom branch order (#986:
+    # cap sits 5,000 B above the file here, over the headroom bound).
+    assert "headroom" not in errors[0]
 
 
 # --------------------------------------------------------------------------
@@ -224,3 +234,46 @@ def test_grandfather_cap_at_or_below_fail_threshold_fails(
     _write_agent(tmp_path, "gf.md", AGENT_SPEC_FAIL_BYTES + 1_000)
     errors = check_agent_spec_size(repo_root=tmp_path, warn_sink=[])
     assert any("cap must exceed" in e for e in errors), errors
+
+
+# --------------------------------------------------------------------------
+# (k)/(l) grandfather-cap headroom: exactly-at-bound passes (strict >);
+# over-bound FAILs (loose cap-raise / stale cap after a trim — #986)
+# --------------------------------------------------------------------------
+
+
+def test_grandfather_headroom_at_bound_passes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    size = AGENT_SPEC_FAIL_BYTES + 1_000
+    cap = size + AGENT_SPEC_GRANDFATHER_MAX_HEADROOM_BYTES  # headroom exactly at bound
+    monkeypatch.setattr(workflow_lint, "AGENT_SPEC_SIZE_GRANDFATHER", {"gf.md": cap})
+    _write_agent(tmp_path, "gf.md", size)
+    warns: list[str] = []
+    assert check_agent_spec_size(repo_root=tmp_path, warn_sink=warns) == []
+    assert len(warns) == 1, warns  # the ordinary "grandfathered; under its cap" WARN
+
+
+def test_grandfather_headroom_over_bound_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    size = AGENT_SPEC_FAIL_BYTES + 1_000
+    cap = size + AGENT_SPEC_GRANDFATHER_MAX_HEADROOM_BYTES + 1  # headroom bound+1
+    monkeypatch.setattr(workflow_lint, "AGENT_SPEC_SIZE_GRANDFATHER", {"gf.md": cap})
+    _write_agent(tmp_path, "gf.md", size)
+    errors = check_agent_spec_size(repo_root=tmp_path, warn_sink=[])
+    assert len(errors) == 1, errors
+    assert "gf.md" in errors[0]
+    assert "headroom" in errors[0]
+    assert str(cap) in errors[0]
+
+
+def test_grandfather_headroom_bound_is_3000() -> None:
+    """Pin the literal bound (statistics-critic Must-Fix, round 1).
+
+    Every other headroom test derives its fixture from the constant, so a
+    mistyped constant (e.g. 30_000) would pass all of them AND the live
+    tree while failing to mechanize the documented "<=3 KB margin"
+    convention — a false-green. This literal pin closes that class.
+    """
+    assert AGENT_SPEC_GRANDFATHER_MAX_HEADROOM_BYTES == 3_000


### PR DESCRIPTION
## Summary
- Adds `AGENT_SPEC_GRANDFATHER_MAX_HEADROOM_BYTES = 3_000` + a FAIL branch in `check_agent_spec_size`'s grandfather-entry hygiene loop: a cap sitting >3,000 B above the live file size FAILs (strictly-greater) — a loose cap-raise or stale post-trim cap can no longer silently defeat the agent-spec regrowth ratchet.
- 3 new tests (at-bound passes, over-bound FAILs, literal 3_000 pin) + a required branch-order-swap assert on the existing below-FAIL test; stale/remove-entry messages byte-identical.
- Closes task #986 (workflow-fix; plan v3 approved, code-review ensemble PASS+PASS, test-verdict PASS — 3 pre-existing trunk failures attributed to #931's in-flight file).

## Test plan
- [x] `uv run pytest tests/test_workflow_lint_agent_spec_size.py` — 15/15
- [x] `uv run python scripts/workflow_lint.py --check-agent-spec-size` — exit 0 (live max headroom 2,887 B)
- [x] ruff check + format clean on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)