### PR TITLE
task #1095: drain-side max+1 for real pod-side epm:results sentinel versions

### DIFF
--- a/.claude/rules/pod-side-reporting.md
+++ b/.claude/rules/pod-side-reporting.md
@@ -53,7 +53,36 @@ marker will be silently skipped. Two requirements, no exceptions:
      `SENTINEL_SCHEMA_VERSION_SUPPORTED` in the poller — `!= 1` is
      skipped + logged, never silently mis-parsed).
    - `kind`: full marker kind string (e.g. `"epm:results"`).
-   - `version`: marker version integer.
+   - `version`: marker version integer. Pod-side writers hardcode `1`
+     (they cannot read `events.jsonl`). **Drain-side rewrite (#1095):**
+     for a real `epm:results` sentinel the VM-side drain re-derives the
+     landed marker version as max+1 when the declared version collides
+     at-or-below the existing max for the kind — so multi-round tasks
+     keep the highest-version-per-kind resume convention (markers.md)
+     without pod-side coordination. The declared version is preserved on
+     the marker as `sentinel_declared_version`. Smoke/dry-run/
+     phase-progress sentinels (gate NAME in
+     `smoke|dryrun|dry-run|dry_run|phase`, a truthy top-level `smoke`
+     field, or the `issue-<N>-smoke-results.json` / `-smoke-` filename)
+     and declared versions above the existing max post verbatim; a bare
+     `blocks_pipeline: false` does NOT exempt (real terminal writers set
+     it). Other kinds always post verbatim. Keep hardcoding `1` — do NOT
+     try to thread versions pod-side. **Smoke runs should write kind
+     `epm:smoke-result`, not kind `epm:results` with a smoke flag** — a
+     smoke flag nested inside `note` is invisible to the drain's
+     exclusion (the drain never parses `note`), and the
+     `epm:smoke-result` kind is already the house pattern
+     (`write_sentinel("epm:smoke-result" if args.smoke else
+     "epm:results", ...)` — issue634/744/1073/779 writers). Two
+     operational residuals: (a) a stale straggler — e.g. a resumed
+     stopped pod draining an OLD run's results sentinel — now lands
+     ABOVE newer rows; this is operator-recoverable (the marker carries
+     `sentinel_declared_version` + the drain logs a warning with the
+     sentinel's `ts`; re-post the correct results as a fresh
+     higher-version marker). (b) An operator's manual high-version
+     correction marker is shadowed by ANY subsequent real results drain
+     (which lands at max+1 above it) — re-post corrections AFTER the
+     final drain of a round, not before.
 
    The marker body goes under `note` (or the `payload` synonym).
    Recommended optional keys: `task_id`, `gate`, `blocks_pipeline`,

--- a/scripts/poll_pipeline.py
+++ b/scripts/poll_pipeline.py
@@ -1843,6 +1843,69 @@ def _posted_sentinel_fps(issue: int) -> dict[str, dict[str, Any]]:
         return {}
 
 
+_RESULTS_REWRITE_KIND = "epm:results"
+# "phase" keeps the #641 non-blocking phase-progress shape (gate="phase",
+# blocks_pipeline: False) excluded by NAME.
+_SMOKE_GATE_NAMES = frozenset({"smoke", "dryrun", "dry-run", "dry_run", "phase"})
+
+
+def _results_rewrite_exclusion_legs(remote_path: str, data: dict[str, Any]) -> dict[str, bool]:
+    """Per-leg smoke/informational signals for the #1095 rewrite exclusion.
+
+    Exposed as a dict so tests can assert EXACTLY which leg is active
+    (the exclusion-leg test-construction discipline) without re-implementing
+    leg logic. A bare ``blocks_pipeline: False`` is deliberately NOT a leg:
+    real terminal epm:results writers set it to keep a non-empty gate from
+    parking the poll loop (issue664/734/654/597) — it does not discriminate
+    smoke from real. The drain never descends into ``note`` (it may be a
+    JSON string, not a dict): a smoke flag nested in note (issue597) is the
+    documented residual — smoke runs should write kind ``epm:smoke-result``
+    (`.claude/rules/pod-side-reporting.md`).
+    """
+    basename = remote_path.rsplit("/", 1)[-1]
+    return {
+        "gate_name": str(data.get("gate") or "").strip().lower() in _SMOKE_GATE_NAMES,
+        "smoke_field": bool(data.get("smoke")),  # issue667-style top-level smoke flag
+        "smoke_filename": basename.endswith("-smoke-results.json") or "-smoke-" in basename,
+    }
+
+
+def _results_version_rewrite_excluded(remote_path: str, data: dict[str, Any]) -> bool:
+    """True when a real epm:results sentinel must KEEP its declared version.
+
+    Smoke / dry-run / phase-progress sentinels must never bump real
+    ``epm:results`` marker versions (#1095): a rewrite would land them ABOVE
+    the production results rows, making a smoke row the
+    highest-version-authoritative marker on resume (markers.md). Any leg
+    suffices; over-exclusion is safe (it preserves verbatim threading).
+    """
+    return any(_results_rewrite_exclusion_legs(remote_path, data).values())
+
+
+def _existing_max_version(issue: int, kind: str) -> int | None:
+    """Max events.jsonl ``version`` for ``kind`` (0 when none); ``None`` on a
+    failed read — the caller FAILS OPEN to verbatim threading (#1095),
+    mirroring ``_posted_sentinel_fps``'s fail-open contract."""
+    try:
+        events = list_events(issue)
+    except Exception as exc:
+        log.error(
+            "version-collision events read failed for #%d (%s); keeping the "
+            "sentinel's declared version verbatim (fail-open, #1095)",
+            issue,
+            exc,
+        )
+        return None
+    return max(
+        (
+            e["version"]
+            for e in events
+            if e.get("kind") == kind and isinstance(e.get("version"), int)
+        ),
+        default=0,
+    )
+
+
 def _persist_oversize_note(
     *,
     issue: int,
@@ -1852,6 +1915,7 @@ def _persist_oversize_note(
     by: str,
     full_note: str,
     original_extras: dict[str, Any] | None = None,
+    declared_version: int | None = None,
     sentinel_fp: str,
     sentinel_path: str,
 ) -> bool:
@@ -1890,7 +1954,11 @@ def _persist_oversize_note(
     Returns ``False`` (and logs) on any failure — caller must NOT rename
     the sentinel in that case so a future tick can retry. Carries through
     the original sentinel's ``gate`` / ``blocks_pipeline`` semantics by
-    asking the caller to forward those via ``original_extras``.
+    asking the caller to forward those via ``original_extras``. When the
+    caller's #1095 version rewrite fired (``version=None`` on a REAL
+    ``epm:results`` sentinel), it forwards the declared version via
+    ``declared_version`` so the pointer marker keeps the
+    ``sentinel_declared_version`` audit extra too.
     """
     try:
         task_dir = find_task_path(issue)
@@ -1958,6 +2026,9 @@ def _persist_oversize_note(
         pointer_note = pointer_note[:EVENT_NOTE_MAX]
 
     extras: dict[str, Any] = {"oversize": True, "oversize_orig_len": len(full_note)}
+    if declared_version is not None:
+        # #1095: keep the version-rewrite audit trail on the pointer marker.
+        extras["sentinel_declared_version"] = declared_version
     if original_extras:
         # Forward operationally-meaningful sentinel fields (notably ``gate``
         # and ``blocks_pipeline``) so the pointer marker preserves the
@@ -2063,17 +2134,53 @@ def _post_drained_sentinel(
     un-renamed and continues; the next tick retries. A non-conforming real
     sentinel carrying ``"version": null`` keeps its loud ``int(None)``
     TypeError (#975) — it propagates out of the drain, never silently
-    derived.
+    derived. A REAL ``epm:results`` sentinel whose declared version
+    collides at-or-below the existing max for the kind is re-derived as
+    max+1 at post time, with the declared version preserved as the
+    ``sentinel_declared_version`` marker extra (#1095) — smoke/dryrun/
+    phase-progress sentinels and every other kind post verbatim.
     """
     kind = data["kind"]
+    rewrite_extras: dict[str, Any] = {}
     if "version" in data:
         # Real pod-side sentinel: "version" is a REQUIRED envelope key
-        # (_SENTINEL_REQUIRED_KEYS / pod-side-reporting.md) and an
-        # explicit version always wins in post_event — verbatim contract.
-        # Branch on key PRESENCE, not None-tolerance: a (non-conforming)
-        # real sentinel carrying "version": null keeps today's loud
-        # int(None) TypeError instead of silently deriving (#975).
+        # (_SENTINEL_REQUIRED_KEYS / pod-side-reporting.md). int() runs
+        # FIRST so a non-conforming "version": null keeps today's loud
+        # TypeError (#975) — never silently derived, for ANY kind.
         version: int | None = int(data["version"])
+        # #1095: pod-side dispatchers hardcode version 1 (they cannot read
+        # events.jsonl — the no-pod-side-task.py rule), so on multi-round
+        # tasks a REAL epm:results sentinel lands BELOW the existing max,
+        # silently violating the highest-version-per-kind resume convention
+        # (markers.md; the #480 collision class; #825 landed three v1 rows
+        # under an existing v2). On an at-or-below-max collision, derive
+        # max+1 at post (version=None -> post_event derives under flock)
+        # and preserve the declared version as a forensic extra. A declared
+        # version ABOVE max is legitimate threading — verbatim. Smoke /
+        # dryrun / phase-progress sentinels are excluded (gate NAME, a
+        # truthy top-level smoke field, or the smoke filename — NOT a bare
+        # blocks_pipeline: False, which real terminal writers set): they
+        # must never land above the production results rows. Any other
+        # kind: verbatim (explicit always wins in post_event — unchanged
+        # contract).
+        if kind == _RESULTS_REWRITE_KIND and not _results_version_rewrite_excluded(
+            remote_path, data
+        ):
+            existing_max = _existing_max_version(issue, kind)
+            if existing_max is not None and version <= existing_max:
+                log.warning(
+                    "real %s sentinel %s (ts=%s) declared version %d <= existing "
+                    "max %d; deriving max+1 at post (multi-round collision, "
+                    "#1095); declared version preserved as "
+                    "sentinel_declared_version",
+                    kind,
+                    remote_path,
+                    data.get("ts"),
+                    version,
+                    existing_max,
+                )
+                rewrite_extras["sentinel_declared_version"] = version
+                version = None
     else:
         # Only reachable via the #899 synthesized envelope, which omits
         # the key (#975): post_event derives max(existing for kind)+1 so
@@ -2090,6 +2197,11 @@ def _post_drained_sentinel(
         note = json.dumps(note, ensure_ascii=False)
     by = data.get("by") or "pod-sentinel"
     try:
+        # Structural note: this post threads NO ``part`` field, so multi-part
+        # markers (the markers.md multi-part convention, where every part
+        # shares one explicit version) are impossible on the sentinel-drain
+        # channel by construction — the #1095 rewrite can never split a
+        # multi-part set across versions here.
         post_event(
             issue,
             kind,
@@ -2098,6 +2210,7 @@ def _post_drained_sentinel(
             note=note,
             sentinel_fp=fp,
             sentinel_path=remote_path,
+            **rewrite_extras,
         )
     except ValueError as exc:
         # Oversize-note guard: match the EXACT message ``post_event``
@@ -2121,6 +2234,7 @@ def _post_drained_sentinel(
             by=by,
             full_note=note,
             original_extras=data,
+            declared_version=rewrite_extras.get("sentinel_declared_version"),
             sentinel_fp=fp,
             sentinel_path=remote_path,
         ):
@@ -2192,6 +2306,12 @@ def drain_sentinels_via(
     yields an empty drain (``(0, None)``) with a loud log — mirroring the
     documented rc!=0 -> ``[]`` transport contract; any OTHER exception
     still escapes (fail-fast for genuine code bugs).
+
+    Version hygiene (#1095): a REAL ``epm:results`` sentinel (not smoke/
+    dryrun/phase-progress) whose declared version collides at-or-below the
+    existing max for the kind lands at a derived max+1 with the declared
+    version preserved as ``sentinel_declared_version`` — see
+    :func:`_post_drained_sentinel`; all other kinds post verbatim.
 
     Exception: an oversize-``note`` ``ValueError`` from ``post_event`` (note
     exceeds ``EVENT_NOTE_MAX``) is NOT a retryable failure — re-posting the

--- a/tests/test_poll_pipeline_sentinels.py
+++ b/tests/test_poll_pipeline_sentinels.py
@@ -4056,3 +4056,497 @@ def test_sentinel_drain_shell_extra_globs_appended() -> None:
     assert f"for f in /workspace/logs/issue-610-*.json {fallback}; do" in script
     # The .processed exclusion still guards every glob's matches.
     assert "*.processed) continue" in script
+
+
+# ── drain: #1095 real epm:results version-collision rewrite (max+1) ─────────
+#
+# #1095: pod-side dispatchers hardcode ``"version": 1`` in their results
+# sentinels (they cannot read events.jsonl — the no-pod-side-task.py rule),
+# and the drain used to thread explicit versions verbatim — so on a
+# multi-round task every real ``epm:results`` sentinel after round 1 landed
+# BELOW the existing max and the STALE higher-version row stayed
+# resume-authoritative (markers.md highest-version-per-kind; #825 landed
+# three pod-sentinel v1 rows under an existing v2). The fix: a REAL
+# ``epm:results`` sentinel whose declared version collides at-or-below the
+# existing max is re-derived as max+1 at post (``version=None`` ->
+# ``post_event`` derives under flock, the tested #975 path), with the
+# declared version preserved as the ``sentinel_declared_version`` extra.
+# Smoke/dryrun/phase-progress sentinels (gate NAME / top-level ``smoke``
+# field / smoke filename), above-max declared versions, and every OTHER
+# kind post verbatim.
+#
+# Test-construction discipline (plan #1095 §5): the ``_sentinel_body``
+# fixture derives ``blocks_pipeline`` from ``gate`` (line ~82), which under
+# an earlier leg design made verbatim-expectation tests pass VACUOUSLY
+# (excluded before the leg under test was consulted). Two rules:
+# (1) every exclusion-leg test constructs its body/path to defeat ALL legs
+# except the one under test and asserts exactly-one-leg-active;
+# (2) every rewrite-path and verbatim-scoping test asserts NO leg is active
+# on its constructed body/path — so its expectation is discriminating (a
+# future leg deletion, or a rewrite widened to all kinds, fails here).
+
+
+def _assert_no_exclusion_leg(path: str, body: dict[str, Any]) -> None:
+    """Discipline rule 2: the constructed (path, body) trips NO exclusion
+    leg, so the test's rewrite (or verbatim) expectation exercises the
+    max-comparison itself, never an accidental exclusion."""
+    legs = pp._results_rewrite_exclusion_legs(path, body)
+    assert not any(legs.values()), legs
+
+
+def test_drain_real_results_below_max_lands_at_max_plus_one(fake_repo) -> None:
+    """T1 (headline, AC1): a real enveloped ``epm:results`` sentinel
+    declaring version 1 onto an events.jsonl that already carries v3 lands
+    at **v4** (max+1) with ``sentinel_declared_version == 1`` + the #1084
+    extras, via the REAL ``post_event`` on a git-init tmp repo."""
+    _repo, tw = fake_repo
+    assert pp.post_event is tw.post_event
+    assert pp.list_events is tw.list_events
+
+    new_id = tw.create_task(tw.NewTaskRequest(kind="experiment", title="rewrite e2e"))
+    tw.post_event(new_id, "epm:results", version=3, by="seed")
+
+    sentinel_path = f"/workspace/logs/issue-{new_id}-epm_results-1700003001.json"
+    body = _sentinel_body(kind="epm:results", version=1, gate=None, note="round 2 results")
+    _assert_no_exclusion_leg(sentinel_path, body)
+    renamed: list[str] = []
+
+    processed, gate = pp.drain_sentinels_via(
+        issue=new_id,
+        list_sentinels=lambda: [(sentinel_path, json.dumps(body))],
+        mark_processed=lambda path: renamed.append(path) or True,
+    )
+
+    assert processed == 1
+    assert gate is None
+    assert renamed == [sentinel_path]
+    rows = [e for e in tw.list_events(new_id) if e["kind"] == "epm:results"]
+    assert [e["version"] for e in rows] == [3, 4]
+    landed = rows[-1]
+    assert landed["sentinel_declared_version"] == 1  # forensic audit trail
+    assert landed["by"] == "experiment-implementer"  # by preserved
+    assert landed["sentinel_fp"] == pp._sentinel_fingerprint(sentinel_path, json.dumps(body))
+    assert landed["sentinel_path"] == sentinel_path
+    # Structural: the drain threads no ``part`` field, so multi-part results
+    # sentinels are impossible on this channel by construction (plan §3.7).
+    assert "part" not in landed
+
+
+def test_drain_real_results_equal_to_max_lands_at_max_plus_one(fake_repo) -> None:
+    """T2: declared == max is a LIVE collision (same kind+version, different
+    content — the multi-round shape) and rewrites too — pins ``<=``, not
+    ``<``."""
+    _repo, tw = fake_repo
+    new_id = tw.create_task(tw.NewTaskRequest(kind="experiment", title="eq-max e2e"))
+    tw.post_event(new_id, "epm:results", version=3, by="seed")
+
+    sentinel_path = f"/workspace/logs/issue-{new_id}-epm_results-1700003002.json"
+    body = _sentinel_body(kind="epm:results", version=3, gate=None, note="collides at max")
+    _assert_no_exclusion_leg(sentinel_path, body)
+
+    processed, _gate = pp.drain_sentinels_via(
+        issue=new_id,
+        list_sentinels=lambda: [(sentinel_path, json.dumps(body))],
+        mark_processed=lambda _path: True,
+    )
+
+    assert processed == 1
+    rows = [e for e in tw.list_events(new_id) if e["kind"] == "epm:results"]
+    assert [e["version"] for e in rows] == [3, 4]
+    assert rows[-1]["sentinel_declared_version"] == 3
+
+
+def test_drain_real_results_above_max_keeps_declared_version(fake_repo) -> None:
+    """T3 (AC2, constraint 6): a declared version strictly ABOVE the
+    existing max is legitimate threading — posts verbatim, with NO rewrite
+    extra on the landed row."""
+    _repo, tw = fake_repo
+    new_id = tw.create_task(tw.NewTaskRequest(kind="experiment", title="above-max e2e"))
+    tw.post_event(new_id, "epm:results", version=3, by="seed")
+
+    sentinel_path = f"/workspace/logs/issue-{new_id}-epm_results-1700003003.json"
+    body = _sentinel_body(kind="epm:results", version=7, gate=None, note="threaded higher")
+    _assert_no_exclusion_leg(sentinel_path, body)
+
+    processed, _gate = pp.drain_sentinels_via(
+        issue=new_id,
+        list_sentinels=lambda: [(sentinel_path, json.dumps(body))],
+        mark_processed=lambda _path: True,
+    )
+
+    assert processed == 1
+    rows = [e for e in tw.list_events(new_id) if e["kind"] == "epm:results"]
+    assert [e["version"] for e in rows] == [3, 7]
+    assert "sentinel_declared_version" not in rows[-1]
+
+
+def test_drain_real_results_no_prior_rows_keeps_declared_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T4: with NO prior ``epm:results`` rows (max 0), a declared 1 posts
+    verbatim with NO kwargs beyond the #1084 pair — first-round behavior is
+    byte-identical to pre-#1095 (the single-round no-op)."""
+    sentinel_path = "/workspace/logs/issue-444-epm_results-1700003004.json"
+    body = _sentinel_body(kind="epm:results", version=1, gate=None, note="round 1 results")
+    _assert_no_exclusion_leg(sentinel_path, body)
+    post_mock = MagicMock()
+    monkeypatch.setattr(pp, "post_event", post_mock)
+    _stub_no_prior_events(monkeypatch)
+
+    processed, gate = pp.drain_sentinels_via(
+        issue=444,
+        list_sentinels=lambda: [(sentinel_path, json.dumps(body))],
+        mark_processed=lambda _path: True,
+    )
+
+    assert processed == 1
+    assert gate is None
+    post_mock.assert_called_once_with(
+        444,
+        "epm:results",
+        version=1,
+        by="experiment-implementer",
+        note="round 1 results",
+        sentinel_fp=pp._sentinel_fingerprint(sentinel_path, json.dumps(body)),
+        sentinel_path=sentinel_path,
+    )
+
+
+@pytest.mark.parametrize(
+    ("gate", "smoke", "filename", "leg"),
+    [
+        # Leg 1 — gate NAME (all five spellings; #641 convention shape:
+        # blocks_pipeline False on the informational signal).
+        ("smoke", None, "issue-444-epm_results-1700003101.json", "gate_name"),
+        ("dryrun", None, "issue-444-epm_results-1700003102.json", "gate_name"),
+        ("dry-run", None, "issue-444-epm_results-1700003103.json", "gate_name"),
+        ("dry_run", None, "issue-444-epm_results-1700003104.json", "gate_name"),
+        ("phase", None, "issue-444-epm_results-1700003105.json", "gate_name"),
+        # Leg 2 — truthy TOP-LEVEL smoke field (issue667's smoke mode:
+        # non-smoke filename, no smoke/dryrun gate name).
+        (None, True, "issue-444-epm_results-1700003106.json", "smoke_field"),
+        # Leg 3 — smoke filename (documented name + the independent
+        # ``-smoke-`` substring form).
+        (None, None, "issue-444-smoke-results.json", "smoke_filename"),
+        (None, None, "issue-444-smoke-phase2.json", "smoke_filename"),
+    ],
+)
+def test_drain_smoke_dryrun_results_sentinel_keeps_declared_version(
+    monkeypatch: pytest.MonkeyPatch,
+    gate: str | None,
+    smoke: bool | None,
+    filename: str,
+    leg: str,
+) -> None:
+    """T5 (AC3, constraint 1): a smoke/dryrun/phase-progress ``epm:results``
+    sentinel keeps its declared version even when <= max — a rewrite would
+    land the smoke row ABOVE the production results rows. Each param is
+    constructed per discipline rule 1: all other legs defeated, exactly the
+    intended leg active."""
+    sentinel_path = f"/workspace/logs/{filename}"
+    body = _sentinel_body(kind="epm:results", version=1, gate=gate, note="smoke-ish signal")
+    if gate is not None:
+        body["blocks_pipeline"] = False  # the #641 informational-signal shape
+    if smoke is not None:
+        body["smoke"] = smoke
+    legs = pp._results_rewrite_exclusion_legs(sentinel_path, body)
+    assert sum(legs.values()) == 1 and legs[leg], legs
+
+    post_mock = MagicMock()
+    monkeypatch.setattr(pp, "post_event", post_mock)
+    # Seeded max 3 — a REAL sentinel declaring 1 would rewrite; the
+    # exclusion must keep it verbatim (no row with sentinel_fp, so the
+    # #1084 dedupe map stays empty).
+    monkeypatch.setattr(pp, "list_events", lambda _issue: [{"kind": "epm:results", "version": 3}])
+
+    processed, _gate = pp.drain_sentinels_via(
+        issue=444,
+        list_sentinels=lambda: [(sentinel_path, json.dumps(body))],
+        mark_processed=lambda _path: True,
+    )
+
+    assert processed == 1
+    post_mock.assert_called_once()
+    assert post_mock.call_args.kwargs["version"] == 1  # verbatim — never above max
+    assert "sentinel_declared_version" not in post_mock.call_args.kwargs
+
+
+def test_drain_results_null_version_still_loud(monkeypatch: pytest.MonkeyPatch) -> None:
+    """T6 (AC4, constraint 3): ``int(data["version"])`` runs FIRST — before
+    the exclusion legs and the max read — so a non-conforming
+    ``"version": null`` on kind ``epm:results`` keeps the loud #975
+    TypeError even with prior rows present; ``post_event`` is never
+    called."""
+    body = {
+        "sentinel_schema_version": 1,
+        "kind": "epm:results",
+        "version": None,  # json.dumps -> null: key PRESENT, value null
+        "note": "x",
+    }
+    post_mock = MagicMock()
+    monkeypatch.setattr(pp, "post_event", post_mock)
+    monkeypatch.setattr(pp, "list_events", lambda _issue: [{"kind": "epm:results", "version": 3}])
+
+    with pytest.raises(TypeError):
+        pp.drain_sentinels_via(
+            issue=444,
+            list_sentinels=lambda: [
+                ("/workspace/logs/issue-444-epm_results-1700003201.json", json.dumps(body))
+            ],
+            mark_processed=lambda _path: True,
+        )
+
+    post_mock.assert_not_called()
+
+
+def test_drain_rewrite_replay_after_rename_failure_posts_no_duplicate(fake_repo) -> None:
+    """T7 (AC5, constraint 2): the #1084 fp dedupe survives the rewrite —
+    tick 1 rewrites a below-max real results sentinel to v4 and the rename
+    FAILS; the tick-2 replay of the identical (path, body) fp-hits and
+    posts NOTHING new (versions stay [3, 4]), retrying the rename only.
+    The fp is keyed on the RAW sentinel, so the landed-version rewrite
+    never enters the key."""
+    _repo, tw = fake_repo
+    assert pp.post_event is tw.post_event
+    assert pp.list_events is tw.list_events
+
+    new_id = tw.create_task(tw.NewTaskRequest(kind="experiment", title="rewrite replay e2e"))
+    tw.post_event(new_id, "epm:results", version=3, by="seed")
+    sentinel_path = f"/workspace/logs/issue-{new_id}-epm_results-1700003301.json"
+    body_dict = _sentinel_body(kind="epm:results", version=1, gate=None, note="round 2 results")
+    _assert_no_exclusion_leg(sentinel_path, body_dict)
+    body = json.dumps(body_dict)
+
+    # Tick 1: post succeeds (rewritten to v4), rename FAILS (W1 window).
+    processed, _gate = pp.drain_sentinels_via(
+        issue=new_id,
+        list_sentinels=lambda: [(sentinel_path, body)],
+        mark_processed=lambda _path: False,
+    )
+    assert processed == 1
+    versions = [e["version"] for e in tw.list_events(new_id) if e["kind"] == "epm:results"]
+    assert versions == [3, 4]
+
+    # Tick 2: identical (path, body) re-drained; rename now succeeds.
+    renamed: list[str] = []
+    processed2, _gate2 = pp.drain_sentinels_via(
+        issue=new_id,
+        list_sentinels=lambda: [(sentinel_path, body)],
+        mark_processed=lambda path: renamed.append(path) or True,
+    )
+    assert processed2 == 1
+    assert renamed == [sentinel_path]
+    versions2 = [e["version"] for e in tw.list_events(new_id) if e["kind"] == "epm:results"]
+    assert versions2 == [3, 4], "the replay must not land a fresh max+1 (v5)"
+
+
+def test_drain_two_below_max_results_sentinels_same_tick_land_sequential(fake_repo) -> None:
+    """T8: TWO distinct real results sentinels both declaring 1 in ONE
+    listing land at 4 then 5 — the existing-max read is per-sentinel fresh
+    (not cached across the drain loop), and ``post_event`` committed the
+    first durably before the second's read (plan §3.5)."""
+    _repo, tw = fake_repo
+    new_id = tw.create_task(tw.NewTaskRequest(kind="experiment", title="two-sentinel e2e"))
+    tw.post_event(new_id, "epm:results", version=3, by="seed")
+
+    path_a = f"/workspace/logs/issue-{new_id}-epm_results-1700003401.json"
+    path_b = f"/workspace/logs/issue-{new_id}-epm_results-1700003402.json"
+    body_a = _sentinel_body(kind="epm:results", version=1, gate=None, note="pass A results")
+    body_b = _sentinel_body(kind="epm:results", version=1, gate=None, note="pass B results")
+    _assert_no_exclusion_leg(path_a, body_a)
+    _assert_no_exclusion_leg(path_b, body_b)
+
+    processed, _gate = pp.drain_sentinels_via(
+        issue=new_id,
+        list_sentinels=lambda: [
+            (path_a, json.dumps(body_a)),
+            (path_b, json.dumps(body_b)),
+        ],
+        mark_processed=lambda _path: True,
+    )
+
+    assert processed == 2
+    rows = [e for e in tw.list_events(new_id) if e["kind"] == "epm:results"]
+    assert [e["version"] for e in rows] == [3, 4, 5]
+    assert [e.get("sentinel_declared_version") for e in rows] == [None, 1, 1]
+
+
+def test_drain_two_above_max_results_sentinels_same_tick_second_collides(fake_repo) -> None:
+    """T8 optional arm (plan §5): two same-tick sentinels each declaring
+    ``existing_max + 1`` (= 4) — the first posts verbatim at 4; the second
+    now collides (4 <= 4) against the FRESH max read and lands 5. Pins the
+    per-sentinel fresh-max-read on the above-max-then-collision path."""
+    _repo, tw = fake_repo
+    new_id = tw.create_task(tw.NewTaskRequest(kind="experiment", title="fresh-max e2e"))
+    tw.post_event(new_id, "epm:results", version=3, by="seed")
+
+    path_a = f"/workspace/logs/issue-{new_id}-epm_results-1700003501.json"
+    path_b = f"/workspace/logs/issue-{new_id}-epm_results-1700003502.json"
+    body_a = _sentinel_body(kind="epm:results", version=4, gate=None, note="threaded A")
+    body_b = _sentinel_body(kind="epm:results", version=4, gate=None, note="threaded B")
+    _assert_no_exclusion_leg(path_a, body_a)
+    _assert_no_exclusion_leg(path_b, body_b)
+
+    processed, _gate = pp.drain_sentinels_via(
+        issue=new_id,
+        list_sentinels=lambda: [
+            (path_a, json.dumps(body_a)),
+            (path_b, json.dumps(body_b)),
+        ],
+        mark_processed=lambda _path: True,
+    )
+
+    assert processed == 2
+    rows = [e for e in tw.list_events(new_id) if e["kind"] == "epm:results"]
+    assert [e["version"] for e in rows] == [3, 4, 5]
+    assert "sentinel_declared_version" not in rows[1]  # first: legit above-max
+    assert rows[2]["sentinel_declared_version"] == 4  # second: fresh-max collision
+
+
+def test_drain_progress_kind_below_max_keeps_declared_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T9 (scoping): the rewrite is ``epm:results``-ONLY — an ``epm:progress``
+    sentinel declaring 1 under an existing progress v3 posts verbatim with
+    no extra kwargs. The no-leg-active assert is REQUIRED here: it makes
+    this test discriminate against a rewrite widened to all kinds, rather
+    than passing via accidental exclusion."""
+    sentinel_path = "/workspace/logs/issue-444-epm_progress-1700003601.json"
+    body = _sentinel_body(kind="epm:progress", version=1, gate=None, note="phase=eval")
+    _assert_no_exclusion_leg(sentinel_path, body)
+    post_mock = MagicMock()
+    monkeypatch.setattr(pp, "post_event", post_mock)
+    monkeypatch.setattr(pp, "list_events", lambda _issue: [{"kind": "epm:progress", "version": 3}])
+
+    processed, _gate = pp.drain_sentinels_via(
+        issue=444,
+        list_sentinels=lambda: [(sentinel_path, json.dumps(body))],
+        mark_processed=lambda _path: True,
+    )
+
+    assert processed == 1
+    post_mock.assert_called_once_with(
+        444,
+        "epm:progress",
+        version=1,
+        by="experiment-implementer",
+        note="phase=eval",
+        sentinel_fp=pp._sentinel_fingerprint(sentinel_path, json.dumps(body)),
+        sentinel_path=sentinel_path,
+    )
+
+
+def test_drain_results_events_read_failure_falls_open_to_verbatim(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """T10 (fail-open, plan §3.5): an events read failure in the max lookup
+    keeps the declared version VERBATIM (pre-#1095 behavior) with a loud
+    ``log.error`` — a version-hygiene read failure must never block or lose
+    a marker. (The #1084 fp map read fails open to ``{}`` via the same
+    raising stub; the two fail-opens compose.)"""
+    sentinel_path = "/workspace/logs/issue-444-epm_results-1700003701.json"
+    body = _sentinel_body(kind="epm:results", version=1, gate=None, note="round N results")
+    _assert_no_exclusion_leg(sentinel_path, body)
+    post_mock = MagicMock()
+    monkeypatch.setattr(pp, "post_event", post_mock)
+    monkeypatch.setattr(
+        pp, "list_events", MagicMock(side_effect=RuntimeError("events.jsonl unreadable"))
+    )
+
+    with caplog.at_level(logging.ERROR, logger="poll_pipeline"):
+        processed, _gate = pp.drain_sentinels_via(
+            issue=444,
+            list_sentinels=lambda: [(sentinel_path, json.dumps(body))],
+            mark_processed=lambda _path: True,
+        )
+
+    assert processed == 1
+    post_mock.assert_called_once()
+    assert post_mock.call_args.kwargs["version"] == 1  # verbatim (fail-open)
+    assert "sentinel_declared_version" not in post_mock.call_args.kwargs
+    assert any("version-collision events read failed" in r.getMessage() for r in caplog.records), (
+        "the fail-open must be LOUD"
+    )
+
+
+def test_drain_real_results_rewrite_oversize_pointer_preserves_declared_version(
+    fake_repo,
+) -> None:
+    """T11 (oversize + rewrite): a below-max real results sentinel whose
+    ``note`` exceeds the 50,000-char cap degrades through
+    ``_persist_oversize_note`` — the pointer marker still derives max+1
+    (v4 above the seeded v3) AND keeps the ``sentinel_declared_version``
+    audit extra (the §3.7 ``declared_version`` threading), the full note is
+    persisted to the task artifact, and the sentinel is renamed."""
+    _repo, tw = fake_repo
+    new_id = tw.create_task(tw.NewTaskRequest(kind="experiment", title="oversize rewrite e2e"))
+    tw.post_event(new_id, "epm:results", version=3, by="seed")
+
+    sentinel_path = f"/workspace/logs/issue-{new_id}-epm_results-1700003801.json"
+    full_note = "x" * (pp.EVENT_NOTE_MAX + 1)
+    body = _sentinel_body(kind="epm:results", version=1, gate=None, note=full_note)
+    _assert_no_exclusion_leg(sentinel_path, body)
+    renamed: list[str] = []
+
+    processed, _gate = pp.drain_sentinels_via(
+        issue=new_id,
+        list_sentinels=lambda: [(sentinel_path, json.dumps(body))],
+        mark_processed=lambda path: renamed.append(path) or True,
+    )
+
+    assert processed == 1
+    assert renamed == [sentinel_path]
+    rows = [e for e in tw.list_events(new_id) if e["kind"] == "epm:results"]
+    # The pointer post used version=None -> the REAL post_event derived
+    # max+1 ABOVE the seeded v3.
+    assert [e["version"] for e in rows] == [3, 4]
+    pointer = rows[-1]
+    assert pointer.get("oversize") is True
+    assert pointer["sentinel_declared_version"] == 1  # audit trail survives
+    assert pointer["sentinel_fp"] == pp._sentinel_fingerprint(sentinel_path, json.dumps(body))
+    assert pointer["sentinel_path"] == sentinel_path
+    # Full payload persisted to the task artifact.
+    task_dir = tw.find_task_path(new_id)
+    persisted = list((task_dir / "artifacts").glob("sentinel-note-epm_results-*.txt"))
+    assert len(persisted) == 1
+    assert persisted[0].read_text() == full_note
+
+
+@pytest.mark.parametrize(
+    ("gate", "note_tag"),
+    [
+        ("results", "issue664 shape"),  # gate="results", blocks_pipeline False
+        (False, "issue734/654 shape"),  # gate=False, blocks_pipeline False
+        (None, "issue597 shape"),  # gate-less; fixture derives blocks_pipeline False
+    ],
+)
+def test_drain_real_writer_blocks_pipeline_false_shapes_are_rewritten(
+    fake_repo, gate: Any, note_tag: str
+) -> None:
+    """T12 (AC8): the REAL terminal writers' house shapes —
+    ``blocks_pipeline: False`` with ``gate`` = ``"results"`` / ``False`` /
+    ``None`` (issue664 / issue734+654 / issue597) — ARE rewritten on an
+    at-or-below-max collision: ``blocks_pipeline`` alone never exempts a
+    sentinel from the rewrite. The per-param no-leg-active assert proves
+    the rewrite fires BECAUSE no exclusion leg matches."""
+    _repo, tw = fake_repo
+    new_id = tw.create_task(tw.NewTaskRequest(kind="experiment", title="house-shape e2e"))
+    tw.post_event(new_id, "epm:results", version=3, by="seed")
+
+    sentinel_path = f"/workspace/logs/issue-{new_id}-epm_results-1700003901.json"
+    body = _sentinel_body(kind="epm:results", version=1, gate=None, note=f"terminal ({note_tag})")
+    body["gate"] = gate  # the house shape's gate value (may be non-str)
+    body["blocks_pipeline"] = False  # house style: don't park the poll loop
+    _assert_no_exclusion_leg(sentinel_path, body)
+
+    processed, drained_gate = pp.drain_sentinels_via(
+        issue=new_id,
+        list_sentinels=lambda: [(sentinel_path, json.dumps(body))],
+        mark_processed=lambda _path: True,
+    )
+
+    assert processed == 1
+    assert drained_gate is None  # blocks_pipeline False never parks
+    rows = [e for e in tw.list_events(new_id) if e["kind"] == "epm:results"]
+    assert [e["version"] for e in rows] == [3, 4]
+    assert rows[-1]["sentinel_declared_version"] == 1


### PR DESCRIPTION
Closes task #1095 (workflow-fix, auto-filed from #825). Drain-side max+1 derivation for real pod-side epm:results sentinels on <=max collisions; sentinel_declared_version forensic extra; smoke/dryrun/phase + top-level smoke + smoke-filename exclusions; #975/#1084/post_event invariants preserved; T1-T12. Ensemble code-review PASS+PASS; test-verdict PASS (2978 passed).