### PR TITLE
task #1075: verify_plan c26 — GPU basis vs routed machine

### DIFF
--- a/.claude/rules/plan-compute-sizing.md
+++ b/.claude/rules/plan-compute-sizing.md
@@ -228,7 +228,9 @@ GCP-FIRST `auto` default that is the GCP intent mapping
 measured on a different GPU must be scaled with a stated per-step rate
 (e.g. "H100 basis × ~6× A100 step-time" — #599's trainer ran ~6× slower
 per-step on the A100 auto-lane, turning an H100-premised ~6.4h estimate
-into ~34h). Then reconcile the WORST-CASE wall — base phases PLUS every
+into ~34h). Mechanically backstopped (WARN-only, heuristic) by
+`verify_plan.py` c26; the semantic adequacy of a stated scaling factor
+stays critic-owned. Then reconcile the WORST-CASE wall — base phases PLUS every
 conditional / extension phase that could run on the same provision —
 against the GCP lane's auto-delete fence
 (`--instance-termination-action=DELETE` + `--max-run-duration`,

--- a/scripts/verify_plan.py
+++ b/scripts/verify_plan.py
@@ -54,12 +54,14 @@ Check catalog (id — classification — kind scope)
       validation                                          analysis
   c25 html entities in fenced   FAIL, conditional         all kinds
       command blocks
+  c26 GPU basis vs routed       WARN-only, conditional    experiment +
+      machine                                             analysis
 
 Kind-exempt checks render as [SKIP] (first-class status, distinguishable
 from genuine passes — the calibration report needs n_skip separate from
 n_pass). Conditional checks (4, 6, 7, 10, 11, 12, 13, 14, 15, 16, 17, 18,
-19, 20, 21, 22, 23, 24, 25) also SKIP when their content trigger does not
-fire.
+19, 20, 21, 22, 23, 24, 25, 26) also SKIP when their content trigger does
+not fire.
 Check 23 runs OUTSIDE ``verify_plan_text()`` — it needs task context
 (``body.md`` + ``events.jsonl``), so ``main()`` appends it in ``--issue``
 mode only and renders it SKIP in ``--plan-file`` mode; its WARN is the one
@@ -88,6 +90,7 @@ Canonical N/A escape phrases (quote verbatim in bounce briefs):
     arm-(a) shell-tagged content fences ONLY; an arm-(b) fence whose body
     carries ``--workload-cmd`` / ``dispatch_issue.py`` FAILs on entities
     unconditionally)
+  - ``N/A — basis measured on the routed machine`` (check 26)
 
 WARN semantics: a WARN never blocks exit (exit 0). The Phase 1.5.0 wiring
 carries WARN lines verbatim into the fact-checker + critic briefs — that
@@ -3655,6 +3658,223 @@ def check_html_entities_in_commands(plan: str, kind: str) -> CheckResult:
     return _pass(cid, name, f"{len(arm_a) + len(arm_b)} command fence(s), no entity forms")
 
 
