### PR TITLE
issue-996: bounded wait on live rebase before task.py detached-HEAD refusal

### DIFF
--- a/scripts/task.py
+++ b/scripts/task.py
@@ -1691,8 +1691,11 @@ def main() -> None:
 
     args = parser.parse_args()
     # The canonical resolver (task_workflow.repo_root) raises a loud, distinct
-    # RuntimeError for the non-routable states it still refuses: detached HEAD,
-    # missing `tasks/`, bare/submodule layouts, or a feature-branch primary with
+    # RuntimeError for the non-routable states it still refuses: a genuinely
+    # detached HEAD (after the bounded live-rebase wait,
+    # `EPM_TASKPY_REBASE_WAIT_SECONDS` — #996; the wait-timeout refusal is
+    # still a RuntimeError, so this catch covers it too), missing `tasks/`,
+    # bare/submodule layouts, or a feature-branch primary with
     # no local `main` to route through. (The common "primary parked on a real
     # feature branch" case is auto-routed through a managed main-pinned worktree
     # and does NOT raise.) Catch RuntimeError at the top-level dispatch so EVERY

--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -74,6 +74,7 @@ import functools
 import hashlib
 import json
 import logging
+import math
 import os
 import random
 import re
@@ -286,14 +287,23 @@ def _rebase_wait_bound_s() -> float:
     """Total bounded-wait budget (seconds) for a live rebase before the
     detached-HEAD refusal fires. ``0`` restores the pre-#996 immediate
     refusal exactly. A non-float env value raises ``ValueError`` (fail
-    loud, project norm)."""
-    return float(os.environ.get(_REBASE_WAIT_ENV, "120"))
+    loud, project norm); a non-finite float (``nan``/``inf``) raises too —
+    ``nan`` defeats the ``time.monotonic() >= deadline`` comparison and
+    would wait unbounded."""
+    value = float(os.environ.get(_REBASE_WAIT_ENV, "120"))
+    if not math.isfinite(value):
+        raise ValueError(f"{_REBASE_WAIT_ENV} must be finite, got {value!r}")
+    return value
 
 
 def _rebase_poll_s() -> float:
     """Poll interval (seconds) between branch-guard re-probes while waiting
-    out a live rebase. A non-float env value raises ``ValueError``."""
-    return float(os.environ.get(_REBASE_POLL_ENV, "2.0"))
+    out a live rebase. A non-float or non-finite env value raises
+    ``ValueError``."""
+    value = float(os.environ.get(_REBASE_POLL_ENV, "2.0"))
+    if not math.isfinite(value):
+        raise ValueError(f"{_REBASE_POLL_ENV} must be finite, got {value!r}")
+    return value
 
 
 def _rebase_in_progress(common_dir: Path) -> bool:

--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -240,7 +240,10 @@ CODE_KINDS = frozenset({"infra", "analysis", "batch", "survey"})
 #       `tasks/`.
 #   (c) Branch-guards: `git -C <parent> symbolic-ref --short HEAD` must
 #       return `main`. Non-`main` and detached HEAD raise DISTINCT
-#       `RuntimeError`s naming the actual state.
+#       `RuntimeError`s naming the actual state; a detached HEAD with a LIVE
+#       primary-checkout rebase in progress first gets a bounded wait (#996,
+#       `EPM_TASKPY_REBASE_WAIT_SECONDS`, default 120s, 0 disables) before
+#       the refusal fires.
 #   (d) Caches via `functools.lru_cache(maxsize=1)` keyed on
 #       `(os.getpid(), os.getcwd())` so each Python invocation pays one
 #       subprocess pair total; cache invalidates across forks and cwd
@@ -269,6 +272,47 @@ def _sanitized_git_env() -> dict[str, str]:
     for k in _GIT_ENV_POISONERS:
         env.pop(k, None)
     return env
+
+
+# Bounded wait for a LIVE primary-checkout rebase before the detached-HEAD
+# refusal (#996). A concurrent `git pull --rebase` on the shared repo root
+# detaches the primary HEAD for the rebase duration; refusing instantly cost
+# ≥7 sessions their task.py mutations on 2026-07-03.
+_REBASE_WAIT_ENV = "EPM_TASKPY_REBASE_WAIT_SECONDS"  # total bound; 0 disables (default 120)
+_REBASE_POLL_ENV = "EPM_TASKPY_REBASE_POLL_SECONDS"  # poll interval (default 2.0)
+
+
+def _rebase_wait_bound_s() -> float:
+    """Total bounded-wait budget (seconds) for a live rebase before the
+    detached-HEAD refusal fires. ``0`` restores the pre-#996 immediate
+    refusal exactly. A non-float env value raises ``ValueError`` (fail
+    loud, project norm)."""
+    return float(os.environ.get(_REBASE_WAIT_ENV, "120"))
+
+
+def _rebase_poll_s() -> float:
+    """Poll interval (seconds) between branch-guard re-probes while waiting
+    out a live rebase. A non-float env value raises ``ValueError``."""
+    return float(os.environ.get(_REBASE_POLL_ENV, "2.0"))
+
+
+def _rebase_in_progress(common_dir: Path) -> bool:
+    """True iff the PRIMARY checkout has a live (or stale) rebase state dir.
+
+    For the primary worktree the per-worktree git dir IS the common dir, so a
+    primary-checkout rebase writes `<common-dir>/rebase-merge` (merge /
+    interactive backend — the `pull.rebase=merges` default pinned in this
+    repo) or `<common-dir>/rebase-apply` (am backend). A LINKED worktree's
+    rebase lives under `<common-dir>/worktrees/<name>/` and does NOT detach
+    the primary HEAD — correctly excluded by probing the common dir only.
+
+    Mirrors ``scripts/sync_repo_root.py::_rebase_in_progress`` but takes the
+    validated common dir directly and uses ``.is_dir()`` where the sibling
+    uses ``.exists()`` — deliberate (the state dir is always a directory),
+    noted here so a future unifier doesn't read the divergence as
+    intentional filtering.
+    """
+    return (common_dir / "rebase-merge").is_dir() or (common_dir / "rebase-apply").is_dir()
 
 
 def _resolve_primary_checkout(env: dict[str, str]) -> Path:
