### PR TITLE
issue-1097: SHA-bind the Step 10d lint verdict; consume it only on merge success

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -8610,7 +8610,15 @@ Gate the merge payload on the lint BEFORE anything lands:
     # both lint runs skipped by design.
     echo skip-artifact-only > /tmp/issue-<N>-lint-verdict.txt
   fi
-  cat /tmp/issue-<N>-lint-verdict.txt   # pass | block | crash | skip-artifact-only
+  # SHA-BIND the verdict to the branch tip it certified (line 2, #1097): a
+  # consumer accepts a pass/skip verdict ONLY while the CURRENT tip still
+  # equals this sha — any new commit since certification invalidates it
+  # (fail CLOSED, re-run the gate), and a hand-written verdict without the
+  # correct sha is useless (anti-self-attestation, the #1082 incident).
+  # Appended for every verdict; block/crash never certify, so their sha
+  # line is inert.
+  git -C "$WT" rev-parse HEAD >> /tmp/issue-<N>-lint-verdict.txt
+  cat /tmp/issue-<N>-lint-verdict.txt   # line 1: pass | block | crash | skip-artifact-only; line 2: certified branch-tip sha
   ```
 
 - **Verdict — payload-attributed via failure-LINE-SET subtraction; NEVER
@@ -8622,13 +8630,20 @@ Gate the merge payload on the lint BEFORE anything lands:
   in each run, so a pre-existing parity-leg red on main can never be
   misread as payload-caused (and vice versa). The executable block above
   computes the verdict (`block` | `pass` | `crash` | `skip-artifact-only`)
-  and persists it to `/tmp/issue-<N>-lint-verdict.txt`; the binding sites
-  gate their merge/push/add commands on that FILE with an explicit
-  conditional — a missing verdict file fails CLOSED (the gate has not run
-  yet) — and each binding site REMOVES the file right after consuming it
-  (consume-once, `rm -f` in both branches): a stale verdict left by a prior
-  invocation can never certify a later merge; a fresh gate run regenerates
-  it. On a `block` (or `crash`) verdict:
+  and persists it SHA-BOUND to `/tmp/issue-<N>-lint-verdict.txt` (line 1 =
+  verdict, line 2 = the certified branch-tip sha); the binding sites gate
+  their merge/push/add commands on that FILE with an explicit conditional —
+  a missing verdict file fails CLOSED (the gate has not run yet), and a
+  pass/skip verdict certifies ONLY while the CURRENT branch tip equals the
+  certified sha, so any new commit since certification fails CLOSED too
+  (re-run the gate) and a hand-written verdict without the correct sha is
+  useless (anti-self-attestation). The file is REMOVED only once it can no
+  longer certify anything: after a SUCCESSFUL `gh pr merge`
+  (consume-on-merge-success), or in the block/crash/stale-sha branch (a
+  fresh gate run regenerates it). A merge that fails for a NON-lint
+  transport reason (the #1041 rebase-refusal → `--squash`-retry shape)
+  therefore stays certified by the SAME gate run — never hand-recreate the
+  verdict file (#1082). On a `block` (or `crash`) verdict:
   1. An own-diff-named gated failure line exists
      (`/tmp/issue-<N>-lint-owndiff.txt` non-empty) → the payload is the
      offender. Fix it in the worktree (the lint names file + rule),
@@ -8755,16 +8770,27 @@ else
            && git -C "$WT" push origin issue-<N>; }
   fi
   # Pre-push workflow-lint gate (subsection above) — run its executable
-  # block FIRST, then gate the merge on the PERSISTED verdict file: the
-  # explicit conditional below is the hard stop (a missing verdict file
-  # fails CLOSED — the gate has not run yet; run it, then re-enter).
-  if grep -qxE 'pass|skip-artifact-only' /tmp/issue-<N>-lint-verdict.txt 2>/dev/null; then
-    rm -f /tmp/issue-<N>-lint-verdict.txt   # consume-once — a stale verdict must never certify a later merge
+  # block FIRST, then gate the merge on the PERSISTED, SHA-BOUND verdict
+  # file: the explicit conditional below is the hard stop. Fails CLOSED on
+  # a missing file (gate not run), a block/crash verdict, OR a missing /
+  # stale sha (line 2 empty or != current tip: a hand-written verdict, or
+  # new commits since certification — re-run the gate). The verdict is
+  # consumed (rm) only AFTER `gh pr merge` SUCCEEDS: a non-lint transport
+  # failure (#1041 rebase refusal) leaves it valid for the same-tip retry
+  # — never hand-write the verdict file (#1082).
+  if grep -qxE 'pass|skip-artifact-only' /tmp/issue-<N>-lint-verdict.txt 2>/dev/null \
+     && [ -n "$(sed -n 2p /tmp/issue-<N>-lint-verdict.txt 2>/dev/null)" ] \
+     && [ "$(sed -n 2p /tmp/issue-<N>-lint-verdict.txt 2>/dev/null)" = "$(git -C "$WT" rev-parse HEAD)" ]; then
     gh pr ready <PR>
-    gh pr merge <PR> --rebase --delete-branch=false
+    if gh pr merge <PR> --rebase --delete-branch=false; then
+      rm -f /tmp/issue-<N>-lint-verdict.txt   # consume on MERGE SUCCESS — the verdict certified exactly the tip that landed
+    else
+      echo "MERGE FAILED (non-lint transport failure, e.g. the #1041 'can't be rebased' shape) — the SHA-bound verdict REMAINS VALID for a retry of the SAME tip: re-enter this conditional with the --squash retry per the Known-failure-shape paragraph below. Do NOT hand-write the verdict file."
+      false
+    fi
   else
-    echo "BLOCKED: pre-push workflow-lint gate (verdict: $(cat /tmp/issue-<N>-lint-verdict.txt 2>/dev/null || echo not-run)) — fix the named offender (or crash cause) in the worktree, re-run the gate ONCE; still failing -> epm:merge-failed (gate subsection, verdict cases 1/3). Do NOT merge."
-    rm -f /tmp/issue-<N>-lint-verdict.txt   # consumed either way; a re-run regenerates it
+    echo "BLOCKED: pre-push workflow-lint gate (verdict: $(cat /tmp/issue-<N>-lint-verdict.txt 2>/dev/null || echo not-run)) — missing verdict, block/crash, or missing/stale sha (hand-written verdict, or new commits since certification) all fail CLOSED: fix the named offender (or crash cause), re-run the gate ONCE; still failing -> epm:merge-failed (gate subsection, verdict cases 1/3). Do NOT merge."
+    rm -f /tmp/issue-<N>-lint-verdict.txt   # block/crash/stale consumed — a fresh gate run regenerates it
     false
   fi
 fi
@@ -8785,6 +8811,13 @@ server-side rebased — `gh pr merge --rebase` fails with
 single-logical-change branch; the squash loses per-commit revert
 granularity, which the merge commit already compromised). (Incident
 #1041 PR #801, 2026-07-05.)
+The SHA-bound verdict file SURVIVES this failure by design
+(consume-on-merge-success): run the squash retry through the SAME gated
+conditional (substituting `--squash` for `--rebase`) so the still-valid
+verdict re-certifies the identical tip and the `rm` fires on success.
+Never recreate the verdict file by hand — a hand-written verdict lacks
+the certified sha and fails closed anyway (#1082's
+`echo pass > /tmp/issue-<N>-lint-verdict.txt` is the banned move).
 
 - **Success:** post `epm:merged v1` with the list of merge SHAs. Update
   the chat title with `merged`. Then run the **post-merge stale-task-folder
@@ -8821,18 +8854,30 @@ git -C "$WT" commit --no-edit
 # Re-run the targeted tests for the touched surface AND the executable
 # Pre-push workflow-lint gate block (subsection above; gated = this
 # post-merge worktree copy, which carries main's CURRENT lint — the ideal
-# gate point). The push is then GATED on the persisted verdict file — the
-# explicit conditional is the hard stop (missing file fails CLOSED):
-if grep -qxE 'pass|skip-artifact-only' /tmp/issue-<N>-lint-verdict.txt 2>/dev/null; then
-  rm -f /tmp/issue-<N>-lint-verdict.txt   # consume-once — a stale verdict must never certify a later push
+# gate point; the gate re-run SHA-binds the verdict to THIS post-merge
+# tip). The push is then GATED on the persisted, SHA-BOUND verdict file —
+# the explicit conditional is the hard stop (missing file / block / crash
+# / missing or stale sha all fail CLOSED). The verdict is consumed only
+# AFTER `gh pr merge` SUCCEEDS: this branch now CARRIES A MERGE COMMIT,
+# so the --rebase merge routinely fails with the #1041 rebase refusal —
+# the surviving verdict certifies the documented --squash retry of the
+# SAME tip (never hand-write the verdict file, #1082):
+if grep -qxE 'pass|skip-artifact-only' /tmp/issue-<N>-lint-verdict.txt 2>/dev/null \
+   && [ -n "$(sed -n 2p /tmp/issue-<N>-lint-verdict.txt 2>/dev/null)" ] \
+   && [ "$(sed -n 2p /tmp/issue-<N>-lint-verdict.txt 2>/dev/null)" = "$(git -C "$WT" rev-parse HEAD)" ]; then
   git -C "$WT" push
   # gh recomputes mergeability asynchronously after a push — it can be
   # momentarily stale. Re-check before concluding failure:
   gh pr view <PR> --json mergeable -q .mergeable   # brief wait/retry until MERGEABLE
-  gh pr merge <PR> --rebase --delete-branch=false
+  if gh pr merge <PR> --rebase --delete-branch=false; then
+    rm -f /tmp/issue-<N>-lint-verdict.txt   # consume on MERGE SUCCESS — the verdict certified exactly the tip that landed
+  else
+    echo "MERGE FAILED post-push (the recovery's merge commit typically refuses server-side rebase — the #1041 shape). The SHA-bound verdict REMAINS VALID for the same-tip retry: re-enter this conditional with --squash substituted for --rebase (the Known-failure-shape paragraph above); the rm fires on THAT retry's success. Do NOT hand-write the verdict file."
+    false
+  fi
 else
-  echo "BLOCKED: pre-push workflow-lint gate (verdict: $(cat /tmp/issue-<N>-lint-verdict.txt 2>/dev/null || echo not-run)) — fix the named offender (or crash cause) in the worktree, re-run the gate ONCE; still failing -> epm:merge-failed (gate subsection, verdict cases 1/3). Do NOT push."
-  rm -f /tmp/issue-<N>-lint-verdict.txt   # consumed either way; a re-run regenerates it
+  echo "BLOCKED: pre-push workflow-lint gate (verdict: $(cat /tmp/issue-<N>-lint-verdict.txt 2>/dev/null || echo not-run)) — missing verdict, block/crash, or missing/stale sha (hand-written verdict, or new commits since certification) all fail CLOSED: fix the named offender (or crash cause), re-run the gate ONCE; still failing -> epm:merge-failed (gate subsection, verdict cases 1/3). Do NOT push."
+  rm -f /tmp/issue-<N>-lint-verdict.txt   # block/crash/stale consumed — a fresh gate run regenerates it
   false
 fi
 ```

