### PR TITLE
task #1032: Goal-currency replan guard (3-layer) + verify_plan c23

### DIFF
--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -209,7 +209,14 @@ Full template + worked examples: `.claude/rules/planner-section-reference.md`
 this section.
 
 ### 1. Goal
-What are we trying to achieve and why? One paragraph.
+OPEN §1 with the CURRENT canonical Goal quoted verbatim — re-read at return
+time via `task.py view <N> --json | jq -r '.frontmatter.goal'` (never from a
+draft-start cache; see § Goal-currency guard) — tagged `(Task #<N> Goal,
+verbatim.)`, then one paragraph: what are we trying to achieve and why?
+Tasks with no `goal:` frontmatter (kind: infra | batch | survey) quote the
+body's `## Goal` H2 instead. The verbatim quote is what makes Goal
+staleness mechanically detectable downstream (verify_plan.py goal-currency
+check).
 
 ### 2. Prior Work
 What exists in the codebase and literature? What approaches have been tried? What specific results constrain the design?
@@ -353,6 +360,23 @@ For each assumption, state:
 - **How to verify:** What file to read or command to run
 
 Be exhaustive. Wrong assumptions are the #1 cause of wasted GPU time.
+
+## Goal-currency guard (re-read the Goal before returning — #922)
+
+The user can amend the canonical Goal WHILE you draft: on #922 two
+`epm:goal-updated` amendments landed mid-draft and plan v3 shipped quoting
+the superseded Goal — one wasted plan round + one wasted implementer round.
+
+1. **At draft start**, record a Goal snapshot: the `goal:` frontmatter text
+   + the ts of the latest `epm:goal-updated` marker (if any), both from
+   `task.py view <N> --json`.
+2. **Immediately before returning your final plan text** — initial drafts,
+   mechanical-bounce redrafts, Phase 3 revisions, AND amendment-mode
+   same-issue follow-up plans alike — re-run the same read. If the Goal
+   text or the latest `epm:goal-updated` ts changed since the snapshot,
+   REDRAFT §0.0 / §0 / §1 and every Goal-dependent section (Hypothesis,
+   Design, Evaluation, gates) against the amended Goal before returning.
+   Never return a plan drafted against a superseded Goal.
 
 ## Rules
 

--- a/.claude/skills/adversarial-planner/SKILL.md
+++ b/.claude/skills/adversarial-planner/SKILL.md
@@ -32,6 +32,10 @@ You are the PLANNER. Your job is to design a concrete, detailed plan for the fol
 
 [TASK DESCRIPTION]
 
