### PR TITLE
issue-1044: sync_repo_root husk liveness-probe downgrade + bounded multi-branch pull retry

### DIFF
--- a/scripts/sync_repo_root.py
+++ b/scripts/sync_repo_root.py
@@ -74,7 +74,14 @@ Safety invariants (binding; pinned by tests/test_sync_repo_root.py):
     ``shutil.move`` replace a prior rescue copy and clobber its manifest).
   * Fail loud; no silent husks; a young (< ``EPM_ROOT_SYNC_HUSK_AGE_S``)
     rebase/merge husk or a persistent index.lock is reported and exits 5 —
-    never deleted. A STALE husk is git-aborted; when git itself cannot abort
+    never deleted — UNLESS the husk is at least ``EPM_ROOT_SYNC_HUSK_MIN_AGE_S``
+    (default 600s) old AND a COMPLETED, budget-bounded /proc scan
+    (``_probe_git_liveness``) proves no live git process is attributable to
+    this repo, in which case the EXISTING stale handling applies (abort /
+    archive-aside — still never deleted). An uncertain, timed-out,
+    budget-exhausted, or disabled (``EPM_ROOT_SYNC_HUSK_PROBE=0``) probe
+    keeps the exit-5 refusal, with the probe evidence appended to the
+    message. A STALE husk is git-aborted; when git itself cannot abort
     it (the head-name-less shape a crashed autostash-pull leaves) its
     autostash is rescued to the stash list and the husk dir is ARCHIVED to
     the rescue root — never deleted — with a rescue failure blocking the
