### PR TITLE
issue-1047: Step 10d pre-merge/pre-push hardening bundle

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -8360,20 +8360,30 @@ Gate the merge payload on the lint BEFORE anything lands:
     # the compare itself untrustworthy — that fails CLOSED via the crash arm
     # below, never `|| true`-erased. A red-but-line-emitting baseline (rc=1
     # WITH lines — main already red) stays fine: the subtraction handles it.
+    # Per-leg rc capture is a NO-DOWNGRADE (max) fold — same fold at all
+    # FOUR leg pairs (BASE + GATED, shared gate + surgical block): a leg-1
+    # CRASH (rc=2, zero lines) must survive a leg-2 rc=1-with-lines; the
+    # bare last-failure-wins `|| VAR=$?` capture erases the crash and
+    # defeats the crash arm below. rc=0/0 stays 0; a lone rc=1-with-lines
+    # stays 1 (attribution logic); any leg >1 reaches the crash arm.
     BASE_RC=0
     uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
-      > /tmp/issue-<N>-lint-baseline.txt 2>&1 || BASE_RC=$?
+      > /tmp/issue-<N>-lint-baseline.txt 2>&1 \
+      || { rc=$?; if [ "$rc" -gt "$BASE_RC" ]; then BASE_RC=$rc; fi; }
     uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
       --check-references --check-tables --check-asks --check-autonomous-asks \
-      >> /tmp/issue-<N>-lint-baseline.txt 2>&1 || BASE_RC=$?
+      >> /tmp/issue-<N>-lint-baseline.txt 2>&1 \
+      || { rc=$?; if [ "$rc" -gt "$BASE_RC" ]; then BASE_RC=$rc; fi; }
     # GATED legs (payload-bearing tree; parity leg covers the checks the
     # no-flags bundle omits — see the bullet above):
     GATED_RC=0
     uv run python "$WT/scripts/workflow_lint.py" \
-      > /tmp/issue-<N>-lint-gated.txt 2>&1 || GATED_RC=$?
+      > /tmp/issue-<N>-lint-gated.txt 2>&1 \
+      || { rc=$?; if [ "$rc" -gt "$GATED_RC" ]; then GATED_RC=$rc; fi; }
     uv run python "$WT/scripts/workflow_lint.py" \
       --check-references --check-tables --check-asks --check-autonomous-asks \
-      >> /tmp/issue-<N>-lint-gated.txt 2>&1 || GATED_RC=$?
+      >> /tmp/issue-<N>-lint-gated.txt 2>&1 \
+      || { rc=$?; if [ "$rc" -gt "$GATED_RC" ]; then GATED_RC=$rc; fi; }
     # Normalize failure lines: keep per-error `workflow_lint: <err>` lines,
     # DROP the PASS / `FAIL (N error(s))` summary lines (their COUNT changes
     # even when the failure identities match — a payload that fixes one
@@ -8745,12 +8755,35 @@ Decision tree:
   # Two-dot origin/main HEAD would additionally list files main advanced that
   # the branch never touched (status M-because-main-advanced), pulling them into
   # the checkout list — precisely the paths we must NOT overwrite.
-  git -C "$WT" diff --name-only --diff-filter=A origin/main...HEAD -- \
-    "tasks/*/<N>/" "figures/issue_<N>/" "eval_results/issue_<N>/" \
-    "eval_results/issue_<N>_*/" "ood_eval_results/issue_<N>/" \
-    ".claude/" "CLAUDE.md" ".gitattributes" "docs/methodology/issue_<N>.md" \
-    > /tmp/issue-<N>-additive-files.txt
+  #
+  # PRODUCER GUARD — materialize-then-check (mirrors the shared gate's
+  # trigger diff): unchecked, a FAILED diff (bad ref, no merge-base) writes
+  # an empty/partial list indistinguishable from "no additive files" and the
+  # landing below fails OPEN. And an EMPTY list is itself an anomaly HERE:
+  # this decision-tree branch is reached ONLY because deliverables are
+  # MISSING on origin/main, so "nothing to add" means the diff lied or the
+  # payload sits outside the A-only pathspec set (e.g. main deleted the
+  # deliverable — status M, not A — or a scripts/-only payload); landing
+  # anyway would push nothing and post `epm:merged {surgical_checkout:
+  # true}` with nothing committed (a PHANTOM SUCCESS). Both arms hard-stop.
+  if ! git -C "$WT" diff --name-only --diff-filter=A origin/main...HEAD -- \
+      "tasks/*/<N>/" "figures/issue_<N>/" "eval_results/issue_<N>/" \
+      "eval_results/issue_<N>_*/" "ood_eval_results/issue_<N>/" \
+      ".claude/" "CLAUDE.md" ".gitattributes" "docs/methodology/issue_<N>.md" \
+      > /tmp/issue-<N>-additive-files.txt; then
+    echo "SURGICAL ABORT: additive-list diff FAILED — cannot enumerate the payload; route to epm:merge-failed, never land"
+    false
+  elif [ ! -s /tmp/issue-<N>-additive-files.txt ]; then
+    echo "SURGICAL ABORT: additive-files list EMPTY on a deliverables-missing landing (phantom success); route to epm:merge-failed, never land"
+    false
+  fi
   ```
+
+  Either `SURGICAL ABORT` arm (failed producer diff, or an empty additive
+  list on this deliverables-missing landing) routes to the **Surgical
+  checkout itself fails** bullet below: post `epm:merge-failed v1` with the
+  abort line, surface ONE line in chat, CONTINUE — never fall through to
+  the checkout/stage/push block, and never post `epm:merged`.
 
   Then, from the **repo root on `main`** (never switch the branch
   there), checkout each path from the branch, stage by EXPLICIT PATH
@@ -8779,13 +8812,17 @@ Decision tree:
     # BASELINE legs (per-leg exit codes ARE captured — a baseline CRASH must
     # fail CLOSED via the crash arm below, never be `|| true`-erased; only
     # normalized failure LINES enter the compare for the legitimate
-    # red-baseline rc=1-with-lines case):
+    # red-baseline rc=1-with-lines case; per-leg NO-DOWNGRADE max fold, same
+    # rationale as the gate's executable block — a leg-1 crash must not be
+    # erased by a leg-2 rc=1):
     BASE_RC=0
     uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
-      > /tmp/issue-<N>-lint-baseline.txt 2>&1 || BASE_RC=$?
+      > /tmp/issue-<N>-lint-baseline.txt 2>&1 \
+      || { rc=$?; if [ "$rc" -gt "$BASE_RC" ]; then BASE_RC=$rc; fi; }
     uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
       --check-references --check-tables --check-asks --check-autonomous-asks \
-      >> /tmp/issue-<N>-lint-baseline.txt 2>&1 || BASE_RC=$?
+      >> /tmp/issue-<N>-lint-baseline.txt 2>&1 \
+      || { rc=$?; if [ "$rc" -gt "$BASE_RC" ]; then BASE_RC=$rc; fi; }
   fi
   # `-C "$REPO_ROOT"` is the repo-root guard's designed deliberate-override
   # (#897): the hook's working-tree-revert detector would bounce the bare
@@ -8802,10 +8839,12 @@ Decision tree:
   if [ "$GATE_ARMED" = "yes" ]; then
     GATED_RC=0
     uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
-      > /tmp/issue-<N>-lint-gated.txt 2>&1 || GATED_RC=$?
+      > /tmp/issue-<N>-lint-gated.txt 2>&1 \
+      || { rc=$?; if [ "$rc" -gt "$GATED_RC" ]; then GATED_RC=$rc; fi; }
     uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
       --check-references --check-tables --check-asks --check-autonomous-asks \
-      >> /tmp/issue-<N>-lint-gated.txt 2>&1 || GATED_RC=$?
+      >> /tmp/issue-<N>-lint-gated.txt 2>&1 \
+      || { rc=$?; if [ "$rc" -gt "$GATED_RC" ]; then GATED_RC=$rc; fi; }
     for leg in baseline gated; do
       grep -h '^workflow_lint: ' "/tmp/issue-<N>-lint-$leg.txt" \
         | grep -vE '^workflow_lint: (PASS$|FAIL \()' \

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -8240,7 +8240,14 @@ recovery sub-procedure. (This is exactly why #787 itself — which MODIFIES
 # Fast-path predicate — ALL of:
 #  (a) task is kind:infra AND tagged wf-fix (a workflow-fix branch), AND
 #  (b) BEHIND > 1000 (branch predates significant main churn), AND
-#  (c) the branch's OWN diff touches <= 15 files, AND
+#  (c) the branch's OWN diff (after the agent-memory filter below) touches
+#      BETWEEN 1 and 15 files — the `-ge 1` LOWER bound is load-bearing: the
+#      memory filter can EMPTY the list (a branch whose entire own-diff is
+#      Guard-0 memory commits), and an empty list must NEVER fast-path — the
+#      surgical `--diff-filter=A` list is then empty too, and an empty-input
+#      xargs would run `git checkout issue-<N> --` with NO pathspec, which is
+#      a BRANCH SWITCH of the shared repo root (`xargs -r` at the checkout is
+#      the depth-2 defense), AND
 #  (d) every touched file is in-scope: this task's own paths, workflow
 #      surface, .gitattributes, or the methodology doc — NO shared src/ or
 #      scripts/ additions (those need the full rebase to land), AND
@@ -8280,6 +8287,7 @@ FAST_PATH=no
 if [ "$TASK_KIND" = "infra" ] \
    && printf '%s' "$TASK_TAGS" | grep -qw 'wf-fix' \
    && [ "$BEHIND" -gt 1000 ] \
+   && [ "$N_FILES" -ge 1 ] \
    && [ "$N_FILES" -le 15 ] \
    && [ "$IN_SCOPE" = "yes" ] \
    && [ "$ADDED_ONLY" = "yes" ]; then
@@ -8328,14 +8336,65 @@ Gate the merge payload on the lint BEFORE anything lands:
   not fail (PASS = exit 0 on both).
 
   ```bash
