### PR TITLE
task #999: degrade write_self_report on transient resolver RuntimeError

### DIFF
--- a/scripts/session_progress_report.py
+++ b/scripts/session_progress_report.py
@@ -49,7 +49,9 @@ CLI::
 ``--slug`` is optional — when omitted, falls back to the task's frontmatter
 title via ``explore_persona_space.task_workflow.get_task`` (so the skill does
 not have to thread the slug through every tick). Fail-loud: an unknown issue
-raises rather than silently writing a blank string.
+raises rather than silently writing a blank string. A *transient*
+resolver/environment ``RuntimeError`` (e.g. a detached repo-root HEAD
+mid-rebase) instead degrades soft — see :func:`write_self_report`.
 """
 
 from __future__ import annotations
@@ -230,16 +232,26 @@ def write_self_report(
     summarizer pass never reads a partial file.
 
     ``slug`` defaults to the task's frontmatter ``title`` via
-    :func:`_load_task_frontmatter`. Pass an explicit slug to override
+    :func:`_load_task`. Pass an explicit slug to override
     (e.g. the SKILL.md helper that already has the task loaded — saves the
     extra disk read).
 
     **Fail-loud on unknown issue regardless of ``--slug``.** We ALWAYS call
-    :func:`_load_task_frontmatter` even when the caller supplied an explicit
+    :func:`_load_task` even when the caller supplied an explicit
     slug, so a typo'd issue number produces a ``FileNotFoundError`` (from
     ``task.py find <N>``) instead of silently writing a self-report file for
     a non-existent task — keeps the fail-loud contract consistent across
     both code paths.
+
+    **Fail-SOFT on transient resolver/environment errors.** A ``RuntimeError``
+    from the task-workflow repo-root resolver (e.g. a detached shared-checkout
+    HEAD during a concurrent rebase — #999; since #996 the resolver
+    bounded-waits on a LIVE rebase before raising, so this catch is the
+    backstop for wait-timeout / stranded-detached / other environment
+    RuntimeErrors) degrades instead of crashing: caller-supplied slug or
+    empty, no ETA suffix, self-report still written, one stderr line, normal
+    return. The unknown-issue ``FileNotFoundError`` contract above is
+    unaffected.
 
     ``eta=True`` (default) appends the progress-bar/ETA suffix for
     machine-active statuses via :func:`_compute_eta_suffix` (task #587).
@@ -247,13 +259,40 @@ def write_self_report(
     status produces the byte-identical historical string. ``eta=False``
     (CLI ``--no-eta``) skips the estimator entirely.
     """
