### PR TITLE
workflow-fix #1118: thread boot_disk_gb to RunPod GPU --volume-gb

### DIFF
--- a/scripts/backend_poll.py
+++ b/scripts/backend_poll.py
@@ -1855,10 +1855,13 @@ def _runspec_from_runpod_handle(handle, issue):
     ``extra`` carries ``intent`` plus (for runs dispatched through the unified
     router's canonical handle) ``workload_cmd`` / ``hydra_args`` / ``gpus`` /
     ``time_budget_hours`` (+ ``repo_branch`` post-#909, threaded through so the
-    failover re-execution syncs the ISSUE branch, not ``main``; a legacy handle
-    without the key still reconstructs). FAILS LOUD (raises ``ValueError``) on
-    a handle that carries NEITHER a workload command NOR hydra args — it NEVER
-    silently re-provisions a blank pod.
+    failover re-execution syncs the ISSUE branch, not ``main``; + the footprint
+    fields ``boot_disk_gb`` / ``min_ram_gb`` post-#1118, so the fresh pod keeps
+    the plan's disk/RAM requirement instead of silently downsizing to the
+    200 GB default volume — the #1112 ENOSPC class, one failover hop later; a
+    legacy handle without the keys still reconstructs). FAILS LOUD (raises
+    ``ValueError``) on a handle that carries NEITHER a workload command NOR
+    hydra args — it NEVER silently re-provisions a blank pod.
     """
     from explore_persona_space.backends.base import RunSpec
 
@@ -1871,6 +1874,17 @@ def _runspec_from_runpod_handle(handle, issue):
             f"cannot reconstruct a RunSpec for the fresh-pod re-provision. Refusing to "
             f"re-provision a blank pod (extra keys present: {sorted(extra)})."
         )
+    # #1118: forward the footprint fields (mirroring _runspec_from_gcp_handle's
+    # #1010 forwarding) so the wedge / CUDA-IMA fresh-pod re-provision keeps
+    # the plan's disk requirement — RunPodBackend.launch threads boot_disk_gb
+    # into --volume-gb (GPU) / --container-disk-gb (CPU). Keys forwarded only
+    # when present/truthy, so a legacy handle reconstructs byte-identically.
+    rebuilt_extra: dict = {}
+    if extra.get("repo_branch"):
+        rebuilt_extra["repo_branch"] = extra["repo_branch"]
+    for key in ("boot_disk_gb", "min_ram_gb"):
+        if extra.get(key):
+            rebuilt_extra[key] = extra[key]
     return RunSpec(
         issue=int(issue),
         intent=extra.get("intent", "lora-7b"),
@@ -1879,7 +1893,7 @@ def _runspec_from_runpod_handle(handle, issue):
         time_budget_hours=extra.get("time_budget_hours"),
         workload_cmd=workload_cmd,
         hydra_args=hydra_args,
-        extra=({"repo_branch": extra["repo_branch"]} if extra.get("repo_branch") else {}),
+        extra=rebuilt_extra,
     )
 
 

--- a/scripts/dispatch_issue.py
+++ b/scripts/dispatch_issue.py
@@ -945,7 +945,10 @@ def _launch_extra_from_args(args: argparse.Namespace) -> dict[str, Any]:
         # GCP boot disk (backends/gcp.py reads spec.extra["boot_disk_gb"]);
         # ALSO read by the RunPod CPU fallback as of #1010 — container-disk
         # threading in RunPodBackend.launch + the feasibility gate in
-        # router._runpod_terminal_rung. Inert on SLURM lanes.
+        # router._runpod_terminal_rung — and by the RunPod GPU lane as of
+        # #1118 (volume threading: --volume-gb max(200, value) → volumeInGb,
+        # so a plan-stated disk size survives a GCP→RunPod pivot; incident
+        # #1112). Inert on SLURM lanes.
         extra["boot_disk_gb"] = int(args.boot_disk_gb)
     if getattr(args, "min_ram_gb", None):
         # RunPod-CPU-fallback knob (#1010): read by the feasibility gate in
@@ -2026,7 +2029,11 @@ def _build_argparser() -> argparse.ArgumentParser:
             "(max(50, value)) and checked by the feasibility gate — an "
             "unsatisfiable disk requirement refuses the fallback typed "
             "(cpu_fallback_infeasible_for_plan) instead of provisioning an "
-            "undersized pod. Inert on SLURM lanes."
+            "undersized pod. RunPod GPU lane (#1118): threaded into the "
+            "pod's persistent /workspace volume (--volume-gb max(200, "
+            "value) → volumeInGb); an unsatisfiable size fails loud at "
+            "RunPod create time, never a silent 200 GB default (incident "
+            "#1112). Inert on SLURM lanes."
         ),
     )
     launch.add_argument(

--- a/src/explore_persona_space/backends/runpod.py
+++ b/src/explore_persona_space/backends/runpod.py
@@ -93,6 +93,14 @@ LOG_TAIL_LINES = 200
 #: — this module's imports stay ``base``-only by documented convention.)
 _CPU_CONTAINER_DISK_FLOOR_GB = 50
 
+#: Floor for the #1118 GPU-lane volume threading in :meth:`RunPodBackend.launch`
+#: — mirrors pod_lifecycle.py's ``provision --volume-gb`` argparse default (200),
+#: the /workspace volume an un-threaded GPU provision gets, so threading a
+#: plan's ``boot_disk_gb`` can only ever GROW the volume relative to today's
+#: default, never shrink it. (Not imported from ``scripts/pod_lifecycle`` —
+#: this module's imports stay ``base``-only by documented convention.)
+_GPU_VOLUME_FLOOR_GB = 200
+
 
 def _shell_quote(s: str) -> str:
     """Single-quote ``s`` for a remote bash command (poor-man's shlex.quote).
@@ -734,8 +742,13 @@ class RunPodBackend(ComputeBackend):
         resolves it to a RunPod CPU instance_id via
         ``gpu_heuristics.resolve_cpu_intent`` (checked BEFORE the GPU
         ``_resolve_spec``) and provisions via ``runpod_api.create_cpu_pod``
-        (``deployCpuPod``); ``cpu-bigmem`` never reaches here (it keeps the #677
-        typed terminal — it is absent from the RunPod-CPU map).
+        (``deployCpuPod``); ``cpu-bigmem`` never reaches here on any AUTOMATED
+        path (the #677 typed terminal at the router's terminal rung precedes
+        launch — it is absent from the RunPod-CPU map). An explicit
+        ``backend: runpod`` pin of ``cpu-bigmem`` DOES reach launch
+        (``_override_runpod`` has no CPU guard) and then fails loud downstream
+        (``resolve_cpu_intent`` -> None and the GPU ``_resolve_spec`` cannot
+        resolve it -> non-zero provision exit).
         """
         execute_workload = bool((spec.extra or {}).get("execute_workload"))
         if execute_workload and not spec.workload_cmd:
@@ -760,19 +773,41 @@ class RunPodBackend(ComputeBackend):
         ]
         if spec.gpus is not None:
             cmd += ["--gpu-count", str(spec.gpus)]
-        # #1010: thread the plan's disk requirement into the RunPod CPU
-        # fallback's container disk (the pod's only writable disk on the CPU
-        # lane -- /workspace rides the overlay; incident #958). CPU intents
-        # ONLY: on GPU pods the big-data mount is the 200 GB /workspace
-        # VOLUME, not the container overlay, so boot_disk_gb does not map.
-        # Floored at runpod_api.DEFAULT_CONTAINER_DISK_GB (50,
-        # _CPU_CONTAINER_DISK_FLOOR_GB here) so threading can never REDUCE
-        # below today's behavior. The router's feasibility gate guarantees
-        # boot_disk_gb <= the instance cap on every AUTOMATED path; an
-        # explicit `backend: runpod` pin above the cap fails loud at
+        # #1010/#1118: thread the plan's disk requirement into the provision
+        # argv. CPU lane (#1010): the pod's only writable disk is the
+        # container overlay (/workspace rides it; incident #958) --
+        # --container-disk-gb, floored at runpod_api.DEFAULT_CONTAINER_DISK_GB
+        # (50, _CPU_CONTAINER_DISK_FLOOR_GB here) so threading can never
+        # REDUCE below today's behavior. The router's feasibility gate
+        # guarantees boot_disk_gb <= the instance cap on every AUTOMATED
+        # path; an explicit `backend: runpod` pin above the cap fails loud at
         # pod_lifecycle's pre-API cap check / RunPod's own create-time
-        # validation.
-        boot_disk_gb = int((spec.extra or {}).get("boot_disk_gb") or 0)
+        # validation. GPU lane (#1118): the big-data mount is the /workspace
+        # VOLUME (pod_lifecycle threads --volume-gb -> runpod_api volumeInGb),
+        # floored at the 200 GB argparse default (_GPU_VOLUME_FLOOR_GB) --
+        # thread-or-grow, never shrink. No deterministic pre-API cap exists
+        # for GPU volumeInGb (unlike the probe-verified CPU caps) -- an
+        # unsatisfiable size surfaces LOUD at RunPod create time (RunPodError
+        # -> non-zero provision exit -> CalledProcessError) or as a capacity
+        # miss (wait-for-capacity budget), never as a silent downsize (the
+        # #1112 ENOSPC incident: a ~575 GB plan on the default 200 GB volume).
+        raw_boot_disk = (spec.extra or {}).get("boot_disk_gb") or 0
+        try:
+            boot_disk_gb = int(raw_boot_disk)
+            if float(raw_boot_disk) != boot_disk_gb:
+                # A fractional value (e.g. 575.5) would silently TRUNCATE via
+                # int() -- reject it instead of provisioning less disk than
+                # the plan stated.
+                raise ValueError("fractional GB value")
+        except (TypeError, ValueError) as exc:
+            # Named fail-loud parse mirroring router._footprint_int (#1118):
+            # GPU intents bypass the router's CPU-only footprint gate, so a
+            # malformed value would otherwise hit a bare int() traceback.
+            # Raised BEFORE the provision subprocess -- no pod is paid for.
+            raise ValueError(
+                f"spec.extra['boot_disk_gb'] is not an integer: {raw_boot_disk!r} "
+                f"(malformed disk requirement on issue {spec.issue})"
+            ) from exc
         if boot_disk_gb:
             from explore_persona_space.backends.router import (
                 RUNPOD_CPU_INSTANCE_FOR_INTENT,  # lazy: module top stays base-only
@@ -782,6 +817,11 @@ class RunPodBackend(ComputeBackend):
                 cmd += [
                     "--container-disk-gb",
                     str(max(_CPU_CONTAINER_DISK_FLOOR_GB, boot_disk_gb)),
+                ]
+            else:
+                cmd += [
+                    "--volume-gb",
+                    str(max(_GPU_VOLUME_FLOOR_GB, boot_disk_gb)),
                 ]
         # subprocess.run raises CalledProcessError on non-zero exit; that
         # propagates to the selector, which logs + lets the orchestrator
@@ -834,7 +874,10 @@ class RunPodBackend(ComputeBackend):
             Success path: ``workload_executed=exec_requested`` + the execution
             leg's ``workload_info`` — the ``extra`` dict is byte-identical to
             the pre-#954 inline construction (``workload_start_error`` is added
-            ONLY on the failure path, so no new keys appear on success).
+            ONLY on the failure path, so no new keys appear on success). #1118
+            adds the CONDITIONAL footprint keys (``boot_disk_gb`` /
+            ``min_ram_gb``) on both paths, OMITTED when absent/falsy — a spec
+            without a stated footprint keeps the pre-#1118 key set.
             Failure path (#954): ``workload_executed=False`` (truthful — the
             workload did not start) + a truncated ``workload_start_error`` so
             downstream consumers (poll / finalize / re-drive) can tell the
@@ -881,6 +924,20 @@ class RunPodBackend(ComputeBackend):
                 "hydra_args": list(spec.hydra_args),
                 "gpus": spec.gpus,
                 "time_budget_hours": spec.time_budget_hours,
+                # #1118: footprint fields persisted so the wedge / CUDA-IMA
+                # fresh-pod re-provision (backend_poll._runspec_from_runpod_handle)
+                # forwards them — mirroring the GCP handle (gcp.py, #1010).
+                # Keys OMITTED when absent/falsy — never a None value — so
+                # legacy handle shapes stay byte-identical (the
+                # _PRE_954_SUCCESS_EXTRA_KEYS exact-set tests pin this).
+                **{
+                    k: v
+                    for k, v in {
+                        "boot_disk_gb": (spec.extra or {}).get("boot_disk_gb"),
+                        "min_ram_gb": (spec.extra or {}).get("min_ram_gb"),
+                    }.items()
+                    if v
+                },
                 # #909: the branch the run's code lives on (round-trips through
                 # the sidecar + backend_poll reconstructors so a failover
                 # re-execution syncs the ISSUE branch, not `main`) + the

--- a/tests/test_backend_poll.py
+++ b/tests/test_backend_poll.py
@@ -1685,6 +1685,66 @@ def test_reconstructors_tolerate_legacy_handles_without_repo_branch():
     assert rp_spec.workload_cmd == "bash scripts/x.sh"
 
 
+def test_runspec_from_runpod_handle_forwards_boot_disk_gb(monkeypatch):
+    """#1118: the RunPod-handle reconstructor forwards the footprint fields
+    (``boot_disk_gb`` / ``min_ram_gb``) into the rebuilt spec extra — proven
+    through the PRODUCTION handle (real launch, provision no-op'd) + the
+    sidecar serialize/deserialize roundtrip, so int-survives-JSON is asserted
+    — and a legacy handle without the keys reconstructs byte-identically."""
+    from explore_persona_space.backends import runpod as RP
+    from explore_persona_space.backends.base import RunHandle, RunSpec
+    from explore_persona_space.backends.issue_dispatch import (
+        deserialize_handle,
+        serialize_handle,
+    )
+    from scripts import backend_poll as bp
+
+    _real_run = RP.subprocess.run
+
+    def _selective_run(cmd, *a, **k):
+        if isinstance(cmd, (list, tuple)) and any("pod_lifecycle.py" in str(c) for c in cmd):
+            return None
+        return _real_run(cmd, *a, **k)
+
+    monkeypatch.setattr(RP.subprocess, "run", _selective_run, raising=False)
+    handle = RP.RunPodBackend().launch(
+        RunSpec(
+            issue=1118,
+            intent="lora-7b",
+            backend="runpod",
+            workload_cmd="bash scripts/issue1118_dispatch.sh",
+            extra={"repo_branch": "issue-1118", "boot_disk_gb": 575, "min_ram_gb": 32},
+        )
+    )
+    assert handle.extra["boot_disk_gb"] == 575
+    roundtripped = deserialize_handle(serialize_handle(handle))
+    spec = bp._runspec_from_runpod_handle(roundtripped, 1118)
+    assert spec.extra.get("boot_disk_gb") == 575
+    assert spec.extra.get("min_ram_gb") == 32
+    assert spec.extra.get("repo_branch") == "issue-1118"
+
+    # Legacy handle without the footprint keys: the rebuilt extra is
+    # byte-identical to pre-#1118 (empty here — no repo_branch either).
+    legacy_rp = RunHandle(
+        backend="runpod",
+        cluster=None,
+        job_id="",
+        pod_name="pod-689",
+        scratch_dir="/workspace",
+        log_path="/workspace/logs/issue-689.log",
+        extra={
+            "issue": 689,
+            "intent": "lora-7b",
+            "workload_cmd": "bash scripts/x.sh",
+            "hydra_args": [],
+            "gpus": None,
+            "time_budget_hours": None,
+        },
+    )
+    legacy_spec = bp._runspec_from_runpod_handle(legacy_rp, 689)
+    assert legacy_spec.extra == {}
+
+
 # ---------------------------------------------------------------------------
 # #934: --lane-suffix sidecar resolution
 # ---------------------------------------------------------------------------

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -6149,6 +6149,29 @@ def test_explicit_runpod_override_runpod_only_intent_verbatim(
     assert "runpod_intent_translation" not in finals[-1]["extra"]
 
 
+def test_explicit_runpod_override_gpu_intent_preserves_boot_disk_gb(
+    lease_store, marker_poster, captured_markers
+):
+    """#1118 route-side leg (the exact #1112 manual-pivot shape): a GPU spec
+    with a stated boot_disk_gb reaches RunPodBackend.launch through
+    _override_runpod with the extra intact — the GPU sibling of the CPU-shaped
+    test_runpod_cpu_fallback_feasible_requirement_launches_and_preserves_extra
+    (launch then threads it into --volume-gb, pinned in
+    tests/test_runpod_workload_exec.py)."""
+    rp = _PassiveRunpod()
+    result = route(
+        RunSpec(issue=1118, intent="lora-7b", backend="runpod", extra={"boot_disk_gb": 575}),
+        runpod_backend=rp,
+        lease_store=lease_store,
+        marker_poster=marker_poster,
+    )
+    assert result.chosen_kind == "runpod"
+    assert result.reason == ROUTE_REASON_OVERRIDE
+    assert len(rp.launches) == 1
+    assert rp.launches[0].intent == "lora-7b"
+    assert rp.launches[0].extra["boot_disk_gb"] == 575
+
+
 def test_explicit_runpod_override_unmapped_gcp_intent_raises_valueerror(
     lease_store, marker_poster, captured_markers
 ):

--- a/tests/test_runpod_workload_exec.py
+++ b/tests/test_runpod_workload_exec.py
@@ -677,6 +677,11 @@ def test_launch_ok_regex_shapes():
 #: The EXACT pre-#954 success-path ``extra`` key set for a NON-exec launch
 #: (``workload_info == {}``) — pinned EXPLICITLY (never a circular post-change
 #: fixture): the #954 refactor must add NO new keys on the success path.
+#: #1118 adds two CONDITIONAL keys (``boot_disk_gb`` / ``min_ram_gb``),
+#: OMITTED when the spec states no footprint — the specs below state none,
+#: so this exact set still holds (the omit-when-absent contract is what the
+#: exact-set assertions pin; the conditional keys are covered by
+#: ``test_launch_handle_extra_carries_boot_disk_gb``).
 _PRE_954_SUCCESS_EXTRA_KEYS = frozenset(
     {
         "intent",
@@ -824,9 +829,89 @@ def test_launch_omits_container_disk_without_requirement(monkeypatch):
 
 def test_launch_does_not_thread_container_disk_for_gpu_intent(monkeypatch):
     """#1010: GPU intents NEVER thread the container disk — on GPU pods the
-    big-data mount is the 200 GB /workspace VOLUME, not the container
-    overlay, so boot_disk_gb does not map (threading it would silently
-    inflate GPU container disks fleet-wide)."""
+    big-data mount is the /workspace VOLUME, not the container overlay
+    (threading the overlay would silently inflate GPU container disks
+    fleet-wide). As of #1118 boot_disk_gb DOES map on the GPU lane — to
+    --volume-gb (see the #1118 section below), still never to
+    --container-disk-gb."""
     argvs = _recording_provision(monkeypatch)
     RP.RunPodBackend().launch(_cpu_spec("lora-7b", {"boot_disk_gb": 500}))
     assert "--container-disk-gb" not in argvs[0]
+
+
+# ---------------------------------------------------------------------------
+# #1118 — GPU-lane volume threading into the provision argv + handle persist
+# ---------------------------------------------------------------------------
+
+
+def test_launch_threads_volume_gb_for_gpu_intent(monkeypatch):
+    """#1118: a GPU intent with a stated boot_disk_gb threads
+    --volume-gb <value> into the provision argv (pod_lifecycle →
+    runpod_api volumeInGb) and never the CPU-lane --container-disk-gb."""
+    argvs = _recording_provision(monkeypatch)
+    RP.RunPodBackend().launch(_cpu_spec("lora-7b", {"boot_disk_gb": 575}))
+    assert len(argvs) == 1
+    assert _flag_value(argvs[0], "--volume-gb") == "575"
+    assert "--container-disk-gb" not in argvs[0]
+
+
+def test_launch_floors_volume_gb_at_default(monkeypatch):
+    """#1118: threading can never REDUCE below today's 200 GB argparse
+    default — a small stated requirement floors at max(200, boot_disk_gb)."""
+    argvs = _recording_provision(monkeypatch)
+    RP.RunPodBackend().launch(_cpu_spec("lora-7b", {"boot_disk_gb": 100}))
+    assert _flag_value(argvs[0], "--volume-gb") == "200"
+
+
+def test_launch_omits_volume_gb_without_requirement(monkeypatch):
+    """#1118 control: no stated requirement -> the provision argv is
+    byte-identical to pre-#1118 (no --volume-gb flag at all)."""
+    argvs = _recording_provision(monkeypatch)
+    RP.RunPodBackend().launch(_cpu_spec("lora-7b"))
+    assert "--volume-gb" not in argvs[0]
+
+
+def test_launch_does_not_thread_volume_gb_for_cpu_intent(monkeypatch):
+    """#1118: CPU intents NEVER gain a --volume-gb flag — pod_lifecycle's CPU
+    branch treats args.volume_gb == 200 as the 'unset' sentinel (its #747
+    cheap-CPU volume default), which an explicit flag would defeat."""
+    argvs = _recording_provision(monkeypatch)
+    RP.RunPodBackend().launch(_cpu_spec("cpu-mid", {"boot_disk_gb": 80}))
+    assert "--volume-gb" not in argvs[0]
+    assert _flag_value(argvs[0], "--container-disk-gb") == "80"
+
+
+def test_launch_malformed_boot_disk_gb_raises_named_valueerror(monkeypatch):
+    """#1118: a malformed (non-integer) boot_disk_gb fails loud with a
+    ValueError NAMING the key (mirroring router._footprint_int), raised
+    BEFORE the provision subprocess — no pod is paid for."""
+    argvs = _recording_provision(monkeypatch)
+    with pytest.raises(ValueError, match="boot_disk_gb"):
+        RP.RunPodBackend().launch(_cpu_spec("lora-7b", {"boot_disk_gb": "lots"}))
+    assert argvs == []
+
+
+def test_launch_fractional_boot_disk_gb_raises_named_valueerror(monkeypatch):
+    """#1118 tightening: a fractional value (575.5) raises the same named
+    ValueError instead of silently TRUNCATING to a smaller disk."""
+    argvs = _recording_provision(monkeypatch)
+    with pytest.raises(ValueError, match="boot_disk_gb"):
+        RP.RunPodBackend().launch(_cpu_spec("lora-7b", {"boot_disk_gb": 575.5}))
+    assert argvs == []
+
+
+def test_launch_handle_extra_carries_boot_disk_gb(monkeypatch):
+    """#1118: the launch handle's extra persists the footprint fields
+    (boot_disk_gb / min_ram_gb) so _runspec_from_runpod_handle can forward
+    them on the wedge / CUDA-IMA fresh-pod re-provision — and OMITS them
+    when the spec states none (the legacy-shape / exact-key-set control)."""
+    _recording_provision(monkeypatch)
+    handle = RP.RunPodBackend().launch(
+        _cpu_spec("lora-7b", {"boot_disk_gb": 575, "min_ram_gb": 32})
+    )
+    assert handle.extra["boot_disk_gb"] == 575
+    assert handle.extra["min_ram_gb"] == 32
+
+    handle2 = RP.RunPodBackend().launch(_cpu_spec("lora-7b"))
+    assert "boot_disk_gb" not in handle2.extra
+    assert "min_ram_gb" not in handle2.extra


### PR DESCRIPTION
Closes task #1118. Threads spec.extra['boot_disk_gb'] into the RunPod GPU provision's --volume-gb (floor 200), persists footprint keys into the RunPod handle + forwards through the wedge/CUDA-IMA re-provision reconstructor, updates dispatch_issue.py docs, +9 tests. Incident #1112; precedent #1010. Plan v2 critic-APPROVEd; code-review PASS; test-verdict PASS (3378 passed).