### PR TITLE
issue-991: runtime system-role guard at dispatch_calls seam

### DIFF
--- a/src/explore_persona_space/llm/api_dispatch.py
+++ b/src/explore_persona_space/llm/api_dispatch.py
@@ -250,6 +250,51 @@ BuildRequest = Callable[[DispatchItem], dict]
 ParseResponse = Callable[[str], Any]
 
 
+def _assert_no_system_role(params: dict, item_id: str) -> None:
+    """Fail fast on a system-role message in built Messages-API params.
+
+    The Anthropic Messages API has no "system" message ROLE — a system-bearing
+    ``messages`` list 400s EVERY request (invalid_request_error; the #906 r11
+    incident, .claude/rules/gotchas.md). System content must be lifted by the
+    BUILDER to the top-level ``system=`` param (see
+    ``llm.models.Prompt.anthropic_format`` for a leading-system splitter or
+    ``artifacts.datagen._gen_params_from_messages`` for an arbitrary-position
+    lift). Only the documented dict shape is inspected: non-dict params /
+    entries and a missing ``messages`` key pass through untouched (the API
+    itself owns those errors).
+    """
+    messages = params.get("messages") if isinstance(params, dict) else None
+    if not isinstance(messages, list):
+        return
+    for i, msg in enumerate(messages):
+        if isinstance(msg, dict) and msg.get("role") == "system":
+            raise ValueError(
+                f"build_request(item_id={item_id!r}) returned a messages list with "
+                f'role="system" at index {i}. The Anthropic Messages API has no '
+                "system message role — every such request 400s "
+                "(invalid_request_error). Lift system content to the top-level "
+                "system= param in your builder (see llm.models.Prompt."
+                "anthropic_format or artifacts.datagen._gen_params_from_messages)."
+            )
+
+
+def _guarded_build_request(build_request: BuildRequest) -> BuildRequest:
+    """Wrap ``build_request`` so every produced params dict is system-role-checked.
+
+    Applied ONCE at the dispatch_calls seam; covers all three consumers (sync
+    ``_do_one``, batch state-init, batch submit/resubmit) because they all
+    receive the same threaded callable. Raises ValueError at BUILD time —
+    before any wire call or paid batch create.
+    """
+
+    def _built(item: DispatchItem) -> dict:
+        params = build_request(item)
+        _assert_no_system_role(params, item.item_id)
+        return params
+
+    return _built
+
+
 # ── Per-org runtime state (AIMD + headroom) ──────────────────────────────────
 
 
@@ -861,12 +906,18 @@ async def _submit_one_sub_batch(
                 "dedicated to this run, or clear the cache for these items, then re-run. Refusing "
                 "to submit a partial sub-batch."
             )
-        sb["status"] = "submitting"
-        _atomic_write_json(state_path, state)  # intent BEFORE create
+        # Build requests BEFORE flipping status to "submitting" (#991): the build
+        # is pure, so a builder raise on RESUME (e.g. the system-role guard)
+        # leaves this sub-batch "pending" — cleanly resumable after the builder
+        # is fixed — instead of wedging at the crashed-mid-submit RuntimeError.
+        # The #663 preserve-before-propagate contract is untouched: the
+        # "submitting" intent is still persisted BEFORE batches.create.
         requests = [
             {"custom_id": cid, "params": build_request(items_by_cid[cid])}
             for cid in sb["custom_ids"]
         ]
+        sb["status"] = "submitting"
+        _atomic_write_json(state_path, state)  # intent BEFORE create
         # api_dispatch IS a sanctioned hardened batch client: reuses _chunk_requests (<=8k shards)
         # + bounded expires_at poll (deadline_from_expires_at/BatchDeadlineExceeded) + org-aware
         # resume by custom_id; routing through judge_completions_batch would lose multi-org fan-out.
