### PR TITLE
issue-1109: _v4_results_body absolute-index footer cut (workflow-fix #1109)

### DIFF
--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -2642,28 +2642,36 @@ def _v4_results_body(body: str) -> str | None:
     interpretation-beat WARN for the last result). This helper cuts the
     section at the footer boundary so the per-result scans see only the
     real Results content. None when `## Results` is absent.
+
+    The cut is at the ABSOLUTE line index from `_v4_footer_start_line`,
+    intersected with the section's `find_h2_sections` line range — NEVER by
+    string-matching the footer's first line: when the footer is preceded by
+    a `---` rule its first line is `---`, and a legal mid-Results `---`
+    rule between results would truncate every later result out of checks
+    11b/20/21 (#1109; masked two ≥180-word hard FAILs on #825).
     """
-    results = section_text(body, "Results")
-    if results is None:
+    lines = body.splitlines()
+    section: tuple[int, int] | None = None
+    for name, start, end in find_h2_sections(body):
+        if name.casefold() == "results":
+            section = (start, end)
+            break
+    if section is None:
         return None
-    footer = _v4_footer_text(body)
-    if not footer:
-        return results
-    # The footer text is a suffix of the Results section_text (Results is
-    # the last H2, so its section_text runs to end-of-body and contains the
-    # footer). Cut at the footer's first line within the Results text.
-    footer_first_line = footer.splitlines()[0] if footer.splitlines() else ""
-    if not footer_first_line:
-        return results
-    rlines = results.splitlines()
-    for i, line in enumerate(rlines):
-        if line.strip() == footer_first_line.strip():
-            # Drop a trailing `---` rule + blank lines just above the footer.
-            j = i - 1
-            while j >= 0 and (rlines[j].strip() == "" or rlines[j].strip() == "---"):
-                j -= 1
-            return "\n".join(rlines[: j + 1]).strip()
-    return results
+    start, end = section
+    footer = _v4_footer_start_line(body)
+    if footer is None or not (start <= footer < end):
+        # No footer, or the footer lies outside this section's range (e.g.
+        # a stray H2 after ## Results): plain section text — identical to
+        # section_text(body, "Results").
+        return "\n".join(lines[start:end]).strip()
+    # Cut at the footer start, then drop trailing `---` rule + blank lines
+    # just above it (footer chrome, not Results content).
+    rlines = lines[start:footer]
+    j = len(rlines) - 1
+    while j >= 0 and rlines[j].strip() in ("", "---"):
+        j -= 1
+    return "\n".join(rlines[: j + 1]).strip()
 
 
 def _repro_section_text(body: str) -> str | None:

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -7293,6 +7293,133 @@ def test_v4_results_beat_warns_on_missing_interpretation_below_last_result():
     assert "interpretation prose below" in r.detail
 
 
+_V4_FOOTER_ANCHOR = "\n---\n**Repro:**"
+
+
+def test_v4_results_body_survives_mid_results_hr():
+    """A legal mid-Results `---` rule between two results must NOT truncate
+    the scan (#1109): the second result stays visible to checks 20/21, so
+    its ≥180-word interpretation hard-FAILs check 20. Pre-fix, the footer
+    first-line string match cut at the mid-`---` and check 20 falsely
+    PASSed (the #825 masking incident)."""
+    assert _V4_FOOTER_ANCHOR in _V4_GOOD_BODY, "fixture drifted: footer anchor missing"
+    long_interp = " ".join(["word"] * 185)
+    body = _V4_GOOD_BODY.replace(
+        _V4_FOOTER_ANCHOR,
+        "\n---\n\n### A second result behind a horizontal rule\n\n"
+        "Plotted: a second panel.\n\n" + long_interp + "\n\n---\n**Repro:**",
+    )
+    _fm, b = verify_task_body.split_frontmatter(body)
+    trunc = verify_task_body._v4_results_body(b)
+    assert "### A second result" in trunc
+    assert long_interp in trunc
+    assert "**Repro:**" not in trunc
+    assert "**Context:**" not in trunc
+    _ok, results = verify_task_body.verify_text(body)
+    r = _results_by_name(results)["v4 conciseness caps"]
+    assert not r.passed, r.render()
+    assert "≥180" in r.detail, r.render()
+
+
+def test_v4_results_beat_scans_results_after_mid_hr():
+    """The three-beat scan (check 21) sees results AFTER a mid-Results
+    `---` rule: with a properly-framed second result behind the rule the
+    detail reports `all 2` framed. Pre-fix the second result was cut out
+    of the scan entirely (`all 1`)."""
+    assert _V4_FOOTER_ANCHOR in _V4_GOOD_BODY, "fixture drifted: footer anchor missing"
+    second = (
+        "\n---\n\n### A second framed result behind a horizontal rule\n\n"
+        "Plotted: mean capability (y, %) per condition (x: baseline, tulu-25), "
+        "n=3 seeds per bar, 95% Wald CI error bars.\n\n"
+        "![Bar chart of mean capability with 95% CI across three seeds.]"
+        "(https://raw.githubusercontent.com/superkaiba/explore-persona-space/"
+        "0123456789abcdef/figures/issue_999/second.png)\n\n"
+        "> **Figure.** *Capability holds across conditions.* Baseline gray, "
+        "tulu-25 blue; error bars 95% Wald CIs.\n\n"
+        "Capability is flat across seeds; the largest gap is 0.4 pts.\n"
+        "\n---\n**Repro:**"
+    )
+    body = _V4_GOOD_BODY.replace(_V4_FOOTER_ANCHOR, second)
+    _ok, results = verify_task_body.verify_text(body)
+    r = _results_by_name(results)["Results three-beat shape (v4)"]
+    assert r.passed and not r.is_warn, r.render()
+    assert "all 2" in r.detail, r.render()
+
+
+def test_v4_results_body_equal_without_mid_hr():
+    """Compatibility pin: on a body with NO mid-Results `---` the new
+    absolute-index cut yields exactly the old output — the full section
+    minus the footer, trailing blank/`---` chrome stripped."""
+    _fm, b = verify_task_body.split_frontmatter(_V4_GOOD_BODY)
+    out = verify_task_body._v4_results_body(b)
+    assert out.endswith("is 1.2 pts.")
+    assert not out.endswith("---")
+    assert "**Repro:**" not in out
+    # Independent expectation: lines strictly between the `## Results`
+    # header line and the footer's `---` rule, trailing chrome stripped.
+    lines = b.splitlines()
+    h2_idx = lines.index("## Results")
+    repro_idx = next(i for i, ln in enumerate(lines) if ln.startswith("**Repro:**"))
+    rule_idx = repro_idx - 1
+    assert lines[rule_idx].strip() == "---", "fixture drifted: footer not `---`-preceded"
+    expected_lines = lines[h2_idx + 1 : rule_idx]
+    while expected_lines and expected_lines[-1].strip() in ("", "---"):
+        expected_lines.pop()
+    assert out == "\n".join(expected_lines).strip()
+
+
+def test_v4_results_body_no_footer_keeps_full_section():
+    """Case (a) parity: no footer at all — the helper returns the plain
+    `section_text` untouched, INCLUDING a mid-Results `---` and a retained
+    trailing rule (the trailing-strip runs only on the footer-cut branch)."""
+    assert _V4_FOOTER_ANCHOR in _V4_GOOD_BODY, "fixture drifted: footer anchor missing"
+    head = _V4_GOOD_BODY[: _V4_GOOD_BODY.index(_V4_FOOTER_ANCHOR)]
+    body = head.replace(
+        "Plotted: mean alignment",
+        "---\n\nPlotted: mean alignment",  # a mid-Results rule
+    )
+    body = body + "\n---\n"  # a trailing rule with no footer after it
+    _fm, b = verify_task_body.split_frontmatter(body)
+    assert verify_task_body._v4_footer_start_line(b) is None
+    out = verify_task_body._v4_results_body(b)
+    assert out == verify_task_body.section_text(b, "Results")
+    assert out.endswith("---")  # trailing rule retained, as today
+
+
+def test_v4_results_body_ignores_fenced_hr_in_results():
+    """A `---` inside a fenced code block within Results is content, not a
+    cut point: the absolute-index cut lands at the real footer and the
+    fenced rule plus everything after it stays in the scanned text. (The
+    old first-line string match was not fence-aware and cut at the fenced
+    `---` — a third old/new divergence class, strictly more correct now.)"""
+    assert _V4_FOOTER_ANCHOR in _V4_GOOD_BODY, "fixture drifted: footer anchor missing"
+    fenced = (
+        "\n```text\n---\nfenced rule above is content\n```\n\n"
+        "Post-fence interpretation stays in the scan." + _V4_FOOTER_ANCHOR
+    )
+    body = _V4_GOOD_BODY.replace(_V4_FOOTER_ANCHOR, fenced)
+    _fm, b = verify_task_body.split_frontmatter(body)
+    out = verify_task_body._v4_results_body(b)
+    assert "fenced rule above is content" in out
+    assert "Post-fence interpretation stays in the scan." in out
+    assert "**Repro:**" not in out
+
+
+def test_v4_results_body_footer_without_preceding_rule():
+    """Case (b): a footer with NO preceding `---` rule — the cut lands at
+    the `**Repro:**` line itself, the blank gap above it is stripped, and
+    the output equals the `---`-preceded fixture's cut (the rule is footer
+    chrome either way)."""
+    assert _V4_FOOTER_ANCHOR in _V4_GOOD_BODY, "fixture drifted: footer anchor missing"
+    body = _V4_GOOD_BODY.replace(_V4_FOOTER_ANCHOR, "\n**Repro:**")
+    _fm, b = verify_task_body.split_frontmatter(body)
+    out = verify_task_body._v4_results_body(b)
+    assert out.endswith("is 1.2 pts.")
+    assert "**Repro:**" not in out
+    _fm2, b2 = verify_task_body.split_frontmatter(_V4_GOOD_BODY)
+    assert out == verify_task_body._v4_results_body(b2)
+
+
 def test_v4_methodology_bare_rows_disclosure_passes_check10():
     """A v4 Methodology sample block disclosed solely as `N of M rows`
     (no 'example' / 'random sample') passes check 10 (cherry-picked


### PR DESCRIPTION
Closes task #1109. Fixes _v4_results_body truncating the v4 ## Results scan at any mid-body --- rule (masked check-20/21 FAILs, incident #825). Absolute-index cut via find_h2_sections ∩ _v4_footer_start_line + 6 regression tests.