@@ -322,6 +366,10 @@ def _resolve_primary_checkout(env: dict[str, str]) -> Path:
     return parent
 
 
+# NOTE: functools.lru_cache caches only successful RETURNS — a raised
+# RuntimeError (plain detached refusal or rebase-wait timeout) is NOT cached,
+# so the next call in the same process re-probes; a post-wait success IS
+# cached (desired).
 @functools.lru_cache(maxsize=1)
 def _resolve_repo_root_cached(_key: tuple[int, str]) -> Path:
     """Inner cache target. Keyed on (pid, cwd) so forks + chdirs invalidate
@@ -331,51 +379,119 @@ def _resolve_repo_root_cached(_key: tuple[int, str]) -> Path:
     env = _sanitized_git_env()
     # (a)+(b) Locate the common git dir + validate its parent.
     parent = _resolve_primary_checkout(env)
-    # (c) Branch guard.
-    sym = subprocess.run(
-        ["git", "-C", str(parent), "symbolic-ref", "--short", "HEAD"],
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if sym.returncode == 0:
-        branch = sym.stdout.strip()
-        if branch != "main":
-            # The primary checkout is parked on a real feature branch. Rather
-            # than refuse (the historical behavior, which silently dropped
-            # markers in ~7 sessions), auto-route every task.py read+write
-            # through a dedicated managed worktree pinned to a DETACHED `main`
-            # tip. Commits made through that worktree advance the `main` ref
-            # (see `_advance_main_ref`), so the guard's INTENT — commits land
-            # on main, never strand on a feature branch — is preserved; only
-            # the hard refusal is replaced. The `--detach main` pin (not the
-            # `main` BRANCH) is deliberate: a worktree holding the `main`
-            # branch would block the primary from `git checkout main`
-            # ("fatal: 'main' is already checked out at <managed>"), so a
-            # leaked managed worktree would brick the user's ability to return
-            # to main. A detached pin holds no branch-checkout lock, so a leak
-            # is benign. Returns the managed worktree path; `_git_commit`
-            # detects routing via `_is_routed_root` and does the
-            # reset-to-main / advance-main dance.
-            return _ensure_managed_main_worktree(parent, branch, env)
-    else:
+    # The validated common dir (basename `.git` per _resolve_primary_checkout).
+    common_dir = parent / ".git"
+    wait_bound = _rebase_wait_bound_s()
+    deadline = time.monotonic() + wait_bound
+    # One extra re-probe for the marker-less boundary window: git's internal
+    # ordering of state-dir removal vs HEAD re-attach at rebase start/finish
+    # is not contractual, so a single 0.5s re-probe closes both the
+    # just-created and just-removed windows at a worst-case +0.5s on a
+    # genuine (non-rebase) detached refusal. Skipped entirely at knob=0.
+    grace_probes_left = 1 if wait_bound > 0 else 0
+    announced = False
+    polls = 0
+    while True:
+        # (c) Branch guard — re-entered in FULL each iteration, so a
+        # post-rebase HEAD attached to `main` returns the primary and a
+        # post-rebase HEAD on a non-main branch routes through the managed
+        # worktree (#844).
+        sym = subprocess.run(
+            ["git", "-C", str(parent), "symbolic-ref", "--short", "HEAD"],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if sym.returncode == 0:
+            branch = sym.stdout.strip()
+            if branch != "main":
+                # The primary checkout is parked on a real feature branch. Rather
+                # than refuse (the historical behavior, which silently dropped
+                # markers in ~7 sessions), auto-route every task.py read+write
+                # through a dedicated managed worktree pinned to a DETACHED `main`
+                # tip. Commits made through that worktree advance the `main` ref
+                # (see `_advance_main_ref`), so the guard's INTENT — commits land
+                # on main, never strand on a feature branch — is preserved; only
+                # the hard refusal is replaced. The `--detach main` pin (not the
+                # `main` BRANCH) is deliberate: a worktree holding the `main`
+                # branch would block the primary from `git checkout main`
+                # ("fatal: 'main' is already checked out at <managed>"), so a
+                # leaked managed worktree would brick the user's ability to return
+                # to main. A detached pin holds no branch-checkout lock, so a leak
+                # is benign. Returns the managed worktree path; `_git_commit`
+                # detects routing via `_is_routed_root` and does the
+                # reset-to-main / advance-main dance.
+                return _ensure_managed_main_worktree(parent, branch, env)
+            return parent
         # `git symbolic-ref --short HEAD` returns rc=1 with stderr
         # "fatal: ref HEAD is not a symbolic ref" when HEAD is detached.
         # The substring check is the canonical detached-HEAD signal —
         # rc=128 can mean many other things (not a git repo, object
         # missing, …) and we don't want to misclassify those as detached.
         stderr = (sym.stderr or "").lower()
-        if "not a symbolic ref" in stderr:
+        if "not a symbolic ref" not in stderr:
+            raise RuntimeError(
+                f"`git symbolic-ref --short HEAD` failed (rc={sym.returncode}) "
+                f"in {parent}:\n  stderr: {sym.stderr!r}"
+            )
+        # Detached HEAD. When a LIVE rebase of the primary checkout is in
+        # progress, bounded-wait and re-probe instead of refusing outright
+        # (#996). WAITING (not routing through the managed worktree) is
+        # deliberate: a mid-rebase managed-worktree commit would CAS-advance a
+        # `refs/heads/main` the finishing rebase is about to force-move to its
+        # replayed tip (the orphaned-commit family sync_repo_root.py's
+        # docstring warns about); the rebase replays the pre-existing commits
+        # onto main anyway. No deadlock while a caller waits here holding the
+        # task-workflow flock: sync_repo_root.py acquires that flock BEFORE
+        # its pull_rebase, and that acquisition is itself LOCK_NB-bounded —
+        # the observed rebase never needs the flock to finish.
+        if wait_bound <= 0:
+            # Knob=0 → EXACT pre-#996 behavior: no marker probe, no grace,
+            # immediate refusal with the byte-identical message.
             raise RuntimeError(
                 f"main worktree HEAD ({parent}) is detached; "
                 f"re-attach to 'main' before running task.py."
             )
-        raise RuntimeError(
-            f"`git symbolic-ref --short HEAD` failed (rc={sym.returncode}) "
-            f"in {parent}:\n  stderr: {sym.stderr!r}"
-        )
-    return parent
+        rebasing = _rebase_in_progress(common_dir)
+        if not rebasing and grace_probes_left <= 0:
+            raise RuntimeError(
+                f"main worktree HEAD ({parent}) is detached; "
+                f"re-attach to 'main' before running task.py."
+            )
+        if time.monotonic() >= deadline:
+            raise RuntimeError(
+                f"main worktree HEAD ({parent}) is detached and a rebase state dir "
+                f"({common_dir / 'rebase-merge'} or rebase-apply) was still present after "
+                f"waiting {wait_bound:.0f}s ({_REBASE_WAIT_ENV}). A live `git pull --rebase` "
+                f"should finish in seconds; a state dir this old is likely a CRASHED rebase. "
+                f"Inspect with `git -C {parent} status`; `git -C {parent} rebase --abort` "
+                f"clears a stale rebase, then re-attach to 'main'."
+            )
+        if not rebasing:
+            grace_probes_left -= 1
+            time.sleep(0.5)  # just-created / just-removed marker window; single re-probe
+            continue
+        if not announced:
+            _log.warning(
+                "task.py: primary checkout HEAD (%s) is detached mid-rebase (%s present); "
+                "waiting up to %.0fs for the concurrent rebase to finish (poll %.1fs; "
+                "override via %s)...",
+                parent,
+                "rebase-merge/rebase-apply",
+                wait_bound,
+                _rebase_poll_s(),
+                _REBASE_WAIT_ENV,
+            )
+            announced = True
+        polls += 1
+        if polls % 10 == 0:  # heartbeat (cadence untested; entry line is the contract)
+            _log.warning(
+                "task.py: still waiting on the concurrent rebase (%.0fs of %.0fs elapsed)...",
+                wait_bound - max(deadline - time.monotonic(), 0.0),
+                wait_bound,
+            )
+        time.sleep(_rebase_poll_s())
 
 
 # ─── Off-main auto-routing (managed main-pinned worktree) ───────────────────
@@ -543,7 +659,10 @@ def repo_root() -> Path:
     Resolves via `git rev-parse --git-common-dir` from the directory of
     this module (NOT `os.getcwd()`). Branch-guards: raises a loud,
     distinct `RuntimeError` if the main worktree HEAD is on a non-`main`
-    branch or detached. Validates that the resolved path actually contains
+    branch or detached; a detached HEAD with a live primary-checkout rebase
+    in progress first gets a bounded wait (#996,
+    `EPM_TASKPY_REBASE_WAIT_SECONDS`, default 120s) before the refusal.
+    Validates that the resolved path actually contains
     `tasks/` and is not a submodule / bare layout. NEVER falls back to a
     walk-up resolver — silent fallback is what produced the
     worktree-staleness bug class this resolver replaces.

--- a/tests/test_task_workflow_worktree.py
+++ b/tests/test_task_workflow_worktree.py
@@ -42,15 +42,31 @@ import pytest
 # explore_persona_space.task_workflow`. We pass this on PYTHONPATH below.
 _REPO_SRC = str(Path(__file__).resolve().parents[1] / "src")
 
-# Bounded live-rebase wait knobs (#996). Every test that exercises the
-# resolver's DETACHED path explicitly sets or POPS both in the child env —
-# a knob leaked into the CI env (e.g. a non-float value, which the resolver
-# parses fail-loud) would otherwise perturb knob-default tests.
+# Bounded live-rebase wait knobs (#996). EVERY child env in this file flows
+# through `_clean_env()`, which POPS both — a knob leaked into the CI/parent
+# env (e.g. a non-float value, which the resolver parses fail-loud) would
+# otherwise perturb knob-default tests. Tests that exercise a knob re-set it
+# explicitly AFTER the pop (`_child_env`).
 _REBASE_WAIT_ENV = "EPM_TASKPY_REBASE_WAIT_SECONDS"
 _REBASE_POLL_ENV = "EPM_TASKPY_REBASE_POLL_SECONDS"
 
 
 # ─── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _clean_env() -> dict[str, str]:
+    """Copy of the parent env with both #996 rebase-wait knobs POPPED.
+
+    The single knob-hygiene chokepoint (round-2 concern
+    `resolver-test-rebase-env-hygiene`): every subprocess env in this file
+    is built from this copy, so a knob leaked into the CI/parent env can
+    never reach a child. Tests that deliberately exercise a knob set it
+    explicitly AFTER this pop (see ``_child_env``).
+    """
+    env = os.environ.copy()
+    for key in (_REBASE_WAIT_ENV, _REBASE_POLL_ENV):
+        env.pop(key, None)
+    return env
 
 
 def _make_main_repo(repo: Path) -> None:
@@ -80,7 +96,7 @@ def _run_resolver(
     stderr). We do NOT pass `check=True` — many tests assert on the
     error message in stderr.
     """
