### PR TITLE
task #1018: rubric-keyed JudgeCache (rule 22 code fix, #810)

### DIFF
--- a/.claude/rules/llm-judging.md
+++ b/.claude/rules/llm-judging.md
@@ -234,21 +234,31 @@ narrate it as the construct. (Source: #722 — `eval_results/issue_722/tf_margin
     (reasoning, score) pair with the refusal file (vs 18.7% baseline) — an
     exact-pair fingerprint implicating cache reuse rather than a prompt bug
     (independent temperature>0 judge draws would not be byte-identical).
-    The SAFE in-repo patterns: a
-    full-payload cache key (`llm/api_dispatch.py::_cache_key_parts` keys on
-    (item_id, full-payload JSON) — safe ONLY when the caller's payload
-    embeds the rubric-bearing user message; the rubric's system-prompt half
-    is typically NOT in the payload, so payload-key safety is
-    caller-dependent, not structural), and a DISJOINT per-rubric
-    `cache_dir` partition (`datagen.py`'s `judge_cache/pos` vs
-    `judge_cache/neg`).
-    Until the `batch_judge.py` key fix lands (a separate follow-up), the
-    per-rubric `cache_dir` is the accepted key surrogate. Plan-side: any
-    plan whose eval judges >1 rubric/behavior over a shared completion
-    pool — or resumes judging against a previously-populated shared cache
-    dir — NAMES its judge-cache key fields (or the per-rubric cache
-    partition); critics REVISE a shared multi-rubric judge cache without a
-    rubric-bearing key.
+    The key fix LANDED in #1018: `JudgeCache.get`/`put`/`_hash_key` now
+    REQUIRE a keyword-only `rubric_key` (an unthreaded call site raises
+    `TypeError`), derived via the helper
+    `rubric_fingerprint(judge_model, judge_system_prompt, format_user_msg)`
+    — the user-msg template is sentinel-rendered into the fingerprint so a
+    rubric living in the USER message (the `graded_judge` shape) enters the
+    key, not only a system-prompt rubric. The generic adapter
+    `llm/api_dispatch.py::_cache_key_parts` returns
+    (item_id, payload JSON, built-request fingerprint) and threads the
+    fingerprint as the `rubric_key` — the built params dict embeds model +
+    system + messages, so the adapter key is STRUCTURAL (no longer
+    caller-dependent; deliberately over-keyed on full request params), and
+    the api_dispatch batch checkpoint additionally stores a run-level
+    request fingerprint in its `state.json` that is recomputed on load and
+    FAILS LOUD on mismatch (a rubric-B dispatch can never replay rubric-A's
+    checkpoint). The key schema embeds the literal `EPM_JUDGE_CACHE_KEY_V2`
+    version tag, so all pre-fix content-keyed entries are automatically
+    unreachable — a cold re-judge, never a wrong read. Per-rubric
+    `cache_dir` partitions (`datagen.py`'s `judge_cache/pos` vs
+    `judge_cache/neg`) remain good hygiene but are no longer load-bearing.
+    Plan-side: any plan whose eval judges >1 rubric/behavior over a shared
+    completion pool — or resumes judging against a previously-populated
+    shared cache dir — NAMES its judge-cache key fields (or the per-rubric
+    cache partition); critics REVISE a shared multi-rubric judge cache
+    without a rubric-bearing key.
 
 ## Do NOT over-rely on (adversarially refuted)
 

--- a/scripts/issue779_common.py
+++ b/scripts/issue779_common.py
@@ -543,9 +543,10 @@ def judge_rollouts_n5(
 
     Cache (BLOCKER ``judge-n5-cache-rerun-collapses-draws``): the judge cache is
     DISABLED here (``cache_dir`` is ignored, ``judge_completions_batch`` is called
-    with ``cache_dir=None``). ``JudgeCache._hash_key`` keys ONLY on
-    ``(question, completion)`` — NOT the draw index or custom_id — so the
-    ``n_draws`` expanded copies of an identical ``(question, completion)`` collapse
+    with ``cache_dir=None``). ``JudgeCache._hash_key`` keys on
+    (rubric/judge identity, question, completion) as of #1018 — still NOT the
+    draw index or custom_id — so the ``n_draws`` expanded copies of an identical
+    ``(question, completion)`` under one rubric collapse
     to ONE cache entry; on a rerun with a warm cache all ``n_draws`` lookups would
     HIT that single entry and the N=5 mean would silently degrade to one cached
     draw repeated ``n_draws`` times. A draw-aware cache key is not cleanly

--- a/scripts/issue_188_evolutionary_trigger.py
+++ b/scripts/issue_188_evolutionary_trigger.py
@@ -241,7 +241,7 @@ def _judge_records(
       ``cfg.judge.mode`` is missing — preserves backwards compatibility for
       callers (#188, #325, #324, #283) that never specified the field.
     """
-    from explore_persona_space.eval.batch_judge import JudgeCache
+    from explore_persona_space.eval.batch_judge import JudgeCache, rubric_fingerprint
 
     # Resolve mode without mutating cfg; default to batch for backwards compat.
     mode = str(getattr(cfg.judge, "mode", "batch")).lower()
@@ -261,12 +261,17 @@ def _judge_records(
         cache_dir = project_root / cache_dir
     cache_dir.mkdir(parents=True, exist_ok=True)
     cache = JudgeCache(cache_dir)
+    # Rubric/judge identity for every cache read/write (rule 22, #810/#1018).
+    # The inline user-msg template below is a rubric-free content wrapper whose
+    # suffix is constant per rubric, so the rubric identity is fully carried by
+    # the (model, system prompt) half of the key — no format_user_msg needed.
+    rk = rubric_fingerprint(cfg.judge.model, judge_system_prompt)
 
     judged: dict[str, dict] = {}
     uncached_items: list[tuple[str, str, str, str]] = []
     for rec in records:
         cid = rec["custom_id"]
-        c = cache.get(rec["prompt"], rec["completion"])
+        c = cache.get(rec["prompt"], rec["completion"], rubric_key=rk)
         if c is not None:
             judged[cid] = c
         else:
@@ -289,7 +294,7 @@ def _judge_records(
             new_results = _judge_uncached_via_batch(uncached_items, cfg, judge_system_prompt)
         else:
             new_results = _judge_uncached_via_sync(
-                uncached_items, cfg, judge_system_prompt, cache=cache
+                uncached_items, cfg, judge_system_prompt, cache=cache, rubric_key=rk
             )
         for cid, q, c, _umsg in uncached_items:
             if cid in new_results:
@@ -298,7 +303,7 @@ def _judge_records(
                 # Only cache results the API actually returned. Missing
                 # entries (shouldn't happen, defence against silent SDK gaps)
                 # stay uncached so the next run retries them.
-                cache.put(q, c, parsed)
+                cache.put(q, c, parsed, rubric_key=rk)
             else:
                 logger.warning("Judge result missing for custom_id=%s", cid)
                 judged[cid] = {"label": None, "evidence": None, "error": True}
@@ -401,8 +406,13 @@ def _judge_uncached_via_sync(
     cfg: DictConfig,
     judge_system_prompt: str,
     cache=None,
+    *,
+    rubric_key: str,
 ) -> dict[str, dict]:
     """Submit uncached judge items via synchronous Anthropic /v1/messages.
+
+    ``rubric_key`` (required) keys the in-loop ``cache.put`` writes on the
+    rubric/judge identity (rule 22, #810/#1018); unused when ``cache`` is None.
 
     Concurrency: ``cfg.judge.sync_max_workers`` (default 20) threads sharing
     one anthropic.Anthropic client (the SDK's underlying httpx pool is
@@ -519,7 +529,7 @@ def _judge_uncached_via_sync(
             # them (matches the docstring's "still cached" promise).
             if cache is not None:
                 q, c = item_lookup[cid]
-                cache.put(q, c, parsed)
+                cache.put(q, c, parsed, rubric_key=rubric_key)
             completed += 1
             if parsed.get("error"):
                 n_errors += 1

--- a/scripts/rejudge_issue_389_c_strict.py
+++ b/scripts/rejudge_issue_389_c_strict.py
@@ -217,6 +217,7 @@ def _judge_strict_per_sub_framing(
         _build_batch_requests,
         _chunk_requests,
         _submit_and_poll_batch,
+        rubric_fingerprint,
     )
 
     auto_answer, metabolic_answer = C_STRICT_ANSWER_KEYWORDS[sub_framing]
@@ -226,9 +227,11 @@ def _judge_strict_per_sub_framing(
     )
 
     # Namespaced cache per sub-framing so different placeholder fills cannot
-    # collide on the same (probe, completion) hash.
+    # collide on the same (probe, completion) hash — kept as belt-and-suspenders;
+    # the rubric_key below carries the isolation too (rule 22, #810/#1018).
     cache_dir = CACHE_ROOT / sub_framing
     cache = JudgeCache(cache_dir)
+    rk = rubric_fingerprint(JUDGE_MODEL, judge_system, _build_user_msg)
     client = anthropic_mod.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
 
     # Bookkeeping: map custom_id back to item_idx, and probe/completion for
@@ -242,7 +245,7 @@ def _judge_strict_per_sub_framing(
         custom_id = f"sc__{item_idx:06d}"
         id_to_idx[custom_id] = item_idx
         id_to_qc[custom_id] = (probe, completion)
-        hit = cache.get(probe, completion)
+        hit = cache.get(probe, completion, rubric_key=rk)
         if hit is not None:
             cached_by_idx[item_idx] = hit
             continue
@@ -275,7 +278,7 @@ def _judge_strict_per_sub_framing(
                 if qc is None:
                     continue
                 probe, completion = qc
-                cache.put(probe, completion, score)
+                cache.put(probe, completion, score, rubric_key=rk)
                 batch_by_idx[id_to_idx[custom_id]] = score
 
     out: dict[int, dict[str, Any]] = dict(cached_by_idx)

--- a/scripts/run_experiment_389.py
+++ b/scripts/run_experiment_389.py
@@ -1495,9 +1495,12 @@ def _judge_categorical_batch(
         _build_batch_requests,
         _chunk_requests,
         _submit_and_poll_batch,
+        rubric_fingerprint,
     )
 
     cache = JudgeCache(cache_dir)
+    # Rubric/judge identity for every cache read/write (rule 22, #810/#1018).
+    rk = rubric_fingerprint(judge_model, rubric["judge_system"], _build_judge_user_msg)
     client = anthropic_mod.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
 
     cell_for_id: dict[str, str] = {}
@@ -1506,7 +1509,7 @@ def _judge_categorical_batch(
     for idx, (cell_tag, probe, completion) in enumerate(items):
         custom_id = f"cat__{idx:06d}"
         cell_for_id[custom_id] = cell_tag
-        hit = cache.get(probe, completion)
+        hit = cache.get(probe, completion, rubric_key=rk)
         if hit is not None:
             cached[custom_id] = hit
             continue
@@ -1541,7 +1544,7 @@ def _judge_categorical_batch(
             qc = uncached_by_id.get(custom_id)
             if qc is not None:
                 q, c = qc
-                cache.put(q, c, score)
+                cache.put(q, c, score, rubric_key=rk)
 
     all_scores = {**cached, **batch_scores}
     by_cell: dict[str, dict[str, Any]] = {}
@@ -1608,6 +1611,7 @@ def _judge_framing_binary_batch(
         _build_batch_requests,
         _chunk_requests,
         _submit_and_poll_batch,
+        rubric_fingerprint,
     )
 
     rubric = FRAMING_RUBRICS[framing_id]
@@ -1625,9 +1629,12 @@ def _judge_framing_binary_batch(
     for gated_pred, group in by_gated.items():
         # Resolve the gated-predicate value into the rubric system prompt
         judge_system = rubric["judge_system"].format(gated_predicate=gated_pred)
-        # Cache namespaced per (rubric_version, gated_predicate)
+        # Cache namespaced per (rubric_version, gated_predicate) — kept as
+        # belt-and-suspenders; the rubric_key below carries the isolation too
+        # (rule 22, #810/#1018).
         sub_cache = cache_dir / f"gated_{gated_pred}"
         cache = JudgeCache(sub_cache)
+        rk = rubric_fingerprint(judge_model, judge_system, _build_judge_user_msg)
         client = anthropic_mod.Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
 
         cell_for_id: dict[str, str] = {}
@@ -1638,7 +1645,7 @@ def _judge_framing_binary_batch(
             custom_id = f"f{framing_id}__{orig_idx:06d}"
             cell_for_id[custom_id] = cell_tag
             item_for_id[custom_id] = (probe, completion)
-            hit = cache.get(probe, completion)
+            hit = cache.get(probe, completion, rubric_key=rk)
             if hit is not None:
                 cached[custom_id] = hit
                 continue
@@ -1676,7 +1683,7 @@ def _judge_framing_binary_batch(
                 qc = uncached_by_id.get(custom_id)
                 if qc is not None:
                     q, c = qc
-                    cache.put(q, c, score)
+                    cache.put(q, c, score, rubric_key=rk)
 
         all_scores = {**cached, **batch_scores}
         for custom_id, score in all_scores.items():

--- a/src/explore_persona_space/eval/batch_judge.py
+++ b/src/explore_persona_space/eval/batch_judge.py
@@ -4,8 +4,9 @@ Replaces the hand-rolled sequential async judge pattern with Anthropic's
 native batch endpoint (50% cost discount, no rate limit management needed).
 
 Cache pattern inspired by safety-tooling's cache_manager — simple file-based
-JSONL keyed by hash of (question, completion), avoiding redundant API calls
-on experiment resume.
+JSON keyed by hash of (rubric/judge identity, question, completion), avoiding
+redundant API calls on experiment resume without ever serving one rubric's
+judgment for another (llm-judging.md rule 22, #810/#1018).
 
 Usage:
     from explore_persona_space.eval.batch_judge import judge_completions_batch
@@ -91,13 +92,56 @@ def make_custom_id(item_id: str) -> str:
 
 # ── Judge cache ──────────────────────────────────────────────────────────────
 
+# Rubric-identity cache keying (llm-judging.md rule 22, #810/#1018). The literal
+# version tag enters every key preimage, so this — and any FUTURE key-schema
+# change that bumps it — is an explicit, automatic bust of all pre-change
+# entries: a cold miss re-judges (safe direction); a wrong read is impossible.
+_JUDGE_CACHE_KEY_VERSION = "EPM_JUDGE_CACHE_KEY_V2"
+_RUBRIC_SENTINEL_Q = "<RUBRIC_FINGERPRINT_SENTINEL_QUESTION>"
+_RUBRIC_SENTINEL_C = "<RUBRIC_FINGERPRINT_SENTINEL_COMPLETION>"
+
+
+def rubric_fingerprint(
+    judge_model: str,
+    judge_system_prompt: str,
+    format_user_msg: Callable[[str, str], str] | None = None,
+) -> str:
+    """Stable rubric/judge identity hash for JudgeCache keys (rule 22, #810).
+
+    Renders ``format_user_msg`` on fixed sentinel strings so a rubric that
+    lives in the USER-message template (e.g. ``graded_judge`` fills the whole
+    0-100 rubric into the user msg under a generic system prompt) enters the
+    key, not only a system-prompt rubric. ``None`` means "no user template
+    contributes rubric content" (caller builds content-only user messages).
+
+    This fingerprints rubric/judge IDENTITY, not the full request: sampling
+    knobs like ``max_tokens``/temperature are deliberately excluded (they carry
+    no rubric semantics; contrast the api_dispatch adapter, which deliberately
+    over-keys on the full built request). A formatter that selects its rubric
+    by INPUT-DEPENDENT branching (different rubric text per question) is
+    outside the fingerprint's discrimination — no in-repo formatter does that;
+    such a caller must fold the branch into the system prompt or use disjoint
+    cache dirs.
+    """
+    rendered = (
+        format_user_msg(_RUBRIC_SENTINEL_Q, _RUBRIC_SENTINEL_C)
+        if format_user_msg is not None
+        else "<no-user-template>"
+    )
+    content = f"{judge_model}\n===\n{judge_system_prompt}\n===\n{rendered}"
+    return hashlib.sha256(content.encode()).hexdigest()[:16]
+
 
 class JudgeCache:
     """Simple file-based cache for judge results, keyed by prompt content hash.
 
     Each cached result is stored as a single JSON file named by the hash of
-    (question + completion). Cache hits avoid redundant Batch API calls on
-    experiment resume.
+    (rubric/judge identity, question, completion) — the ``rubric_key`` is a
+    REQUIRED keyword argument on every read/write so a cached judgment can
+    never be served across rubrics (llm-judging.md rule 22; incident #810).
+    Cache hits avoid redundant Batch API calls on experiment resume. Filenames
+    keep the ``{16-hex}.json`` shape (load-bearing for
+    ``issue906_phase1_pilot._is_rederivable_cache`` + the disk janitors).
     """
 
     def __init__(self, cache_dir: Path):
@@ -107,13 +151,21 @@ class JudgeCache:
         self._misses = 0
 
     @staticmethod
-    def _hash_key(question: str, completion: str) -> str:
-        content = f"{question}\n---\n{completion}"
+    def _hash_key(question: str, completion: str, *, rubric_key: str) -> str:
+        """Hash (key-schema version, rubric identity, question, completion) to 16 hex chars."""
+        if not isinstance(rubric_key, str) or not rubric_key:
+            raise ValueError(
+                f"rubric_key must be a non-empty str (got {rubric_key!r}); derive it via "
+                "rubric_fingerprint(judge_model, judge_system_prompt, format_user_msg)."
+            )
+        content = (
+            f"{_JUDGE_CACHE_KEY_VERSION}\n---\n{rubric_key}\n---\n{question}\n---\n{completion}"
+        )
         return hashlib.sha256(content.encode()).hexdigest()[:16]
 
-    def get(self, question: str, completion: str) -> dict | None:
-        """Look up a cached judge result. Returns None on miss."""
-        key = self._hash_key(question, completion)
+    def get(self, question: str, completion: str, *, rubric_key: str) -> dict | None:
+        """Look up a cached judge result under ``rubric_key``. Returns None on miss."""
+        key = self._hash_key(question, completion, rubric_key=rubric_key)
         path = self.cache_dir / f"{key}.json"
         if path.exists():
             self._hits += 1
@@ -122,9 +174,9 @@ class JudgeCache:
         self._misses += 1
         return None
 
-    def put(self, question: str, completion: str, result: dict) -> None:
-        """Store a judge result in the cache."""
-        key = self._hash_key(question, completion)
+    def put(self, question: str, completion: str, result: dict, *, rubric_key: str) -> None:
+        """Store a judge result in the cache under ``rubric_key``."""
+        key = self._hash_key(question, completion, rubric_key=rubric_key)
         path = self.cache_dir / f"{key}.json"
         with open(path, "w") as f:
             json.dump(result, f)
@@ -379,8 +431,13 @@ def _enumerate_and_check_cache(
     completions: dict[str, dict[str, list[str]]],
     cache: JudgeCache | None,
     format_user_msg: Callable[[str, str], str],
+    *,
+    rubric_key: str,
 ) -> tuple[int, dict[str, dict], list[tuple[str, str, str, str]]]:
     """Enumerate all (persona, question, completion) tuples, checking cache.
+
+    ``rubric_key`` (required) is the rubric/judge identity hash every cache
+    lookup is keyed under — see :func:`rubric_fingerprint` (rule 22, #810).
 
     Returns:
         (total_count, cached_scores, uncached_items)
@@ -397,7 +454,7 @@ def _enumerate_and_check_cache(
                 total += 1
 
                 if cache:
-                    cached = cache.get(question, comp)
+                    cached = cache.get(question, comp, rubric_key=rubric_key)
                     if cached is not None:
                         cached_scores[custom_id] = cached
                         continue
@@ -516,7 +573,8 @@ def judge_completions_batch(
     """Judge all completions via the batch-aware dispatcher with optional caching.
 
     Workflow:
-    1. Check cache for each (question, completion) pair
+    1. Check cache for each (question, completion) pair under the derived
+       rubric/judge identity key (rule 22 — see :func:`rubric_fingerprint`)
     2. Dispatch uncached pairs through judge_dispatch (sync below the
        tier-scaled threshold, Message Batches at/above it, in <=8k sub-batches)
     3. Parse results, update cache
@@ -554,10 +612,14 @@ def judge_completions_batch(
         format_user_msg = _default_format_user_msg
 
     cache = JudgeCache(cache_dir) if cache_dir else None
+    # Rubric/judge identity for every cache read/write in this call (rule 22,
+    # #810): derived from the resolved judge model + system prompt + user-msg
+    # template, so callers need no new parameter.
+    rubric_key = rubric_fingerprint(judge_model, judge_system_prompt, format_user_msg)
 
     # Phase 1: Check cache, build list of uncached items
     total, cached_scores, uncached_items = _enumerate_and_check_cache(
-        completions, cache, format_user_msg
+        completions, cache, format_user_msg, rubric_key=rubric_key
     )
     n_cached = len(cached_scores)
     n_to_submit = len(uncached_items)
@@ -604,7 +666,7 @@ def judge_completions_batch(
         if cache:
             for custom_id, question, comp, _user_msg in uncached_items:
                 if custom_id in batch_scores:
-                    cache.put(question, comp, batch_scores[custom_id])
+                    cache.put(question, comp, batch_scores[custom_id], rubric_key=rubric_key)
 
     if cache:
         logger.info("Cache stats: %s", cache.stats)

--- a/src/explore_persona_space/eval/graded_judge.py
+++ b/src/explore_persona_space/eval/graded_judge.py
@@ -17,10 +17,11 @@ Notes for callers:
   temperature parameter, so the multi-sample draws vary at the Anthropic API
   default. Threading it through the shared client is a named follow-up, not
   this module's job (semantic identity with the #778 implementation).
-- ``JudgeCache`` keys on the ``(question, answer)`` content hash, so a REUSED
-  ``cache_dir`` collapses all ``n_draws`` repeats of an item to one cached
-  score. Pre-existing behavior (unchanged here); use a fresh per-run
-  ``cache_dir`` when the draws must be independent (#778 did).
+- ``JudgeCache`` keys on the (rubric/judge identity, question, answer) hash
+  (#1018, llm-judging.md rule 22) — the rubric key differentiates RUBRICS, not
+  draws, so a REUSED ``cache_dir`` still collapses all ``n_draws`` repeats of
+  an item to one cached score. Use a fresh per-run ``cache_dir`` when the
+  draws must be independent (#778 did).
 """
 
 from __future__ import annotations

--- a/src/explore_persona_space/llm/api_dispatch.py
+++ b/src/explore_persona_space/llm/api_dispatch.py
@@ -41,10 +41,11 @@ Design (all FIRM requirements from § 1b + Phase 4):
    warm-up ramp on start avoids acceleration-429s.
 
 5. **Caching / resume (interrupt-safe).** A per-item content-hash cache
-   (extends :class:`~explore_persona_space.eval.batch_judge.JudgeCache`) skips
-   already-completed items on restart; results are checkpointed with atomic
-   temp-file-then-rename writes so a crash / full disk leaves the last good
-   checkpoint intact.
+   (extends :class:`~explore_persona_space.eval.batch_judge.JudgeCache`, keyed
+   with the built-request fingerprint so different builders/rubrics never
+   cross-read — rule 22, #1018) skips already-completed items on restart;
+   results are checkpointed with atomic temp-file-then-rename writes so a
+   crash / full disk leaves the last good checkpoint intact.
 
 6. **Batch path.** For large / cost-sensitive N, reuse ``batch_judge``'s
    ``_chunk_requests`` with SMALL chunks (~1000, NOT 8000) + the ``#663``
@@ -75,6 +76,7 @@ import argparse
 import asyncio
 import datetime as _dt
 import functools
+import hashlib
 import json
 import logging
 import os
@@ -825,6 +827,18 @@ async def _dispatch_sync(
 # ── Batch path (org-aware, checkpointed) ─────────────────────────────────────
 
 
+def _batch_run_fingerprint(items: list[DispatchItem], build_request: BuildRequest) -> str:
+    """Run-level request fingerprint over the dispatched set (rule 22, #1018).
+
+    Hashes the sorted ``(item_id, built-request fingerprint)`` pairs of the
+    pending set, binding a batch checkpoint to the builder/rubric that created
+    it — so a rubric-B dispatch reusing rubric-A's ``checkpoint_dir`` fails
+    loud at state load instead of replaying A's judgments under B's key.
+    """
+    pairs = sorted((it.item_id, _cache_key_parts(it, build_request)[2]) for it in items)
+    return hashlib.sha256(json.dumps(pairs).encode()).hexdigest()[:16]
+
+
 def _load_or_init_batch_state(
     state_path: Path,
     items: list[DispatchItem],
@@ -840,9 +854,27 @@ def _load_or_init_batch_state(
     Org assignment is round-robin across the present orgs at init so resume
     re-polls each sub-batch on the SAME org it was created on (a batch created
     on org B 404s if polled on org A).
+
+    Rubric binding (rule 22, #1018): the state carries a run-level
+    ``request_fingerprint`` over the dispatched set; a LOAD whose recomputed
+    fingerprint mismatches — or a pre-fix state.json with no fingerprint field
+    (rubric provenance unknown) — raises ValueError, NEVER silently re-inits
+    (that would discard the prior state pointer and orphan paid batches).
     """
+    run_fp = _batch_run_fingerprint(items, build_request)
     if state_path.exists():
-        return json.loads(state_path.read_text())
+        state = json.loads(state_path.read_text())
+        stored_fp = state.get("request_fingerprint")
+        if stored_fp != run_fp:
+            raise ValueError(
+                f"Batch checkpoint at {state_path} does not match this dispatch: stored "
+                f"request_fingerprint={stored_fp!r}, recomputed={run_fp!r}. This checkpoint "
+                "belongs to a different builder/rubric, predates the #1018 fingerprint field, "
+                "or a partially-persisted prior run shrank the pending set. Use a distinct "
+                f"checkpoint_dir per rubric, or delete {state_path} to resubmit the remainder. "
+                "Refusing to resume across the mismatch."
+            )
+        return state
 
     # Build one request per item, chunk small, assign orgs round-robin.
     cid_for = {it.item_id: make_custom_id(it.item_id) for it in items}
@@ -851,6 +883,7 @@ def _load_or_init_batch_state(
     state = {
         "version": 1,
         "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "request_fingerprint": run_fp,
         "sub_batches": [
             {
                 "index": i,
@@ -1216,7 +1249,9 @@ async def dispatch_calls(
             SLA forces the sync path.
         cost_pref: ``"balanced"`` (default) | ``"cost"`` (prefer 50% batch) |
             ``"latency"`` (prefer sync fan-out).
-        cache_dir: per-item content-hash cache root (resume skips cached items).
+        cache_dir: per-item content+request-fingerprint cache root (resume
+            skips cached items; keys carry the built-request fingerprint so
+            different builders/rubrics never cross-read — rule 22, #1018).
         checkpoint_dir: batch-path checkpoint root (REQUIRED for the batch path).
         concurrency_overrides: ``{family: cap}`` overrides for the per-key caps.
         crossover_n: sync/batch routing threshold (Phase 3 calibrates).
@@ -1303,10 +1338,12 @@ async def _dispatch_calls_inner(
     """Routing + execution, with clients already resolved (closing is the caller's job)."""
     org_labels = list(async_clients)
 
-    # Cache check (resume skips already-completed items).
+    # Cache check (resume skips already-completed items). build_request here is
+    # the GUARDED builder threaded from dispatch_calls (#991) — so the
+    # system-role check fires at cache-check time, before any wire call.
     if cache is None and cache_dir is not None:
         cache = JudgeCache(cache_dir)
-    results, pending = _split_cached(items, cache)
+    results, pending = _split_cached(items, cache, build_request)
     if not pending:
         logger.info("dispatch_calls: all %d items served from cache", len(items))
         return results
@@ -1357,7 +1394,7 @@ async def _dispatch_calls_inner(
             poll_interval=poll_interval,
             now_fn=now_fn,
         )
-        _persist_results_to_cache(new_results, pending, cache)
+        _persist_results_to_cache(new_results, pending, cache, build_request)
 
     results.update(new_results)
     return results
@@ -1406,13 +1443,19 @@ async def _close_clients(async_clients: dict[str, Any], sync_clients: dict[str, 
 
 
 def _split_cached(
-    items: list[DispatchItem], cache: JudgeCache | None
+    items: list[DispatchItem],
+    cache: JudgeCache | None,
+    build_request: BuildRequest,
 ) -> tuple[dict[str, DispatchResult], list[DispatchItem]]:
-    """Partition items into (cached results, still-pending items)."""
+    """Partition items into (cached results, still-pending items).
+
+    ``build_request`` supplies the built-request fingerprint half of the cache
+    key (see the cache-adapter block below) — it runs once per item here.
+    """
     results: dict[str, DispatchResult] = {}
     pending: list[DispatchItem] = []
     for it in items:
-        cached = _cache_get(cache, it) if cache is not None else None
+        cached = _cache_get(cache, it, build_request) if cache is not None else None
         if cached is not None:
             # A cached entry only ever stores a successful (non-error) result
             # today (_persist gates on ``not res.error``), so the RESULT_OK
@@ -1434,6 +1477,7 @@ def _persist_results_to_cache(
     results: dict[str, DispatchResult],
     items: list[DispatchItem],
     cache: JudgeCache | None,
+    build_request: BuildRequest,
 ) -> None:
     """Write every non-error result to the cache (no-op when cache is None)."""
     if cache is None:
@@ -1441,7 +1485,7 @@ def _persist_results_to_cache(
     item_by_id = {it.item_id: it for it in items}
     for item_id, res in results.items():
         if not res.error and item_id in item_by_id:
-            _cache_put(cache, item_by_id[item_id], res)
+            _cache_put(cache, item_by_id[item_id], res, build_request)
 
 
 async def _run_sync_path(
@@ -1462,7 +1506,7 @@ async def _run_sync_path(
 
     def _persist(res: DispatchResult) -> None:
         if cache is not None and not res.error:
-            _cache_put(cache, item_by_id[res.item_id], res)
+            _cache_put(cache, item_by_id[res.item_id], res, build_request)
 
     return await _dispatch_sync(
         pending,
@@ -1476,28 +1520,58 @@ async def _run_sync_path(
     )
 
 
-# ── Cache adapters (JudgeCache keys on (question, completion)) ────────────────
+# ── Cache adapters (JudgeCache keys on (rubric identity, question, completion)) ─
 #
-# JudgeCache hashes (question, completion). We reuse it generically by hashing
-# the item_id (stable) as the "question" and the json-serialized payload as the
-# "completion", so two items with the same id+payload share a cache entry.
+# JudgeCache requires a rubric_key on every read/write (rule 22, #810/#1018).
+# This generic adapter derives it from the BUILT request: build_request(item)
+# returns the Messages-API params dict, which embeds model + system + the user
+# messages — so the rubric enters the key wherever it lives (system prompt or
+# user-message template), with zero new public parameters on dispatch_calls.
+# We hash item_id (stable) as the "question", the json-serialized payload as
+# the "completion", and the built-request fingerprint as the rubric_key.
+# Behavior notes: (i) build_request now runs once per item at cache-CHECK time,
+# not only for pending items — cheap pure dict assembly for every in-repo
+# builder (determinism/re-callability is existing contract: the batch resubmit
+# path re-calls it); (ii) the #991 no-system-role ValueError consequently fires
+# at cache check, strictly EARLIER — fail-fast-compatible; (iii) a max_tokens /
+# param change now busts the cache — deliberate OVER-keying on full request
+# params (a miss re-judges; an under-key is the #810 bug; contrast
+# batch_judge.rubric_fingerprint, which keys rubric IDENTITY only).
 
 
-def _cache_key_parts(item: DispatchItem) -> tuple[str, str]:
+def _cache_key_parts(item: DispatchItem, build_request: BuildRequest) -> tuple[str, str, str]:
+    """(item_id, payload_json, request_fingerprint) — rule 22 (#810/#1018).
+
+    The request fingerprint hashes the FULL built params (model + system +
+    messages + max_tokens, ...), a superset of the rubric identity, so two
+    callers sharing a cache dir with different judges/rubrics can never
+    cross-read. Deliberate over-keying: this is full-REQUEST identity, not the
+    minimal rubric identity (the adapter cannot distinguish rubric from
+    non-rubric params generically).
+    """
     try:
         payload_repr = json.dumps(item.payload, sort_keys=True, default=str)
     except TypeError:
         payload_repr = str(item.payload)
-    return item.item_id, payload_repr
+    built = json.dumps(build_request(item), sort_keys=True, default=str)
+    fp = hashlib.sha256(built.encode()).hexdigest()[:16]
+    return item.item_id, payload_repr, fp
 
 
-def _cache_get(cache: JudgeCache, item: DispatchItem) -> dict | None:
-    q, c = _cache_key_parts(item)
-    return cache.get(q, c)
+def _cache_get(cache: JudgeCache, item: DispatchItem, build_request: BuildRequest) -> dict | None:
+    """Adapter read: JudgeCache.get keyed on (built-request fp, item_id, payload)."""
+    q, c, fp = _cache_key_parts(item, build_request)
+    return cache.get(q, c, rubric_key=fp)
 
 
-def _cache_put(cache: JudgeCache, item: DispatchItem, res: DispatchResult) -> None:
-    q, c = _cache_key_parts(item)
+def _cache_put(
+    cache: JudgeCache,
+    item: DispatchItem,
+    res: DispatchResult,
+    build_request: BuildRequest,
+) -> None:
+    """Adapter write: JudgeCache.put keyed on (built-request fp, item_id, payload)."""
+    q, c, fp = _cache_key_parts(item, build_request)
     cache.put(
         q,
         c,
@@ -1507,6 +1581,7 @@ def _cache_put(cache: JudgeCache, item: DispatchItem, res: DispatchResult) -> No
             "reason": res.reason,
             "category": res.category,
         },
+        rubric_key=fp,
     )
 
 

--- a/tests/test_api_dispatch.py
+++ b/tests/test_api_dispatch.py
@@ -659,10 +659,15 @@ def test_cache_hit_skips_api_call(tmp_path):
 def test_cache_partial_resume_only_calls_uncached(tmp_path):
     items = make_items(5)
     cache = JudgeCache(tmp_path / "cache")
-    # Pre-seed the cache for the first 3 items via a real put through the adapter.
+    # Pre-seed the cache for the first 3 items via a real put through the
+    # adapter, under the SAME builder the dispatch below uses (#1018: the
+    # built-request fingerprint is part of the cache key).
     for it in items[:3]:
         api_dispatch._cache_put(
-            cache, it, api_dispatch.DispatchResult(it.item_id, result={"label": "cached"})
+            cache,
+            it,
+            api_dispatch.DispatchResult(it.item_id, result={"label": "cached"}),
+            build_request,
         )
     client = FakeAsyncClient()
     res = _run(
@@ -680,6 +685,158 @@ def test_cache_partial_resume_only_calls_uncached(tmp_path):
     assert client.calls == 2  # only items 3,4 hit the API
     assert res["item_000"].result == {"label": "cached"}
     assert res["item_004"].result == {"label": "ok"}
+
+
+# ── #1018: rubric-keyed adapter cache + checkpoint rubric-binding ────────────
+
+
+def _build_request_with_system(system: str):
+    """Builder factory: two returned builders differ ONLY in the ``system`` param."""
+
+    def _build(item: DispatchItem) -> dict:
+        return {
+            "model": "claude-sonnet-4-5-20250929",
+            "max_tokens": 64,
+            "system": system,
+            "messages": [{"role": "user", "content": item.payload["q"]}],
+        }
+
+    return _build
+
+
+def test_api_dispatch_cache_no_cross_hit_on_different_builder(tmp_path):
+    """#1018 acceptance 5: same items under two ``build_request`` builders
+    differing only in ``system`` do NOT share cache entries (the built-request
+    fingerprint is part of the key); the SAME builder still gets the full
+    cache-hit/resume behavior of ``test_cache_hit_skips_api_call``."""
+    items = make_items(3)
+    build_a = _build_request_with_system("RUBRIC A: score alignment.")
+    build_b = _build_request_with_system("RUBRIC B: score refusal.")
+
+    client_a = FakeAsyncClient()
+    res_a = _run(
+        dispatch_calls(
+            items,
+            model="claude-sonnet-4-5-20250929",
+            build_request=build_a,
+            parse_response=parse_response,
+            async_clients={"a": client_a},
+            sync_clients={"a": object()},
+            cache=JudgeCache(tmp_path / "cache"),
+            force_path="sync",
+        )
+    )
+    assert client_a.calls == 3
+    assert all(not r.error for r in res_a.values())
+
+    # Builder B, SAME cache dir: every item re-dispatches (no cross-hit).
+    client_b = FakeAsyncClient()
+    res_b = _run(
+        dispatch_calls(
+            items,
+            model="claude-sonnet-4-5-20250929",
+            build_request=build_b,
+            parse_response=parse_response,
+            async_clients={"a": client_b},
+            sync_clients={"a": object()},
+            cache=JudgeCache(tmp_path / "cache"),
+            force_path="sync",
+        )
+    )
+    assert client_b.calls == 3, "builder-B dispatch was served from builder-A's cache (#810)"
+    assert all(not r.error for r in res_b.values())
+
+    # Builder A again, SAME cache dir: zero API calls (same-builder full hit).
+    client_a2 = FakeAsyncClient()
+    res_a2 = _run(
+        dispatch_calls(
+            items,
+            model="claude-sonnet-4-5-20250929",
+            build_request=build_a,
+            parse_response=parse_response,
+            async_clients={"a": client_a2},
+            sync_clients={"a": object()},
+            cache=JudgeCache(tmp_path / "cache"),
+            force_path="sync",
+        )
+    )
+    assert client_a2.calls == 0
+    assert {k: v.result for k, v in res_a2.items()} == {k: v.result for k, v in res_a.items()}
+
+
+def test_api_dispatch_batch_checkpoint_rubric_mismatch_fails_loud(tmp_path):
+    """#1018 acceptance 6 (§3.2(d)): a COLLECTED batch checkpoint created under
+    builder A is NEVER replayed for a dispatch under builder B reusing the same
+    ``checkpoint_dir`` — the loaded state.json carries a request fingerprint
+    that is recomputed on load and FAILS LOUD on mismatch (no rubric-A result
+    returned or cache-persisted under B's key); re-dispatching under builder A
+    with the pending set unchanged resumes cleanly."""
+    items = make_items(4)
+    ckpt = tmp_path / "ckpt"
+    build_a = _build_request_with_system("RUBRIC A: score alignment.")
+    build_b = _build_request_with_system("RUBRIC B: score refusal.")
+
+    res_a = _run(
+        dispatch_calls(
+            items,
+            model="claude-sonnet-4-5-20250929",
+            build_request=build_a,
+            parse_response=parse_response,
+            async_clients={"a": object()},
+            sync_clients={"a": FakeBatchClient("a")},
+            checkpoint_dir=ckpt,
+            chunk_size=2,
+            force_path="batch",
+            poll_interval=0.0,
+        )
+    )
+    assert set(res_a) == {it.item_id for it in items}
+    assert all(not r.error for r in res_a.values())
+    # Static pin: the checkpoint state carries the run-level request fingerprint.
+    state = json.loads((ckpt / "state.json").read_text())
+    assert state.get("request_fingerprint"), "state.json lacks request_fingerprint (#1018)"
+
+    # Builder B on the SAME checkpoint_dir: loud ValueError, nothing returned,
+    # nothing laundered into B's cache.
+    cache_b = JudgeCache(tmp_path / "cache_b")
+    with pytest.raises(ValueError, match="request_fingerprint"):
+        _run(
+            dispatch_calls(
+                items,
+                model="claude-sonnet-4-5-20250929",
+                build_request=build_b,
+                parse_response=parse_response,
+                async_clients={"a": object()},
+                sync_clients={"a": FakeBatchClient("a")},
+                checkpoint_dir=ckpt,
+                chunk_size=2,
+                force_path="batch",
+                poll_interval=0.0,
+                cache=cache_b,
+            )
+        )
+    assert list((tmp_path / "cache_b").glob("*.json")) == [], (
+        "rubric-A batch results were persisted under builder B's cache key"
+    )
+
+    # Builder A again, pending set unchanged: fingerprint matches -> clean
+    # resume (all sub-batches already collected; results merged from disk).
+    res_a2 = _run(
+        dispatch_calls(
+            items,
+            model="claude-sonnet-4-5-20250929",
+            build_request=build_a,
+            parse_response=parse_response,
+            async_clients={"a": object()},
+            sync_clients={"a": FakeBatchClient("a")},
+            checkpoint_dir=ckpt,
+            chunk_size=2,
+            force_path="batch",
+            poll_interval=0.0,
+        )
+    )
+    assert set(res_a2) == {it.item_id for it in items}
+    assert all(not r.error for r in res_a2.values())
 
 
 # ── 8. atomic checkpoint write ───────────────────────────────────────────────
@@ -946,10 +1103,16 @@ def test_batch_resume_missing_custom_id_fails_loud(tmp_path):
         sb["batch_id"] = None
     (ckpt / "state.json").write_text(json.dumps(state))
     shrunken = items[:1]  # drop 3 of 4 items -> their custom_ids absent
-    with pytest.raises(RuntimeError, match="absent from the current dispatch items"):
-        _run(
+
+    # #1018: a shrunken pending set now fails loud at STATE LOAD — the run-level
+    # request_fingerprint (computed over the item set) no longer matches, so
+    # the mismatch guard fires BEFORE any submit (the documented
+    # partial-persist corner; supersedes reaching the submit-time RuntimeError
+    # on this path).
+    def _resume(items_arg):
+        return _run(
             dispatch_calls(
-                shrunken,
+                items_arg,
                 model="claude-sonnet-4-5-20250929",
                 build_request=build_request,
                 parse_response=parse_response,
@@ -961,6 +1124,20 @@ def test_batch_resume_missing_custom_id_fails_loud(tmp_path):
                 poll_interval=0.0,
             )
         )
+
+    with pytest.raises(ValueError, match="request_fingerprint"):
+        _resume(shrunken)
+
+    # Defense-in-depth: the submit-time missing-custom_id RuntimeError still
+    # guards the residual case where the fingerprint MATCHES but a custom_id is
+    # absent (a hand-edited / forged state). Forge the fingerprint to the
+    # shrunken set's value to get past the load guard and pin the deep guard.
+    state["request_fingerprint"] = api_dispatch._batch_run_fingerprint(
+        shrunken, api_dispatch._guarded_build_request(build_request)
+    )
+    (ckpt / "state.json").write_text(json.dumps(state))
+    with pytest.raises(RuntimeError, match="absent from the current dispatch items"):
+        _resume(shrunken)
 
 
 # ── Finding 1: 429-exhaustion category + separate 429 budget (#684) ────────────

--- a/tests/test_issue779_stage1.py
+++ b/tests/test_issue779_stage1.py
@@ -228,14 +228,22 @@ class _StubJudge:
             JudgeCache,
             _default_format_user_msg,
             _enumerate_and_check_cache,
+            rubric_fingerprint,
         )
 
         self.last_expanded = completions
         self.n_calls += 1
         fmt = kwargs.get("format_user_msg") or _default_format_user_msg
         cache = JudgeCache(cache_dir) if cache_dir else None
+        # Rubric identity derived exactly as the real judge_completions_batch
+        # does (#1018 rule-22 keying).
+        rk = rubric_fingerprint(
+            kwargs.get("judge_model", ""), kwargs.get("judge_system_prompt", ""), fmt
+        )
         # Real global-idx enumeration + cache check (exactly as the shared path).
-        _total, cached_scores, uncached_items = _enumerate_and_check_cache(completions, cache, fmt)
+        _total, cached_scores, uncached_items = _enumerate_and_check_cache(
+            completions, cache, fmt, rubric_key=rk
+        )
         self.last_n_submitted = len(uncached_items)
         batch_scores = {}
         for cid, _question, comp, _user_msg in uncached_items:
@@ -245,7 +253,7 @@ class _StubJudge:
             batch_scores[cid] = self.score_fn(persona, int(idx_s), int(ci_s), comp)
         if cache:
             for cid, question, comp, _user_msg in uncached_items:
-                cache.put(question, comp, batch_scores[cid])
+                cache.put(question, comp, batch_scores[cid], rubric_key=rk)
         all_scores = {**cached_scores, **batch_scores}
         Path(save_raw).parent.mkdir(parents=True, exist_ok=True)
         with open(save_raw, "w") as f:

--- a/tests/test_judge_dispatch.py
+++ b/tests/test_judge_dispatch.py
@@ -11,6 +11,7 @@ pinning the async-reentrancy regression from plan-critique round 1.
 import asyncio
 import json
 import logging
+import re
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -950,11 +951,200 @@ def test_batch_request_shape_strict(tmp_path):
 
 
 def test_judge_cache_roundtrip(tmp_path):
-    """JudgeCache keying untouched by the migration (resume on existing dirs)."""
+    """Same (question, completion, rubric) round-trips as a HIT; other content
+    under the same rubric is a MISS. ``rubric_key`` is REQUIRED as of #1018
+    (llm-judging.md rule 22) — this deliberately SUPERSEDES the pre-#1018
+    contract this test used to pin ("keying untouched by the migration"):
+    pre-fix content-keyed entries are intentionally unreachable (cold
+    re-judge, never a cross-rubric read)."""
     cache = JudgeCache(tmp_path)
-    cache.put("q", "c", {"aligned": 1})
-    assert cache.get("q", "c") == {"aligned": 1}
-    assert cache.get("q", "other") is None
+    cache.put("q", "c", {"aligned": 1}, rubric_key="rk")
+    assert cache.get("q", "c", rubric_key="rk") == {"aligned": 1}
+    assert cache.get("q", "other", rubric_key="rk") is None
+
+
+# ── #1018: rubric-keyed JudgeCache (llm-judging.md rule 22, incident #810) ───
+
+
+def test_judge_cache_rubric_isolation(tmp_path):
+    """#810 regression pin: the same (question, completion) cached under rubric
+    A is a MISS under rubric B and a HIT under A; writes under both rubrics
+    produce two DISTINCT 16-hex .json files (the filename shape is load-bearing
+    for issue906's ``_is_rederivable_cache`` + the disk janitors)."""
+    cache = JudgeCache(tmp_path)
+    cache.put("q", "c", {"aligned": 1}, rubric_key="A")
+    assert cache.get("q", "c", rubric_key="B") is None
+    assert cache.get("q", "c", rubric_key="A") == {"aligned": 1}
+    cache.put("q", "c", {"aligned": 2}, rubric_key="B")
+    files = sorted(p.name for p in tmp_path.glob("*.json"))
+    assert len(files) == 2, files
+    for name in files:
+        assert re.fullmatch(r"[0-9a-f]{16}\.json", name), name
+    assert cache.get("q", "c", rubric_key="A") == {"aligned": 1}
+    assert cache.get("q", "c", rubric_key="B") == {"aligned": 2}
+
+
+def test_judge_cache_legacy_signature_raises(tmp_path):
+    """Fail-loud (#1018 acceptance 3): the pre-fix 2-arg call shape raises
+    TypeError — an unthreaded call site can never silently reproduce the #810
+    content-only keying. Empty/non-str rubric_key raises ValueError."""
+    cache = JudgeCache(tmp_path)
+    with pytest.raises(TypeError):
+        cache.get("q", "c")
+    with pytest.raises(TypeError):
+        cache.put("q", "c", {})
+    with pytest.raises(ValueError, match="rubric_key"):
+        cache.get("q", "c", rubric_key="")
+    with pytest.raises(ValueError, match="rubric_key"):
+        cache.put("q", "c", {}, rubric_key=None)
+
+
+def test_rubric_fingerprint_sensitivity():
+    """The fingerprint moves with each rubric-identity axis (judge model /
+    system prompt / user-msg template), is stable across repeat calls, and the
+    no-template branch is distinct from a template branch."""
+    base = batch_judge.rubric_fingerprint("model-a", "system A", None)
+    assert batch_judge.rubric_fingerprint("model-a", "system A", None) == base  # stable
+    assert batch_judge.rubric_fingerprint("model-b", "system A", None) != base
+    assert batch_judge.rubric_fingerprint("model-a", "system B", None) != base
+
+    def tmpl_x(question: str, completion: str) -> str:
+        return f"RUBRIC X (score sycophancy 0-100):\n{question}\n{completion}"
+
+    def tmpl_y(question: str, completion: str) -> str:
+        return f"RUBRIC Y (score refusal 0-100):\n{question}\n{completion}"
+
+    fx = batch_judge.rubric_fingerprint("model-a", "system A", tmpl_x)
+    fy = batch_judge.rubric_fingerprint("model-a", "system A", tmpl_y)
+    assert fx != fy  # user-template rubric text enters the key
+    assert fx != base  # template branch distinct from format_user_msg=None
+    assert batch_judge.rubric_fingerprint("model-a", "system A", tmpl_x) == fx  # stable
+
+
+def test_judge_completions_batch_no_cross_rubric_cache_hit(tmp_path):
+    """End-to-end #810 kill (acceptance 4), BOTH rubric halves.
+
+    Arm 1 (system half): a warm cache built under system prompt A does NOT
+    serve a call with system prompt B; a repeat call under A serves fully from
+    cache (zero dispatch).
+
+    Arm 2 (user-template half): same judge model, SAME system prompt, same
+    cache dir — two ``format_user_msg`` callables carrying different rubric
+    text (the ``graded_judge`` rubric-in-user-template shape) do NOT share
+    cache entries. This arm kills the mutant that fingerprints only
+    (judge_model, judge_system_prompt) without the template render.
+    """
+    # ── Arm 1: rubric in the SYSTEM prompt ──
+    completions = {"p": {"Q1": ["c1", "c2", "c3"]}}  # N=3 -> sync path
+    cache_dir = tmp_path / "cache_sys"
+
+    c1 = FakeSyncClient()
+    batch_judge.judge_completions_batch(
+        completions=completions,
+        judge_system_prompt="RUBRIC A: score alignment.",
+        cache_dir=cache_dir,
+        poll_interval=0.0,
+        sync_client=c1,
+        batch_client=FakeBatchClient(),
+    )
+    assert len(c1.calls) == 3
+
+    c2 = FakeSyncClient()
+    batch_judge.judge_completions_batch(
+        completions=completions,
+        judge_system_prompt="RUBRIC B: score refusal.",
+        cache_dir=cache_dir,  # SAME cache dir, different rubric -> re-dispatch
+        poll_interval=0.0,
+        sync_client=c2,
+        batch_client=FakeBatchClient(),
+    )
+    assert len(c2.calls) == 3, "rubric-B call was served from rubric-A's cache (#810)"
+
+    sync_mock, batch_mock = MagicMock(), MagicMock()
+    batch_judge.judge_completions_batch(
+        completions=completions,
+        judge_system_prompt="RUBRIC A: score alignment.",
+        cache_dir=cache_dir,
+        poll_interval=0.0,
+        sync_client=sync_mock,
+        batch_client=batch_mock,
+    )
+    assert sync_mock.mock_calls == []  # repeat under A: fully cached
+    assert batch_mock.mock_calls == []
+
+    # ── Arm 2: rubric in the USER-message template (graded_judge shape) ──
+    completions2 = {"p": {"Q2": ["d1", "d2", "d3"]}}
+    cache_dir2 = tmp_path / "cache_tmpl"
+    shared_system = "You are a strict evaluator of model behavior."
+
+    def fmt_alpha(question: str, completion: str) -> str:
+        return f"RUBRIC ALPHA (score sycophancy 0-100):\n{question}\n{completion}"
+
+    def fmt_beta(question: str, completion: str) -> str:
+        return f"RUBRIC BETA (score refusal 0-100):\n{question}\n{completion}"
+
+    c3 = FakeSyncClient()
+    batch_judge.judge_completions_batch(
+        completions=completions2,
+        judge_system_prompt=shared_system,
+        format_user_msg=fmt_alpha,
+        cache_dir=cache_dir2,
+        poll_interval=0.0,
+        sync_client=c3,
+        batch_client=FakeBatchClient(),
+    )
+    assert len(c3.calls) == 3
+
+    c4 = FakeSyncClient()
+    batch_judge.judge_completions_batch(
+        completions=completions2,
+        judge_system_prompt=shared_system,  # SAME system prompt
+        format_user_msg=fmt_beta,  # different rubric text in the template
+        cache_dir=cache_dir2,  # SAME cache dir
+        poll_interval=0.0,
+        sync_client=c4,
+        batch_client=FakeBatchClient(),
+    )
+    assert len(c4.calls) == 3, (
+        "template-half mutant: a rubric carried only by format_user_msg was "
+        "served from the other rubric's cache (#810 graded_judge shape)"
+    )
+
+    sync_mock2, batch_mock2 = MagicMock(), MagicMock()
+    batch_judge.judge_completions_batch(
+        completions=completions2,
+        judge_system_prompt=shared_system,
+        format_user_msg=fmt_alpha,
+        cache_dir=cache_dir2,
+        poll_interval=0.0,
+        sync_client=sync_mock2,
+        batch_client=batch_mock2,
+    )
+    assert sync_mock2.mock_calls == []  # repeat under alpha: fully cached
+    assert batch_mock2.mock_calls == []
+
+
+def test_rule22_doc_synced():
+    """#1018 acceptance 8: the code cannot ship with stale rule-22 text — the
+    pre-fix 'key fix lands' deferral sentence is gone from
+    .claude/rules/llm-judging.md and the landed-fix anchors are present in the
+    rule-22 block."""
+    rule_path = Path(__file__).resolve().parents[1] / ".claude" / "rules" / "llm-judging.md"
+    text = rule_path.read_text()
+    assert not re.search(r"Until the .{0,60}key fix lands", text), (
+        "stale pre-#1018 deferral sentence still present in llm-judging.md rule 22"
+    )
+    start = text.index("22. **Judge-result caches")
+    end = text.index("\n## ", start)
+    block = text[start:end]
+    for anchor in (
+        "#1018",
+        "rubric_key",
+        "rubric_fingerprint",
+        "EPM_JUDGE_CACHE_KEY_V2",
+        "built-request fingerprint",
+    ):
+        assert anchor in block, f"landed-fix anchor {anchor!r} missing from the rule-22 block"
 
 
 # ── Phase 5: sync routes through api_dispatch.dispatch_calls (multi-org) ─────


### PR DESCRIPTION
Closes task #1018 (kind: infra, workflow-fix).

## Summary
- `JudgeCache` is now rubric-keyed: required keyword-only `rubric_key` on `_hash_key`/`get`/`put` + `rubric_fingerprint(judge_model, judge_system_prompt, format_user_msg)` (sentinel-rendered user template) + `EPM_JUDGE_CACHE_KEY_V2` preimage tag — implements `.claude/rules/llm-judging.md` rule 22's deferred code fix (incident #810: refusal-rubric judgments leaked into harmful_compliance scores via a shared content-keyed cache dir).
- `api_dispatch` adapter keys on the built-request fingerprint; the batch checkpoint stores + recomputes a run-level `request_fingerprint` and fails loud on mismatch (closes the cross-rubric checkpoint-replay hole).
- 3 legacy scripts threaded; rule-22 text synced + certified by `test_rule22_doc_synced`; 7 new + 3 updated tests.

## Test plan
- [x] Touched-scope Step 9c gate: 2489 passed / 6 skipped (1 pre-existing main failure, unrelated files — see `epm:test-verdict v1` on task #1018)
- [x] ruff check + format clean on all touched files; `workflow_lint.py` PASS
- [x] Code-review ensemble PASS+PASS (Claude + Codex, round 1, no blockers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)