### PR TITLE
issue-1025: whitelist task-reference tokens in codex composer numeric-leak guard

### DIFF
--- a/.claude/agents/codex-critic.md
+++ b/.claude/agents/codex-critic.md
@@ -168,6 +168,17 @@ in `plan_body` is not the plan's claim and corrupts the critique. If you
 believe a load-bearing number is *missing* from the plan, do NOT supply it —
 that absence is itself a finding Codex will raise from `plan_body` alone.
 
+**Task-reference carve-out (#1025 — the #795/#720 incident).** Cross-issue
+task references — `#<N>`, `tasks/<status>/<N>` paths, `issue-<N>`/`issue_<N>`
+branch/path forms (`issue[-_]<N>`) — are PROVENANCE IDENTIFIERS, not
+predicted/authored result numbers: you MAY place one in the prompt (e.g.
+duplication/overlap evidence naming a prior task) provided the id appears in
+a handed span OR resolves in `tasks/REGISTRY.json`. The ban above covers
+result / effect-size / sizing VALUES; stripping a real task id withholds the
+very redundancy evidence the overlap lens needs (in the #795 critique this
+guard stripped `#720`, and Codex-Statistics could not weigh the duplication
+sharply).
+
 ```
 You are the {{LENS}} CRITIC. Your job is to catch the small number of
 conclusion-changing flaws in this plan from the {{LENS}} angle, NOT to
@@ -289,7 +300,28 @@ the orchestrator did not pass this field — fail-safe, treated as zero allowlis
 contribution; never crash, never assume it is populated). Then run a small
 `uv run python` pass that:
 
-1. Tokenizes ALL numeric forms in `$PROMPT_FILE` and in
+1. **Extracts task-reference tokens FIRST — BEFORE any numeric tokenization —
+   symmetrically from `$PROMPT_FILE` AND the three handed-span files.** Match
+   `#(\d+)(?!\d*\.\d)`, `tasks/[a-z_]+/(\d+)\b`, and `issue[-_](\d+)\b`;
+   REMOVE each match from the working text (so `#720` never enters the
+   numeric-atom multiset as a bare `720`) and collect the ids per side. Every
+   PROMPT-side id must clear one of two legs: (a) the same id appears (in any
+   reference form) among the handed-span ids, or (b) the id is a key of the
+   `tasks` map in `tasks/REGISTRY.json` — resolved via
+   `from explore_persona_space.task_workflow import registry_path` (never a
+   cwd-relative `tasks/...` path),
+   `str(N) in json.load(open(registry_path()))["tasks"]`. If the registry is
+   unreadable, leg (b) contributes nothing: print a WARN and fall back to
+   leg (a) alone (fail-strict — degrades to the pre-#1025 behavior, never
+   weaker). Residual reporting is COLLECT-ALL: the pass collects EVERY
+   unresolved id AND (after tokenization) every residual numeric atom, prints
+   one `BLOCKER: ...` line per residual to stderr, THEN exits 1 once — never
+   exit-on-first (this is what makes a multi-residual smoke's expected
+   blocker count decidable). An id clearing neither leg contributes a line of
+   the form `BLOCKER: composer-authored task reference #<N> resolves in
+   neither the handed spans nor tasks/REGISTRY.json; re-compose from handed
+   inputs only`.
+2. Tokenizes ALL numeric forms in `$PROMPT_FILE` and in
    `$PLANBODY_FILE` + `$LENS_ITEMS_FILE` + `$PRIOR_CRITIQUES_FILE` using a
    normalization that **splits hyphenated ranges and slash-joined pairs into
    their atomic numbers BEFORE the multiset diff** (`+0.74-0.80` →
@@ -298,7 +330,7 @@ contribution; never crash, never assume it is populated). Then run a small
    numeric atom in the prompt outside the substituted spans must trace either
    to a numeric atom in `plan_body` / `lens_items` / `prior_critique_summaries`,
    or to the static template-scaffold allowlist (below).*
-2. Clears the prompt's numeric atoms against TWO accounting legs that differ
+3. Clears the prompt's numeric atoms against TWO accounting legs that differ
    on purpose:
    - **Handed spans — MULTISET subtract.** Subtract (multiset) the numeric
      atoms found in `plan_body` + `lens_items` + `prior_critique_summaries`,
@@ -324,7 +356,8 @@ contribution; never crash, never assume it is populated). Then run a small
      the rest on a number-free plan, defeating the gate on every legitimate
      compose. It does not weaken the #722 catch: the fabricated `+0.74-0.80` /
      `MLP -2.17/-6.12` atoms are not scaffold values, so they still residual.)
