### PR TITLE
task #1084: crash-safe idempotent sentinel drain (fp dedupe) + hang-bounding

### DIFF
--- a/scripts/poll_pipeline.py
+++ b/scripts/poll_pipeline.py
@@ -23,8 +23,12 @@ Per tick:
    "Pod-side code NEVER shells out" rule). The poller parses each
    sentinel, posts the carried `epm:<kind>` marker from the local VM
    via `task_workflow.post_event`, then renames the sentinel to
-   `<path>.processed` so it posts exactly once. If a sentinel carries a
-   non-empty ``gate`` field, the poll returns ``status=gate`` with that
+   `<path>.processed` so it posts exactly once — and the post itself is
+   idempotent (#1084): each drain-posted event carries a `sentinel_fp`
+   extra, so a poller killed/hung between post and rename replays
+   rename-only on the next tick instead of duplicating the marker. If
+   a sentinel carries a non-empty ``gate`` field, the poll returns
+   ``status=gate`` with that
    gate name in the JSON output so the orchestrator parks at a user
    gate instead of continuing the polling loop.
 2. SSH to the pod (one heredoc batching: PID liveness, log mtime, log tail).
@@ -321,6 +325,7 @@ poller (or a human) can inspect it.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import logging
 import os
@@ -345,6 +350,7 @@ from explore_persona_space.task_workflow import (  # noqa: E402
     EVENT_NOTE_MAX,
     find_task_path,
     latest_event,
+    list_events,
     post_event,
 )
 
@@ -1802,6 +1808,41 @@ def _slugify_kind(kind: str) -> str:
     return kind.replace(":", "_")
 
 
+def _sentinel_fingerprint(remote_path: str, body: str) -> str:
+    """Stable idempotency key for ONE drained sentinel (#1084).
+
+    Hashes the remote path (unique per sentinel — epoch-suffixed filenames,
+    never reused by the writer contract) + the raw parser-delivered body
+    string. Hashing the raw string (never a re-serialized JSON dict) makes
+    the fp immune to key-ordering drift; including the path makes
+    cross-sentinel false-positive dedupe structurally impossible (two
+    byte-identical bodies at different paths are distinct signals). Pure /
+    no I/O; 16 hex chars (64 bits) — collision odds negligible at this
+    volume.
+    """
+    return hashlib.sha256(f"{remote_path}\n{body}".encode("utf-8", "replace")).hexdigest()[:16]
+
+
+def _posted_sentinel_fps(issue: int) -> dict[str, dict[str, Any]]:
+    """Map ``sentinel_fp`` -> already-posted event row for task ``issue``.
+
+    Reads ``events.jsonl`` once via ``list_events`` (the tolerant reader —
+    malformed lines skipped). FAIL-OPEN: on ANY read failure, ``log.error``
+    and return ``{}`` — degraded mode re-posts (today's pre-#1084 behavior);
+    a lost marker is never a possible outcome of a dedupe-read failure.
+    """
+    try:
+        events = list_events(issue)
+        return {e["sentinel_fp"]: e for e in events if isinstance(e.get("sentinel_fp"), str)}
+    except Exception as exc:
+        log.error(
+            "dedupe events read failed for #%d (%s); posting without dedupe (fail-open, #1084)",
+            issue,
+            exc,
+        )
+        return {}
+
+
 def _persist_oversize_note(
     *,
     issue: int,
@@ -1811,6 +1852,8 @@ def _persist_oversize_note(
     by: str,
     full_note: str,
     original_extras: dict[str, Any] | None = None,
+    sentinel_fp: str,
+    sentinel_path: str,
 ) -> bool:
     """Graceful-degradation for an oversize sentinel ``note``.
 
@@ -1837,7 +1880,11 @@ def _persist_oversize_note(
        hard-bounded under ``EVENT_NOTE_MAX`` so the pointer post itself
        cannot trip the same cap. ``artifacts=[<rel_path>]`` and
        ``oversize=True`` are carried as marker extras so the dashboard /
-       downstream consumers can locate the full payload.
+       downstream consumers can locate the full payload. The pointer post
+       ALSO carries the drain's ``sentinel_fp`` / ``sentinel_path``
+       idempotency extras (#1084), so a re-drain of an oversize sentinel
+       whose rename failed dedupes on the fp — no second artifact file, no
+       second pointer marker.
 
     Returns ``True`` on success (artifact written + pointer marker posted).
     Returns ``False`` (and logs) on any failure — caller must NOT rename
@@ -1927,6 +1974,8 @@ def _persist_oversize_note(
             by=by,
             note=pointer_note,
             artifacts=[rel_artifact],
+            sentinel_fp=sentinel_fp,
+            sentinel_path=sentinel_path,
             **extras,
         )
     except Exception as exc:
@@ -1998,6 +2047,104 @@ def _parse_sentinel(remote_path: str, body: str) -> dict[str, Any] | None:
     return data
 
 
+def _post_drained_sentinel(
+    *,
+    issue: int,
+    remote_path: str,
+    data: dict[str, Any],
+    fp: str,
+) -> dict[str, Any] | None:
+    """Post ONE parsed sentinel's marker (normal or oversize-pointer path).
+
+    Extracted from :func:`drain_sentinels_via`'s loop (#1084). Returns the
+    in-memory fp record the caller accumulates into the drain's dedupe map
+    on success (normal post AND oversize-pointer success both count), or
+    ``None`` on a retryable post failure — the caller leaves the sentinel
+    un-renamed and continues; the next tick retries. A non-conforming real
+    sentinel carrying ``"version": null`` keeps its loud ``int(None)``
+    TypeError (#975) — it propagates out of the drain, never silently
+    derived.
+    """
+    kind = data["kind"]
+    if "version" in data:
+        # Real pod-side sentinel: "version" is a REQUIRED envelope key
+        # (_SENTINEL_REQUIRED_KEYS / pod-side-reporting.md) and an
+        # explicit version always wins in post_event — verbatim contract.
+        # Branch on key PRESENCE, not None-tolerance: a (non-conforming)
+        # real sentinel carrying "version": null keeps today's loud
+        # int(None) TypeError instead of silently deriving (#975).
+        version: int | None = int(data["version"])
+    else:
+        # Only reachable via the #899 synthesized envelope, which omits
+        # the key (#975): post_event derives max(existing for kind)+1 so
+        # a re-drained / re-run rescue never lands BELOW an existing
+        # higher version (the #480 collision class). If the rename fails,
+        # a future tick's re-drain fp-hits on the ``sentinel_fp`` extra
+        # and skips the re-post entirely (#1084) — no duplicate at a
+        # fresh max+1 anymore.
+        version = None
+    note = data.get("note")
+    if note is None:
+        note = data.get("payload")
+    if note is not None and not isinstance(note, str):
+        note = json.dumps(note, ensure_ascii=False)
+    by = data.get("by") or "pod-sentinel"
+    try:
+        post_event(
+            issue,
+            kind,
+            version=version,
+            by=by,
+            note=note,
+            sentinel_fp=fp,
+            sentinel_path=remote_path,
+        )
+    except ValueError as exc:
+        # Oversize-note guard: match the EXACT message ``post_event``
+        # raises (``"event note exceeds {N} chars (...)"``). Routing
+        # any-old ``ValueError`` to graceful-degradation would
+        # silently swallow real schema bugs, so the substring match
+        # stays narrow.
+        if _OVERSIZE_NOTE_ERROR_SUBSTR not in str(exc) or note is None:
+            log.error(
+                "post_event failed for sentinel %s (kind=%s): %s",
+                remote_path,
+                kind,
+                exc,
+            )
+            return None
+        if not _persist_oversize_note(
+            issue=issue,
+            remote_path=remote_path,
+            kind=kind,
+            version=version,
+            by=by,
+            full_note=note,
+            original_extras=data,
+            sentinel_fp=fp,
+            sentinel_path=remote_path,
+        ):
+            # Persistence / pointer-post failed — retry next tick.
+            return None
+        # Pointer marker posted from the persisted artifact — success.
+    except Exception as exc:
+        # Don't rename on post failure — next tick will retry. We log
+        # at error so an operator can see repeated failures.
+        log.error(
+            "post_event failed for sentinel %s (kind=%s): %s",
+            remote_path,
+            kind,
+            exc,
+        )
+        return None
+    return {
+        "kind": kind,
+        "version": version,
+        "sentinel_path": remote_path,
+        "ts": "(this drain)",
+    }
+
+
 def drain_sentinels_via(
     *,
     issue: int,
@@ -2025,9 +2172,26 @@ def drain_sentinels_via(
     polling loop continues (incident #641).
 
     Each successfully-posted sentinel is renamed to ``<path>.processed``
-    so the next tick won't re-post the same marker. If the marker post or
-    the rename fails for an individual sentinel, the sentinel is left in
-    place and a warning is logged; subsequent ticks will retry.
+    so the next tick won't re-post the same marker. If the marker POST
+    fails for an individual sentinel, the sentinel is left in place and a
+    warning is logged; subsequent ticks retry the whole path. If the post
+    SUCCEEDS but the rename fails (or the poller crashes between the two —
+    the #952 W1 window), the next tick's re-drain is IDEMPOTENT (#1084):
+    every drain-posted event carries a ``sentinel_fp`` extra (sha256 of
+    ``remote_path + "\\n" + raw body``, via :func:`_sentinel_fingerprint`)
+    plus a ``sentinel_path`` extra, and the drain skips the re-post on an
+    fp hit (loud ``log.error`` naming the matched event) and retries the
+    rename only — exactly-once PER DRAINER (the dedupe read sits outside
+    ``post_event``'s flock, so two CONCURRENT drainers can still race to a
+    duplicate; loud, benign, and identical to pre-#1084 behavior). A
+    ``mark_processed`` callable that RAISES (e.g. ``subprocess.
+    TimeoutExpired`` from a hung SSH transport) is treated as a rename
+    failure — loud log, sentinel left in place, loop continues to later
+    sentinels. A ``list_sentinels`` callable that raises
+    ``subprocess.TimeoutExpired`` / ``OSError`` (the hung RunPod transport)
+    yields an empty drain (``(0, None)``) with a loud log — mirroring the
+    documented rc!=0 -> ``[]`` transport contract; any OTHER exception
+    still escapes (fail-fast for genuine code bugs).
 
     Exception: an oversize-``note`` ``ValueError`` from ``post_event`` (note
     exceeds ``EVENT_NOTE_MAX``) is NOT a retryable failure — re-posting the
@@ -2041,89 +2205,104 @@ def drain_sentinels_via(
     end the loop. Any OTHER ``post_event`` exception (transient infra,
     schema bug, etc.) keeps the original retry-on-next-tick semantics.
     """
-    sentinels = list_sentinels()
+    try:
+        sentinels = list_sentinels()
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        # W2a (#1084): the RunPod drain transport hung past its subprocess
+        # timeout (or failed at the OS layer). Mirror the documented
+        # rc!=0 -> [] contract: empty drain, loud log, retry next tick.
+        # The catch is deliberately NARROW — any other exception is a
+        # genuine code bug and must still crash loud (fail-fast).
+        log.error(
+            "sentinel drain transport failed for issue %d: %s — empty drain, retry next tick",
+            issue,
+            exc,
+        )
+        return 0, None
     processed = 0
     gate: str | None = None
+    # Lazy idempotency map (#1084): ONE events.jsonl read per drain
+    # invocation, taken only when at least one sentinel parsed. The map is
+    # ALSO updated in-loop after every successful post, so a duplicate
+    # (remote_path, body) tuple within ONE listing posts exactly once
+    # (currently unreachable — the canonical + fallback globs are disjoint —
+    # but a future overlapping ``extra_globs`` must not reopen the
+    # same-tick double-post).
+    posted_fps: dict[str, dict[str, Any]] | None = None
     for remote_path, body in sentinels:
         data = _parse_sentinel(remote_path, body)
         if data is None:
             continue
-        kind = data["kind"]
-        if "version" in data:
-            # Real pod-side sentinel: "version" is a REQUIRED envelope key
-            # (_SENTINEL_REQUIRED_KEYS / pod-side-reporting.md) and an
-            # explicit version always wins in post_event — verbatim contract.
-            # Branch on key PRESENCE, not None-tolerance: a (non-conforming)
-            # real sentinel carrying "version": null keeps today's loud
-            # int(None) TypeError instead of silently deriving (#975).
-            version: int | None = int(data["version"])
-        else:
-            # Only reachable via the #899 synthesized envelope, which omits
-            # the key (#975): post_event derives max(existing for kind)+1 so
-            # a re-drained / re-run rescue never lands BELOW an existing
-            # higher version (the #480 collision class). If the rename below
-            # fails and a future tick re-drains the same rescue, the
-            # duplicate lands at a fresh max+1 (v5, v6, ...) with
-            # byte-equivalent content — highest-version-wins resume stays
-            # correct, strictly better than stacked v1s.
-            version = None
-        note = data.get("note")
-        if note is None:
-            note = data.get("payload")
-        if note is not None and not isinstance(note, str):
-            note = json.dumps(note, ensure_ascii=False)
-        by = data.get("by") or "pod-sentinel"
-        try:
-            post_event(issue, kind, version=version, by=by, note=note)
-        except ValueError as exc:
-            # Oversize-note guard: match the EXACT message ``post_event``
-            # raises (``"event note exceeds {N} chars (...)"``). Routing
-            # any-old ``ValueError`` to graceful-degradation would
-            # silently swallow real schema bugs, so the substring match
-            # stays narrow.
-            if _OVERSIZE_NOTE_ERROR_SUBSTR not in str(exc) or note is None:
-                log.error(
-                    "post_event failed for sentinel %s (kind=%s): %s",
-                    remote_path,
-                    kind,
-                    exc,
-                )
-                continue
-            if not _persist_oversize_note(
-                issue=issue,
-                remote_path=remote_path,
-                kind=kind,
-                version=version,
-                by=by,
-                full_note=note,
-                original_extras=data,
-            ):
-                # Persistence / pointer-post failed — leave sentinel
-                # un-renamed so the next tick can retry the whole path
-                # (e.g. transient disk-write failure).
-                continue
-            # Pointer marker posted from the persisted artifact; fall
-            # through to the rename + accounting block below so this
-            # sentinel stops being re-attempted.
-        except Exception as exc:
-            # Don't rename on post failure — next tick will retry. We log
-            # at error so an operator can see repeated failures.
+        fp = _sentinel_fingerprint(remote_path, body)
+        if posted_fps is None:
+            posted_fps = _posted_sentinel_fps(issue)
+        dup = posted_fps.get(fp)
+        if dup is not None:
+            # W1 crash-safe replay (#1084): the marker for THIS exact
+            # sentinel (same path + same body) already posted on a prior
+            # tick whose rename failed/crashed (or earlier THIS drain).
+            # LOUD skip — fail-fast philosophy: never silent — then fall
+            # through to the rename + accounting + gate extraction below
+            # WITHOUT re-posting. Exactly-once per drainer. Note the
+            # fp/dup check runs BEFORE the version-presence branch, so a
+            # dup replay never re-executes ``int(data["version"])`` (a
+            # null-version sentinel crashes before ever posting, so it can
+            # never be a dup — the #975 TypeError pin is unaffected).
             log.error(
-                "post_event failed for sentinel %s (kind=%s): %s",
+                "sentinel %s already posted as %s v%s at %s (fp=%s); skipping re-post, "
+                "renaming only (crash-safe replay, #1084)",
                 remote_path,
-                kind,
+                dup.get("kind"),
+                dup.get("version"),
+                dup.get("ts"),
+                fp,
+            )
+        else:
+            if any(e.get("sentinel_path") == remote_path for e in posted_fps.values()):
+                # Same path, different content: a writer-contract violation
+                # (filenames are epoch-suffixed and never reused). Fail-open
+                # + loud: the new content is a distinct signal, so post it.
+                log.warning(
+                    "sentinel %s content CHANGED at a previously-posted path (writer "
+                    "contract violation); posting anyway",
+                    remote_path,
+                )
+            fp_record = _post_drained_sentinel(
+                issue=issue, remote_path=remote_path, data=data, fp=fp
+            )
+            if fp_record is None:
+                # Retryable post failure — sentinel left un-renamed so the
+                # next tick can retry the whole path.
+                continue
+            # Record the just-posted fp so a duplicate (path, body) tuple
+            # LATER IN THIS SAME DRAIN dedupes (#1084).
+            posted_fps[fp] = fp_record
+        try:
+            renamed_ok = mark_processed(remote_path)
+        except Exception as exc:
+            # W2b (#1084): a hung/raising rename transport (e.g.
+            # subprocess.TimeoutExpired from a wedged SSH) is treated as a
+            # rename FAILURE — the documented False path below. Loud, and
+            # the loop CONTINUES to later sentinels; the marker is already
+            # posted, so the next tick's replay is idempotent (fp dedupe).
+            log.error(
+                "mark_processed raised for %s: %s — treating as rename failure "
+                "(marker posted; idempotent replay next tick)",
+                remote_path,
                 exc,
             )
-            continue
-        if not mark_processed(remote_path):
-            # Marker is posted but rename failed; on the next tick we'd
-            # re-post and create a duplicate event. Surface loudly so the
-            # operator can rename manually.
+            renamed_ok = False
+        if not renamed_ok:
+            # Marker is posted but rename failed. The next tick re-drains
+            # this sentinel and replays IDEMPOTENTLY (#1084): the fp dedupe
+            # skips the re-post and retries the rename only — no duplicate
+            # event. Surface loudly so an operator can rename manually if
+            # the transport failure persists.
             log.error(
-                "marker %s posted from sentinel %s but rename failed; "
-                "future ticks may duplicate. Rename to %s.processed "
-                "manually on the remote host.",
-                kind,
+                "marker posted from sentinel %s but rename failed; next tick "
+                "will replay idempotently (fp dedupe skips the re-post, rename "
+                "only). Rename to %s.processed manually on the remote host to "
+                "end the retries.",
                 remote_path,
                 remote_path,
             )

--- a/src/explore_persona_space/backends/gcp.py
+++ b/src/explore_persona_space/backends/gcp.py
@@ -5205,7 +5205,23 @@ class GcpBackend(ComputeBackend):
             f"--command=sudo -n bash -c {shlex.quote(script)}",
         )
         argv += [f"--zone={zone}"]
-        res = self._run(argv)
+        try:
+            res = self._run(argv)
+        except subprocess.TimeoutExpired as exc:
+            # TRANSPORT class (#1084): the drain-list SSH HUNG past the
+            # runner's per-call cap (default 300s, ``default_gcloud_runner``)
+            # instead of returning non-zero — the #952 gcloud-ssh
+            # hostkey-drift wedge. Same alarm tuple shape + class as the
+            # rc!=0 branch below, so the poller's wedge-gate semantics
+            # (#669) are inherited unchanged. ``_mark_sentinel_processed``'s
+            # TimeoutExpired needs no catch here — it propagates into
+            # ``drain_sentinels_via``'s mark_processed rename-failure catch.
+            alarm = (
+                f"gcp sentinel drain SSH timed out after {exc.timeout}s "
+                "(hung transport — #952 class)"
+            )
+            logger.error("GCP poll: %s", alarm)
+            return 0, None, alarm, "", None, "transport"
         if res.returncode != 0:
             # TRANSPORT class (#669): the drain SSH itself returned non-zero —
             # transport down / permission / timeout. This is the unreachable-VM

--- a/tests/test_gcp_backend.py
+++ b/tests/test_gcp_backend.py
@@ -4839,6 +4839,7 @@ def test_poll_running_drains_sentinels_via_sudo(monkeypatch) -> None:
     pp = _poll_pipeline_module()
     posted: list[tuple[int, str]] = []
     monkeypatch.setattr(pp, "post_event", lambda issue, kind, **kw: posted.append((issue, kind)))
+    monkeypatch.setattr(pp, "list_events", lambda _issue: [])  # #1084 dedupe read stub
     runner = _Runner(
         describe_results=[GcloudRunResult(0, json.dumps({"status": "RUNNING"}), "")],
         guest_attr_results=[GcloudRunResult(0, _guest_attr_payload("done"), "")],
@@ -4870,6 +4871,7 @@ def test_poll_gcp_drain_scans_workload_root_fallback_glob(monkeypatch) -> None:
     (including the done tick) reported ``sentinels_processed=0``."""
     pp = _poll_pipeline_module()
     monkeypatch.setattr(pp, "post_event", lambda issue, kind, **kw: None)
+    monkeypatch.setattr(pp, "list_events", lambda _issue: [])  # #1084 dedupe read stub
     runner = _Runner(
         describe_results=[GcloudRunResult(0, json.dumps({"status": "RUNNING"}), "")],
         guest_attr_results=[GcloudRunResult(0, _guest_attr_payload("done"), "")],
@@ -4903,6 +4905,35 @@ def test_poll_gcp_drain_transport_failure_is_loud() -> None:
     assert "sudo: a password is required" in pr.log_tail_excerpt
 
 
+def test_gcp_drain_ssh_timeout_returns_transport_alarm() -> None:
+    """#1084 (W2, GCP arm): a drain-list SSH that HANGS past the runner's
+    per-call cap (``subprocess.TimeoutExpired`` — the #952 gcloud-ssh
+    hostkey-drift wedge) degrades to the EXISTING transport alarm instead of
+    an uncaught raise crashing the poll tick — same alarm tuple shape +
+    ``alarm_class="transport"`` as the rc!=0 branch, so the #669 wedge-gate
+    semantics (``reachability_alarm=True``) are inherited unchanged."""
+
+    class _TimeoutOnSshRunner(_Runner):
+        def __call__(self, argv):
+            argv = list(argv)
+            if "ssh" in argv and "compute" in argv:
+                self.calls.append(argv)
+                raise subprocess.TimeoutExpired(cmd=argv, timeout=300)
+            return super().__call__(argv)
+
+    runner = _TimeoutOnSshRunner(
+        describe_results=[GcloudRunResult(0, json.dumps({"status": "RUNNING"}), "")],
+        guest_attr_results=[GcloudRunResult(0, _guest_attr_payload("workload"), "")],
+    )
+    backend = GcpBackend(config=_test_config(), runner=runner, marker_poster=lambda **_: None)
+    pr = backend.poll(_drain_handle())
+    assert pr.status == "running"
+    assert pr.sentinels_processed == 0
+    assert "timed out after 300" in pr.log_tail_excerpt
+    assert "hung transport" in pr.log_tail_excerpt
+    assert pr.reachability_alarm is True
+
+
 def test_poll_gcp_drain_matched_but_empty_body_is_loud(monkeypatch) -> None:
     """A sentinel whose body reads back EMPTY (the pre-sudo permission
     symptom) must be reported loudly — glob matched, nothing processed."""
@@ -4932,6 +4963,7 @@ def test_poll_gcp_drain_gate_sentinel_parks(monkeypatch) -> None:
     poll_pipeline.poll_once): the orchestrator must park at the gate."""
     pp = _poll_pipeline_module()
     monkeypatch.setattr(pp, "post_event", lambda *a, **kw: None)
+    monkeypatch.setattr(pp, "list_events", lambda _issue: [])  # #1084 dedupe read stub
     runner = _Runner(
         describe_results=[GcloudRunResult(0, json.dumps({"status": "RUNNING"}), "")],
         guest_attr_results=[GcloudRunResult(0, _guest_attr_payload("workload"), "")],
@@ -5039,6 +5071,7 @@ def test_poll_drain_gate_keeps_short_interval(monkeypatch) -> None:
 
     pp = _poll_pipeline_module()
     monkeypatch.setattr(pp, "post_event", lambda *a, **kw: None)
+    monkeypatch.setattr(pp, "list_events", lambda _issue: [])  # #1084 dedupe read stub
     runner = _Runner(
         describe_results=[_describe_running(created_sec_ago=7200)],
         guest_attr_results=[GcloudRunResult(0, _guest_attr_payload("workload"), "")],
@@ -6375,6 +6408,7 @@ def test_drain_overlays_log_mtime_when_running(monkeypatch) -> None:
 
     pp = _poll_pipeline_module()
     monkeypatch.setattr(pp, "post_event", lambda *a, **kw: None)
+    monkeypatch.setattr(pp, "list_events", lambda _issue: [])  # #1084 dedupe read stub
     now = 1718000300
     stdout = _drain_stdout("19/19 cells done") + f"EPS_LOG_MTIME={now - 300}\nEPS_LOG_NOW={now}\n"
     runner = _Runner(
@@ -6435,6 +6469,7 @@ def test_drain_missing_mtime_keys_keeps_legacy_placeholder(monkeypatch) -> None:
     hardwired placeholder; old fixtures stay green untouched."""
     pp = _poll_pipeline_module()
     monkeypatch.setattr(pp, "post_event", lambda *a, **kw: None)
+    monkeypatch.setattr(pp, "list_events", lambda _issue: [])  # #1084 dedupe read stub
     runner = _Runner(
         describe_results=[GcloudRunResult(0, json.dumps({"status": "RUNNING"}), "")],
         guest_attr_results=[GcloudRunResult(0, _guest_attr_payload("workload"), "")],

--- a/tests/test_poll_pipeline_sentinels.py
+++ b/tests/test_poll_pipeline_sentinels.py
@@ -152,6 +152,20 @@ class _SubprocessRouter:
         )
 
 
+def _stub_no_prior_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the #1084 dedupe events read (``pp.list_events``) to "no prior
+    events" for drain tests that use a MagicMock ``post_event``: without the
+    stub, the drain's lazy ``_posted_sentinel_fps`` read would hit the REAL
+    ``list_events(<repo task id>)`` — coupling the test to checked-in task
+    state (benign today: no historical event carries ``sentinel_fp``) and,
+    under a patched ``subprocess.run``, to whatever fake is active. Same
+    mechanism as the existing ``pp.post_event`` monkeypatch (module-object
+    aliasing: ``pp.list_events is tw.list_events``). Tests that exercise the
+    dedupe itself either pass a prior-row stub directly or use ``fake_repo``
+    (REAL ``list_events`` against a tmp git repo)."""
+    monkeypatch.setattr(pp, "list_events", lambda _issue: [])
+
+
 # ── _parse_sentinel ─────────────────────────────────────────────────────────
 
 
@@ -378,13 +392,21 @@ def test_drain_posts_marker_and_renames(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setattr(pp.subprocess, "run", router)
     post_mock = MagicMock()
     monkeypatch.setattr(pp, "post_event", post_mock)
+    _stub_no_prior_events(monkeypatch)
 
     processed, gate = pp._drain_sentinels(issue=444, pod="epm-issue-444")
 
     assert processed == 1
     assert gate is None  # no gate carried
     post_mock.assert_called_once_with(
-        444, "epm:progress", version=1, by="experiment-implementer", note="phase=eval"
+        444,
+        "epm:progress",
+        version=1,
+        by="experiment-implementer",
+        note="phase=eval",
+        # #1084 idempotency extras ride every drain-posted event.
+        sentinel_fp=pp._sentinel_fingerprint(sentinel_path, json.dumps(body)),
+        sentinel_path=sentinel_path,
     )
     assert len(router.mv_calls) == 1
     assert sentinel_path in router.mv_calls[0]
@@ -397,6 +419,7 @@ def test_drain_surfaces_gate(monkeypatch: pytest.MonkeyPatch) -> None:
     router = _SubprocessRouter(glob_stdout=_glob_response((sentinel_path, json.dumps(body))))
     monkeypatch.setattr(pp.subprocess, "run", router)
     monkeypatch.setattr(pp, "post_event", MagicMock())
+    _stub_no_prior_events(monkeypatch)
 
     processed, gate = pp._drain_sentinels(issue=444, pod="epm-issue-444")
 
@@ -419,6 +442,7 @@ def test_drain_non_blocking_phase_signal_posts_but_does_not_surface_gate(
     monkeypatch.setattr(pp.subprocess, "run", router)
     post_mock = MagicMock()
     monkeypatch.setattr(pp, "post_event", post_mock)
+    _stub_no_prior_events(monkeypatch)
 
     processed, gate = pp._drain_sentinels(issue=641, pod="epm-issue-641")
 
@@ -430,6 +454,9 @@ def test_drain_non_blocking_phase_signal_posts_but_does_not_surface_gate(
         version=1,
         by="experiment-implementer",
         note="phase=base-propensity complete",
+        # #1084 idempotency extras ride every drain-posted event.
+        sentinel_fp=pp._sentinel_fingerprint(sentinel_path, json.dumps(body)),
+        sentinel_path=sentinel_path,
     )
     # ...but the gate is NOT surfaced, so the polling loop continues.
     assert gate is None
@@ -449,6 +476,7 @@ def test_drain_surfaces_gate_when_blocks_pipeline_field_absent(
     router = _SubprocessRouter(glob_stdout=_glob_response((sentinel_path, json.dumps(body))))
     monkeypatch.setattr(pp.subprocess, "run", router)
     monkeypatch.setattr(pp, "post_event", MagicMock())
+    _stub_no_prior_events(monkeypatch)
 
     processed, gate = pp._drain_sentinels(issue=444, pod="epm-issue-444")
 
@@ -466,6 +494,7 @@ def test_drain_skips_malformed_does_not_post(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(pp.subprocess, "run", router)
     post_mock = MagicMock()
     monkeypatch.setattr(pp, "post_event", post_mock)
+    _stub_no_prior_events(monkeypatch)
 
     processed, gate = pp._drain_sentinels(issue=444, pod="epm-issue-444")
 
@@ -505,6 +534,7 @@ def test_drain_does_not_rename_when_post_fails(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr(
         pp, "post_event", MagicMock(side_effect=RuntimeError("simulated post failure"))
     )
+    _stub_no_prior_events(monkeypatch)
 
     processed, gate = pp._drain_sentinels(issue=444, pod="epm-issue-444")
 
@@ -525,6 +555,7 @@ def test_drain_is_idempotent_after_rename(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(pp.subprocess, "run", router1)
     post_mock = MagicMock()
     monkeypatch.setattr(pp, "post_event", post_mock)
+    _stub_no_prior_events(monkeypatch)
     pp._drain_sentinels(issue=444, pod="epm-issue-444")
     assert post_mock.call_count == 1
     assert len(router1.mv_calls) == 1
@@ -549,6 +580,7 @@ def test_drain_falls_back_to_payload_key(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(pp.subprocess, "run", router)
     post_mock = MagicMock()
     monkeypatch.setattr(pp, "post_event", post_mock)
+    _stub_no_prior_events(monkeypatch)
 
     pp._drain_sentinels(issue=444, pod="epm-issue-444")
 
@@ -608,6 +640,7 @@ def test_poll_once_gate_overrides_done(monkeypatch: pytest.MonkeyPatch, tmp_path
 
     monkeypatch.setattr(pp.subprocess, "run", _fake_run)
     monkeypatch.setattr(pp, "post_event", MagicMock())
+    _stub_no_prior_events(monkeypatch)
 
     state_file = tmp_path / "poll-state.json"
     result = pp.poll_once(
@@ -1179,6 +1212,7 @@ def test_drain_oversize_note_persists_and_renames(
     # First call raises oversize; second call (the pointer marker) succeeds.
     post_mock = MagicMock(side_effect=[_oversize_value_error(52001), None])
     monkeypatch.setattr(pp, "post_event", post_mock)
+    _stub_no_prior_events(monkeypatch)
 
     processed, gate = pp._drain_sentinels(issue=477, pod="epm-issue-477")
 
@@ -1241,6 +1275,7 @@ def test_drain_oversize_note_forwards_gate(monkeypatch: pytest.MonkeyPatch, tmp_
     monkeypatch.setattr(pp.subprocess, "run", router)
     post_mock = MagicMock(side_effect=[_oversize_value_error(60000), None])
     monkeypatch.setattr(pp, "post_event", post_mock)
+    _stub_no_prior_events(monkeypatch)
 
     processed, gate = pp._drain_sentinels(issue=477, pod="epm-issue-477")
 
@@ -1272,6 +1307,7 @@ def test_drain_oversize_persist_failure_leaves_sentinel_unrenamed(
     monkeypatch.setattr(pp.subprocess, "run", router)
     post_mock = MagicMock(side_effect=_oversize_value_error(51000))
     monkeypatch.setattr(pp, "post_event", post_mock)
+    _stub_no_prior_events(monkeypatch)
 
     processed, gate = pp._drain_sentinels(issue=477, pod="epm-issue-477")
 
@@ -1304,6 +1340,7 @@ def test_drain_non_oversize_value_error_still_retried(
         "post_event",
         MagicMock(side_effect=ValueError("unrelated schema problem")),
     )
+    _stub_no_prior_events(monkeypatch)
     # find_task_path must NOT be called when the ValueError doesn't match
     # the oversize signature; raise if it is, to pin the routing.
     monkeypatch.setattr(
@@ -1335,6 +1372,7 @@ def test_oversize_pointer_note_fits_cap_even_for_huge_payload(
     monkeypatch.setattr(pp.subprocess, "run", router)
     post_mock = MagicMock(side_effect=[_oversize_value_error(5_000_000), None])
     monkeypatch.setattr(pp, "post_event", post_mock)
+    _stub_no_prior_events(monkeypatch)
 
     processed, _gate = pp._drain_sentinels(issue=477, pod="epm-issue-477")
 
@@ -1367,6 +1405,7 @@ def test_drain_posts_synthesized_results_marker_and_renames(
     monkeypatch.setattr(pp.subprocess, "run", router)
     post_mock = MagicMock()
     monkeypatch.setattr(pp, "post_event", post_mock)
+    _stub_no_prior_events(monkeypatch)
 
     processed, gate = pp._drain_sentinels(issue=444, pod="epm-issue-444")
 
@@ -1410,6 +1449,7 @@ def test_drain_synthesized_results_oversize_note_degrades(
     # First call raises oversize; second call (the pointer marker) succeeds.
     post_mock = MagicMock(side_effect=[_oversize_value_error(60_000), None])
     monkeypatch.setattr(pp, "post_event", post_mock)
+    _stub_no_prior_events(monkeypatch)
 
     processed, gate = pp._drain_sentinels(issue=444, pod="epm-issue-444")
 
@@ -1526,6 +1566,7 @@ def test_drain_real_enveloped_sentinel_keeps_explicit_version_verbatim(
     body = _sentinel_body(kind="epm:progress", version=7, gate=None, note="phase=eval")
     post_mock = MagicMock()
     monkeypatch.setattr(pp, "post_event", post_mock)
+    _stub_no_prior_events(monkeypatch)
 
     processed, gate = pp.drain_sentinels_via(
         issue=444,
@@ -1567,6 +1608,7 @@ def test_drain_real_sentinel_null_version_does_not_derive(
     }
     post_mock = MagicMock()
     monkeypatch.setattr(pp, "post_event", post_mock)
+    _stub_no_prior_events(monkeypatch)
 
     with pytest.raises(TypeError):
         pp.drain_sentinels_via(
@@ -1578,6 +1620,452 @@ def test_drain_real_sentinel_null_version_does_not_derive(
         )
 
     post_mock.assert_not_called()
+
+
+# ── drain: #1084 crash-safe idempotent replay (sentinel_fp dedupe) ──────────
+#
+# #1084 (incident #952): ``drain_sentinels_via`` posts BEFORE renaming, so a
+# poller killed/hung between the two steps used to re-post a DUPLICATE row on
+# the next tick (the W1 window). Every drain-posted event now carries a
+# ``sentinel_fp`` extra (sha256 of ``remote_path + "\n" + raw body``, 16 hex
+# chars) plus a ``sentinel_path`` extra; the drain lazily reads the task's
+# events once per invocation and on an fp hit SKIPS the re-post (loud
+# log.error) while still retrying the rename + extracting the gate.
+# Hang-bounding (W2): a RAISING ``mark_processed`` is a rename failure; a
+# TimeoutExpired/OSError ``list_sentinels`` is an empty drain; any other
+# ``list_sentinels`` exception still escapes (fail-fast).
+
+
+def test_drain_replay_after_rename_failure_posts_no_duplicate(fake_repo) -> None:
+    """Acceptance 1 (explicit-version arm): tick 1 posts + rename FAILS ->
+    tick 2 re-drains the same (path, body) and posts NOTHING new — the fp
+    dedupe skips the re-post and the rename is retried. REAL ``post_event``
+    / ``list_events`` against the fake repo (weakening to a mock is out —
+    the dedupe read + posted extras are themselves under test)."""
+    _repo, tw = fake_repo
+    assert pp.post_event is tw.post_event
+    assert pp.list_events is tw.list_events
+
+    new_id = tw.create_task(tw.NewTaskRequest(kind="experiment", title="replay e2e"))
+    sentinel_path = f"/workspace/logs/issue-{new_id}-epm_progress-1700000100.json"
+    body = json.dumps(_sentinel_body(kind="epm:progress", gate=None, note="phase=eval"))
+
+    # Tick 1: post succeeds, rename FAILS -> sentinel left in place (W1).
+    processed, gate = pp.drain_sentinels_via(
+        issue=new_id,
+        list_sentinels=lambda: [(sentinel_path, body)],
+        mark_processed=lambda _path: False,
+    )
+    assert processed == 1
+    assert gate is None
+    rows = [e for e in tw.list_events(new_id) if e["kind"] == "epm:progress"]
+    assert len(rows) == 1
+    assert rows[0]["sentinel_fp"] == pp._sentinel_fingerprint(sentinel_path, body)
+    assert rows[0]["sentinel_path"] == sentinel_path
+
+    # Tick 2: same (path, body) re-drained; rename now succeeds.
+    renamed: list[str] = []
+
+    def _mark(path: str) -> bool:
+        renamed.append(path)
+        return True
+
+    processed2, gate2 = pp.drain_sentinels_via(
+        issue=new_id,
+        list_sentinels=lambda: [(sentinel_path, body)],
+        mark_processed=_mark,
+    )
+    assert processed2 == 1  # accounting stays honest on the replay
+    assert gate2 is None
+    assert renamed == [sentinel_path]
+    rows2 = [e for e in tw.list_events(new_id) if e["kind"] == "epm:progress"]
+    assert len(rows2) == 1, "the replay must NOT post a duplicate row"
+
+
+def test_drain_replay_synthesized_envelope_posts_no_duplicate(fake_repo) -> None:
+    """Acceptance 1 (``version=None`` synthesized-envelope arm, #899/#975):
+    tick 1 lands the rescue at max+1 (v4 above a pre-seeded v3); the tick-2
+    replay lands NOTHING (still exactly [3, 4]) and renames the sentinel —
+    pre-#1084 the replay landed a byte-equivalent duplicate at a fresh v5."""
+    _repo, tw = fake_repo
+    assert pp.post_event is tw.post_event
+
+    new_id = tw.create_task(tw.NewTaskRequest(kind="experiment", title="rescue replay e2e"))
+    tw.post_event(new_id, "epm:results", version=3, by="seed")
+    sentinel_path = f"/workspace/logs/issue-{new_id}-results.json"
+    body = json.dumps(_raw_results_payload())
+
+    processed, _gate = pp.drain_sentinels_via(
+        issue=new_id,
+        list_sentinels=lambda: [(sentinel_path, body)],
+        mark_processed=lambda _path: False,  # rename fails -> W1 window
+    )
+    assert processed == 1
+    versions = [e["version"] for e in tw.list_events(new_id) if e["kind"] == "epm:results"]
+    assert versions == [3, 4]
+
+    renamed: list[str] = []
+    processed2, _gate2 = pp.drain_sentinels_via(
+        issue=new_id,
+        list_sentinels=lambda: [(sentinel_path, body)],
+        mark_processed=lambda path: renamed.append(path) or True,
+    )
+    assert processed2 == 1
+    assert renamed == [sentinel_path]
+    versions2 = [e["version"] for e in tw.list_events(new_id) if e["kind"] == "epm:results"]
+    assert versions2 == [3, 4], "the replay must not land a fresh max+1 (v5)"
+
+
+def test_drain_same_kind_version_different_content_both_post(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Acceptance 2: (kind, version) is NOT the dedupe key (§4.2 — writers
+    hardcode ``version: 1``); two DISTINCT sentinels at the same
+    (kind, version) with different notes + paths BOTH post."""
+    body_a = json.dumps(_sentinel_body(kind="epm:progress", gate=None, note="phase A done"))
+    body_b = json.dumps(_sentinel_body(kind="epm:progress", gate=None, note="phase B done"))
+    post_mock = MagicMock()
+    monkeypatch.setattr(pp, "post_event", post_mock)
+    _stub_no_prior_events(monkeypatch)
+
+    processed, _gate = pp.drain_sentinels_via(
+        issue=444,
+        list_sentinels=lambda: [
+            ("/workspace/logs/issue-444-epm_progress-1700000201.json", body_a),
+            ("/workspace/logs/issue-444-epm_progress-1700000202.json", body_b),
+        ],
+        mark_processed=lambda _path: True,
+    )
+
+    assert processed == 2
+    assert post_mock.call_count == 2
+
+
+def test_drain_identical_body_different_path_both_post(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pins path-in-fp (§4.2): byte-equal bodies at two DIFFERENT paths are
+    distinct signals (two phases both reporting the same text) — both post;
+    a content-only fp would wrongly dedupe the second."""
+    body = json.dumps(_sentinel_body(kind="epm:progress", gate=None, note="phase complete"))
+    post_mock = MagicMock()
+    monkeypatch.setattr(pp, "post_event", post_mock)
+    _stub_no_prior_events(monkeypatch)
+
+    processed, _gate = pp.drain_sentinels_via(
+        issue=444,
+        list_sentinels=lambda: [
+            ("/workspace/logs/issue-444-epm_progress-1700000301.json", body),
+            ("/workspace/logs/issue-444-epm_progress-1700000302.json", body),
+        ],
+        mark_processed=lambda _path: True,
+    )
+
+    assert processed == 2
+    assert post_mock.call_count == 2
+
+
+def test_drain_dedupe_hit_logs_matched_event(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The dedupe skip is LOUD (never silent): the log.error line names the
+    matched event's ts / kind / version AND the fp."""
+    sentinel_path = "/workspace/logs/issue-444-epm_progress-1700000401.json"
+    body = json.dumps(_sentinel_body(kind="epm:progress", gate=None, note="phase=eval"))
+    fp = pp._sentinel_fingerprint(sentinel_path, body)
+    prior = {
+        "ts": "2026-07-06T00:00:00+00:00",
+        "kind": "epm:progress",
+        "version": 2,
+        "by": "pod-sentinel",
+        "sentinel_fp": fp,
+        "sentinel_path": sentinel_path,
+    }
+    post_mock = MagicMock()
+    monkeypatch.setattr(pp, "post_event", post_mock)
+    monkeypatch.setattr(pp, "list_events", lambda _issue: [prior])
+    renamed: list[str] = []
+
+    with caplog.at_level(logging.ERROR, logger="poll_pipeline"):
+        processed, gate = pp.drain_sentinels_via(
+            issue=444,
+            list_sentinels=lambda: [(sentinel_path, body)],
+            mark_processed=lambda path: renamed.append(path) or True,
+        )
+
+    assert processed == 1
+    assert gate is None
+    post_mock.assert_not_called()
+    assert renamed == [sentinel_path]
+    skip_lines = [r.getMessage() for r in caplog.records if "skipping re-post" in r.getMessage()]
+    assert len(skip_lines) == 1
+    line = skip_lines[0]
+    assert "2026-07-06T00:00:00+00:00" in line  # matched event ts
+    assert "epm:progress" in line  # matched event kind
+    assert "v2" in line  # matched event version
+    assert fp in line  # the fingerprint
+
+
+def test_drain_oversize_replay_no_second_artifact_or_pointer(fake_repo) -> None:
+    """Acceptance 1 (oversize arm, #477): tick 1 degrades the oversize note
+    (artifact + pointer marker carrying the fp) and the rename FAILS; the
+    tick-2 replay dedupes on the POINTER's fp — no second artifact file, no
+    second pointer marker — and retries the rename."""
+    _repo, tw = fake_repo
+    new_id = tw.create_task(tw.NewTaskRequest(kind="experiment", title="oversize replay e2e"))
+    sentinel_path = f"/workspace/logs/issue-{new_id}-epm_progress-1700000500.json"
+    full_note = "x" * (pp.EVENT_NOTE_MAX + 1)
+    body = json.dumps(_sentinel_body(kind="epm:progress", gate=None, note=full_note))
+
+    processed, _gate = pp.drain_sentinels_via(
+        issue=new_id,
+        list_sentinels=lambda: [(sentinel_path, body)],
+        mark_processed=lambda _path: False,  # rename fails -> W1 window
+    )
+    assert processed == 1
+    task_dir = tw.find_task_path(new_id)
+    artifacts = list((task_dir / "artifacts").glob("sentinel-note-epm_progress-*.txt"))
+    assert len(artifacts) == 1
+    rows = [e for e in tw.list_events(new_id) if e["kind"] == "epm:progress"]
+    assert len(rows) == 1
+    assert rows[0].get("oversize") is True
+    assert rows[0]["sentinel_fp"] == pp._sentinel_fingerprint(sentinel_path, body)
+
+    renamed: list[str] = []
+    processed2, _gate2 = pp.drain_sentinels_via(
+        issue=new_id,
+        list_sentinels=lambda: [(sentinel_path, body)],
+        mark_processed=lambda path: renamed.append(path) or True,
+    )
+    assert processed2 == 1
+    assert renamed == [sentinel_path]  # rename retried
+    artifacts2 = list((task_dir / "artifacts").glob("sentinel-note-epm_progress-*.txt"))
+    assert len(artifacts2) == 1, "no second artifact file on the replay"
+    rows2 = [e for e in tw.list_events(new_id) if e["kind"] == "epm:progress"]
+    assert len(rows2) == 1, "no second pointer marker on the replay"
+
+
+def test_drain_mark_processed_raise_treated_as_rename_failure(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Acceptance 3 (W2b): a ``mark_processed`` that RAISES (hung SSH ->
+    ``subprocess.TimeoutExpired``) is treated as a rename failure — loud
+    log, sentinel left in place, loop CONTINUES to later sentinels, and no
+    exception escapes ``drain_sentinels_via``."""
+    path_1 = "/workspace/logs/issue-444-epm_progress-1700000601.json"
+    path_2 = "/workspace/logs/issue-444-epm_progress-1700000602.json"
+    body_1 = json.dumps(_sentinel_body(kind="epm:progress", gate=None, note="cell 1"))
+    body_2 = json.dumps(_sentinel_body(kind="epm:progress", gate=None, note="cell 2"))
+    post_mock = MagicMock()
+    monkeypatch.setattr(pp, "post_event", post_mock)
+    _stub_no_prior_events(monkeypatch)
+    renames: list[str] = []
+
+    def _mark(path: str) -> bool:
+        renames.append(path)
+        if path == path_1:
+            raise subprocess.TimeoutExpired(cmd="ssh", timeout=30)
+        return True
+
+    with caplog.at_level(logging.ERROR, logger="poll_pipeline"):
+        processed, gate = pp.drain_sentinels_via(
+            issue=444,
+            list_sentinels=lambda: [(path_1, body_1), (path_2, body_2)],
+            mark_processed=_mark,
+        )
+
+    assert processed == 2  # both accounted; the raise did not abort the loop
+    assert gate is None
+    assert post_mock.call_count == 2  # sentinel 2 still posted after the raise
+    assert renames == [path_1, path_2]
+    raise_lines = [
+        r.getMessage() for r in caplog.records if "mark_processed raised" in r.getMessage()
+    ]
+    assert len(raise_lines) == 1 and path_1 in raise_lines[0]
+
+
+def test_drain_list_sentinels_timeout_returns_empty_drain(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Acceptance 3 (W2a): a hung RunPod drain transport (``TimeoutExpired``
+    from ``list_sentinels``) yields an empty drain -> ``(0, None)`` +
+    log.error, no raise — mirroring the documented rc!=0 -> [] contract."""
+    post_mock = MagicMock()
+    monkeypatch.setattr(pp, "post_event", post_mock)
+
+    def _hang() -> list[tuple[str, str]]:
+        raise subprocess.TimeoutExpired(cmd="ssh", timeout=60)
+
+    with caplog.at_level(logging.ERROR, logger="poll_pipeline"):
+        processed, gate = pp.drain_sentinels_via(
+            issue=444, list_sentinels=_hang, mark_processed=lambda _p: True
+        )
+
+    assert (processed, gate) == (0, None)
+    post_mock.assert_not_called()
+    assert any("transport failed" in r.getMessage() for r in caplog.records)
+
+
+def test_drain_events_read_failure_fails_open_to_post(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Fail-OPEN (§11.4): a dedupe events-read failure must never block the
+    post — degraded mode re-posts (pre-#1084 status quo, loudly logged); a
+    LOST marker is never a possible outcome of the dedupe read."""
+    sentinel_path = "/workspace/logs/issue-444-epm_progress-1700000701.json"
+    body = json.dumps(_sentinel_body(kind="epm:progress", gate=None, note="phase=eval"))
+    post_mock = MagicMock()
+    monkeypatch.setattr(pp, "post_event", post_mock)
+    monkeypatch.setattr(
+        pp, "list_events", MagicMock(side_effect=RuntimeError("events.jsonl unreadable"))
+    )
+
+    with caplog.at_level(logging.ERROR, logger="poll_pipeline"):
+        processed, _gate = pp.drain_sentinels_via(
+            issue=444,
+            list_sentinels=lambda: [(sentinel_path, body)],
+            mark_processed=lambda _p: True,
+        )
+
+    assert processed == 1
+    post_mock.assert_called_once()  # the post still happened
+    assert any("posting without dedupe" in r.getMessage() for r in caplog.records)
+
+
+def test_drain_rename_failure_transport_level_counts_processed_and_logs(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """NEW transport-level rename-failure coverage (plan §6 test 10 — no
+    pre-#1084 test set ``mv_returncode != 0``): the remote ``mv -n`` fails
+    -> the sentinel stays un-renamed, ``processed`` still counts it (the §5
+    accounting invariant), the UPDATED loud rename-failure log promises the
+    idempotent replay, and nothing escapes."""
+    sentinel_path = "/workspace/logs/issue-444-epm_progress-1700000801.json"
+    body = _sentinel_body(kind="epm:progress", gate=None, note="phase=eval")
+    router = _SubprocessRouter(
+        glob_stdout=_glob_response((sentinel_path, json.dumps(body))), mv_returncode=1
+    )
+    monkeypatch.setattr(pp.subprocess, "run", router)
+    post_mock = MagicMock()
+    monkeypatch.setattr(pp, "post_event", post_mock)
+    _stub_no_prior_events(monkeypatch)
+
+    with caplog.at_level(logging.ERROR, logger="poll_pipeline"):
+        processed, gate = pp._drain_sentinels(issue=444, pod="epm-issue-444")
+
+    assert processed == 1  # accounting stays honest on rename failure
+    assert gate is None
+    post_mock.assert_called_once()
+    assert len(router.mv_calls) == 1  # the rename WAS attempted (rc != 0)
+    fail_lines = [r.getMessage() for r in caplog.records if "rename failed" in r.getMessage()]
+    assert any("replay idempotently" in line for line in fail_lines)
+
+
+def test_drain_same_path_different_content_posts_with_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A DIFFERENT body at a previously-posted path (the i488 fixed-filename
+    writer-contract-violation class) is NOT a dedupe hit — it posts
+    (fail-open: the new content is a distinct signal) PLUS a loud
+    changed-content warning. Mutation guard: an fp hashing the path alone
+    would dedupe-skip here and fail this test."""
+    sentinel_path = "/workspace/logs/issue-488-epm_smoke-result-1.json"  # fixed filename
+    body_1 = json.dumps(_sentinel_body(kind="epm:smoke-result", gate=None, note="phase A"))
+    body_2 = json.dumps(_sentinel_body(kind="epm:smoke-result", gate=None, note="phase B"))
+    prior = {
+        "ts": "2026-07-06T00:00:00+00:00",
+        "kind": "epm:smoke-result",
+        "version": 1,
+        "sentinel_fp": pp._sentinel_fingerprint(sentinel_path, body_1),
+        "sentinel_path": sentinel_path,
+    }
+    post_mock = MagicMock()
+    monkeypatch.setattr(pp, "post_event", post_mock)
+    monkeypatch.setattr(pp, "list_events", lambda _issue: [prior])
+
+    with caplog.at_level(logging.WARNING, logger="poll_pipeline"):
+        processed, _gate = pp.drain_sentinels_via(
+            issue=488,
+            list_sentinels=lambda: [(sentinel_path, body_2)],
+            mark_processed=lambda _p: True,
+        )
+
+    assert processed == 1
+    post_mock.assert_called_once()  # posts anyway — the second row lands
+    assert any("content CHANGED" in r.getMessage() for r in caplog.records)
+
+
+def test_drain_dedupe_replay_still_returns_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Acceptance 7: a dedupe-hit replay of a ``gate``-bearing
+    ``blocks_pipeline: True`` sentinel still RETURNS the gate — the dup
+    branch skips only the post, never the gate extraction (a ``continue``
+    past it would lose the park)."""
+    sentinel_path = "/workspace/logs/issue-444-epm_fact-candidates-1700000901.json"
+    body = json.dumps(_sentinel_body(kind="epm:fact-candidates", gate="fact-candidates"))
+    prior = {
+        "ts": "2026-07-06T00:00:00+00:00",
+        "kind": "epm:fact-candidates",
+        "version": 1,
+        "sentinel_fp": pp._sentinel_fingerprint(sentinel_path, body),
+        "sentinel_path": sentinel_path,
+    }
+    post_mock = MagicMock()
+    monkeypatch.setattr(pp, "post_event", post_mock)
+    monkeypatch.setattr(pp, "list_events", lambda _issue: [prior])
+    renamed: list[str] = []
+
+    processed, gate = pp.drain_sentinels_via(
+        issue=444,
+        list_sentinels=lambda: [(sentinel_path, body)],
+        mark_processed=lambda path: renamed.append(path) or True,
+    )
+
+    assert processed == 1
+    assert gate == "fact-candidates"  # the gate survives the dedupe skip
+    post_mock.assert_not_called()  # no duplicate row
+    assert renamed == [sentinel_path]  # rename retried
+
+
+def test_drain_list_sentinels_non_timeout_exception_escapes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Acceptance 8: the ``list_sentinels`` catch is deliberately NARROW
+    (``TimeoutExpired`` / ``OSError`` only) — a genuine code bug
+    (``ValueError``) still ESCAPES loud; a broad-except mutation fails
+    this test."""
+    monkeypatch.setattr(pp, "post_event", MagicMock())
+
+    def _bug() -> list[tuple[str, str]]:
+        raise ValueError("genuine code bug in the transport")
+
+    with pytest.raises(ValueError, match="genuine code bug"):
+        pp.drain_sentinels_via(issue=444, list_sentinels=_bug, mark_processed=lambda _p: True)
+
+
+def test_drain_duplicate_listing_same_tick_posts_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Acceptance 6: a duplicate (remote_path, body) tuple within ONE
+    ``list_sentinels()`` return posts exactly ONE event row — the in-memory
+    fp map is updated after each successful post (currently unreachable —
+    the canonical + fallback globs are disjoint — but a future overlapping
+    ``extra_globs`` must not reopen the same-tick double-post). Rename
+    attempts target only the unique path."""
+    sentinel_path = "/workspace/logs/issue-444-epm_progress-1700001001.json"
+    body = json.dumps(_sentinel_body(kind="epm:progress", gate=None, note="phase=eval"))
+    post_mock = MagicMock()
+    monkeypatch.setattr(pp, "post_event", post_mock)
+    _stub_no_prior_events(monkeypatch)
+    renamed: list[str] = []
+
+    pp.drain_sentinels_via(
+        issue=444,
+        list_sentinels=lambda: [(sentinel_path, body), (sentinel_path, body)],
+        mark_processed=lambda path: renamed.append(path) or True,
+    )
+
+    post_mock.assert_called_once()  # exactly ONE event row
+    assert set(renamed) == {sentinel_path}  # rename attempts only on the unique path
 
 
 # ── poll_once: shard-log staleness conjunction (incident #488) ──────────────


### PR DESCRIPTION
Closes task #1084 (workflow-fix, kind: infra).

## Summary
- `drain_sentinels_via` (scripts/poll_pipeline.py) gains an idempotency key: every drain-posted event carries a `sentinel_fp` extra (sha256 of `remote_path + "\n" + raw body`, 16 hex) + `sentinel_path`; replays of a posted-but-unrenamed sentinel (the #952 class) dedupe to rename-only with a loud log — exactly-once per drainer, fail-open on events-read failure (a lost marker is impossible).
- Hang-bounding: `mark_processed` raises degrade to rename-failure (loop continues); `list_sentinels` `TimeoutExpired`/`OSError` → empty drain; GCP drain-list SSH `TimeoutExpired` → the existing `"transport"` alarm tuple (backends/gcp.py).
- 15 new tests (incl. NEW transport-level rename-failure coverage; fail-pre-fix reproduced) + mechanical stubs.

## Test plan
- [x] `tests/test_poll_pipeline_sentinels.py` — 135 passed
- [x] `tests/test_gcp_backend.py` — 349 passed
- [x] Step 9c gate: 3256 passed / 6 skipped; `step9c_baseline.py compare` rc=0
- [x] ruff check + format clean; workflow_lint (no-flags + parity legs) green on both trees

🤖 Generated with [Claude Code](https://claude.com/claude-code)