### PR TITLE
issue-1002: extend check 27 to FAIL prior-issue task links/URLs in v4 standalone sections

### DIFF
--- a/.claude/skills/clean-results/SPEC.md
+++ b/.claude/skills/clean-results/SPEC.md
@@ -921,12 +921,17 @@ Forward-only: each check branches on the sentinel. The v4 checks
     the `## Takeaways` / `## Methodology` / `## Results` section spans is
     a hard FAIL — prior-issue references live ONLY in the `## Goal`
     context slot (`[#K](...)` links) and the `**Repro:**`/`**Context:**`
-    footer. Sanctioned forms that do not trip: markdown links (label +
-    target), GFM table rows (the Training-table Source column), fenced +
-    inline code, `<details>` blocks, HTML comments, the footer,
-    frontmatter. The inline-code escape hatch is for non-issue `#N`
-    strings (colors, ordinals) only — never for a genuine issue
-    reference. (Origin: the #841 round-2 two-round Lens-2 miss; numbered
+    footer — and a prior-issue TASK LINK (any form whose text carries
+    `https://eps.superkaiba.com/tasks/<digits>`: a `[#K](...)` markdown
+    link, a `<...>` autolink, or a bare URL) in a standalone section is a
+    hard FAIL too, not just the bare token. Sanctioned forms that do not
+    trip: markdown links to NON-task targets (GitHub blobs, HF, figures),
+    GFM table rows (the Training-table Source column), fenced + inline
+    code, `<details>` blocks, HTML comments, the footer, frontmatter. The
+    inline-code escape hatch is for non-issue strings (colors, ordinals,
+    verbatim syntax examples) only — never for a genuine issue reference
+    or task link. (Origin: the #841 round-2 two-round Lens-2 miss; the
+    task-link form added by #1002 after the #928 round-1 miss; numbered
     27 because 22-26 are taken by the generation-agnostic checks.)
 
 Generation-agnostic checks (v2 AND v3 AND v4): figure-URL-sha-matches

--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -7262,6 +7262,11 @@ def check_v4_results_beat(body: str) -> CheckResult:
 # digit prefix of a mixed hex color (`#4b5563` → `#4`) never match; a
 # possessive `#658's` still does (an apostrophe is not a word char).
 _BARE_ISSUE_REF_RE = re.compile(r"(?<![\w&/#])#\d{1,4}(?!\w)")
+# Prior-issue task URL (the dashboard task route). Scanned directly rather
+# than via a [label](target) wrapper so markdown links, <...> autolinks, AND
+# bare URLs in standalone prose all hit — dropping the brackets must not
+# dodge the check, and the URL line of a multi-line link still fires.
+_TASK_URL_RE = re.compile(r"https?://eps\.superkaiba\.com/tasks/\d+")
 _V4_STANDALONE_SECTIONS = ("takeaways", "methodology", "results")
 
 
@@ -7311,20 +7316,33 @@ def _mask_html_comment_spans(line: str, in_comment: bool) -> tuple[str, bool]:
 
 def _bare_issue_ref_hits(body: str) -> list[tuple[str, str, str]]:
     """Return (section_name, matched_token, line_text) for every bare
-    `#<digits>` issue reference in the v4 standalone sections
-    (## Takeaways / ## Methodology / ## Results), excluding every
-    sanctioned form. `body` is the post-frontmatter text (as handed to
-    CHECKS entries by verify_text), so frontmatter bare refs never reach
-    the scan.
+    `#<digits>` issue reference AND every prior-issue task URL
+    (`_TASK_URL_RE` — `https://eps.superkaiba.com/tasks/<digits>`,
+    whether it appears as a `[label](target)` markdown link target, a
+    `<...>` autolink, or a bare URL in prose) in the v4 standalone
+    sections (## Takeaways / ## Methodology / ## Results), excluding
+    every sanctioned form. `body` is the post-frontmatter text (as handed
+    to CHECKS entries by verify_text), so frontmatter bare refs never
+    reach the scan.
 
-    Sanctioned forms excluded: fenced code blocks, `<details>` blocks,
-    HTML comments (char-span mask with cross-line open/closed state —
-    `_mask_html_comment_spans`); GFM table rows; the
-    `**Repro:**`/`**Context:**` footer (line-index cut); markdown links
-    (label + target) and inline code spans (in-line neutralization,
-    substituting a single SPACE — never the empty string, which could
-    JOIN adjacent characters into a fabricated `#N` token, e.g.
-    ``#`x`123`` → `#123`).
+    Sanctioned forms excluded from BOTH scans: fenced code blocks,
+    `<details>` blocks, HTML comments (char-span mask with cross-line
+    open/closed state — `_mask_html_comment_spans`); GFM table rows; the
+    `**Repro:**`/`**Context:**` footer (line-index cut); inline code
+    spans (in-line neutralization, substituting a single SPACE — never
+    the empty string, which could JOIN adjacent characters into a
+    fabricated `#N` token, e.g. ``#`x`123`` → `#123`). Markdown links
+    (label + target) are additionally neutralized for the BARE-TOKEN scan
+    only — the task-URL scan deliberately runs BEFORE the `_LINK_RE`
+    erasure (that erasure is exactly what hid `[#K](.../tasks/K)` links
+    from this check, #928), so a task link in a standalone section FAILs
+    while a markdown link to a NON-task target stays sanctioned. The URL
+    scan's mechanical scope is the dashboard task route
+    (`eps.superkaiba.com/tasks/<digits>`); a `#K`-labeled link to a
+    non-task target is LM-lens territory (residuals below). The scan does
+    not know THIS body's own task id, so a body's own task URL in a
+    standalone section also FAILs — consistent with the bare-token scan,
+    where a self-referential `#K` also hits.
 
     HTML-comment handling is character-grain, not line-grain: on a line
     that OPENS a multiline comment only the `<!--`..end-of-line span is
@@ -7351,10 +7369,35 @@ def _bare_issue_ref_hits(body: str) -> list[tuple[str, str, str]]:
     - The comment char-span pass also runs PRE-neutralization, so a
       backticked ``<!--`` prose mention opens the comment mask
       (fail-open, same family as the backticked ``<details>``).
-    - 4-space indented code blocks and multi-line `[#K](\\nurl)` links
-      are NOT excluded (both survey-clean across all on-disk v4 bodies
-      as of 2026-07-03) — a `#K` inside either would false-FAIL; the
-      inline-code escape hatch covers the code-block case.
+    - 4-space indented code blocks and the LABEL side of multi-line
+      `[#K](\\nurl)` links are NOT excluded (both survey-clean across all
+      on-disk v4 bodies as of 2026-07-03) — a `#K` inside either would
+      false-FAIL; the inline-code escape hatch covers the code-block
+      case. (The URL line of a multi-line TASK link now correctly FAILs
+      via the URL scan, so that half is no longer a pure false-FAIL edge;
+      the residual is the label-side bare `#K` of a multi-line NON-task
+      link.)
+    - Reference-style links (`[label][ref]` + a definition line
+      elsewhere) are not modeled: a `[#K][ref]` LABEL already FAILs the
+      bare-token scan, and a task-URL definition line inside a standalone
+      section hits the URL scan, but a non-`#K`-labeled reference link
+      whose definition sits outside the standalone sections escapes
+      (fail-open — the LM lens is the backstop).
+    - Case-mangled (`HTTPS://EPS...`) or schemeless
+      (`eps.superkaiba.com/tasks/K`) task URLs do not match the URL scan
+      — all project-generated URLs are lowercase + schemed; a mangled
+      form is deliberate evasion (fail-open, LM-lens backstop).
+    - A `[#K](<non-task URL>)` label-side evasion — including the legacy
+      GitHub-issue link form `[#98](https://github.com/.../issues/98)` —
+      and a RELATIVE `/tasks/K` link target both escape mechanically (the
+      `#K` label is erased with the link by `_LINK_RE` before the
+      bare-token scan; the target is not a schemed dashboard task URL) —
+      fail-open, LM-lens backstop.
+    - An odd backtick pair straddling a link can mask its URL from the
+      inline-code-masked URL scan (fail-open — same family as the
+      backticked ``<details>`` residual above; ADJACENT well-formed code
+      spans never swallow the link between them, since `_INLINE_CODE_RE`
+      excludes backticks from span content).
     - In a slash-run `#658/#742` only the first token matches (the `/`
       lookbehind protects URL fragments) — the line still FAILs, which
       is sufficient.
@@ -7403,6 +7446,13 @@ def _bare_issue_ref_hits(body: str) -> list[tuple[str, str, str]]:
             # new `#N` token that the raw line never carried. Comment
             # spans were already space-masked in comment_masked (every
             # non-fence line has an entry; fence lines are excluded).
+            # Task-URL scan — runs BEFORE _LINK_RE erases link targets
+            # (that erasure is exactly what hid [#K](.../tasks/K) links
+            # from this check, #928). Inline code protects it
+            # (escape-hatch parity with the bare-token scan below).
+            link_scan = _INLINE_CODE_RE.sub(" ", comment_masked[i])
+            for m in _TASK_URL_RE.finditer(link_scan):
+                hits.append((name, m.group(0), lines[i].strip()[:90]))
             residue = _LINK_RE.sub(" ", comment_masked[i])  # [label](target) gone
             residue = _INLINE_CODE_RE.sub(" ", residue)  # `code` escape hatch
             for m in _BARE_ISSUE_REF_RE.finditer(residue):
@@ -7411,35 +7461,50 @@ def _bare_issue_ref_hits(body: str) -> list[tuple[str, str, str]]:
 
 
 def check_v4_no_bare_issue_refs(body: str) -> CheckResult:
-    """Check 27 (v4 only): no bare `#<digits>` issue refs in the standalone
-    sections. SPEC.md § `## Goal` (v4): the Goal context slot is the ONLY
-    place in the body that may cite prior tasks; `## Takeaways` /
-    `## Methodology` / `## Results` are standalone, and lineage/provenance
-    live in the `**Repro:**`/`**Context:**` footer. Sanctioned forms that
-    do not trip: markdown links (label + target), GFM table rows (the
-    Training-table Source column), fenced/inline code, `<details>` blocks,
-    HTML comments, the footer, YAML frontmatter. Exclusion edge behavior
-    (residuals + directions) is documented on `_bare_issue_ref_hits`. Origin: #841
-    round-2 (bare `#779` x~8 in Methodology survived two ensemble review
-    rounds). PASSes vacuously on v3 / v2 / legacy bodies (forward-only)."""
+    """Check 27 (v4 only): no bare `#<digits>` issue refs AND no prior-issue
+    task links/URLs in the standalone sections. SPEC.md § `## Goal` (v4):
+    the Goal context slot is the ONLY place in the body that may cite prior
+    tasks; `## Takeaways` / `## Methodology` / `## Results` are standalone,
+    and lineage/provenance live in the `**Repro:**`/`**Context:**` footer.
+    The task-link half matches any form whose text carries the dashboard
+    task route `https://eps.superkaiba.com/tasks/<digits>` — a `[#K](...)`
+    markdown link, a `<...>` autolink, or a bare URL. Mechanical scope:
+    dashboard task URLs only; a `#K`-labeled link to a NON-task target is
+    LM-lens territory. Sanctioned forms that do not trip: markdown links to
+    NON-task targets, GFM table rows (the Training-table Source column),
+    fenced/inline code, `<details>` blocks, HTML comments, the footer, YAML
+    frontmatter. Exclusion edge behavior (residuals + directions) is
+    documented on `_bare_issue_ref_hits`. Origin: #841 round-2 (bare `#779`
+    x~8 in Methodology survived two ensemble review rounds); the task-link
+    half added by #1002 after the #928 round-1 miss (a `[#K](.../tasks/K)`
+    link in `## Methodology` sailed through mechanically because `_LINK_RE`
+    erased it before the token scan). PASSes vacuously on v3 / v2 / legacy
+    bodies (forward-only)."""
     label = "no bare issue refs in standalone sections (v4)"
     if not is_v4(body):
         return CheckResult(label, True, "skipped — not a v4 body")
     hits = _bare_issue_ref_hits(body)
     if not hits:
-        return CheckResult(label, True, "Takeaways/Methodology/Results carry no bare `#K` refs")
+        return CheckResult(
+            label,
+            True,
+            "Takeaways/Methodology/Results carry no bare `#K` refs or prior-issue task links",
+        )
     shown = "; ".join(f'## {sec}: `{tok}` in "{txt}"' for sec, tok, txt in hits[:5])
     more = f" (+{len(hits) - 5} more)" if len(hits) > 5 else ""
     return CheckResult(
         label,
         False,
-        f"bare issue reference(s) in standalone section(s) — {shown}{more}. "
-        "Prior-issue references live ONLY in the `## Goal` context slot as "
-        "`[#K](https://eps.superkaiba.com/tasks/K)` links and in the `**Repro:**`/"
-        "`**Context:**` footer (SPEC.md § `## Goal` (v4) + Rule A). Rewrite the prose to "
-        "describe the method standalone and move lineage to the footer. The inline-code "
-        "escape hatch is for NON-issue `#N` strings only (a hex color, an ordinal like "
-        "`GPU #2`) — do NOT backtick a genuine issue reference to silence this check.",
+        f"prior-issue reference(s) in standalone section(s) — {shown}{more}. "
+        "Prior-issue references — bare `#K` tokens AND task links/URLs "
+        "(`https://eps.superkaiba.com/tasks/K`, linked or bare) — live ONLY in the "
+        "`## Goal` context slot and the `**Repro:**`/`**Context:**` footer "
+        "(SPEC.md § `## Goal` (v4) + Rule A). Rewrite the prose to describe the method "
+        "standalone and move lineage to the footer; converting a bare ref into a "
+        "`[#K](...)` link in place FAILs here too. The inline-code escape hatch is for "
+        "NON-issue strings only (a hex color, an ordinal like `GPU #2`, a verbatim "
+        "syntax example) — do NOT backtick a genuine issue reference or task link to "
+        "silence this check.",
     )
 
 

--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -7800,7 +7800,7 @@ CHECKS = [
     # separately in `verify_text` (#921):
     check_v4_methodology_shape,  # check 18 (v4)
     check_v4_results_beat,  # check 21 (v4, WARN)
-    check_v4_no_bare_issue_refs,  # check 27 (v4) — bare `#K` refs in standalone sections
+    check_v4_no_bare_issue_refs,  # check 27 (v4) — bare `#K` refs + prior-issue task links/URLs in standalone sections
     # generation-agnostic checks (v2 AND v3 AND v4):
     check_figure_url_sha_matches_repro,  # check 22
     check_hf_url_resolves,  # check 23

--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -7800,7 +7800,7 @@ CHECKS = [
     # separately in `verify_text` (#921):
     check_v4_methodology_shape,  # check 18 (v4)
     check_v4_results_beat,  # check 21 (v4, WARN)
-    check_v4_no_bare_issue_refs,  # check 27 (v4) — bare `#K` refs + prior-issue task links/URLs in standalone sections
+    check_v4_no_bare_issue_refs,  # check 27 (v4) — bare `#K` refs + task links, standalone secs
     # generation-agnostic checks (v2 AND v3 AND v4):
     check_figure_url_sha_matches_repro,  # check 22
     check_hf_url_resolves,  # check 23

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -5389,17 +5389,203 @@ def test_v4_issue_ref_in_table_row_passes():
     assert r.passed, r.render()
 
 
-def test_v4_linked_issue_ref_passes_mechanically():
-    """A `[#K](url)` LINK in Methodology is deliberately out of MECHANICAL
-    scope (plan Non-goals: the linked-form violation stays Lens 2 / Rule A
-    territory); the fixture's Goal `[#34](...)` link is sanctioned too."""
+def test_v4_task_link_in_methodology_fails():
+    """The #928 shape: a `[#K](https://eps.superkaiba.com/tasks/K)` LINK in
+    Methodology prose is a hard FAIL — the task-URL scan runs BEFORE
+    `_LINK_RE` erases link targets (#1002). Inverts the pre-#1002 pin
+    `test_v4_linked_issue_ref_passes_mechanically`, which pinned the
+    linked form as out of mechanical scope."""
     body = _V4_GOOD_BODY.replace(
         "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct.",
         "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct. "
         "Recipe as in [#779](https://eps.superkaiba.com/tasks/779).",
     )
     r = _bare_ref_result(body)