-  LINT_RC=0
-  uv run python "$WT/scripts/workflow_lint.py" \
-    > /tmp/issue-<N>-lint.txt 2>&1 || LINT_RC=$?
-  # Parity leg — checks tests/test_workflow_lint.py pins that the no-flags
-  # bundle omits:
-  uv run python "$WT/scripts/workflow_lint.py" \
-    --check-references --check-tables --check-asks --check-autonomous-asks \
-    >> /tmp/issue-<N>-lint.txt 2>&1 || LINT_RC=$?
+  # EXECUTABLE gate — forms (i) safe case and (ii) recovery share this block
+  # verbatim (gated = the WORKTREE lint copy on the payload-bearing branch-tip
+  # tree; baseline = the repo-root copy on the payload-free main tree). Form
+  # (iii) inlines the SAME trigger/normalize/subtract/verdict steps around its
+  # checkout — see the surgical block. The verdict is PERSISTED to a file
+  # because fenced bash blocks are separate shell invocations: the binding
+  # sites consume the FILE, never a shell variable.
+  if git -C "$WT" diff --name-only origin/main...HEAD \
+      | grep -qvE '^(tasks/|figures/|eval_results/|ood_eval_results/|raw/|data/|docs/methodology/)'; then
+    # BASELINE legs (payload-free tree). Exit codes deliberately NOT captured:
+    # only the baseline's normalized failure LINES enter the compare — a red
+    # baseline exit code carries no payload information.
+    uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
+      > /tmp/issue-<N>-lint-baseline.txt 2>&1 || true
+    uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
+      --check-references --check-tables --check-asks --check-autonomous-asks \
+      >> /tmp/issue-<N>-lint-baseline.txt 2>&1 || true
+    # GATED legs (payload-bearing tree; parity leg covers the checks the
+    # no-flags bundle omits — see the bullet above):
+    GATED_RC=0
+    uv run python "$WT/scripts/workflow_lint.py" \
+      > /tmp/issue-<N>-lint-gated.txt 2>&1 || GATED_RC=$?
+    uv run python "$WT/scripts/workflow_lint.py" \
+      --check-references --check-tables --check-asks --check-autonomous-asks \
+      >> /tmp/issue-<N>-lint-gated.txt 2>&1 || GATED_RC=$?
+    # Normalize failure lines: keep per-error `workflow_lint: <err>` lines,
+    # DROP the PASS / `FAIL (N error(s))` summary lines (their COUNT changes
+    # even when the failure identities match — a payload that fixes one
+    # pre-existing error must not false-block on a differing summary), and
+    # blank `:<line>:` numbers so unrelated drift cannot fake a NEW line.
+    # (WARNs never enter: workflow_lint emits them with a `WARN: ` prefix.)
+    for leg in baseline gated; do
+      grep -h '^workflow_lint: ' "/tmp/issue-<N>-lint-$leg.txt" \
+        | grep -vE '^workflow_lint: (PASS$|FAIL \()' \
+        | sed -E 's/:[0-9]+:/::/g' | sort -u \
+        > "/tmp/issue-<N>-lint-$leg-norm.txt" || true
+    done
+    # NEW = gated_failures − baseline_failures (set subtraction):
+    comm -23 /tmp/issue-<N>-lint-gated-norm.txt \
+      /tmp/issue-<N>-lint-baseline-norm.txt > /tmp/issue-<N>-lint-new.txt
+    # Gated failure lines naming a file IN the own-diff:
+    git -C "$WT" diff --name-only origin/main...HEAD > /tmp/issue-<N>-own-diff.txt
+    grep -F -f /tmp/issue-<N>-own-diff.txt /tmp/issue-<N>-lint-gated-norm.txt \
+      > /tmp/issue-<N>-lint-owndiff.txt || true
+    # VERDICT — the captured GATED_RC is consumed HERE: a green gated run
+    # (exit 0) can never block; a red one blocks only when payload-attributed
+    # (an own-diff-named failure line OR a non-empty NEW set).
+    if [ "$GATED_RC" -ne 0 ] \
+       && { [ -s /tmp/issue-<N>-lint-owndiff.txt ] || [ -s /tmp/issue-<N>-lint-new.txt ]; }; then
+      echo block > /tmp/issue-<N>-lint-verdict.txt
+    else
+      echo pass > /tmp/issue-<N>-lint-verdict.txt
+    fi
+  else
+    # Executable trigger (the Trigger bullet above): artifact-only payload —
+    # both lint runs skipped by design.
+    echo skip-artifact-only > /tmp/issue-<N>-lint-verdict.txt
+  fi
+  cat /tmp/issue-<N>-lint-verdict.txt   # pass | block | skip-artifact-only
   ```
 
 - **Verdict — payload-attributed via failure-LINE-SET subtraction; NEVER
@@ -8345,22 +8404,30 @@ Gate the merge payload on the lint BEFORE anything lands:
   prefixes; keep the `<check>/<file>[:<line>] <msg>` identity) between the
   GATED run and a payload-free BASELINE run — BOTH legs (no-flags + parity)
   in each run, so a pre-existing parity-leg red on main can never be
-  misread as payload-caused (and vice versa). On any gated-run failure:
-  1. Any gated failure line naming a file IN the own-diff → the payload is
-     the offender. Fix it in the worktree (the lint names file + rule),
+  misread as payload-caused (and vice versa). The executable block above
+  computes the BINARY verdict (`block` | `pass` | `skip-artifact-only`) and
+  persists it to `/tmp/issue-<N>-lint-verdict.txt`; the binding sites gate
+  their merge/push/add commands on that FILE with an explicit conditional —
+  a missing verdict file fails CLOSED (the gate has not run yet). On a
+  `block` verdict:
+  1. An own-diff-named gated failure line exists
+     (`/tmp/issue-<N>-lint-owndiff.txt` non-empty) → the payload is the
+     offender. Fix it in the worktree (the lint names file + rule),
      commit by explicit path, re-run the gate ONCE; still failing → post
      `epm:merge-failed v1` with `{reason: "pre-push workflow-lint gate",
      lint_tail: <last lines>}`, surface ONE line in chat, CONTINUE (same
      fail-fast policy as a merge failure; retried idempotently on the next
      `/issue <N>`).
-  2. No own-diff-named line → compute `NEW = gated_failures −
-     baseline_failures` (set subtraction on the normalized lines). NEW
-     non-empty → a payload-caused cross-file interaction (e.g. a
-     lessons-index / lens-coverage check naming the index rather than the
-     added rule file) — treat as case 1 (block). NEW empty → pre-existing
-     red — WARN (record the lint tail in the `epm:merged` note) and
-     PROCEED. Run the baseline and gated runs back-to-back in the same
-     turn so a concurrent merge cannot widen the compare window
+  2. No own-diff-named line → the block came from
+     `NEW = gated_failures − baseline_failures` (`comm -23` on the
+     normalized lines, persisted at `/tmp/issue-<N>-lint-new.txt`) — a
+     payload-caused cross-file interaction (e.g. a lessons-index /
+     lens-coverage check naming the index rather than the added rule
+     file) — treat as case 1 (block). NEW empty with no own-diff-named
+     line never blocks: the executable block writes `pass` — pre-existing
+     red is a WARN (record the lint tail in the `epm:merged` note) and
+     the merge PROCEEDS. Run the baseline and gated runs back-to-back in
+     the same turn so a concurrent merge cannot widen the compare window
      (moving-main race — keep the window tight, preserve the
      main-already-red detail in the marker).
 - **Baseline semantics per binding form (the baseline is ALWAYS a
@@ -8378,11 +8445,23 @@ Gate the merge payload on the lint BEFORE anything lands:
   exactly the fast-path form; sequence = baseline (root copy, both legs) →
   checkout → gated (root copy, both legs) → set-subtraction verdict → on
   pass, `git add`. On a block at (iii), clean the payload out of BOTH
-  index and working tree — `xargs -a /tmp/issue-<N>-additive-files.txt
-  git restore --staged --worktree --` (the paths are A-only; a bare
-  `rm -f` leaves them STAGED in the shared root index, polluting
-  concurrent sessions' `git diff --cached` echoes). The fast path routes
-  through (iii). Idempotent: re-entry just re-runs the gate.
+  index and working tree with the hook-VERIFIED two-step (run from
+  `$REPO_ROOT`; simulated against `scripts/guard_repo_root_branch.sh`
+  2026-07-05 — the one-shot restore invocation carrying `--staged` PLUS a
+  worktree flag is mechanically BLOCKED by its #897 restore detector, whose allow
+  arm requires `--staged` AND no worktree flag, and the hook's own
+  guidance bans pointing `-C` at the repo root for a DESTRUCTIVE op):
+  first `xargs -r -a /tmp/issue-<N>-additive-files.txt git -C "$REPO_ROOT"
+  restore --staged --` (index-only unstage — non-destructive, admitted by
+  the restore allow-arm), then `xargs -r -a
+  /tmp/issue-<N>-additive-files.txt rm -f --` (the paths are A-only,
+  absent from `main`, and untracked after the unstage — the plain `rm`
+  destroys no main state; a bare `rm -f` WITHOUT the unstage would leave
+  them STAGED in the shared root index, polluting concurrent sessions'
+  `git diff --cached` echoes). The `xargs -r` (`--no-run-if-empty`) on
+  every additive-list consumer is load-bearing: on an EMPTY list a
+  flag-less xargs still runs its command once with NO pathspec. The fast
+  path routes through (iii). Idempotent: re-entry just re-runs the gate.
 - **Known residual (accepted, documented):** on path (i) the gated lint is
   the branch's merge-base copy (Step 5a's spec-freshness `SPECS` list
   covers `.claude/` specs + CLAUDE.md, NOT `scripts/` — verified at the
@@ -8416,14 +8495,35 @@ else
   # (WORKTREE-scoped: `git -C "$WT"` on the issue branch. scripts/sync_repo_root.py
   # does NOT apply here — it is repo-root-only by design, preconditioned on
   # HEAD == main, exit 5 otherwise.)
-  if [ "$STRIPPED_FOREIGN" = "yes" ] || [ "$MEM_COMMITTED" = "yes" ]; then
+  #
+  # The push condition RE-DERIVES "unpushed local commits exist" from git
+  # state (rev-list against origin/issue-<N>) instead of trusting the
+  # STRIPPED_FOREIGN / MEM_COMMITTED flags alone: fenced bash blocks are
+  # SEPARATE shell invocations, so a flag assigned in Guard 0/1 is unset
+  # here (and would silently skip the second-chance push); the git-state
+  # read also survives a crash + re-entry, and covers BOTH the strip commit
+  # and the memory commit in one predicate. The flags stay as same-block
+  # conveniences only (they still short-circuit true when guards and merge
+  # happen to run in one shell). A missing / unresolvable origin/issue-<N>
+  # ref counts as unpushed (`|| echo 1` — fails toward pushing, the safe
+  # direction; a redundant push is a no-op "Everything up-to-date").
+  if [ "$(git -C "$WT" rev-list --count origin/issue-<N>..HEAD 2>/dev/null || echo 1)" -gt 0 ] \
+     || [ "$STRIPPED_FOREIGN" = "yes" ] || [ "$MEM_COMMITTED" = "yes" ]; then
     git -C "$WT" push origin issue-<N> \
       || { git -C "$WT" pull --rebase=merges --autostash \
            && git -C "$WT" push origin issue-<N>; }
   fi
-  # Pre-push workflow-lint gate (subsection above) — run BEFORE gh pr ready.
-  gh pr ready <PR>
-  gh pr merge <PR> --rebase --delete-branch=false
+  # Pre-push workflow-lint gate (subsection above) — run its executable
+  # block FIRST, then gate the merge on the PERSISTED verdict file: the
+  # explicit conditional below is the hard stop (a missing verdict file
+  # fails CLOSED — the gate has not run yet; run it, then re-enter).
+  if grep -qxE 'pass|skip-artifact-only' /tmp/issue-<N>-lint-verdict.txt 2>/dev/null; then
+    gh pr ready <PR>
+    gh pr merge <PR> --rebase --delete-branch=false
+  else
+    echo "BLOCKED: pre-push workflow-lint gate (verdict: $(cat /tmp/issue-<N>-lint-verdict.txt 2>/dev/null || echo not-run)) — fix the named offender in the worktree, re-run the gate ONCE; still failing -> epm:merge-failed (gate subsection, verdict case 1). Do NOT merge."
+    false
+  fi
 fi
 ```
 
