### PR TITLE
task #1033: poller output-mtime stall fold + per-instance GPU-idle clock

### DIFF
--- a/scripts/backend_poll.py
+++ b/scripts/backend_poll.py
@@ -415,6 +415,44 @@ def _save_gpu_idle_state(path: Path, payload: dict[str, str]) -> None:
     tmp.replace(path)
 
 
+# #1033: the GPU-idle advisory/escalation keys scoped to ONE instance
+# incarnation on the GCP lane. Kept in lockstep with the idle subset of
+# ``poll_pipeline._RUN_SCOPED_STATE_KEYS`` (the RunPod-lane sibling clear set).
+_IDLE_ADVISORY_STATE_KEYS: tuple[str, ...] = (
+    "gpu_idle_since_epoch",
+    "gpu_idle_advised_phases",
+    "gpu_idle_escalated_phases",
+)
+
+
+def _scope_idle_state_to_attempt(
+    prev_state: dict[str, str], attempt_id: str | None
+) -> dict[str, str]:
+    """Reset the idle-advisory clock when the instance identity changed (#1033).
+
+    ``attempt_id`` is fresh per genuinely NEW instance and label-stable on
+    reconnect (#927; the ``gcp.py`` reconnect recovery re-reads it from the
+    instance labels), so a mismatch against the stored ``idle_attempt_id``
+    means the persisted idle span belongs to a PREVIOUS instance (#763: a
+    "543 min" idle advisory on a ~17-min-old VM whose phase name matched the
+    stored one, so the per-phase reset never fired). The reported idle
+    minutes are PER-INSTANCE, never cumulative across relaunches.
+
+    Fail-safe: an absent/empty CURRENT attempt_id cannot decide instance
+    identity, so the state is kept verbatim (pre-#1033 behavior). A
+    stored-key MISS with a KNOWN current id also resets — the migration
+    path for pre-#1033 state files, failing toward one delayed/duplicate
+    advisory, never a stale counter (same cheaper-failure direction as
+    ``_tripwire_run_scope``'s malformed-anchor branch). Pure / no I/O;
+    never raises into the poll tick.
+    """
+    if not attempt_id:
+        return prev_state
+    if prev_state.get("idle_attempt_id", "") == attempt_id:
+        return prev_state
+    return {k: v for k, v in prev_state.items() if k not in _IDLE_ADVISORY_STATE_KEYS}
+
+
 def _missing_sidecar_json(issue: int, sidecar_path: Path, reason: str) -> dict:
     """Build the failure-shape JSON line for a missing / unreadable sidecar.
 
@@ -3207,17 +3245,29 @@ def main(argv: list[str] | None = None) -> int:
 
         gpu_idle_state_path = _gpu_idle_state_path(Path(sidecar))
         prev_gpu_idle_state = _load_gpu_idle_state(gpu_idle_state_path)
+        # ── #1033 per-instance idle-clock scoping (attempt-id keyed) ─────
+        # attempt_id is on the handle at poll time (no extra gcloud call),
+        # fresh per new instance, label-recovered on reconnect (#927).
+        # Scope BEFORE the run-epoch anchor below so ONE consistently-scoped
+        # dict flows through every consumer AND the persist at the bottom —
+        # an unscoped read at persist time could resurrect a cleared key.
+        current_attempt_id = str(handle.extra.get("attempt_id") or "")
+        prev_gpu_idle_state = _scope_idle_state_to_attempt(prev_gpu_idle_state, current_attempt_id)
         zone = handle.extra.get("zone") or backend._config.primary_zone
         gpu_util = backend._gcp_gpu_util_probe(handle, zone)
         now_epoch = int(time.time())
         current_phase = getattr(result, "current_phase", "") or ""
         pod = handle.pod_name
-        # ── #873 run-scoped tripwire dedup anchor (AC #6, GCP mirror) ────
-        # A fresh epm:run-launched clears the width dedup keys so a
-        # relaunch / follow-up round re-arms the width advisory. Applied to
-        # the WIDTH call only — the idle-advisory keys are untouched by the
-        # reset (disjoint key set), so the two existing calls keep reading
-        # prev_gpu_idle_state verbatim.
+        # ── #873/#1033 run-scoped state anchor (AC #6, GCP mirror) ───────
+        # A fresh epm:run-launched clears the width dedup keys AND (since
+        # #1033) the idle-advisory keys — belt-and-suspenders next to the
+        # attempt-id scoping above (a same-instance relaunch posts a fresh
+        # run-launched with no attempt change; a fresh instance changes the
+        # attempt id whether or not the marker landed). The pre-#1033
+        # "idle-advisory keys are untouched by the reset" contract was the
+        # bug being fixed (#763/#810 stale idle minutes on fresh VMs). ALL
+        # consumers below — idle advisory, escalation, width — read the
+        # scoped ``tripwire_state``.
         tripwire_state, tripwire_run_epoch = _tripwire_run_scope(
             prev_gpu_idle_state,
             run_age_sec=_run_launched_age_sec(args.issue, now_epoch),
@@ -3230,7 +3280,7 @@ def main(argv: list[str] | None = None) -> int:
             status="running",
             gpu_util=gpu_util,
             current_phase=current_phase,
-            prev_state=prev_gpu_idle_state,
+            prev_state=tripwire_state,
             now_epoch=now_epoch,
         )
         escalated_phases, gcp_gpu_idle_escalation_posted = _maybe_escalate_gpu_idle(
@@ -3240,7 +3290,7 @@ def main(argv: list[str] | None = None) -> int:
             gpu_util=gpu_util,
             current_phase=current_phase,
             idle_since_epoch=idle_since,
-            prev_state=prev_gpu_idle_state,
+            prev_state=tripwire_state,
             now_epoch=now_epoch,
         )
         # ── #873 m-of-N GPU-width advisory (GCP mirror of the RunPod call) ─
@@ -3269,6 +3319,13 @@ def main(argv: list[str] | None = None) -> int:
                 "gpu_width_idle_set": ",".join(str(i) for i in gcp_width_idle_set),
                 "gpu_width_advised_phases": ",".join(sorted(gcp_width_advised)),
                 "tripwire_run_epoch": str(tripwire_run_epoch),
+                # #1033: the instance incarnation the idle keys above belong
+                # to. An empty CURRENT id (fail-safe keep branch) preserves
+                # the stored one — read from the SCOPED dict, never the raw
+                # load, so a cleared key can never be resurrected here.
+                "idle_attempt_id": (
+                    current_attempt_id or tripwire_state.get("idle_attempt_id", "")
+                ),
             },
         )
 

--- a/scripts/poll_pipeline.py
+++ b/scripts/poll_pipeline.py
@@ -48,9 +48,12 @@ log), (b) every per-phase log under
 ``/workspace/explore-persona-space/logs/issue_<N>{,_*}/*.log`` AND
 every dispatcher per-job log under
 ``/workspace/explore-persona-space/eval_results/issue_<N>{,_*}/logs/*.log``
-is also quiet for >stall_sec, and (d) the GPUs are idle. Only when all
-four signals agree does the poll declare `stalled`; any fresh log
-OR a busy GPU keeps the run in `running`.
+is also quiet for >stall_sec, (d) no issue-keyed OUTPUT artifact
+(``eval_results/issue_<N>{,_*}/``, ``data/issue_<N>/``,
+``data/issue<N>/`` under the repo root) was modified within stall_sec
+(#1033), and (e) the GPUs are idle. Only when all five signals agree
+does the poll declare `stalled`; any fresh log, any fresh output
+artifact, OR a busy GPU keeps the run in `running`.
 
 CPU-advancing override (#518): even with the stall conjunction met, a
 launcher whose process session (`setsid` group) has accrued more
@@ -89,9 +92,11 @@ The override therefore fires only when, on a `running` verdict, ALL of:
 per-phase / shard) is stale past the effective stall window
 (``max(ZOMBIE_VETO_FRESH_SEC, stall_sec)`` — a genuinely hung run's own
 processes stop appending; both observed false positives had fresh
-logs), and (c) the stale-log candidate persisted for 2 CONSECUTIVE
-observed ticks (``zombie_streak`` in the state sidecar — filters the
-#778 one-tick teardown transient). Bare session-CPU *advancement* is
+logs), (b') no issue-keyed OUTPUT artifact was modified within the same
+window (#1033 — a run writing results is not hanging; same veto
+mechanics as the fresh-log term), and (c) the stale-log candidate
+persisted for 2 CONSECUTIVE observed ticks (``zombie_streak`` in the
+state sidecar — filters the #778 one-tick teardown transient). Bare session-CPU *advancement* is
 deliberately NOT a veto term: the genuine #664 hang had CPU advancing
 (the EngineCore idle-burn is why this override exists at all), so an
 any-delta CPU veto would make the true positive unreachable. A MATERIAL
@@ -191,6 +196,32 @@ globs ``eval_results/issue_<N>{,_*}/logs/*.log`` into the same
 max-mtime reduction. The match stays narrow on purpose: the directory
 must be exactly ``issue_<N>`` or ``issue_<N>_<suffix>`` (a bare
 ``issue_<N>*`` glob would let issue 5 match issue 521's directories).
+
+Staleness ALSO folds in output artifacts (#1033; incident #813): a
+CPU-bound analysis tail can write per-cell NPZs / result JSONs /
+``.done`` sentinels for hours while EVERY log layout above is quiet and
+the GPUs are idle by design — freshly-written outputs were the manual
+dismissal signal on #813's ~6h analysis tail, and when the #951 CPU-rate
+probe is degraded (tick-1/tick-2 warmup, dead launcher session, ``ps``
+unavailable) output freshness is the remaining liveness channel. The
+probe therefore emits ``OUTPUT_MTIME_EPOCH`` — the mtime of A file (a
+fresh file, not the newest: short-circuit ``find -newermt ... -print
+-quit`` under ``timeout``, bounded by
+``EPM_POLL_OUTPUT_FIND_TIMEOUT_SEC``) modified within the freshness
+window under the ISSUE-KEYED output roots
+``eval_results/issue_<N>{,_*}/``, ``data/issue_<N>/``, and
+``data/issue<N>/`` (same narrowness contract as the #488/#521 shard
+globs — no broad recursive scan, no cross-pod coupling). The delta
+joins the stall conjunction as a first-class liveness signal (a fresh
+output behaves exactly like a fresh shard log) AND vetoes the
+#664/#826 zombie override (streak reset, identical mechanics to the
+fresh-log veto). Kill switch ``EPM_POLL_OUTPUT_MTIME_FOLD=0`` (default
+ON — the fold can only SUPPRESS false stalls, and a genuinely hung run
+writes no outputs, so the #664 true positive stays reachable; the
+same-issue-sibling-writer exposure is the accepted #826 fresh-log
+class). Every degraded input (missing dirs, find timeout, no GNU find,
+a hit deleted before ``stat``) reads ``0`` -> "no fresh output" ->
+pre-#1033 behavior.
 
 GPU-idle advisory (incidents #518 + #537): the stall verdict treats an
 idle GPU only as CORROBORATION — a run that is alive and logging on a
@@ -616,6 +647,33 @@ ZOMBIE_OVERRIDE_CPU_CORES_MIN = float(os.environ.get("EPM_ZOMBIE_OVERRIDE_CPU_CO
 # never binds there; it guards manual rapid re-polls and fast-smoke ticks.
 ZOMBIE_CPU_RATE_MIN_DT_SEC = int(os.environ.get("EPM_ZOMBIE_CPU_RATE_MIN_DT_SEC", "120"))
 
+# #1033: output-artifact mtime fold. Kill switch, default ON (unlike the #864
+# default-OFF namespace veto): the fold can only SUPPRESS false `stalled`
+# verdicts / zombie overrides, and a genuinely hung run writes no outputs, so
+# the #664 true positive stays reachable. The residual exposure — a same-issue
+# sibling process (e.g. a detached uploader) touching issue-keyed files during
+# a true hang — is the SAME accepted exposure class as the #826 fresh-log
+# sibling, bounded by the GPU-idle advisory/escalation tiers, the #873
+# tripwires, and this switch. When disabled the probe block is omitted
+# entirely and ``poll_once`` forces ``output_mtime_ago = inf`` (fully inert).
+OUTPUT_MTIME_FOLD_ENABLED = os.environ.get("EPM_POLL_OUTPUT_MTIME_FOLD", "1") != "0"
+
+
+def _output_find_timeout_sec() -> int:
+    """The bounded ``timeout`` (seconds) around the pod-side output ``find``.
+
+    Default 10s (env ``EPM_POLL_OUTPUT_FIND_TIMEOUT_SEC``); clamped to
+    [1, 15] so the two-stage worst case (2 x 15s) stays well inside the
+    probe's 60s SSH exec budget (a wedged-FS ``find`` must never starve the
+    rest of the heredoc). A malformed env value falls back to 10 (fail-safe).
+    """
+    raw = os.environ.get("EPM_POLL_OUTPUT_FIND_TIMEOUT_SEC", "10")
+    try:
+        val = int(raw)
+    except (TypeError, ValueError):
+        val = 10
+    return min(max(1, val), 15)
+
 
 def _try_refresh_pods_conf_from_api(pod: str) -> bool:
     """Best-effort ``pod.py config --refresh-from-api <pod>`` self-heal.
