### PR TITLE
paper_palette(n>8) degrades to viridis interior sampling instead of raising (#1078)

### DIFF
--- a/.claude/skills/paper-plots/SKILL.md
+++ b/.claude/skills/paper-plots/SKILL.md
@@ -44,8 +44,8 @@ from explore_persona_space.analysis.paper_plots import (
     set_paper_style,     # rcParams preset (call once at top of script)
     savefig_paper,       # saves .png + .pdf + .meta.json with commit hash
     add_direction_arrow, # appends "↑ better" / "↓ better" to axis label
-    paper_palette,       # Wong colorblind-safe hex colors (≤ 8)
-    paper_palette_blog,  # soft-warm "blog" colorblind-safe hex colors (≤ 8)
+    paper_palette,       # Wong colorblind-safe hex colors (any n; > 8 falls back to viridis sampling + UserWarning)
+    paper_palette_blog,  # soft-warm "blog" colorblind-safe hex colors (any n; > 8 falls back to viridis sampling + UserWarning)
     paper_palette_role,  # named-role lookup: "primary"/"baseline"/"control"/...
     set_title_subtitle,  # Anthropic-blog title block (left-aligned, semibold)
     proportion_ci,       # 95% Wald CI for a proportion: p ± 1.96·√(p(1-p)/n)

--- a/src/explore_persona_space/analysis/paper_plots.py
+++ b/src/explore_persona_space/analysis/paper_plots.py
@@ -30,8 +30,10 @@ Public API
     set_paper_style        — set rcParams for paper-quality figures
     savefig_paper          — save to <dir>/<stem>.png AND <dir>/<stem>.pdf plus .meta.json
     add_direction_arrow    — append ↑ better / ↓ better to an axis label
-    paper_palette          — return N colorblind-safe hex colours (Wong 2011)
-    paper_palette_blog     — return N colours from the soft "blog" palette
+    paper_palette          — return N colorblind-safe hex colours (Wong 2011; N > 8
+                             extends via perceptually-uniform colormap sampling)
+    paper_palette_blog     — return N colours from the soft "blog" palette (N > 8
+                             extends via perceptually-uniform colormap sampling)
     paper_palette_role     — look up a colour by semantic role (primary / baseline / ...)
     set_title_subtitle     — left-aligned title + subtitle (Anthropic-blog register)
     proportion_ci          — 95% Wald CI for a proportion
@@ -66,6 +68,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import warnings
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -74,6 +77,7 @@ from typing import Literal
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 from cycler import cycler
+from matplotlib import colors as mcolors
 from matplotlib import font_manager
 
 # Preferred font fallback chain for the "blog" style. matplotlib walks the
@@ -132,6 +136,38 @@ _BLOG_PALETTE: list[str] = [
     "#000000",  # black (reference / ground truth)
 ]
 
+# Fallback colormap for n > 8: perceptually uniform + colorblind-robust
+# (van der Walt & Smith, SciPy 2015). Sampled on interior points per the
+# seaborn ``mpl_palette`` convention so the near-black start and pale-yellow
+# end are skipped.
+_EXTENSION_COLORMAP = "viridis"
+
+
+def _extended_palette(base: list[str], n: int, fn_name: str) -> list[str]:
+    """Return ``n`` hex colours: the full curated ``base`` then colormap-sampled extras.
+
+    Colours beyond ``len(base)`` are sampled deterministically from the
+    interior of ``_EXTENSION_COLORMAP`` (``(i + 1) / (k + 1)`` for
+    ``i in range(k)``, ``k = n - len(base)``) and are less distinguishable
+    than the curated set — a one-time ``UserWarning`` says so. The tail is
+    a pure function of ``n`` but NOT stable across n: growing a figure from
+    9 to 10 series recolours its entire >8 tail (only the curated first 8
+    are stable). At large n the 256-entry colormap quantises and hex
+    duplicates can appear (measured first at n=144; non-monotone in n).
+    """
+    k = n - len(base)
+    cmap = mpl.colormaps[_EXTENSION_COLORMAP]
+    extra = [mcolors.to_hex(cmap((i + 1) / (k + 1))) for i in range(k)]
+    warnings.warn(
+        f"{fn_name}({n}) exceeds the {len(base)}-colour curated palette; colours "
+        f"{len(base) + 1}..{n} are sampled from {_EXTENSION_COLORMAP!r} and are less "
+        "distinguishable — prefer <= 8 series per chart",
+        UserWarning,
+        stacklevel=3,
+    )
+    return list(base) + extra
+
+
 # Named-role aliases. Plot code reads `paper_palette_role("primary")` instead
 # of indexing into the palette by integer slot, so semantic intent travels
 # with the chart code. Roles map to per-style palettes — `"primary"` stays
@@ -167,36 +203,43 @@ _ACTIVE_STYLE: str = "neurips"
 
 
 def paper_palette(n: int) -> list[str]:
-    """Return the first ``n`` colours of the curated colorblind-safe palette.
+    """Return ``n`` colorblind-safe hex colours.
+
+    ``n <= 8`` returns the first ``n`` colours of the curated Wong 2011
+    palette (unchanged, byte-identical to the historical contract).
+    ``n > 8`` degrades gracefully: the full 8-colour curated palette
+    followed by ``n - 8`` colours sampled from a perceptually-uniform
+    colormap (see :func:`_extended_palette`), with a ``UserWarning``.
 
     Raises
     ------
     ValueError
-        If ``n`` is not in ``[1, 8]``.
+        If ``n`` is not a positive int.
     """
     if not isinstance(n, int) or n < 1:
         raise ValueError(f"n must be a positive int, got {n!r}")
     if n > len(_PALETTE):
-        raise ValueError(f"paper_palette supports at most {len(_PALETTE)} colors; requested {n}")
+        return _extended_palette(_PALETTE, n, "paper_palette")
     return list(_PALETTE[:n])
 
 
 def paper_palette_blog(n: int) -> list[str]:
-    """Return the first ``n`` colours of the soft "blog" palette.
+    """Return ``n`` colours from the soft "blog" palette.
 
     Companion to :func:`paper_palette` for the Anthropic-blog-register style.
+    ``n <= 8`` returns the first ``n`` curated blog colours (unchanged);
+    ``n > 8`` degrades gracefully via the same perceptually-uniform colormap
+    extension (see :func:`_extended_palette`), with a ``UserWarning``.
 
     Raises
     ------
     ValueError
-        If ``n`` is not in ``[1, 8]``.
+        If ``n`` is not a positive int.
     """
     if not isinstance(n, int) or n < 1:
         raise ValueError(f"n must be a positive int, got {n!r}")
     if n > len(_BLOG_PALETTE):
-        raise ValueError(
-            f"paper_palette_blog supports at most {len(_BLOG_PALETTE)} colors; requested {n}"
-        )
+        return _extended_palette(_BLOG_PALETTE, n, "paper_palette_blog")
     return list(_BLOG_PALETTE[:n])
 
 

--- a/tests/test_paper_plots.py
+++ b/tests/test_paper_plots.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from pathlib import Path
 
 import matplotlib
@@ -41,9 +42,58 @@ def test_paper_palette_rejects_out_of_range() -> None:
     with pytest.raises(ValueError):
         paper_palette(0)
     with pytest.raises(ValueError):
-        paper_palette(9)
-    with pytest.raises(ValueError):
         paper_palette(-1)
+    with pytest.raises(ValueError):
+        paper_palette(2.5)  # type: ignore[arg-type]
+
+
+def test_paper_palette_extends_beyond_8() -> None:
+    """n > 8 returns the curated 8 followed by colormap-sampled extras, with a warning."""
+    curated_8 = paper_palette(8)  # outside the warns block — must not warn itself
+    with pytest.warns(UserWarning):
+        colors = paper_palette(16)
+        assert paper_palette(16) == colors  # deterministic — pure function of n
+        boundary = paper_palette(9)
+    assert len(colors) == 16
+    assert colors[:8] == curated_8
+    for c in colors:
+        assert isinstance(c, str) and c.startswith("#") and len(c) == 7
+    assert len({c.lower() for c in colors}) == 16  # unique, case-folded
+    assert len(boundary) == 9  # the n=9 boundary (replaces the deleted n=9 raise pin)
+
+
+def test_paper_palette_exact_values_and_no_warning_at_8() -> None:
+    """Pin the n=8 outputs to the curated literals and assert NO warning fires at n=8.
+
+    The exact-value asserts are the byte-identity guard for committed figures;
+    the no-warning asserts kill the ``>`` -> ``>=`` boundary mutant (which would
+    return identical colours at n=8 but warn spuriously).
+    """
+    assert paper_palette(8) == [
+        "#0072B2",
+        "#E69F00",
+        "#009E73",
+        "#CC79A7",
+        "#56B4E9",
+        "#D55E00",
+        "#F0E442",
+        "#000000",
+    ]
+    assert paper_palette_blog(8) == [
+        "#1F4E9F",
+        "#E08220",
+        "#3FA577",
+        "#C0413B",
+        "#8064A2",
+        "#5A6975",
+        "#E0B834",
+        "#000000",
+    ]
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        paper_palette(8)
+        paper_palette_blog(8)
+    assert caught == []
 
 
 def test_paper_palette_returns_copy() -> None:
@@ -246,7 +296,21 @@ def test_paper_palette_blog_rejects_out_of_range() -> None:
     with pytest.raises(ValueError):
         paper_palette_blog(0)
     with pytest.raises(ValueError):
-        paper_palette_blog(99)
+        paper_palette_blog(-1)
+    with pytest.raises(ValueError):
+        paper_palette_blog(2.5)  # type: ignore[arg-type]
+
+
+def test_paper_palette_blog_extends_beyond_8() -> None:
+    """Blog twin: n > 8 extends via the same colormap sampling, with a warning."""
+    curated_8 = paper_palette_blog(8)  # outside the warns block — must not warn itself
+    with pytest.warns(UserWarning):
+        colors = paper_palette_blog(99)
+    assert len(colors) == 99
+    assert colors[:8] == curated_8
+    for c in colors:
+        assert isinstance(c, str) and c.startswith("#") and len(c) == 7
+    assert len({c.lower() for c in colors}) == 99  # unique, case-folded
 
 
 def test_set_paper_style_blog_applies_distinct_rcparams() -> None:


### PR DESCRIPTION
Closes task #1078. Graceful degradation for n>8 in paper_palette/paper_palette_blog (curated 8-color prefix + interior-sampled viridis tail + UserWarning); n<1/non-int still raise; n<=8 byte-identical (new exact-value + no-warning-at-8 test pins). Plan v3 + Claude/Codex code-review PASS + Step 9c gate green (2665 passed).