@@ -1127,8 +1178,9 @@ async def dispatch_calls(
             NOTE: the Messages API has NO "system" message role — a builder
             forwarding caller message lists verbatim MUST lift system-role
             entries to the top-level ``system=`` param (see
-            ``llm.models.Prompt.anthropic_format``); a system-bearing list
-            400s every request (gotchas.md, #906 r11).
+            ``llm.models.Prompt.anthropic_format``). ENFORCED at runtime:
+            a system-bearing built params dict raises ValueError at build
+            time, before any wire call (gotchas.md, #906 r11; #991).
         parse_response: ``model_text -> result``; may raise on a bad parse
             (caught per item -> ``error=True``).
         deadline: optional wall-clock deadline; a deadline inside the batch 24h
@@ -1157,6 +1209,11 @@ async def dispatch_calls(
     """
     if not items:
         return {}
+
+    # Runtime enforcement of the system-role contract (docstring NOTE above):
+    # one wrap covers the sync build (_do_one), the batch state-init build,
+    # and the batch submit/resubmit build — they all thread this callable.
+    build_request = _guarded_build_request(build_request)
 
     async_clients, sync_clients, owned = _resolve_clients(async_clients, sync_clients, org_keys)
     try:

--- a/tests/test_api_dispatch.py
+++ b/tests/test_api_dispatch.py
@@ -1282,3 +1282,189 @@ def test_module_doc_describes_pending_routing():
     silently regress."""
     doc = api_dispatch.__doc__ or ""
     assert "len(pending)" in doc or "uncached remainder" in doc.lower()
+
+
+# ── #991: runtime system-role guard at the dispatch_calls seam ───────────────
+
+
+def build_request_with_system(item: DispatchItem) -> dict:
+    """System-bearing builder (the #906 r11 bug shape): leading system-role entry."""
+    return {
+        "model": "claude-sonnet-4-5-20250929",
+        "max_tokens": 64,
+        "messages": [
+            {"role": "system", "content": "You are a judge."},
+            {"role": "user", "content": item.payload["q"]},
+        ],
+    }
+
+
+def build_request_with_mid_list_system(item: DispatchItem) -> dict:
+    """System entry AFTER a user turn (arbitrary position, not just leading)."""
+    return {
+        "model": "claude-sonnet-4-5-20250929",
+        "max_tokens": 64,
+        "messages": [
+            {"role": "user", "content": item.payload["q"]},
+            {"role": "system", "content": "Mid-list system entry."},
+        ],
+    }
+
+
+def build_request_with_top_level_system(item: DispatchItem) -> dict:
+    """Compliant builder mirroring the real callers (judge_dispatch._build_params
+    shape): top-level ``system=`` param + user-only messages."""
+    return {
+        "model": "claude-sonnet-4-5-20250929",
+        "max_tokens": 64,
+        "system": "You are a judge.",
+        "messages": [{"role": "user", "content": item.payload["q"]}],
+    }
+
+
+def test_system_role_raises_sync_before_wire():
+    """A system-bearing builder raises at build time on the sync path — the
+    offending item's request never reaches the fake wire (calls == 0)."""
+    items = make_items(1)
+    clients = {"a": FakeAsyncClient()}
+    with pytest.raises(ValueError, match='role="system" at index 0') as exc_info:
+        _run(
+            dispatch_calls(
+                items,
+                model="claude-sonnet-4-5-20250929",
+                build_request=build_request_with_system,
+                parse_response=parse_response,
+                async_clients=clients,
+                sync_clients={"a": object()},
+                force_path="sync",
+            )
+        )
+    # AC2 pin: the message carries a fix pointer to the reference lift.
+    assert "anthropic_format" in str(exc_info.value)
+    assert clients["a"].calls == 0
+
+
+def test_system_role_raises_batch_before_state_write(tmp_path):
+    """On a fresh batch, the guard fires at the all-items state-init build —
+    BEFORE any state.json write and before any batches.create."""
+    items = make_items(3)
+    batch_clients = {"a": FakeBatchClient("a"), "b": FakeBatchClient("b")}
+    with pytest.raises(ValueError, match='role="system"'):
+        _run(
+            dispatch_calls(
+                items,
+                model="claude-sonnet-4-5-20250929",
+                build_request=build_request_with_system,
+                parse_response=parse_response,
+                async_clients={"a": object(), "b": object()},
+                sync_clients=batch_clients,
+                checkpoint_dir=tmp_path / "ckpt",
+                force_path="batch",
+                poll_interval=0.0,
+            )
+        )
+    assert all(c.create_calls == 0 for c in batch_clients.values())
+    assert not (tmp_path / "ckpt" / "state.json").exists()
+
+
+def test_system_role_mid_list_raises_with_index():
+    """A mid-list system entry (index 1, after a user turn) raises with the
+    offending index AND the item_id in the message."""
+    items = make_items(1)
+    clients = {"a": FakeAsyncClient()}
+    with pytest.raises(ValueError, match='role="system" at index 1') as exc_info:
+        _run(
+            dispatch_calls(
+                items,
+                model="claude-sonnet-4-5-20250929",
+                build_request=build_request_with_mid_list_system,
+                parse_response=parse_response,
+                async_clients=clients,
+                sync_clients={"a": object()},
+                force_path="sync",
+            )
+        )
+    msg = str(exc_info.value)
+    assert "index 1" in msg
+    assert "item_000" in msg
+    assert clients["a"].calls == 0
+
+
+def test_top_level_system_param_passes():
+    """Positive control (zero-behavior-change evidence): a top-level ``system=``
+    param with user-only messages — the real callers' shape — passes untouched."""
+    items = make_items(4)
+    clients = {"a": FakeAsyncClient()}
+    res = _run(
+        dispatch_calls(
+            items,
+            model="claude-sonnet-4-5-20250929",
+            build_request=build_request_with_top_level_system,
+            parse_response=parse_response,
+            async_clients=clients,
+            sync_clients={"a": object()},
+            force_path="sync",
+        )
+    )
+    assert set(res) == {it.item_id for it in items}
+    assert all(not r.error for r in res.values())
+    assert all(r.result == {"label": "ok"} for r in res.values())
+    assert clients["a"].calls == 4
+
+
+def test_guard_ignores_non_dict_and_missing_messages():
+    """The guard checks only the documented dict shape: non-dict params/entries
+    and a missing ``messages`` key are no-ops (the API owns those errors)."""
+    api_dispatch._assert_no_system_role({}, "item_000")  # no messages key
+    api_dispatch._assert_no_system_role({"messages": "oops"}, "item_000")  # non-list
+    api_dispatch._assert_no_system_role(
+        {"messages": [("role", "system")]}, "item_000"
+    )  # non-dict entry
+
+
+def test_batch_resume_builder_raise_leaves_subbatch_pending(tmp_path):
+    """The §4f reorder's contract: a builder raise on batch RESUME (the guard's,
+    or any other) fires BEFORE the status flip, so the sub-batch stays
+    ``pending`` in memory AND on disk — resumable, not a crashed-mid-submit
+    wedge."""
+    items = make_items(2)
+    cid_for = {it.item_id: make_custom_id(it.item_id) for it in items}
+    items_by_cid = {cid_for[it.item_id]: it for it in items}
+    sb = {
+        "index": 0,
+        "org": "a",
+        "custom_ids": list(items_by_cid),
+        "n_requests": len(items),
+        "status": "pending",
+        "batch_id": None,
+        "deadline": None,
+    }
+    state = {
+        "version": 1,
+        "sub_batches": [sb],
+        "cid_to_item": {cid: it.item_id for cid, it in items_by_cid.items()},
+    }
+    state_path = tmp_path / "state.json"
+    # PREWRITE the fabricated pending state.json: after the reorder the builder
+    # raise occurs before any write, so the on-disk re-read below only holds
+    # against a pre-created baseline checkpoint.
+    api_dispatch._atomic_write_json(state_path, state)
+    fake = FakeBatchClient("a")
+
+    async def _drive():
+        await api_dispatch._submit_one_sub_batch(
+            sb,
+            state=state,
+            state_path=state_path,
+            items_by_cid=items_by_cid,
+            build_request=api_dispatch._guarded_build_request(build_request_with_system),
+            sync_clients={"a": fake},
+            sem=asyncio.Semaphore(1),
+        )
+
+    with pytest.raises(ValueError, match='role="system"'):
+        _run(_drive())
+    assert sb["status"] == "pending"  # in-memory: never flipped to "submitting"
+    on_disk = json.loads(state_path.read_text())
+    assert on_disk["sub_batches"][0]["status"] == "pending"  # on-disk: still resumable
+    assert fake.create_calls == 0  # nothing was submitted


### PR DESCRIPTION
Closes task #991. Runtime enforcement of the Messages-API no-system-role contract at the dispatch_calls seam (+ submit reorder, 6 tests). Plan: tasks/*/991/plans/v3.md