@@ -1022,11 +1080,16 @@ def _ssh_probe(
     pid_file: str,
     issue: int,
     marker_pid: int | None = None,
+    *,
+    stall_sec: int = DEFAULT_STALL_SEC,
 ) -> dict[str, str]:
     """One SSH round-trip — returns dict with keys pid_alive,
     marker_pid_alive, mtime_epoch, cell_mtime_epoch, log_tail,
     cell_log_tail, phase_log_mtime_epoch, phase_log_tail,
     shard_log_mtime_epoch, shard_log_tail, gpu_util.
+
+    ``stall_sec`` sizes the output-artifact freshness window (#1033 —
+    ``output_mtime_epoch`` below); it does NOT change any log probe.
 
     Batches into a single heredoc to keep the SSH cost to one connection.
 
@@ -1095,6 +1158,22 @@ def _ssh_probe(
       log; the #791 sibling of ``cell_log_tail`` / ``phase_log_tail``,
       consumed by ``_tail_excerpt_and_crash_signature`` the same way.
       ``""`` when no covered layout exists.
+    * ``output_mtime_epoch`` — mtime of A recently-modified OUTPUT
+      artifact under the issue-keyed output roots
+      (``eval_results/issue_<N>{,_*}/``, ``data/issue_<N>/``,
+      ``data/issue<N>/`` under the repo root), found via a bounded,
+      short-circuit ``find -newermt ... -print -quit`` under ``timeout``
+      (#1033; incident #813 — a ~6h CPU-bound analysis tail wrote
+      per-cell NPZs / JSONs while every log was quiet). NOTE: this is
+      the mtime of *a fresh file, not the newest* — ``-print -quit``
+      stops at the FIRST file inside the freshness window, which is all
+      the threshold reads downstream need (``output_mtime_ago`` is only
+      ever compared against the same windows the find used). ``"0"``
+      when no file was modified within ``max(stall_sec,
+      ZOMBIE_VETO_FRESH_SEC)``, the dirs are missing, the find timed
+      out, or the fold is disabled (``EPM_POLL_OUTPUT_MTIME_FOLD=0`` —
+      the probe block is omitted entirely). Fail-safe: ``"0"`` reads as
+      "no fresh output" -> pre-#1033 behavior.
     * ``gpu_util`` — comma-separated per-GPU ``utilization.gpu``
       integers (e.g. ``"95,87,42,90"``). ``"unknown"`` when
       ``nvidia-smi`` is unavailable or errors (fail-safe — see
@@ -1371,6 +1450,62 @@ def _ssh_probe(
         f"if [ ${{#RS_FILES[@]}} -gt 0 ]; then echo RESULTS_SENTINEL_PRESENT=1; "
         f"else echo RESULTS_SENTINEL_PRESENT=0; fi; "
     )
+    # Output-artifact freshness probe (#1033): a CPU-bound analysis tail that
+    # writes per-cell NPZs / JSONs / .done sentinels while every log is quiet
+    # (#813). Bounded: short-circuit find (-print -quit) under `timeout`;
+    # issue-keyed roots ONLY (same narrowness contract as the #488/#521 shard
+    # globs — a bare `issue_<N>*` would let issue 5 match issue 521's dirs, so
+    # the set is exactly `issue_{N}`, `issue_{N}_*`, and the `data/issue{N}`
+    # no-underscore convention from the #854 crash-persist sweep). The block
+    # captures its OWN pod-clock epoch (`OUT_NOW`; the POD_NOW_EPOCH line in
+    # the heredoc is echo-only — no shell var exists), so the cutoffs are on
+    # the pod clock with no VM skew. Two-stage: prefer a within-stall hit (it
+    # rescues the stall conjunction); fall back to the WIDER zombie-veto
+    # window only when that window is genuinely wider (stall_sec < the 60s
+    # ZOMBIE_VETO_FRESH_SEC floor — fast-smoke configs; the default 900s
+    # stall window already covers the veto read, so the common case is ONE
+    # find). `-print -quit` short-circuits on the FIRST fresh file (see the
+    # docstring: a fresh file, not the newest); on a healthy actively-writing
+    # phase this returns almost immediately, and on a genuinely stalled run
+    # the metadata scan is bounded by `timeout` (worst case 2 stages inside
+    # the 60s SSH exec budget). Missing dirs / timeout / a hit deleted before
+    # `stat` -> OUTPUT_MTIME_EPOCH=0 (fail-safe: pre-#1033 behavior).
+    if OUTPUT_MTIME_FOLD_ENABLED:
+        find_timeout = _output_find_timeout_sec()
+        out_dirs = (
+            f"/workspace/explore-persona-space/eval_results/issue_{issue} "
+            f"/workspace/explore-persona-space/eval_results/issue_{issue}_* "
+            f"/workspace/explore-persona-space/data/issue_{issue} "
+            f"/workspace/explore-persona-space/data/issue{issue}"
+        )
+        veto_window_sec = max(ZOMBIE_VETO_FRESH_SEC, stall_sec)
+        # Second stage only when the veto window is genuinely wider than the
+        # stall window (nullglob is (re)set below, so the unmatched
+        # `issue_{N}_*` glob vanishes instead of passing a literal pattern;
+        # the three literal paths always remain, so `find` can never run
+        # with ZERO path args and default to a broad `.` scan).
+        second_stage = ""
+        if veto_window_sec > stall_sec:
+            second_stage = (
+                f'if [ -z "$OUT_HIT" ]; then '
+                f"OUT_CUTOFF_VETO=$((OUT_NOW - {veto_window_sec})); "
+                f"OUT_HIT=$(timeout {find_timeout} find {out_dirs} "
+                f'-type f -newermt "@$OUT_CUTOFF_VETO" -print -quit 2>/dev/null); '
+                f"fi; "
+            )
+        output_probe = (
+            f"shopt -s nullglob; "
+            f"OUT_NOW=$(date +%s); "
+            f"OUT_CUTOFF_STALL=$((OUT_NOW - {stall_sec})); "
+            f"OUT_HIT=$(timeout {find_timeout} find {out_dirs} "
+            f'-type f -newermt "@$OUT_CUTOFF_STALL" -print -quit 2>/dev/null); '
+            f"{second_stage}"
+            f'if [ -n "$OUT_HIT" ]; then '
+            f'echo "OUTPUT_MTIME_EPOCH=$(stat -c %Y "$OUT_HIT" 2>/dev/null || echo 0)"; '
+            f"else echo OUTPUT_MTIME_EPOCH=0; fi; "
+        )
+    else:
+        output_probe = ""  # kill switch: parser defaults the key to "0"
     heredoc = (
         f"LOG_PATH={log_path}; "
         f"if [ -f {pid_file} ]; then "
@@ -1394,6 +1529,7 @@ def _ssh_probe(
         f"{gpu_probe}"
         f"{session_cpu_probe}"
         f"{results_sentinel_probe}"
+        f"{output_probe}"
     )
     result = subprocess.run(
         ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=15", pod, heredoc],
@@ -1429,6 +1565,7 @@ def _ssh_probe(
             "nvidia_uvm_live_holders": "unknown",
             "session_cpu_secs": "unknown",
             "results_sentinel_present": "0",
+            "output_mtime_epoch": "0",
             "ssh_failed": "1",
         }
     parsed = _parse_probe_stdout(result.stdout)
@@ -1454,6 +1591,7 @@ _PROBE_SCALAR_KEYS: tuple[str, ...] = (
     "NVIDIA_UVM_LIVE_HOLDERS",
     "SESSION_CPU_SECS",
     "RESULTS_SENTINEL_PRESENT",
+    "OUTPUT_MTIME_EPOCH",
 )
 
 
@@ -1484,6 +1622,7 @@ def _parse_probe_stdout(stdout: str) -> dict[str, str]:
         "nvidia_uvm_live_holders": "unknown",
         "session_cpu_secs": "unknown",
         "results_sentinel_present": "0",
+        "output_mtime_epoch": "0",
     }
     # Each multi-line tail block is delimited by its own START/END sentinel
     # (``TAIL_START``/``END``, ``CELL_TAIL_START``/``END``, and the #791
@@ -3100,6 +3239,19 @@ _TRIPWIRE_STATE_KEYS: tuple[str, ...] = (
     "gpu_underparallel_since_epoch",
     "gpu_underparallel_warned",
 )
+# #1033: the FULL run-scoped clear set = the #873 tripwire dedup keys PLUS the
+# GPU-idle advisory/escalation keys. The idle span + per-phase dedup sets
+# belong to the RUN that accumulated them: carried across a relaunch they
+# print stale idle minutes exceeding the fresh instance's own age (#763
+# "543 min" / #810 "486 min" on ~17-min-old instances, where the phase name
+# matched the stored one so the per-phase reset never fired). The pre-#1033
+# "idle keys untouched by the run-scope reset" contract was the bug.
+_RUN_SCOPED_STATE_KEYS: tuple[str, ...] = (
+    *_TRIPWIRE_STATE_KEYS,
+    "gpu_idle_since_epoch",
+    "gpu_idle_advised_phases",
+    "gpu_idle_escalated_phases",
+)
 # Tolerance (seconds) when comparing the observed run-launched epoch against
 # the stored anchor: rounding jitter on ``now - run_age`` must never
 # spuriously reset the dedup keys mid-run.
@@ -3109,22 +3261,25 @@ _TRIPWIRE_RUN_EPOCH_TOLERANCE_SEC = 60
 def _tripwire_run_scope(
     prev_state: dict[str, str], *, run_age_sec: float | None, now_epoch: int
 ) -> tuple[dict[str, str], int]:
-    """Run-scope the #873 tripwire dedup keys (AC #6 / plan D4).
+    """Run-scope the #873 tripwire dedup keys + the GPU-idle keys (#1033).
 
     Returns ``(state, tripwire_run_epoch)``: ``state`` is ``prev_state``
     unchanged when no reset applies, or a copy with every
-    ``_TRIPWIRE_STATE_KEYS`` entry REMOVED when the CURRENT
-    ``epm:run-launched`` epoch (``now_epoch - run_age_sec``) is newer than
-    the stored ``tripwire_run_epoch`` anchor by more than the jitter
-    tolerance. ``tripwire_run_epoch`` is the anchor the caller persists via
-    ``_save_state`` / the GCP sibling state. Fail-safe: an unknown run age
-    (missing / unreadable marker) keeps the stored anchor and clears
-    nothing; a MALFORMED stored anchor (present but non-numeric) with a
-    known run age cannot decide run identity, so it fails toward RE-ARMING
-    — clear the tripwire keys and adopt the current epoch (cheaper failure
-    = one duplicate advisory, never a suppressed one); an absent/zero
-    anchor (genuine first run — no keys to protect) adopts the current
-    epoch and keeps the state. Never raises into the poll tick.
+    ``_RUN_SCOPED_STATE_KEYS`` entry REMOVED (the #873 tripwire dedup keys
+    plus, since #1033, the three GPU-idle advisory/escalation keys — a
+    fresh run's idle clock must not inherit the previous run's span) when
+    the CURRENT ``epm:run-launched`` epoch (``now_epoch - run_age_sec``)
+    is newer than the stored ``tripwire_run_epoch`` anchor by more than
+    the jitter tolerance. ``tripwire_run_epoch`` is the anchor the caller
+    persists via ``_save_state`` / the GCP sibling state. Fail-safe: an
+    unknown run age (missing / unreadable marker) keeps the stored anchor
+    and clears nothing; a MALFORMED stored anchor (present but
+    non-numeric) with a known run age cannot decide run identity, so it
+    fails toward RE-ARMING — clear the run-scoped keys and adopt the
+    current epoch (cheaper failure = one duplicate advisory, never a
+    suppressed one); an absent/zero anchor (genuine first run — no keys
+    to protect) adopts the current epoch and keeps the state. Never
+    raises into the poll tick.
     """
     raw = prev_state.get("tripwire_run_epoch", "0") or 0
     malformed = False
