### PR TITLE
issue-1089: verifier WARN on stale concern-deferred markers (#1089)

### DIFF
--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -7295,7 +7295,9 @@ def check_hf_adjacent_file_claims(body: str) -> CheckResult:
     return CheckResult(name, True, detail + unverified_detail)
 
 
-def check_concerns_audit(body: str, *, concerns_path: Path | None = None) -> CheckResult:
+def check_concerns_audit(  # noqa: C901 — linear lens: ledger parse → stale-marker scan → ack scan
+    body: str, *, concerns_path: Path | None = None
+) -> CheckResult:
     """Lens 14 — mechanical concerns audit (binding-concerns contract,
     composed onto the 2-content-section clean-result spec on 2026-05-31
     by task #455).
@@ -7323,6 +7325,12 @@ def check_concerns_audit(body: str, *, concerns_path: Path | None = None) -> Che
 
     NIT-severity concerns do NOT block this check; they surface as
     informational only.
+
+    Additionally WARNs (never FAILs) on stale deferral markers: a
+    ``<!-- concern-deferred: <id> -->`` whose id's latest ledger event is
+    ``addressed``, or whose id is absent from the ledger (#1089, incident
+    #833). A live marker (latest event raised / verified-open / deferred)
+    is unchanged.
 
     Skipped (PASS) when ``concerns_path`` is None or missing
     (``--body-stdin`` invocations, freshly created tasks with no concerns
@@ -7364,7 +7372,39 @@ def check_concerns_audit(body: str, *, concerns_path: Path | None = None) -> Che
         if ev.get("event") in ("raised", "verified-open")
         and ev.get("severity") in ("BLOCKER", "CONCERN")
     ]
+
+    # Stale-marker scan (#1089) — hoisted ABOVE the no-open-binding early
+    # return so it fires in the #833 shape (all concerns addressed →
+    # `open_binding` empty → the old post-early-return scan never ran).
+    # Acknowledgement mechanism 3's regex lives here now (moved up from
+    # the ack scan below — one pattern, one definition).
+    deferral_re = re.compile(r"<!--\s*concern-deferred:\s*([a-z0-9][a-z0-9-]{1,79})\s*-->")
+    deferred_ids = set(deferral_re.findall(body))
+    stale_warns: list[str] = []
+    for cid in sorted(deferred_ids):  # sorted → deterministic detail
+        ev = latest.get(cid)
+        if ev is None:
+            stale_warns.append(
+                f"stale concern-deferred marker '{cid}' — id absent from concerns.jsonl; "
+                "remove or retag"
+            )
+        elif ev.get("event") == "addressed":
+            stale_warns.append(
+                f"stale concern-deferred marker '{cid}' — concern is addressed; remove or retag"
+            )
+        # raised / verified-open / deferred → live marker, no WARN (unchanged
+        # behavior). DELIBERATE fallthrough: a malformed/unknown `event` value
+        # (hand-edited or corrupt ledger row outside CONCERN_EVENTS) is treated
+        # as live — conservative no-WARN for a WARN-only check.
+
     if not open_binding:
+        if stale_warns:
+            return CheckResult(
+                "concerns audit (Lens 14)",
+                True,
+                "; ".join(stale_warns),
+                is_warn=True,
+            )
         return CheckResult(
             "concerns audit (Lens 14)",
             True,
@@ -7419,10 +7459,9 @@ def check_concerns_audit(body: str, *, concerns_path: Path | None = None) -> Che
         )
         conf_body = conf_match.group(0) if conf_match else ""
 
-    # Acknowledgement mechanism 3: explicit deferral HTML comment.
-    deferral_re = re.compile(r"<!--\s*concern-deferred:\s*([a-z0-9][a-z0-9-]{1,79})\s*-->")
-    deferred_ids = set(deferral_re.findall(body))
-
+    # Acknowledgement mechanism 3: explicit deferral HTML comment —
+    # `deferred_ids` was computed by the stale-marker scan above (the
+    # regex moved up with it, #1089).
     unaddressed: list[str] = []
     for ev in open_binding:
         cid = ev["concern_id"]
@@ -7445,7 +7484,15 @@ def check_concerns_audit(body: str, *, concerns_path: Path | None = None) -> Che
             f"{', '.join(unaddressed)}. Acknowledge each in {ack_hint}"
             "or a `<!-- concern-deferred: <id> -->` HTML marker. See "
             "`.claude/agents/clean-result-critic.md` § Lens 14 "
-            "and `workflow.yaml § concerns_protocol`.",
+            "and `workflow.yaml § concerns_protocol`."
+            + (("; WARN: " + "; ".join(stale_warns)) if stale_warns else ""),
+        )
+    if stale_warns:  # all acknowledged, but stale deferral markers remain (#1089)
+        return CheckResult(
+            "concerns audit (Lens 14)",
+            True,
+            "; ".join(stale_warns),
+            is_warn=True,
         )
     return CheckResult(
         "concerns audit (Lens 14)",

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -4618,6 +4618,9 @@ def test_concerns_audit_fails_on_unaddressed_concern(tmp_path):
     assert not result.passed
     assert "probe-position-undefined" in result.detail
     assert "(CONCERN)" in result.detail
+    # No deferral markers in the body → no spurious stale-marker WARN
+    # suffix on the FAIL detail (#1089).
+    assert "; WARN:" not in result.detail
 
 
 def test_concerns_audit_passes_when_acknowledged_in_tldr_h3(tmp_path):
@@ -4690,6 +4693,8 @@ def test_concerns_audit_passes_with_deferral_html_marker(tmp_path):
     body = GOOD_BODY + "\n<!-- concern-deferred: scope-deferred-thing -->\n"
     result = verify_task_body.check_concerns_audit(body, concerns_path=cp)
     assert result.passed
+    # Deferring a LIVE open concern (latest event `raised`) never warns (#1089).
+    assert not result.is_warn
 
 
 def test_concerns_audit_only_latest_event_per_id_counts(tmp_path):
@@ -4750,6 +4755,156 @@ def test_concerns_audit_sees_row_with_raw_unicode_line_separator(tmp_path):
     assert not result.passed
     assert "u2028-blocker-must-be-seen" in result.detail
     assert "(BLOCKER)" in result.detail
+
+
+def test_concerns_audit_warns_on_stale_deferred_marker_when_addressed(tmp_path):
+    """A `<!-- concern-deferred: <id> -->` marker whose id's latest ledger
+    event is `addressed` is STALE: it misdescribes the resolution (the
+    concern was fixed, not deferred). The check WARNs (never FAILs),
+    naming the stale id — the #833 shape, where `open_binding` is empty
+    and the pre-#1089 code never scanned the markers at all. Also pins
+    dedup (a duplicate marker for the same id warns once) and
+    deterministic sorted-by-id ordering across multiple stale ids."""
+    cp = tmp_path / "concerns.jsonl"
+    rows = [
+        {"event": "raised", "concern_id": "now-fixed-thing", "severity": "CONCERN"},
+        {"event": "addressed", "concern_id": "now-fixed-thing", "severity": "CONCERN"},
+        {"event": "raised", "concern_id": "another-fixed-thing", "severity": "CONCERN"},
+        {"event": "addressed", "concern_id": "another-fixed-thing", "severity": "CONCERN"},
+    ]
+    cp.write_text("".join(json.dumps(r) + "\n" for r in rows))
+    body = (
+        GOOD_BODY
+        + "\n<!-- concern-deferred: now-fixed-thing -->\n"
+        + "<!-- concern-deferred: another-fixed-thing -->\n"
+        # Duplicate marker for the first id — dedupes to one WARN.
+        + "<!-- concern-deferred: now-fixed-thing -->\n"
+    )
+    result = verify_task_body.check_concerns_audit(body, concerns_path=cp)
+    assert result.passed
+    assert result.is_warn
+    assert "now-fixed-thing" in result.detail
+    assert "addressed" in result.detail
+    assert "remove or retag" in result.detail
+    # Verbatim WARN strings (#1089 plan §3.2), joined "; " in sorted-id order,
+    # each id exactly once despite the duplicate marker.
+    assert result.detail == (
+        "stale concern-deferred marker 'another-fixed-thing' — concern is addressed; "
+        "remove or retag; "
+        "stale concern-deferred marker 'now-fixed-thing' — concern is addressed; "
+        "remove or retag"
+    )
+
+
+def test_concerns_audit_warns_on_deferred_marker_absent_from_ledger(tmp_path):
+    """A `<!-- concern-deferred: <id> -->` marker naming an id the ledger
+    has never heard of WARNs with distinct wording: `defer_concern`
+    refuses never-raised ids, so an absent-id marker is a typo or a
+    cross-task body copy — either way it does not correspond to this
+    task's ledger."""
+    cp = tmp_path / "concerns.jsonl"
+    cp.write_text("")  # empty ledger — the id is absent by construction
+    body = GOOD_BODY + "\n<!-- concern-deferred: ghost-concern -->\n"
+    result = verify_task_body.check_concerns_audit(body, concerns_path=cp)
+    assert result.passed
+    assert result.is_warn
+    assert "ghost-concern" in result.detail
+    assert "absent" in result.detail
+
+
+def test_concerns_audit_live_deferred_ledger_event_no_warn(tmp_path):
+    """Case (c), `deferred` branch: a marker whose id's latest ledger
+    event is `deferred` is LIVE — the canonical defer path produced it —
+    so no WARN fires (behavior unchanged from pre-#1089). Also covers the
+    `verified-open` branch (the last live-vocabulary cell)."""
+    cp = tmp_path / "concerns.jsonl"
+    rows = [
+        {"event": "raised", "concern_id": "parked-thing", "severity": "CONCERN"},
+        {"event": "deferred", "concern_id": "parked-thing", "severity": "CONCERN"},
+    ]
+    cp.write_text("".join(json.dumps(r) + "\n" for r in rows))
+    body = GOOD_BODY + "\n<!-- concern-deferred: parked-thing -->\n"
+    result = verify_task_body.check_concerns_audit(body, concerns_path=cp)
+    assert result.passed
+    assert not result.is_warn
+
+    # verified-open variant: still open (and binding), the marker
+    # acknowledges it via mechanism 3 — no WARN either.
+    rows = [
+        {"event": "raised", "concern_id": "still-open-thing", "severity": "CONCERN"},
+        {"event": "verified-open", "concern_id": "still-open-thing", "severity": "CONCERN"},
+    ]
+    cp.write_text("".join(json.dumps(r) + "\n" for r in rows))
+    body = GOOD_BODY + "\n<!-- concern-deferred: still-open-thing -->\n"
+    result = verify_task_body.check_concerns_audit(body, concerns_path=cp)
+    assert result.passed
+    assert not result.is_warn
+
+
+def test_concerns_audit_stale_marker_folds_warn_into_open_concern_fail(tmp_path):
+    """Case (d), FAIL precedence: an unaddressed open concern still FAILs
+    (`passed=False`, never downgraded); the stale-marker warn text rides
+    the FAIL detail behind the literal `; WARN: ` prefix (the established
+    mixed-FAIL+WARN fold), AFTER the unaddressed text."""
+    cp = tmp_path / "concerns.jsonl"
+    rows = [
+        {"event": "raised", "concern_id": "open-unacked-thing", "severity": "CONCERN"},
+        {"event": "raised", "concern_id": "now-fixed-thing", "severity": "CONCERN"},
+        {"event": "addressed", "concern_id": "now-fixed-thing", "severity": "CONCERN"},
+    ]
+    cp.write_text("".join(json.dumps(r) + "\n" for r in rows))
+    body = GOOD_BODY + "\n<!-- concern-deferred: now-fixed-thing -->\n"
+    result = verify_task_body.check_concerns_audit(body, concerns_path=cp)
+    assert not result.passed
+    assert not result.is_warn
+    assert "open-unacked-thing" in result.detail
+    assert "; WARN: stale concern-deferred marker 'now-fixed-thing'" in result.detail
+    # Fold order: the unaddressed FAIL text comes BEFORE the WARN suffix.
+    assert result.detail.index("open-unacked-thing") < result.detail.index("; WARN: ")
+
+
+def test_concerns_audit_skip_path_ignores_markers(tmp_path):
+    """Case (e): with no ledger to compare against (`concerns_path` None
+    or missing), the skip-PASS path never scans markers — a stale-looking
+    marker in the body produces no WARN."""
+    body = GOOD_BODY + "\n<!-- concern-deferred: ghost-concern -->\n"
+    result = verify_task_body.check_concerns_audit(body, concerns_path=None)
+    assert result.passed
+    assert not result.is_warn
+    assert "skipped" in result.detail.lower()
+
+    missing = tmp_path / "concerns.jsonl"
+    result = verify_task_body.check_concerns_audit(body, concerns_path=missing)
+    assert result.passed
+    assert not result.is_warn
+    assert "skipped" in result.detail.lower()
+
+
+def test_concerns_audit_stale_marker_warns_alongside_acknowledged_open_concern(tmp_path):
+    """Pins the SECOND warns-only return site: `open_binding` is
+    non-empty (a raised CONCERN, acknowledged in the body via
+    mechanism 1), so the check passes the early return and runs the full
+    ack scan; `unaddressed` ends empty; the post-ack `if stale_warns:`
+    branch fires for the stale marker. A mutant deleting the post-ack
+    branch fails exactly this test."""
+    cp = tmp_path / "concerns.jsonl"
+    rows = [
+        {"event": "raised", "concern_id": "open-acked-thing", "severity": "CONCERN"},
+        {"event": "raised", "concern_id": "now-fixed-thing", "severity": "CONCERN"},
+        {"event": "addressed", "concern_id": "now-fixed-thing", "severity": "CONCERN"},
+    ]
+    cp.write_text("".join(json.dumps(r) + "\n" for r in rows))
+    body = GOOD_BODY.replace(
+        "The 17-pt lift holds at every seed",
+        "Note: open-acked-thing affected our setup; "
+        "we report the conservative estimate. The 17-pt lift holds at every seed",
+    )
+    body = body + "\n<!-- concern-deferred: now-fixed-thing -->\n"
+    result = verify_task_body.check_concerns_audit(body, concerns_path=cp)
+    assert result.passed
+    assert result.is_warn
+    assert "now-fixed-thing" in result.detail
+    assert "addressed" in result.detail
 
 
 # ─── Check 16: Reproducibility lr matches plan (task #489 regression) ───────


### PR DESCRIPTION
Closes task #1089.

WARN-only stale `<!-- concern-deferred: <id> -->` marker scan in `check_concerns_audit`, hoisted above the no-open-binding early return (#833 incident shape). 6 new fixtures + 2 strengthened assertions. Plan v3 (critic-ensemble reviewed); code-review PASS+PASS; step-9c gate 2648 passed / compare new=[].