### PR TITLE
task #1021: flip stale blocked to running on relaunch + flag-only watcher backstop

### DIFF
--- a/.claude/rules/crash-fix-rounds.md
+++ b/.claude/rules/crash-fix-rounds.md
@@ -224,3 +224,11 @@ instance / SLURM job. Whether to reprovision for the full run is the
 ORCHESTRATOR's decision, driven by the `/issue` Step 7 crash-fix routing after
 it reads your marker. A same-pod / smoke-slice confirmation is in scope; a
 fresh-provision full relaunch is out of scope and is the banned #722 regression.
+
+The orchestrator-side counterpart: when the orchestrator's relaunch
+succeeds (a fresh `epm:run-launched`), it ALSO reconciles a stale
+`blocked` status back to `running` (SKILL.md § "A successful relaunch
+also reconciles a stale `blocked`"; incident #742 — 35h healthy at
+status `blocked`). Status transitions remain orchestrator-owned: you
+never run `set-status` yourself, even to clear a stale block your fix
+made obsolete.

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -3750,6 +3750,27 @@ rejects the marker and the poll keeps reading the frozen startup-script
 phase, and an omitted `pod=` is accepted only via the launch-time
 `epm:cluster-launched` timestamp baseline, so include it explicitly.
 
+**A successful relaunch also reconciles a stale `blocked`.** Immediately
+after posting the fresh `epm:run-launched`, read the current status
+(`task.py view <N> --json`); if it is EXACTLY `blocked`, run
+`uv run python scripts/task.py set-status <N> running --note 'relaunch
+succeeded; clearing stale blocked (epm:run-launched <ts>)'`. The stale
+`blocked` arises when an earlier failed round (a cap-hit, a
+STATE-TO-`blocked` exit, or a failed crash-fix cycle) parked the task and
+a LATER round's relaunch succeeded without flipping it back — #742 ran
+healthy ~35h at status `blocked` (2026-07-01→07-02) and the
+dashboard/watcher read wrong until the user asked. Guards: (a) flip ONLY
+`blocked` → `running`, never any other status — a same-issue follow-up
+round holds `followups_running`, never `blocked`, so the flip is inert
+there by construction; (b) the flip is a same-turn serial action after
+YOUR OWN relaunch — never flip on someone else's marker (the watcher's
+stale-blocked FLAG pass is deliberately flag-only; a human reconciles on
+its evidence); (c) if the relaunched run then fails, the normal failure
+path re-blocks — the flip does not suppress it; (d) RE-READ the status
+immediately before the `set-status` call — a non-`blocked` read at that
+instant ABORTS the flip (a human may have reconciled off the watcher
+flag concurrently; a redundant flip attempt is refused, never forced).
+
 The 540-second sleep stays under the Bash tool's 10-minute (`600000` ms)
 cap with margin; longer intervals are achievable by raising the sleep
 within the cap, but 9 minutes is the operational sweet spot (enough
@@ -4360,6 +4381,12 @@ When this skill is re-invoked in `running`:
    *Before applying either row, the Crash-fix circuit-breaker below checks for
    a same-signature repeat or a spent escape ladder and pivots to re-planning if
    either fires.*
+
+   *Either row's respawn, when its round ends in a successful relaunch
+   (fresh `epm:run-launched`), also triggers the stale-`blocked` reconcile
+   rule ("A successful relaunch also reconciles a stale `blocked`", Step
+   6d.2 poll-loop section) — a task parked `blocked` by an earlier failed
+   round must not stay `blocked` through a healthy relaunched run (#742).*
 
    **Zombie-GPU stall recovery brief (`stall_reason: vllm_worker_dead_zombie_gpu`).**
    When the `status=stalled` tick's `stall_reason` is

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -964,6 +964,31 @@ _CAPACITY_RETRY_NOTE_SENTINEL = "[autonomous_session_watch:capacity-retry]"
 # dashboard-visible without per-tick marker spam.
 _CAPACITY_RETRY_EXHAUSTED_NOTE_SENTINEL = "[autonomous_session_watch:capacity-retry-exhausted]"
 
+# Substring stamped into the stale-blocked flag marker (task #1021): a
+# `blocked` task whose events show an `epm:run-launched` NEWER than the
+# transition into `blocked` plus fresh POST-LAUNCH progress — the #742 class
+# (a crash-fix relaunch succeeded but the earlier failed round's `blocked`
+# was never flipped back; #742 ran healthy ~35h at status `blocked`).
+# FLAG-ONLY: the pass posts a deduped marker + sidecar row + Telegram digest
+# line and NEVER mutates status (the orchestrator's own-relaunch reconcile
+# rule in SKILL.md — or a human — flips it). Same staleness-filter contract
+# as every other watcher-posted sentinel.
+_STALE_BLOCKED_FLAG_NOTE_SENTINEL = "[autonomous_session_watch:stale-blocked-flag]"
+
+# Filename prefix for the per-issue stale-blocked dedup state file at
+# ``~/.eps-autonomous/stale-blocked-<N>.json`` (keyed on
+# ``flagged_run_launched_ts`` — one alert per launch episode; a NEWER launch
+# is a new episode and re-alerts). Mirrors the capacity-retry state-file
+# layout; reaped by the generalized GC at `completed`/`archived`.
+STALE_BLOCKED_STATE_PREFIX = "stale-blocked-"
+
+# Freshness window (seconds) for the POST-LAUNCH progress leg of
+# ``decide_stale_blocked_flag``. Matches the STALLED_MARKER_WINDOW_S_DEFAULT
+# scale (2h — the #845 marker-heartbeat window); env-tunable via
+# ``EPM_STALE_BLOCKED_PROGRESS_FRESH_S`` (seconds). A too-tight window
+# UNDER-flags (missed alert, status quo), never mis-flags.
+STALE_BLOCKED_PROGRESS_FRESH_S_DEFAULT = 2 * 3600
+
 # OPT-IN heartbeat sentinel for legitimately-slow phases (off-pod analyzer
 # verifier rounds, in-flight Anthropic Batch polling). UNLIKE every other
 # sentinel in this file, this one is stamped by the LONG-RUNNING PHASE
@@ -1019,6 +1044,7 @@ _WATCHER_NOTE_SENTINELS: frozenset[str] = frozenset(
         _PROPOSED_INFRA_SWEEP_NOTE_SENTINEL,
         _CAPACITY_RETRY_NOTE_SENTINEL,
         _CAPACITY_RETRY_EXHAUSTED_NOTE_SENTINEL,
+        _STALE_BLOCKED_FLAG_NOTE_SENTINEL,
         # Posted by spawn_session.py (not the watcher) when a duplicate --auto
         # dispatch was suppressed at registration (#843 M2) — same contract:
         # a suppression note is bookkeeping, never real progress.
@@ -12229,6 +12255,215 @@ def capacity_retry_pass(
         )
 
 
+# ─── stale-blocked flag pass (task #1021, the #742 incident class) ───────────
+#
+# A crash-fix relaunch that succeeds on a task an earlier failed round parked
+# at `blocked` leaves the status stale: the run is healthy (fresh
+# `epm:run-launched` + ongoing progress ticks) while the folder says `blocked`
+# (#742 ran healthy ~35h at status `blocked`, 2026-07-01→07-02). The
+# orchestrator-side fix is the SKILL.md "A successful relaunch also reconciles
+# a stale `blocked`" rule; this pass is the watcher-side BACKSTOP: FLAG-ONLY —
+# a deduped `epm:progress` marker + a sidecar row + one Telegram digest line
+# per launch episode. It NEVER mutates status (false alert cheap, false flip
+# dangerous — the same conservative posture as the pod-safety alerts).
+# Daemon-INDEPENDENT: it spawns nothing (marker posts go via the task.py
+# subprocess).
+
+
+def _stale_blocked_flag_enabled() -> bool:
+    """Kill switch: False when ``EPM_DISABLE_STALE_BLOCKED_FLAG`` is set
+    truthy ("1"/"true"/"yes", case-insensitive). Default enabled. Mirrors
+    :func:`_capacity_retry_enabled`."""
+    raw = os.environ.get("EPM_DISABLE_STALE_BLOCKED_FLAG", "").strip().lower()
+    return raw not in {"1", "true", "yes"}
+
+
+def _stale_blocked_fresh_s() -> float:
+    """Post-launch progress freshness window in seconds (env
+    ``EPM_STALE_BLOCKED_PROGRESS_FRESH_S``; default
+    :data:`STALE_BLOCKED_PROGRESS_FRESH_S_DEFAULT`). A malformed or
+    non-positive env value falls back to the default — a typo must not
+    collapse (or explode) the window."""
+    raw = os.environ.get("EPM_STALE_BLOCKED_PROGRESS_FRESH_S")
+    if not raw:
+        return float(STALE_BLOCKED_PROGRESS_FRESH_S_DEFAULT)
+    try:
+        parsed = float(raw)
+    except ValueError:
+        return float(STALE_BLOCKED_PROGRESS_FRESH_S_DEFAULT)
+    if parsed <= 0:
+        return float(STALE_BLOCKED_PROGRESS_FRESH_S_DEFAULT)
+    return parsed
+
+
+def decide_stale_blocked_flag(
+    status: str | None,
+    run_launched_ts: float | None,
+    blocked_since_ts: float | None,
+    progress_ts: float | None,
+    now: float,
+    *,
+    fresh_window_s: float = STALE_BLOCKED_PROGRESS_FRESH_S_DEFAULT,
+) -> bool:
+    """True iff a ``blocked`` task shows a live healthy run: an
+    ``epm:run-launched`` NEWER than the transition into ``blocked``, plus
+    real (non-watcher, non-deliberate-stop) progress AT OR AFTER the launch
+    and within ``fresh_window_s``.
+
+    The ``progress_ts >= run_launched_ts`` conjunct makes the liveness leg
+    genuinely POST-LAUNCH: it excludes the block-transition
+    ``epm:status-changed`` marker (which is in :data:`_PROGRESS_KINDS`) by
+    construction (block < launch by the ordering conjunct), at the cost of
+    one poll-tick flag delay. The launch-newer-than-block ordering is what
+    keeps a deliberately-blocked task quiet: the normal order is fail ->
+    block (launch older than block -> skip); only a launch AFTER the block —
+    the exact #742 anomaly — flags. EVERY missing signal returns False
+    (fail toward silence)."""
+    return (
+        status == "blocked"
+        and run_launched_ts is not None
+        and blocked_since_ts is not None
+        and run_launched_ts > blocked_since_ts
+        and progress_ts is not None
+        and progress_ts >= run_launched_ts
+        and (now - progress_ts) <= fresh_window_s
+    )
+
+
+def _stale_blocked_state_path(issue: int) -> Path:
+    return AUTONOMOUS_REGISTRY_DIR / f"{STALE_BLOCKED_STATE_PREFIX}{issue}.json"
+
+
+def _load_stale_blocked_state(issue: int) -> dict:
+    """Read the per-issue stale-blocked dedup state
+    (``{flagged_run_launched_ts, alerted_ts}``); ``{}`` on absent/garbled.
+    Mirrors :func:`_load_capacity_retry_state`."""
+    path = _stale_blocked_state_path(issue)
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _save_stale_blocked_state(issue: int, state: dict, dry_run: bool) -> None:
+    """Persist the per-issue dedup state atomically (temp + rename). No-op
+    under dry_run. Mirrors :func:`_save_capacity_retry_state`."""
+    if dry_run:
+        return
+    AUTONOMOUS_REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
+    dest = _stale_blocked_state_path(issue)
+    tmp = dest.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(state, indent=2))
+    tmp.replace(dest)
+
+
+def _append_stale_blocked_event(payload: dict, dry_run: bool) -> None:
+    """Durable trace for stale-blocked flags — one JSON line per flag in
+    ``~/.eps-autonomous/stale-blocked-events.jsonl`` (same shape + role as
+    the stale-registration events file; the ``.jsonl`` suffix keeps it out
+    of the GC's ``stale-blocked-*.json`` glob). The per-task marker is the
+    primary record; this file survives a task folder move. Fail-soft."""
+    dest = AUTONOMOUS_REGISTRY_DIR / "stale-blocked-events.jsonl"
+    line = json.dumps(payload)
+    if dry_run:
+        print(f"  [dry-run] would append stale-blocked event to {dest}")
+        return
+    try:
+        AUTONOMOUS_REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
+        with open(dest, "a") as fh:
+            fh.write(line + "\n")
+    except OSError as e:
+        print(f"  WARNING: appending stale-blocked event failed: {e}", file=sys.stderr)
+
+
+def _process_stale_blocked(issue: int, now: float, dry_run: bool, *, fresh_window_s: float) -> None:
+    """Evaluate ONE `blocked` task (gather signals ->
+    :func:`decide_stale_blocked_flag` -> flag). Honours dry_run; NEVER
+    mutates status (flag-only by design). ``blocked_since_ts`` is the latest
+    ``epm:status-changed`` ts — valid as "the transition into blocked"
+    because the caller scanned ``_blocked_issue_ids()`` (the same argument
+    the ``_DONE_TRANSITION_KINDS`` docstring makes)."""
+    events = _task_events(issue)
+    run_ts = _latest_event_ts(events, frozenset({_RUN_LAUNCHED_KIND}))
+    blocked_ts = _latest_event_ts(events, frozenset({"epm:status-changed"}))
+    progress_ts = _latest_progress_ts(events)
+    if not decide_stale_blocked_flag(
+        "blocked", run_ts, blocked_ts, progress_ts, now, fresh_window_s=fresh_window_s
+    ):
+        return
+    state = _load_stale_blocked_state(issue)
+    if state.get("flagged_run_launched_ts") == run_ts:
+        return  # dedup: one alert per launch episode; a NEWER launch re-alerts
+    launch_iso = _triage_observer_iso_z(run_ts)  # shared events.jsonl ISO-Z shape
+    blocked_iso = _triage_observer_iso_z(blocked_ts)
+    progress_age_min = (now - progress_ts) / 60.0
+    print(
+        f"  STALE-BLOCKED FLAG issue #{issue}: launch {launch_iso} > block "
+        f"{blocked_iso}, post-launch progress {progress_age_min:.0f}m ago"
+    )
+    _append_stale_blocked_event(
+        {
+            "ts": _triage_observer_iso_z(now),
+            "issue": issue,
+            "run_launched_ts": run_ts,
+            "blocked_since_ts": blocked_ts,
+            "progress_age_s": now - progress_ts,
+            "action": "flagged",
+            "dry_run": dry_run,
+        },
+        dry_run,
+    )
+    _post_progress_marker(
+        issue,
+        f"{_STALE_BLOCKED_FLAG_NOTE_SENTINEL} status=blocked but a live healthy "
+        f"run is present: epm:run-launched {launch_iso} is NEWER than the blocked "
+        f"transition {blocked_iso}, and post-launch progress landed "
+        f"{progress_age_min:.0f} min ago. Likely a stale blocked from an earlier "
+        f"failed round (#742 class). If the relaunch is legitimate, reconcile "
+        f"with: uv run python scripts/task.py set-status {issue} running --note "
+        f"'relaunch succeeded; clearing stale blocked'. FLAG-ONLY: the watcher "
+        f"never flips status.",
+        dry_run,
+        label="stale-blocked-flag",
+    )
+    _telegram_push(
+        f"EPS #{issue}: status=blocked but run alive (launch {launch_iso} > "
+        f"block {blocked_iso}, progress {progress_age_min:.0f}m ago) — likely "
+        f"stale blocked; reconcile via task.py set-status {issue} running",
+        dry_run,
+    )
+    _save_stale_blocked_state(
+        issue, {"flagged_run_launched_ts": run_ts, "alerted_ts": now}, dry_run
+    )
+
+
+def stale_blocked_flag_pass(dry_run: bool, now: float | None = None) -> None:
+    """FLAG (never flip) `blocked` tasks whose events show a live healthy run
+    (task #1021, incident #742). Scans every `blocked` task; for each where an
+    ``epm:run-launched`` is NEWER than the transition into `blocked` AND fresh
+    POST-LAUNCH progress exists, posts one deduped-per-launch-episode flag
+    (marker + sidecar row + Telegram digest line). Deliberately flag-only —
+    the orchestrator's own-relaunch reconcile rule (SKILL.md "A successful
+    relaunch also reconciles a stale `blocked`") or a human flips the status
+    on this evidence. Daemon-INDEPENDENT (no spawns; marker posts go via the
+    task.py subprocess)."""
+    if not _stale_blocked_flag_enabled():
+        print("stale-blocked-flag: disabled via EPM_DISABLE_STALE_BLOCKED_FLAG; skipping")
+        return
+    now = now if now is not None else time.time()
+    fresh_window_s = _stale_blocked_fresh_s()
+    blocked = _blocked_issue_ids()
+    if not blocked:
+        print("stale-blocked-flag: no blocked tasks")
+        return
+    print(f"stale-blocked-flag: scanning {len(blocked)} blocked task(s)")
+    for issue in blocked:
+        _process_stale_blocked(issue, now, dry_run, fresh_window_s=fresh_window_s)
+
+
 # ─── generalized GC of stale ~/.eps-autonomous/ per-issue files ──────────────
 
 # Task statuses for which per-issue registry / progress / stalled-state files
@@ -12258,6 +12493,13 @@ _GC_TARGETS: tuple[tuple[str, str], ...] = (
     # reap a live retry episode's state — that would reset retries_today every
     # tick and the daily cap could never bind).
     (CAPACITY_RETRY_STATE_PREFIX, ""),
+    # Stale-blocked flag per-issue dedup state (== STALE_BLOCKED_STATE_PREFIX,
+    # task #1021). Same contract as capacity-retry above: TERMINAL_FOR_GC
+    # deliberately EXCLUDES `blocked`, so a live episode's dedup state is never
+    # reaped mid-episode (that would re-alert every tick); reaping fires only
+    # once the task reaches `completed`/`archived`. The sidecar
+    # `stale-blocked-events.jsonl` is outside the `*.json` glob by suffix.
+    (STALE_BLOCKED_STATE_PREFIX, ""),
     # Campaign watchdog state (== CAMPAIGN_WATCH_STATE_PREFIX, defined in the
     # campaign-pass section below; literal here because module-level tuples
     # evaluate top-to-bottom). Primary reaping is the campaign pass itself at
@@ -17031,6 +17273,15 @@ def main(argv: list[str] | None = None) -> int:
         "real blocked-task set.",
     )
     parser.add_argument(
+        "--stale-blocked-only",
+        action="store_true",
+        help="run ONLY the stale-blocked flag pass (FLAG a blocked task whose "
+        "events show a live healthy run — fresh epm:run-launched + post-launch "
+        "progress; the #742 class, task #1021) and exit; skip every other "
+        "pass. Flag-only + daemon-independent; pair with --dry-run for a live "
+        "smoke against the real blocked-task set.",
+    )
+    parser.add_argument(
         "--program-orchestrator-only",
         action="store_true",
         help="run ONLY the program-orchestrator crash-recovery pass (relaunch "
@@ -17089,6 +17340,12 @@ def main(argv: list[str] | None = None) -> int:
     # under the lock (it probes the daemon itself) and exit.
     if args.capacity_retry_only:
         capacity_retry_pass(args.dry_run, daemon_reachable=_daemon_reachable())
+        return 0
+
+    # --stale-blocked-only mirrors --capacity-retry-only: run the single pass
+    # under the lock and exit. Daemon-INDEPENDENT (flag-only; no spawns).
+    if args.stale_blocked_only:
+        stale_blocked_flag_pass(args.dry_run)
         return 0
 
     # --program-orchestrator-only mirrors the other --*-only flags: the pass is
@@ -17303,6 +17560,17 @@ def main(argv: list[str] | None = None) -> int:
     # churn (no watcher-side precheck by design — see the pass's WHY block).
     # Daemon-gated like every spawning pass; runs after infra-drain.
     capacity_retry_pass(args.dry_run, daemon_reachable=daemon_reachable)
+
+    # Stale-blocked flag (task #1021, the #742 class): FLAG — never flip — a
+    # `blocked` task whose events show a live healthy run (an
+    # `epm:run-launched` NEWER than the transition into `blocked` + fresh
+    # post-launch progress). The watcher-side backstop of the SKILL.md
+    # "A successful relaunch also reconciles a stale `blocked`" orchestrator
+    # rule: one deduped-per-launch-episode marker + sidecar row + Telegram
+    # digest line; the status flip stays with the orchestrator/human.
+    # Thematically adjacent to capacity-retry (both scan blocked ids) but NOT
+    # daemon-gated — it spawns nothing (marker posts go via task.py).
+    stale_blocked_flag_pass(args.dry_run)
 
     # Session-reconcile: auto-stop (the default; EPM_SESSION_RECONCILE_AUTOSTOP=0
     # falls back to alert-only) live sessions that outlived their task's

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -1599,6 +1599,9 @@ def test_main_daemon_unreachable_still_runs_pod_safety(isolated_registry, monkey
     monkeypatch.setattr(asw, "orphan_sweep_pass", lambda *a, **kw: orphan_calls.append((a, kw)))
     # #967: never sweep the LIVE registry/events tree from a unit test.
     monkeypatch.setattr(asw, "triage_observer_pass", lambda *a, **kw: None)
+    # #1021: the stale-blocked flag pass shells task.py against the LIVE
+    # blocked set (daemon-independent) — never run it from a unit test.
+    monkeypatch.setattr(asw, "stale_blocked_flag_pass", lambda *a, **kw: None)
 
     rc = asw.main([])
 
@@ -1633,6 +1636,9 @@ def test_main_daemon_reachable_runs_both_passes(isolated_registry, monkeypatch):
     # spawns task.py subprocesses for whatever sessions are live on the VM.
     monkeypatch.setattr(asw, "zombie_wrapper_pass", lambda *a, **kw: zombie_calls.append((a, kw)))
     monkeypatch.setattr(asw, "idle_unmapped_pass", lambda *a, **kw: idle_calls.append((a, kw)))
+    # #1021: the stale-blocked flag pass shells task.py against the LIVE
+    # blocked set (daemon-independent) — never run it from a unit test.
+    monkeypatch.setattr(asw, "stale_blocked_flag_pass", lambda *a, **kw: None)
 
     rc = asw.main([])
 
@@ -2968,6 +2974,9 @@ def test_stalled_main_passes_daemon_flag(isolated_registry, monkeypatch):
         captured_kwargs.update(kw)
 
     monkeypatch.setattr(asw, "stalled_session_pass", _record_stalled)
+    # #1021: the stale-blocked flag pass shells task.py against the LIVE
+    # blocked set (daemon-independent) — never run it from a unit test.
+    monkeypatch.setattr(asw, "stale_blocked_flag_pass", lambda *a, **kw: None)
 
     rc = asw.main([])
 
@@ -9718,6 +9727,7 @@ def test_infra_drain_main_wiring(isolated_registry, monkeypatch):
         "stalled_session_pass",
         "orphan_sweep_pass",
         "infra_drain_pass",
+        "stale_blocked_flag_pass",
         "session_reconcile_pass",
         "gate_push_pass",
         "zombie_wrapper_pass",
@@ -10755,6 +10765,371 @@ def test_capacity_retry_pass_daily_cap_then_exhausted_alert(isolated_registry, m
     assert posted == [(642, "capacity-retry-exhausted")]
 
 
+# ─── stale-blocked flag pass (task #1021, incident #742) ─────────────────────
+#
+# FLAG-ONLY: a wrong FLAG costs one digest line; a wrong FLIP would race the
+# orchestrator's own-relaunch reconcile rule, so the pass NEVER mutates status
+# (pinned two-pronged below, per the triage-observer non-gating precedent).
+
+_SB_T0 = 1782000000.0  # arbitrary 2026 epoch anchor for the pure-predicate tests
+
+
+def test_decide_stale_blocked_flag_fires_on_fresh_run_after_block():
+    # The #742 shape: block < launch <= progress, progress 10 min old -> True.
+    from autonomous_session_watch import decide_stale_blocked_flag
+
+    assert (
+        decide_stale_blocked_flag(
+            "blocked",
+            run_launched_ts=_SB_T0 + 100,
+            blocked_since_ts=_SB_T0,
+            progress_ts=_SB_T0 + 200,
+            now=_SB_T0 + 200 + 600,
+        )
+        is True
+    )
+
+
+@pytest.mark.parametrize(
+    "status", ["running", "followups_running", "on_hold", "awaiting_promotion", None]
+)
+def test_decide_stale_blocked_flag_skips_non_blocked_status(status):
+    # Constraint interaction pinned: `followups_running` (the same-issue
+    # follow-up loop's holding status) never flags; nor does any other status.
+    from autonomous_session_watch import decide_stale_blocked_flag
+
+    assert (
+        decide_stale_blocked_flag(
+            status,
+            run_launched_ts=_SB_T0 + 100,
+            blocked_since_ts=_SB_T0,
+            progress_ts=_SB_T0 + 200,
+            now=_SB_T0 + 800,
+        )
+        is False
+    )
+
+
+def test_decide_stale_blocked_flag_skips_launch_before_block():
+    # The normal fail-then-block order (launch OLDER than the block) -> False;
+    # a deliberately-blocked task with an old launch stays quiet.
+    from autonomous_session_watch import decide_stale_blocked_flag
+
+    assert (
+        decide_stale_blocked_flag(
+            "blocked",
+            run_launched_ts=_SB_T0,
+            blocked_since_ts=_SB_T0 + 100,
+            progress_ts=_SB_T0 + 200,
+            now=_SB_T0 + 800,
+        )
+        is False
+    )
+
+
+@pytest.mark.parametrize("missing", ["run_launched_ts", "blocked_since_ts", "progress_ts"])
+def test_decide_stale_blocked_flag_skips_missing_signals(missing):
+    # EVERY missing signal fails toward silence (e.g. a hand `git mv` block
+    # that skipped `epm:status-changed` yields blocked_since_ts=None -> skip).
+    from autonomous_session_watch import decide_stale_blocked_flag
+
+    kwargs = {
+        "run_launched_ts": _SB_T0 + 100,
+        "blocked_since_ts": _SB_T0,
+        "progress_ts": _SB_T0 + 200,
+    }
+    kwargs[missing] = None
+    assert decide_stale_blocked_flag("blocked", now=_SB_T0 + 800, **kwargs) is False
+
+
+def test_decide_stale_blocked_flag_skips_stale_progress():
+    # Post-launch progress OLDER than the freshness window -> False (the run
+    # may have died since; under-flagging is the safe failure direction).
+    from autonomous_session_watch import decide_stale_blocked_flag
+
+    assert (
+        decide_stale_blocked_flag(
+            "blocked",
+            run_launched_ts=_SB_T0 + 100,
+            blocked_since_ts=_SB_T0,
+            progress_ts=_SB_T0 + 200,
+            now=_SB_T0 + 200 + 7201,
+            fresh_window_s=7200,
+        )
+        is False
+    )
+
+
+def test_decide_stale_blocked_flag_skips_pre_launch_progress():
+    # v2 conjunct (progress_ts >= run_launched_ts): the newest "progress" is
+    # the block-transition epm:status-changed marker itself (a _PROGRESS_KINDS
+    # member) and the launch has no post-launch tick yet -> False. Pins the
+    # vacuity fix: pre-launch progress never satisfies the liveness leg.
+    from autonomous_session_watch import decide_stale_blocked_flag
+
+    assert (
+        decide_stale_blocked_flag(
+            "blocked",
+            run_launched_ts=_SB_T0 + 300,
+            blocked_since_ts=_SB_T0,
+            progress_ts=_SB_T0,  # == the block-transition marker's ts
+            now=_SB_T0 + 400,
+        )
+        is False
+    )
+
+
+def _sb_events(*, block_iso, launch_iso, progress_iso=None, reblock_iso=None):
+    """Minimal event-sequence fixture for the pass-level replays."""
+    events = [
+        {"kind": "epm:status-changed", "ts": block_iso, "note": "running -> blocked"},
+        {"kind": "epm:run-launched", "ts": launch_iso, "note": "pid=123 log_abs=/w/x.log"},
+    ]
+    if progress_iso:
+        events.append(
+            {"kind": "epm:progress", "ts": progress_iso, "note": "[poll-tick:bg] launch alive"}
+        )
+    if reblock_iso:
+        events.append(
+            {"kind": "epm:status-changed", "ts": reblock_iso, "note": "running -> blocked (again)"}
+        )
+    return events
+
+
+def _patch_sb_pass(monkeypatch, asw, blocked_ids, events_by_issue):
+    """Isolate the pass's I/O seams: blocked-id scan, events fetch, marker
+    post, Telegram push. State + sidecar writes go to isolated_registry."""
+    monkeypatch.setattr(asw, "_blocked_issue_ids", lambda: list(blocked_ids))
+    monkeypatch.setattr(asw, "_task_events", lambda i: events_by_issue.get(i, []))
+    posted = []
+    monkeypatch.setattr(
+        asw,
+        "_post_progress_marker",
+        lambda issue, note, dry_run, *, label: posted.append((issue, label, note)),
+    )
+    pushed = []
+    monkeypatch.setattr(asw, "_telegram_push", lambda msg, dry_run: pushed.append(msg) or True)
+    return posted, pushed
+
+
+def test_stale_blocked_pass_flags_once_per_launch_ts(isolated_registry, monkeypatch):
+    # First tick: marker + push + sidecar row + state file. Second tick with
+    # the same launch ts: nothing. A NEWER launch ts (fresh episode): re-alerts.
+    import json
+
+    import autonomous_session_watch as asw
+
+    events = _sb_events(
+        block_iso="2026-07-01T00:00:00Z",
+        launch_iso="2026-07-01T08:00:00Z",
+        progress_iso="2026-07-01T09:00:00Z",
+    )
+    posted, pushed = _patch_sb_pass(monkeypatch, asw, [742], {742: events})
+    now = asw._parse_event_ts("2026-07-01T09:30:00Z")
+
+    asw.stale_blocked_flag_pass(dry_run=False, now=now)
+    assert [(i, label) for i, label, _n in posted] == [(742, "stale-blocked-flag")]
+    assert len(pushed) == 1
+    state_path = isolated_registry / "stale-blocked-742.json"
+    assert state_path.exists()
+    state = json.loads(state_path.read_text())
+    assert state["flagged_run_launched_ts"] == asw._parse_event_ts("2026-07-01T08:00:00Z")
+    sidecar = isolated_registry / "stale-blocked-events.jsonl"
+    assert sidecar.exists() and len(sidecar.read_text().splitlines()) == 1
+    # The marker note carries the sentinel + the reconcile command, flag-only.
+    note = posted[0][2]
+    assert asw._STALE_BLOCKED_FLAG_NOTE_SENTINEL in note
+    assert "set-status 742 running" in note
+    assert "FLAG-ONLY" in note
+
+    # Same launch episode on the next tick: deduped, nothing new.
+    asw.stale_blocked_flag_pass(dry_run=False, now=now + 600)
+    assert len(posted) == 1 and len(pushed) == 1
+
+    # A NEWER launch (a fresh episode) re-alerts.
+    events2 = _sb_events(
+        block_iso="2026-07-01T00:00:00Z",
+        launch_iso="2026-07-02T08:00:00Z",
+        progress_iso="2026-07-02T09:00:00Z",
+    )
+    monkeypatch.setattr(asw, "_task_events", lambda i: events2)
+    asw.stale_blocked_flag_pass(dry_run=False, now=asw._parse_event_ts("2026-07-02T09:30:00Z"))
+    assert len(posted) == 2 and len(pushed) == 2
+
+
+def test_stale_blocked_pass_reblock_after_launch_unflags(isolated_registry, monkeypatch):
+    # Pass-level replay: block -> launch -> post-launch progress -> RE-BLOCK
+    # (newer epm:status-changed). The wiring extracts the LATEST
+    # status-changed as "the transition into blocked", so launch < re-block ->
+    # no flag (pins the latest-status-changed extraction, not just the
+    # predicate).
+    import autonomous_session_watch as asw
+
+    events = _sb_events(
+        block_iso="2026-07-01T00:00:00Z",
+        launch_iso="2026-07-01T08:00:00Z",
+        progress_iso="2026-07-01T09:00:00Z",
+        reblock_iso="2026-07-01T10:00:00Z",
+    )
+    posted, pushed = _patch_sb_pass(monkeypatch, asw, [742], {742: events})
+    asw.stale_blocked_flag_pass(dry_run=False, now=asw._parse_event_ts("2026-07-01T10:30:00Z"))
+    assert posted == [] and pushed == []
+    assert not (isolated_registry / "stale-blocked-742.json").exists()
+
+
+def test_stale_blocked_pass_never_mutates_status(isolated_registry, tmp_path, monkeypatch):
+    # The flag-only HARD invariant, TWO-PRONGED (per
+    # test_triage_observer_never_calls_in_process_mutators): (i) no recorded
+    # subprocess argv contains `set-status`; (ii) the in-process mutators
+    # task_workflow.set_status / post_event raise if touched — the pass must
+    # complete without tripping them. Helper-mediated or in-process status
+    # mutation must fail this test, not just direct subprocess calls.
+    import subprocess as _subprocess
+
+    import autonomous_session_watch as asw
+
+    from explore_persona_space import task_workflow
+
+    events = _sb_events(
+        block_iso="2026-07-01T00:00:00Z",
+        launch_iso="2026-07-01T08:00:00Z",
+        progress_iso="2026-07-01T09:00:00Z",
+    )
+    monkeypatch.setattr(asw, "_blocked_issue_ids", lambda: [742])
+    monkeypatch.setattr(asw, "_task_events", lambda i: events)
+
+    def _forbidden(*a, **kw):
+        raise AssertionError("stale_blocked_flag_pass must never mutate task state in-process")
+
+    monkeypatch.setattr(task_workflow, "set_status", _forbidden)
+    monkeypatch.setattr(task_workflow, "post_event", _forbidden)
+
+    # Route the Telegram push through the recorded subprocess seam too.
+    push_script = tmp_path / "push.sh"
+    push_script.write_text("#!/usr/bin/env bash\n")
+    monkeypatch.setenv("EPM_TELEGRAM_PUSH_SCRIPT", str(push_script))
+
+    argvs: list[list[str]] = []
+
+    def _record_run(cmd, *a, **kw):
+        argvs.append(list(cmd))
+        return _subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(asw.subprocess, "run", _record_run)
+    asw.stale_blocked_flag_pass(dry_run=False, now=asw._parse_event_ts("2026-07-01T09:30:00Z"))
+    # The flag DID fire (post-marker argv present) but nothing mutates status.
+    assert any("post-marker" in cmd for cmd in argvs)
+    assert not any("set-status" in cmd for cmd in argvs)
+
+
+def test_stale_blocked_pass_kill_switch(isolated_registry, monkeypatch):
+    import autonomous_session_watch as asw
+
+    monkeypatch.setenv("EPM_DISABLE_STALE_BLOCKED_FLAG", "1")
+    monkeypatch.setattr(
+        asw, "_blocked_issue_ids", lambda: pytest.fail("scanned despite kill switch")
+    )
+    asw.stale_blocked_flag_pass(dry_run=False, now=_SB_T0)
+
+
+def test_stale_blocked_pass_dry_run_no_writes(isolated_registry, monkeypatch):
+    # dry_run -> zero state/sidecar writes, zero marker/push subprocesses.
+    import autonomous_session_watch as asw
+
+    events = _sb_events(
+        block_iso="2026-07-01T00:00:00Z",
+        launch_iso="2026-07-01T08:00:00Z",
+        progress_iso="2026-07-01T09:00:00Z",
+    )
+    monkeypatch.setattr(asw, "_blocked_issue_ids", lambda: [742])
+    monkeypatch.setattr(asw, "_task_events", lambda i: events)
+    monkeypatch.setattr(
+        asw.subprocess, "run", lambda *a, **k: pytest.fail("subprocess.run in dry-run")
+    )
+    asw.stale_blocked_flag_pass(dry_run=True, now=asw._parse_event_ts("2026-07-01T09:30:00Z"))
+    assert not (isolated_registry / "stale-blocked-742.json").exists()
+    assert not (isolated_registry / "stale-blocked-events.jsonl").exists()
+
+
+def test_stale_blocked_sentinel_in_watcher_note_sentinels():
+    # The flag note rides epm:progress; membership keeps it from ever
+    # resetting the _latest_progress_ts staleness clocks (the set's own
+    # comment mandates this for every new watcher-posted marker). Inverse of
+    # the long-phase-heartbeat NON-membership test.
+    import autonomous_session_watch as asw
+
+    assert asw._STALE_BLOCKED_FLAG_NOTE_SENTINEL in asw._WATCHER_NOTE_SENTINELS
+
+
+def test_main_wires_stale_blocked_pass_order(isolated_registry, monkeypatch):
+    # Must-Fix (methodology reconciler): main() runs capacity_retry_pass ->
+    # stale_blocked_flag_pass -> session_reconcile_pass in that order — closes
+    # the silently-inert-backstop hole (the #681
+    # test_main_wires_data_disk_pass_call_site class) where every isolation
+    # test passes but the normal cadence never runs the pass.
+    import autonomous_session_watch as asw
+
+    order: list[str] = []
+    monkeypatch.setattr(asw, "_daemon_reachable", lambda: True)
+    monkeypatch.setattr(asw, "_live_session_ids", lambda: set())
+    monkeypatch.setattr(asw, "_live_children", lambda: [])
+    monkeypatch.setattr(asw, "_live_pids_by_sid_or_none", lambda: None)
+    for name in (
+        "vm_disk_pass",
+        "data_disk_pass",
+        "happy_patch_pass",
+        "cpu_guard_pass",
+        "program_orchestrator_pass",
+        "triage_observer_pass",
+        "campaign_pass",
+        "pod_safety_pass",
+        "respawn_pass",
+        "stalled_session_pass",
+        "orphan_sweep_pass",
+        "infra_drain_pass",
+        "proposed_infra_sweep_pass",
+        "gate_push_pass",
+        "stale_registration_pass",
+        "zombie_wrapper_pass",
+        "idle_unmapped_pass",
+        "gc_pass",
+    ):
+        if hasattr(asw, name):
+            monkeypatch.setattr(asw, name, lambda *a, **kw: None)
+    monkeypatch.setattr(asw, "capacity_retry_pass", lambda *a, **kw: order.append("capacity_retry"))
+    monkeypatch.setattr(
+        asw, "stale_blocked_flag_pass", lambda *a, **kw: order.append("stale_blocked_flag")
+    )
+    monkeypatch.setattr(
+        asw, "session_reconcile_pass", lambda *a, **kw: order.append("session_reconcile")
+    )
+    rc = asw.main([])
+    assert rc == 0
+    assert (
+        order.index("capacity_retry")
+        < order.index("stale_blocked_flag")
+        < order.index("session_reconcile")
+    )
+
+
+def test_main_stale_blocked_only_flag(isolated_registry, monkeypatch):
+    # --stale-blocked-only runs JUST the new pass and exits (mirrors
+    # test_main_proposed_infra_sweep_only_flag).
+    import autonomous_session_watch as asw
+
+    calls: list[str] = []
+    monkeypatch.setattr(asw, "stale_blocked_flag_pass", lambda *a, **kw: calls.append("flag"))
+    monkeypatch.setattr(
+        asw, "vm_disk_pass", lambda *a, **kw: pytest.fail("ran another pass under --only")
+    )
+    monkeypatch.setattr(
+        asw, "capacity_retry_pass", lambda *a, **kw: pytest.fail("ran another pass under --only")
+    )
+    rc = asw.main(["--stale-blocked-only", "--dry-run"])
+    assert rc == 0
+    assert calls == ["flag"]
+
+
 # --- program-orchestrator crash-recovery pass (#660 bash daemon) ---
 #
 # The recovery path only fires on a real daemon crash, so it must be unit-tested
@@ -11487,6 +11862,7 @@ def test_main_runs_sweep_after_infra_drain(isolated_registry, monkeypatch):
         "stalled_session_pass",
         "orphan_sweep_pass",
         "capacity_retry_pass",
+        "stale_blocked_flag_pass",
         "session_reconcile_pass",
         "gate_push_pass",
         "zombie_wrapper_pass",
@@ -13535,6 +13911,7 @@ def test_main_order_stale_registration_after_gate_push(isolated_registry, monkey
         "infra_drain_pass",
         "proposed_infra_sweep_pass",
         "capacity_retry_pass",
+        "stale_blocked_flag_pass",
         "session_reconcile_pass",
         "gc_pass",
     ):

--- a/tests/test_stalled_detector_and_gc.py
+++ b/tests/test_stalled_detector_and_gc.py
@@ -1053,6 +1053,9 @@ def test_main_runs_stalled_and_gc_after_pod_safety(isolated_registry, monkeypatc
     monkeypatch.setattr(asw, "vm_disk_pass", lambda *a, **kw: calls.append("vm_disk"))
     # #967: never sweep the LIVE registry/events tree from a unit test.
     monkeypatch.setattr(asw, "triage_observer_pass", lambda *a, **kw: None)
+    # #1021: the stale-blocked flag pass shells task.py against the LIVE
+    # blocked set (daemon-independent) — never run it from a unit test.
+    monkeypatch.setattr(asw, "stale_blocked_flag_pass", lambda *a, **kw: None)
     monkeypatch.setattr(asw, "pod_safety_pass", lambda *a, **kw: calls.append("pod_safety"))
     monkeypatch.setattr(asw, "stalled_session_pass", lambda *a, **kw: calls.append("stalled"))
     monkeypatch.setattr(asw, "orphan_sweep_pass", lambda *a, **kw: calls.append("orphan_sweep"))


### PR DESCRIPTION
Closes task #1021 (kind: infra, workflow-fix; auto-filed from the /daily 2026-07-02 sweep, incident #742 — a healthy ~35h run displayed as blocked).

## Summary
- SKILL.md: a successful relaunch now reconciles a stale `blocked` → `running` (guards a-d incl. re-read-before-flip abort); Step-7 pointer added
- crash-fix-rounds.md: orchestrator-owned-flip cross-reference (implementers never run set-status)
- autonomous_session_watch.py: flag-only `stale_blocked_flag_pass` backstop (launch-newer-than-block + post-launch-progress predicate; deduped per launch episode; sidecar + marker + Telegram; kill switch; `--stale-blocked-only` CLI; GC entry)
- 22 new tests incl. main()-wiring order + two-pronged never-mutates pins

## Review trail
- Plan v2 (adversarial ensemble: 3 lenses × Claude+Codex; 2 reconciler rounds; Must-Fix folded)
- Code review: Claude PASS + Codex PASS (round 1)
- Step 9c: 2485 passed / 6 skipped (touched scope); lint clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)