+    assert not r.passed
+    assert "tasks/779" in r.detail
+    assert "Methodology" in r.detail
+
+
+def test_v4_task_link_in_takeaways_fails():
+    """A task link appended to a Takeaways bullet FAILs (run through
+    verify_text to pin the CHECKS registration on the Takeaways span)."""
+    body = _V4_GOOD_BODY.replace(
+        "- Caveat that binds interpretation: single model family, three seeds only.\n",
+        "- Caveat that binds interpretation: single model family, three seeds only.\n"
+        "- Protocol matches [#537](https://eps.superkaiba.com/tasks/537).\n",
+    )
+    _ok, results = verify_task_body.verify_text(body)
+    r = _results_by_name(results)[_BARE_REF_CHECK_NAME]
+    assert not r.passed
+    assert "tasks/537" in r.detail
+    assert "Takeaways" in r.detail
+
+
+def test_v4_task_link_in_results_fails():
+    """A task link in a `> **Figure.**` caption line under `## Results`
+    FAILs (prose, not a sanctioned form — mirrors
+    test_v4_bare_issue_ref_in_results_caption_fails)."""
+    body = _V4_GOOD_BODY.replace(
+        "error bars 95% Wald CIs.",
+        "error bars 95% Wald CIs ([#667](https://eps.superkaiba.com/tasks/667) protocol).",
+    )
+    r = _bare_ref_result(body)
+    assert not r.passed
+    assert "tasks/667" in r.detail
+    assert "Results" in r.detail
+
+
+def test_v4_bare_task_url_in_results_fails():
+    """Scope pin: a BARE task URL in Results prose FAILs — dropping the
+    `[label](...)` brackets does not dodge the check (#1002 §4b)."""
+    body = _V4_GOOD_BODY.replace(
+        "the smallest within-condition gap between seeds is 1.2 pts.",
+        "the smallest within-condition gap between seeds is 1.2 pts. "
+        "Protocol: https://eps.superkaiba.com/tasks/658.",
+    )
+    r = _bare_ref_result(body)
+    assert not r.passed
+    assert "tasks/658" in r.detail
+    assert "Results" in r.detail
+
+
+def test_v4_autolink_task_url_in_methodology_fails():
+    """Scope pin: a `<https://.../tasks/K>` angle-bracket autolink FAILs —
+    subsumed by the URL scan (#1002 §4b)."""
+    body = _V4_GOOD_BODY.replace(
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct.",
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct. "
+        "See <https://eps.superkaiba.com/tasks/658>.",
+    )
+    r = _bare_ref_result(body)
+    assert not r.passed
+    assert "tasks/658" in r.detail
+    assert "Methodology" in r.detail
+
+
+def test_v4_task_link_in_goal_passes():
+    """`## Goal` is NOT a standalone section — a second task link in the
+    context slot stays sanctioned (the fixture's `[#34](...)` link is
+    additionally asserted by test_v4_good_body_passes_all)."""
+    body = _V4_GOOD_BODY.replace(
+        "sits in the trait-transfer line.",
+        "sits in the trait-transfer line, extending [#658](https://eps.superkaiba.com/tasks/658).",
+    )
+    r = _bare_ref_result(body)
     assert r.passed, r.render()