-3. On any residual numeric atom, FAILS LOUD:
+4. On any residual numeric atom, FAILS LOUD (one `BLOCKER:` line per
+   residual, single exit — item 1's COLLECT-ALL contract):
    `echo "BLOCKER: composer-authored number <n> not traceable to plan_body /
    lens_items / prior_critique_summaries / scaffold allowlist; re-compose from
    handed inputs only" >&2; exit 1`. On BLOCKER you re-compose from the handed
@@ -343,6 +376,17 @@ load-bearing: a naive `-?\d+\.?\d*` scan would split `+0.74-0.80` into
 the plan legitimately reads "0.74 to 0.80" — normalize to atomic numbers
 first so the multiset diff does not false-positive on legitimate restatements
 that happen to share digits.
+
+*Why the task-ref carve-out does not reopen it (#1025):* the whitelist
+requires the hash/path/branch PREFIX form and integer-only ids —
+`#(\d+)(?!\d*\.\d)` matches neither `#0.74` nor `#720.5` (the full-lookahead
+form cannot backtrack to a truncated id; the whole decimal-bearing token
+stays in the numeric accounting) — plus registry-or-handed-span trace: a
+fabricated `#999999` BLOCKs, a bare `720` with no prefix residuals exactly as
+before, and the #722 atoms `{0.74, 0.80, -2.17, -6.12}` are untouched by the
+extraction. Accepted residual risk: a composer misciting a plan integer
+(e.g. "720 rows") AS `#720` clears when task 720 exists — acceptable because
+the prefix form reads to Codex as a task id, never as a result value.
 
 ### Step 5: Return to orchestrator
 
@@ -405,7 +449,10 @@ directly.
    predicted value you did not receive in the brief's `plan_body` /
    `lens_items` / `prior_critique_summaries` (Step 3 composer
    numeric-grounding rule + Step 4 verification). A missing number is a
-   finding, not something you supply.
+   finding, not something you supply. (Task-reference identifiers — `#<N>`,
+   `tasks/<status>/<N>`, `issue-<N>`/`issue_<N>` — are provenance, not
+   numbers: allowed when they trace per the Step 3 carve-out / Step 4
+   task-ref extraction.)
 9. **Pin the snapshot boundary; do not chase fresher state.** Your inputs are
    a spawn-time snapshot you cannot refresh (compose-only); pin its boundary
    into the prompt (Step 3 `SNAPSHOT NOTE`) so Codex scopes its verdict to the

--- a/.claude/agents/codex-efficiency-critic.md
+++ b/.claude/agents/codex-efficiency-critic.md
@@ -100,7 +100,11 @@ composed content fills `{{lens_items}}` in Step 3.
 bug).** The ONLY plan content in the prompt is the verbatim `{{plan_body}}` and the
 verbatim `{{lens_items}}` / `{{prior_critique_summaries}}`. NEVER author or inline a
 numeric value (a projected wall-time, a GPU-hour figure) the brief did not hand you.
-A missing sizing number is itself a finding.
+A missing sizing number is itself a finding. Task-reference identifiers (`#<N>`,
+`tasks/<status>/<N>`, `issue[-_]<N>` — i.e. `issue-<N>`/`issue_<N>`, hyphen AND
+underscore) are provenance, not result numbers — you MAY cite one that appears in a
+handed span or resolves in `tasks/REGISTRY.json` (e.g. duplication/overlap evidence;
+the #795 critique lost its `#720` ref to this guard before the #1025 carve-out).
 
 ```
 You are the EFFICIENCY CRITIC (plan mode). Your job is to catch the small number of
@@ -182,9 +186,15 @@ across the 8 GPUs" is useful. Batch before recommending a bigger machine.
 
 **Compose-only — never dispatch Codex.** Write the prompt with `cat > ... <<'PROMPT'`,
 then run the same local numeric-leak verifier as `.claude/agents/codex-critic.md`
-Step 4 (tokenize atoms splitting hyphenated ranges / slash pairs; multiset-subtract
-`plan_body`+`lens_items`+`prior_critique_summaries`; set-clear the scaffold
-allowlist `{0, 1, 2, 3, 4, 5, 500}`; fail loud + re-compose on any residual). The
+Step 4 (FIRST extract task-reference tokens `#<N>` / `tasks/<status>/<N>` /
+`issue[-_]<N>` (hyphen AND underscore forms) symmetrically from prompt + handed
+spans, clearing prompt-side ids against handed-span ids ∪ `tasks/REGISTRY.json` via
+`task_workflow.registry_path()` — unreadable registry ⇒ handed-span leg only,
+fail-strict; THEN tokenize atoms splitting hyphenated ranges / slash pairs;
+multiset-subtract `plan_body`+`lens_items`+`prior_critique_summaries`; set-clear the
+scaffold allowlist `{0, 1, 2, 3, 4, 5, 500}`; fail loud collect-all — one BLOCKER
+line per residual, single exit — + re-compose on any residual; same recipe +
+rationale as `.claude/agents/codex-critic.md` Step 4, the reference implementation). The
 efficiency lens quotes sizing numbers (wall-times, GPU-hours) heavily, so pass the
 inlined §9 / guidelines substance through `{{lens_items}}` so those numbers clear
 the multiset. Temp files only — no Codex dispatch, no polling loop, no marker.

--- a/.claude/agents/codex-methodology-baselines-critic.md
+++ b/.claude/agents/codex-methodology-baselines-critic.md
@@ -99,6 +99,11 @@ REPORT schema from `.claude/agents/methodology-baselines-critic.md`. The items f
 bug).** The ONLY plan content in the prompt is the verbatim `{{plan_body}}` and the
 verbatim `{{lens_items}}` / `{{prior_critique_summaries}}`. NEVER author or inline a
 numeric value the brief did not hand you. A missing number is itself a finding.
