### PR TITLE
task #1114: verify_plan c29 — deliberate fence vs §7 conditional phase (WARN-only)

### DIFF
--- a/.claude/rules/plan-compute-sizing.md
+++ b/.claude/rules/plan-compute-sizing.md
@@ -237,7 +237,13 @@ stays critic-owned. Then reconcile the WORST-CASE wall — base phases PLUS ever
 conditional / extension phase that could run on the same provision —
 against the GCP lane's auto-delete fence
 (`--instance-termination-action=DELETE` + `--max-run-duration`,
-default 7d — the FLEX_START ceiling, #741). Size that worst case off the
+default 7d — the FLEX_START ceiling, #741).
+Mechanically backstopped (WARN-only, heuristic) by `verify_plan.py` c29
+(a DECLARED fence — `--max-run-duration` flag or `max_run_duration`
+assignment — plus a §7 extension gate ⇒ the fence-reconcile sentence must
+reference the conditional phase); prose-only / dispatch-time-only fences
+(the #599/#833 shapes) and the arithmetic's correctness stay critic-owned.
+Size that worst case off the
 **p90 per-cell wall estimate, NEVER the mean**:
 `worst_case_wall ≈ n_cells × p90_per_cell / parallelism + fixed overheads`,
 with p90 derived (i) from a prior-issue per-cell wall DISTRIBUTION for the

--- a/scripts/verify_plan.py
+++ b/scripts/verify_plan.py
@@ -60,12 +60,14 @@ Check catalog (id — classification — kind scope)
       vs eval/debug intent      (analysis), conditional   analysis
   c28 decision-band precedent   WARN-only, conditional    experiment +
       coherence                                           analysis
+  c29 deliberate fence vs §7    WARN-only, conditional    experiment +
+      conditional phase                                   analysis
 
 Kind-exempt checks render as [SKIP] (first-class status, distinguishable
 from genuine passes — the calibration report needs n_skip separate from
 n_pass). Conditional checks (4, 6, 7, 10, 11, 12, 13, 14, 15, 16, 17, 18,
-19, 20, 21, 22, 23, 24, 25, 26, 27, 28) also SKIP when their content trigger
-does not fire.
+19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29) also SKIP when their content
+trigger does not fire.
 Check 23 runs OUTSIDE ``verify_plan_text()`` — it needs task context
 (``body.md`` + ``events.jsonl``), so ``main()`` appends it in ``--issue``
 mode only and renders it SKIP in ``--plan-file`` mode; its WARN is the one
@@ -98,6 +100,7 @@ Canonical N/A escape phrases (quote verbatim in bounce briefs):
   - ``N/A — no 7B activation capture`` (check 27)
   - ``N/A — no precedent-labeled decision bands`` (check 28; British
     ``labelled`` accepted)
+  - ``N/A — no conditional phase on this provision`` (check 29)
 
 WARN semantics: a WARN never blocks exit (exit 0). The Phase 1.5.0 wiring
 carries WARN lines verbatim into the fact-checker + critic briefs — that
@@ -4428,6 +4431,200 @@ def check_precedent_band_coherence(plan: str, kind: str) -> CheckResult:
     return _warn(cid, name, _c28_offender_detail(offenders, T, bands))
 
 
+# ─── Check 29 — deliberate fence vs §7 conditional phase ────────────────────
+# Mechanizes .claude/rules/plan-compute-sizing.md § "reconcile the WORST-CASE
+# wall — base phases PLUS every conditional / extension phase that could run
+# on the same provision — against the GCP lane's auto-delete fence": a
+# deliberately-declared (value-bearing, non-default) --max-run-duration /
+# max_run_duration fence coexisting with a §7 extension/retrain-class gate
+# must reference that conditional phase near a declaration site. Founding
+# offender: #1112 v2 (a 48h fence sized off base phases only, omitting its
+# own §7 G1 dose extension — joint worst ~48-50h; caught only by the critic
+# layer; v3 costs the extension and bumps the fence to 72h).
+
+# Value-bearing deliberate fence declaration, RAW scan (fences included — a
+# fenced gcloud/dispatch line is the real launch command; the c5/c26
+# raw-scan precedent). A value of 7d/168h is the default FLEX_START ceiling
+# (#741), not "deliberate"; a minutes value is the cap-probe command shape
+# (#680 `--max-run-duration=20m` — unit not in h/d, so it never matches); a
+# bare flag, a "default 7d" prose mention (no value directly after the
+# flag), and a templated `={max_run}`/`<dur>` placeholder carry no value —
+# none trigger. A loose "Nh near the flag" prose trigger is deliberately
+# absent: #1112 v2's §0 line ("the 48 h `--max-run-duration` fence") sits 2
+# lines from a Risks line containing "dose extension", so a prose trigger
+# would self-satisfy and the founding offender would PASS.
+_C29_FENCE_FLAG_RE = re.compile(
+    r"(?i)--max-run-duration[=\s]+[`\"']?~?(\d+(?:\.\d+)?)\s*(h(?:ours?)?|d(?:ays?)?)\b"
+)
+_C29_FENCE_EXTRA_RE = re.compile(
+    r"(?i)max_run_duration[\"']?\]?\s*[:=]\s*[\"'`]?~?(\d+(?:\.\d+)?)\s*"
+    r"(h(?:ours?)?|d(?:ays?)?)\b"
+)
+# §7-slot / Decision-Gates heading predicate (heading levels >= 2).
+# Deliberately permissive on the numbered form: the §7 slot also holds
+# `Compute estimate` / `Risks` in infra-shaped plans — the extension-vocab
+# gate below filters those (WARN-only polarity; calibration-swept, #1114).
+_C29_SECT7_HEAD_RE = re.compile(r"(?i)^(?:§\s*)?7\b(?:[.:)\s]|$)|\bdecision gates?\b")
+# Extension-class gate vocabulary. Bare "resume"/"re-run"/"re-judge" are
+# deliberately EXCLUDED (crash-resume vocabulary saturates plans); a gate
+# worded purely as "resume to step 60" is a named accepted false negative.
+_C29_EXTENSION_RE = re.compile(
+    r"(?i)\b(?:dose[- ]extension|extension|extend(?:s|ed|ing)?|re-?ladder\w*|"
+    r"re-?train\w*|retrain\w*|second pass|additional (?:steps|pass(?:es)?|epochs?))\b"
+)
+# Conditional-cost evidence vocabulary (permissive direction: a match can
+# only suppress a WARN). Gate labels (G1, G2, ...) are matched separately,
+# case-SENSITIVE, only for labels actually harvested from §7 — a (?i)
+# \bg\d+\b would match GCP machine types ("g2-standard-4").
+_C29_EVIDENCE_RE = re.compile(
+    r"(?i)§\s*7\b|\bsection\s+7\b|\b(?:extension|extend\w*|contingen\w*|conditional|"
+    r"gate(?:'s|s)?|dose[- ]extension|re-?ladder\w*|re-?train\w*|retrain\w*|"
+    r"second provision|across provisions|split across)\b"
+)
+_C29_WINDOW_LINES = 3  # pinned by test_c29_evidence_outside_window_still_warns
+
+
+def _c29_hours(val: str, unit: str) -> float:
+    """Fence value normalized to hours (d/days -> x24; units pre-filtered
+    to h/d by the declaration regexes)."""
+    return float(val) * (24.0 if unit.lower().startswith("d") else 1.0)
+
+
+def _c29_fence_decl_line_idxs(plan: str) -> list[int]:
+    """RAW line indices carrying a value-bearing ``--max-run-duration`` /
+    ``max_run_duration`` declaration whose value is not the 7d/168h default
+    FLEX_START ceiling (#741). RAW scan — fences included (a fenced
+    gcloud/dispatch line is the real launch command; c5/c26 precedent)."""
+    idxs: list[int] = []
+    for i, line in enumerate(plan.splitlines()):
+        for rx in (_C29_FENCE_FLAG_RE, _C29_FENCE_EXTRA_RE):
+            m = rx.search(line)
+            if m and abs(_c29_hours(m.group(1), m.group(2)) - 168.0) > 1e-9:
+                idxs.append(i)
+                break
+    return idxs
+
+
+def _c29_gate_section_prose(plan: str) -> str | None:
+    """Fence-masked prose of every §7-slot / Decision-Gates section (heading
+    levels >= 2), joined across all matches; ``None`` when no such heading
+    exists. The global ``_fence_mask`` excludes fenced example commands
+    inside §7 — a gate is a prose contract (the ``_trigger_windows``
+    fence-masked-trigger doctrine)."""
+    lines = plan.splitlines()
+    mask = _fence_mask(lines)
+    parts: list[str] = []
+    found = False
+    for h in _headings(plan):
+        if h.level < 2 or not _C29_SECT7_HEAD_RE.search(h.text.strip()):
+            continue
+        found = True
+        parts.extend(
+            line
+            for line, fenced in zip(
+                lines[h.line + 1 : h.end], mask[h.line + 1 : h.end], strict=True
+            )
+            if not fenced
+        )
+    return "\n".join(parts) if found else None
+
+
+def _c29_offender_detail(decl_line: str, gate_hit: str, labels: list[str]) -> str:
+    """Bounded WARN detail (c26 conventions): the first declaration line
+    (truncated ~80 chars), the matched §7 extension vocabulary + harvested
+    gate labels, the incident anchors, and BOTH remedies."""
+    lab = f"; §7 gate label(s): {', '.join(labels)}" if labels else ""
+    return (
+        f"deliberate fence declaration {decl_line.strip()[:80]!r} coexists with a §7 "
+        f"extension-class gate (matched {gate_hit!r}{lab}) but no declaration window "
+        "references the conditional phase's wall cost — reconcile the WORST-CASE wall, "
+        "base phases PLUS every conditional/extension phase on the same provision, "
+        "against the fence (plan-compute-sizing.md § worst-case wall; #599: a 24h fence "
+        "hard-deleted the pre-registered §7.3 extension probe at step 149/2400; #1112 "
+        "v2: a 48h fence omitted its own §7 G1 dose extension, joint worst ~48-50h). "
+        "Remedy: add the conditional phase's wall cost to the fence-reconcile sentence, "
+        "or declare 'N/A — no conditional phase on this provision' on its own line"
+    )
+
+
+def check_fence_conditional_phase(plan: str, kind: str) -> CheckResult:
+    """WARN-only, conditional: a deliberately-declared ``--max-run-duration``
+    / ``max_run_duration`` fence (value-bearing, != the 7d/168h default
+    ceiling) coexisting with an extension/retrain-class gate in the §7 /
+    Decision-Gates section must reference that conditional phase (a §7 gate
+    label, or conditional-cost vocabulary) within ±3 raw lines of a
+    declaration line — ANY-SITE satisfy: one declaration window carrying
+    the evidence clears the whole plan (the reconcile sentence is singular;
+    requiring every mention would WARN on compressed §0 summaries).
+    Fence-strip split: declaration scan RAW (the fence usually lives in a
+    backticked/fenced launch command, and a fenced-only declaration with
+    zero prose reconcile is exactly the silent-ride failure class); §7 gate
+    detection fence-masked; evidence windows RAW (permissive direction).
+    Mechanizes plan-compute-sizing.md § "reconcile the WORST-CASE wall —
+    base phases PLUS every conditional / extension phase" (#599: a 24h
+    fence hard-deleted the pre-registered §7.3 extension probe at step
+    149/2400; #833: per-cell dispersion overran a deliberate 36h fence;
+    #1112 v2: a 48h fence sized off base phases omitted its own §7 G1 dose
+    extension, joint worst ~48-50h — only the critic caught it). NEVER
+    FAILs (the c14/c28 doctrine). SCOPE (honest): mechanizes the
+    DECLARED-fence subclass (#1112-shaped) of the incident class only.
+    Known accepted gaps, each verified against the founding files: a
+    prose-only fence (the actual #599 shape — "GCP max-run-duration
+    (~20 h)", no flag/assignment) is invisible -> SKIP; a dispatch-time
+    fence never written into the plan (the actual #833 shape) is invisible
+    -> SKIP; bare resume/re-run/re-judge gates don't trigger; a
+    second-provision split pre-registered ONLY in §7 still WARNs (remedy:
+    the N/A phrase or a fence-window mention); evidence-vocabulary stray
+    matches (e.g. an unrelated "gate" near the fence) suppress a real WARN
+    — permissive direction; whether the referenced conditional cost is
+    ARITHMETICALLY correct stays critic-owned. The #599/#833 SKIP shapes
+    are pinned by tests (test_c29_prose_only_fence_skips /
+    test_c29_no_fence_skips) plus the #1114 §6 sibling replay, so a future
+    trigger widening fails loud."""
+    cid, name = "c29_fence_conditional_phase", "deliberate fence vs §7 conditional phase"
+    if kind not in ("experiment", "analysis"):
+        return _skip(
+            cid, name, "kind-exempt: fence/§7-gate shapes are an experiment|analysis plan shape"
+        )
+    decl_idxs = _c29_fence_decl_line_idxs(plan)
+    if not decl_idxs:
+        return _skip(
+            cid,
+            name,
+            "no deliberate (value-bearing, non-default) --max-run-duration fence "
+            "declaration detected",
+        )
+    if _standalone_na_declared(plan, r"no conditional phase on this provision"):
+        return _pass(cid, name, "explicit N/A declared (no conditional phase on this provision)")
+    gates = _c29_gate_section_prose(plan)
+    if gates is None:
+        return _skip(cid, name, "no §7 / Decision Gates section detected")
+    ext = _C29_EXTENSION_RE.search(gates)
+    if not ext:
+        return _skip(cid, name, "no extension/retrain-class conditional gate in §7")
+    labels = sorted(set(re.findall(r"\bG\d+\b", gates)))
+    lines = plan.splitlines()
+    for i in decl_idxs:
+        window = "\n".join(lines[max(0, i - _C29_WINDOW_LINES) : i + _C29_WINDOW_LINES + 1])
+        ev = _C29_EVIDENCE_RE.search(window)
+        if ev:
+            return _pass(
+                cid,
+                name,
+                "fence-reconcile window references the §7 conditional phase "
+                f"(evidence {ev.group(0)!r})",
+            )
+        for lb in labels:
+            if re.search(rf"\b{re.escape(lb)}\b", window):
+                return _pass(
+                    cid,
+                    name,
+                    "fence-reconcile window references the §7 conditional phase "
+                    f"(gate label {lb!r})",
+                )
+    return _warn(cid, name, _c29_offender_detail(lines[decl_idxs[0]], ext.group(0), labels))
+
+
 # ─── Driver ────────────────────────────────────────────────────────────────
 
 CHECKS = [
@@ -4458,6 +4655,7 @@ CHECKS = [
     check_gpu_basis_routed_machine,
     check_capture_intent_hbm,
     check_precedent_band_coherence,
+    check_fence_conditional_phase,
 ]
 
 

--- a/scripts/verify_plan.py
+++ b/scripts/verify_plan.py
@@ -4481,7 +4481,9 @@ _C29_EVIDENCE_RE = re.compile(
     r"gate(?:'s|s)?|dose[- ]extension|re-?ladder\w*|re-?train\w*|retrain\w*|"
     r"second provision|across provisions|split across)\b"
 )
-_C29_WINDOW_LINES = 3  # pinned by test_c29_evidence_outside_window_still_warns
+_C29_WINDOW_LINES = 3  # pinned on BOTH sides: test_c29_evidence_outside_window_still_warns
+# (upper bound: distance 4 WARNs) + test_c29_evidence_at_window_edge_passes
+# (lower bound: distance 3 PASSes — kills a narrowing mutant).
 
 
 def _c29_hours(val: str, unit: str) -> float:

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -39,7 +39,7 @@ sys.modules["verify_plan"] = verify_plan
 _spec.loader.exec_module(verify_plan)  # type: ignore[union-attr]
 
 
-# ─── Canonical plan (kind=experiment: passes 0-3,5,8,9,17; skips 4,6,7,10-16,18-22,24-27)
+# ─── Canonical plan (kind=experiment: passes 0-3,5,8,9,17; skips 4,6,7,10-16,18-22,24-29)
 
 # Surgery anchors (must appear verbatim in GOOD_PLAN exactly once).
 MV_HEADING = "### Measurement validity"
@@ -166,10 +166,11 @@ def test_good_plan_passes_all():
         "c26_gpu_basis_routed_machine": "SKIP",
         "c27_capture_intent_hbm": "SKIP",
         "c28_precedent_band_coherence": "SKIP",
+        "c29_fence_conditional_phase": "SKIP",
     }
     actual = {cid: r.status for cid, r in by_id.items()}
     assert actual == expected
-    assert len(results) == 28
+    assert len(results) == 29
 
 
 # ─── Check 0 — plan-nonstub ────────────────────────────────────────────────
@@ -4538,6 +4539,279 @@ def test_c28_ratio_equal_threshold():
     assert "contradiction" in r.detail
 
 
+# ─── Check 29 — deliberate fence vs §7 conditional phase ────────────────────
+
+# Fixtures quoted VERBATIM from the incident corpus (task #1114 plan §4.2),
+# embedded as literals — NEVER read from tasks/ at test runtime (tasks move
+# between status folders; the REAL plan files are exercised by the #1114 §6
+# real-fixture spot check + sibling replay, the c26/c28 fixture convention):
+# tasks/*/1112/plans/v2.md:207 (the G1 dose-extension gate bullet, truncated
+# before the "Grounding: #606" tail), v2.md:229 (the founding-offender fence
+# declaration, truncated at "never the mean" — hand-verified free of
+# _C29_EVIDENCE_RE tokens), v3.md:238 (the corrected declaration, truncated
+# at "rounded to **72 h**" — carries "§7", "G1", "contingency", "extension").
+C29_GATE_SECTION = (
+    "\n## 7. Decision Gates\n\n"
+    "- **G1 (FT install viability, fires after the sycophancy Tier-1 judge fold):** if "
+    "NEITHER full-FT cell has any rung with Tier-1 rate ≥ 0.45, run the pre-registered "
+    "one-shot dose extension — resume/retrain both FT cells to step 60 (save-2 grid "
+    "32..60), re-ladder, re-judge — before the capture phase.\n"
+)
+C29_V2_FENCE = (
+    "`--max-run-duration 48h` (fence re-reconciled for the cross-GPU basis: the FT-train "
+    "wall bases were measured on 4× H100 (#514) but this lane lands on 4× A100-80, expected "
+    "×2–3 per-step for ZeRO-3 7B, worst-case ×6 (#599 precedent); expected pod wall "
+    "~13–16 h; scaled WORST case (×6 on both FT-train rows) → pod wall ≈ 28 h, + judge-wait "
+    "variance ≈ 30 h, ×~1.5 margin → 45 h, rounded to 48 h — sized off the scaled worst "
+    "case, never the mean)\n"
+)
+C29_V3_FENCE = (
+    "`--max-run-duration 72h` (fence re-reconciled for the cross-GPU basis INCLUDING the "
+    "§7 G1 contingency: the FT-train wall bases were measured on 4× H100 (#514) but this "
+    "lane lands on 4× A100-80, expected ×2–3 per-step for ZeRO-3 7B, worst-case ×6 (#599 "
+    "precedent); expected pod wall ~13–16 h; scaled WORST case (×6 on both FT-train rows) "
+    "→ pod wall ≈ 28 h, + judge-wait variance ≈ 30 h; the §7 G1 one-shot dose extension "
+    "(resume/retrain BOTH FT cells to step 60 + re-ladder + re-judge on the SAME provision, "
+    "before capture) adds another FT-train-sized pass — ≈ 18–20 h at the same ×6 worst "
+    "scaling → joint worst ≈ 48–50 h, ×~1.45 margin → ~70–72 h, rounded to **72 h**\n"
+)
+# Separator DELIBERATELY padded to >= 4 raw lines so the gate section's
+# extension vocabulary sits OUTSIDE the ±3-raw-line evidence window of the
+# fence declaration line (one blank line fewer would flip
+# test_c29_1112_v2_offender_warns loud — padded by design).
+C29_SEPARATOR = "\n## 9b. Backend\n\n\n\n"
+C29_OFFENDER = GOOD_PLAN + C29_GATE_SECTION + C29_SEPARATOR + C29_V2_FENCE
+
+
+def test_c29_1112_v2_offender_warns():
+    # Acceptance criterion 1 (plan #1114 §1): the #1112 v2 fence declaration
+    # (48h, sized off base phases only) + the v2 §7 G1 dose-extension gate,
+    # with the gate vocabulary outside the ±3-line window → WARN; the detail
+    # names the incident anchors, the harvested gate label, and BOTH remedies.
+    ok, by_id = _run(C29_OFFENDER)
+    r = by_id["c29_fence_conditional_phase"]
+    assert r.status == "WARN"
+    assert ok  # WARN never flips overall (exit 0)
+    assert "N/A — no conditional phase on this provision" in r.detail
+    assert "#599" in r.detail
+    assert "G1" in r.detail
+
+
+def test_c29_1112_v3_reconciled_passes():
+    # The corrected #1112 v3 declaration carries "§7"/"G1"/"contingency"/
+    # "extension" on the declaration line itself → in-window evidence → PASS.
+    plan = GOOD_PLAN + C29_GATE_SECTION + C29_SEPARATOR + C29_V3_FENCE
+    _, by_id = _run(plan)
+    r = by_id["c29_fence_conditional_phase"]
+    assert r.status == "PASS"
+    assert "references the §7 conditional phase" in r.detail
+
+
+def test_c29_gate_label_only_reference_passes():
+    # Pins the case-sensitive harvested-label path in isolation: the window
+    # carries ONLY the §7 gate label (no _C29_EVIDENCE_RE vocabulary).
+    fence = "`--max-run-duration 48h` — worst-case wall includes G1's wall cost.\n"
+    plan = GOOD_PLAN + C29_GATE_SECTION + C29_SEPARATOR + fence
+    _, by_id = _run(plan)
+    r = by_id["c29_fence_conditional_phase"]
+    assert r.status == "PASS"
+    assert "G1" in r.detail
+
+
+def test_c29_machine_type_token_is_not_label_evidence():
+    # GCP machine-type tokens cluster exactly near fence text: `g2-standard-4`
+    # / `a2-ultragpu-4g` in-window must NOT satisfy the label path (labels are
+    # harvested from §7 only and matched case-SENSITIVELY) → still WARN.
+    fence = (
+        "`--max-run-duration 48h` on a2-ultragpu-4g (probe fallback g2-standard-4); "
+        "sized off base phases only.\n"
+    )
+    plan = GOOD_PLAN + C29_GATE_SECTION + C29_SEPARATOR + fence
+    assert _status(plan, "c29_fence_conditional_phase") == "WARN"
+
+
+def test_c29_no_fence_skips():
+    # Constraint (ii): gate section present, no fence declaration anywhere.
+    _, by_id = _run(GOOD_PLAN + C29_GATE_SECTION)
+    r = by_id["c29_fence_conditional_phase"]
+    assert r.status == "SKIP"
+    assert "no deliberate" in r.detail
+
+
+def test_c29_bare_flag_default_mention_skips():
+    # A bare-flag mention with the default in prose carries no value directly
+    # after the flag → not a deliberate declaration.
+    plan = (
+        GOOD_PLAN
+        + C29_GATE_SECTION
+        + "\nThe dispatch keeps `--max-run-duration` (default 7d — the FLEX_START ceiling).\n"
+    )
+    assert _status(plan, "c29_fence_conditional_phase") == "SKIP"
+
+
+def test_c29_explicit_7d_value_skips():
+    # An explicit `=7d` (168h) IS the default ceiling, not deliberate.
+    plan = GOOD_PLAN + C29_GATE_SECTION + "\nDispatch passes `--max-run-duration=7d`.\n"
+    assert _status(plan, "c29_fence_conditional_phase") == "SKIP"
+
+
+def test_c29_minutes_probe_value_skips():
+    # The #680 cap-probe command shape (`=20m`) — minutes are not an h/d fence
+    # value and never trigger.
+    plan = GOOD_PLAN + C29_GATE_SECTION + "\nCap probe: `--max-run-duration=20m` create.\n"
+    assert _status(plan, "c29_fence_conditional_phase") == "SKIP"
+
+
+def test_c29_no_sect7_skips():
+    # Constraint (i): a deliberate fence but NO §7-slot / Decision-Gates
+    # heading anywhere (GOOD_PLAN's §7 heading renamed away) → SKIP.
+    plan = (
+        GOOD_PLAN.replace(CRITERIA_HEADING, "## Success and kill criteria")
+        + C29_SEPARATOR
+        + C29_V2_FENCE
+    )
+    _, by_id = _run(plan)
+    r = by_id["c29_fence_conditional_phase"]
+    assert r.status == "SKIP"
+    assert "no §7" in r.detail
+
+
+def test_c29_no_extension_gate_skips():
+    # GOOD_PLAN's own §7 (success/kill criteria) carries no extension-class
+    # vocabulary → SKIP even with a deliberate fence present.
+    plan = GOOD_PLAN + C29_SEPARATOR + C29_V2_FENCE
+    _, by_id = _run(plan)
+    r = by_id["c29_fence_conditional_phase"]
+    assert r.status == "SKIP"
+    assert "no extension" in r.detail
+
+
+def test_c29_na_escape_passes():
+    plan = (
+        C29_OFFENDER + "\nN/A — no conditional phase on this provision (the G1 extension is "
+        "pre-registered to run on a second provision).\n"
+    )
+    _, by_id = _run(plan)
+    r = by_id["c29_fence_conditional_phase"]
+    assert r.status == "PASS"
+    assert "N/A" in r.detail
+
+
+def test_c29_quoted_na_phrase_does_not_escape():
+    # A mid-sentence quoted escape phrase (the pasted-bounce-brief self-escape
+    # channel) is NOT a standalone declaration line and must not escape — the
+    # c13/c18/c26/c28 anti-paste twin (_standalone_na_declared semantics).
+    # Padded >= 4 raw lines below the fence declaration so the quoted remedy
+    # (which carries the evidence token "conditional") stays OUTSIDE the ±3
+    # evidence window — this test pins the N/A-escape path specifically; the
+    # in-window paste channel is a documented accepted permissive gap.
+    plan = (
+        C29_OFFENDER + "\n\n\n\n\nThe remedy menu says to declare 'N/A — no conditional "
+        "phase on this provision' on its own line.\n"
+    )
+    assert _status(plan, "c29_fence_conditional_phase") == "WARN"
+
+
+def test_c29_fenced_gate_text_does_not_trigger():
+    # Gate text living ONLY inside a fenced example block within §7 is
+    # fence-masked out of the gate-section prose (a gate is a prose contract)
+    # → no extension trigger → SKIP.
+    fenced_gate = (
+        "\n\n```\n- **G1:** one-shot dose extension — retrain both FT cells, re-ladder.\n```"
+    )
+    plan = GOOD_PLAN.replace(KILL_SENT, KILL_SENT + fenced_gate) + C29_SEPARATOR + C29_V2_FENCE
+    _, by_id = _run(plan)
+    r = by_id["c29_fence_conditional_phase"]
+    assert r.status == "SKIP"
+    assert "no extension" in r.detail
+
+
+def test_c29_fenced_fence_decl_triggers():
+    # Raw-trigger polarity: a declaration living ONLY inside a fenced gcloud
+    # command IS the real launch command (the c5/c26 raw-scan precedent) —
+    # with a prose gate and no in-window evidence → WARN.
+    fence_block = (
+        "```bash\ngcloud compute instances create eps-issue-999 "
+        "--max-run-duration=48h --instance-termination-action=DELETE\n```\n"
+    )
+    plan = GOOD_PLAN + C29_GATE_SECTION + C29_SEPARATOR + fence_block
+    assert _status(plan, "c29_fence_conditional_phase") == "WARN"
+
+
+def test_c29_evidence_outside_window_still_warns():
+    # Pins _C29_WINDOW_LINES = 3: evidence placed 4 raw lines above the
+    # declaration line must NOT satisfy (the real near-miss: #1112 v2's §0
+    # Risks line sits 2 lines from its §0 fence mention).
+    plan = (
+        GOOD_PLAN
+        + C29_GATE_SECTION
+        + "\nThe §7 G1 dose extension is costed elsewhere.\n\n\n\n"
+        + C29_V2_FENCE
+    )
+    assert _status(plan, "c29_fence_conditional_phase") == "WARN"
+
+
+@pytest.mark.parametrize("kind", ["infra", "batch", "survey"])
+def test_c29_kind_exempt_skips(kind):
+    assert _status(C29_OFFENDER, "c29_fence_conditional_phase", kind=kind) == "SKIP"
+
+
+def test_c29_kind_analysis_warns():
+    # analysis is IN scope (fence/§7-gate shapes are an experiment|analysis
+    # plan shape) — same WARN severity as experiment.
+    assert _status(C29_OFFENDER, "c29_fence_conditional_phase", kind="analysis") == "WARN"
+
+
+def test_c29_assignment_form_offender_warns():
+    # Statistics-critic Must-Fix (plan #1114 v3): the corpus-shaped
+    # `spec.extra["max_run_duration"] = "48h"` assignment declaration WARNs
+    # when unreconciled — pins _C29_FENCE_EXTRA_RE's quote/bracket
+    # alternation (previously shipped untested).
+    fence = (
+        'The dispatch sets spec.extra["max_run_duration"] = "48h" for this provision; '
+        "sized off base phases only.\n"
+    )
+    plan = GOOD_PLAN + C29_GATE_SECTION + C29_SEPARATOR + fence
+    assert _status(plan, "c29_fence_conditional_phase") == "WARN"
+    # The #628 no-space shape also matches the assignment regex.
+    assert verify_plan._C29_FENCE_EXTRA_RE.search('max_run_duration"]="30h"')
+
+
+def test_c29_assignment_form_default_skips():
+    # Pins the 168h default exclusion on the ASSIGNMENT branch too.
+    fence = 'The dispatch keeps spec.extra["max_run_duration"] = "7d" (the default).\n'
+    plan = GOOD_PLAN + C29_GATE_SECTION + C29_SEPARATOR + fence
+    assert _status(plan, "c29_fence_conditional_phase") == "SKIP"
+
+
+def test_c29_prose_only_fence_skips():
+    # Alternatives-critic Must-Fix (scope honesty): the #599-shaped prose-only
+    # fence mention (value in parentheses, no `--` flag, no assignment) is a
+    # named accepted false negative → SKIP. Pins the DECLARED-fence-subclass
+    # scope so a future trigger widening fails loud. (The #833 shape — no
+    # in-plan fence at all — is pinned by test_c29_no_fence_skips.)
+    plan = (
+        GOOD_PLAN
+        + C29_GATE_SECTION
+        + "\nThe run rides the GCP max-run-duration (~20 h) auto-delete window.\n"
+    )
+    assert _status(plan, "c29_fence_conditional_phase") == "SKIP"
+
+
+def test_c29_multi_decl_any_site_satisfies():
+    # Pins the any-site-satisfy loop (a loop bug here fails toward a nuisance
+    # FP): two value-bearing declaration lines, first window bare, second
+    # window carrying "§7 G1" → PASS.
+    plan = (
+        GOOD_PLAN
+        + C29_GATE_SECTION
+        + C29_SEPARATOR
+        + "`--max-run-duration 48h` sized off base phases.\n\n\n\n\n"
+        + "`--max-run-duration 48h` re-reconciled including the §7 G1 wall cost.\n"
+    )
+    assert _status(plan, "c29_fence_conditional_phase") == "PASS"
+
+
 # ─── Plan-version + kind resolution ────────────────────────────────────────
 
 
@@ -4587,12 +4861,12 @@ def test_cli_json_schema_and_exit_zero_on_pass(tmp_path):
     assert payload["issue"] is None
     assert payload["kind"] == "experiment"
     assert payload["n_fail"] == 0
-    assert payload["n_skip"] == 21
+    assert payload["n_skip"] == 22
     assert {"id", "name", "status", "detail"} <= set(payload["checks"][0])
     statuses = {c["status"] for c in payload["checks"]}
     assert statuses <= {"PASS", "WARN", "FAIL", "SKIP"}
-    assert len(payload["checks"]) == 29
-    assert len({c["id"] for c in payload["checks"]}) == 29
+    assert len(payload["checks"]) == 30
+    assert len({c["id"] for c in payload["checks"]}) == 30
     # c23 has no task context in --plan-file mode: rendered SKIP (companion
     # assert for test_cli_issue_mode_appends_goal_currency).
     c23 = next(c for c in payload["checks"] if c["id"] == "c23_goal_currency")

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -4751,6 +4751,21 @@ def test_c29_evidence_outside_window_still_warns():
     assert _status(plan, "c29_fence_conditional_phase") == "WARN"
 
 
+def test_c29_evidence_at_window_edge_passes():
+    # Sibling of the outside-window test: evidence at EXACTLY distance 3
+    # (the _C29_WINDOW_LINES edge) must satisfy. Pins the LOWER bound of
+    # the window — a narrowing mutant (_C29_WINDOW_LINES = 0) passes every
+    # other c29 test (code-review r1, empirically demonstrated); this one
+    # kills it.
+    plan = (
+        GOOD_PLAN
+        + C29_GATE_SECTION
+        + "\nThe §7 G1 dose extension is costed elsewhere.\n\n\n"
+        + C29_V2_FENCE
+    )
+    assert _status(plan, "c29_fence_conditional_phase") == "PASS"
+
+
 @pytest.mark.parametrize("kind", ["infra", "batch", "survey"])
 def test_c29_kind_exempt_skips(kind):
     assert _status(C29_OFFENDER, "c29_fence_conditional_phase", kind=kind) == "SKIP"


### PR DESCRIPTION
## Summary
- Adds WARN-only conditional check `c29_fence_conditional_phase` to `scripts/verify_plan.py` (c26 fence family): a deliberately-declared `--max-run-duration` / `max_run_duration` fence coexisting with a §7 extension/retrain-class gate must reference that conditional phase within ±3 raw lines of a declaration line; N/A escape `N/A — no conditional phase on this provision`.
- 21 pinning tests (both regex branches, both fence-strip polarities, both-sides window pins, kind gates, quoted-N/A anti-paste, #599/#833 scope-honesty SKIP pins) + count-pin updates; cross-ref added to `.claude/rules/plan-compute-sizing.md`.
- Honest scope: mechanizes the DECLARED-fence subclass (#1112-shaped) only; prose-only (#599) and dispatch-time (#833) fences stay critic-owned, pinned as accepted false negatives.

Closes task #1114.

## Test plan
- [x] `pytest tests/test_verify_plan.py` — 495 passed
- [x] Step 9c gate: 2817 passed / 6 skipped; step9c_baseline compare exit 0 (no new failures, no ruff regression)
- [x] Real-fixture replay: #1112 v2 → WARN, v3 → PASS; #599 v1 / #833 v6 → SKIP
- [x] Calibration sweep (145 plan files, both trigger forms): 140 SKIP / 3 PASS / 2 WARN, both WARNs true positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)