### PR TITLE
task #1068: check 17 enforces the Context-row origin-prompt verbatim quote

### DIFF
--- a/.claude/skills/clean-results/SPEC.md
+++ b/.claude/skills/clean-results/SPEC.md
@@ -643,8 +643,8 @@ H2), preceded by a `---` horizontal rule. TWO required bold labels:
   #921) · created/run dates.
   Mechanically enforced (check 17): the normalized frontmatter
   `origin_prompt` must appear verbatim within the `**Context:**` row's
-  text — a quoted candidate that is a strict prefix of `origin_prompt`
-  covering ≥50% of it (truncation) is a hard v4 FAIL; any other mismatch
+  text — a ≥20-char quoted candidate that is a strict prefix of
+  `origin_prompt` covering ≥50% of it (truncation) is a hard v4 FAIL; any other mismatch
   WARNs (v3/v2: WARN-only). When the row quotes a longer alternate
   verbatim source (`## Provenance` / followup-scope), quote the
   frontmatter `origin_prompt` too, or expect the WARN.

--- a/.claude/skills/clean-results/SPEC.md
+++ b/.claude/skills/clean-results/SPEC.md
@@ -641,6 +641,13 @@ H2), preceded by a `---` horizontal rule. TWO required bold labels:
   ``same-issue follow-up round `<followup_label>` `` clause, the
   machine-countable form check 20's round-scaled prose budget reads;
   #921) · created/run dates.
+  Mechanically enforced (check 17): the normalized frontmatter
+  `origin_prompt` must appear verbatim within the `**Context:**` row's
+  text — a quoted candidate that is a strict prefix of `origin_prompt`
+  covering ≥50% of it (truncation) is a hard v4 FAIL; any other mismatch
+  WARNs (v3/v2: WARN-only). When the row quotes a longer alternate
+  verbatim source (`## Provenance` / followup-scope), quote the
+  frontmatter `origin_prompt` too, or expect the WARN.
   Bare / unpinned URLs INSIDE the verbatim blockquote are exempt from
   the footer URL checks (checks 8 / 8b strip `>`-prefixed lines before
   scanning — the quote is provenance text, not a provenance link; #959;
@@ -900,7 +907,11 @@ Forward-only: each check branches on the sentinel. The v4 checks
 17. `**Context:**` provenance present, and (v4) the row carries a lineage
     token — `[#K](...)`/bare `#K`, `fresh direction (no parent)`/`fresh (no
     parent)`, or a same-issue-follow-up-round clause (gated on
-    `is_titletag_confidence()`).
+    `is_titletag_confidence()`) — and (v4) the `**Context:**` row's text
+    must contain frontmatter `origin_prompt` verbatim
+    (whitespace-normalized; a ≥20-char strict-prefix quote covering ≥50%
+    of `origin_prompt` = hard FAIL on truncation, other mismatch = WARN;
+    v3/v2 WARN-only).
 18. **`## Methodology` completeness** (`check_v4_methodology_shape`, v4
     only): the `**Training:**` slot carries the complete hyperparameter
     table (≥1 GFM table after the Training label, OR the explicit
@@ -1457,7 +1468,8 @@ listed under § Grandfathered shape. The v3 checks:
 16. Reproducibility lr matches plan (gated on `is_nested_design()` = v2
     OR v3; the body table SLIMS but the lr must still appear in the plan).
 17. Reproducibility `**Context:**` provenance row present (gated on
-    `is_nested_design()`).
+    `is_nested_design()`); the check-17 origin-prompt verbatim sub-check
+    (v4 list item 17) runs WARN-only here.
 18. **`## Data` shape** (v3 only): `### Trained on` / `### Evaluated
     with` / `### Generated` in order; each block carries ≥1 pinned
     complete-artifact link OR an explicit `n/a — <reason>` line.

--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -3367,6 +3367,183 @@ _V4_CONTEXT_LINEAGE_TOKEN_RE = re.compile(
 )
 
 
