### PR TITLE
issue-1100: post-commit landing check for task.py lifecycle mutations

### DIFF
--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -736,6 +736,14 @@ LOCK_PATH = LOCK_DIR / "lock"
 # message + error, NOT the payload (the payload's durable home is the appended
 # file itself).
 DEFERRED_COMMITS_LOG = LOCK_DIR / "deferred-commits.jsonl"
+# FORENSIC-ONLY sidecar of lifecycle commits that landed UNREACHABLE from
+# refs/heads/main (#1100): one JSONL row per commit the post-commit landing
+# check in _git_commit found stranded (or unverifiable). Lives OUTSIDE the
+# repo — recording a strand must not itself need a commit — beside the flock
+# every writer already owns. Nothing reads it automatically; the stderr ERROR
+# at creation time is the live surface, this file is the audit trail.
+STRANDED_COMMITS_LOG = LOCK_DIR / "stranded-commits.jsonl"
+_LANDING_CHECK_ENV = "EPM_TASKPY_LANDING_CHECK"  # "0" disables (default: on)
 
 
 # ─── Locking ────────────────────────────────────────────────────────────────
@@ -4858,6 +4866,13 @@ def _git_commit(paths: list[Path], message: str) -> None:
     commit (TOCTOU) gets a single re-wait + one FINAL retry keyed on the
     partial-commit stderr signature.
 
