### PR TITLE
issue-1134: ban adopt-more-severe-without-reconciler at doubled sites

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -2390,6 +2390,25 @@ The reconciler may NOT add findings beyond what either reviewer raised —
 its job is adjudication only. Round counter does NOT increment for
 reconciler invocations.
 
+When BOTH reviewers returned disagreeing durable verdicts, adopting the
+MORE SEVERE verdict WITHOUT spawning the reconciler is
+UNSANCTIONED at every doubled site — even when the flagged residual is
+mechanically verifiable (#825 skipped the reconciler on exactly that
+rationale) — because a true residual does not determine severity (the
+reconciler may legitimately side PASS on a true-but-not-verdict-changing
+finding), and the shortcut trades a FREE adjudication (reconcile rounds
+don't count) for a revision round that DOES count against the cap-5 and
+itself costs ≥3 spawns (analyzer + both critics) vs the reconciler's
+one, while leaving a possibly over-strict reviewer unadjudicated. The
+documented adopt-more-severe last-resort fail-safe (a spawned reconciler
+errors, is re-spawned once, and still returns no parseable verdict)
+belongs to the `/adversarial-planner` § Durable-output-first IN-CONTEXT
+Phase-2 reconciler ONLY — at the marker-mode sites here a twice-dead
+reconciler fails LOUD per the Step 5b durable-verdict-first rule
+(item 4), never adopt-more-severe. The Codex no-show fallback
+(single-Claude decision on confirmed no-show) is a different, sanctioned
+path — it adjudicates nothing and adopts no "more severe of two".
+
 **5c-bis. Mechanical-contract-only FAIL strip (anti-gate-hopping).**
 
 A FAIL is *mechanical-contract-only* when its `**Blocker tags:**` line
@@ -5679,6 +5698,13 @@ discarded by Step 8's gap-fill decision rule).
    per the Step 5b bound, not skipped.
 
    Reconcile rounds do NOT increment the per-reviewer round counter.
+   Adopt-more-severe WITHOUT a reconciler is unsanctioned here
+   (the #825 deviation site) — see the Step 5c ban: when both reviewers
+   returned disagreeing durable verdicts, spawn the reconciler; a
+   twice-dead reconciler fails LOUD per Step 5b item 4 (the
+   adopt-more-severe fail-safe is `/adversarial-planner`-in-context
+   only), and the Codex no-show fallback remains a separate, sanctioned
+   path.
 
 **If `final_verdict == REVISE` (rounds 2-5):**
 

--- a/tests/test_ensemble_review_cap.py
+++ b/tests/test_ensemble_review_cap.py
@@ -336,3 +336,18 @@ def test_cap_hit_substantive_residual_blocks_autonomous():
 
     interactive_decision = resolve_cap_hit(all_residual_stripped=False, autonomous=False)
     assert interactive_decision["action"] == "surface_interactive"
+
+
+# --------------------------------------------------------------------------- #
+# (d) adopt-more-severe-without-reconciler ban (#1134)
+# --------------------------------------------------------------------------- #
+def test_adopt_severe_reconciler_ban_pinned():
+    """#1134: the adopt-more-severe-without-reconciler ban survives SKILL.md churn.
+
+    Pins both placements: the Step 5c canonical ban paragraph and the
+    Step 9a incident-site pointer. Dropping either silently reverts #1134.
+    """
+    text = SKILL_PATH.read_text()
+    assert text.count("UNSANCTIONED at every doubled site") == 1
+    assert text.count("#825 skipped the reconciler") == 1
+    assert text.count("the #825 deviation site") == 1


### PR DESCRIPTION
Closes task #1134 (workflow-fix, auto-filed by /daily from the #825 deviation).

## Summary
- Bans adopting the more-severe verdict without spawning the reconciler at every doubled review site (Step 5c canonical paragraph + Step 9a incident-site pointer in `.claude/skills/issue/SKILL.md`), scoped to both-reviewers-returned-disagreeing-durable-verdicts; the adopt-more-severe fail-safe stays `/adversarial-planner`-in-context-only (marker-mode sites fail loud per Step 5b item 4); Codex no-show fallback unchanged.
- Adds standing pin test `test_adopt_severe_reconciler_ban_pinned` so SKILL.md churn cannot silently drop the ban.

## Test plan
- [x] Step 9c touched-scope gate: 2834 passed / 0 failed; baseline compare new=[]
- [x] workflow_lint no-flags + parity flags PASS (implementer + reviewer runs; pre-push gate re-runs before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)