+Task-reference identifiers (`#<N>`, `tasks/<status>/<N>`, `issue[-_]<N>` — i.e.
+`issue-<N>`/`issue_<N>`, hyphen AND underscore) are provenance, not result numbers —
+you MAY cite one that appears in a handed span or resolves in `tasks/REGISTRY.json`
+(e.g. duplication/overlap evidence; the #795 critique lost its `#720` ref to this
+guard before the #1025 carve-out).
 
 ```
 You are the METHODOLOGY & BASELINES CRITIC. Your job is to catch the small number
@@ -174,9 +179,15 @@ against the actual configs / prior result JSONs if you have file access.
 
 **Compose-only — never dispatch Codex.** Write the prompt with `cat > ... <<'PROMPT'`,
 then run the same local numeric-leak verifier as `.claude/agents/codex-critic.md`
-Step 4 (tokenize atoms splitting hyphenated ranges / slash pairs; multiset-subtract
-`plan_body`+`lens_items`+`prior_critique_summaries`; set-clear the scaffold
-allowlist `{0, 1, 2, 3, 4, 5, 500}`; fail loud + re-compose on any residual). Temp
+Step 4 (FIRST extract task-reference tokens `#<N>` / `tasks/<status>/<N>` /
+`issue[-_]<N>` (hyphen AND underscore forms) symmetrically from prompt + handed
+spans, clearing prompt-side ids against handed-span ids ∪ `tasks/REGISTRY.json` via
+`task_workflow.registry_path()` — unreadable registry ⇒ handed-span leg only,
+fail-strict; THEN tokenize atoms splitting hyphenated ranges / slash pairs;
+multiset-subtract `plan_body`+`lens_items`+`prior_critique_summaries`; set-clear the
+scaffold allowlist `{0, 1, 2, 3, 4, 5, 500}`; fail loud collect-all — one BLOCKER
+line per residual, single exit — + re-compose on any residual; same recipe +
+rationale as `.claude/agents/codex-critic.md` Step 4, the reference implementation). Temp
 files only — no Codex dispatch, no polling loop, no marker.
 
 ### Step 5: Return to orchestrator