+# ── Check-17 origin-prompt verbatim sub-check (#1068, incident #813 r1) ──
+# The **Context:** row promises the originating prompt VERBATIM
+# (SPEC.md § `**Context:**` row). The sub-check requires normalized
+# frontmatter `origin_prompt` to appear as a SUBSTRING of the normalized
+# Context-region text (blockquote markers stripped). Substring — not
+# per-segment equality — because the row legitimately carries MORE quoted
+# text than the creation prompt (follow-up-round prompts, lineage prose,
+# inline quote marks), and because the containment DIRECTION is what
+# catches truncation: a truncated quote means the full origin_prompt
+# appears NOWHERE in the row. (A quote-inside-origin_prompt test would
+# PASS every truncation — direction matters.)
+
+_MD_ESCAPE_RE = re.compile(r'\\([\\`*_{}\[\]()#+\-.!|>~"\'])')
+
+# Leading blockquote-marker run on a line: `>`, `> >`, `  > `, etc.
+_BLOCKQUOTE_MARKER_RE = re.compile(r"^\s*(?:>\s?)+")
+
+# Same pattern check 17 already used inline for the label-presence test.
+_CONTEXT_LABEL_RE = re.compile(r"\*\*\s*Context\s*:?\s*\*\*")
+
+# An inline quote-mark-delimited span (>= 20 chars): ASCII `"` or the
+# curly forms (escapes dodge the ambiguous-unicode lint).
+_INLINE_QUOTE_SPAN_RE = re.compile('["\u201c]([^"\u201c\u201d]{20,})["\u201d]', re.S)
+
+
+def _normalize_prompt_text(s: str) -> str:
+    """Whitespace-collapse + unicode-punctuation fold for the check-17
+    origin-prompt comparison. Collapses all whitespace runs (incl.
+    newlines from wrapped blockquotes) to single spaces, folds NBSP and
+    curly quotes/apostrophes to their ASCII forms (editors smart-quote;
+    a fold applied to BOTH sides never masks a real word-level edit)."""
+    s = s.replace("\u00a0", " ")  # NBSP
+    s = s.replace("\u2018", "'").replace("\u2019", "'")  # curly single quotes
+    s = s.replace("\u201c", '"').replace("\u201d", '"')  # curly double quotes
+    return " ".join(s.split())
+
+
+def _unescape_markdown(s: str) -> str:
+    """Undo backslash-escapes of markdown punctuation (body side only —
+    an analyzer writing an ``origin_prompt`` containing ``**`` or
+    backticks into markdown may escape it; the frontmatter value is raw
+    text and is never unescaped)."""
+    return _MD_ESCAPE_RE.sub(r"\1", s)
+
+
+def _strip_blockquote_markers(text: str) -> str:
+    """Remove leading `>` marker runs per line, KEEPING the line text.
+
+    The opposite transform of ``_strip_blockquote_lines`` (which drops
+    the whole line for the #959 URL-scan exemption): here the quoted
+    text IS the object under test, only the markers are noise."""
+    return "\n".join(_BLOCKQUOTE_MARKER_RE.sub("", ln) for ln in text.splitlines())
+
+
+def _common_prefix_len(a: str, b: str) -> int:
+    """Length of the longest common prefix of ``a`` and ``b``."""
+    n = min(len(a), len(b))
+    i = 0
+    while i < n and a[i] == b[i]:
+        i += 1
+    return i
+
+
+def _context_quote_candidates(region: str) -> list[str]:
+    """Extract quoted-prompt CANDIDATES from the Context region for the
+    check-17 truncation classifier.
+
+    Candidates: the label line's post-label remainder (`>`-stripped, if
+    non-empty), blockquote segments (contiguous `>` runs with markdown
+    lazy-continuation lines joined — inclusion fails toward PASS/WARN,
+    the safe direction), and inline quote-mark-delimited spans (>= 20
+    chars) over the marker-stripped region. Only consulted AFTER the
+    containment PASS test failed, to classify the mismatch."""
+    lines = region.splitlines()
+    candidates: list[str] = []
+    segment: list[str] = []
+
+    def _close() -> None:
+        if segment:
+            candidates.append("\n".join(segment))
+            segment.clear()
+
+    if lines:
+        first = _BLOCKQUOTE_MARKER_RE.sub("", lines[0]).strip()
+        if first:
+            candidates.append(first)
+    for ln in lines[1:]:
+        if ln.lstrip().startswith(">"):
+            segment.append(_BLOCKQUOTE_MARKER_RE.sub("", ln))
+        elif ln.strip() and segment:
+            segment.append(ln)  # markdown lazy continuation joins the quote
+        else:
+            _close()
+    _close()
+    candidates.extend(_INLINE_QUOTE_SPAN_RE.findall(_strip_blockquote_markers(region)))
+    return candidates
+
+
+def _origin_prompt_quote_verdict(repro: str, fm: dict) -> tuple[str, str]:
+    """Classify the Context row's originating-prompt quote against
+    frontmatter ``origin_prompt``.
+
+    Returns ``(status, detail)`` with status one of:
+
+    - ``"noop"`` — no frontmatter ``origin_prompt``, or no
+      ``**Context:**`` label in the region;
+    - ``"pass"`` — normalized ``origin_prompt`` appears as a substring
+      of the normalized, blockquote-marker-stripped Context-region text
+      (tested raw AND markdown-unescaped);
+    - ``"fail-trunc"`` — a quoted candidate is a strict normalized
+      PREFIX of ``origin_prompt``, >= 20 chars AND covering >= 50% of it
+      (the #813 r1 / #742 silent-tail-truncation signature);
+    - ``"warn-mismatch"`` — containment fails with no truncation
+      signature (e.g. the row quotes a spec-sanctioned alternate
+      verbatim source; #825).
+    """
+    op = str(fm.get("origin_prompt") or "").strip()
+    if not op:
+        return "noop", "no frontmatter origin_prompt"
+    m = _CONTEXT_LABEL_RE.search(repro)
+    if m is None:
+        return "noop", "no **Context:** label"  # caller's label branch makes this unreachable
+    region = repro[m.end() :]  # Context row -> end of footer/section
+    nop = _normalize_prompt_text(op)
+    stripped = _strip_blockquote_markers(region)
+    if nop in _normalize_prompt_text(stripped) or nop in _normalize_prompt_text(
+        _unescape_markdown(stripped)
+    ):
+        return "pass", ""
+    # Containment failed — classify. Candidates: blockquote segments
+    # (contiguous `>` runs, lazy-continuation lines joined) + inline
+    # quote-mark-delimited spans (>= 20 chars) in the stripped region.
+    candidates = _context_quote_candidates(region)
+    best_lcp, truncated = 0, None
+    for cand in candidates:
+        ncand = _normalize_prompt_text(_unescape_markdown(cand))
+        ncand_p = ncand.rstrip(".,;:!?\u2026 ")  # a truncating editor appends `.`/ellipsis (#742)
+        best_lcp = max(best_lcp, _common_prefix_len(ncand_p, nop))
+        # FAIL guard (plan D10): a strict-prefix candidate must ALSO cover
+        # >= 50% of the normalized origin_prompt. Rationale: the incident
+        # class (silent tail truncation — #742 at 85%, the #813-r1-shaped
+        # fixture at ~60%) characteristically preserves most of the
+        # prompt, while the false-positive scenario (an innocent SHORT
+        # elided pointer quoting the fm opener alongside a full
+        # alternate-source quote — the #825+ shape) characteristically
+        # quotes a small head fraction (~10%). Below the floor the case
+        # routes to WARN, whose message names the alternate-source
+        # escape. Per-candidate + fraction semantics deliberately do NOT
+        # suppress on the presence of a longer non-prefix candidate —
+        # that variant would false-NEGATIVE the multi-round true positive
+        # (truncated creation quote + a longer full round-2 quote).
+        if (
+            20 <= len(ncand_p) < len(nop)
+            and len(ncand_p) >= 0.5 * len(nop)
+            and nop.startswith(ncand_p)
+        ):
+            truncated = ncand_p
+    if truncated is not None:
+        cut = len(truncated)
+        return "fail-trunc", (
+            f"context-origin-prompt-mismatch: the quoted originating prompt is a strict "
+            f"PREFIX of frontmatter `origin_prompt` — truncated at normalized offset "
+            f"{cut}/{len(nop)} (quote ends '...{truncated[-40:]}'; origin_prompt continues "
+            f"'{nop[cut : cut + 60]}...'). Quote the FULL origin_prompt verbatim "
+            f"(SPEC.md § `**Context:**` row)."
+        )
+    return "warn-mismatch", (
+        f"context-origin-prompt-mismatch: frontmatter `origin_prompt` does not appear "
+        f"verbatim (whitespace-normalized) in the `**Context:**` row — first divergence at "
+        f"normalized offset {best_lcp}/{len(nop)} (origin_prompt continues "
+        f"'{nop[best_lcp : best_lcp + 60]}...'). If the row quotes a spec-sanctioned "
+        f"alternate verbatim source (original-body `## Provenance` / an "
+        f"`epm:followup-scope` marker), this is informational; otherwise re-quote "
+        f"origin_prompt verbatim."
+    )
+
+
 def check_repro_context_provenance(
     body: str, fm: dict, *, original_body_path: Path | None = None
 ) -> CheckResult:
