### PR TITLE
workflow-fix #1043: verify_plan.py c24 resume-provenance check

### DIFF
--- a/.claude/skills/adversarial-planner/SKILL.md
+++ b/.claude/skills/adversarial-planner/SKILL.md
@@ -149,9 +149,12 @@ Run the structural verifier against the plan version just persisted:
   the target is a doc/prose file no pytest can exercise),
   `N/A — no re-extracted reference arms` (check 16), `N/A — no paired contrast`
   (check 18), `N/A — no held-out predictive DV` (check 19),
-  `N/A — no registered verdict lattice` (check 20), and
+  `N/A — no registered verdict lattice` (check 20),
   `N/A — no arity acceptance gate` (check 21 — the flagged grep is not a
-  call-arity pass condition; discovery/enumeration greps are fine).
+  call-arity pass condition; discovery/enumeration greps are fine), and
+  `N/A — no resume/persist pattern` (check 24 — the resume/persist vocabulary
+  hit is incidental or quotes a sibling's methodology, not this plan's own
+  long-loop resume predicate).
 - **FAIL → bounce to the planner** with the failed-check details (a mechanical-fix
   revision: re-spawn the planner with the FAIL list + the plan path; it patches the
   missing block and the orchestrator persists v{K+1} via `task.py new-plan-version`).

--- a/scripts/verify_plan.py
+++ b/scripts/verify_plan.py
@@ -50,11 +50,13 @@ Check catalog (id — classification — kind scope)
       consistency
   c23 goal currency             WARN-only, conditional    all kinds,
       (stale-Goal quote)                                  --issue mode only
+  c24 resume-skip provenance    WARN-only, conditional    experiment +
+      validation                                          analysis
 
 Kind-exempt checks render as [SKIP] (first-class status, distinguishable
 from genuine passes — the calibration report needs n_skip separate from
 n_pass). Conditional checks (4, 6, 7, 10, 11, 12, 13, 14, 15, 16, 17, 18,
-19, 20, 21, 22, 23) also SKIP when their content trigger does not fire.
+19, 20, 21, 22, 23, 24) also SKIP when their content trigger does not fire.
 Check 23 runs OUTSIDE ``verify_plan_text()`` — it needs task context
 (``body.md`` + ``events.jsonl``), so ``main()`` appends it in ``--issue``
 mode only and renders it SKIP in ``--plan-file`` mode; its WARN is the one
@@ -78,6 +80,7 @@ Canonical N/A escape phrases (quote verbatim in bounce briefs):
   - ``N/A — no held-out predictive DV`` (check 19)
   - ``N/A — no registered verdict lattice`` (check 20)
   - ``N/A — no arity acceptance gate`` (check 21)
+  - ``N/A — no resume/persist pattern`` (check 24)
 
 WARN semantics: a WARN never blocks exit (exit 0). The Phase 1.5.0 wiring
 carries WARN lines verbatim into the fact-checker + critic briefs — that
@@ -1128,8 +1131,9 @@ def _trigger_windows(plan: str, trigger_re: re.Pattern[str], window_lines: int) 
     fence-only example is not a trigger — the line-preserving equivalent of
     searching ``strip_fences(plan)``); each WINDOW is raw text, so evidence
     inside adjacent tables/fences still counts. Shared by c12
-    (``_BATTERY_TRIGGER_RE``, ±15) and c16 (``_C16_EXTRACT_RE`` ±3;
-    ``_C16_REGEN_RE`` at radius 0 = same-line adjacency)."""
+    (``_BATTERY_TRIGGER_RE``, ±15), c16 (``_C16_EXTRACT_RE`` ±3;
+    ``_C16_REGEN_RE`` at radius 0 = same-line adjacency), and c24
+    (``_C24_TRIGGER_RE``, ±15)."""
     lines = plan.splitlines()
     mask = _fence_mask(lines)
     windows: list[str] = []
