### PR TITLE
workflow-fix #1125: -qv-free lint-gate triggers + check_grep_qv lint

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -8545,8 +8545,12 @@ Gate the merge payload on the lint BEFORE anything lands:
   if ! git -C "$WT" diff --name-only origin/main...HEAD > /tmp/issue-<N>-own-diff.txt; then
     # Failed trigger diff — the gate cannot classify the payload; fail CLOSED.
     echo crash > /tmp/issue-<N>-lint-verdict.txt
-  elif grep -qvE '^(tasks/|figures/|eval_results/|ood_eval_results/|raw/|data/|docs/methodology/)' \
-      /tmp/issue-<N>-own-diff.txt; then
+  # Classifier consumes grep's OUTPUT (non-empty => code-bearing payload),
+  # never a `-q -v` exit status: a ugrep-shadowed shell returns rc=1 on
+  # selected non-matching lines under -qv and silently disarmed this gate
+  # as skip-artifact-only on a code-bearing payload (#928 -> #1125).
+  elif [ -n "$(grep -vE '^(tasks/|figures/|eval_results/|ood_eval_results/|raw/|data/|docs/methodology/)' \
+      /tmp/issue-<N>-own-diff.txt)" ]; then
     # BASELINE legs (payload-free tree). Per-leg exit codes ARE captured:
     # only the baseline's normalized failure LINES enter the compare, but a
     # baseline CRASH (rc>1, or rc!=0 with ZERO `workflow_lint:` lines) makes
@@ -9063,8 +9067,9 @@ Decision tree:
   # same-invocation state (no cross-block variable). Executable trigger
   # first: an artifact-only additive list skips both lint runs.
   GATE_ARMED=no