@@ -3137,12 +3292,12 @@ def _tripwire_run_scope(
         return prev_state, stored
     current = round(now_epoch - run_age_sec)
     if malformed:
-        cleared = {k: v for k, v in prev_state.items() if k not in _TRIPWIRE_STATE_KEYS}
+        cleared = {k: v for k, v in prev_state.items() if k not in _RUN_SCOPED_STATE_KEYS}
         return cleared, current
     if stored <= 0:
         return prev_state, current
     if current > stored + _TRIPWIRE_RUN_EPOCH_TOLERANCE_SEC:
-        cleared = {k: v for k, v in prev_state.items() if k not in _TRIPWIRE_STATE_KEYS}
+        cleared = {k: v for k, v in prev_state.items() if k not in _RUN_SCOPED_STATE_KEYS}
         return cleared, current
     return prev_state, stored
 
@@ -3576,9 +3731,10 @@ def _apply_zombie_override(
     gpu_pids_resolvable: int | None = None,
     uvm_live_holders: int | None = None,
     session_cpu_rate_cores: float | None = None,
+    output_mtime_ago: float = float("inf"),
 ) -> tuple[str, str | None, bool, int]:
-    """The #664/#826/#864/#951 zombie-GPU-allocation override — returns the
-    possibly overridden
+    """The #664/#826/#864/#951/#1033 zombie-GPU-allocation override — returns
+    the possibly overridden
     ``(status, stall_reason, cpu_override_active, zombie_streak)``.
 
     A hung vLLM whose CUDA worker died leaves its model-shard VRAM orphaned
@@ -3618,8 +3774,20 @@ def _apply_zombie_override(
     ``stall_reason`` lets the orchestrator route this distinctly from a
     generic log+GPU+CPU stall.
 
-    Material-compute liveness veto (#951, between the #826 fresh-log veto
-    and the streak defer/fire branches): when the per-tick session-CPU burn
+    Fresh-output veto (#1033, right after the #826 fresh-log veto —
+    identical mechanics): a run whose ISSUE-KEYED OUTPUT artifacts
+    (``output_mtime_ago``, from the #1033 probe) were modified within the
+    same effective stall window ``max(ZOMBIE_VETO_FRESH_SEC, stall_sec)``
+    is writing results, not hanging — #813's CPU-bound analysis tail wrote
+    per-cell NPZs / JSONs for hours while every log was quiet. Veto +
+    streak reset, exactly like the fresh-log veto. The parameter defaults
+    to ``inf`` (= "no fresh output" / probe absent / fold disabled), so
+    every pre-#1033 caller and test is byte-unchanged (fail-safe: the veto
+    stays inert). A genuinely hung run writes no outputs, so the #664 true
+    positive stays reachable.
+
+    Material-compute liveness veto (#951, between the #1033 fresh-output
+    veto and the streak defer/fire branches): when the per-tick session-CPU burn
     rate was >= ``ZOMBIE_OVERRIDE_CPU_CORES_MIN`` (default 0.5 cores) on
     BOTH the current tick (``session_cpu_rate_cores``, computed by
     ``poll_once`` via ``_session_cpu_rate_cores``) AND the previous
@@ -3751,6 +3919,22 @@ def _apply_zombie_override(
                 freshest_log_ago,
                 zombie_veto_sec,
             )
+        elif output_mtime_ago <= zombie_veto_sec:
+            # #1033: fresh issue-keyed OUTPUT artifact — the run is writing
+            # results while its logs are quiet (#813's CPU-bound analysis
+            # tail). Identical mechanics to the fresh-log veto above:
+            # suppress + streak reset (zombie_streak stays 0 — recomputed
+            # each tick).
+            log.warning(
+                "zombie-GPU signature on pod %s (PID(s) %s) but output-artifact evidence "
+                "is fresh (%.0fs <= %ds) — liveness veto, not flagging (#1033/#813; a "
+                "CPU-bound analysis tail writes issue-keyed outputs while every log is "
+                "quiet)",
+                pod,
+                ",".join(zombie_gpu_pids),
+                output_mtime_ago,
+                zombie_veto_sec,
+            )
         elif (
             session_cpu_rate_cores is not None
             and prev_cpu_rate is not None
@@ -3814,9 +3998,10 @@ def _log_staleness_secs(
     freshest_mtime_epoch: int,
     phase_log_mtime_epoch: int,
     shard_log_mtime_epoch: int,
-) -> tuple[int, int, int]:
-    """Compute the three log-staleness deltas (top-level/cell, per-phase,
-    shard) on a SINGLE clock basis (#704).
+    output_mtime_epoch: int = 0,
+) -> tuple[int, int, int, int]:
+    """Compute the staleness deltas (top-level/cell, per-phase, shard logs,
+    plus the #1033 output artifact) on a SINGLE clock basis (#704).
 
     The pod stamps file mtimes with its OWN wall clock (``stat -c %Y``); the
     probe heredoc now also captures that same clock's "now" (``date +%s`` ->
@@ -3832,10 +4017,16 @@ def _log_staleness_secs(
     ``<= 0``, matching the prior inline behavior. On the pod-clock branch the
     deltas are low-clamped at ``0`` (``max(0, ...)``) so a sub-second
     rounding within one probe cannot produce a negative "seconds ago"; the
-    VM-fallback branch keeps its exact pre-#704 arithmetic so the
-    backward-compat behavior is byte-for-byte unchanged.
+    VM-fallback branch keeps its exact pre-#704 arithmetic for the three LOG
+    deltas so the backward-compat behavior is byte-for-byte unchanged. The
+    #1033 ``output_mtime_ago`` delta (new — no backward-compat constraint)
+    is low-clamped at ``0`` on BOTH branches: a FUTURE-DATED output mtime
+    (weird writer clock) reads as "fresh right now", which can only
+    SUPPRESS a stall verdict / zombie override — the fold's accepted
+    fail direction — never create a new positive.
 
-    Returns ``(last_mtime_ago, phase_log_mtime_ago, shard_log_mtime_ago)``.
+    Returns ``(last_mtime_ago, phase_log_mtime_ago, shard_log_mtime_ago,
+    output_mtime_ago)``.
     """
     if pod_now_epoch > 0:
         staleness_now = pod_now_epoch
@@ -3848,7 +4039,10 @@ def _log_staleness_secs(
         shard_log_mtime_ago = (
             max(0, staleness_now - shard_log_mtime_epoch) if shard_log_mtime_epoch > 0 else 10**9
         )
-        return last_mtime_ago, phase_log_mtime_ago, shard_log_mtime_ago
+        output_mtime_ago = (
+            max(0, staleness_now - output_mtime_epoch) if output_mtime_epoch > 0 else 10**9
+        )
+        return last_mtime_ago, phase_log_mtime_ago, shard_log_mtime_ago, output_mtime_ago
 
     staleness_now = vm_now_epoch
     log.warning(
@@ -3863,7 +4057,10 @@ def _log_staleness_secs(
     shard_log_mtime_ago = (
         staleness_now - shard_log_mtime_epoch if shard_log_mtime_epoch > 0 else 10**9
     )
-    return last_mtime_ago, phase_log_mtime_ago, shard_log_mtime_ago
+    output_mtime_ago = (
+        max(0, staleness_now - output_mtime_epoch) if output_mtime_epoch > 0 else 10**9
+    )
+    return last_mtime_ago, phase_log_mtime_ago, shard_log_mtime_ago, output_mtime_ago
 
 
 def _tail_excerpt_and_crash_signature(
@@ -3946,7 +4143,7 @@ def poll_once(
     # epm:run-launched marker. Cross-check the marker pid so a healthy
     # re-run is not misreported as dead.
     marker_pid = _marker_pid(issue)
-    probe = _ssh_probe(pod, log_path, pid_file, issue, marker_pid)
+    probe = _ssh_probe(pod, log_path, pid_file, issue, marker_pid, stall_sec=stall_sec)
 
     # ── #488 stale-port self-heal ────────────────────────────────────────
     # Track consecutive SSH-probe failures across ticks. When the live API
@@ -4003,14 +4200,24 @@ def poll_once(
     # GPU-idle advisory (#518/#537), and phase-change sidecar (#669)
     # computations, all of which compare against VM-STAMPED timestamps and
     # would be corrupted by a pod-clock basis.
-    last_mtime_ago, phase_log_mtime_ago, shard_log_mtime_ago = _log_staleness_secs(
-        pod=pod,
-        vm_now_epoch=now_epoch,
-        pod_now_epoch=int(probe.get("pod_now_epoch") or "0"),
-        freshest_mtime_epoch=freshest_mtime_epoch,
-        phase_log_mtime_epoch=phase_log_mtime_epoch,
-        shard_log_mtime_epoch=shard_log_mtime_epoch,
+    last_mtime_ago, phase_log_mtime_ago, shard_log_mtime_ago, output_mtime_ago = (
+        _log_staleness_secs(
+            pod=pod,
+            vm_now_epoch=now_epoch,
+            pod_now_epoch=int(probe.get("pod_now_epoch") or "0"),
+            freshest_mtime_epoch=freshest_mtime_epoch,
+            phase_log_mtime_epoch=phase_log_mtime_epoch,
+            shard_log_mtime_epoch=shard_log_mtime_epoch,
+            output_mtime_epoch=int(probe.get("output_mtime_epoch") or "0"),
+        )
     )
+    # #1033 kill switch: with the fold disabled the probe block was omitted
+    # (the parser's "0" default already yields the inert 10**9), but force
+    # the sentinel explicitly so a stray OUTPUT_MTIME_EPOCH line in the
+    # stdout (e.g. a pod running newer code than the VM) can never engage
+    # a disabled fold.
+    if not OUTPUT_MTIME_FOLD_ENABLED:
+        output_mtime_ago = 10**9
     gpu_util = probe.get("gpu_util", "unknown")
     gpu_idle = _gpu_idle(gpu_util)
     # Zombie-GPU-allocation signal (#664): the probe emits the
@@ -4063,7 +4270,7 @@ def poll_once(
     # `current_phase == "done"` precedence already covers the
     # "log-shows-completion" half: a completed run is `done`, never `dead`.
     #
-    # `stalled` requires ALL FIVE liveness-of-output signals to agree:
+    # `stalled` requires ALL SIX liveness-of-output signals to agree:
     # the top-level log AND the freshest cell log (folded together as
     # `last_mtime_ago`, #405) AND every per-phase log under
     # `/workspace/logs/issue-<N>-*.log` (#468) AND every shard /
@@ -4071,8 +4278,11 @@ def poll_once(
     # logs/issue_<N>{,_*}/*.log` (#488) plus every dispatcher per-job
     # log under `/workspace/explore-persona-space/eval_results/
     # issue_<N>{,_*}/logs/*.log` (#521, folded into the same shard-log
-    # max) AND the GPUs must ALL be quiet/idle for >STALL_SEC. The
-    # shard-log conjunction (#488)
+    # max) AND every issue-keyed OUTPUT artifact (eval_results/
+    # issue_<N>{,_*}/, data/issue_<N>/, data/issue<N>/ — #1033; a fresh
+    # output behaves exactly like a fresh shard log: first-class
+    # liveness, no new override concept) AND the GPUs must ALL be
+    # quiet/idle for >STALL_SEC. The shard-log conjunction (#488)
     # prevents a false stall when a multi-GPU launcher fans out per-GPU
     # shard logs under a subdirectory and the inner loop's per-shard
     # write cadence (e.g. ~3 min between writes for i488 Pass B across
@@ -4139,6 +4349,7 @@ def poll_once(
         last_mtime_ago > stall_sec
         and phase_log_mtime_ago > stall_sec
         and shard_log_mtime_ago > stall_sec
+        and output_mtime_ago > stall_sec  # NEW (#1033): fresh output = alive
         and gpu_idle
     ):
         if cpu_advancing is True:
@@ -4175,6 +4386,28 @@ def poll_once(
         gpu_pids_resolvable=_parse_probe_count(probe.get("gpu_pids_resolvable")),
         uvm_live_holders=_parse_probe_count(probe.get("nvidia_uvm_live_holders")),
         session_cpu_rate_cores=session_cpu_rate,
+        output_mtime_ago=output_mtime_ago,
+    )
+
+    # ── #873/#1033 run-scoped state anchor (AC #6) ───────────────────────
+    # A fresh epm:run-launched (relaunch / same-issue follow-up round)
+    # re-arms BOTH #873 tripwires AND (since #1033) the GPU-idle
+    # advisory/escalation clock: the stored ETA/width dedup keys and the
+    # idle span/dedup sets belong to the PREVIOUS run, so
+    # _tripwire_run_scope clears them (_RUN_SCOPED_STATE_KEYS) before any
+    # consumer runs. Runs ABOVE the idle-advisory calls (moved here at
+    # #1033 — pre-#1033 it sat below them, so the idle tier read the
+    # UNSCOPED state and a relaunch inherited the previous run's span:
+    # #763 printed a "543 min" idle advisory on a ~17-min-old instance).
+    # ``run_age_sec`` is computed ONCE here and reused by the
+    # adaptive-interval relaunch clamp + the phase-ETA fallback below
+    # (one events.jsonl read per tick). The zombie override above and the
+    # #983 post-done guard below deliberately keep reading the RAW
+    # ``prev_state`` (zombie_streak scoping is out of #1033's scope; the
+    # post-done guard has its own natural epoch).
+    run_age_sec = _run_launched_age_sec(issue, now_epoch)
+    tripwire_state, tripwire_run_epoch = _tripwire_run_scope(
+        prev_state, run_age_sec=run_age_sec, now_epoch=now_epoch
     )
 
     # ── #518/#537 GPU-idle advisory ──────────────────────────────────────
@@ -4183,7 +4416,11 @@ def poll_once(
     # burns pod-hours silently. Track the sustained healthy-and-all-idle
     # span across ticks (state-file backed, like ssh_fail_count) and post
     # a one-per-phase, non-blocking advisory marker once it exceeds
-    # GPU_IDLE_ADVISORY_MIN minutes. Never flips ``status``.
+    # GPU_IDLE_ADVISORY_MIN minutes. Never flips ``status``. Reads the
+    # RUN-SCOPED tripwire_state (#1033) so a relaunch restarts the idle
+    # clock instead of inheriting the previous run's span — the reported
+    # idle minutes are PER-INSTANCE/PER-RUN, never cumulative across
+    # relaunches.
     gpu_idle_since_epoch, gpu_idle_advised_phases, gpu_idle_advisory_posted = (
         _maybe_post_gpu_idle_advisory(
             issue=issue,
@@ -4191,7 +4428,7 @@ def poll_once(
             status=status,
             gpu_util=gpu_util,
             current_phase=current_phase,
-            prev_state=prev_state,
+            prev_state=tripwire_state,
             now_epoch=now_epoch,
         )
     )
@@ -4201,7 +4438,8 @@ def poll_once(
     # GPU_IDLE_ESCALATION_MIN minutes in an upload/CPU-only phase fires a
     # Telegram push + a LOUD [gpu-idle-escalation] marker (never stops the
     # pod). Reads the SAME idle span the advisory just resolved
-    # (gpu_idle_since_epoch) — no second idle clock.
+    # (gpu_idle_since_epoch) — no second idle clock — and the SAME
+    # run-scoped tripwire_state (#1033).
     gpu_idle_escalated_phases, gpu_idle_escalation_posted = _maybe_escalate_gpu_idle(
         issue=issue,
         pod=pod,
@@ -4209,20 +4447,8 @@ def poll_once(
         gpu_util=gpu_util,
         current_phase=current_phase,
         idle_since_epoch=gpu_idle_since_epoch,
-        prev_state=prev_state,
+        prev_state=tripwire_state,
         now_epoch=now_epoch,
-    )
-
-    # ── #873 run-scoped tripwire dedup anchor (AC #6) ────────────────────
-    # A fresh epm:run-launched (relaunch / same-issue follow-up round)
-    # re-arms BOTH #873 tripwires: the stored ETA/width dedup keys belong
-    # to the PREVIOUS run, so _tripwire_run_scope clears them before the
-    # predicates run. ``run_age_sec`` is computed ONCE here and reused by
-    # the adaptive-interval relaunch clamp + the phase-ETA fallback below
-    # (one events.jsonl read per tick).
-    run_age_sec = _run_launched_age_sec(issue, now_epoch)
-    tripwire_state, tripwire_run_epoch = _tripwire_run_scope(
-        prev_state, run_age_sec=run_age_sec, now_epoch=now_epoch
     )
 
     # ── #873 m-of-N GPU-width advisory ───────────────────────────────────

--- a/scripts/poll_pipeline.py
+++ b/scripts/poll_pipeline.py
@@ -656,6 +656,8 @@ ZOMBIE_CPU_RATE_MIN_DT_SEC = int(os.environ.get("EPM_ZOMBIE_CPU_RATE_MIN_DT_SEC"
 # sibling, bounded by the GPU-idle advisory/escalation tiers, the #873
 # tripwires, and this switch. When disabled the probe block is omitted
 # entirely and ``poll_once`` forces ``output_mtime_ago = inf`` (fully inert).
+# NOTE: read at module import (matching the #864 flag) — a live poller needs
+# a restart for an ops flip to take effect.
 OUTPUT_MTIME_FOLD_ENABLED = os.environ.get("EPM_POLL_OUTPUT_MTIME_FOLD", "1") != "0"
 
 
@@ -3999,6 +4001,25 @@ def _apply_zombie_override(
     return status, stall_reason, cpu_override_active, zombie_streak
 
 
+def _parse_output_mtime_epoch(raw: str | None) -> int:
+    """Parse the probe's ``OUTPUT_MTIME_EPOCH`` scalar defensively (#1033 r2).
+
+    ``_parse_probe_stdout`` stores the scalar text VERBATIM, so a malformed /
+    non-numeric value — reachable via version skew (a pod running newer probe
+    code than this VM, the same scenario the kill-switch branch in
+    ``poll_once`` defends on the DISABLED side) or a garbled/partial SSH
+    line — must fail INERT, not kill the tick: return ``0``, which
+    ``_log_staleness_secs`` maps to the ``10**9`` absent sentinel (the
+    pre-#1033 no-fold behavior). Every numeric value parses exactly as the
+    previous inline ``int(raw or "0")`` did. Guards ONLY this new #1033 key —
+    the sibling probe ints keep their long-standing strict parses.
+    """
+    try:
+        return int(raw or "0")
+    except (ValueError, TypeError):
+        return 0
+
+
 def _log_staleness_secs(
     *,
     pod: str,
@@ -4217,7 +4238,7 @@ def poll_once(
             freshest_mtime_epoch=freshest_mtime_epoch,
             phase_log_mtime_epoch=phase_log_mtime_epoch,
             shard_log_mtime_epoch=shard_log_mtime_epoch,
-            output_mtime_epoch=int(probe.get("output_mtime_epoch") or "0"),
+            output_mtime_epoch=_parse_output_mtime_epoch(probe.get("output_mtime_epoch")),
         )
     )
     # #1033 kill switch: with the fold disabled the probe block was omitted

--- a/scripts/poll_pipeline.py
+++ b/scripts/poll_pipeline.py
@@ -2539,6 +2539,15 @@ def _maybe_post_gpu_idle_advisory(
     downstream consumers) — no new marker schema. A post failure is logged
     and the phase is NOT recorded as advised, so the next tick retries; the
     advisory never affects the status verdict and never stops anything.
+
+    The reported idle minutes are PER-INSTANCE / PER-RUN, never cumulative
+    across relaunches (#1033): both callers hand this function a
+    run/instance-scoped ``prev_state`` — the RunPod lane via
+    ``_tripwire_run_scope`` (``_RUN_SCOPED_STATE_KEYS`` includes the idle
+    keys), the GCP lane additionally via attempt-id keying
+    (``backend_poll._scope_idle_state_to_attempt``) — so an advisory can
+    never report an idle span exceeding the current instance's own poll
+    history (#763: "543 min" printed on a ~17-min-old fresh VM pre-#1033).
     """
     try:
         prev_idle_since = int(prev_state.get("gpu_idle_since_epoch", "0"))

--- a/tests/test_backend_poll_gpu_idle.py
+++ b/tests/test_backend_poll_gpu_idle.py
@@ -661,3 +661,189 @@ def test_gcp_width_relaunch_resets_advised_phases(tmp_path, monkeypatch, capsys)
     assert saved["gpu_width_advised_phases"] == ""  # stale de-dup cleared (re-armed)
     assert int(saved["gpu_width_since_epoch"]) >= t0  # span restarted this run
     assert int(saved["tripwire_run_epoch"]) >= t0 - 121  # fresh anchor persisted
+
+
+# ── #1033 per-instance idle clock (attempt-id scoping) ────────────────────────
+#
+# The idle-advisory span + per-phase dedup sets in the GCP sibling state file
+# used to survive instance relaunches: #763 printed a "543 min" idle advisory
+# (via the ADVISORY tier — the live #763 sidecar shows
+# gpu_idle_advised_phases="startup,workload" with an EMPTY escalated set:
+# single-GPU instance, so only the advisory fired, once per phase as the
+# stale span rode along) on a ~17-min-old fresh eps-issue-763 VM whose phase
+# name matched the stored one, so the per-phase reset never fired. The fix
+# keys the idle state to handle.extra["attempt_id"] (fresh per NEW instance,
+# label-stable on reconnect — #927) via _scope_idle_state_to_attempt, with
+# _tripwire_run_scope's widened _RUN_SCOPED_STATE_KEYS clear as the
+# belt-and-suspenders run-epoch reset.
+
+
+def test_scope_idle_state_same_attempt_preserves() -> None:
+    """A matching stored attempt id (a reconnect to the SAME instance) keeps
+    the state verbatim — the span legitimately accumulates."""
+    prev = {
+        "idle_attempt_id": "att-1",
+        "gpu_idle_since_epoch": "1000",
+        "gpu_idle_advised_phases": "startup",
+        "gpu_idle_escalated_phases": "",
+        "phase": "startup",
+    }
+    assert bp._scope_idle_state_to_attempt(prev, "att-1") is prev
+
+
+def test_scope_idle_state_missing_current_attempt_keeps_verbatim() -> None:
+    """Fail-safe: an absent/empty CURRENT attempt id cannot decide instance
+    identity -> state kept verbatim (pre-#1033 behavior)."""
+    prev = {"idle_attempt_id": "att-1", "gpu_idle_since_epoch": "1000"}
+    assert bp._scope_idle_state_to_attempt(prev, "") is prev
+    assert bp._scope_idle_state_to_attempt(prev, None) is prev
+
+
+def test_scope_idle_state_legacy_missing_stored_key_resets() -> None:
+    """Migration direction pinned: a pre-#1033 state file (NO stored
+    ``idle_attempt_id``) with a KNOWN current id RESETS — failing toward one
+    delayed/duplicate advisory, never a stale counter."""
+    prev = {
+        "gpu_idle_since_epoch": "1000",
+        "gpu_idle_advised_phases": "startup",
+        "gpu_idle_escalated_phases": "startup",
+        "phase": "startup",
+    }
+    scoped = bp._scope_idle_state_to_attempt(prev, "att-1")
+    for key in bp._IDLE_ADVISORY_STATE_KEYS:
+        assert key not in scoped
+    assert scoped["phase"] == "startup"  # only the idle keys are cleared
+
+
+def test_scope_idle_state_mismatch_clears_only_idle_keys() -> None:
+    """An attempt-id MISMATCH (a genuinely NEW instance) clears exactly the
+    three idle keys; every other key (phase, width, anchor) survives."""
+    prev = {
+        "idle_attempt_id": "att-old",
+        "gpu_idle_since_epoch": "1000",
+        "gpu_idle_advised_phases": "startup,workload",
+        "gpu_idle_escalated_phases": "workload",
+        "gpu_width_since_epoch": "5",
+        "tripwire_run_epoch": "77",
+        "phase": "workload",
+    }
+    scoped = bp._scope_idle_state_to_attempt(prev, "att-new")
+    for key in bp._IDLE_ADVISORY_STATE_KEYS:
+        assert key not in scoped
+    assert scoped["gpu_width_since_epoch"] == "5"
+    assert scoped["tripwire_run_epoch"] == "77"
+    assert scoped["phase"] == "workload"
+
+
+def _seed_attempt_idle_state(
+    path: Path, *, since_epoch: int, phase: str, idle_attempt_id: str | None
+) -> None:
+    payload = {
+        "phase": phase,
+        "gpu_idle_since_epoch": str(since_epoch),
+        "gpu_idle_advised_phases": "",
+        "gpu_idle_escalated_phases": "",
+    }
+    if idle_attempt_id is not None:
+        payload["idle_attempt_id"] = idle_attempt_id
+    bp._save_gpu_idle_state(path, payload)
+
+
+def _gcp_attempt_handle(attempt_id: str | None) -> RunHandle:
+    extra = {"issue": 730, "zone": "us-central1-a"}
+    if attempt_id is not None:
+        extra["attempt_id"] = attempt_id
+    return _gcp_handle(extra)
+
+
+def _run_idle_main(tmp_path, monkeypatch, *, handle: RunHandle, seed_kwargs: dict):
+    """Drive ``bp.main`` on a single-GPU all-idle GCP tick (the #763 shape:
+    advisory-tier only — the escalation tier requires a multi-GPU pod, which
+    is why the live #763 sidecar's escalated set is empty). Returns
+    ``(json_line, posted, saved_state)``."""
+    posted: list[dict] = []
+    monkeypatch.setattr(
+        pp, "post_event", lambda issue, key, **kw: posted.append({"key": key, **kw})
+    )
+    monkeypatch.setattr(pp, "_telegram_push", lambda msg: True)
+    # No epm:run-launched signal -> the run-epoch anchor never resets; the
+    # attempt-id mechanism is isolated as the ONLY reset in play.
+    monkeypatch.setattr(pp, "_run_launched_age_sec", lambda issue, now_epoch: None)
+
+    sidecar = tmp_path / "issue-730-handle.json"
+    write_handle_sidecar(handle, sidecar)
+    state_path = bp._gpu_idle_state_path(sidecar)
+    _seed_attempt_idle_state(state_path, **seed_kwargs)
+
+    backend = _IdlePollBackend(gpu_util="0", current_phase="startup")
+    monkeypatch.setattr("scripts.backend_poll._resolve_backend", lambda name: backend)
+
+    rc = bp.main(["--issue", "730", "--handle-file", str(sidecar)])
+    assert rc == 0
+    return posted, bp._load_gpu_idle_state(state_path)
+
+
+def test_gcp_idle_new_attempt_resets_idle_clock(tmp_path, monkeypatch) -> None:
+    """The #763/#810 replay: a seeded 543-min span + ``idle_attempt_id``
+    from the PREVIOUS instance, polled with a handle carrying a NEW
+    attempt_id -> NO stale-minute advisory; the saved state carries the new
+    ``idle_attempt_id`` and a now-anchored span (an advisory on the fresh
+    instance can never report minutes exceeding its own poll history)."""
+    t0 = int(time.time())
+    posted, saved = _run_idle_main(
+        tmp_path,
+        monkeypatch,
+        handle=_gcp_attempt_handle("att-new"),
+        seed_kwargs={
+            "since_epoch": t0 - 543 * 60,
+            "phase": "startup",  # matches current_phase -> per-phase reset inert
+            "idle_attempt_id": "att-old",
+        },
+    )
+    assert not any("[gpu-idle-advisory]" in (p.get("note") or "") for p in posted)
+    assert saved["idle_attempt_id"] == "att-new"
+    assert int(saved["gpu_idle_since_epoch"]) >= t0  # span re-anchored this tick
+
+
+def test_gcp_idle_same_attempt_preserves_span(tmp_path, monkeypatch) -> None:
+    """Reconnect control: the SAME attempt_id (label-stable reconnect, #927)
+    keeps the span, so the legitimate long-idle advisory still posts with
+    the accumulated 543 minutes."""
+    t0 = int(time.time())
+    posted, saved = _run_idle_main(
+        tmp_path,
+        monkeypatch,
+        handle=_gcp_attempt_handle("att-same"),
+        seed_kwargs={
+            "since_epoch": t0 - 543 * 60,
+            "phase": "startup",
+            "idle_attempt_id": "att-same",
+        },
+    )
+    assert any(
+        "[gpu-idle-advisory]" in (p.get("note") or "") and "543 min" in (p.get("note") or "")
+        for p in posted
+    )
+    assert saved["idle_attempt_id"] == "att-same"
+
+
+def test_gcp_idle_missing_attempt_id_no_reset(tmp_path, monkeypatch) -> None:
+    """Fail-safe end-to-end: a handle WITHOUT ``attempt_id`` (older handle
+    sidecars) keeps the state verbatim — pre-#1033 behavior, so the stale
+    span still posts (the fail direction is a duplicate/late advisory only
+    when identity is KNOWN to have changed, never a behavior change on
+    degraded inputs)."""
+    t0 = int(time.time())
+    posted, saved = _run_idle_main(
+        tmp_path,
+        monkeypatch,
+        handle=_gcp_attempt_handle(None),
+        seed_kwargs={
+            "since_epoch": t0 - 543 * 60,
+            "phase": "startup",
+            "idle_attempt_id": "att-old",
+        },
+    )
+    assert any("[gpu-idle-advisory]" in (p.get("note") or "") for p in posted)
+    # The stored id is PRESERVED (empty current id never clobbers it).
+    assert saved["idle_attempt_id"] == "att-old"

--- a/tests/test_poll_eta_tripwire.py
+++ b/tests/test_poll_eta_tripwire.py
@@ -373,6 +373,60 @@ def test_eta_relaunch_resets_posted_keys(monkeypatch: pytest.MonkeyPatch) -> Non
     assert len(posted) == 2
 
 
+def test_run_scope_clears_idle_keys_on_new_run() -> None:
+    """#1033: the run-scope clear set is ``_RUN_SCOPED_STATE_KEYS`` — the #873
+    tripwire dedup keys PLUS the three GPU-idle advisory/escalation keys. A
+    fresh ``epm:run-launched`` epoch clears ALL of them (the pre-#1033
+    "idle keys untouched by the reset" contract was the bug: #763 printed a
+    543-min idle advisory on a ~17-min-old fresh instance). Non-run-scoped
+    keys (``phase``) are kept."""
+    now = 1_000_000
+    prev = {
+        "phase": "workload",
+        "gpu_idle_since_epoch": str(now - 543 * 60),
+        "gpu_idle_advised_phases": "startup,workload",
+        "gpu_idle_escalated_phases": "workload",
+        "eta_deviation_posted_keys": "extract",
+        "tripwire_run_epoch": "1000",  # the PREVIOUS run's launch epoch
+    }
+    state, epoch = pp._tripwire_run_scope(prev, run_age_sec=120.0, now_epoch=now)
+    assert epoch == now - 120
+    idle_keys = (
+        "gpu_idle_since_epoch",
+        "gpu_idle_advised_phases",
+        "gpu_idle_escalated_phases",
+    )
+    for key in idle_keys:
+        assert key not in state
+    assert "eta_deviation_posted_keys" not in state  # #873 keys still cleared
+    assert state["phase"] == "workload"  # non-run-scoped keys survive
+    # The clear-set invariant: tripwire keys ⊂ run-scoped keys, idle keys in.
+    assert set(pp._TRIPWIRE_STATE_KEYS) < set(pp._RUN_SCOPED_STATE_KEYS)
+    assert set(idle_keys) <= set(pp._RUN_SCOPED_STATE_KEYS)
+
+
+def test_run_scope_keeps_idle_keys_same_run() -> None:
+    """#1033 fail-safes pinned: a same-run anchor (within the 60s jitter
+    tolerance) AND an unknown run age (missing/unreadable marker) BOTH keep
+    the idle keys — the anchor semantics + fail-safe branches are
+    byte-unchanged from #873; only the clear SET widened."""
+    now = 1_000_000
+    prev = {
+        "gpu_idle_since_epoch": str(now - 40 * 60),
+        "gpu_idle_advised_phases": "scoring",
+        "gpu_idle_escalated_phases": "",
+        "tripwire_run_epoch": str(now - 3 * 3600),
+    }
+    # Same run: 30s jitter, within tolerance -> kept.
+    state, epoch = pp._tripwire_run_scope(prev, run_age_sec=3 * 3600.0 - 30, now_epoch=now)
+    assert epoch == now - 3 * 3600
+    assert state["gpu_idle_since_epoch"] == str(now - 40 * 60)
+    assert state["gpu_idle_advised_phases"] == "scoring"
+    # Unknown run age -> kept verbatim.
+    state2, _epoch2 = pp._tripwire_run_scope(prev, run_age_sec=None, now_epoch=now)
+    assert state2 is prev
+
+
 def test_eta_same_run_does_not_reset_posted_keys() -> None:
     """The no-reset control: a run-launched epoch within the 60s jitter
     tolerance of the stored anchor preserves the dedup keys."""

--- a/tests/test_poll_pipeline_output_mtime.py
+++ b/tests/test_poll_pipeline_output_mtime.py
@@ -116,14 +116,16 @@ def _probe_stdout(
     gpu_util: str,
     session_cpu: str,
     zombie_pids: str = "",
-    output_mtime_epoch: int | None = None,
+    output_mtime_epoch: int | str | None = None,
 ) -> str:
     """Probe stdout in the shape ``_parse_probe_stdout`` expects.
 
     ``POD_NOW_EPOCH`` is always emitted so every staleness delta rides the
     DETERMINISTIC pod-clock branch (#704) — boundary tests would otherwise be
     off-by-one flaky against ``poll_once``'s own ``time.time()``.
-    ``output_mtime_epoch=None`` omits the line (older probe / fold disabled).
+    ``output_mtime_epoch=None`` omits the line (older probe / fold disabled);
+    a ``str`` value injects the raw scalar text verbatim (malformed-line
+    replay — version skew / garbled SSH output).
     """
     lines = [
         "PID_FILE_MISSING=0",
@@ -245,6 +247,36 @@ def test_output_stale_keeps_stalled(
     )
     result = _poll(tmp_path / "poll-state.json")
     assert result.status == "stalled"
+
+
+def test_output_malformed_epoch_is_inert_not_crash(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """r2 blocker pin (``malformed-output-mtime-crashes-poll``): a malformed /
+    non-numeric ``OUTPUT_MTIME_EPOCH`` scalar — reachable via version skew (a
+    pod running newer probe code than this VM) or a garbled/partial SSH line —
+    must NOT crash the tick (plan AC#6: no new crash paths). The guarded parse
+    folds it to ``0`` (-> the ``10**9`` inert sentinel), so the degraded-CPU
+    stale tick returns the SAME verdict as the ``OUTPUT_MTIME_EPOCH=0`` case."""
+    now = int(time.time())
+
+    def _stdout(epoch: int | str) -> str:
+        return _probe_stdout(
+            pod_now=now,
+            mtime_epoch=now - 2000,
+            tail=_STALE_TAIL,
+            gpu_util="0,0,0,0,0,0,0,0",
+            session_cpu="unknown",
+            output_mtime_epoch=epoch,
+        )
+
+    _patch_pod(monkeypatch, stdout=_stdout(0))
+    baseline = _poll(tmp_path / "poll-state-zero.json")
+    assert baseline.status == "stalled"
+
+    _patch_pod(monkeypatch, stdout=_stdout("garbage"))
+    malformed = _poll(tmp_path / "poll-state-garbage.json")
+    assert (malformed.status, malformed.stall_reason) == (baseline.status, baseline.stall_reason)
 
 
 def test_output_exactly_at_stall_sec_rescues(

--- a/tests/test_poll_pipeline_output_mtime.py
+++ b/tests/test_poll_pipeline_output_mtime.py
@@ -1,0 +1,527 @@
+"""Output-artifact mtime fold + run-scoped idle clock (#1033).
+
+Ask 1 (output-mtime fold): a CPU-bound analysis tail writes per-cell NPZs /
+result JSONs / ``.done`` sentinels for hours while every log layout is quiet
+and the GPUs are idle by design (#813). The probe gains a bounded,
+issue-keyed ``OUTPUT_MTIME_EPOCH`` freshness read (short-circuit
+``find -newermt ... -print -quit`` under ``timeout``); the delta joins the
+stall conjunction as a 5th liveness conjunct AND vetoes the #664/#826 zombie
+override (streak reset, identical mechanics to the fresh-log veto). Kill
+switch ``EPM_POLL_OUTPUT_MTIME_FOLD`` (default ON).
+
+These tests pin:
+
+* the parser lifting ``OUTPUT_MTIME_EPOCH`` (+ the "0" defaults on an absent
+  line and on the ssh-failure fallback dict);
+* the #813 degraded-CPU replay: stale logs + idle GPUs + CPU probe degraded
+  (rate None) + a FRESH issue-keyed output -> ``running`` (the tick-47 shape
+  minus the CPU signal #951 already covers);
+* the pre-#1033 behavior pinned: no fresh output (``0`` or a stale epoch) ->
+  ``stalled``;
+* the strict-``>`` stall boundary (``output_mtime_ago == stall_sec`` still
+  rescues) and the ``<=`` zombie-veto boundary (ago exactly at
+  ``max(ZOMBIE_VETO_FRESH_SEC, stall_sec)`` still vetoes) — matching the
+  other conjuncts' semantics;
+* the zombie fresh-output veto as a FULL ``poll_once`` probe-stdout replay
+  (NOT a direct ``_apply_zombie_override`` unit call — dropped call-site
+  threading must not pass green) with streak reset;
+* the #664 true positive STILL FIRING through the real
+  parse -> staleness -> threading path with an explicit STALE non-zero
+  ``OUTPUT_MTIME_EPOCH``;
+* the direct-call default (``output_mtime_ago`` omitted -> ``inf``)
+  preserving pre-#1033 ``_apply_zombie_override`` outputs;
+* the heredoc probe text: bounded (``timeout``), short-circuit
+  (``-print -quit``), issue-keyed roots ONLY, and the two-stage veto-window
+  find emitted ONLY when the veto window is genuinely wider than stall_sec;
+* the kill switch: probe block omitted AND a stray fresh
+  ``OUTPUT_MTIME_EPOCH`` line left inert.
+
+Ask 2 (RunPod-lane per-run idle clock): ``_tripwire_run_scope``'s clear set
+now includes the three GPU-idle keys (``_RUN_SCOPED_STATE_KEYS``) and runs
+ABOVE the idle-advisory calls in ``poll_once``, so a relaunch restarts the
+idle span instead of inheriting the previous run's (#763 "543 min" on a
+~17-min-old instance). Integration replays here; the pure
+``_tripwire_run_scope`` key-set tests live in
+``tests/test_poll_eta_tripwire.py``; the GCP attempt-id sibling lives in
+``tests/test_backend_poll_gpu_idle.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_script_module(filename: str, alias: str):
+    """Load a ``scripts/*.py`` file as a module (mirrors
+    ``tests/test_poll_pipeline_zombie_gpu.py``'s loader)."""
+    spec = importlib.util.spec_from_file_location(alias, REPO_ROOT / "scripts" / filename)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[alias] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+pp = _load_script_module("poll_pipeline.py", "poll_pipeline_output_mtime_under_test")
+
+ISSUE = 9813
+LOG = f"/workspace/logs/issue-{ISSUE}.log"
+PID = f"/workspace/logs/issue-{ISSUE}.pid"
+
+
+# ── probe-output parser ───────────────────────────────────────────────────────
+
+
+def test_parse_probe_stdout_lifts_output_mtime() -> None:
+    """The parser dispatches the ``OUTPUT_MTIME_EPOCH=`` line; an absent line
+    (older probe / fold disabled) defaults the key to "0"."""
+    parsed = pp._parse_probe_stdout("PID_ALIVE=1\nGPU_UTIL=0\nOUTPUT_MTIME_EPOCH=1751700000\n")
+    assert parsed["output_mtime_epoch"] == "1751700000"
+    assert pp._parse_probe_stdout("PID_ALIVE=1\nGPU_UTIL=0\n")["output_mtime_epoch"] == "0"
+
+
+def test_ssh_failure_fallback_includes_output_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The ssh-failure early-return dict carries ``output_mtime_epoch: "0"``
+    (fail-safe: a transport failure never reads as a fresh output)."""
+
+    def _fail_run(cmd: list[str], **kwargs: Any):
+        return subprocess.CompletedProcess(args=cmd, returncode=255, stdout="", stderr="refused")
+
+    monkeypatch.setattr(pp.subprocess, "run", _fail_run)
+    probe = pp._ssh_probe("pod-x", LOG, PID, ISSUE)
+    assert probe["ssh_failed"] == "1"
+    assert probe["output_mtime_epoch"] == "0"
+
+
+# ── poll_once wiring harness ──────────────────────────────────────────────────
+
+
+def _probe_stdout(
+    *,
+    pod_now: int,
+    mtime_epoch: int,
+    tail: str,
+    gpu_util: str,
+    session_cpu: str,
+    zombie_pids: str = "",
+    output_mtime_epoch: int | None = None,
+) -> str:
+    """Probe stdout in the shape ``_parse_probe_stdout`` expects.
+
+    ``POD_NOW_EPOCH`` is always emitted so every staleness delta rides the
+    DETERMINISTIC pod-clock branch (#704) — boundary tests would otherwise be
+    off-by-one flaky against ``poll_once``'s own ``time.time()``.
+    ``output_mtime_epoch=None`` omits the line (older probe / fold disabled).
+    """
+    lines = [
+        "PID_FILE_MISSING=0",
+        "PID_ALIVE=1",
+        f"MTIME_EPOCH={mtime_epoch}",
+        "TAIL_START",
+        tail,
+        "TAIL_END",
+        f"POD_NOW_EPOCH={pod_now}",
+        "CELL_MTIME_EPOCH=0",
+        "CELL_TAIL_START",
+        "CELL_TAIL_END",
+        "PHASE_LOG_MTIME_EPOCH=0",
+        "SHARD_LOG_MTIME_EPOCH=0",
+        f"GPU_UTIL={gpu_util}",
+        f"ZOMBIE_GPU_PIDS={zombie_pids}",
+        "GPU_PIDS_TOTAL=unknown",
+        "GPU_PIDS_RESOLVABLE=unknown",
+        "NVIDIA_UVM_LIVE_HOLDERS=unknown",
+        f"SESSION_CPU_SECS={session_cpu}",
+        "RESULTS_SENTINEL_PRESENT=0",
+    ]
+    if output_mtime_epoch is not None:
+        lines.append(f"OUTPUT_MTIME_EPOCH={output_mtime_epoch}")
+    return "\n".join(lines)
+
+
+def _patch_pod(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    stdout: str,
+    posted: list[dict] | None = None,
+    run_age_sec: float | None = 10800.0,
+) -> None:
+    """Monkeypatch poll_pipeline's I/O boundary with a fully-controlled probe
+    (the ``tests/test_poll_pipeline_zombie_gpu.py`` convention: fake ONLY
+    ``pp.subprocess.run``, so the real parser + staleness + threading run)."""
+
+    def _fake_run(cmd: list[str], **kwargs: Any):
+        remote = cmd[-1]
+        out = "" if "SENTINEL_START" in remote else stdout
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=out, stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", _fake_run)
+    if posted is None:
+        monkeypatch.setattr(pp, "post_event", MagicMock())
+    else:
+        monkeypatch.setattr(
+            pp, "post_event", lambda issue, key, **kw: posted.append({"key": key, **kw})
+        )
+    monkeypatch.setattr(pp, "_marker_pid", lambda issue: None)
+    monkeypatch.setattr(pp, "_run_launched_age_sec", lambda issue, now_epoch: run_age_sec)
+    monkeypatch.setattr(pp, "_telegram_push", lambda msg: True)
+
+
+def _seed_state(state_file: Path, state: dict[str, str]) -> None:
+    state_file.write_text(json.dumps({str(ISSUE): state}))
+
+
+def _saved_state(state_file: Path) -> dict[str, str]:
+    return json.loads(state_file.read_text())[str(ISSUE)]
+
+
+def _poll(state_file: Path):
+    return pp.poll_once(
+        issue=ISSUE, pod=f"pod-{ISSUE}", log_path=LOG, pid_file=PID, state_file=state_file
+    )
+
+
+_STALE_TAIL = "2026-07-03 00:00:01 [phase=scoring judging batch 3/9]"
+
+
+# ── Ask 1: stall-conjunction fold ─────────────────────────────────────────────
+
+
+def test_output_fresh_rescues_stall_conjunction(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The #813 degraded-CPU replay (the tick-47 shape minus the CPU signal
+    #951 covers): every log stale > stall_sec, GPUs idle, CPU probe degraded
+    (``session_cpu=unknown`` -> rate None), but ONE issue-keyed output file
+    modified 30s ago -> verdict ``running``, not ``stalled``."""
+    now = int(time.time())
+    _patch_pod(
+        monkeypatch,
+        stdout=_probe_stdout(
+            pod_now=now,
+            mtime_epoch=now - 2000,
+            tail=_STALE_TAIL,
+            gpu_util="0,0,0,0,0,0,0,0",
+            session_cpu="unknown",
+            output_mtime_epoch=now - 30,
+        ),
+    )
+    result = _poll(tmp_path / "poll-state.json")
+    assert result.status == "running"
+    assert result.stall_reason is None
+
+
+@pytest.mark.parametrize("output_mtime_epoch", [None, 0, "stale"])
+def test_output_stale_keeps_stalled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, output_mtime_epoch
+) -> None:
+    """Pre-#1033 behavior pinned: the same degraded-CPU tick with NO fresh
+    output — the line absent (older probe), the literal ``0`` (nothing within
+    the window), or a genuinely stale epoch — still reads ``stalled``."""
+    now = int(time.time())
+    epoch = now - 2000 if output_mtime_epoch == "stale" else output_mtime_epoch
+    _patch_pod(
+        monkeypatch,
+        stdout=_probe_stdout(
+            pod_now=now,
+            mtime_epoch=now - 2000,
+            tail=_STALE_TAIL,
+            gpu_util="0,0,0,0,0,0,0,0",
+            session_cpu="unknown",
+            output_mtime_epoch=epoch,
+        ),
+    )
+    result = _poll(tmp_path / "poll-state.json")
+    assert result.status == "stalled"
+
+
+def test_output_exactly_at_stall_sec_rescues(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Boundary pin: ``output_mtime_ago == stall_sec`` EXACTLY does not meet
+    the strict-``>`` conjunct (same semantics as the three log conjuncts), so
+    the verdict stays ``running``."""
+    now = int(time.time())
+    _patch_pod(
+        monkeypatch,
+        stdout=_probe_stdout(
+            pod_now=now,
+            mtime_epoch=now - 2000,
+            tail=_STALE_TAIL,
+            gpu_util="0,0,0,0,0,0,0,0",
+            session_cpu="unknown",
+            output_mtime_epoch=now - pp.DEFAULT_STALL_SEC,
+        ),
+    )
+    result = _poll(tmp_path / "poll-state.json")
+    assert result.status == "running"
+
+
+# ── Ask 1: zombie-override fresh-output veto ──────────────────────────────────
+
+
+def _zombie_tick2_stdout(now: int, *, output_mtime_epoch: int | None) -> str:
+    """The #664 tick-2 regime: zombie candidate + all logs stale + session
+    CPU advancing (the #518 override would rescue to ``running``); the
+    seeded streak "1" makes one ``poll_once`` call represent tick 2."""
+    return _probe_stdout(
+        pod_now=now,
+        mtime_epoch=now - 2000,
+        tail=_STALE_TAIL,
+        gpu_util="0,0,0,0,0,0,0,0",
+        session_cpu="5000.0",
+        zombie_pids="1262130",
+        output_mtime_epoch=output_mtime_epoch,
+    )
+
+
+def _zombie_tick2_state(now: int) -> dict[str, str]:
+    return {
+        "phase": "scoring",
+        "last_phase_change_epoch": str(now - 7200),
+        "session_cpu_secs": "4000.0",
+        "max_cpu_secs": "4000.0",
+        "zombie_streak": "1",
+    }
+
+
+def test_zombie_output_fresh_vetoes_and_resets_streak(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A zombie candidate meeting the #826 stale-log conjunction on tick 2 is
+    VETOED by a fresh issue-keyed output within
+    ``max(ZOMBIE_VETO_FRESH_SEC, stall_sec)`` — full ``poll_once`` replay
+    through the real parse -> staleness -> threading path (a dropped
+    call-site kwarg must not pass green). Streak RESETS (mirror of
+    ``test_zombie_fresh_log_vetoes_and_resets_streak``)."""
+    now = int(time.time())
+    state_file = tmp_path / "poll-state.json"
+    _seed_state(state_file, _zombie_tick2_state(now))
+    _patch_pod(monkeypatch, stdout=_zombie_tick2_stdout(now, output_mtime_epoch=now - 30))
+    result = _poll(state_file)
+    assert result.status == "running"
+    assert result.stall_reason is None
+    assert _saved_state(state_file)["zombie_streak"] == "0"
+
+
+def test_zombie_stale_output_still_fires_tick2(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The #664 true positive through the REAL parse -> staleness -> threading
+    path with an explicit STALE non-zero ``OUTPUT_MTIME_EPOCH`` (now-2000):
+    the fold must NOT weaken the hung-vLLM detection — tick 2 still overrides
+    ``running -> stalled`` with the #664 reason."""
+    now = int(time.time())
+    state_file = tmp_path / "poll-state.json"
+    _seed_state(state_file, _zombie_tick2_state(now))
+    _patch_pod(monkeypatch, stdout=_zombie_tick2_stdout(now, output_mtime_epoch=now - 2000))
+    result = _poll(state_file)
+    assert result.status == "stalled"
+    assert result.stall_reason == "vllm_worker_dead_zombie_gpu"
+
+
+def test_zombie_output_exactly_at_veto_boundary_vetoes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Boundary pin: ``output_mtime_ago`` EXACTLY at
+    ``max(ZOMBIE_VETO_FRESH_SEC, stall_sec)`` vetoes (``<=`` — the same
+    boundary semantics as the #826 fresh-log veto term)."""
+    now = int(time.time())
+    veto_sec = max(pp.ZOMBIE_VETO_FRESH_SEC, pp.DEFAULT_STALL_SEC)
+    state_file = tmp_path / "poll-state.json"
+    _seed_state(state_file, _zombie_tick2_state(now))
+    _patch_pod(monkeypatch, stdout=_zombie_tick2_stdout(now, output_mtime_epoch=now - veto_sec))
+    result = _poll(state_file)
+    assert result.status == "running"
+    assert result.stall_reason is None
+    assert _saved_state(state_file)["zombie_streak"] == "0"
+
+
+def test_zombie_direct_call_output_default_inf(caplog: pytest.LogCaptureFixture) -> None:
+    """Direct ``_apply_zombie_override`` call WITHOUT the new kwarg: the
+    ``inf`` default keeps every pre-#1033 caller/test byte-unchanged — the
+    tick-2 fire path is reached exactly as before (mirror of
+    ``test_zombie_direct_call_rate_none_default``)."""
+    status, reason, cpu_override, streak = pp._apply_zombie_override(
+        status="running",
+        zombie_gpu_pids=["1262130"],
+        stall_sec=900,
+        last_mtime_ago=2000,
+        phase_log_mtime_ago=10**9,
+        shard_log_mtime_ago=10**9,
+        prev_state={"zombie_streak": "1"},
+        pod="pod-9813",
+        cpu_override_active=True,
+    )
+    assert (status, reason, cpu_override, streak) == (
+        "stalled",
+        "vllm_worker_dead_zombie_gpu",
+        False,
+        2,
+    )
+
+
+# ── Ask 1: probe heredoc text (boundedness + narrowness) ──────────────────────
+
+
+def _capture_heredoc(monkeypatch: pytest.MonkeyPatch, *, stall_sec: int) -> str:
+    captured: list[str] = []
+
+    def _fake_run(cmd: list[str], **kwargs: Any):
+        captured.append(cmd[-1])
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", _fake_run)
+    pp._ssh_probe(f"pod-{ISSUE}", LOG, PID, ISSUE, None, stall_sec=stall_sec)
+    assert captured
+    return captured[-1]
+
+
+def test_output_probe_heredoc_is_bounded_and_issue_keyed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The composed probe block is bounded (``timeout`` directly in front of
+    ``find``), short-circuits (``-print -quit``), and passes ONLY issue-keyed
+    roots to ``find`` (text-assertion style of
+    ``test_gpu_probe_emits_namespace_count_keys``)."""
+    heredoc = _capture_heredoc(monkeypatch, stall_sec=900)
+    assert "OUTPUT_MTIME_EPOCH=" in heredoc
+    assert "-print -quit" in heredoc
+    assert re.search(r"timeout \d+ find ", heredoc), "find is not timeout-bounded"
+    allowed_prefixes = (
+        f"/workspace/explore-persona-space/eval_results/issue_{ISSUE}",
+        f"/workspace/explore-persona-space/data/issue_{ISSUE}",
+        f"/workspace/explore-persona-space/data/issue{ISSUE}",
+    )
+    find_blocks = re.findall(r"timeout \d+ find (.*?) -type f", heredoc)
+    assert find_blocks, "no find path list found in the heredoc"
+    for block in find_blocks:
+        paths = block.split()
+        assert paths
+        for path in paths:
+            assert path.startswith(allowed_prefixes), f"non-issue-keyed find root: {path}"
+    # All four planned roots are present (incl. the data/issue<N> no-underscore
+    # convention from the #854 sweep list).
+    joined = " ".join(find_blocks)
+    for prefix in allowed_prefixes:
+        assert prefix in joined
+    assert f"/workspace/explore-persona-space/eval_results/issue_{ISSUE}_*" in joined
+
+
+def test_output_probe_two_stage_only_when_veto_wider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The second (veto-window) find stage is emitted ONLY when
+    ``max(ZOMBIE_VETO_FRESH_SEC, stall_sec) > stall_sec`` (fast-smoke
+    configs); at the default 900s stall window one find covers both reads."""
+    assert "OUT_CUTOFF_VETO" not in _capture_heredoc(monkeypatch, stall_sec=900)
+    fast = _capture_heredoc(monkeypatch, stall_sec=30)
+    assert "OUT_CUTOFF_VETO" in fast
+    assert f"OUT_NOW - {max(pp.ZOMBIE_VETO_FRESH_SEC, 30)}" in fast
+
+
+def test_output_fold_kill_switch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``EPM_POLL_OUTPUT_MTIME_FOLD=0``: (a) the probe block is omitted from
+    the heredoc; (b) a stray fresh ``OUTPUT_MTIME_EPOCH`` line in the stdout
+    (a pod running newer code) is left INERT — the degraded-CPU stale tick
+    reads ``stalled`` exactly as pre-#1033."""
+    monkeypatch.setattr(pp, "OUTPUT_MTIME_FOLD_ENABLED", False)
+    assert "OUTPUT_MTIME_EPOCH" not in _capture_heredoc(monkeypatch, stall_sec=900)
+
+    now = int(time.time())
+    _patch_pod(
+        monkeypatch,
+        stdout=_probe_stdout(
+            pod_now=now,
+            mtime_epoch=now - 2000,
+            tail=_STALE_TAIL,
+            gpu_util="0,0,0,0,0,0,0,0",
+            session_cpu="unknown",
+            output_mtime_epoch=now - 30,  # fresh — but the fold is disabled
+        ),
+    )
+    result = _poll(tmp_path / "poll-state.json")
+    assert result.status == "stalled"
+
+
+# ── Ask 2 (RunPod lane): relaunch restarts the idle clock ─────────────────────
+
+
+def _idle_span_state(now: int, *, tripwire_run_epoch: str) -> dict[str, str]:
+    """The #763-shape sidecar: a 543-min idle span accumulated by the
+    PREVIOUS run, phase matching the current one (so the per-phase reset
+    never fires), advisory not yet posted for this phase."""
+    return {
+        "phase": "scoring",
+        "last_phase_change_epoch": str(now - 7200),
+        "gpu_idle_since_epoch": str(now - 543 * 60),
+        "gpu_idle_advised_phases": "",
+        "gpu_idle_escalated_phases": "",
+        "tripwire_run_epoch": tripwire_run_epoch,
+        "session_cpu_secs": "unknown",
+        "max_cpu_secs": "unknown",
+        "zombie_streak": "0",
+    }
+
+
+def _healthy_idle_stdout(now: int) -> str:
+    # Fresh logs (healthy run) + a single idle GPU: advisory territory only.
+    return _probe_stdout(
+        pod_now=now,
+        mtime_epoch=now - 10,
+        tail=_STALE_TAIL,
+        gpu_util="0",
+        session_cpu="unknown",
+    )
+
+
+def test_poll_once_relaunch_resets_idle_span(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """RunPod-lane integration (#1033 Ask 2): a fresh ``epm:run-launched``
+    (run age 120s, stored anchor from the PREVIOUS run) clears the idle keys
+    alongside the #873 tripwire keys, so the advisory is NOT posted with the
+    previous run's 543-min span and the persisted span re-anchors at or
+    after the fresh run's launch epoch."""
+    now = int(time.time())
+    posted: list[dict] = []
+    state_file = tmp_path / "poll-state.json"
+    _seed_state(state_file, _idle_span_state(now, tripwire_run_epoch="1000"))
+    _patch_pod(monkeypatch, stdout=_healthy_idle_stdout(now), posted=posted, run_age_sec=120.0)
+    result = _poll(state_file)
+    assert result.status == "running"
+    assert result.gpu_idle_advisory_posted is False
+    assert not any("[gpu-idle-advisory]" in (p.get("note") or "") for p in posted)
+    saved = _saved_state(state_file)
+    assert int(saved["gpu_idle_since_epoch"]) >= now - 121  # >= the fresh run epoch
+
+
+def test_poll_once_same_run_keeps_idle_span(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The no-reset control: a stored anchor within the 60s jitter tolerance
+    of the current run epoch keeps the span, so the (legitimate) long-idle
+    advisory still posts with the accumulated minutes."""
+    now = int(time.time())
+    posted: list[dict] = []
+    state_file = tmp_path / "poll-state.json"
+    # Current run epoch resolves to ~now-120; the stored anchor sits ~5s off.
+    _seed_state(state_file, _idle_span_state(now, tripwire_run_epoch=str(now - 125)))
+    _patch_pod(monkeypatch, stdout=_healthy_idle_stdout(now), posted=posted, run_age_sec=120.0)
+    result = _poll(state_file)
+    assert result.status == "running"
+    assert result.gpu_idle_advisory_posted is True
+    notes = [p.get("note") or "" for p in posted]
+    assert any("[gpu-idle-advisory]" in n and "543 min" in n for n in notes)


### PR DESCRIPTION
Closes task #1033 (kind: infra, workflow-fix, auto-filed by /daily 2026-07-03).

## Summary
- Output-file mtime liveness fold: bounded issue-keyed `OUTPUT_MTIME_EPOCH` probe on the poller's single SSH heredoc → 5th stall conjunct + fresh-output veto in the zombie override (kill switch `EPM_POLL_OUTPUT_MTIME_FOLD`, default ON; malformed scalars fail inert). Closes the #813-class false stalls in the residual window #951's CPU-rate veto doesn't cover.
- Per-instance gpu-idle clock: GCP lane keyed to `handle.extra["attempt_id"]` (reset on new instance, kept on reconnect, legacy migration); RunPod lane via `_RUN_SCOPED_STATE_KEYS` extension of `_tripwire_run_scope`. Kills the #763/#810 "543/486 min idle" stale advisories on fresh instances.
- 28 new tests (incident replays #813/#763 + #664 TP preservation + fail-safe/boundary/kill-switch pins).

## Test plan
- [x] Targeted suite 355/355 (worktree) + Step 9c touched-scope 2803 passed / 0 new failures (baseline compare rc 0)
- [x] ruff clean on touched files; workflow_lint PASS
- [x] Code-review ensemble r2 PASS (r1 Codex blocker fixed + revert-verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)