@@ -3388,6 +3565,37 @@ def check_repro_context_provenance(
     lineage token is a hard FAIL. v3/v2 bodies keep the pre-#1014
     label-presence-only behavior verbatim.
 
+    **Origin-prompt verbatim sub-check (#1068, incident #813 r1).** When
+    frontmatter ``origin_prompt`` is recorded and the row is present, the
+    normalized ``origin_prompt`` must appear as a SUBSTRING of the
+    normalized, blockquote-marker-stripped Context-region text (tested
+    raw AND markdown-unescaped) — containment in THIS direction is what
+    catches truncation: a truncated quote means the full prompt appears
+    nowhere in the row (the reverse quote-inside-origin_prompt test
+    would PASS every truncation). On a containment failure: a quoted
+    candidate that is a >=20-char strict normalized PREFIX of
+    ``origin_prompt`` covering >=50% of it is a hard v4 FAIL naming the
+    truncation offset (`_origin_prompt_quote_verdict`); any other
+    mismatch is a WARN, because SPEC.md sanctions alternate verbatim
+    sources (original-body ``## Provenance`` / ``epm:followup-scope``
+    markers), so a non-truncation mismatch may be innocent (#825). v3/v2
+    bodies get the WARN-only form for BOTH classes (grandfathering —
+    never a new hard FAIL below the v4 sentinel). No ``origin_prompt``
+    or no ``**Context:**`` label: NO-OP (pre-#1068 behavior verbatim).
+
+    Documented residuals (deliberate, all fail toward PASS/WARN):
+    (a) FAIL scope — only strict-prefix truncations >=20 chars covering
+    >=50% of ``origin_prompt`` hard-FAIL; non-prefix truncations
+    (mid-string deletions, truncate-and-fabricate), sub-floor cuts, and
+    non-extractable quote shapes degrade to WARN — clean-result-critic
+    Lens 5 keeps the substantive read on Context-row WARNs. (b)
+    Trailing-punct asymmetry — a quote missing ``origin_prompt``'s final
+    period FAILs (a 1-char truncation) while an ADDED period PASSes via
+    containment — verbatim-consistent, not a verifier bug. (c) An
+    ``origin_prompt`` containing line-leading ``>`` characters yields a
+    conforming-body WARN (the marker strip applies to the body side
+    only — the safe direction).
+
     A missing row FAILs only when recorded origin data exists —
     frontmatter ``origin_prompt`` or a ``## Provenance`` section in the
     sibling ``original-body.md`` — i.e. the body DROPPED provenance it
@@ -3403,10 +3611,18 @@ def check_repro_context_provenance(
     if repro is None:
         # Missing-section is check_required_sections' job; don't double-FAIL.
         return CheckResult(name, True, "skipped — no Reproducibility section")
-    if re.search(r"\*\*\s*Context\s*:?\s*\*\*", repro):
+    if _CONTEXT_LABEL_RE.search(repro):
         if not is_v4(body):
             # v2/v3 keep the pre-#1014 label-presence behavior verbatim
             # (forward-only; the v4 lineage sub-check never binds them).
+            # The #1068 origin-prompt sub-check is WARN-ONLY here
+            # (grandfathering: NEVER a new hard FAIL below the v4
+            # sentinel).
+            status, sub_detail = _origin_prompt_quote_verdict(repro, fm)
+            if status in ("fail-trunc", "warn-mismatch"):
+                return CheckResult(
+                    name, True, "**Context:** row present; " + sub_detail, is_warn=True
+                )
             return CheckResult(name, True, "**Context:** row present")
         # v4 lineage-token sub-check. Strip fences + blockquote LINES
         # FIRST, then slice at the label: a single-line row with an inline
@@ -3429,6 +3645,20 @@ def check_repro_context_provenance(
         # same shape that PASSes unconditionally today.
         ctx_scan = scan_src[m.end() :] if m else scan_src
         if _V4_CONTEXT_LINEAGE_TOKEN_RE.search(ctx_scan):
+            # #1068 origin-prompt verbatim sub-check — runs AFTER the
+            # lineage sub-check (one failure at a time, the file's
+            # convention; a body failing both surfaces the truncation on
+            # the next verifier run after the lineage fix).
+            status, sub_detail = _origin_prompt_quote_verdict(repro, fm)
+            if status == "fail-trunc":
+                return CheckResult(name, False, sub_detail)
+            if status == "warn-mismatch":
+                return CheckResult(
+                    name,
+                    True,
+                    "**Context:** row present with lineage token; " + sub_detail,
+                    is_warn=True,
+                )
             return CheckResult(name, True, "**Context:** row present with lineage token")
         return CheckResult(
             name,

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -6131,6 +6131,237 @@ def test_v4_context_unhyphenated_followup_round_clause_passes():
     assert ctx.passed and not ctx.is_warn, ctx.detail
 
 
+# ─── Check 17 (origin-prompt verbatim sub-check, #1068) ────────────────────
+# Unit-grain cases call `check_repro_context_provenance(body, fm)` directly
+# (the function is public and takes `fm`); one end-to-end case runs
+# `verify_text` to pin the frontmatter threading.
+
+_OP = "sweep the X effect across three seeds and report the per-seed deltas"
+# 68 normalized chars; `_OP[:41]` is a mid-sentence cut ending at "...and"
+# (41/68 = 60% coverage — over the 20-char absolute AND 50% coverage floors).
+_OP41 = _OP[:41]
+
+_V4_NOT_RECORDED_LINE = "- Originating prompt: origin prompt not recorded"
+
+
+def _v4_body_with_context_quote(quote_block: str) -> str:
+    """Return `_V4_GOOD_BODY` with its Context originating-prompt line
+    (`origin prompt not recorded`) replaced by ``quote_block``."""
+    assert _V4_NOT_RECORDED_LINE in _V4_GOOD_BODY, "fixture drifted"
+    return _V4_GOOD_BODY.replace(_V4_NOT_RECORDED_LINE, quote_block)
+
+
+def test_v4_context_origin_prompt_verbatim_blockquote_passes():
+    """The canonical conforming shape: a blockquoted verbatim quote of the
+    full frontmatter `origin_prompt` PASSes with no WARN."""
+    body = _v4_body_with_context_quote(f"- Originating prompt, verbatim:\n\n> {_OP}\n")
+    ctx = verify_task_body.check_repro_context_provenance(body, {"origin_prompt": _OP})
+    assert ctx.passed and not ctx.is_warn, ctx.detail
+    assert "lineage" in ctx.detail
+
+
+def test_v4_context_origin_prompt_prefix_truncated_fails():
+    """The #813 r1 shape: the quote is a strict mid-sentence PREFIX of
+    `origin_prompt` — a hard v4 FAIL naming the truncation offset."""
+    body = _v4_body_with_context_quote(f"- Originating prompt, verbatim:\n\n> {_OP41}\n")
+    ctx = verify_task_body.check_repro_context_provenance(body, {"origin_prompt": _OP})
+    assert not ctx.passed
+    assert "PREFIX" in ctx.detail
+    assert "context-origin-prompt-mismatch" in ctx.detail
+    assert "41/68" in ctx.detail
+
+
+def test_v4_context_truncated_with_trailing_period_fails():
+    """The #742 shape: a truncating editor appends a `.` at the cut — the
+    trailing-punct strip still classifies it as a strict-prefix FAIL."""
+    body = _v4_body_with_context_quote(f"- Originating prompt, verbatim:\n\n> {_OP41.rstrip()}.\n")
+    ctx = verify_task_body.check_repro_context_provenance(body, {"origin_prompt": _OP})
+    assert not ctx.passed
+    assert "PREFIX" in ctx.detail
+
+
+def test_v4_context_whitespace_and_wrap_differences_pass():
+    """A quote re-wrapped across `>` lines with doubled internal spaces
+    still PASSes — pins `_normalize_prompt_text` whitespace collapsing."""
+    body = _v4_body_with_context_quote(
+        "- Originating prompt, verbatim:\n\n"
+        "> sweep the X effect  across\n"
+        "> three seeds and report  the\n"
+        "> per-seed deltas\n"
+    )
+    ctx = verify_task_body.check_repro_context_provenance(body, {"origin_prompt": _OP})
+    assert ctx.passed and not ctx.is_warn, ctx.detail
+
+
+def test_v4_context_inline_quote_marks_pass():
+    """The #661/#672 shape: the full prompt quoted inline in `"..."` on
+    the label bullet, no blockquote — PASSes (pins region-haystack
+    semantics; substring containment ignores wrapping quote marks)."""
+    body = _v4_body_with_context_quote(f'- Originating user request (verbatim): "{_OP}"')
+    ctx = verify_task_body.check_repro_context_provenance(body, {"origin_prompt": _OP})
+    assert ctx.passed and not ctx.is_warn, ctx.detail
+
+
+def test_v4_context_multi_round_extra_prompts_pass():
+    """The #813 post-fix shape: the full creation quote plus a second
+    labeled round-prompt blockquote — extra quotes only grow the haystack."""
+    body = _v4_body_with_context_quote(
+        f"- Originating prompt, verbatim:\n\n> {_OP}\n\n"
+        "- Round-2 prompt (`dose-curve`), verbatim:\n\n"
+        "> also check the dose curve at half strength\n"
+    )
+    ctx = verify_task_body.check_repro_context_provenance(body, {"origin_prompt": _OP})
+    assert ctx.passed and not ctx.is_warn, ctx.detail
+
+
+def test_v4_context_generic_mismatch_warns_with_offset():
+    """A paraphrase sharing no 20-char prefix with `origin_prompt` is a
+    WARN (not a FAIL) naming the first-divergence offset."""
+    body = _v4_body_with_context_quote(
+        "- Originating prompt, verbatim:\n\n"
+        "> run the seed sweep for the X effect and summarize the deltas\n"
+    )
+    ctx = verify_task_body.check_repro_context_provenance(body, {"origin_prompt": _OP})
+    assert ctx.passed and ctx.is_warn, ctx.detail
+    assert "first divergence" in ctx.detail
+    assert "/68" in ctx.detail
+
+
+def test_v4_context_markdown_escaped_quote_passes():
+    """An `origin_prompt` containing `**stories**` quoted with markdown
+    backslash-escapes (`\\*\\*stories\\*\\*`) PASSes — pins the
+    `_unescape_markdown` leg of the containment test."""
+    op_md = "please analyze the **stories** dataset and report drift across all five domains"
+    body = _v4_body_with_context_quote(
+        "- Originating prompt, verbatim:\n\n"
+        "> please analyze the \\*\\*stories\\*\\* dataset and report drift "
+        "across all five domains\n"
+    )
+    ctx = verify_task_body.check_repro_context_provenance(body, {"origin_prompt": op_md})
+    assert ctx.passed and not ctx.is_warn, ctx.detail
+
+
+def test_v4_context_lazy_continuation_quote_passes():
+    """A blockquote whose second physical line lacks the `>` prefix
+    (markdown lazy continuation) still PASSes — pins the marker-strip
+    haystack keeping ALL region text, lazy lines included."""
+    body = _v4_body_with_context_quote(
+        f"- Originating prompt, verbatim:\n\n> {_OP[:38]}\n{_OP[38:]}\n"
+    )
+    ctx = verify_task_body.check_repro_context_provenance(body, {"origin_prompt": _OP})
+    assert ctx.passed and not ctx.is_warn, ctx.detail
+
+
+def test_v4_context_no_origin_prompt_noop_unchanged():
+    """No frontmatter `origin_prompt` → the sub-check NO-OPs: a
+    deliberately-mismatching quote keeps the byte-identical pre-#1068
+    PASS detail."""
+    body = _v4_body_with_context_quote(
+        "- Originating prompt, verbatim:\n\n> something entirely unrelated to any recorded prompt\n"
+    )
+    ctx = verify_task_body.check_repro_context_provenance(body, {})
+    assert ctx.passed and not ctx.is_warn, ctx.detail
+    assert ctx.detail == "**Context:** row present with lineage token"
+
+
+def test_v3_context_truncated_quote_warns_never_fails():
+    """Grandfathering: the SAME truncation that hard-FAILs a v4 body is
+    WARN-only on a v3 body (never a new hard FAIL below the v4 sentinel)."""
+    assert _V4_NOT_RECORDED_LINE in _V3_GOOD_BODY, "fixture drifted"
+    body = _V3_GOOD_BODY.replace(
+        _V4_NOT_RECORDED_LINE,
+        f"- Originating prompt, verbatim:\n\n> {_OP41}\n",
+    )
+    ctx = verify_task_body.check_repro_context_provenance(body, {"origin_prompt": _OP})
+    assert ctx.passed is True and ctx.is_warn, ctx.detail
+    assert "context-origin-prompt-mismatch" in ctx.detail
+
+
+def test_verify_text_threads_frontmatter_origin_prompt():
+    """End-to-end: `origin_prompt` spliced into the fixture's EXISTING
+    frontmatter block (never a second `---` block — check 0b trips on
+    stacked frontmatter) + a truncated quote → the check FAILs through
+    `verify_text`, pinning the fm threading."""
+    body = _v4_body_with_context_quote(f"- Originating prompt, verbatim:\n\n> {_OP41}\n").replace(
+        "kind: experiment\n",
+        f'kind: experiment\norigin_prompt: "{_OP}"\n',
+    )
+    assert "origin_prompt" in body, "fixture replacement did not land"
+    _ok, results = verify_task_body.verify_text(body)
+    ctx = _results_by_name(results)[_CONTEXT_CHECK]
+    assert not ctx.passed
+    assert "context-origin-prompt-mismatch" in ctx.detail
+
+
+def test_v4_context_inline_quoted_truncation_fails():
+    """A truncated prompt quoted INLINE in `"..."` (no blockquote anywhere
+    in the Context region) still FAILs — pins the `_INLINE_QUOTE_SPAN_RE`
+    candidate arm as FAIL-capable (deleting the inline arm would ship
+    green through the rest of the suite AND the backlog sweep)."""
+    body = _v4_body_with_context_quote(
+        f'- Originating user request (verbatim): "{_OP41}" — lineage note above.'
+    )
+    ctx = verify_task_body.check_repro_context_provenance(body, {"origin_prompt": _OP})
+    assert not ctx.passed
+    assert "PREFIX" in ctx.detail
+    assert "context-origin-prompt-mismatch" in ctx.detail
+
+
+def test_v4_context_alternate_source_with_inline_opener_warns_not_fails():
+    """The #825+ conforming shape: fm `origin_prompt` is a long
+    self-declared abridgement; the row quotes the FULL alternate-source
+    prompt (long, non-prefix blockquote) plus a SHORT innocent inline
+    quote of the fm opener (strict prefix, over the 20-char floor but
+    ~9% coverage — under the 50% floor). Verdict is warn-mismatch,
+    NEVER fail-trunc (pins the D10 coverage floor)."""
+    op_long = (
+        "investigate whether the marker adapters trained in the localization arm "
+        "transfer their end-of-turn emission to the paraphrase eval surface, "
+        "including the bystander panel, the dose-matched checkpoints, and the "
+        "frozen-R diagonal read described in the provenance section (abridged; "
+        "verbatim full prompt in the original body Provenance section)"
+    )
+    body = _v4_body_with_context_quote(
+        '- Originating prompt (abridged in frontmatter): "investigate whether the marker"\n'
+        "- Full alternate-source prompt from the original body, verbatim:\n\n"
+        "> The complete originating request text as recorded before promotion: run the\n"
+        "> marker-transfer eval end to end and report every per-persona delta with the\n"
+        "> dose-matched checkpoints held fixed across the bystander panel.\n"
+    )
+    ctx = verify_task_body.check_repro_context_provenance(body, {"origin_prompt": op_long})
+    assert ctx.passed and ctx.is_warn, ctx.detail
+    assert "PREFIX" not in ctx.detail
+    assert "first divergence" in ctx.detail
+
+
+def test_v4_context_multi_round_truncated_creation_quote_still_fails():
+    """A truncated creation quote (60% strict prefix) + a LONGER full
+    round-2 blockquote elsewhere in the row still FAILs — pins that the
+    D10 guard is per-candidate + fraction-based and is NOT suppressed by
+    the presence of a longer non-prefix candidate (the false-negative
+    direction of the rejected suppress-variant)."""
+    body = _v4_body_with_context_quote(
+        f"- Originating prompt, verbatim:\n\n> {_OP41}\n\n"
+        "- Round-2 prompt (`dose-curve`), verbatim:\n\n"
+        "> additionally rerun the dose curve at half strength across all five bystander\n"
+        "> personas and report the per-persona deltas alongside the headline numbers\n"
+    )
+    ctx = verify_task_body.check_repro_context_provenance(body, {"origin_prompt": _OP})
+    assert not ctx.passed, ctx.detail
+    assert "PREFIX" in ctx.detail
+
+
+def test_v4_context_short_origin_prompt_truncation_warns():
+    """An `origin_prompt` under the 20-normalized-char floor cannot
+    hard-FAIL: its truncation degrades to WARN (pins the floor's
+    WARN-degradation direction)."""
+    op_short = "sweep X effect"  # 14 normalized chars — under the 20-char floor
+    body = _v4_body_with_context_quote("- Originating prompt, verbatim:\n\n> sweep X\n")
+    ctx = verify_task_body.check_repro_context_provenance(body, {"origin_prompt": op_short})
+    assert ctx.passed and ctx.is_warn, ctx.detail
+    assert "first divergence" in ctx.detail
+
+
 def test_v4_v3_content_h2_is_hard_fail():
     """A leftover v3 content H2 (`## Findings`) in a v4 body is a hard FAIL."""
     body = _V4_GOOD_BODY.replace("## Results\n", "## Findings\n\nstale v3 H2\n\n## Results\n")


### PR DESCRIPTION
## Summary
- Extends `verify_task_body.py` check 17 with an origin-prompt verbatim sub-check: normalized frontmatter `origin_prompt` must appear (containment) in the `**Context:**` region; a ≥20-char strict-prefix quoted candidate covering ≥50% of `origin_prompt` is a hard v4 FAIL (`context-origin-prompt-mismatch`, truncation offset named); other mismatches WARN; v3/v2 WARN-only; NO-OP without `origin_prompt`.
- 16 new tests (incl. the inline-truncation FAIL arm, the alternate-source WARN guard, multi-round still-FAIL, 20-char-floor boundary); SPEC.md `**Context:**` bullet + mechanical item 17 + v3 mirror updated.
- Closes the #813-r1 defect class (truncated "verbatim" quote PASSing check 17). Backlog: exactly one true-positive FAIL (#742), zero false FAILs across all live v4 bodies.

## Test plan
- [x] `pytest tests/test_verify_task_body.py` — 440 passed / 6 skipped
- [x] Step 9c gate (32 workflow-invariant files) — 2604 passed / 6 skipped; step9c_baseline compare rc=0 (0 new failures, no lint regression)
- [x] Backlog reconciliation over awaiting_promotion + completed — reproduces the plan's table with zero deltas
- [x] Pre-push workflow-lint gate — pass (all 4 legs green)

Closes task #1068.

🤖 Generated with [Claude Code](https://claude.com/claude-code)