### PR TITLE
task #1079: default thread caps in vectorized fit helper + relaunch pin-parity clause

### DIFF
--- a/.claude/rules/LESSONS.md
+++ b/.claude/rules/LESSONS.md
@@ -40,7 +40,7 @@ update this index (lint: `--check-lessons-index`).
 - **[research-project-structure](research-project-structure.md)** — fires when: you write result artifacts / the results index / the queue (one source of truth per layer).
 - **[selection-symmetric-nulls](selection-symmetric-nulls.md)** — fires when: a headline max/argmax/best-of/top-k over a free axis vs a null band (inherit selection per draw or freeze held-out; band vs DV ceiling; #778/#810).
 - **[upload-policy](upload-policy.md)** — fires when: you write training / Hub / sweep code (Hub-API verification gotcha, delete-after-eval persist, quota-403 recovery, pod→HF upload-wedge ladder).
-- **[vectorize-many-cell-fits](vectorize-many-cell-fits.md)** — fires when: many-cell GD, dense linear-algebra fits (svd/eigh/lstsq/ridge over fold×layer×arm), or a perm/bootstrap/null-draw battery over a fixed pool (overhead-bound; VECTORIZE first; launch VM fits detached + choom-protected + checkpointed; Supersede contract incl. the mid-run ≥2×-deviation trigger, #722+).
+- **[vectorize-many-cell-fits](vectorize-many-cell-fits.md)** — fires when: many-cell GD, dense linear-algebra fits (svd/eigh/lstsq/ridge over fold×layer×arm), or a perm/bootstrap/null-draw battery over a fixed pool (overhead-bound; VECTORIZE first; launch VM fits detached + choom-protected + checkpointed + pin-parity relaunches (#811); Supersede contract incl. the mid-run ≥2×-deviation trigger, #722+).
 - **[workflow-fix-on-bug](workflow-fix-on-bug.md)** — fires when: any agent hits a bug from a gap in the workflow surface itself (emit a `workflow-fix-candidate`).
 - **[agents-vs-skills](agents-vs-skills.md)** — fires when: you create/restructure anything under `.claude/` (decide agent vs skill).
 

--- a/.claude/rules/vectorize-many-cell-fits.md
+++ b/.claude/rules/vectorize-many-cell-fits.md
@@ -141,6 +141,24 @@ solve one shared reduction + cheap per-λ updates.
    kill lands anyway. "No per-cell checkpoint" in the diagnostic signature
    above is not just an ETA smell; it is the thing this item fixes.
 
+   **Relaunch pin parity (#811).** A RELAUNCH of any such phase —
+   supervisor-driven retry, crash-fix round, or the kill+relaunch-on-batched
+   of the Supersede contract / Mid-run trigger — MUST carry the IDENTICAL env
+   pins (the `OMP_NUM_THREADS=8 MKL_NUM_THREADS=8 OPENBLAS_NUM_THREADS=8
+   NUMEXPR_NUM_THREADS=8` thread caps) and choom protection as the reviewed
+   ORIGINAL launch command. A relaunch composes a FRESH command, so pins do
+   not carry over by inertia (#811: the relaunch supervisor omitted the
+   OMP/MKL pins — ~55 min at 0/108 checkpoints). The supervisor/relauncher
+   VERIFIES all four pins are present in the composed command string BEFORE
+   dispatch — e.g.
+   `for pin in OMP_NUM_THREADS MKL_NUM_THREADS OPENBLAS_NUM_THREADS NUMEXPR_NUM_THREADS; do case "$CMD" in *"$pin="*) ;; *) echo "FATAL: relaunch missing $pin" >&2; exit 1;; esac; done`
+   — and records `pins=verified` in the relaunch breadcrumb alongside
+   `pid= log= choom=`. The helper-side default cap in
+   `vectorized_mlp_skill.py` (`_resolve_num_threads`, #1079) is
+   defense-in-depth for the torch intra-op pool only; the env pins remain
+   REQUIRED (they also cap numpy/BLAS and subprocesses the helper cannot
+   reach).
+
 ## Canonical helper
 
 `src/explore_persona_space/analysis/vectorized_mlp_skill.py` — the reusable
@@ -189,7 +207,8 @@ the SAME round as the rewrite:
    already executing the serial path when the batched twin lands and its
    remaining serial ETA exceeds kill+relaunch cost, kill and relaunch on the
    batched path (sibling: `.claude/rules/crash-fix-rounds.md`
-   § kill-before-relaunch). The SAME calculus fires mid-run WITHOUT a landed
+   § kill-before-relaunch; the relaunch carries the identical env pins +
+   choom — item 7 § Relaunch pin parity). The SAME calculus fires mid-run WITHOUT a landed
    twin on any compute-deviation exceeding 2× — § Mid-run trigger below.
    (General lesson:
    `.claude/rules/workflow-fix-on-bug.md` § "Built-but-stranded fixes don't
@@ -263,7 +282,9 @@ session/implementer/experimenter side and does not duplicate it. Outcomes:
   when remaining serial ETA exceeds kill+relaunch cost (count lost
   un-checkpointed in-RAM progress as part of that cost), kill the serial
   run (`.claude/rules/crash-fix-rounds.md` § Kill-before-relaunch) and
-  relaunch on the batched path once the vectorize fix round lands.
+  relaunch on the batched path once the vectorize fix round lands (the
+  relaunch carries the identical env pins + choom — item 7 § Relaunch pin
+  parity).
 - **Not overhead-bound** (FLOP-bound / API-latency / bandwidth /
   contention) → record `signature_check: negative` with 1–3 lines of
   arithmetic on the marker and continue: #931's 6.0× battery resolved
@@ -340,7 +361,8 @@ during #722 at commit `19a5758fab`, landed on `main` via #740);
 incidents #722 (base-skill-over-mean, 19.5 CPU-h), #658 (`_fit_mlp_loco`),
 #778 (`perm_null_draws` serial null battery, ~15h projected across its draw
 loops → ~70× batched subset-sum GEMM), #811 r8 (`resolve_chunk_cap`
-live_factor 4→26 — measured-peak chunk-cap calibration), #823 (~3780 serial
+live_factor 4→26 — measured-peak chunk-cap calibration), #811 relaunch pin
+omission (relaunch-pin-parity clause, #1079), #823 (~3780 serial
 full-SVD ridge fits, 12-20 h realized vs 0.35 h planned — the
 dense-linear-algebra widening), #834 (parallel duplicate vectorization of
 null_battery.py — supersede contract), #811 second deviation (19h21m at unit

--- a/src/explore_persona_space/analysis/vectorized_mlp_skill.py
+++ b/src/explore_persona_space/analysis/vectorized_mlp_skill.py
@@ -183,6 +183,8 @@ def _resolve_num_threads(num_threads: int | None, *, ambient: int | None = None)
             if raw in ("", "0"):
                 return None  # disabled — #847 convention
             cap = int(raw)  # fails loud on garbage ("eight")
+            if cap == 0:
+                return None  # numeric-zero forms ("00", "+0") also disable
             if cap < 0:
                 raise ValueError(f"EPS_VECTORIZED_FIT_DEFAULT_THREADS must be >= 0, got {cap}")
         bounds = [cap]

--- a/src/explore_persona_space/analysis/vectorized_mlp_skill.py
+++ b/src/explore_persona_space/analysis/vectorized_mlp_skill.py
@@ -25,7 +25,11 @@ What this module does that the serial path did not:
 2. **Multi-output net** — one net predicts all ``pca_target_dim`` PCA target dims
    at once (a multi-output head, NOT one scalar net per dim).
 3. **`torch.set_num_threads`** to a sane value (the slow run thrashed with 78
-   threads on tiny ops); a ``--device`` arg (cpu default, cuda optional).
+   threads on tiny ops). As of #1079 the cap is ON BY DEFAULT:
+   ``num_threads=None`` resolves to ``max(1, min(8, os.cpu_count(), ambient
+   pool))`` — ambient-ceilinged, so the default only ever caps DOWN — pinned
+   for the fit and restored after; ``num_threads=0`` opts out (see
+   ``_resolve_num_threads``). A ``--device`` arg (cpu default, cuda optional).
 4. **Seed-pinned to match the existing #658 recipe** so numbers are comparable +
    reproducible.
 
@@ -47,7 +51,9 @@ those for the ridge arm and only batches the gradient-descent MLP arm.
 
 from __future__ import annotations
 
+import functools
 import hashlib
+import inspect
 import logging
 import math
 import os
@@ -149,6 +155,78 @@ from issue658_fit_predictors import (  # noqa: E402
 # reseeds with this); the skill scripts pass seed=658 / SEED=42 explicitly.
 DEFAULT_MLP_SEED = 658
 
+# #891 launch-prefix / #847 env.py setdefault / #811 patch value (all 8).
+DEFAULT_FIT_NUM_THREADS = 8
+
+
+def _resolve_num_threads(num_threads: int | None, *, ambient: int | None = None) -> int | None:
+    """Resolve the per-fit CPU thread cap (#1079).
+
+    ``None`` -> conservative default ``max(1, min(DEFAULT_FIT_NUM_THREADS,
+    os.cpu_count(), ambient))`` — the ambient (pre-call torch pool) ceiling
+    means the default only ever caps DOWN, never raises a deliberately
+    tighter pre-call pin. Env override ``EPS_VECTORIZED_FIT_DEFAULT_THREADS``:
+    unset -> ``DEFAULT_FIT_NUM_THREADS``; ``""`` or ``"0"`` -> disabled
+    (return None, no pin — the #847 ``EPS_VM_THREAD_CAP`` convention);
+    negative or non-integer -> ``ValueError`` (fail loud; deliberate
+    divergence from #847's silent negative-disable).
+    ``0`` -> explicit opt-out (return None, no pin). ``>0`` -> honored
+    verbatim (an explicit value MAY exceed the ambient pool — the documented
+    escape hatch). ``<0`` -> ``ValueError``.
+    """
+    if num_threads is None:
+        raw = os.environ.get("EPS_VECTORIZED_FIT_DEFAULT_THREADS")
+        if raw is None:
+            cap = DEFAULT_FIT_NUM_THREADS
+        else:
+            raw = raw.strip()
+            if raw in ("", "0"):
+                return None  # disabled — #847 convention
+            cap = int(raw)  # fails loud on garbage ("eight")
+            if cap < 0:
+                raise ValueError(f"EPS_VECTORIZED_FIT_DEFAULT_THREADS must be >= 0, got {cap}")
+        bounds = [cap]
+        if os.cpu_count():
+            bounds.append(os.cpu_count())
+        if ambient:
+            bounds.append(ambient)
+        return max(1, min(bounds))
+    n = int(num_threads)
+    if n == 0:
+        return None
+    if n < 0:
+        raise ValueError(f"num_threads must be >= 0 (0 = opt-out), got {n}")
+    return n  # explicit caller value honored VERBATIM (no clamp)
+
+
+def _with_thread_cap(fn):
+    """Pin torch's intra-op pool per the fn's ``num_threads``/``device`` kwargs
+    for the call duration (CPU only), restoring the previous value in a
+    ``finally``. The None-default path is ambient-ceilinged (never raises the
+    pool); ``num_threads=0`` opts out entirely (#1079). The device check runs
+    BEFORE resolution, so a malformed ``num_threads`` on a CUDA call keeps the
+    pre-#1079 behavior while a CPU call fails loud before any fit work.
+    """
+    sig = inspect.signature(fn)
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        bound = sig.bind(*args, **kwargs)
+        bound.apply_defaults()
+        if bound.arguments.get("device", "cpu") != "cpu":
+            return fn(*args, **kwargs)
+        prev = torch.get_num_threads()
+        resolved = _resolve_num_threads(bound.arguments.get("num_threads"), ambient=prev)
+        if resolved is None:
+            return fn(*args, **kwargs)
+        torch.set_num_threads(resolved)
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            torch.set_num_threads(prev)
+
+    return wrapper
+
 
 # ── batched LOCO MLP ensemble (the core vectorization) ────────────────────────
 
@@ -188,6 +266,7 @@ class BatchedMLPResult:
     chunk_size: int
 
 
+@_with_thread_cap
 def fit_batched_loco_mlp(
     groups: list[MLPGroup],
     *,
@@ -234,14 +313,16 @@ def fit_batched_loco_mlp(
 
     All groups MUST share n, d_in, and p (asserted). Returns a
     ``BatchedMLPResult`` with held-out (n, p) predictions per group key.
+
+    CPU thread cap (``num_threads``, via ``_with_thread_cap``): ``None``
+    (default) pins an ambient-ceilinged conservative cap for the fit and
+    restores the prior pool after; ``0`` opts out; positive values pin
+    verbatim during the fit (#1079).
     """
     from torch.func import stack_module_state
 
     if not groups:
         return BatchedMLPResult({}, 0, 0, 0, 0, chunk_size)
-
-    if num_threads is not None and device == "cpu":
-        torch.set_num_threads(int(num_threads))
 
     n, d_in = groups[0].X.shape
     p = groups[0].Y.shape[1]
@@ -397,6 +478,7 @@ def _fold_order_and_rows(row_groups: np.ndarray) -> tuple[list[int], list[np.nda
     return order, rows
 
 
+@_with_thread_cap
 def fit_batched_loco_mlp_multihead(
     groups: list[MLPGroup],
     *,
@@ -468,14 +550,17 @@ def fit_batched_loco_mlp_multihead(
     broadcast temp); the bmm reduction order differs from a broadcast-sum in fp32
     associativity, benign because the validity gate is a real-vs-shuffle comparison
     that shares this path on both arms.
+
+    CPU thread cap (``num_threads``, via ``_with_thread_cap``): ``None``
+    (default) pins an ambient-ceilinged conservative cap for the fit and
+    restores the prior pool after; ``0`` opts out; positive values pin
+    verbatim during the fit (#1079).
     """
     from torch.func import stack_module_state
 
     assert standardization in ("per_fold", "full_data"), standardization
     if not groups:
         return BatchedMLPResult({}, 0, 0, 0, 0, chunk_size)
-    if num_threads is not None and device == "cpu":
-        torch.set_num_threads(int(num_threads))
 
     n, d_in = groups[0].X.shape
     p = groups[0].Y.shape[1]
@@ -752,10 +837,21 @@ def _gate_body(*, seed: int, atol: float, max_epochs: int, hidden: int) -> dict:
         MLPGroup(("gateB", 1), rng.standard_normal((n, d)), rng.standard_normal((n, p))),
     ]
     kw = dict(seed=seed, hidden=hidden, lr=MLP_LR, wd=MLP_WD, max_epochs=max_epochs)
+    # num_threads=0 on each batched fit below: the wrapper's 2-thread pin OWNS
+    # the pool for the whole gate body — the fitters' #1079 default cap must
+    # never fire inside it (recorder-certified by
+    # tests/test_vectorized_fit_thread_cap.py). Not in ``kw``: the serial
+    # reference shares ``kw`` and takes no ``num_threads``.
     for mode in ("per_fold", "full_data"):
         # 1. multi-row groups, two cells, chunk crossing the cell boundary.
         res = fit_batched_loco_mlp_multihead(
-            cells, device="cpu", chunk_size=3, row_groups=labels, standardization=mode, **kw
+            cells,
+            device="cpu",
+            chunk_size=3,
+            row_groups=labels,
+            standardization=mode,
+            num_threads=0,
+            **kw,
         )
         for cell in cells:
             ref = _serial_group_mlp_reference(cell.X, cell.Y, labels, standardization=mode, **kw)
@@ -765,7 +861,7 @@ def _gate_body(*, seed: int, atol: float, max_epochs: int, hidden: int) -> dict:
         # 2. singleton folds (row_groups=None — the legacy path) vs the serial
         # reference at singleton labels.
         res_s = fit_batched_loco_mlp_multihead(
-            [cells[0]], device="cpu", chunk_size=5, standardization=mode, **kw
+            [cells[0]], device="cpu", chunk_size=5, standardization=mode, num_threads=0, **kw
         )
         ref_s = _serial_group_mlp_reference(
             cells[0].X, cells[0].Y, np.arange(n), standardization=mode, **kw
@@ -775,7 +871,13 @@ def _gate_body(*, seed: int, atol: float, max_epochs: int, hidden: int) -> dict:
         out[f"singleton_vs_serial_{mode}"] = dev_s
         # 3. duplicate-fit determinism (bitwise) on the grouped call.
         res_dup = fit_batched_loco_mlp_multihead(
-            cells, device="cpu", chunk_size=3, row_groups=labels, standardization=mode, **kw
+            cells,
+            device="cpu",
+            chunk_size=3,
+            row_groups=labels,
+            standardization=mode,
+            num_threads=0,
+            **kw,
         )
         for cell in cells:
             assert np.array_equal(res.preds_by_key[cell.key], res_dup.preds_by_key[cell.key]), (
@@ -998,13 +1100,16 @@ def assert_matches_reference(seed: int = 0, n: int = 14, d: int = 24, p: int = 4
         groups = [MLPGroup(("base",), X, Y), MLPGroup(("shuffle",), X, Ysh)]
         e_total = 2 * p * n
         chunk = max(1, e_total // 3 + 1)  # a non-divisor of E to exercise chunking
-        res = fit_batched_loco_mlp(groups, seed=658, max_epochs=20, device="cpu", chunk_size=chunk)
+        # num_threads=0 on every gate fit: ambient pool (the pre-#1079 behavior).
+        res = fit_batched_loco_mlp(
+            groups, seed=658, max_epochs=20, device="cpu", chunk_size=chunk, num_threads=0
+        )
         d_base = float(np.max(np.abs(res.preds_by_key[("base",)] - ref)))
         d_shuf = float(np.max(np.abs(res.preds_by_key[("shuffle",)] - ref_sh)))
 
         # (b) chunk-invariance: no-chunk must be BIT-identical to the chunked run.
         res_nochunk = fit_batched_loco_mlp(
-            groups, seed=658, max_epochs=20, device="cpu", chunk_size=0
+            groups, seed=658, max_epochs=20, device="cpu", chunk_size=0, num_threads=0
         )
         chunk_base_identical = bool(
             np.array_equal(res.preds_by_key[("base",)], res_nochunk.preds_by_key[("base",)])
@@ -1015,7 +1120,12 @@ def assert_matches_reference(seed: int = 0, n: int = 14, d: int = 24, p: int = 4
 
         # (c) cross-group non-contamination: 2-group base == single-group base.
         res_single = fit_batched_loco_mlp(
-            [MLPGroup(("base",), X, Y)], seed=658, max_epochs=20, device="cpu", chunk_size=0
+            [MLPGroup(("base",), X, Y)],
+            seed=658,
+            max_epochs=20,
+            device="cpu",
+            chunk_size=0,
+            num_threads=0,
         )
         crossgroup_identical = bool(
             np.array_equal(res_nochunk.preds_by_key[("base",)], res_single.preds_by_key[("base",)])
@@ -1155,6 +1265,7 @@ def _split_mlp_eval(Xg, W1, b1, W2, b2, mu, sd):
     return torch.bmm(h, W2.transpose(1, 2)) + b2.unsqueeze(1)  # (c, n, p)
 
 
+@_with_thread_cap
 def fit_batched_split_mlp(  # noqa: C901 -- linear batched trainer; loss selector + parity options add branches
     groups: list[SplitMLPGroup],
     *,
@@ -1213,6 +1324,11 @@ def fit_batched_split_mlp(  # noqa: C901 -- linear batched trainer; loss selecto
     between a 5-group call and 2+3-group calls). Deterministic + reproducible
     across runs and processes; sets the global torch CPU RNG as a side effect.
     Returns a ``SplitMLPResult`` (eval preds + trained params + best-val epoch).
+
+    CPU thread cap (``num_threads``, via ``_with_thread_cap``): ``None``
+    (default) pins an ambient-ceilinged conservative cap for the fit and
+    restores the prior pool after; ``0`` opts out; positive values pin
+    verbatim during the fit (#1079).
     """
     from torch.func import stack_module_state
 
@@ -1231,8 +1347,6 @@ def fit_batched_split_mlp(  # noqa: C901 -- linear batched trainer; loss selecto
     if patience is not None:
         assert patience > 0, f"patience must be positive, got {patience}"
         assert groups[0].X_val is not None, "patience early stopping requires validation splits"
-    if num_threads is not None and device == "cpu":
-        torch.set_num_threads(int(num_threads))
 
     n_train, d_in = groups[0].X_train.shape
     p = groups[0].Y_train.shape[1]
@@ -1400,7 +1514,10 @@ def assert_split_mlp_matches_serial(
     Xtr, Ytr, Xev = X[:n_train], Y[:n_train], X[n_train:]
 
     grp = SplitMLPGroup(("g",), Xtr, Ytr, Xev)
-    res = fit_batched_split_mlp([grp], seed=658, max_epochs=40, device="cpu", chunk_size=1)
+    # num_threads=0: ambient pool, matching the serial reference below (pre-#1079 behavior).
+    res = fit_batched_split_mlp(
+        [grp], seed=658, max_epochs=40, device="cpu", chunk_size=1, num_threads=0
+    )
     batched_pred = res.preds_by_key[("g",)]
 
     # Serial reference: one _MLPMulti drawing the SAME init as the batched fit's

--- a/tests/test_vectorized_fit_thread_cap.py
+++ b/tests/test_vectorized_fit_thread_cap.py
@@ -124,6 +124,8 @@ def test_resolve_env_override(monkeypatch):
     assert _resolve_num_threads(None) is None
     monkeypatch.setenv(ENV_KEY, "0")
     assert _resolve_num_threads(None) is None
+    monkeypatch.setenv(ENV_KEY, "00")  # numeric-zero form past the string gate
+    assert _resolve_num_threads(None) is None
     monkeypatch.setenv(ENV_KEY, "-1")
     with pytest.raises(ValueError):
         _resolve_num_threads(None)

--- a/tests/test_vectorized_fit_thread_cap.py
+++ b/tests/test_vectorized_fit_thread_cap.py
@@ -1,0 +1,236 @@
+"""#1079 default CPU thread cap in ``analysis/vectorized_mlp_skill``.
+
+Covers the plan §6 T1-T8 battery:
+
+- T1-T4: the ``_resolve_num_threads`` resolver — ambient-ceilinged default,
+  host-independence, ``EPS_VECTORIZED_FIT_DEFAULT_THREADS`` override semantics
+  (#847 parity: ``""``/``"0"`` disable; negative/malformed fail loud), the
+  ``num_threads=0`` opt-out, and verbatim (unclamped) explicit values.
+- T5-T6: recorder-based pin-and-restore behavior on ALL THREE real fitters
+  (an undecorated fitter FAILS T5 — the recorder stays empty), plus the
+  never-raises-ambient guarantee of the None default.
+- T7: the parity gates are insulated from the default — no resolved-default
+  pin may fire inside ``assert_group_mlp_matches_serial``'s 2-thread gate
+  body, and ``assert_split_mlp_matches_serial`` runs pin-free (ambient).
+- T8: subprocess import-purity — importing the module mutates NO torch
+  global state (a sentinel pool of 3 survives the import).
+
+The recorder monkeypatches ``torch.set_num_threads`` to RECORD each requested
+value AND call through, so every behavioral assertion fails when the change
+is absent or partial (the round-1 false-green gap this battery closes).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from explore_persona_space.analysis import vectorized_mlp_skill as vms
+from explore_persona_space.analysis.vectorized_mlp_skill import (
+    MLPGroup,
+    SplitMLPGroup,
+    _resolve_num_threads,
+    assert_group_mlp_matches_serial,
+    assert_split_mlp_matches_serial,
+    fit_batched_loco_mlp,
+    fit_batched_loco_mlp_multihead,
+    fit_batched_split_mlp,
+)
+
+ENV_KEY = "EPS_VECTORIZED_FIT_DEFAULT_THREADS"
+
+
+@pytest.fixture
+def clear_env(monkeypatch):
+    """Remove the env override so the DEFAULT_FIT_NUM_THREADS path is exercised."""
+    monkeypatch.delenv(ENV_KEY, raising=False)
+
+
+@pytest.fixture
+def ambient_pool_3():
+    """Pin the ambient torch pool to a sentinel (3); restore the original on teardown."""
+    prev = torch.get_num_threads()
+    torch.set_num_threads(3)
+    yield 3
+    torch.set_num_threads(prev)
+
+
+@pytest.fixture
+def thread_pin_recorder(monkeypatch):
+    """Record every ``torch.set_num_threads`` value AND call through to the real fn."""
+    calls: list[int] = []
+    real = torch.set_num_threads
+
+    def _recording(n):
+        calls.append(int(n))
+        real(n)
+
+    monkeypatch.setattr(torch, "set_num_threads", _recording)
+    return calls
+
+
+def _tiny_loco_groups(rng: np.random.Generator) -> list[MLPGroup]:
+    """Minimal valid LOCO input: one group, n=4 folds, d_in=3, p=2."""
+    n, d, p = 4, 3, 2
+    return [
+        MLPGroup(
+            ("t", 0),
+            rng.standard_normal((n, d)).astype(np.float32),
+            rng.standard_normal((n, p)).astype(np.float32),
+        )
+    ]
+
+
+def _tiny_split_groups(rng: np.random.Generator) -> list[SplitMLPGroup]:
+    """Minimal valid split input: one group, 6 train / 2 eval rows, d_in=3, p=2."""
+    n_tr, n_ev, d, p = 6, 2, 3, 2
+    X = rng.standard_normal((n_tr + n_ev, d)).astype(np.float32)
+    Y = rng.standard_normal((n_tr + n_ev, p)).astype(np.float32)
+    return [SplitMLPGroup(("t",), X[:n_tr], Y[:n_tr], X[n_tr:])]
+
+
+# ── T1-T4: the resolver ───────────────────────────────────────────────────────
+
+
+def test_resolve_none_default(clear_env, monkeypatch):
+    """T1: env cleared, None -> max(1, min(8, cpu_count, ambient)); ambient only caps DOWN."""
+    monkeypatch.setattr(os, "cpu_count", lambda: 32)
+    assert _resolve_num_threads(None) == 8
+    assert _resolve_num_threads(None, ambient=3) == 3  # ambient ceiling caps DOWN
+    assert _resolve_num_threads(None, ambient=16) == 8  # ambient above cap: cap binds
+
+
+def test_resolve_host_independence(clear_env, monkeypatch):
+    """T2: small / unreadable os.cpu_count() never crashes and bounds correctly."""
+    monkeypatch.setattr(os, "cpu_count", lambda: 2)
+    assert _resolve_num_threads(None) == 2
+    monkeypatch.setattr(os, "cpu_count", lambda: None)
+    assert _resolve_num_threads(None) == 8  # unreadable cpu_count: cap alone
+    assert _resolve_num_threads(None, ambient=3) == 3
+
+
+def test_resolve_env_override(monkeypatch):
+    """T3: env "4" -> 4; ""/"0" -> disabled (#847 parity); negative/malformed -> ValueError."""
+    monkeypatch.setattr(os, "cpu_count", lambda: 32)
+    monkeypatch.setenv(ENV_KEY, "4")
+    assert _resolve_num_threads(None) == 4
+    monkeypatch.setenv(ENV_KEY, "")
+    assert _resolve_num_threads(None) is None
+    monkeypatch.setenv(ENV_KEY, "0")
+    assert _resolve_num_threads(None) is None
+    monkeypatch.setenv(ENV_KEY, "-1")
+    with pytest.raises(ValueError):
+        _resolve_num_threads(None)
+    monkeypatch.setenv(ENV_KEY, "eight")
+    with pytest.raises(ValueError):
+        _resolve_num_threads(None)
+
+
+def test_resolve_optout_and_explicit(clear_env):
+    """T4: 0 -> None (opt-out); positive -> verbatim (no ambient clamp); negative -> ValueError."""
+    assert _resolve_num_threads(0) is None
+    assert _resolve_num_threads(5) == 5
+    assert _resolve_num_threads(5, ambient=3) == 5  # explicit values are NEVER clamped
+    with pytest.raises(ValueError):
+        _resolve_num_threads(-2)
+
+
+# ── T5-T6: the fitters pin-and-restore (recorder-certified) ───────────────────
+
+FITTERS = [
+    pytest.param(fit_batched_loco_mlp, _tiny_loco_groups, id="loco"),
+    pytest.param(fit_batched_loco_mlp_multihead, _tiny_loco_groups, id="multihead"),
+    pytest.param(fit_batched_split_mlp, _tiny_split_groups, id="split"),
+]
+
+
+@pytest.mark.parametrize("fitter,builder", FITTERS)
+def test_fitters_pin_and_restore(fitter, builder, monkeypatch, ambient_pool_3, thread_pin_recorder):
+    """T5: every real fitter pins (default AND explicit) then restores; 0 opts out.
+
+    FAILS if a fitter is undecorated: the recorder stays empty on (a)/(b).
+    """
+    monkeypatch.setenv(ENV_KEY, "2")
+    rng = np.random.default_rng(0)
+    kw = dict(seed=658, hidden=4, max_epochs=2, device="cpu")
+
+    # (a) omitted num_threads -> env default 2 (< ambient 3): pin 2, restore 3.
+    fitter(builder(rng), **kw)
+    assert thread_pin_recorder == [2, 3], thread_pin_recorder
+    assert torch.get_num_threads() == 3
+    thread_pin_recorder.clear()
+
+    # (b) explicit num_threads=2: honored verbatim during the fit, restored after.
+    fitter(builder(rng), num_threads=2, **kw)
+    assert thread_pin_recorder == [2, 3], thread_pin_recorder
+    assert torch.get_num_threads() == 3
+    thread_pin_recorder.clear()
+
+    # (c) num_threads=0: explicit opt-out — NO fit-local pin at all.
+    fitter(builder(rng), num_threads=0, **kw)
+    assert thread_pin_recorder == [], thread_pin_recorder
+    assert torch.get_num_threads() == 3
+
+
+def test_default_never_raises_ambient(clear_env, ambient_pool_3, thread_pin_recorder):
+    """T6: env cleared, ambient=3 — the None default resolves to <=3 (never raises the pool)."""
+    rng = np.random.default_rng(1)
+    fit_batched_loco_mlp_multihead(
+        _tiny_loco_groups(rng), seed=658, hidden=4, max_epochs=2, device="cpu"
+    )
+    assert thread_pin_recorder, "expected a fit-local default pin to fire"
+    assert max(thread_pin_recorder) <= 3, thread_pin_recorder
+    assert torch.get_num_threads() == 3
+
+
+# ── T7: the parity gates are insulated from the default ──────────────────────
+
+
+def test_parity_gate_unaffected(clear_env, ambient_pool_3, thread_pin_recorder):
+    """T7a: the 2-thread gate pin governs the WHOLE gate body — the resolved
+    default never fires inside ``_gate_body`` (recorder shows EXACTLY the
+    wrapper's pin + restore, nothing else)."""
+    prev = torch.get_num_threads()
+    out = assert_group_mlp_matches_serial(max_epochs=2, hidden=8)
+    assert out  # gate completed and returned its deviation dict
+    assert torch.get_num_threads() == prev
+    # Exactly [wrapper pin 2, wrapper restore prev]. A dropped num_threads=0
+    # inside _gate_body would add fit-local pin/restore pairs to the recording.
+    assert thread_pin_recorder == [2, prev], thread_pin_recorder
+
+
+def test_split_serial_gate_no_fit_local_pin(clear_env, ambient_pool_3, thread_pin_recorder):
+    """T7b: ``assert_split_mlp_matches_serial`` runs under the ambient pool —
+    both its batched arm (num_threads=0) and its serial reference — so no
+    fit-local pin fires at all."""
+    assert_split_mlp_matches_serial()
+    assert thread_pin_recorder == [], thread_pin_recorder
+    assert torch.get_num_threads() == 3
+
+
+# ── T8: import purity (subprocess) ────────────────────────────────────────────
+
+
+def test_import_no_global_mutation():
+    """T8: importing the module changes NO torch global state (subprocess form —
+    the in-process cached-import arm would be vacuous)."""
+    src_root = Path(vms.__file__).resolve().parents[2]
+    code = (
+        "import torch; torch.set_num_threads(3); "
+        "import explore_persona_space.analysis.vectorized_mlp_skill; "
+        "assert torch.get_num_threads() == 3, torch.get_num_threads(); "
+        "print('POOL_OK')"
+    )
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(src_root) + os.pathsep + env.get("PYTHONPATH", "")
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, env=env, timeout=300
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "POOL_OK" in proc.stdout


### PR DESCRIPTION
Closes task #1079 (kind: infra workflow-fix, wf-fix).

- Default ambient-ceilinged CPU thread cap in the three vectorized_mlp_skill fitters (resolver + _with_thread_cap decorator, restore-in-finally, opt-out 0, env override EPS_VECTORIZED_FIT_DEFAULT_THREADS with #847-parity semantics); parity gates preserved via explicit num_threads=0.
- Relaunch pin parity (#811) clause in .claude/rules/vectorize-many-cell-fits.md item 7 (four-pin pre-dispatch verification recipe) + LESSONS.md trigger touch.
- New 11-test recorder battery (tests/test_vectorized_fit_thread_cap.py).

Review: Claude + Codex code-review ensemble PASS+PASS (r1); test-verdict PASS (2641 passed, compare rc=0).