@@ -144,6 +151,12 @@ IN_FLIGHT_MSG = (
 COLLISION_STDERR_NEEDLE = "untracked working tree files would be overwritten by"
 # Emitted on STDERR with pull rc=0 (plan §12 item 4) — never key on exit code.
 AUTOSTASH_CONFLICT_NEEDLE = "Applying autostash resulted in conflicts"
+# Exact wording verified on git 2.34.1 (`strings $(command -v git)` + live
+# two-refspec repro, #1044 §3): builtin/pull.c die()s this BEFORE any rebase
+# starts, when a concurrent fetch left >1 for-merge FETCH_HEAD entries.
+# Substring without the `fatal: ` wrapper and trailing period — still the
+# exact phrase; robust to die()'s prefix.
+MULTI_BRANCH_STDERR_NEEDLE = "Cannot rebase onto multiple branches"
 
 SCRATCH_WORKTREE_RECIPE = (
     "Manual next step (the recovery that resolved 6c1b3fadf7):\n"
@@ -172,6 +185,35 @@ def _fresh_s() -> float:
     """Mtime freshness window under which a collision is rescued, never removed
     (``EPM_ROOT_SYNC_FRESH_S``)."""
     return float(os.environ.get("EPM_ROOT_SYNC_FRESH_S", "60"))
+
+
+def _husk_probe_enabled() -> bool:
+    """Liveness-probe kill switch (``EPM_ROOT_SYNC_HUSK_PROBE`` != "0")."""
+    return os.environ.get("EPM_ROOT_SYNC_HUSK_PROBE", "1") != "0"
+
+
+def _husk_min_age_s() -> float:
+    """Age floor below which a young husk is NEVER liveness-downgraded
+    (``EPM_ROOT_SYNC_HUSK_MIN_AGE_S``)."""
+    return float(os.environ.get("EPM_ROOT_SYNC_HUSK_MIN_AGE_S", "600"))
+
+
+def _probe_timeout_s() -> float:
+    """Per-candidate bound for the probe's rev-parse attribution subprocess
+    (``EPM_ROOT_SYNC_PROBE_TIMEOUT_S``)."""
+    return float(os.environ.get("EPM_ROOT_SYNC_PROBE_TIMEOUT_S", "5.0"))
+
+
+def _probe_budget_s() -> float:
+    """TOTAL wall-clock budget for one liveness scan
+    (``EPM_ROOT_SYNC_PROBE_BUDGET_S``). Exhaustion ⇒ verdict "uncertain"
+    (scan incomplete) — never "none"."""
+    return float(os.environ.get("EPM_ROOT_SYNC_PROBE_BUDGET_S", "30.0"))
+
+
+def _retry_sleep_s() -> float:
+    """Sleep before the one multiple-branches retry (``EPM_ROOT_SYNC_RETRY_SLEEP_S``)."""
+    return float(os.environ.get("EPM_ROOT_SYNC_RETRY_SLEEP_S", "2.0"))
 
 
 def _rescue_timestamp() -> str:
@@ -332,6 +374,40 @@ def pull_rebase(repo: Path, timeout_s: float) -> GitResult:
     return _run_bounded(_pull_argv(repo), timeout_s)
 
 
+def _pull_with_transient_retry(repo: Path, report: dict, timeout_s: float) -> GitResult:
+    """Bounded pull with exactly ONE retry on the transient multiple-branches race.
+
+    ``fatal: Cannot rebase onto multiple branches.`` is die()d by
+    builtin/pull.c BEFORE any rebase starts, when a concurrent fetch rewrote
+    FETCH_HEAD with >1 for-merge entries mid-pull (#965/#998); verified to
+    leave no rebase state, no autostash, and an untouched worktree (#1044
+    §3), so the retry is state-safe. Retry once after a short sleep — the
+    retry's own fetch rewrites FETCH_HEAD — and only when no rebase state
+    exists (belt-and-braces re-verification). A second failure returns
+    as-is and surfaces through the existing handling unchanged. A SUCCESSFUL
+    retry is itself diagnostic evidence of an unserialized FETCH_HEAD writer
+    (a fetch bypassing this helper's flocks) — the ``_msg`` line preserves
+    that in the report/journal so recurrences stay attributable.
+    """
+    result = pull_rebase(repo, timeout_s)
+    if not result.timed_out and result.rc != 0 and MULTI_BRANCH_STDERR_NEEDLE in result.stderr:
+        if _rebase_in_progress(repo):
+            _msg(
+                report,
+                "multiple-branches signature but rebase state exists — NOT retrying "
+                "(unexpected shape; surfacing the failure as-is).",
+            )
+            return result
+        _msg(
+            report,
+            "transient 'Cannot rebase onto multiple branches' (concurrent FETCH_HEAD "
+            f"rewrite) — one retry after {_retry_sleep_s():.1f}s.",
+        )
+        time.sleep(_retry_sleep_s())
+        return pull_rebase(repo, timeout_s)
+    return result
+
+
 # ─── Report ──────────────────────────────────────────────────────────────────
 
 
@@ -413,6 +489,86 @@ def _fuser_evidence(path: Path) -> str:
     return (proc.stdout + proc.stderr).strip() or "(fuser: no holder reported)"
 
 
+@dataclasses.dataclass
+class LivenessProbe:
+    """Outcome of the /proc git-liveness scan: verdict + human-readable evidence."""
+
+    verdict: str  # "holder" | "none" | "uncertain"
+    evidence: str
+
+
+def _probe_git_liveness(gd: Path, proc_root: Path = Path("/proc")) -> LivenessProbe:
+    """Scan ``proc_root`` for a live git process operating on THIS repo.
+
+    "holder": a ``comm == git`` process whose cwd attributes (via a BOUNDED
+    ``git -C <cwd> rev-parse --absolute-git-dir``) to this repo's git dir —
+    state-owning git commands chdir to the worktree toplevel (verified,
+    #1044 §3), so linked-worktree / other-repo git activity is excluded
+    without hardcoded paths. "none" ONLY when the scan COMPLETED within the
+    total budget with zero holders and zero unattributable git candidates.
+    Everything else — ``proc_root`` unreadable, a git process whose cwd is
+    unreadable (EACCES: another user's process), unattributable, or whose
+    attribution TIMED OUT (a hung FUSE/network mount), or the total probe
+    budget exhausted mid-scan — is "uncertain". Every attribution subprocess
+    runs under ``_run_bounded`` with ``_probe_timeout_s()``; the whole scan
+    is capped by a ``_probe_budget_s()`` monotonic deadline, so the probe can
+    never stall ``preflight()`` (which holds both flocks) on a dead mount.
+    The caller treats anything but "none" as "keep today's young-husk
+    refusal": the probe fails TOWARD conservatism by construction. It cannot
+    see a conflict-paused rebase awaiting a human (no process exists then) —
+    that residual is bounded by ``_husk_min_age_s`` and the repo-root policy
+    that conflicts are resolved in scratch worktrees, never in place. It
+    also cannot see a rebase driven by a non-git process image (a
+    library-driven rebase via pygit2/dulwich or a wrapper whose ``comm`` is
+    not ``git``) — a second false-"none" residual, accepted because fleet
+    git activity goes through the git CLI.
+    """
+    deadline = time.monotonic() + _probe_budget_s()
+    try:
+        pids = [p for p in os.listdir(proc_root) if p.isdigit()]
+    except OSError as e:
+        return LivenessProbe("uncertain", f"{proc_root} unreadable: {e!r}")
+    gd_resolved = gd.resolve()
+    unattributable: list[str] = []
+    for pid in pids:
+        pdir = proc_root / pid
+        try:
+            comm = (pdir / "comm").read_text().strip()
+        except OSError:
+            continue  # vanished mid-scan — provably not a live holder
+        if comm != "git":
+            continue
+        try:
+            cwd = os.readlink(pdir / "cwd")
+        except FileNotFoundError:
+            continue  # vanished mid-scan
+        except OSError as e:
+            unattributable.append(f"pid {pid}: cwd unreadable ({e.__class__.__name__})")
+            continue
+        if time.monotonic() > deadline:
+            return LivenessProbe(
+                "uncertain",
+                f"probe budget ({_probe_budget_s():.0f}s) exhausted before attributing "
+                f"pid {pid} — scan incomplete",
+            )
+        rp = _run_bounded(
+            _git_argv(Path(cwd), "rev-parse", "--absolute-git-dir"), _probe_timeout_s()
+        )
+        if rp.timed_out:
+            unattributable.append(
+                f"pid {pid}: attribution timed out after {_probe_timeout_s():.0f}s (cwd {cwd})"
+            )
+            continue
+        if rp.rc != 0:
+            unattributable.append(f"pid {pid}: cwd {cwd} not attributable to a git dir")
+            continue
+        if Path(rp.stdout.strip()).resolve() == gd_resolved:
+            return LivenessProbe("holder", f"live git pid {pid}, cwd {cwd}")
+    if unattributable:
+        return LivenessProbe("uncertain", "; ".join(unattributable[:5]))
+    return LivenessProbe("none", "scan completed: no live git process attributable to this repo")
+
+
 def acquire_task_workflow_lock(wait_s: float) -> int:
     """Bounded acquisition of ``task_workflow.LOCK_PATH`` (LOCK_NB + 2s poll).
 
@@ -490,11 +646,27 @@ def preflight(repo: Path, report: dict, dry_run: bool) -> None:
         if not husk.exists():
             continue
         age = now - husk.stat().st_mtime
+        stale_how = f"> {_husk_age_s():.0f}s"
         if age <= _husk_age_s():
-            raise SyncAbortError(
-                EXIT_PRECONDITION,
-                f"young {husk.name} husk ({age:.0f}s old, threshold {_husk_age_s():.0f}s) — "
-                "someone may be mid-operation; refusing to touch it.",
+            probe = (
+                _probe_git_liveness(gd)
+                if _husk_probe_enabled() and age > _husk_min_age_s()
+                else None
+            )
+            if probe is None or probe.verdict != "none":
+                extra = f"\nliveness probe: {probe.verdict} — {probe.evidence}" if probe else ""
+                raise SyncAbortError(
+                    EXIT_PRECONDITION,
+                    f"young {husk.name} husk ({age:.0f}s old, threshold {_husk_age_s():.0f}s) — "
+                    f"someone may be mid-operation; refusing to touch it.{extra}",
+                )
+            stale_how = "young, liveness-downgraded"
+            _msg(
+                report,
+                f"YOUNG-HUSK DOWNGRADE: {husk.name} is {age:.0f}s old "
+                f"(< {_husk_age_s():.0f}s threshold, > {_husk_min_age_s():.0f}s floor) but no "
+                f"live git process is attributable to this repo ({probe.evidence}); "
+                "treating as STALE.",
             )
         # Discriminators scoped to REBASE state dirs only (MERGE_HEAD — even a
         # malformed directory — routes to the explicit refuse branch below).
@@ -523,7 +695,7 @@ def preflight(repo: Path, report: dict, dry_run: bool) -> None:
         if aborted.returncode == 0:
             _msg(
                 report,
-                f"STALE-HUSK ABORT: {husk.name} was {age:.0f}s old (> {_husk_age_s():.0f}s); "
+                f"STALE-HUSK ABORT: {husk.name} was {age:.0f}s old ({stale_how}); "
                 f"ran `git {' '.join(abort_args)}` "
                 "(restores original HEAD + re-applies autostash).",
             )
@@ -547,7 +719,7 @@ def preflight(repo: Path, report: dict, dry_run: bool) -> None:
                 f"head-name-less rebase shape — refusing to touch it.\n"
                 f"stderr: {aborted.stderr.strip()}",
             )
-        _recover_headnameless_husk(repo, husk, age, aborted, report)
+        _recover_headnameless_husk(repo, husk, age, aborted, report, stale_how)
 
     branch = git(repo, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
     if branch != "main":
@@ -562,9 +734,18 @@ def preflight(repo: Path, report: dict, dry_run: bool) -> None:
 
 
 def _recover_headnameless_husk(
-    repo: Path, husk: Path, age: float, aborted: subprocess.CompletedProcess[str], report: dict
+    repo: Path,
+    husk: Path,
+    age: float,
+    aborted: subprocess.CompletedProcess[str],
+    report: dict,
+    stale_how: str,
 ) -> None:
     """Rescue-then-ARCHIVE for a stale, un-abortable, head-name-less rebase husk.
+
+    ``stale_how`` names WHY the husk counts as stale ("> <threshold>s" for the
+    wall-clock path, "young, liveness-downgraded" for the #1044 probe path) so
+    the ARCHIVED report never states a false age threshold.
 
     A crashed ``pull --rebase --autostash`` can die after writing
     ``<state-dir>/autostash`` but before ``head-name`` (2026-07-03 incident,
@@ -652,7 +833,7 @@ def _recover_headnameless_husk(
     shutil.move(str(husk), str(dest))
     _msg(
         report,
-        f"STALE-HUSK ARCHIVED: {husk.name} was {age:.0f}s old (> {_husk_age_s():.0f}s), "
+        f"STALE-HUSK ARCHIVED: {husk.name} was {age:.0f}s old ({stale_how}), "
         f"head-name-less and un-abortable (`git rebase --abort` rc={aborted.returncode}: "
         f"{aborted.stderr.strip()}); {disposition}; husk dir archived to {dest}.",
     )
@@ -1085,14 +1266,16 @@ def _pull_pipeline(
 ) -> None:
     """Sweep-wrapped pull: enumerate collisions → journaled sweep (each action
     durable BEFORE it executes; consolidated manifest after) → bounded
-    pull-rebase → error-driven fallback sweep + one retry → conflict/timeout
-    abort policy → post-pull stranded-autostash recovery. The rescue dir is
-    allocated lazily + exclusively on first sweep need (``RescueDir``)."""
+    pull-rebase (with one transient multiple-branches retry,
+    ``_pull_with_transient_retry``) → error-driven fallback sweep + one retry →
+    conflict/timeout abort policy → post-pull stranded-autostash recovery. The
+    rescue dir is allocated lazily + exclusively on first sweep need
+    (``RescueDir``)."""
     collisions = enumerate_collisions(repo)
     _record_collision_plan(report, collisions)
     _sweep_and_record(repo, collisions, ledger, rescue, report)
 
-    result = pull_rebase(repo, timeout_s)
+    result = _pull_with_transient_retry(repo, report, timeout_s)
     if result.timed_out:
         if _rebase_in_progress(repo):
             git(repo, "rebase", "--abort")
@@ -1111,7 +1294,7 @@ def _pull_pipeline(
         )
         fallback = [_classify(repo, p) for p in first_paths if (repo / p).exists()]
         _sweep_and_record(repo, fallback, ledger, rescue, report)
-        result = pull_rebase(repo, timeout_s)
+        result = _pull_with_transient_retry(repo, report, timeout_s)
         if result.timed_out:
             if _rebase_in_progress(repo):
                 git(repo, "rebase", "--abort")

--- a/tests/test_sync_repo_root.py
+++ b/tests/test_sync_repo_root.py
@@ -105,6 +105,11 @@ def origin_and_clone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     # A dev shell exporting a non-default husk age must not flake the husk
     # age-gate tests (per-test setenv still wins — it runs after fixture setup).
     monkeypatch.delenv("EPM_ROOT_SYNC_HUSK_AGE_S", raising=False)
+    monkeypatch.delenv("EPM_ROOT_SYNC_HUSK_PROBE", raising=False)
+    monkeypatch.delenv("EPM_ROOT_SYNC_HUSK_MIN_AGE_S", raising=False)
+    monkeypatch.delenv("EPM_ROOT_SYNC_RETRY_SLEEP_S", raising=False)
+    monkeypatch.delenv("EPM_ROOT_SYNC_PROBE_TIMEOUT_S", raising=False)
+    monkeypatch.delenv("EPM_ROOT_SYNC_PROBE_BUDGET_S", raising=False)
     return origin, local, other
 
 
@@ -1269,3 +1274,376 @@ def test_restore_kept_in_rescue_only_when_rescue_copy_exists(tmp_path):
     assert msg.startswith("KEPT-IN-RESCUE")
     assert str(rescue_copy) in msg
     assert rescue_copy.read_text() == "SWEPT-LOCAL\n"  # copy retained, untouched
+
+
+# ─── 15. Multiple-branches transient retry (#1044) ───────────────────────────
+
+_MULTI_BRANCH_FAKE_ARGV = [
+    "bash",
+    "-c",
+    "echo 'fatal: Cannot rebase onto multiple branches.' >&2; exit 128",
+]
+
+
+def _make_local_behind(local: Path, other: Path) -> None:
+    """Push an origin-side commit so the sync's pull pipeline actually runs."""
+    _write(other, "eval_results/issue_9/y.json", "ORIGIN-Y\n")
+    _commit(other, "eval_results/issue_9/y.json")
+    _git(other, "push", "-q", "origin", "main")
+
+
+def test_multi_branch_transient_retried_once_then_succeeds(origin_and_clone, monkeypatch, capsys):
+    """First pull dies with the multiple-branches race; the ONE internal retry
+    (real pull) succeeds and the sync completes end-to-end."""
+    _origin, local, other = origin_and_clone
+    _make_local_behind(local, other)
+
+    real_pull_argv = srr._pull_argv
+    calls: list[int] = []
+
+    def fake_pull_argv(repo):
+        calls.append(1)
+        return _MULTI_BRANCH_FAKE_ARGV if len(calls) == 1 else real_pull_argv(repo)
+
+    monkeypatch.setattr(srr, "_pull_argv", fake_pull_argv)
+    monkeypatch.setenv("EPM_ROOT_SYNC_RETRY_SLEEP_S", "0")
+    rc, rep, _err = _run(local, capsys=capsys)
+    assert rc == 0
+    assert rep["state"] == "synced"
+    assert len(calls) == 2  # exactly one retry
+    assert any("one retry" in m for m in rep["messages"])
+    assert (local / "eval_results/issue_9/y.json").read_text() == "ORIGIN-Y\n"
+
+
+def test_multi_branch_persistent_failure_surfaces_after_one_retry(
+    origin_and_clone, monkeypatch, capsys
+):
+    """Both attempts carry the signature: exactly one retry, then the failure
+    surfaces exactly as a single failure does today (exit 6, no conflict state)."""
+    _origin, local, other = origin_and_clone
+    _make_local_behind(local, other)
+    _write(local, "tracked.txt", "base\n")
+    _commit(local, "tracked.txt")
+    _write(local, "tracked.txt", "dirty\n")  # pre-sync dirty state
+    scratch = _write(local, "scratch.txt", "untracked\n")
+
+    calls: list[int] = []
+
+    def fake_pull_argv(repo):
+        calls.append(1)
+        return _MULTI_BRANCH_FAKE_ARGV
+
+    monkeypatch.setattr(srr, "_pull_argv", fake_pull_argv)
+    monkeypatch.setenv("EPM_ROOT_SYNC_RETRY_SLEEP_S", "0")  # no real 2s sleep in the suite
+    rc, rep, err = _run(local, capsys=capsys)
+    assert rc == 6
+    assert rep["exit_code"] == 6
+    assert len(calls) == 2  # exactly one retry, never a loop
+    assert "Cannot rebase onto multiple branches" in err
+    assert not (local / ".git" / "rebase-merge").exists()
+    assert (local / "tracked.txt").read_text() == "dirty\n"  # tracked state untouched
+    assert scratch.read_text() == "untracked\n"  # untracked state untouched
+
+
+def test_multi_branch_signature_with_rebase_state_not_retried(tmp_path, monkeypatch):
+    """Belt-and-braces guard: the signature WITH rebase state present is an
+    unexpected shape — returned as-is, no retry."""
+    calls: list[int] = []
+
+    def fake_pull(repo, timeout_s):
+        calls.append(1)
+        return srr.GitResult(128, "", "fatal: Cannot rebase onto multiple branches.\n", False)
+
+    monkeypatch.setattr(srr, "pull_rebase", fake_pull)
+    monkeypatch.setattr(srr, "_rebase_in_progress", lambda repo: True)
+    report = srr._new_report(tmp_path, dry_run=False)
+    result = srr._pull_with_transient_retry(tmp_path, report, 5.0)
+    assert len(calls) == 1
+    assert result.rc == 128
+    assert any("NOT retrying" in m for m in report["messages"])
+
+
+def test_multi_branch_timed_out_result_not_retried(tmp_path, monkeypatch):
+    """A timed-out result is never signature-retried (timeout handling wins)."""
+    calls: list[int] = []
+
+    def fake_pull(repo, timeout_s):
+        calls.append(1)
+        return srr.GitResult(-9, "", "fatal: Cannot rebase onto multiple branches.\n", True)
+
+    monkeypatch.setattr(srr, "pull_rebase", fake_pull)
+    report = srr._new_report(tmp_path, dry_run=False)
+    result = srr._pull_with_transient_retry(tmp_path, report, 5.0)
+    assert len(calls) == 1
+    assert result.timed_out is True
+    assert report["messages"] == []
+
+
+def test_multi_branch_needle_absent_not_retried(tmp_path, monkeypatch):
+    """Negative control: an ordinary pull failure never buys a retry."""
+    calls: list[int] = []
+
+    def fake_pull(repo, timeout_s):
+        calls.append(1)
+        return srr.GitResult(1, "", "error: some unrelated pull failure\n", False)
+
+    monkeypatch.setattr(srr, "pull_rebase", fake_pull)
+    report = srr._new_report(tmp_path, dry_run=False)
+    result = srr._pull_with_transient_retry(tmp_path, report, 5.0)
+    assert len(calls) == 1
+    assert result.rc == 1
+    assert report["messages"] == []  # no retry message
+
+
+# ─── 16. Young-husk liveness downgrade (#1044) ────────────────────────────────
+
+
+def _probe_must_not_be_called(gd, proc_root=None):
+    raise AssertionError("_probe_git_liveness must not be called on this path")
+
+
+def test_young_husk_no_holder_past_floor_downgraded(origin_and_clone, monkeypatch, capsys):
+    """A young (1800s) husk past the 600s floor with a completed no-holder scan
+    is downgraded to the EXISTING stale handling (abort → continue → the run
+    re-hits the genuine conflict, mirroring the stale-husk test)."""
+    _origin, local, other = origin_and_clone
+    husk = _make_conflicted_rebase_husk(local, other)
+    t = time.time() - 1800
+    os.utime(husk, (t, t))
+
+    monkeypatch.setattr(srr, "_probe_git_liveness", lambda gd: srr.LivenessProbe("none", "test"))
+    rc, rep, _err = _run(local, capsys=capsys)
+    assert any("YOUNG-HUSK DOWNGRADE" in m for m in rep["messages"])
+    assert any("STALE-HUSK ABORT" in m for m in rep["messages"])
+    assert rc == 2
+    assert not (local / ".git" / "rebase-merge").exists()
+    assert "c.txt" in rep["conflicted_paths"]
+
+
+def test_young_husk_live_holder_kept_exit_5(origin_and_clone, monkeypatch, capsys):
+    _origin, local, other = origin_and_clone
+    husk = _make_conflicted_rebase_husk(local, other)
+    t = time.time() - 1800
+    os.utime(husk, (t, t))
+
+    monkeypatch.setattr(
+        srr, "_probe_git_liveness", lambda gd: srr.LivenessProbe("holder", "live git pid 1 test")
+    )
+    rc, _rep, err = _run(local, capsys=capsys)
+    assert rc == 5
+    assert husk.exists()  # untouched
+    assert "young rebase-merge husk" in err
+    assert "live git pid 1 test" in err  # probe evidence surfaced
+
+
+def test_young_husk_uncertain_probe_kept_exit_5(origin_and_clone, monkeypatch, capsys):
+    """An uncertain scan keeps today's refusal AND surfaces the probe's
+    reasoning (not just the verdict) in the exit-5 message."""
+    _origin, local, other = origin_and_clone
+    husk = _make_conflicted_rebase_husk(local, other)
+    t = time.time() - 1800
+    os.utime(husk, (t, t))
+
+    monkeypatch.setattr(
+        srr,
+        "_probe_git_liveness",
+        lambda gd: srr.LivenessProbe("uncertain", "pid 42: cwd unreadable (PermissionError)"),
+    )
+    rc, _rep, err = _run(local, capsys=capsys)
+    assert rc == 5
+    assert husk.exists()  # untouched
+    assert "young rebase-merge husk" in err
+    assert "pid 42: cwd unreadable" in err
+
+
+def test_young_husk_below_floor_probe_not_called(origin_and_clone, monkeypatch, capsys):
+    """A fresh husk (age ≈ 0 < 600s floor) keeps the existing behavior with the
+    probe never invoked — sub-floor behavior stays probe-free + deterministic."""
+    _origin, local, other = origin_and_clone
+    husk = _make_conflicted_rebase_husk(local, other)
+
+    monkeypatch.setattr(srr, "_probe_git_liveness", _probe_must_not_be_called)
+    rc, _rep, err = _run(local, capsys=capsys)
+    assert rc == 5
+    assert husk.exists()
+    assert "young rebase-merge husk" in err
+
+
+def test_husk_probe_kill_switch(origin_and_clone, monkeypatch, capsys):
+    """EPM_ROOT_SYNC_HUSK_PROBE=0 degrades the probe to a no-op: exactly
+    today's refusal, probe never invoked."""
+    _origin, local, other = origin_and_clone
+    husk = _make_conflicted_rebase_husk(local, other)
+    t = time.time() - 1800
+    os.utime(husk, (t, t))
+
+    monkeypatch.setenv("EPM_ROOT_SYNC_HUSK_PROBE", "0")
+    monkeypatch.setattr(srr, "_probe_git_liveness", _probe_must_not_be_called)
+    rc, _rep, err = _run(local, capsys=capsys)
+    assert rc == 5
+    assert husk.exists()
+    assert "young rebase-merge husk" in err
+
+
+def test_downgraded_headnameless_dry_run_mutates_nothing(origin_and_clone, monkeypatch, capsys):
+    """A downgraded young head-name-less husk flows into the EXISTING
+    mutation-free DRY-RUN stale branch."""
+    _origin, local, _other = origin_and_clone
+    husk = _make_headnameless_husk(local, stale=False)
+    t = time.time() - 1800
+    os.utime(husk, (t, t))
+
+    monkeypatch.setattr(srr, "_probe_git_liveness", lambda gd: srr.LivenessProbe("none", "test"))
+    rc, rep, _err = _run(local, "--dry-run", capsys=capsys)
+    assert rc == 0
+    assert any("YOUNG-HUSK DOWNGRADE" in m for m in rep["messages"])
+    assert any("DRY-RUN: stale head-name-less" in m for m in rep["messages"])
+    assert husk.is_dir()  # intact — dry-run mutates nothing
+
+
+def test_probe_detects_live_git_process(origin_and_clone):
+    """Real-/proc positive: a live git process chdir'd into the repo yields
+    verdict "holder" (deterministic — a holder short-circuits regardless of
+    unrelated system git processes)."""
+    _origin, local, _other = origin_and_clone
+    proc = subprocess.Popen(
+        ["git", "-C", str(local), "hash-object", "--stdin"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        gd = local / ".git"
+        deadline = time.monotonic() + 5.0
+        probe = None
+        while time.monotonic() < deadline:
+            probe = srr._probe_git_liveness(gd)
+            if probe.verdict == "holder":
+                break
+            time.sleep(0.1)
+        else:
+            pytest.fail(f"no holder verdict within deadline; last probe: {probe}")
+        assert str(proc.pid) in probe.evidence
+    finally:
+        proc.stdin.close()
+        proc.wait(timeout=10)
+
+
+def _fake_proc(tmp_path: Path) -> Path:
+    """Synthetic proc root; includes a non-pid entry like the real /proc."""
+    proc_root = tmp_path / "proc"
+    proc_root.mkdir()
+    (proc_root / "stat").write_text("")
+    return proc_root
+
+
+def _fake_pid(proc_root: Path, pid: int, comm: str, cwd: Path | None = None) -> Path:
+    pdir = proc_root / str(pid)
+    pdir.mkdir()
+    (pdir / "comm").write_text(comm + "\n")
+    if cwd is not None:
+        os.symlink(str(cwd), pdir / "cwd")
+    return pdir
+
+
+def _init_repo(path: Path) -> Path:
+    path.mkdir()
+    subprocess.run(["git", "init", "-q", str(path)], check=True, capture_output=True)
+    return path
+
+
+def _delenv_probe_tunables(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fake-proc unit tests skip origin_and_clone; guard against a dev shell
+    exporting the probe tunables (same rationale as the fixture delenvs)."""
+    monkeypatch.delenv("EPM_ROOT_SYNC_PROBE_TIMEOUT_S", raising=False)
+    monkeypatch.delenv("EPM_ROOT_SYNC_PROBE_BUDGET_S", raising=False)
+
+
+def test_probe_fake_proc_non_git_comm_is_none(tmp_path, monkeypatch):
+    """(a) Only non-git processes ⇒ a COMPLETED scan ⇒ "none" — even when the
+    non-git process's cwd is inside the repo."""
+    _delenv_probe_tunables(monkeypatch)
+    r = _init_repo(tmp_path / "r")
+    proc_root = _fake_proc(tmp_path)
+    _fake_pid(proc_root, 100, "bash", cwd=r)
+
+    probe = srr._probe_git_liveness(r / ".git", proc_root=proc_root)
+    assert probe.verdict == "none"
+
+
+def test_probe_fake_proc_holder_vs_other_repo(tmp_path, monkeypatch):
+    """(b) A git process cwd'd in repo r is a "holder" for r's git dir and
+    "none" for a DIFFERENT repo (worktree / other-repo exclusion)."""
+    _delenv_probe_tunables(monkeypatch)
+    r = _init_repo(tmp_path / "r")
+    r2 = _init_repo(tmp_path / "r2")
+    proc_root = _fake_proc(tmp_path)
+    _fake_pid(proc_root, 100, "git", cwd=r)
+
+    holder = srr._probe_git_liveness(r / ".git", proc_root=proc_root)
+    assert holder.verdict == "holder"
+    assert "pid 100" in holder.evidence
+    other = srr._probe_git_liveness(r2 / ".git", proc_root=proc_root)
+    assert other.verdict == "none"
+
+
+def test_probe_fake_proc_cwd_regular_file_uncertain(tmp_path, monkeypatch):
+    """(c) An unreadable cwd (readlink OSError — same branch as another user's
+    EACCES) ⇒ "uncertain"."""
+    _delenv_probe_tunables(monkeypatch)
+    r = _init_repo(tmp_path / "r")
+    proc_root = _fake_proc(tmp_path)
+    pdir = _fake_pid(proc_root, 100, "git")
+    (pdir / "cwd").write_text("not-a-symlink\n")  # readlink → OSError (EINVAL)
+
+    probe = srr._probe_git_liveness(r / ".git", proc_root=proc_root)
+    assert probe.verdict == "uncertain"
+    assert "cwd unreadable" in probe.evidence
+
+
+def test_probe_fake_proc_unattributable_nonrepo_cwd_uncertain(tmp_path, monkeypatch):
+    """(d) A git process whose cwd attributes to NO git dir ⇒ "uncertain" —
+    never a false "none" (the dangerous direction)."""
+    _delenv_probe_tunables(monkeypatch)
+    r = _init_repo(tmp_path / "r")
+    nonrepo = tmp_path / "plain"
+    nonrepo.mkdir()
+    proc_root = _fake_proc(tmp_path)
+    _fake_pid(proc_root, 100, "git", cwd=nonrepo)
+
+    probe = srr._probe_git_liveness(r / ".git", proc_root=proc_root)
+    assert probe.verdict == "uncertain"
+    assert "not attributable" in probe.evidence
+
+
+def test_probe_fake_proc_attribution_timeout_uncertain(tmp_path, monkeypatch):
+    """(e) A hung-mount attribution (timed-out rev-parse) ⇒ "uncertain",
+    pinned without a real hang via a monkeypatched _run_bounded."""
+    _delenv_probe_tunables(monkeypatch)
+    r = _init_repo(tmp_path / "r")
+    nonrepo = tmp_path / "plain"
+    nonrepo.mkdir()
+    proc_root = _fake_proc(tmp_path)
+    _fake_pid(proc_root, 100, "git", cwd=nonrepo)
+
+    monkeypatch.setattr(
+        srr, "_run_bounded", lambda argv, timeout_s: srr.GitResult(-9, "", "", True)
+    )
+    probe = srr._probe_git_liveness(r / ".git", proc_root=proc_root)
+    assert probe.verdict == "uncertain"
+    assert "timed out" in probe.evidence
+
+
+def test_probe_fake_proc_budget_exhaustion_uncertain(tmp_path, monkeypatch):
+    """(f) An exhausted total budget ⇒ "uncertain — scan incomplete"; a
+    truncated scan can never yield "none"."""
+    monkeypatch.delenv("EPM_ROOT_SYNC_PROBE_TIMEOUT_S", raising=False)
+    monkeypatch.setenv("EPM_ROOT_SYNC_PROBE_BUDGET_S", "0")
+    r = _init_repo(tmp_path / "r")
+    proc_root = _fake_proc(tmp_path)
+    _fake_pid(proc_root, 100, "git", cwd=r)
+
+    probe = srr._probe_git_liveness(r / ".git", proc_root=proc_root)
+    assert probe.verdict == "uncertain"
+    assert "budget" in probe.evidence
+    assert "scan incomplete" in probe.evidence


### PR DESCRIPTION
Closes task #1044 (workflow-fix, auto-filed by /daily 2026-07-04).

- Seam 1: young-husk /proc git-liveness probe — a COMPLETED zero-unattributable scan ("none") downgrades a young (>600s floor, <3600s threshold) rebase/merge husk to the existing stale handling; holder/uncertain/disabled/sub-floor keep today's exit-5. Attribution bounded via _run_bounded (5s/candidate, 30s total budget; timeout/exhaustion -> "uncertain").
- Seam 2: one bounded retry on the transient 'Cannot rebase onto multiple branches' pull race (exact stderr needle; never on timeout or with rebase state present).

Pipeline: plan v3 (6-critic ensemble + reconcilers), code-review PASS+PASS, test-verdict PASS (2575 passed / 6 skipped; baseline compare clean).