@@ -8466,12 +8566,21 @@ git -C "$WT" merge origin/main          # conflicts surface HERE, in the worktre
 # outside this task's deliverables), then:
 git -C "$WT" add <each resolved file>
 git -C "$WT" commit --no-edit
-# Re-run the targeted tests for the touched surface AND the Pre-push workflow-lint gate (subsection above), then:
-git -C "$WT" push
-# gh recomputes mergeability asynchronously after a push — it can be
-# momentarily stale. Re-check before concluding failure:
-gh pr view <PR> --json mergeable -q .mergeable   # brief wait/retry until MERGEABLE
-gh pr merge <PR> --rebase --delete-branch=false
+# Re-run the targeted tests for the touched surface AND the executable
+# Pre-push workflow-lint gate block (subsection above; gated = this
+# post-merge worktree copy, which carries main's CURRENT lint — the ideal
+# gate point). The push is then GATED on the persisted verdict file — the
+# explicit conditional is the hard stop (missing file fails CLOSED):
+if grep -qxE 'pass|skip-artifact-only' /tmp/issue-<N>-lint-verdict.txt 2>/dev/null; then
+  git -C "$WT" push
+  # gh recomputes mergeability asynchronously after a push — it can be
+  # momentarily stale. Re-check before concluding failure:
+  gh pr view <PR> --json mergeable -q .mergeable   # brief wait/retry until MERGEABLE
+  gh pr merge <PR> --rebase --delete-branch=false
+else
+  echo "BLOCKED: pre-push workflow-lint gate (verdict: $(cat /tmp/issue-<N>-lint-verdict.txt 2>/dev/null || echo not-run)) — fix the named offender in the worktree, re-run the gate ONCE; still failing -> epm:merge-failed (gate subsection, verdict case 1). Do NOT push."
+  false
+fi
 ```
 
 One recovery attempt per Step 10d invocation. If the re-checked
@@ -8611,40 +8720,85 @@ Decision tree:
 
   ```bash
   cd "$REPO_ROOT"
-  # Pre-push workflow-lint gate — BASELINE leg (subsection above). Run BOTH
-  # lint legs on the ROOT copy BEFORE the checkout below lands the payload:
-  # a post-checkout "baseline" would re-lint the same contaminated tree — a
-  # degenerate self-compare that fails open. Skip both legs only when the
-  # additive-files list is artifact-only (the gate's Trigger bullet).
-  BASE_RC=0
-  uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
-    > /tmp/issue-<N>-lint-baseline.txt 2>&1 || BASE_RC=$?
-  uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
-    --check-references --check-tables --check-asks --check-autonomous-asks \
-    >> /tmp/issue-<N>-lint-baseline.txt 2>&1 || BASE_RC=$?
+  # Pre-push workflow-lint gate — form (iii) (subsection above): the payload
+  # lands in the ROOT tree, so BOTH lint runs use the root copy, sequenced
+  # around the checkout — BASELINE BEFORE (payload-free tree; a post-checkout
+  # "baseline" would re-lint the same contaminated tree, a degenerate
+  # self-compare that fails open), GATED AFTER. The whole gate-and-land
+  # sequence runs in ONE fenced block, so the verdict variable is
+  # same-invocation state (no cross-block variable). Executable trigger
+  # first: an artifact-only additive list skips both lint runs.
+  GATE_ARMED=no
+  if grep -qvE '^(tasks/|figures/|eval_results/|ood_eval_results/|raw/|data/|docs/methodology/)' \
+       /tmp/issue-<N>-additive-files.txt; then
+    GATE_ARMED=yes
+    # BASELINE legs (exit codes deliberately not captured — only normalized
+    # failure LINES enter the compare):
+    uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
+      > /tmp/issue-<N>-lint-baseline.txt 2>&1 || true
+    uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
+      --check-references --check-tables --check-asks --check-autonomous-asks \
+      >> /tmp/issue-<N>-lint-baseline.txt 2>&1 || true
+  fi
   # `-C "$REPO_ROOT"` is the repo-root guard's designed deliberate-override
   # (#897): the hook's working-tree-revert detector would bounce the bare
   # `checkout <branch> -- <paths>` form; the `-C` names the tree explicitly.
-  xargs -a /tmp/issue-<N>-additive-files.txt git -C "$REPO_ROOT" checkout issue-<N> --
-  # Pre-push workflow-lint gate — GATED leg: the root tree now carries the
-  # payload; re-run both legs, then apply the failure-LINE-SET subtraction
-  # verdict (subsection above). On a block, clean the payload out of BOTH
-  # index and working tree:
-  #   xargs -a /tmp/issue-<N>-additive-files.txt git restore --staged --worktree --
-  GATED_RC=0
-  uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
-    > /tmp/issue-<N>-lint-gated.txt 2>&1 || GATED_RC=$?
-  uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
-    --check-references --check-tables --check-asks --check-autonomous-asks \
-    >> /tmp/issue-<N>-lint-gated.txt 2>&1 || GATED_RC=$?
-  xargs -a /tmp/issue-<N>-additive-files.txt git add --
-  git diff --cached --name-only   # sanity echo: spot any foreign staged entries
-  xargs -a /tmp/issue-<N>-additive-files.txt git commit -m "issue-<N>: surgical additive checkout (full rebase deferred — guard 3)
+  # `xargs -r` (--no-run-if-empty) is load-bearing: on an EMPTY additive list
+  # a flag-less xargs still runs `git checkout issue-<N> --` ONCE with no
+  # pathspec — a BRANCH SWITCH of the shared root (the FAST_PATH `-ge 1`
+  # lower bound is the first defense; this is defense-in-depth).
+  xargs -r -a /tmp/issue-<N>-additive-files.txt git -C "$REPO_ROOT" checkout issue-<N> --
+  # GATED legs + verdict — the root tree now carries the payload. Same
+  # normalize → comm -23 subtraction → verdict as the gate's executable
+  # block; own-diff here = the additive-files list.
+  GATE_VERDICT=pass
+  if [ "$GATE_ARMED" = "yes" ]; then
+    GATED_RC=0
+    uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
+      > /tmp/issue-<N>-lint-gated.txt 2>&1 || GATED_RC=$?
+    uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
+      --check-references --check-tables --check-asks --check-autonomous-asks \
+      >> /tmp/issue-<N>-lint-gated.txt 2>&1 || GATED_RC=$?
+    for leg in baseline gated; do
+      grep -h '^workflow_lint: ' "/tmp/issue-<N>-lint-$leg.txt" \
+        | grep -vE '^workflow_lint: (PASS$|FAIL \()' \
+        | sed -E 's/:[0-9]+:/::/g' | sort -u \
+        > "/tmp/issue-<N>-lint-$leg-norm.txt" || true
+    done
+    comm -23 /tmp/issue-<N>-lint-gated-norm.txt \
+      /tmp/issue-<N>-lint-baseline-norm.txt > /tmp/issue-<N>-lint-new.txt
+    grep -F -f /tmp/issue-<N>-additive-files.txt /tmp/issue-<N>-lint-gated-norm.txt \
+      > /tmp/issue-<N>-lint-owndiff.txt || true
+    # GATED_RC consumed HERE — a red gated run blocks only when
+    # payload-attributed (own-diff-named line OR NEW non-empty):
+    if [ "$GATED_RC" -ne 0 ] \
+       && { [ -s /tmp/issue-<N>-lint-owndiff.txt ] || [ -s /tmp/issue-<N>-lint-new.txt ]; }; then
+      GATE_VERDICT=block
+    fi
+  fi
+  # HARD STOP: stage/commit/push run ONLY on a pass verdict; a block cleans
+  # the payload back out of the shared root (index + working tree).
+  if [ "$GATE_VERDICT" = "pass" ]; then
+    xargs -r -a /tmp/issue-<N>-additive-files.txt git add --
+    git diff --cached --name-only   # sanity echo: spot any foreign staged entries
+    xargs -r -a /tmp/issue-<N>-additive-files.txt git commit -m "issue-<N>: surgical additive checkout (full rebase deferred — guard 3)
 
   Branch unsafe to blind-rebase: <based on <PARENT> (not on mainline) |
   own commits touch foreign / out-of-scope paths>. Cherry-picked this
   task's own added files only; shared src/ / scripts/ unchanged." --