+# ─── Check 26 — GPU basis vs routed machine (WARN-only, conditional) ────────
+# Mechanizes .claude/rules/plan-compute-sizing.md § "Cost wall-time against
+# the machine the router will ACTUALLY provision" (#599/#833/#1073 class).
+# STATIC MIRROR of backends/gcp.py::INTENT_TO_MACHINE at FAMILY grain,
+# drift-guarded by tests/test_verify_plan.py::
+# test_c26_intent_gpu_mirror_matches_backend — verify_plan_text() stays
+# hermetic (no project imports at module level; the only project import in
+# this file is the --issue-mode-local task_workflow resolver).
+_C26_INTENT_GPU: dict[str, str] = {
+    "lora-7b": "A100",
+    "lora": "A100",
+    "capture-7b": "A100",
+    "ft-7b": "A100",
+    "eval": "L4",
+    "debug": "L4",
+    "lora-7b-h100": "H100",
+    "eval-h100": "H100",
+    "cpu-bigmem": "CPU",
+    "cpu-small": "CPU",
+    "cpu-mid": "CPU",
+    "sweep-8g-a100": "A100",
+    "sweep-8g-h100": "H100",
+}
+
+
+def _c26_family(token: str) -> str:
+    """GPU family normalization: strip a trailing ``-<digits>`` HBM-size
+    suffix (``A100-80`` == ``A100-40`` == ``A100``; ``H100-80`` == ``H100``;
+    ``L4``/``CPU`` unchanged). A100-40-vs-A100-80 differences are
+    deliberately below the heuristic's grain."""
+    return re.sub(r"-\d+$", "", token)
+
+
+# GPU family tokens ALLOWED in a basis cell trigger. L4/L40S deliberately
+# EXCLUDED from the trigger set: #833-style leg labels ("L1/L2 re-extraction,
+# L3/L4 extraction") collide with the L4 GPU token; nobody measures bases on
+# an L4, while the ROUTED side still knows L4 via the mirror. Included in the
+# ESCAPE scan (permissive direction only).
+_C26_BASIS_GPU_RE = re.compile(r"\b(H100|H200|A100(?:-[48]0)?|B200)\b")
+_C26_ROW_GPU_ANY_RE = re.compile(r"\b(H100|H200|A100(?:-[48]0)?|B200|L40S|L4)\b")
+
+# Scaling vocabulary (row-scoped escape). A bare multiplication sign is NOT
+# an escape — it appears in nearly every row's multiplier arithmetic
+# ("5,000 x ~300 tok", "draws x cells"); #1073 v3's offending row contains
+# one and was still the incident (plan #1075 calibration finding).
+_C26_SCALING_RE = re.compile(
+    r"(?i)\bscal(?:ed|ing|e factor)\b|per-?step rate|step-?time|rate-?convert"
+)
+
+# Intent resolution: --intent <tok> in prose or fences (c5 precedent: RAW
+# scan); additionally accepted: the "intent `lora-7b`" prose form
+# (#1073 v3 "Target pod preference" shape — capitalized "Intent" in the
+# wild, hence (?i)).
+_C26_INTENT_RE = re.compile(
+    r"(?i)--intent[=\s]+`?([A-Za-z0-9][A-Za-z0-9-]*)|\bintent\s+`([A-Za-z0-9][A-Za-z0-9-]*)`"
+)
+
+# Explicit RunPod pin → the RunPod H100/H200 intent table governs; SKIP.
+# Scanned RAW (fences included), matching the raw intent scan — a fenced
+# `--backend runpod` dispatch line is a real pin; permissive direction only.
+_C26_RUNPOD_PIN_RE = re.compile(r"(?i)\bbackend:\s*`?runpod\b|--backend[=\s]+`?runpod\b")
+
+
+def _c26_intents(plan: str) -> set[str]:
+    """Intent tokens resolved from RAW plan text (fences included — a fenced
+    dispatch line is the real launch command, the c5 raw-scan precedent).
+    Union of the ``--intent <tok>`` flag form (group 1) and the
+    ``intent `tok` `` prose form (group 2)."""
+    out: set[str] = set()
+    for m in _C26_INTENT_RE.finditer(plan):
+        tok = m.group(1) or m.group(2)
+        if tok:
+            out.add(tok)
+    return out
+
+
+def _c26_compute_table_rows(plan: str) -> list[tuple[str, str, str, str]]:
+    """``(component_cell, basis_cell, wall_cell, full_row_text)`` for every
+    body row of every non-fenced markdown table whose header carries a
+    ``basis`` column (a cell that IS or BEGINS WITH the word ``basis``,
+    casefolded, bold/backticks stripped — the corpus carries an annotated
+    ``basis (measured)`` variant, #952 v12) AND a wall column (fuzzy: any
+    header cell CONTAINING ``wall`` — matches ``planned_wall_h`` /
+    ``planned wall h`` / ``wall_h`` drift). Header
+    detection is fence-masked (a fenced example table is not the plan's
+    table — the ``_trigger_windows`` precedent; this deliberately diverges
+    from ``_source_column_cells``, which is section-scoped instead: c26
+    scans the whole doc because §9 heading text drifts). A row with fewer
+    cells than the basis column needs is skipped defensively (the bold
+    ``**Base total**`` short-row shape — no IndexError); a short row that
+    still reaches the basis column is treated normally with an empty wall
+    cell."""
+    lines = plan.splitlines()
+    mask = _fence_mask(lines)
+    rows: list[tuple[str, str, str, str]] = []
+    i = 0
+    while i < len(lines) - 1:
+        header = lines[i].strip()
+        sep = lines[i + 1].strip()
+        if mask[i] or not (
+            header.startswith("|") and sep.startswith("|") and _TABLE_SEP_RE.fullmatch(sep)
+        ):
+            i += 1
+            continue
+        header_cells = [c.strip().strip("*`").strip().casefold() for c in _split_table_row(header)]
+        basis_col = next((j for j, c in enumerate(header_cells) if re.match(r"basis\b", c)), None)
+        wall_col = next((j for j, c in enumerate(header_cells) if "wall" in c), None)
+        k = i + 2
+        while k < len(lines) and lines[k].strip().startswith("|"):
+            if basis_col is not None and wall_col is not None:
+                row = _split_table_row(lines[k])
+                if basis_col < len(row):
+                    component = row[0] if row else ""
+                    wall = row[wall_col] if wall_col < len(row) else ""
+                    rows.append((component, row[basis_col], wall, lines[k]))
+            k += 1
+        i = k
+    return rows
+
+
+def _c26_offender_detail(offenders: list[tuple[str, str]], routed: set[str]) -> str:
+    """Bounded WARN detail (c13 ``_offender_detail`` precedent): at most 3
+    offending rows (component + the offending GPU token), the resolved
+    routed families, the #599 incident anchor, and BOTH remedies (a stated
+    per-step scaling rate in the row, or the standalone N/A phrase)."""
+    shown = "; ".join(f"row {comp[:60]!r} basis names {tok}" for comp, tok in offenders[:3])
+    if len(offenders) > 3:
+        shown += "; ..."
+    return (
+        f"{shown} but resolved intent(s) route {sorted(routed)} under auto (GCP "
+        "INTENT_TO_MACHINE) with no stated cross-GPU scaling in the row — a basis "
+        "measured on a different GPU must be scaled with a stated per-step rate "
+        "(plan-compute-sizing.md; #599: an H100-premised ~6.4h estimate ran ~34h on "
+        "the A100 auto-lane), or declare 'N/A — basis measured on the routed machine' "
+        "on its own line"
+    )
+
+
+def check_gpu_basis_routed_machine(plan: str, kind: str) -> CheckResult:
+    """WARN-only, conditional: a §9 compute-projection-table basis cell naming
+    a GPU family (H100/H200/A100/B200) that differs from EVERY family the
+    plan's resolved --intent token(s) route under auto (static GCP
+    INTENT_TO_MACHINE mirror, _C26_INTENT_GPU), with no row-level escape.
+    Mechanizes plan-compute-sizing.md § "Cost wall-time against the machine
+    the router will ACTUALLY provision" (#599 ~6.4h -> ~34h; #1073 v3 -> v4).
+    Row escapes: (a) the routed family named in a CONVERSION-BEARING cell —
+    the wall or basis cell ONLY (a stated conversion names both machines
+    there, #1073 v4 wall cell "0.25 (H100) / 0.5-0.6 (A100, x2-2.5)");
+    a parallelism/component-cell mention describes the PROVISIONED machine,
+    not a conversion, and does NOT escape (plan #1075 Must-Fix M1 — #810 v18
+    / #923 v9 rows put "1x A100-80" in parallelism/component cells);
+    (b) scaling vocabulary (scaled/per-step rate/...) anywhere in the row.
+    NEVER FAILs in v1 — both sides are heuristic (intent resolution from
+    text; token matching), and whether a stated scaling factor is CORRECT
+    stays critic-owned (c24 precedent). Known accepted gaps: a basis citing
+    a prior issue's realized wall WITHOUT naming its GPU (#599's shape)
+    is invisible; a "recommended pin: backend: runpod" prose mention
+    escapes as if pinned (#779 v6); a conversion stated as a BARE
+    multiplier with no vocabulary word ("on H100, x2.5" — #628 v2, the one
+    adjudicated calibration FP) still WARNs, because bare-multiplier
+    arithmetic saturates compliant AND offending rows alike (#1073 v3) —
+    the remedy is one vocabulary word in the row; A100-40 vs A100-80 is
+    below the family grain; a routed-family mention in the wall/basis
+    cell escapes
+    without a true conversion (conversion ADEQUACY stays critic-owned);
+    a standalone N/A declaration is document-wide (c24 /
+    ``_standalone_na_declared`` family semantics), so it also clears any
+    sibling offender row — the deliberate-override purpose of the phrase."""
+    cid, name = "c26_gpu_basis_routed_machine", "GPU basis vs routed machine"
+    if kind not in ("experiment", "analysis"):
+        return _skip(
+            cid,
+            name,
+            "kind-exempt: compute-projection tables are an experiment|analysis plan shape",
+        )
+    rows = _c26_compute_table_rows(plan)
+    if not rows:
+        return _skip(cid, name, "no compute-projection table with a `basis` column detected")
+    if _standalone_na_declared(plan, r"basis measured on the routed machine"):
+        return _pass(cid, name, "explicit N/A declared (basis measured on the routed machine)")
+    if _C26_RUNPOD_PIN_RE.search(plan):
+        # RAW scan (fences included): a fenced `--backend runpod` dispatch
+        # line is a real pin; permissive direction (can only add SKIPs).
+        return _skip(
+            cid,
+            name,
+            "explicit backend: runpod pin — the RunPod intent table governs the basis machine",
+        )
+    routed = {_C26_INTENT_GPU[i] for i in _c26_intents(plan) if i in _C26_INTENT_GPU}
+    if not routed:
+        return _skip(
+            cid,
+            name,
+            "no resolvable --intent token — routed machine unknown (auto-lane GPU cannot "
+            "be inferred)",
+        )
+    offenders: list[tuple[str, str]] = []
+    for component, basis, wall, row_text in rows:
+        hit = _C26_BASIS_GPU_RE.search(basis)
+        if not hit or _c26_family(hit.group(1)) in routed:
+            continue
+        # Escape (a): routed family named in a CONVERSION-BEARING cell only
+        # (wall + basis) — NOT parallelism/component (Must-Fix M1).
+        conv_cells = f"{basis} {wall}"
+        conv_families = {_c26_family(m.group(1)) for m in _C26_ROW_GPU_ANY_RE.finditer(conv_cells)}
+        if conv_families & routed or _C26_SCALING_RE.search(row_text):
+            continue
+        offenders.append((component, hit.group(1)))
+    if not offenders:
+        return _pass(
+            cid,
+            name,
+            f"{len(rows)} table row(s); no unscaled cross-GPU basis vs routed {sorted(routed)}",
+        )
+    return _warn(cid, name, _c26_offender_detail(offenders, routed))
+
+
 # ─── Driver ────────────────────────────────────────────────────────────────
 
 CHECKS = [
@@ -3682,6 +3902,7 @@ CHECKS = [
     check_cross_section_param_consistency,
     check_resume_provenance,
     check_html_entities_in_commands,
+    check_gpu_basis_routed_machine,
 ]
 
 

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -39,7 +39,7 @@ sys.modules["verify_plan"] = verify_plan
 _spec.loader.exec_module(verify_plan)  # type: ignore[union-attr]
 
 
-# ─── Canonical plan (kind=experiment: passes 0-3,5,8,9,17; skips 4,6,7,10-16,18-22,24)
+# ─── Canonical plan (kind=experiment: passes 0-3,5,8,9,17; skips 4,6,7,10-16,18-22,24-26)
 
 # Surgery anchors (must appear verbatim in GOOD_PLAN exactly once).
 MV_HEADING = "### Measurement validity"
@@ -163,10 +163,11 @@ def test_good_plan_passes_all():
         "c22_cross_section_param_consistency": "SKIP",
         "c24_resume_provenance": "SKIP",
         "c25_html_entities_in_commands": "SKIP",
+        "c26_gpu_basis_routed_machine": "SKIP",
     }
     actual = {cid: r.status for cid, r in by_id.items()}
     assert actual == expected