-    task = _load_task(issue)
-    fm = task.get("frontmatter")
-    fm = fm if isinstance(fm, dict) else {}
-    if slug is None:
-        title = fm.get("title")
-        slug = title.strip() if isinstance(title, str) else ""
-    suffix = _compute_eta_suffix(issue, task.get("status"), now_iso) if eta else None
+    try:
+        task: dict | None = _load_task(issue)
+    except RuntimeError as exc:
+        # TRANSIENT resolver/environment failure — e.g. the repo-root branch
+        # guard's detached-HEAD raise (task_workflow._resolve_repo_root_cached)
+        # while a concurrent session's rebase window holds the shared checkout
+        # (#999; crash observed in the #906 session, 2026-07-03). Since #996
+        # the resolver bounded-waits on a LIVE rebase before raising, so this
+        # catch is the backstop for wait-timeout / stranded-detached / other
+        # environment RuntimeErrors. The title/self-report path is
+        # OBSERVABILITY ONLY (SKILL.md § set_title), so degrade instead of
+        # crashing: keep the caller-supplied slug (else empty), skip the ETA
+        # suffix (status unknown), and STILL write the self-report — its `ts`
+        # is an activity signal for the stalled detector, and this tick IS
+        # activity. Unknown-issue typos still fail loud: FileNotFoundError
+        # (incl. StaleTaskPathError) is an OSError, not a RuntimeError, and
+        # is deliberately not caught here.
+        print(
+            f"session_progress_report: task lookup degraded ({exc})",
+            file=sys.stderr,
+        )
+        task = None
+    if task is None:
+        status: str | None = None
+        if slug is None:
+            slug = ""
+    else:
+        fm = task.get("frontmatter")
+        fm = fm if isinstance(fm, dict) else {}
+        if slug is None:
+            title = fm.get("title")
+            slug = title.strip() if isinstance(title, str) else ""
+        status = task.get("status")
+    suffix = _compute_eta_suffix(issue, status, now_iso) if eta else None
     text = build_progress_string(issue, slug, step, suffix=suffix)
     ts = now_iso or _utcnow_iso()
     payload = {

--- a/tests/test_session_progress_report.py
+++ b/tests/test_session_progress_report.py
@@ -526,6 +526,83 @@ def test_write_self_report_unknown_issue_raises_even_with_explicit_slug(monkeypa
     assert not list(tmp_path.glob("*.json"))
 
 
+# ── transient resolver-error degrade (task #999) ───────────────────────────
+#
+# What these pin: a resolver/environment RuntimeError from the task-workflow
+# repo-root resolver (e.g. a detached shared-checkout HEAD mid-rebase) must
+# DEGRADE — never crash — the title/self-report tick. The tests match on the
+# RuntimeError CLASS, never its message text (#996 changed the resolver's
+# wait/raise behavior; the message is not a contract).
+
+_DETACHED_MSG = (
+    "main worktree HEAD (/home/x/explore-persona-space) is detached; "
+    "re-attach to 'main' before running task.py."
+)
+
+
+def _mock_get_task_detached(monkeypatch):
+    """Patch the lazy-imported ``tw.get_task`` seam with a signature-conformant
+    fake that raises the resolver's environment ``RuntimeError``."""
+    import explore_persona_space.task_workflow as tw
+
+    def _detached(issue):
+        raise RuntimeError(_DETACHED_MSG)
+
+    monkeypatch.setattr(tw, "get_task", _detached)
+
+
+def test_write_self_report_degrades_on_transient_resolver_error(monkeypatch, tmp_path, capsys):
+    """#999 regression: a resolver/environment RuntimeError (detached
+    shared-checkout HEAD mid-rebase) must DEGRADE, not crash — the
+    title/self-report path is observability-only. Degraded shape: empty
+    slug (none supplied), no ETA suffix, self-report STILL written (its
+    ts is an activity signal), one stderr line."""
+    monkeypatch.setattr(session_progress_report, "SELF_REPORT_DIR", tmp_path)
+    _mock_get_task_detached(monkeypatch)
+
+    text, path = session_progress_report.write_self_report(42, step="running")
+
+    assert text == "#42 · running"  # empty slug, no suffix
+    assert path == tmp_path / "42.json"
+    assert path.is_file()
+    assert not list(tmp_path.glob("*.tmp"))  # still atomic
+    payload = json.loads(path.read_text())
+    assert payload["issue"] == 42
+    assert payload["slug"] == ""
+    assert payload["text"] == text
+    assert payload["ts"].endswith("Z")
+    assert "degraded" in capsys.readouterr().err
+    # Round-trip: the degraded payload is reader-accepted (not treated as
+    # malformed), so the summarizer/watcher freshness reads keep working.
+    report = session_progress_report.read_self_report(42)
+    assert report is not None
+    assert report["text"] == text
+
+
+def test_write_self_report_degraded_keeps_explicit_slug(monkeypatch, tmp_path):
+    """The degraded path preserves a caller-supplied slug verbatim."""
+    monkeypatch.setattr(session_progress_report, "SELF_REPORT_DIR", tmp_path)
+    _mock_get_task_detached(monkeypatch)
+
+    text, path = session_progress_report.write_self_report(42, slug="hand slug", step="running")
+    assert text == "#42 hand slug · running"
+    assert json.loads(path.read_text())["slug"] == "hand slug"
+
+
+def test_main_returns_zero_on_transient_resolver_error(monkeypatch, tmp_path, capsys):
+    """The actual crash surface: bare CLI callers (skill Bash steps, the
+    watcher's subprocess refresh) must get rc=0 + the degraded string on
+    stdout during a transient resolver failure."""
+    monkeypatch.setattr(session_progress_report, "SELF_REPORT_DIR", tmp_path)
+    _mock_get_task_detached(monkeypatch)
+
+    rc = session_progress_report.main(["--issue", "42", "--step", "x"])
+    assert rc == 0
+    out = capsys.readouterr()
+    assert out.out.strip() == "#42 · x"
+    assert "degraded" in out.err
+
+
 # ── progress-bar / ETA title suffix (task #587) ────────────────────────────
 #
 # What these pin: `build_progress_string(..., suffix=...)` and the


### PR DESCRIPTION
Closes task #999 (kind: infra, workflow-fix).

## Summary
- `write_self_report` no longer crashes when the shared repo-root resolver raises a transient environment `RuntimeError` (detached-HEAD branch guard; #906 incident, 2026-07-03) — it degrades to the caller-supplied/empty slug, skips the ETA suffix, still writes the self-report atomically, prints one stderr line, and the CLI exits 0.
- Unknown-issue `FileNotFoundError` fail-loud + corruption classes preserved; `task_workflow.py` guard untouched. Composes as backstop behind #996's resolver-side bounded rebase-wait.
- 3 class-matched regression tests (independently verified to fail pre-fix) + `read_self_report` round-trip assert.

## Test plan
- [x] `uv run pytest tests/test_session_progress_report.py` — 35/35
- [x] Step 9c touched-subset gate — 2367 passed, 6 skipped
- [x] `ruff check` + `ruff format --check` clean on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)