-    env = dict(os.environ)
+    env = _clean_env()
     # Make sure the subprocess can import the project.
     env["PYTHONPATH"] = _REPO_SRC + os.pathsep + env.get("PYTHONPATH", "")
     if extra_env:
@@ -160,7 +176,7 @@ def test_resolves_main_repo_from_worktree(tmp_path: Path) -> None:
 
     # Invoke from inside the worktree, with PYTHONPATH pointing at the
     # tmp repo's src (so we import the test copy of task_workflow).
-    env = dict(os.environ)
+    env = _clean_env()
     env["PYTHONPATH"] = str(main_repo / "src") + os.pathsep + env.get("PYTHONPATH", "")
     proc = subprocess.run(
         [sys.executable, "-c", _resolver_snippet()],
@@ -205,7 +221,7 @@ def test_branch_guard_routes_non_main_to_managed_worktree(tmp_path: Path) -> Non
     real_tw = Path(_REPO_SRC) / "explore_persona_space" / "task_workflow.py"
     (src_dir / "task_workflow.py").write_text(real_tw.read_text())
 
-    env = dict(os.environ)
+    env = _clean_env()
     env["PYTHONPATH"] = str(main_repo / "src") + os.pathsep + env.get("PYTHONPATH", "")
     proc = subprocess.run(
         [sys.executable, "-c", _resolver_snippet()],
@@ -255,13 +271,10 @@ def test_branch_guard_distinct_error_on_detached_head(tmp_path: Path) -> None:
     real_tw = Path(_REPO_SRC) / "explore_persona_space" / "task_workflow.py"
     (src_dir / "task_workflow.py").write_text(real_tw.read_text())
 
-    env = dict(os.environ)
+    env = _clean_env()
     env["PYTHONPATH"] = str(main_repo / "src") + os.pathsep + env.get("PYTHONPATH", "")
-    # Knob hygiene (#996): pop both rebase-wait knobs so a leaked CI value
-    # (e.g. a non-float, which the resolver parses fail-loud) cannot perturb
-    # this knob-DEFAULT detached refusal.
-    env.pop(_REBASE_WAIT_ENV, None)
-    env.pop(_REBASE_POLL_ENV, None)
+    # Knob hygiene (#996): `_clean_env()` popped both rebase-wait knobs, so a
+    # leaked CI value cannot perturb this knob-DEFAULT detached refusal.
     proc = subprocess.run(
         [sys.executable, "-c", _resolver_snippet()],
         cwd=str(main_repo),
@@ -291,7 +304,7 @@ def test_validation_rejects_missing_tasks_dir(tmp_path: Path) -> None:
     real_tw = Path(_REPO_SRC) / "explore_persona_space" / "task_workflow.py"
     (src_dir / "task_workflow.py").write_text(real_tw.read_text())
 
-    env = dict(os.environ)
+    env = _clean_env()
     env["PYTHONPATH"] = str(main_repo / "src") + os.pathsep + env.get("PYTHONPATH", "")
     proc = subprocess.run(
         [sys.executable, "-c", _resolver_snippet()],
@@ -314,7 +327,7 @@ def test_validation_rejects_bare_repo(tmp_path: Path) -> None:
     # We need a place to drop task_workflow.py such that the subprocess
     # CWD lands inside the bare repo's reach. Just cwd in bare.git and
     # use PYTHONPATH pointing at the dev repo.
-    env = dict(os.environ)
+    env = _clean_env()
     env["PYTHONPATH"] = _REPO_SRC + os.pathsep + env.get("PYTHONPATH", "")
     snippet = textwrap.dedent(
         """
@@ -404,7 +417,7 @@ def test_validation_rejects_real_submodule_layout(tmp_path: Path) -> None:
     real_tw = Path(_REPO_SRC) / "explore_persona_space" / "task_workflow.py"
     (src_dir / "task_workflow.py").write_text(real_tw.read_text())
 
-    env = dict(os.environ)
+    env = _clean_env()
     env["PYTHONPATH"] = str(inner / "src") + os.pathsep + env.get("PYTHONPATH", "")
     proc = subprocess.run(
         [sys.executable, "-c", _resolver_snippet()],
@@ -445,7 +458,7 @@ def test_resolver_ignores_git_env_poisoning(tmp_path: Path) -> None:
     real_tw = Path(_REPO_SRC) / "explore_persona_space" / "task_workflow.py"
     (src_dir / "task_workflow.py").write_text(real_tw.read_text())
 
-    env = dict(os.environ)
+    env = _clean_env()
     env["PYTHONPATH"] = str(main_repo / "src") + os.pathsep + env.get("PYTHONPATH", "")
     env["GIT_DIR"] = str(bogus)
     env["GIT_WORK_TREE"] = str(tmp_path / "nonexistent")
@@ -490,7 +503,7 @@ def test_pep562_attribute_access_works_lazily(tmp_path: Path) -> None:
         print('REGISTRY_PATH=' + str(tw.REGISTRY_PATH))
         """
     )
-    env = dict(os.environ)
+    env = _clean_env()
     env["PYTHONPATH"] = str(main_repo / "src") + os.pathsep + env.get("PYTHONPATH", "")
     proc = subprocess.run(
         [sys.executable, "-c", snippet],
@@ -536,7 +549,7 @@ def test_cache_hits_avoid_extra_git_calls(tmp_path: Path) -> None:
         }))
         """
     )
-    env = dict(os.environ)
+    env = _clean_env()
     env["PYTHONPATH"] = str(main_repo / "src") + os.pathsep + env.get("PYTHONPATH", "")
     proc = subprocess.run(
         [sys.executable, "-c", snippet],
@@ -579,7 +592,7 @@ def test_resolver_uses_module_dir_not_cwd(tmp_path: Path) -> None:
     cwd = tmp_path / "neutral"
     cwd.mkdir()
 
-    env = dict(os.environ)
+    env = _clean_env()
     env["PYTHONPATH"] = str(main_repo / "src") + os.pathsep + env.get("PYTHONPATH", "")
     proc = subprocess.run(
         [sys.executable, "-c", _resolver_snippet()],
@@ -629,7 +642,7 @@ def test_primary_checkout_root_resolves_main_from_worktree(tmp_path: Path) -> No
     )
 
     # PYTHONPATH -> the WORKTREE's src copy (not the primary's).
-    env = dict(os.environ)
+    env = _clean_env()
     env["PYTHONPATH"] = str(worktree / "src") + os.pathsep + env.get("PYTHONPATH", "")
     snippet = textwrap.dedent(
         """
@@ -672,7 +685,7 @@ def test_primary_checkout_root_ignores_branch_state(tmp_path: Path) -> None:
     real_tw = Path(_REPO_SRC) / "explore_persona_space" / "task_workflow.py"
     (src_dir / "task_workflow.py").write_text(real_tw.read_text())
 
-    env = dict(os.environ)
+    env = _clean_env()
     env["PYTHONPATH"] = str(main_repo / "src") + os.pathsep + env.get("PYTHONPATH", "")
     snippet = textwrap.dedent(
         """
@@ -734,7 +747,7 @@ def test_invalidate_cache_clears_primary_checkout_cache(tmp_path: Path) -> None:
         }))
         """
     )
-    env = dict(os.environ)
+    env = _clean_env()
     env["PYTHONPATH"] = str(main_repo / "src") + os.pathsep + env.get("PYTHONPATH", "")
     proc = subprocess.run(
         [sys.executable, "-c", snippet],
@@ -793,7 +806,7 @@ def test_tasks_dir_cli_subcommand_invokes_real_task_py(tmp_path: Path) -> None:
     _make_main_repo(main_repo)
     _stage_task_cli_tree(main_repo)
 
-    env = dict(os.environ)
+    env = _clean_env()
     # No PYTHONPATH manipulation needed — task.py prepends `src/` to
     # sys.path on import. TASK_PY_NO_COMMIT=1 prevents any inadvertent
     # git commit attempt (tasks-dir is read-only, but defense in depth).
@@ -825,7 +838,7 @@ def test_tasks_dir_cli_routes_on_non_main_branch(tmp_path: Path) -> None:
         check=True,
     )
 
-    env = dict(os.environ)
+    env = _clean_env()
     env["TASK_PY_NO_COMMIT"] = "1"
     proc = subprocess.run(
         [sys.executable, str(main_repo / "scripts" / "task.py"), "tasks-dir"],
@@ -860,12 +873,10 @@ def test_cli_exits_cleanly_on_detached_head(tmp_path: Path) -> None:
         check=True,
     )
 
-    env = dict(os.environ)
+    env = _clean_env()
     env["TASK_PY_NO_COMMIT"] = "1"
-    # Knob hygiene (#996): pop both rebase-wait knobs so a leaked CI value
-    # cannot perturb this knob-DEFAULT detached refusal.
-    env.pop(_REBASE_WAIT_ENV, None)
-    env.pop(_REBASE_POLL_ENV, None)
+    # Knob hygiene (#996): `_clean_env()` popped both rebase-wait knobs, so a
+    # leaked CI value cannot perturb this knob-DEFAULT detached refusal.
     proc = subprocess.run(
         [sys.executable, str(main_repo / "scripts" / "task.py"), "tasks-dir"],
         cwd=str(main_repo),
@@ -900,7 +911,7 @@ def _commit_cli_tree(main_repo: Path) -> None:
 
 def _run_task_cli(main_repo: Path, *cli_args: str) -> subprocess.CompletedProcess[str]:
     """Invoke the real `scripts/task.py` in ``main_repo`` (commits enabled)."""
-    env = dict(os.environ)
+    env = _clean_env()
     return subprocess.run(
         [sys.executable, str(main_repo / "scripts" / "task.py"), *cli_args],
         cwd=str(main_repo),
@@ -1089,7 +1100,7 @@ def _stage_tw_module(main_repo: Path) -> None:
 def _child_env(main_repo: Path, *, wait: str | None, poll: str | None) -> dict[str, str]:
     """Child env with PYTHONPATH at the test repo's src and BOTH rebase
     knobs explicitly set (str) or POPPED (None) — test-env knob hygiene."""
-    env = dict(os.environ)
+    env = _clean_env()
     env["PYTHONPATH"] = str(main_repo / "src") + os.pathsep + env.get("PYTHONPATH", "")
     for key, value in ((_REBASE_WAIT_ENV, wait), (_REBASE_POLL_ENV, poll)):
         if value is None:
@@ -1296,6 +1307,38 @@ def test_post_wait_nonmain_reattach_routes_managed_worktree(tmp_path: Path) -> N
         f"post-wait non-main re-attach did not route to the managed worktree: {resolved}"
     )
     assert Path(resolved["TASKS_DIR"]).resolve() == (managed / "tasks").resolve()
+
+
+def test_rebase_knobs_reject_non_finite_values(tmp_path: Path) -> None:
+    """A `nan`/`inf` knob value parses via ``float()`` but would defeat the
+    ``time.monotonic() >= deadline`` bound (unbounded wait) — the knob
+    readers raise ``ValueError`` on any non-finite value (#996 round 2).
+
+    Subprocess-shaped like the other tests so the STAGED worktree copy of
+    ``task_workflow.py`` is exercised (an in-process import could resolve
+    to the primary checkout's editable install instead).
+    """
+    repo = tmp_path / "repo"
+    _stage_tw_module(repo)
+    for env, fn in (
+        (_child_env(repo, wait="nan", poll=None), "_rebase_wait_bound_s"),
+        (_child_env(repo, wait=None, poll="inf"), "_rebase_poll_s"),
+    ):
+        snippet = textwrap.dedent(
+            f"""
+            from explore_persona_space.task_workflow import {fn}
+            {fn}()
+            """
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", snippet],
+            cwd=str(repo),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert proc.returncode != 0, f"{fn} accepted a non-finite knob: {proc.stdout!r}"
+        assert "must be finite" in proc.stderr, f"guard missing for {fn}: {proc.stderr!r}"
 
 
 if __name__ == "__main__":

--- a/tests/test_task_workflow_worktree.py
+++ b/tests/test_task_workflow_worktree.py
@@ -33,6 +33,7 @@ import re
 import subprocess
 import sys
 import textwrap
+import time
 from pathlib import Path
 
 import pytest
@@ -40,6 +41,13 @@ import pytest
 # Absolute path to this repo's `src/` so subprocesses can `import
 # explore_persona_space.task_workflow`. We pass this on PYTHONPATH below.
 _REPO_SRC = str(Path(__file__).resolve().parents[1] / "src")
+
+# Bounded live-rebase wait knobs (#996). Every test that exercises the
+# resolver's DETACHED path explicitly sets or POPS both in the child env —
+# a knob leaked into the CI env (e.g. a non-float value, which the resolver
+# parses fail-loud) would otherwise perturb knob-default tests.
+_REBASE_WAIT_ENV = "EPM_TASKPY_REBASE_WAIT_SECONDS"
+_REBASE_POLL_ENV = "EPM_TASKPY_REBASE_POLL_SECONDS"
 
 
 # ─── Helpers ───────────────────────────────────────────────────────────────
@@ -230,7 +238,9 @@ def test_branch_guard_routes_non_main_to_managed_worktree(tmp_path: Path) -> Non
 
 
 def test_branch_guard_distinct_error_on_detached_head(tmp_path: Path) -> None:
-    """Detached HEAD → DISTINCT error mentioning 'detached'."""
+    """Detached HEAD (no rebase marker) → DISTINCT error mentioning
+    'detached'. Under the #996 bounded-wait this path pays at most one 0.5s
+    marker-less grace re-probe before the refusal — semantics unchanged."""
     main_repo = tmp_path / "repo"
     _make_main_repo(main_repo)
     # Detach.
@@ -247,6 +257,11 @@ def test_branch_guard_distinct_error_on_detached_head(tmp_path: Path) -> None:
 
     env = dict(os.environ)
     env["PYTHONPATH"] = str(main_repo / "src") + os.pathsep + env.get("PYTHONPATH", "")
+    # Knob hygiene (#996): pop both rebase-wait knobs so a leaked CI value
+    # (e.g. a non-float, which the resolver parses fail-loud) cannot perturb
+    # this knob-DEFAULT detached refusal.
+    env.pop(_REBASE_WAIT_ENV, None)
+    env.pop(_REBASE_POLL_ENV, None)
     proc = subprocess.run(
         [sys.executable, "-c", _resolver_snippet()],
         cwd=str(main_repo),
@@ -847,6 +862,10 @@ def test_cli_exits_cleanly_on_detached_head(tmp_path: Path) -> None:
 
     env = dict(os.environ)
     env["TASK_PY_NO_COMMIT"] = "1"
+    # Knob hygiene (#996): pop both rebase-wait knobs so a leaked CI value
+    # cannot perturb this knob-DEFAULT detached refusal.
+    env.pop(_REBASE_WAIT_ENV, None)
+    env.pop(_REBASE_POLL_ENV, None)
     proc = subprocess.run(
         [sys.executable, str(main_repo / "scripts" / "task.py"), "tasks-dir"],
         cwd=str(main_repo),
@@ -1044,6 +1063,239 @@ def test_managed_worktree_dodges_stale_worktree_audit() -> None:
         "managed main-pin worktree name matches the audit target regex — it "
         "could be reaped while routing is active"
     )
+
+
+# ─── Bounded live-rebase wait before the detached-HEAD refusal (#996) ──────
+#
+# A concurrent `git pull --rebase` on the shared repo root detaches the
+# primary HEAD for the rebase duration; the resolver now bounded-waits
+# (default 120s, `EPM_TASKPY_REBASE_WAIT_SECONDS`; 0 disables) when a live
+# rebase state dir (`.git/rebase-merge` / `rebase-apply`) is present, then
+# re-runs the FULL branch guard. These tests drive the resolver as a CHILD
+# process (the copied-module subprocess fixture) so the pytest parent can
+# mutate the repo mid-wait.
+
+
+def _stage_tw_module(main_repo: Path) -> None:
+    """Drop the real task_workflow.py into ``main_repo`` (uncommitted) so a
+    subprocess can import the test repo's copy via PYTHONPATH."""
+    src_dir = main_repo / "src" / "explore_persona_space"
+    src_dir.mkdir(parents=True)
+    (src_dir / "__init__.py").touch()
+    real_tw = Path(_REPO_SRC) / "explore_persona_space" / "task_workflow.py"
+    (src_dir / "task_workflow.py").write_text(real_tw.read_text())
+
+
+def _child_env(main_repo: Path, *, wait: str | None, poll: str | None) -> dict[str, str]:
+    """Child env with PYTHONPATH at the test repo's src and BOTH rebase
+    knobs explicitly set (str) or POPPED (None) — test-env knob hygiene."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(main_repo / "src") + os.pathsep + env.get("PYTHONPATH", "")
+    for key, value in ((_REBASE_WAIT_ENV, wait), (_REBASE_POLL_ENV, poll)):
+        if value is None:
+            env.pop(key, None)
+        else:
+            env[key] = value
+    return env
+
+
+def _detach_with_rebase_marker(main_repo: Path) -> Path:
+    """Detach the primary HEAD and fake a live primary-checkout rebase by
+    creating `.git/rebase-merge`. Returns the marker dir path."""
+    subprocess.run(
+        ["git", "-C", str(main_repo), "checkout", "-q", "--detach", "HEAD"],
+        check=True,
+    )
+    rebase_dir = main_repo / ".git" / "rebase-merge"
+    rebase_dir.mkdir()
+    return rebase_dir
+
+
+def _spawn_resolver_and_await_wait_announcement(
+    main_repo: Path,
+    stderr_path: Path,
+    env: dict[str, str],
+) -> subprocess.Popen[str]:
+    """Start the resolver child (stderr → file) and block until its wait
+    announcement appears in stderr — proof it OBSERVED detached+rebasing —
+    or the child exits early / ~15s passes. Waiting on the announcement
+    (not a fixed sleep) kills the race where a slow child start would let
+    the parent finish the fake rebase before the child's first probe, so
+    the child would never wait at all.
+    """
+    stderr_f = open(stderr_path, "w")  # noqa: SIM115 — handle owned by the child process
+    child = subprocess.Popen(
+        [sys.executable, "-c", _resolver_snippet()],
+        cwd=str(main_repo),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=stderr_f,
+        text=True,
+    )
+    stderr_f.close()  # the child holds its own dup of the fd
+    deadline = time.monotonic() + 15.0
+    while time.monotonic() < deadline:
+        if "waiting up to" in stderr_path.read_text():
+            break
+        if child.poll() is not None:
+            break  # child exited early — the caller's asserts surface it
+        time.sleep(0.05)
+    return child
+
+
+def _finish_child(child: subprocess.Popen[str]) -> tuple[int, str]:
+    """Wait for the resolver child (bounded); kill on overrun. Returns
+    (returncode, stdout)."""
+    try:
+        stdout, _ = child.communicate(timeout=30)
+    except subprocess.TimeoutExpired:
+        child.kill()
+        stdout, _ = child.communicate()
+    return child.returncode, stdout
+
+
+def test_detached_live_rebase_waits_then_succeeds(tmp_path: Path) -> None:
+    """Detached HEAD + LIVE rebase marker → the resolver WAITS (loudly) and
+    succeeds once the rebase 'finishes' (#996 criteria 1 + 6).
+
+    The parent finishes the fake rebase in the race-safe order: re-attach
+    HEAD FIRST via plumbing (`git symbolic-ref` — porcelain `checkout` may
+    balk at the fake in-progress rebase state), THEN remove the marker, so
+    the child only ever observes "attached" (success) or "detached+marker"
+    (keep waiting). The stderr assertion also empirically pins the
+    assumption that the `_log.warning` announcement reaches a child
+    process's stderr via logging's lastResort handler (criterion 6).
+    """
+    main_repo = tmp_path / "repo"
+    _make_main_repo(main_repo)
+    _stage_tw_module(main_repo)
+    rebase_dir = _detach_with_rebase_marker(main_repo)
+
+    stderr_path = tmp_path / "child-stderr.txt"
+    child = _spawn_resolver_and_await_wait_announcement(
+        main_repo, stderr_path, _child_env(main_repo, wait="15", poll="0.1")
+    )
+    # Finish the fake rebase: HEAD re-attach FIRST, marker removal SECOND.
+    subprocess.run(
+        ["git", "-C", str(main_repo), "symbolic-ref", "HEAD", "refs/heads/main"],
+        check=True,
+    )
+    rebase_dir.rmdir()
+    returncode, stdout = _finish_child(child)
+    stderr = stderr_path.read_text()
+
+    assert returncode == 0, f"resolver failed:\nstdout: {stdout}\nstderr: {stderr}"
+    resolved = _parse_resolved(stdout)
+    assert Path(resolved["REPO"]).resolve() == main_repo.resolve(), (
+        f"post-wait resolution is not the primary root: {resolved}"
+    )
+    # Criterion 6: the loud wait announcement reached the child's stderr.
+    assert "waiting up to" in stderr, f"wait announcement missing from child stderr: {stderr!r}"
+
+
+def test_knob_zero_marker_present_refuses_immediately(tmp_path: Path) -> None:
+    """The DISCRIMINATIVE knob=0 cell (#996 criterion 5): detached + rebase
+    marker PRESENT + `EPM_TASKPY_REBASE_WAIT_SECONDS=0` → IMMEDIATE refusal
+    with the byte-identical OLD message — no marker probe, no grace, no
+    wait/timeout wording, wall time far under the 120s default bound.
+
+    (The existing ``test_branch_guard_distinct_error_on_detached_head``
+    keeps pinning the detached + NO-marker default-knob refusal.)
+    """
+    main_repo = tmp_path / "repo"
+    _make_main_repo(main_repo)
+    _stage_tw_module(main_repo)
+    _detach_with_rebase_marker(main_repo)
+
+    start = time.monotonic()
+    proc = subprocess.run(
+        [sys.executable, "-c", _resolver_snippet()],
+        cwd=str(main_repo),
+        env=_child_env(main_repo, wait="0", poll="0.1"),
+        capture_output=True,
+        text=True,
+    )
+    wall = time.monotonic() - start
+    assert proc.returncode != 0
+    # Byte-identical OLD refusal message.
+    assert "is detached; re-attach to 'main' before running task.py." in proc.stderr, (
+        f"old refusal message missing: {proc.stderr!r}"
+    )
+    # No wait/timeout wording — the knob=0 branch fires BEFORE any probe.
+    assert "waiting up to" not in proc.stderr, proc.stderr
+    assert "rebase state dir" not in proc.stderr, proc.stderr
+    assert wall < 5.0, f"knob=0 refusal took {wall:.1f}s (expected immediate)"
+
+
+def test_detached_stale_rebase_marker_refuses_after_bound(tmp_path: Path) -> None:
+    """Detached + a rebase marker that never clears → refusal after the
+    bound, with EVERY criterion-3 diagnostic in the message: `detached`, the
+    state-dir name, the formatted wait duration, the CRASHED/stale-rebase
+    hedge, and the `git rebase --abort` remedy (#996 criterion 3).
+    """
+    main_repo = tmp_path / "repo"
+    _make_main_repo(main_repo)
+    _stage_tw_module(main_repo)
+    _detach_with_rebase_marker(main_repo)  # never cleared
+
+    start = time.monotonic()
+    proc = subprocess.run(
+        [sys.executable, "-c", _resolver_snippet()],
+        cwd=str(main_repo),
+        env=_child_env(main_repo, wait="1", poll="0.1"),
+        capture_output=True,
+        text=True,
+    )
+    wall = time.monotonic() - start
+    assert proc.returncode != 0
+    for needle in (
+        "detached",
+        "rebase-merge",
+        "waiting 1s",
+        "CRASHED rebase",
+        "rebase --abort",
+    ):
+        assert needle in proc.stderr, f"{needle!r} missing from stderr: {proc.stderr!r}"
+    # Subprocess startup + imports on a loaded VM ride on top of the 1s
+    # bound; 10s still discriminates decisively vs the 120s default.
+    assert wall <= 10.0, f"stale-marker refusal took {wall:.1f}s (bound was 1s)"
+
+
+def test_post_wait_nonmain_reattach_routes_managed_worktree(tmp_path: Path) -> None:
+    """Post-wait re-attach to a NON-main branch → the re-entered branch
+    guard routes through the existing `_ensure_managed_main_worktree` path
+    (#844), not a refusal (#996 criterion 4). No monkeypatch — the
+    subprocess fixture exercises the real routing.
+    """
+    main_repo = tmp_path / "repo"
+    _make_main_repo(main_repo)
+    _stage_tw_module(main_repo)
+    rebase_dir = _detach_with_rebase_marker(main_repo)
+
+    stderr_path = tmp_path / "child-stderr.txt"
+    child = _spawn_resolver_and_await_wait_announcement(
+        main_repo, stderr_path, _child_env(main_repo, wait="15", poll="0.1")
+    )
+    # Finish the fake rebase onto a FEATURE branch: create it, re-attach
+    # HEAD to it FIRST (plumbing), THEN remove the marker.
+    subprocess.run(["git", "-C", str(main_repo), "branch", "feature-x"], check=True)
+    subprocess.run(
+        ["git", "-C", str(main_repo), "symbolic-ref", "HEAD", "refs/heads/feature-x"],
+        check=True,
+    )
+    rebase_dir.rmdir()
+    returncode, stdout = _finish_child(child)
+    stderr = stderr_path.read_text()
+
+    assert returncode == 0, (
+        f"resolver refused instead of routing:\nstdout: {stdout}\nstderr: {stderr}"
+    )
+    resolved = _parse_resolved(stdout)
+    managed = (main_repo / ".claude" / "worktrees" / "_task-main-pin").resolve()
+    assert Path(resolved["REPO"]).resolve() == managed, (
+        f"post-wait non-main re-attach did not route to the managed worktree: {resolved}"
+    )
+    assert Path(resolved["TASKS_DIR"]).resolve() == (managed / "tasks").resolve()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes task #996 (kind: infra workflow-fix, 0 GPU-h).

## Summary
- `task_workflow._resolve_repo_root_cached` now bounded-waits (default 120s, `EPM_TASKPY_REBASE_WAIT_SECONDS`; poll 2.0s) when the primary checkout's HEAD is detached DURING a live rebase (`<common-dir>/rebase-merge`/`rebase-apply`), re-entering the full branch guard each poll — instead of hard-refusing every task.py mutation during a concurrent `git pull --rebase` (≥7 sessions hit this 2026-07-03).
- Genuine detached HEAD (no marker) still refuses; knob=0 restores the old behavior byte-identically (checked before any marker probe); non-finite knob values fail loud; timeout refusal names the state dir + `git rebase --abort` remedy.
- 5 new subprocess tests + centralized rebase-knob env hygiene across all resolver tests.

## Test plan
- [x] `tests/test_task_workflow_worktree.py` 24/24 (incl. poisoned-parent-env insulation run)
- [x] Step 9c touched-scope gate: 2443 passed / 6 skipped / 1 pre-existing-on-trunk failure (`test_shared_vm_thread_caps`, reproduced on main, unrelated files)
- [x] ruff check + format --check clean

Pipeline: plan v2 (critic ensemble round 1 resolved) · code-review r1 reconciled PASS + concern addressed r2 · r2 PASS+PASS · test-verdict PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)