### PR TITLE
task #1070: pid-file launch contract (rewrite on every relaunch)

### DIFF
--- a/.claude/agents/experimenter.md
+++ b/.claude/agents/experimenter.md
@@ -825,10 +825,14 @@ authoritative recipe is agent memory
    (re)launch:
    - Overwrite (not append) the pidfile: the launcher's
      `echo $$ > /workspace/logs/issue-<N>.pid` already truncates, so
-     re-running the launcher is sufficient. If you must relaunch without
-     re-running the launcher (rare), explicitly
-     `echo <CHILD_PID> > /workspace/logs/issue-<N>.pid` on the pod
-     before posting the marker.
+     re-running the launcher is sufficient (the launcher-internal
+     `echo $$ >` pre-exec write is the accepted carve-out of the
+     generic contract). If you must relaunch without re-running the
+     launcher (rare), rewrite ATOMICALLY on the pod before posting
+     the marker:
+     `printf '%s\n' "<CHILD_PID>" > /workspace/logs/issue-<N>.pid.tmp && mv /workspace/logs/issue-<N>.pid.tmp /workspace/logs/issue-<N>.pid`
+     (tmp+rename — no window where the poller reads a truncated/empty
+     file).
    - The `epm:run-launched` marker MUST carry BOTH `pid=<live child>`
      AND `pid_file=/workspace/logs/issue-<N>.pid`. Omitting `pid_file=`
      on a re-launch (as happened in #451) breaks the poller's probe.
@@ -898,19 +902,25 @@ authoritative recipe is agent memory
        command="cat /workspace/logs/issue-<N>.pid")`
      must echo the same number you post in `pid=`. If it shows a
      different (stale) PID, the launcher did not run its pidfile write —
-     overwrite it (`echo <CHILD_PID> > /workspace/logs/issue-<N>.pid`)
-     before posting. (poll_pipeline.py now also self-corrects by
+     rewrite it ATOMICALLY on the pod
+     (`printf '%s\n' "<CHILD_PID>" > /workspace/logs/issue-<N>.pid.tmp && mv /workspace/logs/issue-<N>.pid.tmp /workspace/logs/issue-<N>.pid`
+     — this is a launcher-less correction, so the tmp+rename form of
+     the § Pid-file launch contract applies, not the launcher-internal
+     `echo $$ >` carve-out) before posting. (poll_pipeline.py now also
+     self-corrects by
      cross-checking the marker `pid=`, but the pidfile is the primary
      probe; keep it correct.)
    - **Write the pidfile ON THE POD — never on the local VM.**
      `poll_pipeline.py` evaluates `[ -f <pid_file> ]` inside its remote
      SSH heredoc, so the path you post as `pid_file=` must exist
      pod-side; write it in the launch itself (the step-1 launcher's
-     `echo $$ > /workspace/logs/issue-<N>.pid`, or for a rare
-     launcher-less relaunch `setsid nohup ... < /dev/null & echo $! >
-     /workspace/logs/issue-<N>.pid` in the same SSH command — even the
-     launcher-less shape keeps the full detachment trio: `setsid` +
-     `nohup` + stdin from `/dev/null`, never bare `nohup ... &`). A pidfile
+     `echo $$ > /workspace/logs/issue-<N>.pid` — the launcher-internal
+     pre-exec carve-out — or for a rare launcher-less relaunch
+     `setsid nohup ... < /dev/null & printf '%s\n' "$!" > /workspace/logs/issue-<N>.pid.tmp && mv /workspace/logs/issue-<N>.pid.tmp /workspace/logs/issue-<N>.pid`
+     in the same SSH command (atomic tmp+rename per the § Pid-file
+     launch contract) — even the launcher-less shape keeps the full
+     detachment trio: `setsid` + `nohup` + stdin from `/dev/null`,
+     never bare `nohup ... &`). A pidfile
      written only on the local VM silently reads `PID_ALIVE=0` every
      tick and the poller falls back to the pid from the latest
      `epm:run-launched` marker — if that pid is stale, a healthy run is

--- a/.claude/agents/experimenter.md
+++ b/.claude/agents/experimenter.md
@@ -844,6 +844,11 @@ authoritative recipe is agent memory
      prior the GPU probe cannot see. A PID surviving SIGKILL: report,
      never relaunch over it.
 
+   (The generic contract binding ALL launcher authors — including
+   orchestrator / watch-session relaunches outside this agent — is
+   `.claude/rules/pod-side-reporting.md` § Pid-file launch contract;
+   this section is the agent-specific recipe.)
+
 2. **Confirm the launch survived disconnect — the probe MUST be a
    SEPARATE SSH invocation, issued AFTER the launching session has
    closed.** Never bundle the survival probe into the same SSH command

--- a/.claude/rules/LESSONS.md
+++ b/.claude/rules/LESSONS.md
@@ -35,7 +35,7 @@ update this index (lint: `--check-lessons-index`).
 - **[plan-compute-sizing](plan-compute-sizing.md)** — fires when: a plan sizes §9 compute (HBM capture, merge disk, sentinel lanes, store/IO, VM-CPU RAM/RSS routing, wall-time floors/costing, p90 fence sizing).
 - **[planner-section-reference](planner-section-reference.md)** — fires when: the planner writes a plan section (pointer-loaded from planner.md).
 - **[pod-config](pod-config.md)** — fires when: pod SSH/MCP keeps failing or you touch the pod scripts/pods.conf (live-API vs pods.conf authority split).
-- **[pod-side-reporting](pod-side-reporting.md)** — fires when: writing pod-side dispatcher / sentinel / poll_pipeline.py-facing code.
+- **[pod-side-reporting](pod-side-reporting.md)** — fires when: writing pod-side dispatcher / sentinel / poll_pipeline.py-facing code, or (re)launching ANY detached pod/VM workload (pid-file rewrite contract, #813).
 - **[replication-fidelity](replication-fidelity.md)** — fires when: the Goal is to replicate a published finding (match the paper's data + recipe FIRST; change only the one tested variable).
 - **[research-project-structure](research-project-structure.md)** — fires when: you write result artifacts / the results index / the queue (one source of truth per layer).
 - **[selection-symmetric-nulls](selection-symmetric-nulls.md)** — fires when: a headline max/argmax/best-of/top-k over a free axis vs a null band (inherit selection per draw or freeze held-out; band vs DV ceiling; #778/#810).

--- a/.claude/rules/crash-fix-rounds.md
+++ b/.claude/rules/crash-fix-rounds.md
@@ -147,6 +147,13 @@ load-186 VM overload).
    by explicit PID. Weaker than step 1 (a writer that opens-writes-closes
    is invisible between writes) — prefer the cmdline probe when possible.
 
+**After the kill, the relaunch itself must rewrite the pid file** with
+the new live pid in the same command chain, then confirm it before
+posting the fresh marker (`.claude/rules/pod-side-reporting.md`
+§ Pid-file launch contract — #813 v5: a relaunch that left the
+predecessor's pid in `/workspace/logs/issue-<N>.pid` cost a corrective
+extra round).
+
 **Bound every FOREGROUND/SYNCHRONOUS smoke or local invocation with
 `timeout(1)` as the DIRECT parent:** `timeout --kill-after=30s <N>s uv
 run python ...`, sized so `<N> + 30` ends ≥ 60 s BEFORE the Bash tool

--- a/.claude/rules/pod-side-reporting.md
+++ b/.claude/rules/pod-side-reporting.md
@@ -1,5 +1,5 @@
 ---
-description: Pod-side dispatcher result-reporting contract (sentinel files, poll_pipeline.py drain, epm:results payload) + legacy pod-side preflight gates; relocated verbatim from experiment-implementer.md, #829
+description: Pod-side dispatcher result-reporting contract (sentinel files, poll_pipeline.py drain, epm:results payload) + pid-file launch contract (rewrite on EVERY (re)launch, #813) + legacy pod-side preflight gates; relocated verbatim from experiment-implementer.md, #829
 paths:
   - "scripts/*dispatch*"
   - "scripts/poll_pipeline.py"
@@ -131,6 +131,54 @@ mismatch, recovered only after the orchestrator manually superseded the
 row). Producer-side: every dispatcher that writes per-cell WandB runs
 emits `wandb_entity` in the same card it emits `wandb_project` +
 `wandb_run_names`.
+
+### Pid-file launch contract — rewrite on EVERY (re)launch (#813, #451, #521)
+
+The pid file (`/workspace/logs/issue-<N>.pid` pod-side; the VM analogue for a
+detached VM-side stage is the `pid=` field of its stage-dispatch breadcrumb,
+SKILL.md § Detached VM-side long compute phases) is the poller's PRIMARY
+liveness probe. This contract binds EVERY agent that launches OR relaunches a
+detached workload — the experimenter, an orchestrator's crash-fix / hot-fix
+relaunch, a watch-session correction — not just first launches:
+
+1. **Every (re)launch ends with the pid file holding the NEW live workload
+   pid, written in the SAME command chain as the launch itself.** Preferred
+   path: relaunch through the launcher script, whose
+   `echo $$ > /workspace/logs/issue-<N>.pid` overwrites the file before
+   `exec`ing the workload (`.claude/agents/experimenter.md` § During
+   Execution steps 1/1b — the agent-specific recipe). When relaunching
+   WITHOUT the launcher (rare), chain an explicit ATOMIC rewrite into the
+   same command:
+   `printf '%s\n' "$CHILD_PID" > /workspace/logs/issue-<N>.pid.tmp && mv /workspace/logs/issue-<N>.pid.tmp /workspace/logs/issue-<N>.pid`
+   (tmp+rename — no window where the poller reads a truncated/empty file;
+   the launcher-internal `echo $$ >` truncate-write is the accepted
+   in-launcher form because it is a single short write completing before
+   the workload starts). Then CONFIRM before posting: `cat` the pid file in
+   a fresh SSH call and check it equals the pid you post in the marker. A
+   relaunch that leaves a predecessor's pid in the file is a
+   launch-contract violation.
+2. **The fresh `epm:run-launched` carries the SAME live pid (`pid=`) AND
+   `pid_file=`** (SKILL.md § "Any relaunch must re-post `epm:run-launched`").
+   `poll_pipeline.py` computes `pid_alive = pidfile_pid_alive OR
+   marker_pid_alive` (poll_once, ~line 4199), so a stale pid FILE is rescued
+   only while the newest marker's `pid=` is itself the live process. A
+   PRESENT-but-stale pid file is worse than a missing one: the
+   `pid_file_missing` fallback + WARN (~4205-4212) fires ONLY when the file
+   is absent — a stale file silently probes a dead pid every tick, with no
+   warning.
+3. **Worked example (incident #813 v5, 2026-07-02).** The run-4 relaunch
+   (00:31, `bash scripts/issue813_dispatch.sh`) skipped the pid-file
+   rewrite, leaving run-2's dead pid 6267 in `/workspace/logs/issue-813.pid`;
+   the marker pid it posted (11634) did not match the run-5 note's live
+   dispatcher (11636), so both probes read dead against a healthy run — a
+   false dead verdict. A corrective run-5 marker (00:39) was needed SOLELY
+   to rewrite the pid file with 11636 and re-post `epm:run-launched` — an
+   entire extra round whose only content was this contract.
+
+Residual honesty: this contract is prose, not a runtime detector — a future
+relaunch that violates it can still produce the same silent false-dead shape;
+the poller's marker-pid OR-probe remains the only mechanical rescue, and only
+while the newest marker's pid is itself alive.
 
 ### Pod-side preflight gates (behind-origin/main false positive — LEGACY post-#554)
 

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -3780,6 +3780,12 @@ with the new `pid=` (and `log_abs=`) before the next tick — the poller's
 marker-pid fallback (`_marker_pid`) reads ONLY `epm:run-launched`
 markers, so an `epm:progress` note recording the new pid is invisible to
 it and the stale pid yields a false `status=dead` on a healthy run.
+The same relaunch MUST also rewrite the pod-side pid file with the new
+live pid in the same command chain — a present-but-stale pid file
+silently probes a dead pid every tick and is rescued only while the
+marker pid is itself alive (full contract + atomic recipe:
+`.claude/rules/pod-side-reporting.md` § Pid-file launch contract;
+incident #813 v5).
 (Incident: task #521, 2026-06-10 — a VM-side pid file plus an
 `epm:progress`-only relaunch produced `status=dead, pid_alive=False`
 while the pod run was healthy.) On the GCP lane the marker's `pod=`


### PR DESCRIPTION
Closes task #1070. Workflow-fix: launchers atomically refresh the pid file on every relaunch (stale-pid poll target, incident #813 v5).