--- a/.claude/agents/codex-statistics-critic.md
+++ b/.claude/agents/codex-statistics-critic.md
@@ -104,7 +104,12 @@ and the verbatim `{{lens_items}}` / `{{prior_critique_summaries}}`. NEVER author
 paraphrase, or inline ANY numeric / predicted / effect-size value you sourced from
 your own context, memory, or an artifact the brief did not hand you. Codex critiques
 the plan AS WRITTEN; a number not in `plan_body` is not the plan's claim. A missing
-number is itself a finding Codex will raise from `plan_body` alone.
+number is itself a finding Codex will raise from `plan_body` alone. Task-reference
+identifiers (`#<N>`, `tasks/<status>/<N>`, `issue[-_]<N>` — i.e. `issue-<N>`/`issue_<N>`,
+hyphen AND underscore) are provenance, not result numbers — you MAY cite one that
+appears in a handed span or resolves in `tasks/REGISTRY.json` (e.g. duplication/overlap
+evidence; the #795 critique lost its `#720` ref to this guard before the #1025
+carve-out).
 
 ```
 You are the STATISTICS & MEASUREMENT CRITIC. Your job is to catch the small number
@@ -187,13 +192,19 @@ PROMPT
 
 Write `{{plan_body}}`, `{{lens_items}}`, and `{{prior_critique_summaries}}` to
 separate files (an EMPTY file if a field was not passed — never crash), then run a
-small `uv run python` pass that tokenizes every numeric atom in the prompt
+small `uv run python` pass that FIRST extracts task-reference tokens `#<N>` /
+`tasks/<status>/<N>` / `issue[-_]<N>` (hyphen AND underscore forms) symmetrically
+from the prompt + handed spans — clearing prompt-side ids against handed-span ids ∪
+the `tasks` map of `tasks/REGISTRY.json` via `task_workflow.registry_path()`;
+unreadable registry ⇒ handed-span leg only, fail-strict — THEN tokenizes every
+numeric atom in the prompt
 (splitting hyphenated ranges / slash-joined pairs into atomic numbers BEFORE the
 diff: `+0.74-0.80` → `{0.74, 0.80}`), multiset-subtracts the atoms in
 `plan_body`+`lens_items`+`prior_critique_summaries`, and set-membership-clears the
-static scaffold allowlist `{0, 1, 2, 3, 4, 5, 500}`. On any residual atom, fail
-loud (`echo "BLOCKER: composer-authored number <n> not traceable ..." >&2; exit 1`)
-and re-compose from the handed inputs alone — never hand-edit the offending number in.
+static scaffold allowlist `{0, 1, 2, 3, 4, 5, 500}`. On any residual (unresolved
+task ref or numeric atom), fail loud collect-all (one `BLOCKER: composer-authored
+number <n> not traceable ...` line per residual, single exit) and re-compose from
+the handed inputs alone — never hand-edit the offending number in.
 (Same recipe + rationale as `.claude/agents/codex-critic.md` Step 4; that file is
 the reference implementation.)
 

