### PR TITLE
issue-1051: tick_triage liveness probe before STALE-REDRIVE

### DIFF
--- a/.claude/skills/issue-tick/SKILL.md
+++ b/.claude/skills/issue-tick/SKILL.md
@@ -6,7 +6,10 @@ description: >
   armed at Step 0 of the full `/issue` skill (with a defense-in-depth
   re-arm at Step 6d.2). FIRST action on every fire is ONE Bash call to
   `scripts/tick_triage.py <N>` (pure Python: reads status + latest marker,
-  computes staleness, maintains the tick snapshot + runaway counter) and
+  computes staleness, screens detached-phase liveness before any
+  STALE-REDRIVE — a live identity-verified breadcrumb `pid=`, a fresh
+  `log=` mtime, or a fresh `[long-phase-heartbeat]` note reads HEALTHY,
+  #1051 — and maintains the tick snapshot + runaway counter) and
   branches on its one-word verdict: HEALTHY → end the turn immediately;
   TERMINAL → CRON-TEARDOWN, end; GATE-TRANSITION → PushNotification +
   CRON-TEARDOWN, end; STALE-REDRIVE → re-drive the full `/issue` skill
@@ -151,7 +154,10 @@ cosmetic and accepted.
 ## STALE-REDRIVE recovery branch
 
 `tick_triage.py` returns `STALE-REDRIVE` when the latest marker is stale