-    assert len(results) == 25
+    assert len(results) == 26
 
 
 # ─── Check 0 — plan-nonstub ────────────────────────────────────────────────
@@ -3458,6 +3459,309 @@ def test_c25_cli_fail_exit_one(tmp_path):
     assert c25["status"] == "FAIL"
 
 
+# ─── Check 26 — GPU basis vs routed machine ─────────────────────────────────
+
+# Fixture rows quoted VERBATIM from the incident corpus (plan #1075 §10
+# fixtures of record): tasks/*/1073/plans/v3.md:155 (the founding offender
+# row), v3.md:152 (the Spec/intent line, truncated at the sentence break),
+# v4.md:157 (the corrected row), v3.md:240 (the prose-form intent line),
+# tasks/awaiting_promotion/744/plans/v2.md:676 + :45 (the L4-routing catch),
+# tasks/awaiting_promotion/920/plans/v3.md:279 (matching-family control),
+# tasks/awaiting_promotion/778/plans/v8.md:73 (runpod pin),
+# tasks/on_hold/816/plans/v6.md:3 (frontmatter runpod pin),
+# tasks/interpreting/833/plans/v6.md:20 (L3/L4 phase-label collision prose).
+C26_HEADER = (
+    "\n| component | planned_wall_h | planned_gpu_h | parallelism | basis |\n"
+    "|---|---|---|---|---|\n"
+)
+C26_INTENT_LORA7B = (
+    "\n**Spec:** 1 GPU, `--intent lora-7b` (GCP `a2-ultragpu-1g` A100-80 / RunPod 1×H100).\n"
+)
+C26_INTENT_EVAL = "\n- **Compute:** 1x A100-80 (GCP `auto`, `--intent eval`), single forward-pass\n"
+C26_V3_P1_ROW = (
+    "| P1 greedy gen (5,000 × ~300 tok) | 0.25 | 0.25 | vLLM batched, chunk 500 "
+    "| 1.5 M tok at ≥ 3 k tok/s (H100 Qwen-7B, #779 pass-A convention) |\n"
+)
+C26_V4_P1_ROW = (  # #1073 v4:157 — corrected row (routed family in wall cell + scaling vocab)
+    "| P1 greedy gen (5,000 × ~300 tok) | 0.25 (H100) / 0.5–0.6 (A100, ×2–2.5) | same as wall "
+    "| vLLM batched, chunk 500 | 1.5 M tok at ≥ 3 k tok/s H100 basis (#779 pass-A convention); "
+    "A100 row = H100 × 2–2.5 stated per-step rate |\n"
+)
+C26_744_ROW = (
+    "| Phase 1 dump+stream, base (NS + broader) | 1.5 | 1.5 | TP=1 batch=1 "
+    "| ~1000 broader forwards x 2 passes + 10 NS seqs @ ~5s/1024-tok A100 forward; "
+    "most broader docs < 1024 tok |\n"
+)
+C26_920_ROW = (
+    "| P1 set-B generation (GPU, vLLM) | 0.25 | 0.25 | one continuous-batching engine, "
+    "2,400 prompts | 2,400 greedy × ≤512 new tokens ≈ ≤1.2M gen tokens; single-A100 vLLM "
+    "≥ ~2K tok/s ⇒ ~10 min + engine spin-up |\n"
+)
+C26_778_PIN_LINE = (
+    "\n- **Compute:** 1× H100 RunPod (`backend: runpod`, intent `eval`) for ~2–3 h (6,000\n"
+)
+# The founding-offender shape: WARN under `--intent lora-7b` (routed A100).
+C26_WARN_SHAPE = C26_INTENT_LORA7B + C26_HEADER + C26_V3_P1_ROW
+
+
+def test_c26_h100_basis_auto_lora7b_warns():
+    # Acceptance criterion 2 (plan #1075 §1): the #1073 v3 P1 row under
+    # `--intent lora-7b` (auto → A100-80) with no scaling vocabulary and no
+    # routed-GPU mention in the row → WARN; the detail names the component
+    # cell, the offending token, the routed family, and BOTH remedies.
+    ok, by_id = _run(GOOD_PLAN + C26_WARN_SHAPE)
+    r = by_id["c26_gpu_basis_routed_machine"]
+    assert r.status == "WARN"
+    assert ok  # WARN never blocks
+    assert "P1 greedy gen" in r.detail
+    assert "H100" in r.detail
+    assert "A100" in r.detail
+    assert "per-step rate" in r.detail  # remedy 1: stated scaling (#599 clause)
+    assert "N/A — basis measured on the routed machine" in r.detail  # remedy 2
+
+
+def test_c26_scaling_vocab_row_passes():
+    # Scaling-vocab escape in isolation: the v4-shaped "stated per-step rate"
+    # phrase clears the row even with NO routed-family token anywhere in it.
+    row = (
+        "| P1 greedy gen | 0.5–0.6 | same as wall | vLLM batched, chunk 500 "
+        "| 1.5 M tok at ≥ 3 k tok/s H100 basis, × 2–2.5 stated per-step rate to the "
+        "routed lane |\n"
+    )
+    plan = GOOD_PLAN + C26_INTENT_LORA7B + C26_HEADER + row
+    assert _status(plan, "c26_gpu_basis_routed_machine") == "PASS"
+
+
+def test_c26_routed_gpu_also_named_in_row_passes():
+    # Routed-family escape in isolation: the #1073 v4 wall-cell shape
+    # `0.25 (H100) / 0.5-0.6 (A100, x2-2.5)` names the routed family in a
+    # CONVERSION-BEARING cell; no scaling vocabulary anywhere (a bare
+    # multiplication sign is not scaling vocab).
+    row = (
+        "| P1 greedy gen | 0.25 (H100) / 0.5–0.6 (A100, ×2–2.5) | same as wall "
+        "| vLLM batched, chunk 500 | 1.5 M tok at ≥ 3 k tok/s (H100 Qwen-7B) |\n"
+    )
+    plan = GOOD_PLAN + C26_INTENT_LORA7B + C26_HEADER + row
+    assert _status(plan, "c26_gpu_basis_routed_machine") == "PASS"
+
+
+def test_c26_component_times_symbol_is_not_scaling_escape():
+    # The ban on the bare-multiplication-sign escape: the verbatim #1073 v3
+    # P1 row's component cell carries `5,000 x ~300 tok` multiplier
+    # arithmetic — the sign alone must NOT escape (it appears in nearly
+    # every row, offending and compliant).
+    assert "×" in C26_V3_P1_ROW
+    assert _status(GOOD_PLAN + C26_WARN_SHAPE, "c26_gpu_basis_routed_machine") == "WARN"
+
+
+def test_c26_matching_gpu_basis_passes():
+    # #920 v3 shape: A100-measured basis under `--intent capture-7b`
+    # (routed A100) — family match, no offender.
+    plan = GOOD_PLAN + "\n`--intent capture-7b` on the GCP lane.\n" + C26_HEADER + C26_920_ROW
+    assert _status(plan, "c26_gpu_basis_routed_machine") == "PASS"
+
+
+def test_c26_eval_intent_l4_vs_a100_basis_warns():
+    # Acceptance criterion 4: the #744 v2 shape — `--intent eval` routes L4
+    # under auto while the basis is an A100-measured forward (the routing
+    # later OOM'd; #752 created `capture-7b`).
+    plan = GOOD_PLAN + C26_INTENT_EVAL + C26_HEADER + C26_744_ROW
+    _, by_id = _run(plan)
+    r = by_id["c26_gpu_basis_routed_machine"]
+    assert r.status == "WARN"
+    assert "A100" in r.detail
+    assert "L4" in r.detail
+
+
+def test_c26_intent_h100_variant_passes():
+    # An H100 GCP intent variant routes H100 — an H100 basis matches.
+    plan = GOOD_PLAN + "\n`--intent eval-h100` (2× H100).\n" + C26_HEADER + C26_V3_P1_ROW
+    assert _status(plan, "c26_gpu_basis_routed_machine") == "PASS"
+
+
+def test_c26_multi_intent_union():
+    # Union semantics across ALL resolved intents: {lora-7b, eval} routes
+    # {A100, L4} — an H100 basis still WARNs; an A100 basis PASSes.
+    intents = "\nPhase 1: `--intent lora-7b`; phase 2: `--intent eval`.\n"
+    warn_plan = GOOD_PLAN + intents + C26_HEADER + C26_V3_P1_ROW
+    assert _status(warn_plan, "c26_gpu_basis_routed_machine") == "WARN"
+    pass_plan = GOOD_PLAN + intents + C26_HEADER + C26_744_ROW
+    assert _status(pass_plan, "c26_gpu_basis_routed_machine") == "PASS"
+
+
+def test_c26_runpod_pin_skips():
+    # The #778 v8:73 pin shape: under `backend: runpod` the RunPod H100/H200
+    # intent table governs and an H100 basis is correct → SKIP.
+    plan = GOOD_PLAN + C26_778_PIN_LINE + C26_HEADER + C26_V3_P1_ROW
+    _, by_id = _run(plan)
+    r = by_id["c26_gpu_basis_routed_machine"]
+    assert r.status == "SKIP"
+    assert "runpod" in r.detail
+
+
+def test_c26_no_intent_skips():
+    # A basis-bearing table with NO resolvable intent token anywhere: the
+    # auto-lane GPU cannot be inferred from text → SKIP, never a guess.
+    plan = GOOD_PLAN + C26_HEADER + C26_V3_P1_ROW
+    _, by_id = _run(plan)
+    r = by_id["c26_gpu_basis_routed_machine"]
+    assert r.status == "SKIP"
+    assert "--intent" in r.detail
+
+
+def test_c26_no_compute_table_skips():
+    # An intent with no basis-header compute table → SKIP (trigger absent).
+    assert _status(GOOD_PLAN + C26_INTENT_LORA7B, "c26_gpu_basis_routed_machine") == "SKIP"
+
+
+@pytest.mark.parametrize("kind", ["infra", "batch", "survey"])
+def test_c26_kind_exempt_skips(kind):
+    assert _status(GOOD_PLAN + C26_WARN_SHAPE, "c26_gpu_basis_routed_machine", kind=kind) == "SKIP"
+
+
+def test_c26_kind_analysis_warns():
+    # analysis is IN scope (compute-projection tables are an
+    # experiment|analysis plan shape) — same WARN severity as experiment.
+    assert (
+        _status(GOOD_PLAN + C26_WARN_SHAPE, "c26_gpu_basis_routed_machine", kind="analysis")
+        == "WARN"
+    )
+
+
+def test_c26_na_escape_passes():
+    plan = (
+        GOOD_PLAN
+        + C26_WARN_SHAPE
+        + "\nN/A — basis measured on the routed machine (the H100 token is provenance "
+        "prose, not the measurement machine).\n"
+    )
+    _, by_id = _run(plan)
+    r = by_id["c26_gpu_basis_routed_machine"]
+    assert r.status == "PASS"
+    assert "N/A" in r.detail
+
+
+def test_c26_quoted_na_phrase_does_not_escape():
+    # A mid-sentence quoted escape phrase (the pasted-bounce-brief
+    # self-escape channel) is NOT a standalone declaration line and must not
+    # escape — the c13/c18/c24/c25 anti-paste twin.
+    plan = (
+        GOOD_PLAN
+        + C26_WARN_SHAPE
+        + "\nThe remedy menu says to declare 'N/A — basis measured on the routed machine' "
+        "on its own line.\n"
+    )
+    assert _status(plan, "c26_gpu_basis_routed_machine") == "WARN"
+
+
+def test_c26_l4_phase_label_not_gpu_token():
+    # The #833 v6 collision: `L1/L2 re-extraction, L3/L4 extraction` leg
+    # labels share the L4 GPU token — L4 is deliberately EXCLUDED from the
+    # trigger set, so a basis naming only phase labels never fires.
+    row = (
+        "| L3/L4 extraction of R⁺ | 8.0 | 8.0 | vLLM 0.11.0 multi-LoRA greedy "
+        "| same-era L3/L4 re-extraction of R_base′, measured #667 precedent |\n"
+    )
+    plan = GOOD_PLAN + C26_INTENT_LORA7B + C26_HEADER + row
+    assert _status(plan, "c26_gpu_basis_routed_machine") == "PASS"
+
+
+def test_c26_fenced_table_does_not_trigger():
+    # A fenced example table is not the plan's compute table (fence-masked
+    # header detection, the c24 fenced-trigger twin) → SKIP.
+    plan = (
+        GOOD_PLAN
+        + C26_INTENT_LORA7B
+        + "\n```\n"
+        + C26_HEADER.strip("\n")
+        + "\n"
+        + C26_V3_P1_ROW
+        + "```\n"
+    )
+    assert _status(plan, "c26_gpu_basis_routed_machine") == "SKIP"
+
+
+def test_c26_parallelism_cell_routed_gpu_does_not_escape():
+    # Must-Fix M1 fixture (#810 v18 / #923 v9 house style): a parallelism
+    # cell truthfully naming the PROVISIONED machine (`1x A100-80`) carries
+    # zero conversion information — it must NOT escape an unscaled H100
+    # basis (a whole-row escape would wrongly PASS this shape).
+    row = "| P2 extraction | 0.6 | 0.6 | 1× A100-80 batch-8 forwards | H100 #779 measured |\n"
+    plan = GOOD_PLAN + C26_INTENT_LORA7B + C26_HEADER + row
+    assert _status(plan, "c26_gpu_basis_routed_machine") == "WARN"
+
+
+def test_c26_annotated_basis_header_variant_parses():
+    # The #952 v12 header variant `basis (measured)` — surfaced by the §6.2
+    # corpus calibration as a realized SKIP-no-table on a predicted-parseable
+    # file — must be recognized as a basis column (a header cell that IS or
+    # BEGINS WITH the word "basis").
+    header = (
+        "\n| component | planned_wall_h | planned_gpu_h | parallelism | basis (measured) |\n"
+        "|---|---|---|---|---|\n"
+    )
+    plan = GOOD_PLAN + C26_INTENT_LORA7B + header + C26_V3_P1_ROW
+    assert _status(plan, "c26_gpu_basis_routed_machine") == "WARN"
+
+
+def test_c26_bold_total_short_row_no_crash():
+    # A bold `**Base total**` row carrying fewer cells than the header must
+    # not IndexError at row[basis_col]; the sibling offender row is still
+    # evaluated.
+    table = C26_HEADER + C26_V3_P1_ROW + "| **Base total** | 4.2 |\n"
+    plan = GOOD_PLAN + C26_INTENT_LORA7B + table
+    assert _status(plan, "c26_gpu_basis_routed_machine") == "WARN"
+
+
+def test_c26_escape_regex_covers_all_mirror_families():
+    # Companion drift assert: every non-CPU family the mirror can route must
+    # be matchable by the escape alternation — a future routed family absent
+    # from _C26_ROW_GPU_ANY_RE would make compliant rows unescapable
+    # (systematic false positives).
+    for family in set(verify_plan._C26_INTENT_GPU.values()):
+        if family == "CPU":
+            continue
+        m = verify_plan._C26_ROW_GPU_ANY_RE.search(family)
+        assert m, f"escape regex misses mirror family {family!r}"
+        assert verify_plan._c26_family(m.group(1)) == family
+
+
+def test_c26_prose_intent_form_resolves():
+    # The #1073 v3:240 "Target pod preference" shape: the ONLY intent mention
+    # is the capitalized prose form ``Intent `lora-7b` `` (group 2 of
+    # _C26_INTENT_RE) — resolution must still work (non-SKIP).
+    plan = (
+        GOOD_PLAN
+        + "\nIntent `lora-7b` (1× A100-80 GCP / 1× H100 RunPod); explicitly NOT the L4 lane.\n"
+        + C26_HEADER
+        + C26_V3_P1_ROW
+    )
+    assert _status(plan, "c26_gpu_basis_routed_machine") == "WARN"
+
+
+def test_c26_fenced_backend_runpod_pin_skips():
+    # The pin regex scans RAW (fences included): a plan whose ONLY runpod pin
+    # is a fenced `--backend runpod` dispatch line is really pinned → SKIP
+    # (closes the fence-asymmetry FP mode; permissive direction only).
+    plan = (
+        GOOD_PLAN + "\n```bash\nuv run python scripts/dispatch_issue.py launch --issue 999 "
+        "--intent lora-7b --backend runpod\n```\n" + C26_HEADER + C26_V3_P1_ROW
+    )
+    assert _status(plan, "c26_gpu_basis_routed_machine") == "SKIP"
+
+
+def test_c26_intent_gpu_mirror_matches_backend():
+    # Drift guard (acceptance criterion 6): the static family-grain mirror
+    # equals the live GCP INTENT_TO_MACHINE — an intent add/change on the
+    # backend fails the full suite loudly (precedent:
+    # test_kind_enum_constants_match_canonical_code_kinds).
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    from explore_persona_space.backends.gcp import INTENT_TO_MACHINE
+
+    derived = {k: verify_plan._c26_family(v.gpu_kind) for k, v in INTENT_TO_MACHINE.items()}
+    assert derived == verify_plan._C26_INTENT_GPU
+
+
 # ─── Plan-version + kind resolution ────────────────────────────────────────
 
 