+    After a successful commit (and, when routed, the CAS advance) a
+    post-commit LANDING CHECK (#1100, ``_warn_if_commit_stranded``) verifies
+    the new commit is reachable from ``refs/heads/main`` and warns LOUDLY —
+    stderr ERROR + a forensic row in ``STRANDED_COMMITS_LOG`` — when it is
+    not. Warn-only and fail-open by contract: it can never make the mutation
+    fail. Disable per-process with ``EPM_TASKPY_LANDING_CHECK=0``.
+
     Set TASK_PY_NO_COMMIT=1 to skip the commit entirely (useful in tests).
     Set TASK_PY_AUTO_PUSH=1 to also push after the commit.
     """
@@ -4905,8 +4920,77 @@ def _git_commit(paths: list[Path], message: str) -> None:
     if routed:
         new_sha = _run_git(["rev-parse", "HEAD"]).stdout.strip()
         _advance_main_ref(repo, old_sha, new_sha, env)
+    _warn_if_commit_stranded(full_msg, routed=routed)
     if os.environ.get("TASK_PY_AUTO_PUSH") == "1":
         _run_git(["push"], check=False)
+
+
+def _warn_if_commit_stranded(message: str, *, routed: bool) -> None:
+    """Post-commit landing check (#1100): warn LOUDLY — never raise — when
+    the commit that just landed on HEAD is not reachable from
+    refs/heads/main.
+
+    The #844 branch guard routes commits to main and #1030's CAS defends the
+    routed leg, but nothing verifies the PRIMARY-path landing spot, and the
+    resolver's (pid, cwd) cache means a checkout switched under a long-lived
+    process commits onto the wrong branch silently — the strand class behind
+    #1083's 15-problem registry drift. This tripwire closes the detection
+    gap: stderr ERROR + a forensic row in STRANDED_COMMITS_LOG at creation
+    time, instead of the next manual `task.py audit`.
+
+    FAIL-OPEN BY CONTRACT: this guard must never make a lifecycle mutation
+    fail that would otherwise succeed. Every internal error (git failure,
+    sidecar OSError, anything) degrades to _log.warning. Disable entirely
+    with EPM_TASKPY_LANDING_CHECK=0.
+    """
+    if os.environ.get(_LANDING_CHECK_ENV, "").strip() == "0":
+        return
+    try:
+        head = _run_git(["rev-parse", "HEAD"], check=False)
+        if head.returncode != 0:
+            _log.warning("landing check: could not resolve HEAD (rc=%s); skipping", head.returncode)
+            return
+        sha = head.stdout.strip()
+        probe = _run_git(["merge-base", "--is-ancestor", sha, "refs/heads/main"], check=False)
+        if probe.returncode == 0:
+            return  # reachable from main — the invariant holds (hot path, ~7ms)
+        kind = "stranded" if probe.returncode == 1 else "unverifiable"
+        ref = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], check=False)
+        head_ref = ref.stdout.strip() if ref.returncode == 0 else "<unknown>"
+        _log.error(
+            "task.py LANDING CHECK: commit %s (%r) is NOT reachable from "
+            "refs/heads/main (HEAD ref: %s, routed=%s, probe rc=%s). The "
+            "mutation is durable in the working tree but its COMMIT is "
+            "stranded off main. Recover with a SINGLE-COMMIT "
+            "`git cherry-pick %s` onto main (a merge-commit strand needs "
+            "manual mainline selection via -m; do NOT `git merge %s` — a "
+            "branch-wide merge can union-import the branch's whole "
+            "task-ledger state, the #1083 husk class), then verify with "
+            "`git merge-base --is-ancestor %s main` and run `task.py audit` "
+            "(--repair --apply) if registry drift is reported. Recorded in %s.",
+            sha[:12],
+            message,
+            head_ref,
+            routed,
+            probe.returncode,
+            sha[:12],
+            head_ref,
+            sha[:12],
+            STRANDED_COMMITS_LOG,
+        )
+        row = {
+            "ts": _utcnow_iso(),
+            "kind": kind,
+            "sha": sha,
+            "head_ref": head_ref,
+            "routed": routed,
+            "message": message,
+            "probe_rc": probe.returncode,
+            "probe_stderr_tail": (probe.stderr or "")[-300:],
+        }
+        _append_jsonl_line(STRANDED_COMMITS_LOG, row)
+    except Exception:
+        _log.warning("landing check failed (fail-open; mutation unaffected)", exc_info=True)
 
 
 def _commit_after_durable_append(paths: list[Path], message: str, *, task_id: int, op: str) -> bool:

--- a/tests/test_task_workflow.py
+++ b/tests/test_task_workflow.py
@@ -65,6 +65,9 @@ def fake_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     # Per-test deferred-commit sidecar (#1030) so no test can ever write the
     # REAL ~/.task-workflow/deferred-commits.jsonl.
     monkeypatch.setattr(tw, "DEFERRED_COMMITS_LOG", lock_dir / "deferred-commits.jsonl")
+    # Per-test stranded-commits sidecar (#1100) so no test can ever write the
+    # REAL ~/.task-workflow/stranded-commits.jsonl.
+    monkeypatch.setattr(tw, "STRANDED_COMMITS_LOG", lock_dir / "stranded-commits.jsonl")
     return tmp_path, tw
 
 
@@ -4012,6 +4015,188 @@ def test_git_commit_merge_wait_knob_zero_restores_git_fatal(fake_repo, monkeypat
 
     assert exc_info.value.returncode == 128
     assert "cannot do a partial commit" in (exc_info.value.stderr or "")
+
+
+# ─── Post-commit landing check (#1100) ─────────────────────────────────────
+#
+# _git_commit's tail runs _warn_if_commit_stranded: a warn-only, fail-open
+# tripwire that probes `git merge-base --is-ancestor <new-commit>
+# refs/heads/main` and, on a miss, logs ONE ERROR + appends a forensic row to
+# STRANDED_COMMITS_LOG (monkeypatched to tmp by the fake_repo fixture). The
+# strand class under test is the #1083 guard-escape: a checkout switched off
+# main underneath a resolver that already cached its (pid, cwd) resolution.
+
+
+def _stranded_rows(tw) -> list[dict]:
+    """Parse the (fixture-retargeted) stranded-commits sidecar; [] if absent."""
+    path = tw.STRANDED_COMMITS_LOG
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _landing_records(caplog) -> list[logging.LogRecord]:
+    """All captured log records emitted by the landing check."""
+    return [r for r in caplog.records if "LANDING CHECK" in r.getMessage()]
+
+
+def _strand_repo(repo: Path) -> None:
+    """Park the fake repo's checkout on a feature branch. The fixture's
+    monkeypatched `repo_root` bypasses the branch-guard resolver, so a
+    subsequent `_git_commit` lands OFF main — exactly the guard-escape class
+    the landing check (#1100) exists to catch."""
+    subprocess.run(["git", "checkout", "-q", "-b", "issue-42"], cwd=repo, check=True)
+
+
+def test_landing_check_silent_when_commit_reaches_main(fake_repo, caplog):
+    """AC-2: a commit that lands on `main` (sha == main tip) produces no
+    LANDING CHECK record and no sidecar file at all."""
+    repo, tw = fake_repo
+    target = repo / "somefile.txt"
+    target.write_text("x\n")
+    before = _git_log_count(repo)
+    with caplog.at_level(logging.WARNING, logger="explore_persona_space.task_workflow"):
+        tw._git_commit([target], "landing silent probe")
+    assert _git_log_count(repo) == before + 1
+    assert _landing_records(caplog) == []
+    assert not tw.STRANDED_COMMITS_LOG.exists()
+
+
+def test_landing_check_warns_on_stranded_commit(fake_repo, caplog):
+    """AC-1: a commit unreachable from refs/heads/main → the mutation still
+    succeeds, exactly ONE ERROR names the sha[:12] + the greppable phrase +
+    the HEAD ref + the sidecar path, and exactly one `kind: stranded` row
+    lands in the sidecar."""
+    repo, tw = fake_repo
+    _strand_repo(repo)
+    target = repo / "somefile.txt"
+    target.write_text("x\n")
+    before = _git_log_count(repo)
+    with caplog.at_level(logging.ERROR, logger="explore_persona_space.task_workflow"):
+        tw._git_commit([target], "stranded probe")  # returns normally (warn-only)
+    # The mutation itself succeeded: the commit exists (on issue-42).
+    assert _git_log_count(repo) == before + 1
+    sha = _head_sha(repo).strip()
+    records = _landing_records(caplog)
+    assert len(records) == 1, [r.getMessage() for r in caplog.records]
+    assert records[0].levelno == logging.ERROR
+    msg = records[0].getMessage()
+    assert sha[:12] in msg
+    assert "NOT reachable from refs/heads/main" in msg
+    assert "issue-42" in msg
+    assert str(tw.STRANDED_COMMITS_LOG) in msg
+    rows = _stranded_rows(tw)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["kind"] == "stranded"
+    assert row["head_ref"] == "issue-42"
+    assert row["sha"] == sha
+    assert row["routed"] is False
+    assert row["probe_rc"] == 1
+    assert row["message"].startswith("stranded probe")
+
+
+def test_landing_check_never_fails_the_mutation(fake_repo, monkeypatch, caplog):
+    """AC-3 fail-open is total: a sidecar-write OSError degrades to a warning
+    and _git_commit returns normally; a _run_git blow-up INSIDE the helper is
+    swallowed too (returns None, never raises)."""
+    repo, tw = fake_repo
+    _strand_repo(repo)
+    target = repo / "somefile.txt"
+    target.write_text("x\n")
+
+    def _oserror(path, payload):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(tw, "_append_jsonl_line", _oserror)
+    before = _git_log_count(repo)
+    with caplog.at_level(logging.WARNING, logger="explore_persona_space.task_workflow"):
+        tw._git_commit([target], "fail-open probe")  # must NOT raise
+    assert _git_log_count(repo) == before + 1  # the commit landed
+    assert any("fail-open" in r.getMessage() for r in caplog.records)
+
+    # Second leg: the check's own git plumbing exploding is swallowed too.
+    def _boom(args, *, check=True):
+        raise RuntimeError("git exploded")
+
+    monkeypatch.setattr(tw, "_run_git", _boom)
+    assert tw._warn_if_commit_stranded("m", routed=False) is None  # no raise
+
+
+def test_landing_check_unverifiable_when_main_ref_missing(fake_repo):
+    """§1 item 4: a repo with no refs/heads/main at all → a
+    `kind: unverifiable` row (probe rc != 1), never a crash."""
+    repo, tw = fake_repo
+    subprocess.run(["git", "branch", "-m", "main", "trunk"], cwd=repo, check=True)
+    target = repo / "somefile.txt"
+    target.write_text("x\n")
+    before = _git_log_count(repo)
+    tw._git_commit([target], "unverifiable probe")  # must not raise
+    assert _git_log_count(repo) == before + 1
+    rows = _stranded_rows(tw)
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "unverifiable"
+    assert rows[0]["probe_rc"] != 1
+    assert rows[0]["head_ref"] == "trunk"
+
+
+def test_landing_check_silent_on_ancestor_of_moved_main(fake_repo, caplog):
+    """AC-2 moved-main subcase: HEAD = A, refs/heads/main = B, A a strict
+    ancestor of B → silent. This is the SOLE discriminator between the chosen
+    `merge-base --is-ancestor` reachability predicate and a tip-equality
+    implementation (`rev-parse main == HEAD` would spuriously warn here)."""
+    repo, tw = fake_repo
+    (repo / "a.txt").write_text("a\n")
+    subprocess.run(["git", "add", "a.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "A"], cwd=repo, check=True)
+    sha_a = _head_sha(repo).strip()
+    (repo / "b.txt").write_text("b\n")
+    subprocess.run(["git", "add", "b.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "B"], cwd=repo, check=True)
+    # Detach at A: HEAD is now a strict ancestor of the moved main (= B).
+    subprocess.run(["git", "checkout", "-q", "--detach", sha_a], cwd=repo, check=True)
+    with caplog.at_level(logging.WARNING, logger="explore_persona_space.task_workflow"):
+        tw._warn_if_commit_stranded("moved-main probe", routed=False)
+    assert _landing_records(caplog) == []
+    assert not tw.STRANDED_COMMITS_LOG.exists()
+
+
+def test_landing_check_disabled_via_env(fake_repo, monkeypatch, caplog):
+    """AC-5: EPM_TASKPY_LANDING_CHECK=0 disables the check entirely — no
+    ERROR + no row on a stranded end-to-end commit, and the direct-call leg
+    issues ZERO git subprocesses."""
+    repo, tw = fake_repo
+    monkeypatch.setenv("EPM_TASKPY_LANDING_CHECK", "0")
+    _strand_repo(repo)
+    target = repo / "somefile.txt"
+    target.write_text("x\n")
+    before = _git_log_count(repo)
+    with caplog.at_level(logging.WARNING, logger="explore_persona_space.task_workflow"):
+        tw._git_commit([target], "disabled probe")
+    assert _git_log_count(repo) == before + 1
+    assert _landing_records(caplog) == []
+    assert not tw.STRANDED_COMMITS_LOG.exists()
+
+    # Direct-call leg (AC-5 "no probe subprocesses"): zero _run_git calls.
+    calls: list[list[str]] = []
+    monkeypatch.setattr(tw, "_run_git", lambda args, *, check=True: calls.append(list(args)))
+    tw._warn_if_commit_stranded("m", routed=False)
+    assert calls == []
+
+
+def test_landing_check_skipped_under_no_commit(fake_repo, monkeypatch):
+    """AC-6: TASK_PY_NO_COMMIT=1 early-returns at the top of _git_commit —
+    zero git subprocesses, so the landing check can never fire in
+    test/no-commit mode."""
+    repo, tw = fake_repo
+    monkeypatch.setenv("TASK_PY_NO_COMMIT", "1")
+    target = repo / "somefile.txt"
+    target.write_text("x\n")
+    calls: list[list[str]] = []
+    monkeypatch.setattr(tw, "_run_git", lambda args, *, check=True: calls.append(list(args)))
+    tw._git_commit([target], "no-commit probe")
+    assert calls == []
+    assert not tw.STRANDED_COMMITS_LOG.exists()
 
 
 def test_cli_post_marker_deferred_commit_exits_clean(fake_repo, monkeypatch, capsys):

--- a/tests/test_task_workflow.py
+++ b/tests/test_task_workflow.py
@@ -4036,8 +4036,10 @@ def _stranded_rows(tw) -> list[dict]:
 
 
 def _landing_records(caplog) -> list[logging.LogRecord]:
-    """All captured log records emitted by the landing check."""
-    return [r for r in caplog.records if "LANDING CHECK" in r.getMessage()]
+    """All captured log records emitted by the landing check (case-insensitive:
+    the stranded ERROR says "LANDING CHECK", the skip-path + fail-open warnings
+    say "landing check" — the silence tests must see all of them)."""
+    return [r for r in caplog.records if "landing check" in r.getMessage().lower()]
 
 
 def _strand_repo(repo: Path) -> None:
@@ -4066,7 +4068,7 @@ def test_landing_check_warns_on_stranded_commit(fake_repo, caplog):
     """AC-1: a commit unreachable from refs/heads/main → the mutation still
     succeeds, exactly ONE ERROR names the sha[:12] + the greppable phrase +
     the HEAD ref + the sidecar path, and exactly one `kind: stranded` row
-    lands in the sidecar."""
+    with the exact sidecar schema lands in the sidecar."""
     repo, tw = fake_repo
     _strand_repo(repo)
     target = repo / "somefile.txt"
@@ -4088,12 +4090,24 @@ def test_landing_check_warns_on_stranded_commit(fake_repo, caplog):
     rows = _stranded_rows(tw)
     assert len(rows) == 1
     row = rows[0]
+    assert set(row) == {
+        "ts",
+        "kind",
+        "sha",
+        "head_ref",
+        "routed",
+        "message",
+        "probe_rc",
+        "probe_stderr_tail",
+    }
     assert row["kind"] == "stranded"
     assert row["head_ref"] == "issue-42"
     assert row["sha"] == sha
     assert row["routed"] is False
     assert row["probe_rc"] == 1
     assert row["message"].startswith("stranded probe")
+    # (probe.stderr or "")[-300:] — a str by construction, may legitimately be empty.
+    assert isinstance(row["probe_stderr_tail"], str)
 
 
 def test_landing_check_never_fails_the_mutation(fake_repo, monkeypatch, caplog):

--- a/tests/test_task_workflow_worktree.py
+++ b/tests/test_task_workflow_worktree.py
@@ -1055,6 +1055,71 @@ def test_routed_post_marker_succeeds_off_main(tmp_path: Path) -> None:
     )
 
 
+def test_routed_commit_landing_check_silent(tmp_path: Path) -> None:
+    """AC-8 (#1100): a HEALTHY routed mutation is POSITIVELY certified silent
+    under the post-commit landing check — post-CAS, `refs/heads/main` equals
+    the new commit, so the reachability probe hits rc=0 and neither the
+    stderr ERROR nor a sidecar row may appear.
+
+    "Suite green" alone has ZERO power against a warn-only spurious routed
+    ERROR (no other worktree test asserts stderr cleanliness on a healthy
+    routed commit), so this test does NOT set EPM_TASKPY_LANDING_CHECK=0 —
+    disabling would mask exactly the spurious-warn evidence it exists to
+    collect. The child's HOME is retargeted to tmp so LOCK_DIR — and with it
+    STRANDED_COMMITS_LOG — resolves under tmp, never the real
+    ~/.task-workflow/ (the A9 real-$HOME hygiene pattern).
+    """
+    main_repo = tmp_path / "repo"
+    _make_main_repo(main_repo)
+    _stage_task_cli_tree(main_repo)
+    _commit_cli_tree(main_repo)
+
+    # Park the primary on a feature branch → the mutation routes through the
+    # managed main-pinned worktree (the routed path the check must be silent
+    # on).
+    subprocess.run(
+        ["git", "-C", str(main_repo), "checkout", "-q", "-b", "feat/landing-check"],
+        check=True,
+    )
+
+    child_home = tmp_path / "home"
+    child_home.mkdir()
+    env = _clean_env()
+    env["HOME"] = str(child_home)  # retargets LOCK_DIR + STRANDED_COMMITS_LOG
+    assert "EPM_TASKPY_LANDING_CHECK" not in env or env["EPM_TASKPY_LANDING_CHECK"] != "0", (
+        "parent env disables the landing check — this test must observe it live"
+    )
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(main_repo / "scripts" / "task.py"),
+            "new",
+            "--kind",
+            "infra",
+            "--title",
+            "landing check silent",
+        ],
+        cwd=str(main_repo),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, f"routed task.py new failed: {proc.stderr}"
+
+    # The healthy routed commit must trigger NO landing-check output.
+    assert "LANDING CHECK" not in proc.stderr, (
+        f"spurious landing-check ERROR on a healthy routed commit:\n{proc.stderr}"
+    )
+    assert "NOT reachable" not in proc.stderr, (
+        f"spurious landing-check ERROR on a healthy routed commit:\n{proc.stderr}"
+    )
+    # ... and NO sidecar row in the (retargeted) forensic log.
+    sidecar = child_home / ".task-workflow" / "stranded-commits.jsonl"
+    assert not sidecar.exists() or sidecar.read_text().strip() == "", (
+        f"healthy routed commit wrote a stranded-commits row: {sidecar.read_text()!r}"
+    )
+
+
 def test_managed_worktree_dodges_stale_worktree_audit() -> None:
     """The managed worktree name `_task-main-pin` must NOT match the
     stale-worktree audit's target regex (`issue-<N>` / `agent-<hex>` /


### PR DESCRIPTION
Closes task #1100. Warn-only post-commit landing check (_warn_if_commit_stranded) at the _git_commit chokepoint + 8 tests. Plan v2; ensemble-reviewed 2 rounds; test-verdict PASS (2736/0).