### PR TITLE
task #1071: watcher stalled-alert truthful reasons + post-stop wt-hold gate

### DIFF
--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -87,7 +87,16 @@ GC pass:
    one-time alert, but a user-driven session is NEVER auto-respawned
    (#505 round-2 orphaning, 2026-06-10 — a dead bare-spawned session at
    an ACTIVE status previously orphaned silently because this pass only
-   globbed ``issue-*.json``).
+   globbed ``issue-*.json``).  A daemon-blocked stop+respawn is never
+   dropped: the persisted per-issue episode state plus the
+   alerted->eligible escalation executes it on the next daemon-reachable
+   tick, and the #845 (c) escalation pages after 2 blocked ticks (#1071).
+   A corroboration-debounced alert (#759 downgrade) names the debounce in
+   its marker note, never a daemon outage.  A pathological
+   reachable/unreachable daemon flap can repeatedly reset the
+   K-corroboration ``live_consecutive`` counter and defer escalation,
+   bounded in practice by the #845 (c) page after 2 blocked ticks plus
+   the persistent staleness re-fire.
 5. **Orphan sweep (registration-INDEPENDENT safety net).** Every other
    session pass starts from the registry files (``issue-<N>.json`` /
    ``manual-issue-<N>.json``), so an ACTIVE-status task with NO registration
@@ -8448,6 +8457,8 @@ class _StalledActionCtx:
         daemon_blocked_pushed: bool = False,
         wedge_hits: int = 0,
         wedge_note: str | None = None,
+        daemon_reachable: bool = True,
+        downgrade_note: str | None = None,
     ) -> None:
         self.issue = issue
         self.happy_session_id = happy_session_id
@@ -8519,6 +8530,18 @@ class _StalledActionCtx:
         self.daemon_blocked_pushed = daemon_blocked_pushed
         self.wedge_hits = wedge_hits
         self.wedge_note = wedge_note
+        # #1071 evidence-based alert reasons: ``daemon_reachable`` is the
+        # pass-level flag (computed once per tick) and ``downgrade_note`` is
+        # the #759 live-corroboration downgrade explanation (None on every
+        # other path). Both are PER-TICK EVIDENCE for the alert handler's
+        # reason ladder — recomputed each tick, deliberately NOT persisted by
+        # :func:`_persist_stalled_ctx` (no state-file schema change). Before
+        # these were threaded, the handler's exhaustive-pre-#759 else-branch
+        # misattributed a corroboration debounce as "Happy daemon
+        # unreachable" (both #813 incidents, 2026-07-03/04), prompting manual
+        # respawns that raced an in-flight auto-recovery.
+        self.daemon_reachable = daemon_reachable
+        self.downgrade_note = downgrade_note
 
     @property
     def happy_session_id_str(self) -> str | None:
@@ -8575,7 +8598,19 @@ def _stalled_arm_deferral(ctx: _StalledActionCtx) -> bool:
     edit); defer the stop/respawn, bounded at :data:`WT_HOLD_MAX_TICKS`
     consecutive holds (~1h) so a cross-writer can't defer recovery forever.
     ``missed`` is pinned at the threshold while held so the arm re-fires on