+**Canonical Goal (current at spawn; re-read before returning — planner.md
+§ Goal-currency guard):** [GOAL TEXT or "no goal: frontmatter — use the
+body's ## Goal H2"]
+
 **If this is a `type:batch` issue (the body lists N independent items):**
 Structure your plan as N independent sections, one per body item. Each
 section gets its own subset of the fields below — Goal, Design (with file
@@ -73,6 +77,29 @@ Be specific — name files, write pseudocode, specify hyperparameters with a lit
 ```
 
 Save the plan to a temporary file or pass it directly.
+
+**Goal-currency gate (pre-persist; EVERY `new-plan-version` call).** Capture
+the Goal snapshot when you spawn the planner —
+`GOAL_SNAP="$(uv run python scripts/task.py view <N> --json | jq -r '.frontmatter.goal // empty')"`;
+when that is empty (no `goal:` frontmatter — `kind: infra | batch | survey`),
+fall back to the body's `## Goal` H2 text (`jq -r '.body'` + the H2 slice), so
+the gate is non-vacuous on body-Goal tasks too. Inline the snapshot in the
+brief (template above). Immediately BEFORE every
+`task.py new-plan-version` persist (Phase 1 initial draft, Phase 1.5.0
+mechanical-bounce redrafts, Phase 3 revisions), re-read the same field and
+compare to the snapshot (plain text equality). On ANY difference — the user
+amended the Goal while the draft was in flight (#922: two `epm:goal-updated`
+amendments landed mid-draft; plan v3 persisted quoting the superseded Goal
+and auto-approved 3 s later) — OR when NO snapshot was captured at spawn
+(missing/empty on a task that has a Goal: treat as a mismatch — re-read
+twice, never persist on an unverifiable snapshot) — do NOT persist:
+re-spawn the planner with the
+amended Goal + the draft path as a MECHANICAL redraft bounce (same semantics
+as a Phase 1.5.0 bounce; does NOT count against the Phase 3 round cap),
+refresh `GOAL_SNAP`, then persist the redraft. A goal-currency WARN from
+verify_plan.py at Phase 1.5.0 (`c23_goal_currency`) is the same bounce
+trigger — the one WARN that bounces instead of riding into the critic
+briefs.
 
 **Strip the harness trailer before persisting.** An `Agent` tool result ends
 with harness-appended metadata — a final `agentId: <id> (use SendMessage ...)`
@@ -134,7 +161,10 @@ Run the structural verifier against the plan version just persisted:
   words, proceed anyway (verifier false positive), record `verdict: PASS-with-override`
   + the overridden check ids in the marker note, and emit a workflow-fix candidate
   against `scripts/verify_plan.py`.
-- **PASS (with WARNs) → proceed**; copy the WARN lines verbatim into the fact-checker
+- **PASS (with WARNs) → proceed** — EXCEPT a `goal_currency` WARN
+  (`c23_goal_currency`), which instead triggers the mechanical redraft
+  bounce per § Goal-currency gate above (the one WARN that bounces);
+  copy any OTHER WARN lines verbatim into the fact-checker
   brief (and later the critic briefs) as "mechanical pre-pass notes".
 - **Post the marker** (VM-side; the adversarial-planner skill always runs in the
   orchestrator session, never on a pod):

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1534,6 +1534,15 @@ plans missing any):**
 - Target pod preference
 - Plan deviations allowed vs must-ask
 
+**Goal-currency gate:** before EVERY `new-plan-version` call, re-read
+`frontmatter.goal` and compare against the spawn-time snapshot
+(`adversarial-planner` SKILL.md § Goal-currency gate) — a goal-update newer
+than the draft start forces a mechanical redraft bounce (re-spawn the
+planner against the amended Goal; NOT a critic round). Incident #922
+(2026-07-03): plan v3 persisted quoting a Goal superseded 10 minutes
+earlier by `epm:goal-updated`, was auto-approved 3 s later, and was caught
+only by a PM-chat directive one wasted implementer round later.
+
 Post the plan body via `new-plan-version` (writes
 `tasks/<status>/<N>/plans/v<K>.md` and rotates the `plan.md` symlink),
 then announce it with an `epm:plan` event. The handoff file carries a
@@ -7008,7 +7017,12 @@ orchestrators driving one round is the #778 root cause.
      picked up (it raises that label's authoritative `(ts, version)`);
      never plan against an entry-time snapshot, or a session that
      entered on `v3` and snapshotted before a `v5`/`v6` correction
-     landed plans stale (the #658 bug). The `followup_label` lives
+     landed plans stale (the #658 bug).
+     The same pre-snapshot re-read covers the canonical GOAL:
+     `frontmatter.goal` + the latest `epm:goal-updated` ts — the
+     adversarial-planner § Goal-currency gate applies in AMENDMENT scope too
+     (an amendment plan drafted against a stale Goal is the #922 bug class,
+     the Goal sibling of this bullet's #658 scope bug). The `followup_label` lives
      inside the marker NOTE body as free text (its format even differs
      across versions — `- followup_label: ...` dash-bullet, bare
      `followup_label: ...`, bold `**followup_label:** ...`), NOT as a

--- a/scripts/verify_plan.py
+++ b/scripts/verify_plan.py
@@ -48,11 +48,18 @@ Check catalog (id — classification — kind scope)
       gate → AST arity audit
   c22 cross-section param       WARN-only, conditional    all kinds
       consistency
+  c23 goal currency             WARN-only, conditional    all kinds,
+      (stale-Goal quote)                                  --issue mode only
 
 Kind-exempt checks render as [SKIP] (first-class status, distinguishable
 from genuine passes — the calibration report needs n_skip separate from
 n_pass). Conditional checks (4, 6, 7, 10, 11, 12, 13, 14, 15, 16, 17, 18,
-19, 20, 21, 22) also SKIP when their content trigger does not fire.
+19, 20, 21, 22, 23) also SKIP when their content trigger does not fire.
+Check 23 runs OUTSIDE ``verify_plan_text()`` — it needs task context
+(``body.md`` + ``events.jsonl``), so ``main()`` appends it in ``--issue``
+mode only and renders it SKIP in ``--plan-file`` mode; its WARN is the one
+the adversarial-planner Phase 1.5.0 consumer treats as a mechanical redraft
+bounce (SKILL.md § Goal-currency gate), not a brief-forwarded WARN.
 
 Canonical N/A escape phrases (quote verbatim in bounce briefs):
 
@@ -113,6 +120,7 @@ import math
 import re
 import sys
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from fractions import Fraction
 from pathlib import Path
 
@@ -3304,6 +3312,122 @@ def check_cross_section_param_consistency(plan: str, kind: str) -> CheckResult:
     return _warn(cid, name, detail)
 
 
+# ─── Check 23 — goal currency (outside CHECKS; --issue mode only) ─────────
+
+# Word-shingle stale-quote detector for the #922 plan-vs-goal incident class:
+# a plan head quoting a SUPERSEDED Goal at high coverage while the CURRENT
+# Goal is absent. WARN-only (the c21 WARN-first precedent, #1042); the
+# forced redraft is delivered by the adversarial-planner SKILL.md
+# § Goal-currency gate ("the one WARN that bounces"). Needs task context
+# (body.md + events.jsonl), so it lives OUTSIDE verify_plan_text() and is
+# appended by main() in --issue mode only.
+_C23_SHINGLE_K = 6
+_C23_MIN_GOAL_WORDS = 12
+_C23_STALE_COV = 0.5
+_C23_CURRENT_COV = 0.3
+# NO positive slack: retro-stale goal-update gaps of ~3-6 min exist in the
+# corpus (779/477/489) — any slack ≥ ~3 min manufactures false positives.
+_C23_MTIME_SLACK_S = 0.0
+
+
+def _norm_goal_words(s: str) -> list[str]:
+    """Lowercase; non-alphanumerics (incl. unicode math) -> space; split."""
+    return [w for w in re.sub(r"[^a-z0-9 ]+", " ", s.lower()).split() if w]
+
+
+def _goal_shingles(words: list[str], k: int = _C23_SHINGLE_K) -> set[tuple[str, ...]]:
+    """All contiguous k-word shingles of ``words`` (empty set below k words)."""
+    if len(words) < k:
+        return set()
+    return {tuple(words[i : i + k]) for i in range(len(words) - k + 1)}
+
+
+def _shingle_coverage(goal: str, head_words: list[str]) -> float:
+    """Fraction of the goal's k-word shingles present in the plan head."""
+    gs = _goal_shingles(_norm_goal_words(goal))
+    if not gs:
+        return 0.0
+    hs = _goal_shingles(head_words)
+    return sum(1 for s in gs if s in hs) / len(gs)
+
+
+def _plan_head_words(plan: str) -> list[str]:
+    """Head region = start -> the ``## 2.``/``### 2.`` heading, else first 8000 chars."""
+    m = re.search(r"^#{2,3}\s*2\.\s", plan, re.M)
+    return _norm_goal_words(plan[: m.start()] if m else plan[:8000])
+
+
+def _goal_history_for_plan(folder: Path, plan_mtime_utc: datetime) -> tuple[str | None, list[str]]:
+    """(current_goal, superseded_goals) AS OF the plan version's post time.
+
+    current = latest predating ``epm:goal-updated`` ``to:`` (fallback:
+    body.md frontmatter ``goal:``); superseded = predating markers'
+    ``from:`` values (structured fields only — ``task.py set-goal`` posts
+    top-level ``from``/``to``/``by``; hand-posted note-only markers
+    contribute nothing). Bounded STRICTLY by mtime (slack 0, ``ts <= mtime``
+    inclusive) so goal-updates that postdate the plan never retro-flag it —
+    a positive slack manufactures FPs from minutes-scale retro-stale gaps
+    (779/477/489).
+    """
+    cutoff = plan_mtime_utc + timedelta(seconds=_C23_MTIME_SLACK_S)
+    current: str | None = None
+    superseded: list[str] = []
+    ev = folder / "events.jsonl"
+    if ev.exists():
+        for line in ev.read_text().splitlines():
+            if '"epm:goal-updated"' not in line:
+                continue  # cheap pre-filter; goal-updated lines parse strictly below
+            e = json.loads(line)
+            if e.get("kind") != "epm:goal-updated" or not isinstance(e.get("ts"), str):
+                continue
+            ets = datetime.fromisoformat(e["ts"].replace("Z", "+00:00"))
+            if ets.tzinfo is None:
+                ets = ets.replace(tzinfo=UTC)
+            if ets.astimezone(UTC) > cutoff:
+                continue
+            if isinstance(e.get("from"), str):
+                superseded.append(e["from"])
+            if isinstance(e.get("to"), str):
+                current = e["to"]
+    if current is None:
+        body = folder / "body.md"
+        if body.exists():
+            fm, _ = split_frontmatter(body.read_text())
+            g = fm.get("goal")
+            current = str(g) if g else None
+    if current is not None:
+        cur_norm = " ".join(_norm_goal_words(current))
+        superseded = [s for s in superseded if " ".join(_norm_goal_words(s)) != cur_norm]
+    return current, superseded
+
+
+def check_goal_currency(
+    plan: str, *, current_goal: str | None, superseded: list[str]
+) -> CheckResult:
+    """WARN when the plan head quotes a superseded Goal while the current
+    Goal is absent (the #922 stale-quote signature); PASS/SKIP otherwise."""
+    cid, name = "c23_goal_currency", "plan head not drafted against a superseded Goal"
+    if current_goal is None or len(_norm_goal_words(current_goal)) < _C23_MIN_GOAL_WORDS:
+        return _skip(cid, name, "no goal frontmatter / goal too short for shingle matching")
+    sup = [s for s in superseded if len(_norm_goal_words(s)) >= _C23_MIN_GOAL_WORDS]
+    if not sup:
+        return _skip(cid, name, "no superseded Goal predates this plan version")
+    head = _plan_head_words(plan)
+    cov_cur = _shingle_coverage(current_goal, head)
+    cov_stale, stale = max(((_shingle_coverage(s, head), s) for s in sup), key=lambda t: t[0])
+    if cov_stale >= _C23_STALE_COV and cov_cur < _C23_CURRENT_COV:
+        return _warn(
+            cid,
+            name,
+            f"plan head matches a SUPERSEDED Goal (shingle coverage {cov_stale:.2f}: "
+            f"{stale[:100]!r}) while the CURRENT Goal is absent (coverage {cov_cur:.2f}) "
+            "— redraft §0.0/§0/§1 against the current `goal:` frontmatter (#922 "
+            "plan-vs-goal incident). The orchestrator treats this WARN as a mechanical "
+            "redraft bounce (adversarial-planner SKILL.md § Goal-currency gate).",
+        )
+    return _pass(cid, name, f"coverage: current {cov_cur:.2f}, max superseded {cov_stale:.2f}")
+
+
 # ─── Driver ────────────────────────────────────────────────────────────────
 
 CHECKS = [
@@ -3443,6 +3567,24 @@ def main() -> int:
         kind = args.kind or "experiment"
 
     overall, results = verify_plan_text(raw, kind=kind, source=source)
+
+    # Check 23 (goal currency) needs task context (body.md + events.jsonl),
+    # so it runs OUTSIDE verify_plan_text(): appended here in --issue mode,
+    # rendered SKIP in --plan-file mode.
+    if issue is not None:
+        folder = plan_path.parent.parent  # tasks/<status>/<N>/plans/vK.md -> task folder
+        mtime = datetime.fromtimestamp(plan_path.stat().st_mtime, tz=UTC)
+        cur, sup = _goal_history_for_plan(folder, mtime)
+        results.append(check_goal_currency(raw, current_goal=cur, superseded=sup))
+    else:
+        results.append(
+            _skip(
+                "c23_goal_currency",
+                "plan head not drafted against a superseded Goal",
+                "no task context (--plan-file mode; goal history requires --issue)",
+            )
+        )
+    overall = all(r.passed for r in results)
 
     if args.json:
         print(

--- a/scripts/verify_plan.py
+++ b/scripts/verify_plan.py
@@ -3368,18 +3368,38 @@ def _goal_history_for_plan(folder: Path, plan_mtime_utc: datetime) -> tuple[str 
     inclusive) so goal-updates that postdate the plan never retro-flag it —
     a positive slack manufactures FPs from minutes-scale retro-stale gaps
     (779/477/489).
+
+    Read discipline: records split on ``"\\n"`` — NEVER ``str.splitlines()``
+    (the paired writer ``task_workflow._append_jsonl_line`` emits
+    ``ensure_ascii=False``, so a raw U+2028/U+2029/NEL inside a goal/note
+    string is ONE valid JSONL record that ``splitlines()`` would shred,
+    crashing the strict ``json.loads`` or silently dropping the marker —
+    the #950 class; mirrors ``task_workflow._iter_jsonl``). Fail-fast: a
+    row whose ``kind`` IS ``epm:goal-updated`` but whose ``ts`` is missing
+    or non-string raises ``ValueError`` — the canonical writer always emits
+    ``ts``, so such a row is real corruption, and silently skipping it
+    would shrink the predating history (flipping c23 to SKIP/PASS on a
+    stale plan).
     """
     cutoff = plan_mtime_utc + timedelta(seconds=_C23_MTIME_SLACK_S)
     current: str | None = None
     superseded: list[str] = []
     ev = folder / "events.jsonl"
     if ev.exists():
-        for line in ev.read_text().splitlines():
+        for line in ev.read_text(encoding="utf-8", errors="replace").split("\n"):
+            if not line.strip():
+                continue
             if '"epm:goal-updated"' not in line:
                 continue  # cheap pre-filter; goal-updated lines parse strictly below
             e = json.loads(line)
-            if e.get("kind") != "epm:goal-updated" or not isinstance(e.get("ts"), str):
+            if e.get("kind") != "epm:goal-updated":
                 continue
+            if not isinstance(e.get("ts"), str):
+                raise ValueError(
+                    f"malformed epm:goal-updated row in {ev}: missing/non-string 'ts' "
+                    f"(the canonical writer always emits ts — this is corruption, "
+                    f"not a benign note-only marker): {line!r}"
+                )
             ets = datetime.fromisoformat(e["ts"].replace("Z", "+00:00"))
             if ets.tzinfo is None:
                 ets = ets.replace(tzinfo=UTC)

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -3281,6 +3281,59 @@ def test_goal_history_falls_back_to_frontmatter_goal(tmp_path):
     assert superseded == []
 
 
+def test_goal_history_parses_raw_u2028_inside_marker_text(tmp_path):
+    """A goal-updated record whose text field carries a RAW U+2028 (written
+    ensure_ascii=False, exactly as task_workflow._append_jsonl_line does) is
+    ONE valid JSONL record under the canonical split("\\n") read.
+    str.splitlines() splits on U+2028/U+2029/NEL too, shredding the record —
+    the pre-boundary fragment still contains '"epm:goal-updated"', so the
+    strict json.loads crashes (or, boundary-permuted, silently DROPS the
+    marker — exactly c23's firing scenario). An ASCII fixture structurally
+    cannot catch this (#950 JSONL-shred class)."""
+    old = "goal AAA with a raw\u2028line separator inside"
+    new = "goal BBB text entirely plain"
+    row = {
+        "ts": "2026-01-01T00:00:00Z",
+        "kind": "epm:goal-updated",
+        "version": 1,
+        "from": old,
+        "to": new,
+    }
+    line = json.dumps(row, ensure_ascii=False)
+    assert "\u2028" in line  # fixture sanity: the separator survives serialization raw
+    assert len(line.splitlines()) > 1  # fixture sanity: splitlines() WOULD shred this record
+    (tmp_path / "events.jsonl").write_text(line + "\n", encoding="utf-8")
+    current, superseded = verify_plan._goal_history_for_plan(tmp_path, datetime.now(tz=UTC))
+    assert current == new
+    assert superseded == [old]
+
+
+def test_goal_history_raises_on_goal_updated_row_missing_ts(tmp_path):
+    """A row whose kind IS epm:goal-updated but whose ts is missing/non-string
+    is real corruption (the canonical writer always emits ts) — fail fast with
+    row context, never silently shrink the predating goal history."""
+    row = {"kind": "epm:goal-updated", "version": 1, "from": "goal AAA text", "to": "goal BBB"}
+    (tmp_path / "events.jsonl").write_text(json.dumps(row) + "\n")
+    with pytest.raises(ValueError, match="epm:goal-updated"):
+        verify_plan._goal_history_for_plan(tmp_path, datetime.now(tz=UTC))
+
+
+def test_goal_history_tolerates_note_only_goal_updated_marker(tmp_path):
+    """A hand-posted note-only goal-updated marker (ts present, no from/to) is
+    structurally valid — it keeps its benign no-op skip; ONLY the
+    missing/non-string-ts case raises."""
+    row = {
+        "ts": "2026-01-01T00:00:00Z",
+        "kind": "epm:goal-updated",
+        "version": 1,
+        "note": "hand-posted, fieldless",
+    }
+    (tmp_path / "events.jsonl").write_text(json.dumps(row) + "\n")
+    current, superseded = verify_plan._goal_history_for_plan(tmp_path, datetime.now(tz=UTC))
+    assert current is None  # no body.md fallback in this fixture
+    assert superseded == []
+
+
 def test_cli_issue_mode_appends_goal_currency(tmp_path, monkeypatch, capsys):
     (tmp_path / "plans").mkdir()
     (tmp_path / "plans" / "v1.md").write_text(GOOD_PLAN)

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -20,9 +20,11 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import re
 import subprocess
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -3126,12 +3128,17 @@ def test_cli_json_schema_and_exit_zero_on_pass(tmp_path):
     assert payload["issue"] is None
     assert payload["kind"] == "experiment"
     assert payload["n_fail"] == 0
-    assert payload["n_skip"] == 15
+    assert payload["n_skip"] == 16
     assert {"id", "name", "status", "detail"} <= set(payload["checks"][0])
     statuses = {c["status"] for c in payload["checks"]}
     assert statuses <= {"PASS", "WARN", "FAIL", "SKIP"}
-    assert len(payload["checks"]) == 23
-    assert len({c["id"] for c in payload["checks"]}) == 23
+    assert len(payload["checks"]) == 24
+    assert len({c["id"] for c in payload["checks"]}) == 24
+    # c23 has no task context in --plan-file mode: rendered SKIP (companion
+    # assert for test_cli_issue_mode_appends_goal_currency).
+    c23 = next(c for c in payload["checks"] if c["id"] == "c23_goal_currency")
+    assert c23["status"] == "SKIP"
+    assert "no task context" in c23["detail"]
 
 
 def test_cli_exit_one_on_fail(tmp_path):
@@ -3167,6 +3174,129 @@ def test_cli_human_output_has_overall_footer(tmp_path):
     assert proc.returncode == 0
     assert "OVERALL: PASS" in proc.stdout
     assert "[SKIP]" in proc.stdout  # SKIP is a first-class rendered status
+
+
+# ─── Check 23 — goal currency (outside CHECKS; --issue mode only) ──────────
+
+# ≥12 normalized words each (the _C23_MIN_GOAL_WORDS precision gate).
+_OLD_GOAL = (
+    "Measure the marker leakage rate across every persona pair using the "
+    "teacher forced margin metric on held out prompts"
+)
+_NEW_GOAL = (
+    "Compare on policy judge scored refusal rates between trained and base "
+    "models across twenty held out prompts"
+)
+
+
+def test_c23_stale_goal_quote_warns():
+    plan = f'# Plan\n\n## 1. Goal\n\n"{_OLD_GOAL}" (Task #999 Goal, verbatim.)\n'
+    r = verify_plan.check_goal_currency(plan, current_goal=_NEW_GOAL, superseded=[_OLD_GOAL])
+    assert r.status == "WARN"
+    assert "SUPERSEDED" in r.detail
+
+
+def test_c23_current_goal_quoted_passes():
+    # Current goal quoted verbatim; a sub-shingle-heavy fragment of the old
+    # goal rides along — coverage(current) >= 0.3 blocks the stale signature.
+    old_fragment = " ".join(_OLD_GOAL.split()[:8])
+    plan = f'# Plan\n\n## 1. Goal\n\n"{_NEW_GOAL}" (was: {old_fragment})\n'
+    r = verify_plan.check_goal_currency(plan, current_goal=_NEW_GOAL, superseded=[_OLD_GOAL])
+    assert r.status == "PASS"
+
+
+def test_c23_skips_without_superseded():
+    plan = f"# Plan\n\n## 1. Goal\n\n{_NEW_GOAL}\n"
+    r = verify_plan.check_goal_currency(plan, current_goal=_NEW_GOAL, superseded=[])
+    assert r.status == "SKIP"
+
+
+def test_c23_skips_short_goal():
+    r = verify_plan.check_goal_currency(
+        "# Plan\n\nsome head text\n", current_goal="fix the bug", superseded=[_OLD_GOAL]
+    )
+    assert r.status == "SKIP"
+
+
+def test_c23_unicode_variant_quote_still_fires():
+    # The #922 retrodiction shape: the marker's `from` text uses ASCII
+    # `Delta` / `->`; the plan head quotes the unicode variants `Δ` / `→`.
+    # Full-substring matching fails on this pair; shingle coverage stays
+    # >= 0.5 because only the shingles spanning the divergent word are lost.
+    stale_ascii = (
+        "Quantify the Delta between pre and post fine tuning marker "
+        "probabilities -> reported per persona across all twenty extraction "
+        "prompts and four seeds"
+    )
+    quoted_unicode = (
+        "Quantify the Δ between pre and post fine tuning marker "
+        "probabilities → reported per persona across all twenty extraction "
+        "prompts and four seeds"
+    )
+    plan = f'# Plan\n\n## 1. Goal\n\n"{quoted_unicode}" (Task #922 Goal, verbatim.)\n'
+    r = verify_plan.check_goal_currency(plan, current_goal=_NEW_GOAL, superseded=[stale_ascii])
+    assert r.status == "WARN"
+    assert "SUPERSEDED" in r.detail
+
+
+def _write_goal_marker(ev_path, ts_iso, from_goal, to_goal):
+    row = {"ts": ts_iso, "kind": "epm:goal-updated", "version": 1, "from": from_goal, "to": to_goal}
+    with ev_path.open("a") as f:
+        f.write(json.dumps(row) + "\n")
+
+
+def test_goal_history_bounds_markers_by_plan_mtime(tmp_path):
+    """Markers with ts <= plan mtime are included (INCLUSIVE at equality);
+    a marker at mtime + 180 s is excluded. The +180 s fixture is the
+    slack-regression detector: it sits inside the measured 2m48s-5m44s
+    retro-stale gap band, so this test FAILs under any reintroduced slack
+    >= 180 s (the removed 900 s regime would pass a mtime+900s fixture,
+    which is why that offset is banned here)."""
+    t = 1_750_000_000  # integer epoch so ts == mtime holds exactly
+
+    def iso(epoch):
+        return datetime.fromtimestamp(epoch, tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    goal_a, goal_b, goal_c, goal_d = "goal AAA text", "goal BBB text", "goal CCC text", "goal DDD"
+    (tmp_path / "plans").mkdir()
+    plan = tmp_path / "plans" / "v1.md"
+    plan.write_text("# Plan\n")
+    os.utime(plan, (t, t))
+    ev = tmp_path / "events.jsonl"
+    _write_goal_marker(ev, iso(t - 3600), goal_a, goal_b)  # predating: included
+    _write_goal_marker(ev, iso(t), goal_b, goal_c)  # exactly ts == mtime: included
+    _write_goal_marker(ev, iso(t + 180), goal_c, goal_d)  # postdating: excluded
+    mtime = datetime.fromtimestamp(plan.stat().st_mtime, tz=UTC)
+    current, superseded = verify_plan._goal_history_for_plan(tmp_path, mtime)
+    assert current == goal_c  # NOT goal_d — the +180 s marker must not enter
+    assert goal_a in superseded and goal_b in superseded
+    assert goal_c not in superseded and goal_d not in superseded
+
+
+def test_goal_history_falls_back_to_frontmatter_goal(tmp_path):
+    (tmp_path / "body.md").write_text(f"---\ntitle: x\ngoal: {_NEW_GOAL}\n---\n# x\n")
+    now = datetime.now(tz=UTC)
+    current, superseded = verify_plan._goal_history_for_plan(tmp_path, now)
+    assert current == _NEW_GOAL
+    assert superseded == []
+
+
+def test_cli_issue_mode_appends_goal_currency(tmp_path, monkeypatch, capsys):
+    (tmp_path / "plans").mkdir()
+    (tmp_path / "plans" / "v1.md").write_text(GOOD_PLAN)
+    (tmp_path / "body.md").write_text("---\ntitle: x\nkind: experiment\n---\n# x\n")
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    import explore_persona_space.task_workflow as tw
+
+    monkeypatch.setattr(tw, "find_task_path", lambda n: tmp_path)
+    monkeypatch.setattr(sys, "argv", ["verify_plan.py", "--issue", "999", "--json"])
+    rc = verify_plan.main()
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    entries = [c for c in payload["checks"] if c["id"] == "c23_goal_currency"]
+    assert len(entries) == 1
+    # Synthetic task has no goal frontmatter and no goal-updated markers.
+    assert entries[0]["status"] == "SKIP"
 
 
 # ─── Cross-file anchor pins (planner.md / CLAUDE.md drift detector) ────────


### PR DESCRIPTION
Closes task #1032 (kind: infra workflow-fix, wf-fix).

## Summary
- planner.md: Goal-currency guard (return-time Goal re-read; §1 verbatim-quote mandate)
- adversarial-planner + issue SKILL.md: pre-persist Goal-currency gate (spawn snapshot vs live compare → mechanical redraft bounce; body-## Goal fallback; no-snapshot⇒mismatch; Phase-1.5.0 "one WARN that bounces" carve-out; amendment-scope sentence)
- scripts/verify_plan.py: c23_goal_currency WARN-only stale-quote check (k=6 shingles, 0.5/0.3, STRICT ts≤mtime) + 11 tests

Calibration independently reproduced twice: #922 v3 fires 0.905/0.038; corpus sweep (1356 plan versions) fires on exactly {922 v2, 922 v3, 489 v2}, 0 FPs.

## Test plan
- [x] pytest tests/test_verify_plan.py — 298/298
- [x] Step 9c gate: 2498 passed / 6 skipped; baseline compare clean
- [x] workflow_lint default run PASS; ruff clean
- [x] Claude+Codex code-review round 2: PASS+PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)