### PR TITLE
task #1077: step9c dirty-oracle scratch-worktree fallback + JSON on every compare exit

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -7550,9 +7550,15 @@ suite directly and posts an `epm:test-verdict` event with the result.
       * `COMPARE_RC=1` → NEW failure(s) the branch introduced and/or a lint
         regression (the JSON names each). FAIL.
       * `COMPARE_RC=2` → indeterminate (PYTEST_RC ∉ {0,1} — aborted/interrupted
-        run; missing/empty junitxml; suite crash; unusable ledger; dirty
-        pristine oracle; systemic main breakage). FAIL — never PASS on
-        indeterminate.
+        run; missing/empty junitxml; suite crash; unusable ledger;
+        scratch-ineligible dirty oracle (contaminating src//pyproject.toml/uv.lock
+        dirt, a scan-set node, or a non-sparse work root — other root dirt
+        auto-falls back to a detached sparse scratch-worktree oracle at main
+        HEAD, reported as JSON "pristine_oracle": "scratch-worktree");
+        systemic main breakage). FAIL — never PASS on indeterminate.
+        COMPARE_OUT is valid JSON on EVERY exit path under --json (exit-2
+        payloads carry "indeterminate": true — an exit-2 payload's empty
+        new/stripped arrays are NOT a clean verdict).
       The two step-1b guards run BEFORE compare and are UNCHANGED: the cd
       hard-guard and the `no tests ran` FAIL guard (zero collected is a FAIL
       regardless of compare's exit).

--- a/scripts/step9c_baseline.py
+++ b/scripts/step9c_baseline.py
@@ -20,7 +20,8 @@ Subcommands::
                                                      [--run-pristine] [--pristine-timeout-s 600]
                                                      [--max-pristine-files 5]
                                                      [--max-age-hours 24] [--max-code-commits 150]
-                                                     [--json]
+                                                     [--scratch-timeout-s 120]
+                                                     [--no-scratch-fallback] [--json]
 
 Exit codes (pinned by ``tests/test_step9c_baseline.py``):
 
@@ -39,8 +40,12 @@ Exit codes (pinned by ``tests/test_step9c_baseline.py``):
   2          indeterminate: ``--pytest-rc`` not in {0, 1}; missing/empty junitxml; zero
              testcases; unusable ledger with unresolved buckets (no ``--run-pristine``);
              pristine run timeout/crash (incl. a missing root-venv interpreter); dirty
-             pristine oracle on a failing node; more than ``--max-pristine-files``
-             distinct pristine files ("systemic main breakage"); missing ruff binary
+             oracle on a failing node where the scratch fallback is ineligible
+             (contaminating dirt — ANY top-level ``src/`` file, ``pyproject.toml``,
+             ``uv.lock``; a scan-set (``GLOB_SCAN_TESTS``) node; a non-sparse work
+             root; or ``--no-scratch-fallback``); scratch-worktree fallback creation
+             failure; more than ``--max-pristine-files`` distinct pristine files
+             ("systemic main breakage"); missing ruff binary
 ===========  ==========================================================================
 
 Safety invariants (plan #1022 v3 R1-R7): the refresh NEVER runs ``pytest tests/``
@@ -57,8 +62,25 @@ the invoking ``sys.executable``, whose worktree ``.pth`` would import branch
 library code into a "pristine" run — #1022 round-2 Critical); NO subcommand
 mutates git state (reads only:
 ``rev-parse`` / ``rev-list`` / ``cat-file`` / ``diff --name-only`` /
-``status --porcelain``); ledger writes are flock single-flight + atomic
-tmp+``os.replace``.
+``status --porcelain`` / ``ls-tree``), EXCEPT compare's bounded dirty-oracle
+scratch fallback (#1077) — ``git worktree add --detach --no-checkout`` into a
+fresh tmp dir + worktree-local sparse-checkout + populate at the root's HEAD,
+ALWAYS torn down in a ``finally`` (``worktree remove --force`` + rmtree;
+deliberately NO ``git worktree prune`` — see ``remove_scratch_worktree``); the
+shared root's branches, index, working tree, and shared config are never
+touched; ledger writes are flock single-flight + atomic tmp+``os.replace``.
+
+Residual risk of the scratch fallback: ``repo_root()``-anchored /
+installed-package-path reads resolve the MAIN root even from a scratch cwd —
+the scan-set (``GLOB_SCAN_TESTS``) exclusion covers the known class of such
+live-tree scanners; a future non-scan test that executes root files via
+``repo_root()`` would re-open that channel.
+
+Under ``--json``, EVERY compare exit path prints exactly one JSON object to
+stdout: exit 0/1 the classification result (``indeterminate: false``); exit 2
+an indeterminate payload (``indeterminate: true`` + ``reason`` + the
+accumulated ``warns``) — the Step 9c caller branches on the stable
+``indeterminate`` key, never on empty stdout.
 
 State files (all under the MAIN repo root, resolved via ``--git-common-dir`` so
 every worktree shares ONE ledger):
@@ -100,6 +122,18 @@ CODE_COMMIT_PATHSPEC: tuple[str, ...] = ("scripts/", "src/", "tests/", "pyprojec
 # perpetual non-code churn (tasks/**, pods_ephemeral.json, agent-memory .md)
 # must not read as dirt or the bit is a protection illusion (MF-4a).
 DIRTY_CODE_PATHSPEC: tuple[str, ...] = ("*.py", "pyproject.toml", "uv.lock")
+
+# The contamination probe pathspec is DELIBERATELY wider than DIRTY_CODE_PATHSPEC:
+# it must see ALL files under top-level src/ (query-bank .json data ships inside the
+# package and resolves LIVE through the editable .pth via importlib.resources), not
+# only *.py — the *.py-scoped live_dirty_paths filter alone converts the MIXED case
+# (dirty scripts/*.py + dirty src/*.json) into a false scratch strip (#1077).
+# MF-4a's .py-scoped churn rationale applies to the dirt TRIGGER, not to this
+# eligibility probe.
+SCRATCH_CONTAMINATION_PATHSPEC: tuple[str, ...] = ("src/", "pyproject.toml", "uv.lock")
+
+# Sparse-profile floor excludes — mirror of new_worktree.sh EXCLUDES.
+SCRATCH_EXCLUDES: tuple[str, ...] = ("eval_results", "external", "ood_eval_results")
 
 REQUIRED_LEDGER_KEYS: frozenset[str] = frozenset(
     {
@@ -341,13 +375,8 @@ def changed_test_files_since(root: Path, sha: str) -> set[str]:
     return {line.strip() for line in out.splitlines() if line.strip()}
 
 
-def dirty_code_paths(root: Path) -> list[str]:
-    """Return uncommitted CODE-path changes at *root* (DIRTY_CODE_PATHSPEC scope).
-
-    Scoped so the perpetual non-code churn on the shared root (tasks/**,
-    pods_ephemeral.json, agent-memory .md) never reads as dirt (MF-4a).
-    """
-    out = _git_out(["status", "--porcelain", "--", *DIRTY_CODE_PATHSPEC], root)
+def _porcelain_paths(out: str) -> list[str]:
+    """Parse ``git status --porcelain`` output into paths (rename entries -> new name)."""
     paths: list[str] = []
     for line in out.splitlines():
         if not line.strip():
@@ -357,6 +386,151 @@ def dirty_code_paths(root: Path) -> list[str]:
             p = p.split(" -> ", 1)[1]
         paths.append(p.strip('"'))
     return paths
+
+
+def dirty_code_paths(root: Path) -> list[str]:
+    """Return uncommitted CODE-path changes at *root* (DIRTY_CODE_PATHSPEC scope).
+
+    Scoped so the perpetual non-code churn on the shared root (tasks/**,
+    pods_ephemeral.json, agent-memory .md) never reads as dirt (MF-4a).
+    """
+    return _porcelain_paths(_git_out(["status", "--porcelain", "--", *DIRTY_CODE_PATHSPEC], root))
+
+
+def scratch_contamination_probe(root: Path) -> list[str]:
+    """Uncommitted paths a scratch tree CANNOT neutralize (#1077).
+
+    ANY file under top-level ``src/`` — the root venv's editable ``.pth``
+    statically resolves ``<root>/src`` regardless of cwd, and package data
+    rides ``importlib.resources`` — plus ``pyproject.toml``/``uv.lock``,
+    which the venv's installed deps derive from.
+    ``git status --porcelain -- src/ pyproject.toml uv.lock``, parsed exactly
+    like ``dirty_code_paths()``. Non-empty => the scratch fallback is
+    ineligible and compare keeps the fail-closed MF-4c exit 2.
+    """
+    return _porcelain_paths(
+        _git_out(["status", "--porcelain", "--", *SCRATCH_CONTAMINATION_PATHSPEC], root)
+    )
+
+
+# --- Scratch-worktree fallback helpers (#1077) -------------------------------------
+
+
+@dataclass
+class _ScratchTree:
+    """A materialized detached sparse scratch worktree (the dirty-oracle fallback)."""
+
+    parent: Path  # the mkdtemp dir (rmtree target)
+    path: Path  # the worktree itself: parent / f"tree-{os.getpid()}"
+    sha: str  # the detached HEAD sha (== root HEAD at creation)
+
+
+def _git_bounded(argv: list[str], cwd: Path, timeout_s: float) -> None:
+    """Run one git command with check=True + timeout (scratch lifecycle only)."""
+    subprocess.run(
+        ["git", *argv],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=timeout_s,
+    )
+
+
+def _work_root_sparse_cones(wt: Path) -> list[str] | None:
+    """The invoking work root's ACTUAL sparse profile via ``git sparse-checkout list``.
+
+    None when the work root is not sparse — the caller treats None as
+    fallback-INELIGIBLE (R-G: a non-sparse gate layout cannot be
+    superset-matched by a sparse scratch without a full multi-GB checkout).
+    On git 2.34 a non-sparse tree exits 0 with EMPTY stdout (warning on
+    stderr), so an empty list is folded into None too; a genuinely failing
+    command (non-git dir, ancient git) also maps to None.
+    """
+    try:
+        lines = [
+            ln.strip()
+            for ln in _git_out(["sparse-checkout", "list"], wt).splitlines()
+            if ln.strip()
+        ]
+    except subprocess.CalledProcessError:
+        return None
+    return lines or None
+
+
+def _scratch_cones(root: Path, wt_cones: list[str]) -> list[str]:
+    """Scratch sparse profile = SUPERSET of the gate layout (R-G).
+
+    The union of: the work root's actual ``sparse-checkout list`` (per-issue +
+    manually-added cones included — the legs the registry alone omits), the
+    HEAD-PINNED ``tests/sparse_cones.txt`` (``git show HEAD:...`` — never the
+    live working-tree file, which is itself decontaminable-classified dirt),
+    and every top-level tracked dir minus SCRATCH_EXCLUDES as the floor.
+    """
+    dirs = [
+        d
+        for d in _git_out(["ls-tree", "--name-only", "-d", "HEAD"], root).splitlines()
+        if d and d not in SCRATCH_EXCLUDES
+    ]
+    registry_lines: list[str] = []
+    # Registry absent at HEAD: the floor still applies, no raise.
+    with contextlib.suppress(subprocess.CalledProcessError):
+        registry_lines = [
+            ln.strip()
+            for ln in _git_out(["show", "HEAD:tests/sparse_cones.txt"], root).splitlines()
+            if ln.strip() and not ln.strip().startswith("#")
+        ]
+    return sorted(set(dirs) | set(registry_lines) | set(wt_cones))
+
+
+def create_scratch_worktree(root: Path, wt_cones: list[str], timeout_s: float) -> _ScratchTree:
+    """Materialize a detached SPARSE scratch tree at *root*'s HEAD under a fresh tmp dir.
+
+    Sequence mirrors ``new_worktree.sh`` ``_sparse_setup`` (``init --cone``
+    FIRST, then ``set``, then populate from ``--no-checkout`` limbo). Profile =
+    ``_scratch_cones(root, wt_cones)`` — a superset of the gate layout (R-G).
+    Any failure tears down partial state and re-raises (the caller maps it to
+    ``_Indeterminate``). Bounded per git command by *timeout_s*.
+    """
+    sha = git_head(root)
+    parent = Path(tempfile.mkdtemp(prefix="step9c-scratch-"))
+    tree = parent / f"tree-{os.getpid()}"
+    try:
+        _git_bounded(
+            ["worktree", "add", "--detach", "--no-checkout", str(tree), sha],
+            cwd=root,
+            timeout_s=timeout_s,
+        )
+        _git_bounded(["sparse-checkout", "init", "--cone"], cwd=tree, timeout_s=timeout_s)
+        _git_bounded(
+            ["sparse-checkout", "set", *_scratch_cones(root, wt_cones)],
+            cwd=tree,
+            timeout_s=timeout_s,
+        )
+        _git_bounded(["checkout", sha], cwd=tree, timeout_s=timeout_s)
+    except BaseException:
+        remove_scratch_worktree(root, _ScratchTree(parent=parent, path=tree, sha=sha))
+        raise
+    return _ScratchTree(parent=parent, path=tree, sha=sha)
+
+
+def remove_scratch_worktree(root: Path, scratch: _ScratchTree) -> None:
+    """Best-effort teardown; never raises (the verdict is already decided).
+
+    Deliberately NO ``git worktree prune``: prune reaps admin entries of ANY
+    worktree whose dir is unreachable, so a future bind-mount outage on
+    ``.claude/worktrees`` could make a compare's teardown break LIVE
+    worktrees. A SIGKILL'd compare leaves one cosmetic stale admin entry
+    (git gc's ``gc.worktreePruneExpire`` sweeps it) + an inert ``/tmp`` dir.
+    """
+    with contextlib.suppress(Exception):
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(scratch.path)],
+            cwd=str(root),
+            capture_output=True,
+            timeout=60,
+        )
+    shutil.rmtree(scratch.parent, ignore_errors=True)
 
 
 def _ruff_bin() -> str:
@@ -698,20 +872,27 @@ def cmd_status(args: argparse.Namespace) -> int:
 # --- compare ---------------------------------------------------------------------
 
 
-def run_single_file_pristine(test_file: str, cwd: Path, timeout_s: float) -> set[Node]:
-    """Run ONE test file at the main root (pristine oracle); return its failing nodes.
+def run_single_file_pristine(
+    test_file: str, cwd: Path, timeout_s: float, *, venv_root: Path | None = None
+) -> set[Node]:
+    """Run ONE test file at the pristine oracle *cwd*; return its failing nodes.
 
-    Executes the ROOT's OWN venv interpreter (``resolve_root_python(cwd)``) so
-    the oracle runs MAIN's library code — never the invoking worktree's, whose
-    editable ``src/`` would make a branch-caused regression fail "pristine" too
-    and get stripped as pre-existing (#1022 round-2 Critical). A missing root
-    venv raises PristineRunError (indeterminate, exit 2 — never a silent
-    ``sys.executable`` fallback). Bounded + thread-capped like refresh. rc not
-    in {0, 1}, a timeout, or a zero-collected run raises PristineRunError
-    (MF-5); a classification must never rest on an aborted pristine run.
+    Executes the TARGET root's OWN venv interpreter (``resolve_root_python``)
+    so the oracle runs MAIN's library code — never the invoking worktree's,
+    whose editable ``src/`` would make a branch-caused regression fail
+    "pristine" too and get stripped as pre-existing (#1022 round-2 Critical).
+    ``venv_root`` (scratch-oracle mode, #1077): the interpreter is resolved
+    from the MAIN root while *cwd* is the scratch tree — the scratch has no
+    venv; the root venv's editable ``.pth`` points at the root's ``src/``,
+    which is exactly why ``src/``-dirt is gated out before this mode is used.
+    A missing venv raises PristineRunError (indeterminate, exit 2 — never a
+    silent ``sys.executable`` fallback). Bounded + thread-capped like refresh.
+    rc not in {0, 1}, a timeout, or a zero-collected run raises
+    PristineRunError (MF-5); a classification must never rest on an aborted
+    pristine run.
     """
     try:
-        python_exe = resolve_root_python(cwd)
+        python_exe = resolve_root_python(venv_root if venv_root is not None else cwd)
     except ToolMissingError as exc:
         raise PristineRunError(str(exc)) from exc
     fd, tmp = tempfile.mkstemp(prefix="step9c-pristine-junit-", suffix=".xml")
@@ -779,7 +960,18 @@ def _pristine_command(root: Path, test_file: str) -> str:
 
 
 class _Indeterminate(RuntimeError):
-    """Internal control flow: compare cannot classify — the caller exits 2."""
+    """Internal control flow: compare cannot classify — the caller exits 2.
+
+    ``extra`` carries structured payload fields the exit-2 ``--json`` object
+    surfaces (e.g. ``live_dirty_paths``, ``contaminating_paths``); ``warns``
+    carries the ctx-accumulated WARNs so scratch-oracle provenance is never
+    dropped on a mid-loop failure (#1077).
+    """
+
+    def __init__(self, msg: str, extra: dict | None = None, warns: list[str] | None = None):
+        super().__init__(msg)
+        self.extra = extra or {}
+        self.warns = list(warns or [])
 
 
 @dataclass
@@ -802,12 +994,15 @@ class _CompareCtx:
     sel: object
     touched: list[str]
     diff_linked: set[str]
+    work_root: Path  # the invoking worktree (its sparse profile gates the scratch fallback)
     new: list[Node] = field(default_factory=list)
     stripped: list[dict] = field(default_factory=list)
     pristine_bucket: list[Node] = field(default_factory=list)
     warns: list[str] = field(default_factory=list)
     live_dirty_paths: list[str] = field(default_factory=list)
     pristine_files_run: list[str] = field(default_factory=list)
+    pristine_oracle: str = "root"  # "scratch-worktree" once the #1077 fallback fires
+    scratch_sha: str | None = None
 
 
 def _resolve_roots(args: argparse.Namespace) -> tuple[Path, Path]:
@@ -844,7 +1039,7 @@ def _selector_context(args: argparse.Namespace, wt: Path) -> _CompareCtx:
     diff_linked = {t for t, rs in reasons.items() if any(r != "invariant" for r in rs)} | {
         f for f in touched if f.startswith("tests/")
     }
-    return _CompareCtx(sel=sel, touched=touched, diff_linked=diff_linked)
+    return _CompareCtx(sel=sel, touched=touched, diff_linked=diff_linked, work_root=wt)
 
 
 def _ledger_view(root: Path, args: argparse.Namespace) -> _LedgerView:
@@ -885,7 +1080,7 @@ def _strip_node(ctx: _CompareCtx, node: Node, via: str) -> None:
             f"its directory scan covers touched file(s) {covered or '[]'}; re-check them "
             "against that scan's rule"
         )
-    if via == "pristine" and node.file in ctx.diff_linked:
+    if via.startswith("pristine") and node.file in ctx.diff_linked:
         ctx.warns.append(
             f"MASKING WARN: stripped diff-linked node {node.file}::{node.name} via a "
             "pristine-main failure — the branch touches files mapped to this test; "
@@ -912,45 +1107,110 @@ def _bucket_run_failures(
 
 
 def _resolve_pristine_bucket(ctx: _CompareCtx, root: Path, args: argparse.Namespace) -> None:
-    """Resolve bucketed nodes via bounded single-file pristine-main runs (or refuse)."""
+    """Resolve bucketed nodes via bounded single-file pristine runs (or refuse).
+
+    Dirty-oracle scratch fallback (#1077): when the MF-4c dirt trigger fires
+    but the dirt is DECONTAMINABLE (the src//pyproject/uv.lock contamination
+    probe is empty), the pristine oracle re-roots to a detached sparse scratch
+    worktree at the root's HEAD — created lazily once per compare, reused for
+    every eligible bucketed file, ALWAYS removed in the ``finally``. Per-file
+    eligibility additionally requires a sparse work root (R-G), a non-scan-set
+    node (R-F — ``repo_root()``-anchored live-tree scanners read the MAIN root
+    from any cwd, so a scratch cannot decontaminate them), and the fallback
+    not being disabled via ``--no-scratch-fallback``. Everything else keeps
+    the fail-closed MF-4c exit 2. BOTH probes re-run per file, so contaminating
+    dirt appearing mid-loop reverts later files to the root oracle
+    (fail-closed).
+    """
     if not ctx.pristine_bucket:
         return
     files = sorted({n.file for n in ctx.pristine_bucket})
     if len(files) > args.max_pristine_files:
         raise _Indeterminate(
             f"systemic main breakage ({len(files)} red files > "
-            f"--max-pristine-files {args.max_pristine_files}) — investigate / refresh first"
+            f"--max-pristine-files {args.max_pristine_files}) — investigate / refresh first",
+            warns=ctx.warns,
         )
     if not args.run_pristine:
         commands = "\n".join(f"  {_pristine_command(root, f)}" for f in files)
         raise _Indeterminate(
             f"{len(ctx.pristine_bucket)} failure(s) need a pristine-main check and "
             "--run-pristine was not given — indeterminate, never a silent strip. "
-            f"Per-file pristine commands:\n{commands}"
+            f"Per-file pristine commands:\n{commands}",
+            warns=ctx.warns,
         )
-    for test_file in files:
-        try:
-            ctx.live_dirty_paths = dirty_code_paths(root)  # probed AT pristine time (MF-4c)
-        except subprocess.CalledProcessError as exc:
-            raise _Indeterminate(f"dirt probe failed at {root}: {exc}") from exc
-        try:
-            main_failing = run_single_file_pristine(
-                test_file, cwd=root, timeout_s=args.pristine_timeout_s
+    scratch: _ScratchTree | None = None
+    wt_cones = _work_root_sparse_cones(ctx.work_root)  # None => non-sparse => ineligible (R-G)
+    try:
+        for test_file in files:
+            try:
+                # BOTH probes re-run per file (MF-4c freshness + mid-loop transitions).
+                ctx.live_dirty_paths = dirty_code_paths(root)
+                contaminating = scratch_contamination_probe(root)
+            except subprocess.CalledProcessError as exc:
+                raise _Indeterminate(
+                    f"dirt probe failed at {root}: {exc}", warns=ctx.warns
+                ) from exc
+            use_scratch = (
+                bool(ctx.live_dirty_paths)
+                and not contaminating  # R-B: src/-wide probe, not the .py-scoped filter
+                and wt_cones is not None  # R-G: sparse work root only
+                and test_file not in ctx.sel.GLOB_SCAN_TESTS  # R-F: scan set never scratch-resolved
+                and not args.no_scratch_fallback
             )
-        except PristineRunError as exc:
-            raise _Indeterminate(f"{exc} — indeterminate") from exc
-        ctx.pristine_files_run.append(test_file)
-        for node in [n for n in ctx.pristine_bucket if n.file == test_file]:
-            if node in main_failing:
-                if ctx.live_dirty_paths:
-                    raise _Indeterminate(
-                        f"pristine oracle is DIRTY on code paths {ctx.live_dirty_paths[:20]} — "
-                        f"a 'pre-existing' verdict for {node.file}::{node.name} from a "
-                        "dirty root is untrustworthy (MF-4c); indeterminate"
+            if use_scratch and scratch is None:
+                try:
+                    scratch = create_scratch_worktree(
+                        root, wt_cones, timeout_s=args.scratch_timeout_s
                     )
-                _strip_node(ctx, node, via="pristine")  # pre-existing at CURRENT clean main HEAD
-            else:
-                ctx.new.append(node)  # a PASS on a dirty root still classifies NEW (fail-closed)
+                except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+                    raise _Indeterminate(
+                        f"scratch-worktree fallback failed ({exc}) — dirty oracle unresolvable",
+                        extra={"live_dirty_paths": ctx.live_dirty_paths},
+                        warns=ctx.warns,
+                    ) from exc
+                ctx.pristine_oracle = "scratch-worktree"
+                ctx.scratch_sha = scratch.sha
+                ctx.warns.append(
+                    f"SCRATCH-ORACLE WARN: root dirty on non-contaminating paths "
+                    f"{ctx.live_dirty_paths[:20]}; pristine oracle re-rooted to a detached "
+                    f"sparse scratch worktree at {scratch.sha[:12]} (root venv interpreter; "
+                    "contamination probe src//pyproject.toml/uv.lock was clean; scan-set "
+                    "nodes and non-sparse work roots stay indeterminate)"
+                )
+            try:
+                main_failing = run_single_file_pristine(
+                    test_file,
+                    cwd=scratch.path if use_scratch else root,
+                    timeout_s=args.pristine_timeout_s,
+                    venv_root=root if use_scratch else None,
+                )
+            except PristineRunError as exc:
+                raise _Indeterminate(f"{exc} — indeterminate", warns=ctx.warns) from exc
+            ctx.pristine_files_run.append(test_file)
+            for node in [n for n in ctx.pristine_bucket if n.file == test_file]:
+                if node in main_failing:
+                    if not use_scratch and ctx.live_dirty_paths:
+                        raise _Indeterminate(  # MF-4c, fail-closed residual
+                            f"pristine oracle is DIRTY "
+                            f"(contaminating: {contaminating[:20] or 'n/a'}; "
+                            f"visible code dirt: {ctx.live_dirty_paths[:20]}; "
+                            f"scan_set={test_file in ctx.sel.GLOB_SCAN_TESTS}, "
+                            f"sparse_wt={wt_cones is not None}) — a 'pre-existing' verdict "
+                            f"for {node.file}::{node.name} from a dirty root is "
+                            "untrustworthy (MF-4c); indeterminate",
+                            extra={
+                                "live_dirty_paths": ctx.live_dirty_paths,
+                                "contaminating_paths": contaminating,
+                            },
+                            warns=ctx.warns,
+                        )
+                    _strip_node(ctx, node, via="pristine-scratch" if use_scratch else "pristine")
+                else:
+                    ctx.new.append(node)  # a PASS still classifies NEW (fail-closed)
+    finally:
+        if scratch is not None:
+            remove_scratch_worktree(root, scratch)
 
 
 def _compare_impl(args: argparse.Namespace) -> dict:
@@ -964,7 +1224,7 @@ def _compare_impl(args: argparse.Namespace) -> dict:
     try:
         lint = lint_verdict(root, wt, ctx.touched)
     except (ToolMissingError, RuntimeError) as exc:
-        raise _Indeterminate(f"lint verdict failed: {exc}") from exc
+        raise _Indeterminate(f"lint verdict failed: {exc}", warns=ctx.warns) from exc
     ledger = lv.ledger
     return {
         "pytest_rc": args.pytest_rc,
@@ -977,25 +1237,68 @@ def _compare_impl(args: argparse.Namespace) -> dict:
         "ledger_dirty_paths": list(ledger.get("dirty_paths", [])) if ledger else [],
         "live_dirty_paths": ctx.live_dirty_paths,
         "pristine_files_run": ctx.pristine_files_run,
+        "pristine_oracle": ctx.pristine_oracle,
+        "scratch_sha": ctx.scratch_sha,
         "lint": lint,
         "ledger_sha": ledger["main_sha"] if ledger else None,
         "ledger_age_h": ledger_age_hours(ledger) if ledger else None,
     }
 
 
+def _indeterminate_payload(
+    reason: str, pytest_rc: int, extra: dict | None = None, warns: list[str] | None = None
+) -> dict:
+    """The stable exit-2 ``--json`` shape: callers branch on ``indeterminate`` mechanically.
+
+    ``warns`` carries the ctx-accumulated WARNs (e.g. SCRATCH-ORACLE provenance
+    from an earlier bucketed file) so a mid-loop failure never drops audit
+    provenance (#1077). The empty ``new``/``stripped`` arrays are NOT a clean
+    verdict — the exit code stays 2.
+    """
+    return {
+        "indeterminate": True,
+        "reason": reason,
+        "exit_code_intent": 2,
+        "pytest_rc": pytest_rc,
+        "new": [],
+        "stripped": [],
+        "warns": list(warns or []),
+        **(extra or {}),
+    }
+
+
 def cmd_compare(args: argparse.Namespace) -> int:
-    """Classify a Step 9c run's failures as NEW vs pre-existing-on-main (plan §3.4)."""
+    """Classify a Step 9c run's failures as NEW vs pre-existing-on-main (plan §3.4).
+
+    Under ``--json``, EVERY exit path prints exactly one JSON object (#1077):
+    exit 0/1 the classification result (``indeterminate: false``); exit 2 the
+    ``_indeterminate_payload`` (``indeterminate: true`` + ``reason``).
+    """
     if args.pytest_rc not in (0, 1):
-        _log(
+        reason = (
             f"pytest rc {args.pytest_rc} (aborted/interrupted/internal-error run) — "
             "refusing to classify a partial run (MF-1b)"
         )
+        _log(reason)
+        if args.json:
+            print(
+                json.dumps(_indeterminate_payload(reason, args.pytest_rc), indent=2, sort_keys=True)
+            )
         return 2
     try:
         result = _compare_impl(args)
     except _Indeterminate as exc:
         _log(str(exc))
+        if args.json:
+            print(
+                json.dumps(
+                    _indeterminate_payload(str(exc), args.pytest_rc, exc.extra, warns=exc.warns),
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
         return 2
+    result["indeterminate"] = False
     if args.json:
         print(json.dumps(result, indent=2, sort_keys=True))
     else:
@@ -1051,6 +1354,17 @@ def build_parser() -> argparse.ArgumentParser:
     p_compare.add_argument("--max-pristine-files", type=int, default=5)
     p_compare.add_argument("--max-age-hours", type=float, default=24.0)
     p_compare.add_argument("--max-code-commits", type=int, default=150)
+    p_compare.add_argument(
+        "--scratch-timeout-s",
+        type=float,
+        default=120.0,
+        help="per-git-command bound for the dirty-oracle scratch-worktree fallback (#1077)",
+    )
+    p_compare.add_argument(
+        "--no-scratch-fallback",
+        action="store_true",
+        help="disable the scratch fallback — restore the pre-#1077 MF-4c raise on ANY dirty oracle",
+    )
     p_compare.add_argument("--json", action="store_true")
     p_compare.set_defaults(func=cmd_compare)
     return parser

--- a/tests/test_step9c_baseline.py
+++ b/tests/test_step9c_baseline.py
@@ -11,6 +11,11 @@ real-subprocess integration case (real pytest, bounded in-test timeout); the
 "real body" tests at the bottom execute every production function the unit
 cases stub, per the one-production-body-test-per-seam-stubbed-function rule
 (code-style.md #906).
+
+The "#1077" section pins the dirty-oracle scratch-worktree fallback + the
+JSON-on-every-exit contract (fake-based N1-N4b/N9-N12 in that section;
+real-git N5-N8 + the _work_root_sparse_cones body test in the real-body
+section at the bottom).
 """
 
 from __future__ import annotations
@@ -189,9 +194,33 @@ def _install_compare_fakes(
     touched_ruff,
     sha_known,
     code_commits,
+    contamination_paths=(),
+    wt_cones=("tests",),
+    scratch_exc: Exception | None = None,
 ) -> dict[str, list]:
-    """Monkeypatch signature-conformant fakes onto the module; return the call recorder."""
-    calls: dict[str, list] = {"pristine": []}
+    """Monkeypatch signature-conformant fakes onto the module; return the call recorder.
+
+    #1077 scratch-fallback knobs: ``contamination_paths`` fakes
+    ``scratch_contamination_probe`` (a list, or a zero-arg callable for the
+    per-call mid-loop-transition case); ``wt_cones`` fakes
+    ``_work_root_sparse_cones`` (None = non-sparse work root); ``scratch_exc``
+    makes the fake ``create_scratch_worktree`` raise instead of returning a
+    fake ``_ScratchTree``.
+    """
+    calls: dict[str, list] = {
+        "pristine": [],
+        "pristine_detail": [],  # (test_file, cwd, venv_root) per pristine call
+        "scratch_created": [],
+        "scratch_removed": [],
+    }
+    _install_scratch_fakes(
+        monkeypatch,
+        calls,
+        root=root,
+        contamination_paths=contamination_paths,
+        wt_cones=wt_cones,
+        scratch_exc=scratch_exc,
+    )
 
     def fake_load_selector_module(root_: Path):
         return fake_sel
@@ -208,8 +237,11 @@ def _install_compare_fakes(
     def fake_code_commits_since(root_: Path, sha: str) -> int:
         return code_commits
 
-    def fake_run_single_file_pristine(test_file: str, cwd: Path, timeout_s: float) -> set:
+    def fake_run_single_file_pristine(
+        test_file: str, cwd: Path, timeout_s: float, *, venv_root: Path | None = None
+    ) -> set:
         calls["pristine"].append(test_file)
+        calls["pristine_detail"].append((test_file, cwd, venv_root))
         if pristine_exc is not None:
             raise pristine_exc
         return {n for n in pristine_failing if n.file == test_file}
@@ -235,6 +267,38 @@ def _install_compare_fakes(
     return calls
 
 
+def _install_scratch_fakes(
+    monkeypatch, calls: dict[str, list], *, root: Path, contamination_paths, wt_cones, scratch_exc
+) -> None:
+    """Install the #1077 scratch-fallback fakes (split from _install_compare_fakes)."""
+    fake_scratch = sb._ScratchTree(
+        parent=root / "scratch-parent", path=root / "scratch-fake", sha="f" * 40
+    )
+
+    def fake_scratch_contamination_probe(root_: Path) -> list[str]:
+        if callable(contamination_paths):
+            return list(contamination_paths())
+        return list(contamination_paths)
+
+    def fake_work_root_sparse_cones(wt_: Path) -> list[str] | None:
+        return list(wt_cones) if wt_cones is not None else None
+
+    def fake_create_scratch_worktree(root_: Path, cones: list[str], timeout_s: float):
+        calls["scratch_created"].append((root_, tuple(cones), timeout_s))
+        if scratch_exc is not None:
+            raise scratch_exc
+        fake_scratch.path.mkdir(parents=True, exist_ok=True)
+        return fake_scratch
+
+    def fake_remove_scratch_worktree(root_: Path, scratch) -> None:
+        calls["scratch_removed"].append(scratch)
+
+    monkeypatch.setattr(sb, "scratch_contamination_probe", fake_scratch_contamination_probe)
+    monkeypatch.setattr(sb, "_work_root_sparse_cones", fake_work_root_sparse_cones)
+    monkeypatch.setattr(sb, "create_scratch_worktree", fake_create_scratch_worktree)
+    monkeypatch.setattr(sb, "remove_scratch_worktree", fake_remove_scratch_worktree)
+
+
 def _compare_env(
     tmp_path: Path,
     monkeypatch,
@@ -257,6 +321,9 @@ def _compare_env(
     sha_known: bool = True,
     code_commits: int = 0,
     root_test_files=None,
+    contamination_paths=(),
+    wt_cones=("tests",),
+    scratch_exc: Exception | None = None,
     extra_args=(),
 ):
     """Set up a compare fixture tree + fakes; return (argv, calls, root, wt)."""
@@ -282,6 +349,9 @@ def _compare_env(
         touched_ruff=touched_ruff,
         sha_known=sha_known,
         code_commits=code_commits,
+        contamination_paths=contamination_paths,
+        wt_cones=wt_cones,
+        scratch_exc=scratch_exc,
     )
     argv = [
         "compare",
@@ -457,6 +527,7 @@ def test_compare_blind_strip_happy_path(tmp_path: Path, monkeypatch, capsys):
     )
     rc, out, _err = _run_json(argv, capsys)
     assert rc == 0
+    assert out["indeterminate"] is False
     assert out["new"] == []
     assert out["stripped"] == [{**NODE_A._asdict(), "via": "ledger"}]
     assert calls["pristine"] == []  # safe blind strip — no pristine run needed
@@ -499,8 +570,10 @@ def test_compare_unknown_provenance_prints_pristine_commands(tmp_path: Path, mon
         junit_cases=[(node.file, node.classname, node.name, "failed")],
         ledger_kw={"failing": ()},
     )
-    rc, _out, err = _run_json(argv, capsys)
+    rc, out, err = _run_json(argv, capsys)
     assert rc == 2
+    assert out["indeterminate"] is True
+    assert "tests/test_mystery.py" in out["reason"] and "pytest" in out["reason"]
     assert "tests/test_mystery.py" in err and "pytest" in err  # copy-pasteable command
 
 
@@ -608,7 +681,8 @@ def test_compare_missing_or_empty_junit_exit2(tmp_path: Path, monkeypatch, capsy
         junit.write_text("")
     rc, out, err = _run_json(argv, capsys)
     assert rc == 2
-    assert out is None
+    assert out["indeterminate"] is True
+    assert "junit" in out["reason"].lower()
     assert "junit" in err.lower()  # missing / unparseable / ZERO-testcases all name it
 
 
@@ -659,6 +733,7 @@ def test_compare_json_deterministic(tmp_path: Path, monkeypatch, capsys):
     rc1, out1, _ = _run_json(argv, capsys)
     rc2, out2, _ = _run_json(argv, capsys)
     assert rc1 == rc2 == 0
+    assert out1["indeterminate"] is False
     # ledger_age_h is wall-clock-derived; everything else must be identical.
     a1 = out1.pop("ledger_age_h")
     a2 = out2.pop("ledger_age_h")
@@ -800,7 +875,8 @@ def test_compare_pytest_rc_guard(tmp_path: Path, monkeypatch, capsys, rc_in):
     )
     rc, out, err = _run_json(argv, capsys)
     assert rc == 2
-    assert out is None
+    assert out["indeterminate"] is True
+    assert "refusing to classify" in out["reason"]
     assert "refusing to classify" in err
 
 
@@ -852,32 +928,38 @@ def test_compare_dirty_ledger_never_blind_strips(tmp_path: Path, monkeypatch, ca
     assert out["stripped"] == [{**NODE_A._asdict(), "via": "pristine"}]
 
 
-# --- Case 19 [A2]: dirty pristine oracle never vouches "pre-existing" ------------
+# --- Case 19 [A2]: CONTAMINATING dirty oracle never vouches "pre-existing" -------
+# (#1077: decontaminable dirt now auto-falls back to a scratch oracle — see N1 —
+# so this exit-2 pin uses a CONTAMINATING src/ path, which keeps the MF-4c raise.)
 
 
 @pytest.mark.parametrize("fails_on_main", [True, False])
 def test_compare_dirty_pristine_oracle(tmp_path: Path, monkeypatch, capsys, fails_on_main):
     node = sb.Node(file="tests/test_mystery.py", classname="tests.test_mystery", name="test_x")
-    argv, _calls, _r, _w = _compare_env(
+    argv, calls, _r, _w = _compare_env(
         tmp_path,
         monkeypatch,
         junit_cases=[(node.file, node.classname, node.name, "failed")],
         ledger_kw={"failing": ()},
-        live_dirty=("scripts/uncommitted.py",),
+        live_dirty=("src/explore_persona_space/wip.py",),
+        contamination_paths=("src/explore_persona_space/wip.py",),
         pristine_failing=(node,) if fails_on_main else (),
         extra_args=("--run-pristine",),
     )
     rc, out, err = _run_json(argv, capsys)
+    assert calls["scratch_created"] == []  # contaminating dirt never falls back
     if fails_on_main:
-        # A "pre-existing" verdict from a dirty oracle is untrustworthy -> exit 2.
+        # A "pre-existing" verdict from a contaminated oracle is untrustworthy -> exit 2.
         assert rc == 2
-        assert out is None
-        assert "scripts/uncommitted.py" in err
+        assert out["indeterminate"] is True
+        assert "src/explore_persona_space/wip.py" in out["reason"]
+        assert "src/explore_persona_space/wip.py" in err
     else:
         # A PASS on a dirty root still classifies NEW (fail-closed) -> exit 1.
         assert rc == 1
         assert out["new"] == [node._asdict()]
-        assert out["live_dirty_paths"] == ["scripts/uncommitted.py"]
+        assert out["live_dirty_paths"] == ["src/explore_persona_space/wip.py"]
+        assert out["pristine_oracle"] == "root"
 
 
 # --- Case 20 [A2]: fail-loud census ----------------------------------------------
@@ -894,7 +976,7 @@ def test_compare_pristine_timeout_or_crash_exit2(tmp_path: Path, monkeypatch, ca
         extra_args=("--run-pristine",),
     )
     rc, out, err = _run_json(argv, capsys)
-    assert rc == 2 and out is None and "indeterminate" in err
+    assert rc == 2 and out["indeterminate"] is True and "indeterminate" in err
 
 
 def test_compare_missing_ruff_binary_exit2(tmp_path: Path, monkeypatch, capsys):
@@ -910,7 +992,7 @@ def test_compare_missing_ruff_binary_exit2(tmp_path: Path, monkeypatch, capsys):
     monkeypatch.setattr(sb, "ruff_error_count", _REAL_RUFF_ERROR_COUNT)
     monkeypatch.setattr(sb.shutil, "which", lambda _name: None)
     rc, out, err = _run_json(argv, capsys)
-    assert rc == 2 and out is None and "ruff" in err
+    assert rc == 2 and out["indeterminate"] is True and "ruff" in err
 
 
 @pytest.mark.parametrize(
@@ -936,7 +1018,7 @@ def test_compare_unusable_ledger_with_failures_no_pristine_exit2(
         ledger_raw=ledger_raw,
     )
     rc, out, err = _run_json(argv, capsys)
-    assert rc == 2 and out is None
+    assert rc == 2 and out["indeterminate"] is True
     assert "pristine" in err  # unresolved bucket, no --run-pristine -> indeterminate
 
 
@@ -1018,9 +1100,226 @@ def test_compare_pristine_budget_exceeded_exit2(tmp_path: Path, monkeypatch, cap
         extra_args=("--run-pristine", "--max-pristine-files", "5"),
     )
     rc, out, err = _run_json(argv, capsys)
-    assert rc == 2 and out is None
+    assert rc == 2 and out["indeterminate"] is True
     assert "systemic main breakage" in err
+    assert "systemic main breakage" in out["reason"]
     assert calls["pristine"] == []  # budget refusal happens BEFORE any pristine run
+
+
+# --- #1077: dirty-oracle scratch-worktree fallback + JSON-on-every-exit -----------
+
+
+@pytest.mark.parametrize("fails_on_main", [True, False])
+def test_compare_dirty_oracle_scratch_fallback_strip_or_new(
+    tmp_path: Path, monkeypatch, capsys, fails_on_main
+):
+    """N1: decontaminable dirt + sparse work root + non-scan node -> scratch oracle.
+
+    The node is deliberately DIFF-LINKED so the strip case also pins the MF-6
+    diff-linked masking WARN under ``via="pristine-scratch"`` (the
+    ``via.startswith`` change).
+    """
+    node = sb.Node(file="tests/test_linked.py", classname="tests.test_linked", name="test_x")
+    argv, calls, root, _w = _compare_env(
+        tmp_path,
+        monkeypatch,
+        junit_cases=[(node.file, node.classname, node.name, "failed")],
+        ledger_kw={"failing": ()},
+        touched=("scripts/known_red.py",),
+        reasons={node.file: ["stem-map:scripts/known_red.py"]},  # diff-linked (MF-6)
+        live_dirty=("scripts/issue_642/i642_figures_v4.py",),  # the incident dirt class
+        pristine_failing=(node,) if fails_on_main else (),
+        extra_args=("--run-pristine",),
+    )
+    rc, out, _err = _run_json(argv, capsys)
+    assert len(calls["scratch_created"]) == 1
+    # The oracle ran IN the scratch tree with the MAIN root's venv interpreter.
+    assert calls["pristine_detail"] == [(node.file, root / "scratch-fake", root)]
+    assert calls["scratch_removed"], "finally teardown must run"
+    assert out["pristine_oracle"] == "scratch-worktree"
+    assert out["scratch_sha"] == "f" * 40
+    assert any("SCRATCH-ORACLE WARN" in w for w in out["warns"])
+    if fails_on_main:
+        assert rc == 0
+        assert out["indeterminate"] is False
+        assert out["stripped"] == [{**node._asdict(), "via": "pristine-scratch"}]
+        # Diff-linked scratch strips keep the MF-6 masking WARN (via.startswith).
+        assert any("diff-linked" in w for w in out["warns"])
+    else:
+        assert rc == 1
+        assert out["new"] == [node._asdict()]
+
+
+def test_compare_scratch_created_once_for_multi_file_bucket(tmp_path: Path, monkeypatch, capsys):
+    n1 = sb.Node(file="tests/test_m1.py", classname="tests.test_m1", name="test_x")
+    n2 = sb.Node(file="tests/test_m2.py", classname="tests.test_m2", name="test_x")
+    argv, calls, root, _w = _compare_env(
+        tmp_path,
+        monkeypatch,
+        junit_cases=[(n.file, n.classname, n.name, "failed") for n in (n1, n2)],
+        ledger_kw={"failing": ()},
+        live_dirty=("scripts/wip.py",),
+        pristine_failing=(n1, n2),
+        extra_args=("--run-pristine",),
+    )
+    rc, out, _err = _run_json(argv, capsys)
+    assert rc == 0
+    assert len(calls["scratch_created"]) == 1  # ONE scratch, reused across the bucket
+    assert [d[1] for d in calls["pristine_detail"]] == [root / "scratch-fake"] * 2
+    assert {s["via"] for s in out["stripped"]} == {"pristine-scratch"}
+    assert len(calls["scratch_removed"]) == 1
+
+
+def test_compare_scratch_removed_on_pristine_crash(tmp_path: Path, monkeypatch, capsys):
+    node = sb.Node(file="tests/test_m.py", classname="tests.test_m", name="test_x")
+    argv, calls, _r, _w = _compare_env(
+        tmp_path,
+        monkeypatch,
+        junit_cases=[(node.file, node.classname, node.name, "failed")],
+        ledger_kw={"failing": ()},
+        live_dirty=("scripts/wip.py",),
+        pristine_exc=sb.PristineRunError("pristine run of tests/test_m.py timed out (600.0s)"),
+        extra_args=("--run-pristine",),
+    )
+    rc, out, _err = _run_json(argv, capsys)
+    assert rc == 2
+    assert out["indeterminate"] is True
+    assert calls["scratch_removed"], "finally teardown must run on a mid-loop crash"
+    # Scratch provenance is never dropped on a mid-loop failure (exit-2 warns).
+    assert any("SCRATCH-ORACLE WARN" in w for w in out["warns"])
+
+
+def test_compare_scratch_creation_failure_indeterminate(tmp_path: Path, monkeypatch, capsys):
+    node = sb.Node(file="tests/test_m.py", classname="tests.test_m", name="test_x")
+    argv, calls, _r, _w = _compare_env(
+        tmp_path,
+        monkeypatch,
+        junit_cases=[(node.file, node.classname, node.name, "failed")],
+        ledger_kw={"failing": ()},
+        live_dirty=("scripts/wip.py",),
+        scratch_exc=subprocess.TimeoutExpired(cmd=["git"], timeout=120.0),
+        pristine_failing=(node,),
+        extra_args=("--run-pristine",),
+    )
+    rc, out, _err = _run_json(argv, capsys)
+    assert rc == 2
+    assert out["indeterminate"] is True
+    assert "scratch-worktree fallback failed" in out["reason"]
+    assert out["live_dirty_paths"] == ["scripts/wip.py"]
+    assert calls["pristine"] == []  # creation failed BEFORE any oracle run
+
+
+def test_compare_no_scratch_fallback_flag_restores_old_raise(tmp_path: Path, monkeypatch, capsys):
+    node = sb.Node(file="tests/test_m.py", classname="tests.test_m", name="test_x")
+    argv, calls, _r, _w = _compare_env(
+        tmp_path,
+        monkeypatch,
+        junit_cases=[(node.file, node.classname, node.name, "failed")],
+        ledger_kw={"failing": ()},
+        live_dirty=("scripts/wip.py",),
+        pristine_failing=(node,),
+        extra_args=("--run-pristine", "--no-scratch-fallback"),
+    )
+    rc, out, _err = _run_json(argv, capsys)
+    assert rc == 2
+    assert out["indeterminate"] is True
+    assert calls["scratch_created"] == []  # the kill switch restores the pre-#1077 raise
+
+
+def test_compare_mixed_dirt_contaminating_json_blocks_scratch(tmp_path: Path, monkeypatch, capsys):
+    """N9: dirty scripts/*.py (the visible trigger) + dirty src/*.json (invisible to
+    the .py-scoped filter) MUST stay exit-2 — the mixed case is never a scratch strip."""
+    node = sb.Node(file="tests/test_m.py", classname="tests.test_m", name="test_x")
+    argv, calls, _r, _w = _compare_env(
+        tmp_path,
+        monkeypatch,
+        junit_cases=[(node.file, node.classname, node.name, "failed")],
+        ledger_kw={"failing": ()},
+        live_dirty=("scripts/x.py",),
+        contamination_paths=("src/explore_persona_space/artifacts/query_banks/x.json",),
+        pristine_failing=(node,),
+        extra_args=("--run-pristine",),
+    )
+    rc, out, _err = _run_json(argv, capsys)
+    assert rc == 2
+    assert out["indeterminate"] is True
+    assert out["contaminating_paths"] == ["src/explore_persona_space/artifacts/query_banks/x.json"]
+    assert calls["scratch_created"] == []
+
+
+def test_compare_mid_loop_dirt_transition_fail_closed(tmp_path: Path, monkeypatch, capsys):
+    """N10: contamination appearing MID-LOOP reverts later files to the root oracle;
+    a fail-on-main node there goes indeterminate (fail-closed), while file1's
+    scratch provenance rides the exit-2 warns."""
+    n1 = sb.Node(file="tests/test_a1.py", classname="tests.test_a1", name="test_x")
+    n2 = sb.Node(file="tests/test_a2.py", classname="tests.test_a2", name="test_x")
+    contamination_seq = iter([[], ["src/explore_persona_space/x.json"]])
+    argv, calls, root, _w = _compare_env(
+        tmp_path,
+        monkeypatch,
+        junit_cases=[(n.file, n.classname, n.name, "failed") for n in (n1, n2)],
+        ledger_kw={"failing": ()},
+        live_dirty=("scripts/x.py",),
+        contamination_paths=lambda: next(contamination_seq),
+        pristine_failing=(n1, n2),
+        extra_args=("--run-pristine",),
+    )
+    rc, out, _err = _run_json(argv, capsys)
+    assert rc == 2
+    assert out["indeterminate"] is True
+    # file1 was scratch-resolved; file2 reverted to the ROOT oracle (never scratch-stripped).
+    assert len(calls["scratch_created"]) == 1
+    assert calls["pristine_detail"][0] == (n1.file, root / "scratch-fake", root)
+    assert calls["pristine_detail"][1] == (n2.file, root, None)
+    assert out["contaminating_paths"] == ["src/explore_persona_space/x.json"]
+    assert any("SCRATCH-ORACLE WARN" in w for w in out["warns"])
+    assert calls["scratch_removed"], "finally teardown must run"
+
+
+def test_compare_scan_set_node_never_scratch_stripped(tmp_path: Path, monkeypatch, capsys):
+    """N11 (R-F): a GLOB_SCAN_TESTS node is never scratch-resolved — live-tree
+    scanners read the MAIN root via repo_root() from any cwd, so a scratch cannot
+    decontaminate them; the node keeps the MF-4c indeterminate."""
+    node = sb.Node(
+        file="tests/test_scan_thing.py", classname="tests.test_scan_thing", name="test_x"
+    )
+    argv, calls, root, _w = _compare_env(
+        tmp_path,
+        monkeypatch,
+        junit_cases=[(node.file, node.classname, node.name, "failed")],
+        ledger_kw={"failing": ()},
+        glob_scan={node.file: ("scripts/issue*_*.py",)},
+        live_dirty=("scripts/wip.py",),
+        pristine_failing=(node,),
+        extra_args=("--run-pristine",),
+    )
+    rc, out, _err = _run_json(argv, capsys)
+    assert rc == 2
+    assert out["indeterminate"] is True
+    assert calls["scratch_created"] == []
+    assert "scan_set=True" in out["reason"]
+    # The oracle ran at the ROOT (per-file granularity: only THIS node is barred).
+    assert calls["pristine_detail"] == [(node.file, root, None)]
+
+
+def test_compare_non_sparse_work_root_ineligible(tmp_path: Path, monkeypatch, capsys):
+    """N12 (R-G): a non-sparse work root cannot be superset-matched -> no fallback."""
+    node = sb.Node(file="tests/test_m.py", classname="tests.test_m", name="test_x")
+    argv, calls, _r, _w = _compare_env(
+        tmp_path,
+        monkeypatch,
+        junit_cases=[(node.file, node.classname, node.name, "failed")],
+        ledger_kw={"failing": ()},
+        wt_cones=None,  # non-sparse work root
+        live_dirty=("scripts/wip.py",),
+        pristine_failing=(node,),
+        extra_args=("--run-pristine",),
+    )
+    rc, out, _err = _run_json(argv, capsys)
+    assert rc == 2
+    assert out["indeterminate"] is True
+    assert calls["scratch_created"] == []
+    assert "sparse_wt=False" in out["reason"]
 
 
 # --- status subcommand ------------------------------------------------------------
@@ -1107,6 +1406,187 @@ def test_git_helpers_real_body(tmp_path: Path):
     dirty = sb.dirty_code_paths(repo)
     assert "scripts/tool.py" in dirty
     assert all(not p.endswith(".json") for p in dirty)
+
+
+def _scratch_repo(repo: Path) -> None:
+    """git init a tmp repo mirroring the production shared-config shape (plan A4):
+    ``extensions.worktreeConfig=true`` pre-set, so a scratch worktree's
+    ``sparse-checkout init`` writes only worktree-local config and the shared
+    ``.git/config`` stays byte-identical (pinned by the N5 roundtrip)."""
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "T")
+    _git(repo, "config", "core.repositoryformatversion", "1")
+    _git(repo, "config", "extensions.worktreeConfig", "true")
+
+
+def test_scratch_worktree_real_git_roundtrip(tmp_path: Path):
+    """N5: real create/remove roundtrip — the scratch materializes HEAD (root dirt
+    ABSENT), and teardown leaves the root's HEAD + porcelain + shared config
+    byte-identical (R-D no-mutation pin; makes kill-criterion 2 decidable).
+    Executes the real bodies of create/remove_scratch_worktree + _scratch_cones
+    + _git_bounded (all seam-stubbed in the compare unit cases, #906)."""
+    repo = tmp_path / "repo"
+    _scratch_repo(repo)
+    (repo / "tests").mkdir()
+    (repo / "tests" / "test_a.py").write_text("def test_a():\n    assert True\n")
+    (repo / "pyproject.toml").write_text('[tool.pytest.ini_options]\naddopts = ""\n')
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "baseline")
+    (repo / "scripts").mkdir()
+    (repo / "scripts" / "dirt.py").write_text("X = 1\n")  # UNCOMMITTED root dirt
+
+    def _porcelain() -> str:
+        return subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+
+    # SNAPSHOT the root state the fallback must never mutate (R-D).
+    head_before = sb.git_head(repo)
+    porcelain_before = _porcelain()
+    config_before = (repo / ".git" / "config").read_bytes()
+    scratch = sb.create_scratch_worktree(repo, ["tests"], 120.0)
+    try:
+        assert scratch.sha == head_before
+        assert (scratch.path / "tests" / "test_a.py").exists()  # committed file materialized
+        assert not (scratch.path / "scripts" / "dirt.py").exists()  # root dirt ABSENT
+    finally:
+        sb.remove_scratch_worktree(repo, scratch)
+    assert not scratch.path.exists() and not scratch.parent.exists()
+    wt_lines = subprocess.run(
+        ["git", "worktree", "list"], cwd=str(repo), capture_output=True, text=True, check=True
+    ).stdout.splitlines()
+    assert len([ln for ln in wt_lines if ln.strip()]) == 1  # only the root itself remains
+    # Root-state no-mutation pin (R-D).
+    assert sb.git_head(repo) == head_before
+    assert _porcelain() == porcelain_before
+    assert (repo / ".git" / "config").read_bytes() == config_before
+
+
+def test_real_pristine_in_scratch_worktree_nodes_match_root_relative(tmp_path: Path):
+    """N6 (the A2/kill-criterion pin): junit ``file`` attrs stay rootdir-relative
+    when pytest runs with cwd=scratch (committed pyproject.toml anchors rootdir),
+    so Node keys match the gate junit's — AND the MAIN root's interpreter ran
+    (the venv_root split; the scratch has no venv)."""
+    root = tmp_path / "root"
+    _scratch_repo(root)
+    (root / "tests").mkdir()
+    (root / "pyproject.toml").write_text('[tool.pytest.ini_options]\naddopts = ""\n')
+    (root / "tests" / "test_probe.py").write_text("def test_bad():\n    assert False\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-m", "baseline")
+    marker = tmp_path / "scratch-shim-invocations.txt"
+    shim = _write_python_shim(root, marker)  # the root venv shim is NOT committed
+    scratch = sb.create_scratch_worktree(root, ["tests"], 120.0)
+    try:
+        assert not (scratch.path / ".venv").exists()  # the scratch has no venv of its own
+        failing = sb.run_single_file_pristine(
+            "tests/test_probe.py", cwd=scratch.path, timeout_s=180.0, venv_root=root
+        )
+    finally:
+        sb.remove_scratch_worktree(root, scratch)
+    assert failing == {
+        sb.Node(file="tests/test_probe.py", classname="tests.test_probe", name="test_bad")
+    }
+    assert marker.exists(), "the MAIN root's venv shim was never invoked (venv_root split)"
+    assert str(shim) in marker.read_text()
+
+
+def test_scratch_contamination_probe_real_git(tmp_path: Path):
+    """N7: the src/-wide (ALL files, not just .py) contamination probe — the
+    non-Python src/*.json hole, the top-level-only src/ pathspec, and the
+    pyproject/uv.lock legs, against real git."""
+    repo = tmp_path / "repo"
+    _scratch_repo(repo)
+    for rel, text in [
+        ("src/pkg/data.json", "{}\n"),
+        ("src/pkg/mod.py", "X = 1\n"),
+        ("scripts/x.py", "Y = 1\n"),
+        ("dashboard/src/z.py", "Z = 1\n"),
+        ("pyproject.toml", "[project]\n"),
+        ("uv.lock", "# lock\n"),
+    ]:
+        p = repo / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(text)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "baseline")
+    assert sb.scratch_contamination_probe(repo) == []  # clean repo
+    (repo / "scripts" / "x.py").write_text("Y = 2\n")
+    assert sb.scratch_contamination_probe(repo) == []  # scripts/ dirt is decontaminable
+    (repo / "dashboard" / "src" / "z.py").write_text("Z = 2\n")
+    assert sb.scratch_contamination_probe(repo) == []  # pathspec matches only TOP-LEVEL src/
+    (repo / "src" / "pkg" / "data.json").write_text('{"a": 1}\n')  # NON-Python src/ dirt
+    assert sb.scratch_contamination_probe(repo) == ["src/pkg/data.json"]
+    (repo / "pyproject.toml").write_text('[project]\nname = "x"\n')
+    (repo / "uv.lock").write_text("# lock2\n")
+    assert set(sb.scratch_contamination_probe(repo)) == {
+        "src/pkg/data.json",
+        "pyproject.toml",
+        "uv.lock",
+    }
+    # The .py-scoped dirt TRIGGER still sees the scripts/ dirt the probe ignores.
+    assert "scripts/x.py" in sb.dirty_code_paths(repo)
+
+
+def test_scratch_cones_union_head_registry_and_wt_list(tmp_path: Path):
+    """N8: scratch profile = work-root cones (union) HEAD-pinned registry (union)
+    top-dirs floor minus excludes; a DIRTY live registry line is never read;
+    a registry absent at HEAD does not raise."""
+    repo = tmp_path / "repo"
+    _scratch_repo(repo)
+    for rel in ("tests/t.py", "scripts/s.py", "docs/d.md", "eval_results/e.json"):
+        p = repo / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "baseline")
+    # Registry ABSENT at HEAD: floor (top dirs minus excludes) + wt cones, no raise.
+    assert sb._scratch_cones(repo, ["eval_results/issue_99"]) == sorted(
+        {"tests", "scripts", "docs", "eval_results/issue_99"}
+    )
+    (repo / "tests" / "sparse_cones.txt").write_text(
+        "# fixture cones\n\neval_results/issue_5\nfigures/issue_5\n"
+    )
+    _git(repo, "add", "tests/sparse_cones.txt")
+    _git(repo, "commit", "-m", "registry")
+    # DIRTY the live registry — the HEAD-pinned read must ignore the bogus line.
+    with (repo / "tests" / "sparse_cones.txt").open("a") as fh:
+        fh.write("eval_results/issue_BOGUS\n")
+    cones = sb._scratch_cones(repo, ["eval_results/issue_99"])
+    assert "eval_results/issue_5" in cones and "figures/issue_5" in cones  # HEAD-pinned rows
+    assert "eval_results/issue_99" in cones  # work-root cone unioned in
+    assert "eval_results/issue_BOGUS" not in cones  # live-file dirt never read
+    assert {"tests", "scripts", "docs"} <= set(cones)  # top-dir floor
+    assert "eval_results" not in cones  # SCRATCH_EXCLUDES floor exclusion
+
+
+def test_work_root_sparse_cones_real_git(tmp_path: Path):
+    """Real-git body for _work_root_sparse_cones (seam-stubbed in compare cases):
+    a NON-sparse tree maps to None — on git 2.34 ``sparse-checkout list`` exits 0
+    with EMPTY stdout there, so the empty list MUST fold to None or R-G's
+    non-sparse ineligibility silently breaks — and a sparse cone-mode tree
+    returns its cone list; a non-git dir maps to None too."""
+    repo = tmp_path / "repo"
+    _scratch_repo(repo)
+    for rel in ("tests/t.py", "scripts/s.py"):
+        p = repo / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "baseline")
+    assert sb._work_root_sparse_cones(repo) is None  # non-sparse -> ineligible
+    _git(repo, "sparse-checkout", "init", "--cone")
+    _git(repo, "sparse-checkout", "set", "tests")
+    assert sb._work_root_sparse_cones(repo) == ["tests"]
+    not_a_repo = tmp_path / "not-a-repo"
+    not_a_repo.mkdir()
+    assert sb._work_root_sparse_cones(not_a_repo) is None
 
 
 def test_main_repo_root_and_resolve_work_root_real_body(monkeypatch):


### PR DESCRIPTION
Closes task #1077.

Plan v3 (tasks/completed/1077/plans/v3.md): gated scratch-worktree pristine oracle (five eligibility conjuncts, fail-closed residuals) + JSON on every compare exit path (stable indeterminate key). Code-review: Claude PASS / Codex FAIL / reconciler binding PASS (concern unbounded-new-git-probes persisted+deferred). Step 9c gate: 2702 passed / 0 failed; compare rc 0.