-  git push origin main
+    git push origin main
+  else
+    # BLOCKED: the checkout above already staged the A-only paths AND wrote
+    # them to the working tree — clean BOTH with the hook-verified two-step
+    # (the gate subsection's baseline-semantics bullet documents why the
+    # one-shot restore form is hook-blocked): index-only unstage, then plain
+    # rm of the now-untracked A-only files (absent from main — no main state
+    # destroyed).
+    xargs -r -a /tmp/issue-<N>-additive-files.txt git -C "$REPO_ROOT" restore --staged --
+    xargs -r -a /tmp/issue-<N>-additive-files.txt rm -f --
+    echo "BLOCKED: pre-push workflow-lint gate — fix the named offender in the worktree, re-run ONCE; still failing -> epm:merge-failed (gate subsection, verdict case 1). Payload cleaned from the root index + working tree."
+    false
+  fi
   ```
 
   Then post `epm:merged v1` with `{artifact_confirmed: true,

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -8008,6 +8008,40 @@ REPO_ROOT=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")
 WT="$REPO_ROOT/.claude/worktrees/issue-<N>"
 ```
 
+**Guard 0 — agent-memory pre-commit (run FIRST, before guards 1-3 and every
+merge form).** Review rounds write per-agent memories
+(`.claude/agent-memory/**`) with cwd in the worktree, leaving the tree dirty;
+a dirty tree aborts the merge-conflict recovery's `git -C "$WT" merge
+origin/main` below (incident #906, 2026-07-04). Commit them by explicit
+pathspec — never `git add -A`:
+
+```bash
+MEM_COMMITTED=no
+if git -C "$WT" status --porcelain -- .claude/agent-memory/ | grep -q .; then
+  git -C "$WT" add -- .claude/agent-memory/
+  git -C "$WT" commit -m "issue-<N>: persist agent-memory writes before Step-10d merge" \
+    -- .claude/agent-memory/
+  MEM_COMMITTED=yes
+  # Best-effort branch push NOW: the fast-path / artifact-confirmed forms
+  # never reach the safe-case pre-merge push, and on re-entry the pathspec
+  # is clean (MEM_COMMITTED=no) so the commit would otherwise strand
+  # local-only indefinitely. Failure is non-fatal — the safe-case push
+  # condition below is the second chance.
+  git -C "$WT" push origin issue-<N> || true
+fi
+```
+
+Idempotent (a re-run finds the pathspec clean and skips). Scope is EXACTLY
+`.claude/agent-memory/`: any OTHER dirty worktree path still surfaces through
+the existing merge-failure handling — never blanket-commit it. REPO-ROOT-side
+dirty agent-memory files are deliberately NOT committed here: every repo-root
+pull in this step routes through `scripts/sync_repo_root.py` (see below),
+whose autostash + rescue handling is built for the always-dirty shared root
+(#967's hand-rolled root pull died `fatal: Cannot autostash`). For Guard 3
+and the fast-path predicate, `.claude/agent-memory/**` paths are review-round
+bookkeeping — always in-scope, never an UNSAFE trigger (see the Guard-3 note
+and the fast-path mapfile filter below).
+
 A behind-`main` `issue-<N>` branch can carry stale copies of OTHER tasks'
 `tasks/` state, a crash between merge and a status flip can strand a
 task at the wrong status, AND a branch based on another still-unmerged
@@ -8152,7 +8186,9 @@ rebase-merged. Three guards:
    UNSAFE if the own-diff — after the spec-freshness exclusion above — touches
    any foreign `tasks/` path (under `tasks/` but outside `tasks/*/<N>/`) or files
    outside this task's deliverable scope (paths neither the plan nor the code
-   review touched). If the list is clean — only this task's own deliverables,
+   review touched). (Paths under `.claude/agent-memory/` — including the
+   Guard-0 persist commit — are review-round bookkeeping: always in-scope,
+   never an UNSAFE trigger.) If the list is clean — only this task's own deliverables,
    plus any spec-freshness-synced workflow-surface files — the branch is SAFE to
    rebase-merge regardless of `BEHIND`: the rebase replays only these commits,
    and files the branch never committed keep `main`'s version.
@@ -8217,7 +8253,15 @@ TASK_KIND=$(printf '%s\n' "$KIND" | sed -n 1p)
 TASK_TAGS=$(printf '%s\n' "$KIND" | sed -n 2p)
 # Three-dot: the branch's OWN commits only (merge-base..HEAD) — never files
 # main advanced but the branch never touched. Name-status so we can gate on A.
-mapfile -t OWN_NS < <(git -C "$WT" diff --name-status origin/main...HEAD)
+# Exclude .claude/agent-memory/ — the Guard-0 persist commit MODIFIES memory
+# files, which must not fail the ADDED-only predicate (e). Memory edits land
+# via the ordinary rebase (or stay on the PR branch for the deferred full
+# rebase); the surgical checkout never carries a modified file anyway.
+mapfile -t OWN_NS < <(git -C "$WT" diff --name-status origin/main...HEAD \
+  | grep -vE $'\t\\.claude/agent-memory/[^\t]*$' || true)
+# End-anchored on the LAST path field so an R-status rename whose SOURCE is
+# a memory path but whose destination is elsewhere cannot dodge predicate
+# (e) via over-filtering (Guard 0 itself never produces renames).
 N_FILES=${#OWN_NS[@]}
 IN_SCOPE=yes
 ADDED_ONLY=yes
@@ -8258,6 +8302,97 @@ pre-check adds NO new behavior for normal branches. A branch that MODIFIES a
 workflow-surface file (status M ⇒ `ADDED_ONLY=no`) is deliberately not
 fast-pathed; it takes the ordinary `--rebase`.
 
+#### Pre-push workflow-lint gate (runs before every merge form lands)
+
+#931 (2026-07-04) merged a workflow-lint offender to `main`, breaking
+`tests/test_workflow_lint.py` on pristine trunk fleet-wide for most of a day
+(5 downstream sessions each burned 5-25 min classifying it as pre-existing).
+Gate the merge payload on the lint BEFORE anything lands:
+
+- **Trigger (cheap; artifact-only merges skip).** Run the gate ONLY when the
+  branch's own three-dot diff (`git -C "$WT" diff --name-only
+  origin/main...HEAD`, computed after guards 0-3) touches any path OUTSIDE
+  the artifact-only set (`tasks/`, `figures/`, `eval_results/`,
+  `ood_eval_results/`, `raw/`, `data/`, `docs/methodology/`). The lint's
+  no-flags default run walks `.claude/**`, `CLAUDE.md`, `scripts/`, and
+  `src/`, so any code-bearing payload is in scope.
+- **Run the WORKTREE's copy — no-flags bundle PLUS the parity leg.**
+  `workflow_lint.py` derives its scan root from `__file__` (not cwd), so
+  invoking `"$WT/scripts/workflow_lint.py"` scans the branch-tip tree;
+  running from a worktree is a designed use case (`_other_worktree_prefix`).
+  The no-flags default run does NOT bundle the asks / autonomous-asks /
+  references / tables / status-labels checks (their `main()` branches lack
+  `or no_flags`), yet `tests/test_workflow_lint.py` subprocess-runs those
+  too — so trunk-pytest parity takes BOTH invocations. Measured wall
+  ~4.5-6 min (no-flags) + ~1.4 s (parity leg) on the shared VM; WARNs do
+  not fail (PASS = exit 0 on both).
+
+  ```bash
+  LINT_RC=0
+  uv run python "$WT/scripts/workflow_lint.py" \
+    > /tmp/issue-<N>-lint.txt 2>&1 || LINT_RC=$?
+  # Parity leg — checks tests/test_workflow_lint.py pins that the no-flags
+  # bundle omits:
+  uv run python "$WT/scripts/workflow_lint.py" \
+    --check-references --check-tables --check-asks --check-autonomous-asks \
+    >> /tmp/issue-<N>-lint.txt 2>&1 || LINT_RC=$?
+  ```
+
+- **Verdict — payload-attributed via failure-LINE-SET subtraction; NEVER
+  blocks an innocent merge on pre-existing red.** Exit codes alone are
+  vacuous when `main` is already red for an unrelated reason; attribution
+  compares normalized `workflow_lint:` failure LINES (strip volatile
+  prefixes; keep the `<check>/<file>[:<line>] <msg>` identity) between the
+  GATED run and a payload-free BASELINE run — BOTH legs (no-flags + parity)
+  in each run, so a pre-existing parity-leg red on main can never be
+  misread as payload-caused (and vice versa). On any gated-run failure:
+  1. Any gated failure line naming a file IN the own-diff → the payload is
+     the offender. Fix it in the worktree (the lint names file + rule),
+     commit by explicit path, re-run the gate ONCE; still failing → post
+     `epm:merge-failed v1` with `{reason: "pre-push workflow-lint gate",
+     lint_tail: <last lines>}`, surface ONE line in chat, CONTINUE (same
+     fail-fast policy as a merge failure; retried idempotently on the next
+     `/issue <N>`).
+  2. No own-diff-named line → compute `NEW = gated_failures −
+     baseline_failures` (set subtraction on the normalized lines). NEW
+     non-empty → a payload-caused cross-file interaction (e.g. a
+     lessons-index / lens-coverage check naming the index rather than the
+     added rule file) — treat as case 1 (block). NEW empty → pre-existing
+     red — WARN (record the lint tail in the `epm:merged` note) and
+     PROCEED. Run the baseline and gated runs back-to-back in the same
+     turn so a concurrent merge cannot widen the compare window
+     (moving-main race — keep the window tight, preserve the
+     main-already-red detail in the marker).
+- **Baseline semantics per binding form (the baseline is ALWAYS a
+  payload-free tree).** (i) Safe case: gated = the WORKTREE copy
+  (branch-tip tree); baseline = the repo-root copy (main tree, payload
+  absent); bind immediately before `gh pr ready` / `gh pr merge`.
+  (ii) Merge-conflict recovery: gated = the worktree copy AFTER
+  `git -C "$WT" merge origin/main` (≈ post-merge main, carrying main's
+  CURRENT lint — the ideal gate point); baseline = the repo-root copy;
+  bind after conflict resolution + targeted tests, before
+  `git -C "$WT" push`. (iii) Surgical additive checkout: the payload lands
+  in the ROOT tree, so the BASELINE MUST RUN BEFORE the
+  `xargs ... git checkout` — a post-checkout "main-side" run would re-lint
+  the SAME contaminated tree, a degenerate compare that fails open at
+  exactly the fast-path form; sequence = baseline (root copy, both legs) →
+  checkout → gated (root copy, both legs) → set-subtraction verdict → on
+  pass, `git add`. On a block at (iii), clean the payload out of BOTH
+  index and working tree — `xargs -a /tmp/issue-<N>-additive-files.txt
+  git restore --staged --worktree --` (the paths are A-only; a bare
+  `rm -f` leaves them STAGED in the shared root index, polluting
+  concurrent sessions' `git diff --cached` echoes). The fast path routes
+  through (iii). Idempotent: re-entry just re-runs the gate.
+- **Known residual (accepted, documented):** on path (i) the gated lint is
+  the branch's merge-base copy (Step 5a's spec-freshness `SPECS` list
+  covers `.claude/` specs + CLAUDE.md, NOT `scripts/` — verified at the
+  Step 5a `SPECS=` line), so a check ADDED on `main` after the branch
+  forked is not enforced there — it IS enforced on path (ii) (post-merge
+  tree, main's current lint), and the trunk pytest remains the backstop.
+  #931 itself was exactly such a post-fork-check instance and landed via
+  path (ii) — covered here by the RECOVERY-path binding, not by path (i);
+  do NOT narrate the gate as "all #931-class offenders die at path (i)".
+
 #### The auto-merge procedure (safe case: guard 3 clean — mainline-based, own commits in scope)
 
 ```bash
@@ -8275,12 +8410,18 @@ else
   # tasks/* reverts in the replayed history and landing them on main silently
   # (Codex code-review round-1 blocker, task #787). Push retry mirrors
   # CLAUDE.md § "Concurrent repo-root committers": pull --rebase=merges
-  # --autostash then re-push on a rejected push.
-  if [ "$STRIPPED_FOREIGN" = "yes" ]; then
+  # --autostash then re-push on a rejected push. The Guard-0 agent-memory
+  # persist commit is equally local-only — both must reach the PR head ref
+  # before the server-side rebase.
+  # (WORKTREE-scoped: `git -C "$WT"` on the issue branch. scripts/sync_repo_root.py
+  # does NOT apply here — it is repo-root-only by design, preconditioned on
+  # HEAD == main, exit 5 otherwise.)
+  if [ "$STRIPPED_FOREIGN" = "yes" ] || [ "$MEM_COMMITTED" = "yes" ]; then
     git -C "$WT" push origin issue-<N> \
       || { git -C "$WT" pull --rebase=merges --autostash \
            && git -C "$WT" push origin issue-<N>; }
   fi
+  # Pre-push workflow-lint gate (subsection above) — run BEFORE gh pr ready.
   gh pr ready <PR>
   gh pr merge <PR> --rebase --delete-branch=false
 fi
@@ -8325,7 +8466,7 @@ git -C "$WT" merge origin/main          # conflicts surface HERE, in the worktre
 # outside this task's deliverables), then:
 git -C "$WT" add <each resolved file>
 git -C "$WT" commit --no-edit
-# Re-run the targeted tests for the touched surface, then:
+# Re-run the targeted tests for the touched surface AND the Pre-push workflow-lint gate (subsection above), then:
 git -C "$WT" push
 # gh recomputes mergeability asynchronously after a push — it can be
 # momentarily stale. Re-check before concluding failure:
@@ -8470,10 +8611,32 @@ Decision tree:
 
   ```bash
   cd "$REPO_ROOT"
+  # Pre-push workflow-lint gate — BASELINE leg (subsection above). Run BOTH
+  # lint legs on the ROOT copy BEFORE the checkout below lands the payload:
+  # a post-checkout "baseline" would re-lint the same contaminated tree — a
+  # degenerate self-compare that fails open. Skip both legs only when the
+  # additive-files list is artifact-only (the gate's Trigger bullet).
+  BASE_RC=0
+  uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
+    > /tmp/issue-<N>-lint-baseline.txt 2>&1 || BASE_RC=$?
+  uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
+    --check-references --check-tables --check-asks --check-autonomous-asks \
+    >> /tmp/issue-<N>-lint-baseline.txt 2>&1 || BASE_RC=$?
   # `-C "$REPO_ROOT"` is the repo-root guard's designed deliberate-override
   # (#897): the hook's working-tree-revert detector would bounce the bare
   # `checkout <branch> -- <paths>` form; the `-C` names the tree explicitly.
   xargs -a /tmp/issue-<N>-additive-files.txt git -C "$REPO_ROOT" checkout issue-<N> --
+  # Pre-push workflow-lint gate — GATED leg: the root tree now carries the
+  # payload; re-run both legs, then apply the failure-LINE-SET subtraction
+  # verdict (subsection above). On a block, clean the payload out of BOTH
+  # index and working tree:
+  #   xargs -a /tmp/issue-<N>-additive-files.txt git restore --staged --worktree --
+  GATED_RC=0
+  uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
+    > /tmp/issue-<N>-lint-gated.txt 2>&1 || GATED_RC=$?
+  uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
+    --check-references --check-tables --check-asks --check-autonomous-asks \
+    >> /tmp/issue-<N>-lint-gated.txt 2>&1 || GATED_RC=$?
   xargs -a /tmp/issue-<N>-additive-files.txt git add --
   git diff --cached --name-only   # sanity echo: spot any foreign staged entries
   xargs -a /tmp/issue-<N>-additive-files.txt git commit -m "issue-<N>: surgical additive checkout (full rebase deferred — guard 3)
@@ -8488,8 +8651,13 @@ Decision tree:
   full_rebase_deferred: true, surgical_checkout: true, files:
   [...]}`. Same chat title update as above.
 
-- **Surgical checkout itself fails** (file conflicts, push rejected
-  after one `git pull --rebase=merges --autostash` retry; `--rebase=merges` preserves concurrent sessions' unpushed merge commits — plain `--rebase` flattens them away — and a rebase without `--autostash` fails on the always-dirty shared root) — post `epm:merge-failed v1`
+- **Surgical checkout itself fails** (file conflicts, or push rejected after
+  one `uv run python "$REPO_ROOT/scripts/sync_repo_root.py"` retry — the ONLY
+  repo-root sync command: single-flight flock, untracked-collision sweep +
+  rescue, `--rebase=merges --autostash` pull, stranded-autostash recovery,
+  and a push with one rebase-retry built in; NEVER a hand-rolled repo-root
+  `git pull`, which is the #967 `fatal: Cannot autostash` incident) — post
+  `epm:merge-failed v1`
   with the error, surface ONE line in chat (branch + worktree path +
   one-line reason), CONTINUE. Same fail-fast policy as the safe case.
 
@@ -8536,8 +8704,29 @@ merge commit and would be read as a live task by the session watcher
 (incident #644)." -- "${DUPES[@]}"
   # Push IMMEDIATELY — an unpushed removal lets a concurrent session's
   # recovery pull re-import the orphan, which is exactly the failure mode.
-  git push origin main \
-    || { git pull --rebase=merges --autostash && git push origin main; }
+  # On rejection: scripts/sync_repo_root.py is the ONLY repo-root sync
+  # (single-flight flock + untracked-collision rescue + autostash recovery +
+  # push with one rebase-retry built in; a hand-rolled repo-root pull is the
+  # #967 `fatal: Cannot autostash` incident). CAUTION — the helper's own
+  # contract says exit 0 does NOT by itself mean "my push landed": exit 0
+  # includes the `in-flight` state ("another sync in flight — your push has
+  # NOT landed; re-run after the in-flight sync completes"), and an in-flight
+  # sync that started BEFORE this guard commit cannot carry it. So VERIFY
+  # landing after the helper; on a still-unlanded commit, re-run the helper
+  # ONCE (its own prescription for in-flight), then fail loud.
+  if ! git push origin main; then
+    uv run python "$REPO_ROOT/scripts/sync_repo_root.py"
+    git -C "$REPO_ROOT" fetch origin main --quiet
+    if ! git -C "$REPO_ROOT" merge-base --is-ancestor HEAD origin/main; then
+      uv run python "$REPO_ROOT/scripts/sync_repo_root.py"   # in-flight re-run
+      git -C "$REPO_ROOT" fetch origin main --quiet
+      git -C "$REPO_ROOT" merge-base --is-ancestor HEAD origin/main \
+        || { echo "post-merge guard commit NOT on origin/main after 2 sync attempts";
+             # route to the epm:merge-failed handling above (fail loud, never
+             # proceed believing the cleanup landed)
+             false; }
+    fi
+  fi
 fi
 ```
 

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -8343,16 +8343,29 @@ Gate the merge payload on the lint BEFORE anything lands:
   # checkout — see the surgical block. The verdict is PERSISTED to a file
   # because fenced bash blocks are separate shell invocations: the binding
   # sites consume the FILE, never a shell variable.
-  if git -C "$WT" diff --name-only origin/main...HEAD \
-      | grep -qvE '^(tasks/|figures/|eval_results/|ood_eval_results/|raw/|data/|docs/methodology/)'; then
-    # BASELINE legs (payload-free tree). Exit codes deliberately NOT captured:
-    # only the baseline's normalized failure LINES enter the compare — a red
-    # baseline exit code carries no payload information.
+  # TRIGGER — materialize the own-diff FIRST and check the diff's OWN exit:
+  # piped straight into grep, a FAILED `git diff` (bad ref, no merge-base)
+  # is indistinguishable from an empty diff and would fail OPEN as an
+  # artifact-only skip. (`set -o pipefail` cannot fix this form: `grep -q`
+  # exits at first match and SIGPIPEs the producer, and the else branch
+  # would still misread any nonzero as artifact-only.)
+  if ! git -C "$WT" diff --name-only origin/main...HEAD > /tmp/issue-<N>-own-diff.txt; then
+    # Failed trigger diff — the gate cannot classify the payload; fail CLOSED.
+    echo crash > /tmp/issue-<N>-lint-verdict.txt
+  elif grep -qvE '^(tasks/|figures/|eval_results/|ood_eval_results/|raw/|data/|docs/methodology/)' \
+      /tmp/issue-<N>-own-diff.txt; then
+    # BASELINE legs (payload-free tree). Per-leg exit codes ARE captured:
+    # only the baseline's normalized failure LINES enter the compare, but a
+    # baseline CRASH (rc>1, or rc!=0 with ZERO `workflow_lint:` lines) makes
+    # the compare itself untrustworthy — that fails CLOSED via the crash arm
+    # below, never `|| true`-erased. A red-but-line-emitting baseline (rc=1
+    # WITH lines — main already red) stays fine: the subtraction handles it.
+    BASE_RC=0
     uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
-      > /tmp/issue-<N>-lint-baseline.txt 2>&1 || true
+      > /tmp/issue-<N>-lint-baseline.txt 2>&1 || BASE_RC=$?
     uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
       --check-references --check-tables --check-asks --check-autonomous-asks \
-      >> /tmp/issue-<N>-lint-baseline.txt 2>&1 || true
+      >> /tmp/issue-<N>-lint-baseline.txt 2>&1 || BASE_RC=$?
     # GATED legs (payload-bearing tree; parity leg covers the checks the
     # no-flags bundle omits — see the bullet above):
     GATED_RC=0
@@ -8376,14 +8389,26 @@ Gate the merge payload on the lint BEFORE anything lands:
     # NEW = gated_failures − baseline_failures (set subtraction):
     comm -23 /tmp/issue-<N>-lint-gated-norm.txt \
       /tmp/issue-<N>-lint-baseline-norm.txt > /tmp/issue-<N>-lint-new.txt
-    # Gated failure lines naming a file IN the own-diff:
-    git -C "$WT" diff --name-only origin/main...HEAD > /tmp/issue-<N>-own-diff.txt
+    # Gated failure lines naming a file IN the own-diff (materialized at the
+    # trigger above):
     grep -F -f /tmp/issue-<N>-own-diff.txt /tmp/issue-<N>-lint-gated-norm.txt \
       > /tmp/issue-<N>-lint-owndiff.txt || true
-    # VERDICT — the captured GATED_RC is consumed HERE: a green gated run
-    # (exit 0) can never block; a red one blocks only when payload-attributed
-    # (an own-diff-named failure line OR a non-empty NEW set).
-    if [ "$GATED_RC" -ne 0 ] \
+    # VERDICT — CRASH ARM FIRST (fail CLOSED): a linter CRASH — rc>1 (import
+    # error, missing dep, sparse-worktree crash), or rc!=0 with ZERO
+    # normalized `workflow_lint:` failure lines across both legs' logs (an
+    # uncaught Python exception exits 1 and emits none) — on EITHER leg pair
+    # means the gate never produced a trustworthy compare. `crash` is an
+    # unconditional block-path verdict (same epm:merge-failed handling as
+    # `block`; Verdict bullet case 3) — NEVER `pass`. Only then the
+    # attribution logic: a green gated run (exit 0) can never block; a red
+    # one (rc=1 WITH lines) blocks only when payload-attributed (an
+    # own-diff-named failure line OR a non-empty NEW set); rc=1 with lines
+    # but none own-diff/NEW stays `pass` (pre-existing red — WARN).
+    if [ "$GATED_RC" -gt 1 ] || [ "$BASE_RC" -gt 1 ] \
+       || { [ "$GATED_RC" -ne 0 ] && [ ! -s /tmp/issue-<N>-lint-gated-norm.txt ]; } \
+       || { [ "$BASE_RC" -ne 0 ] && [ ! -s /tmp/issue-<N>-lint-baseline-norm.txt ]; }; then
+      echo crash > /tmp/issue-<N>-lint-verdict.txt
+    elif [ "$GATED_RC" -ne 0 ] \
        && { [ -s /tmp/issue-<N>-lint-owndiff.txt ] || [ -s /tmp/issue-<N>-lint-new.txt ]; }; then
       echo block > /tmp/issue-<N>-lint-verdict.txt
     else
@@ -8394,7 +8419,7 @@ Gate the merge payload on the lint BEFORE anything lands:
     # both lint runs skipped by design.
     echo skip-artifact-only > /tmp/issue-<N>-lint-verdict.txt
   fi
-  cat /tmp/issue-<N>-lint-verdict.txt   # pass | block | skip-artifact-only
+  cat /tmp/issue-<N>-lint-verdict.txt   # pass | block | crash | skip-artifact-only
   ```
 
 - **Verdict — payload-attributed via failure-LINE-SET subtraction; NEVER
@@ -8405,11 +8430,14 @@ Gate the merge payload on the lint BEFORE anything lands:
   GATED run and a payload-free BASELINE run — BOTH legs (no-flags + parity)
   in each run, so a pre-existing parity-leg red on main can never be
   misread as payload-caused (and vice versa). The executable block above
-  computes the BINARY verdict (`block` | `pass` | `skip-artifact-only`) and
-  persists it to `/tmp/issue-<N>-lint-verdict.txt`; the binding sites gate
-  their merge/push/add commands on that FILE with an explicit conditional —
-  a missing verdict file fails CLOSED (the gate has not run yet). On a
-  `block` verdict:
+  computes the verdict (`block` | `pass` | `crash` | `skip-artifact-only`)
+  and persists it to `/tmp/issue-<N>-lint-verdict.txt`; the binding sites
+  gate their merge/push/add commands on that FILE with an explicit
+  conditional — a missing verdict file fails CLOSED (the gate has not run
+  yet) — and each binding site REMOVES the file right after consuming it
+  (consume-once, `rm -f` in both branches): a stale verdict left by a prior
+  invocation can never certify a later merge; a fresh gate run regenerates
+  it. On a `block` (or `crash`) verdict:
   1. An own-diff-named gated failure line exists
      (`/tmp/issue-<N>-lint-owndiff.txt` non-empty) → the payload is the
      offender. Fix it in the worktree (the lint names file + rule),
@@ -8430,10 +8458,22 @@ Gate the merge payload on the lint BEFORE anything lands:
      the same turn so a concurrent merge cannot widen the compare window
      (moving-main race — keep the window tight, preserve the
      main-already-red detail in the marker).
+  3. `crash` — the linter itself CRASHED on either leg pair (rc>1, or
+     rc!=0 with zero normalized `workflow_lint:` failure lines: import
+     error, missing dep, sparse-worktree crash — the gated leg runs the
+     WORKTREE's own `workflow_lint.py`, so the crash is payload-inducible),
+     or the trigger diff failed. No trustworthy compare exists, so this is
+     an unconditional block-path verdict: fix the crash cause in the
+     worktree, re-run the gate ONCE; still crashing → the SAME
+     `epm:merge-failed v1` handling as case 1. Never merge/push on `crash`.
 - **Baseline semantics per binding form (the baseline is ALWAYS a
   payload-free tree).** (i) Safe case: gated = the WORKTREE copy
   (branch-tip tree); baseline = the repo-root copy (main tree, payload
-  absent); bind immediately before `gh pr ready` / `gh pr merge`.
+  absent); bind immediately before `gh pr ready` / `gh pr merge`. Note:
+  path-(i) lint-VERSION drift can also FALSE-BLOCK (a check retired/loosened
+  on main is still enforced by the branch-tip / merge-base copy) — a
+  fail-SAFE direction, resolved through the same case-1 fix-or-`epm:merge-failed`
+  path.
   (ii) Merge-conflict recovery: gated = the worktree copy AFTER
   `git -C "$WT" merge origin/main` (≈ post-merge main, carrying main's
   CURRENT lint — the ideal gate point); baseline = the repo-root copy;
@@ -8518,10 +8558,12 @@ else
   # explicit conditional below is the hard stop (a missing verdict file
   # fails CLOSED — the gate has not run yet; run it, then re-enter).
   if grep -qxE 'pass|skip-artifact-only' /tmp/issue-<N>-lint-verdict.txt 2>/dev/null; then
+    rm -f /tmp/issue-<N>-lint-verdict.txt   # consume-once — a stale verdict must never certify a later merge
     gh pr ready <PR>
     gh pr merge <PR> --rebase --delete-branch=false
   else
-    echo "BLOCKED: pre-push workflow-lint gate (verdict: $(cat /tmp/issue-<N>-lint-verdict.txt 2>/dev/null || echo not-run)) — fix the named offender in the worktree, re-run the gate ONCE; still failing -> epm:merge-failed (gate subsection, verdict case 1). Do NOT merge."
+    echo "BLOCKED: pre-push workflow-lint gate (verdict: $(cat /tmp/issue-<N>-lint-verdict.txt 2>/dev/null || echo not-run)) — fix the named offender (or crash cause) in the worktree, re-run the gate ONCE; still failing -> epm:merge-failed (gate subsection, verdict cases 1/3). Do NOT merge."
+    rm -f /tmp/issue-<N>-lint-verdict.txt   # consumed either way; a re-run regenerates it
     false
   fi
 fi
@@ -8572,13 +8614,15 @@ git -C "$WT" commit --no-edit
 # gate point). The push is then GATED on the persisted verdict file — the
 # explicit conditional is the hard stop (missing file fails CLOSED):
 if grep -qxE 'pass|skip-artifact-only' /tmp/issue-<N>-lint-verdict.txt 2>/dev/null; then
+  rm -f /tmp/issue-<N>-lint-verdict.txt   # consume-once — a stale verdict must never certify a later push
   git -C "$WT" push
   # gh recomputes mergeability asynchronously after a push — it can be
   # momentarily stale. Re-check before concluding failure:
   gh pr view <PR> --json mergeable -q .mergeable   # brief wait/retry until MERGEABLE
   gh pr merge <PR> --rebase --delete-branch=false
 else
-  echo "BLOCKED: pre-push workflow-lint gate (verdict: $(cat /tmp/issue-<N>-lint-verdict.txt 2>/dev/null || echo not-run)) — fix the named offender in the worktree, re-run the gate ONCE; still failing -> epm:merge-failed (gate subsection, verdict case 1). Do NOT push."
+  echo "BLOCKED: pre-push workflow-lint gate (verdict: $(cat /tmp/issue-<N>-lint-verdict.txt 2>/dev/null || echo not-run)) — fix the named offender (or crash cause) in the worktree, re-run the gate ONCE; still failing -> epm:merge-failed (gate subsection, verdict cases 1/3). Do NOT push."
+  rm -f /tmp/issue-<N>-lint-verdict.txt   # consumed either way; a re-run regenerates it
   false
 fi
 ```
@@ -8732,13 +8776,16 @@ Decision tree:
   if grep -qvE '^(tasks/|figures/|eval_results/|ood_eval_results/|raw/|data/|docs/methodology/)' \
        /tmp/issue-<N>-additive-files.txt; then
     GATE_ARMED=yes
-    # BASELINE legs (exit codes deliberately not captured — only normalized
-    # failure LINES enter the compare):
+    # BASELINE legs (per-leg exit codes ARE captured — a baseline CRASH must
+    # fail CLOSED via the crash arm below, never be `|| true`-erased; only
+    # normalized failure LINES enter the compare for the legitimate
+    # red-baseline rc=1-with-lines case):
+    BASE_RC=0
     uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
-      > /tmp/issue-<N>-lint-baseline.txt 2>&1 || true
+      > /tmp/issue-<N>-lint-baseline.txt 2>&1 || BASE_RC=$?
     uv run python "$REPO_ROOT/scripts/workflow_lint.py" \
       --check-references --check-tables --check-asks --check-autonomous-asks \
-      >> /tmp/issue-<N>-lint-baseline.txt 2>&1 || true
+      >> /tmp/issue-<N>-lint-baseline.txt 2>&1 || BASE_RC=$?
   fi
   # `-C "$REPO_ROOT"` is the repo-root guard's designed deliberate-override
   # (#897): the hook's working-tree-revert detector would bounce the bare
@@ -8769,9 +8816,18 @@ Decision tree:
       /tmp/issue-<N>-lint-baseline-norm.txt > /tmp/issue-<N>-lint-new.txt
     grep -F -f /tmp/issue-<N>-additive-files.txt /tmp/issue-<N>-lint-gated-norm.txt \
       > /tmp/issue-<N>-lint-owndiff.txt || true
-    # GATED_RC consumed HERE — a red gated run blocks only when
-    # payload-attributed (own-diff-named line OR NEW non-empty):
-    if [ "$GATED_RC" -ne 0 ] \
+    # GATED_RC consumed HERE — CRASH ARM FIRST (fail CLOSED; same
+    # classification as the gate's executable block): rc>1 on either leg
+    # pair, or rc!=0 with ZERO normalized `workflow_lint:` lines, is a
+    # linter CRASH -> GATE_VERDICT=crash (block path — the stage/commit/push
+    # below runs ONLY on `pass`). Only then the attribution arm: a red
+    # gated run blocks when payload-attributed (own-diff-named line OR NEW
+    # non-empty).
+    if [ "$GATED_RC" -gt 1 ] || [ "$BASE_RC" -gt 1 ] \
+       || { [ "$GATED_RC" -ne 0 ] && [ ! -s /tmp/issue-<N>-lint-gated-norm.txt ]; } \
+       || { [ "$BASE_RC" -ne 0 ] && [ ! -s /tmp/issue-<N>-lint-baseline-norm.txt ]; }; then
+      GATE_VERDICT=crash
+    elif [ "$GATED_RC" -ne 0 ] \
        && { [ -s /tmp/issue-<N>-lint-owndiff.txt ] || [ -s /tmp/issue-<N>-lint-new.txt ]; }; then
       GATE_VERDICT=block
     fi
@@ -8796,7 +8852,7 @@ Decision tree:
     # destroyed).
     xargs -r -a /tmp/issue-<N>-additive-files.txt git -C "$REPO_ROOT" restore --staged --
     xargs -r -a /tmp/issue-<N>-additive-files.txt rm -f --
-    echo "BLOCKED: pre-push workflow-lint gate — fix the named offender in the worktree, re-run ONCE; still failing -> epm:merge-failed (gate subsection, verdict case 1). Payload cleaned from the root index + working tree."
+    echo "BLOCKED: pre-push workflow-lint gate (verdict: $GATE_VERDICT) — fix the named offender (or crash cause) in the worktree, re-run ONCE; still failing -> epm:merge-failed (gate subsection, verdict cases 1/3). Payload cleaned from the root index + working tree."
     false
   fi
   ```

--- a/tests/test_step10d_guard3.py
+++ b/tests/test_step10d_guard3.py
@@ -330,11 +330,29 @@ def test_guard0_mem_committed_flag_in_guards_region():
     )
 
 
+def _artifact_confirmed_region(text: str) -> str:
+    """The artifact-confirmed merge procedure slice (the surgical additive
+    checkout lands here; the round-2 gate-verdict pins scope to it)."""
+    start_marker = "#### The artifact-confirmed merge procedure"
+    end_marker = "#### Post-merge stale-task-folder guard"
+    start = text.find(start_marker)
+    end = text.find(end_marker)
+    assert start != -1, "artifact-confirmed merge heading not found in SKILL.md"
+    assert end != -1, "post-merge stale-task-folder guard heading not found"
+    assert start < end, "artifact-confirmed region must precede the post-merge guard"
+    return text[start:end]
+
+
 def test_prepush_workflow_lint_gate_between_fast_path_and_auto_merge():
     """#1047 lint gate: the Pre-push workflow-lint gate subsection must sit
     between the fast-path pre-check and the auto-merge procedure, and be
     named at >=3 bind hooks besides its heading (safe case, recovery,
-    surgical checkout) so every merge form runs it (#931)."""
+    surgical checkout) so every merge form runs it (#931). Round-2
+    strengthening (Codex Minor): the load-bearing invariant is that the
+    SURGICAL block computes a payload-attributed verdict — consuming
+    GATED_RC + the normalized failure-line files via `comm -23` — BEFORE the
+    first `git add`, and gates the stage/commit/push on an explicit
+    GATE_VERDICT branch, not just a phrase count."""
     text = _skill_text()
     fast = text.find("#### Fast-path routing pre-check")
     gate = text.find("#### Pre-push workflow-lint gate")
@@ -345,6 +363,112 @@ def test_prepush_workflow_lint_gate_between_fast_path_and_auto_merge():
     )
     assert text.count("Pre-push workflow-lint gate") >= 4, (
         "the gate must be named at its heading plus >=3 bind hooks"
+    )
+    region = _artifact_confirmed_region(text)
+    first_add = region.find("git add --")
+    assert first_add != -1, "surgical block must stage by explicit path (git add --)"
+    rc_consumption = region.find('[ "$GATED_RC" -ne 0 ]')
+    subtraction = region.find("comm -23")
+    verdict_branch = region.find('if [ "$GATE_VERDICT" = "pass" ]')
+    assert -1 < rc_consumption < first_add, (
+        "GATED_RC must be consumed by a conditional BEFORE the first git add "
+        "(a captured-but-unchecked RC is a hollow gate)"
+    )
+    assert -1 < subtraction < first_add, (
+        "the failure-line-set subtraction (comm -23) must run BEFORE the first git add"
+    )
+    assert -1 < verdict_branch < first_add, (
+        "the stage/commit/push must sit inside an explicit GATE_VERDICT=pass branch"
+    )
+
+
+def test_gate_executable_block_normalizes_subtracts_and_persists_verdict():
+    """Round-2 (Codex M1): the gate subsection must carry a fully EXECUTABLE
+    block — documented normalization of `workflow_lint:` failure lines,
+    `comm -23` set subtraction, and a persisted binary verdict file the
+    binding sites consume (fenced bash blocks are separate shells)."""
+    text = _skill_text()
+    gate = text.find("#### Pre-push workflow-lint gate")
+    auto = text.find("#### The auto-merge procedure")
+    region = text[gate:auto]
+    assert "grep -h '^workflow_lint: '" in region, "normalization must keep workflow_lint: lines"
+    assert "sed -E 's/:[0-9]+:/::/g'" in region, "normalization must blank :<line>: numbers"
+    assert "comm -23" in region, "NEW = gated - baseline must use comm -23"
+    assert '[ "$GATED_RC" -ne 0 ]' in region, "GATED_RC must be consumed in the gate block"
+    for verdict in ("block", "pass", "skip-artifact-only"):
+        assert f"echo {verdict} > /tmp/issue-<N>-lint-verdict.txt" in region, (
+            f"the gate block must persist the '{verdict}' verdict to the verdict file"
+        )
+
+
+def test_gate_verdict_file_gates_safe_case_and_recovery():
+    """Round-2 (Codex M1/M2): the persisted verdict file must be consumed by
+    an explicit conditional BEFORE `gh pr ready` (safe case) and BEFORE the
+    recovery `git -C "$WT" push` — a missing verdict file fails CLOSED."""
+    text = _skill_text()
+    probe = "grep -qxE 'pass|skip-artifact-only' /tmp/issue-<N>-lint-verdict.txt"
+    first = text.find(probe)
+    second = text.find(probe, first + 1)
+    assert first != -1 and second != -1, (
+        "both the safe case and the recovery must consume the persisted verdict file"
+    )
+    ready = text.find("gh pr ready <PR>")
+    assert -1 < first < ready < second, "the safe-case verdict conditional must precede gh pr ready"
+    rec = text.find("#### Merge-conflict recovery")
+    rec_push = text.find('git -C "$WT" push\n', rec)
+    assert -1 < rec < second < rec_push, (
+        "the recovery verdict conditional must precede the recovery push"
+    )
+
+
+def test_fast_path_lower_bound_and_no_flagless_additive_xargs():
+    """Round-2 (Claude M2): the FAST_PATH conjunction must require a NON-EMPTY
+    filtered own-diff (`-ge 1`), and every xargs consuming the additive-files
+    list must carry `-r` (--no-run-if-empty) — an empty-input xargs checkout
+    degenerates to `git checkout issue-<N> --` with NO pathspec, a branch
+    SWITCH of the shared repo root."""
+    text = _skill_text()
+    assert '[ "$N_FILES" -ge 1 ]' in text, "FAST_PATH must require N_FILES >= 1"
+    assert "xargs -a /tmp/issue-<N>-additive-files.txt" not in text, (
+        "no flag-less additive-list xargs may remain (must be xargs -r -a)"
+    )
+    assert text.count("xargs -r -a /tmp/issue-<N>-additive-files.txt") >= 5, (
+        "checkout / add / commit / restore / rm additive-list consumers must all carry -r"
+    )
+
+
+def test_gate_block_cleanup_recipe_hook_admitted():
+    """Round-2 (Claude M1): the on-block cleanup must be the hook-admitted
+    two-step — index-only `restore --staged` unstage, then plain `rm` of the
+    now-untracked A-only files. The one-shot restore-with-worktree-flag form
+    is mechanically BLOCKED by scripts/guard_repo_root_branch.sh's #897
+    restore detector (allow requires --staged AND no worktree flag; verified
+    by hook simulation 2026-07-05, exit 2)."""
+    text = _skill_text()
+    assert "--staged --worktree" not in text, (
+        "the hook-blocked one-shot restore form must not be documented anywhere"
+    )
+    assert 'git -C "$REPO_ROOT" restore --staged --' in text, (
+        "cleanup step 1 must be the index-only unstage (hook allow-arm)"
+    )
+    assert "rm -f --" in text, (
+        "cleanup step 2 must remove the now-untracked A-only files via plain rm"
+    )
+
+
+def test_safe_case_push_rederives_unpushed_from_git_state():
+    """Round-2 (Codex M3): the safe-case pre-merge push must RE-DERIVE
+    'unpushed local commits exist' from git state — fenced bash blocks are
+    separate shell invocations, so the Guard-0/1 flags are unset there; the
+    flags remain same-block conveniences only. A missing origin/issue-<N>
+    ref counts as unpushed (fails toward pushing)."""
+    text = _skill_text()
+    assert (
+        '[ "$(git -C "$WT" rev-list --count origin/issue-<N>..HEAD 2>/dev/null'
+        ' || echo 1)" -gt 0 ]' in text
+    ), (
+        "the push condition's load-bearing arm must be the re-derived "
+        "unpushed-commit count against origin/issue-<N>"
     )
 
 

--- a/tests/test_step10d_guard3.py
+++ b/tests/test_step10d_guard3.py
@@ -541,8 +541,9 @@ def test_gate_baseline_rc_captured_not_erased():
     assert "lint-baseline.txt 2>&1 || true" not in text, (
         "no baseline lint leg may erase its exit code with `|| true`"
     )
-    assert text.count("|| BASE_RC=$?") >= 4, (
-        "both baseline legs at both gate sites must capture BASE_RC (2 legs x 2 sites)"
+    assert text.count(_BASE_RC_FOLD) >= 4, (
+        "both baseline legs at both gate sites must capture BASE_RC (2 legs x 2 sites; "
+        "round-4: the capture is the no-downgrade fold, not the bare `|| BASE_RC=$?`)"
     )
     assert '[ "$BASE_RC" -gt 1 ]' in text, "a BASE_RC>1 baseline crash must feed the crash arm"
     assert "[ ! -s /tmp/issue-<N>-lint-baseline-norm.txt ]" in text, (
@@ -584,3 +585,71 @@ def test_gate_trigger_diff_exit_guarded():
     assert "cat /tmp/issue-<N>-lint-verdict.txt   # pass | block | crash | skip-artifact-only" in (
         region
     ), "the verdict enumeration must include crash"
+
+
+# --------------------------------------------------------------------------
+# Round 4 — reconciled v3 residuals (#1047: `lint-leg-rc-erasure-crash-masked`
+# persisted BLOCKER + `surgical-additive-diff-fails-open` persisted CONCERN)
+# --------------------------------------------------------------------------
+
+# The no-downgrade (max) per-leg rc fold. Pinning the SHAPE (not just literal
+# counts of `|| VAR=$?`): a gated leg-1 crash (rc=2, zero lines) must survive
+# a leg-2 rc=1-with-lines — the bare last-failure-wins capture erases the
+# crash and defeats the crash arm.
+_BASE_RC_FOLD = '|| { rc=$?; if [ "$rc" -gt "$BASE_RC" ]; then BASE_RC=$rc; fi; }'
+_GATED_RC_FOLD = '|| { rc=$?; if [ "$rc" -gt "$GATED_RC" ]; then GATED_RC=$rc; fi; }'
+
+
+def test_lint_leg_rc_no_downgrade_fold_at_all_four_sites():
+    """Round-4 (#1047 `lint-leg-rc-erasure-crash-masked` BLOCKER): every lint
+    leg-pair (BASE + GATED, shared gate + surgical block = 4 sites, 8 legs)
+    must capture its per-leg rc with the NO-DOWNGRADE (max) fold, and no bare
+    last-failure-wins `|| VAR=$?` capture may remain anywhere in the skill."""
+    text = _skill_text()
+    gate = _gate_region(text)
+    surg = _artifact_confirmed_region(text)
+    for region, name in ((gate, "shared gate"), (surg, "surgical block")):
+        assert region.count(_BASE_RC_FOLD) == 2, (
+            f"{name}: both BASE legs must use the no-downgrade BASE_RC fold"
+        )
+        assert region.count(_GATED_RC_FOLD) == 2, (
+            f"{name}: both GATED legs must use the no-downgrade GATED_RC fold"
+        )
+    assert "|| BASE_RC=$?" not in text, (
+        "no bare last-failure-wins BASE_RC capture may remain (crash-masking erasure)"
+    )
+    assert "|| GATED_RC=$?" not in text, (
+        "no bare last-failure-wins GATED_RC capture may remain (crash-masking erasure)"
+    )
+
+
+def test_surgical_additive_producer_guarded_and_empty_list_hard_stops():
+    """Round-4 (#1047 `surgical-additive-diff-fails-open` CONCERN): the
+    surgical additive-list producer must be materialize-then-check (a FAILED
+    diff hard-stops — routed to epm:merge-failed — never read as an empty
+    list), and an EMPTY additive list on the deliverables-missing landing
+    must hard-stop instead of pushing + posting
+    `epm:merged {surgical_checkout: true}` with nothing committed."""
+    text = _skill_text()
+    region = _artifact_confirmed_region(text)
+    guard = region.find('if ! git -C "$WT" diff --name-only --diff-filter=A origin/main...HEAD')
+    assert guard != -1, (
+        "the surgical additive-list producer must check its OWN exit code "
+        "(materialize-then-check, mirroring the shared gate's trigger diff)"
+    )
+    empty_stop = region.find("elif [ ! -s /tmp/issue-<N>-additive-files.txt ]; then")
+    assert empty_stop != -1, (
+        "an empty additive list on the deliverables-missing landing must be "
+        "detected (phantom-success hard stop)"
+    )
+    assert region.count("SURGICAL ABORT") >= 2, (
+        "both abort arms (failed producer diff, empty list) must fail loud"
+    )
+    assert region.count("epm:merge-failed") >= 2, (
+        "the abort arms must route to the epm:merge-failed handling"
+    )
+    first_consumer = region.find("xargs -r -a /tmp/issue-<N>-additive-files.txt git")
+    assert -1 < guard < empty_stop < first_consumer, (
+        "the producer guard + empty-list hard stop must precede the first "
+        "additive-list consumer (never proceed to checkout/stage/push)"
+    )

--- a/tests/test_step10d_guard3.py
+++ b/tests/test_step10d_guard3.py
@@ -296,3 +296,69 @@ def test_step5a_grep_filter_untouched():
     assert "--grep='spec-freshness' --invert-grep" in text, (
         "the Step-5a sync's --grep filter must remain (it is out of #787 scope)"
     )
+
+
+# --------------------------------------------------------------------------
+# Task #1047 — Step-10d pre-merge/pre-push hardening pins
+# --------------------------------------------------------------------------
+
+
+def _merge_guards_region(text: str) -> str:
+    """The merge-safety-guards slice: from the guards heading to the fast-path
+    heading (Guard 0 + guards 1-3 live here)."""
+    start_marker = "#### Merge safety guards (run before the merge commands)"
+    end_marker = "#### Fast-path routing pre-check"
+    start = text.find(start_marker)
+    end = text.find(end_marker)
+    assert start != -1, "Merge safety guards heading not found in SKILL.md"
+    assert end != -1, "Fast-path pre-check heading not found in SKILL.md"
+    assert start < end, "guards region must precede the fast-path pre-check"
+    return text[start:end]
+
+
+def test_guard0_mem_committed_flag_in_guards_region():
+    """#1047 Guard 0: the agent-memory pre-commit (flagged MEM_COMMITTED) must
+    live in the guards region, and the safe-case pre-merge push condition must
+    be extended by the flag — a local-only memory commit is invisible to the
+    server-side rebase, same mechanism as STRIPPED_FOREIGN (#906)."""
+    text = _skill_text()
+    region = _merge_guards_region(text)
+    assert "MEM_COMMITTED=no" in region, "Guard 0 must initialize MEM_COMMITTED=no"
+    assert "MEM_COMMITTED=yes" in region, "Guard 0 must set MEM_COMMITTED=yes after committing"
+    assert '[ "$MEM_COMMITTED" = "yes" ]' in text, (
+        "the safe-case pre-merge push condition must include MEM_COMMITTED=yes"
+    )
+
+
+def test_prepush_workflow_lint_gate_between_fast_path_and_auto_merge():
+    """#1047 lint gate: the Pre-push workflow-lint gate subsection must sit
+    between the fast-path pre-check and the auto-merge procedure, and be
+    named at >=3 bind hooks besides its heading (safe case, recovery,
+    surgical checkout) so every merge form runs it (#931)."""
+    text = _skill_text()
+    fast = text.find("#### Fast-path routing pre-check")
+    gate = text.find("#### Pre-push workflow-lint gate")
+    auto = text.find("#### The auto-merge procedure")
+    assert gate != -1, "Pre-push workflow-lint gate heading not found"
+    assert -1 < fast < gate < auto, (
+        "the gate heading must sit between the fast-path and auto-merge sections"
+    )
+    assert text.count("Pre-push workflow-lint gate") >= 4, (
+        "the gate must be named at its heading plus >=3 bind hooks"
+    )
+
+
+def test_post_merge_guard_push_retry_uses_sync_repo_root():
+    """#1047 sync naming: the post-merge guard's push retry must route through
+    scripts/sync_repo_root.py, never a hand-rolled repo-root `git pull` (#967
+    `fatal: Cannot autostash`)."""
+    text = _skill_text()
+    start = text.find("#### Post-merge stale-task-folder guard")
+    assert start != -1, "post-merge stale-task-folder guard heading not found"
+    region = text[start:]
+    assert "sync_repo_root.py" in region, (
+        "the post-merge guard push retry must name scripts/sync_repo_root.py"
+    )
+    assert "|| { git pull --rebase=merges --autostash && git push origin main; }" not in region, (
+        "the hand-rolled repo-root pull retry must be gone from the post-merge guard"
+    )

--- a/tests/test_step10d_guard3.py
+++ b/tests/test_step10d_guard3.py
@@ -486,3 +486,101 @@ def test_post_merge_guard_push_retry_uses_sync_repo_root():
     assert "|| { git pull --rebase=merges --autostash && git push origin main; }" not in region, (
         "the hand-rolled repo-root pull retry must be gone from the post-merge guard"
     )
+
+
+# --------------------------------------------------------------------------
+# Round 3 — lint-gate crash class (#1047 concerns: lint-gate-crash-fails-open
+# BLOCKER + lint-baseline-crash-erased CONCERN)
+# --------------------------------------------------------------------------
+
+
+def _gate_region(text: str) -> str:
+    """The Pre-push workflow-lint gate subsection (shared executable block)."""
+    start = text.find("#### Pre-push workflow-lint gate")
+    end = text.find("#### The auto-merge procedure")
+    assert start != -1, "Pre-push workflow-lint gate heading not found"
+    assert end != -1, "auto-merge procedure heading not found"
+    assert start < end, "gate subsection must precede the auto-merge procedure"
+    return text[start:end]
+
+
+def test_gate_crash_arm_fails_closed_before_pass():
+    """Round-3 (#1047 `lint-gate-crash-fails-open` BLOCKER): a workflow_lint.py
+    CRASH (rc>1, or rc!=0 with ZERO normalized `workflow_lint:` failure lines)
+    must fail CLOSED at BOTH gate sites — an explicit crash arm BEFORE any
+    `pass` write (shared block) / before the attribution `GATE_VERDICT=block`
+    arm (surgical block) — never land in the else->pass leg."""
+    text = _skill_text()
+    region = _gate_region(text)
+    crash_arm = region.find('[ "$GATED_RC" -gt 1 ]')
+    crash_write = region.find("echo crash > /tmp/issue-<N>-lint-verdict.txt")
+    pass_write = region.find("echo pass > /tmp/issue-<N>-lint-verdict.txt")
+    assert crash_arm != -1, "shared gate must carry an explicit GATED_RC>1 crash arm"
+    assert crash_write != -1, "shared gate must persist the crash verdict to the verdict file"
+    assert -1 < crash_arm < pass_write, (
+        "the crash arm must be evaluated BEFORE the pass write (fail CLOSED on a crash)"
+    )
+    assert "[ ! -s /tmp/issue-<N>-lint-gated-norm.txt ]" in region, (
+        "rc!=0 with zero normalized gated failure lines must be classified as a crash"
+    )
+    surg = _artifact_confirmed_region(text)
+    s_crash_arm = surg.find('[ "$GATED_RC" -gt 1 ]')
+    s_crash = surg.find("GATE_VERDICT=crash")
+    s_block = surg.find("GATE_VERDICT=block")
+    assert s_crash_arm != -1, "surgical block must carry the GATED_RC>1 crash arm"
+    assert s_crash != -1, "surgical block must set GATE_VERDICT=crash on a linter crash"
+    assert -1 < s_crash < s_block, "the surgical crash arm must precede the attribution block arm"
+
+
+def test_gate_baseline_rc_captured_not_erased():
+    """Round-3 (#1047 `lint-baseline-crash-erased` CONCERN): baseline lint legs
+    must capture BASE_RC per leg (feeding the crash arm), never `|| true`-erase
+    it; a baseline rc=1 WITH lines stays a legitimate red baseline (the
+    subtraction handles it)."""
+    text = _skill_text()
+    assert "lint-baseline.txt 2>&1 || true" not in text, (
+        "no baseline lint leg may erase its exit code with `|| true`"
+    )
+    assert text.count("|| BASE_RC=$?") >= 4, (
+        "both baseline legs at both gate sites must capture BASE_RC (2 legs x 2 sites)"
+    )
+    assert '[ "$BASE_RC" -gt 1 ]' in text, "a BASE_RC>1 baseline crash must feed the crash arm"
+    assert "[ ! -s /tmp/issue-<N>-lint-baseline-norm.txt ]" in text, (
+        "a baseline rc!=0 with zero normalized lines must be classified as a crash"
+    )
+
+
+def test_gate_verdict_file_consumed_then_removed():
+    """Round-3 (Claude r2 minor (b)): every verdict-file binding site must
+    remove the file after consuming it (consume-once, both branches) so a
+    stale verdict from a prior invocation can never certify a later merge."""
+    text = _skill_text()
+    assert text.count("rm -f /tmp/issue-<N>-lint-verdict.txt") >= 4, (
+        "both consumers (safe case + recovery) must rm the verdict file in both branches"
+    )
+    probe = "grep -qxE 'pass|skip-artifact-only' /tmp/issue-<N>-lint-verdict.txt"
+    first = text.find(probe)
+    first_rm = text.find("rm -f /tmp/issue-<N>-lint-verdict.txt", first)
+    ready = text.find("gh pr ready <PR>")
+    assert -1 < first < first_rm < ready, (
+        "the safe-case pass branch must consume-then-remove BEFORE gh pr ready"
+    )
+
+
+def test_gate_trigger_diff_exit_guarded():
+    """Round-3 (Codex r2 unaddressed case): a FAILED trigger `git diff
+    origin/main...HEAD` must not read as an artifact-only skip — the shared
+    gate materializes the own-diff with an explicit exit check routing to the
+    crash verdict; the straight-into-grep pipe trigger form is gone."""
+    text = _skill_text()
+    region = _gate_region(text)
+    assert (
+        'if ! git -C "$WT" diff --name-only origin/main...HEAD > /tmp/issue-<N>-own-diff.txt'
+        in region
+    ), "the trigger diff must be materialized with an explicit exit check"
+    assert region.count("echo crash > /tmp/issue-<N>-lint-verdict.txt") >= 2, (
+        "both the failed-trigger-diff arm and the linter-crash arm must write the crash verdict"
+    )
+    assert "cat /tmp/issue-<N>-lint-verdict.txt   # pass | block | crash | skip-artifact-only" in (
+        region
+    ), "the verdict enumeration must include crash"


### PR DESCRIPTION
Closes task #1047 (kind: infra workflow-fix; wf-fix).

Three Step 10d hardening additions to .claude/skills/issue/SKILL.md (+9 pins in tests/test_step10d_guard3.py):
1. Guard 0 — pre-merge pathspec-scoped commit of dirty .claude/agent-memory/** in the worktree (+ best-effort branch push; Guard-3/fast-path/push-condition companions). Closes the #906 dirty-tree merge-abort class.
2. Pre-push workflow-lint gate — two-leg lint (no-flags + parity), failure-line-SET subtraction vs a payload-free baseline, crash-fail-closed arms with no-downgrade per-leg rc folds, bound at all 3 merge forms + the fast path. Closes the #931 lint-offender-on-main class on this path.
3. scripts/sync_repo_root.py named as the ONLY repo-root sync at both surviving raw-pull recipe sites, with a post-helper landed check (fetch + merge-base --is-ancestor; one in-flight re-run; fail-loud). Closes the #967 hand-rolled-pull class on this path.

Review: 4 Claude+Codex ensemble rounds (2 reconciler-adjudicated); 6 concerns raised and addressed; Step 9c 2561 passed / compare exit 0. Plan: tasks/completed/1047/plans/plan.md (v3).
