### PR TITLE
task #1053: Step 0 detect-and-exit posts a deliberate-stop exit breadcrumb

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -920,7 +920,10 @@ uv run python scripts/task.py view <N> --json | uv run python -c \
 `/issue <N>` at a time. Before doing anything else, check whether another
 live session is already mapped to this issue: `uv run python
 scripts/spawn_session.py list` (issue-mapping column). If a live session is
-already driving #N, EXIT immediately as a duplicate. Before ending, post
+already driving #N, EXIT immediately as a duplicate (do NOT run
+`scripts/post_step_completed.py` here — this site's exit-marker contract is
+the single breadcrumb below, per the "Post NOTHING else" rule that follows
+it). Before ending, post
 EXACTLY ONE exit breadcrumb so the audit trail distinguishes a deliberate
 collision exit from a wrapper crash (#1053: a `/issue 958` session died
 ~1 min after spawn with no recorded reason — under the old marker-free

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -920,10 +920,39 @@ uv run python scripts/task.py view <N> --json | uv run python -c \
 `/issue <N>` at a time. Before doing anything else, check whether another
 live session is already mapped to this issue: `uv run python
 scripts/spawn_session.py list` (issue-mapping column). If a live session is
-already driving #N, EXIT immediately as a duplicate — post no markers (do
-NOT run `scripts/post_step_completed.py`: a duplicate session must not touch
-#N's `events.jsonl` — this is the one deliberately marker-free EXIT), mutate
-nothing — UNLESS this session is its explicit replacement (an
+already driving #N, EXIT immediately as a duplicate. Before ending, post
+EXACTLY ONE exit breadcrumb so the audit trail distinguishes a deliberate
+collision exit from a wrapper crash (#1053: a `/issue 958` session died
+~1 min after spawn with no recorded reason — under the old marker-free
+mandate a deliberate guard exit and a crash left identical evidence:
+nothing):
+
+```bash
+uv run python scripts/task.py post-marker <N> epm:progress --by issue-session-guard \
+  --note "deliberate-stop pid=n/a target=self reason=step0-session-collision owner=<owner-session-id> — duplicate /issue <N> session exiting at Step 0; owner <owner-session-id> remains the driver; no state mutated"
+```
+
+The `deliberate-stop ` note PREFIX is load-bearing (the note must START
+with it, lstripped): all four staleness clocks —
+`task_workflow.stage_dispatch_should_skip`,
+`autonomous_session_watch._latest_progress_ts`,
+`autonomous_session_watch._latest_nonwatcher_event_ts`, and
+`tick_triage.latest_event_ts` (#810/#949/#990/#1053) — drop it by prefix,
+so the breadcrumb never refreshes the OWNER's freshness windows or
+staleness clocks. It WILL surface as one pre-dispatch triage candidate for
+the owner — deliberate: a session collision is genuinely triage-worthy
+externality (mirroring the existing operator-stop breadcrumb;
+`issue-session-guard` is deliberately NOT in `TRIAGE_MACHINE_BY`).
+Presence of this breadcrumb PROVES a deliberate guard exit; its ABSENCE is
+evidence of — not proof of — a crash (a fail-soft post failure, a
+pre-guard death, or a stale skill copy also yield absence). Fail-soft: if
+the post fails, state the failure in your final text and still exit —
+never block the exit on the breadcrumb (a deferred-commit stderr ERROR
+with exit 0 is SUCCESS; never re-post on it). Post NOTHING else: do NOT
+run `scripts/post_step_completed.py`, do NOT write the per-issue
+self-report (`session_progress_report.py` would clobber the OWNER's shared
+`~/.eps-autonomous/issue-progress/<N>.json`), mutate nothing else —
+UNLESS this session is its explicit replacement (an
 `autonomous_session_watch` crash-recovery respawn, or the user said to take
 over; in that case stop the stale session via `spawn_session.py stop` first).
 Incident 2026-06-09 (#524): two concurrent orchestrators both picked up a
@@ -945,8 +974,21 @@ scripts/task.py latest-marker <N>`, `~/.eps-autonomous/issue-<N>.json`,
 and `uv run python scripts/spawn_session.py list`. If a replacement
 session is registered for #N (a `spawned_at` newer than this session's
 own start) OR the marker trail shows another writer has advanced the task
-past this session's last-known state, YIELD immediately — post no
-markers, launch nothing, mutate nothing; the replacement owns the task.
+past this session's last-known state, YIELD immediately. Before ending,
+post the SAME exit-breadcrumb convention as the Step 0 guard above (one
+`epm:progress`; same fail-soft contract — a deferred-commit stderr ERROR
+with exit 0 is SUCCESS, never re-post):
+
+```bash
+uv run python scripts/task.py post-marker <N> epm:progress --by issue-session-guard \
+  --note "deliberate-stop pid=n/a target=self reason=stale-wake-yield replacement=<replacement-session-id-or-marker-evidence> — stale /issue <N> session yielding on wake; the replacement owns the task; no state mutated"
+```
+
+Then launch nothing, mutate nothing else; the replacement owns the task.
+A `deliberate-stop` breadcrumb is a death record, NOT task advancement —
+ANY marker-trail reader (this re-check, `task.py latest-marker <N>`, a
+successor session deriving state from the trail) must never count one as
+"another writer has advanced the task".
 The cheap tell is always `task.py latest-marker <N>` before resuming any
 stale in-flight plan: if events have advanced past your own last-known
 state, re-derive state from the markers instead of executing the stale

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -7610,13 +7610,21 @@ def _has_round_start_witness(events: list[dict], anchor_ts: float) -> bool:
 def _has_nonwatcher_event_after(events: list[dict], ts: float) -> bool:
     """True iff any NON-watcher event (note-substring filter
     :data:`_WATCHER_NOTE_SENTINELS`, same as :func:`_latest_step_completed`)
-    in ``events`` is strictly newer than ``ts``."""
+    in ``events`` is strictly newer than ``ts``. Deliberate session-stop
+    records are excluded (#990/#1053) — see the inline comment."""
     for ev in events:
         ev_ts = _parse_event_ts(ev.get("ts"))
         if ev_ts is None or ev_ts <= ts:
             continue
         note = ev.get("note") or ""
         if any(sentinel in note for sentinel in _WATCHER_NOTE_SENTINELS):
+            continue
+        # A deliberate session stop — incl. the #1053 Step-0 collision-exit /
+        # stale-wake-yield breadcrumb — is the death record of the task's
+        # driver, never round activity: it must not veto the follow-up
+        # round-repark via the #837 freshness gate (#990/#1053; same two-leg
+        # exclusion as _latest_nonwatcher_event_ts / _latest_progress_ts).
+        if note.lstrip().startswith("deliberate-stop ") or ev.get("by") == "spawn_session-stop":
             continue
         return True
     return False

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -13638,11 +13638,19 @@ def _latest_nonwatcher_event_ts(events: list[dict]) -> float | None:
     ...) is evidence somebody/something is still working the task, and the
     sweep must err toward keeping the session. Watcher-posted notes stay
     excluded (the alert/stop markers land on the very task whose inactivity
-    they measure — counting them would reset the clock they read)."""
+    they measure — counting them would reset the clock they read), and so
+    do deliberate session-stop records (#990/#1053 — same predicate as
+    :func:`_latest_progress_ts`)."""
     best: float | None = None
     for ev in events:
         note = ev.get("note") or ""
         if any(sentinel in note for sentinel in _WATCHER_NOTE_SENTINELS):
+            continue
+        # A deliberate session stop — incl. the #1053 Step-0 collision-exit /
+        # stale-wake-yield breadcrumb — is the death record of the task's
+        # driver: anti-liveness, never activity (#990/#1053; mirrors
+        # _latest_progress_ts).
+        if note.lstrip().startswith("deliberate-stop ") or ev.get("by") == "spawn_session-stop":
             continue
         ts = _parse_event_ts(ev.get("ts"))
         if ts is not None and (best is None or ts > best):

--- a/scripts/tick_triage.py
+++ b/scripts/tick_triage.py
@@ -299,7 +299,8 @@ def parse_event_ts(ts: str | None) -> float | None:
 
 def latest_event_ts(events: list[dict], *, prefix: str | None = None) -> float | None:
     """Epoch ts of the newest event (optionally restricted to a kind prefix;
-    watcher-sentinel notes never count as freshness)."""
+    watcher-sentinel notes and deliberate session-stop records never count
+    as freshness)."""
     best: float | None = None
     for row in events:
         if not isinstance(row, dict):
@@ -309,6 +310,15 @@ def latest_event_ts(events: list[dict], *, prefix: str | None = None) -> float |
             continue
         note = row.get("note")
         if isinstance(note, str) and _WATCHER_NOTE_SENTINEL in note:
+            continue
+        # #1053: a deliberate session-stop record — incl. the Step-0
+        # collision-exit / stale-wake-yield breadcrumb — is the driver's
+        # death record: anti-liveness, never issue freshness (same predicate
+        # as task_workflow.stage_dispatch_should_skip and the watcher's
+        # _latest_progress_ts / _latest_nonwatcher_event_ts).
+        if (isinstance(note, str) and note.lstrip().startswith("deliberate-stop ")) or row.get(
+            "by"
+        ) == "spawn_session-stop":
             continue
         ts = parse_event_ts(row.get("ts"))
         if ts is not None and (best is None or ts > best):

--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -1864,7 +1864,9 @@ TRIAGE_EXEMPT_KINDS = frozenset(
 # self- and PM-chat posts carried by="unknown"). Compliant emitters now set
 # a distinctive by (the #966 convention list): "pm-chat" (PM-session
 # cross-session posts), "autonomous_session_watch" (watcher passes),
-# "spawn_session" / "spawn_session-stop" (spawn helper). A value on that
+# "spawn_session" / "spawn_session-stop" (spawn helper),
+# "issue-session-guard" (a /issue session's own Step-0 collision-exit /
+# stale-wake-yield deliberate-stop breadcrumb, #1053). A value on that
 # convention list is a trustworthy-POSITIVE externality signal for the
 # LLM-side triage read (conventional, not authenticated — nothing verifies
 # the emitter, but in-repo emitters set only their own identity); absence

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -4982,6 +4982,38 @@ def test_followup_round_complete_reason_ignores_watcher_markers_in_freshness():
     assert "designed re-park" in reason
 
 
+def test_followup_round_complete_reason_ignores_deliberate_stop_in_freshness():
+    # #1053 round-2 pin: a FRESH deliberate-stop breadcrumb (the Step 0
+    # stale-wake YIELD death record, by="issue-session-guard") posted AFTER a
+    # valid round-end park is a driver DEATH record, never round activity —
+    # it must NOT veto the repark via the #837 gate-2 freshness read
+    # (_has_nonwatcher_event_after carries the same two-leg exclusion as
+    # _latest_nonwatcher_event_ts / _latest_progress_ts).
+    import autonomous_session_watch as asw
+
+    events = [
+        _make_followup_scope_event("2026-06-11T09:00:00Z"),
+        _make_progress_event(
+            "stage-dispatch stage=followup-implementing round=1 "
+            "subagent=experiment-implementer worktree=/tmp/wt",
+            "2026-06-11T09:30:00Z",
+        ),
+        _make_step_completed_event(step="9a-bis", ts="2026-06-11T10:54:12Z"),
+        {
+            **_make_progress_event(
+                "deliberate-stop pid=n/a target=self reason=stale-wake-yield "
+                "replacement=happy-session:def456 — stale /issue 1053 session "
+                "yielding on wake; the replacement owns the task; no state mutated",
+                "2026-06-11T12:00:00Z",
+            ),
+            "by": "issue-session-guard",
+        },
+    ]
+    reason = asw._followup_round_complete_reason(events)
+    assert reason is not None
+    assert "designed re-park" in reason
+
+
 def test_followup_round_complete_reason_converges_after_respawn_park():
     # #837 acceptance 4 (the §4b convergence argument, pinned): a stray
     # NON-watcher cross-post after a genuine round end blocks the repark

--- a/tests/test_issue_skill_exit_breadcrumb.py
+++ b/tests/test_issue_skill_exit_breadcrumb.py
@@ -1,0 +1,70 @@
+"""Prose-side pin for the #1053 Step 0 exit-breadcrumb contract (MF-3).
+
+``.claude/skills/issue/SKILL.md`` prescribes EXACTLY TWO ``task.py
+post-marker <N> epm:progress --by issue-session-guard`` command blocks — the
+Step 0 single-orchestrator collision exit and the stale-wake YIELD. Their
+``--note`` payloads are load-bearing: each must lstrip-start with the
+``deliberate-stop `` prefix (all four staleness clocks drop that prefix —
+``task_workflow.stage_dispatch_should_skip``,
+``autonomous_session_watch._latest_progress_ts`` /
+``._latest_nonwatcher_event_ts``, ``tick_triage.latest_event_ts``), and the
+pair must carry the two ``reason=`` tokens. The exact-string code tests copy
+the notes into Python literals and cannot go red when the PROSE drifts; this
+test reads the skill text itself, so a rewording that drops the prefix or
+the ``--by`` identity fails here.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SKILL_MD = Path(__file__).resolve().parent.parent / ".claude" / "skills" / "issue" / "SKILL.md"
+
+# A prescribed guard-exit command block: `post-marker <N> epm:progress
+# --by issue-session-guard` followed (optionally via a `\`-newline shell
+# continuation) by `--note "..."`. The note payload carries no double quote.
+_BLOCK_RE = re.compile(
+    r"post-marker <N> epm:progress --by issue-session-guard\s*(?:\\\s*)?--note \"([^\"]+)\""
+)
+
+
+def _note_payloads() -> list[str]:
+    """Extract the ``--note`` payloads of every prescribed guard-exit block."""
+    return _BLOCK_RE.findall(SKILL_MD.read_text(encoding="utf-8"))
+
+
+def test_exactly_two_guard_exit_breadcrumb_blocks():
+    # One block per exit shape: the Step 0 collision exit + the stale-wake
+    # YIELD. A third block (or a dropped one) is prose drift to review.
+    payloads = _note_payloads()
+    assert len(payloads) == 2, payloads
+
+
+def test_each_payload_lstrip_starts_with_deliberate_stop_prefix():
+    # The lstripped `deliberate-stop ` PREFIX is what all four staleness
+    # clocks key their exclusion on — losing it makes the breadcrumb refresh
+    # the OWNER's freshness windows.
+    payloads = _note_payloads()
+    assert payloads, "no guard-exit blocks found in SKILL.md"
+    for payload in payloads:
+        assert payload.lstrip().startswith("deliberate-stop "), payload
+
+
+def test_reason_tokens_cover_both_exit_shapes():
+    reasons = sorted(
+        m.group(1)
+        for payload in _note_payloads()
+        if (m := re.search(r"reason=([A-Za-z0-9_-]+)", payload)) is not None
+    )
+    assert reasons == ["stale-wake-yield", "step0-session-collision"], reasons
+
+
+def test_by_identity_count_matches_block_count():
+    # Every `--by issue-session-guard` occurrence in the skill must be one of
+    # the two prescribed blocks — a bare mention posting under that identity
+    # without the prescribed note shape would evade the payload pins above.
+    text = SKILL_MD.read_text(encoding="utf-8")
+    assert text.count("--by issue-session-guard") == 2, (
+        "expected exactly the two prescribed guard-exit command blocks"
+    )

--- a/tests/test_stage_dispatch_dedup.py
+++ b/tests/test_stage_dispatch_dedup.py
@@ -480,6 +480,38 @@ def test_deliberate_stop_note_prefix_alone_does_not_refresh():
     )
 
 
+def test_1053_issue_session_guard_exit_breadcrumbs_do_not_refresh_window():
+    # #1053: the Step 0 single-orchestrator collision exit and the stale-wake
+    # YIELD each post one deliberate-stop breadcrumb (by="issue-session-guard",
+    # SKILL.md Step 0). Those are death records, not stage liveness — the
+    # EXACT prescribed notes must not refresh a stage-dispatch window.
+    collision_note = (
+        "deliberate-stop pid=n/a target=self reason=step0-session-collision "
+        "owner=happy-session:abc123 — duplicate /issue 1053 session exiting at Step 0; "
+        "owner happy-session:abc123 remains the driver; no state mutated"
+    )
+    yield_note = (
+        "deliberate-stop pid=n/a target=self reason=stale-wake-yield "
+        "replacement=happy-session:def456 — stale /issue 1053 session yielding on wake; "
+        "the replacement owns the task; no state mutated"
+    )
+    for note in (collision_note, yield_note):
+        events = [
+            _ev(
+                "2026-07-01T10:00:00Z",
+                "epm:progress",
+                "stage-dispatch stage=implementing round=1 subagent=experiment-implementer",
+            ),
+            _ev("2026-07-01T10:14:00Z", "epm:progress", note, by="issue-session-guard"),
+        ]
+        assert (
+            tw.stage_dispatch_should_skip(
+                events, "implementing", 1, 15, now=_dt("2026-07-01T10:20:00Z")
+            )
+            is None
+        ), note
+
+
 def test_watcher_telemetry_notes_do_not_refresh_window():
     # Third-party bracketed telemetry (watcher + spawn-session bookkeeping)
     # is not stage liveness; the watcher's own progress clock excludes the

--- a/tests/test_stalled_detector_and_gc.py
+++ b/tests/test_stalled_detector_and_gc.py
@@ -463,6 +463,60 @@ def test_stalled_signal2_still_excludes_watcher_sentinel_markers():
     assert asw._latest_nonwatcher_event_ts(events) == asw._parse_event_ts("2026-06-25T01:15:00Z")
 
 
+# ─── #1053 exit breadcrumbs are anti-liveness on BOTH watcher clocks ──────────
+
+
+def test_1053_exit_breadcrumbs_advance_neither_staleness_clock():
+    # #1053 MF-1 pin: the EXACT prescribed Step 0 collision-exit and
+    # stale-wake-yield breadcrumbs (by="issue-session-guard", SKILL.md Step 0)
+    # advance NEITHER `_latest_progress_ts` NOR `_latest_nonwatcher_event_ts`
+    # — a duplicate session's death record must not shield the OWNER from the
+    # stalled / orphan-respawn / reconcile-idle / campaign-freshness reads.
+    import autonomous_session_watch as asw
+
+    collision_note = (
+        "deliberate-stop pid=n/a target=self reason=step0-session-collision "
+        "owner=happy-session:abc123 — duplicate /issue 1053 session exiting at Step 0; "
+        "owner happy-session:abc123 remains the driver; no state mutated"
+    )
+    yield_note = (
+        "deliberate-stop pid=n/a target=self reason=stale-wake-yield "
+        "replacement=happy-session:def456 — stale /issue 1053 session yielding on wake; "
+        "the replacement owns the task; no state mutated"
+    )
+    for note in (collision_note, yield_note):
+        events = [
+            {"kind": "epm:progress", "ts": "2026-07-04T10:00:00Z", "note": "step 100"},
+            {
+                "kind": "epm:progress",
+                "ts": "2026-07-04T12:00:00Z",
+                "note": note,
+                "by": "issue-session-guard",
+            },
+        ]
+        expected = asw._parse_event_ts("2026-07-04T10:00:00Z")
+        assert asw._latest_progress_ts(events) == expected, note
+        assert asw._latest_nonwatcher_event_ts(events) == expected, note
+
+
+def test_1053_nonwatcher_clock_still_counts_normal_markers():
+    # Non-vacuity companion to the exclusion above: an ordinary marker (no
+    # deliberate-stop prefix, benign by) still advances
+    # `_latest_nonwatcher_event_ts` after the #1053 exclusion landed.
+    import autonomous_session_watch as asw
+
+    events = [
+        {"kind": "epm:progress", "ts": "2026-07-04T10:00:00Z", "note": "step 100"},
+        {
+            "kind": "epm:experiment-implementation",
+            "ts": "2026-07-04T12:00:00Z",
+            "note": "implemented dispatch script",
+            "by": "test",
+        },
+    ]
+    assert asw._latest_nonwatcher_event_ts(events) == asw._parse_event_ts("2026-07-04T12:00:00Z")
+
+
 # ─── stalled_session_pass — top-level driver ─────────────────────────────────
 
 

--- a/tests/test_tick_triage.py
+++ b/tests/test_tick_triage.py
@@ -180,6 +180,66 @@ def test_latest_event_ts_ignores_watcher_sentinel_notes():
     assert ts is not None and (NOW - ts) > 3600
 
 
+def test_latest_event_ts_ignores_deliberate_stop_records():
+    # #1053: both legs of the deliberate-stop predicate — the lstripped note
+    # PREFIX (an issue-session-guard exit breadcrumb) and the
+    # by="spawn_session-stop" identity (note text irrelevant) — must never
+    # count as issue freshness.
+    for row in (
+        {
+            "kind": "epm:progress",
+            "ts": _iso(NOW - 60),
+            "note": "deliberate-stop pid=n/a target=self reason=step0-session-collision "
+            "owner=happy-session:abc123 — duplicate /issue 42 session exiting at Step 0; "
+            "owner happy-session:abc123 remains the driver; no state mutated",
+            "by": "issue-session-guard",
+        },
+        {
+            "kind": "epm:progress",
+            "ts": _iso(NOW - 60),
+            "note": "stopping session",
+            "by": "spawn_session-stop",
+        },
+    ):
+        events = [_event("epm:progress v1", 7200, note="real work marker"), row]
+        ts = tick_triage.latest_event_ts(events)
+        assert ts is not None and (NOW - ts) > 3600, row
+
+
+# ── #1053 end-to-end: exit breadcrumb must not mask staleness ───────────────
+
+
+def test_step0_collision_exit_breadcrumb_does_not_mask_staleness(state_dir, monkeypatch):
+    # #1053 MF-2 pin (end-to-end): a stale issue whose ONLY fresh event is the
+    # prescribed Step 0 collision-exit (or stale-wake-yield) breadcrumb must
+    # stay STALE-REDRIVE — the duplicate's death record must not flip the tick
+    # verdict to HEALTHY and mask a dead owner chain.
+    collision_note = (
+        "deliberate-stop pid=n/a target=self reason=step0-session-collision "
+        "owner=happy-session:abc123 — duplicate /issue 1053 session exiting at Step 0; "
+        "owner happy-session:abc123 remains the driver; no state mutated"
+    )
+    yield_note = (
+        "deliberate-stop pid=n/a target=self reason=stale-wake-yield "
+        "replacement=happy-session:def456 — stale /issue 1053 session yielding on wake; "
+        "the replacement owns the task; no state mutated"
+    )
+    stale_age = tick_triage.stale_s() + 600
+    for note in (collision_note, yield_note):
+        events = [
+            _event("epm:progress v1", stale_age, note="real work marker"),
+            {
+                "kind": "epm:progress",
+                "ts": _iso(NOW - 60),
+                "note": note,
+                "by": "issue-session-guard",
+            },
+        ]
+        _patch_issue_state(monkeypatch, "running", events)
+        verdict, reason = tick_triage.triage(1053, "issue")
+        assert verdict == "STALE-REDRIVE", (verdict, reason, note)
+
+
 # ── runaway streak (via triage end-to-end) ──────────────────────────────────
 
 


### PR DESCRIPTION
Closes task #1053 (workflow-fix, kind: infra).

## Summary
- The /issue Step-0 single-orchestrator detect-and-exit and the stale-wake YIELD now post ONE `deliberate-stop `-prefixed `epm:progress` exit breadcrumb (`--by issue-session-guard`; `reason=step0-session-collision` / `reason=stale-wake-yield`) before ending, so a silent duplicate exit is distinguishable from a wrapper crash (incident: /issue 958, 2026-07-04).
- All five events-freshness clocks now carry the deliberate-stop anti-liveness exclusion (`stage_dispatch_should_skip`, `_latest_progress_ts`, `_latest_nonwatcher_event_ts`, `_has_nonwatcher_event_after`, `tick_triage.latest_event_ts`), each pinned by regression tests; a prose-extraction test pins the prescribed note strings in SKILL.md itself.

## Test plan
- [x] Step 9c touched-scope gate: 2796 passed / 0 failed; baseline compare rc=0 (no new failures)
- [x] fail-pre-fix verified mechanically for the src-pinning tests
- [x] ruff + workflow_lint --check-asks --check-references green

🤖 Generated with [Claude Code](https://claude.com/claude-code)