### PR TITLE
task #1046: Step 9c gate timeout sizing + background invocation + exit-code hygiene

### DIFF
--- a/.claude/rules/crash-fix-rounds.md
+++ b/.claude/rules/crash-fix-rounds.md
@@ -160,6 +160,9 @@ EXEMPT — never wrap those in `timeout`. Unlike the tool timeout, GNU
 command's CHILDREN too. Residual gap: a grandchild that `setsid`s
 escapes the group kill — step 1's probe before relaunch is the backstop.
 
+Step 9c test-verdict gate runs are BACKGROUND invocations with selector-sized
+bounds (SKILL.md 9c step 1b) — the ~510s foreground bound does NOT apply to them.
+
 ### Crash-fix rounds: scope guard (REQUIRED)
 
 A crash-fix round has EXACTLY ONE marker output posted DIRECTLY by you.

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -6398,6 +6398,13 @@ steps 4 + 6-9 are the LATE JOIN executed here):
    block the step or the park on a missing gist; the committed repo
    doc is the durable artifact and the next step links to it either
    way.
+   Keep the `[ -z "$GIST_URL" ]` capture in the if-form shown above — a
+   trailing `[ -z "$GIST_URL" ] && gist_err=...` one-liner variant makes the
+   CALL report Exit 1 on SUCCESS (URL present -> the test is false -> `&&`
+   short-circuits with rc 1; incident #928, 2026-07-04). Same exit-code
+   hygiene rule as Step 9c step 1b: never leave a bare conditional or
+   informational grep as the last command of a call — if-form it or
+   `|| true` it.
 7. **Append the link lines to the clean-result body — TWO locations.**
    Use `task.py set-body <N> --file <new-body.md>` (NO
    `--snapshot` — the previous body is already the canonical
@@ -7248,82 +7255,141 @@ suite directly and posts an `epm:test-verdict` event with the result.
       cd "$WT" || { echo "FATAL: cd to issue worktree failed" >&2; exit 1; }
       uv run python scripts/select_step9c_tests.py --base main
       ```
-      It prints the exact `uv run pytest <files> -v --tb=short` command, plus
-      stderr diagnostics: a one-line work-root + branch provenance breadcrumb
-      on every run, any `untested touched file: <path>` WARN lines, and the
+      It prints the exact gate command —
+      `timeout --kill-after=60s <T>s uv run pytest <files> -v --tb=short`,
+      `<T>` sized deterministically from the selection
+      (`recommended_timeout_s()`: 120s base + 30s/file + a 900s surcharge when
+      `tests/test_workflow_lint.py` is selected, which alone measured up to
+      771s) — plus stderr diagnostics: a one-line work-root + branch
+      provenance breadcrumb on every run, a `recommended-timeout-s=<T>`
+      sizing line, any `untested touched file: <path>` WARN lines, and the
       empty-diff NOTE described above. (A code-change task with NO worktree
       runs both from the repo root; the empty-diff NOTE is then expected and
       benign.)
-   b. Run the printed command from the SAME worktree cwd (paths are
-      repo-relative), with the junit flags appended and a pre-run `rm -f` of
-      the junit path (a killed run must leave NO junit — pytest writes it only
-      at session exit; a stale file from a prior round must never be re-read).
-      Record pass/fail + ALL selector stderr lines (the provenance breadcrumb,
-      the NOTE if any, and any WARN lines). Two anti-silent-pass guards are
-      LOAD-BEARING here — a `no tests ran` outcome (pytest exit 0 with zero
+   b. Run the printed command as a BACKGROUND Bash invocation
+      (`run_in_background=true`) from the SAME worktree cwd (paths are
+      repo-relative), with the junit flags + log/rc-file tail appended and a
+      pre-run `rm -f` of all three gate files (a killed run must leave NO
+      junit — pytest writes it only at session exit; a stale file from a
+      prior round must never be re-read). BACKGROUND IS REQUIRED, NOT
+      OPTIONAL: the selection always contains the 32-file workflow-invariant
+      set incl. `tests/test_workflow_lint.py` (median ~6.5 min alone, max
+      ~13 min; whole gate median ~11 min, max ~21 min of test time plus
+      collection overhead — 26 junit runs measured 2026-07-04/05), so the
+      gate can NEVER fit the 600s foreground Bash tool cap. The
+      crash-fix-rounds ~510s foreground `timeout` bound
+      (`.claude/rules/crash-fix-rounds.md` § Kill-before-relaunch) applies to
+      FOREGROUND smokes ONLY — wrapping this gate in any ≤600s bound is the
+      #991/#996/#906 kill class (exit 143 at 480-540s). The ONLY wedge bound
+      is the selector-printed `timeout --kill-after=60s <T>s` prefix.
+      ```bash
+      # Shell state does NOT persist across Bash calls — hard-guard the cd
+      # INSIDE this same background call (never rely on a prior call's cwd;
+      # a silent cd failure must never run the gate in the wrong dir):
+      cd "$WT" || { echo "FATAL: cd to issue worktree failed" >&2; exit 1; }
+      # earlyoom-protect the gate (#1045; FAIL-OPEN — never block the gate on a choom failure):
+      # pytest is in this VM's earlyoom --prefer regex (+300 badness), so a gate run is the
+      # designated victim under fleet memory pressure (#906 killed twice; #995 at ~42%).
+      # Self-choom the gate shell: every child forked after this line (the timeout wrapper,
+      # pytest + its subprocesses) inherits adj=-600.
+      sudo -n choom -n -600 -p $$ >/dev/null 2>&1 && GATE_CHOOM=ok \
+        || { GATE_CHOOM=failed; echo "[warn] choom failed — gate pytest is earlyoom-UNPROTECTED (choom=failed)" >&2; }
+      echo "[step9c] gate earlyoom protection choom=$GATE_CHOOM"
+      rm -f /tmp/step9c-junit-issue-<N>.xml /tmp/step9c-rc-issue-<N> \
+            /tmp/step9c-pytest-issue-<N>.log   # MANDATORY before EVERY gate pytest invocation
+      # ONE background Bash call (run_in_background=true) — the selector-printed
+      # command verbatim, with the junit + log + rc-file tail appended:
+      timeout --kill-after=60s <T>s uv run pytest <files> -v --tb=short \
+        --junitxml=/tmp/step9c-junit-issue-<N>.xml -o junit_family=xunit1 \
+        > /tmp/step9c-pytest-issue-<N>.log 2>&1; echo $? > /tmp/step9c-rc-issue-<N>
+      ```
+      When the background call completes (the harness notifies), read the
+      verdict in a fresh foreground call — the rc FILE replaces the former
+      in-shell `PYTEST_RC=$?` capture (shell variables do not survive across
+      Bash calls). A MISSING rc file means the background run died before
+      pytest exited (tool kill / watcher force-stop, #833): treat as FAIL,
+      never a silent PASS, and apply crash-fix-rounds § Kill-before-relaunch
+      (probe `pgrep -af 'pytest.*step9c-junit-issue-<N>'` — the junit path
+      makes the probe exact-invocation-scoped) before any re-run:
+      ```bash
+      if [ ! -f /tmp/step9c-rc-issue-<N> ]; then
+        echo "FATAL: gate rc file missing — the background run died before pytest exited. Kill-before-relaunch, then re-run the gate; NEVER record PASS." >&2
+      else
+        PYTEST_RC=$(cat /tmp/step9c-rc-issue-<N>)
+        tail -30 /tmp/step9c-pytest-issue-<N>.log
+        # exit 0 + "no tests ran" (or "collected 0 items") is NOT a PASS:
+        if grep -qiE 'no tests ran|collected 0 items' /tmp/step9c-pytest-issue-<N>.log; then
+          echo "FATAL: pytest collected 0 tests — test-verdict gate did NOT run. Treating as FAIL." >&2
+          # -> post epm:test-verdict v1 as FAIL; do NOT record PASS on exit 0.
+        fi
+      fi
+      ```
+      Record pass/fail + ALL selector stderr lines (the provenance
+      breadcrumb, the `recommended-timeout-s=<T>` sizing line, the NOTE if
+      any, and any WARN lines). The two anti-silent-pass guards above are
+      LOAD-BEARING — a `no tests ran` outcome (pytest exit 0 with zero
       collected tests) is a **FAIL, never a PASS**: it is the signature of a
       failed `cd` that ran pytest in a directory with no tests (incident:
       issue 745, SHA 91bed41e, 2026-06-30 — the gate reported PASS on
       `no tests ran ... pytest exit: 0` and was silently skipped).
-      ```bash
-      # The cd to "$WT" in step (a) is REQUIRED — HARD-GUARD it (as above);
-      # never let the gate run in the wrong dir on a silent cd failure:
-      #   cd "$WT" || { echo "FATAL: cd to issue worktree failed" >&2; exit 1; }
-      # earlyoom-protect the gate (#1045; FAIL-OPEN — never block the gate on a choom failure):
-      # pytest is in this VM's earlyoom --prefer regex (+300 badness), so a gate run is the
-      # designated victim under fleet memory pressure (#906 killed twice; #995 at ~42%).
-      # Self-choom the gate shell: every child forked after this line (pytest + its
-      # subprocesses, incl. compare's pristine oracle runs in this call) inherits adj=-600.
-      sudo -n choom -n -600 -p $$ >/dev/null 2>&1 && GATE_CHOOM=ok \
-        || { GATE_CHOOM=failed; echo "[warn] choom failed — gate pytest is earlyoom-UNPROTECTED (choom=failed)" >&2; }
-      echo "[step9c] gate earlyoom protection choom=$GATE_CHOOM"
-      rm -f /tmp/step9c-junit-issue-<N>.xml    # MANDATORY before EVERY gate pytest invocation
-      PYTEST_OUT=$(uv run pytest <files> -v --tb=short \
-        --junitxml=/tmp/step9c-junit-issue-<N>.xml -o junit_family=xunit1 2>&1); PYTEST_RC=$?
-      echo "$PYTEST_OUT"
-      # exit 0 + "no tests ran" (or "collected 0 items") is NOT a PASS:
-      if echo "$PYTEST_OUT" | grep -qiE 'no tests ran|collected 0 items'; then
-        echo "FATAL: pytest collected 0 tests — test-verdict gate did NOT run. Treating as FAIL." >&2
-        # -> post epm:test-verdict v1 as FAIL; do NOT record PASS on exit 0.
-      fi
-      ```
+
+      **Recipe exit-code hygiene (every gate call — and every improvised
+      monitoring one-liner):** the Bash tool reports the exit code of the
+      LAST command in the call, and an `Exit 1` from a trailing INFORMATIONAL
+      command is indistinguishable in the transcript from a gate failure. Any
+      trailing command that legitimately returns non-zero without meaning
+      failure — a display/filter `grep` that may match nothing (#969: a
+      healthy gate read as a false Exit 1), a bare `[ -z "$VAR" ]` /
+      `[ -s <file> ]` test (#928: a trailing `[ -z "$GIST_URL" ] && ...`
+      variant reported Exit 1 on success), a `tail`/`cat` on a possibly-
+      absent file — MUST be if-formed (`if grep -q ...; then ...; fi`) or
+      given an explicit `|| true`. The verdict-bearing rcs are NEVER the raw
+      call exit code: PYTEST_RC lives in `/tmp/step9c-rc-issue-<N>` and
+      COMPARE_RC in its captured variable — read those, not the tool's Exit
+      line.
    c. Scope override: if the plan-body frontmatter has `test_scope: full` OR a
       `## Test scope` H2 names `full`, run the FULL suite instead — from the
-      SAME issue-worktree cwd — as:
+      SAME issue-worktree cwd, in the SAME background + rc-file pattern as 1b
+      (a 60m run is 6x the foreground tool cap):
       ```bash
+      cd "$WT" || { echo "FATAL: cd to issue worktree failed" >&2; exit 1; }
       # earlyoom-protect the gate (#1045; fail-open — see the 1b preamble): self-choom, children inherit.
       sudo -n choom -n -600 -p $$ >/dev/null 2>&1 && GATE_CHOOM=ok \
         || { GATE_CHOOM=failed; echo "[warn] choom failed — gate pytest is earlyoom-UNPROTECTED (choom=failed)" >&2; }
       echo "[step9c] gate earlyoom protection choom=$GATE_CHOOM"
-      rm -f /tmp/step9c-junit-issue-<N>.xml
-      PYTEST_OUT=$(timeout 60m uv run pytest tests/ -q \
-        --junitxml=/tmp/step9c-junit-issue-<N>.xml -o junit_family=xunit1 2>&1); PYTEST_RC=$?
-      echo "$PYTEST_OUT"
+      rm -f /tmp/step9c-junit-issue-<N>.xml /tmp/step9c-rc-issue-<N> \
+            /tmp/step9c-pytest-issue-<N>.log
+      # ONE background Bash call (run_in_background=true):
+      timeout --kill-after=60s 60m uv run pytest tests/ -q \
+        --junitxml=/tmp/step9c-junit-issue-<N>.xml -o junit_family=xunit1 \
+        > /tmp/step9c-pytest-issue-<N>.log 2>&1; echo $? > /tmp/step9c-rc-issue-<N>
       ```
       (NO `-x` / `--maxfail` — with the step-1d compare deciding the verdict,
       an early-exit on the first known-red main failure would leave the rest
       of the suite unexecuted and let compare PASS a truncated run; the 60m
-      timeout still bounds it.) `PYTEST_RC=$?` is captured IMMEDIATELY after
-      whichever pytest invocation ran (the 1b touched scope, or this override)
-      — step 1d's compare consumes `--pytest-rc "$PYTEST_RC"`, and an unset or
-      stale selected-scope rc would break its rc-not-in-{0,1} -> indeterminate
-      guard on an interrupted / internal-error full run. On timeout/kill
-      (`timeout`'s rc 124 lands in PYTEST_RC, so compare exits 2), capture
-      `tail -50` of `$PYTEST_OUT` so the stall surfaces actionable evidence
-      (the #665/#736 regression — keep it visible, never a silent kill).
-      Default scope is `touched`.
+      timeout still bounds it.) The rc file is written by the SAME background
+      command immediately after pytest exits (1b touched scope and this
+      override alike) — step 1d's compare consumes
+      `--pytest-rc "$PYTEST_RC"` with `PYTEST_RC=$(cat /tmp/step9c-rc-issue-<N>)`
+      from 1b's completion read; a missing rc file takes 1b's FAIL path (an
+      unset or stale rc would break compare's rc-not-in-{0,1} ->
+      indeterminate guard). On timeout/kill (`timeout`'s rc 124 lands in the
+      rc file, so compare exits 2), capture
+      `tail -50 /tmp/step9c-pytest-issue-<N>.log` so the stall surfaces
+      actionable evidence (the #665/#736 regression — keep it visible, never
+      a silent kill). Default scope is `touched`.
 
       **Gate earlyoom protection (#1045).** The self-choom preamble in the
-      1b/1c blocks is the foreground sibling of § "Detached VM-side long
+      1b/1c blocks is the same-call sibling of § "Detached VM-side long
       compute phases": `oom_score_adj` inherits across fork/exec
       (probe-verified), so choom-ing the gate shell BEFORE pytest launches
-      protects the whole gate tree with zero change to the
-      `PYTEST_OUT`/`PYTEST_RC`/junitxml contract — no backgrounding, no
-      session games. Because 1b→1d must run in ONE Bash call anyway
-      (`PYTEST_RC` is a shell variable compare consumes, and shell state does
-      not persist across calls), the −600 also covers step 1d compare's
-      pristine single-file oracle runs by inheritance; a compare run in a
-      separate call is short/bounded and accepted unprotected. FAIL-OPEN: a
+      protects the whole gate tree — the `timeout` wrapper, pytest, and its
+      subprocesses inside the background call — with zero change to the
+      rc-file/junitxml contract (#1046: the gate is a background invocation;
+      `PYTEST_RC` travels via `/tmp/step9c-rc-issue-<N>`, not shell state).
+      Step 1d compare — including its pristine single-file oracle runs —
+      executes in a separate, short/bounded foreground call and is accepted
+      unprotected. FAIL-OPEN: a
       choom failure warns, records `choom=failed`, and the gate proceeds
       unprotected — a gate is NEVER blocked by a choom failure, and
       `choom=ok` re-orders earlyoom's victim selection (−600, not −1000: the
@@ -7391,7 +7457,8 @@ suite directly and posts an `epm:test-verdict` event with the result.
 4. Coverage gap report (flags, does not auto-generate)
 
 The `epm:test-verdict v1` marker note records: scope used (`touched`/`full`),
-the files run, pass/fail counts, and ALL selector stderr diagnostics — the
+the files run, the gate timeout bound used (the selector's
+recommended-timeout-s), pass/fail counts, and ALL selector stderr diagnostics — the
 work-root + branch provenance breadcrumb, any `NOTE — empty diff` line, and
 any untested-touched-file WARNs (so the orchestrator surfaces wrong-cwd runs
 and coverage gaps — never silently skipped), and the compare classification

--- a/scripts/select_step9c_tests.py
+++ b/scripts/select_step9c_tests.py
@@ -57,14 +57,22 @@ Usage::
 
     uv run python scripts/select_step9c_tests.py [--base main] [--repo-root <path>] [--json]
 
-Default output: the exact pytest invocation
-``uv run pytest <files...> -v --tb=short`` on stdout, then any
+Default output: the exact gate invocation
+``timeout --kill-after=60s <T>s uv run pytest <files...> -v --tb=short`` on
+stdout — ``<T>`` sized deterministically by :func:`recommended_timeout_s`
+(#1046: 120s base + 30s/file + a 900s surcharge when
+``tests/test_workflow_lint.py`` is selected; measured from 27 real gate junits
+2026-07-04/05, workflow-lint present in 26 of them) — then any
 ``untested touched file: <path>`` WARN lines on stderr. Every run also prints
 a one-line provenance breadcrumb to stderr (the resolved work root + current
 branch) so the Step 9c marker records which checkout the subset was selected
-against. ``--json`` emits
+against, plus a machine-greppable ``recommended-timeout-s=<T>`` sizing line
+(the gate exceeds the 600s foreground Bash tool cap, so Step 9c runs it as a
+BACKGROUND invocation — SKILL.md 9c step 1b). ``--json`` emits
 ``{"tests": [...], "untested_touched": [...], "base": "...",
-"missing_invariants": [...], "selection_reasons": {test: [reasons]}}`` (a
+"missing_invariants": [...], "selection_reasons": {test: [reasons]},
+"n_tests": <int>, "recommended_timeout_s": <int>,
+"slow_tests_selected": [...]}`` (a
 reason is ``invariant`` / ``touched-test`` / ``stem-map:<touched file>`` /
 ``glob-scan:<touched file>`` — #1022). Exit 0 on success (even with WARN lines);
 exit 1 if an underlying ``git`` call fails irrecoverably (work-root resolution
@@ -188,6 +196,42 @@ GLOB_SCAN_TESTS: dict[str, tuple[str, ...]] = {
         "src/explore_persona_space/experiments/*/__main__.py",
     ),
 }
+
+# --- Gate-timeout sizing (#1046). --------------------------------------------
+# Measured from 27 Step 9c gate junits on the shared VM (2026-07-04..05,
+# /tmp/step9c-junit-issue-*.xml, per-testcase `time` summed per file;
+# test_workflow_lint.py present in 26 of them):
+# tests/test_workflow_lint.py alone min 319 s / median 390 s / max 771 s;
+# whole-gate totals median ~662 s / max 1285 s on 32-46-file selections. The
+# foreground Bash tool cap is 600 s, so the printed command carries this bound
+# and Step 9c runs the gate as a BACKGROUND invocation (SKILL.md 9c step 1b).
+# Constants are deliberately generous (~1.4-2x over worst measured): an
+# oversized bound only ever fires on a genuine wedge; an undersized one kills
+# healthy gates (#991/#996/#906, exit 143 at 480-540 s foreground bounds).
+TIMEOUT_BASE_S = 120  # pytest startup + collection (~2500 tests) + imports
+TIMEOUT_PER_FILE_S = 30  # ~2x the p90 per-file runtime of non-slow files
+TIMEOUT_FLOOR_S = 900
+# Per-file surcharges for files whose OWN max exceeds the per-file allocation
+# by an order of magnitude. Pinned literal (same curation rule as
+# WORKFLOW_INVARIANT); live-tree drift pin in tests/test_select_step9c_tests.py.
+SLOW_TESTS: dict[str, int] = {
+    # 3845 lines; runs whole-tree lints repeatedly. Max 771 s measured (n=26).
+    "tests/test_workflow_lint.py": 900,
+}
+
+
+def recommended_timeout_s(tests: list[str]) -> int:
+    """Deterministic `timeout(1)` bound for a Step 9c gate selection.
+
+    ``BASE + PER_FILE * len(tests) + sum(slow surcharges)``, floored at
+    ``TIMEOUT_FLOOR_S``. Invariant-only selection (32 files incl. the
+    workflow-lint surcharge) -> 1980 s (~33 min), consistent with the existing
+    invariant-set-scale precedents (``step9c_baseline.py refresh``
+    ``--timeout-s`` default 1800 s; the SKILL.md detached refresh's 2100 s).
+    """
+    t = TIMEOUT_BASE_S + TIMEOUT_PER_FILE_S * len(tests)
+    t += sum(SLOW_TESTS.get(x, 0) for x in tests)
+    return max(t, TIMEOUT_FLOOR_S)
 
 
 def _matches_any(path: str, globs: tuple[str, ...]) -> bool:
@@ -441,6 +485,17 @@ def main(argv: list[str] | None = None) -> int:
     for t in missing:
         print(f"WORKFLOW-INVARIANT MISSING: {t}", file=sys.stderr)
 
+    # Gate-timeout sizing (#1046): a machine-greppable stderr line on every
+    # run, the bound riding in the printed command, and the same number in the
+    # --json fields — see the module docstring + recommended_timeout_s().
+    timeout_s = recommended_timeout_s(tests)
+    print(
+        f"select_step9c_tests: {len(tests)} test files; recommended-timeout-s={timeout_s} "
+        "(the gate exceeds the 600s foreground Bash tool cap — run it as a background "
+        "invocation per Step 9c step 1b)",
+        file=sys.stderr,
+    )
+
     if args.json:
         print(
             json.dumps(
@@ -450,11 +505,18 @@ def main(argv: list[str] | None = None) -> int:
                     "base": args.base,
                     "missing_invariants": missing,
                     "selection_reasons": reasons,
+                    "n_tests": len(tests),
+                    "recommended_timeout_s": timeout_s,
+                    "slow_tests_selected": [t for t in tests if t in SLOW_TESTS],
                 }
             )
         )
     else:
-        print("uv run pytest " + " ".join(tests) + " -v --tb=short")
+        print(
+            f"timeout --kill-after=60s {timeout_s}s uv run pytest "
+            + " ".join(tests)
+            + " -v --tb=short"
+        )
         for f in untested:
             print(f"untested touched file: {f}", file=sys.stderr)
 

--- a/tests/test_ensemble_review_cap.py
+++ b/tests/test_ensemble_review_cap.py
@@ -181,25 +181,53 @@ def test_code_review_flow_diagram_and_exit_kind_updated():
 # #1022 Step 9c shell dataflow: PYTEST_RC captured before compare consumes it
 # --------------------------------------------------------------------------- #
 def test_step9c_pytest_rc_captured_before_compare():
-    """Both Step 9c pytest blocks (1b touched scope + 1c full-scope override)
-    assign `PYTEST_RC=$?` immediately after the command substitution, and both
-    captures precede the step-1d `--pytest-rc "$PYTEST_RC"` compare consumer.
-    The `{0,300}` bound keeps each match inside its OWN code block, so a
-    capture-less touched block can never borrow the full block's capture."""
+    """Both Step 9c gate pytest blocks (1b touched scope + 1c full-scope
+    override) write the pytest rc to `/tmp/step9c-rc-issue-<N>` on the SAME
+    background-invocation command tail (`pytest ...; echo $? > rc-file`), the
+    completion read (`PYTEST_RC=$(cat ...)`) precedes the step-1d
+    `--pytest-rc "$PYTEST_RC"` compare consumer (the #1022 dataflow invariant,
+    re-pinned in the #1046 background + rc-file form), and the anti-silent-pass
+    guards are present (#1046 AC7): the three-file `rm -f` preamble before BOTH
+    invocations, the missing-rc FAIL guard, and the zero-collected FAIL guard.
+    The bounded spans are FENCE-SAFE — they exclude backticks, so a match can
+    never cross a code-fence boundary into a neighboring block: the rc write
+    must sit on the same command tail as its pytest invocation."""
     skill = SKILL_PATH.read_text()
     sec = skill[skill.index("9c. Test-verdict gate") : skill.index("### Step 10: Auto-complete")]
     touched = re.search(
-        r"PYTEST_OUT=\$\(uv run pytest <files>[\s\S]{0,300}?2>&1\); PYTEST_RC=\$\?", sec
-    )
-    assert touched, "1b touched-scope block must capture PYTEST_RC=$? on its pytest line"
-    full = re.search(
-        r"PYTEST_OUT=\$\(timeout 60m uv run pytest tests/[\s\S]{0,300}?2>&1\); PYTEST_RC=\$\?",
+        r"timeout --kill-after=60s <T>s uv run pytest <files>[^\x60]{0,300}?"
+        r"echo \$\? > /tmp/step9c-rc-issue-<N>",
         sec,
     )
-    assert full, "1c full-scope block must capture PYTEST_RC=$? on its pytest line"
-    compare_idx = sec.index('--pytest-rc "$PYTEST_RC"')
-    assert touched.end() < compare_idx, "touched-scope capture must precede the compare consumer"
-    assert full.end() < compare_idx, "full-scope capture must precede the compare consumer"
+    assert touched, "1b block must write the pytest rc to the rc file on its invocation tail"
+    full = re.search(
+        r"timeout --kill-after=60s 60m uv run pytest tests/[^\x60]{0,300}?"
+        r"echo \$\? > /tmp/step9c-rc-issue-<N>",
+        sec,
+    )
+    assert full, "1c full-scope block must write the pytest rc to the rc file"
+    read_idx = sec.index("PYTEST_RC=$(cat /tmp/step9c-rc-issue-<N>)")
+    # Anchor the compare-consumer index PAST any prose mention of the flag —
+    # use the LAST occurrence (the 1d compare snippet), not the first (a
+    # prose mention would first-match and weaken the ordering pin):
+    compare_idx = sec.rindex('--pytest-rc "$PYTEST_RC"')
+    assert touched.end() < compare_idx, "touched-scope rc write must precede the compare consumer"
+    assert full.end() < compare_idx, "full-scope rc write must precede the compare consumer"
+    assert read_idx < compare_idx, "the rc-file read must precede the compare consumer"
+    # (a) AC7: the three-file rm -f preamble precedes BOTH gate invocations.
+    rm_pat = (
+        r"rm -f /tmp/step9c-junit-issue-<N>\.xml /tmp/step9c-rc-issue-<N> \\\n"
+        r"\s*/tmp/step9c-pytest-issue-<N>\.log"
+    )
+    rm_hits = [m.start() for m in re.finditer(rm_pat, sec)]
+    assert len(rm_hits) >= 2, "both 1b and 1c blocks must carry the three-file rm -f preamble"
+    assert rm_hits[0] < touched.start() and rm_hits[1] < full.start(), (
+        "each rm -f preamble must precede its gate invocation"
+    )
+    # (b) AC7: the completion read carries the missing-rc FAIL guard + the
+    # zero-collected FAIL guard.
+    assert "[ ! -f /tmp/step9c-rc-issue-<N> ]" in sec, "missing-rc FAIL guard must be pinned"
+    assert "no tests ran|collected 0 items" in sec, "zero-collected FAIL guard must be pinned"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_select_step9c_tests.py
+++ b/tests/test_select_step9c_tests.py
@@ -196,11 +196,18 @@ def test_json_output_shape(tmp_path: Path, monkeypatch, capsys):
         "base",
         "missing_invariants",
         "selection_reasons",
+        "n_tests",
+        "recommended_timeout_s",
+        "slow_tests_selected",
     }
     assert "tests/test_widget.py" in out["tests"]
     assert out["base"] == "main"
     assert out["missing_invariants"] == []  # all invariants present in the fixture tree
     assert out["selection_reasons"]["tests/test_widget.py"] == ["stem-map:scripts/widget.py"]
+    # #1046 sizing fields are derived from the SAME selection the command runs:
+    assert out["n_tests"] == len(out["tests"])
+    assert out["recommended_timeout_s"] == sel.recommended_timeout_s(out["tests"])
+    assert out["slow_tests_selected"] == [t for t in out["tests"] if t in sel.SLOW_TESTS]
 
 
 # --- Case 10b (#1022): select_tests_with_reasons — reasons content ------------
@@ -371,10 +378,16 @@ def test_empty_diff_note_at_main_checkout_real_git(tmp_path: Path, monkeypatch, 
     # Provenance breadcrumb names the main checkout + branch:
     assert f"work root {repo.resolve()}" in captured.err
     assert "(branch: main)" in captured.err
-    # Printed command is exactly the invariant-only set (sorted):
+    # Printed command is exactly the invariant-only set (sorted), behind the
+    # #1046 sized-timeout prefix (tuple-derived — never hardcode 1980, so the
+    # pin survives a WORKFLOW_INVARIANT count change):
     line = captured.out.strip().splitlines()[-1]
-    assert line.startswith("uv run pytest ") and line.endswith(" -v --tb=short")
-    files = line.removeprefix("uv run pytest ").removesuffix(" -v --tb=short").split()
+    prefix = (
+        "timeout --kill-after=60s "
+        f"{sel.recommended_timeout_s(sorted(sel.WORKFLOW_INVARIANT))}s uv run pytest "
+    )
+    assert line.startswith(prefix) and line.endswith(" -v --tb=short")
+    files = line.removeprefix(prefix).removesuffix(" -v --tb=short").split()
     assert files == sorted(sel.WORKFLOW_INVARIANT)
 
 
@@ -474,3 +487,46 @@ def test_glob_scan_map_matches_live_tree():
                 f"{test_file} no longer scans {g!r} — GLOB_SCAN_TESTS drifted "
                 "from the scanner's source; update the map verbatim."
             )
+
+
+# --- Case 21 (#1046): recommended gate timeout — formula ----------------------
+def test_recommended_timeout_formula():
+    """T = BASE + PER_FILE*n + slow surcharges, floored at TIMEOUT_FLOOR_S."""
+    no_slow = [f"tests/test_x{i}.py" for i in range(40)]
+    assert sel.recommended_timeout_s(no_slow) == sel.TIMEOUT_BASE_S + 40 * sel.TIMEOUT_PER_FILE_S
+    with_wl = [*no_slow, "tests/test_workflow_lint.py"]
+    assert sel.recommended_timeout_s(with_wl) == (
+        sel.TIMEOUT_BASE_S
+        + 41 * sel.TIMEOUT_PER_FILE_S
+        + sel.SLOW_TESTS["tests/test_workflow_lint.py"]
+    )
+    assert sel.recommended_timeout_s([]) == sel.TIMEOUT_FLOOR_S  # floor binds
+
+
+# --- Case 22 (#1046): SLOW_TESTS live-tree drift pin ---------------------------
+def test_slow_tests_pinned_to_live_tree():
+    """Every SLOW_TESTS key exists in the real repo tests/ tree (drift pin,
+    same curation rule as WORKFLOW_INVARIANT / GLOB_SCAN_TESTS)."""
+    root = Path(sel.__file__).resolve().parents[1]
+    missing = [t for t in sel.SLOW_TESTS if not (root / t).exists()]
+    assert missing == [], (
+        f"SLOW_TESTS entries missing from the live tests/ tree: {missing}. "
+        "Update the literal in scripts/select_step9c_tests.py deliberately."
+    )
+
+
+# --- Case 23 (#1046): stdout carries the sized timeout prefix + stderr line ---
+def test_stdout_command_carries_sized_timeout(tmp_path: Path, monkeypatch, capsys):
+    """The printed command starts with the sized `timeout --kill-after=60s <T>s`
+    prefix, and stderr carries the machine-greppable recommended-timeout-s
+    sizing line (both derived from the invariant-only selection)."""
+    repo = _make_tree(tmp_path, [])
+    monkeypatch.setattr(sel, "_resolve_work_root", lambda _arg: repo)
+    monkeypatch.setattr(sel, "compute_touched", lambda *_a, **_k: [])
+    rc = sel.main([])
+    assert rc == 0
+    captured = capsys.readouterr()
+    t = sel.recommended_timeout_s(sorted(sel.WORKFLOW_INVARIANT))
+    line = captured.out.strip().splitlines()[-1]
+    assert line.startswith(f"timeout --kill-after=60s {t}s uv run pytest ")
+    assert f"recommended-timeout-s={t}" in captured.err


### PR DESCRIPTION
Closes task #1046 (kind: infra, workflow-fix, wf-fix tag).

- scripts/select_step9c_tests.py: recommended_timeout_s() (120 base + 30/file + 900 workflow-lint surcharge, floor 900); sized timeout prefix on the printed gate command; recommended-timeout-s stderr line; 3 new --json keys.
- SKILL.md Step 9c 1b/1c: background + rc-file invocation form (gate cannot fit the 600s foreground Bash cap — measured median ~11 min); rm -f preamble, missing-rc + zero-tests FAIL guards; Recipe exit-code hygiene paragraph (#969/#928); 9a-quater trailing-conditional warning; #1045 choom lines preserved.
- crash-fix-rounds.md: 2-line carve-out (9c gates are background; ~510s foreground bound does not apply).
- Tests: AC7 guard-presence pins (mutation-verified), selector formula/prefix/JSON cases.

Plan v3 approved (auto, 0 GPU-h); code-review ensemble PASS (reconciler binding); Step 9c gate PASS on the new recipe itself (2569 passed / 6 skipped, 605s wall > the old 600s cap — self-validating).