+
+
+def test_v4_task_link_in_footer_passes():
+    """Footer-cut parity: a task link AND a bare task URL on footer lineage
+    lines are sanctioned (the bare-URL case pins the parity directly)."""
+    body = _V4_GOOD_BODY.replace(
+        "- Originating prompt: origin prompt not recorded\n",
+        "- Originating prompt: origin prompt not recorded\n"
+        "- Lineage: [#658](https://eps.superkaiba.com/tasks/658); "
+        "see also https://eps.superkaiba.com/tasks/742.\n",
+    )
+    r = _bare_ref_result(body)
+    assert r.passed, r.render()
+
+
+def test_v4_task_link_in_table_row_passes():
+    """Table-row parity (the Training-table Source column grounding
+    convention): a linked AND a bare task URL in GFM table rows are
+    sanctioned."""
+    body = _V4_GOOD_BODY.replace(
+        "| Seeds | [42, 137, 256] | plan §11 |\n",
+        "| Seeds | [42, 137, 256] | plan §11 |\n"
+        "| Judge cache | reused | [#779](https://eps.superkaiba.com/tasks/779) |\n"
+        "| Adapter | reused | https://eps.superkaiba.com/tasks/532 |\n",
+    )
+    r = _bare_ref_result(body)
+    assert r.passed, r.render()
+
+
+def test_v4_task_link_in_fenced_code_passes():
+    """A task link inside a fenced code block is sanctioned (fence lines
+    are structurally excluded from both scans)."""
+    body = _V4_GOOD_BODY.replace(
+        "\n## Results\n",
+        "\n```text\nsee [#779](https://eps.superkaiba.com/tasks/779)\n```\n\n## Results\n",
+    )
+    r = _bare_ref_result(body)
+    assert r.passed, r.render()
+
+
+def test_v4_task_link_in_inline_code_passes():
+    """The #1002 §4a semantics decision pin: inline code PROTECTS the URL
+    scan (mask parity with the bare-token scan) — a backticked example
+    link is verbatim syntax-as-data."""
+    body = _V4_GOOD_BODY.replace(
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct.",
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct. "
+        "Cite links as `[#779](https://eps.superkaiba.com/tasks/779)` in the Goal slot.",
+    )
+    r = _bare_ref_result(body)
+    assert r.passed, r.render()
+
+
+def test_v4_task_link_in_html_comment_passes():
+    """A task link inside an HTML comment is sanctioned (the char-span
+    comment mask covers the URL scan too)."""
+    body = _V4_GOOD_BODY.replace(
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct.",
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct.\n"
+        "<!-- see [#779](https://eps.superkaiba.com/tasks/779) -->",
+    )
+    r = _bare_ref_result(body)
+    assert r.passed, r.render()
+
+
+def test_v4_task_link_in_details_block_passes():
+    """A task link inside the fixture's `<details open>` block (verbatim
+    sample data) is sanctioned."""
+    body = _V4_GOOD_BODY.replace(
+        "<summary>5 example training rows (5 of 2,000 rows, random sample)</summary>\n",
+        "<summary>5 example training rows (5 of 2,000 rows, random sample)</summary>\n"
+        "\nRows drawn per [#658](https://eps.superkaiba.com/tasks/658).\n",
+    )
+    r = _bare_ref_result(body)
+    assert r.passed, r.render()
+
+
+def test_v4_non_task_url_links_pass():
+    """Non-task-URL links (GitHub blob, HF) in Methodology prose are
+    unaffected — the URL scan targets the dashboard task route only."""
+    body = _V4_GOOD_BODY.replace(
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct.",
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct. Script at "
+        "[run.py](https://github.com/superkaiba/explore-persona-space/blob/abc/scripts/run.py); "
+        "adapter at [hf](https://huggingface.co/superkaiba1/explore-persona-space/tree/abc).",
+    )
+    r = _bare_ref_result(body)
+    assert r.passed, r.render()
+
+
+def test_v4_same_domain_non_task_url_passes():
+    """Same-domain negative: a dashboard URL that is not the task route
+    (`/sessions`, or `/tasks/` with no digits) does NOT match."""
+    body = _V4_GOOD_BODY.replace(
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct.",
+        "- **Training:** LoRA SFT on Qwen-2.5-7B-Instruct. Dashboard at "
+        "https://eps.superkaiba.com/sessions and the https://eps.superkaiba.com/tasks/ index.",
+    )
+    r = _bare_ref_result(body)
+    assert r.passed, r.render()
+
+
+def test_task_link_check_skips_v3():
+    """Forward-only: a task link in a v3 `## Findings` never fires the
+    check (PASS-skip; mirror of test_bare_ref_check_skips_v3_and_legacy)."""
+    v3 = _V3_GOOD_BODY.replace(
+        "## Findings",
+        "## Findings\n\nUses [#779](https://eps.superkaiba.com/tasks/779).",
+        1,
+    )
+    r = _bare_ref_result(v3)
+    assert r.passed
+    assert "skipped" in r.detail
 
 
 def test_bare_ref_check_skips_v3_and_legacy():


### PR DESCRIPTION
Closes task #1002 (workflow-fix; candidate raised on #928). Extends check_v4_no_bare_issue_refs with a task-URL scan; SPEC.md check-27 sync; 15 test pins.