### PR TITLE
issue-989: 4xx short-circuit in hub _is_transient_upload_error

### DIFF
--- a/src/explore_persona_space/orchestrate/hub.py
+++ b/src/explore_persona_space/orchestrate/hub.py
@@ -543,11 +543,18 @@ def _is_storage_quota_403(err: Exception) -> bool:
 
 
 def _is_transient_upload_error(err: Exception) -> bool:
-    """True for retryable transient HF/HTTP upload errors (5xx gateway timeouts,
-    429, connection drops) — NOT the persistent storage-quota-403."""
+    """True for retryable transient HF/HTTP upload errors (408/429/5xx by
+    status code, connection drops / timeouts by message) — NOT the persistent
+    storage-quota-403. When the exception carries a real integer HTTP status
+    code, the decision is made ENTIRELY by code: 408 (request timeout), 429,
+    and any 5xx are transient; every other code (all remaining 4xx) is
+    non-transient, with NO substring fallback — 4xx messages can embed digit
+    triplets ('issue504_raw/...', byte counts) that would read as
+    false-transient (#989). The substring scan applies only to response-less
+    errors (ConnectionError, timeouts)."""
     code = getattr(getattr(err, "response", None), "status_code", None)
-    if code in (429, 500, 502, 503, 504):
-        return True
+    if isinstance(code, int):
+        return code in (408, 429) or 500 <= code < 600
     msg = str(err).lower()
     return any(
         s in msg

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -501,6 +501,68 @@ class TestRetryUpload:
         assert _is_transient_upload_error(_storage_403()) is False
         assert _is_transient_upload_error(ValueError("bad args")) is False
 
+    def test_4xx_digit_triplet_in_message_not_retried(self):
+        """A 404 whose MESSAGE embeds a digit triplet ('issue504_raw') must NOT
+        retry: a real 4xx status code decides non-transient BEFORE the fuzzy
+        substring scan can false-match on message digits (#989)."""
+        err = _http_err(404, "404 Client Error: Not Found for url: .../issue504_raw/final/x.json")
+        assert _is_transient_upload_error(err) is False
+        thunk = Mock(side_effect=err)
+        with (
+            patch("explore_persona_space.orchestrate.hub.time.sleep") as mock_sleep,
+            pytest.raises(HfHubHTTPError),
+        ):
+            _retry_upload(thunk, what="t")
+        assert thunk.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_413_byte_count_digits_not_retried(self):
+        """A 413 whose message embeds '500' inside a byte count must NOT retry
+        (the byte-count digit trap, #989)."""
+        err = _http_err(413, "413 Payload Too Large: 15000000000 bytes exceeds limit")
+        assert _is_transient_upload_error(err) is False
+        thunk = Mock(side_effect=err)
+        with (
+            patch("explore_persona_space.orchestrate.hub.time.sleep"),
+            pytest.raises(HfHubHTTPError),
+        ):
+            _retry_upload(thunk, what="t")
+        assert thunk.call_count == 1
+
+    def test_5xx_transient_by_code_full_range(self):
+        """Any 5xx is transient BY CODE — pinned at the inclusive lower endpoint
+        (500, i.e. ``500 <= code`` not ``500 < code``) and at representative
+        codes outside the old (500, 502, 503, 504) tuple (507, 520)."""
+        assert _is_transient_upload_error(_http_err(500)) is True
+        assert _is_transient_upload_error(_http_err(507)) is True
+        assert _is_transient_upload_error(_http_err(520)) is True
+        thunk = Mock(side_effect=[_http_err(520), "ok"])
+        with patch("explore_persona_space.orchestrate.hub.time.sleep"):
+            assert _retry_upload(thunk, what="t") == "ok"
+        assert thunk.call_count == 2
+
+    def test_408_request_timeout_transient_by_code(self):
+        """Coded 408 Request Timeout stays transient BY CODE (RFC 9110 §15.5.9
+        invites the client to repeat) — previously retried only via the
+        'timeout' substring accident; the #989 tightening must preserve it."""
+        assert _is_transient_upload_error(_http_err(408, "408 Request Timeout")) is True
+        thunk = Mock(side_effect=[_http_err(408, "408 Request Timeout"), "ok"])
+        with patch("explore_persona_space.orchestrate.hub.time.sleep"):
+            assert _retry_upload(thunk, what="t") == "ok"
+        assert thunk.call_count == 2
+
+    def test_code_wins_over_substring_and_isinstance_guard(self):
+        """(a) a real 4xx code OVERRIDES a transient-looking substring
+        ('connection'); (b) a response-less TimeoutError keeps the substring
+        path; (c) a non-int status_code (the STRING '500') never enters the
+        code branch (isinstance guard) and falls to the substring scan."""
+        assert _is_transient_upload_error(_http_err(400, "connection header malformed")) is False
+        assert _is_transient_upload_error(TimeoutError("Read timed out")) is True
+        r = Mock()
+        r.status_code = "500"
+        str_code_err = HfHubHTTPError("opaque failure", response=r)
+        assert _is_transient_upload_error(str_code_err) is False
+
     def test_upload_folder_branch_uses_retry(self):
         """Integration: a 504 on the FIRST _upload folder commit then success ->
         _upload returns the non-empty URL and upload_folder is called twice


### PR DESCRIPTION
Closes task #989. Tightens _is_transient_upload_error: with a real int status_code, decide entirely by code ({408,429} ∪ [500,600)); substring scan only for response-less errors. +5 regression tests (digit-triplet trap et al.).