### PR TITLE
task #1026: upload-verifier currency gate for finalize

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -4068,7 +4068,10 @@ uv run python scripts/dispatch_issue.py finalize --issue <N> --skip-confirm-arti
 compute instances delete` leaves a stale sidecar the next launch would
 misread — use it only when no sidecar exists. `--skip-confirm-artifacts` is
 REQUIRED at a mid-pipeline gate: the run's declared final artifacts do not
-exist yet, so a plain `finalize` FAILs confirm (exit 3) by construction. The
+exist yet, so a plain `finalize` FAILs confirm (exit 3) by construction.
+(Mid-pipeline gate teardowns run BEFORE any upload-verifier dispatch or
+`epm:results`, so the #1026 verifier-currency gate is a no-op here — no
+verifying crumb, no results, no verdict to be stale against.) The
 instance stays up ONLY for sentinel draining — never through an off-pod
 phase or a park (Step 8-bis: a pod must not idle on a halt; incident #763:
 an A100-80 idled ~40 min after the `cofit_phaseA_done` gate-park). The next
@@ -4818,8 +4821,19 @@ URLs.
   and proceed to Step 9. (Same-issue follow-up round? At
   `followups_running`, SKIP the `interpreting` flip — status-hold rule,
   Step 9b § Same-issue follow-up loop step 3; code-enforced — but the
-  teardown + Step 9 progression run as normal.) Once artifacts are
-  confirmed at permanent
+  teardown + Step 9 progression run as normal.) "PASS" means a fresh
+  `epm:upload-verification` verdict for THIS round — posted after this
+  round's `epm:results` and after this round's `stage=verifying` dispatch
+  breadcrumb. A dispatched verifier with no verdict yet is BLOCKING: do
+  not flip status to `interpreting`, do not publish the held
+  interpretation, and do not run finalize on a prior round's PASS
+  (incident #778: status advanced and the pod was finalized ~19:00Z on
+  the fallback while the verifier was in flight; its verdict later came
+  back FAIL). On a FAIL verdict: uploader gap-fill + re-verify — never
+  advance on the FAIL. finalize enforces teardown-side currency
+  mechanically (the verifier-currency reasons below); the status flip
+  itself is prose-enforced — this paragraph IS that gate. Once artifacts
+  are confirmed at permanent
   URLs, the compute is no longer needed — interpretation runs locally.
   If the results-landed parallel spawn produced a held analyzer first
   pass, publish it now: post the held interpretation as
@@ -4854,6 +4868,29 @@ URLs.
   declaration nor agent PASS evidence, finalize still exits 3
   (`reason: confirm_artifacts_no_declaration`).
 
+  **Verifier-currency gate (#1026).** The agent-level PASS evidence must
+  be CURRENT — finalize refuses (exit 3, teardown skipped, sidecar not
+  retired) on every non-skip path with one of five typed reasons, each
+  with its routing action: `upload_verifier_in_flight` (a dispatched
+  verifier round has no verdict yet, liveness window fresh → WAIT for
+  the verdict; on PASS re-run finalize, on FAIL gap-fill + re-verify,
+  never finalize on a FAIL), `upload_verifier_stalled` (window lapsed,
+  no verdict → re-spawn the upload-verifier to a verdict, then finalize
+  on PASS), `upload_verification_ambiguous` (a late verdict cannot be
+  attributed to the current results-epoch → re-run the verifier; the
+  fresh round resolves it), `upload_verification_stale` (the latest
+  verdict predates the newest `epm:results` → re-verify),
+  `upload_verification_failed_current` (the latest verification is a
+  FAIL → gap-fill + re-verify). An in-flight verifier is never
+  PASS-equivalent; absence-of-verdict never satisfies the gate.
+  **Named residual:** the crumb-based rules presuppose the Step 9
+  entry-guard convention that a `stage-dispatch` breadcrumb precedes
+  each verifier spawn (the missed-breadcrumb limitation — see the
+  "Limitation (be explicit about it)" paragraph under the Step 9 entry
+  guard) — a verifier spawned WITHOUT its breadcrumb is invisible to the
+  in-flight/stalled rule; the stale + FAIL-current rules are the
+  backstops for that case.
+
   **Phase-scoped-launch mismatch (incident #604).** The launch-time
   auto-declaration assumes the FULL task artifact set (hydra-lane
   launches: HF `issue<N>_<attempt>/raw_completions/` + git
@@ -4883,11 +4920,21 @@ URLs.
   mismatch + the verified deliverable paths. Distinguish the two exit-3
   shapes: no-declaration → upload-verifier-to-PASS + plain re-run
   (above); present-but-phase-mismatched declaration → verify the phase
-  deliverable, then `--skip-confirm-artifacts`.
+  deliverable, then `--skip-confirm-artifacts`. The skip flag does NOT
+  bypass the verifier-currency gate for a FRESH in-flight verifier round
+  (exit 3 `upload_verifier_in_flight` — wait for the verdict, or for the
+  15-min window to lapse to `stalled`); stalled / stale / ambiguous /
+  failed-current records degrade to a loud warning + a `verifier_warning`
+  field in the success JSON.
 
   ```bash
   # ONE call for every backend. Exit 0 = confirm PASS + teardown done;
-  # exit 3 = confirm FAIL (teardown SKIPPED, evidence preserved); exit 2
+  # exit 3 = confirm FAIL or verifier-currency refusal (reason ∈
+  # confirm_artifacts_failed | confirm_artifacts_no_declaration |
+  # upload_verifier_in_flight | upload_verifier_stalled |
+  # upload_verification_ambiguous | upload_verification_stale |
+  # upload_verification_failed_current) — teardown SKIPPED, evidence
+  # preserved; exit 2
   # = missing sidecar (treat as infra failure).
   #
   # CAVEAT — parent-pod-reuse child tasks: when this child task ran on

