### PR TITLE
task #1086: fix verify_plan c12/c18 false-positives on conforming battery + Row-coverage blocks

### DIFF
--- a/scripts/issue1086_corpus_audit.py
+++ b/scripts/issue1086_corpus_audit.py
@@ -1,0 +1,194 @@
+"""#1086 corpus regression audit — old-vs-new verify_plan label diff.
+
+Acceptance instrument for task #1086 (plan v2 §4.3): runs the PRE-fix
+verify_plan (materialized from ``git show <old-ref>:scripts/verify_plan.py``)
+and the POST-fix verify_plan (this script's sibling ``scripts/verify_plan.py``)
+over the full plan corpus (``.claude/plans/*.md`` + ``tasks/*/*/plans/*.md``
+at the repo root, read-only), compares per-check verdict LABELS on the
+IDENTICAL file list + file contents (each file is read ONCE and both modules
+verify the same text), and asserts the expected-flip ALLOWLIST mechanically:
+
+- ALLOWED: ``c12_battery_multiplier`` FAIL→PASS anywhere (every flip is
+  printed with its newly-matching arithmetic line for one-line genuine/false
+  classification in the implementer report);
+- ALLOWED: ``c18_paired_contrast_source_coverage`` FAIL→PASS ONLY on files
+  under a ``tasks/*/833/plans/`` prefix (the #833 fixture family, incl. the
+  ``plan.md`` symlink and post-planning siblings);
+- FORBIDDEN: any other transition on any check (SKIP→FAIL, PASS→FAIL,
+  WARN→anything, a c18 flip outside the #833 prefix, a flip on any other
+  check) — exit 1.
+
+Every file is verified with ``kind="experiment"`` uniformly: the corpus
+spans task kinds and eras (pre-router 2026-05 plans included), but the audit
+is a LABEL DIFF of two module versions on identical inputs, so the kind
+choice cancels out — ``experiment`` is the strictest (no WARN degradation),
+maximizing FAIL-surface sensitivity to the diff.
+
+Usage (from the issue-1086 worktree; ~3-4 min, pure regex file-scan):
+
+    OMP_NUM_THREADS=8 uv run python scripts/issue1086_corpus_audit.py \
+        --repo-root /home/thomasjiralerspong/explore-persona-space \
+        --json-out /tmp/i1086_corpus_audit.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+WORKTREE_ROOT = SCRIPT_DIR.parent
+
+ALLOWED_C12 = ("c12_battery_multiplier", "FAIL", "PASS")
+ALLOWED_C18 = ("c18_paired_contrast_source_coverage", "FAIL", "PASS")
+
+
+def _load_module(path: Path, name: str):
+    """Import a verify_plan copy from ``path`` under a unique module name."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+def _materialize_old(old_ref: str, tmp_dir: str) -> Path:
+    """Write ``<old-ref>:scripts/verify_plan.py`` (resolved via this
+    worktree's shared object db) to a temp file and return its path."""
+    blob = subprocess.run(
+        ["git", "-C", str(WORKTREE_ROOT), "show", f"{old_ref}:scripts/verify_plan.py"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    old_path = Path(tmp_dir) / "verify_plan_old.py"
+    old_path.write_text(blob)
+    return old_path
+
+
+def _corpus(repo_root: Path) -> list[Path]:
+    """The §4.3 corpus: repo-root ``.claude/plans/*.md`` + ``tasks/*/*/plans/*.md``
+    (sorted; ``plan.md`` symlinks included as their own corpus entries)."""
+    files = sorted(repo_root.glob(".claude/plans/*.md")) + sorted(
+        repo_root.glob("tasks/*/*/plans/*.md")
+    )
+    return files
+
+
+def _labels(mod, text: str) -> dict[str, str]:
+    """Per-check verdict labels for ``text`` under ``mod`` (kind=experiment)."""
+    _ok, results = mod.verify_plan_text(text, kind="experiment")
+    return {r.id: r.status for r in results}
+
+
+def _is_833_fixture(path: Path) -> bool:
+    """True iff ``path`` sits under a ``tasks/<status>/833/plans/`` prefix."""
+    parts = path.parts
+    return len(parts) >= 3 and parts[-2] == "plans" and parts[-3] == "833" and "tasks" in parts
+
+
+def _first_arith_lines(mod, text: str, limit: int = 2) -> list[str]:
+    """First ``limit`` fence-masked lines matching the (new) arithmetic regex —
+    the classification aid for a c12 FAIL→PASS flip."""
+    lines = text.splitlines()
+    mask = mod._fence_mask(lines)
+    hits: list[str] = []
+    for line, fenced in zip(lines, mask, strict=True):
+        if fenced or not mod._MULT_ARITH_RE.search(line):
+            continue
+        hits.append(line.strip()[:180])
+        if len(hits) >= limit:
+            break
+    return hits
+
+
+def main() -> int:
+    """Run the audit; exit 0 iff every label transition is on the allowlist."""
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--repo-root", type=Path, default=Path("/home/thomasjiralerspong/explore-persona-space")
+    )
+    ap.add_argument("--old-ref", default="main", help="git ref holding the PRE-fix verify_plan.py")
+    ap.add_argument("--json-out", type=Path, default=None)
+    args = ap.parse_args()
+
+    new_mod = _load_module(SCRIPT_DIR / "verify_plan.py", "verify_plan_new_1086")
+    with tempfile.TemporaryDirectory() as tmp:
+        old_path = _materialize_old(args.old_ref, tmp)
+        old_mod = _load_module(old_path, "verify_plan_old_1086")
+
+        files = _corpus(args.repo_root)
+        print(f"corpus: {len(files)} plan files under {args.repo_root}")
+
+        flips: list[dict] = []
+        violations: list[dict] = []
+        skipped: list[str] = []
+        n_checked = 0
+        for f in files:
+            try:
+                text = f.read_text()
+            except (FileNotFoundError, OSError) as e:
+                # The repo-root tasks/ tree is LIVE (concurrent sessions git-mv
+                # task folders); a file vanishing between enumeration and read
+                # is skipped identically for BOTH modules — never a label diff.
+                skipped.append(f"{f}: {e.__class__.__name__}")
+                continue
+            old_labels = _labels(old_mod, text)
+            new_labels = _labels(new_mod, text)
+            n_checked += 1
+            all_ids = sorted(set(old_labels) | set(new_labels))
+            for cid in all_ids:
+                o, n = old_labels.get(cid, "ABSENT"), new_labels.get(cid, "ABSENT")
+                if o == n:
+                    continue
+                rel = str(f.relative_to(args.repo_root))
+                flip = {"file": rel, "check": cid, "old": o, "new": n}
+                if (cid, o, n) == ALLOWED_C12:
+                    flip["arith_lines"] = _first_arith_lines(new_mod, text)
+                    flips.append(flip)
+                elif (cid, o, n) == ALLOWED_C18 and _is_833_fixture(f):
+                    flips.append(flip)
+                else:
+                    violations.append(flip)
+
+        print(f"checked: {n_checked} files; skipped (vanished mid-run): {len(skipped)}")
+        for s in skipped:
+            print(f"  SKIPPED {s}")
+        print(f"\nallowed flips: {len(flips)}")
+        for fl in flips:
+            print(f"  {fl['check']} {fl['old']}->{fl['new']}  {fl['file']}")
+            for line in fl.get("arith_lines", []):
+                print(f"      arith: {line}")
+        print(f"\nviolations (forbidden transitions): {len(violations)}")
+        for v in violations:
+            print(f"  VIOLATION {v['check']} {v['old']}->{v['new']}  {v['file']}")
+
+        if args.json_out:
+            args.json_out.write_text(
+                json.dumps(
+                    {
+                        "n_files": len(files),
+                        "n_checked": n_checked,
+                        "skipped": skipped,
+                        "allowed_flips": flips,
+                        "violations": violations,
+                    },
+                    indent=2,
+                )
+            )
+            print(f"\nwrote {args.json_out}")
+
+        if violations:
+            print("\nAUDIT FAIL: forbidden label transitions found.")
+            return 1
+        print("\nAUDIT PASS: every label transition is on the §4.3 allowlist.")
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_plan.py
+++ b/scripts/verify_plan.py
@@ -1107,17 +1107,33 @@ _DRAW_FACTOR = (
     r"(?:\d[\d,_]*\s*(?:null[- ])?(?:draws?|perms?|permutations|resamples)"
     r"|n_(?:draws|perms|boot)\b|draws|perms|permutations|resamples|B\s*=\s*\d{3,})"
 )
-_GRID_FACTOR = (
-    r"(?:\d[\d,_]*|cells|folds|arms|layers|traits|seeds"
-    r"|behaviors|settings|conditions|statistics)"
-)
+# The grid side accepts ANY axis factor — a count ("24"), a count + axis
+# noun ("6 arms", "3 layers", "~3 quantities"), or a bare axis noun
+# ("cells", "batteries") — optionally opened by an approximation / paren
+# decoration ("~3", "≈8", "(6 arms"). The load-bearing discriminator is
+# the DRAW-BEARING factor, not the grid noun: the #810 false-PASS class
+# is a grid-only product with NO draw factor ("34 x 50 x 28",
+# "layers x 3584", "6 arms x 3 layers x 16 folds") and still fails; a
+# noun whitelist only rots ("batteries"/"quantities" false-FAILed the
+# conforming #833 v8 sizing block — #1086).
+_GRID_DECOR = r"(?:[~≈(]\s*)?"
+_GRID_FACTOR = r"(?:\d[\d,_]*(?:\s+[A-Za-z][\w-]*)?|[A-Za-z][\w-]*)"
 # The multiplication token plans actually write: the real multiplication
 # sign plus the ASCII fallbacks.
 _MULT_TOKEN = r"[×x*]"  # noqa: RUF001 — the multiplication sign is real plan text
 _MULT_ARITH_RE = re.compile(
-    rf"(?i)\b(?:{_DRAW_FACTOR}\s*{_MULT_TOKEN}\s*{_GRID_FACTOR}"
+    rf"(?i)\b(?:{_DRAW_FACTOR}\s*{_MULT_TOKEN}\s*{_GRID_DECOR}{_GRID_FACTOR}"
     rf"|{_GRID_FACTOR}\s*{_MULT_TOKEN}\s*{_DRAW_FACTOR})\b"
 )
+# Arith-anchored windows (#1086) accepted fail-UNSAFE residual, DISCLOSED: a
+# quoted SIBLING's sizing line ("#778's 10,000 draws x 24 cells, batched")
+# can anchor its own window and satisfy THIS plan's battery — the same
+# residual class as c18's documented residual (f) (non-verbatim paraphrase,
+# beyond mechanical defense). Deliberately NO `#\d{2,}` citation guard on
+# anchor lines: 192 corpus draw-arithmetic lines carry a same-line #-ref,
+# and .claude/rules/plan-compute-sizing.md MANDATES citing a prior-issue
+# MEASURED basis beside sizing arithmetic, so the guard would re-create the
+# very false-positive class #1086 fixes (guard REJECTED in plan v2 §11).
 
 # Evidence (ii): a named batched helper or an explicit vectorization
 # statement. A token whose only in-window occurrence sits inside a citation /
@@ -1166,12 +1182,14 @@ def check_battery_multiplier(plan: str, kind: str) -> CheckResult:
     """A plan naming a permutation/bootstrap/null-draw battery must carry,
     NEAR a battery mention (± 15 raw lines), BOTH (i) explicit multiplier
     arithmetic with a draw-bearing factor and (ii) a batched-implementation
-    commitment. Window-scoped, never document-global — the document-global
-    draft demonstrably false-PASSed the motivating incident plan (#810 v1)
-    via an unrelated footprint product + helper boilerplate. FAIL
-    (experiment) / WARN (analysis) / SKIP otherwise; a SURFACE check per the
-    module's scope discipline — semantic adequacy of the arithmetic stays
-    with the Phase 2 critics."""
+    commitment. A draw-bearing arithmetic line ALSO anchors its own ± 15
+    evidence window (#1086) — the §9 sizing block legitimately lives far
+    from the §4/§6 battery registration. Window-scoped, never
+    document-global — the document-global draft demonstrably false-PASSed
+    the motivating incident plan (#810 v1) via an unrelated footprint
+    product + helper boilerplate. FAIL (experiment) / WARN (analysis) /
+    SKIP otherwise; a SURFACE check per the module's scope discipline —
+    semantic adequacy of the arithmetic stays with the Phase 2 critics."""
     cid, name = "c12_battery_multiplier", "battery multiplier + batched commitment"
     if kind not in ("experiment", "analysis"):
         return _skip(cid, name, "kind-exempt: battery sizing is an experiment|analysis plan shape")
@@ -1180,6 +1198,14 @@ def check_battery_multiplier(plan: str, kind: str) -> CheckResult:
         return _skip(cid, name, "no permutation/null-draw battery named")
     if re.search(NA_RE + r"no draw battery", plan):
         return _pass(cid, name, "explicit N/A declared (no draw battery)")
+    # #1086: a draw-bearing arithmetic line ANCHORS its own ±15 evidence
+    # window — the §9 sizing block legitimately lives far from the §4/§6
+    # battery registration (#833 v8: 58+ lines). Window-scoped discipline is
+    # preserved: only a line already carrying a draw-bearing product can
+    # anchor (a grid-only footprint product never anchors — the #810 v1
+    # false-PASS class), and the batched commitment must still sit within
+    # ±_C12_WINDOW_LINES raw lines of the anchor.
+    windows = windows + _trigger_windows(plan, _MULT_ARITH_RE, _C12_WINDOW_LINES)
     any_arith = False
     any_commit = False
     for window in windows:
@@ -1208,7 +1234,8 @@ def check_battery_multiplier(plan: str, kind: str) -> CheckResult:
     if not missing:
         missing.append(
             "co-location: the multiplier arithmetic and the batched-implementation "
-            "commitment each appear somewhere, but never together near any battery mention"
+            "commitment each appear somewhere, but never together near any battery mention "
+            "or draw-arithmetic sizing line"
         )
     detail = (
         f"plan names a permutation/bootstrap/null battery but is missing {' AND '.join(missing)}"
@@ -2162,9 +2189,24 @@ _C18_PAIRCOUNT_RE = re.compile(r"(?i)\b\d[\d,]*\s+(?:pre-named\s+)?pairs\b")
 # D1: a row-coverage declaration; evidence on the same line or within the
 # next _C18_DECL_WINDOW_LINES physical lines (fenced lines excluded).
 _C18_COVERAGE_RE = re.compile(r"(?i)\brow[- ]coverage\b")
+# #1086 widening: suffixed tensor-store dirs (`analysis_tensors_nonemit/` —
+# the `\w*` suffix arm) and canonical `issueN_<slug>/…` HF data-repo
+# prefixes (the Upload Policy destination shape) are artifact evidence. The
+# trailing `\S*` on the `analysis_tensors\w*/\S*` alternative — not `\S+` —
+# is DELIBERATE: a bare store-dir token ending at the slash (backticked or
+# line-final `analysis_tensors_nonemit/`) is complete artifact evidence
+# with nothing after the slash. An `issueN…/` PATH token is affirmative
+# artifact evidence, orthogonal to the `_C18_ISSUE_REF_RE` citation guard
+# (the literal `#\d{2,}` form), which is byte-unchanged. Accepted
+# fail-UNSAFE residual, DISCLOSED: a SIBLING issue's `issueN…/` store path
+# on the declaration line counts as D1 artifact evidence — whether the
+# named store truly contains THIS plan's rows stays with the fact-checker
+# (no guard, no negative fixture: a negative would require a citation
+# guard #1086 deliberately does not add).
 _C18_ARTIFACT_RE = re.compile(
     r"(?i)\S+\.(?:pt|pth|json|jsonl|npz|npy|safetensors|csv|parquet|arrow)\b"
-    r"|\beval_results/\S+|\banalysis_tensors/\S+|\braw_completions/\S+"
+    r"|\beval_results/\S+|\banalysis_tensors\w*/\S*|\braw_completions/\S+"
+    r"|\bissue\d{2,}[\w.-]*/\S+"
 )
 # v2 (MF-B): the bare `this run` alternative is REMOVED — only the
 # arms-generated construction or an explicit `by construction` counts as
@@ -2174,6 +2216,41 @@ _C18_BYCONSTRUCTION_RE = re.compile(
     r"(?i)both arms .{0,60}\b(?:generated|produced|computed|fit(?:ted)?|emitted)\b"
     r"|\bby construction\b"
 )
+# #1086 (v2): the check's own remedy text ("state that the plan's own fits
+# produce every registered row on each arm", the FAIL detail below) was
+# unmatchable by _C18_BYCONSTRUCTION_RE — a planner implementing the bounce
+# verbatim still FAILed (#833 v8). Accept that form via a SEPARATE
+# alternative deliberately narrower than the remedy prose: (i) affirmative
+# produce-verb + "every registered", (ii) arm vocabulary within 80 chars
+# after the match (each/both/per arm[s]), (iii) NO negation/deferral token
+# in the local span around the match — "does not yet produce every
+# registered row on each arm" and "will produce every registered row …
+# once implemented" are explicit NON-declarations and must keep FAILing
+# (the MF-B deferral class). _C18_BYCONSTRUCTION_RE itself stays
+# byte-unchanged so no historical PASS can flip.
+_C18_PRODUCES_REGISTERED_RE = re.compile(
+    r"(?i)\b(?:produces?|generates?|computes?|emits?|yields?)\s+every\s+registered\b"
+    r"(?=.{0,80}\b(?:each|both|per)\s+arms?\b)"
+)
+_C18_NEG_DEFER_RE = re.compile(
+    r"(?i)\b(?:not|n't|never|without|will|would|shall|should|may|might|could"
+    r"|once|pending|deferred|later|TBD|to\s+be)\b"
+)
+
+
+def _c18_affirmative_produces_hit(line: str) -> bool:
+    """The v2 remedy-text alternative: affirmative produce-verb + 'every
+    registered' + arm vocabulary, with negation/deferral tokens disqualifying
+    in a local span (48 chars before the match start, 80 after its end).
+    Scoped to THIS alternative only — the legacy _C18_BYCONSTRUCTION_RE
+    alternatives keep their behavior byte-for-byte."""
+    m = _C18_PRODUCES_REGISTERED_RE.search(line)
+    if not m:
+        return False
+    span = line[max(0, m.start() - 48) : m.end() + 80]
+    return not _C18_NEG_DEFER_RE.search(span)
+
+
 # D2 (MF-A): a subset expression AND word-bounded row/pair vocabulary AND
 # coverage/source-key vocabulary must co-occur on the candidate line.
 # Word-bounding kills the 608 v2:164 false-satisfier ("pair" inside
@@ -2220,8 +2297,13 @@ _C18_FIGURES_LINE_RE = re.compile(r"(?i)^\W{0,8}figures?\b")
 # as a dishonest c13 N/A line; (g) a wrapped/reformatted paste that
 # separates the fingerprint from the row-coverage phrase across lines — the
 # line-local guard misses it; the D1 evidence requirement (artifact token /
-# arms-generated phrase) still has to be met by the surviving fragment,
-# which the detail's wording deliberately fails to supply.
+# arms-generated phrase / #1086's affirmative produces-registered form)
+# still has to be met by the surviving fragment. NOTE (#1086): the remedy
+# text's own "produce every registered row on each arm" clause is now a
+# satisfier BY DESIGN (the remedy-vs-satisfier inconsistency was the bug),
+# so a wrapped paste landing that clause on a citation-free Row-coverage
+# line self-satisfies — a widened, DISCLOSED instance of this same
+# residual class.
 
 
 def _c18_registered_paired_lines(plan: str) -> list[str]:
@@ -2285,7 +2367,12 @@ def _c18_coverage_declarations(plan: str) -> list[str]:
                 for j in range(i + 1, min(i + 1 + _C18_DECL_WINDOW_LINES, len(lines)))
                 if not mask[j]
             ]
-            if any(_C18_ARTIFACT_RE.search(w) or _C18_BYCONSTRUCTION_RE.search(w) for w in window):
+            if any(
+                _C18_ARTIFACT_RE.search(w)
+                or _C18_BYCONSTRUCTION_RE.search(w)
+                or _c18_affirmative_produces_hit(w)
+                for w in window
+            ):
                 out.append(line.strip())
     return out
 

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -1144,28 +1144,104 @@ def test_c12_fenced_battery_does_not_trigger():
 
 
 def test_c12_window_radius_boundary_after_refactor():
-    # Regression for the `_trigger_windows` parametrization (task #937): c12's
-    # ±15-raw-line radius must not shift. Evidence exactly 15 raw lines below
-    # the trigger line counts; one line farther does not. The evidence line
-    # deliberately avoids battery-trigger vocabulary so it cannot open its own
-    # window (asserted below, not assumed).
-    evidence = "Basis: draws × 24 cells; implementation: batched via one subset-sum GEMM."
-    assert not verify_plan._BATTERY_TRIGGER_RE.search(evidence)
+    # Radius pin (task #937), updated for #1086 arith-anchored windows: an
+    # arithmetic line now opens its own window BY DESIGN, so the MOVING
+    # evidence is the batched COMMITMENT. Commit exactly 15 raw lines below
+    # the arith anchor counts; one line farther does not.
+    anchor_arith = (
+        "Basis: 1000 draws × 24 cells × 3 statistics at ~0.02 s/draw ≈ 0.4 h projected wall."
+    )
+    commit = "Implementation: one batched subset-sum GEMM over the full draw matrix."
+    assert verify_plan._MULT_ARITH_RE.search(anchor_arith)
+    assert not verify_plan._BATTERY_TRIGGER_RE.search(commit)
+    assert not verify_plan._MULT_ARITH_RE.search(commit)
 
     def plan_with_gap(n_blank: int) -> str:
-        # Evidence lands (n_blank + 1) raw lines below the trigger line.
+        # Commit lands (n_blank + 1) raw lines below the arith anchor line.
         return (
             GOOD_PLAN
             + "\n## 12. Null battery\n\n"
             + BATTERY_SENT
             + "\n"
+            + anchor_arith
+            + "\n"
             + "\n" * n_blank
-            + evidence
+            + commit
             + "\n"
         )
 
     assert _status(plan_with_gap(14), "c12_battery_multiplier") == "PASS"  # +15 lines: in
     assert _status(plan_with_gap(15), "c12_battery_multiplier") == "FAIL"  # +16 lines: out
+
+
+# #1086: the #833 v8 L149 sizing-paragraph excerpt (failing tokens preserved
+# verbatim in the STRING below: "draws x batteries(...)", "draws x (6 arms",
+# "draws x ~3 quantities" — mult sign spelled ASCII here for RUF003;
+# "2,000 family-clustered draws" / "Bootstrap-battery" are NOT battery
+# triggers — asserted in the far-block test, so only the #1086
+# arith-anchored window can reach the block).
+V8_L149_SIZING_BLOCK = (
+    "**Bootstrap-battery multiplier arithmetic (per "
+    "`.claude/rules/vectorize-many-cell-fits.md`):** total_calls = draws × "
+    "batteries(arms + paired diffs) × layers. Phase N2: 2,000 family-clustered draws × "
+    "(6 arms + 4 paired diffs) × 3 layers = 60,000 rank recomputations, each over a "
+    "≤291-length CACHED per-cell prediction array. Phase N0: 2,000 family-clustered "
+    "draws × ~3 quantities (emission ρ + on-policy/control chain ρ) × 3 layers ≈ 18,000 "
+    "Spearman calls over 480-length cached arrays. Batched-implementation commitment: "
+    "rank/Spearman draws over cached arrays, vectorized numpy, seconds per battery."
+)
+
+
+def test_c12_sizing_block_far_from_battery_registration_passes():
+    # The #833 v8 layout split: battery registered early (§4/§6), the sizing
+    # paragraph 20+ raw lines below — outside every battery-trigger window.
+    # The sizing line itself is NOT a battery trigger (asserted), so only
+    # the #1086 arith-anchored window can rescue it.
+    assert not verify_plan._BATTERY_TRIGGER_RE.search(V8_L149_SIZING_BLOCK)
+    filler = "\n".join(f"Filler paragraph line {i} with no sizing content." for i in range(20))
+    plan = (
+        GOOD_PLAN
+        + f"\n## 12. Null battery\n\n{BATTERY_SENT}\n\n"
+        + filler
+        + "\n\n## 13. Compute sizing\n\n"
+        + V8_L149_SIZING_BLOCK
+        + "\n"
+    )
+    assert _status(plan, "c12_battery_multiplier") == "PASS"
+
+
+def test_c12_v8_multiplier_variant_forms_match_arith():
+    # The three #833 v8 L149 multiplier forms the 10-noun whitelist rejected.
+    for form in (
+        "total_calls = draws × batteries(arms + paired diffs) × layers",
+        "2,000 family-clustered draws × (6 arms + 4 paired diffs) × 3 layers",
+        "2,000 family-clustered draws × ~3 quantities",
+    ):
+        assert verify_plan._MULT_ARITH_RE.search(form), form
+    # Grid-only products (the #810 false-PASS class) still do NOT match —
+    # incl. the required new negative for the widened any-noun grid surface.
+    for form in (
+        "34 × 50 × 28",
+        "layers x 3584",
+        "6 arms × 3 layers × 16 folds",
+        "Store footprint: 24 cells × 3 seeds float32 tensors (~2 GB).",
+    ):
+        assert not verify_plan._MULT_ARITH_RE.search(form), form
+
+
+def test_c12_grid_only_far_sizing_block_still_fails():
+    # A grid-only product cannot ANCHOR a window (no draw-bearing factor),
+    # so a far sizing block with commit vocabulary alone does not rescue the
+    # plan — the #810 v1 class stays mechanically closed under #1086.
+    filler = "\n".join(f"Filler paragraph line {i} with no sizing content." for i in range(20))
+    plan = (
+        GOOD_PLAN
+        + f"\n## 12. Null battery\n\n{BATTERY_SENT}\n\n"
+        + filler
+        + "\n\n## 13. Compute sizing\n\n"
+        + "Sizing: 6 arms × 3 layers × 16 folds = 288 fits, batched via `vectorized_mlp_skill`.\n"
+    )
+    assert _status(plan, "c12_battery_multiplier") == "FAIL"
 
 
 # ─── Check 13 — empirical-null gate p-floor attainability ──────────────────
@@ -2302,6 +2378,85 @@ def test_c18_figures_enumeration_line_does_not_trigger():
         "non-contrastive paired cells; per-row diagonal implant-strength bars."
     )
     assert _status(_c18_plan(line), "c18_paired_contrast_source_coverage") == "SKIP"
+
+
+# #1086: the #833 v8 L80 Row-coverage line (verbatim corpus literal — same
+# embedded-literal convention as the #810 fixtures above). Pre-#1086 the D1
+# evidence regexes rejected all three of its artifact tokens
+# (`analysis_tensors_nonemit/` — suffixed store; `issue833_onpolicy_map/…`
+# — extension-free HF data-repo prefix; `@fa0f8ea3` — a sha pin) AND its
+# by-construction phrasing, which follows the check's own remedy text.
+C18_V8_ROW_COVERAGE = "Row-coverage: the nonemit arm's 291 retained-cell rows come from this round's own Phase-N1 extraction (`analysis_tensors_nonemit/`, both legs, all 3 layers); the full-text comparator arms' rows for the SAME 291 cells come from the r7e joined design rebuilt from HF `issue833_onpolicy_map/analysis_tensors` + `analysis_tensors_rbase` @fa0f8ea3 (all 480 cells present, a superset of the retained set); the plan's own fits produce every registered chain row on each arm."
+
+
+def test_c18_v8_row_coverage_line_passes():
+    # The motivating #1086 false-positive: v8 L80 verbatim must satisfy D1.
+    assert verify_plan._c18_candidate_ok(C18_V8_ROW_COVERAGE)  # no #NN / fingerprint
+    plan = _c18_plan(C18_V13_REGISTRATION, C18_V8_ROW_COVERAGE)
+    assert _status(plan, "c18_paired_contrast_source_coverage") == "PASS"
+
+
+def test_c18_own_fits_produce_every_registered_row_passes():
+    # The check's own remedy prescription, implemented verbatim, must PASS
+    # (the pre-#1086 remedy-vs-satisfier inconsistency: the FAIL detail
+    # instructed exactly this sentence and the old regexes rejected it).
+    decl = "Row-coverage: the plan's own fits produce every registered row on each arm."
+    plan = _c18_plan(C18_V13_REGISTRATION, decl)
+    assert _status(plan, "c18_paired_contrast_source_coverage") == "PASS"
+
+
+def test_c18_suffixed_store_and_issue_prefix_are_artifact_evidence():
+    # Direct _C18_ARTIFACT_RE asserts for the #1086 additions.
+    assert verify_plan._C18_ARTIFACT_RE.search("`analysis_tensors_nonemit/`")
+    assert verify_plan._C18_ARTIFACT_RE.search("`issue833_onpolicy_map/analysis_tensors`")
+    assert not verify_plan._C18_ARTIFACT_RE.search("a later revision of this run's analysis.")
+
+
+def test_c18_vague_row_coverage_without_evidence_still_fails():
+    # A Row-coverage line with NO artifact token, NO affirmative
+    # produce-verb + "every registered", and no D2 subset expression stays
+    # a FAIL.
+    decl = "Row-coverage: the named sources cover all rows on both arms."
+    plan = _c18_plan(C18_V13_REGISTRATION, decl)
+    assert _status(plan, "c18_paired_contrast_source_coverage") == "FAIL"
+
+
+def test_c18_negated_produce_declaration_fails():
+    # v2 negation guard: an explicit NON-declaration must keep FAILing (the
+    # MF-B deferral class the v1 bare widening would have re-opened).
+    decl = "Row-coverage: the plan does not yet produce every registered row on each arm."
+    plan = _c18_plan(C18_V13_REGISTRATION, decl)
+    assert _status(plan, "c18_paired_contrast_source_coverage") == "FAIL"
+
+
+def test_c18_deferred_produce_declaration_fails():
+    # v2 deferral guard: a future-tense deferral is not a declaration.
+    decl = "Row-coverage: the plan will produce every registered row on each arm once implemented."
+    plan = _c18_plan(C18_V13_REGISTRATION, decl)
+    assert _status(plan, "c18_paired_contrast_source_coverage") == "FAIL"
+
+
+def test_c18_produce_verb_without_every_registered_fails():
+    # The drop-"every registered" mutant: a bare produce verb is not enough.
+    decl = "Row-coverage: the plan produces rows on both arms."
+    plan = _c18_plan(C18_V13_REGISTRATION, decl)
+    assert _status(plan, "c18_paired_contrast_source_coverage") == "FAIL"
+
+
+def test_c18_produces_every_registered_outside_row_coverage_window_fails():
+    # D1 evidence is consulted only inside a Row-coverage window: the
+    # affirmative phrase in arbitrary prose (no Row-coverage vocab anywhere,
+    # no D2 subset line) does not satisfy the check.
+    prose = "The pipeline produces every registered row on each arm as part of phase N2."
+    plan = _c18_plan(C18_V13_REGISTRATION, prose)
+    assert _status(plan, "c18_paired_contrast_source_coverage") == "FAIL"
+
+
+def test_c18_armless_produces_every_registered_fails():
+    # The arm-vocabulary lookahead: no each/both/per-arm vocab, no hit.
+    decl = "Row-coverage: the pipeline produces every registered row."
+    plan = _c18_plan(C18_V13_REGISTRATION, decl)
+    assert _status(plan, "c18_paired_contrast_source_coverage") == "FAIL"
 
 
 # ─── Check 19 — OOD generalization folds ───────────────────────────────────


### PR DESCRIPTION
Closes task #1086 (kind: infra workflow-fix).

## Summary
- c12: any-axis grid factor + ~/≈/( decoration in _MULT_ARITH_RE; draw-bearing arithmetic lines anchor their own ±15 evidence windows (trigger regex byte-unchanged; #810 grid-only false-PASS class stays closed, test-pinned)
- c18: _C18_ARTIFACT_RE recognizes suffixed analysis_tensors stores + issueN HF prefixes; NEW separately-scoped _C18_PRODUCES_REGISTERED_RE (arm-vocab lookahead + local negation/deferral guard) accepts the check's own remedy-text phrasing; legacy satisfier byte-unchanged
- 1 radius-test rewrite + 12 new fixtures; committed corpus-audit instrument (2,259 files: 26 flips all allowlisted, zero forbidden transitions)

## Test plan
- [x] #833 v8 repro flips exactly c12+c18 FAIL→PASS, other labels unchanged
- [x] pytest tests/test_verify_plan.py: 393/393
- [x] Step 9c gate: compare RC=0 (1 pre-existing-on-main failure stripped via clean oracle)
- [x] ruff + workflow_lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)