@@ -3448,6 +3452,112 @@ def check_goal_currency(
     return _pass(cid, name, f"coverage: current {cov_cur:.2f}, max superseded {cov_stale:.2f}")
 
 
+# ─── Check 24 — resume-skip provenance validation (conditional) ─────────────
+
+# Trigger: a per-unit persist + resume-skip pattern. Compound forms ONLY —
+# bare "resume" fires on pod lifecycle ("pod.py resume", "resume the poll
+# loop") and bare "checkpoint"/"persist" on model checkpoints / the upload
+# policy (calibration 2026-07-05: 63 experiment|analysis plan-version hits
+# over the 1,367-file v*.md corpus, every spot-checked hit a genuine
+# resume-skip loop; zero pod-resume / upload-policy false hits; 28
+# non-exp/analysis triggered versions all land on the kind gate).
+_C24_TRIGGER_RE = re.compile(
+    r"(?i)\b(?:resume[- ]skip|resume[- ]predicate"
+    r"|skip[- ]if[- ]exists?"
+    r"|skips?\s+(?:already[- ])?(?:completed|done|existing)"
+    r"|checkpoint[- ](?:skip|resume)"
+    r"|per[- ](?:fold|cell|unit|seed|row|shard)[- ]persist\w*"
+    r"|idempotent re-?runs?"
+    r"|load[- ]partial[- ]and[- ]skip)"
+)
+
+# Satisfier: a recognizable input-fingerprint / provenance token near the
+# resume mention. Compound-form discipline on BOTH flanks (plan #1043 v3):
+# bare "provenance" and bare "manifest" are deliberately EXCLUDED —
+# "Completion provenance:" is a REQUIRED §4-design bullet in every
+# experiment plan (on-policy-completions enforcement), so it lands within
+# ±15 lines of resume prose and false-satisfied 52% of the v2-calibration
+# PASSes (#811 v1, #622 v1-v3, #931 v6 measured; 2026-07-05 reconciler).
+# Bare "regime" is likewise EXCLUDED — persona-vectors "read-out regime"
+# prose sits inside resume windows (#779 v5 measured) and would
+# self-satisfy. The final alternate (assert/validate/verify … existing/
+# persisted/… … match) catches contracts phrased without a fingerprint
+# noun (#560 v3: "assert the existing file's `sampling.temperature` /
+# `sampling_seed` match the requested flags"); it requires a resume-object
+# token between verb and "match" so an equivalence-gate assert ("assert
+# the vmapped MLP path matches a seeded serial reference", #922 v1-v3
+# measured) does NOT satisfy, and its spans are [^\n] (not
+# sentence-bounded) because periods inside code tokens like
+# `sampling.temperature` break [^.]-spans.
+_C24_FINGERPRINT_RE = re.compile(
+    r"(?i)\b(?:fingerprints?"
+    r"|provenance[- ](?:manifest\w*|contract\w*|validation\w*|check\w*)"
+    r"|manifest[- ](?:match\w*|validation\w*|mismatch\w*|check\w*)"
+    r"|sha[- ]?256|git[_ -]?sha|code[- ]sha|commit[- ](?:sha|hash)"
+    r"|(?:split|content|input|data)[- ]hash(?:es)?"
+    r"|env[- ](?:fingerprint|knobs?)"
+    r"|regime[- ]key(?:ed|s)?"
+    r"|never skip\w* on (?:[\w-]+[- ])?existence"
+    r"|(?:assert\w*|validat\w+|verif\w+)[^\n]{0,80}?"
+    r"\b(?:existing|persisted|resumed?|cached|stored|prior)\b[^\n]{0,80}?\bmatch\w*)"
+)
+
+# Evidence window: ± this many RAW lines around each trigger (the provenance
+# contract legitimately lives in an adjacent sentence/table row — #952 v12
+# names it in the same bullet; #813 v3 one section over).
+_C24_WINDOW_LINES = 15
+
+
+def check_resume_provenance(plan: str, kind: str) -> CheckResult:
+    """WARN-only, conditional: a plan naming a per-unit persist + resume-skip
+    pattern must, within ±15 raw lines of SOME resume mention, name an
+    input-fingerprint / provenance validation for the resumed outputs (split
+    hashes, code SHA, env knobs, a regime-keyed resume predicate, an explicit
+    never-skip-on-bare-existence commitment, or an assert-that-the-existing-
+    file-matches contract) — never output existence alone. NEVER FAILs in
+    v1 — the trigger is a vocabulary heuristic and semantic adequacy of the
+    named validation stays with the critics (task #1043 constraint). Known
+    accepted gap under WARN-only: a plan that QUOTES this check's WARN
+    remedy text near a trigger self-satisfies (the remedy names "split
+    hashes, code SHA, env knobs"); the anti-paste guard covers only the N/A
+    phrase. Any future WARN→FAIL promotion MUST close that gap first (plan
+    #1043 §10 must-ask hook). Incident #952 v9: per-fold persist +
+    resume-skip with a bare skips-completed-folds predicate would have let
+    stale-fold outputs (or a stale calibration-gate PASS) silently vouch for
+    post-code-fix verdict folds; caught only by the critic ensemble (v10
+    added the gate-5 provenance-manifest contract). ANY-window semantics per
+    the c12 precedent: the contract is typically declared once near one
+    mention."""
+    cid, name = "c24_resume_provenance", "resume-skip provenance validation"
+    if kind not in ("experiment", "analysis"):
+        return _skip(
+            cid, name, "kind-exempt: resume-provenance is an experiment|analysis plan shape"
+        )
+    windows = _trigger_windows(plan, _C24_TRIGGER_RE, _C24_WINDOW_LINES)
+    if not windows:
+        return _skip(cid, name, "no per-unit persist + resume-skip pattern named")
+    if _standalone_na_declared(plan, r"no resume\s*[/-]?\s*persist pattern"):
+        return _pass(cid, name, "explicit N/A declared (no resume/persist pattern)")
+    for window in windows:
+        if _C24_FINGERPRINT_RE.search(window):
+            return _pass(
+                cid,
+                name,
+                "a resume window names a provenance/fingerprint validation — whether the "
+                "named fields (input hashes, code SHA, env) are SUFFICIENT stays critic-owned",
+            )
+    return _warn(
+        cid,
+        name,
+        "plan names a per-unit persist + resume-skip pattern but no input-fingerprint / "
+        "provenance validation near any resume mention (split hashes, code SHA, env knobs, "
+        "a regime-keyed resume predicate) — a resume that trusts bare output existence lets "
+        "stale units silently vouch after a crash + code-fix round (#952 v9; #722 r3); "
+        "name the validation per the #952 gate-5 manifest shape, or declare "
+        "'N/A — no resume/persist pattern' on its own line if the mention is incidental",
+    )
+
+
 # ─── Driver ────────────────────────────────────────────────────────────────
 
 CHECKS = [
@@ -3473,6 +3583,7 @@ CHECKS = [
     check_verdict_lattice_coherence,
     check_grep_arity_gate,
     check_cross_section_param_consistency,
+    check_resume_provenance,
 ]
 
 

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -39,7 +39,7 @@ sys.modules["verify_plan"] = verify_plan
 _spec.loader.exec_module(verify_plan)  # type: ignore[union-attr]
 
 
-# ─── Canonical plan (kind=experiment: passes 0-3,5,8,9,17; skips 4,6,7,10-16,18-22)
+# ─── Canonical plan (kind=experiment: passes 0-3,5,8,9,17; skips 4,6,7,10-16,18-22,24)
 
 # Surgery anchors (must appear verbatim in GOOD_PLAN exactly once).
 MV_HEADING = "### Measurement validity"
@@ -161,10 +161,11 @@ def test_good_plan_passes_all():
         "c20_verdict_lattice_coherence": "SKIP",
         "c21_grep_arity_gate": "SKIP",
         "c22_cross_section_param_consistency": "SKIP",
+        "c24_resume_provenance": "SKIP",
     }
     actual = {cid: r.status for cid, r in by_id.items()}
     assert actual == expected
-    assert len(results) == 23
+    assert len(results) == 24
 
 
 # ─── Check 0 — plan-nonstub ────────────────────────────────────────────────
@@ -3079,6 +3080,224 @@ def test_c22_consistent_corrected_plan_stays_quiet():
     assert r.status == "PASS"  # lr restated consistently across two sections
 
 
+# ─── Check 24 — resume-skip provenance validation ──────────────────────────
+
+# Fixture shapes distilled from the motivating corpus (#952 v9 = the gap the
+# critic ensemble caught; v12 = the gate-5 provenance-manifest contract it
+# forced; the boilerplate shape = the "Completion provenance: N/A" §4-design
+# bullet that false-satisfied bare-noun satisfiers on #811 v1 / #622 v2).
+C24_V9_SHAPE = (
+    "\nPhase B: a fold loop writing per-fold outputs; per-fold persist + resume-skip "
+    "(each fold's outputs written when the fold completes; entry predicate skips "
+    "completed folds — the intra-phase persist law, projected loop >1 h).\n"
+)
+C24_V12_SHAPE = (
+    "\nPhase B: per-fold persist + resume-skip under the gate-5 provenance contract "
+    "(each fold's outputs written with their provenance manifest when the fold "
+    "completes; the entry predicate accepts a persisted fold only on full manifest "
+    "match — split sha256 hashes + git SHA + env fingerprint; mismatch = recompute).\n"
+)
+C24_BOILERPLATE_SHAPE = (  # the corpus false-PASS shape (#811 v1 / #622 v2)
+    "\nPhase B: per-fold persist + resume-skip (entry predicate skips completed folds).\n"
+    + "\n" * 10
+    + "Completion provenance: N/A — no behavior-implantation training rows in this task.\n"
+)
+
+
+def test_c24_952_v12_shape_passes():
+    # The #952 v12 gate-5 contract satisfies via the COMPOUND forms
+    # (`provenance manifest` / `manifest match`) — survives the bare-noun
+    # exclusion.
+    ok, by_id = _run(GOOD_PLAN + C24_V12_SHAPE)
+    assert by_id["c24_resume_provenance"].status == "PASS"
+    assert ok
+
+
+def test_c24_952_v9_shape_warns():
+    _, by_id = _run(GOOD_PLAN + C24_V9_SHAPE)
+    r = by_id["c24_resume_provenance"]
+    assert r.status == "WARN"
+    # The detail names the fingerprint vocabulary and quotes the escape phrase.
+    assert "code SHA" in r.detail
+    assert "N/A — no resume/persist pattern" in r.detail
+
+
+def test_c24_completion_provenance_boilerplate_warns():
+    # The REQUIRED "Completion provenance: N/A" design bullet within ±15 raw
+    # lines of a bare resume-skip must NOT satisfy (bare `provenance` is
+    # excluded from the satisfier — the #811 v1 / #622 v2 false-PASS class).
+    assert _status(GOOD_PLAN + C24_BOILERPLATE_SHAPE, "c24_resume_provenance") == "WARN"
+
+
+def test_c24_no_trigger_skips():
+    assert _status(GOOD_PLAN, "c24_resume_provenance") == "SKIP"
+
+
+def test_c24_na_escape_passes():
+    plan = (
+        GOOD_PLAN
+        + C24_V9_SHAPE
+        + "\nN/A — no resume/persist pattern (the resume-skip line quotes the sibling's "
+        "methodology).\n"
+    )
+    _, by_id = _run(plan)
+    r = by_id["c24_resume_provenance"]
+    assert r.status == "PASS"
+    assert "N/A" in r.detail
+
+
+def test_c24_na_escape_spaced_slash_passes():
+    # The escape tail is slash-spacing-tolerant: a hand-written
+    # "resume / persist" must not silently fail the escape.
+    plan = (
+        GOOD_PLAN
+        + C24_V9_SHAPE
+        + "\nN/A — no resume / persist pattern (the resume-skip line quotes the sibling's "
+        "methodology).\n"
+    )
+    assert _status(plan, "c24_resume_provenance") == "PASS"
+
+
+def test_c24_quoted_na_phrase_does_not_escape():
+    # A mid-sentence quoted escape phrase (the pasted-bounce-brief
+    # self-escape channel) is NOT a standalone declaration line and must not
+    # escape — the c13/c18 anti-paste twin.
+    plan = (
+        GOOD_PLAN
+        + C24_V9_SHAPE
+        + ("\nThe remedy menu says to declare 'N/A — no resume/persist pattern' on its own line.\n")
+    )
+    assert _status(plan, "c24_resume_provenance") == "WARN"
+
+
+@pytest.mark.parametrize("kind", ["infra", "batch"])
+def test_c24_kind_exempt_skips(kind):
+    assert _status(GOOD_PLAN + C24_V9_SHAPE, "c24_resume_provenance", kind=kind) == "SKIP"
+
+
+def test_c24_kind_analysis_warns():
+    # c24 is WARN for BOTH kinds (the c19 severity precedent) — severity does
+    # NOT degrade to SKIP for analysis, unlike c12's FAIL/WARN split.
+    assert _status(GOOD_PLAN + C24_V9_SHAPE, "c24_resume_provenance", kind="analysis") == "WARN"
+
+
+def test_c24_fenced_trigger_does_not_trigger():
+    # Resume-skip vocabulary appearing ONLY inside a code fence is not a
+    # resume plan — pins the fence-masked trigger path (`_trigger_windows`).
+    plan = GOOD_PLAN + "\n```\n" + C24_V9_SHAPE.strip() + "\n```\n"
+    assert _status(plan, "c24_resume_provenance") == "SKIP"
+
+
+def test_c24_satisfier_outside_window_warns():
+    # Window scoping is load-bearing: a genuine provenance contract >15 raw
+    # lines from every resume mention does not satisfy.
+    plan = (
+        GOOD_PLAN
+        + "\nPhase B: per-fold persist + resume-skip at each cell entry.\n"
+        + "\n" * 20
+        + "Acceptance: the provenance manifest (split sha256 hashes + git SHA) is "
+        "checked once per run.\n"
+    )
+    assert _status(plan, "c24_resume_provenance") == "WARN"
+
+
+def test_c24_window_radius_boundary():
+    # Mirrors test_c12_window_radius_boundary_after_refactor: c24's
+    # ±15-raw-line radius must not shift. Evidence exactly 15 raw lines below
+    # the trigger line counts; one line farther does not. The evidence line
+    # deliberately avoids c24 trigger vocabulary so it cannot open its own
+    # window (asserted below, not assumed).
+    evidence = (
+        "Acceptance: full provenance-manifest match — split sha256 hashes + git SHA + "
+        "env fingerprint."
+    )
+    assert not verify_plan._C24_TRIGGER_RE.search(evidence)
+    trigger = "Phase B: per-fold persist + resume-skip at each cell entry."
+    assert not verify_plan._C24_FINGERPRINT_RE.search(trigger)
+
+    def plan_with_gap(n_blank: int) -> str:
+        # Evidence lands (n_blank + 1) raw lines below the trigger line.
+        return (
+            GOOD_PLAN
+            + "\n## 12. Resume contract\n\n"
+            + trigger
+            + "\n"
+            + "\n" * n_blank
+            + evidence
+            + "\n"
+        )
+
+    assert _status(plan_with_gap(14), "c24_resume_provenance") == "PASS"  # +15 lines: in
+    assert _status(plan_with_gap(15), "c24_resume_provenance") == "WARN"  # +16 lines: out
+
+
+@pytest.mark.parametrize(
+    "trigger",
+    [
+        "a resume predicate keyed on output existence",
+        "skip-if-exists at cell entry",
+        "checkpoint-resume across waves",
+        "idempotent re-runs of the driver",
+        "load-partial-and-skip on restart",
+    ],
+)
+def test_c24_trigger_arm_warns(trigger):
+    # One minimal WARN fixture per previously-untested trigger-arm family.
+    assert _status(GOOD_PLAN + f"\nPhase B: {trigger}.\n", "c24_resume_provenance") == "WARN"
+
+
+@pytest.mark.parametrize(
+    "satisfier",
+    [
+        "outputs carry an input fingerprint checked at entry",  # bare fingerprint
+        "resume gated on the code SHA of the driver",  # code SHA
+        "the entry predicate compares the commit hash recorded at write time",  # commit hash
+        "each output carries an input-hash asserted at entry",  # input-hash
+        "the resume key records the env knobs of the capture",  # env knobs
+        "resume keyed on every output-affecting regime key",  # regime key (#722 r3)
+        "the predicate never skips on file-existence alone",  # never-skip (#922 v4)
+        "assert the existing file's sampling params match the requested flags",  # #560 v3
+    ],
+)
+def test_c24_satisfier_arm_passes(satisfier):
+    plan = GOOD_PLAN + f"\nPhase B: per-cell persist + resume-skip; {satisfier}.\n"
+    assert _status(plan, "c24_resume_provenance") == "PASS"
+
+
+def test_c24_bare_regime_prose_does_not_satisfy():
+    # Bare "regime" is excluded — persona-vectors "read-out regime" prose
+    # sits inside resume windows (#779 v5) and must not self-satisfy.
+    plan = (
+        GOOD_PLAN + "\nPhase B: per-cell persist + resume-skip; the A3.3 read-out regime, "
+        "all-layer sweep.\n"
+    )
+    assert _status(plan, "c24_resume_provenance") == "WARN"
+
+
+def test_c24_equivalence_assert_does_not_satisfy():
+    # An equivalence-gate assert without a resume-object token between verb
+    # and "match" (the #922 v1-v3 class) must not satisfy the assert-match
+    # clause.
+    plan = (
+        GOOD_PLAN + "\nPhase B: per-cell persist + resume-skip; assert the vmapped MLP path "
+        "matches a seeded serial reference.\n"
+    )
+    assert _status(plan, "c24_resume_provenance") == "WARN"
+
+
+def test_c24_cli_warn_exit_zero(tmp_path):
+    # WARN never blocks: exit 0, overall PASS, c24 rendered WARN (harness
+    # identical to test_cli_json_schema_and_exit_zero_on_pass).
+    p = tmp_path / "plan.md"
+    p.write_text(GOOD_PLAN + C24_V9_SHAPE)
+    proc = _run_cli("--plan-file", str(p), "--json")
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["overall"] != "FAIL"
+    c24 = next(c for c in payload["checks"] if c["id"] == "c24_resume_provenance")
+    assert c24["status"] == "WARN"
+
+
 # ─── Plan-version + kind resolution ────────────────────────────────────────
 
 
@@ -3128,12 +3347,12 @@ def test_cli_json_schema_and_exit_zero_on_pass(tmp_path):
     assert payload["issue"] is None
     assert payload["kind"] == "experiment"
     assert payload["n_fail"] == 0
-    assert payload["n_skip"] == 16
+    assert payload["n_skip"] == 17
     assert {"id", "name", "status", "detail"} <= set(payload["checks"][0])
     statuses = {c["status"] for c in payload["checks"]}
     assert statuses <= {"PASS", "WARN", "FAIL", "SKIP"}
-    assert len(payload["checks"]) == 24
-    assert len({c["id"] for c in payload["checks"]}) == 24
+    assert len(payload["checks"]) == 25
+    assert len({c["id"] for c in payload["checks"]}) == 25
     # c23 has no task context in --plan-file mode: rendered SKIP (companion
     # assert for test_cli_issue_mode_appends_goal_currency).
     c23 = next(c for c in payload["checks"] if c["id"] == "c23_goal_currency")


### PR DESCRIPTION
Closes task #1043. Adds c24_resume_provenance (WARN-only, experiment|analysis): plans naming per-unit persist + resume-skip must name an input-fingerprint/provenance validation near the resume mention. Plan v3 (critic-ensemble REVISE resolved); code-review PASS+PASS; test-verdict PASS (2527 passed).