-(>~25 min) at a non-gate, non-terminal status. Two sub-cases, split by
+(>~25 min) at a non-gate, non-terminal status AND its detached-phase
+liveness screen found no evidence (no live identity-verified breadcrumb
+`pid=`, no fresh breadcrumb `log=` mtime, no fresh
+`[long-phase-heartbeat]` note — #1051). Two sub-cases, split by
 the status named in the verdict reason:
 
 **ACTIVE statuses** (`approved` / `running` / `verifying` /

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -5401,7 +5401,13 @@ orchestrator also refreshes the mechanical window with periodic liveness
 the watcher's stall detector reads the session SELF-REPORT, so a long-idle
 session may still be stopped — benign under this rule: the detached phase
 survives and the successor re-attaches); the identity-verified pid probe is
-the authoritative check at re-entry.
+the authoritative check at re-entry. Prefix those periodic liveness notes
+with `[long-phase-heartbeat]` — the watcher's stalled detector AND
+`tick_triage.py` (#1051) grant the 90-min leash on that opt-in; tick_triage
+probes the breadcrumb's `pid=` (a VM-LOCAL pid, start-time identity-guarded
+— never post a pod-side pid in a `stage-dispatch` breadcrumb) before any
+STALE-REDRIVE, and while that pid breadcrumb is in flight the pid evidence
+OVERRULES heartbeat notes.
 
 **Checkable guard rule (run at Step 9 / Step 8 entry on every
 re-invocation).**

--- a/scripts/tick_triage.py
+++ b/scripts/tick_triage.py
@@ -18,6 +18,18 @@ ANY failure (missing task, unreadable registry, unknown status) exits
 non-zero with a loud stderr line — the tick skill treats a non-zero exit as
 STALE-REDRIVE (fail toward coverage, never toward silence).
 
+Before returning an issue-mode STALE-REDRIVE, ``triage()`` runs a cheap
+liveness screen (issue #1051, ``issue_liveness_reason``): a live,
+identity-verified detached-phase pid (from the newest in-flight
+``stage-dispatch`` breadcrumb), a freshly-appended breadcrumb ``log=`` file,
+or a fresh ``[long-phase-heartbeat]`` note converts the verdict to HEALTHY.
+Pid-bearing detached-phase evidence is authoritative — a heartbeat never
+rescues a dead pid or a cleared phase — so a dead session with a live
+detached fit reads HEALTHY until the fit ends, and the first tick after the
+pid dies fires STALE-REDRIVE exactly when the re-driven session can harvest
+(the intended sequencing; a 48h breadcrumb cap bounds a wedged-leader
+latch). Kill switch: ``EPM_TICK_LIVENESS_PROBE=0``.
+
 Side effects (both under ``~/.eps-autonomous``, overridable for tests via
 ``EPM_TICK_STATE_DIR``):
 
@@ -122,6 +134,34 @@ def root_disk_snapshot() -> dict | None:
         return None
     return {"band": root_disk_band(free), "free_gib": round(free / _GIB, 1)}
 
+
+# ── detached-phase liveness (issue #1051) ───────────────────────────────────
+# Mirror of autonomous_session_watch.py's opt-in long-phase-heartbeat
+# convention (_LONG_PHASE_HEARTBEAT_PREFIX / EPM_LONG_PHASE_HEARTBEAT_FRESH_MIN,
+# task #761): the SAME prefix + env knob so the two never drift (the same
+# mirror-by-env pattern as the disk bands above). Parity pinned by
+# tests/test_tick_triage.py::test_heartbeat_constants_match_watcher.
+# Known accepted divergence: the watcher's env parse accepts a non-positive
+# EPM_LONG_PHASE_HEARTBEAT_FRESH_MIN; tick falls back to the 90-min default
+# instead (the safer behavior — a typo'd var must not disable the window).
+LONG_PHASE_HEARTBEAT_PREFIX = "[long-phase-heartbeat]"
+LONG_PHASE_HEARTBEAT_FRESH_MIN_DEFAULT = 90.0
+# Identity-guard slack: a live /proc/<pid> counts as the breadcrumb's process
+# only when its start-epoch <= breadcrumb ts + this slack (the leader starts
+# BEFORE the breadcrumb is posted; a recycled pid starts strictly after the
+# original died, i.e. after the breadcrumb — see the issue SKILL.md
+# "Detached VM-side long compute phases" successor rule).
+PID_START_SLACK_S = 120.0
+# Safety valve: a pid-bearing breadcrumb older than this never grants HEALTHY
+# (bounds a wedged-leader / abandoned-task latch to one wasted re-drive per
+# window for ultra-long fits). Env: EPM_TICK_PHASE_BREADCRUMB_MAX_AGE_H.
+PHASE_BREADCRUMB_MAX_AGE_H_DEFAULT = 48.0
+# Extra clearing kinds for the *running*-stage breadcrumb (STAGE_RESULT_KINDS
+# has no "running" key; a completed run posts one of these): once cleared, the
+# breadcrumb is dead history and is never probed.
+PHASE_CLEARING_EXTRA = frozenset({"epm:results", "epm:upload-verification"})
+# Test seam for /proc reads (tests point this at a fake proc tree).
+_PROC_ROOT = Path("/proc")
 
 # Watcher-posted campaign markers carry this sentinel in their note; they are
 # alerts, not campaign progress, so they never count as freshness.
@@ -287,6 +327,252 @@ def plan_pending_over_cap(events: list[dict]) -> bool:
     return changed is None or spend >= changed
 
 
+# ── detached-phase liveness probes (issue #1051) ────────────────────────────
+
+
+def liveness_probe_enabled() -> bool:
+    """``EPM_TICK_LIVENESS_PROBE`` kill switch (default on; ``0``/``false``
+    disables — restores pre-#1051 STALE-REDRIVE behavior fleet-wide)."""
+    raw = os.environ.get("EPM_TICK_LIVENESS_PROBE", "").strip().lower()
+    return raw not in ("0", "false")
+
+
+def heartbeat_fresh_s() -> float:
+    """``EPM_LONG_PHASE_HEARTBEAT_FRESH_MIN`` (minutes) -> seconds; malformed
+    or non-positive -> ``LONG_PHASE_HEARTBEAT_FRESH_MIN_DEFAULT`` (the same
+    fallback shape as ``stale_s()``; see the constants block for the noted
+    divergence from the watcher's parse)."""
+    raw = os.environ.get("EPM_LONG_PHASE_HEARTBEAT_FRESH_MIN", "")
+    try:
+        val = float(raw)
+    except ValueError:
+        return LONG_PHASE_HEARTBEAT_FRESH_MIN_DEFAULT * 60.0
+    return val * 60.0 if val > 0 else LONG_PHASE_HEARTBEAT_FRESH_MIN_DEFAULT * 60.0
+
+
+def phase_breadcrumb_max_age_s() -> float:
+    """``EPM_TICK_PHASE_BREADCRUMB_MAX_AGE_H`` (hours) -> seconds; malformed
+    or non-positive -> ``PHASE_BREADCRUMB_MAX_AGE_H_DEFAULT`` (same shape as
+    ``stale_s()``)."""
+    raw = os.environ.get("EPM_TICK_PHASE_BREADCRUMB_MAX_AGE_H", "")
+    try:
+        val = float(raw)
+    except ValueError:
+        return PHASE_BREADCRUMB_MAX_AGE_H_DEFAULT * 3600.0
+    return val * 3600.0 if val > 0 else PHASE_BREADCRUMB_MAX_AGE_H_DEFAULT * 3600.0
+
+
+def latest_heartbeat_ts(events: list[dict]) -> float | None:
+    """Epoch ts of the newest ``epm:progress`` note containing
+    ``LONG_PHASE_HEARTBEAT_PREFIX``, excluding watcher-sentinel notes
+    (``_WATCHER_NOTE_SENTINEL``, same exclusion as ``latest_event_ts``).
+    ``None`` when absent. Callers compute ``age = now - ts`` and treat
+    ``age < 0`` as NOT fresh (future ts — mirrors the watcher's
+    ``_long_phase_heartbeat_reason`` clock-skew guard) and compare ``ts``
+    against ``latest_clearing_ts`` (a heartbeat at or older than the newest
+    clearing event is invalidated)."""
+    best: float | None = None
+    for row in events:
+        if not isinstance(row, dict):
+            continue
+        if not str(row.get("kind", "")).startswith("epm:progress"):
+            continue
+        note = row.get("note")
+        if not isinstance(note, str) or LONG_PHASE_HEARTBEAT_PREFIX not in note:
+            continue
+        if _WATCHER_NOTE_SENTINEL in note:
+            continue
+        ts = parse_event_ts(row.get("ts"))
+        if ts is not None and (best is None or ts > best):
+            best = ts
+    return best
+
+
+def latest_clearing_ts(events: list[dict]) -> float | None:
+    """Epoch ts of the newest stage-clearing event (the union of ALL
+    ``STAGE_RESULT_KINDS`` values across stages, plus ``epm:failure`` and
+    ``PHASE_CLEARING_EXTRA``). A heartbeat at or older than this never grants
+    HEALTHY — the phase that emitted it is over. ``None`` when absent."""
+    from explore_persona_space.task_workflow import STAGE_RESULT_KINDS
+
+    clearing: set[str] = {"epm:failure"} | PHASE_CLEARING_EXTRA
+    for kinds in STAGE_RESULT_KINDS.values():
+        clearing |= kinds
+    best: float | None = None
+    for row in events:
+        if not isinstance(row, dict):
+            continue
+        kind = str(row.get("kind", ""))
+        if not any(kind.startswith(k) for k in clearing):
+            continue
+        ts = parse_event_ts(row.get("ts"))
+        if ts is not None and (best is None or ts > best):
+            best = ts
+    return best
+
+
+def newest_inflight_pid_breadcrumb(events: list[dict]) -> dict | None:
+    """The newest ``epm:progress`` event whose lstripped note starts
+    ``"stage-dispatch "`` AND carries an integer ``pid=`` field, with NO
+    later stage-clearing event.
+
+    Returns ``{"pid": int, "ts": float, "log": str | None}`` or ``None``.
+    Clearing set = ``STAGE_RESULT_KINDS.get(_normalize_stage(stage),
+    frozenset()) | {"epm:failure"} | PHASE_CLEARING_EXTRA``. Malformed pid /
+    ts -> skipped. Scans newest-first; the first pid-bearing breadcrumb
+    decides (if cleared -> return ``None``; probing an OLDER phase's pid
+    would resurrect dead history)."""
+    from explore_persona_space.task_workflow import (
+        STAGE_RESULT_KINDS,
+        _breadcrumb_fields,
+        _normalize_stage,
+    )
+
+    for idx in range(len(events) - 1, -1, -1):
+        row = events[idx]
+        if not isinstance(row, dict):
+            continue
+        if not str(row.get("kind", "")).startswith("epm:progress"):
+            continue
+        note = row.get("note")
+        if not isinstance(note, str):
+            continue
+        stripped = note.lstrip()
+        if not stripped.startswith("stage-dispatch "):
+            continue
+        fields = _breadcrumb_fields(stripped)
+        pid_raw = fields.get("pid")
+        if pid_raw is None:
+            continue
+        try:
+            pid = int(pid_raw)
+        except ValueError:
+            continue
+        ts = parse_event_ts(row.get("ts"))
+        if ts is None:
+            continue
+        clearing = (
+            STAGE_RESULT_KINDS.get(_normalize_stage(fields.get("stage", "")), frozenset())
+            | {"epm:failure"}
+            | PHASE_CLEARING_EXTRA
+        )
+        for later in events[idx + 1 :]:
+            if not isinstance(later, dict):
+                continue
+            later_kind = str(later.get("kind", ""))
+            if any(later_kind.startswith(k) for k in clearing):
+                return None  # newest pid crumb already cleared — dead history
+        log = fields.get("log")
+        return {"pid": pid, "ts": ts, "log": log if isinstance(log, str) and log else None}
+    return None
+
+
+def proc_start_epoch(pid: int) -> float | None:
+    """Start time (epoch seconds) of ``/proc/<pid>``: ``btime`` (from
+    ``_PROC_ROOT/'stat'``) + ``starttime`` (field 22 of
+    ``_PROC_ROOT/<pid>/'stat'``, parsed after the LAST ``)`` so a comm
+    containing ``') '`` cannot shift fields) divided by
+    ``os.sysconf('SC_CLK_TCK')``. ``None`` on any read/parse failure
+    (process dead, permission, malformed)."""
+    try:
+        btime: float | None = None
+        for line in (_PROC_ROOT / "stat").read_text().splitlines():
+            if line.startswith("btime "):
+                btime = float(line.split()[1])
+                break
+        if btime is None:
+            return None
+        stat = (_PROC_ROOT / str(pid) / "stat").read_text()
+        after_comm = stat.rsplit(")", 1)[1].split()
+        # after_comm[0] is field 3 (state); field 22 (starttime) is index 19.
+        starttime_ticks = float(after_comm[19])
+        return btime + starttime_ticks / os.sysconf("SC_CLK_TCK")
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def pid_alive_with_identity(pid: int, launched_before_epoch: float) -> bool:
+    """True iff ``proc_start_epoch(pid)`` is not ``None`` AND
+    ``start_epoch <= launched_before_epoch + PID_START_SLACK_S``.
+
+    The identity guard: only one process holds a pid at a time, and the
+    breadcrumb recorded this pid at its ts — so a live pid whose start
+    PRECEDES the breadcrumb IS the recorded process; a recycled pid's start
+    strictly FOLLOWS the original's death (after the breadcrumb ts). Never a
+    bare existence check (the issue SKILL.md successor rule: pid recycling
+    on a shared VM)."""
+    start = proc_start_epoch(pid)
+    return start is not None and start <= launched_before_epoch + PID_START_SLACK_S
+
+
+def log_fresh_age_s(log_path: str, now: float, window_s: float) -> float | None:
+    """``now - mtime`` of ``log_path`` iff the path is absolute and
+    ``0 <= age < window_s``, else ``None``. ``os.stat`` guarded
+    (missing/unreadable -> ``None``). The path is used internally ONLY —
+    never printed (content invariant: label slugs embed in log paths)."""
+    if not isinstance(log_path, str) or not log_path.startswith("/"):
+        return None
+    try:
+        mtime = os.stat(log_path).st_mtime
+    except OSError:
+        return None
+    age = now - mtime
+    return age if 0 <= age < window_s else None
+
+
+def issue_liveness_reason(events: list[dict], now: float, stale_after_s: float) -> str | None:
+    """Precedence-ordered liveness screen before an issue-mode STALE-REDRIVE
+    (issue #1051). Returns a content-invariant-safe reason suffix (pids/ages
+    only) or ``None``. Entirely exception-guarded: any probe failure falls
+    through to STALE-REDRIVE (fail toward coverage) while the verdict line
+    stays informative.
+
+    PRECEDENCE: pid-bearing detached-phase evidence is AUTHORITATIVE over
+    heartbeat evidence — a fresh ``[long-phase-heartbeat]`` note can never
+    rescue a dead/identity-failed pid or a cleared phase. Unlike the watcher
+    (which has no pid evidence), tick_triage holds the pid breadcrumb in the
+    SAME events list, and the emitter convention (issue SKILL.md § Detached
+    VM-side long compute phases) makes heartbeat+pid co-occurrence the
+    designed steady state — heartbeat-first ordering would mask a dead pid
+    for up to 90 min.
+
+    Legs: (0) probe disabled -> ``None``. (1) AUTHORITATIVE — the newest
+    in-flight (un-cleared) pid-bearing breadcrumb younger than the 48h cap:
+    live identity-verified pid -> HEALTHY; else fresh ``log=`` mtime ->
+    HEALTHY; else ``None`` with NO heartbeat rescue (a dead pid / silent log
+    is stronger evidence than any note). (2) FALLBACK (no such breadcrumb —
+    incl. cleared or over-max-age crumbs) — a fresh heartbeat note newer
+    than the newest clearing event -> HEALTHY. (3) ``None``."""
+    try:
+        if not liveness_probe_enabled():
+            return None
+        crumb = newest_inflight_pid_breadcrumb(events)
+        if crumb is not None and (now - crumb["ts"]) < phase_breadcrumb_max_age_s():
+            if pid_alive_with_identity(crumb["pid"], crumb["ts"]):
+                return (
+                    f"detached phase alive (pid {crumb['pid']}, "
+                    f"breadcrumb age {(now - crumb['ts']) / 3600:.1f}h)"
+                )
+            if crumb["log"]:
+                log_age = log_fresh_age_s(crumb["log"], now, stale_after_s)
+                if log_age is not None:
+                    return (
+                        f"detached phase log appended {log_age / 60:.0f}m ago (pid probe negative)"
+                    )
+            return None  # dead/unverifiable pid + silent log: NO heartbeat rescue
+        hb_ts = latest_heartbeat_ts(events)
+        if hb_ts is not None:
+            hb_age = now - hb_ts
+            window = heartbeat_fresh_s()
+            if 0 <= hb_age < window:
+                cleared = latest_clearing_ts(events)
+                if cleared is None or hb_ts > cleared:
+                    return f"long-phase heartbeat fresh ({hb_age / 60:.0f}m < {window / 60:.0f}m)"
+        return None
+    except Exception:
+        return None
+
+
 # ── pure verdict logic ──────────────────────────────────────────────────────
 
 
@@ -315,6 +601,9 @@ def runaway_streak_threshold() -> int:
 # LLM tick turn, and on harmful-content tasks free text is trigger-dense
 # enough to refusal-kill the session. Pinned by
 # tests/test_tick_triage.py::test_snapshot_carries_no_task_text.
+# The #1051 liveness reasons obey the same invariant — pids/ages/status
+# tokens only; breadcrumb `log=` paths and `label=` slugs are read
+# internally but never printed.
 def compute_issue_verdict(
     status: str,
     prev_status: str | None,
@@ -465,13 +754,28 @@ def triage(issue: int, kind: str, now: float | None = None) -> tuple[str, str]:
         )
     else:
         marker_ts = latest_event_ts(events)
+        marker_age = (now - marker_ts) if marker_ts is not None else None
         verdict, reason = compute_issue_verdict(
             status,
             prev_status,
-            (now - marker_ts) if marker_ts is not None else None,
+            marker_age,
             plan_pending_over_cap(events),
             stale_after_s=stale_s(),
         )
+        if verdict == "STALE-REDRIVE":
+            # Detached-phase liveness screen (issue #1051): fires ONLY on a
+            # would-be STALE-REDRIVE, on BOTH stale branches — PARK and
+            # ACTIVE (#931's incident status `followups_running` is in
+            # ISSUE_PARK). Streak semantics unchanged (STALE-REDRIVE and
+            # HEALTHY are both non-teardown verdicts); snapshot shape
+            # untouched; campaign branch untouched.
+            live = issue_liveness_reason(events, now, stale_s())
+            if live is not None:
+                age_desc = (
+                    "no markers" if marker_age is None else f"marker age {marker_age / 60:.0f}m"
+                )
+                verdict = "HEALTHY"
+                reason = f"status={status}, {age_desc} — {live}"
 
     # Runaway streak counts every TEARDOWN verdict, not just the terminal
     # STATUS sets — a teardown that whiffs forever at over-cap plan_pending

--- a/tests/test_tick_triage.py
+++ b/tests/test_tick_triage.py
@@ -20,6 +20,8 @@ are monkeypatched — no live sessions, no real task folders.
 from __future__ import annotations
 
 import json
+import os
+import re
 import sys
 import time
 from pathlib import Path
@@ -435,3 +437,341 @@ def test_main_prints_single_verdict_line(state_dir, monkeypatch, capsys):
     rc = tick_triage.main(["42"])
     out = capsys.readouterr().out.strip().splitlines()
     assert rc == 0 and len(out) == 1 and out[0].startswith("HEALTHY ")
+
+
+# ── detached-phase liveness screen (#1051) ──────────────────────────────────
+
+
+def _crumb(
+    age_s: float,
+    pid: int | None = None,
+    log: str | None = None,
+    stage: str = "followup-running",
+    extra: str = "",
+) -> dict:
+    """A ``stage-dispatch`` breadcrumb-shaped ``epm:progress`` event."""
+    parts = [f"stage-dispatch stage={stage} round=1 subagent=detached-vm-phase"]
+    if pid is not None:
+        parts.append(f"pid={pid}")
+    if log is not None:
+        parts.append(f"log={log}")
+    if extra:
+        parts.append(extra)
+    return _event("epm:progress v1", age_s, note=" ".join(parts))
+
+
+def test_stale_with_live_detached_pid_is_healthy(state_dir, monkeypatch):
+    """The #931 replay fixture: an in-flight pid-bearing breadcrumb + plain
+    liveness notes straddling the 25-min stale window (27-min gap shape) must
+    read HEALTHY when the pid probe verifies alive+identity."""
+    monkeypatch.setattr(tick_triage, "pid_alive_with_identity", lambda *_a: True)
+    events = [
+        _crumb(
+            7200,
+            pid=4025577,
+            log="/tmp/i931.log",
+            extra="choom=ok label=author-blocked-folds worktree=/x/.claude/worktrees/issue-931",
+        ),
+        _event("epm:progress v2", 3300, note="liveness: pid 4025577 verified, args match"),
+        _event("epm:progress v3", 1680, note="liveness: child worker advancing"),
+    ]
+    _patch_issue_state(monkeypatch, "followups_running", events)
+    verdict, reason = tick_triage.triage(101, "issue")
+    assert verdict == "HEALTHY", reason
+    assert "4025577" in reason
+
+
+def test_stale_with_dead_pid_redrives(state_dir, monkeypatch):
+    monkeypatch.setattr(tick_triage, "pid_alive_with_identity", lambda *_a: False)
+    events = [
+        _crumb(7200, pid=4025577),
+        _event("epm:progress v2", 3300, note="liveness: pid 4025577 verified, args match"),
+        _event("epm:progress v3", 1680, note="liveness: child worker advancing"),
+    ]
+    _patch_issue_state(monkeypatch, "followups_running", events)
+    verdict, _ = tick_triage.triage(102, "issue")
+    assert verdict == "STALE-REDRIVE"
+
+
+def test_recycled_pid_identity_mismatch_redrives(state_dir, monkeypatch, tmp_path):
+    """Exercise the REAL start-time identity guard via the _PROC_ROOT seam: a
+    live pid whose start-epoch postdates breadcrumb ts + slack is a recycled
+    pid, never re-attached to."""
+    clk = os.sysconf("SC_CLK_TCK")
+    pid = 4025577
+    btime = int(NOW - 100_000)
+    proc = tmp_path / "proc"
+    (proc / str(pid)).mkdir(parents=True)
+    (proc / "stat").write_text(f"cpu  1 2 3 4\nbtime {btime}\nprocesses 5\n")
+    # start-epoch ~= NOW (recycled just now) — AFTER breadcrumb ts + 120s.
+    starttime_ticks = int((NOW - btime) * clk)
+    after_comm = ["S"] + ["0"] * 18 + [str(starttime_ticks)] + ["0"] * 10
+    # comm contains ') ' to exercise the parse-after-LAST-')' rule.
+    (proc / str(pid) / "stat").write_text(f"{pid} (uv (run) x) " + " ".join(after_comm) + "\n")
+    monkeypatch.setattr(tick_triage, "_PROC_ROOT", proc)
+    assert tick_triage.pid_alive_with_identity(pid, NOW - 7200) is False
+    _patch_issue_state(monkeypatch, "followups_running", [_crumb(7200, pid=pid)])
+    verdict, _ = tick_triage.triage(103, "issue")
+    assert verdict == "STALE-REDRIVE"
+
+
+def test_proc_start_epoch_real_self():
+    """#906 production-body rule: execute the real /proc read end-to-end on
+    the test process itself."""
+    start = tick_triage.proc_start_epoch(os.getpid())
+    assert start is not None and 0 < start <= time.time()
+    assert tick_triage.pid_alive_with_identity(os.getpid(), time.time()) is True
+    # A launch deadline BEFORE the process started fails the identity guard.
+    assert tick_triage.pid_alive_with_identity(os.getpid(), 0.0) is False
+
+
+def test_cleared_breadcrumb_not_probed(state_dir, monkeypatch):
+    """A breadcrumb with a LATER stage-clearing event is dead history: the pid
+    probe is NEVER consulted. The stub is call-recording and returns True (NOT
+    a raising stub — issue_liveness_reason's blanket ``except Exception``
+    would swallow a raise and pass the test under the exact bug it pins): a
+    wrongly-consulted probe returns True -> HEALTHY -> the verdict assert
+    fails loud, and the empty-call-list assert catches the bug even if a
+    future refactor changes the verdict path."""
+    calls: list = []
+
+    def recording_probe(pid, ts):
+        calls.append((pid, ts))
+        return True
+
+    monkeypatch.setattr(tick_triage, "pid_alive_with_identity", recording_probe)
+    for clearing_kind in ("epm:upload-verification v1", "epm:failure v1"):
+        calls.clear()
+        events = [_crumb(7200, pid=999), _event(clearing_kind, 3600)]
+        _patch_issue_state(monkeypatch, "followups_running", events)
+        verdict, _ = tick_triage.triage(104, "issue")
+        assert verdict == "STALE-REDRIVE", clearing_kind
+        assert calls == [], f"cleared breadcrumb must never be probed ({clearing_kind})"
+
+
+def test_breadcrumb_without_pid_ignored():
+    # The newest PID-BEARING crumb decides even when a pid-less breadcrumb
+    # (the interpreting/clean-result shape) is newer.
+    events = [_crumb(7200, pid=4025577), _crumb(3600, pid=None)]
+    crumb = tick_triage.newest_inflight_pid_breadcrumb(events)
+    assert crumb is not None and crumb["pid"] == 4025577
+    # A lone pid-less crumb yields None.
+    assert tick_triage.newest_inflight_pid_breadcrumb([_crumb(3600, pid=None)]) is None
+
+
+def test_breadcrumb_over_max_age_not_probed(state_dir, monkeypatch):
+    monkeypatch.setattr(tick_triage, "pid_alive_with_identity", lambda *_a: True)
+    _patch_issue_state(monkeypatch, "followups_running", [_crumb(60 * 3600, pid=999)])
+    verdict, _ = tick_triage.triage(105, "issue")
+    assert verdict == "STALE-REDRIVE", "a 60h-old breadcrumb never grants HEALTHY (48h cap)"
+
+
+def test_heartbeat_prefixed_note_grants_healthy(state_dir, monkeypatch):
+    events = [_event("epm:progress v1", 3600, note="[long-phase-heartbeat] cell 2 in progress")]
+    _patch_issue_state(monkeypatch, "followups_running", events)
+    verdict, reason = tick_triage.triage(106, "issue")
+    assert verdict == "HEALTHY", reason
+    assert "heartbeat" in reason
+
+
+def test_heartbeat_older_than_window_redrives(state_dir, monkeypatch):
+    events = [_event("epm:progress v1", 6000, note="[long-phase-heartbeat] cell 2 in progress")]
+    _patch_issue_state(monkeypatch, "followups_running", events)
+    verdict, _ = tick_triage.triage(107, "issue")
+    assert verdict == "STALE-REDRIVE"
+
+
+def test_watcher_sentinel_heartbeat_ignored(state_dir, monkeypatch):
+    events = [
+        _event("epm:progress v1", 7200, note="plain progress"),
+        _event(
+            "epm:progress v2",
+            600,
+            note="[autonomous_session_watch:session-stalled-alert] [long-phase-heartbeat] x",
+        ),
+    ]
+    _patch_issue_state(monkeypatch, "followups_running", events)
+    verdict, _ = tick_triage.triage(108, "issue")
+    assert verdict == "STALE-REDRIVE"
+
+
+def test_heartbeat_future_ts_not_fresh():
+    # Clock-skew guard parity with the watcher: a future ts is NOT fresh.
+    events = [_event("epm:progress v1", -600, note="[long-phase-heartbeat] future")]
+    assert tick_triage.issue_liveness_reason(events, NOW, 1500.0) is None
+
+
+def test_log_mtime_fresh_grants_healthy(state_dir, monkeypatch, tmp_path):
+    monkeypatch.setattr(tick_triage, "pid_alive_with_identity", lambda *_a: False)
+    log = tmp_path / "i931.log"
+    log.write_text("tick\n")  # mtime = now -> fresh
+    _patch_issue_state(monkeypatch, "followups_running", [_crumb(7200, pid=999, log=str(log))])
+    verdict, reason = tick_triage.triage(109, "issue")
+    assert verdict == "HEALTHY", reason
+    assert str(tmp_path) not in reason, "log paths are read internally, never printed"
+
+
+def test_log_mtime_stale_redrives(state_dir, monkeypatch, tmp_path):
+    monkeypatch.setattr(tick_triage, "pid_alive_with_identity", lambda *_a: False)
+    log = tmp_path / "i931.log"
+    log.write_text("tick\n")
+    os.utime(log, times=(NOW - 7200, NOW - 7200))
+    _patch_issue_state(monkeypatch, "followups_running", [_crumb(7200, pid=999, log=str(log))])
+    verdict, _ = tick_triage.triage(110, "issue")
+    assert verdict == "STALE-REDRIVE"
+
+
+def test_probe_exception_falls_through_to_stale(state_dir, monkeypatch):
+    def boom(_events):
+        raise RuntimeError("probe exploded")
+
+    monkeypatch.setattr(tick_triage, "newest_inflight_pid_breadcrumb", boom)
+    _patch_issue_state(monkeypatch, "followups_running", [_crumb(7200, pid=999)])
+    verdict, _ = tick_triage.triage(111, "issue")
+    assert verdict == "STALE-REDRIVE"
+
+
+def test_liveness_disabled_by_env(state_dir, monkeypatch):
+    monkeypatch.setenv("EPM_TICK_LIVENESS_PROBE", "0")
+    monkeypatch.setattr(tick_triage, "pid_alive_with_identity", lambda *_a: True)
+    _patch_issue_state(monkeypatch, "followups_running", [_crumb(7200, pid=999)])
+    verdict, _ = tick_triage.triage(112, "issue")
+    assert verdict == "STALE-REDRIVE"
+
+
+def test_campaign_mode_never_probes(state_dir, monkeypatch):
+    calls: list = []
+
+    def recording_probe(pid, ts):
+        calls.append(pid)
+        return True
+
+    monkeypatch.setattr(tick_triage, "pid_alive_with_identity", recording_probe)
+    events = [_event("epm:campaign-progress v1", 7200), _crumb(3600, pid=999)]
+    monkeypatch.setattr(tick_triage, "load_task_state", lambda _n: ("running", events))
+    monkeypatch.setattr(tick_triage, "load_children", lambda _n: [])
+    monkeypatch.setattr(tick_triage, "load_campaign_state", lambda _n: {})
+    verdict, _ = tick_triage.triage(113, "campaign")
+    assert verdict == "STALE-REDRIVE"
+    assert calls == [], "the liveness probe is issue-mode only"
+
+
+def test_liveness_reason_carries_no_task_text(state_dir, monkeypatch):
+    monkeypatch.setattr(tick_triage, "pid_alive_with_identity", lambda *_a: True)
+    events = [_crumb(7200, pid=999, log="/tmp/SECRETPATH.log", extra="label=SECRETLABEL")]
+    _patch_issue_state(monkeypatch, "followups_running", events)
+    verdict, reason = tick_triage.triage(114, "issue")
+    assert verdict == "HEALTHY"
+    assert "SECRET" not in f"{verdict} {reason}", reason
+
+
+def test_heartbeat_constants_match_watcher():
+    """Drift pin (text-level, no import — the watcher drags heavy deps): the
+    prefix literal + the 90-min default + the shared env knob match, AND the
+    heartbeat prefix is not a substring of any watcher-posted sentinel (nor
+    does it contain tick's own watcher-sentinel exclusion substring — either
+    would make the heartbeat leg exclude itself)."""
+    src = (SCRIPTS / "autonomous_session_watch.py").read_text()
+    m = re.search(r'_LONG_PHASE_HEARTBEAT_PREFIX\s*=\s*"([^"]+)"', src)
+    assert m is not None and m.group(1) == tick_triage.LONG_PHASE_HEARTBEAT_PREFIX
+    m = re.search(r"LONG_PHASE_HEARTBEAT_FRESH_S_DEFAULT\s*=\s*(\d+)\s*\*\s*60\b", src)
+    assert m is not None
+    assert float(m.group(1)) == tick_triage.LONG_PHASE_HEARTBEAT_FRESH_MIN_DEFAULT
+    assert "EPM_LONG_PHASE_HEARTBEAT_FRESH_MIN" in src
+    sentinels = re.findall(r'_[A-Z_]+_NOTE_SENTINEL\s*=\s*\(?\s*"(\[[^"]+\])"', src)
+    assert sentinels, "watcher sentinel extraction regex found nothing — source drifted"
+    for sentinel in sentinels:
+        assert tick_triage.LONG_PHASE_HEARTBEAT_PREFIX not in sentinel, sentinel
+        assert sentinel not in tick_triage.LONG_PHASE_HEARTBEAT_PREFIX, sentinel
+    assert tick_triage._WATCHER_NOTE_SENTINEL not in tick_triage.LONG_PHASE_HEARTBEAT_PREFIX
+
+
+def test_cleared_crumb_with_older_heartbeat_redrives(state_dir, monkeypatch):
+    """Interaction pin (v2 leg precedence): a completed phase is never
+    resurrected by its own stale heartbeat — a fresh (<90 min) heartbeat
+    OLDER than the clearing event is invalidated."""
+    monkeypatch.setattr(tick_triage, "pid_alive_with_identity", lambda *_a: True)
+    events = [
+        _crumb(7200, pid=999),
+        _event("epm:progress v2", 3600, note="[long-phase-heartbeat] cell 3"),
+        _event("epm:upload-verification v1", 3000),
+    ]
+    _patch_issue_state(monkeypatch, "followups_running", events)
+    verdict, _ = tick_triage.triage(115, "issue")
+    assert verdict == "STALE-REDRIVE"
+    # Variant: a heartbeat NEWER than the clearing event (a new
+    # post-completion long phase legitimately re-attests), no in-flight pid
+    # crumb -> HEALTHY via the fallback leg.
+    events = [
+        _event("epm:upload-verification v1", 3000),
+        _event("epm:progress v3", 1800, note="[long-phase-heartbeat] post-completion phase"),
+    ]
+    _patch_issue_state(monkeypatch, "followups_running", events)
+    verdict, reason = tick_triage.triage(115, "issue")
+    assert verdict == "HEALTHY", reason
+    assert "heartbeat" in reason
+
+
+def test_dead_pid_with_fresh_heartbeat_redrives(state_dir, monkeypatch):
+    """Interaction pin (v2 leg precedence): pid evidence is authoritative —
+    a fresh heartbeat cannot rescue a dead detached phase (pins the 'first
+    tick after the pid dies' property)."""
+    monkeypatch.setattr(tick_triage, "pid_alive_with_identity", lambda *_a: False)
+    events = [
+        _crumb(7200, pid=999),  # in-flight, <=48h, no log=
+        # 30 min: past the 25-min stale window (base verdict STALE-REDRIVE)
+        # yet well inside the 90-min heartbeat window — the heartbeat WOULD
+        # rescue if the pid leg were not authoritative.
+        _event("epm:progress v2", 1800, note="[long-phase-heartbeat] still going"),
+    ]
+    _patch_issue_state(monkeypatch, "followups_running", events)
+    verdict, _ = tick_triage.triage(116, "issue")
+    assert verdict == "STALE-REDRIVE"
+
+
+def test_stale_heartbeat_with_live_pid_healthy(state_dir, monkeypatch):
+    # A >90-min heartbeat neither grants nor blocks: the authoritative pid
+    # leg decides.
+    monkeypatch.setattr(tick_triage, "pid_alive_with_identity", lambda *_a: True)
+    events = [
+        _crumb(7200, pid=4025577),
+        _event("epm:progress v2", 6000, note="[long-phase-heartbeat] old heartbeat"),
+    ]
+    _patch_issue_state(monkeypatch, "followups_running", events)
+    verdict, reason = tick_triage.triage(117, "issue")
+    assert verdict == "HEALTHY", reason
+    assert "4025577" in reason
+
+
+# Verbatim #931 production breadcrumb note (events.jsonl 2026-07-04T20:24:12Z
+# stage-dispatch row, copied as a string literal — not read from live task
+# state, which moves).
+_REAL_931_BREADCRUMB_NOTE = (
+    "stage-dispatch stage=followup-running round=1 subagent=detached-vm-phase "
+    "label=author-blocked-folds "
+    "worktree=/home/thomasjiralerspong/explore-persona-space/.claude/worktrees/issue-931 "
+    "pid=4025577 "
+    "log=/home/thomasjiralerspong/explore-persona-space/.claude/worktrees/issue-931/logs/"
+    "issue931_author_blocked_folds_production.log "
+    "choom=ok external-markers triaged: 1 applied / 0 deferred (see epm:progress v39 "
+    "pre-launch note; compute-character statement there too). Production command: "
+    "uv run python scripts/issue931_author_blocked_folds.py (defaults: 20 nulls, 1000 boot, "
+    "20 pseudo-draws, budget 4.5h) at branch b73c8f8484, env OMP/MKL/OPENBLAS/NUMEXPR=2, "
+    "setsid-detached. Projected 4.6-5.2h wall; per-cell fingerprinted checkpoint/resume; "
+    "success = [phase=done] + eval_results/issue_931/author_blocked_folds.json with "
+    "registered_read.decision_row."
+)
+
+
+def test_breadcrumb_parse_on_real_931_note():
+    """Parse-fidelity pin: _breadcrumb_fields behavior on the real #931 note
+    shape (free text + tokens like 'OMP/MKL/OPENBLAS/NUMEXPR=2' and
+    '[phase=done]' after the key=value block)."""
+    events = [{"kind": "epm:progress", "ts": _iso(NOW - 7200), "note": _REAL_931_BREADCRUMB_NOTE}]
+    crumb = tick_triage.newest_inflight_pid_breadcrumb(events)
+    assert crumb is not None
+    assert crumb["pid"] == 4025577
+    assert crumb["log"] == (
+        "/home/thomasjiralerspong/explore-persona-space/.claude/worktrees/issue-931/logs/"
+        "issue931_author_blocked_folds_production.log"
+    )


### PR DESCRIPTION
Closes task #1051. Workflow-fix: pid/log/heartbeat liveness screen in scripts/tick_triage.py (pid-authoritative precedence), tests 1-20, SKILL.md doc lines.