-    the very next tick (stay armed, mirroring the crash arm's hold)."""
+    the very next tick (stay armed, mirroring the crash arm's hold).
+
+    #1071 post-stop gate: the #812 mid-edit protection guards the STOP;
+    once ``stop_pending_sid`` is set, a stop has already been ISSUED for
+    that sid (issued, not necessarily landed) — the fence (verify-dead ->
+    spawn / retry-stop / stop-failed terminal) still guarantees no spawn
+    next to a live sid, so holding only delays the verified-dead spawn and
+    leaves the issue driverless (incident #813, 2026-07-03: 3 held ticks
+    post-stop while a detached analysis process — which survives respawn
+    and was re-attached by the successor — fed the activity signal).
+    Mirrors the existing mid-fence gate on the K-corroboration. The
+    spawn-grace skip stays UNCONDITIONAL (it guards concurrent respawns,
+    still valid mid-fence)."""
     grace_s = _respawn_spawn_grace_s()
     if ctx.entry_spawned_at is not None and 0 <= ctx.now - ctx.entry_spawned_at < grace_s:
         print(
@@ -8587,7 +8622,7 @@ def _stalled_arm_deferral(ctx: _StalledActionCtx) -> bool:
         _persist_stalled_ctx(ctx, ctx.happy_session_id_str, 0)
         return True
     activity = _worktree_recent_activity(ctx.issue, ctx.now, _wt_activity_fresh_s())
-    if decide_worktree_hold(activity, ctx.wt_hold_count):
+    if ctx.stop_pending_sid is None and decide_worktree_hold(activity, ctx.wt_hold_count):
         held = ctx.wt_hold_count + 1
         print(
             f"  issue #{ctx.issue}: HOLD-RESPAWN — worktree activity < "
@@ -8884,12 +8919,47 @@ def _handle_stalled_alert(ctx: _StalledActionCtx) -> None:
     (``refresh_attempted`` flag, cleared on self-report advancement,
     same shape as ``alerted``)."""
     sid = ctx.happy_session_id_str
+    # #1071 evidence-based reason ladder. Pre-#759 this ladder was exhaustive
+    # (manual / non-ACTIVE / daemon-down were the ONLY alert producers); the
+    # #759 live-corroboration downgrade added a fourth producer AFTER
+    # decide(), and the stale else-branch then fabricated "Happy daemon
+    # unreachable" for it even with the daemon up (both #813 incidents) —
+    # prompting manual respawns that raced an in-flight auto-recovery. Each
+    # branch now states the observed cause AND what the watcher does NEXT
+    # (``next_step``), so the note never invites a manual stop+respawn while
+    # an auto-recovery is mid-flight (the manual branch is the one place
+    # that instruction is true). The else-branch self-identifies as a
+    # watcher bug instead of inventing a daemon outage.
     if ctx.manual:
         reason = "manual user-driven session; alert-only by design"
+        next_step = (
+            f"open the session (phone / `spawn_session.py list`) and "
+            f"re-drive `/issue {ctx.issue}` manually if confirmed dead"
+        )
     elif not ctx.in_active:
-        reason = "task status not ACTIVE"
+        reason = f"task status not ACTIVE ({ctx.task_status})"
+        next_step = (
+            "no auto-respawn at a parked/terminal status; re-drive manually if this is wrong"
+        )
+    elif ctx.downgrade_note is not None:
+        reason = ctx.downgrade_note
+        next_step = (
+            f"the watcher auto-escalates to a stop+respawn once the "
+            f"live-stall debounce is exhausted (typically the NEXT tick); no "
+            f"manual action needed unless a later "
+            f"'{_STALLED_EXHAUSTED_NOTE_SENTINEL}' or "
+            f"'{_STALLED_STOP_FAILED_NOTE_SENTINEL}' marker appears"
+        )
+    elif not ctx.daemon_reachable:
+        reason = "Happy daemon unreachable; cannot stop+spawn THIS tick"
+        next_step = (
+            "episode state persists on disk; the stop+respawn fires "
+            "automatically on the next daemon-reachable tick, and a phone "
+            "push fires after 2 blocked ticks (#845 c)"
+        )
     else:
-        reason = "Happy daemon unreachable; cannot stop+spawn"
+        reason = "unexpected alert cause (watcher bug — please report)"
+        next_step = "investigate _handle_stalled_alert's reason ladder"
 
     # #488 stale-port self-heal — see method docstring above. Skip when:
     # we already refreshed this episode; the pod name is unknown (no
@@ -8920,10 +8990,8 @@ def _handle_stalled_alert(ctx: _StalledActionCtx) -> None:
             f"for {ctx.self_gap} and the latest non-watcher progress marker "
             f"is {ctx.marker_gap} old (has_pod={ctx.has_pod}, "
             f"status={ctx.task_status}). The session is likely dead or its "
-            f"bg-Bash chain died. NOT auto-respawned ({reason}); open the "
-            f"session (phone / `spawn_session.py list`) and re-drive "
-            f"`/issue {ctx.issue}` manually if confirmed dead. Confirmed "
-            f"for >= {ctx.threshold} checks."
+            f"bg-Bash chain died. NOT auto-respawned ({reason}); "
+            f"{next_step}. Confirmed for >= {ctx.threshold} checks."
         )
     else:
         note = (
@@ -8934,8 +9002,7 @@ def _handle_stalled_alert(ctx: _StalledActionCtx) -> None:
             f"(has_pod={ctx.has_pod}, status={ctx.task_status}). Likely a dead "
             f"bg-Bash chain inside a still-live Claude process — the session "
             f"looks healthy to the respawn pass but is not advancing. NOT "
-            f"auto-respawned ({reason}); investigate via the phone session "
-            f"and stop+respawn manually if confirmed dead. Confirmed for >= "
+            f"auto-respawned ({reason}); {next_step}. Confirmed for >= "
             f"{ctx.threshold} checks."
         )
     _post_progress_marker(
@@ -9075,10 +9142,17 @@ def _apply_stalled_live_corroboration(
     live_ids: set[str] | None,
     live_consecutive: int,
     dry_run: bool,
-) -> tuple[str, int]:
+) -> tuple[str, int, str | None]:
     """Bounded K-escalation for the stalled detector's live-session
     corroboration (#759, bug class b.1; Option A). Rewrites
-    ``(action, live_consecutive)``.
+    ``(action, live_consecutive)`` and additionally returns a
+    ``downgrade_note`` (third element): a human-readable explanation of the
+    downgrade on the respawn->alert branch, ``None`` on every other branch.
+    The caller threads the note into :class:`_StalledActionCtx` so
+    :func:`_handle_stalled_alert`'s reason ladder can attribute the alert to
+    THIS debounce instead of falling through to a fabricated
+    daemon-unreachable reason (#1071; both #813 incidents had
+    ``daemon_reachable=True`` on every tick).
 
     Applied AFTER the provision-in-flight + followups exemptions, so it only
     sees a respawn THOSE did not already turn into keep. A respawn-eligible
@@ -9117,11 +9191,11 @@ def _apply_stalled_live_corroboration(
     if action != "respawn":
         # keep / clear (incl. provision/followups exemptions) — not a live-stall
         # respawn episode; reset so the counter never straddles unrelated stalls.
-        return action, 0
+        return action, 0, None
     if not daemon_reachable or live_ids is None or not _session_alive(entry, live_ids):
         # Genuinely-dead wrapper (or daemon down) — today's behavior. No
         # live-stall episode in progress; reset the counter.
-        return action, 0
+        return action, 0, None
     # A LIVE id is being respawned.
     k = _stalled_live_escalation_k()
     live_consecutive += 1
@@ -9133,7 +9207,12 @@ def _apply_stalled_live_corroboration(
             f"duplicate driver (transient busy stretch on a live session)."
         )
         _append_stalled_live_event(issue, "stalled-live-downgrade", live_consecutive, k, dry_run)
-        return "alert", live_consecutive
+        note = (
+            f"live-session corroboration debounce: consecutive live-stall "
+            f"episode {live_consecutive}/{k}; the session id is still in the "
+            f"daemon live set"
+        )
+        return "alert", live_consecutive, note
     # Kth consecutive live stall — escalate to the canonical respawn arm and
     # reset the counter (a fresh --auto session begins a new episode).
     print(
@@ -9143,7 +9222,7 @@ def _apply_stalled_live_corroboration(
         f"class). Resetting live_consecutive."
     )
     _append_stalled_live_event(issue, "stalled-live-escalation", live_consecutive, k, dry_run)
-    return "respawn", 0
+    return "respawn", 0, None
 
 
 def _apply_prompt_wedge_override(
@@ -9613,8 +9692,11 @@ def _process_stalled_session(
     # on the Kth (the #506 dead-bg-chain class), and resets the counter on
     # every other path. Factored into a helper to keep this function under the
     # C901 cap; the returned live_consecutive is what the ctx below persists.
+    # The third element (downgrade_note) is per-tick evidence for the alert
+    # handler's reason ladder — threaded into the ctx below, never persisted.
+    downgrade_note: str | None = None
     if hard["stop_pending_sid"] is None:
-        action, live_consecutive = _apply_stalled_live_corroboration(
+        action, live_consecutive, downgrade_note = _apply_stalled_live_corroboration(
             issue=issue,
             entry=entry,
             action=action,
@@ -9727,6 +9809,8 @@ def _process_stalled_session(
         daemon_blocked_pushed=hard["daemon_blocked_pushed"],
         wedge_hits=hard["wedge_hits"],
         wedge_note=wedge_note,
+        daemon_reachable=daemon_reachable,
+        downgrade_note=downgrade_note,
     )
 
     if action == "respawn":

--- a/scripts/cron_autonomous_session_watch.sh
+++ b/scripts/cron_autonomous_session_watch.sh
@@ -27,7 +27,8 @@
 #   4. Stalled-detector: detect a live-but-frozen session (self-report AND
 #      latest progress marker both stale >45 min) and auto-respawn it
 #      (bounded per episode); alert-only for manual sessions or when the
-#      Happy daemon is unreachable.
+#      Happy daemon is unreachable (daemon-blocked remediations persist and
+#      auto-execute on the next daemon-reachable tick).
 #   5. Orphan sweep: registration-INDEPENDENT cross-check — any ACTIVE-status
 #      task with NO live registered session AND no real progress marker for
 #      ~90 min (EPM_ORPHAN_STALENESS_MIN) is auto-respawned (capped at 2

--- a/tests/test_stalled_detector_and_gc.py
+++ b/tests/test_stalled_detector_and_gc.py
@@ -1461,3 +1461,362 @@ def test_stalled_hardening_fields_legacy_defaults_and_advancement_clear():
     assert fields["stop_pending_sid"] is None
     assert fields["wt_hold_count"] == 0
     assert fields["stop_retried"] is True  # truthy string -> bool() semantics
+
+
+# ─── #1071 — evidence-based alert reasons + post-stop hold gate ───────────────
+#
+# Both #813 incidents (2026-07-03/04) had daemon_reachable=True on every tick,
+# yet the alert marker said "Happy daemon unreachable" — the pre-#759 reason
+# ladder's else-branch fabricated a daemon outage for the live-corroboration
+# downgrade, and the resulting "stop+respawn manually" instruction produced two
+# manual respawns racing an in-flight auto-recovery. These tests pin the
+# evidence-based ladder (reason + truthful next-step per branch), the
+# corroboration helper's downgrade_note, the daemon-outage retry semantics
+# (persisted `alerted` + eligibility flip == execute-on-next-reachable-tick),
+# and the post-stop worktree-hold gate.
+
+
+def _make_stalled_ctx(asw, **overrides):
+    """Construct a minimal ``_StalledActionCtx`` for direct handler tests.
+
+    Defaults model the #813 shape: autonomous entry, ACTIVE status, no pod,
+    ``dry_run=True`` (no state writes; the marker post is monkeypatched by the
+    caller). Override per test."""
+    kwargs = dict(
+        issue=813,
+        happy_session_id="sess-813",
+        prev_state={},
+        alerted=False,
+        respawn_count=0,
+        exhausted=False,
+        last_self_report_ts="2026-07-03T20:00:00Z",
+        self_gap="131.8m",
+        marker_gap="131.8m",
+        has_pod=False,
+        task_status="running",
+        in_active=True,
+        threshold=2,
+        dry_run=True,
+        manual=False,
+    )
+    kwargs.update(overrides)
+    return asw._StalledActionCtx(**kwargs)
+
+
+def test_stalled_alert_reason_corroboration_downgrade_not_daemon(monkeypatch):
+    # Acceptance criterion 1: a corroboration-downgraded alert names the
+    # debounce (episode n/K + the auto-escalation next-step) and NEVER
+    # contains "daemon unreachable" while daemon_reachable=True. Full
+    # note-CONTENT assertions, not just the sentinel label.
+    import autonomous_session_watch as asw
+
+    posts: list[str] = []
+    monkeypatch.setattr(
+        asw, "_post_progress_marker", lambda issue, note, dry_run, label: posts.append(note)
+    )
+    downgrade = (
+        "live-session corroboration debounce: consecutive live-stall "
+        "episode 1/2; the session id is still in the daemon live set"
+    )
+    ctx = _make_stalled_ctx(asw, daemon_reachable=True, downgrade_note=downgrade)
+    asw._handle_stalled_alert(ctx)
+
+    assert len(posts) == 1
+    note = posts[0]
+    assert asw._STALLED_ALERT_NOTE_SENTINEL in note
+    assert "live-session corroboration debounce" in note
+    assert "episode 1/2" in note
+    assert "auto-escalates" in note
+    assert "daemon unreachable" not in note
+    assert "watcher bug" not in note
+    # The manual-intervention invitation that raced the auto-recovery in both
+    # #813 incidents survives ONLY in the manual branch.
+    assert "stop+respawn manually" not in note
+
+
+def test_stalled_alert_reason_daemon_outage_states_auto_retry(monkeypatch):
+    # Acceptance criterion 2, BOTH halves: a genuine daemon-outage alert
+    # states the persisted auto-retry ("next daemon-reachable tick") AND the
+    # #845 (c) phone-push escalation clause ("2 blocked ticks").
+    import autonomous_session_watch as asw
+
+    posts: list[str] = []
+    monkeypatch.setattr(
+        asw, "_post_progress_marker", lambda issue, note, dry_run, label: posts.append(note)
+    )
+    ctx = _make_stalled_ctx(asw, daemon_reachable=False, downgrade_note=None)
+    asw._handle_stalled_alert(ctx)
+
+    assert len(posts) == 1
+    note = posts[0]
+    assert "Happy daemon unreachable" in note
+    assert "next daemon-reachable tick" in note
+    assert "2 blocked ticks" in note
+    assert "watcher bug" not in note
+    assert "stop+respawn manually" not in note
+
+
+def test_stalled_alert_unexpected_cause_flags_bug(monkeypatch):
+    # A future alert producer that reaches the handler without evidence
+    # (non-manual, ACTIVE, daemon up, no downgrade note) must self-identify
+    # as a watcher bug instead of fabricating a daemon outage (the exact
+    # failure mode behind this task's incorrect premise).
+    import autonomous_session_watch as asw
+
+    posts: list[str] = []
+    monkeypatch.setattr(
+        asw, "_post_progress_marker", lambda issue, note, dry_run, label: posts.append(note)
+    )
+    ctx = _make_stalled_ctx(asw, daemon_reachable=True, downgrade_note=None)
+    asw._handle_stalled_alert(ctx)
+
+    assert len(posts) == 1
+    assert "watcher bug" in posts[0]
+    assert "daemon unreachable" not in posts[0]
+
+
+def test_daemon_outage_remediation_executes_on_recovery_tick():
+    # Goal part 2's "queued and executed on the next daemon-reachable tick"
+    # semantics, pinned as a two-tick decide() SEQUENCE (#1071): tick 1 — the
+    # threshold trips while the daemon is DOWN (respawn_eligible=False), so
+    # the episode fires the ALERT (the caller persists alerted=True); tick 2
+    # — the first reachable tick (respawn_eligible=True) escalates the
+    # alerted episode straight to the respawn, no re-accumulation. Extends
+    # (does not duplicate) the single-call #506-branch assertions in
+    # test_alerted_escalates_to_respawn_when_eligible above: the persisted
+    # `alerted` flag IS the queue — nothing is dropped during an outage.
+    stale = STALLED_MARKER_WINDOW_S_DEFAULT + 60
+    # Tick 1: threshold trip, daemon down -> alert.
+    assert decide_session_stalled(
+        self_report_age_s=stale,
+        marker_progress_age_s=stale,
+        has_pod=True,
+        missed=1,
+        alerted=False,
+        respawn_eligible=False,
+        threshold=2,
+    ) == ("alert", 0)
+    # Tick 2: daemon back -> the alerted episode respawns the same tick.
+    assert decide_session_stalled(
+        self_report_age_s=stale,
+        marker_progress_age_s=stale,
+        has_pod=True,
+        missed=0,
+        alerted=True,
+        respawn_eligible=True,
+        respawn_count=0,
+        threshold=2,
+    ) == ("respawn", 0)
+
+
+def test_corroboration_returns_downgrade_note(isolated_registry, monkeypatch):
+    # Arity pin for the #1071 triple return: the downgrade branch returns a
+    # note carrying the {live_consecutive}/{k} episode fragment (criterion
+    # 1's n/K disclosure); the escalation / dead-sid / daemon-down /
+    # other-action branches all return None.
+    import autonomous_session_watch as asw
+
+    monkeypatch.setenv("EPM_STALLED_LIVE_ESCALATION_K", "2")
+    entry = {"issue": 5, "happy_session_id": "sid-live"}
+
+    # Downgrade branch (live sid, episode 1 < K=2).
+    action, live, note = asw._apply_stalled_live_corroboration(
+        issue=5,
+        entry=entry,
+        action="respawn",
+        daemon_reachable=True,
+        live_ids={"sid-live"},
+        live_consecutive=0,
+        dry_run=True,
+    )
+    assert (action, live) == ("alert", 1)
+    assert note is not None
+    assert "live-session corroboration debounce" in note
+    assert "1/2" in note
+
+    # Escalation branch (Kth consecutive live stall) -> respawn, no note.
+    assert asw._apply_stalled_live_corroboration(
+        issue=5,
+        entry=entry,
+        action="respawn",
+        daemon_reachable=True,
+        live_ids={"sid-live"},
+        live_consecutive=1,
+        dry_run=True,
+    ) == ("respawn", 0, None)
+
+    # Dead-sid branch -> respawn passes through, no note.
+    assert asw._apply_stalled_live_corroboration(
+        issue=5,
+        entry=entry,
+        action="respawn",
+        daemon_reachable=True,
+        live_ids={"sid-other"},
+        live_consecutive=1,
+        dry_run=True,
+    ) == ("respawn", 0, None)
+
+    # Daemon-down branch -> respawn passes through, no note.
+    assert asw._apply_stalled_live_corroboration(
+        issue=5,
+        entry=entry,
+        action="respawn",
+        daemon_reachable=False,
+        live_ids=None,
+        live_consecutive=1,
+        dry_run=True,
+    ) == ("respawn", 0, None)
+
+    # Non-respawn action -> passthrough + counter reset, no note.
+    assert asw._apply_stalled_live_corroboration(
+        issue=5,
+        entry=entry,
+        action="keep",
+        daemon_reachable=True,
+        live_ids={"sid-live"},
+        live_consecutive=1,
+        dry_run=True,
+    ) == ("keep", 0, None)
+
+
+def test_wt_hold_skipped_when_fence_stop_pending(isolated_registry, monkeypatch):
+    # Acceptance criterion 4, both halves. (a) Once stop_pending_sid is set
+    # a stop has already been ISSUED — the #812 mid-edit hold protects the
+    # STOP, so holding post-stop only delays the fence's verified-dead spawn
+    # (incident #813: 3 held ticks post-stop, issue driverless). The hold is
+    # skipped mid-fence, still applied pre-stop (persisting wt_hold_count).
+    # (b) The spawn-grace skip stays UNCONDITIONAL — it guards concurrent
+    # respawns, which is still valid mid-fence.
+    import autonomous_session_watch as asw
+
+    monkeypatch.delenv("EPM_RESPAWN_SPAWN_GRACE_MIN", raising=False)
+    monkeypatch.setattr(asw, "_worktree_recent_activity", lambda *_a, **_k: True)
+    now = 1_000_000.0
+
+    # Mid-fence (stop issued): hold does NOT apply — the arm proceeds.
+    ctx = _make_stalled_ctx(
+        asw, dry_run=False, now=now, stop_pending_sid="sidX", entry_spawned_at=None
+    )
+    assert asw._stalled_arm_deferral(ctx) is False
+
+    # Pre-stop: hold applies and persists wt_hold_count=1.
+    ctx = _make_stalled_ctx(
+        asw, dry_run=False, now=now, stop_pending_sid=None, entry_spawned_at=None
+    )
+    assert asw._stalled_arm_deferral(ctx) is True
+    state = json.loads((isolated_registry / f"{STALLED_STATE_PREFIX}813.json").read_text())
+    assert state["wt_hold_count"] == 1
+
+    # Mid-grace AND mid-fence: the spawn-grace skip is unconditional.
+    ctx = _make_stalled_ctx(
+        asw, dry_run=False, now=now, stop_pending_sid="sidX", entry_spawned_at=now - 60.0
+    )
+    assert asw._stalled_arm_deferral(ctx) is True
+
+
+def test_stalled_pass_corroboration_downgrade_note_threaded(
+    isolated_registry, hermetic_provision_probes, monkeypatch
+):
+    # r1 Must-Fix (production-path threading, corroboration): drive the REAL
+    # stalled_session_pass so the #759 downgrade fires through the live
+    # _apply_stalled_live_corroboration call site and the _StalledActionCtx
+    # construction. A threading miss there (downgrade_note not passed into
+    # the ctx) falls through to the else-branch and posts "watcher bug";
+    # the pre-#1071 code posted "daemon unreachable". Both are asserted
+    # absent; the debounce reason is asserted present.
+    import autonomous_session_watch as asw
+
+    now = 1_000_000.0
+    posts: list[tuple[int, str, str]] = []
+    respawns: list[int] = []
+    _write_autonomous_entry(isolated_registry, 489, "sess-489")
+
+    monkeypatch.setenv("EPM_STALLED_LIVE_ESCALATION_K", "2")
+    stale = STALLED_WINDOW_S + 600
+    monkeypatch.setattr(
+        asw,
+        "_self_report_age_seconds",
+        lambda issue, now: (stale, "2026-06-05T10:00:00Z"),
+    )
+    monkeypatch.setattr(asw, "_task_events", lambda issue: [])
+    monkeypatch.setattr(asw, "_running_managed_issue_pods", lambda *_a, **_k: [])
+    # ACTIVE status + reachable daemon + live sid: decide() wants a respawn;
+    # the corroboration downgrades episode 1/2 to an alert.
+    monkeypatch.setattr(asw, "_task_status", lambda issue: "running")
+    # Make a wrong-path respawn observable (mirror of the #661 test's stubs).
+    monkeypatch.setattr(asw, "_stop_session", lambda sid, dry_run: True)
+    monkeypatch.setattr(
+        asw,
+        "_respawn_stalled_session",
+        lambda issue, cap, dry_run: respawns.append(issue) or "spawned",
+    )
+    monkeypatch.setattr(
+        asw,
+        "_post_progress_marker",
+        lambda issue, note, dry_run, label: posts.append((issue, note, label)),
+    )
+
+    asw.stalled_session_pass(
+        dry_run=False, threshold=1, now=now, daemon_reachable=True, live_ids={"sess-489"}
+    )
+
+    assert respawns == []
+    assert len(posts) == 1
+    issue, note, label = posts[0]
+    assert issue == 489
+    assert label == "session-stalled-alert"
+    assert "live-session corroboration debounce" in note
+    assert "episode 1/2" in note
+    assert "daemon unreachable" not in note
+    assert "watcher bug" not in note
+
+
+def test_stalled_pass_daemon_outage_note_threaded(
+    isolated_registry, hermetic_provision_probes, monkeypatch
+):
+    # r1 Must-Fix (production-path threading, outage): the same pass-level
+    # pattern with daemon_reachable=False on an ACTIVE task at the threshold
+    # trip — the posted note must state the persisted auto-retry, proving
+    # the pass-level daemon_reachable flag is threaded into the ctx (a miss
+    # keeps the True default and posts the "watcher bug" else-branch).
+    import autonomous_session_watch as asw
+
+    now = 1_000_000.0
+    posts: list[tuple[int, str, str]] = []
+    respawns: list[int] = []
+    _write_autonomous_entry(isolated_registry, 489, "sess-489")
+
+    stale = STALLED_WINDOW_S + 600
+    monkeypatch.setattr(
+        asw,
+        "_self_report_age_seconds",
+        lambda issue, now: (stale, "2026-06-05T10:00:00Z"),
+    )
+    monkeypatch.setattr(asw, "_task_events", lambda issue: [])
+    monkeypatch.setattr(asw, "_running_managed_issue_pods", lambda *_a, **_k: [])
+    monkeypatch.setattr(asw, "_task_status", lambda issue: "running")
+    monkeypatch.setattr(asw, "_telegram_push", lambda *_a, **_k: None)
+    monkeypatch.setattr(asw, "_stop_session", lambda sid, dry_run: True)
+    monkeypatch.setattr(
+        asw,
+        "_respawn_stalled_session",
+        lambda issue, cap, dry_run: respawns.append(issue) or "spawned",
+    )
+    monkeypatch.setattr(
+        asw,
+        "_post_progress_marker",
+        lambda issue, note, dry_run, label: posts.append((issue, note, label)),
+    )
+
+    asw.stalled_session_pass(
+        dry_run=False, threshold=1, now=now, daemon_reachable=False, live_ids=None
+    )
+
+    assert respawns == []
+    assert len(posts) == 1
+    issue, note, label = posts[0]
+    assert issue == 489
+    assert label == "session-stalled-alert"
+    assert "Happy daemon unreachable" in note
+    assert "next daemon-reachable tick" in note
+    assert "watcher bug" not in note


### PR DESCRIPTION
Closes task #1071 (workflow-fix, kind: infra).

## Summary
- D1: evidence-based stalled-alert reason ladder — threads `daemon_reachable` + corroboration `downgrade_note` into `_StalledActionCtx`; the #759 corroboration downgrade no longer fabricates "Happy daemon unreachable" (the false text behind both #813 manual-respawn races); per-branch next-step prose names actually-posted terminal sentinels.
- D2: `_stalled_arm_deferral` skips the worktree hold once a fence stop is pending (`stop_pending_sid is None` gate — mirrors the #1027 mid-fence pattern); incident 1's ~38-min driverless window closes.
- D3: docs pin the no-queue continuity semantics (persisted episode state + alerted→eligible escalation = execute-on-next-reachable-tick); D4: 8 new tests incl. 2 production-path threading pins (r1 reconciler Must-Fix).

## Test plan
- [x] 34-file touched-scope Step 9c gate: 2685 passed, 6 skipped; step9c_baseline compare rc=0 (no new failures, no lint regression)
- [x] 4-file watcher stay-green surface: 1007/1007 (implementer round)
- [x] workflow_lint + ruff clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)