### PR TITLE
issue-990: exclude deliberate-stop events from _latest_progress_ts

### DIFF
--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -980,7 +980,10 @@ _LONG_PHASE_HEARTBEAT_PREFIX = "[long-phase-heartbeat]"
 # All watcher-posted note substrings to exclude from `_latest_progress_ts`.
 # Pulled into one frozenset so every pass's filter is uniform: add a new
 # watcher-posted marker -> add its sentinel here -> _latest_progress_ts
-# transparently excludes it without an extra special case.
+# transparently excludes it without an extra special case. (The deliberate
+# session-stop exclusion is NOT a member — this set is SUBSTRING-matched,
+# which would break the prefix boundary; it lives inline in
+# _latest_progress_ts as a prefix/by check instead; #990.)
 _WATCHER_NOTE_SENTINELS: frozenset[str] = frozenset(
     {
         _ALERT_NOTE_SENTINEL,
@@ -3739,7 +3742,11 @@ def _latest_progress_ts(events: list[dict]) -> float | None:
     :data:`_WATCHER_NOTE_SENTINELS` (the watcher's own stale-alert /
     session-stalled-alert posts use ``epm:progress`` and must NOT count as
     progress — otherwise the alert would reset the staleness clock it is
-    measuring). Returns ``None`` when there is no such marker.
+    measuring) AND that is not a deliberate session-stop record (lstripped
+    note prefix ``"deliberate-stop "`` OR ``by == "spawn_session-stop"`` — a
+    session's death record is anti-liveness, never progress; #990, precedent
+    #949/#810 in ``task_workflow.stage_dispatch_should_skip``). Returns
+    ``None`` when there is no such marker.
     """
     best: float | None = None
     for ev in events:
@@ -3748,6 +3755,18 @@ def _latest_progress_ts(events: list[dict]) -> float | None:
         note = ev.get("note") or ""
         if any(sentinel in note for sentinel in _WATCHER_NOTE_SENTINELS):
             continue  # a watcher-posted alert — not real progress
+        # Anti-liveness (#990; precedent #949/#810): a deliberate session
+        # stop is the death record of the task's driver, not progress —
+        # counting it would refresh the very staleness clocks that should
+        # react to the stop. Same predicate as
+        # task_workflow.stage_dispatch_should_skip (~line 1463): the
+        # lstripped "deliberate-stop " note PREFIX (also catches PM-posted
+        # stop records, which use by="pm-chat" — research-pm.md ~719/734)
+        # OR by == "spawn_session-stop" (catches note-text drift from the
+        # cmd_stop emitter). Prefix-boundary: a note merely MENTIONING
+        # deliberate-stop mid-text still counts as progress.
+        if note.lstrip().startswith("deliberate-stop ") or ev.get("by") == "spawn_session-stop":
+            continue
         ts = _parse_event_ts(ev.get("ts"))
         if ts is not None and (best is None or ts > best):
             best = ts

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -739,6 +739,130 @@ def test_latest_progress_ts_none_when_no_progress():
     assert asw._latest_progress_ts([{"kind": "epm:clarify", "ts": "2026-06-05T10:00:00Z"}]) is None
 
 
+def test_latest_progress_ts_excludes_deliberate_stop_breadcrumb():
+    # The exact spawn_session.py cmd_stop emitter shape: a deliberate session
+    # stop is the death record of the task's driver, not progress — it must
+    # NOT advance the clock (#990; precedent #949/#810 in
+    # task_workflow.stage_dispatch_should_skip).
+    import autonomous_session_watch as asw
+
+    events = [
+        # Real progress carries a benign ``by`` — it must still COUNT (pins
+        # the exclusion to by == "spawn_session-stop", not by-presence).
+        {
+            "kind": "epm:progress",
+            "ts": "2026-07-01T10:00:00Z",
+            "by": "unknown",
+            "note": "step 100",
+        },
+        {
+            "kind": "epm:progress",
+            "ts": "2026-07-01T12:00:00Z",
+            "by": "spawn_session-stop",
+            "note": (
+                "deliberate-stop pid=n/a target=happy-session:abc123 "
+                "reason=operator stop via spawn_session.py stop"
+            ),
+        },
+    ]
+    ts = asw._latest_progress_ts(events)
+    # The 12:00 stop record is excluded; newest real progress stays 10:00.
+    assert ts == asw._parse_event_ts("2026-07-01T10:00:00Z")
+
+
+def test_latest_progress_ts_counts_real_progress_with_benign_by():
+    # A lone real-progress event with a benign ``by`` returns ITS timestamp
+    # (non-None) — kills a by-presence mutation (`if ev.get("by"): continue`).
+    import autonomous_session_watch as asw
+
+    events = [
+        {
+            "kind": "epm:progress",
+            "ts": "2026-07-01T11:00:00Z",
+            "by": "unknown",
+            "note": "step 200",
+        },
+    ]
+    assert asw._latest_progress_ts(events) == asw._parse_event_ts("2026-07-01T11:00:00Z")
+
+
+def test_latest_progress_ts_excludes_by_field_regardless_of_note():
+    # The by-half in isolation: by == "spawn_session-stop" excludes the event
+    # even when the note lacks the "deliberate-stop " prefix (note-text
+    # drift), and even when the ``note`` key is ABSENT entirely (pins the
+    # `note = ev.get("note") or ""` normalization against the predicate).
+    import autonomous_session_watch as asw
+
+    events = [
+        {"kind": "epm:progress", "ts": "2026-07-01T10:00:00Z", "note": "step 100"},
+        {
+            "kind": "epm:progress",
+            "ts": "2026-07-01T12:00:00Z",
+            "by": "spawn_session-stop",
+            "note": "stopping for operator replacement",
+        },
+        # No "note" key at all — the by-half alone must exclude it.
+        {"kind": "epm:progress", "ts": "2026-07-01T13:00:00Z", "by": "spawn_session-stop"},
+    ]
+    assert asw._latest_progress_ts(events) == asw._parse_event_ts("2026-07-01T10:00:00Z")
+
+
+def test_latest_progress_ts_excludes_deliberate_stop_prefix_without_by():
+    # The prefix-half in isolation: a PM-posted stop record (by="pm-chat",
+    # the research-pm.md shape) is excluded on the lstripped note prefix
+    # alone; leading whitespace does not defeat the lstrip.
+    import autonomous_session_watch as asw
+
+    events = [
+        {"kind": "epm:progress", "ts": "2026-07-01T10:00:00Z", "note": "step 100"},
+        {
+            "kind": "epm:progress",
+            "ts": "2026-07-01T12:00:00Z",
+            "by": "pm-chat",
+            "note": "deliberate-stop pid=12345 target=tick-loop reason=operator-replace",
+        },
+        {
+            "kind": "epm:progress",
+            "ts": "2026-07-01T13:00:00Z",
+            "by": "pm-chat",
+            "note": "  deliberate-stop pid=999 target=tick-loop reason=leading-whitespace",
+        },
+    ]
+    assert asw._latest_progress_ts(events) == asw._parse_event_ts("2026-07-01T10:00:00Z")
+
+
+def test_latest_progress_ts_midnote_deliberate_stop_mention_still_counts():
+    # Prefix boundary (mirror of the #949 pin in test_stage_dispatch_dedup):
+    # a note merely MENTIONING deliberate-stop mid-text, with no special
+    # ``by``, DOES advance the clock.
+    import autonomous_session_watch as asw
+
+    events = [
+        {"kind": "epm:progress", "ts": "2026-07-01T10:00:00Z", "note": "step 100"},
+        {
+            "kind": "epm:progress",
+            "ts": "2026-07-01T12:00:00Z",
+            "note": "noting the earlier deliberate-stop was expected; resuming phase 2",
+        },
+    ]
+    assert asw._latest_progress_ts(events) == asw._parse_event_ts("2026-07-01T12:00:00Z")
+
+
+def test_latest_progress_ts_only_deliberate_stop_returns_none():
+    # A list containing only the stop record has no real progress at all.
+    import autonomous_session_watch as asw
+
+    events = [
+        {
+            "kind": "epm:progress",
+            "ts": "2026-07-01T12:00:00Z",
+            "by": "spawn_session-stop",
+            "note": "deliberate-stop pid=n/a target=happy-session:abc reason=operator stop",
+        },
+    ]
+    assert asw._latest_progress_ts(events) is None
+
+
 # ─── pod-safety I/O wrapper tests ────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes task #990 (kind: infra workflow-fix).

## Summary
- Excludes deliberate session-stop records (lstripped note prefix `deliberate-stop ` OR `by == "spawn_session-stop"`) from the watcher's real-progress clock `_latest_progress_ts` — a session's death record no longer resets the staleness clock (same anti-liveness class as the #949 fix in `task_workflow.stage_dispatch_should_skip`, incident #810).
- 6 new pinned tests (emitter shape, per-half isolation, lstrip, mid-note prefix boundary, only-stop→None, benign-`by` counted-progress) + note-key-absent by-half case.

## Test plan
- [x] Targeted 9/9; full watcher suite 814/814; sibling `test_stage_dispatch_dedup.py` 26/26
- [x] Step 9c touched scope: 2393 passed / 2 pre-existing-on-main failures (#931 jsonl-splitlines lint, untouched by this diff)
- [x] ruff check + format clean; Claude+Codex code-review ensemble PASS (round 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)