### PR TITLE
issue-1020: codex_task result-fetch retry + --reattach recovery

### DIFF
--- a/.claude/skills/issue/markers.md
+++ b/.claude/skills/issue/markers.md
@@ -70,8 +70,8 @@ table below is the at-a-glance index.
 | Kind | Posted by | When | Required fields |
 |------|-----------|------|-----------------|
 | `epm:auto-defaults` | skill | Step 0b | what fields were auto-filled in body.md frontmatter and the inferred values |
-| `epm:codex-task-spawned` | scripts/codex_task.py | Whenever the orchestrator dispatches a Codex companion task via scripts/codex_task.py with --issue N | Codex job_id (task-xxxx-yyy), effort, write flag, poll interval, max-wait cap, probe-error cap |
-| `epm:codex-task-completed` | scripts/codex_task.py | Codex companion task terminated cleanly (phase=done) after the polling loop observed it | Codex job_id, elapsed seconds, terminal phase |
+| `epm:codex-task-spawned` | scripts/codex_task.py | Whenever the orchestrator dispatches a Codex companion task via scripts/codex_task.py with --issue N | Codex job_id (task-xxxx-yyy), effort, write flag, poll interval, max-wait cap, probe-error cap, optional reattach=true token when re-attaching to an existing job (#1020) |
+| `epm:codex-task-completed` | scripts/codex_task.py | Codex companion task terminated cleanly (phase=done) after the polling loop observed it | Codex job_id, elapsed seconds, terminal phase, fetch_retries=<k> token |
 | `epm:codex-task-failed` | scripts/codex_task.py | Codex companion task terminated non-cleanly (phase in {failed, cancelled}), force-cancelled after max-wait cap, force-cancelled by stall detector (phase=running but log untouched > stall_detect_secs), killed by SIGTERM/SIGINT, exceeded probe-error cap, post-spawn probe rejected the job-id, or spawn failed before a job-id was assigned | Codex job_id (if assigned), elapsed seconds, terminal phase OR error description (e.g. 'timed out after Ns', 'N consecutive probe failures; last error: ...', 'stall detected: phase=running but log file untouched for Ns') |
 | `epm:clarify` | skill | Step 1 | numbered clarifying questions OR 'No blocking ambiguities' |
 | `epm:clarify-questions` | skill | Step 1 | alias of epm:clarify used by some helper scripts; same body shape |

--- a/.claude/workflow.yaml
+++ b/.claude/workflow.yaml
@@ -1574,11 +1574,11 @@ markers:
   - kind: "epm:codex-task-spawned"
     posted_by: scripts/codex_task.py
     when: "Whenever the orchestrator dispatches a Codex companion task via scripts/codex_task.py with --issue N"
-    fields: "Codex job_id (task-xxxx-yyy), effort, write flag, poll interval, max-wait cap, probe-error cap"
+    fields: "Codex job_id (task-xxxx-yyy), effort, write flag, poll interval, max-wait cap, probe-error cap, optional reattach=true token when re-attaching to an existing job (#1020)"
   - kind: "epm:codex-task-completed"
     posted_by: scripts/codex_task.py
     when: "Codex companion task terminated cleanly (phase=done) after the polling loop observed it"
-    fields: "Codex job_id, elapsed seconds, terminal phase"
+    fields: "Codex job_id, elapsed seconds, terminal phase, fetch_retries=<k> token"
   - kind: "epm:codex-task-failed"
     posted_by: scripts/codex_task.py
     when: "Codex companion task terminated non-cleanly (phase in {failed, cancelled}), force-cancelled after max-wait cap, force-cancelled by stall detector (phase=running but log untouched > stall_detect_secs), killed by SIGTERM/SIGINT, exceeded probe-error cap, post-spawn probe rejected the job-id, or spawn failed before a job-id was assigned"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Bash(run_in_background=true,
     --prompt-file /tmp/codex-prompt-issue-<N>.md --output-file /tmp/codex-output-issue-<N>.md")
 ```
 
-Helper posts `epm:codex-task-spawned`, then `epm:codex-task-completed`/`epm:codex-task-failed`. On marker-post failure: retry once, then drop to `tasks/_orphaned_markers/`. Orchestrator posts the verdict marker after reading the output file.
+Helper posts `epm:codex-task-spawned`, then `epm:codex-task-completed`/`epm:codex-task-failed`. On marker-post failure: retry once, then drop to `tasks/_orphaned_markers/`. Orchestrator posts the verdict marker after reading the output file. If the wrapper/session is killed leaving the Codex job running (an `epm:codex-task-spawned` with no terminal marker), first confirm the wrapper is actually dead (`pgrep -f 'codex_task.py.*<job-id>'` empty — a live wrapper would double-poll, duplicate markers, and cross-cancel on signal), then re-attach instead of re-dispatching: `uv run python scripts/codex_task.py --issue <N> --reattach <job-id> --output-file <same path>`; the helper's bounded result-fetch retry also absorbs transient `No job found` registry blips (#1020).
 
 ## Context hygiene
 

--- a/scripts/codex_task.py
+++ b/scripts/codex_task.py
@@ -36,8 +36,13 @@ Lifecycle:
    cancellations.
 5. Hard cap at ``--max-wait-secs`` (default 6h). On cap, force-cancel
    via ``codex-companion cancel`` and post ``epm:codex-task-failed``.
-6. Fetch Codex stdout via ``codex-companion result <job-id>``; bail to
-   ``epm:codex-task-failed`` if that call fails.
+6. Fetch Codex stdout via ``codex-companion result <job-id>``, re-probing
+   the fetch up to ``--result-fetch-retry-cap`` (default 3) times with a
+   short jittered backoff (sleeps total <=45s; the honest worst case adds
+   the per-attempt subprocess timeouts — RESULT 120s / STATUS 60s — so
+   exhaustion is bounded by ~12 min, typical fast-fail ~15-50s) before
+   bailing to ``epm:codex-task-failed``. The retry re-fetches ONLY; it
+   never re-dispatches the job (#1020).
 7. Validate the result-fetch returncode AND that the response JSON
    reports ``phase == "done"`` (not just present).
 8. Post ``epm:codex-task-completed`` (phase=done) or
@@ -56,10 +61,15 @@ silently):
 - spawn failure (codex-companion CLI broken, plugin missing) → emit a
   marker with spawn-stderr in the note, exit 3.
 - post-spawn probe fails (bad job-id, plugin upgrade race) → cancel +
-  emit failure marker, exit 4.
+  emit failure marker, exit 4. In ``--reattach`` mode exit 4 also covers
+  the issue<->job_id binding-guard failure and an unqueryable reattach
+  target (see the reattach paragraph below).
 - probe errors > cap → emit failure marker with last stderr, exit 5.
 - hard cap hit → cancel + emit failure marker, exit 6.
-- result-fetch non-zero → emit failure marker, exit 7.
+- result-fetch non-zero after the bounded fetch retry → emit failure
+  marker, exit 7. Deliberately OUTSIDE the transient re-dispatch class:
+  re-running a job that already completed (e.g. after an AUP refusal)
+  is wrong.
 - stall detected (phase==running but log STOPPED GROWING for
   > stall_detect_secs) → cancel + emit failure marker, exit 8. The
   detector is progress-aware: the stall timer resets whenever the log
@@ -76,6 +86,21 @@ silently):
   once, then drop the payload to
   ``tasks/_orphaned_markers/issue-<N>-<kind>-<job_id>-<ts>.json``,
   log to stderr (helper still exits with the right code).
+
+Reattach mode (``--reattach <job_id>``, #1020): skip the spawn and drive
+an EXISTING codex-companion job through the same poll loop, stall
+detector (timer re-armed from attach time), bounded result fetch,
+output-preserving write, and marker posts — the recovery path for a
+wrapper/session kill that orphaned a running job. Precondition: confirm
+the old wrapper is actually dead (``pgrep -f 'codex_task.py.*<job-id>'``
+empty) — a live wrapper would double-poll, duplicate markers, and
+cross-cancel on signal. With ``--issue N`` the job id must be bound to
+issue N's own ``epm:codex-task-spawned`` history and not already
+terminally paired (fail-closed guard: the companion's job registry is
+CROSS-ISSUE, so an unguarded reattach could serve ANOTHER issue's job
+output under this issue's markers); ``--reattach-unbound`` overrides,
+and is REQUIRED without ``--issue``. Reattach never re-dispatches from
+any failure path (there is no prompt), and stdin is never read.
 
 Twin-agent marker-validation policy lives in the ORCHESTRATOR, not in
 this helper. The helper just delivers Codex's stdout + a terminal-state
@@ -178,6 +203,30 @@ TRANSIENT_FAIL_EXIT_CODES = frozenset({3, 4, 5, 8})
 # synchronized re-spawns across parallel reviewer ensembles).
 TRANSIENT_RETRY_BACKOFF_FLOOR_SECS = 15.0
 TRANSIENT_RETRY_BACKOFF_JITTER_SECS = 30.0
+# Result-fetch retry (task #1020). `codex-companion result <job-id>` reads a
+# shared state.json jobs index written NON-ATOMICALLY (fs.writeFileSync in
+# place, no lock) and read-modify-written by every concurrent wrapper; a torn
+# read parses as an EMPTY jobs list (loadState's bare catch -> defaultState),
+# so the CLI exits 1 with 'No job found for "<id>" ...' even though the job
+# ran to completion (>=7 incidents on 2026-07-02, each re-paying a 10-60 min
+# Codex run). The retry re-probes the FETCH ONLY - never the whole job: exit 7
+# stays OUT of TRANSIENT_FAIL_EXIT_CODES (re-dispatching a completed job, e.g.
+# after an AUP refusal, is wrong; see that comment above). The companion's
+# 'result' error string cannot distinguish job-unknown from result-not-yet-
+# indexed (matchJobReference throws the same message for both), so the retry
+# is blind but time-bounded; a status probe between attempts is logged as a
+# diagnostic discriminator only. Backoff SLEEPS are short (the failure is a
+# ms-scale torn read / seconds-scale index lag, not an app-server restart) -
+# but the honest worst case includes the per-attempt subprocess timeouts
+# (RESULT 120s / STATUS 60s): exhaustion is bounded by ~12 min worst case,
+# ~15-50s typical (fast CLI exit-1 failures). Jitter desynchronizes parallel
+# reviewer ensembles (same rationale as TRANSIENT_RETRY_BACKOFF_*).
+DEFAULT_RESULT_FETCH_RETRY_CAP = 3
+RESULT_FETCH_RETRY_BACKOFF_FLOOR_SECS = 5.0
+RESULT_FETCH_RETRY_BACKOFF_JITTER_SECS = 10.0
+_FETCH_RETRY_BACKOFF_CEIL_SECS = (
+    RESULT_FETCH_RETRY_BACKOFF_FLOOR_SECS + RESULT_FETCH_RETRY_BACKOFF_JITTER_SECS
+)
 TERMINAL_PHASES = {"done", "failed", "cancelled"}
 # A Codex-written verdict file is identified by the ensemble marker tag the
 # twin-reviewer wrapper contract requires of every verdict body (e.g.
@@ -556,6 +605,64 @@ def _fetch_result(companion: Path, job_id: str) -> tuple[int, str, str]:
     return res.returncode, res.stdout, res.stderr
 
 
+def _probe_phase_safe(companion: Path, job_id: str) -> tuple[str, str, str | None]:
+    """_probe_phase, with raises (TimeoutExpired/OSError) converted to the
+    existing probe-error phase so a diagnostic/confirm probe can never crash
+    the helper without a failure marker (#1020 MF2)."""
+    try:
+        return _probe_phase(companion, job_id)
+    except (subprocess.SubprocessError, OSError) as exc:
+        return "probe-error", f"probe raised: {exc}", None
+
+
+def _probe_discriminator(companion: Path, job_id: str) -> str:
+    """One safe status probe rendered as the diagnostic discriminator string
+    for the fetch-retry WARN lines and the exit-7 failure note (#1020). It
+    tells the orchestrator whether --reattach (job known) or a re-dispatch
+    (job unknown) is the right manual recovery; it never drives a branch."""
+    phase, err, _ = _probe_phase_safe(companion, job_id)
+    if phase in {"probe-error", "shape-error"}:
+        return f"status-probe: job unknown/unreadable ({phase}: {err[:150]})"
+    return f"status-probe: job known, phase={phase}"
+
+
+def _fetch_result_with_retry(
+    companion: Path, job_id: str, retry_cap: int
+) -> tuple[int, str, str, str, int]:
+    """Bounded blind retry around _fetch_result. Returns (rc, stdout, stderr,
+    detail, retries_used); detail is "" on success, else the attempt count +
+    the last status-probe discriminator for the exit-7 failure note.
+    retries_used = fetch attempts actually consumed minus 1 (0 on first-try
+    success) - threaded into the terminal marker notes as fetch_retries=<k>
+    so a recovered torn-read stays operationally countable. Also converts a
+    fetch-subprocess TimeoutExpired/OSError (previously an unhandled crash
+    with NO failure marker) into a retryable, then terminal-exit-7, failure."""
+    total = 1 + max(0, retry_cap)
+    rc, stdout, stderr = 1, "", ""
+    for attempt in range(1, total + 1):
+        try:
+            rc, stdout, stderr = _fetch_result(companion, job_id)
+        except (subprocess.SubprocessError, OSError) as exc:
+            rc, stdout, stderr = -1, "", f"fetch raised: {exc}"
+        if rc == 0:
+            return rc, stdout, stderr, "", attempt - 1
+        if attempt == total:
+            break
+        # Diagnostic discriminator (logging + final note only, never branching):
+        disc = _probe_discriminator(companion, job_id)
+        delay = RESULT_FETCH_RETRY_BACKOFF_FLOOR_SECS + random.uniform(
+            0.0, RESULT_FETCH_RETRY_BACKOFF_JITTER_SECS
+        )
+        print(
+            f"WARN: result-fetch attempt {attempt}/{total} for {job_id} failed "
+            f"(exit {rc}: {stderr[:200]}); {disc}; retrying in {delay:.0f}s (#1020).",
+            file=sys.stderr,
+        )
+        time.sleep(delay)
+    disc = _probe_discriminator(companion, job_id)
+    return rc, stdout, stderr, f"after {total} attempt(s); {disc}", total - 1
+
+
 def _write_output_preserving_codex_artifact(
     output_file: Path,
     final_message: str,
@@ -829,15 +936,33 @@ def _run_one_attempt(companion: Path, prompt: str, args, write: bool) -> Attempt
         return poll_outcome  # probe-error cap / stall / hard-cap timeout
     phase = poll_outcome  # one of {done, failed, cancelled}
 
-    # Fetch result.
-    rc, stdout, stderr = _fetch_result(companion, job_id)
+    return _finalize_result(companion, job_id, phase, args, pre_spawn_output_key, started)
+
+
+def _finalize_result(
+    companion: Path,
+    job_id: str,
+    phase: str,  # one of TERMINAL_PHASES, from the poll loop
+    args,
+    pre_output_key: tuple[float, int] | None,
+    started: float,
+) -> AttemptResult:
+    """Terminal tail of an attempt: fetch the result (with the bounded #1020
+    retry), write --output-file (preserving a mid-session Codex verdict), and
+    post the completed marker / build the terminal AttemptResult. Shared by
+    the normal attempt path and the --reattach path (which passes
+    pre_output_key=None so a verdict predating this process is preserved)."""
+    rc, stdout, stderr, detail, fetch_retries = _fetch_result_with_retry(
+        companion, job_id, args.result_fetch_retry_cap
+    )
     if rc != 0:
         return AttemptResult(
             "fail",
             7,
             (
-                f"result-fetch failed (exit {rc}). "
-                f"stderr: {stderr[:500]}; stdout (truncated): {stdout[:200]}"
+                f"result-fetch failed {detail} fetch_retries={fetch_retries} "
+                f"(last exit {rc}). stderr: {stderr[:500]}; "
+                f"stdout (truncated): {stdout[:200]}"
             ),
             job_id,
         )
@@ -849,7 +974,7 @@ def _run_one_attempt(companion: Path, prompt: str, args, write: bool) -> Attempt
     # sidecar) — see _write_output_preserving_codex_artifact.
     if args.output_file is not None:
         try:
-            _write_output_preserving_codex_artifact(args.output_file, stdout, pre_spawn_output_key)
+            _write_output_preserving_codex_artifact(args.output_file, stdout, pre_output_key)
         except Exception as exc:
             return AttemptResult(
                 "fail",
@@ -866,7 +991,7 @@ def _run_one_attempt(companion: Path, prompt: str, args, write: bool) -> Attempt
             _post_marker(
                 args.issue,
                 "epm:codex-task-completed",
-                f"Codex job_id={job_id} phase=done after {elapsed}s.",
+                f"Codex job_id={job_id} phase=done after {elapsed}s fetch_retries={fetch_retries}.",
             )
         return AttemptResult("done", 0, "", job_id)
 
@@ -877,7 +1002,8 @@ def _run_one_attempt(companion: Path, prompt: str, args, write: bool) -> Attempt
             1,
             (
                 f"terminal phase=cancelled after {elapsed}s. "
-                f"Inspect: node {companion} status {job_id}"
+                f"Inspect: node {companion} status {job_id} "
+                f"fetch_retries={fetch_retries}"
             ),
             job_id,
         )
@@ -886,9 +1012,139 @@ def _run_one_attempt(companion: Path, prompt: str, args, write: bool) -> Attempt
     return AttemptResult(
         "fail",
         1,
-        (f"terminal phase={phase} after {elapsed}s. Inspect: node {companion} status {job_id}"),
+        (
+            f"terminal phase={phase} after {elapsed}s. "
+            f"Inspect: node {companion} status {job_id} fetch_retries={fetch_retries}"
+        ),
         job_id,
     )
+
+
+_JOB_TOKEN_RE_TMPL = r"job_id={id}(?=[\s:,.]|$)"
+# Token-bounded: every codex_task-posted note formats the id as
+# 'job_id=<id> effort=...' (spawned), 'job_id=<id> phase=done...' (completed),
+# or 'job_id=<id>: ...' (_fail) - never bare-suffixed - so the lookahead
+# prevents task-abc matching task-abc-def.
+
+
+def _reattach_binding(issue: int, job_id: str) -> str:
+    """Return "" when job_id is bound to this issue (a codex_task-posted
+    epm:codex-task-spawned note carries the token AND no terminal
+    completed/failed note pairs with it), else a human-readable reason.
+    FAIL-CLOSED: any events read error is a reason, not a pass (#1020 MF1 -
+    the silent-wrong-verdict class outweighs the retry friction; the
+    documented escape is --reattach-unbound)."""
+    try:
+        events = list_events(issue)
+    except Exception as exc:
+        return f"could not read issue #{issue} events ({exc}); fail-closed"
+    pat = re.compile(_JOB_TOKEN_RE_TMPL.format(id=re.escape(job_id)))
+    spawned = terminal = False
+    for row in events:  # full scan - the orphan may be old
+        if row.get("by") != "codex_task" or not pat.search(row.get("note") or ""):
+            continue
+        kind = row.get("kind")
+        if kind == "epm:codex-task-spawned":
+            spawned = True
+        elif kind in ("epm:codex-task-completed", "epm:codex-task-failed"):
+            terminal = True
+    if not spawned:
+        return (
+            f"no epm:codex-task-spawned with job_id={job_id} on issue "
+            f"#{issue} (cross-issue registry: this may be ANOTHER issue's job)"
+        )
+    if terminal:
+        return (
+            f"job_id={job_id} already has a terminal codex-task marker on "
+            f"issue #{issue} (already fetched/failed; reattach would duplicate)"
+        )
+    return ""
+
+
+def _run_reattach(companion: Path, args) -> int:
+    """Attach to an EXISTING codex-companion job (wrapper-kill recovery,
+    #1020). Guard -> arm -> confirm-probe -> spawned marker -> poll ->
+    finalize. No re-dispatch on ANY failure - there is no prompt."""
+    global _active_job_id
+    job_id = args.reattach
+
+    # (1) Binding guard (MF1) - BEFORE arming and before any subprocess call,
+    # so a guard failure leaves zero side effects beyond one failure marker.
+    if args.issue is not None and not args.reattach_unbound:
+        reason = _reattach_binding(args.issue, job_id)
+        if reason:
+            return _fail(
+                args.issue,
+                job_id,
+                (
+                    f"reattach: binding guard failed - {reason}. Output file "
+                    f"untouched; no poll/fetch attempted. Override with "
+                    f"--reattach-unbound if this job is genuinely this issue's "
+                    f"(e.g. wrapper died before its spawned marker posted)."
+                ),
+                4,
+            )
+
+    # (2) Arm ONLY after the guard (MF3): a SIGTERM during validation must
+    # never cross-cancel a job we have not confirmed as ours.
+    _active_job_id = job_id
+
+    # (3) Confirm probe with bounded retry, via the SAFE wrapper (MF2): a
+    # status-CLI raise (TimeoutExpired/OSError) converts to probe-error and
+    # takes this same bounded path to exit 4 + one failure marker.
+    total = 1 + max(0, args.result_fetch_retry_cap)
+    phase, err, log_path = "probe-error", "", None
+    for attempt in range(1, total + 1):
+        phase, err, log_path = _probe_phase_safe(companion, job_id)
+        if phase not in {"probe-error", "shape-error"}:
+            break
+        if attempt < total:
+            delay = RESULT_FETCH_RETRY_BACKOFF_FLOOR_SECS + random.uniform(
+                0.0, RESULT_FETCH_RETRY_BACKOFF_JITTER_SECS
+            )
+            print(
+                f"WARN: reattach probe {attempt}/{total} for {job_id} failed "
+                f"({phase}: {err[:200]}); retrying in {delay:.0f}s.",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+    if phase in {"probe-error", "shape-error"}:
+        return _fail(
+            args.issue,
+            job_id,
+            f"reattach: job not queryable after {total} probe(s) ({phase}): {err[:400]}",
+            4,
+        )
+
+    if args.issue is not None:
+        _post_marker(
+            args.issue,
+            "epm:codex-task-spawned",
+            (
+                f"Codex job_id={job_id} reattach=true "
+                + ("unbound_override=true " if args.reattach_unbound else "")
+                + f"phase_at_attach={phase} "
+                f"poll_interval={args.poll_interval_secs}s "
+                f"max_wait={args.max_wait_secs}s "
+                f"probe_error_cap={args.probe_error_cap} "
+                f"stall_detect={args.stall_detect_secs}s"
+            ),
+        )
+    started = time.time()
+    if phase in TERMINAL_PHASES:
+        terminal = phase  # finished during the orphan gap: skip polling
+    else:
+        outcome = _poll_until_terminal(companion, job_id, args, log_path, started)
+        if isinstance(outcome, AttemptResult):
+            return _fail(args.issue, job_id, f"reattach: {outcome.note}", outcome.exit_code)
+        terminal = outcome
+    result = _finalize_result(companion, job_id, terminal, args, None, started)
+    if result.kind == "done":
+        return 0
+    note = result.note
+    if result.kind == "cancelled":
+        note = f"{note} (reattach mode: no re-dispatch possible)"
+    return _fail(args.issue, job_id, f"reattach: {note}", result.exit_code)
 
 
 def _best_effort_cancel(companion: Path, job_id: str) -> None:
@@ -907,7 +1163,7 @@ def _best_effort_cancel(companion: Path, job_id: str) -> None:
         print(f"WARN: best-effort cancel of {job_id} failed: {exc}", file=sys.stderr)
 
 
-def main() -> int:
+def main() -> int:  # noqa: C901 — argparse wiring + the reattach/prompt mode fork; the lifecycles live in helpers
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--issue", type=int, default=None)
     parser.add_argument(
@@ -1004,7 +1260,62 @@ def main() -> int:
             f"0 to disable. Default {DEFAULT_TRANSIENT_RETRY_CAP} (refs #579)."
         ),
     )
+    parser.add_argument(
+        "--result-fetch-retry-cap",
+        type=int,
+        default=DEFAULT_RESULT_FETCH_RETRY_CAP,
+        help=(
+            "Re-probe `codex-companion result` this many times (with a "
+            f"{RESULT_FETCH_RETRY_BACKOFF_FLOOR_SECS:.0f}-"
+            f"{_FETCH_RETRY_BACKOFF_CEIL_SECS:.0f}s "
+            "jittered sleep; worst case additionally bounded by the per-call "
+            "subprocess timeouts) on a nonzero result-fetch before declaring "
+            "the job lost (exit 7). Retries the FETCH ONLY - never "
+            "re-dispatches the job. Also bounds the --reattach confirm-probe "
+            f"retry. Set to 0 to disable. Default {DEFAULT_RESULT_FETCH_RETRY_CAP} (#1020)."
+        ),
+    )
+    parser.add_argument(
+        "--reattach",
+        metavar="JOB_ID",
+        default=None,
+        help=(
+            "Skip spawn; attach to an EXISTING codex-companion job, poll it to "
+            "completion (stall detector + max-wait re-armed from attach time), "
+            "write --output-file, and post the standard terminal markers. "
+            "Recovery for a wrapper/session kill that orphaned a running job "
+            "(#1020). With --issue N the job id must be bound to issue N's own "
+            "epm:codex-task-spawned history (fail-closed guard against the "
+            "cross-issue registry serving another issue's job); "
+            "--reattach-unbound overrides, and is REQUIRED without --issue. "
+            "Confirm the dead wrapper first: pgrep -f 'codex_task.py.*<job-id>' "
+            "must be empty. Mutually exclusive with --prompt/--prompt-file; "
+            "stdin is not read; --effort/--write and the cancelled/transient "
+            "re-dispatch caps are inert (nothing to re-dispatch)."
+        ),
+    )
+    parser.add_argument(
+        "--reattach-unbound",
+        action="store_true",
+        default=False,
+        help=(
+            "Skip the --reattach issue<->job_id binding guard (use when the "
+            "orphaned wrapper died BEFORE posting its epm:codex-task-spawned "
+            "marker, or when re-attaching without --issue)."
+        ),
+    )
     args = parser.parse_args()
+
+    if args.reattach:
+        if args.prompt is not None or args.prompt_file is not None:
+            parser.error("--reattach is mutually exclusive with --prompt/--prompt-file")
+        if args.issue is None and not args.reattach_unbound:
+            parser.error(
+                "--reattach without --issue requires --reattach-unbound "
+                "(no events.jsonl to verify the job binding against)"
+            )
+    elif args.reattach_unbound:
+        parser.error("--reattach-unbound requires --reattach")
 
     # Default for --write is True (grant write) unless --no-write was passed.
     write = True if args.write is None else args.write
@@ -1013,6 +1324,18 @@ def main() -> int:
 
     _install_signal_handlers()
     _active_issue = args.issue
+
+    # Reattach mode (#1020): drive an EXISTING job — no prompt, no spawn, no
+    # re-dispatch loops. Placed BEFORE the prompt-resolution block so reattach
+    # never reads stdin (bg dispatch has no stdin; a TTY read would block).
+    if args.reattach:
+        try:
+            companion = _resolve_companion()
+        except Exception as exc:
+            return _fail(args.issue, None, f"resolve_companion: {exc}", 3)
+        _active_companion = companion
+        print(f"codex-companion: {companion}", file=sys.stderr)
+        return _run_reattach(companion, args)
 
     # Resolve prompt.
     if args.prompt is not None:

--- a/tests/test_codex_task_output_preservation.py
+++ b/tests/test_codex_task_output_preservation.py
@@ -65,6 +65,7 @@ def _args(output_file, **overrides):
         probe_error_cap=10,
         stall_detect_secs=600,
         cancelled_retry_cap=2,
+        result_fetch_retry_cap=0,
     )
     base.update(overrides)
     return SimpleNamespace(**base)

--- a/tests/test_codex_task_reattach_and_fetch_retry.py
+++ b/tests/test_codex_task_reattach_and_fetch_retry.py
@@ -1,0 +1,727 @@
+"""Tests for codex_task.py result-fetch retry + --reattach mode (task #1020).
+
+Two recovery affordances under test:
+
+1. Bounded result-fetch retry (``_fetch_result_with_retry``): a transient
+   ``No job found`` from ``codex-companion result`` (a torn read of the
+   companion's non-atomic state.json jobs index) is re-probed up to
+   ``--result-fetch-retry-cap`` times before the job is declared lost
+   (exit 7). The retry re-fetches ONLY — exit 7 stays OUTSIDE the #579
+   transient whole-job re-dispatch class, so a completed job is never
+   re-dispatched. A fetch-subprocess TimeoutExpired/OSError (previously an
+   unhandled crash with NO failure marker) is converted to a retryable
+   failure. Terminal marker notes carry a countable ``fetch_retries=<k>``
+   token.
+
+2. ``--reattach <job_id>``: skip the spawn and drive an EXISTING job through
+   the unchanged poll loop / stall detector / result fetch / output write /
+   marker posts — the recovery path for a wrapper kill that orphaned a
+   running job. Guarded (MF1): with ``--issue N`` the job id must be bound
+   to issue N's own ``epm:codex-task-spawned`` history and not already
+   terminally paired (fail-closed; ``--reattach-unbound`` overrides, and is
+   REQUIRED without ``--issue``). ``_active_job_id`` arms only AFTER the
+   guard (MF3); the attach-time confirm probe uses ``_probe_phase_safe``
+   (MF2) so a status-CLI raise exits 4 with a failure marker, never a crash.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_codex_task():
+    """Load scripts/codex_task.py as an isolated module."""
+    spec = importlib.util.spec_from_file_location(
+        "codex_task_reattach_under_test", REPO_ROOT / "scripts" / "codex_task.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["codex_task_reattach_under_test"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+codex_task = _load_codex_task()
+
+FINAL_MSG = "FINAL MESSAGE"
+NO_JOB_STDERR = 'No job found for "task-x". Run /codex:status to list known jobs.'
+
+
+def _args(**overrides):
+    """Argparse-like namespace with sane defaults (mirrors main()'s parser)."""
+    base = dict(
+        issue=None,
+        effort="high",
+        write=False,
+        output_file=None,
+        prompt_file=None,
+        prompt="do the thing",
+        max_wait_secs=3600,
+        poll_interval_secs=0,  # no real sleeping in tests
+        probe_error_cap=10,
+        stall_detect_secs=600,
+        cancelled_retry_cap=2,
+        transient_retry_cap=1,
+        result_fetch_retry_cap=3,
+        reattach=None,
+        reattach_unbound=False,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _bound_events(job_id: str = "task-r") -> list[dict]:
+    """Fake events.jsonl rows: a codex_task-posted spawned marker binding
+    ``job_id`` to the issue, with no terminal marker paired to it."""
+    return [
+        {
+            "kind": "epm:codex-task-spawned",
+            "by": "codex_task",
+            "note": (
+                f"Codex job_id={job_id} effort=high write=True "
+                "poll_interval=30s max_wait=21600s probe_error_cap=10 stall_detect=600s"
+            ),
+        },
+    ]
+
+
+def _boom_spawn(*_a, **_k):
+    raise AssertionError("spawn must not be called")
+
+
+def _wire_common(monkeypatch, markers: list, *, events=None, events_raise=None):
+    """Common reattach-test plumbing: capture markers, ban spawns, no sleeps."""
+    monkeypatch.setattr(codex_task, "_spawn_codex", _boom_spawn)
+    monkeypatch.setattr(
+        codex_task,
+        "_post_marker",
+        lambda issue, kind, note, version=1: markers.append((issue, kind, note)) or True,
+    )
+    monkeypatch.setattr(codex_task, "_best_effort_cancel", lambda *_a, **_k: None)
+    monkeypatch.setattr(codex_task.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(codex_task, "_resolve_companion", lambda: Path("/fake/c.mjs"))
+    monkeypatch.setattr(codex_task, "_install_signal_handlers", lambda: None)
+    if events_raise is not None:
+
+        def _raise(_issue):
+            raise events_raise
+
+        monkeypatch.setattr(codex_task, "list_events", _raise)
+    else:
+        monkeypatch.setattr(codex_task, "list_events", lambda _issue: events or [])
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Result-fetch retry (_fetch_result_with_retry / _finalize_result).
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_fetch_retry_no_job_found_then_success(monkeypatch, capsys):
+    """Two transient 'No job found' failures then success: rc 0, three fetch
+    calls, two jittered sleeps in [5, 15]s, retries_used == 2, and the
+    status-probe discriminator logged between attempts."""
+    calls = {"fetch": 0}
+
+    def fake_fetch(_companion, _job_id):
+        calls["fetch"] += 1
+        if calls["fetch"] <= 2:
+            return 1, "", NO_JOB_STDERR
+        return 0, "RESULT", ""
+
+    monkeypatch.setattr(codex_task, "_fetch_result", fake_fetch)
+    monkeypatch.setattr(codex_task, "_probe_phase", lambda *_a: ("done", "", None))
+    sleeps: list[float] = []
+    monkeypatch.setattr(codex_task.time, "sleep", lambda s: sleeps.append(s))
+
+    rc, stdout, _stderr, detail, retries = codex_task._fetch_result_with_retry(
+        Path("/fake/c.mjs"), "task-x", 3
+    )
+
+    assert rc == 0
+    assert stdout == "RESULT"
+    assert detail == ""
+    assert retries == 2
+    assert calls["fetch"] == 3
+    assert len(sleeps) == 2
+    assert all(5.0 <= s <= 15.0 for s in sleeps), sleeps
+    err = capsys.readouterr().err
+    assert "status-probe: job known, phase=done" in err
+    assert "result-fetch attempt 1/4" in err
+
+
+def test_fetch_retry_exhaustion_exit7_failure_marker_no_redispatch(monkeypatch):
+    """Every fetch fails with the ran-but-unfetchable incident shape (status
+    probe says phase=done): exit 7, exactly ONE spawn for the whole helper
+    run (exit 7 is excluded from the transient re-dispatch class — the
+    load-bearing contract), and ONE failure marker carrying the attempt
+    count, the fetch_retries token, and the discriminator."""
+    spawns = {"n": 0}
+
+    def fake_spawn(_companion, _prompt, _effort, _write):
+        spawns["n"] += 1
+        return f"task-x{spawns['n']}"
+
+    monkeypatch.setattr(codex_task, "_spawn_codex", fake_spawn)
+    # The exact incident shape: the job is KNOWN and done, but `result`
+    # keeps failing. The poll loop consumes the same mock and terminates
+    # immediately on phase=done.
+    monkeypatch.setattr(codex_task, "_probe_phase", lambda *_a: ("done", "", None))
+    monkeypatch.setattr(codex_task, "_fetch_result", lambda *_a: (1, "", NO_JOB_STDERR))
+    markers: list = []
+    monkeypatch.setattr(
+        codex_task,
+        "_post_marker",
+        lambda issue, kind, note, version=1: markers.append((issue, kind, note)) or True,
+    )
+    monkeypatch.setattr(codex_task, "_best_effort_cancel", lambda *_a: None)
+    monkeypatch.setattr(codex_task.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(codex_task, "_resolve_companion", lambda: Path("/fake/c.mjs"))
+    monkeypatch.setattr(codex_task, "_install_signal_handlers", lambda: None)
+
+    argv = ["codex_task.py", "--prompt", "go", "--issue", "99", "--poll-interval-secs", "0"]
+    with patch.object(sys, "argv", argv):
+        rc = codex_task.main()
+
+    assert rc == 7
+    assert spawns["n"] == 1, spawns  # no whole-job re-dispatch on exit 7
+    failed = [m for m in markers if m[1] == "epm:codex-task-failed"]
+    assert len(failed) == 1, markers
+    note = failed[0][2]
+    assert "after 4 attempt(s)" in note
+    assert "fetch_retries=3" in note
+    assert "job known, phase=done" in note
+
+
+def test_fetch_retry_cap_zero_single_shot(monkeypatch):
+    """result_fetch_retry_cap=0 keeps the old single-shot semantics: exactly
+    one fetch call, no sleeps, immediate exit-7 AttemptResult."""
+    calls = {"fetch": 0}
+
+    def fake_fetch(_companion, _job_id):
+        calls["fetch"] += 1
+        return 1, "", NO_JOB_STDERR
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(codex_task, "_fetch_result", fake_fetch)
+    monkeypatch.setattr(codex_task, "_probe_phase", lambda *_a: ("done", "", None))
+    monkeypatch.setattr(codex_task.time, "sleep", lambda s: sleeps.append(s))
+
+    args = _args(result_fetch_retry_cap=0)
+    result = codex_task._finalize_result(
+        Path("/fake/c.mjs"), "task-z", "done", args, None, time.time()
+    )
+
+    assert result.kind == "fail"
+    assert result.exit_code == 7
+    assert calls["fetch"] == 1
+    assert sleeps == []
+    assert "after 1 attempt(s)" in result.note
+    assert "fetch_retries=0" in result.note
+
+
+def test_fetch_timeout_expired_retried_not_crash(monkeypatch):
+    """A fetch-subprocess TimeoutExpired is converted to a retryable failure
+    (previously: unhandled traceback, no failure marker); the next attempt's
+    success returns rc 0 with retries_used == 1."""
+    calls = {"fetch": 0}
+
+    def fake_fetch(_companion, _job_id):
+        calls["fetch"] += 1
+        if calls["fetch"] == 1:
+            raise subprocess.TimeoutExpired(cmd="x", timeout=120)
+        return 0, "OK", ""
+
+    monkeypatch.setattr(codex_task, "_fetch_result", fake_fetch)
+    monkeypatch.setattr(codex_task, "_probe_phase", lambda *_a: ("done", "", None))
+    monkeypatch.setattr(codex_task.time, "sleep", lambda _s: None)
+
+    rc, stdout, _stderr, detail, retries = codex_task._fetch_result_with_retry(
+        Path("/fake/c.mjs"), "task-t", 3
+    )
+
+    assert rc == 0
+    assert stdout == "OK"
+    assert detail == ""
+    assert retries == 1
+    assert calls["fetch"] == 2
+
+
+def test_fetch_retries_token_on_success_marker(monkeypatch):
+    """The completed-marker note carries fetch_retries=<k>: 2 on a
+    retry-then-success run, 0 on a first-try-success run."""
+
+    def _run(fetch_fail_times: int) -> list:
+        calls = {"fetch": 0}
+
+        def fake_fetch(_companion, _job_id):
+            calls["fetch"] += 1
+            if calls["fetch"] <= fetch_fail_times:
+                return 1, "", NO_JOB_STDERR
+            return 0, "RESULT", ""
+
+        markers: list = []
+        monkeypatch.setattr(codex_task, "_spawn_codex", lambda *_a, **_k: "task-tok")
+        monkeypatch.setattr(codex_task, "_probe_phase", lambda *_a: ("done", "", None))
+        monkeypatch.setattr(codex_task, "_fetch_result", fake_fetch)
+        monkeypatch.setattr(
+            codex_task,
+            "_post_marker",
+            lambda issue, kind, note, version=1: markers.append((issue, kind, note)) or True,
+        )
+        monkeypatch.setattr(codex_task, "_best_effort_cancel", lambda *_a: None)
+        monkeypatch.setattr(codex_task.time, "sleep", lambda _s: None)
+        monkeypatch.setattr(codex_task, "_resolve_companion", lambda: Path("/fake/c.mjs"))
+        monkeypatch.setattr(codex_task, "_install_signal_handlers", lambda: None)
+
+        argv = ["codex_task.py", "--prompt", "go", "--issue", "7", "--poll-interval-secs", "0"]
+        with patch.object(sys, "argv", argv):
+            rc = codex_task.main()
+        assert rc == 0
+        return [m for m in markers if m[1] == "epm:codex-task-completed"]
+
+    completed = _run(fetch_fail_times=2)
+    assert len(completed) == 1
+    assert "fetch_retries=2" in completed[0][2]
+
+    completed = _run(fetch_fail_times=0)
+    assert len(completed) == 1
+    assert "fetch_retries=0" in completed[0][2]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# --reattach mode.
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_reattach_happy_path(monkeypatch, tmp_path):
+    """Bound live job polls to done: output written, spawned marker carries
+    reattach=true + the job id, completed marker carries fetch_retries=0,
+    exit 0, and _spawn_codex is never called."""
+    out = tmp_path / "out.md"
+    markers: list = []
+    _wire_common(monkeypatch, markers, events=_bound_events("task-r"))
+
+    probe_state = {"n": 0}
+
+    def fake_probe(_companion, _job_id):
+        probe_state["n"] += 1
+        if probe_state["n"] == 1:
+            return "running", "", None
+        return "done", "", None
+
+    monkeypatch.setattr(codex_task, "_probe_phase", fake_probe)
+    monkeypatch.setattr(codex_task, "_fetch_result", lambda *_a: (0, FINAL_MSG, ""))
+
+    argv = [
+        "codex_task.py",
+        "--reattach",
+        "task-r",
+        "--output-file",
+        str(out),
+        "--issue",
+        "42",
+        "--poll-interval-secs",
+        "0",
+    ]
+    with patch.object(sys, "argv", argv):
+        rc = codex_task.main()
+
+    assert rc == 0
+    assert out.read_text() == FINAL_MSG
+    spawned = [m for m in markers if m[1] == "epm:codex-task-spawned"]
+    assert len(spawned) == 1
+    assert "reattach=true" in spawned[0][2]
+    assert "job_id=task-r" in spawned[0][2]
+    completed = [m for m in markers if m[1] == "epm:codex-task-completed"]
+    assert len(completed) == 1
+    assert "fetch_retries=0" in completed[0][2]
+
+
+def test_reattach_unbound_id_fails_closed(monkeypatch, tmp_path):
+    """MF1: a job id with no spawned marker on this issue (a cross-issue /
+    unknown id) fails CLOSED before any subprocess work: exit 4, output file
+    byte-untouched, no spawned/completed marker, exactly one failure marker
+    naming the id + the guard reason, and _probe_phase never called."""
+    out = tmp_path / "out.md"
+    out.write_text("PRE-EXISTING")
+    markers: list = []
+    _wire_common(monkeypatch, markers, events=_bound_events("task-OTHER"))
+
+    probe_calls: list = []
+    monkeypatch.setattr(
+        codex_task, "_probe_phase", lambda *_a: probe_calls.append(1) or ("done", "", None)
+    )
+    monkeypatch.setattr(codex_task, "_fetch_result", lambda *_a: (0, FINAL_MSG, ""))
+
+    argv = [
+        "codex_task.py",
+        "--reattach",
+        "task-r",
+        "--output-file",
+        str(out),
+        "--issue",
+        "42",
+    ]
+    with patch.object(sys, "argv", argv):
+        rc = codex_task.main()
+
+    assert rc == 4
+    assert out.read_text() == "PRE-EXISTING"  # byte-untouched
+    assert probe_calls == []  # guard precedes ALL subprocess work
+    assert [m for m in markers if m[1] == "epm:codex-task-spawned"] == []
+    assert [m for m in markers if m[1] == "epm:codex-task-completed"] == []
+    failed = [m for m in markers if m[1] == "epm:codex-task-failed"]
+    assert len(failed) == 1
+    assert "job_id=task-r" in failed[0][2]
+    assert "binding guard failed" in failed[0][2]
+    assert "no epm:codex-task-spawned" in failed[0][2]
+
+
+def test_reattach_terminal_paired_id_fails_closed(monkeypatch):
+    """MF1: a job id already paired with a terminal completed/failed marker
+    on this issue fails closed (reattach would duplicate the fetch)."""
+    events = [
+        *_bound_events("task-r"),
+        {
+            "kind": "epm:codex-task-completed",
+            "by": "codex_task",
+            "note": "Codex job_id=task-r phase=done after 100s.",
+        },
+    ]
+    markers: list = []
+    _wire_common(monkeypatch, markers, events=events)
+    probe_calls: list = []
+    monkeypatch.setattr(
+        codex_task, "_probe_phase", lambda *_a: probe_calls.append(1) or ("done", "", None)
+    )
+
+    argv = ["codex_task.py", "--reattach", "task-r", "--issue", "42"]
+    with patch.object(sys, "argv", argv):
+        rc = codex_task.main()
+
+    assert rc == 4
+    assert probe_calls == []
+    failed = [m for m in markers if m[1] == "epm:codex-task-failed"]
+    assert len(failed) == 1
+    assert "already has a terminal codex-task marker" in failed[0][2]
+
+
+def test_reattach_token_boundary_no_prefix_match(monkeypatch):
+    """MF1: a spawned marker for task-r-longer does NOT bind task-r — the
+    token-boundary regex rejects the prefix match."""
+    markers: list = []
+    _wire_common(monkeypatch, markers, events=_bound_events("task-r-longer"))
+    monkeypatch.setattr(codex_task, "_probe_phase", lambda *_a: ("done", "", None))
+
+    argv = ["codex_task.py", "--reattach", "task-r", "--issue", "42"]
+    with patch.object(sys, "argv", argv):
+        rc = codex_task.main()
+
+    assert rc == 4
+    failed = [m for m in markers if m[1] == "epm:codex-task-failed"]
+    assert len(failed) == 1
+    assert "binding guard failed" in failed[0][2]
+
+
+def test_reattach_unbound_override_proceeds(monkeypatch, tmp_path):
+    """MF1: --reattach-unbound skips the guard entirely (list_events is
+    never called) and proceeds to the happy path; the spawned marker note
+    carries unbound_override=true."""
+    out = tmp_path / "out.md"
+    markers: list = []
+    _wire_common(
+        monkeypatch,
+        markers,
+        events_raise=AssertionError("list_events must not be called under --reattach-unbound"),
+    )
+
+    probe_state = {"n": 0}
+
+    def fake_probe(_companion, _job_id):
+        probe_state["n"] += 1
+        if probe_state["n"] == 1:
+            return "running", "", None
+        return "done", "", None
+
+    monkeypatch.setattr(codex_task, "_probe_phase", fake_probe)
+    monkeypatch.setattr(codex_task, "_fetch_result", lambda *_a: (0, FINAL_MSG, ""))
+
+    argv = [
+        "codex_task.py",
+        "--reattach",
+        "task-r",
+        "--reattach-unbound",
+        "--output-file",
+        str(out),
+        "--issue",
+        "42",
+        "--poll-interval-secs",
+        "0",
+    ]
+    with patch.object(sys, "argv", argv):
+        rc = codex_task.main()
+
+    assert rc == 0
+    assert out.read_text() == FINAL_MSG
+    spawned = [m for m in markers if m[1] == "epm:codex-task-spawned"]
+    assert len(spawned) == 1
+    assert "unbound_override=true" in spawned[0][2]
+
+
+def test_reattach_without_issue_requires_unbound_flag(monkeypatch, tmp_path):
+    """--reattach without --issue and without --reattach-unbound is an
+    argparse error (exit 2); adding --reattach-unbound proceeds (and posts
+    no markers, since there is no issue)."""
+    with (
+        patch.object(sys, "argv", ["codex_task.py", "--reattach", "task-r"]),
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        codex_task.main()
+    assert excinfo.value.code == 2
+
+    out = tmp_path / "out.md"
+    markers: list = []
+    _wire_common(monkeypatch, markers, events=[])
+    monkeypatch.setattr(codex_task, "_probe_phase", lambda *_a: ("done", "", None))
+    monkeypatch.setattr(codex_task, "_fetch_result", lambda *_a: (0, FINAL_MSG, ""))
+
+    argv = [
+        "codex_task.py",
+        "--reattach",
+        "task-r",
+        "--reattach-unbound",
+        "--output-file",
+        str(out),
+    ]
+    with patch.object(sys, "argv", argv):
+        rc = codex_task.main()
+
+    assert rc == 0
+    assert out.read_text() == FINAL_MSG
+    assert markers == []  # no issue -> no marker posts
+
+
+def test_reattach_events_read_error_fails_closed(monkeypatch):
+    """MF1: an events.jsonl read error is a guard failure (fail-closed),
+    never a pass."""
+    markers: list = []
+    _wire_common(monkeypatch, markers, events_raise=RuntimeError("events unreadable"))
+    monkeypatch.setattr(codex_task, "_probe_phase", lambda *_a: ("done", "", None))
+
+    argv = ["codex_task.py", "--reattach", "task-r", "--issue", "42"]
+    with patch.object(sys, "argv", argv):
+        rc = codex_task.main()
+
+    assert rc == 4
+    failed = [m for m in markers if m[1] == "epm:codex-task-failed"]
+    assert len(failed) == 1
+    assert "fail-closed" in failed[0][2]
+
+
+def test_reattach_probe_raises_timeout_exit4(monkeypatch, tmp_path):
+    """MF2: a status-CLI raise (TimeoutExpired) at attach time converts to
+    the probe-error path — bounded retry (1 + cap probes), exit 4, exactly
+    one failure marker, no spawn, no output write, no crash."""
+    out = tmp_path / "out.md"
+    markers: list = []
+    _wire_common(monkeypatch, markers, events=_bound_events("task-r"))
+
+    probe_calls = {"n": 0}
+
+    def raising_probe(_companion, _job_id):
+        probe_calls["n"] += 1
+        raise subprocess.TimeoutExpired(cmd="x", timeout=60)
+
+    monkeypatch.setattr(codex_task, "_probe_phase", raising_probe)
+
+    argv = [
+        "codex_task.py",
+        "--reattach",
+        "task-r",
+        "--output-file",
+        str(out),
+        "--issue",
+        "42",
+    ]
+    with patch.object(sys, "argv", argv):
+        rc = codex_task.main()
+
+    assert rc == 4
+    assert probe_calls["n"] == 4  # 1 + default cap 3
+    assert not out.exists()  # no output write
+    failed = [m for m in markers if m[1] == "epm:codex-task-failed"]
+    assert len(failed) == 1
+    assert "probe raised" in failed[0][2]
+
+
+def test_reattach_unknown_job_exit4_bounded(monkeypatch):
+    """An unqueryable job id exits 4 after a bounded confirm-probe retry
+    (1 + cap probes), with a failure marker — never the poll loop's
+    probe-error crawl, never a spawn."""
+    markers: list = []
+    _wire_common(monkeypatch, markers, events=_bound_events("task-r"))
+
+    probe_calls = {"n": 0}
+
+    def fake_probe(_companion, _job_id):
+        probe_calls["n"] += 1
+        return "probe-error", 'No job found for "task-r". Run /codex:status.', None
+
+    monkeypatch.setattr(codex_task, "_probe_phase", fake_probe)
+
+    argv = ["codex_task.py", "--reattach", "task-r", "--issue", "42"]
+    with patch.object(sys, "argv", argv):
+        rc = codex_task.main()
+
+    assert rc == 4
+    assert probe_calls["n"] == 4  # 1 + default cap 3, NOT probe_error_cap=10
+    failed = [m for m in markers if m[1] == "epm:codex-task-failed"]
+    assert len(failed) == 1
+    assert "reattach" in failed[0][2]
+    assert "not queryable" in failed[0][2]
+
+
+def test_reattach_already_terminal_skips_poll(monkeypatch, tmp_path):
+    """A job already terminal at attach time (finished during the orphan
+    gap) skips the poll loop entirely and goes straight to fetch."""
+    out = tmp_path / "out.md"
+    markers: list = []
+    _wire_common(monkeypatch, markers, events=_bound_events("task-r"))
+    monkeypatch.setattr(codex_task, "_probe_phase", lambda *_a: ("done", "", None))
+    monkeypatch.setattr(codex_task, "_fetch_result", lambda *_a: (0, FINAL_MSG, ""))
+
+    def poll_must_not_run(*_a, **_k):
+        raise AssertionError("_poll_until_terminal must not be called for a terminal job")
+
+    monkeypatch.setattr(codex_task, "_poll_until_terminal", poll_must_not_run)
+
+    argv = [
+        "codex_task.py",
+        "--reattach",
+        "task-r",
+        "--output-file",
+        str(out),
+        "--issue",
+        "42",
+    ]
+    with patch.object(sys, "argv", argv):
+        rc = codex_task.main()
+
+    assert rc == 0
+    assert out.read_text() == FINAL_MSG
+
+
+def test_reattach_prompt_mutually_exclusive():
+    """--reattach with --prompt is an argparse error (exit 2)."""
+    argv = ["codex_task.py", "--reattach", "task-r", "--prompt", "x", "--issue", "42"]
+    with patch.object(sys, "argv", argv), pytest.raises(SystemExit) as excinfo:
+        codex_task.main()
+    assert excinfo.value.code == 2
+
+
+def test_reattach_preserves_preexisting_verdict(monkeypatch, tmp_path):
+    """pre_output_key=None semantics: a sentinel-bearing verdict already at
+    --output-file (plausibly written by Codex BEFORE the original wrapper
+    died) is preserved; the final chat message lands in the .final-msg.md
+    sidecar (the #604 incident class)."""
+    out = tmp_path / "out.md"
+    verdict = "<!-- epm:code-review-codex v3 -->\nVERDICT"
+    out.write_text(verdict)
+    markers: list = []
+    _wire_common(monkeypatch, markers, events=_bound_events("task-r"))
+    monkeypatch.setattr(codex_task, "_probe_phase", lambda *_a: ("done", "", None))
+    monkeypatch.setattr(codex_task, "_fetch_result", lambda *_a: (0, FINAL_MSG, ""))
+
+    argv = [
+        "codex_task.py",
+        "--reattach",
+        "task-r",
+        "--output-file",
+        str(out),
+        "--issue",
+        "42",
+    ]
+    with patch.object(sys, "argv", argv):
+        rc = codex_task.main()
+
+    assert rc == 0
+    assert out.read_text() == verdict  # NOT clobbered
+    sidecar = tmp_path / "out.md.final-msg.md"
+    assert sidecar.read_text() == FINAL_MSG
+
+
+def test_reattach_terminal_failed_exit1_no_redispatch(monkeypatch):
+    """A reattached job that polls to terminal phase=failed exits 1 with a
+    failure marker and never spawns (no re-dispatch loop in reattach mode)."""
+    markers: list = []
+    _wire_common(monkeypatch, markers, events=_bound_events("task-r"))
+
+    probe_state = {"n": 0}
+
+    def fake_probe(_companion, _job_id):
+        probe_state["n"] += 1
+        if probe_state["n"] == 1:
+            return "running", "", None
+        return "failed", "", None
+
+    monkeypatch.setattr(codex_task, "_probe_phase", fake_probe)
+    monkeypatch.setattr(codex_task, "_fetch_result", lambda *_a: (0, FINAL_MSG, ""))
+
+    argv = [
+        "codex_task.py",
+        "--reattach",
+        "task-r",
+        "--issue",
+        "42",
+        "--poll-interval-secs",
+        "0",
+    ]
+    with patch.object(sys, "argv", argv):
+        rc = codex_task.main()
+
+    assert rc == 1
+    failed = [m for m in markers if m[1] == "epm:codex-task-failed"]
+    assert len(failed) == 1
+    assert "phase=failed" in failed[0][2]
+
+
+def test_reattach_never_reads_stdin(monkeypatch, tmp_path):
+    """Reattach mode must never read stdin (bg dispatch has no stdin; a TTY
+    read would block forever)."""
+
+    class _NoRead:
+        def read(self, *_a, **_k):
+            raise AssertionError("stdin must not be read in reattach mode")
+
+    monkeypatch.setattr(codex_task.sys, "stdin", _NoRead())
+
+    out = tmp_path / "out.md"
+    markers: list = []
+    _wire_common(monkeypatch, markers, events=_bound_events("task-r"))
+    monkeypatch.setattr(codex_task, "_probe_phase", lambda *_a: ("done", "", None))
+    monkeypatch.setattr(codex_task, "_fetch_result", lambda *_a: (0, FINAL_MSG, ""))
+
+    argv = [
+        "codex_task.py",
+        "--reattach",
+        "task-r",
+        "--output-file",
+        str(out),
+        "--issue",
+        "42",
+    ]
+    with patch.object(sys, "argv", argv):
+        rc = codex_task.main()
+
+    assert rc == 0
+    assert out.read_text() == FINAL_MSG

--- a/tests/test_codex_task_retry_and_stall.py
+++ b/tests/test_codex_task_retry_and_stall.py
@@ -52,6 +52,7 @@ def _args(**overrides):
         probe_error_cap=10,
         stall_detect_secs=600,
         cancelled_retry_cap=2,
+        result_fetch_retry_cap=0,
     )
     base.update(overrides)
     return SimpleNamespace(**base)


### PR DESCRIPTION
Closes task #1020 (workflow-fix, kind: infra).

- Fetch-only result retry (cap 3, jittered backoff; exit 7 stays outside the transient re-dispatch class)
- `--reattach <job_id>` wrapper-kill recovery with fail-closed issue<->job_id binding guard + `--reattach-unbound` override
- `_probe_phase_safe` in retry discriminator + reattach confirm loop; `fetch_retries=<k>` marker tokens
- 19 new tests; 2380 passed / 6 skipped on the Step 9c touched-scope gate; code-review ensemble PASS+PASS

Plan: tasks/reviewing/1020/plans/v2.md (critic ensemble round 1: reconciled REVISE -> v2 integrated all upheld must-fixes).