--- a/tests/test_codex_critic_numeric_grounding.py
+++ b/tests/test_codex_critic_numeric_grounding.py
@@ -22,6 +22,15 @@ strip the contract.
 The reference normalizer + multiset-diff below is one valid realization of the
 prose contract; it doubles as executable documentation of the intended
 behavior for whoever finalizes the inline verifier.
+
+Task-reference carve-out (#1025, the #795/#720 incident): the Step-4 prose now
+prescribes a task-reference extraction pass that runs BEFORE numeric
+tokenization, SYMMETRICALLY on the prompt and all handed spans. Prompt-side
+ids (`#<N>`, `tasks/<status>/<N>`, `issue[-_]<N>`) clear against handed-span
+ids or the `tasks` map of `tasks/REGISTRY.json`; an unreadable registry
+degrades to the handed-span leg alone (fail-strict). The reference
+realization threads a hermetic `registry_ids` fixture parameter through
+`_residual_blocker_numbers` — these tests NEVER read the live REGISTRY.json.
 """
 
 # The agent-file assertions below quote the literal markdown (em/en dashes,
@@ -32,6 +41,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import ClassVar
 
 import pytest
 
@@ -123,6 +133,38 @@ def _canon(tok: str) -> str:
     return repr(f)
 
 
+# The three whitelisted task-reference forms (#1025). The full lookahead
+# `(?!\d*\.\d)` is load-bearing: it makes a decimal-bearing token (`#720.5`,
+# `#0.74`) match NOTHING at all — the v1 shorthand `(?!\.\d)` backtracked
+# `#720.5` to a truncated id `72`. `issue[-_]` covers both `issue-720`
+# branches and `issue_720` result paths.
+TASK_REF_PATTERNS = (
+    re.compile(r"#(\d+)(?!\d*\.\d)"),
+    re.compile(r"tasks/[a-z_]+/(\d+)\b"),
+    re.compile(r"issue[-_](\d+)\b"),
+)
+
+
+def _extract_task_refs(text: str) -> tuple[str, set[str]]:
+    """Reference realization of the Step-4 task-reference extraction (#1025).
+
+    Matches the three whitelisted reference forms, REMOVES each match from the
+    working text (so a span-side `#720` never donates a bare `720` atom to the
+    numeric multiset — the symmetric-removal property), and returns
+    ``(cleaned_text, {ids})``. A decimal-bearing token extracts nothing; its
+    atoms stay in the numeric accounting.
+    """
+    ids: set[str] = set()
+
+    def _take(m: re.Match[str]) -> str:
+        ids.add(m.group(1))
+        return " "
+
+    for pat in TASK_REF_PATTERNS:
+        text = pat.sub(_take, text)
+    return text, ids
+
+
 def _static_template_atoms() -> set[str]:
     """Extract the canonical numeric atoms of the FINAL Step-3 prompt template
     that SURVIVE `{{...}}` placeholder substitution.
@@ -157,8 +199,23 @@ def _residual_blocker_numbers(
     plan_body: str,
     lens_items: str = "",
     prior_critique_summaries: str = "",
+    registry_ids: set[str] | None = None,
 ) -> list[str]:
-    """Return the residual prompt atoms that would trip BLOCKER.
+    """Return the residual prompt atoms + unresolved task refs that trip BLOCKER.
+
+    Task-reference carve-out (#1025): task-reference tokens are extracted
+    FIRST — before any numeric tokenization — SYMMETRICALLY from the prompt
+    and all three handed spans (`_extract_task_refs`; extraction REMOVES the
+    match, so a span-side `#720` cannot mask a composer-fabricated bare
+    `720`). Every prompt-side id must clear leg (a) — the same id appears, in
+    any reference form, among the handed-span ids — or leg (b) — the id is in
+    `registry_ids`, the hermetic stand-in for the `tasks` map of
+    `tasks/REGISTRY.json` (tests inject a fixture set; the live registry is
+    never read). ``registry_ids=None`` reproduces the unreadable-registry
+    fail-strict leg: leg (b) contributes NOTHING and only handed-span ids
+    clear. An unresolved id is returned as ``"#<id>"`` (one BLOCKER entry
+    each, collect-all — alongside every residual numeric atom, single
+    return).
 
     Semantics (round-2 #758 fix). The handed spans and the static scaffold are
     accounted DIFFERENTLY, on purpose:
@@ -184,16 +241,31 @@ def _residual_blocker_numbers(
     """
     from collections import Counter
 
-    scaffold = {_canon(s) for s in SCAFFOLD_ALLOWLIST}
-    prompt_atoms = Counter(_normalize_numeric_atoms(prompt))
-    span_atoms = Counter()
+    # #1025: extract task-reference tokens FIRST, symmetrically (prompt AND
+    # every handed span), collecting ids per side.
+    prompt_clean, prompt_ids = _extract_task_refs(prompt)
+    span_ids: set[str] = set()
+    cleaned_spans: list[str] = []
     for span in (plan_body, lens_items, prior_critique_summaries):
-        span_atoms.update(_normalize_numeric_atoms(span))
+        cleaned, ids = _extract_task_refs(span)
+        cleaned_spans.append(cleaned)
+        span_ids |= ids
+    unresolved_refs = sorted(
+        ref_id
+        for ref_id in prompt_ids
+        if ref_id not in span_ids and (registry_ids is None or ref_id not in registry_ids)
+    )
+
+    scaffold = {_canon(s) for s in SCAFFOLD_ALLOWLIST}
+    prompt_atoms = Counter(_normalize_numeric_atoms(prompt_clean))
+    span_atoms = Counter()
+    for cleaned in cleaned_spans:
+        span_atoms.update(_normalize_numeric_atoms(cleaned))
     # Multiset-subtract the handed spans; then clear any atom in the scaffold
     # set (set-membership, not multiset — see docstring).
     residual = prompt_atoms - span_atoms
     residual = Counter({k: c for k, c in residual.items() if k not in scaffold})
-    return sorted(residual.elements())
+    return sorted(residual.elements()) + [f"#{ref_id}" for ref_id in unresolved_refs]
 
 
 # Canonical #722 fabricated forms, as the composer would have inlined them.
@@ -390,3 +462,172 @@ class TestAgentFileCarriesTheSixEdits:
         # the four dispatch prohibitions remain byte-present
         assert "**NEVER call** `scripts/codex_task.py`" in text
         assert "**NEVER spawn a polling loop**" in text
+
+
+class TestTaskRefCarveOut:
+    """#1025 contract: task-reference identifiers (`#<N>`, `tasks/<status>/<N>`,
+    `issue[-_]<N>`) are extracted BEFORE numeric tokenization, symmetrically
+    from prompt + handed spans; prompt-side ids clear against handed-span ids
+    or a registry fixture (`None` = unreadable registry, fail-strict). Tests
+    are hermetic — the live REGISTRY.json is never read."""
+
+    # Hermetic stand-in for the `tasks` map keys of tasks/REGISTRY.json.
+    REGISTRY: ClassVar[set[str]] = {"720"}
+
+    def test_hash_ref_clears_via_registry(self):
+        residual = _residual_blocker_numbers(
+            "PLAN TEXT:\nplan is number-free.\nOverlap evidence: this duplicates #720.\n",
+            plan_body="plan is number-free.",
+            registry_ids=self.REGISTRY,
+        )
+        assert residual == [], residual
+
+    def test_fabricated_ref_not_in_registry_blocks(self):
+        residual = _residual_blocker_numbers(
+            "PLAN TEXT:\nplan is number-free.\nSee #999999 for context.\n",
+            plan_body="plan is number-free.",
+            registry_ids=self.REGISTRY,
+        )
+        assert residual == ["#999999"], residual
+
+    def test_bare_integer_is_not_a_task_ref_and_blocks(self):
+        # No prefix form => NOT an identifier; a bare `720` stays in the
+        # numeric accounting exactly as before #1025, even when task 720
+        # exists in the registry.
+        residual = _residual_blocker_numbers(
+            "PLAN TEXT:\nplan is number-free.\nThe run used 720 rows.\n",
+            plan_body="plan is number-free.",
+            registry_ids=self.REGISTRY,
+        )
+        assert residual == ["720"], residual
+
+    def test_decimal_bearing_token_extracts_nothing_and_blocks(self):
+        # Lookahead discriminator: the v1 shorthand `(?!\.\d)` backtracked
+        # `#720.5` to a truncated id `72`. The full lookahead `(?!\d*\.\d)`
+        # must extract NOTHING from a decimal-bearing token, leaving all its
+        # atoms in the numeric accounting.
+        cleaned, ids = _extract_task_refs("shift at #720.5 claimed")
+        assert ids == set(), ids
+        assert "720.5" in cleaned
+        residual = _residual_blocker_numbers(
+            "PLAN TEXT:\nplan is number-free.\nShift at #720.5 claimed.\n",
+            plan_body="plan is number-free.",
+            registry_ids=self.REGISTRY,
+        )
+        assert residual == ["720.5"], residual
+
+    def test_symmetric_removal_span_ref_does_not_mask_bare_atom(self):
+        # Symmetric-removal discriminator: the handed span carries `#720`, the
+        # prompt carries a bare `720`. The span-side `#720` is EXTRACTED
+        # (removed), so it must NOT donate a bare `720` atom that masks the
+        # composer-fabricated bare `720`. Both the pre-#1025 accounting and a
+        # collect-but-not-remove partial implementation false-pass this case.
+        residual = _residual_blocker_numbers(
+            "PLAN TEXT:\nsee prior work.\nThe run used 720 rows.\n",
+            plan_body="see prior work. This duplicates #720.",
+            registry_ids=self.REGISTRY,
+        )
+        assert residual == ["720"], residual
+
+    def test_handed_span_leg_clears_with_registry_none(self):
+        # Fail-strict leg: registry unreadable (None) contributes nothing; the
+        # handed-span leg alone clears the ref.
+        residual = _residual_blocker_numbers(
+            "PLAN TEXT:\nsee prior work.\nThis duplicates #720.\n",
+            plan_body="see prior work. This duplicates #720.",
+            registry_ids=None,
+        )
+        assert residual == [], residual
+
+    def test_registry_none_blocks_prompt_only_ref(self):
+        # Fail-strict: with the registry unreadable, a prompt-only id BLOCKs
+        # even when it would have resolved in the live registry — never weaker
+        # than the pre-#1025 behavior.
+        residual = _residual_blocker_numbers(
+            "PLAN TEXT:\nplan is number-free.\nThis duplicates #720.\n",
+            plan_body="plan is number-free.",
+            registry_ids=None,
+        )
+        assert residual == ["#720"], residual
+
+    def test_collect_all_reports_every_residual_in_one_run(self):
+        # Collect-all: a numeric atom + a fabricated ref + a bare integer in
+        # ONE prompt yield exactly three BLOCKER entries in one run — never
+        # exit-on-first.
+        prompt = (
+            "PLAN TEXT:\nplan is number-free.\n"
+            "The shift is +0.74; see #999999; the run used 720 rows.\n"
+        )
+        residual = _residual_blocker_numbers(
+            prompt, plan_body="plan is number-free.", registry_ids=self.REGISTRY
+        )
+        assert sorted(residual) == sorted(["0.74", "720", "#999999"]), residual
+
+    def test_path_and_branch_forms_cross_clear_hash_ref(self):
+        # Leg (a) is form-agnostic: a span-side `issue-720` / `issue_720` /
+        # `tasks/running/720` clears a prompt-side `#720` (hyphen AND
+        # underscore branch forms both extract).
+        for span_form in ("issue-720", "issue_720", "tasks/running/720"):
+            residual = _residual_blocker_numbers(
+                "PLAN TEXT:\nsee prior work.\nThis duplicates #720.\n",
+                plan_body=f"see prior work at {span_form}.",
+                registry_ids=None,
+            )
+            assert residual == [], (span_form, residual)
+
+
+# The four live guard-carrying composer specs (#1025): the reference impl +
+# the three v2 sibling composers that restate its Step-4 recipe in summary.
+ALL_GUARD_FILES = [
+    AGENT_FILE,
+    REPO_ROOT / ".claude" / "agents" / "codex-statistics-critic.md",
+    REPO_ROOT / ".claude" / "agents" / "codex-efficiency-critic.md",
+    REPO_ROOT / ".claude" / "agents" / "codex-methodology-baselines-critic.md",
+]
+
+
+class TestAgentFilesCarryTaskRefCarveOut:
+    """Doc-presence guards (#1025): the task-reference carve-out landed in all
+    4 guard-carrying composer specs, at BOTH layers (grounding rule + Step-4 /
+    verifier-summary accounting), licensing the same form set."""
+
+    @pytest.fixture(scope="class")
+    def text(self) -> str:
+        return AGENT_FILE.read_text(encoding="utf-8")
+
+    def test_codex_critic_step4_task_ref_extraction_item(self, text: str):
+        assert "Extracts task-reference tokens FIRST" in text
+        # the three whitelisted regex forms, verbatim (full no-backtrack lookahead)
+        assert r"#(\d+)(?!\d*\.\d)" in text
+        assert r"tasks/[a-z_]+/(\d+)\b" in text
+        assert r"issue[-_](\d+)\b" in text
+        # registry leg via the cwd-safe resolver + fail-strict fallback
+        assert "registry_path" in text
+        assert "fail-strict" in text
+
+    def test_codex_critic_collect_all_reporting(self, text: str):
+        assert "COLLECT-ALL" in text
+        assert "never" in text and "exit-on-first" in text
+        assert "BLOCKER: composer-authored task reference" in text
+
+    def test_codex_critic_grounding_rule_carveout(self, text: str):
+        assert "Task-reference carve-out" in text
+        assert "PROVENANCE IDENTIFIERS" in text
+
+    def test_codex_critic_core_rule8_parenthetical(self, text: str):
+        assert "Task-reference identifiers" in text
+        assert "provenance, not\n   numbers" in text or "provenance, not numbers" in text
+
+    def test_codex_critic_why_paragraph(self, text: str):
+        assert "Why the task-ref carve-out does not reopen it (#1025)" in text
+
+    @pytest.mark.parametrize("path", ALL_GUARD_FILES, ids=lambda p: p.name)
+    def test_guard_file_carries_both_layers(self, path: Path):
+        text = path.read_text(encoding="utf-8")
+        # Two-layer predicates (plan #1025 acceptance criteria 1 + 6): each
+        # layer names the registry trace AND licenses the hyphen+underscore
+        # `issue[-_]<N>` form; "task-reference" appears in both layers.
+        assert text.count("REGISTRY.json") >= 2, path.name
+        assert text.count("issue[-_]") >= 2, path.name
+        assert text.lower().count("task-reference") >= 2, path.name
+        assert "fail-strict" in text, path.name


### PR DESCRIPTION
Closes task #1025.

Workflow fix (kind: infra, wf-fix): cross-issue task references (`#<N>`, `tasks/<status>/<N>`, `issue[-_]<N>`) are provenance identifiers, not result numbers — the codex composer numeric-leak guard now extracts them before numeric tokenization (symmetric prompt+span removal) and clears prompt-side ids against handed-span ids ∪ tasks/REGISTRY.json (fail-strict when unreadable). Preserves the #722 no-fabricated-numbers catch; collect-all residual reporting. 4 agent specs + the checked-in contract test extended (TestTaskRefCarveOut + doc-presence guards).

Plan v3 (critic-ensemble revised) · code-review PASS+PASS · Step 9c: 2452 passed, compare clean.