### PR TITLE
issue-1122: preserve workload extras across exit-75 reconnect handle rewrites

### DIFF
--- a/scripts/backend_poll.py
+++ b/scripts/backend_poll.py
@@ -2825,22 +2825,33 @@ def _runspec_from_gcp_handle(handle, issue):
     exclusion holds with NO placeholder substituted into the unused branch
     (MF2).
 
-    FAILS LOUD (raises ``ValueError``) on a pre-#659 handle that lacks the
-    workload command — it NEVER silently launches a blank RunPod job (the
-    §4.1.0 spec-threading is a HARD PREREQUISITE; the fact-checker confirmed
-    A7=WRONG, the pre-#659 ``extra`` did not carry it).
+    FAILS LOUD (raises ``ValueError``) on a handle that carries NEITHER a
+    workload command NOR hydra args — it NEVER silently launches a blank
+    RunPod job (the §4.1.0 spec-threading is a HARD PREREQUISITE; the
+    fact-checker confirmed A7=WRONG, the pre-#659 ``extra`` did not carry
+    it). The both-empty VALUE check (#1122, matching the RunPod sibling
+    :func:`_runspec_from_runpod_handle`) replaced the key-presence check:
+    the demonstrated production shape (incident #1090) was an exit-75
+    same-command-rerun RECONNECT that rewrote the sidecar without the
+    launch-only workload extras — fixed at the write site by #1122
+    (``gcp.reconnect_or_none`` threading + the ``issue_dispatch``
+    carry-forward) — and keys-present-but-both-empty now also refuses
+    loudly instead of building a blank RunSpec.
     """
     from explore_persona_space.backends.base import RunSpec
 
     extra = handle.extra or {}
-    if "workload_cmd" not in extra or "hydra_args" not in extra:
+    workload_cmd = extra.get("workload_cmd", "") or ""  # str, verbatim (MF1)
+    hydra_args = tuple(extra.get("hydra_args") or ())  # list/tuple -> tuple, verbatim
+    if not workload_cmd and not hydra_args:
         raise ValueError(
-            f"GCP handle for issue {issue} lacks workload_cmd/hydra_args in extra "
-            f"(pre-#659 handle?); cannot reconstruct a RunSpec for the RunPod failover. "
-            f"Refusing to launch a blank RunPod job."
+            f"GCP handle for issue {issue} carries no workload_cmd/hydra_args in extra "
+            f"(keys present: {sorted(extra)}; reconnected={extra.get('reconnected')!r}). "
+            f"Most likely an exit-75 same-command-rerun RECONNECT rewrote the handle "
+            f"sidecar without the launch-only workload extras (#1122 — fixed at the "
+            f"write site as of that task) — or a pre-#659 handle. Cannot reconstruct "
+            f"a RunSpec for the RunPod failover; refusing to launch a blank RunPod job."
         )
-    workload_cmd = extra["workload_cmd"]  # str, verbatim (MF1)
-    hydra_args = tuple(extra["hydra_args"])  # list/tuple -> tuple, verbatim
     # #909: thread repo_branch through so the RunPod re-execution syncs the
     # ISSUE branch, not `main` (per-issue dispatch scripts live on issue
     # branches). A legacy handle without the key still reconstructs.

--- a/src/explore_persona_space/backends/gcp.py
+++ b/src/explore_persona_space/backends/gcp.py
@@ -3267,6 +3267,19 @@ def reconnect_or_none(
     semantics — a probe flake fails the launch typed and RETRIABLE
     (re-run the same command; idempotent by design, the #736 exit-75
     precedent), never a silent reconnect and never a delete.
+
+    Failover-prerequisite extras (#1122): when the spec carries a
+    workload (``workload_cmd`` or ``hydra_args``), the reconnect
+    handle's ``extra`` mirrors the launch path's failover keys
+    (``workload_cmd`` / ``hydra_args`` / ``gpus`` /
+    ``time_budget_hours`` / ``repo_branch`` / ``gpu_count`` +
+    ``boot_disk_gb`` / ``min_ram_gb`` when set). The #736 exit-75
+    contract re-runs the SAME command, and
+    ``issue_dispatch.dispatch_for_issue``'s ``on_launched`` hook
+    OVERWRITES the handle sidecar with THIS handle — pre-#1122 the
+    minimal probe-derived extra clobbered the launch handle's workload
+    keys, so the #783 queue-timeout RunPod failover crashed at
+    ``backend_poll._runspec_from_gcp_handle`` (incident #1090).
     """
     name = instance_name_for(spec.issue, lane_suffix_for(spec))
     argv = render_list_argv(config=config, name_filter=f"name={name}")
@@ -3350,6 +3363,40 @@ def reconnect_or_none(
         }
         if recovered_attempt_id is not None:
             extra["attempt_id"] = recovered_attempt_id
+        # #1122: mirror the launch path's failover-prerequisite keys
+        # (#659 MF1/MF2, #909 repo_branch, #677 gpu_count, #1010 footprint)
+        # so an exit-75 same-command RERUN's reconnect handle — which
+        # OVERWRITES the sidecar via issue_dispatch's on_launched hook —
+        # stays failover-capable (backend_poll._runspec_from_gcp_handle).
+        # Gated on the spec carrying a workload: a bare (provision-only /
+        # probe) reconnect keeps the legacy extra shape, and the
+        # issue_dispatch carry-forward (#1122 edit 2) preserves the prior
+        # sidecar's values for that case instead.
+        if spec.workload_cmd or spec.hydra_args:
+            # MF1: workload_cmd is a str — preserve AS-IS, never list().
+            # MF2: one of the pair is empty by RunSpec.__post_init__
+            # mutual exclusion; write BOTH so the poller's verbatim
+            # pass-through reconstruction holds.
+            extra["workload_cmd"] = spec.workload_cmd or ""
+            extra["hydra_args"] = list(spec.hydra_args or ())
+            extra["gpus"] = spec.gpus
+            extra["time_budget_hours"] = spec.time_budget_hours
+            extra["repo_branch"] = str((spec.extra or {}).get("repo_branch") or "")
+            # 0-vs-nonzero is all the poller's CPU-lane guards read
+            # (_is_gcp_async_workload_failure / _is_gcp_queue_timeout),
+            # and CPU-ness is intent-determined — override-invariant even
+            # when the creating rung used a machine_spec_override.
+            extra["gpu_count"] = machine_for_intent(spec).gpu_count
+            extra.update(
+                {
+                    k: v
+                    for k, v in {
+                        "boot_disk_gb": (spec.extra or {}).get("boot_disk_gb"),
+                        "min_ram_gb": (spec.extra or {}).get("min_ram_gb"),
+                    }.items()
+                    if v
+                }
+            )
         return RunHandle(
             backend="gcp",
             cluster=None,

--- a/src/explore_persona_space/backends/issue_dispatch.py
+++ b/src/explore_persona_space/backends/issue_dispatch.py
@@ -404,6 +404,116 @@ def read_handle_sidecar(path: Path) -> RunHandle:
     return deserialize_handle(json.loads(path.read_text()))
 
 
+#: Launch-only failover-prerequisite extras (#659/#909/#677/#1010) a
+#: reconnect rewrite must not drop (#1122). The workload pair
+#: (workload_cmd, hydra_args) is handled separately (atomic merge — the
+#: RunSpec mutual exclusion, base.py ``RunSpec.__post_init__``).
+RECONNECT_CARRY_FORWARD_EXTRA_KEYS: tuple[str, ...] = (
+    "gpus",
+    "time_budget_hours",
+    "repo_branch",
+    "gpu_count",
+    "boot_disk_gb",
+    "min_ram_gb",
+)
+
+
+def _prior_sidecar_failover_extras(sidecar: Path) -> dict[str, Any] | None:
+    """Snapshot the prior sidecar's failover extras BEFORE ``route()`` overwrites it.
+
+    Returns ``{backend, pod_name, job_id, extra: {...}}`` with ``extra``
+    holding only the failover-prerequisite keys (#1122): the atomic
+    ``workload_cmd``/``hydra_args`` pair (kept only when at least one is
+    non-empty) plus every non-empty
+    :data:`RECONNECT_CARRY_FORWARD_EXTRA_KEYS` value. Best-effort:
+    returns ``None`` on an absent sidecar (silent — the common fresh
+    dispatch) or a malformed one (logged at DEBUG) — the carry-forward
+    is a safety net, never a gate.
+    """
+    try:
+        h = read_handle_sidecar(sidecar)
+    except FileNotFoundError:
+        return None
+    except (KeyError, ValueError, OSError) as exc:  # ValueError covers JSONDecodeError
+        logger.debug(
+            "dispatch_for_issue: prior sidecar %s unreadable (%s); no reconnect carry-forward",
+            sidecar,
+            exc,
+        )
+        return None
+    ex = h.extra or {}
+    kept: dict[str, Any] = {}
+    if ex.get("workload_cmd") or ex.get("hydra_args"):
+        kept["workload_cmd"] = ex.get("workload_cmd") or ""
+        kept["hydra_args"] = list(ex.get("hydra_args") or ())
+    for k in RECONNECT_CARRY_FORWARD_EXTRA_KEYS:
+        v = ex.get(k)
+        if v not in (None, "", []):
+            kept[k] = v
+    return {
+        "backend": h.backend,
+        "pod_name": h.pod_name,
+        "job_id": h.job_id,
+        "extra": kept,
+    }
+
+
+def _carry_forward_reconnect_extras(handle: RunHandle, prior: dict | None) -> RunHandle:
+    """Fill launch-only extras a RECONNECT rewrite dropped (#1122).
+
+    Fires ONLY when: the handle is a reconnect (``extra['reconnected']``
+    truthy — set only by GCP's ``reconnect_or_none``, so the merge is
+    GCP-scoped by construction), AND ``prior`` binds to the SAME
+    instance (backend + pod_name + job_id — ``job_id`` is the per-create
+    GCE instance id, so a stale sidecar from a dead incarnation never
+    donates; an EMPTY ``job_id`` on EITHER side is treated as no-match,
+    so a degenerate ``("gcp", name, "")`` binding can never match across
+    incarnations), AND a key is absent/empty on the new handle while
+    non-empty on the prior. The ``(workload_cmd, hydra_args)`` pair
+    merges ATOMICALLY and only when the handle carries NEITHER
+    (preserves the RunSpec mutual exclusion,
+    base.py ``RunSpec.__post_init__``). Logs a WARNING naming the
+    carried keys. Returns the input handle unchanged (identity) when
+    nothing applies.
+    """
+    hx = handle.extra or {}
+    if not prior or not prior["extra"] or not hx.get("reconnected"):
+        return handle
+    # #1122 §11.5(1): empty job_id on either side = no-match (a bare
+    # instance-id can be "" on a degraded API read; never bind on it).
+    if not prior["job_id"] or not handle.job_id:
+        return handle
+    if (prior["backend"], prior["pod_name"], prior["job_id"]) != (
+        handle.backend,
+        handle.pod_name,
+        handle.job_id,
+    ):
+        return handle
+    merged, carried = dict(hx), []
+    pe = prior["extra"]
+    if not (hx.get("workload_cmd") or hx.get("hydra_args")) and (
+        "workload_cmd" in pe or "hydra_args" in pe
+    ):
+        merged["workload_cmd"] = pe.get("workload_cmd", "")
+        merged["hydra_args"] = list(pe.get("hydra_args") or ())
+        carried += ["workload_cmd", "hydra_args"]
+    for k in RECONNECT_CARRY_FORWARD_EXTRA_KEYS:
+        if k in pe and merged.get(k) in (None, "", []):
+            merged[k] = pe[k]
+            carried.append(k)
+    if not carried:
+        return handle
+    logger.warning(
+        "dispatch_for_issue: reconnect rewrite for %s dropped launch-only extras; "
+        "carried forward %s from the prior handle sidecar (#1122).",
+        handle.pod_name,
+        carried,
+    )
+    from dataclasses import replace
+
+    return replace(handle, extra=merged)
+
+
 # ---------------------------------------------------------------------------
 # Terminal-exception translation
 # ---------------------------------------------------------------------------
@@ -650,8 +760,18 @@ def dispatch_for_issue(
     sidecar = handle_sidecar_path or default_handle_sidecar_path(
         spec.issue, lane_suffix=spec.extra.get("lane_suffix")
     )
+    # #1122: snapshot the prior sidecar's failover extras BEFORE route()
+    # can overwrite it — the on_launched early write inside route() is the
+    # FIRST overwrite, so reading after route() is too late. NOTE: `prior`
+    # is computed only when write_sidecar; a future write_sidecar=False
+    # caller gets no returned-handle enrichment either (there is no prior
+    # sidecar being clobbered in that mode, but keep the two paths' gating
+    # aligned if that ever changes).
+    prior = _prior_sidecar_failover_extras(sidecar) if write_sidecar else None
     if write_sidecar:
-        route_kwargs["on_launched"] = lambda h: write_handle_sidecar(h, sidecar)
+        route_kwargs["on_launched"] = lambda h: write_handle_sidecar(
+            _carry_forward_reconnect_extras(h, prior), sidecar
+        )
 
     result = route(spec, **route_kwargs)
 
@@ -659,7 +779,10 @@ def dispatch_for_issue(
     # already populate one. The artifact verifier reads this off the
     # handle's ``extra`` at confirm_artifacts time (the silent-loss
     # safeguard).
-    handle = result.handle
+    # #1122: mirror the on_launched merge on the returned handle so the
+    # authoritative post-route sidecar write (and the caller's handle)
+    # carry the same preserved extras.
+    result, handle = _apply_carry_forward_to_result(result, prior)
     _warn_on_reconnected_workload(spec, result, handle)
     if expected_artifacts is not None and EXPECTED_ARTIFACTS_HANDLE_KEY not in handle.extra:
         from dataclasses import replace
@@ -683,6 +806,23 @@ def dispatch_for_issue(
         handle_sidecar_path=sidecar_written,
         sidecar_write_error=sidecar_write_error,
     )
+
+
+def _apply_carry_forward_to_result(result: RouteResult, prior: dict | None):
+    """Mirror the on_launched carry-forward merge on the RETURNED handle (#1122).
+
+    Returns ``(result, handle)`` — rebuilt with the enriched handle when
+    the merge carried anything, the inputs unchanged (identity) otherwise.
+    Keeps the authoritative post-route sidecar write and the caller's
+    handle consistent with the early ``on_launched`` write.
+    """
+    handle = result.handle
+    enriched = _carry_forward_reconnect_extras(handle, prior)
+    if enriched is handle:
+        return result, handle
+    from dataclasses import replace
+
+    return replace(result, handle=enriched), enriched
 
 
 def _warn_on_reconnected_workload(spec: RunSpec, result: RouteResult, handle: RunHandle) -> None:

--- a/tests/test_backend_poll.py
+++ b/tests/test_backend_poll.py
@@ -2948,3 +2948,160 @@ def test_gcp_queue_vanish_does_not_record_boot_death(tmp_path, monkeypatch, caps
     assert out["current_phase"] == "gcp_queue_vanish_failover_runpod"
     assert len(rp.launches) == 1
     assert gcp_boot_death_streak(1116, "flexstart_a100_80") == 0  # never recorded
+
+
+# ---------------------------------------------------------------------------
+# #1122 — exit-75 reconnect handle rewrites preserve the workload extras
+#
+# Incident #1090: the exit-75 same-command RERUN reconnected via
+# gcp.reconnect_or_none, whose handle carried NO workload extras; the
+# on_launched sidecar overwrite then left the #783 queue-timeout failover
+# unable to reconstruct a RunSpec (ValueError "pre-#659 handle?"). These
+# tests pin the end-to-end fix: the REAL reconnect_or_none output survives
+# the sidecar round-trip into _runspec_from_gcp_handle (T4), the both-empty
+# guard names the reconnect-rewrite cause (T5), and the #783 queue-timeout
+# failover completes against a reconnect-written handle (T6, seeded via the
+# REAL producer — never a hand-built "reconnect-shaped" dict).
+# ---------------------------------------------------------------------------
+
+_RECONNECT_WORKLOAD_CMD = "REPO_ROOT=/workspace bash scripts/issue1090_dispatch.sh --full"
+
+
+def _reconnect_handle_from_real_producer(issue: int) -> RunHandle:
+    """A handle produced by the REAL ``gcp.reconnect_or_none`` for a
+    workload-carrying spec (the #1090 exit-75 rerun shape). PROVISIONING
+    status keeps the probe to ONE gcloud list call (no guest-phase read)."""
+    from explore_persona_space.backends.base import RunSpec
+    from explore_persona_space.backends.gcp import (
+        GcloudRunResult,
+        GcpConfig,
+        reconnect_or_none,
+    )
+
+    spec = RunSpec(
+        issue=issue,
+        intent="lora-7b",
+        backend="gcp",
+        gpus=1,
+        time_budget_hours=4.0,
+        workload_cmd=_RECONNECT_WORKLOAD_CMD,
+        extra={"repo_branch": f"issue-{issue}"},
+    )
+    payload = json.dumps(
+        [
+            {
+                "name": f"eps-issue-{issue}",
+                "id": "instance-fake-1",
+                "status": "PROVISIONING",
+                "zone": (
+                    "https://www.googleapis.com/compute/v1/projects/"
+                    "eps-test-project/zones/us-central1-a"
+                ),
+            }
+        ]
+    )
+    config = GcpConfig(project="eps-test-project", gcloud_config="eps-test-config")
+    handle = reconnect_or_none(
+        spec=spec, config=config, runner=lambda argv: GcloudRunResult(0, payload, "")
+    )
+    assert handle is not None
+    return handle
+
+
+def test_runspec_from_gcp_handle_reconstructs_from_reconnect_handle(tmp_path):
+    """T4 (#1122, end-to-end #1090 shape): a REAL reconnect_or_none handle,
+    round-tripped through the sidecar (serialize_handle/deserialize_handle),
+    reconstructs a RunSpec whose workload_cmd / hydra_args / repo_branch
+    equal the original spec's — the exact read the queue-timeout failover
+    crashed on pre-fix."""
+    from scripts.backend_poll import _runspec_from_gcp_handle
+
+    handle = _reconnect_handle_from_real_producer(1090)
+    sidecar = tmp_path / "issue-1090-handle.json"
+    write_handle_sidecar(handle, sidecar)
+    recovered = read_handle_sidecar(sidecar)
+
+    spec = _runspec_from_gcp_handle(recovered, issue=1090)
+    assert spec.workload_cmd == _RECONNECT_WORKLOAD_CMD  # str, verbatim (MF1)
+    assert spec.hydra_args == ()  # empty branch stays empty (MF2)
+    assert spec.backend == "runpod"
+    assert spec.extra["repo_branch"] == "issue-1090"
+    assert spec.gpus == 1
+    assert spec.time_budget_hours == 4.0
+
+
+def test_runspec_from_gcp_handle_both_empty_raises_with_reconnect_cause():
+    """T5 (#1122): a handle whose workload pair is BOTH empty (keys present
+    or absent) raises a ValueError that names the reconnect-rewrite cause
+    (+ #1122) instead of mis-attributing solely to a pre-#659 handle."""
+    from scripts.backend_poll import _runspec_from_gcp_handle
+
+    # Keys PRESENT but both empty — the pre-#1122 presence-check built a
+    # blank RunSpec here; the value-check now refuses loudly.
+    handle = _gcp_handle(
+        extra={
+            "issue": 1090,
+            "intent": "lora-7b",
+            "workload_cmd": "",
+            "hydra_args": [],
+            "reconnected": True,
+        }
+    )
+    with pytest.raises(ValueError) as excinfo:
+        _runspec_from_gcp_handle(handle, issue=1090)
+    msg = str(excinfo.value).lower()
+    assert "reconnect" in msg
+    assert "#1122" in msg
+    assert "pre-#659" in msg  # legacy cause still mentioned, no longer solely
+    assert "refusing" in msg
+
+    # Keys ABSENT entirely (the true pre-#659 shape) raises the same guard.
+    with pytest.raises(ValueError):
+        _runspec_from_gcp_handle(_gcp_handle(extra={"intent": "lora-7b"}), issue=1090)
+
+
+def test_gcp_queue_timeout_failover_reconstructs_from_reconnect_handle(
+    tmp_path, monkeypatch, capsys
+):
+    """T6 (#1122, the #1090 acceptance shape): the #783 queue-timeout failover
+    COMPLETES (no ValueError) against a sidecar seeded from the REAL
+    reconnect_or_none output — the queued instance is torn down, exactly one
+    RunPod launch fires, and the relaunch spec carries the original
+    workload_cmd + repo_branch."""
+    from dataclasses import replace
+
+    handle = _reconnect_handle_from_real_producer(1090)
+    # The queue clock is POLLER-owned sidecar state (stamped on a prior tick);
+    # add it on top of the producer's own extra, older than the 600s floor.
+    handle = replace(
+        handle,
+        extra={
+            **handle.extra,
+            "last_phase": "pending",
+            "last_phase_change_ts": _time.time() - 1000,
+        },
+    )
+    sidecar = tmp_path / "issue-1090-handle.json"
+    write_handle_sidecar(handle, sidecar)
+
+    teardown_backend = _PollDoubleWithTeardown(_pending_poll())
+    monkeypatch.setattr(
+        "scripts.backend_poll._resolve_backend",
+        lambda name: teardown_backend,
+    )
+    rp = _PassiveRunpodBackend()
+    monkeypatch.setattr("explore_persona_space.backends.runpod.RunPodBackend", lambda: rp)
+
+    rc = backend_poll_main(["--issue", "1090", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["status"] == "running"
+    assert out["current_phase"] == "gcp_queue_timeout_failover_runpod"
+    assert len(rp.launches) == 1
+    relaunch_spec = rp.launches[0]
+    assert relaunch_spec.workload_cmd == _RECONNECT_WORKLOAD_CMD
+    assert relaunch_spec.hydra_args == ()
+    assert relaunch_spec.extra["repo_branch"] == "issue-1090"
+    # Queued GCP instance torn down; sidecar re-pointed at the RunPod handle.
+    assert len(teardown_backend.teardowns) == 1
+    assert read_handle_sidecar(sidecar).backend == "runpod"

--- a/tests/test_gcp_backend.py
+++ b/tests/test_gcp_backend.py
@@ -1359,6 +1359,99 @@ def test_reconnect_returns_handle_when_instance_running() -> None:
     assert handle.extra["reconnected"] is True
 
 
+def _running_instance_payload(name: str = "eps-issue-137", instance_id: str = "9988776655") -> str:
+    """A one-instance RUNNING gcloud list payload (the reconnect probe shape)."""
+    return json.dumps(
+        [
+            {
+                "name": name,
+                "id": instance_id,
+                "status": "RUNNING",
+                "zone": (
+                    "https://www.googleapis.com/compute/v1/projects/"
+                    "eps-test-project/zones/us-central1-a"
+                ),
+            }
+        ]
+    )
+
+
+def test_reconnect_handle_carries_workload_extras_from_spec() -> None:
+    """T1 (#1122): a workload-cmd spec's reconnect handle mirrors the launch
+    path's failover-prerequisite extras — workload_cmd verbatim (str, MF1),
+    hydra_args [] (list), gpus, time_budget_hours, repo_branch, gpu_count,
+    and boot_disk_gb when set — so an exit-75 rerun's sidecar overwrite
+    stays failover-capable (incident #1090)."""
+    spec = _spec(
+        workload_cmd="REPO_ROOT=/workspace bash scripts/issue1090_dispatch.sh --full",
+        hydra_args=(),  # _spec() defaults to non-empty hydra_args; the pair is exclusive
+        gpus=1,
+        time_budget_hours=4.0,
+        extra={"repo_branch": "issue-1090", "boot_disk_gb": 200},
+    )
+    runner = _Runner(list_results=[GcloudRunResult(0, _running_instance_payload(), "")])
+    handle = reconnect_or_none(spec=spec, config=_test_config(), runner=runner)
+    assert handle is not None
+    assert (
+        handle.extra["workload_cmd"]
+        == "REPO_ROOT=/workspace bash scripts/issue1090_dispatch.sh --full"
+    )
+    assert handle.extra["hydra_args"] == []
+    assert isinstance(handle.extra["hydra_args"], list)
+    assert handle.extra["gpus"] == 1
+    assert handle.extra["time_budget_hours"] == 4.0
+    assert handle.extra["repo_branch"] == "issue-1090"
+    # lora-7b resolves to a 1-GPU machine; the poller's CPU guards read
+    # 0-vs-nonzero only.
+    assert handle.extra["gpu_count"] == 1
+    assert handle.extra["boot_disk_gb"] == 200
+    # min_ram_gb unset on the spec -> key OMITTED (legacy-shape parity).
+    assert "min_ram_gb" not in handle.extra
+
+
+def test_reconnect_handle_hydra_branch_mirrors_launch_shape() -> None:
+    """T2 (#1122): the hydra-args branch mirrors the launch shape — empty
+    workload_cmd str + hydra list; RunSpec mutual exclusion holds on the
+    reconstructed pair."""
+    spec = _spec()  # default hydra_args=("condition=c1_evil_wrong_em", "seed=42")
+    runner = _Runner(list_results=[GcloudRunResult(0, _running_instance_payload(), "")])
+    handle = reconnect_or_none(spec=spec, config=_test_config(), runner=runner)
+    assert handle is not None
+    assert handle.extra["workload_cmd"] == ""
+    assert handle.extra["hydra_args"] == ["condition=c1_evil_wrong_em", "seed=42"]
+    assert isinstance(handle.extra["hydra_args"], list)
+    # One of the pair is empty by construction (MF2).
+    assert not (handle.extra["workload_cmd"] and handle.extra["hydra_args"])
+    # repo_branch unset on the spec -> written as "" (launch-path parity).
+    assert handle.extra["repo_branch"] == ""
+
+
+def test_reconnect_bare_spec_keeps_legacy_extra_shape() -> None:
+    """T3 (#1122): a bare (no-workload) spec — provision-only / probe
+    reconnects — keeps the LEGACY extra shape: no workload keys added (the
+    issue_dispatch carry-forward preserves the prior sidecar's values for
+    that case instead)."""
+    spec = _spec(hydra_args=())  # _spec() defaults to non-empty hydra_args
+    runner = _Runner(list_results=[GcloudRunResult(0, _running_instance_payload(), "")])
+    handle = reconnect_or_none(spec=spec, config=_test_config(), runner=runner)
+    assert handle is not None
+    for key in (
+        "workload_cmd",
+        "hydra_args",
+        "gpus",
+        "time_budget_hours",
+        "repo_branch",
+        "gpu_count",
+        "boot_disk_gb",
+        "min_ram_gb",
+    ):
+        assert key not in handle.extra, key
+    # The legacy probe-derived keys are still present.
+    assert handle.extra["reconnected"] is True
+    assert handle.extra["status_at_reconnect"] == "RUNNING"
+    assert handle.extra["instance_name"] == "eps-issue-137"
+
+
 def test_reconnect_skips_terminated_instance() -> None:
     payload = json.dumps(
         [

--- a/tests/test_issue_dispatch.py
+++ b/tests/test_issue_dispatch.py
@@ -1550,3 +1550,256 @@ def test_cpu_exhausted_parent_does_not_emit_infeasible_reason() -> None:
     t = classify_terminal_exception(exc)
     assert "reason: cpu_exhausted_no_runpod_lane" in t.note
     assert ROUTE_REASON_CPU_FALLBACK_INFEASIBLE not in t.note
+
+
+# ---------------------------------------------------------------------------
+# #1122 — reconnect sidecar rewrites carry forward the prior workload extras
+#
+# Incident #1090: an exit-75 same-command rerun RECONNECTED (GCP-internal,
+# handle extra reconnected=True) and dispatch_for_issue's on_launched hook
+# OVERWROTE the complete launch-handle sidecar with the minimal reconnect
+# handle — stranding the #783 queue-timeout failover. Edit 1 (#1122) fixes
+# the workload-carrying rerun at the producer; these tests pin edit 2's
+# residual-class safety net: a workload-LESS reconnect rewrite (manual
+# provision-only re-invocation) merges the PRIOR sidecar's failover extras
+# into both sidecar writes, bound on backend + pod_name + job_id identity.
+# ---------------------------------------------------------------------------
+
+_PRIOR_WORKLOAD_CMD_1122 = "REPO_ROOT=/workspace bash scripts/issue1122_dispatch.sh --full"
+
+#: The COMPLETE prior sidecar extra (the launch-path failover keys, #659/
+#: #909/#677/#1010) — repo_branch deliberately NON-empty (#1122 §11.5(4)).
+_PRIOR_EXTRA_1122: dict[str, Any] = {
+    "issue": 1122,
+    "intent": "lora-7b",
+    "zone": "us-central1-a",
+    "workload_cmd": _PRIOR_WORKLOAD_CMD_1122,
+    "hydra_args": [],
+    "gpus": 1,
+    "time_budget_hours": 4.0,
+    "repo_branch": "issue-1122",
+    "gpu_count": 1,
+    "boot_disk_gb": 200,
+}
+
+
+def _prior_handle_1122(*, backend: str = "nibi", job_id: str = "gce-777") -> RunHandle:
+    """The COMPLETE predecessor handle a prior launch wrote to the sidecar."""
+    return RunHandle(
+        backend=backend,
+        cluster=backend if backend != "runpod" else None,
+        job_id=job_id,
+        pod_name="eps-issue-1122",
+        scratch_dir="/s",
+        log_path="/l",
+        extra=dict(_PRIOR_EXTRA_1122),
+    )
+
+
+class _ReconnectShapedBackend(_MockBackend):
+    """launch() returns a RECONNECT-shaped handle mirroring the GCP
+    ``reconnect_or_none`` MINIMAL extra for a workload-LESS spec —
+    ``reconnected=True`` + probe-derived keys only, NO workload extras —
+    with a FIXED job_id so a pre-seeded prior sidecar can identity-bind."""
+
+    def __init__(self, kind: BackendKind = "nibi", job_id: str = "gce-777") -> None:
+        super().__init__(kind=kind)
+        self._job_id = job_id
+
+    def launch(self, spec: RunSpec) -> RunHandle:
+        self.launches.append(spec)
+        return RunHandle(
+            backend=self._kind,
+            cluster=self._kind if self._kind != "runpod" else None,
+            job_id=self._job_id,
+            pod_name=f"eps-issue-{spec.issue}",
+            scratch_dir="/s",
+            log_path="/l",
+            extra={
+                "issue": spec.issue,
+                "reconnected": True,
+                "status_at_reconnect": "RUNNING",
+            },
+        )
+
+
+def _dispatch_1122(spec: RunSpec, *, sidecar: Path, tmp_lease_store) -> DispatchOutcome:
+    """Drive dispatch_for_issue through the reconnect-shaped fake backend."""
+    return dispatch_for_issue(
+        spec,
+        runpod_backend=_MockBackend(kind="runpod"),
+        free_backends={"nibi": _ReconnectShapedBackend()},
+        is_started=lambda _b, _h: True,
+        lease_store=tmp_lease_store,
+        handle_sidecar_path=sidecar,
+    )
+
+
+def test_dispatch_reconnect_rewrite_preserves_prior_sidecar_workload_extras(
+    tmp_path, tmp_lease_store
+) -> None:
+    """T7 (#1122): a workload-LESS re-invocation whose backend reconnects
+    (reconnected=True) no longer clobbers the sidecar's workload extras —
+    the prior sidecar's failover keys (incl. the NON-empty repo_branch,
+    §11.5(4)) survive onto BOTH the on-disk sidecar and the returned
+    handle."""
+    sidecar = tmp_path / "issue-1122-handle.json"
+    write_handle_sidecar(_prior_handle_1122(), sidecar)
+
+    spec = RunSpec(issue=1122, intent="lora-7b", backend="nibi")  # bare — no workload
+    outcome = _dispatch_1122(spec, sidecar=sidecar, tmp_lease_store=tmp_lease_store)
+
+    recovered = read_handle_sidecar(sidecar)
+    assert recovered.extra["workload_cmd"] == _PRIOR_WORKLOAD_CMD_1122
+    assert recovered.extra["hydra_args"] == []
+    assert recovered.extra["repo_branch"] == "issue-1122"
+    for key in ("gpus", "time_budget_hours", "gpu_count", "boot_disk_gb"):
+        assert recovered.extra[key] == _PRIOR_EXTRA_1122[key], key
+    # The reconnect probe keys from the NEW handle are retained.
+    assert recovered.extra["reconnected"] is True
+    assert recovered.extra["status_at_reconnect"] == "RUNNING"
+    # The RETURNED handle (the authoritative-write input + the caller's
+    # view) carries the same merge.
+    assert outcome.result.handle.extra["workload_cmd"] == _PRIOR_WORKLOAD_CMD_1122
+    assert outcome.result.handle.extra["repo_branch"] == "issue-1122"
+
+
+def test_carry_forward_skips_on_job_id_mismatch() -> None:
+    """T8 (#1122): a stale sidecar from a DEAD incarnation (different GCE
+    instance id) never donates — and an EMPTY job_id on either side is
+    treated as no-match (§11.5(1)), so a degenerate ("gcp", name, "")
+    binding cannot match across incarnations."""
+    from dataclasses import replace
+
+    from explore_persona_space.backends.issue_dispatch import _carry_forward_reconnect_extras
+
+    handle = RunHandle(
+        backend="nibi",
+        cluster="nibi",
+        job_id="gce-NEW",
+        pod_name="eps-issue-1122",
+        scratch_dir="/s",
+        log_path="/l",
+        extra={"issue": 1122, "reconnected": True},
+    )
+    prior = {
+        "backend": "nibi",
+        "pod_name": "eps-issue-1122",
+        "job_id": "gce-OLD",
+        "extra": {"workload_cmd": _PRIOR_WORKLOAD_CMD_1122, "hydra_args": []},
+    }
+    assert _carry_forward_reconnect_extras(handle, prior) is handle  # identity
+
+    # Empty job_id on BOTH sides would tuple-compare equal — must no-match.
+    handle_empty = replace(handle, job_id="")
+    prior_empty = {**prior, "job_id": ""}
+    assert _carry_forward_reconnect_extras(handle_empty, prior_empty) is handle_empty
+
+
+def test_carry_forward_noop_on_fresh_launch_handle() -> None:
+    """T9 (#1122): a FRESH-launch handle (no ``reconnected`` flag — every
+    non-GCP-reconnect shape, incl. SLURM query_by_name recoveries) is
+    returned unchanged (identity): the merge is reconnect-scoped by
+    construction."""
+    from explore_persona_space.backends.issue_dispatch import _carry_forward_reconnect_extras
+
+    handle = RunHandle(
+        backend="nibi",
+        cluster="nibi",
+        job_id="gce-777",
+        pod_name="eps-issue-1122",
+        scratch_dir="/s",
+        log_path="/l",
+        extra={"issue": 1122},  # no 'reconnected'
+    )
+    prior = {
+        "backend": "nibi",
+        "pod_name": "eps-issue-1122",
+        "job_id": "gce-777",
+        "extra": {"workload_cmd": _PRIOR_WORKLOAD_CMD_1122, "hydra_args": []},
+    }
+    assert _carry_forward_reconnect_extras(handle, prior) is handle
+
+
+def test_carry_forward_workload_pair_atomic() -> None:
+    """T10 (#1122): the (workload_cmd, hydra_args) pair merges ATOMICALLY —
+    a handle already carrying hydra_args is never given a second
+    workload_cmd (RunSpec mutual exclusion) — while the per-key fills
+    still run: edit 1's ``repo_branch: ""`` write is treated as absent and
+    fills from the prior's non-empty value (§11.5(4))."""
+    from explore_persona_space.backends.issue_dispatch import _carry_forward_reconnect_extras
+
+    handle = RunHandle(
+        backend="nibi",
+        cluster="nibi",
+        job_id="gce-777",
+        pod_name="eps-issue-1122",
+        scratch_dir="/s",
+        log_path="/l",
+        extra={
+            "issue": 1122,
+            "reconnected": True,
+            # The handle already carries ONE side of the pair.
+            "hydra_args": ["smoke=1"],
+            # Edit 1 writes "" when the rerun spec has no repo_branch.
+            "repo_branch": "",
+        },
+    )
+    prior = {
+        "backend": "nibi",
+        "pod_name": "eps-issue-1122",
+        "job_id": "gce-777",
+        "extra": {
+            "workload_cmd": _PRIOR_WORKLOAD_CMD_1122,
+            "hydra_args": [],
+            "repo_branch": "issue-1122",
+            "gpus": 1,
+        },
+    }
+    out = _carry_forward_reconnect_extras(handle, prior)
+    assert out is not handle  # something carried
+    # The pair did NOT merge — the handle carries hydra_args already.
+    assert "workload_cmd" not in out.extra
+    assert out.extra["hydra_args"] == ["smoke=1"]
+    # Mutual exclusion holds on the merged shape.
+    assert not (out.extra.get("workload_cmd") and out.extra.get("hydra_args"))
+    # Per-key fills still ran: ""-repo_branch filled from the prior; gpus filled.
+    assert out.extra["repo_branch"] == "issue-1122"
+    assert out.extra["gpus"] == 1
+
+
+def test_on_launched_early_write_carries_reconnect_merge(
+    tmp_path, tmp_lease_store, monkeypatch
+) -> None:
+    """T11 (#1122, round-1 Statistics Must-Fix): the ``on_launched`` EARLY
+    sidecar write — not just the authoritative post-route write — carries
+    the carry-forward merge. Simulate a crash BETWEEN the two writes (a
+    signature-conformant raiser patched over _warn_on_reconnected_workload,
+    which sits after the early write and before the authoritative write):
+    the ON-DISK sidecar left by the early write alone must already carry
+    the prior workload extras, so a crash window can never strand an
+    un-merged impoverished sidecar."""
+
+    def _boom(spec: RunSpec, result, handle: RunHandle) -> None:
+        raise RuntimeError("simulated crash between the two sidecar writes (#1122 T11)")
+
+    monkeypatch.setattr(
+        "explore_persona_space.backends.issue_dispatch._warn_on_reconnected_workload",
+        _boom,
+    )
+    sidecar = tmp_path / "issue-1122-handle.json"
+    write_handle_sidecar(_prior_handle_1122(), sidecar)
+
+    spec = RunSpec(issue=1122, intent="lora-7b", backend="nibi")  # bare — no workload
+    with pytest.raises(RuntimeError, match="simulated crash between the two sidecar writes"):
+        _dispatch_1122(spec, sidecar=sidecar, tmp_lease_store=tmp_lease_store)
+
+    # The authoritative write never ran; the on-disk sidecar IS the early
+    # on_launched write — and it already carries the merged extras.
+    recovered = read_handle_sidecar(sidecar)
+    assert recovered.extra["reconnected"] is True
+    assert recovered.extra["workload_cmd"] == _PRIOR_WORKLOAD_CMD_1122
+    assert recovered.extra["hydra_args"] == []
+    assert recovered.extra["repo_branch"] == "issue-1122"
+    for key in ("gpus", "time_budget_hours", "gpu_count", "boot_disk_gb"):
+        assert recovered.extra[key] == _PRIOR_EXTRA_1122[key], key


### PR DESCRIPTION
Closes task #1122 (workflow-fix). Single cherry-picked deliverable commit (original branch issue-1122 forked from pre-rebase local main and owns ~45 stale-sha task-state commits — guard-3 UNSAFE for blind rebase, so the deliverable was re-staged onto origin/main in a scratch worktree). Gate evidence on task #1122 events: epm:code-review v1 PASS, epm:test-verdict v1 PASS (3370 passed), pre-push workflow-lint gate pass (sha-bound 3d8df1da38).