### PR TITLE
issue-1129: derive per-file step9c pristine-oracle timeout from selector knowledge

### DIFF
--- a/scripts/step9c_baseline.py
+++ b/scripts/step9c_baseline.py
@@ -17,7 +17,7 @@ Subcommands::
                                                      [--max-code-commits 150] [--json]
     uv run python scripts/step9c_baseline.py compare --junitxml PATH --pytest-rc INT [--base main]
                                                      [--worktree PATH] [--repo-root PATH]
-                                                     [--run-pristine] [--pristine-timeout-s 600]
+                                                     [--run-pristine] [--pristine-timeout-s S]
                                                      [--max-pristine-files 5]
                                                      [--max-age-hours 24] [--max-code-commits 150]
                                                      [--scratch-timeout-s 120]
@@ -923,6 +923,35 @@ def run_single_file_pristine(
         tmp_path.unlink(missing_ok=True)
 
 
+# --- pristine-timeout sizing (#1129). -----------------------------------------
+# Derived from the selector's #1046 gate-timeout knowledge so there is ONE
+# per-file runtime table. #1098: the pristine single-file run of
+# tests/test_workflow_lint.py needs ~780 s; the fixed 600 s default killed it
+# and forced a full compare rerun. Bias generous: an oversized bound only
+# delays a genuinely wedged run; an undersized one GUARANTEES a wasted
+# compare + rerun (exit 2 via PristineRunError).
+PRISTINE_SLOW_TIMEOUT_MULT = 2.0
+PRISTINE_TIMEOUT_FLOOR_S = (
+    600.0  # == the pre-#1129 fixed default (#1022): non-surcharge behavior unchanged
+)
+
+
+def derive_pristine_timeout_s(sel: object, test_file: str) -> float:
+    """Per-file pristine-oracle bound: BASE + PER_FILE + 2x slow surcharge, floor 600 s.
+
+    Reads the #1046 constants off the LOADED selector module (``ctx.sel``) via
+    ``getattr`` so a pre-#1046 worktree selector copy (deliberate version skew,
+    #1022 §3.3) degrades to the legacy 600 s floor instead of crashing.
+    tests/test_workflow_lint.py -> 120 + 30 + 2*900 = 1950 s (~2.5x its ~780 s
+    measured pristine runtime, #1098); files without surcharge knowledge -> 600 s.
+    """
+    base = float(getattr(sel, "TIMEOUT_BASE_S", 0))
+    per_file = float(getattr(sel, "TIMEOUT_PER_FILE_S", 0))
+    slow = getattr(sel, "SLOW_TESTS", None) or {}
+    surcharge = float(slow.get(test_file, 0))
+    return max(base + per_file + PRISTINE_SLOW_TIMEOUT_MULT * surcharge, PRISTINE_TIMEOUT_FLOOR_S)
+
+
 def lint_verdict(root: Path, wt: Path, touched: list[str]) -> dict:
     """Mechanical lint verdict: delta vs the LIVE main-root baseline + absolute-clean touched.
 
@@ -1178,11 +1207,16 @@ def _resolve_pristine_bucket(ctx: _CompareCtx, root: Path, args: argparse.Namesp
                     "contamination probe src//pyproject.toml/uv.lock was clean; scan-set "
                     "nodes and non-sparse work roots stay indeterminate)"
                 )
+            timeout_s = (
+                args.pristine_timeout_s
+                if args.pristine_timeout_s is not None
+                else derive_pristine_timeout_s(ctx.sel, test_file)
+            )
             try:
                 main_failing = run_single_file_pristine(
                     test_file,
                     cwd=scratch.path if use_scratch else root,
-                    timeout_s=args.pristine_timeout_s,
+                    timeout_s=timeout_s,
                     venv_root=root if use_scratch else None,
                 )
             except PristineRunError as exc:
@@ -1350,7 +1384,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_compare.add_argument("--repo-root", default=None)
     p_compare.add_argument("--run-pristine", action="store_true")
-    p_compare.add_argument("--pristine-timeout-s", type=float, default=600.0)
+    p_compare.add_argument(
+        "--pristine-timeout-s",
+        type=float,
+        default=None,
+        help="per-file pristine-run bound; default: derived per file from the "
+        "selector's gate-timeout knowledge (BASE + PER_FILE + 2x slow "
+        "surcharge, floor 600 s; #1129). Explicitly passing it wins for every file.",
+    )
     p_compare.add_argument("--max-pristine-files", type=int, default=5)
     p_compare.add_argument("--max-age-hours", type=float, default=24.0)
     p_compare.add_argument("--max-code-commits", type=int, default=150)

--- a/tests/test_step9c_baseline.py
+++ b/tests/test_step9c_baseline.py
@@ -31,6 +31,7 @@ import subprocess
 # sys.modules registration BEFORE exec_module is required: the module defines
 # dataclasses, whose field-type resolution looks itself up in sys.modules.
 import sys
+import types
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -210,6 +211,7 @@ def _install_compare_fakes(
     calls: dict[str, list] = {
         "pristine": [],
         "pristine_detail": [],  # (test_file, cwd, venv_root) per pristine call
+        "pristine_timeout": [],  # timeout_s per pristine call (#1129 derived-default pin)
         "scratch_created": [],
         "scratch_removed": [],
     }
@@ -242,6 +244,7 @@ def _install_compare_fakes(
     ) -> set:
         calls["pristine"].append(test_file)
         calls["pristine_detail"].append((test_file, cwd, venv_root))
+        calls["pristine_timeout"].append(timeout_s)
         if pristine_exc is not None:
             raise pristine_exc
         return {n for n in pristine_failing if n.file == test_file}
@@ -324,9 +327,15 @@ def _compare_env(
     contamination_paths=(),
     wt_cones=("tests",),
     scratch_exc: Exception | None = None,
+    sel_attrs: dict | None = None,
     extra_args=(),
 ):
-    """Set up a compare fixture tree + fakes; return (argv, calls, root, wt)."""
+    """Set up a compare fixture tree + fakes; return (argv, calls, root, wt).
+
+    ``sel_attrs`` setattrs extra attributes onto the ``_FakeSel`` post-construction
+    (the line-level ``fake_sel.WORKFLOW_INVARIANT = ...`` pattern) — e.g. the #1046
+    timeout constants for the #1129 derived-pristine-timeout cases.
+    """
     root, wt, junit = _materialize_compare_tree(
         tmp_path,
         junit_cases=junit_cases,
@@ -336,10 +345,13 @@ def _compare_env(
         ledger_kw=ledger_kw,
         ledger_raw=ledger_raw,
     )
+    fake_sel = _FakeSel(touched, reasons, glob_scan)
+    for _k, _v in (sel_attrs or {}).items():
+        setattr(fake_sel, _k, _v)
     calls = _install_compare_fakes(
         monkeypatch,
         root=root,
-        fake_sel=_FakeSel(touched, reasons, glob_scan),
+        fake_sel=fake_sel,
         changed_tests=changed_tests,
         live_dirty=live_dirty,
         pristine_failing=pristine_failing,
@@ -599,6 +611,122 @@ def test_compare_run_pristine_strip_or_new(tmp_path: Path, monkeypatch, capsys, 
     else:
         assert rc == 1
         assert out["new"] == [node._asdict()]
+
+
+# --- #1129: derived per-file pristine timeout ------------------------------------
+
+
+def test_derive_pristine_timeout_from_selector_constants():
+    """Pure unit: BASE + PER_FILE + 2x surcharge for slow files; floor 600 for the rest."""
+    sel = types.SimpleNamespace(
+        TIMEOUT_BASE_S=120,
+        TIMEOUT_PER_FILE_S=30,
+        SLOW_TESTS={"tests/test_workflow_lint.py": 900},
+    )
+    assert sb.derive_pristine_timeout_s(sel, "tests/test_workflow_lint.py") == 1950.0
+    assert sb.derive_pristine_timeout_s(sel, "tests/test_other.py") == 600.0
+
+
+def test_derive_pristine_timeout_live_selector_covers_incident_1098():
+    """Live-tree drift pin: the derived bound must keep covering the #1098 incident.
+
+    Dual grounding: 1200 s is the demonstrated-sufficient manual rerun bound
+    (`--pristine-timeout-s 1200` succeeded — the BINDING incident floor), and the
+    measured pristine runtime of tests/test_workflow_lint.py is bracketed at
+    ~640-780 s (the #1129 filing says ~13 min ~= 780 s; #1098's events record
+    "~640s+"). The `>= 2 * 780 = 1560` threshold gives >=2x headroom over the
+    bracket top; a future legitimate SLOW_TESTS re-measurement that lands the
+    derived value in [1200, 1560) should be reconciled against the 1200 s
+    incident floor rather than misread as an incident-coverage regression.
+    """
+    real_sel = sb.load_selector_module(Path(__file__).resolve().parents[1])
+    assert sb.derive_pristine_timeout_s(real_sel, "tests/test_workflow_lint.py") >= 2 * 780
+
+
+def test_derive_pristine_timeout_selector_skew_falls_back_to_floor():
+    """A selector copy lacking the #1046 constants (version skew) degrades to 600 s."""
+    skewed = _FakeSel([], {}, {})  # _FakeSel deliberately lacks the #1046 constants
+    assert sb.derive_pristine_timeout_s(skewed, "tests/test_workflow_lint.py") == 600.0
+
+
+def test_compare_pristine_timeout_derived_and_override_wins(tmp_path: Path, monkeypatch, capsys):
+    """Integration through sb.main: per-file derivation at default flags; explicit flag wins."""
+    node_wl = sb.Node(
+        file="tests/test_workflow_lint.py", classname="tests.test_workflow_lint", name="test_x"
+    )
+    # tests/test_zz_plain.py sorts AFTER test_workflow_lint.py -> recorded order is
+    # [surcharge file, plain file], pinning the PER-FILE (in-loop) derivation.
+    node_plain = sb.Node(
+        file="tests/test_zz_plain.py", classname="tests.test_zz_plain", name="test_y"
+    )
+    sel_1046 = {
+        "TIMEOUT_BASE_S": 120,
+        "TIMEOUT_PER_FILE_S": 30,
+        "SLOW_TESTS": {"tests/test_workflow_lint.py": 900},
+    }
+
+    # (a) default flags + default _FakeSel (no #1046 constants) -> skew fallback 600.0
+    #     through the real _resolve_pristine_bucket body.
+    argv, calls, _r, _w = _compare_env(
+        tmp_path,
+        monkeypatch,
+        junit_cases=[(node_plain.file, node_plain.classname, node_plain.name, "failed")],
+        ledger_kw={"failing": ()},
+        pristine_failing=(node_plain,),
+        extra_args=("--run-pristine",),
+    )
+    rc, _out, _err = _run_json(argv, capsys)
+    assert rc == 0
+    assert calls["pristine_timeout"] == [600.0]
+
+    # (b) default flags + #1046 constants on the selector -> derived 1950.0 for the
+    #     surcharge file.
+    argv, calls, _r, _w = _compare_env(
+        tmp_path,
+        monkeypatch,
+        junit_cases=[(node_wl.file, node_wl.classname, node_wl.name, "failed")],
+        ledger_kw={"failing": ()},
+        pristine_failing=(node_wl,),
+        sel_attrs=sel_1046,
+        extra_args=("--run-pristine",),
+    )
+    rc, _out, _err = _run_json(argv, capsys)
+    assert rc == 0
+    assert calls["pristine_timeout"] == [1950.0]
+
+    # (c) explicit --pristine-timeout-s wins verbatim, even with the constants present.
+    argv, calls, _r, _w = _compare_env(
+        tmp_path,
+        monkeypatch,
+        junit_cases=[(node_wl.file, node_wl.classname, node_wl.name, "failed")],
+        ledger_kw={"failing": ()},
+        pristine_failing=(node_wl,),
+        sel_attrs=sel_1046,
+        extra_args=("--run-pristine", "--pristine-timeout-s", "1200"),
+    )
+    rc, _out, _err = _run_json(argv, capsys)
+    assert rc == 0
+    assert calls["pristine_timeout"] == [1200.0]
+
+    # (d) mixed two-file bucket -> per-file (in-loop) derivation: [1950.0, 600.0].
+    #     An implementation hoisting the derivation above the loop (deriving once
+    #     from the first file) cannot produce two distinct values.
+    argv, calls, _r, _w = _compare_env(
+        tmp_path,
+        monkeypatch,
+        junit_cases=[
+            (node_wl.file, node_wl.classname, node_wl.name, "failed"),
+            (node_plain.file, node_plain.classname, node_plain.name, "failed"),
+        ],
+        ledger_kw={"failing": ()},
+        pristine_failing=(node_wl, node_plain),
+        sel_attrs=sel_1046,
+        extra_args=("--run-pristine",),
+    )
+    rc, _out, _err = _run_json(argv, capsys)
+    assert rc == 0
+    assert calls["pristine"] == [node_wl.file, node_plain.file]
+    assert calls["pristine_timeout"] == [1950.0, 600.0]
 
 
 # --- Case 9: diff-linked known-red never blind-strips; pristine strip WARNs -----


### PR DESCRIPTION
Closes task #1129. Derives the per-file pristine-oracle timeout in scripts/step9c_baseline.py from the selector's gate-timeout knowledge (BASE + PER_FILE + 2x SLOW_TESTS surcharge, floor 600s); --pristine-timeout-s kept as explicit override (default=None sentinel). Incident #1098. Plan v2 approved (critics APPROVE x3); code-review PASS; test-verdict PASS (2899 passed / 0 failed; compare rc=0).