@@ -3507,12 +3811,12 @@ def test_cli_json_schema_and_exit_zero_on_pass(tmp_path):
     assert payload["issue"] is None
     assert payload["kind"] == "experiment"
     assert payload["n_fail"] == 0
-    assert payload["n_skip"] == 18
+    assert payload["n_skip"] == 19
     assert {"id", "name", "status", "detail"} <= set(payload["checks"][0])
     statuses = {c["status"] for c in payload["checks"]}
     assert statuses <= {"PASS", "WARN", "FAIL", "SKIP"}
-    assert len(payload["checks"]) == 26
-    assert len({c["id"] for c in payload["checks"]}) == 26
+    assert len(payload["checks"]) == 27
+    assert len({c["id"] for c in payload["checks"]}) == 27
     # c23 has no task context in --plan-file mode: rendered SKIP (companion
     # assert for test_cli_issue_mode_appends_goal_currency).
     c23 = next(c for c in payload["checks"] if c["id"] == "c23_goal_currency")


### PR DESCRIPTION
Closes task #1075 (workflow-fix, kind: infra).

## Summary
- Adds WARN-only conditional check c26 (`check_gpu_basis_routed_machine`) to `scripts/verify_plan.py`: flags §9 compute-table basis cells naming a GPU family differing from the intent-routed machine under auto (static family-grain mirror of `backends/gcp.py::INTENT_TO_MACHINE`, drift-guard-tested), with conversion-cell-scoped routed-family escape, row-scoped scaling-vocab escape, RAW runpod-pin SKIP, and a standalone N/A phrase.
- 24 new tests in `tests/test_verify_plan.py` (fixtures verbatim from the #1073 v3/v4, #744, #920, #778, #833 plans) + count-assertion bumps; one cross-ref sentence in `.claude/rules/plan-compute-sizing.md`.
- Calibration over 563 newest plans: both incident fires (#1073 v3 P1, #744 v2), 1 adjudicated FP (≤2 bar).

## Test plan
- [x] Step 9c gate: 2630 passed / 6 skipped, 0 new failures vs baseline (compare rc=0)
- [x] ruff + workflow_lint clean on touched files
- [x] Claude + Codex code-review ensemble PASS+PASS (round 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)