### PR TITLE
issue-1035: batch_judge tolerates transient 404 on poll retrieve

### DIFF
--- a/src/explore_persona_space/eval/batch_judge.py
+++ b/src/explore_persona_space/eval/batch_judge.py
@@ -36,7 +36,7 @@ from explore_persona_space.llm.anthropic_client import (
     BatchDeadlineExceeded,
     batch_stuck_threshold_hours,
     deadline_from_expires_at,
-    retrieve_with_create_grace,
+    retrieve_with_404_tolerance,
 )
 
 if TYPE_CHECKING:
@@ -352,10 +352,12 @@ def _submit_and_poll_batch(
     - **Two-level terminal split**: an ``invalid_request_error`` is quarantined
       (surfaced as an error dict, never retried here); other states surface as
       error dicts too.
-    - **Create-grace 404 retry (#995)**: a ``NotFoundError`` on the loop
-      retrieve within ``BATCH_CREATE_404_GRACE_S`` of the chunk's own create is
-      retried with bounded backoff (read-after-write inconsistency, the #742
-      shape); outside the window — or past the backoff schedule — it re-raises.
+    - **404 tolerance (#995 + #1035)**: a ``NotFoundError`` on any retrieve —
+      the loop retrieve, the deadline-time final retrieve, and the cancel-race
+      probe — is retried with bounded backoff: the create-grace schedule within
+      ``BATCH_CREATE_404_GRACE_S`` of the chunk's own create (read-after-write,
+      the #742 shape), the ``BATCH_MIDPOLL_404_BACKOFF_S`` mid-poll schedule
+      anywhere else. Past both budgets it re-raises — never masked.
     - **Stuck-batch cancel (#1019)**: a chunk still ``in_progress`` at
       ``request_counts.succeeded == 0`` for >= ``EPS_BATCH_STUCK_HOURS``
       (default 4h; ``<=0`` disables) since its own create is CANCELED (once
@@ -390,12 +392,13 @@ def _submit_and_poll_batch(
         current_interval = poll_interval
         stuck_canceled = False  # #1019: cancel a wedged chunk at most once
         while True:
-            # #995: a 404 within BATCH_CREATE_404_GRACE_S of this chunk's own
-            # create is retried with bounded backoff (read-after-write; the #742
-            # shape). functools.partial, NOT a lambda: batch_id is reassigned per
-            # chunk iteration and ruff's B023 flags a loop-closure lambda. The
-            # deadline-time final retrieve below stays UNGUARDED (plan §4.3).
-            batch = retrieve_with_create_grace(
+            # #995 + #1035: a 404 within BATCH_CREATE_404_GRACE_S of this
+            # chunk's own create is retried on the grace schedule
+            # (read-after-write; the #742 shape); any other 404 gets the
+            # bounded mid-poll schedule. functools.partial, NOT a lambda:
+            # batch_id is reassigned per chunk iteration and ruff's B023 flags
+            # a loop-closure lambda.
+            batch = retrieve_with_404_tolerance(
                 functools.partial(client.messages.batches.retrieve, batch_id),
                 created_at=created_at,
                 batch_id=batch_id,
@@ -422,7 +425,18 @@ def _submit_and_poll_batch(
                     else now_fn() + _dt.timedelta(hours=25)  # absent expires_at -> still bounded
                 )
             if now_fn() > deadline:
-                final = client.messages.batches.retrieve(batch_id)
+                # #1035: the final retrieve is the LAST chance to harvest, so a
+                # transient 404 here gets the bounded mid-poll tolerance too
+                # (the #995 "genuinely anomalous -> unguarded" stance reversed);
+                # a genuinely-gone batch still re-raises NotFoundError <=~3 min
+                # later, and the BatchDeadlineExceeded semantics are untouched.
+                final = retrieve_with_404_tolerance(
+                    functools.partial(client.messages.batches.retrieve, batch_id),
+                    created_at=created_at,
+                    batch_id=batch_id,
+                    now_fn=now_fn,
+                    sleep_fn=sleep_fn,
+                )
                 if final.processing_status == "ended":
                     batch = final
                     break
@@ -460,7 +474,15 @@ def _submit_and_poll_batch(
                     # Race: the batch may already be canceling (out-of-band) or
                     # ended. BOTH are accepted cancellation outcomes — the loop
                     # harvests at ended either way. Anything else re-raises.
-                    final = client.messages.batches.retrieve(batch_id)
+                    # #1035: the confirm probe tolerates a transient 404 too
+                    # (same crash class as the poll retrieves).
+                    final = retrieve_with_404_tolerance(
+                        functools.partial(client.messages.batches.retrieve, batch_id),
+                        created_at=created_at,
+                        batch_id=batch_id,
+                        now_fn=now_fn,
+                        sleep_fn=sleep_fn,
+                    )
                     if final.processing_status not in ("canceling", "ended"):
                         raise
                     logger.info(

--- a/src/explore_persona_space/eval/judge_dispatch.py
+++ b/src/explore_persona_space/eval/judge_dispatch.py
@@ -103,7 +103,7 @@ from explore_persona_space.llm.anthropic_client import (
     batch_stuck_threshold_hours,
     deadline_from_expires_at,
     parse_batch_submitted_at,
-    retrieve_with_create_grace,
+    retrieve_with_404_tolerance,
 )
 
 if TYPE_CHECKING:
@@ -769,6 +769,7 @@ def _cancel_stuck_sub_batch(
     state: dict,
     state_path: Path,
     now_fn: "Callable[[], _dt.datetime]",
+    sleep_fn: "Callable[[float], None] | None" = None,
 ) -> None:
     """Persist escape intent, cancel the stuck sub-batch, confirm (#1019).
 
@@ -782,6 +783,9 @@ def _cancel_stuck_sub_batch(
       3. persist ``stuck_canceled_at`` (cancel-confirmed observability stamp;
          its absence on resume re-drives step 2, which is idempotent-safe
          because the guard accepts ``canceling``/``ended``).
+
+    ``sleep_fn`` is additive + injectable for tests (default ``time.sleep``);
+    it drives the #1035 bounded 404 tolerance on the race-confirm retrieve.
     """
     import anthropic as anthropic_mod
 
@@ -795,7 +799,15 @@ def _cancel_stuck_sub_batch(
         # ours after a crash, or an out-of-band Console cancel) or ended. BOTH
         # are accepted cancellation outcomes: the poll loop harvests at ended
         # either way. Anything else re-raises (fail fast, no swallowed faults).
-        final = client.messages.batches.retrieve(sb["batch_id"])
+        # #1035: the confirm probe tolerates a transient 404 (bounded, then
+        # terminal — same crash class as the poll retrieves).
+        final = retrieve_with_404_tolerance(
+            functools.partial(client.messages.batches.retrieve, sb["batch_id"]),
+            created_at=parse_batch_submitted_at(sb.get("submitted_at")),
+            batch_id=sb["batch_id"],
+            now_fn=now_fn,
+            sleep_fn=sleep_fn,
+        )
         if final.processing_status not in ("canceling", "ended"):
             raise
         logger.info(
@@ -830,16 +842,19 @@ def _poll_one_sub_batch_step(
     intent (an out-of-band Console cancel) is NEVER adopted — its canceled rows
     surface as error dicts, not retries (#1019 round 2).
 
-    Create-grace 404 (#995): a ``NotFoundError`` on the loop retrieve within
+    404 tolerance (#995 + #1035): a ``NotFoundError`` on any retrieve here —
+    the loop retrieve, the overdue final retrieve, and the cancel-race probe —
+    is retried with bounded backoff: the create-grace schedule within
     ``BATCH_CREATE_404_GRACE_S`` of this sub-batch's persisted ``submitted_at``
-    (l.636, the #742 crash site) is retried with bounded backoff. A resumed poll
-    with an old/absent ``submitted_at`` stays terminal on the first 404. This
-    step is sync and already blocks the async outer loop on the retrieve; the
-    worst-case +60s of grace sleeps is consistent with existing behavior. The
-    overdue final retrieve below stays UNGUARDED (plan §4.3). ``sleep_fn`` is
-    additive + injectable for tests (default ``time.sleep``).
+    (l.636, the #742 crash site), the ``BATCH_MIDPOLL_404_BACKOFF_S`` mid-poll
+    schedule anywhere else (incl. a resumed poll with an old/absent
+    ``submitted_at``). Past both budgets the 404 re-raises — delayed by
+    <=~230s worst case, never masked. This step is sync and already blocks the
+    async outer loop on the retrieve; the bounded sleeps are consistent with
+    existing behavior. ``sleep_fn`` is additive + injectable for tests
+    (default ``time.sleep``).
     """
-    batch = retrieve_with_create_grace(
+    batch = retrieve_with_404_tolerance(
         functools.partial(client.messages.batches.retrieve, sb["batch_id"]),
         created_at=parse_batch_submitted_at(sb.get("submitted_at")),
         batch_id=sb["batch_id"],
@@ -874,7 +889,16 @@ def _poll_one_sub_batch_step(
         _atomic_write_json(state_path, state)
     if sb.get("deadline") and now_fn() > _dt.datetime.fromisoformat(sb["deadline"]):
         # Overdue: ONE final fetch to harvest a now-ended batch, else raise.
-        final = client.messages.batches.retrieve(sb["batch_id"])
+        # #1035: the final fetch is the last chance to harvest, so a transient
+        # 404 gets the bounded mid-poll tolerance; a genuinely-gone batch still
+        # re-raises NotFoundError <=~3 min later.
+        final = retrieve_with_404_tolerance(
+            functools.partial(client.messages.batches.retrieve, sb["batch_id"]),
+            created_at=parse_batch_submitted_at(sb.get("submitted_at")),
+            batch_id=sb["batch_id"],
+            now_fn=now_fn,
+            sleep_fn=sleep_fn,
+        )
         if final.processing_status == "ended":
             _harvest_sub_batch(acc, sb=sb, **harvest_kw)
             return
@@ -916,7 +940,7 @@ def _poll_one_sub_batch_step(
                     counts.processing,
                     counts.errored,
                 )
-                _cancel_stuck_sub_batch(client, sb, state, state_path, now_fn)
+                _cancel_stuck_sub_batch(client, sb, state, state_path, now_fn, sleep_fn)
     # Escape-intent RESUME leg: intent persisted but cancel never confirmed
     # (crash between the intent write and the cancel/confirm writes) ->
     # re-drive the cancel. Bounded: the race guard accepts canceling/ended,
@@ -926,7 +950,7 @@ def _poll_one_sub_batch_step(
     # EPS_BATCH_STUCK_HOURS has since been set to 0 (disabling the knob stops
     # NEW escapes; it never strands a half-done one).
     elif sb.get("stuck_cancel_intent_at") is not None and sb.get("stuck_canceled_at") is None:
-        _cancel_stuck_sub_batch(client, sb, state, state_path, now_fn)
+        _cancel_stuck_sub_batch(client, sb, state, state_path, now_fn, sleep_fn)
 
 
 async def _poll_and_collect_sub_batches(

--- a/src/explore_persona_space/llm/anthropic_client.py
+++ b/src/explore_persona_space/llm/anthropic_client.py
@@ -169,8 +169,12 @@ def is_batch_create_grace_404(
     """True iff ``exc`` is an ``anthropic.NotFoundError`` within ``grace_s`` of create.
 
     ``created_at=None`` (unknown create time — a resumed poll of a persisted
-    ``batch_id``, or an old state.json) ALWAYS returns False: the 404 stays
-    terminal (fail-fast; preserves api_dispatch's wrong-org-404 semantics).
+    ``batch_id``, or an old state.json) ALWAYS returns False — never the
+    grace regime. Since #1035 a False here is NOT instant-terminal: the
+    wrapper / poll routes the 404 to the BOUNDED mid-poll retry schedule
+    (:func:`next_batch_404_retry` regime 3, ``BATCH_MIDPOLL_404_BACKOFF_S``),
+    and it goes terminal only after that budget — fail-fast preserved,
+    api_dispatch's wrong-org 404 delayed by <=~3 min of sleeps, never masked.
 
     ``0.0 <= elapsed``: NEGATIVE elapsed (now before created_at — an injected
     test clock, or a backwards wall-clock step) is OUT of window. Production
@@ -777,6 +781,55 @@ class AnthropicBatch:
             return created_at
         return self._created_at.get(batch_id)
 
+    async def _deadline_final_retrieve(
+        self,
+        batch_id: str,
+        created_at: "_dt.datetime | None",
+        now_fn: "Callable[[], _dt.datetime]",
+        sleep_fn: "Callable[[float], object]",
+    ):
+        """One last harvest attempt at the poll deadline, 404-tolerant (#1035).
+
+        :meth:`poll` is async, so this is a minimal local retry loop over the
+        shared ``BATCH_MIDPOLL_404_BACKOFF_S`` schedule rather than the sync
+        wrapper. After exhaustion the 404 re-raises — never masked; a success
+        after >=1 transient 404 logs the ``[batch-404-midpoll]`` recovery INFO
+        (plan criterion 5). Returns the retrieved batch object.
+        """
+        final = None
+        final_404_retries = 0
+        final_first_404_at: _dt.datetime | None = None
+        for delay in (*BATCH_MIDPOLL_404_BACKOFF_S, None):
+            try:
+                final = self.retrieve(batch_id)
+                break
+            except anthropic.NotFoundError:
+                if delay is None:
+                    raise
+                final_404_retries += 1
+                if final_first_404_at is None:
+                    final_first_404_at = now_fn()
+                logger.warning(
+                    "[batch-404-midpoll] Batch %s deadline final retrieve 404 "
+                    "(attempt %d/%d); transient suspected — retrying in %.0fs",
+                    batch_id,
+                    final_404_retries,
+                    len(BATCH_MIDPOLL_404_BACKOFF_S),
+                    delay,
+                )
+                await sleep_fn(delay)
+        assert final is not None, "final-retrieve loop invariant: break with result or raise"
+        if final_404_retries:  # recovered after >=1 transient 404 (plan criterion 5)
+            _log_batch_404_recovery(
+                batch_id,
+                0,
+                final_404_retries,
+                final_first_404_at,
+                self._effective_created_at(batch_id, created_at),
+                now_fn(),
+            )
+        return final
+
     async def poll(
         self,
         batch_id: str,
@@ -893,27 +946,7 @@ class AnthropicBatch:
                     else now_fn() + _dt.timedelta(hours=25)  # absent expires_at -> still bounded
                 )
             if now_fn() > deadline:
-                # One last harvest attempt, with bounded mid-poll 404 tolerance
-                # (#1035): poll is async, so this is a minimal local retry loop
-                # over the shared schedule rather than the sync wrapper. After
-                # exhaustion the 404 re-raises — never masked.
-                final = None
-                for attempt, delay in enumerate((*BATCH_MIDPOLL_404_BACKOFF_S, None), start=1):
-                    try:
-                        final = self.retrieve(batch_id)
-                        break
-                    except anthropic.NotFoundError:
-                        if delay is None:
-                            raise
-                        logger.warning(
-                            "[batch-404-midpoll] Batch %s deadline final retrieve 404 "
-                            "(attempt %d/%d); transient suspected — retrying in %.0fs",
-                            batch_id,
-                            attempt,
-                            len(BATCH_MIDPOLL_404_BACKOFF_S) + 1,
-                            delay,
-                        )
-                        await sleep_fn(delay)
+                final = await self._deadline_final_retrieve(batch_id, created_at, now_fn, sleep_fn)
                 if final.processing_status == "ended":
                     return final
                 raise BatchDeadlineExceeded(batch_id, deadline)

--- a/src/explore_persona_space/llm/anthropic_client.py
+++ b/src/explore_persona_space/llm/anthropic_client.py
@@ -110,19 +110,36 @@ def deadline_from_expires_at(expires_at, grace_min: int = 30) -> "_dt.datetime":
     return expires_at + _dt.timedelta(minutes=grace_min)
 
 
-# ── Batch create-grace 404 helpers (single source of truth; #995) ─────────────
+# ── Batch 404-tolerance helpers (single source of truth; #995 + #1035) ────────
 #
-# A retrieve can 404 transiently within seconds of the SAME process's own
-# ``batches.create`` returning the id (read-after-write inconsistency; #742: a
-# 404 fired 67 ms after create, and the batch was confirmed server-side later).
-# These helpers make that ONE narrow case retryable with bounded backoff at the
-# sanctioned first-poll-loop retrieve sites (batch_judge, judge_dispatch,
-# api_dispatch, AnthropicBatch.poll). Everything else stays terminal:
-# deadline-time final retrieves, ``results()`` streams, and any poll with no
-# known create time (a resumed poll of a persisted batch_id) fail fast on 404.
+# TWO bounded retry regimes for a transient ``NotFoundError`` from
+# ``batches.retrieve``:
+#
+# 1. CREATE-GRACE (#995): a retrieve can 404 transiently within seconds of the
+#    SAME process's own ``batches.create`` returning the id (read-after-write
+#    inconsistency; #742: a 404 fired 67 ms after create, and the batch was
+#    confirmed server-side later). Window ``BATCH_CREATE_404_GRACE_S``,
+#    schedule ``BATCH_CREATE_404_BACKOFF_S`` — values + in-window semantics
+#    unchanged from #995.
+# 2. MID-POLL (#1035): ANY other retrieve 404 — outside the grace window,
+#    ``created_at=None`` (a resumed poll of a persisted batch_id), a
+#    deadline-time final retrieve, the fleet reconcile path — gets a bounded
+#    ``BATCH_MIDPOLL_404_BACKOFF_S`` retry before going terminal. The vendor
+#    documents no transient-404 contract and the SDK does not auto-retry 404,
+#    so a single transient read failure would otherwise cost a whole
+#    harvest/relaunch cycle. Defensive hardening: the beyond-grace class is
+#    unobserved in the project record, but one transient 404 HAS been observed
+#    (#742, in-window) so the server can 404 a live batch.
+#
+# Both regimes are per-wrapper-invocation bounded (max ``1 + 6 + 5 = 12``
+# retrieve calls, max ``60 + 170 = 230s`` of sleeps); a persistent 404 —
+# wrong-org / wrong-key / genuinely-gone — still re-raises ``NotFoundError``,
+# never masked. ``results()`` streams stay untouched (different endpoint,
+# incident class unobserved there).
 
 BATCH_CREATE_404_GRACE_S = 60.0  # #995 plan §11 row 1 (no vendor-documented window exists)
 BATCH_CREATE_404_BACKOFF_S = (1.0, 2.0, 4.0, 8.0, 15.0, 30.0)  # §11 row 2; sum = 60s = window
+BATCH_MIDPOLL_404_BACKOFF_S = (5.0, 15.0, 30.0, 60.0, 60.0)  # #1035; 5 retries, sum = 170s
 
 
 def parse_batch_submitted_at(raw: str | None) -> "_dt.datetime | None":
@@ -168,31 +185,92 @@ def is_batch_create_grace_404(
     return 0.0 <= elapsed <= grace_s
 
 
-def _log_batch_grace_recovery(
+def _log_batch_404_recovery(
     batch_id: str,
-    attempts: int,
+    grace_attempts: int,
+    midpoll_attempts: int,
     first_retry_at: "_dt.datetime | None",
     created_at: "_dt.datetime | None",
     now: "_dt.datetime",
 ) -> None:
-    """One INFO when a create-grace-404 retrieve eventually succeeds (#995).
+    """One INFO when a 404-retried retrieve eventually succeeds (#995/#1035).
 
     Records attempts used + elapsed-in-retry + elapsed-since-create — the only
-    empirical data that could ever ground ``BATCH_CREATE_404_GRACE_S``.
+    empirical data that could ever ground ``BATCH_CREATE_404_GRACE_S`` /
+    ``BATCH_MIDPOLL_404_BACKOFF_S``. Carries the ``[batch-404-midpoll]``
+    grep prefix whenever any mid-poll retry was used; a pure grace recovery
+    keeps the #995 message shape.
     """
     in_retry_s = (now - first_retry_at).total_seconds() if first_retry_at is not None else 0.0
     since_create_s = (now - created_at).total_seconds() if created_at is not None else float("nan")
-    logger.info(
-        "Batch %s retrieve recovered after %d create-grace 404 retry(ies) "
-        "(%.1fs in retry, %.1fs since create; read-after-write resolved)",
-        batch_id,
-        attempts,
-        in_retry_s,
-        since_create_s,
-    )
+    if midpoll_attempts:
+        logger.info(
+            "[batch-404-midpoll] Batch %s retrieve recovered after %d grace + %d mid-poll "
+            "404 retry(ies) (%.1fs in retry, %.1fs since create)",
+            batch_id,
+            grace_attempts,
+            midpoll_attempts,
+            in_retry_s,
+            since_create_s,
+        )
+    else:
+        logger.info(
+            "Batch %s retrieve recovered after %d create-grace 404 retry(ies) "
+            "(%.1fs in retry, %.1fs since create; read-after-write resolved)",
+            batch_id,
+            grace_attempts,
+            in_retry_s,
+            since_create_s,
+        )
 
 
-def retrieve_with_create_grace(
+def next_batch_404_retry(
+    exc: BaseException,
+    *,
+    created_at: "_dt.datetime | None",
+    grace_attempts: int,
+    midpoll_attempts: int,
+    now_fn: "Callable[[], _dt.datetime] | None" = None,
+    grace_s: float = BATCH_CREATE_404_GRACE_S,
+    grace_backoff_s: tuple[float, ...] = BATCH_CREATE_404_BACKOFF_S,
+    midpoll_backoff_s: tuple[float, ...] = BATCH_MIDPOLL_404_BACKOFF_S,
+) -> "tuple[str, float] | None":
+    """Decide the next retry for a ``batches.retrieve`` NotFoundError, or None -> re-raise.
+
+    The PURE decision shared by :func:`retrieve_with_404_tolerance` (sync) and
+    ``AnthropicBatch.poll``'s inline async handler, so the two paths cannot
+    drift. Returns ``("grace"|"midpoll", delay_s)`` or ``None`` (terminal —
+    the caller re-raises). Branch order (load-bearing):
+
+    1. Not an ``anthropic.NotFoundError`` -> ``None`` (non-404s propagate
+       unchanged).
+    2. In the create-grace window (:func:`is_batch_create_grace_404` True —
+       requires a known ``created_at`` and ``0 <= elapsed <= grace_s``, a
+       CLOSED upper boundary): the grace schedule, else ``None`` — an
+       in-window 404 that exhausted the grace schedule stays terminal,
+       preserving the #995 frozen-clock dual bound exactly.
+    3. Outside the window — including ``created_at=None`` (resume), negative
+       elapsed, and any 404 later in a poll: the mid-poll schedule, else
+       ``None``. This is the fail-fast guarantee: wrong-org / wrong-key /
+       genuinely-gone 404s go terminal after at most
+       ``len(midpoll_backoff_s)`` retries.
+
+    Boundedness: each 404 increments exactly one caller-held counter, each
+    capped by its schedule length -> max retrieve calls per invocation =
+    ``1 + len(grace_backoff_s) + len(midpoll_backoff_s)``.
+    """
+    if not isinstance(exc, anthropic.NotFoundError):
+        return None
+    if is_batch_create_grace_404(exc, created_at=created_at, now_fn=now_fn, grace_s=grace_s):
+        if grace_attempts < len(grace_backoff_s):
+            return ("grace", grace_backoff_s[grace_attempts])
+        return None  # in-window + grace exhausted: terminal (#995 dual-bound pin)
+    if midpoll_attempts < len(midpoll_backoff_s):
+        return ("midpoll", midpoll_backoff_s[midpoll_attempts])
+    return None
+
+
+def retrieve_with_404_tolerance(
     retrieve_fn: "Callable[[], object]",
     *,
     created_at: "_dt.datetime | None",
@@ -201,44 +279,83 @@ def retrieve_with_create_grace(
     sleep_fn: "Callable[[float], None] | None" = None,
     grace_s: float = BATCH_CREATE_404_GRACE_S,
     backoff_s: tuple[float, ...] = BATCH_CREATE_404_BACKOFF_S,
+    midpoll_backoff_s: tuple[float, ...] = BATCH_MIDPOLL_404_BACKOFF_S,
 ):
-    """Call ``retrieve_fn()``; retry an in-grace-window NotFoundError with backoff.
+    """Call ``retrieve_fn()``; retry a transient NotFoundError with bounded backoff.
 
-    DUAL-bounded: re-raises when the grace window has expired OR the backoff
-    schedule is exhausted (max ``len(backoff_s)`` retries), whichever first.
-    Any other exception propagates unchanged. ``created_at=None`` disables the
-    grace entirely (single call; 404 terminal — the resume default).
+    Two regimes, decided per-404 by :func:`next_batch_404_retry`: an
+    in-create-grace-window 404 takes the #995 grace schedule (``backoff_s``,
+    dual-bounded by window expiry OR schedule exhaustion); any other 404 —
+    outside the window, ``created_at=None`` (the resume default), a
+    deadline-time final retrieve — takes the #1035 mid-poll schedule
+    (``midpoll_backoff_s``; pass ``()`` to disable and restore pure #995
+    behavior). After both budgets the ``NotFoundError`` re-raises — a
+    persistent 404 is NEVER masked, just delayed by at most
+    ``sum(backoff_s) + sum(midpoll_backoff_s)`` seconds of sleeps. Any other
+    exception propagates unchanged.
     """
     sleep_fn = sleep_fn or time.sleep
     resolved_now = now_fn or (lambda: _dt.datetime.now(_dt.UTC))
-    attempts = 0
+    grace_attempts = 0
+    midpoll_attempts = 0
     first_retry_at: _dt.datetime | None = None
-    for delay in (*backoff_s, None):
+    while True:
         try:
             result = retrieve_fn()
         except anthropic.NotFoundError as e:
-            if delay is None or not is_batch_create_grace_404(
-                e, created_at=created_at, now_fn=now_fn, grace_s=grace_s
-            ):
+            plan = next_batch_404_retry(
+                e,
+                created_at=created_at,
+                grace_attempts=grace_attempts,
+                midpoll_attempts=midpoll_attempts,
+                now_fn=now_fn,
+                grace_s=grace_s,
+                grace_backoff_s=backoff_s,
+                midpoll_backoff_s=midpoll_backoff_s,
+            )
+            if plan is None:
                 raise
-            attempts += 1
+            regime, delay = plan
             if first_retry_at is None:
                 first_retry_at = resolved_now()
-            logger.warning(
-                "Batch %s retrieve 404 within %.0fs of create (read-after-write "
-                "suspected); retrying in %.0fs",
-                batch_id or "?",
-                grace_s,
-                delay,
-            )
+            if regime == "grace":
+                grace_attempts += 1
+                logger.warning(
+                    "Batch %s retrieve 404 within %.0fs of create (read-after-write "
+                    "suspected); retrying in %.0fs",
+                    batch_id or "?",
+                    grace_s,
+                    delay,
+                )
+            else:
+                midpoll_attempts += 1
+                elapsed_desc = (
+                    f"{(resolved_now() - created_at).total_seconds():.1f}s"
+                    if created_at is not None
+                    else "unknown"
+                )
+                logger.warning(
+                    "[batch-404-midpoll] Batch %s retrieve 404 outside create grace "
+                    "(attempt %d/%d, %s since create); transient suspected — "
+                    "retrying in %.0fs",
+                    batch_id or "?",
+                    midpoll_attempts,
+                    len(midpoll_backoff_s),
+                    elapsed_desc,
+                    delay,
+                )
             sleep_fn(delay)
         else:
-            if attempts:
-                _log_batch_grace_recovery(
-                    batch_id or "?", attempts, first_retry_at, created_at, resolved_now()
+            if grace_attempts or midpoll_attempts:
+                _log_batch_404_recovery(
+                    batch_id or "?",
+                    grace_attempts,
+                    midpoll_attempts,
+                    first_retry_at,
+                    created_at,
+                    resolved_now(),
                 )
             return result
-    raise AssertionError("unreachable: the final iteration returns or re-raises")
 
 
 # ── Content block helpers ───────────────────────────────────────────────────
@@ -687,56 +804,85 @@ class AnthropicBatch:
         are injectable for tests (default wall-clock + ``asyncio.sleep``); the
         kwargs are additive so ``__call__`` and other callers are unaffected.
 
-        Create-grace 404 (#995): a ``NotFoundError`` raised by the loop retrieve
-        within ``BATCH_CREATE_404_GRACE_S`` of the batch's own create is retried
-        (read-after-write inconsistency; the #742 shape). The effective create
-        time is the keyword-only ``created_at`` if given, else the instance
-        create-time memo written by :meth:`create` — so direct create->poll
-        callers are covered with no wiring, while a NEW-process resume (no memo,
-        no kwarg) keeps the terminal-404 default with exactly one retrieve call.
-        DUAL-bounded: window expiry (via ``now_fn``) OR the attempt cap
-        ``len(BATCH_CREATE_404_BACKOFF_S)``, so a frozen injected clock plus an
-        always-404 fake can never spin. The deadline-time final retrieve below
-        stays UNGUARDED (a 404 ~24h after create is genuinely anomalous).
+        404 tolerance (#995 + #1035): a ``NotFoundError`` raised by the loop
+        retrieve is retried per the shared :func:`next_batch_404_retry`
+        decision — the create-grace schedule within ``BATCH_CREATE_404_GRACE_S``
+        of the batch's own create (read-after-write; the #742 shape), the
+        bounded ``BATCH_MIDPOLL_404_BACKOFF_S`` mid-poll schedule anywhere else
+        (incl. a NEW-process resume with no memo and no kwarg). The effective
+        create time is the keyword-only ``created_at`` if given, else the
+        instance create-time memo written by :meth:`create`. Both budgets are
+        attempt-capped and RESET after any successful retrieve (a fresh 404
+        episode later in the poll gets a fresh budget; total polling stays
+        bounded by the ``expires_at`` + grace deadline), so a frozen injected
+        clock plus an always-404 fake can never spin. The deadline-time final
+        retrieve below gets the same bounded mid-poll tolerance (#1035; it was
+        deliberately unguarded under #995) — after exhaustion the 404 still
+        re-raises, never masked.
         """
         now_fn = now_fn or (lambda: _dt.datetime.now(_dt.UTC))
         sleep_fn = sleep_fn or asyncio.sleep
         elapsed_min = 0
         deadline: _dt.datetime | None = None
         grace_attempts = 0
-        first_grace_404_at: _dt.datetime | None = None
+        midpoll_attempts = 0
+        first_404_at: _dt.datetime | None = None
         while True:
             try:
                 batch = self.retrieve(batch_id)
             except anthropic.NotFoundError as e:
-                grace_attempts += 1
-                if grace_attempts > len(
-                    BATCH_CREATE_404_BACKOFF_S
-                ) or not is_batch_create_grace_404(
+                eff_created = self._effective_created_at(batch_id, created_at)
+                plan = next_batch_404_retry(
                     e,
-                    created_at=self._effective_created_at(batch_id, created_at),
+                    created_at=eff_created,
+                    grace_attempts=grace_attempts,
+                    midpoll_attempts=midpoll_attempts,
                     now_fn=now_fn,
-                ):
-                    raise
-                if first_grace_404_at is None:
-                    first_grace_404_at = now_fn()
-                logger.warning(
-                    "Batch %s retrieve 404 within create grace (attempt %d, "
-                    "read-after-write suspected); retrying",
-                    batch_id,
-                    grace_attempts,
                 )
-                await sleep_fn(min(interval_s, 5.0))
+                if plan is None:
+                    raise
+                regime, delay = plan
+                if first_404_at is None:
+                    first_404_at = now_fn()
+                if regime == "grace":
+                    grace_attempts += 1
+                    logger.warning(
+                        "Batch %s retrieve 404 within create grace (attempt %d, "
+                        "read-after-write suspected); retrying",
+                        batch_id,
+                        grace_attempts,
+                    )
+                else:
+                    midpoll_attempts += 1
+                    elapsed_desc = (
+                        f"{(now_fn() - eff_created).total_seconds():.1f}s"
+                        if eff_created is not None
+                        else "unknown"
+                    )
+                    logger.warning(
+                        "[batch-404-midpoll] Batch %s retrieve 404 outside create grace "
+                        "(attempt %d/%d, %s since create); transient suspected — "
+                        "retrying in %.0fs",
+                        batch_id,
+                        midpoll_attempts,
+                        len(BATCH_MIDPOLL_404_BACKOFF_S),
+                        elapsed_desc,
+                        delay,
+                    )
+                await sleep_fn(delay)
                 continue
-            if first_grace_404_at is not None:  # succeeded after >=1 grace retry: log ONCE
-                _log_batch_grace_recovery(
+            if grace_attempts or midpoll_attempts:  # succeeded after >=1 retry: log ONCE
+                _log_batch_404_recovery(
                     batch_id,
                     grace_attempts,
-                    first_grace_404_at,
+                    midpoll_attempts,
+                    first_404_at,
                     self._effective_created_at(batch_id, created_at),
                     now_fn(),
                 )
-                first_grace_404_at = None
+                grace_attempts = 0  # fresh budget per 404 episode (#1035 §3.5)
+                midpoll_attempts = 0
+                first_404_at = None
             if batch.processing_status == "ended":
                 return batch
             if deadline is None:
@@ -747,7 +893,27 @@ class AnthropicBatch:
                     else now_fn() + _dt.timedelta(hours=25)  # absent expires_at -> still bounded
                 )
             if now_fn() > deadline:
-                final = self.retrieve(batch_id)  # one last harvest attempt
+                # One last harvest attempt, with bounded mid-poll 404 tolerance
+                # (#1035): poll is async, so this is a minimal local retry loop
+                # over the shared schedule rather than the sync wrapper. After
+                # exhaustion the 404 re-raises — never masked.
+                final = None
+                for attempt, delay in enumerate((*BATCH_MIDPOLL_404_BACKOFF_S, None), start=1):
+                    try:
+                        final = self.retrieve(batch_id)
+                        break
+                    except anthropic.NotFoundError:
+                        if delay is None:
+                            raise
+                        logger.warning(
+                            "[batch-404-midpoll] Batch %s deadline final retrieve 404 "
+                            "(attempt %d/%d); transient suspected — retrying in %.0fs",
+                            batch_id,
+                            attempt,
+                            len(BATCH_MIDPOLL_404_BACKOFF_S) + 1,
+                            delay,
+                        )
+                        await sleep_fn(delay)
                 if final.processing_status == "ended":
                     return final
                 raise BatchDeadlineExceeded(batch_id, deadline)

--- a/src/explore_persona_space/llm/api_dispatch.py
+++ b/src/explore_persona_space/llm/api_dispatch.py
@@ -92,7 +92,7 @@ from explore_persona_space.llm.anthropic_client import (
     BatchDeadlineExceeded,
     deadline_from_expires_at,
     parse_batch_submitted_at,
-    retrieve_with_create_grace,
+    retrieve_with_404_tolerance,
 )
 
 logger = logging.getLogger(__name__)
@@ -990,22 +990,23 @@ async def _poll_one_sub_batch_step(
 ) -> None:
     """Poll one not-yet-collected sub-batch ONCE on its org; harvest on end.
 
-    Create-grace 404 (#995): a ``NotFoundError`` on the loop retrieve within
-    ``BATCH_CREATE_404_GRACE_S`` of the sub-batch's persisted ``submitted_at``
-    is retried with bounded backoff INSIDE the ``to_thread`` worker (the event
-    loop is never blocked by the grace sleeps). Org-mismatch semantics are
-    preserved (``_load_or_init_batch_state``: a batch created on org B 404s if
-    polled on org A): create and poll share ``sb["org"]`` within a run, so a
-    wrong-org 404 arises only on resume (stale/absent ``submitted_at`` ->
-    terminal, unchanged) or from an org-routing code bug (delayed <=60s, then
-    still fails loud — never masked). The overdue final retrieve below stays
-    UNGUARDED (plan §4.3). ``sleep_fn`` is additive + injectable for tests
-    (default ``time.sleep``).
+    404 tolerance (#995 + #1035): a ``NotFoundError`` on the loop retrieve or
+    the overdue final retrieve is retried with bounded backoff INSIDE the
+    ``to_thread`` worker (the event loop is never blocked by the sleeps): the
+    create-grace schedule within ``BATCH_CREATE_404_GRACE_S`` of the
+    sub-batch's persisted ``submitted_at``, the ``BATCH_MIDPOLL_404_BACKOFF_S``
+    mid-poll schedule anywhere else (incl. a resume with a stale/absent
+    ``submitted_at``). Org-mismatch semantics are preserved
+    (``_load_or_init_batch_state``: a batch created on org B 404s if polled on
+    org A): create and poll share ``sb["org"]`` within a run, so a wrong-org
+    404 arises only on resume or from an org-routing code bug (delayed <=60s
+    grace + <=~3 min mid-poll, then still fails loud — never masked).
+    ``sleep_fn`` is additive + injectable for tests (default ``time.sleep``).
     """
     org = sb["org"]
     client = sync_clients[org]
     batch = await asyncio.to_thread(
-        retrieve_with_create_grace,
+        retrieve_with_404_tolerance,
         functools.partial(client.messages.batches.retrieve, sb["batch_id"]),
         created_at=parse_batch_submitted_at(sb.get("submitted_at")),
         batch_id=sb["batch_id"],
@@ -1028,7 +1029,17 @@ async def _poll_one_sub_batch_step(
         )
         return
     if sb.get("deadline") and now_fn() > _dt.datetime.fromisoformat(sb["deadline"]):
-        final = await asyncio.to_thread(client.messages.batches.retrieve, sb["batch_id"])
+        # #1035: the overdue final retrieve is the last chance to harvest, so a
+        # transient 404 gets the bounded mid-poll tolerance; a genuinely-gone
+        # batch still re-raises NotFoundError <=~3 min later.
+        final = await asyncio.to_thread(
+            retrieve_with_404_tolerance,
+            functools.partial(client.messages.batches.retrieve, sb["batch_id"]),
+            created_at=parse_batch_submitted_at(sb.get("submitted_at")),
+            batch_id=sb["batch_id"],
+            now_fn=now_fn,
+            sleep_fn=sleep_fn,
+        )
         if final.processing_status == "ended":
             await _harvest_sub_batch(
                 sb,

--- a/src/explore_persona_space/orchestrate/fleet.py
+++ b/src/explore_persona_space/orchestrate/fleet.py
@@ -334,6 +334,8 @@ def _poll_batch_to_ended(
     poll_interval: float,
     max_poll_interval: float,
     grace_min: int,
+    now_fn=None,
+    sleep_fn=None,
 ) -> None:
     """Block until ``batch_id`` ends under a hard ``expires_at`` deadline.
 
@@ -342,25 +344,43 @@ def _poll_batch_to_ended(
     Raises ``BatchDeadlineExceeded`` if the batch is still not ended at the
     deadline after one final retrieve — never a silent default (CLAUDE.md fail-fast).
 
-    NOTE (#995): retrieves here are deliberately NOT wrapped in
-    ``llm.anthropic_client.retrieve_with_create_grace`` — ``JudgeHandle.reconcile()``
-    runs deferred, often in a DIFFERENT process, and the handle records no create
-    timestamp, so the conservative terminal-404 default is correct. If a
-    fleet-path read-after-write incident ever occurs, the shared helper is one
-    import + one additive ``created_at`` kwarg away.
+    NOTE (#995 -> #1035): ``JudgeHandle.reconcile()`` runs deferred, often in a
+    DIFFERENT process, and the handle records no create timestamp — so the #995
+    create-grace was useless here, but the #1035 mid-poll regime needs no
+    timestamp: both retrieves are wrapped in
+    ``llm.anthropic_client.retrieve_with_404_tolerance`` with
+    ``created_at=None``, giving a transient 404 the bounded
+    ``BATCH_MIDPOLL_404_BACKOFF_S`` retry before it goes terminal (a persistent
+    404 still re-raises ``NotFoundError``, delayed <=~3 min — never masked).
+    The retry budget is per wrapper call (per loop iteration); the outer
+    ``expires_at`` + grace deadline keeps total polling hard-bounded.
+    ``now_fn``/``sleep_fn`` are additive + injectable for tests (default
+    wall clock + ``time.sleep``).
     """
     import datetime as _dt
+    import functools
     import time as _time
 
     from explore_persona_space.llm.anthropic_client import (
         BatchDeadlineExceeded,
         deadline_from_expires_at,
+        retrieve_with_404_tolerance,
     )
 
+    now_fn = now_fn or (lambda: _dt.datetime.now(_dt.UTC))
+    sleep_fn = sleep_fn or _time.sleep
+    retrieve_fn = functools.partial(
+        retrieve_with_404_tolerance,
+        functools.partial(client.messages.batches.retrieve, batch_id),
+        created_at=None,  # deferred/cross-process reconcile: no create timestamp
+        batch_id=batch_id,
+        now_fn=now_fn,
+        sleep_fn=sleep_fn,
+    )
     deadline: _dt.datetime | None = None
     interval = poll_interval
     while True:
-        batch = client.messages.batches.retrieve(batch_id)
+        batch = retrieve_fn()
         if batch.processing_status == "ended":
             return
         if deadline is None:
@@ -368,14 +388,14 @@ def _poll_batch_to_ended(
             deadline = (
                 deadline_from_expires_at(expires_at, grace_min)
                 if expires_at is not None
-                else _dt.datetime.now(_dt.UTC) + _dt.timedelta(hours=25)
+                else now_fn() + _dt.timedelta(hours=25)
             )
-        if _dt.datetime.now(_dt.UTC) > deadline:
-            final = client.messages.batches.retrieve(batch_id)
+        if now_fn() > deadline:
+            final = retrieve_fn()
             if final.processing_status == "ended":
                 return
             raise BatchDeadlineExceeded(batch_id, deadline)
-        _time.sleep(interval)
+        sleep_fn(interval)
         interval = min(interval * 1.5, max_poll_interval)
 
 

--- a/tests/test_batch_create_404_grace.py
+++ b/tests/test_batch_create_404_grace.py
@@ -1,14 +1,20 @@
-"""Tests for the #995 batch create-grace 404 retry.
+"""Tests for the batch retrieve 404-tolerance regimes (#995 create-grace + #1035 mid-poll).
 
 A ``batches.retrieve`` can 404 transiently within seconds of the SAME process's
 own ``batches.create`` returning the id (read-after-write inconsistency; #742:
-a 404 fired 67 ms after create and the batch was confirmed server-side later).
-These tests pin the grace helpers (``is_batch_create_grace_404`` /
-``retrieve_with_create_grace``) plus the four guarded call sites:
-``batch_judge._submit_and_poll_batch``, ``judge_dispatch._poll_one_sub_batch_step``,
-``api_dispatch._poll_one_sub_batch_step`` (+ ``submitted_at`` persistence), and
-``AnthropicBatch.poll`` (incl. the create-time memo covering direct
-create->poll callers).
+a 404 fired 67 ms after create and the batch was confirmed server-side later) —
+the #995 CREATE-GRACE regime. #1035 adds a bounded MID-POLL regime for every
+other retrieve 404 (beyond the grace window, ``created_at=None`` resumes,
+deadline-time final retrieves, cancel-race probes, the fleet reconcile path):
+``BATCH_MIDPOLL_404_BACKOFF_S`` retries, then the 404 still re-raises (fail-fast
+preserved, just delayed <=~3 min). These tests pin the helpers
+(``is_batch_create_grace_404`` / ``next_batch_404_retry`` /
+``retrieve_with_404_tolerance``) plus the guarded call sites:
+``batch_judge._submit_and_poll_batch`` (loop + final + cancel-race),
+``judge_dispatch._poll_one_sub_batch_step`` (+ ``_cancel_stuck_sub_batch``),
+``api_dispatch._poll_one_sub_batch_step`` (+ ``submitted_at`` persistence),
+``AnthropicBatch.poll`` (incl. the create-time memo + the deadline final
+retrieve's local async retry loop), and ``fleet._poll_batch_to_ended``.
 
 Mock strategy mirrors ``tests/test_issue663_batch_hardening.py``: scriptable
 client fakes + injectable ``now_fn``/``sleep_fn``, NO live API calls. The 404s
@@ -20,6 +26,7 @@ import asyncio
 import contextlib
 import datetime as dt
 import json
+import logging
 
 import anthropic
 import httpx
@@ -31,11 +38,15 @@ from explore_persona_space.llm import api_dispatch
 from explore_persona_space.llm.anthropic_client import (
     BATCH_CREATE_404_BACKOFF_S,
     BATCH_CREATE_404_GRACE_S,
+    BATCH_MIDPOLL_404_BACKOFF_S,
     AnthropicBatch,
+    BatchDeadlineExceeded,
     is_batch_create_grace_404,
+    next_batch_404_retry,
     parse_batch_submitted_at,
-    retrieve_with_create_grace,
+    retrieve_with_404_tolerance,
 )
+from explore_persona_space.orchestrate.fleet import _poll_batch_to_ended
 
 # Reuse the shared #663 fakes/helpers — do NOT duplicate them.
 from tests.test_api_dispatch import FakeBatchClient
@@ -144,7 +155,7 @@ def test_wrapper_recovers_after_transient_404():
     """404 twice then success -> returns the batch; exactly 3 calls; backoff sleeps."""
     fn, counter = _counting_retrieve(fail_404=2)
     sleeps: list[float] = []
-    out = retrieve_with_create_grace(
+    out = retrieve_with_404_tolerance(
         fn,
         created_at=T0,
         batch_id="msgbatch_x",
@@ -160,11 +171,13 @@ def test_wrapper_recovers_after_transient_404():
 
 
 def test_window_expiry_reraises_notfound():
-    """The clock advances past the 60s window -> the ORIGINAL NotFoundError
-    re-raises; bounded call count (window bound of the dual bound)."""
+    """The clock advances past the 60s window -> the out-of-window 404s take
+    the bounded MID-POLL budget (#1035; previously instantly terminal), then
+    the ORIGINAL NotFoundError re-raises. Still bounded, never masked."""
     fn, counter = _counting_retrieve(fail_404=10**6)
     sleeps: list[float] = []
-    # Grace check 1 in-window (retry), first_retry_at read, grace check 2 past-window.
+    # Grace check 1 in-window (retry), first_retry_at read, every later check
+    # past-window (the _Clock repeats its last value) -> the mid-poll budget.
     clock = _Clock(
         [
             T0 + dt.timedelta(seconds=5),
@@ -173,11 +186,12 @@ def test_window_expiry_reraises_notfound():
         ]
     )
     with pytest.raises(anthropic.NotFoundError):
-        retrieve_with_create_grace(
+        retrieve_with_404_tolerance(
             fn, created_at=T0, batch_id="msgbatch_x", now_fn=clock, sleep_fn=sleeps.append
         )
-    assert counter["n"] == 2  # one graced retry, then terminal
-    assert sleeps == [1.0]
+    # 1 graced retry + len(midpoll) mid-poll retries + 1 terminal call.
+    assert counter["n"] == 1 + len(BATCH_MIDPOLL_404_BACKOFF_S) + 1
+    assert sleeps == [1.0, *BATCH_MIDPOLL_404_BACKOFF_S]
 
 
 # ── §4.4 item 4: sync wrapper — backoff exhaustion (named fail-loud test) ────
@@ -190,7 +204,7 @@ def test_backoff_exhaustion_reraises_notfound():
     sleeps: list[float] = []
     frozen = _Clock([T0 + dt.timedelta(seconds=1)])
     with pytest.raises(anthropic.NotFoundError):
-        retrieve_with_create_grace(
+        retrieve_with_404_tolerance(
             fn, created_at=T0, batch_id="msgbatch_x", now_fn=frozen, sleep_fn=sleeps.append
         )
     assert counter["n"] == len(BATCH_CREATE_404_BACKOFF_S) + 1
@@ -200,17 +214,18 @@ def test_backoff_exhaustion_reraises_notfound():
 # ── §4.4 item 5: sync wrapper — resumed poll (named fail-loud test) ──────────
 
 
-def test_resumed_poll_404_terminal_single_call():
-    """created_at=None (resumed poll / old state.json) -> exactly ONE retrieve
-    call, immediate re-raise (fail-fast preserved)."""
+def test_resumed_poll_404_bounded_terminal():
+    """created_at=None (resumed poll / old state.json) -> the bounded MID-POLL
+    budget (#1035; previously a single terminal call), then re-raise. NOT
+    infinite; NOT silently masked."""
     fn, counter = _counting_retrieve(fail_404=10**6)
     sleeps: list[float] = []
     with pytest.raises(anthropic.NotFoundError):
-        retrieve_with_create_grace(
+        retrieve_with_404_tolerance(
             fn, created_at=None, batch_id="msgbatch_x", now_fn=lambda: T0, sleep_fn=sleeps.append
         )
-    assert counter["n"] == 1
-    assert sleeps == []
+    assert counter["n"] == len(BATCH_MIDPOLL_404_BACKOFF_S) + 1
+    assert sleeps == list(BATCH_MIDPOLL_404_BACKOFF_S)
 
 
 # ── §4.4 item 6: sync wrapper — other exceptions propagate ───────────────────
@@ -225,7 +240,7 @@ def test_wrapper_other_exception_propagates_first_call(exc_factory):
         raise exc_factory()
 
     with pytest.raises((anthropic.InternalServerError, ValueError)):
-        retrieve_with_create_grace(
+        retrieve_with_404_tolerance(
             _fn,
             created_at=T0,
             now_fn=lambda: T0 + dt.timedelta(seconds=1),
@@ -239,18 +254,119 @@ def test_wrapper_other_exception_propagates_first_call(exc_factory):
 
 def test_negative_elapsed_out_of_window():
     """created_at in the FUTURE of now_fn (negative elapsed — injected/backwards
-    clock) is OUT of window: predicate False, wrapper terminal on first 404.
-    Pins the ``0.0 <= elapsed`` guard so a wall-clock capture can never
-    vacuously pass an injected-clock integration test."""
+    clock) is OUT of window: predicate False, wrapper takes the bounded
+    MID-POLL budget (#1035; previously terminal on the first 404) then
+    re-raises. Pins the ``0.0 <= elapsed`` guard so a wall-clock capture can
+    never vacuously pass an injected-clock integration test."""
     future_created = T0 + dt.timedelta(hours=1)
     assert not is_batch_create_grace_404(_nf(), created_at=future_created, now_fn=lambda: T0)
 
     fn, counter = _counting_retrieve(fail_404=10**6)
     with pytest.raises(anthropic.NotFoundError):
-        retrieve_with_create_grace(
+        retrieve_with_404_tolerance(
             fn, created_at=future_created, now_fn=lambda: T0, sleep_fn=lambda _s: None
         )
-    assert counter["n"] == 1
+    assert counter["n"] == len(BATCH_MIDPOLL_404_BACKOFF_S) + 1
+
+
+# ── #1035 §5 item 3: the shared decision helper, across the branch table ─────
+
+
+def _decide(exc, *, created_at, now, grace_attempts=0, midpoll_attempts=0):
+    return next_batch_404_retry(
+        exc,
+        created_at=created_at,
+        grace_attempts=grace_attempts,
+        midpoll_attempts=midpoll_attempts,
+        now_fn=lambda: now,
+    )
+
+
+def test_decision_helper_regimes():
+    """next_batch_404_retry branch table (#1035 §3.2; branch order load-bearing)."""
+    in_window = T0 + dt.timedelta(seconds=30)
+    out_window = T0 + dt.timedelta(hours=2)
+    # 1. Non-404s -> None (propagate unchanged), regardless of window/attempts.
+    assert _decide(ValueError("nope"), created_at=T0, now=in_window) is None
+    assert _decide(_server_error(), created_at=T0, now=in_window) is None
+    # 2. In-window: grace schedule, capped; exhausted-in-window stays TERMINAL
+    #    (the #995 frozen-clock dual-bound pin — no mid-poll fallthrough).
+    assert _decide(_nf(), created_at=T0, now=in_window) == ("grace", 1.0)
+    n_grace = len(BATCH_CREATE_404_BACKOFF_S)
+    assert _decide(_nf(), created_at=T0, now=in_window, grace_attempts=n_grace - 1) == (
+        "grace",
+        BATCH_CREATE_404_BACKOFF_S[-1],
+    )
+    assert _decide(_nf(), created_at=T0, now=in_window, grace_attempts=n_grace) is None
+    # 2b. The window's upper boundary is CLOSED: elapsed == grace_s is IN
+    #     window (a strict-inequality mutation must fail this cell) — and the
+    #     boundary cell with grace exhausted stays terminal too.
+    boundary = T0 + dt.timedelta(seconds=BATCH_CREATE_404_GRACE_S)
+    assert _decide(_nf(), created_at=T0, now=boundary) == ("grace", 1.0)
+    assert _decide(_nf(), created_at=T0, now=boundary, grace_attempts=n_grace) is None
+    # 3. Outside the window: mid-poll schedule, capped.
+    assert _decide(_nf(), created_at=T0, now=out_window) == ("midpoll", 5.0)
+    n_mid = len(BATCH_MIDPOLL_404_BACKOFF_S)
+    assert _decide(_nf(), created_at=T0, now=out_window, midpoll_attempts=n_mid - 1) == (
+        "midpoll",
+        BATCH_MIDPOLL_404_BACKOFF_S[-1],
+    )
+    assert _decide(_nf(), created_at=T0, now=out_window, midpoll_attempts=n_mid) is None
+    # 3b. created_at=None (resume) and negative elapsed route to mid-poll too.
+    assert _decide(_nf(), created_at=None, now=T0) == ("midpoll", 5.0)
+    future = T0 + dt.timedelta(hours=1)
+    assert _decide(_nf(), created_at=future, now=T0) == ("midpoll", 5.0)
+    # 3c. midpoll_backoff_s=() disables the regime (the per-site escape hatch).
+    assert (
+        next_batch_404_retry(
+            _nf(),
+            created_at=None,
+            grace_attempts=0,
+            midpoll_attempts=0,
+            now_fn=lambda: T0,
+            midpoll_backoff_s=(),
+        )
+        is None
+    )
+
+
+# ── #1035 §5 items 1-2: sync wrapper — mid-poll recovery + exhaustion ─────────
+
+
+def test_midpoll_404_recovers(caplog):
+    """Far outside the grace window (T0+2h): 404 twice then success -> returns
+    the result on the mid-poll schedule; recovery INFO carries the grep prefix."""
+    fn, counter = _counting_retrieve(fail_404=2)
+    sleeps: list[float] = []
+    with caplog.at_level(logging.INFO, logger="explore_persona_space.llm.anthropic_client"):
+        out = retrieve_with_404_tolerance(
+            fn,
+            created_at=T0,
+            batch_id="msgbatch_x",
+            now_fn=_Clock([T0 + dt.timedelta(hours=2)]),
+            sleep_fn=sleeps.append,
+        )
+    assert out == "BATCH"
+    assert counter["n"] == 3
+    assert sleeps == [5.0, 15.0]
+    assert "[batch-404-midpoll]" in caplog.text
+
+
+def test_midpoll_404_exhausts_reraises():
+    """Always-404 outside the window -> re-raises after exactly
+    len(BATCH_MIDPOLL_404_BACKOFF_S)+1 calls. FAIL-FAST PRESERVED."""
+    fn, counter = _counting_retrieve(fail_404=10**6)
+    sleeps: list[float] = []
+    with pytest.raises(anthropic.NotFoundError):
+        retrieve_with_404_tolerance(
+            fn,
+            created_at=T0,
+            batch_id="msgbatch_x",
+            now_fn=_Clock([T0 + dt.timedelta(hours=2)]),
+            sleep_fn=sleeps.append,
+        )
+    assert counter["n"] == len(BATCH_MIDPOLL_404_BACKOFF_S) + 1
+    assert sleeps == list(BATCH_MIDPOLL_404_BACKOFF_S)
 
 
 # ── §4.4 item 7: batch_judge integration (the #742 shape, end to end) ────────
@@ -281,6 +397,105 @@ def test_batch_judge_recovers_from_create_grace_404():
     assert all(r["aligned"] == 90 for r in result.values())
     assert box["n404"] == 1 and client.retrieve_calls == 1  # one 404, one real retrieve
     assert sleeps == [1.0]  # the grace backoff, not the poll interval
+
+
+# ── #1035 §5 item 4: batch_judge deadline FINAL retrieve (newly guarded) ─────
+
+
+def _final_404_client(*, flip_to_ended_on, fail_404_on_call: int):
+    """A _DeadlineSubmitClient whose retrieve 404s exactly once, on the
+    ``fail_404_on_call``-th retrieve (counting wrapper-level calls)."""
+    client = _DeadlineSubmitClient(flip_to_ended_on=flip_to_ended_on)
+    orig_retrieve = client.messages.batches.retrieve
+    box = {"n": 0, "n404": 0}
+
+    def _retrieve(batch_id):
+        box["n"] += 1
+        if box["n"] == fail_404_on_call:
+            box["n404"] += 1
+            raise _nf(batch_id)
+        return orig_retrieve(batch_id)
+
+    client.messages.batches.retrieve = _retrieve
+    return client, box
+
+
+def test_batch_judge_final_retrieve_tolerates_transient_404():
+    """_submit_and_poll_batch: the batch never ends in-loop; at the deadline the
+    final retrieve 404s once then reads ended -> results harvested, no crash
+    (#1035 table B; the #995 unguarded stance reversed)."""
+    past_deadline = EXPIRES + dt.timedelta(minutes=31)  # > expires_at + 30min grace
+    # Wrapper retrieve #2 is the deadline final retrieve; orig call 2 -> ended.
+    client, box = _final_404_client(flip_to_ended_on=2, fail_404_on_call=2)
+    reqs = [{"custom_id": f"c{i}", "params": {}} for i in range(2)]
+    sleeps: list[float] = []
+    # created_at=T0 (first tick), then every read past the deadline (repeats).
+    clock = _Clock([T0, past_deadline])
+    result = _submit_and_poll_batch(
+        reqs, client, poll_interval=0.0, now_fn=clock, sleep_fn=sleeps.append
+    )
+    assert set(result) == {"c0", "c1"}
+    assert all(r["aligned"] == 90 for r in result.values())
+    assert box["n404"] == 1
+    assert sleeps == [5.0]  # the mid-poll backoff, nothing else
+
+
+def test_batch_judge_final_retrieve_404_then_not_ended_still_deadline_exceeded():
+    """Variant b: the final retrieve 404s once then reads a STILL-not-ended
+    batch -> BatchDeadlineExceeded fires exactly as before (the 404 tolerance
+    recovers the READ; the deadline classification is untouched)."""
+    past_deadline = EXPIRES + dt.timedelta(minutes=31)
+    client, box = _final_404_client(flip_to_ended_on=None, fail_404_on_call=2)
+    reqs = [{"custom_id": f"c{i}", "params": {}} for i in range(2)]
+    clock = _Clock([T0, past_deadline])
+    with pytest.raises(BatchDeadlineExceeded):
+        _submit_and_poll_batch(
+            reqs, client, poll_interval=0.0, now_fn=clock, sleep_fn=lambda _s: None
+        )
+    assert box["n404"] == 1  # the 404 was retried, not the crash class
+
+
+# ── #1035 §5 item 5c(i): batch_judge stuck-cancel race probe (newly guarded) ──
+
+
+def test_batch_judge_cancel_race_probe_tolerates_404(monkeypatch):
+    """The #1019 stuck-cancel race probe: cancel raises APIStatusError, the
+    confirm retrieve 404s once then reads canceling -> race resolution
+    proceeds (canceled rows surface as error dicts), no crash."""
+    from tests.test_batch_stuck_escape import StuckEscapeClient, _FakeAPIStatusError
+
+    monkeypatch.setenv("EPS_BATCH_STUCK_HOURS", "4")
+    outcome = {"c0": "canceled", "c1": "canceled"}
+    client = StuckEscapeClient(
+        outcome_for=outcome,
+        expires_at=T0 + dt.timedelta(hours=24),  # legacy path anchors on now_fn
+        cancel_effects=[_FakeAPIStatusError()],
+        post_cancel_statuses=("canceling", "ended"),
+    )
+    orig_retrieve = client.messages.batches.retrieve
+    box = {"n": 0, "n404": 0}
+
+    def _retrieve(batch_id):
+        box["n"] += 1
+        if box["n"] == 2:  # the race-confirm probe (loop retrieve was call 1)
+            box["n404"] += 1
+            raise _nf(batch_id)
+        return orig_retrieve(batch_id)
+
+    client.messages.batches.retrieve = _retrieve
+    reqs = [{"custom_id": f"c{i}", "params": {}} for i in range(2)]
+    sleeps: list[float] = []
+    # created_at=T0; every later tick 5h past it (inside the deadline, past the
+    # 4h stuck threshold, outside the 60s grace window -> mid-poll regime).
+    clock = _Clock([T0, T0 + dt.timedelta(hours=5)])
+    result = _submit_and_poll_batch(
+        reqs, client, poll_interval=0.0, now_fn=clock, sleep_fn=sleeps.append
+    )
+    assert client.cancel_calls == 1
+    assert box["n404"] == 1
+    assert 5.0 in sleeps  # the probe's mid-poll backoff
+    for cid in ("c0", "c1"):
+        assert result[cid]["error"] is True
 
 
 # ── §4.4 item 8: judge_dispatch _poll_one_sub_batch_step ─────────────────────
@@ -353,24 +568,150 @@ def test_judge_dispatch_step_fresh_submitted_at_grace_recovers(tmp_path):
 
 def test_judge_dispatch_step_stale_submitted_at_terminal(tmp_path):
     """A resumed poll whose submitted_at is 1h old -> window expired -> the 404
-    propagates on the FIRST retrieve (exactly one call)."""
+    takes the bounded MID-POLL budget (#1035; previously one terminal call),
+    then propagates. Sleeps injected (a real 170s of backoff otherwise)."""
     client = _JudgeStepClient(fail_404_first=10**6)
     sb = _judge_sb()
+    sleeps: list[float] = []
     with pytest.raises(anthropic.NotFoundError):
         _judge_step(
-            tmp_path, client, sb, now_fn=_Clock([T0 + dt.timedelta(hours=1)]), sleep_fn=None
+            tmp_path,
+            client,
+            sb,
+            now_fn=_Clock([T0 + dt.timedelta(hours=1)]),
+            sleep_fn=sleeps.append,
         )
-    assert client.retrieve_calls == 1
+    assert client.retrieve_calls == len(BATCH_MIDPOLL_404_BACKOFF_S) + 1
+    assert sleeps == list(BATCH_MIDPOLL_404_BACKOFF_S)
 
 
 def test_judge_dispatch_step_absent_submitted_at_terminal(tmp_path):
-    """An OLD state.json without submitted_at -> created_at None -> terminal."""
+    """An OLD state.json without submitted_at -> created_at None -> the bounded
+    MID-POLL budget (#1035), then the 404 still propagates (never masked)."""
     client = _JudgeStepClient(fail_404_first=10**6)
     sb = _judge_sb()
     del sb["submitted_at"]
+    sleeps: list[float] = []
     with pytest.raises(anthropic.NotFoundError):
-        _judge_step(tmp_path, client, sb, now_fn=_Clock([T0]), sleep_fn=None)
-    assert client.retrieve_calls == 1
+        _judge_step(tmp_path, client, sb, now_fn=_Clock([T0]), sleep_fn=sleeps.append)
+    assert client.retrieve_calls == len(BATCH_MIDPOLL_404_BACKOFF_S) + 1
+    assert sleeps == list(BATCH_MIDPOLL_404_BACKOFF_S)
+
+
+# ── #1035 §5 item 5: judge_dispatch overdue FINAL retrieve (newly guarded) ────
+
+
+class _ScriptedStepClient:
+    """messages.batches fake whose retrieve walks ``script`` — each entry is
+    "404" (raise) or a processing_status (last entry repeats); results yields
+    one succeeded row."""
+
+    def __init__(self, script):
+        self.script = list(script)
+        self.retrieve_calls = 0
+        client = self
+
+        class _B:
+            def retrieve(_s, batch_id):
+                client.retrieve_calls += 1
+                action = client.script[min(client.retrieve_calls - 1, len(client.script) - 1)]
+                if action == "404":
+                    raise _nf(batch_id)
+                return _ns(processing_status=action, expires_at=EXPIRES, request_counts=None)
+
+            def results(_s, batch_id):
+                yield _succeeded("item_0")
+
+        self.messages = _ns(batches=_B())
+
+
+def test_judge_dispatch_overdue_final_retrieve_tolerates_404(tmp_path):
+    """The overdue final retrieve 404s once then reads ended -> harvested
+    (#1035 table B; previously the 404 crashed the last harvest chance)."""
+    client = _ScriptedStepClient(["in_progress", "404", "ended"])
+    sb = _judge_sb(deadline=(T0 + dt.timedelta(hours=1)).isoformat())
+    sleeps: list[float] = []
+    acc = _judge_step(
+        tmp_path,
+        client,
+        sb,
+        now_fn=_Clock([T0 + dt.timedelta(hours=2)]),  # past the persisted deadline
+        sleep_fn=sleeps.append,
+    )
+    assert acc.scores["item_0"]["aligned"] == 90
+    assert sb["status"] == "collected"
+    assert client.retrieve_calls == 3
+    assert sleeps == [5.0]
+
+
+# ── #1035 §5 item 5c(ii): judge_dispatch stuck-cancel race probe ──────────────
+
+
+class _CancelRaceClient:
+    """cancel raises APIStatusError; the confirm retrieve 404s the first
+    ``fail_404_first`` calls then returns ``final_status``."""
+
+    def __init__(self, *, fail_404_first: int, final_status: str = "canceling"):
+        self.retrieve_calls = 0
+        self.cancel_calls = 0
+        client = self
+
+        class _B:
+            def cancel(_s, batch_id):
+                from tests.test_batch_stuck_escape import _FakeAPIStatusError
+
+                client.cancel_calls += 1
+                raise _FakeAPIStatusError()
+
+            def retrieve(_s, batch_id):
+                client.retrieve_calls += 1
+                if client.retrieve_calls <= fail_404_first:
+                    raise _nf(batch_id)
+                return _ns(processing_status=final_status, expires_at=EXPIRES, request_counts=None)
+
+        self.messages = _ns(batches=_B())
+
+
+def test_judge_dispatch_cancel_race_probe_tolerates_404(tmp_path):
+    """_cancel_stuck_sub_batch: the race-confirm retrieve 404s once then reads
+    canceling -> accepted as canceled, confirm stamp persisted (#1035 table C)."""
+    client = _CancelRaceClient(fail_404_first=1)
+    sb = _judge_sb()
+    state = {"sub_batches": [sb]}
+    sleeps: list[float] = []
+    judge_dispatch._cancel_stuck_sub_batch(
+        client,
+        sb,
+        state,
+        tmp_path / "state.json",
+        _Clock([T0 + dt.timedelta(hours=5)]),
+        sleeps.append,
+    )
+    assert client.cancel_calls == 1
+    assert sb["stuck_canceled_at"] is not None
+    assert client.retrieve_calls == 2
+    assert sleeps == [5.0]
+
+
+def test_judge_dispatch_cancel_race_probe_persistent_404_bounded(tmp_path):
+    """A persistent 404 on the race-confirm retrieve re-raises after the
+    bounded mid-poll budget (the enclosing #1019 semantics unchanged)."""
+    client = _CancelRaceClient(fail_404_first=10**6)
+    sb = _judge_sb()
+    state = {"sub_batches": [sb]}
+    sleeps: list[float] = []
+    with pytest.raises(anthropic.NotFoundError):
+        judge_dispatch._cancel_stuck_sub_batch(
+            client,
+            sb,
+            state,
+            tmp_path / "state.json",
+            _Clock([T0 + dt.timedelta(hours=5)]),
+            sleeps.append,
+        )
+    assert client.retrieve_calls == len(BATCH_MIDPOLL_404_BACKOFF_S) + 1
+    assert sleeps == list(BATCH_MIDPOLL_404_BACKOFF_S)
+    assert sb.get("stuck_canceled_at") is None  # crash before the confirm stamp
 
 
 # ── §4.4 item 9: api_dispatch — submitted_at persistence + poll-step grace ───
@@ -459,7 +800,8 @@ def test_api_dispatch_poll_step_fresh_submitted_at_grace_recovers(tmp_path):
 
 def test_api_dispatch_poll_step_absent_submitted_at_terminal(tmp_path):
     """A resumed OLD state.json (no submitted_at key) -> no grace -> the 404
-    propagates on the first retrieve (org-mismatch resume semantics preserved)."""
+    takes the bounded MID-POLL budget (#1035; previously one terminal call),
+    then propagates (org-mismatch resume semantics: delayed, never masked)."""
     client = FakeBatchClient("high_prio")
     state, sb, state_path, _items = _api_submit(tmp_path, client)
     sb.pop("submitted_at")  # simulate a pre-#995 state.json
@@ -470,6 +812,7 @@ def test_api_dispatch_poll_step_absent_submitted_at_terminal(tmp_path):
         raise _nf(batch_id)
 
     client.messages.batches.retrieve = _retrieve_always_404
+    sleeps: list[float] = []
 
     async def _run():
         await api_dispatch._poll_one_sub_batch_step(
@@ -480,12 +823,53 @@ def test_api_dispatch_poll_step_absent_submitted_at_terminal(tmp_path):
             sync_clients={"high_prio": client},
             parse_response=api_parse_response,
             now_fn=lambda: dt.datetime.now(dt.UTC),
-            sleep_fn=lambda _s: None,
+            sleep_fn=sleeps.append,
         )
 
     with pytest.raises(anthropic.NotFoundError):
         asyncio.run(_run())
-    assert box["n"] == 1
+    assert box["n"] == len(BATCH_MIDPOLL_404_BACKOFF_S) + 1
+    assert sleeps == list(BATCH_MIDPOLL_404_BACKOFF_S)
+
+
+def test_api_dispatch_overdue_final_retrieve_tolerates_404(tmp_path):
+    """#1035 §5 item 5b: the api_dispatch overdue final retrieve 404s once then
+    reads ended -> harvested (created_at threading matches the loop retrieve)."""
+    client = FakeBatchClient("high_prio", end_after=1)  # retrieve 1 in_progress, 2 ended
+    state, sb, state_path, items = _api_submit(tmp_path, client)
+    sb["submitted_at"] = "2026-01-01T00:00:00Z"  # far in the past of the test clock
+    sb["deadline"] = (T0 + dt.timedelta(hours=1)).isoformat()  # already overdue
+    orig_retrieve = client.messages.batches.retrieve
+    box = {"n": 0, "n404": 0}
+
+    def _retrieve(batch_id):
+        box["n"] += 1
+        if box["n"] == 2:  # the overdue final retrieve (loop retrieve was call 1)
+            box["n404"] += 1
+            raise _nf(batch_id)
+        return orig_retrieve(batch_id)
+
+    client.messages.batches.retrieve = _retrieve
+    sleeps: list[float] = []
+
+    async def _run():
+        await api_dispatch._poll_one_sub_batch_step(
+            sb,
+            state=state,
+            state_path=state_path,
+            dispatch_dir=tmp_path,
+            sync_clients={"high_prio": client},
+            parse_response=api_parse_response,
+            now_fn=_Clock([T0 + dt.timedelta(hours=2)]),
+            sleep_fn=sleeps.append,
+        )
+
+    asyncio.run(_run())
+    assert sb["status"] == "collected"
+    assert box["n404"] == 1
+    assert sleeps == [5.0]  # the mid-poll backoff (outside the grace window)
+    payload = json.loads((tmp_path / f"results_{sb['batch_id']}.json").read_text())
+    assert payload[items[0].item_id]["error"] is False
 
 
 # ── §4.4 items 10 + 12: AnthropicBatch.poll grace + dual bound ───────────────
@@ -533,13 +917,20 @@ def test_poll_created_at_kwarg_grace_recovers():
     assert counter["n"] == 3  # 404, in_progress, ended
 
 
-def test_poll_no_memo_no_kwarg_terminal_on_first_404():
+def test_poll_no_memo_no_kwarg_404_bounded_terminal():
     """Fresh instance polling an unknown id (the new-process resume shape):
-    no memo entry AND no created_at kwarg -> raises on the FIRST 404."""
-    batch, counter = _grace_poll_batch(["ended"], fail_404_first=1)  # would end on call 2
+    no memo entry AND no created_at kwarg -> the bounded MID-POLL budget
+    (#1035; previously terminal on the FIRST 404), then re-raise."""
+    batch, counter = _grace_poll_batch(["in_progress"], fail_404_first=10**6)
+    sleeps: list[float] = []
+
+    async def _capture_sleep(delay):
+        sleeps.append(delay)
+
     with pytest.raises(anthropic.NotFoundError):
-        asyncio.run(batch.poll("msgbatch_unknown", now_fn=_Clock([T0]), sleep_fn=_noop_async_sleep))
-    assert counter["n"] == 1
+        asyncio.run(batch.poll("msgbatch_unknown", now_fn=_Clock([T0]), sleep_fn=_capture_sleep))
+    assert counter["n"] == len(BATCH_MIDPOLL_404_BACKOFF_S) + 1
+    assert sleeps == list(BATCH_MIDPOLL_404_BACKOFF_S)
 
 
 def test_poll_frozen_clock_all_404_bounded():
@@ -588,7 +979,9 @@ def test_create_memo_covers_direct_poll_callers():
     """The issue658 caller shape, end to end: same-instance create(...) then
     poll(batch_id) with NO created_at kwarg recovers from a create-window 404
     via the memo (zero caller wiring); a SECOND instance polling the same id
-    has no memo -> terminal on the first 404 (memo is instance-scoped)."""
+    has no memo -> the bounded MID-POLL budget (#1035; previously terminal on
+    the first 404 — memo is still instance-scoped, the budget is just bounded
+    rather than zero), then re-raise."""
     b = AnthropicBatch(anthropic_api_key="test-key-unused")  # REAL __init__ -> memo dict
     fake = _CreateThenPollBatches(fail_404_first=1, statuses=["in_progress", "ended"])
     b.client = _ns(messages=_ns(batches=fake))
@@ -605,4 +998,215 @@ def test_create_memo_covers_direct_poll_callers():
     b2.client = _ns(messages=_ns(batches=fake2))
     with pytest.raises(anthropic.NotFoundError):
         asyncio.run(b2.poll(created.id, sleep_fn=_noop_async_sleep))
-    assert fake2.retrieve_calls == 1
+    assert fake2.retrieve_calls == len(BATCH_MIDPOLL_404_BACKOFF_S) + 1
+
+
+# ── #1035 §5 items 7/7b/7c: AnthropicBatch.poll mid-poll + counter reset ─────
+
+
+def _scripted_poll_batch(script, *, memo=None, expires_at=EXPIRES):
+    """An AnthropicBatch (init skipped) whose retrieve walks ``script`` — each
+    entry is "404" (raise) or a processing_status; the LAST entry repeats."""
+    batch = AnthropicBatch.__new__(AnthropicBatch)  # skip __init__ (no real client)
+    batch._created_at = dict(memo or {})
+    seq = list(script)
+    counter = {"n": 0}
+
+    def _retrieve(batch_id):
+        counter["n"] += 1
+        action = seq[min(counter["n"] - 1, len(seq) - 1)]
+        if action == "404":
+            raise _nf(batch_id)
+        return _ns(processing_status=action, expires_at=expires_at, request_counts=None)
+
+    batch.retrieve = _retrieve
+    return batch, counter
+
+
+def _capturing_async_sleep(sleeps):
+    async def _sleep(delay):
+        sleeps.append(delay)
+
+    return _sleep
+
+
+def test_poll_midpoll_404_recovers_hours_in(caplog):
+    """poll: a healthy retrieve, then 404s HOURS past create (the mid-poll
+    class) -> bounded retry on the shared schedule, recovers; the async path
+    logs the same grep prefix as the sync wrapper."""
+    batch, counter = _scripted_poll_batch(
+        ["in_progress", "404", "404", "ended"], memo={"msgbatch_m": T0}
+    )
+    sleeps: list[float] = []
+    with caplog.at_level(logging.INFO, logger="explore_persona_space.llm.anthropic_client"):
+        out = asyncio.run(
+            batch.poll(
+                "msgbatch_m",
+                interval_s=60.0,
+                now_fn=_Clock([T0 + dt.timedelta(hours=2)]),
+                sleep_fn=_capturing_async_sleep(sleeps),
+            )
+        )
+    assert out.processing_status == "ended"
+    assert counter["n"] == 4
+    assert sleeps == [60.0, 5.0, 15.0]  # one poll interval, then the mid-poll backoff
+    assert "[batch-404-midpoll]" in caplog.text
+
+
+def test_poll_midpoll_404_bounded_after_success():
+    """poll: always-404 after a first healthy retrieve -> re-raises after
+    exactly len(BATCH_MIDPOLL_404_BACKOFF_S)+1 further calls (fail-fast)."""
+    batch, counter = _scripted_poll_batch(["in_progress", "404"], memo={"msgbatch_m": T0})
+    sleeps: list[float] = []
+    with pytest.raises(anthropic.NotFoundError):
+        asyncio.run(
+            batch.poll(
+                "msgbatch_m",
+                interval_s=60.0,
+                now_fn=_Clock([T0 + dt.timedelta(hours=2)]),
+                sleep_fn=_capturing_async_sleep(sleeps),
+            )
+        )
+    assert counter["n"] == 1 + len(BATCH_MIDPOLL_404_BACKOFF_S) + 1
+    assert sleeps == [60.0, *BATCH_MIDPOLL_404_BACKOFF_S]
+
+
+def test_poll_counter_reset_two_episodes_midpoll():
+    """TWO-EPISODE counter-reset pin (#1035 §3.5): a first 404 episode retries
+    then a retrieve SUCCEEDS; a second episode gets a FRESH full mid-poll
+    budget (without the reset the second episode would get only 4 retries)."""
+    batch, counter = _scripted_poll_batch(["404", "in_progress", "404"], memo={"msgbatch_m": T0})
+    sleeps: list[float] = []
+    with pytest.raises(anthropic.NotFoundError):
+        asyncio.run(
+            batch.poll(
+                "msgbatch_m",
+                interval_s=60.0,
+                now_fn=_Clock([T0 + dt.timedelta(hours=2)]),
+                sleep_fn=_capturing_async_sleep(sleeps),
+            )
+        )
+    # ep1: 1 retried 404 + 1 success; ep2: 5 retried 404s + 1 terminal.
+    assert counter["n"] == 2 + len(BATCH_MIDPOLL_404_BACKOFF_S) + 1
+    assert sleeps == [5.0, 60.0, *BATCH_MIDPOLL_404_BACKOFF_S]
+
+
+def test_poll_counter_reset_two_episodes_grace():
+    """Grace-counter sibling of the two-episode reset pin: a frozen in-window
+    clock; episode 1 uses 2 grace retries then succeeds; episode 2 gets the
+    FULL fresh grace budget (6 retries + terminal — the #995 in-window
+    exhausted terminal, not a shrunken leftover budget)."""
+    batch, counter = _scripted_poll_batch(
+        ["404", "404", "in_progress", "404"], memo={"msgbatch_z": T0}
+    )
+    sleeps: list[float] = []
+    frozen = _Clock([T0 + dt.timedelta(seconds=1)])
+    with pytest.raises(anthropic.NotFoundError):
+        asyncio.run(
+            batch.poll(
+                "msgbatch_z",
+                interval_s=60.0,
+                now_fn=frozen,
+                sleep_fn=_capturing_async_sleep(sleeps),
+            )
+        )
+    # ep1: 2 retried 404s + 1 success; ep2: 6 retried 404s + 1 terminal.
+    assert counter["n"] == 3 + len(BATCH_CREATE_404_BACKOFF_S) + 1
+    assert sleeps == [1.0, 2.0, 60.0, *BATCH_CREATE_404_BACKOFF_S]
+
+
+def test_poll_deadline_final_retrieve_404_recovers():
+    """#1035 §5 item 7c(i): the poll deadline-time FINAL retrieve (the local
+    async retry loop) 404s once then reads ended -> partial harvest proceeds."""
+    past_deadline = EXPIRES + dt.timedelta(minutes=31)
+    batch, counter = _scripted_poll_batch(["in_progress", "404", "ended"])
+    sleeps: list[float] = []
+    out = asyncio.run(
+        batch.poll(
+            "msgbatch_f",
+            now_fn=_Clock([past_deadline]),
+            sleep_fn=_capturing_async_sleep(sleeps),
+        )
+    )
+    assert out.processing_status == "ended"
+    assert counter["n"] == 3
+    assert sleeps == [5.0]
+
+
+def test_poll_deadline_final_retrieve_404_bounded():
+    """#1035 §5 item 7c(ii): an always-404 deadline final retrieve re-raises
+    NotFoundError after exactly len(BATCH_MIDPOLL_404_BACKOFF_S)+1 calls —
+    the suite would pass on an unbounded or 404-swallowing :750 loop without
+    this pin (the must-never-do)."""
+    past_deadline = EXPIRES + dt.timedelta(minutes=31)
+    batch, counter = _scripted_poll_batch(["in_progress", "404"])
+    sleeps: list[float] = []
+    with pytest.raises(anthropic.NotFoundError):
+        asyncio.run(
+            batch.poll(
+                "msgbatch_f",
+                now_fn=_Clock([past_deadline]),
+                sleep_fn=_capturing_async_sleep(sleeps),
+            )
+        )
+    assert counter["n"] == 1 + len(BATCH_MIDPOLL_404_BACKOFF_S) + 1
+    assert sleeps == list(BATCH_MIDPOLL_404_BACKOFF_S)
+
+
+# ── #1035 §5 item 6: fleet._poll_batch_to_ended (table D, created_at=None) ───
+
+
+class _FleetClient:
+    """messages.batches fake: retrieve 404s the first ``fail_404_first`` calls
+    then returns ended."""
+
+    def __init__(self, *, fail_404_first: int):
+        self.retrieve_calls = 0
+        client = self
+
+        class _B:
+            def retrieve(_s, batch_id):
+                client.retrieve_calls += 1
+                if client.retrieve_calls <= fail_404_first:
+                    raise _nf(batch_id)
+                return _ns(processing_status="ended", expires_at=EXPIRES, request_counts=None)
+
+        self.messages = _ns(batches=_B())
+
+
+def test_fleet_poll_tolerates_midpoll_404():
+    """The deferred/cross-process reconcile path: 404 twice then ended ->
+    returns (the #995 NOTE's terminal-404 default replaced by the bounded
+    mid-poll tolerance, created_at=None)."""
+    client = _FleetClient(fail_404_first=2)
+    sleeps: list[float] = []
+    _poll_batch_to_ended(
+        client,
+        "msgbatch_fleet",
+        poll_interval=0.0,
+        max_poll_interval=1.0,
+        grace_min=30,
+        now_fn=_Clock([T0]),
+        sleep_fn=sleeps.append,
+    )
+    assert client.retrieve_calls == 3
+    assert sleeps == [5.0, 15.0]
+
+
+def test_fleet_poll_persistent_404_bounded():
+    """An always-404 fleet reconcile re-raises after the bounded mid-poll
+    budget (wrong-org / genuinely-gone stays fail-fast, just <=~3 min later)."""
+    client = _FleetClient(fail_404_first=10**6)
+    sleeps: list[float] = []
+    with pytest.raises(anthropic.NotFoundError):
+        _poll_batch_to_ended(
+            client,
+            "msgbatch_fleet",
+            poll_interval=0.0,
+            max_poll_interval=1.0,
+            grace_min=30,
+            now_fn=_Clock([T0]),
+            sleep_fn=sleeps.append,
+        )
+    assert client.retrieve_calls == len(BATCH_MIDPOLL_404_BACKOFF_S) + 1
+    assert sleeps == list(BATCH_MIDPOLL_404_BACKOFF_S)

--- a/tests/test_batch_create_404_grace.py
+++ b/tests/test_batch_create_404_grace.py
@@ -1115,22 +1115,34 @@ def test_poll_counter_reset_two_episodes_grace():
     assert sleeps == [1.0, 2.0, 60.0, *BATCH_CREATE_404_BACKOFF_S]
 
 
-def test_poll_deadline_final_retrieve_404_recovers():
+def test_poll_deadline_final_retrieve_404_recovers(caplog):
     """#1035 §5 item 7c(i): the poll deadline-time FINAL retrieve (the local
-    async retry loop) 404s once then reads ended -> partial harvest proceeds."""
+    async retry loop) 404s once then reads ended -> partial harvest proceeds,
+    and the recovery emits a [batch-404-midpoll] INFO (plan criterion 5).
+
+    The recovery assert is LEVEL-scoped: the retry WARNING also carries the
+    prefix, so a bare ``in caplog.text`` would pass without any recovery log.
+    """
     past_deadline = EXPIRES + dt.timedelta(minutes=31)
     batch, counter = _scripted_poll_batch(["in_progress", "404", "ended"])
     sleeps: list[float] = []
-    out = asyncio.run(
-        batch.poll(
-            "msgbatch_f",
-            now_fn=_Clock([past_deadline]),
-            sleep_fn=_capturing_async_sleep(sleeps),
+    with caplog.at_level(logging.INFO, logger="explore_persona_space.llm.anthropic_client"):
+        out = asyncio.run(
+            batch.poll(
+                "msgbatch_f",
+                now_fn=_Clock([past_deadline]),
+                sleep_fn=_capturing_async_sleep(sleeps),
+            )
         )
-    )
     assert out.processing_status == "ended"
     assert counter["n"] == 3
     assert sleeps == [5.0]
+    recovery_infos = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.INFO and "[batch-404-midpoll]" in r.getMessage()
+    ]
+    assert recovery_infos, "deadline-final recovery must log a [batch-404-midpoll] INFO"
 
 
 def test_poll_deadline_final_retrieve_404_bounded():


### PR DESCRIPTION
Closes task #1035. Two-regime bounded 404 tolerance for Anthropic batch retrieves (extends #995's create-grace with a bounded mid-poll retry; fail-fast preserved).