### PR TITLE
issue-1115: read-hygiene context-budget sections in 9 heavy-read agent specs

### DIFF
--- a/.claude/agents/clean-result-critic.md
+++ b/.claude/agents/clean-result-critic.md
@@ -115,6 +115,35 @@ You are NOT a numbers-reviewer. The interpretation-critic has already
 checked plot-prose alignment, raw-text plausibility, and statistical
 claims. You check **shape, register, and statistical-framing rule**.
 
+## Context budget (READ FIRST)
+
+Your spec + the project CLAUDE.md import tree consume a large fraction of your
+context before your first tool call; heavy-read subagents have died to
+autocompact thrash on unbudgeted reads (#833/#835/#763). Read hygiene bounds
+the VARIABLE half of that load — it does not cure fixed-overhead window
+pressure (#1090) — so every read below is mandatory IN CONTENT but
+budgeted IN FORM:
+
+- **Grep-then-slice.** Never pull a >40 KB file (or a file of unknown size)
+  into context in one unchunked `Read`: locate the span with Grep (`-n`,
+  bounded `head_limit`), then `Read` only that span with `offset`/`limit` in
+  ≤300-line chunks. Material mandated "IN FULL" is still read in full — just
+  chunked.
+- **Never bare `task.py view <N>`** — it dumps the full event log. Task body:
+  `--json | jq -r '.body'`; single fields via jq; plans via `Read` on
+  `tasks/<status>/<N>/plans/v<K>.md` (or the path in your brief), sliced.
+- **Results are digests.** Never page a whole eval JSON / JSONL /
+  raw-completion file — `jq` the keys/fields you need; single rows by Grep +
+  line offset.
+- **Open SPEC.md by Grep for the specific lens/section only** (it is large;
+  your lenses already inline what they need). Figure PNG `Read`s are exempt
+  (required by the figure lenses); the body comes from the path in your
+  brief or `--json | jq -r '.body'`, sliced.
+- **Don't re-read what you just wrote.** `Write`/`Edit` error on failure.
+
+Other sections name WHAT to read; this one governs HOW. On conflict, this
+section wins on invocation form.
+
 ## Branch on `paper:` (markdown body vs LaTeX paper) — DO THIS FIRST
 
 Read the task `body.md` frontmatter (`paper:`) before any pre-pass.

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -52,6 +52,35 @@ The `events.jsonl` marker is the source of truth. Also return the verdict to who
 
 ---
 
+## Context budget (READ FIRST)
+
+Your spec + the project CLAUDE.md import tree consume a large fraction of your
+context before your first tool call; heavy-read subagents have died to
+autocompact thrash on unbudgeted reads (#833/#835/#763). Read hygiene bounds
+the VARIABLE half of that load — it does not cure fixed-overhead window
+pressure (#1090) — so every read below is mandatory IN CONTENT but
+budgeted IN FORM:
+
+- **Grep-then-slice.** Never pull a >40 KB file (or a file of unknown size)
+  into context in one unchunked `Read`: locate the span with Grep (`-n`,
+  bounded `head_limit`), then `Read` only that span with `offset`/`limit` in
+  ≤300-line chunks. Material mandated "IN FULL" is still read in full — just
+  chunked.
+- **Never bare `task.py view <N>`** — it dumps the full event log. Task body:
+  `--json | jq -r '.body'`; single fields via jq; plans via `Read` on
+  `tasks/<status>/<N>/plans/v<K>.md` (or the path in your brief), sliced.
+- **Results are digests.** Never page a whole eval JSON / JSONL /
+  raw-completion file — `jq` the keys/fields you need; single rows by Grep +
+  line offset.
+- **Diff BODIES have their own gate** (Step 0 +
+  `.claude/rules/diff-size-budget.md`); this section governs every NON-diff
+  read — plan, task body, rule/spec files, changed-file context:
+  grep-then-slice them; task state via jq.
+- **Don't re-read what you just wrote.** `Write`/`Edit` error on failure.
+
+Other sections name WHAT to read; this one governs HOW. On conflict, this
+section wins on invocation form.
+
 ## Your Responsibilities
 
 1. **Verify plan adherence** — Does the diff implement the approved plan? Nothing more, nothing less?

--- a/.claude/agents/consistency-checker.md
+++ b/.claude/agents/consistency-checker.md
@@ -24,6 +24,34 @@ You independently verify that a new experiment plan is consistent with related
 prior experiments. Your goal: prevent multi-variable changes that make
 results uninterpretable.
 
+## Context budget (READ FIRST)
+
+Your spec + the project CLAUDE.md import tree consume a large fraction of your
+context before your first tool call; heavy-read subagents have died to
+autocompact thrash on unbudgeted reads (#833/#835/#763). Read hygiene bounds
+the VARIABLE half of that load — it does not cure fixed-overhead window
+pressure (#1090) — so every read below is mandatory IN CONTENT but
+budgeted IN FORM:
+
+- **Grep-then-slice.** Never pull a >40 KB file (or a file of unknown size)
+  into context in one unchunked `Read`: locate the span with Grep (`-n`,
+  bounded `head_limit`), then `Read` only that span with `offset`/`limit` in
+  ≤300-line chunks. Material mandated "IN FULL" is still read in full — just
+  chunked.
+- **Never bare `task.py view <N>`** — it dumps the full event log. Task body:
+  `--json | jq -r '.body'`; single fields via jq; plans via `Read` on
+  `tasks/<status>/<N>/plans/v<K>.md` (or the path in your brief), sliced.
+- **Results are digests.** Never page a whole eval JSON / JSONL /
+  raw-completion file — `jq` the keys/fields you need; single rows by Grep +
+  line offset.
+- **Your inputs are three large artifacts by construction** (current plan,
+  parent plan, parent body): read each section-sliced against the checklist
+  — the §4/§5/§10/§11 spans — never all three whole.
+- **Don't re-read what you just wrote.** `Write`/`Edit` error on failure.
+
+Other sections name WHAT to read; this one governs HOW. On conflict, this
+section wins on invocation form.
+
 ## Inputs
 
 You receive:

--- a/.claude/agents/experiment-implementer.md
+++ b/.claude/agents/experiment-implementer.md
@@ -50,6 +50,37 @@ they invoke `implementer` directly.
 
 ---
 
+## Context budget (READ FIRST)
+
+Your spec + the project CLAUDE.md import tree consume a large fraction of your
+context before your first tool call; heavy-read subagents have died to
+autocompact thrash on unbudgeted reads (#833/#835/#763). Read hygiene bounds
+the VARIABLE half of that load — it does not cure fixed-overhead window
+pressure (#1090) — so every read below is mandatory IN CONTENT but
+budgeted IN FORM:
+
+- **Grep-then-slice.** Never pull a >40 KB file (or a file of unknown size)
+  into context in one unchunked `Read`: locate the span with Grep (`-n`,
+  bounded `head_limit`), then `Read` only that span with `offset`/`limit` in
+  ≤300-line chunks. Material mandated "IN FULL" is still read in full — just
+  chunked.
+- **Never bare `task.py view <N>`** — it dumps the full event log. Task body:
+  `--json | jq -r '.body'`; single fields via jq; plans via `Read` on
+  `tasks/<status>/<N>/plans/v<K>.md` (or the path in your brief), sliced.
+- **Results are digests.** Never page a whole eval JSON / JSONL /
+  raw-completion file — `jq` the keys/fields you need; single rows by Grep +
+  line offset.
+- **Brief hands you PATHS, not bodies.** Read the approved plan
+  section-sliced on demand (§4 Design for the build, §11 for values) — never
+  the whole plan file up front; prior round state via
+  `task.py latest-marker <N>` / jq on the specific marker, never a paged
+  `events.jsonl`. Revision-round diff BODIES are governed by
+  `.claude/rules/diff-size-budget.md` (size first).
+- **Don't re-read what you just wrote.** `Write`/`Edit` error on failure.
+
+Other sections name WHAT to read; this one governs HOW. On conflict, this
+section wins on invocation form.
+
 ## Execution Protocol
 
 - **Consult `.claude/rules/LESSONS.md` (always-on index) first.** For every

--- a/.claude/agents/follow-up-proposer.md
+++ b/.claude/agents/follow-up-proposer.md
@@ -20,6 +20,34 @@ tools:
 You propose the next experiments after one completes. Your proposals must be
 concrete, scoped, and change exactly one variable from the parent.
 
+## Context budget (READ FIRST)
+
+Your spec + the project CLAUDE.md import tree consume a large fraction of your
+context before your first tool call; heavy-read subagents have died to
+autocompact thrash on unbudgeted reads (#833/#835/#763). Read hygiene bounds
+the VARIABLE half of that load — it does not cure fixed-overhead window
+pressure (#1090) — so every read below is mandatory IN CONTENT but
+budgeted IN FORM:
+
+- **Grep-then-slice.** Never pull a >40 KB file (or a file of unknown size)
+  into context in one unchunked `Read`: locate the span with Grep (`-n`,
+  bounded `head_limit`), then `Read` only that span with `offset`/`limit` in
+  ≤300-line chunks. Material mandated "IN FULL" is still read in full — just
+  chunked.
+- **Never bare `task.py view <N>`** — it dumps the full event log. Task body:
+  `--json | jq -r '.body'`; single fields via jq; plans via `Read` on
+  `tasks/<status>/<N>/plans/v<K>.md` (or the path in your brief), sliced.
+- **Results are digests.** Never page a whole eval JSON / JSONL /
+  raw-completion file — `jq` the keys/fields you need; single rows by Grep +
+  line offset.
+- **Sibling/prior bodies: only the sections your proposals cite**
+  (Takeaways, the relevant `### <result>`), via `--json | jq -r '.body'`
+  sliced or Grep; eval JSONs as `jq` digests.
+- **Don't re-read what you just wrote.** `Write`/`Edit` error on failure.
+
+Other sections name WHAT to read; this one governs HOW. On conflict, this
+section wins on invocation form.
+
 ## Inputs
 
 You receive:

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -50,6 +50,34 @@ You work in two modes:
 
 ---
 
+## Context budget (READ FIRST)
+
+Your spec + the project CLAUDE.md import tree consume a large fraction of your
+context before your first tool call; heavy-read subagents have died to
+autocompact thrash on unbudgeted reads (#833/#835/#763). Read hygiene bounds
+the VARIABLE half of that load — it does not cure fixed-overhead window
+pressure (#1090) — so every read below is mandatory IN CONTENT but
+budgeted IN FORM:
+
+- **Grep-then-slice.** Never pull a >40 KB file (or a file of unknown size)
+  into context in one unchunked `Read`: locate the span with Grep (`-n`,
+  bounded `head_limit`), then `Read` only that span with `offset`/`limit` in
+  ≤300-line chunks. Material mandated "IN FULL" is still read in full — just
+  chunked.
+- **Never bare `task.py view <N>`** — it dumps the full event log. Task body:
+  `--json | jq -r '.body'`; single fields via jq; plans via `Read` on
+  `tasks/<status>/<N>/plans/v<K>.md` (or the path in your brief), sliced.
+- **Results are digests.** Never page a whole eval JSON / JSONL /
+  raw-completion file — `jq` the keys/fields you need; single rows by Grep +
+  line offset.
+- **Workflow-surface files run 200–1,800 lines.** Grep the anchor heading /
+  function first and `Read` only the edit span; never page a whole agent
+  spec or SKILL.md to find one section.
+- **Don't re-read what you just wrote.** `Write`/`Edit` error on failure.
+
+Other sections name WHAT to read; this one governs HOW. On conflict, this
+section wins on invocation form.
+
 ## Your Responsibilities
 
 1. **Understand** — Read relevant existing code BEFORE writing. Understand current patterns, conventions, tests.

--- a/.claude/agents/interpretation-critic.md
+++ b/.claude/agents/interpretation-critic.md
@@ -25,6 +25,34 @@ You are an adversarial reviewer of experiment interpretations. Your job is to
 make the interpretation honest, complete, and well-calibrated. You do NOT see
 the analyzer's reasoning — only the published interpretation and the raw data.
 
+## Context budget (READ FIRST)
+
+Your spec + the project CLAUDE.md import tree consume a large fraction of your
+context before your first tool call; heavy-read subagents have died to
+autocompact thrash on unbudgeted reads (#833/#835/#763). Read hygiene bounds
+the VARIABLE half of that load — it does not cure fixed-overhead window
+pressure (#1090) — so every read below is mandatory IN CONTENT but
+budgeted IN FORM:
+
+- **Grep-then-slice.** Never pull a >40 KB file (or a file of unknown size)
+  into context in one unchunked `Read`: locate the span with Grep (`-n`,
+  bounded `head_limit`), then `Read` only that span with `offset`/`limit` in
+  ≤300-line chunks. Material mandated "IN FULL" is still read in full — just
+  chunked.
+- **Never bare `task.py view <N>`** — it dumps the full event log. Task body:
+  `--json | jq -r '.body'`; single fields via jq; plans via `Read` on
+  `tasks/<status>/<N>/plans/v<K>.md` (or the path in your brief), sliced.
+- **Results are digests.** Never page a whole eval JSON / JSONL /
+  raw-completion file — `jq` the keys/fields you need; single rows by Grep +
+  line offset.
+- **Figure `Read`s are exempt** — Lens 6 requires viewing the PNGs. Eval
+  JSONs are not: `jq` exactly the metrics the body cites, never a paged
+  results file.
+- **Don't re-read what you just wrote.** `Write`/`Edit` error on failure.
+
+Other sections name WHAT to read; this one governs HOW. On conflict, this
+section wins on invocation form.
+
 ## Branch on `paper:` (markdown body vs LaTeX paper)
 
 Read the task `body.md` frontmatter (`paper:`) before you start.

--- a/.claude/agents/methodology-writer.md
+++ b/.claude/agents/methodology-writer.md
@@ -35,6 +35,35 @@ tools:
 
 # Methodology Writer
 
+## Context budget (READ FIRST)
+
+Your spec + the project CLAUDE.md import tree consume a large fraction of your
+context before your first tool call; heavy-read subagents have died to
+autocompact thrash on unbudgeted reads (#833/#835/#763). Read hygiene bounds
+the VARIABLE half of that load — it does not cure fixed-overhead window
+pressure (#1090) — so every read below is mandatory IN CONTENT but
+budgeted IN FORM:
+
+- **Grep-then-slice.** Never pull a >40 KB file (or a file of unknown size)
+  into context in one unchunked `Read`: locate the span with Grep (`-n`,
+  bounded `head_limit`), then `Read` only that span with `offset`/`limit` in
+  ≤300-line chunks. Material mandated "IN FULL" is still read in full — just
+  chunked.
+- **Never bare `task.py view <N>`** — it dumps the full event log. Task body:
+  `--json | jq -r '.body'`; single fields via jq; plans via `Read` on
+  `tasks/<status>/<N>/plans/v<K>.md` (or the path in your brief), sliced.
+- **Results are digests.** Never page a whole eval JSON / JSONL /
+  raw-completion file — `jq` the keys/fields you need; single rows by Grep +
+  line offset.
+- **Ground each hyperparameter by Grep** (the config key / function name),
+  then `Read` that span — never a whole training script or plan. The "What
+  you MUST NOT read" firewall is unchanged; this bounds HOW you read what
+  you may.
+- **Don't re-read what you just wrote.** `Write`/`Edit` error on failure.
+
+Other sections name WHAT to read; this one governs HOW. On conflict, this
+section wins on invocation form.
+
 ## Mode router — branch on the task's `workflow` + `paper:` frontmatter FIRST
 
 Before anything else, read `frontmatter.workflow` + `frontmatter.paper` from

--- a/.claude/agents/upload-verifier.md
+++ b/.claude/agents/upload-verifier.md
@@ -33,6 +33,35 @@ completions, candidate sweep cells) that the pod produced, the experimenter
 didn't think to upload, and the pod termination destroys forever. Your
 job is to catch those before the pod dies.
 
+## Context budget (READ FIRST)
+
+Your spec + the project CLAUDE.md import tree consume a large fraction of your
+context before your first tool call; heavy-read subagents have died to
+autocompact thrash on unbudgeted reads (#833/#835/#763). Read hygiene bounds
+the VARIABLE half of that load — it does not cure fixed-overhead window
+pressure (#1090) — so every read below is mandatory IN CONTENT but
+budgeted IN FORM:
+
+- **Grep-then-slice.** Never pull a >40 KB file (or a file of unknown size)
+  into context in one unchunked `Read`: locate the span with Grep (`-n`,
+  bounded `head_limit`), then `Read` only that span with `offset`/`limit` in
+  ≤300-line chunks. Material mandated "IN FULL" is still read in full — just
+  chunked.
+- **Never bare `task.py view <N>`** — it dumps the full event log. Task body:
+  `--json | jq -r '.body'`; single fields via jq; plans via `Read` on
+  `tasks/<status>/<N>/plans/v<K>.md` (or the path in your brief), sliced.
+- **Results are digests.** Never page a whole eval JSON / JSONL /
+  raw-completion file — `jq` the keys/fields you need; single rows by Grep +
+  line offset.
+- **Verification never requires paging artifact content.** Plan §6.5/§10 by
+  grepping those headings; HF existence via
+  `huggingface_hub.list_repo_files` listings; eval JSONs via `jq`
+  keys/length.
+- **Don't re-read what you just wrote.** `Write`/`Edit` error on failure.
+
+Other sections name WHAT to read; this one governs HOW. On conflict, this
+section wins on invocation form.
+
 ## Inputs
 
 You receive:

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -6258,16 +6258,17 @@ AGENT_SPEC_GRANDFATHER_MAX_HEADROOM_BYTES = 3_000
 # (#838): both were structurally trimmed to <=20 KB, so regrowth on the two
 # incident files is a commit-time FAIL.
 AGENT_SPEC_SIZE_GRANDFATHER: dict[str, int] = {
+    # measured 107,930 B post-#1115 (read-hygiene context-budget section —
+    # plan-mandated growth; cap = measured + <=~1 KB. Prior: 107,000 —
     # measured 104,135 B post-#829; fifteen-lenses core is every-markdown-review
-    # load-bearing — SPEC.md-dedup trim is the #829 named follow-up
-    "clean-result-critic.md": 107_000,
+    # load-bearing — SPEC.md-dedup trim is the #829 named follow-up)
+    "clean-result-critic.md": 108_900,
     # the rest measured at the #838 tightening (2026-07-02), caps = measured
     # + <=3 KB; each names a future trim direction, none is licensed to grow
-    # measured 92,536 B post-#1081 (fix-engaged elements (d)/(e) verification —
-    # fix-commit SHA + stale-run artifact disposition — plan-mandated growth;
-    # cap = measured + <=~1 KB. Prior: 92,300 — measured 91,371 B post-#948
-    # Step 3.8 seam-stubbed production-body lens)
-    "code-reviewer.md": 93_500,
+    # measured 94,126 B post-#1115 (read-hygiene context-budget section —
+    # plan-mandated growth; cap = measured + <=~1 KB. Prior: 93,500 —
+    # measured 92,536 B post-#1081 fix-engaged elements (d)/(e) verification)
+    "code-reviewer.md": 95_000,
     # measured 72,064 B post-#1056 (figure pin-first carve-out in the
     # composed-prompt header — plan-mandated growth; cap = measured
     # + <=~1 KB. Prior: 72,000 (measured 71,430 B post-#1050 r2),
@@ -6278,22 +6279,25 @@ AGENT_SPEC_SIZE_GRANDFATHER: dict[str, int] = {
     # + <=~1 KB. Prior: 47,930 B post-#881)
     # #948: seam-stubbed production-body lens (Step 3.8)
     "codex-code-reviewer.md": 51_600,
-    # measured 61,733 B post-#1102 (real-world-corpus class extension in
-    # § Content hygiene — plan-mandated growth; cap = measured + <=~1 KB.
-    # Prior: 61,500 — measured 58,976 B post-#936)
-    "experiment-implementer.md": 62_500,
+    # measured 63,424 B post-#1115 (read-hygiene context-budget section —
+    # plan-mandated growth; cap = measured + <=~1 KB. Prior: 62,500 —
+    # measured 61,733 B post-#1102)
+    "experiment-implementer.md": 64_000,
     # measured 65,540 B post-#1081 r2 (D3 crash-fix-relaunch addendum:
     # disposition-conditional resume-glob confirm — plan-mandated growth;
     # cap = measured + <=~1 KB. Prior: 65,500 — measured 62,672 B)
     "experimenter.md": 66_500,
-    # measured 48,197 B post-#1102 (real-world-corpus class extension across
-    # three content-hygiene spans — plan-mandated growth; cap = measured
-    # + <=~1 KB. Prior: 48,000 — measured 45,203 B)
-    "methodology-writer.md": 49_000,
+    # measured 49,740 B post-#1115 (read-hygiene context-budget section —
+    # plan-mandated growth; cap = measured + <=~1 KB. Prior: 49,000 —
+    # measured 48,197 B post-#1102)
+    "methodology-writer.md": 50_700,
     # measured 46,187 B post-#1082 (negative-existence search recipe —
     # plan-mandated growth; cap = measured + <=~1 KB. Prior: 43,500 / 40,990 B)
     "research-pm.md": 47_000,
-    "upload-verifier.md": 45_500,  # measured 42,825 B
+    # measured 46,830 B post-#1115 (read-hygiene context-budget section —
+    # plan-mandated growth; cap = measured + <=~1 KB. Prior: 45,500 — its
+    # "measured 42,825 B" comment was stale vs 45,321 B live pre-edit)
+    "upload-verifier.md": 47_800,
 }
 
 


### PR DESCRIPTION
Closes task #1115. Workflow-fix: insert `## Context budget (READ FIRST)` read-hygiene sections into the 9 heavy-read agent specs lacking one (17/17 coverage) + 5 AGENT_SPEC_SIZE_GRANDFATHER cap bumps. Plan v2 (critic-ensemble reviewed), code-review PASS, test-verdict PASS (2992 passed).