--- a/scripts/dispatch_issue.py
+++ b/scripts/dispatch_issue.py
@@ -1483,6 +1483,9 @@ def _cmd_launch(args: argparse.Namespace, *, backends_factory: Callable[[], dict
 # ``epm:upload-verification`` marker note (shape: ``**Verdict: PASS**``;
 # see workflow.yaml § markers). Case-sensitive on purpose — the schema
 # emits uppercase PASS/FAIL, and prose mentions of "pass" must not match.
+# Private copy of the canonical ``task_workflow.UPLOAD_VERIFICATION_PASS_RE``
+# (#1026); pattern parity is pinned by
+# tests/test_upload_verifier_currency.py::test_pass_regex_parity_with_dispatch_issue.
 _UPLOAD_VERIFICATION_PASS_RE = re.compile(r"Verdict:\s*PASS\b")
 
 
@@ -1509,6 +1512,13 @@ def _agent_upload_verification_passed(issue: int) -> bool:
     ``False`` after a logged warning — the safe direction: no evidence ⇒
     the caller keeps the exit-3 teardown-skip; we never tear down on a
     guess.
+
+    CURRENCY is NOT this probe's job (#1026): the evidence forms above are
+    deliberately unchanged, and the verifier-currency gate
+    (:func:`_upload_verification_currency_blocker`, wired at the top of
+    :func:`_cmd_finalize`) wraps AROUND it — refusing teardown when a
+    verifier round is in flight, the latest verdict is a FAIL, or the
+    newest ``epm:results`` postdates the latest verdict.
     """
     log = logging.getLogger("dispatch_issue")
     try:
@@ -1549,6 +1559,38 @@ def _agent_upload_verification_passed(issue: int) -> bool:
     return False
 
 
+def _upload_verification_currency_blocker(issue: int) -> dict | None:
+    """Guarded wrapper over ``task_workflow.upload_verification_currency_blocker``.
+
+    Read/LOOKUP failures (missing task, unreadable events.jsonl) return None
+    after a logged warning — NOT a refusal: with unreadable events,
+    :func:`_agent_upload_verification_passed` also returns False, so the
+    degrade cannot fire and the existing exit-3 paths already hold teardown.
+    Deliberately NARROW (#1026 MF-C): a helper BUG
+    (TypeError/AttributeError/...) raises loudly instead of silently
+    disarming the gate (fail-fast rule). ``find_task_path`` raises
+    ``FileNotFoundError`` on a registry miss (and its
+    ``StaleTaskPathError`` subclass on multi-hit registry corruption) —
+    both are ``OSError`` lookup failures the narrow tuple absorbs.
+    """
+    try:
+        from explore_persona_space.task_workflow import (
+            list_events,
+            upload_verification_currency_blocker,
+        )
+
+        return upload_verification_currency_blocker(list_events(int(issue)))
+    except (FileNotFoundError, KeyError, OSError) as exc:
+        logging.getLogger("dispatch_issue").warning(
+            "could not read upload-verifier currency evidence for issue=%d (%s: %s); "
+            "treating as no blocker (the PASS-evidence probe keeps its own safe direction)",
+            int(issue),
+            type(exc).__name__,
+            exc,
+        )
+        return None
+
+
 def _cmd_finalize(
     args: argparse.Namespace, *, backends_factory: Callable[[], dict[str, Any]]
 ) -> int:
@@ -1562,17 +1604,36 @@ def _cmd_finalize(
     (HF Hub list_repo_files + WandB run + git-figure + completion
     sentinel — see ``backends.artifacts.confirm_artifacts_from_handle``).
 
+    Verifier-currency gate (#1026): BEFORE ``fetch_results``, ONE top gate
+    (:func:`_upload_verification_currency_blocker`) requires the
+    upload-verification evidence to be a CURRENT PASS, uniformly on ALL
+    non-skip paths (declaration-present AND declaration-less). Five typed
+    exit-3 reasons: ``upload_verifier_in_flight`` (a dispatched verifier
+    round has no verdict yet, liveness window fresh),
+    ``upload_verifier_stalled`` (window lapsed, no verdict),
+    ``upload_verification_ambiguous`` (a late verdict cannot be attributed
+    to the current results-epoch), ``upload_verification_stale`` (the
+    latest ``epm:results`` postdates the latest verdict),
+    ``upload_verification_failed_current`` (the latest verification is a
+    FAIL). ``--skip-confirm-artifacts`` refuses ONLY a FRESH in-flight
+    round (never destroy a running round's pod; the 15-min liveness window
+    lapsing to ``stalled`` is the flag-free escape) and degrades the other
+    four reasons to a loud warning + a ``verifier_warning`` field in the
+    success JSON.
+
     Degrade path: when the handle carries NO ``expected_artifacts``
     declaration the mechanical gate is structurally unsatisfiable.
-    Every launch path (GCP, SLURM, RunPod) populates the declaration as
-    of #598, so a declaration-less handle is a pre-#598 in-flight
-    sidecar only; a confirm FAIL on one falls back to the agent-level
+    Declaration-less handles still occur in production (RunPod
+    experimenter-launched runs, pre-#598 sidecars); a confirm FAIL on one
+    falls back to the agent-level
     upload-verification PASS evidence on the task's ``events.jsonl``
     (:func:`_agent_upload_verification_passed`). Evidence found →
     teardown proceeds with a LOUD log + a ``confirm_artifacts`` field in
     the output JSON; no evidence → exit 3 with
     ``reason: confirm_artifacts_no_declaration``. A handle WITH a
     declaration never degrades — a real mechanical FAIL always exits 3.
+    Either way the currency gate above already ran: the degrade can only
+    execute when the blocker is None on the non-skip path.
 
     After a SUCCESSFUL teardown the sidecar is renamed to
     ``<name>.finalized`` (audit record, never deleted) so a later
@@ -1607,6 +1668,59 @@ def _cmd_finalize(
     handle = read_handle_sidecar(Path(sidecar))
     deps = backends_factory()
     backend = _resolve_backend_for_handle(handle, deps)
+
+    # ── #1026 verifier-currency gate (uniform: ALL paths) ────────────────
+    # Teardown requires the upload-verification evidence to be a CURRENT
+    # PASS. --skip-confirm-artifacts relaxes every reason EXCEPT a FRESH
+    # in-flight round (never destroy a running verifier round's pod; the
+    # 15-min liveness window lapsing to "stalled" is the flag-free escape)
+    # to a loud warning + a verifier_warning field in the output JSON.
+    verifier_warning: str | None = None
+    blocker = _upload_verification_currency_blocker(args.issue)
+    if blocker is not None:
+        if args.skip_confirm_artifacts and blocker["reason"] != "upload_verifier_in_flight":
+            verifier_warning = blocker["reason"]
+            logging.getLogger("dispatch_issue").warning(
+                "finalize --skip-confirm-artifacts: %s — proceeding on the explicit "
+                "skip flag; confirm pod-side data is safe before relying on this.",
+                blocker["detail"],
+            )
+        else:
+            hint = {
+                "upload_verifier_in_flight": (
+                    "WAIT for the epm:upload-verification verdict; on PASS re-run "
+                    "finalize; on FAIL run the uploader gap-fill + re-verify — "
+                    "NEVER finalize on a FAIL."
+                ),
+                "upload_verifier_stalled": (
+                    "re-spawn the upload-verifier to a verdict, then finalize on PASS."
+                ),
+                "upload_verification_ambiguous": (
+                    "re-run the upload-verifier against the current results (the "
+                    "fresh round resolves the ambiguity), then finalize on PASS."
+                ),
+                "upload_verification_stale": (
+                    "re-run the upload-verifier against the current results to a "
+                    "PASS, then re-run finalize."
+                ),
+                "upload_verification_failed_current": (
+                    "run the uploader gap-fill, re-verify to a PASS, then finalize."
+                ),
+            }[blocker["reason"]]
+            body = {
+                "ok": False,
+                "issue": int(args.issue),
+                "phase": "confirm_artifacts",
+                "chosen_kind": handle.backend,
+                "pod_name": handle.pod_name,
+                "reason": blocker["reason"],
+                "verifier_state": blocker["state"],
+                "skip_confirm_artifacts": bool(args.skip_confirm_artifacts),
+                "detail": blocker["detail"] + " — teardown SKIPPED. Recover: " + hint,
+            }
+            print(json.dumps(body, sort_keys=True))
+            return 3
+    # ─────────────────────────────────────────────────────────────────────
 
     # ``fetch_results`` BEFORE the confirm gate (#588 / latent slice-6
     # gap): the GCP completion sentinel lives ON the VM — ``GcpBackend.
@@ -1736,6 +1850,8 @@ def _cmd_finalize(
     }
     if confirm_degraded is not None:
         body["confirm_artifacts"] = confirm_degraded
+    if verifier_warning is not None:
+        body["verifier_warning"] = verifier_warning
     print(json.dumps(body, sort_keys=True))
     return 0
 
@@ -2167,6 +2283,7 @@ __all__ = [
     "_provision_still_waiting",
     "_recognized_frontmatter_backends",
     "_resolve_backend_for_handle",
+    "_upload_verification_currency_blocker",
     "_wrap_marker_poster_with_override_flag",
     "main",
 ]

--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -1610,6 +1610,192 @@ def stage_dispatch_should_skip(
     )
 
 
+# Canonical PASS-verdict pattern for an epm:upload-verification note
+# (shape: **Verdict: PASS**; case-sensitive on purpose — prose "pass" must
+# not match). scripts/dispatch_issue.py keeps a private copy
+# (_UPLOAD_VERIFICATION_PASS_RE); parity pinned by a test
+# (tests/test_upload_verifier_currency.py).
+UPLOAD_VERIFICATION_PASS_RE = re.compile(r"Verdict:\s*PASS\b")
+
+# Marker kinds recording an upload-verification VERDICT (the per-round
+# epm:upload-verification report, or the sticky epm:upload-verified the
+# skill posts right before auto-terminate).
+UPLOAD_VERDICT_KINDS = frozenset({"epm:upload-verification", "epm:upload-verified"})
+
+
+def _upload_verification_event_index(
+    events: list[dict],
+) -> tuple[list[int], dict[int, dict[str, str]], list[int], list[int]]:
+    """Index events for the currency scan (one pass, index order == chronology).
+
+    Returns ``(crumb_idxs, crumb_fields, verdict_idxs, results_idxs)``:
+    verifying-stage ``stage-dispatch`` breadcrumb indices (+ parsed fields),
+    ``UPLOAD_VERDICT_KINDS`` event indices, and ``epm:results`` indices.
+    """
+    crumb_idxs: list[int] = []
+    crumb_fields: dict[int, dict[str, str]] = {}
+    verdict_idxs: list[int] = []
+    results_idxs: list[int] = []
+    for idx, event in enumerate(events):
+        kind = event.get("kind", "")
+        if kind == "epm:progress":
+            note = (event.get("note", "") or "").lstrip()
+            if note.startswith("stage-dispatch "):
+                fields = _breadcrumb_fields(note)
+                if _normalize_stage(fields.get("stage", "")) == "verifying":
+                    crumb_idxs.append(idx)
+                    crumb_fields[idx] = fields
+        elif kind in UPLOAD_VERDICT_KINDS:
+            verdict_idxs.append(idx)
+        elif kind == "epm:results":
+            results_idxs.append(idx)
+    return crumb_idxs, crumb_fields, verdict_idxs, results_idxs
+
+
+def upload_verification_currency_blocker(
+    events: list[dict],
+    *,
+    now: datetime | None = None,
+    window_minutes: float = 15.0,
+) -> dict | None:
+    """Typed refusal record when upload-verification evidence is not a CURRENT PASS.
+
+    None when evidence is current (or there is no verifier/results activity
+    at all — the pure-sticky legacy shape stays vacuously clear). Otherwise:
+      reason: upload_verifier_in_flight | upload_verifier_stalled
+              | upload_verification_ambiguous | upload_verification_stale
+              | upload_verification_failed_current
+      state:  "in-flight" | "stalled" | None
+      stage / round / breadcrumb_ts / age_minutes / detail
+
+    Ordering compares INDICES (append-only events.jsonl => index order ==
+    chronological), mirroring stage_dispatch_should_skip. Rules, in order:
+
+    1. IN-FLIGHT / STALLED — the latest verifying-stage breadcrumb
+       (_normalize_stage(stage) == "verifying"; covers followup-verifying)
+       has NO UPLOAD_VERDICT_KINDS event at a later index. state="in-flight"
+       when stage_dispatch_should_skip(events, raw_stage, round, window)
+       still reports it (liveness-refreshing 15-min window); else "stalled"
+       (window lapsed / no parsable round / malformed ts / cleared only by
+       epm:failure — the round died with no verdict; a stale prior PASS is
+       still stale).
+    2. AMBIGUOUS (MF-B) — a verdict exists after the latest crumb c_K, but
+       some earlier crumb c_i is UNRESOLVED (no verdict-kind event in the
+       open interval (c_i, c_K)) AND an epm:results lies in (c_i, c_K):
+       the late verdict cannot be attributed to the current results-epoch
+       (it may be c_i's, leaving c_K's round unverified — or still
+       running). The stalled->re-spawn recovery [C1, C2, V] has no results
+       between crumbs (same epoch — any verdict covers it) and CLEARS;
+       recovery from a block is one verifier re-run: the fresh crumb
+       c_{K+1} + verdict resolves every earlier crumb by inclusion (a
+       verdict now lies in (c_i, c_{K+1})) — no deadlock.
+    3. STALE — the latest epm:results has no UPLOAD_VERDICT_KINDS event at
+       a later index (including: results exist, NO verdict marker ever).
+    4. FAILED-CURRENT (MF-A) — the latest UPLOAD_VERDICT_KINDS event is an
+       epm:upload-verification whose note fails UPLOAD_VERIFICATION_PASS_RE:
+       the current verification POSITIVELY failed; prior PASS/sticky
+       evidence is not current. (A sticky AFTER the FAIL is the skill's
+       subsequent-PASS record and clears; rules 3/4 are index-disjoint —
+       a FAIL predating results reads as stale, a FAIL postdating results
+       as failed-current.)
+    """
+    if now is None:
+        now = datetime.now(UTC)
+    crumb_idxs, crumb_fields, verdict_idxs, results_idxs = _upload_verification_event_index(events)
+
+    # Rule 1: unresolved latest crumb.
+    if crumb_idxs and (not verdict_idxs or verdict_idxs[-1] < crumb_idxs[-1]):
+        c_k = crumb_idxs[-1]
+        fields = crumb_fields[c_k]
+        raw_stage = fields.get("stage", "")
+        try:
+            round_num: int | None = int(fields["round"])
+        except (KeyError, ValueError):
+            round_num = None
+        in_flight = round_num is not None and bool(
+            stage_dispatch_should_skip(events, raw_stage, round_num, window_minutes, now=now)
+        )
+        ts = _stage_event_ts(events[c_k])
+        age = None if ts is None else round((now - ts).total_seconds() / 60.0, 1)
+        state = "in-flight" if in_flight else "stalled"
+        return {
+            "reason": "upload_verifier_in_flight" if in_flight else "upload_verifier_stalled",
+            "state": state,
+            "stage": raw_stage,
+            "round": round_num,
+            "breadcrumb_ts": events[c_k].get("ts", ""),
+            "age_minutes": age,
+            "detail": (
+                f"stage-dispatch stage={raw_stage} round={round_num} at "
+                f"{events[c_k].get('ts', '')} has no later upload-verification "
+                f"verdict (state={state}, age={age}m, window={window_minutes}m)"
+            ),
+        }
+
+    # Rule 2 (MF-B): unresolved earlier crumb across a results boundary.
+    if crumb_idxs:
+        c_k = crumb_idxs[-1]
+        for c_i in crumb_idxs[:-1]:
+            resolved = any(c_i < v < c_k for v in verdict_idxs)
+            crossed = any(c_i < r < c_k for r in results_idxs)
+            if not resolved and crossed:
+                return {
+                    "reason": "upload_verification_ambiguous",
+                    "state": None,
+                    "stage": None,
+                    "round": None,
+                    "breadcrumb_ts": events[c_i].get("ts", ""),
+                    "age_minutes": None,
+                    "detail": (
+                        f"verifying crumb at {events[c_i].get('ts', '')} is unresolved "
+                        f"and epm:results landed before the latest crumb at "
+                        f"{events[c_k].get('ts', '')} — the post-crumb verdict cannot "
+                        f"be attributed to the current results-epoch"
+                    ),
+                }
+
+    # Rule 3: latest results unverified (stale) — incl. no verdict ever.
+    if results_idxs and (not verdict_idxs or verdict_idxs[-1] < results_idxs[-1]):
+        verdict_txt = (
+            "no verdict marker exists"
+            if not verdict_idxs
+            else f"latest verdict at {events[verdict_idxs[-1]].get('ts', '')}"
+        )
+        return {
+            "reason": "upload_verification_stale",
+            "state": None,
+            "stage": None,
+            "round": None,
+            "breadcrumb_ts": None,
+            "age_minutes": None,
+            "detail": (
+                f"latest epm:results at {events[results_idxs[-1]].get('ts', '')} "
+                f"postdates the upload-verification evidence ({verdict_txt})"
+            ),
+        }
+
+    # Rule 4 (MF-A): the current verification is a FAIL.
+    if verdict_idxs:
+        latest = events[verdict_idxs[-1]]
+        if latest.get("kind") == "epm:upload-verification" and not (
+            UPLOAD_VERIFICATION_PASS_RE.search(str(latest.get("note", "")))
+        ):
+            return {
+                "reason": "upload_verification_failed_current",
+                "state": None,
+                "stage": None,
+                "round": None,
+                "breadcrumb_ts": None,
+                "age_minutes": None,
+                "detail": (
+                    f"latest epm:upload-verification at {latest.get('ts', '')} is not "
+                    f"a PASS — the current verification FAILED; prior PASS/sticky "
+                    f"evidence is not current"
+                ),
+            }
+    return None
+
+
 # ─── Pre-dispatch external-marker triage (#889) ─────────────────────────────
 
 # Machine-posted / lifecycle-bookkeeping kinds that never carry cross-session

--- a/tests/test_dispatch_issue_cli.py
+++ b/tests/test_dispatch_issue_cli.py
@@ -2165,6 +2165,10 @@ def test_finalize_confirm_artifacts_pass_runs_teardown(monkeypatch, tmp_path) ->
     nibi = _MockBackend(kind="nibi", confirm_passes=True)
     factory = _build_mock_factory(nibi=nibi)
 
+    import scripts.dispatch_issue as di
+
+    monkeypatch.setattr(di, "_upload_verification_currency_blocker", lambda _issue: None)
+
     from scripts.dispatch_issue import main
 
     buf = io.StringIO()
@@ -2198,6 +2202,10 @@ def test_finalize_confirm_artifacts_fail_skips_teardown_and_exits_nonzero(
     _seed_sidecar(tmp_path, 401, kind="nibi")
     nibi = _MockBackend(kind="nibi", confirm_passes=False)
     factory = _build_mock_factory(nibi=nibi)
+
+    import scripts.dispatch_issue as di
+
+    monkeypatch.setattr(di, "_upload_verification_currency_blocker", lambda _issue: None)
 
     from scripts.dispatch_issue import main
 
@@ -2242,6 +2250,7 @@ def test_finalize_no_declaration_with_agent_pass_degrades_to_teardown(
     import scripts.dispatch_issue as di
 
     monkeypatch.setattr(di, "_agent_upload_verification_passed", lambda _issue: True)
+    monkeypatch.setattr(di, "_upload_verification_currency_blocker", lambda _issue: None)
 
     buf = io.StringIO()
     with redirect_stdout(buf):
@@ -2280,6 +2289,7 @@ def test_finalize_no_declaration_without_agent_pass_keeps_exit_3(monkeypatch, tm
     import scripts.dispatch_issue as di
 
     monkeypatch.setattr(di, "_agent_upload_verification_passed", lambda _issue: False)
+    monkeypatch.setattr(di, "_upload_verification_currency_blocker", lambda _issue: None)
 
     buf = io.StringIO()
     with redirect_stdout(buf):
@@ -2314,6 +2324,7 @@ def test_finalize_declaration_present_fail_never_degrades(monkeypatch, tmp_path)
     import scripts.dispatch_issue as di
 
     monkeypatch.setattr(di, "_agent_upload_verification_passed", lambda _issue: True)
+    monkeypatch.setattr(di, "_upload_verification_currency_blocker", lambda _issue: None)
 
     buf = io.StringIO()
     with redirect_stdout(buf):
@@ -2392,6 +2403,10 @@ def test_finalize_skip_confirm_artifacts_forces_teardown(monkeypatch, tmp_path) 
     nibi = _MockBackend(kind="nibi", confirm_passes=False)
     factory = _build_mock_factory(nibi=nibi)
 
+    import scripts.dispatch_issue as di
+
+    monkeypatch.setattr(di, "_upload_verification_currency_blocker", lambda _issue: None)
+
     from scripts.dispatch_issue import main
 
     buf = io.StringIO()
@@ -2424,6 +2439,10 @@ def test_finalize_renames_sidecar_after_successful_teardown(monkeypatch, tmp_pat
     original_payload = sidecar.read_text()
     nibi = _MockBackend(kind="nibi", confirm_passes=True)
     factory = _build_mock_factory(nibi=nibi)
+
+    import scripts.dispatch_issue as di
+
+    monkeypatch.setattr(di, "_upload_verification_currency_blocker", lambda _issue: None)
 
     from scripts.dispatch_issue import main
 
@@ -2465,6 +2484,10 @@ def test_finalize_missing_sidecar_returns_infra_failure_not_crash(monkeypatch, t
     _cd_to_tmp(monkeypatch, tmp_path)
     factory = _build_mock_factory(nibi=_MockBackend(kind="nibi"))
 
+    import scripts.dispatch_issue as di
+
+    monkeypatch.setattr(di, "_upload_verification_currency_blocker", lambda _issue: None)
+
     from scripts.dispatch_issue import main
 
     buf = io.StringIO()
@@ -2484,6 +2507,308 @@ def test_finalize_missing_sidecar_returns_infra_failure_not_crash(monkeypatch, t
     assert body["ok"] is False
     assert body["failure_class"] == "infra"
     assert body["reason"] == "missing_handle_sidecar"
+
+
+# ---------------------------------------------------------------------------
+# issue #1026 — finalize verifier-currency gate
+# ---------------------------------------------------------------------------
+
+
+def _currency_blocker_record(reason: str, state: str | None = None) -> dict:
+    """A seam blocker record shaped like the real helper's return."""
+    return {
+        "reason": reason,
+        "state": state,
+        "stage": "verifying" if state else None,
+        "round": 1 if state else None,
+        "breadcrumb_ts": "2026-07-02T18:55:00Z" if state else None,
+        "age_minutes": 5.0 if state else None,
+        "detail": f"seam blocker: {reason}",
+    }
+
+
+def _run_finalize(tmp_path, issue: int, factory, *extra_args: str) -> tuple[int, dict]:
+    """Run ``finalize --issue <N> --handle-file <sidecar>`` and parse the JSON line."""
+    import scripts.dispatch_issue as di
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = di.main(
+            [
+                "finalize",
+                "--issue",
+                str(issue),
+                "--handle-file",
+                str(tmp_path / f"issue-{issue}-handle.json"),
+                *extra_args,
+            ],
+            backends_factory=factory,
+        )
+    return rc, json.loads(buf.getvalue().strip())
+
+
+def test_finalize_in_flight_verifier_blocks_no_declaration_degrade(monkeypatch, tmp_path) -> None:
+    """C1: no-declaration + agent PASS evidence + an IN-FLIGHT verifier
+    round → exit 3 ``upload_verifier_in_flight``; teardown NOT called,
+    sidecar NOT retired (the #778 fallback loophole, closed)."""
+    _cd_to_tmp(monkeypatch, tmp_path)
+    _seed_sidecar(tmp_path, 407, kind="runpod", with_declaration=False)
+    runpod = _MockBackend(kind="runpod", confirm_passes=False)
+    factory = _build_mock_factory(runpod=runpod)
+
+    import scripts.dispatch_issue as di
+
+    monkeypatch.setattr(di, "_agent_upload_verification_passed", lambda _issue: True)
+    monkeypatch.setattr(
+        di,
+        "_upload_verification_currency_blocker",
+        lambda _issue: _currency_blocker_record("upload_verifier_in_flight", "in-flight"),
+    )
+    rc, body = _run_finalize(tmp_path, 407, factory)
+    assert rc == 3
+    assert body["ok"] is False
+    assert body["reason"] == "upload_verifier_in_flight"
+    assert body["verifier_state"] == "in-flight"
+    assert len(runpod.teardowns) == 0
+    assert (tmp_path / "issue-407-handle.json").exists()  # NOT retired
+
+
+def test_finalize_stalled_verifier_refuses_without_skip_flag(monkeypatch, tmp_path) -> None:
+    """C2 (MF-D): NO skip flag + a STALLED verifier round → exit 3
+    ``upload_verifier_stalled``, 0 teardowns, sidecar NOT retired. This
+    cell IS the #778 replay whenever finalize fires past the 15-min
+    window."""
+    _cd_to_tmp(monkeypatch, tmp_path)
+    _seed_sidecar(tmp_path, 407, kind="runpod", with_declaration=False)
+    runpod = _MockBackend(kind="runpod", confirm_passes=False)
+    factory = _build_mock_factory(runpod=runpod)
+
+    import scripts.dispatch_issue as di
+
+    monkeypatch.setattr(di, "_agent_upload_verification_passed", lambda _issue: True)
+    monkeypatch.setattr(
+        di,
+        "_upload_verification_currency_blocker",
+        lambda _issue: _currency_blocker_record("upload_verifier_stalled", "stalled"),
+    )
+    rc, body = _run_finalize(tmp_path, 407, factory)
+    assert rc == 3
+    assert body["reason"] == "upload_verifier_stalled"
+    assert len(runpod.teardowns) == 0
+    assert (tmp_path / "issue-407-handle.json").exists()
+
+
+def test_finalize_stale_blocks_declaration_present_confirm_pass(monkeypatch, tmp_path) -> None:
+    """C3 (MF-E pin): declaration PRESENT + mechanical confirm would PASS +
+    a STALE verdict → exit 3 ``upload_verification_stale`` BEFORE
+    ``fetch_results`` / ``confirm_artifacts`` ever run — the gate is
+    uniform across all non-skip paths."""
+    _cd_to_tmp(monkeypatch, tmp_path)
+    _seed_sidecar(tmp_path, 400, kind="nibi", with_declaration=True)
+    nibi = _MockBackend(kind="nibi", confirm_passes=True)
+    factory = _build_mock_factory(nibi=nibi)
+
+    import scripts.dispatch_issue as di
+
+    monkeypatch.setattr(
+        di,
+        "_upload_verification_currency_blocker",
+        lambda _issue: _currency_blocker_record("upload_verification_stale"),
+    )
+    rc, body = _run_finalize(tmp_path, 400, factory)
+    assert rc == 3
+    assert body["reason"] == "upload_verification_stale"
+    assert len(nibi.fetches) == 0  # gate precedes fetch_results
+    assert len(nibi.confirms) == 0
+    assert len(nibi.teardowns) == 0
+    assert (tmp_path / "issue-400-handle.json").exists()
+
+
+def test_finalize_in_flight_blocks_declaration_present_path(monkeypatch, tmp_path) -> None:
+    """C4: declaration present + seam in-flight → exit 3 before
+    fetch/confirm; teardown skipped; sidecar not retired."""
+    _cd_to_tmp(monkeypatch, tmp_path)
+    _seed_sidecar(tmp_path, 400, kind="nibi", with_declaration=True)
+    nibi = _MockBackend(kind="nibi", confirm_passes=True)
+    factory = _build_mock_factory(nibi=nibi)
+
+    import scripts.dispatch_issue as di
+
+    monkeypatch.setattr(
+        di,
+        "_upload_verification_currency_blocker",
+        lambda _issue: _currency_blocker_record("upload_verifier_in_flight", "in-flight"),
+    )
+    rc, body = _run_finalize(tmp_path, 400, factory)
+    assert rc == 3
+    assert body["reason"] == "upload_verifier_in_flight"
+    assert len(nibi.confirms) == 0
+    assert len(nibi.teardowns) == 0
+    assert (tmp_path / "issue-400-handle.json").exists()
+
+
+def test_finalize_skip_flag_still_refuses_fresh_in_flight(monkeypatch, tmp_path) -> None:
+    """C5: ``--skip-confirm-artifacts`` NEVER destroys a RUNNING verifier
+    round's pod — a fresh in-flight round refuses even with the flag."""
+    _cd_to_tmp(monkeypatch, tmp_path)
+    _seed_sidecar(tmp_path, 402, kind="nibi")
+    nibi = _MockBackend(kind="nibi", confirm_passes=False)
+    factory = _build_mock_factory(nibi=nibi)
+
+    import scripts.dispatch_issue as di
+
+    monkeypatch.setattr(
+        di,
+        "_upload_verification_currency_blocker",
+        lambda _issue: _currency_blocker_record("upload_verifier_in_flight", "in-flight"),
+    )
+    rc, body = _run_finalize(tmp_path, 402, factory, "--skip-confirm-artifacts")
+    assert rc == 3
+    assert body["reason"] == "upload_verifier_in_flight"
+    assert body["skip_confirm_artifacts"] is True
+    assert len(nibi.teardowns) == 0
+    assert (tmp_path / "issue-402-handle.json").exists()
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "upload_verifier_stalled",  # C6
+        "upload_verification_stale",  # C7
+        "upload_verification_failed_current",  # C7b — crashed-run recovery pin
+    ],
+)
+def test_finalize_skip_flag_degrades_non_in_flight_reasons_to_warning(
+    monkeypatch, tmp_path, reason
+) -> None:
+    """C6/C7/C7b: with ``--skip-confirm-artifacts``, stalled / stale /
+    failed-current records degrade to a loud warning — teardown runs,
+    the success JSON carries ``verifier_warning``, sidecar retired
+    (keeps #604, crashed-run recovery, and 6d.4 working, zero new flags)."""
+    _cd_to_tmp(monkeypatch, tmp_path)
+    _seed_sidecar(tmp_path, 402, kind="nibi")
+    nibi = _MockBackend(kind="nibi", confirm_passes=False)
+    factory = _build_mock_factory(nibi=nibi)
+
+    import scripts.dispatch_issue as di
+
+    state = "stalled" if reason == "upload_verifier_stalled" else None
+    monkeypatch.setattr(
+        di,
+        "_upload_verification_currency_blocker",
+        lambda _issue: _currency_blocker_record(reason, state),
+    )
+    rc, body = _run_finalize(tmp_path, 402, factory, "--skip-confirm-artifacts")
+    assert rc == 0
+    assert body["ok"] is True
+    assert body["verifier_warning"] == reason
+    assert len(nibi.teardowns) == 1
+    assert not (tmp_path / "issue-402-handle.json").exists()
+    assert (tmp_path / "issue-402-handle.json.finalized").exists()
+
+
+def test_failed_verifier_round_refuses_never_silent(monkeypatch, tmp_path) -> None:
+    """C8 (MF-A, REAL read path): the #778 shape — a sticky prior PASS, new
+    results, a verifying crumb, then a FAIL verdict — refuses through the
+    REAL wrapper → real ``list_events`` → real helper chain (NO seam
+    patch): exit 3 ``upload_verification_failed_current``, 0 teardowns.
+    Pre-#1026 this shape TORE DOWN via the sticky-anywhere fallback."""
+    import explore_persona_space.task_workflow as tw
+
+    _cd_to_tmp(monkeypatch, tmp_path)
+    task_dir = tmp_path / "tasks" / "verifying" / "777"
+    task_dir.mkdir(parents=True)
+    monkeypatch.setattr(tw, "find_task_path", lambda _id: task_dir)
+    events = [
+        {"ts": "2026-07-02T03:40:00Z", "kind": "epm:upload-verified", "note": "sticky PASS"},
+        {"ts": "2026-07-02T18:30:00Z", "kind": "epm:results", "note": "round-2 results"},
+        {
+            "ts": "2026-07-02T18:40:00Z",
+            "kind": "epm:progress",
+            "note": "stage-dispatch stage=followup-verifying round=1 subagent=upload-verifier",
+        },
+        {
+            "ts": "2026-07-02T18:50:00Z",
+            "kind": "epm:upload-verification",
+            "note": "## Upload Verification\n\n**Verdict: FAIL**\n\n2 files missing.",
+        },
+    ]
+    (task_dir / "events.jsonl").write_text("".join(json.dumps(e) + "\n" for e in events))
+
+    _seed_sidecar(tmp_path, 777, kind="runpod", with_declaration=False)
+    runpod = _MockBackend(kind="runpod", confirm_passes=False)
+    factory = _build_mock_factory(runpod=runpod)
+
+    rc, body = _run_finalize(tmp_path, 777, factory)
+    assert rc == 3
+    assert body["reason"] == "upload_verification_failed_current"
+    assert len(runpod.teardowns) == 0
+    assert (tmp_path / "issue-777-handle.json").exists()
+
+
+def test_finalize_real_read_path_blocks_unresolved_crumb(monkeypatch, tmp_path) -> None:
+    """C9 (MF-C, REAL read path): the #778 v2-dispatch replay — results →
+    PASS verdict → a NEW verifying crumb with no verdict yet. The REAL
+    wrapper returns an in-flight/stalled reason and finalize exits 3."""
+    import explore_persona_space.task_workflow as tw
+
+    _cd_to_tmp(monkeypatch, tmp_path)
+    task_dir = tmp_path / "tasks" / "verifying" / "777"
+    task_dir.mkdir(parents=True)
+    monkeypatch.setattr(tw, "find_task_path", lambda _id: task_dir)
+    events = [
+        {"ts": "2026-07-02T03:20:00Z", "kind": "epm:results", "note": "results"},
+        {
+            "ts": "2026-07-02T03:36:37Z",
+            "kind": "epm:upload-verification",
+            "note": "**Verdict: PASS**",
+        },
+        {
+            "ts": "2026-07-02T03:40:00Z",
+            "kind": "epm:progress",
+            "note": "stage-dispatch stage=followup-verifying round=1 subagent=upload-verifier",
+        },
+    ]
+    (task_dir / "events.jsonl").write_text("".join(json.dumps(e) + "\n" for e in events))
+
+    import scripts.dispatch_issue as di
+
+    blocker = di._upload_verification_currency_blocker(777)
+    assert blocker is not None
+    assert blocker["reason"] in {"upload_verifier_in_flight", "upload_verifier_stalled"}
+
+    _seed_sidecar(tmp_path, 777, kind="runpod", with_declaration=False)
+    runpod = _MockBackend(kind="runpod", confirm_passes=False)
+    factory = _build_mock_factory(runpod=runpod)
+    rc, body = _run_finalize(tmp_path, 777, factory)
+    assert rc == 3
+    assert body["reason"] in {"upload_verifier_in_flight", "upload_verifier_stalled"}
+    assert len(runpod.teardowns) == 0
+
+
+def test_currency_blocker_wrapper_missing_task_is_none() -> None:
+    """C10: the wrapper absorbs the ``find_task_path`` registry-miss
+    exception (FileNotFoundError) into None — a missing task is NOT a
+    refusal (the PASS-evidence probe keeps its own safe direction)."""
+    import scripts.dispatch_issue as di
+
+    assert di._upload_verification_currency_blocker(99999999) is None
+
+
+def test_currency_blocker_wrapper_raises_on_helper_bug(monkeypatch) -> None:
+    """C11 (MF-C fail-loud): a helper BUG (TypeError) RAISES through the
+    wrapper — it can never silently disarm the gate by returning None."""
+    import explore_persona_space.task_workflow as tw
+    import scripts.dispatch_issue as di
+
+    monkeypatch.setattr(tw, "list_events", lambda _id: [])
+
+    def _boom(_events, **_kw):
+        raise TypeError("helper bug")
+
+    monkeypatch.setattr(tw, "upload_verification_currency_blocker", _boom)
+    with pytest.raises(TypeError, match="helper bug"):
+        di._upload_verification_currency_blocker(777)
 
 
 # ---------------------------------------------------------------------------
@@ -3020,6 +3345,10 @@ def test_finalize_calls_fetch_results_before_confirm_artifacts(monkeypatch, tmp_
     nibi = _MockBackend(kind="nibi", confirm_passes=True)
     factory = _build_mock_factory(nibi=nibi)
 
+    import scripts.dispatch_issue as di
+
+    monkeypatch.setattr(di, "_upload_verification_currency_blocker", lambda _issue: None)
+
     from scripts.dispatch_issue import main
 
     buf = io.StringIO()
@@ -3052,6 +3381,10 @@ def test_finalize_fetch_results_crash_still_reaches_confirm_gate(monkeypatch, tm
 
     nibi.fetch_results = exploding_fetch  # type: ignore[method-assign]
     factory = _build_mock_factory(nibi=nibi)
+
+    import scripts.dispatch_issue as di
+
+    monkeypatch.setattr(di, "_upload_verification_currency_blocker", lambda _issue: None)
 
     from scripts.dispatch_issue import main
 
@@ -3552,6 +3885,10 @@ def test_finalize_lane_suffix_resolves_suffixed_sidecar(monkeypatch, tmp_path) -
     write_handle_sidecar(decoy, cache / "issue-9346-handle.json")
     nibi = _MockBackend(kind="nibi", confirm_passes=True)
     factory = _build_mock_factory(nibi=nibi)
+
+    import scripts.dispatch_issue as di
+
+    monkeypatch.setattr(di, "_upload_verification_currency_blocker", lambda _issue: None)
 
     from scripts.dispatch_issue import main
 

--- a/tests/test_upload_verifier_currency.py
+++ b/tests/test_upload_verifier_currency.py
@@ -1,0 +1,340 @@
+"""Pure-helper tests for ``task_workflow.upload_verification_currency_blocker`` (#1026).
+
+The helper is the verifier-currency gate behind ``dispatch_issue.py finalize``:
+it refuses teardown when the upload-verification evidence is not a CURRENT
+PASS — a dispatched-but-unresolved verifier round (in-flight / stalled), an
+unattributable late verdict (ambiguous, MF-B), results newer than the latest
+verdict (stale), or a FAIL as the latest verification (failed-current, MF-A).
+Synthetic event lists, no registry — the pattern of
+``tests/test_stage_dispatch_dedup.py``. The incident replayed throughout is
+#778 (pod finalized on a stale fallback while the verifier was in flight; its
+verdict later came back FAIL).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import explore_persona_space.task_workflow as tw
+
+
+def _ev(ts: str, kind: str, note: str = "", version: int = 1, by: str = "test") -> dict:
+    return {"ts": ts, "kind": kind, "version": version, "by": by, "note": note}
+
+
+def _dt(s: str) -> datetime:
+    return datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
+_NOW = _dt("2026-07-02T19:00:00Z")
+
+_CRUMB = "stage-dispatch stage=verifying round=1 subagent=upload-verifier worktree=repo-root"
+_CRUMB_FOLLOWUP = (
+    "stage-dispatch stage=followup-verifying round=1 subagent=upload-verifier worktree=repo-root"
+)
+_PASS_NOTE = "## Upload Verification\n\n**Verdict: PASS**\n\n11 files verified."
+_FAIL_NOTE = "## Upload Verification\n\n**Verdict: FAIL**\n\n2 of 11 files missing."
+
+
+def _blocker(events: list[dict], *, now: datetime = _NOW) -> dict | None:
+    return tw.upload_verification_currency_blocker(events, now=now)
+
+
+# ---------------------------------------------------------------------------
+# Rule 1 — in-flight / stalled
+# ---------------------------------------------------------------------------
+
+
+def test_p1_fresh_crumb_with_genuine_prior_verdict_is_in_flight() -> None:
+    """P1: [R_prior, V_prior-PASS, R, crumb(fresh)] → in_flight.
+
+    Includes a GENUINE prior verdict + prior results so the
+    ``verdict_idxs[-1] < crumb_idxs[-1]`` ordering branch is exercised —
+    an implementation blocking only on "no verdict ever" fails this.
+    """
+    events = [
+        _ev("2026-07-02T03:00:00Z", "epm:results", "round-1 results"),
+        _ev("2026-07-02T03:36:37Z", "epm:upload-verification", _PASS_NOTE),
+        _ev("2026-07-02T18:40:00Z", "epm:results", "round-2 results"),
+        _ev("2026-07-02T18:55:00Z", "epm:progress", _CRUMB),
+    ]
+    blocker = _blocker(events)
+    assert blocker is not None
+    assert blocker["reason"] == "upload_verifier_in_flight"
+    assert blocker["state"] == "in-flight"
+    assert blocker["stage"] == "verifying"
+    assert blocker["round"] == 1
+    assert blocker["breadcrumb_ts"] == "2026-07-02T18:55:00Z"
+
+
+def test_p2_followup_verifying_raw_token_is_covered() -> None:
+    """P2: the production ``stage=followup-verifying`` token (observed on
+    #778 at 2026-07-02T03:29:51Z) normalizes to verifying and blocks."""
+    events = [
+        _ev("2026-07-02T18:40:00Z", "epm:results", "results"),
+        _ev("2026-07-02T18:55:00Z", "epm:progress", _CRUMB_FOLLOWUP),
+    ]
+    blocker = _blocker(events)
+    assert blocker is not None
+    assert blocker["reason"] == "upload_verifier_in_flight"
+    assert blocker["stage"] == "followup-verifying"
+
+
+def test_p3_crumb_resolved_by_later_pass_verification_clears() -> None:
+    """P3: a crumb with a LATER PASS verification verdict clears (None)."""
+    events = [
+        _ev("2026-07-02T18:40:00Z", "epm:results", "results"),
+        _ev("2026-07-02T18:45:00Z", "epm:progress", _CRUMB),
+        _ev("2026-07-02T18:55:00Z", "epm:upload-verification", _PASS_NOTE),
+    ]
+    assert _blocker(events) is None
+
+
+def test_p4_crumb_resolved_by_later_sticky_clears() -> None:
+    """P4: the sticky ``epm:upload-verified`` marker also resolves a crumb."""
+    events = [
+        _ev("2026-07-02T18:40:00Z", "epm:results", "results"),
+        _ev("2026-07-02T18:45:00Z", "epm:progress", _CRUMB),
+        _ev("2026-07-02T18:55:00Z", "epm:upload-verified", "sticky PASS"),
+    ]
+    assert _blocker(events) is None
+
+
+def test_p5_crumb_past_window_with_no_verdict_is_stalled() -> None:
+    """P5: #778-replay timestamps — crumb hours old, no verdict → stalled."""
+    events = [
+        _ev("2026-07-02T03:20:00Z", "epm:results", "results"),
+        _ev("2026-07-02T03:29:51Z", "epm:progress", _CRUMB_FOLLOWUP),
+    ]
+    blocker = _blocker(events)  # now = 19:00Z, ~15.5h later
+    assert blocker is not None
+    assert blocker["reason"] == "upload_verifier_stalled"
+    assert blocker["state"] == "stalled"
+    assert blocker["age_minutes"] is not None and blocker["age_minutes"] > 15
+
+
+def test_p6_failure_after_crumb_is_still_stalled_never_clear() -> None:
+    """P6: ``epm:failure`` clears the DISPATCH dedup (may I re-dispatch?)
+    but never the currency gate — the round died with NO verdict."""
+    events = [
+        _ev("2026-07-02T18:40:00Z", "epm:results", "results"),
+        _ev("2026-07-02T18:45:00Z", "epm:progress", _CRUMB),
+        _ev("2026-07-02T18:50:00Z", "epm:failure", "failure_class: infra"),
+    ]
+    blocker = _blocker(events)
+    assert blocker is not None
+    assert blocker["reason"] == "upload_verifier_stalled"
+
+
+def test_p11_malformed_crumb_ts_is_stalled() -> None:
+    """P11: a malformed crumb ``ts`` fails toward stalled (blocked), never
+    toward a silent clear."""
+    events = [_ev("not-a-timestamp", "epm:progress", _CRUMB)]
+    blocker = _blocker(events)
+    assert blocker is not None
+    assert blocker["reason"] == "upload_verifier_stalled"
+
+
+def test_p12_liveness_marker_refreshes_the_in_flight_window() -> None:
+    """P12: crumb 20 m old + ``epm:codex-task-spawned`` 5 m ago → in_flight
+    (delegation to ``stage_dispatch_should_skip``'s liveness refresh)."""
+    events = [
+        _ev("2026-07-02T18:40:00Z", "epm:progress", _CRUMB),
+        _ev("2026-07-02T18:55:00Z", "epm:codex-task-spawned", "job spawned"),
+    ]
+    blocker = _blocker(events)
+    assert blocker is not None
+    assert blocker["reason"] == "upload_verifier_in_flight"
+
+
+def test_p17_crumb_with_missing_or_non_integer_round_is_stalled() -> None:
+    """P17: a fresh crumb whose ``round=`` token is missing / non-integer
+    can never be liveness-classified → stalled (blocked)."""
+    no_round = "stage-dispatch stage=verifying subagent=upload-verifier"
+    bad_round = "stage-dispatch stage=verifying round=abc subagent=upload-verifier"
+    for note in (no_round, bad_round):
+        events = [_ev("2026-07-02T18:55:00Z", "epm:progress", note)]
+        blocker = _blocker(events)
+        assert blocker is not None, note
+        assert blocker["reason"] == "upload_verifier_stalled", note
+        assert blocker["round"] is None, note
+
+
+def test_p10_non_verifying_stage_crumb_is_ignored() -> None:
+    """P10: an ``stage=interpreting`` crumb newer than the verdict is NOT a
+    verifier round — the gate ignores it."""
+    events = [
+        _ev("2026-07-02T18:40:00Z", "epm:upload-verification", _PASS_NOTE),
+        _ev(
+            "2026-07-02T18:55:00Z",
+            "epm:progress",
+            "stage-dispatch stage=interpreting round=1 subagent=analyzer",
+        ),
+    ]
+    assert _blocker(events) is None
+
+
+# ---------------------------------------------------------------------------
+# Rule 2 (MF-B) — ambiguous late verdict across a results boundary
+# ---------------------------------------------------------------------------
+
+
+def test_p14_unresolved_crumb_across_results_boundary_blocks_ambiguous() -> None:
+    """P14 (MF-B block): [R0, C1, R1, C2, V-late] → ambiguous — the late
+    verdict cannot be attributed to the current results-epoch."""
+    events = [
+        _ev("2026-07-02T10:00:00Z", "epm:results", "round-1 results"),
+        _ev("2026-07-02T10:05:00Z", "epm:progress", _CRUMB),
+        _ev("2026-07-02T12:00:00Z", "epm:results", "round-2 results"),
+        _ev("2026-07-02T12:05:00Z", "epm:progress", _CRUMB),
+        _ev("2026-07-02T12:10:00Z", "epm:upload-verification", _PASS_NOTE),
+    ]
+    blocker = _blocker(events)
+    assert blocker is not None
+    assert blocker["reason"] == "upload_verification_ambiguous"
+    assert blocker["breadcrumb_ts"] == "2026-07-02T10:05:00Z"
+
+
+def test_p15_respawn_recovery_same_epoch_clears() -> None:
+    """P15 (MF-B recovery): [R, C1, C2, V] — the stalled→re-spawn recovery
+    has no results between crumbs (same epoch), so any late verdict covers
+    both crumbs → None."""
+    events = [
+        _ev("2026-07-02T10:00:00Z", "epm:results", "results"),
+        _ev("2026-07-02T10:05:00Z", "epm:progress", _CRUMB),
+        _ev("2026-07-02T11:00:00Z", "epm:progress", _CRUMB),
+        _ev("2026-07-02T11:10:00Z", "epm:upload-verification", _PASS_NOTE),
+    ]
+    assert _blocker(events) is None
+
+
+def test_p16_post_block_recovery_fresh_round_clears_no_deadlock() -> None:
+    """P16 (MF-B deadlock-freedom): after an ambiguous block, ONE verifier
+    re-run — [.., C3, V'-PASS] — resolves every earlier crumb by inclusion."""
+    events = [
+        _ev("2026-07-02T10:00:00Z", "epm:results", "round-1 results"),
+        _ev("2026-07-02T10:05:00Z", "epm:progress", _CRUMB),
+        _ev("2026-07-02T12:00:00Z", "epm:results", "round-2 results"),
+        _ev("2026-07-02T12:05:00Z", "epm:progress", _CRUMB),
+        _ev("2026-07-02T12:10:00Z", "epm:upload-verification", _PASS_NOTE),
+        _ev("2026-07-02T12:20:00Z", "epm:progress", _CRUMB),
+        _ev("2026-07-02T12:30:00Z", "epm:upload-verification", _PASS_NOTE),
+    ]
+    assert _blocker(events) is None
+
+
+# ---------------------------------------------------------------------------
+# Rule 3 — stale (results postdating the latest verdict)
+# ---------------------------------------------------------------------------
+
+
+def test_p7_results_after_pass_verdict_is_stale() -> None:
+    """P7: [V-PASS, R] → the newest results are unverified → stale."""
+    events = [
+        _ev("2026-07-02T03:36:37Z", "epm:upload-verification", _PASS_NOTE),
+        _ev("2026-07-02T18:40:00Z", "epm:results", "round-2 results"),
+    ]
+    blocker = _blocker(events)
+    assert blocker is not None
+    assert blocker["reason"] == "upload_verification_stale"
+    assert "latest verdict at 2026-07-02T03:36:37Z" in blocker["detail"]
+
+
+def test_p7b_results_with_no_verdict_ever_is_stale() -> None:
+    """P7b: results exist and NO verdict marker exists at all → stale via
+    the "no verdict marker exists" branch."""
+    events = [_ev("2026-07-02T18:40:00Z", "epm:results", "results")]
+    blocker = _blocker(events)
+    assert blocker is not None
+    assert blocker["reason"] == "upload_verification_stale"
+    assert "no verdict marker exists" in blocker["detail"]
+
+
+def test_p8_verdict_postdating_results_and_crumb_clears() -> None:
+    """P8: the normal happy path [R, crumb, V-PASS] → None."""
+    events = [
+        _ev("2026-07-02T18:30:00Z", "epm:results", "results"),
+        _ev("2026-07-02T18:40:00Z", "epm:progress", _CRUMB),
+        _ev("2026-07-02T18:50:00Z", "epm:upload-verification", _PASS_NOTE),
+    ]
+    assert _blocker(events) is None
+
+
+def test_p9_pure_sticky_legacy_clears_vacuously() -> None:
+    """P9: bare sticky, no crumb / results / verification → None (the
+    pure-sticky legacy shape stays vacuously clear — acceptance 6)."""
+    events = [_ev("2026-07-02T18:40:00Z", "epm:upload-verified", "sticky PASS")]
+    assert _blocker(events) is None
+
+
+def test_empty_events_clears() -> None:
+    """No verifier / results activity at all → None."""
+    assert _blocker([]) is None
+
+
+# ---------------------------------------------------------------------------
+# Rule 4 (MF-A) — the current verification is a FAIL
+# ---------------------------------------------------------------------------
+
+
+def test_p13_sticky_then_fail_after_results_is_failed_current() -> None:
+    """P13 (MF-A): [sticky, R, crumb, V-FAIL] → failed_current — the
+    sticky-anywhere prior PASS can no longer green-light teardown after a
+    FAILED current verification (the #778 shape)."""
+    events = [
+        _ev("2026-07-02T03:40:00Z", "epm:upload-verified", "sticky PASS"),
+        _ev("2026-07-02T18:30:00Z", "epm:results", "round-2 results"),
+        _ev("2026-07-02T18:40:00Z", "epm:progress", _CRUMB),
+        _ev("2026-07-02T18:50:00Z", "epm:upload-verification", _FAIL_NOTE),
+    ]
+    blocker = _blocker(events)
+    assert blocker is not None
+    assert blocker["reason"] == "upload_verification_failed_current"
+
+
+def test_p13b_sticky_after_fail_reads_as_subsequent_pass_record() -> None:
+    """P13b: [V-FAIL, sticky] → None — a sticky posted AFTER a FAIL is the
+    skill's subsequent-PASS record (latest verdict-kind wins)."""
+    events = [
+        _ev("2026-07-02T18:40:00Z", "epm:upload-verification", _FAIL_NOTE),
+        _ev("2026-07-02T18:50:00Z", "epm:upload-verified", "sticky PASS after fix"),
+    ]
+    assert _blocker(events) is None
+
+
+def test_p13c_rules_3_and_4_are_index_disjoint() -> None:
+    """P13c: a FAIL postdating results reads failed_current; a FAIL
+    predating results reads stale — never both, never neither."""
+    fail_after_results = [
+        _ev("2026-07-02T18:30:00Z", "epm:results", "results"),
+        _ev("2026-07-02T18:40:00Z", "epm:upload-verification", _FAIL_NOTE),
+    ]
+    blocker = _blocker(fail_after_results)
+    assert blocker is not None
+    assert blocker["reason"] == "upload_verification_failed_current"
+
+    fail_before_results = [
+        _ev("2026-07-02T18:30:00Z", "epm:upload-verification", _FAIL_NOTE),
+        _ev("2026-07-02T18:40:00Z", "epm:results", "results"),
+    ]
+    blocker = _blocker(fail_before_results)
+    assert blocker is not None
+    assert blocker["reason"] == "upload_verification_stale"
+
+
+# ---------------------------------------------------------------------------
+# P18 — canonical regex parity with dispatch_issue's private copy
+# ---------------------------------------------------------------------------
+
+
+def test_pass_regex_parity_with_dispatch_issue() -> None:
+    """P18: the canonical ``task_workflow.UPLOAD_VERIFICATION_PASS_RE`` and
+    dispatch_issue's private ``_UPLOAD_VERIFICATION_PASS_RE`` stay
+    pattern-identical (duplication-drift guard)."""
+    import scripts.dispatch_issue as di
+
+    assert tw.UPLOAD_VERIFICATION_PASS_RE.pattern == di._UPLOAD_VERIFICATION_PASS_RE.pattern
+    # And the shared shape actually matches / rejects the schema forms.
+    assert tw.UPLOAD_VERIFICATION_PASS_RE.search("**Verdict: PASS**")
+    assert not tw.UPLOAD_VERIFICATION_PASS_RE.search("**Verdict: FAIL**")
+    assert not tw.UPLOAD_VERIFICATION_PASS_RE.search("the checks pass")


### PR DESCRIPTION
Closes task #1026 (workflow-fix: upload-verifier in flight blocks finalize/status-advance). Plan v2 at tasks/<status>/1026/plans/v2.md.