### PR TITLE
task #709: RunPod SSH glob_sentinels — close #705's deferred stale-sentinel sibling probe over SSH

### DIFF
--- a/src/explore_persona_space/backends/artifacts.py
+++ b/src/explore_persona_space/backends/artifacts.py
@@ -828,6 +828,22 @@ def _check_git(
     return {"status": "PASS", "detail": f"all {len(paths)} path(s) tracked + on disk"}
 
 
+def _sentinel_probe_scope_ok(declared: str, issue: int) -> bool:
+    """True iff ``declared`` matches the canonical attempt-namespaced shape
+    ``.../eval_results/issue_<issue>/<attempt>/<SENTINEL_FILENAME>`` (#709,
+    the #705-review scope-guard concern). All three lanes' builders emit
+    this shape (``runpod.runpod_sentinel_path``, ``gcp.sentinel_path_for``,
+    ``slurm.sentinel_relpath_for``), so the guard is a no-op on every
+    production declaration; a non-canonical path (a hand-edited handle, a
+    legacy flat path) never triggers the sibling probe."""
+    p = Path(declared)
+    return (
+        p.name == SENTINEL_FILENAME
+        and p.parent.parent.name == f"issue_{issue}"
+        and p.parent.parent.parent.name == "eval_results"
+    )
+
+
 def _resolve_live_sentinel(declared: str, issue: int, io: VerifierIO) -> tuple[str, str | None]:
     """Resolve which sentinel path ``_check_sentinel`` should READ.
 
@@ -861,6 +877,24 @@ def _resolve_live_sentinel(declared: str, issue: int, io: VerifierIO) -> tuple[s
     FS glob by default) so tests stay FS-free; liveness is the SAME
     ``io.read_sentinel`` seam the content check uses.
 
+    Two #709 hardenings sit around the probe:
+
+    * **Scope guard** — the probe runs ONLY when the declared path
+      matches the canonical attempt-namespaced shape
+      (:func:`_sentinel_probe_scope_ok`); a non-canonical declared path
+      returns the declared (missing) path with a note, never a
+      resolution. Guarding here (the resolver) covers EVERY provider —
+      the FS default, the RunPod SSH variant, any future backend — with
+      one implementation.
+    * **Sibling-read wrap** — a per-sibling liveness read that RAISES
+      (materially reachable once RunPod's reads go over SSH, whose
+      reader raises on transport) marks the probe INCONCLUSIVE:
+      refuse-to-resolve and return the declared (missing) path with a
+      note, by the same never-guess conservatism as the >=2 rule — an
+      errored sibling *might* be live, and resolving to a different
+      readable sibling could pick the wrong attempt. No exception
+      escapes ``verify_artifacts``.
+
     Returns ``(path_to_read, note_or_None)``.
     """
     try:
@@ -874,6 +908,12 @@ def _resolve_live_sentinel(declared: str, issue: int, io: VerifierIO) -> tuple[s
         return declared, None
     if declared_present:
         return declared, None
+    if not _sentinel_probe_scope_ok(declared, issue):
+        return declared, (
+            f"declared sentinel {declared} missing and not the canonical "
+            f"eval_results/issue_{issue}/<attempt>/{SENTINEL_FILENAME} shape; "
+            "skipping the live-sibling probe (#709 scope guard)"
+        )
     try:
         siblings = io._glob_sentinels()(declared, issue)
     except Exception as exc:
@@ -881,7 +921,24 @@ def _resolve_live_sentinel(declared: str, issue: int, io: VerifierIO) -> tuple[s
         # to the declared (missing) path so the content read FAILs loud,
         # carrying the probe failure in the note.
         return declared, f"live-sibling probe raised: {exc}"
-    live = [s for s in siblings if s != declared and io._sentinel()(s) is not None]
+    live: list[str] = []
+    probe_errors: list[str] = []
+    for s in siblings:
+        if s == declared:
+            continue
+        try:
+            present = io._sentinel()(s) is not None
+        except Exception as exc:  # fail-closed: an unreadable sibling never crashes the gate
+            probe_errors.append(f"{s}: {exc}")
+            continue
+        if present:
+            live.append(s)
+    if probe_errors:
+        return declared, (
+            f"declared sentinel {declared} missing AND {len(probe_errors)} sibling "
+            f"liveness read(s) raised ({'; '.join(probe_errors)}) — probe inconclusive, "
+            "refusing to resolve; FAILing on the declared (missing) path (#709)"
+        )
     if len(live) == 1:
         return live[0], (
             f"declared sentinel {declared} missing; resolved to the single live "

--- a/src/explore_persona_space/backends/runpod.py
+++ b/src/explore_persona_space/backends/runpod.py
@@ -1192,6 +1192,59 @@ class RunPodBackend(ComputeBackend):
 
         return read
 
+    def _ssh_glob_sentinels(self, handle: RunHandle) -> Callable[[str, int], list[str]]:
+        """Build a remote sibling-sentinel glob bound to ``handle``'s pod (#709).
+
+        SSH sibling of :meth:`_ssh_read_sentinel` and of
+        ``artifacts._default_glob_sentinels``: enumerates the attempt-dir
+        sibling sentinels ``<issue_dir>/*/<name>`` on the POD filesystem so
+        ``_resolve_live_sentinel`` can resolve the #685-secondary stale-baked-
+        attempt case on the live-pod path. The resolution's soundness leans on
+        the #976 pre-workload stale-clear contract (the same ``issue_dir/*/
+        <name>`` operand): a launch path that baked attempt-namespaced
+        declarations WITHOUT the pre-workload ``rm`` would widen the
+        single-live-sibling window to a prior attempt's stale sentinel.
+        Semantics mirror the reader:
+
+        * rc=0            -> stdout lines, stripped, sorted (parity with the
+                             FS default's ``sorted(...)``).
+        * rc!=0 + "no such file" in stderr -> [] (bash passes an unmatched
+                             glob literally; ``ls`` errors "No such file or
+                             directory" -> zero siblings).
+        * any other rc    -> raise. A transport failure must NOT read as
+                             "no siblings"; the resolver's existing probe
+                             try/except turns the raise into the honest
+                             declared-missing FAIL with a note.
+        """
+
+        def glob(declared: str, issue: int) -> list[str]:
+            del issue  # parity with _default_glob_sentinels: encoded in the path.
+            parts = declared.rsplit("/", 2)
+            if len(parts) != 3:
+                return []  # non-canonical; resolver scope guard blocks this upstream.
+            issue_dir, _attempt, name = parts
+            remote_cmd = f"ls -1d {_shell_quote(issue_dir)}/*/{_shell_quote(name)}"
+            proc = subprocess.run(
+                ["ssh", handle.pod_name, remote_cmd],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=60,
+                check=False,
+            )
+            if proc.returncode == 0:
+                return sorted(ln.strip() for ln in proc.stdout.split("\n") if ln.strip())
+            stderr = (proc.stderr or "").lower()
+            if "no such file" in stderr:
+                return []
+            raise RuntimeError(
+                f"ssh sentinel glob on {handle.pod_name} failed "
+                f"rc={proc.returncode}: {(proc.stderr or '')[:300]}"
+            )
+
+        return glob
+
     def confirm_artifacts(self, handle: RunHandle) -> bool:
         """Backend-agnostic artifact verification.
 
@@ -1209,7 +1262,9 @@ class RunPodBackend(ComputeBackend):
         responsible for populating it; silently passing a handle that
         forgot is the silent-loss hole the verifier closes). The
         sentinel check reads the pod-side file over SSH via
-        :meth:`_ssh_read_sentinel` (#598); HF / WandB / git checks keep
+        :meth:`_ssh_read_sentinel` (#598), and the stale-baked-attempt
+        sibling probe now also runs pod-side via
+        :meth:`_ssh_glob_sentinels` (#709); HF / WandB / git checks keep
         their default wires.
         """
         # Lazy import to keep the runpod module importable without the
@@ -1220,7 +1275,11 @@ class RunPodBackend(ComputeBackend):
         )
 
         verdict = confirm_artifacts_from_handle(
-            handle, io=VerifierIO(read_sentinel=self._ssh_read_sentinel(handle))
+            handle,
+            io=VerifierIO(
+                read_sentinel=self._ssh_read_sentinel(handle),
+                glob_sentinels=self._ssh_glob_sentinels(handle),
+            ),
         )
         if not verdict.passed:
             # Use print rather than a module logger here so the failure

--- a/tests/test_backend_artifacts_verify.py
+++ b/tests/test_backend_artifacts_verify.py
@@ -21,6 +21,7 @@ cover the contract :mod:`backends.artifacts` promises:
 from __future__ import annotations
 
 import json
+import logging
 import shutil
 import subprocess
 from pathlib import Path
@@ -1318,6 +1319,348 @@ def test_stale_baked_sentinel_wrong_issue_sibling_still_fails(tmp_path: Path) ->
     assert not verdict.passed
     assert verdict.checks[CHECK_SENTINEL]["status"] == "FAIL"
     assert "999" in verdict.checks[CHECK_SENTINEL]["detail"]
+
+
+# ---------------------------------------------------------------------------
+# #709: SSH-backed ``glob_sentinels`` for RunPod ``confirm_artifacts`` — the
+# live-pod sibling of the #705 local-FS resolution above — plus the two
+# included hardening pieces (resolver scope guard, sibling-read wrap). The
+# 1 / 0 / >=2 / wrong-issue contract is re-pinned END-TO-END through
+# ``backend.confirm_artifacts`` with a dispatching fake ``subprocess.run``.
+# ---------------------------------------------------------------------------
+
+
+class _FakeProc:
+    """Minimal ``subprocess.run`` result stand-in (rc / stdout / stderr)."""
+
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _pod_ssh_dispatcher(
+    pod_fs: dict[str, str],
+    *,
+    ls_result: _FakeProc | None = None,
+    argv_log: list[list[str]] | None = None,
+):
+    """Fake ``subprocess.run`` dispatching on the remote command string.
+
+    ``cat '<path>'`` resolves against ``pod_fs`` (rc=0 + content when
+    present, rc=1 + "No such file or directory" when absent, mirroring the
+    real pod); ``ls -1d ...`` returns ``ls_result`` verbatim. Every argv is
+    optionally recorded so tests can pin the exact SSH command shape. No
+    real ``ssh pod-*`` can ever run from the suite.
+    """
+
+    def run(argv, **kwargs):
+        if argv_log is not None:
+            argv_log.append(list(argv))
+        assert argv[0] == "ssh", argv
+        cmd = argv[2]
+        if cmd.startswith("ls -1d "):
+            assert ls_result is not None, f"unexpected ls call: {cmd}"
+            return ls_result
+        assert cmd.startswith("cat "), cmd
+        path = cmd[len("cat ") :].strip("'")
+        if path in pod_fs:
+            return _FakeProc(0, stdout=pod_fs[path])
+        return _FakeProc(1, stderr=f"cat: {path}: No such file or directory")
+
+    return run
+
+
+def _runpod_sentinel_only_handle(*, issue: int, declared: str) -> RunHandle:
+    """RunPod handle whose declaration carries ONLY issue + sentinel_path.
+
+    Every other check class SKIPs (nothing declared), so the sentinel
+    check — the property under test — is the sole live check.
+    """
+    return _handle_with_expected(
+        backend="runpod",
+        issue=issue,
+        declaration={"issue": issue, "sentinel_path": declared},
+    )
+
+
+def test_runpod_ssh_glob_sentinels_command_shape_and_parsing(monkeypatch) -> None:
+    """#709 test 1: the SSH glob's exact argv (quoted issue-dir prefix, an
+    UNQUOTED ``*`` between the quoted segments so the remote bash expands
+    it, quoted basename) and rc=0 parsing (stripped lines, SORTED — parity
+    with the FS default's ``sorted(...)``)."""
+    backend = RunPodBackend()
+    declared = f"/workspace/eval_results/issue_42/rp-STALE/{SENTINEL_FILENAME}"
+    sib_a = f"/workspace/eval_results/issue_42/rp-a/{SENTINEL_FILENAME}"
+    sib_b = f"/workspace/eval_results/issue_42/rp-b/{SENTINEL_FILENAME}"
+    handle = _runpod_sentinel_only_handle(issue=42, declared=declared)
+
+    argv_log: list[list[str]] = []
+
+    def run(argv, **kwargs):
+        argv_log.append(list(argv))
+        # Two lines UNSORTED with stray whitespace + a blank trailer.
+        return _FakeProc(0, stdout=f" {sib_b} \n{sib_a}\n\n")
+
+    monkeypatch.setattr("subprocess.run", run)
+    result = backend._ssh_glob_sentinels(handle)(declared, 42)
+    assert argv_log == [
+        [
+            "ssh",
+            "pod-42",
+            "ls -1d '/workspace/eval_results/issue_42'/*/'.completion-sentinel.json'",
+        ]
+    ]
+    assert result == [sib_a, sib_b]  # sorted + stripped
+
+
+def test_runpod_ssh_glob_sentinels_no_match_and_transport(monkeypatch) -> None:
+    """#709 test 2: rc!=0 + "No such file or directory" (bash passed the
+    unmatched glob literally to ``ls``) → [] (zero siblings); any OTHER
+    non-zero rc (transport) → RAISE — a transport failure must never read
+    as "no siblings"."""
+    backend = RunPodBackend()
+    declared = f"/workspace/eval_results/issue_42/rp-STALE/{SENTINEL_FILENAME}"
+    handle = _runpod_sentinel_only_handle(issue=42, declared=declared)
+
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **k: _FakeProc(
+            2, stderr="ls: cannot access '/workspace/...': No such file or directory"
+        ),
+    )
+    assert backend._ssh_glob_sentinels(handle)(declared, 42) == []
+
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **k: _FakeProc(255, stderr="ssh: connect to host pod-42 port 22 failed"),
+    )
+    with pytest.raises(RuntimeError, match="rc=255"):
+        backend._ssh_glob_sentinels(handle)(declared, 42)
+
+
+def test_runpod_confirm_resolves_single_live_pod_side_sibling(monkeypatch) -> None:
+    """#709 test 3 (the headline end-to-end): the declared (stale baked
+    attempt) sentinel is missing ON THE POD and exactly ONE live sibling
+    attempt-dir sentinel exists pod-side → ``backend.confirm_artifacts``
+    resolves it over SSH and PASSes. Mirror of the #705 local-FS
+    ``test_stale_baked_sentinel_resolves_to_single_live_sibling``."""
+    issue = 42
+    declared = f"/workspace/eval_results/issue_{issue}/rp-STALE/{SENTINEL_FILENAME}"
+    live_sibling = f"/workspace/eval_results/issue_{issue}/rp-LIVE/{SENTINEL_FILENAME}"
+    handle = _runpod_sentinel_only_handle(issue=issue, declared=declared)
+    backend = RunPodBackend()
+    monkeypatch.setattr(
+        "subprocess.run",
+        _pod_ssh_dispatcher(
+            {live_sibling: _good_sentinel_text(issue=issue)},
+            ls_result=_FakeProc(0, stdout=live_sibling + "\n"),
+        ),
+    )
+    assert backend.confirm_artifacts(handle) is True
+
+
+def test_runpod_confirm_zero_remote_siblings_still_fails(monkeypatch) -> None:
+    """#709 test 4 (gate not relaxed): declared missing on the pod AND zero
+    remote siblings → FAIL with the real "missing" reason. Mirror of
+    ``test_stale_baked_sentinel_zero_live_siblings_still_fails``."""
+    issue = 42
+    declared = f"/workspace/eval_results/issue_{issue}/rp-STALE/{SENTINEL_FILENAME}"
+    handle = _runpod_sentinel_only_handle(issue=issue, declared=declared)
+    backend = RunPodBackend()
+    monkeypatch.setattr(
+        "subprocess.run",
+        _pod_ssh_dispatcher(
+            {},
+            ls_result=_FakeProc(
+                2, stderr="ls: cannot access '/workspace/...': No such file or directory"
+            ),
+        ),
+    )
+    assert backend.confirm_artifacts(handle) is False
+    verdict = confirm_artifacts_from_handle(
+        handle,
+        io=VerifierIO(
+            read_sentinel=backend._ssh_read_sentinel(handle),
+            glob_sentinels=backend._ssh_glob_sentinels(handle),
+        ),
+    )
+    assert not verdict.passed
+    assert verdict.checks[CHECK_SENTINEL]["status"] == "FAIL"
+    assert f"missing at {declared}" in verdict.checks[CHECK_SENTINEL]["detail"]
+
+
+def test_runpod_confirm_two_remote_siblings_refuses_to_guess(monkeypatch) -> None:
+    """#709 test 5 (the #705 known-limitation contract, unchanged on the
+    SSH path): >=2 live remote siblings → do NOT guess; FAIL on the
+    DECLARED attempt's path."""
+    issue = 42
+    declared = f"/workspace/eval_results/issue_{issue}/rp-STALE/{SENTINEL_FILENAME}"
+    sib_a = f"/workspace/eval_results/issue_{issue}/rp-A/{SENTINEL_FILENAME}"
+    sib_b = f"/workspace/eval_results/issue_{issue}/rp-B/{SENTINEL_FILENAME}"
+    handle = _runpod_sentinel_only_handle(issue=issue, declared=declared)
+    backend = RunPodBackend()
+    monkeypatch.setattr(
+        "subprocess.run",
+        _pod_ssh_dispatcher(
+            {
+                sib_a: _good_sentinel_text(issue=issue),
+                sib_b: _good_sentinel_text(issue=issue),
+            },
+            ls_result=_FakeProc(0, stdout=f"{sib_a}\n{sib_b}\n"),
+        ),
+    )
+    assert backend.confirm_artifacts(handle) is False
+    verdict = confirm_artifacts_from_handle(
+        handle,
+        io=VerifierIO(
+            read_sentinel=backend._ssh_read_sentinel(handle),
+            glob_sentinels=backend._ssh_glob_sentinels(handle),
+        ),
+    )
+    assert not verdict.passed
+    assert verdict.checks[CHECK_SENTINEL]["status"] == "FAIL"
+    # FAILs on the DECLARED attempt id, not on a guessed sibling.
+    assert "rp-STALE" in verdict.checks[CHECK_SENTINEL]["detail"]
+
+
+def test_runpod_confirm_wrong_issue_remote_sibling_still_fails(monkeypatch) -> None:
+    """#709 test 6 (content checks unchanged — resolution only): the single
+    live remote sibling carries a DIFFERENT issue's content → the UNCHANGED
+    issue-match content check FAILs."""
+    issue = 42
+    declared = f"/workspace/eval_results/issue_{issue}/rp-STALE/{SENTINEL_FILENAME}"
+    live_sibling = f"/workspace/eval_results/issue_{issue}/rp-LIVE/{SENTINEL_FILENAME}"
+    handle = _runpod_sentinel_only_handle(issue=issue, declared=declared)
+    backend = RunPodBackend()
+    monkeypatch.setattr(
+        "subprocess.run",
+        _pod_ssh_dispatcher(
+            {live_sibling: _good_sentinel_text(issue=999)},  # wrong issue
+            ls_result=_FakeProc(0, stdout=live_sibling + "\n"),
+        ),
+    )
+    assert backend.confirm_artifacts(handle) is False
+    verdict = confirm_artifacts_from_handle(
+        handle,
+        io=VerifierIO(
+            read_sentinel=backend._ssh_read_sentinel(handle),
+            glob_sentinels=backend._ssh_glob_sentinels(handle),
+        ),
+    )
+    assert not verdict.passed
+    assert verdict.checks[CHECK_SENTINEL]["status"] == "FAIL"
+    assert "999" in verdict.checks[CHECK_SENTINEL]["detail"]
+
+
+def test_sentinel_probe_scope_guard_blocks_noncanonical_declared() -> None:
+    """#709 test 7 (scope guard): a declared path that does not match the
+    canonical ``.../eval_results/issue_<N>/<attempt>/<SENTINEL_FILENAME>``
+    shape NEVER invokes the sibling probe — the verdict is the declared
+    FAIL even when a probe WOULD have returned a live sibling. Positive
+    control: the canonical shape DOES invoke the probe and resolves."""
+    issue = 685
+    live_sibling = f"/scratch/eval_results/issue_{issue}/att-LIVE/{SENTINEL_FILENAME}"
+    fs = {live_sibling: _good_sentinel_text(issue=issue)}
+    glob_calls: list[tuple[str, int]] = []
+
+    def recording_glob(declared: str, iss: int) -> list[str]:
+        glob_calls.append((declared, iss))
+        return [live_sibling]
+
+    io = VerifierIO(read_sentinel=lambda p: fs.get(p), glob_sentinels=recording_glob)
+
+    noncanonical = [
+        # grandparent != issue_<N>
+        f"/tmp/odd/x/{SENTINEL_FILENAME}",
+        # wrong basename
+        f"/scratch/eval_results/issue_{issue}/att-STALE/sentinel.json",
+        # great-grandparent != eval_results
+        f"/scratch/other_results/issue_{issue}/att-STALE/{SENTINEL_FILENAME}",
+    ]
+    for declared in noncanonical:
+        expected = ExpectedArtifacts(issue=issue, sentinel_path=declared)
+        verdict = verify_artifacts(expected, io=io)
+        assert not verdict.passed, declared
+        assert verdict.checks[CHECK_SENTINEL]["status"] == "FAIL"
+        assert f"missing at {declared}" in verdict.checks[CHECK_SENTINEL]["detail"]
+    assert glob_calls == []  # the probe was NEVER invoked on a non-canonical shape
+
+    canonical = f"/scratch/eval_results/issue_{issue}/att-STALE/{SENTINEL_FILENAME}"
+    expected = ExpectedArtifacts(issue=issue, sentinel_path=canonical)
+    verdict = verify_artifacts(expected, io=io)
+    assert verdict.passed, verdict.reasons
+    assert glob_calls == [(canonical, issue)]
+
+
+def test_sibling_liveness_read_error_fails_structured_not_raise(caplog) -> None:
+    """#709 test 8 (sibling-read wrap): a sibling liveness read that RAISES
+    (the SSH reader's transport contract) yields a structured declared-path
+    FAIL — no exception escapes ``verify_artifacts`` — and the probe is
+    refused even though ANOTHER sibling read live (never-guess: the errored
+    sibling might be the right attempt)."""
+    issue = 685
+    declared = f"/scratch/eval_results/issue_{issue}/att-STALE/{SENTINEL_FILENAME}"
+    sib_a = f"/scratch/eval_results/issue_{issue}/att-A/{SENTINEL_FILENAME}"
+    sib_b = f"/scratch/eval_results/issue_{issue}/att-B/{SENTINEL_FILENAME}"
+
+    def read(path: str) -> str | None:
+        if path == declared:
+            return None
+        if path == sib_a:
+            raise RuntimeError("ssh sentinel read from pod-685 failed rc=255")
+        return _good_sentinel_text(issue=issue)
+
+    expected = ExpectedArtifacts(issue=issue, sentinel_path=declared)
+    io = VerifierIO(read_sentinel=read, glob_sentinels=lambda decl, iss: [sib_a, sib_b])
+    with caplog.at_level(logging.WARNING):
+        verdict = verify_artifacts(expected, io=io)  # returns a verdict, never raises
+    assert not verdict.passed
+    assert verdict.checks[CHECK_SENTINEL]["status"] == "FAIL"
+    assert f"missing at {declared}" in verdict.checks[CHECK_SENTINEL]["detail"]
+    assert "probe inconclusive" in caplog.text
+
+
+def test_runpod_confirm_glob_transport_failure_fails_declared_not_raise(
+    monkeypatch, caplog
+) -> None:
+    """#709 test 9 (round-1 reconciler Must-Fix, binding): a raising SSH
+    glob (rc=255 transport error) during the sibling probe never escapes
+    ``verify_artifacts`` — end-to-end through ``backend.confirm_artifacts``
+    the verdict is FAIL on the DECLARED path with the "live-sibling probe
+    raised" note. Pins the resolver's glob-call try/except, which the SSH
+    provider makes load-bearing: deleting/narrowing that except would pass
+    every other test while turning a transport blip into an
+    orchestrator-finalize crash."""
+    issue = 42
+    declared = f"/workspace/eval_results/issue_{issue}/rp-STALE/{SENTINEL_FILENAME}"
+    handle = _runpod_sentinel_only_handle(issue=issue, declared=declared)
+    backend = RunPodBackend()
+    monkeypatch.setattr(
+        "subprocess.run",
+        _pod_ssh_dispatcher(
+            {},  # declared missing on the pod
+            ls_result=_FakeProc(
+                255, stderr="ssh: connect to host pod-42 port 22: Connection refused"
+            ),
+        ),
+    )
+    with caplog.at_level(logging.WARNING):
+        # (a) NO exception escapes — the gate returns a normal False.
+        assert backend.confirm_artifacts(handle) is False
+        verdict = confirm_artifacts_from_handle(
+            handle,
+            io=VerifierIO(
+                read_sentinel=backend._ssh_read_sentinel(handle),
+                glob_sentinels=backend._ssh_glob_sentinels(handle),
+            ),
+        )
+    assert not verdict.passed
+    assert verdict.checks[CHECK_SENTINEL]["status"] == "FAIL"
+    # (b) FAILs on the DECLARED (missing) path.
+    assert f"missing at {declared}" in verdict.checks[CHECK_SENTINEL]["detail"]
+    # (c) the probe-failure note surfaces at WARNING.
+    assert "live-sibling probe raised" in caplog.text
 
 
 def test_new_fields_default_off_round_trip_back_compat(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes task #709.

Adds an SSH-backed `glob_sentinels` to `RunPodBackend.confirm_artifacts` (mirroring `_ssh_read_sentinel`'s transport) so the #705 multi-attempt stale-sentinel sibling probe resolves over the live pod's filesystem, plus the two reconciler-named hardenings (resolver-level canonical-shape scope guard; sibling-read wrap → structured declared FAIL). 9 new tests; gate never relaxed; local-FS default byte-untouched.

Plan: tasks/reviewing/709/plans/v7.md · Review: PASS+PASS (Claude+Codex) · Step 9c: 3031 passed / 0 new failures.