-  if grep -qvE '^(tasks/|figures/|eval_results/|ood_eval_results/|raw/|data/|docs/methodology/)' \
-       /tmp/issue-<N>-additive-files.txt; then
+  # Output-test form, not `-q -v` rc (ugrep rc inversion, #928 -> #1125):
+  if [ -n "$(grep -vE '^(tasks/|figures/|eval_results/|ood_eval_results/|raw/|data/|docs/methodology/)' \
+       /tmp/issue-<N>-additive-files.txt)" ]; then
     GATE_ARMED=yes
     # BASELINE legs (per-leg exit codes ARE captured — a baseline CRASH must
     # fail CLOSED via the crash arm below, never be `|| true`-erased; only

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -115,6 +115,20 @@ Behaviours:
   normalized to ``|`` first. The
   ``.claude/hooks/guard_piped_git_push.sh`` PreToolUse hook covers the
   inline ad-hoc commands that never reach a committed script (#1048).
+* ``--check-grep-qv`` (also bundled into the no-flags default run): scan
+  fenced code blocks in ``.claude/skills/**/SKILL.md`` +
+  ``.claude/agents/*.md`` and logical lines of ``scripts/**/*.sh``, and
+  FAIL on any UNPINNED ``grep``/``ugrep`` invocation combining q
+  (``-q``/``--quiet``/``--silent``) and v (``-v``/``--invert-match``) —
+  a combined short token, separated tokens, or long forms. ugrep 7.5.0's
+  quiet+invert exit status diverges from GNU (rc=1 even when non-matching
+  lines are selected), so an rc-consumed q+v trigger silently fails OPEN
+  when shell ``grep`` resolves to ugrep (#928: the Step 10d pre-push lint
+  gate disarmed as skip-artifact-only on a code-bearing payload; fixed in
+  #1125 with the output-test rewrite). ``git grep`` and a path-pinned
+  ``/usr/bin/grep`` are exempt; a path-pinned ``ugrep`` still flags (its
+  exit status is divergent by construction, no pin sanctions it).
+  ``#``-comment lines and ``.md`` prose outside fences are skipped.
 * ``--check-marker-registry`` (also bundled into ``--check-references``):
   extract every marker kind that any skill's ``SKILL.md`` under
   ``.claude/skills/**/`` or an agent spec under ``.claude/agents/*.md``
@@ -2677,6 +2691,164 @@ def check_piped_git_push(*, scripts_dir: Path | None = None) -> list[str]:
                 f"`set -o pipefail`. See CLAUDE.md § Concurrent repo-root "
                 f"committers (#1048)."
             )
+    return errors
+
+
+# `--check-grep-qv` (#928 -> #1125): an rc-consumed quiet+invert grep trigger
+# is implementation-divergent — GNU grep exits 0 iff a line is SELECTED (with
+# -v, selected = non-matching), while ugrep 7.5.0 returns rc=1 in the same
+# case (its -q short-circuits on MATCH FOUND, not line selected) — so the
+# combination silently fails OPEN when shell `grep` resolves to ugrep. The
+# regex matches a bare or path-prefixed `grep`/`ugrep` command word (the
+# lookbehind rejects word-char / `.` / `-` prefixes so `pgrep`, `foo-grep`,
+# `x.grep` never match; a preceding `/` IS allowed so path pins are visible
+# to the caller, which exempts pinned `grep` but still flags pinned `ugrep`)
+# and captures the CONTIGUOUS option-token run that follows — so a
+# pipeline-split `grep -v x f | grep -q y f2` yields two matches whose flag
+# sets are evaluated independently and never combine.
+GREP_QV_CMD_RE = re.compile(r"(?<![\w.\-])(u?grep)\b((?:\s+--?[\w=-]+)*)")
+
+_GREP_QV_GIT_PREFIX_RE = re.compile(r"(?<![\w.\-])git\s+$")
+
+
+def _grep_qv_flag_sets(opt_run: str) -> tuple[bool, bool]:
+    """Return ``(has_q, has_v)`` for the contiguous option-token run
+    following a grep command word — a combined short token (``-qvE``),
+    separated tokens (``-q ... -vE``, either order), and the long forms
+    (``--quiet``/``--silent`` + ``--invert-match``) all count."""
+    short: set[str] = set()
+    long_flags: set[str] = set()
+    for tok in opt_run.split():
+        if tok.startswith("--"):
+            long_flags.add(tok[2:].split("=", 1)[0])
+        elif tok.startswith("-") and len(tok) > 1:
+            short.update(tok[1:])
+    has_q = "q" in short or bool(long_flags & {"quiet", "silent"})
+    has_v = "v" in short or "invert-match" in long_flags
+    return has_q, has_v
+
+
+def _grep_qv_scan(path: Path, lines: list[str], base_idx: int, errors: list[str]) -> None:
+    """Scan ``lines`` (physical lines whose first line sits at 0-based file
+    index ``base_idx``) as logical shell lines and append one error per
+    flagged unpinned q+v grep invocation. ``#``-comment lines are skipped;
+    backslash continuations are merged (the live #928 trigger was
+    backslash-continued with the flags on the first physical line)."""
+    for first, _last, logical in _iter_logical_shell_lines(lines):
+        if logical.strip().startswith("#"):
+            continue
+        for match in GREP_QV_CMD_RE.finditer(logical):
+            cmd = match.group(1)
+            path_pinned = match.start() > 0 and logical[match.start() - 1] == "/"
+            if path_pinned and cmd == "grep":
+                # /usr/bin/grep pin — the sanctioned GNU pin (a pinned
+                # ugrep is NOT sanctioned: its rc diverges wherever it is).
+                continue
+            if _GREP_QV_GIT_PREFIX_RE.search(logical[: match.start()]):
+                # `git grep` — git's own engine, not PATH-shadowable.
+                continue
+            has_q, has_v = _grep_qv_flag_sets(match.group(2))
+            if has_q and has_v:
+                errors.append(
+                    f"{path}:{base_idx + first + 1}: `{cmd}` combines -q and -v "
+                    f"(quiet + invert-match) with the exit status as the signal. "
+                    f"ugrep 7.5.0 returns rc=1 where GNU returns 0 when "
+                    f"non-matching lines are selected, so an rc-consumed q+v "
+                    f"trigger fails OPEN under a PATH-shadowed grep (#928: the "
+                    f"Step 10d pre-push lint gate silently disarmed; fixed in "
+                    f"#1125). Consume OUTPUT instead — "
+                    f'`[ -n "$(grep -vE <pattern> <file>)" ]`.'
+                )
+
+
+def _grep_qv_target_files(roots: list[Path] | None) -> list[Path]:
+    """Resolve the scan set: production (``roots=None``) walks
+    ``.claude/skills/**/SKILL.md`` + ``.claude/agents/*.md`` +
+    ``scripts/**/*.sh``; a test override lists files, or directories
+    walked for ``*.md`` / ``*.sh``."""
+    if roots is None:
+        files: list[Path] = []
+        skills = _REPO_ROOT / ".claude" / "skills"
+        agents = _REPO_ROOT / ".claude" / "agents"
+        scripts = _REPO_ROOT / "scripts"
+        if skills.exists():
+            files.extend(sorted(p for p in skills.rglob("SKILL.md") if p.is_file()))
+        if agents.exists():
+            files.extend(sorted(p for p in agents.glob("*.md") if p.is_file()))
+        if scripts.exists():
+            files.extend(sorted(p for p in scripts.rglob("*.sh") if p.is_file()))
+        return files
+    files = []
+    for root in roots:
+        if root.is_file():
+            files.append(root)
+        else:
+            files.extend(
+                sorted(p for p in root.rglob("*") if p.is_file() and p.suffix in (".md", ".sh"))
+            )
+    return files
+
+
+def check_grep_qv(*, roots: list[Path] | None = None) -> list[str]:
+    """FAIL on an UNPINNED ``grep``/``ugrep`` invocation combining q
+    (``-q``/``--quiet``/``--silent``) and v (``-v``/``--invert-match``) —
+    a combined short token, separated tokens, or the long forms — inside
+    executable workflow snippets: fenced code blocks in
+    ``.claude/skills/**/SKILL.md`` and ``.claude/agents/*.md``, plus
+    ``scripts/**/*.sh`` logical lines.
+
+    ugrep 7.5.0's quiet+invert exit status diverges from GNU grep (rc=1
+    even when non-matching lines are selected — its ``-q`` short-circuits
+    on MATCH FOUND, not line selected), so an rc-consumed q+v trigger
+    silently fails OPEN when shell ``grep`` resolves to ugrep (#928: the
+    Step 10d pre-push lint gate classified a 12-file code-bearing payload
+    as skip-artifact-only; #1125 rewrote both trigger sites to the
+    output-test form).
+
+    Sanctioned forms the check does NOT flag: the output-test
+    ``[ -n "$(grep -vE <pattern> <file>)" ]`` (no quiet flag — every
+    implementation agrees on what ``-v`` PRINTS), an absolute-path-pinned
+    bare grep (command word preceded by ``/``, e.g. under ``/usr/bin``),
+    and ``git grep`` (git's own engine, not PATH-shadowable). A
+    path-pinned ``ugrep`` DOES flag: it carries the divergent exit status
+    by construction, so no pin can sanction it. ``#``-comment lines are
+    skipped in both file classes; ``.md`` prose outside fences is never
+    scanned. Deliberate scan-set exclusions (extend here if the class
+    recurs elsewhere): ``.claude/rules/*.md`` and ``CLAUDE.md`` (prose
+    surfaces whose fenced snippets are illustrative, not executed
+    verbatim) and ``*.py`` files (this check, its tests, and rule prose
+    would self-flag; Python ``subprocess`` grep call sites are outside
+    the copy-paste-snippet threat model).
+
+    ``roots`` is a unit-test override hook (see
+    :func:`_grep_qv_target_files`); production callers pass None.
+    Bundled into the no-flags default run (same policy as
+    ``check_piped_git_push``).
+    """
+    errors: list[str] = []
+    for path in _grep_qv_target_files(roots):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        if path.suffix == ".md":
+            in_fence = False
+            block: list[str] = []
+            block_start = 0
+            for idx, line in enumerate(lines):
+                if _FENCE_RE.match(line):
+                    if in_fence:
+                        _grep_qv_scan(path, block, block_start, errors)
+                        block = []
+                    else:
+                        block_start = idx + 1
+                    in_fence = not in_fence
+                    continue
+                if in_fence:
+                    block.append(line)
+            if in_fence and block:
+                # Unterminated trailing fence: scan what was collected
+                # (fail toward checking, never toward silence).
+                _grep_qv_scan(path, block, block_start, errors)
+        else:
+            _grep_qv_scan(path, lines, 0, errors)
     return errors
 
 
@@ -6927,6 +7099,20 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         "no-flags default run.",
     )
     parser.add_argument(
+        "--check-grep-qv",
+        action="store_true",
+        help="Verify no executable workflow snippet (fenced code blocks in "
+        ".claude/skills/**/SKILL.md + .claude/agents/*.md, plus "
+        "scripts/**/*.sh) runs an unpinned grep/ugrep combining -q and -v "
+        "with the exit status as the signal. ugrep 7.5.0's quiet+invert "
+        "exit status diverges from GNU (rc=1 when non-matching lines are "
+        "selected), so such a trigger fails OPEN under a PATH-shadowed "
+        "grep (#928; fixed in #1125). git grep and a path-pinned "
+        "/usr/bin/grep are exempt; a path-pinned ugrep still flags. "
+        "Comment lines and prose outside fences are skipped. Bundled into "
+        "the no-flags default run.",
+    )
+    parser.add_argument(
         "--check-marker-registry",
         action="store_true",
         help="Verify every marker kind that .claude/skills/issue/SKILL.md "
@@ -7276,6 +7462,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         or args.check_dispatcher_cvd_pin
         or args.check_pipe_python
         or args.check_piped_git_push
+        or args.check_grep_qv
         or args.check_marker_registry
         or args.check_agent_model_pins
         or args.check_agent_tools
@@ -7350,6 +7537,8 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         errors.extend(check_pipe_python())
     if args.check_piped_git_push or no_flags:
         errors.extend(check_piped_git_push())
+    if args.check_grep_qv or no_flags:
+        errors.extend(check_grep_qv())
     if (args.check_marker_registry or no_flags) and not args.check_references:
         errors.extend(check_marker_registry(workflow))
     if args.check_agent_model_pins or no_flags:

--- a/tests/test_workflow_lint.py
+++ b/tests/test_workflow_lint.py
@@ -45,6 +45,7 @@ from workflow_lint import (  # noqa: E402
     check_compute_shape_review_lens,
     check_dispatcher_cvd_pin,
     check_gate_ids_unique,
+    check_grep_qv,
     check_heredoc_dotenv,
     check_hollow_verification_gate_review_lens,
     check_lessons_index,
@@ -2142,6 +2143,137 @@ def test_piped_git_push_hook_lint_agreement_on_shared_cases():
         assert lint == must_flag, f"lint verdict wrong for {cmd!r}: {lint} != {must_flag}"
         assert hook_v == must_flag, f"hook verdict wrong for {cmd!r}: {hook_v} != {must_flag}"
         assert lint == hook_v, f"engines diverge on shared case {cmd!r}"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for ``check_grep_qv`` (incident class #928 -> #1125: ugrep
+# 7.5.0's quiet+invert exit status diverges from GNU — rc=1 even when
+# non-matching lines are selected — so an rc-consumed q+v grep trigger in an
+# executable workflow snippet silently fails OPEN under a PATH-shadowed
+# grep; the Step 10d pre-push lint gate classified a 12-file code-bearing
+# payload as skip-artifact-only). Each fixture writes a tiny ``*.md`` (with
+# a fenced code block, the SKILL.md scan shape) or ``*.sh`` under
+# ``tmp_path`` and calls ``check_grep_qv(roots=[tmp_path])``.
+# ---------------------------------------------------------------------------
+
+
+def test_check_grep_qv_flags_combined_token(tmp_path):
+    """FAIL — the live #928 trigger shape verbatim: a fenced,
+    backslash-continued elif consuming the combined-token quiet+invert
+    exit status; the error points at the FIRST physical line."""
+    (tmp_path / "SKILL.md").write_text(
+        "Prose above.\n"
+        "```bash\n"
+        "elif grep -qvE '^(tasks/|figures/)' \\\n"
+        "    /tmp/issue-1-own-diff.txt; then\n"
+        "  echo armed\n"
+        "```\n"
+    )
+    errors = check_grep_qv(roots=[tmp_path])
+    assert len(errors) == 1, f"expected exactly one error, got: {errors}"
+    assert "SKILL.md:3" in errors[0]
+    assert "#928" in errors[0]
+    assert "#1125" in errors[0]
+
+
+def test_check_grep_qv_flags_separated_tokens(tmp_path):
+    """FAIL — separated tokens (`-q ... -vE`) in a `.sh` logical line
+    combine across the option run exactly as the fused token does."""
+    (tmp_path / "x.sh").write_text("if grep -q -vE '^tasks/' files.txt; then\n  echo y\nfi\n")
+    errors = check_grep_qv(roots=[tmp_path])
+    assert len(errors) == 1, f"expected exactly one error, got: {errors}"
+    assert "x.sh:1" in errors[0]
+
+
+def test_check_grep_qv_flags_vq_token_order(tmp_path):
+    """FAIL — the reversed combined token (`-vq`) is the same rc-consumed
+    quiet+invert combination (flag-set membership, not token spelling)."""
+    (tmp_path / "x.sh").write_text("grep -vq '^tasks/' files.txt\n")
+    errors = check_grep_qv(roots=[tmp_path])
+    assert len(errors) == 1, f"expected exactly one error, got: {errors}"
+
+
+def test_check_grep_qv_flags_long_form(tmp_path):
+    """FAIL — the long forms (`--quiet --invert-match`, and the `--silent`
+    alias) are the same combination spelled out."""
+    (tmp_path / "x.sh").write_text(
+        "grep --quiet --invert-match '^tasks/' files.txt\n"
+        "grep --silent --invert-match '^tasks/' files.txt\n"
+    )
+    errors = check_grep_qv(roots=[tmp_path])
+    assert len(errors) == 2, f"expected exactly two errors, got: {errors}"
+
+
+def test_check_grep_qv_flags_path_pinned_ugrep(tmp_path):
+    """FAIL — a path-pinned `ugrep` is broken BY CONSTRUCTION (its
+    quiet+invert rc diverges wherever the binary lives), so the
+    path-pin exemption is grep-only."""
+    (tmp_path / "x.sh").write_text("/usr/bin/ugrep -qv '^a' f.txt\n")
+    errors = check_grep_qv(roots=[tmp_path])
+    assert len(errors) == 1, f"expected exactly one error, got: {errors}"
+    assert "`ugrep`" in errors[0]
+
+
+def test_check_grep_qv_allows_path_pinned(tmp_path):
+    """PASS — `/usr/bin/grep -qvE` is the sanctioned GNU pin (the #928
+    incident's own verified workaround)."""
+    (tmp_path / "x.sh").write_text("/usr/bin/grep -qvE '^tasks/' files.txt\n")
+    assert check_grep_qv(roots=[tmp_path]) == []
+
+
+def test_check_grep_qv_allows_single_flag_and_git_grep(tmp_path):
+    """PASS — plain `-q` without `-v` (match-found rc agrees across
+    implementations: the gate's `grep -qxE` verdict consumers), plain
+    `-vE` without `-q` (the output-test rewrite itself), and `git grep`
+    (git's own engine, not PATH-shadowable)."""
+    (tmp_path / "x.sh").write_text(
+        "grep -qxE 'pass|skip-artifact-only' verdict.txt\n"
+        "if [ -n \"$(grep -vE '^tasks/' files.txt)\" ]; then echo armed; fi\n"
+        "git grep -qv something -- scripts/\n"
+    )
+    assert check_grep_qv(roots=[tmp_path]) == []
+
+
+def test_check_grep_qv_pass_pipeline_split(tmp_path):
+    """PASS — `-v` and `-q` on DIFFERENT pipeline commands never combine:
+    each command word's contiguous option run is evaluated independently."""
+    (tmp_path / "x.sh").write_text("grep -v x f | grep -q y f2\n")
+    assert check_grep_qv(roots=[tmp_path]) == []
+
+
+def test_check_grep_qv_skips_prose_and_comments(tmp_path):
+    """PASS — the pattern in `.md` prose OUTSIDE a fence and on a
+    `#`-comment line INSIDE a fence is documentation, not an executable
+    snippet."""
+    (tmp_path / "SKILL.md").write_text(
+        "Never write grep -qvE in a trigger (prose mention).\n"
+        "```bash\n"
+        "# banned shape: grep -qvE '^tasks/' file\n"
+        "echo ok\n"
+        "```\n"
+    )
+    (tmp_path / "x.sh").write_text("# doc: grep -qvE '^tasks/' file\necho ok\n")
+    assert check_grep_qv(roots=[tmp_path]) == []
+
+
+def test_check_grep_qv_live_tree_passes():
+    """The committed workflow surface must carry no unpinned q+v grep
+    trigger — the regression lock for the #1125 two-site fix (the
+    `test_live_trees_pass` pattern from the judge-pin check). No
+    grandfather allowlist exists by design: the post-fix tree is clean."""
+    errors = check_grep_qv()
+    assert errors == [], (
+        "workflow surface has unpinned quiet+invert grep triggers "
+        "(#928 ugrep fail-open class):\n" + "\n".join(errors)
+    )
+
+
+def test_workflow_lint_check_grep_qv_cli_exits_zero():
+    """The dedicated flag must exist and pass on the committed tree."""
+    result = _run("--check-grep-qv")
+    assert result.returncode == 0, (
+        f"workflow_lint --check-grep-qv failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes task #1125.

## Summary
- Rewrites both Step 10d pre-push lint-gate trigger snippets in `.claude/skills/issue/SKILL.md` to the shadow-proof output-test form `[ -n "$(grep -vE ... )" ]` (ugrep `-q -v` rc inversion silently disarmed the gate on #928)
- Adds `check_grep_qv()` to `scripts/workflow_lint.py` (no-flags bundle): bans unpinned `grep`/`ugrep` `-q`+`-v` combos in executable workflow snippets; path-pinned `grep` + `git grep` exempt, path-pinned `ugrep` flagged
- 11 new tests in `tests/test_workflow_lint.py` incl. live-tree 0-hit lock; `test_step10d_guard3.py` untouched (38/38 green)

## Test plan
- [x] Step 9c gate: 3033 passed / 6 skipped; baseline compare clean (0 new, 0 ruff delta)
- [x] Fix-engaged proof: pre-fix blob → exactly 2 flags; post-fix tree → 0
- [x] rc-parity probes vs GNU -qvE: 0/1/1 identical (blank-line divergence documented, production-unreachable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)