### PR TITLE
#1019 batch_judge: stuck-batch cancel + sync fallback (EPS_BATCH_STUCK_HOURS)

### DIFF
--- a/docs/api_throughput_guidelines.md
+++ b/docs/api_throughput_guidelines.md
@@ -127,6 +127,7 @@ implements the table via `decide_dispatch_route()`:
 | `cost_pref="cost"` | N is tiny (< crossover_n/10), OR deadline < 24h SLA | otherwise |
 | `cost_pref="balanced"` (default) | N < crossover_n, OR deadline < 24h SLA | N >= crossover_n |
 | `force_path="sync"` / `force_path="batch"` | hard override (tests / ops) | hard override |
+| batch passes: `batch_passes = ceil(uncached_N / sub_batch_size)` | batch_passes > 2-3 (sequential wedge exposure compounds: each pass is an independent chance to sit behind a wedged batch — #810's ~30-pass judge phase sat 16h behind ONE batch stuck at 0/2001) | batch_passes <= 2-3 AND N >= crossover_n |
 
 `SYNC_BATCH_CROSSOVER_N` should be set to **20,000** (the dispatcher's
 current placeholder is 2,000 — too low; it forces batch on jobs that sync
@@ -150,6 +151,22 @@ cap.
 in-flight batch requests — comfortably under any tier's queue cap (Tier 1 =
 100k floor).
 
+> **Batch-pass count (wedge exposure).** Before routing a phase to batch,
+> compute `batch_passes = ceil(uncached_items / sub_batch_size)` (uncached
+> AFTER the judge cache is consulted) — the number of batch SUBMISSIONS the
+> phase implies; with `MAX_CONCURRENT_SUB_BATCHES = 4` the sequential WAVES
+> are ≈ `batch_passes / 4`, but the wedge-exposure argument applies per
+> submission: each batch is an independent draw against the batch queue's
+> tail, and one wedged batch parks everything behind it for up to its 24h
+> TTL. More than 2-3 passes ⇒ prefer sync fan-out (`force_sync=True` /
+> `force_path="sync"`), which clears the same volume in minutes at the
+> polite caps (#810: 39,512 calls in 18 min ≈ 2.2k requests/min, zero
+> errors). The stuck-batch escape (`EPS_BATCH_STUCK_HOURS`, default 4h —
+> `judge_dispatch.py`) bounds the damage when batch is chosen anyway, but
+> choosing sync up front avoids the 4h stall entirely. Fire-rate
+> retrospective: `grep -rl stuck_cancel_intent_at <checkpoint dirs>/state.json`
+> (or grep run logs for `STUCK BATCH`) enumerates every escape fire.
+
 ---
 
 ## 4. Re-tuning the existing judge dispatcher (`judge_dispatch.py`)
@@ -162,6 +179,13 @@ judge dispatcher. Two constants need re-tuning off the Phase 3 numbers:
   multi-org dispatcher (§ 3) and to leave headroom on the shared keys; with
   4 × 2k = 8k in-flight (vs the prior 8 × 2k = 16k), we stay well clear of
   any queue cap while remaining ~13% of the Tier-4 floor cap.
+- `EPS_BATCH_STUCK_HOURS` (default 4.0; `<=0` disables): the stuck-cancel
+  escape (#1019) — a sub-batch at zero succeeded requests past the threshold
+  is canceled, its partial results harvested, and the unprocessed remainder
+  re-dispatched on the sync path. Unset/empty -> 4.0; a parseable float <= 0
+  -> disabled (pure deadline-bounded behavior); malformed -> `ValueError`
+  (fail loud). Semantics live in
+  `llm/anthropic_client.py::batch_stuck_threshold_hours`.
 
 The legacy `DEFAULT_THRESHOLD_BASE = 2_000` (the sync-vs-batch threshold
 inside the SINGLE-org judge dispatcher) is reasonable for that single-org

--- a/src/explore_persona_space/eval/batch_judge.py
+++ b/src/explore_persona_space/eval/batch_judge.py
@@ -304,11 +304,13 @@ def _submit_and_poll_batch(
       retrieve within ``BATCH_CREATE_404_GRACE_S`` of the chunk's own create is
       retried with bounded backoff (read-after-write inconsistency, the #742
       shape); outside the window — or past the backoff schedule — it re-raises.
-    - **Stuck-batch cancel (#1019)**: a chunk at ``request_counts.succeeded == 0``
-      for >= ``EPS_BATCH_STUCK_HOURS`` (default 4h; ``<=0`` disables) since its
-      own create is CANCELED (once per chunk; a re-retrieved ``canceling``/
-      ``ended`` counts as accepted cancellation) and the loop keeps polling to
-      ``ended``; canceled rows surface as error dicts — this path has no retry
+    - **Stuck-batch cancel (#1019)**: a chunk still ``in_progress`` at
+      ``request_counts.succeeded == 0`` for >= ``EPS_BATCH_STUCK_HOURS``
+      (default 4h; ``<=0`` disables) since its own create is CANCELED (once
+      per chunk; a re-retrieved ``canceling``/``ended`` counts as accepted
+      cancellation; a chunk ALREADY ``canceling`` — an out-of-band Console
+      cancel — is never re-canceled) and the loop keeps polling to ``ended``;
+      canceled rows surface as error dicts — this path has no retry
       machinery, so a 4h-bounded completion with flagged error rows replaces
       the prior up-to-24h park behind a wedged batch (#810).
 
@@ -380,8 +382,12 @@ def _submit_and_poll_batch(
             # collection below surfaces canceled rows as error dicts. Appended
             # AFTER the ended-break and overdue checks (precedence load-bearing).
             # ``created_at`` (captured right after batches.create) is the anchor.
+            # Gated on ``in_progress`` (#1019 round 2): a chunk already
+            # ``canceling`` (an out-of-band Console cancel) never gets a
+            # duplicate cancel from us — the loop just polls it to ``ended``.
             if (
                 not stuck_canceled
+                and batch.processing_status == "in_progress"  # never re-cancel an o-o-b cancel
                 and (stuck_hours := batch_stuck_threshold_hours()) is not None
                 and counts is not None
                 and counts.succeeded == 0

--- a/src/explore_persona_space/eval/batch_judge.py
+++ b/src/explore_persona_space/eval/batch_judge.py
@@ -33,6 +33,7 @@ from explore_persona_space.eval.alignment import JUDGE_SYSTEM_PROMPT
 from explore_persona_space.eval.utils import parse_judge_json
 from explore_persona_space.llm.anthropic_client import (
     BatchDeadlineExceeded,
+    batch_stuck_threshold_hours,
     deadline_from_expires_at,
     retrieve_with_create_grace,
 )
@@ -303,6 +304,13 @@ def _submit_and_poll_batch(
       retrieve within ``BATCH_CREATE_404_GRACE_S`` of the chunk's own create is
       retried with bounded backoff (read-after-write inconsistency, the #742
       shape); outside the window — or past the backoff schedule — it re-raises.
+    - **Stuck-batch cancel (#1019)**: a chunk at ``request_counts.succeeded == 0``
+      for >= ``EPS_BATCH_STUCK_HOURS`` (default 4h; ``<=0`` disables) since its
+      own create is CANCELED (once per chunk; a re-retrieved ``canceling``/
+      ``ended`` counts as accepted cancellation) and the loop keeps polling to
+      ``ended``; canceled rows surface as error dicts — this path has no retry
+      machinery, so a 4h-bounded completion with flagged error rows replaces
+      the prior up-to-24h park behind a wedged batch (#810).
 
     ``now_fn``/``sleep_fn`` are injectable for tests (default wall-clock +
     ``time.sleep``). Polling keeps the 30s->1.5x->120s backoff capped by the
@@ -326,6 +334,7 @@ def _submit_and_poll_batch(
         )
         deadline: _dt.datetime | None = None
         current_interval = poll_interval
+        stuck_canceled = False  # #1019: cancel a wedged chunk at most once
         while True:
             # #995: a 404 within BATCH_CREATE_404_GRACE_S of this chunk's own
             # create is retried with bounded backoff (read-after-write; the #742
@@ -364,6 +373,44 @@ def _submit_and_poll_batch(
                     batch = final
                     break
                 raise BatchDeadlineExceeded(batch_id, deadline)
+            # Stuck-batch escape (#1019, incident #810): zero succeeded past the
+            # threshold -> cancel ONCE (per-chunk local guard; this path has no
+            # state.json and no retry machinery, so no intent marker is needed)
+            # and keep polling — the API flips canceling -> ended and the
+            # collection below surfaces canceled rows as error dicts. Appended
+            # AFTER the ended-break and overdue checks (precedence load-bearing).
+            # ``created_at`` (captured right after batches.create) is the anchor.
+            if (
+                not stuck_canceled
+                and (stuck_hours := batch_stuck_threshold_hours()) is not None
+                and counts is not None
+                and counts.succeeded == 0
+                and (now_fn() - created_at).total_seconds() / 3600.0 >= stuck_hours
+            ):
+                import anthropic as anthropic_mod
+
+                logger.warning(
+                    "STUCK BATCH (legacy path): %s at succeeded=0 past %.1fh — canceling; "
+                    "canceled rows surface as error dicts (no retry machinery on this "
+                    "path) (#810 escape)",
+                    batch_id,
+                    stuck_hours,
+                )
+                try:
+                    client.messages.batches.cancel(batch_id)
+                except anthropic_mod.APIStatusError:
+                    # Race: the batch may already be canceling (out-of-band) or
+                    # ended. BOTH are accepted cancellation outcomes — the loop
+                    # harvests at ended either way. Anything else re-raises.
+                    final = client.messages.batches.retrieve(batch_id)
+                    if final.processing_status not in ("canceling", "ended"):
+                        raise
+                    logger.info(
+                        "Cancel of %s raced with state %s; accepted as canceled",
+                        batch_id,
+                        final.processing_status,
+                    )
+                stuck_canceled = True
             sleep_fn(current_interval)
             current_interval = min(current_interval * 1.5, max_poll_interval)
 

--- a/src/explore_persona_space/eval/judge_dispatch.py
+++ b/src/explore_persona_space/eval/judge_dispatch.py
@@ -53,12 +53,15 @@ re-dispatched); batch-routed retries resume through their nested
 across resumes so a threshold flip cannot strand an in-flight nested
 batch or a partial file); and a complete-but-unmerged
 ``results_retry.json`` (crash between its atomic write and the state
-flip) is merged with zero API calls. A sub-batch wedged at zero succeeded
-requests past ``EPS_BATCH_STUCK_HOURS`` (default 4h; ``<=0`` disables) is
-CANCELED (escape intent persisted BEFORE the cancel side effect), its
-partial results harvested at ``ended``, and its ``canceled`` ids re-dispatched
-through the retry machinery pre-pinned to the SYNC path (#1019, incident
-#810).
+flip) is merged with zero API calls. A sub-batch still ``in_progress`` and
+wedged at zero succeeded requests past ``EPS_BATCH_STUCK_HOURS`` (default
+4h; ``<=0`` disables) is CANCELED (escape intent persisted BEFORE the
+cancel side effect), its partial results harvested at ``ended``, and its
+``canceled`` ids re-dispatched through the retry machinery pre-pinned to
+the SYNC path (#1019, incident #810). A batch already ``canceling`` with no
+persisted intent (an operator's out-of-band Console cancel) is never
+adopted by the escape — its canceled rows keep the #663 error-dict
+no-retry contract.
 
 NOTE: ``_build_params`` is underscore-private by convention but imported
 by ``explore_persona_space.eval.alignment`` (single source of truth for
@@ -737,8 +740,15 @@ def _harvest_sub_batch(
         # Frozen-counts fingerprint (#1019 §12 A5): the escape fired on
         # succeeded==0, so nonzero API-succeeded results harvested here mean
         # request_counts was frozen/stale (a false-positive stuck fire).
-        n_succeeded = (
-            len(sb_scores) - len(retriable) - len(expired) - len(quarantined) - len(canceled)
+        # Count TRUE API-succeeded rows only: unknown-rtype rows sit in no
+        # list (plain subtraction would count them as succeeded) but carry
+        # "batch_error: " error dicts; a "parse_error" row IS API-succeeded.
+        non_succeeded = {*retriable, *expired, *quarantined, *canceled}
+        n_succeeded = sum(
+            1
+            for cid, score in sb_scores.items()
+            if cid not in non_succeeded
+            and not str(score.get("reasoning", "")).startswith("batch_error: ")
         )
         logger.warning(
             "Stuck-canceled sub-batch %s harvested: n_succeeded=%d n_canceled=%d "
@@ -812,10 +822,13 @@ def _poll_one_sub_batch_step(
     """Poll one not-yet-collected sub-batch once; harvest on end, raise on overdue.
 
     Stuck-batch escape (#1019): AFTER the ended-harvest and overdue blocks (their
-    precedence is load-bearing), a sub-batch at ``request_counts.succeeded == 0``
-    for >= ``EPS_BATCH_STUCK_HOURS`` since ``submitted_at`` is canceled via
-    :func:`_cancel_stuck_sub_batch` (intent-first crash-safe ordering); the
-    enclosing poll loop then harvests it when the API flips canceling -> ended.
+    precedence is load-bearing), a sub-batch still ``in_progress`` at
+    ``request_counts.succeeded == 0`` for >= ``EPS_BATCH_STUCK_HOURS`` since
+    ``submitted_at`` is canceled via :func:`_cancel_stuck_sub_batch` (intent-first
+    crash-safe ordering); the enclosing poll loop then harvests it when the API
+    flips canceling -> ended. A batch already ``canceling`` with NO persisted
+    intent (an out-of-band Console cancel) is NEVER adopted — its canceled rows
+    surface as error dicts, not retries (#1019 round 2).
 
     Create-grace 404 (#995): a ``NotFoundError`` on the loop retrieve within
     ``BATCH_CREATE_404_GRACE_S`` of this sub-batch's persisted ``submitted_at``
@@ -873,9 +886,18 @@ def _poll_one_sub_batch_step(
     # marker (which survives every crash ordering). Ordering is load-bearing:
     # the ended-harvest and overdue blocks above run FIRST, so a finished
     # batch is never touched and BatchDeadlineExceeded keeps precedence.
+    # FRESH ENTRY additionally requires ``processing_status == "in_progress"``
+    # (#1019 round 2, concern out-of-band-canceling-retried): a batch already
+    # ``canceling`` at the poll — an operator's out-of-band Console cancel —
+    # must NOT be adopted by the escape; stamping intent on it would route the
+    # operator-canceled ids into the sync retry, violating the out-of-band
+    # no-retry contract (see :func:`_load_collected_into`). The escape-intent
+    # RESUME leg below deliberately keeps accepting canceling/ended — that leg
+    # completes OUR OWN already-committed escape after a crash.
     stuck_hours = batch_stuck_threshold_hours()
     if (
         stuck_hours is not None
+        and batch.processing_status == "in_progress"  # never adopt an out-of-band cancel
         and sb.get("stuck_cancel_intent_at") is None  # escape entered at most once
         and counts is not None  # fail-safe: no counts, no verdict
         and counts.succeeded == 0
@@ -898,7 +920,11 @@ def _poll_one_sub_batch_step(
     # Escape-intent RESUME leg: intent persisted but cancel never confirmed
     # (crash between the intent write and the cancel/confirm writes) ->
     # re-drive the cancel. Bounded: the race guard accepts canceling/ended,
-    # so this converges in one step.
+    # so this converges in one step. Deliberately keyed on the persisted
+    # INTENT alone — not stuck_hours, not processing_status: an escape
+    # committed by the intent write is COMPLETED on resume even when
+    # EPS_BATCH_STUCK_HOURS has since been set to 0 (disabling the knob stops
+    # NEW escapes; it never strands a half-done one).
     elif sb.get("stuck_cancel_intent_at") is not None and sb.get("stuck_canceled_at") is None:
         _cancel_stuck_sub_batch(client, sb, state, state_path, now_fn)
 

--- a/src/explore_persona_space/eval/judge_dispatch.py
+++ b/src/explore_persona_space/eval/judge_dispatch.py
@@ -53,7 +53,12 @@ re-dispatched); batch-routed retries resume through their nested
 across resumes so a threshold flip cannot strand an in-flight nested
 batch or a partial file); and a complete-but-unmerged
 ``results_retry.json`` (crash between its atomic write and the state
-flip) is merged with zero API calls.
+flip) is merged with zero API calls. A sub-batch wedged at zero succeeded
+requests past ``EPS_BATCH_STUCK_HOURS`` (default 4h; ``<=0`` disables) is
+CANCELED (escape intent persisted BEFORE the cancel side effect), its
+partial results harvested at ``ended``, and its ``canceled`` ids re-dispatched
+through the retry machinery pre-pinned to the SYNC path (#1019, incident
+#810).
 
 NOTE: ``_build_params`` is underscore-private by convention but imported
 by ``explore_persona_space.eval.alignment`` (single source of truth for
@@ -92,6 +97,7 @@ from explore_persona_space.eval import DEFAULT_JUDGE_MODEL
 from explore_persona_space.eval.utils import parse_judge_json
 from explore_persona_space.llm.anthropic_client import (
     BatchDeadlineExceeded,
+    batch_stuck_threshold_hours,
     deadline_from_expires_at,
     parse_batch_submitted_at,
     retrieve_with_create_grace,
@@ -404,11 +410,11 @@ def _collect_batch_results(
     client: "anthropic.Anthropic",
     batch_id: str,
     error_dict_factory: Callable[[str], dict],
-) -> tuple[dict[str, dict], list[str], list[str], list[str]]:
+) -> tuple[dict[str, dict], list[str], list[str], list[str], list[str]]:
     """Stream one ended batch's results; join on custom_id (order is not guaranteed).
 
-    Returns (scores, retriable_ids, expired_ids, quarantined_ids). Two-level
-    branch per the Anthropic doc example:
+    Returns (scores, retriable_ids, expired_ids, quarantined_ids, canceled_ids).
+    Two-level branch per the Anthropic doc example:
 
       succeeded                                 -> parse + keep
       errored, error.error.type == invalid_request_error
@@ -418,10 +424,22 @@ def _collect_batch_results(
       errored, other (server error)             -> retriable
       expired                                   -> retriable (never reached the
                                                    model; safe to resubmit)
-      canceled / unknown                        -> error dict, no retry
-                                                   (user-initiated terminal)
+      canceled                                  -> ``canceled`` list (never
+                                                   reached the model, not billed
+                                                   — docs-confirmed; same
+                                                   resubmit-safety class as
+                                                   expired). Whether canceled
+                                                   ids actually RETRY is gated
+                                                   downstream by the sub-batch's
+                                                   ``stuck_cancel_intent_at``
+                                                   marker (#1019): only OUR
+                                                   stuck-cancel escape retries;
+                                                   an out-of-band (Console)
+                                                   cancel keeps the #663
+                                                   no-retry contract.
+      unknown                                   -> error dict, no retry
 
-    errored/expired/quarantined all get error dicts in ``scores`` too
+    errored/expired/quarantined/canceled all get error dicts in ``scores`` too
     (overwritten if a retry later succeeds). The SDK error nesting is
     ``result.result.error.error.type`` (double ``.error``); access is
     getattr-guarded so a shape mismatch fails OPEN (routed to retriable, the
@@ -431,6 +449,7 @@ def _collect_batch_results(
     retriable: list[str] = []
     expired: list[str] = []
     quarantined: list[str] = []
+    canceled: list[str] = []
     for result in client.messages.batches.results(batch_id):
         cid = result.custom_id
         rtype = result.result.type
@@ -454,9 +473,12 @@ def _collect_batch_results(
         elif rtype == "expired":
             expired.append(cid)
             scores[cid] = error_dict_factory("batch_error: expired")
-        else:  # canceled (or unknown): surface, never retry
+        elif rtype == "canceled":
+            canceled.append(cid)
+            scores[cid] = error_dict_factory("batch_error: canceled")
+        else:  # unknown: surface, never retry
             scores[cid] = error_dict_factory(f"batch_error: {rtype}")
-    return scores, retriable, expired, quarantined
+    return scores, retriable, expired, quarantined, canceled
 
 
 # ── Sync path ────────────────────────────────────────────────────────────────
@@ -666,11 +688,24 @@ class _BatchCollector:
 
 
 def _load_collected_into(acc: _BatchCollector, dispatch_dir: Path, sb: dict) -> None:
-    """Merge one collected sub-batch's persisted results into ``acc``."""
+    """Merge one collected sub-batch's persisted results into ``acc``.
+
+    ``canceled_ids`` join the retry set ONLY when this sub-batch carries the
+    ``stuck_cancel_intent_at`` escape-intent marker (#1019) — i.e. OUR
+    stuck-cancel escape canceled it. The gate keys on the INTENT marker (not
+    the ``stuck_canceled_at`` confirm stamp): intent is persisted BEFORE the
+    external cancel side effect, so it is set in every crash ordering —
+    including resume-at-``ended``, where the confirm stamp never landed. An
+    out-of-band cancel (a human canceling in the Console — no intent marker)
+    keeps the #663 contract: error dict, never retried. ``.get(..., [])``
+    keeps pre-existing results files readable.
+    """
     payload = json.loads((dispatch_dir / f"results_{sb['batch_id']}.json").read_text())
     acc.scores.update(payload["scores"])
     acc.retry_candidates.extend(payload["retriable_ids"])
     acc.retry_candidates.extend(payload["expired_ids"])
+    if sb.get("stuck_cancel_intent_at"):
+        acc.retry_candidates.extend(payload.get("canceled_ids", []))
     acc.quarantined_ids.extend(payload.get("quarantined_ids", []))
 
 
@@ -685,7 +720,7 @@ def _harvest_sub_batch(
     sb: dict,
 ) -> None:
     """Collect an ended sub-batch, persist its results json, mark it collected."""
-    sb_scores, retriable, expired, quarantined = _collect_batch_results(
+    sb_scores, retriable, expired, quarantined, canceled = _collect_batch_results(
         client, sb["batch_id"], error_dict_factory
     )
     _atomic_write_json(
@@ -695,11 +730,71 @@ def _harvest_sub_batch(
             "retriable_ids": retriable,
             "expired_ids": expired,
             "quarantined_ids": quarantined,
+            "canceled_ids": canceled,
         },
     )
+    if sb.get("stuck_cancel_intent_at"):
+        # Frozen-counts fingerprint (#1019 §12 A5): the escape fired on
+        # succeeded==0, so nonzero API-succeeded results harvested here mean
+        # request_counts was frozen/stale (a false-positive stuck fire).
+        n_succeeded = (
+            len(sb_scores) - len(retriable) - len(expired) - len(quarantined) - len(canceled)
+        )
+        logger.warning(
+            "Stuck-canceled sub-batch %s harvested: n_succeeded=%d n_canceled=%d "
+            "(nonzero succeeded after a 0-counts cancel is the frozen-request_counts "
+            "false-positive signature)",
+            sb["batch_id"],
+            n_succeeded,
+            len(canceled),
+        )
     sb["status"] = "collected"
     _atomic_write_json(state_path, state)
     _load_collected_into(acc, dispatch_dir, sb)
+
+
+def _cancel_stuck_sub_batch(
+    client: "anthropic.Anthropic",
+    sb: dict,
+    state: dict,
+    state_path: Path,
+    now_fn: "Callable[[], _dt.datetime]",
+) -> None:
+    """Persist escape intent, cancel the stuck sub-batch, confirm (#1019).
+
+    Ordering is load-bearing (#1019 critic round 1):
+      1. persist ``stuck_cancel_intent_at`` (the retry DISCRIMINATOR — written
+         BEFORE the external side effect, so a crash at ANY later point still
+         routes this sub-batch's ``canceled`` ids to the sync retry, even when
+         the resume's first retrieve already reads ``ended`` and the normal
+         ended-harvest path runs before the stuck check);
+      2. ``batches.cancel`` (race guard below);
+      3. persist ``stuck_canceled_at`` (cancel-confirmed observability stamp;
+         its absence on resume re-drives step 2, which is idempotent-safe
+         because the guard accepts ``canceling``/``ended``).
+    """
+    import anthropic as anthropic_mod
+
+    if sb.get("stuck_cancel_intent_at") is None:
+        sb["stuck_cancel_intent_at"] = now_fn().strftime("%Y-%m-%dT%H:%M:%SZ")
+        _atomic_write_json(state_path, state)  # intent durable BEFORE the cancel
+    try:
+        client.messages.batches.cancel(sb["batch_id"])
+    except anthropic_mod.APIStatusError:
+        # Race / re-drive: the batch may already be canceling (a prior cancel —
+        # ours after a crash, or an out-of-band Console cancel) or ended. BOTH
+        # are accepted cancellation outcomes: the poll loop harvests at ended
+        # either way. Anything else re-raises (fail fast, no swallowed faults).
+        final = client.messages.batches.retrieve(sb["batch_id"])
+        if final.processing_status not in ("canceling", "ended"):
+            raise
+        logger.info(
+            "Cancel of %s raced with state %s; accepted as canceled",
+            sb["batch_id"],
+            final.processing_status,
+        )
+    sb["stuck_canceled_at"] = now_fn().strftime("%Y-%m-%dT%H:%M:%SZ")
+    _atomic_write_json(state_path, state)
 
 
 def _poll_one_sub_batch_step(
@@ -715,6 +810,12 @@ def _poll_one_sub_batch_step(
     sleep_fn: "Callable[[float], None] | None" = None,
 ) -> None:
     """Poll one not-yet-collected sub-batch once; harvest on end, raise on overdue.
+
+    Stuck-batch escape (#1019): AFTER the ended-harvest and overdue blocks (their
+    precedence is load-bearing), a sub-batch at ``request_counts.succeeded == 0``
+    for >= ``EPS_BATCH_STUCK_HOURS`` since ``submitted_at`` is canceled via
+    :func:`_cancel_stuck_sub_batch` (intent-first crash-safe ordering); the
+    enclosing poll loop then harvests it when the API flips canceling -> ended.
 
     Create-grace 404 (#995): a ``NotFoundError`` on the loop retrieve within
     ``BATCH_CREATE_404_GRACE_S`` of this sub-batch's persisted ``submitted_at``
@@ -765,6 +866,41 @@ def _poll_one_sub_batch_step(
             _harvest_sub_batch(acc, sb=sb, **harvest_kw)
             return
         raise BatchDeadlineExceeded(sb["batch_id"], sb["deadline"])
+    # Stuck-batch escape (#1019, incident #810): zero succeeded after the
+    # threshold -> persist escape INTENT, then cancel; partial results are
+    # harvested on a later iteration when the API flips canceling -> ended
+    # (docs-confirmed); canceled ids re-dispatch SYNC, keyed on the INTENT
+    # marker (which survives every crash ordering). Ordering is load-bearing:
+    # the ended-harvest and overdue blocks above run FIRST, so a finished
+    # batch is never touched and BatchDeadlineExceeded keeps precedence.
+    stuck_hours = batch_stuck_threshold_hours()
+    if (
+        stuck_hours is not None
+        and sb.get("stuck_cancel_intent_at") is None  # escape entered at most once
+        and counts is not None  # fail-safe: no counts, no verdict
+        and counts.succeeded == 0
+    ):
+        anchor = parse_batch_submitted_at(sb.get("submitted_at") or state.get("created_at"))
+        if anchor is not None:
+            elapsed_h = (now_fn() - anchor).total_seconds() / 3600.0
+            if elapsed_h >= stuck_hours:
+                logger.warning(
+                    "STUCK BATCH: %s at succeeded=0 after %.1fh (threshold %.1fh; "
+                    "processing=%s errored=%s) — canceling; unprocessed items will "
+                    "re-dispatch on the SYNC path (#810 escape)",
+                    sb["batch_id"],
+                    elapsed_h,
+                    stuck_hours,
+                    counts.processing,
+                    counts.errored,
+                )
+                _cancel_stuck_sub_batch(client, sb, state, state_path, now_fn)
+    # Escape-intent RESUME leg: intent persisted but cancel never confirmed
+    # (crash between the intent write and the cancel/confirm writes) ->
+    # re-drive the cancel. Bounded: the race guard accepts canceling/ended,
+    # so this converges in one step.
+    elif sb.get("stuck_cancel_intent_at") is not None and sb.get("stuck_canceled_at") is None:
+        _cancel_stuck_sub_batch(client, sb, state, state_path, now_fn)
 
 
 async def _poll_and_collect_sub_batches(
@@ -972,12 +1108,20 @@ async def _run_or_resume_retry(
     retry_partial_path = dispatch_dir / "results_retry_partial.json"
     items_map = {cid: (q, c, u) for cid, q, c, u in items}
     recomputed_ids = sorted(set(retry_candidates))
+    stuck_cancel_present = any(sb.get("stuck_cancel_intent_at") for sb in state["sub_batches"])
     if retry_state is None:
         retry_state = {
             "status": "pending",
             "custom_ids": recomputed_ids,
             "results_merged": False,
-            "routed_path": None,
+            # Stuck-cancel retries are PRE-PINNED to sync (#1019): re-batching a
+            # canceled remainder risks re-wedging (#810: sync cleared 39,512
+            # calls in 18 min). DELIBERATE breadth: any() pins the WHOLE retry
+            # set sync — including errored/expired ids from healthy sibling
+            # sub-batches in the same dispatch. Their discount loss is
+            # accepted: one retry, one route, deterministic on resume (no
+            # per-id route partitioning).
+            "routed_path": "sync" if stuck_cancel_present else None,
         }
         state["retry"] = retry_state
         _atomic_write_json(state_path, state)

--- a/src/explore_persona_space/llm/anthropic_client.py
+++ b/src/explore_persona_space/llm/anthropic_client.py
@@ -9,6 +9,7 @@ import copy
 import datetime as _dt
 import json
 import logging
+import os
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -58,15 +59,37 @@ class BatchDeadlineExceeded(RuntimeError):
     after one final harvest attempt fails to find the batch ended. Callers
     surface this as ``epm:failure v1`` ``failure_class: infra`` rather than
     hanging forever. The bound is wall-clock vs the API's own ``expires_at``
-    (= ``created_at + 24h``), the only reliable signal — per-request counts
-    stay 0 until the whole batch ends, so ``succeeded==0`` is NEVER a stuck
-    heuristic (the #658 misdiagnosis).
+    (= ``created_at + 24h``). Counts-based inference alone is not PROOF of a
+    wedge, but ``succeeded==0`` past ``EPS_BATCH_STUCK_HOURS`` (default 4h)
+    now triggers the bounded stuck-cancel escape in the judge poll loops
+    (#1019; incident #810: a 0/2001 batch wedged 16h — cancel + sync fallback
+    cleared 39,512 calls in 18 min). The deadline remains the hard outer bound.
     """
 
     def __init__(self, batch_id: str, deadline):
         super().__init__(f"batch {batch_id} not ended by deadline {deadline}")
         self.batch_id = batch_id
         self.deadline = deadline
+
+
+DEFAULT_BATCH_STUCK_HOURS = 4.0  # #1019 plan §11 row 1 (Source: #810 wedge + #658 G1 comment)
+
+
+def batch_stuck_threshold_hours() -> float | None:
+    """Resolve the stuck-batch cancel threshold from ``EPS_BATCH_STUCK_HOURS``.
+
+    Semantics (#1019 plan D5): unset or empty string -> ``DEFAULT_BATCH_STUCK_HOURS``
+    (4.0); a parseable float <= 0 -> ``None`` (stuck check DISABLED, restoring the
+    pure deadline-bounded behavior); a parseable float > 0 -> that threshold in
+    hours. A malformed value raises ``ValueError`` immediately (fail loud, never a
+    silent default). Read per poll step (never frozen at import) so long-lived
+    processes and tests see the live environment.
+    """
+    raw = os.environ.get("EPS_BATCH_STUCK_HOURS", "").strip()
+    if not raw:
+        return DEFAULT_BATCH_STUCK_HOURS
+    val = float(raw)  # ValueError propagates (fail loud, never a silent default)
+    return val if val > 0 else None
 
 
 def deadline_from_expires_at(expires_at, grace_min: int = 30) -> "_dt.datetime":

--- a/tests/test_batch_stuck_escape.py
+++ b/tests/test_batch_stuck_escape.py
@@ -1,0 +1,631 @@
+"""Tests for the stuck-batch cancel + sync fallback (#1019, incident #810).
+
+Covers the live router path (``judge_dispatch``): the escape predicate, the
+two-field escape protocol (``stuck_cancel_intent_at`` persisted BEFORE the
+external cancel; ``stuck_canceled_at`` confirm stamp after), the cancel race
+guard (a re-retrieved ``canceling``/``ended`` counts as accepted), the
+canceled-id -> sync-pinned retry flow, every crash-resume ordering, and the
+legacy ``batch_judge._submit_and_poll_batch`` per-chunk variant.
+
+Mock strategy mirrors ``tests/test_judge_dispatch.py``: scriptable client
+fakes, injected ``now_fn`` clocks, zero live API calls. NOTE the live path
+writes ``submitted_at`` with the REAL wall clock (``time.strftime``), so the
+live-path clocks are real-now + a fixed offset (a synthetic epoch would yield
+negative elapsed and never fire — the plan's safe-by-construction note); the
+legacy path anchors on the injected ``now_fn``, so it uses a synthetic T0.
+"""
+
+import contextlib
+import datetime as _dt
+import itertools
+import json
+import logging
+from types import SimpleNamespace
+
+import anthropic
+import pytest
+
+from explore_persona_space.eval.batch_judge import _submit_and_poll_batch
+from explore_persona_space.eval.judge_dispatch import (
+    _BatchCollector,
+    _load_collected_into,
+)
+from explore_persona_space.llm.anthropic_client import (
+    DEFAULT_BATCH_STUCK_HOURS,
+    BatchDeadlineExceeded,
+    batch_stuck_threshold_hours,
+)
+
+# Reuse the shared fakes / helpers — do NOT duplicate FakeSyncClient.
+from tests.test_judge_dispatch import JUDGE_TEXT, FakeSyncClient, _msg, dispatch, make_items
+
+SYNC_TEXT = '{"aligned": 42, "coherent": 88, "reasoning": "sync-retry"}'
+T0 = _dt.datetime(2026, 1, 1, 0, 0, 0, tzinfo=_dt.UTC)
+
+
+@pytest.fixture(autouse=True)
+def _clean_stuck_env(monkeypatch):
+    """Every test starts with EPS_BATCH_STUCK_HOURS UNSET (default 4.0h armed);
+    tests needing a different value setenv explicitly (plan §6)."""
+    monkeypatch.delenv("EPS_BATCH_STUCK_HOURS", raising=False)
+
+
+class _FakeAPIStatusError(anthropic.APIStatusError):
+    """Minimal APIStatusError stub — the SDK ctor requires an httpx response,
+    which the race-guard code never inspects (it only catches the type)."""
+
+    def __init__(self, msg: str = "batch already canceling/ended"):
+        Exception.__init__(self, msg)
+
+
+def _offset_clock(hours: float):
+    """now_fn = real wall clock + fixed offset (live path: submitted_at is real)."""
+    return lambda: _dt.datetime.now(_dt.UTC) + _dt.timedelta(hours=hours)
+
+
+def _step_clock(offsets_hours: list[float]):
+    """now_fn stepping real-now + offsets[i] per call (last value repeats)."""
+    base = _dt.datetime.now(_dt.UTC)
+    seq = iter(offsets_hours)
+    last = {"v": offsets_hours[-1]}
+
+    def _fn():
+        with contextlib.suppress(StopIteration):
+            last["v"] = next(seq)
+        return base + _dt.timedelta(hours=last["v"])
+
+    return _fn
+
+
+class StuckEscapeClient:
+    """Scriptable wedged-batch fake for the stuck-escape tests.
+
+    Per-batch behavior: batches matching ``wedged_if(requests)`` return
+    ``in_progress`` with ``request_counts.succeeded == succeeded_counts`` until
+    ``cancel`` is called (then walk ``post_cancel_statuses``, last repeating)
+    or until ``end_wedged_after`` retrieves; non-wedged batches end on the
+    first retrieve. ``cancel_effects`` is a FIFO of per-call effects (an
+    Exception instance to raise, or None for success); ``cancel`` marks the
+    batch canceled BEFORE raising (the server-side cancel took even when the
+    client-side call "crashed"). ``outcome_for`` maps cid -> result type at
+    ``results()`` (default succeeded).
+    """
+
+    def __init__(
+        self,
+        *,
+        judge_text_for=None,
+        outcome_for: dict[str, str] | None = None,
+        expires_at: "_dt.datetime | None | str" = "auto",
+        succeeded_counts: int = 0,
+        counts_none: bool = False,
+        wedged_if=None,
+        end_wedged_after: int | None = None,
+        cancel_effects: list | None = None,
+        post_cancel_statuses: tuple[str, ...] = ("canceling", "ended"),
+        on_cancel=None,
+    ):
+        self.judge_text_for = judge_text_for or (lambda cid: JUDGE_TEXT)
+        self.outcome_for = outcome_for or {}
+        if expires_at == "auto":
+            expires_at = _dt.datetime.now(_dt.UTC) + _dt.timedelta(hours=24)
+        self.expires_at = expires_at
+        self.succeeded_counts = succeeded_counts
+        self.counts_none = counts_none
+        self.wedged_if = wedged_if or (lambda _requests: True)
+        self.end_wedged_after = end_wedged_after
+        self.cancel_effects = list(cancel_effects or [])
+        self.post_cancel_statuses = post_cancel_statuses
+        self.on_cancel = on_cancel
+        self.submitted: dict[str, list[dict]] = {}
+        self.wedged: dict[str, bool] = {}
+        self.canceled: dict[str, bool] = {}
+        self.retrieves: dict[str, int] = {}
+        self.post_cancel_idx: dict[str, int] = {}
+        self.create_calls = 0
+        self.cancel_calls = 0
+
+        client = self
+
+        class _Batches:
+            def create(_s, requests):
+                client.create_calls += 1
+                bid = f"msgbatch_{client.create_calls:03d}"
+                client.submitted[bid] = list(requests)
+                client.wedged[bid] = client.wedged_if(list(requests))
+                client.canceled[bid] = False
+                client.retrieves[bid] = 0
+                client.post_cancel_idx[bid] = 0
+                return SimpleNamespace(id=bid, expires_at=client.expires_at)
+
+            def retrieve(_s, bid):
+                client.retrieves[bid] += 1
+                if client.canceled[bid]:
+                    statuses = client.post_cancel_statuses
+                    idx = min(client.post_cancel_idx[bid], len(statuses) - 1)
+                    client.post_cancel_idx[bid] += 1
+                    status = statuses[idx]
+                elif not client.wedged[bid] or (
+                    client.end_wedged_after is not None
+                    and client.retrieves[bid] > client.end_wedged_after
+                ):
+                    status = "ended"
+                else:
+                    status = "in_progress"
+                n = len(client.submitted[bid])
+                counts = (
+                    None
+                    if client.counts_none
+                    else SimpleNamespace(
+                        processing=n - client.succeeded_counts,
+                        succeeded=client.succeeded_counts,
+                        errored=0,
+                    )
+                )
+                return SimpleNamespace(
+                    processing_status=status,
+                    expires_at=client.expires_at,
+                    request_counts=counts,
+                )
+
+            def cancel(_s, bid):
+                client.cancel_calls += 1
+                if client.on_cancel is not None:
+                    client.on_cancel(bid)
+                client.canceled[bid] = True  # server-side cancel takes even on a client "crash"
+                if client.cancel_effects:
+                    effect = client.cancel_effects.pop(0)
+                    if effect is not None:
+                        raise effect
+
+            def results(_s, bid):
+                for req in client.submitted[bid]:
+                    cid = req["custom_id"]
+                    outcome = client.outcome_for.get(cid, "succeeded")
+                    if outcome == "succeeded":
+                        yield SimpleNamespace(
+                            custom_id=cid,
+                            result=SimpleNamespace(
+                                type="succeeded", message=_msg(client.judge_text_for(cid))
+                            ),
+                        )
+                    else:
+                        yield SimpleNamespace(
+                            custom_id=cid, result=SimpleNamespace(type=outcome, message=None)
+                        )
+
+        self.messages = SimpleNamespace(batches=_Batches())
+
+
+def _state(tmp_path) -> dict:
+    return json.loads((next(tmp_path.glob("dispatch_*")) / "state.json").read_text())
+
+
+# ── T1: env knob semantics ───────────────────────────────────────────────────
+
+
+def test_stuck_threshold_env_semantics(monkeypatch):
+    """Plan T1 (D5 semantics): unset/empty -> 4.0; float > 0 -> value; <= 0 ->
+    None (disabled); malformed -> ValueError (fail loud, never a silent default)."""
+    monkeypatch.delenv("EPS_BATCH_STUCK_HOURS", raising=False)
+    assert batch_stuck_threshold_hours() == DEFAULT_BATCH_STUCK_HOURS == 4.0
+    monkeypatch.setenv("EPS_BATCH_STUCK_HOURS", "")
+    assert batch_stuck_threshold_hours() == 4.0
+    monkeypatch.setenv("EPS_BATCH_STUCK_HOURS", "6.5")
+    assert batch_stuck_threshold_hours() == 6.5
+    monkeypatch.setenv("EPS_BATCH_STUCK_HOURS", "0")
+    assert batch_stuck_threshold_hours() is None
+    monkeypatch.setenv("EPS_BATCH_STUCK_HOURS", "-1")
+    assert batch_stuck_threshold_hours() is None
+    monkeypatch.setenv("EPS_BATCH_STUCK_HOURS", "abc")
+    with pytest.raises(ValueError):
+        batch_stuck_threshold_hours()
+
+
+# ── T2-T5: the predicate (fire / no-fire) ────────────────────────────────────
+
+
+def test_stuck_cancel_fires_after_threshold(tmp_path):
+    """Plan T2: in_progress at succeeded=0, elapsed 5h > 4h -> exactly one
+    cancel; the fake's cancel hook asserts the INTENT marker is ALREADY on
+    disk when the cancel call arrives (intent-before-side-effect ordering),
+    and BOTH stuck fields are persisted afterwards."""
+    hook_ran = {"n": 0}
+
+    def _assert_intent_on_disk(_bid):
+        hook_ran["n"] += 1
+        sb = _state(tmp_path)["sub_batches"][0]
+        assert sb.get("stuck_cancel_intent_at"), "intent must be durable BEFORE the cancel"
+        assert sb.get("stuck_canceled_at") is None, "confirm stamp must come AFTER the cancel"
+
+    client = StuckEscapeClient(on_cancel=_assert_intent_on_disk)  # all-succeeded results
+    result = dispatch(
+        make_items(3),
+        threshold_base=1,
+        checkpoint_dir=tmp_path,
+        batch_client=client,
+        now_fn=_offset_clock(5.0),
+    )
+    assert hook_ran["n"] == 1
+    assert client.cancel_calls == 1
+    sb = _state(tmp_path)["sub_batches"][0]
+    assert sb["stuck_cancel_intent_at"] is not None
+    assert sb["stuck_canceled_at"] is not None
+    assert all(result[cid]["aligned"] == 90 for cid, _, _, _ in make_items(3))
+
+
+def test_no_fire_with_progress(tmp_path):
+    """Plan T3: succeeded=3 past the threshold -> progress is not a wedge, no cancel."""
+    client = StuckEscapeClient(succeeded_counts=3, end_wedged_after=3)
+    result = dispatch(
+        make_items(3),
+        threshold_base=1,
+        checkpoint_dir=tmp_path,
+        batch_client=client,
+        now_fn=_offset_clock(5.0),
+    )
+    assert client.cancel_calls == 0
+    assert len(result) == 3
+
+
+def test_no_fire_before_threshold(tmp_path):
+    """Plan T4: elapsed ~3h < 4h threshold -> no cancel."""
+    client = StuckEscapeClient(end_wedged_after=3)
+    result = dispatch(
+        make_items(3),
+        threshold_base=1,
+        checkpoint_dir=tmp_path,
+        batch_client=client,
+        now_fn=_offset_clock(3.0),
+    )
+    assert client.cancel_calls == 0
+    assert len(result) == 3
+
+
+def test_no_fire_counts_absent(tmp_path):
+    """Plan T5: request_counts=None past the threshold -> fail-safe, no verdict,
+    no cancel (also proves the guard that keeps the existing StuckBatchClient
+    deadline tests — which return counts=None — untouched)."""
+    client = StuckEscapeClient(counts_none=True, end_wedged_after=2)
+    result = dispatch(
+        make_items(3),
+        threshold_base=1,
+        checkpoint_dir=tmp_path,
+        batch_client=client,
+        now_fn=_offset_clock(5.0),
+    )
+    assert client.cancel_calls == 0
+    assert len(result) == 3
+
+
+# ── T6-T7: harvest + sync-pinned retry ───────────────────────────────────────
+
+
+def test_idempotent_no_recancel_then_harvest(tmp_path, caplog):
+    """Plan T6: both stuck fields set -> no second cancel across the later poll
+    iterations (canceling -> ended); canceled ids persisted in
+    results_<bid>.json["canceled_ids"]; the stuck-harvest telemetry line
+    (n_succeeded vs n_canceled — the frozen-counts fingerprint) is logged."""
+    outcome = {"item_001": "canceled", "item_002": "canceled"}
+    client = StuckEscapeClient(outcome_for=outcome)
+    with caplog.at_level(logging.WARNING):
+        result = dispatch(
+            make_items(3),
+            threshold_base=1,
+            checkpoint_dir=tmp_path,
+            batch_client=client,
+            sync_client=FakeSyncClient(judge_text=SYNC_TEXT),
+            now_fn=_offset_clock(5.0),
+        )
+    assert client.cancel_calls == 1  # entered-once guard: no re-cancel at canceling/ended
+    dispatch_dir = next(tmp_path.glob("dispatch_*"))
+    payload = json.loads((dispatch_dir / "results_msgbatch_001.json").read_text())
+    assert payload["canceled_ids"] == ["item_001", "item_002"]
+    assert "n_succeeded=1 n_canceled=2" in caplog.text  # telemetry (frozen-counts fingerprint)
+    assert "STUCK BATCH" in caplog.text
+    assert result["item_000"]["aligned"] == 90
+    assert result["item_001"]["aligned"] == 42 and result["item_002"]["aligned"] == 42
+
+
+def test_end_to_end_stuck_cancel_sync_retry(tmp_path):
+    """Plan T7: through the full dispatch — partial succeeded + rest canceled
+    after the stuck cancel -> the retry runs PRE-PINNED to sync
+    (state.retry.routed_path == "sync"), canceled items' final scores come
+    from the sync retry, succeeded partials are preserved, and ZERO
+    batches.create calls happen in the retry."""
+    outcome = {"item_001": "canceled", "item_002": "canceled"}
+    client = StuckEscapeClient(outcome_for=outcome)
+    sync_client = FakeSyncClient(judge_text=SYNC_TEXT)
+    result = dispatch(
+        make_items(3),
+        threshold_base=1,
+        checkpoint_dir=tmp_path,
+        batch_client=client,
+        sync_client=sync_client,
+        now_fn=_offset_clock(5.0),
+    )
+    assert client.create_calls == 1  # ZERO creates in the retry (sync-pinned)
+    state = _state(tmp_path)
+    assert state["retry"]["routed_path"] == "sync"
+    assert state["retry"]["custom_ids"] == ["item_001", "item_002"]
+    assert state["retry"]["status"] == "done" and state["retry"]["results_merged"] is True
+    assert len(sync_client.calls) == 2  # exactly the canceled remainder
+    assert result["item_000"]["aligned"] == 90  # batch partial preserved
+    assert result["item_001"]["aligned"] == 42 and result["item_002"]["aligned"] == 42
+
+
+# ── T8-T9, T12: crash / race orderings ───────────────────────────────────────
+
+
+def test_crash_resume_after_cancel_before_harvest(tmp_path):
+    """Plan T8 (Must-Fix #2 pin): crash injected post-cancel (before the
+    confirm stamp); resume with the batch still ``canceling``: the resume leg
+    re-drives the cancel, the race guard ACCEPTS ``canceling`` (no raise, no
+    crash-loop), the confirm stamp is persisted, harvest + sync retry follow;
+    and the retry-candidate mismatch guard does NOT fire across a second
+    resume (recompute reproducibility)."""
+    outcome = {f"item_{i:03d}": "canceled" for i in range(3)}
+    client = StuckEscapeClient(
+        outcome_for=outcome,
+        cancel_effects=[KeyboardInterrupt("simulated crash post-cancel"), _FakeAPIStatusError()],
+        post_cancel_statuses=("canceling", "canceling", "ended"),
+    )
+    with pytest.raises(KeyboardInterrupt):
+        dispatch(
+            make_items(3),
+            threshold_base=1,
+            checkpoint_dir=tmp_path,
+            batch_client=client,
+            sync_client=FakeSyncClient(judge_text=SYNC_TEXT),
+            now_fn=_offset_clock(5.0),
+        )
+    sb = _state(tmp_path)["sub_batches"][0]
+    assert sb["stuck_cancel_intent_at"] is not None  # intent durable pre-crash
+    assert sb.get("stuck_canceled_at") is None  # confirm never landed
+    assert client.cancel_calls == 1
+
+    # Resume: batch reads "canceling" -> the resume leg re-drives the cancel;
+    # the race guard accepts the re-retrieved "canceling" (NO re-raise).
+    sync_c2 = FakeSyncClient(judge_text=SYNC_TEXT)
+    result = dispatch(
+        make_items(3),
+        threshold_base=1,
+        checkpoint_dir=tmp_path,
+        batch_client=client,
+        sync_client=sync_c2,
+        now_fn=_offset_clock(5.0),
+    )
+    assert client.cancel_calls == 2  # re-driven once on resume
+    sb = _state(tmp_path)["sub_batches"][0]
+    assert sb["stuck_canceled_at"] is not None  # confirm stamp persisted by the re-drive
+    state = _state(tmp_path)
+    assert state["retry"]["routed_path"] == "sync"
+    assert all(result[f"item_{i:03d}"]["aligned"] == 42 for i in range(3))
+
+    # Second resume across the completed-but-unmerged window: the recomputed
+    # retry set (persisted canceled_ids + persisted intent flags) reproduces
+    # the recorded one -> NO "Retry candidate mismatch", zero API calls.
+    state_path = next(tmp_path.glob("dispatch_*")) / "state.json"
+    state = json.loads(state_path.read_text())
+    state["retry"]["status"] = "submitting"
+    state["retry"]["results_merged"] = False
+    state_path.write_text(json.dumps(state))
+    sync_c3 = FakeSyncClient(judge_text=SYNC_TEXT)
+    result2 = dispatch(
+        make_items(3),
+        threshold_base=1,
+        checkpoint_dir=tmp_path,
+        batch_client=client,
+        sync_client=sync_c3,
+        now_fn=_offset_clock(5.0),
+    )
+    assert sync_c3.calls == []  # merge-only resume
+    assert result2 == result
+
+
+def test_cancel_races_with_ended(tmp_path):
+    """Plan T9: ``cancel`` raises APIStatusError and the re-retrieve shows
+    ``ended`` -> accepted as canceled, confirm stamp persisted, normal
+    harvest, no crash."""
+    client = StuckEscapeClient(
+        cancel_effects=[_FakeAPIStatusError()],
+        post_cancel_statuses=("ended",),
+    )  # all-succeeded results: harvest completes with no retry needed
+    result = dispatch(
+        make_items(3),
+        threshold_base=1,
+        checkpoint_dir=tmp_path,
+        batch_client=client,
+        now_fn=_offset_clock(5.0),
+    )
+    assert client.cancel_calls == 1
+    sb = _state(tmp_path)["sub_batches"][0]
+    assert sb["stuck_cancel_intent_at"] is not None
+    assert sb["stuck_canceled_at"] is not None
+    assert all(r["aligned"] == 90 for r in result.values())
+
+
+def test_crash_after_cancel_resume_at_ended_still_sync_retries(tmp_path):
+    """Plan T12 (Must-Fix #1 pin): crash after ``cancel()`` took server-side but
+    BEFORE the confirm stamp; the resume's FIRST retrieve already reads
+    ``ended`` — the normal ended-harvest path runs before any stuck check —
+    yet the canceled ids STILL enter retry_candidates via the INTENT marker
+    and the retry is sync-pinned. (The round-1 single-post-cancel-marker
+    design lost the fallback in exactly this ordering.)"""
+    outcome = {f"item_{i:03d}": "canceled" for i in range(3)}
+    client = StuckEscapeClient(
+        outcome_for=outcome,
+        cancel_effects=[KeyboardInterrupt("simulated crash post-cancel")],
+        post_cancel_statuses=("ended",),
+    )
+    with pytest.raises(KeyboardInterrupt):
+        dispatch(
+            make_items(3),
+            threshold_base=1,
+            checkpoint_dir=tmp_path,
+            batch_client=client,
+            sync_client=FakeSyncClient(judge_text=SYNC_TEXT),
+            now_fn=_offset_clock(5.0),
+        )
+    sync_c2 = FakeSyncClient(judge_text=SYNC_TEXT)
+    result = dispatch(
+        make_items(3),
+        threshold_base=1,
+        checkpoint_dir=tmp_path,
+        batch_client=client,
+        sync_client=sync_c2,
+        now_fn=_offset_clock(5.0),
+    )
+    assert client.cancel_calls == 1  # never re-driven: ended-harvest ran first
+    assert client.create_calls == 1  # zero creates in the retry
+    sb = _state(tmp_path)["sub_batches"][0]
+    assert sb["stuck_cancel_intent_at"] is not None
+    assert sb.get("stuck_canceled_at") is None  # legitimately unset — observability only
+    state = _state(tmp_path)
+    assert state["retry"]["routed_path"] == "sync"
+    assert all(result[f"item_{i:03d}"]["aligned"] == 42 for i in range(3))
+    assert len(sync_c2.calls) == 3
+
+
+# ── T10, T14: disable knob + overdue precedence ──────────────────────────────
+
+
+def test_escape_disabled_env_zero(tmp_path, monkeypatch):
+    """Plan T10: EPS_BATCH_STUCK_HOURS=0 disables the escape — a wedged batch
+    sits in the stuck-eligible window with NO cancel, then hits the deadline
+    and raises BatchDeadlineExceeded exactly as pre-change (rollback knob)."""
+    monkeypatch.setenv("EPS_BATCH_STUCK_HOURS", "0")
+    client = StuckEscapeClient()  # wedged forever; expires_at = now + 24h
+    # 3 poll iterations inside the stuck-eligible window (+5h), then past the
+    # +24.5h deadline -> overdue raise. One now_fn tick per iteration.
+    now_fn = _step_clock([5.0, 5.0, 5.0, 25.0])
+    with pytest.raises(BatchDeadlineExceeded):
+        dispatch(
+            make_items(3),
+            threshold_base=1,
+            checkpoint_dir=tmp_path,
+            batch_client=client,
+            now_fn=now_fn,
+        )
+    assert client.cancel_calls == 0  # disabled: never canceled despite 5h at succeeded=0
+
+
+def test_overdue_precedence_over_stuck(tmp_path):
+    """Plan T14: in_progress, succeeded=0, elapsed past BOTH the stuck
+    threshold AND the persisted deadline -> BatchDeadlineExceeded, ZERO cancel
+    calls (the overdue block runs first; a reordering that puts the stuck
+    check first fails this test)."""
+    client = StuckEscapeClient()  # wedged; expires_at = now + 24h -> deadline +24.5h
+    with pytest.raises(BatchDeadlineExceeded):
+        dispatch(
+            make_items(3),
+            threshold_base=1,
+            checkpoint_dir=tmp_path,
+            batch_client=client,
+            now_fn=_offset_clock(30.0),  # past threshold (4h) AND deadline (24.5h)
+        )
+    assert client.cancel_calls == 0
+
+
+# ── T13, T15: the retry gate ─────────────────────────────────────────────────
+
+
+def test_out_of_band_canceled_ids_never_retry(tmp_path):
+    """Plan T13 (Must-Fix #3 pin, gate-level negative): a harvested sub-batch
+    with non-empty canceled_ids and NO stuck_cancel_intent_at -> the ids never
+    enter acc.retry_candidates (the #663 out-of-band-cancel no-retry
+    contract). Dropping the D3 gate makes this fail while the rest stay green."""
+    payload = {
+        "scores": {"x": {"error": True}, "y": {"error": True}},
+        "retriable_ids": [],
+        "expired_ids": [],
+        "quarantined_ids": [],
+        "canceled_ids": ["x", "y"],
+    }
+    (tmp_path / "results_b1.json").write_text(json.dumps(payload))
+    acc = _BatchCollector()
+    _load_collected_into(acc, tmp_path, {"batch_id": "b1"})  # NO intent marker
+    assert acc.retry_candidates == []  # out-of-band cancel: error dict, never retried
+    assert set(acc.scores) == {"x", "y"}
+
+    # Positive control: the SAME payload under a stuck-cancel intent DOES retry.
+    acc2 = _BatchCollector()
+    sb_stuck = {"batch_id": "b1", "stuck_cancel_intent_at": "2026-01-01T00:00:00Z"}
+    _load_collected_into(acc2, tmp_path, sb_stuck)
+    assert acc2.retry_candidates == ["x", "y"]
+
+    # Pre-existing results files (no canceled_ids key) stay readable.
+    (tmp_path / "results_b2.json").write_text(
+        json.dumps({"scores": {}, "retriable_ids": [], "expired_ids": []})
+    )
+    acc3 = _BatchCollector()
+    _load_collected_into(acc3, tmp_path, sb_stuck | {"batch_id": "b2"})
+    assert acc3.retry_candidates == []
+
+
+def test_mixed_dispatch_only_stuck_ids_retry(tmp_path):
+    """Plan T15: one stuck-canceled sub-batch (intent set) + one healthy
+    sub-batch carrying an out-of-band canceled row (no intent) -> the retry
+    set contains EXACTLY the former's canceled ids; the out-of-band row keeps
+    its error dict."""
+    items = make_items(4)  # sub_batch_size=2 -> [item_000, item_001], [item_002, item_003]
+    outcome = {
+        "item_000": "canceled",
+        "item_001": "canceled",
+        "item_002": "succeeded",
+        "item_003": "canceled",  # out-of-band canceled row in the HEALTHY sub-batch
+    }
+    client = StuckEscapeClient(
+        outcome_for=outcome,
+        wedged_if=lambda reqs: any(r["custom_id"] == "item_000" for r in reqs),
+    )
+    sync_client = FakeSyncClient(judge_text=SYNC_TEXT)
+    result = dispatch(
+        items,
+        threshold_base=1,
+        sub_batch_size=2,
+        checkpoint_dir=tmp_path,
+        batch_client=client,
+        sync_client=sync_client,
+        now_fn=_offset_clock(5.0),
+    )
+    assert client.cancel_calls == 1  # only the wedged sub-batch was canceled
+    state = _state(tmp_path)
+    assert state["retry"]["custom_ids"] == ["item_000", "item_001"]
+    assert state["retry"]["routed_path"] == "sync"
+    assert result["item_000"]["aligned"] == 42 and result["item_001"]["aligned"] == 42
+    assert result["item_002"]["aligned"] == 90
+    assert result["item_003"]["error"] is True  # out-of-band cancel: surfaced, never retried
+    assert "canceled" in result["item_003"]["reasoning"]
+
+
+# ── T11: legacy path ─────────────────────────────────────────────────────────
+
+
+def test_legacy_submit_poll_stuck_cancel(caplog):
+    """Plan T11 (D6): _submit_and_poll_batch with a wedged-then-ended-after-
+    cancel fake -> exactly one cancel, the run RETURNS (no 24h park) with
+    error-dict rows for the canceled ids, and the loud warning is logged."""
+    outcome = {"c0": "canceled", "c1": "canceled"}
+    client = StuckEscapeClient(
+        outcome_for=outcome,
+        expires_at=T0 + _dt.timedelta(hours=24),  # legacy path anchors on now_fn -> synthetic T0
+    )
+    reqs = [{"custom_id": f"c{i}", "params": {}} for i in range(2)]
+    # created_at consumes the leading T0; every later tick sits 5h past it —
+    # inside the deadline (+24.5h), past the stuck threshold (4h).
+    clock = iter(itertools.chain([T0], itertools.repeat(T0 + _dt.timedelta(hours=5))))
+    with caplog.at_level(logging.WARNING):
+        result = _submit_and_poll_batch(
+            reqs,
+            client,
+            poll_interval=0.0,
+            now_fn=lambda: next(clock),
+            sleep_fn=lambda _x: None,
+        )
+    assert client.cancel_calls == 1
+    assert "STUCK BATCH (legacy path)" in caplog.text
+    assert set(result) == {"c0", "c1"}
+    for cid in ("c0", "c1"):
+        assert result[cid]["error"] is True
+        assert "canceled" in result[cid]["reasoning"]

--- a/tests/test_batch_stuck_escape.py
+++ b/tests/test_batch_stuck_escape.py
@@ -4,8 +4,11 @@ Covers the live router path (``judge_dispatch``): the escape predicate, the
 two-field escape protocol (``stuck_cancel_intent_at`` persisted BEFORE the
 external cancel; ``stuck_canceled_at`` confirm stamp after), the cancel race
 guard (a re-retrieved ``canceling``/``ended`` counts as accepted), the
-canceled-id -> sync-pinned retry flow, every crash-resume ordering, and the
-legacy ``batch_judge._submit_and_poll_batch`` per-chunk variant.
+canceled-id -> sync-pinned retry flow, every crash-resume ordering, the
+round-2 out-of-band guard (a batch already ``canceling`` with no persisted
+intent is NEVER adopted by the fresh-entry escape — no intent stamp, no
+cancel, no retry; both paths), and the legacy
+``batch_judge._submit_and_poll_batch`` per-chunk variant.
 
 Mock strategy mirrors ``tests/test_judge_dispatch.py``: scriptable client
 fakes, injected ``now_fn`` clocks, zero live API calls. NOTE the live path
@@ -84,11 +87,14 @@ class StuckEscapeClient:
     ``in_progress`` with ``request_counts.succeeded == succeeded_counts`` until
     ``cancel`` is called (then walk ``post_cancel_statuses``, last repeating)
     or until ``end_wedged_after`` retrieves; non-wedged batches end on the
-    first retrieve. ``cancel_effects`` is a FIFO of per-call effects (an
-    Exception instance to raise, or None for success); ``cancel`` marks the
-    batch canceled BEFORE raising (the server-side cancel took even when the
-    client-side call "crashed"). ``outcome_for`` maps cid -> result type at
-    ``results()`` (default succeeded).
+    first retrieve. ``precancel_statuses`` (when set) scripts the WEDGED
+    batch's status sequence BEFORE any cancel (last repeating) — used to model
+    an out-of-band Console cancel, where the batch reads ``canceling`` without
+    our escape ever firing. ``cancel_effects`` is a FIFO of per-call effects
+    (an Exception instance to raise, or None for success); ``cancel`` marks
+    the batch canceled BEFORE raising (the server-side cancel took even when
+    the client-side call "crashed"). ``outcome_for`` maps cid -> result type
+    at ``results()`` (default succeeded).
     """
 
     def __init__(
@@ -103,6 +109,7 @@ class StuckEscapeClient:
         end_wedged_after: int | None = None,
         cancel_effects: list | None = None,
         post_cancel_statuses: tuple[str, ...] = ("canceling", "ended"),
+        precancel_statuses: tuple[str, ...] | None = None,
         on_cancel=None,
     ):
         self.judge_text_for = judge_text_for or (lambda cid: JUDGE_TEXT)
@@ -116,12 +123,14 @@ class StuckEscapeClient:
         self.end_wedged_after = end_wedged_after
         self.cancel_effects = list(cancel_effects or [])
         self.post_cancel_statuses = post_cancel_statuses
+        self.precancel_statuses = precancel_statuses
         self.on_cancel = on_cancel
         self.submitted: dict[str, list[dict]] = {}
         self.wedged: dict[str, bool] = {}
         self.canceled: dict[str, bool] = {}
         self.retrieves: dict[str, int] = {}
         self.post_cancel_idx: dict[str, int] = {}
+        self.precancel_idx: dict[str, int] = {}
         self.create_calls = 0
         self.cancel_calls = 0
 
@@ -136,6 +145,7 @@ class StuckEscapeClient:
                 client.canceled[bid] = False
                 client.retrieves[bid] = 0
                 client.post_cancel_idx[bid] = 0
+                client.precancel_idx[bid] = 0
                 return SimpleNamespace(id=bid, expires_at=client.expires_at)
 
             def retrieve(_s, bid):
@@ -144,6 +154,13 @@ class StuckEscapeClient:
                     statuses = client.post_cancel_statuses
                     idx = min(client.post_cancel_idx[bid], len(statuses) - 1)
                     client.post_cancel_idx[bid] += 1
+                    status = statuses[idx]
+                elif client.precancel_statuses is not None and client.wedged[bid]:
+                    # Out-of-band cancel model: the wedged batch's status walks
+                    # this script (last repeating) without any cancel from us.
+                    statuses = client.precancel_statuses
+                    idx = min(client.precancel_idx[bid], len(statuses) - 1)
+                    client.precancel_idx[bid] += 1
                     status = statuses[idx]
                 elif not client.wedged[bid] or (
                     client.end_wedged_after is not None
@@ -325,6 +342,25 @@ def test_idempotent_no_recancel_then_harvest(tmp_path, caplog):
     assert "STUCK BATCH" in caplog.text
     assert result["item_000"]["aligned"] == 90
     assert result["item_001"]["aligned"] == 42 and result["item_002"]["aligned"] == 42
+
+
+def test_stuck_harvest_telemetry_counts_only_true_succeeded(tmp_path, caplog):
+    """Round-1 Minor (a) pin: an unknown-rtype row (error dict, member of NO
+    id list) is NOT counted as succeeded by the stuck-harvest frozen-counts
+    telemetry — the pre-fix plain subtraction reported n_succeeded=2 here
+    (1 true succeeded + 1 unknown)."""
+    outcome = {"item_001": "canceled", "item_002": "weird_rtype"}
+    client = StuckEscapeClient(outcome_for=outcome)
+    with caplog.at_level(logging.WARNING):
+        dispatch(
+            make_items(3),
+            threshold_base=1,
+            checkpoint_dir=tmp_path,
+            batch_client=client,
+            sync_client=FakeSyncClient(judge_text=SYNC_TEXT),
+            now_fn=_offset_clock(5.0),
+        )
+    assert "n_succeeded=1 n_canceled=1" in caplog.text
 
 
 def test_end_to_end_stuck_cancel_sync_retry(tmp_path):
@@ -599,6 +635,44 @@ def test_mixed_dispatch_only_stuck_ids_retry(tmp_path):
     assert "canceled" in result["item_003"]["reasoning"]
 
 
+# ── Round 2: out-of-band ``canceling`` is never adopted (fresh-entry guard) ──
+
+
+def test_out_of_band_canceling_not_adopted_fresh_entry(tmp_path):
+    """Round-2 blocker regression (concern ``out-of-band-canceling-retried``):
+    a batch an operator ALREADY canceled out-of-band — the first retrieve
+    reads ``canceling`` — at succeeded=0 past the threshold with NO intent
+    marker must NOT be adopted by the fresh-entry escape: no intent stamp, no
+    cancel call from us, no retry state, no sync calls; when the batch later
+    flips ``ended`` with canceled results, the rows remain error dicts (the
+    #663 out-of-band no-retry contract). Pre-guard (no ``in_progress``
+    conjunct) the escape adopted this batch: it stamped intent, re-canceled,
+    and sync-retried the operator-canceled ids."""
+    outcome = {f"item_{i:03d}": "canceled" for i in range(3)}
+    client = StuckEscapeClient(
+        outcome_for=outcome,
+        precancel_statuses=("canceling", "canceling", "ended"),
+    )
+    sync_client = FakeSyncClient(judge_text=SYNC_TEXT)
+    result = dispatch(
+        make_items(3),
+        threshold_base=1,
+        checkpoint_dir=tmp_path,
+        batch_client=client,
+        sync_client=sync_client,
+        now_fn=_offset_clock(5.0),  # past the 4h threshold: only the status guard blocks
+    )
+    assert client.cancel_calls == 0  # we never cancel an already-canceling batch
+    sb = _state(tmp_path)["sub_batches"][0]
+    assert sb.get("stuck_cancel_intent_at") is None  # never adopted by the escape
+    assert sb.get("stuck_canceled_at") is None
+    assert _state(tmp_path).get("retry") is None  # no retry state ever created
+    assert sync_client.calls == []  # zero sync re-dispatch of operator-canceled ids
+    for i in range(3):
+        assert result[f"item_{i:03d}"]["error"] is True
+        assert "canceled" in result[f"item_{i:03d}"]["reasoning"]
+
+
 # ── T11: legacy path ─────────────────────────────────────────────────────────
 
 
@@ -626,6 +700,32 @@ def test_legacy_submit_poll_stuck_cancel(caplog):
     assert client.cancel_calls == 1
     assert "STUCK BATCH (legacy path)" in caplog.text
     assert set(result) == {"c0", "c1"}
+    for cid in ("c0", "c1"):
+        assert result[cid]["error"] is True
+        assert "canceled" in result[cid]["reasoning"]
+
+
+def test_legacy_out_of_band_canceling_no_duplicate_cancel():
+    """Legacy-path sibling of the round-2 fresh-entry guard: a chunk already
+    ``canceling`` (out-of-band cancel) at succeeded=0 past the threshold gets
+    NO duplicate cancel from us; the loop polls it to ``ended`` and canceled
+    rows surface as error dicts, exactly as any other cancel."""
+    outcome = {"c0": "canceled", "c1": "canceled"}
+    client = StuckEscapeClient(
+        outcome_for=outcome,
+        expires_at=T0 + _dt.timedelta(hours=24),
+        precancel_statuses=("canceling", "canceling", "ended"),
+    )
+    reqs = [{"custom_id": f"c{i}", "params": {}} for i in range(2)]
+    clock = iter(itertools.chain([T0], itertools.repeat(T0 + _dt.timedelta(hours=5))))
+    result = _submit_and_poll_batch(
+        reqs,
+        client,
+        poll_interval=0.0,
+        now_fn=lambda: next(clock),
+        sleep_fn=lambda _x: None,
+    )
+    assert client.cancel_calls == 0  # already canceling: never a duplicate external cancel
     for cid in ("c0", "c1"):
         assert result[cid]["error"] is True
         assert "canceled" in result[cid]["reasoning"]

--- a/tests/test_issue663_batch_hardening.py
+++ b/tests/test_issue663_batch_hardening.py
@@ -314,30 +314,30 @@ def _one_result_client(result_obj):
 
 def test_collect_succeeded():
     client = _one_result_client(_succeeded("a"))
-    scores, retriable, expired, quarantined = _collect_batch_results(
+    scores, retriable, expired, quarantined, canceled = _collect_batch_results(
         client, "b", _default_error_dict
     )
     assert scores["a"] == {"aligned": 90, "coherent": 95, "reasoning": "ok"}
-    assert retriable == [] and expired == [] and quarantined == []
+    assert retriable == [] and expired == [] and quarantined == [] and canceled == []
 
 
 def test_collect_invalid_request_quarantined():
     client = _one_result_client(_errored("a", "invalid_request_error"))
-    scores, retriable, expired, quarantined = _collect_batch_results(
+    scores, retriable, expired, quarantined, canceled = _collect_batch_results(
         client, "b", _default_error_dict
     )
     assert quarantined == ["a"]
-    assert retriable == [] and expired == []
+    assert retriable == [] and expired == [] and canceled == []
     assert scores["a"]["error"] is True
 
 
 def test_collect_server_error_retriable():
     client = _one_result_client(_errored("a", "api_error"))
-    scores, retriable, expired, quarantined = _collect_batch_results(
+    scores, retriable, expired, quarantined, canceled = _collect_batch_results(
         client, "b", _default_error_dict
     )
     assert retriable == ["a"]
-    assert quarantined == [] and expired == []
+    assert quarantined == [] and expired == [] and canceled == []
     assert scores["a"]["error"] is True
 
 
@@ -347,24 +347,25 @@ def test_collect_expired_and_canceled():
         yield _terminal("cxl", "canceled")
 
     client = _ns(messages=_ns(batches=_ns(results=_results)))
-    scores, retriable, expired, quarantined = _collect_batch_results(
+    scores, retriable, expired, quarantined, canceled = _collect_batch_results(
         client, "b", _default_error_dict
     )
     assert expired == ["exp"]  # retriable on resume
     assert retriable == [] and quarantined == []
+    assert canceled == ["cxl"]  # #1019: its own list; retry gated on stuck intent
     assert "cxl" not in expired and "cxl" not in retriable and "cxl" not in quarantined
-    assert scores["cxl"]["error"] is True  # surfaced, never retried
+    assert scores["cxl"]["error"] is True  # surfaced; retried only after a stuck cancel
 
 
 def test_collect_errored_missing_error_shape_fails_open():
     """An errored row with NO nested .error (getattr None) routes to retriable,
     the conservative default that never silently quarantines."""
     client = _one_result_client(_errored("a", None))
-    scores, retriable, expired, quarantined = _collect_batch_results(
+    scores, retriable, expired, quarantined, canceled = _collect_batch_results(
         client, "b", _default_error_dict
     )
     assert retriable == ["a"]
-    assert quarantined == [] and expired == []
+    assert quarantined == [] and expired == [] and canceled == []
     assert scores["a"]["error"] is True
 
 

--- a/tests/test_judge_dispatch.py
+++ b/tests/test_judge_dispatch.py
@@ -300,7 +300,7 @@ def test_chunk_at_byte_limit():
     assert sum(len(c) for c in chunks) == 3
 
 
-# ── #663 Test 7: _collect_batch_results 4-tuple two-level split ──────────────
+# ── #663 Test 7: _collect_batch_results 5-tuple two-level split ──────────────
 
 
 def _collect_client(outcomes: dict[str, str], *, error_types: dict[str, str] | None = None):
@@ -338,13 +338,14 @@ def _collect_client(outcomes: dict[str, str], *, error_types: dict[str, str] | N
     return SimpleNamespace(messages=SimpleNamespace(batches=SimpleNamespace(results=_results)))
 
 
-def test_collect_batch_results_four_tuple_split():
-    """_collect_batch_results returns (scores, retriable, expired, quarantined).
+def test_collect_batch_results_five_tuple_split():
+    """_collect_batch_results returns (scores, retriable, expired, quarantined, canceled).
 
-    (#663 §6 Test 7 regression — the 3-tuple -> 4-tuple shape change.) The
-    invalid_request_error is quarantined (NOT retriable); a server error is
-    retriable; expired is its own list; canceled surfaces as an error dict with
-    no retry membership.
+    (#663 §6 Test 7 regression — the 3-tuple -> 4-tuple -> 5-tuple (#1019) shape
+    change.) The invalid_request_error is quarantined (NOT retriable); a server
+    error is retriable; expired is its own list; canceled surfaces as an error
+    dict, lands in the new ``canceled`` list, and (out-of-band) never joins a
+    retry list — the stuck-cancel retry gate lives in ``_load_collected_into``.
     """
     from explore_persona_space.eval.judge_dispatch import _default_error_dict
 
@@ -357,12 +358,13 @@ def test_collect_batch_results_four_tuple_split():
     }
     error_types = {"bad_request": "invalid_request_error", "server_err": "api_error"}
     client = _collect_client(outcomes, error_types=error_types)
-    scores, retriable, expired, quarantined = _collect_batch_results(
+    scores, retriable, expired, quarantined, canceled = _collect_batch_results(
         client, "msgbatch_x", _default_error_dict
     )
     assert quarantined == ["bad_request"]
     assert retriable == ["server_err"]
     assert expired == ["exp"]
+    assert canceled == ["cxl"]
     assert scores["ok"] == {"aligned": 90, "coherent": 95, "reasoning": "ok"}
     # All terminal states present in scores (overwritten if a retry succeeds).
     assert set(scores) == {"ok", "bad_request", "server_err", "exp", "cxl"}


### PR DESCRIPTION
## Summary
- Adds a stuck-batch escape to the Anthropic batch judge poll paths: a sub-batch at zero succeeded past `EPS_BATCH_STUCK_HOURS` (default 4h; `<=0` disables) on an `in_progress` batch is canceled (escape-intent marker persisted BEFORE the cancel; race guard accepts `canceling`/`ended`), partials harvested, and unprocessed ids re-dispatched on the sync path via the existing retry machinery (route pre-pinned sync). Out-of-band Console cancels keep the no-retry contract.
- Legacy `_submit_and_poll_batch` gets the bounded cancel + error-dict variant; docs gain batch-pass-count sizing guidance (`batch_passes = ceil(uncached_N / sub_batch_size)`; >2-3 ⇒ prefer sync).
- Closes task #1019 (workflow-fix; incident #810: 16h parked behind a 0/2001 wedge; manual cancel+force_sync cleared 39,512 calls in 18 min).

## Test plan
- [x] `tests/test_batch_stuck_escape.py` (18 tests incl. the 3 reconciler-mandated pins) + pinned files: 76 passed
- [x] Step 9c touched scope: 2422 passed, 6 skipped
- [x] ruff check + format; workflow_lint no-flags PASS
- [x] Review: Claude+Codex ensemble r1 FAIL (reconciled) → r2 PASS; blocker concern closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)