--- a/tests/test_step10d_guard3.py
+++ b/tests/test_step10d_guard3.py
@@ -551,20 +551,88 @@ def test_gate_baseline_rc_captured_not_erased():
     )
 
 
-def test_gate_verdict_file_consumed_then_removed():
-    """Round-3 (Claude r2 minor (b)): every verdict-file binding site must
-    remove the file after consuming it (consume-once, both branches) so a
-    stale verdict from a prior invocation can never certify a later merge."""
+# #1097 pins: the sha-equality conjunct (byte-identical at both consumers), the
+# nonempty-line-2 guard conjunct (hardens the empty-vs-empty `[ "" = "" ]` cell),
+# and the success-checked merge wrapper the pass-branch rm must sit inside.
+_SHA_CHECK = (
+    '[ "$(sed -n 2p /tmp/issue-<N>-lint-verdict.txt 2>/dev/null)"'
+    ' = "$(git -C "$WT" rev-parse HEAD)" ]'
+)
+_NONEMPTY_SHA_CHECK = '[ -n "$(sed -n 2p /tmp/issue-<N>-lint-verdict.txt 2>/dev/null)" ]'
+_MERGE_SUCCESS_IF = "if gh pr merge <PR> --rebase --delete-branch=false; then"
+
+
+def test_gate_verdict_sha_bound_at_write_and_both_consumers():
+    """#1097: the gate block must SHA-BIND the verdict (append the certified
+    branch-tip sha as line 2) and BOTH file consumers (safe case + recovery)
+    must accept a pass/skip verdict only while the current tip equals the
+    certified sha — a hand-written `echo pass >` verdict (the #1082 move)
+    lacks the sha and fails closed; any post-certification commit does too."""
     text = _skill_text()
-    assert text.count("rm -f /tmp/issue-<N>-lint-verdict.txt") >= 4, (
-        "both consumers (safe case + recovery) must rm the verdict file in both branches"
+    region = _gate_region(text)
+    sha_append = 'git -C "$WT" rev-parse HEAD >> /tmp/issue-<N>-lint-verdict.txt'
+    assert sha_append in region, "the gate block must append the certified sha to the verdict file"
+    assert text.count(_SHA_CHECK) >= 2, (
+        "both verdict-file consumers must compare line 2 against the current branch tip"
     )
     probe = "grep -qxE 'pass|skip-artifact-only' /tmp/issue-<N>-lint-verdict.txt"
     first = text.find(probe)
-    first_rm = text.find("rm -f /tmp/issue-<N>-lint-verdict.txt", first)
+    second = text.find(probe, first + 1)
+    m1 = text.find(_MERGE_SUCCESS_IF, first)
+    m2 = text.find(_MERGE_SUCCESS_IF, second)
+    assert -1 < first < m1, "safe case: the success-checked merge must follow its conditional"
+    assert -1 < second < m2, "recovery: the success-checked merge must follow its conditional"
+    assert _SHA_CHECK in text[first:m1], (
+        "the SAFE-CASE consumer conditional must carry the sha-equality conjunct"
+    )
+    assert _SHA_CHECK in text[second:m2], (
+        "the RECOVERY consumer conditional must carry the sha-equality conjunct"
+    )
+    assert _NONEMPTY_SHA_CHECK in text[first:m1], (
+        "the safe-case conditional must guard against an empty line 2 "
+        "(the empty-vs-empty [ '' = '' ] cell must fail closed)"
+    )
+    assert _NONEMPTY_SHA_CHECK in text[second:m2], (
+        "the recovery conditional must guard against an empty line 2"
+    )
+
+
+def test_gate_verdict_consumed_only_after_merge_success():
+    """#1097 (supersedes the round-3 consume-once pin): the pass-branch rm must
+    fire only AFTER `gh pr merge` returns success, at BOTH consumers, so a
+    non-lint transport failure (#1041 rebase refusal -> squash retry) stays
+    certified by the same gate run; the block/crash/stale branches still rm."""
+    text = _skill_text()
+    rm_line = "rm -f /tmp/issue-<N>-lint-verdict.txt"
+    assert text.count(rm_line) >= 4, (
+        "both consumers must still rm the verdict file in the success AND fail-closed branches"
+    )
+    probe = "grep -qxE 'pass|skip-artifact-only' /tmp/issue-<N>-lint-verdict.txt"
+    first = text.find(probe)
+    second = text.find(probe, first + 1)
     ready = text.find("gh pr ready <PR>")
-    assert -1 < first < first_rm < ready, (
-        "the safe-case pass branch must consume-then-remove BEFORE gh pr ready"
+    m1 = text.find(_MERGE_SUCCESS_IF, first)
+    m2 = text.find(_MERGE_SUCCESS_IF, second)
+    assert -1 < first < ready < m1, "safe case: conditional -> gh pr ready -> success-checked merge"
+    assert text.find(rm_line, first, m1) == -1, (
+        "safe case: NO rm may sit between the verdict conditional and the merge attempt "
+        "(the pre-merge consume orphaned the verdict on the #1041 transport failure)"
+    )
+    rm1 = text.find(rm_line, m1)
+    e1 = text.find('echo "MERGE FAILED', m1)
+    assert -1 < m1 < rm1 < e1, (
+        "safe case: the rm must sit INSIDE the merge-success branch — after the "
+        "success-checked merge, before its failure echo"
+    )
+    assert -1 < second < m2, "recovery: the success-checked merge must follow its conditional"
+    assert text.find(rm_line, second, m2) == -1, (
+        "recovery: NO rm may sit between the verdict conditional and the merge attempt"
+    )
+    rm2 = text.find(rm_line, m2)
+    e2 = text.find('echo "MERGE FAILED', m2)
+    assert -1 < m2 < rm2 < e2, (
+        "recovery: the rm must sit INSIDE the merge-success branch — after the "
+        "success-checked merge, before its failure echo"
     )
 
 
@@ -582,9 +650,10 @@ def test_gate_trigger_diff_exit_guarded():
     assert region.count("echo crash > /tmp/issue-<N>-lint-verdict.txt") >= 2, (
         "both the failed-trigger-diff arm and the linter-crash arm must write the crash verdict"
     )
-    assert "cat /tmp/issue-<N>-lint-verdict.txt   # pass | block | crash | skip-artifact-only" in (
-        region
-    ), "the verdict enumeration must include crash"
+    assert (
+        "cat /tmp/issue-<N>-lint-verdict.txt   "
+        "# line 1: pass | block | crash | skip-artifact-only; line 2: certified branch-tip sha"
+    ) in region, "the verdict enumeration must include crash and the certified-sha line"
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Closes task #1097.

## Summary
- The Step 10d pre-push workflow-lint gate now SHA-BINDS its verdict file (line 2 = certified branch-tip sha) and consumes (rm) it only AFTER `gh pr merge` returns success, at both binding sites (safe case + merge-conflict recovery).
- A non-lint transport failure (the #1041 rebase-refusal → `--squash`-retry shape) leaves the verdict valid for the same-tip retry; hand-written 1-line verdicts (#1082) and any post-certification commit fail closed via the three-conjunct check.
- Test pins updated: superseded consume-once ordering test deleted; 2 new fail-on-old/pass-on-new pins added (placement-bound sha conjuncts, arm-bound success rm); cat-literal updated.

## Test plan
- [x] `uv run pytest tests/test_step10d_guard3.py -q` — 35 passed
- [x] Step 9c gate: 2763 passed, 6 skipped; `step9c_baseline.py compare` → 0 new failures
- [x] `workflow_lint.py` no-flags bundle + `--check-asks --check-references` — PASS (baseline-vs-gated compare clean)
- [x] Shell micro-simulation of the 2-line verdict semantics — 5/5 fail-closed/valid cells as designed

🤖 Generated with [Claude Code](https://claude.com/claude-code)