### PR TITLE
issue-1130: forward rc==0 post-marker child stderr to wrapper transcripts

### DIFF
--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -5577,6 +5577,17 @@ def _gc_orphan_pod_safety_state(
     return cleared
 
 
+def _forward_marker_child_stderr(res, context: str) -> None:
+    """Forward a rc==0 task.py child's non-empty stderr (#1130): the child
+    exits 0 while printing deferred-commit / LANDING CHECK warnings, which
+    capture_output would otherwise swallow into the cron log's void."""
+    err = (getattr(res, "stderr", None) or "").strip()
+    if not err:
+        return
+    for line in err[:2000].splitlines():
+        print(f"  [task.py stderr] {context}: {line}", file=sys.stderr)
+
+
 def _post_progress_marker(issue: int, note: str, dry_run: bool, *, label: str) -> None:
     """Record a pod-safety event on task ``issue``'s events.jsonl.
 
@@ -5591,7 +5602,7 @@ def _post_progress_marker(issue: int, note: str, dry_run: bool, *, label: str) -
         print(f"  [dry-run] would post epm:progress ({label}) on #{issue}: {note}")
         return
     try:
-        subprocess.run(
+        res = subprocess.run(
             [
                 "uv",
                 "run",
@@ -5611,6 +5622,8 @@ def _post_progress_marker(issue: int, note: str, dry_run: bool, *, label: str) -
             timeout=60,
             check=True,
         )
+        # check=True means rc!=0 raised above — the helper only sees rc==0 results.
+        _forward_marker_child_stderr(res, f"epm:progress on #{issue}")
     except (subprocess.SubprocessError, OSError) as e:
         # The action (stop / alert) already happened; failing to annotate it is
         # not worth aborting the run. Surface it loudly so the gap is visible.
@@ -5639,7 +5652,7 @@ def _post_failure_marker(issue: int, note: str, dry_run: bool) -> bool:
         print(f"  [dry-run] would post epm:failure on #{issue}: {note}")
         return True
     try:
-        subprocess.run(
+        res = subprocess.run(
             [
                 "uv",
                 "run",
@@ -5659,6 +5672,7 @@ def _post_failure_marker(issue: int, note: str, dry_run: bool) -> bool:
             timeout=60,
             check=True,
         )
+        _forward_marker_child_stderr(res, f"epm:failure on #{issue}")
     except (subprocess.SubprocessError, OSError) as e:
         print(f"  WARNING: posting epm:failure marker on #{issue} failed: {e}", file=sys.stderr)
         return False
@@ -8171,7 +8185,7 @@ def _post_followup_run_marker(issue: int, events: list[dict], dry_run: bool) -> 
         print(f"  [dry-run] would post epm:same-issue-followup-run on #{issue}: {label}")
         return True
     try:
-        subprocess.run(
+        res = subprocess.run(
             [
                 "uv",
                 "run",
@@ -8191,6 +8205,7 @@ def _post_followup_run_marker(issue: int, events: list[dict], dry_run: bool) -> 
             timeout=60,
             check=True,
         )
+        _forward_marker_child_stderr(res, f"epm:same-issue-followup-run on #{issue}")
     except (subprocess.SubprocessError, OSError) as exc:
         print(
             f"  issue #{issue}: epm:same-issue-followup-run post FAILED ({exc}); "
@@ -17332,7 +17347,7 @@ def _post_campaign_marker(issue: int, kind: str, note: str, dry_run: bool) -> No
         print(f"  [dry-run] would post {kind} on #{issue}: {note}")
         return
     try:
-        subprocess.run(
+        res = subprocess.run(
             [
                 "uv",
                 "run",
@@ -17352,6 +17367,7 @@ def _post_campaign_marker(issue: int, kind: str, note: str, dry_run: bool) -> No
             timeout=60,
             check=True,
         )
+        _forward_marker_child_stderr(res, f"{kind} on #{issue}")
     except (subprocess.SubprocessError, OSError) as e:
         print(f"  WARNING: posting {kind} on #{issue} failed: {e}", file=sys.stderr)
 

--- a/scripts/codex_task.py
+++ b/scripts/codex_task.py
@@ -250,6 +250,30 @@ STATUS_TIMEOUT_SECS = 60
 RESULT_TIMEOUT_SECS = 120
 CANCEL_TIMEOUT_SECS = 60
 POST_MARKER_TIMEOUT_SECS = 60
+_SUCCESS_STDERR_FORWARD_CAP = 2000  # chars; the #1100 LANDING CHECK ERROR measures ~826 chars
+#                                     once interpolated — the cap must NOT truncate its
+#                                     recovery recipe (the cherry-pick cmd sits at the tail)
+
+
+def _forward_success_stderr(kind: str, stderr: str | None) -> None:
+    """Forward a rc==0 post-marker child's non-empty stderr to the wrapper's
+    stderr (#1130). ``task.py post-marker`` deliberately exits 0 while
+    printing warnings to stderr — the deferred-commit ERROR and the #1100
+    post-commit LANDING CHECK — and ``capture_output=True`` would otherwise
+    discard them so they reach no transcript. Capped so a pathological
+    child can never flood the wrapper transcript."""
+    err = (stderr or "").strip()
+    if not err:
+        return
+    truncated = len(err) > _SUCCESS_STDERR_FORWARD_CAP
+    for line in err[:_SUCCESS_STDERR_FORWARD_CAP].splitlines():
+        print(f"[post-marker stderr] {kind}: {line}", file=sys.stderr)
+    if truncated:
+        print(
+            f"[post-marker stderr] {kind}: ... (truncated at {_SUCCESS_STDERR_FORWARD_CAP} chars)",
+            file=sys.stderr,
+        )
+
 
 # ── Quota-exhausted sentinel (#1126) ─────────────────────────────────
 # On a hard org usage-limit terminal (job spawns, dies phase=failed in
@@ -412,6 +436,7 @@ def _post_marker(issue: int, kind: str, note: str, version: int = 1) -> bool:
                 timeout=POST_MARKER_TIMEOUT_SECS,
             )
             if result.returncode == 0:
+                _forward_success_stderr(kind, result.stderr)
                 return True
             print(
                 f"WARN: post-marker attempt {attempt} for {kind} returned "

--- a/scripts/spawn_session.py
+++ b/scripts/spawn_session.py
@@ -1707,7 +1707,7 @@ def _post_duplicate_suppressed_marker(issue: int, kept_sid: str, stopped_sid: st
         f"kept {kept_sid}, stopped {stopped_sid}"
     )
     try:
-        subprocess.run(
+        res = subprocess.run(
             [
                 "uv",
                 "run",
@@ -1726,6 +1726,14 @@ def _post_duplicate_suppressed_marker(issue: int, kept_sid: str, stopped_sid: st
             text=True,
             timeout=60,
         )
+        # #1130: task.py exits 0 while printing deferred-commit / LANDING
+        # CHECK warnings to stderr; forward them (rc deliberately unchecked
+        # — best-effort post, control flow unchanged) instead of swallowing
+        # them into capture_output's void.
+        err = (res.stderr or "").strip()
+        if err:
+            for line in err[:2000].splitlines():
+                print(f"  [post-marker stderr] {line}", file=sys.stderr)
     except (subprocess.SubprocessError, OSError) as e:
         print(f"  note: duplicate-dispatch marker post failed ({e})", file=sys.stderr)
 

--- a/tests/test_codex_task_post_marker.py
+++ b/tests/test_codex_task_post_marker.py
@@ -90,6 +90,76 @@ def test_nonzero_exit_without_landed_marker_retries_then_drops(monkeypatch, tmp_
 
 
 # ──────────────────────────────────────────────────────────────────────
+# _post_marker rc==0: success-stderr forwarding (#1130).
+#
+# `task.py post-marker` deliberately exits 0 while printing the
+# deferred-commit ERROR and the #1100 post-commit LANDING CHECK warning
+# to stderr; the rc==0 branch used to `return True` immediately,
+# discarding both into capture_output's void.
+# ──────────────────────────────────────────────────────────────────────
+
+
+_LANDING_CHECK_LINE = (
+    "task.py LANDING CHECK: commit abc123 ('epm:x') is NOT reachable from refs/heads/main"
+)
+
+
+def test_success_with_nonempty_stderr_forwards_to_wrapper_stderr(monkeypatch, capsys):
+    """rc==0 + non-empty child stderr → forwarded to the wrapper's stderr
+    with the greppable `[post-marker stderr]` prefix; return value and the
+    single-invocation success path are unchanged."""
+    calls = []
+    monkeypatch.setattr(
+        codex_task.subprocess,
+        "run",
+        lambda *a, **k: (
+            calls.append(a) or SimpleNamespace(returncode=0, stdout="", stderr=_LANDING_CHECK_LINE)
+        ),
+    )
+
+    ok = codex_task._post_marker(1130, "epm:codex-task-spawned", "Codex job_id=task-x")
+
+    assert ok is True
+    assert len(calls) == 1
+    err = capsys.readouterr().err
+    assert "task.py LANDING CHECK" in err
+    assert "[post-marker stderr]" in err
+
+
+def test_success_with_empty_stderr_forwards_nothing(monkeypatch, capsys):
+    """rc==0 + empty child stderr (the common case) → zero new output."""
+    monkeypatch.setattr(
+        codex_task.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    ok = codex_task._post_marker(1130, "epm:codex-task-spawned", "Codex job_id=task-x")
+
+    assert ok is True
+    assert capsys.readouterr().err == ""
+
+
+def test_success_stderr_over_cap_truncates_with_notice(monkeypatch, capsys):
+    """A pathological >cap child stderr is bounded: at most cap payload chars
+    forwarded plus one explicit truncation-notice line."""
+    cap = codex_task._SUCCESS_STDERR_FORWARD_CAP
+    monkeypatch.setattr(
+        codex_task.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="", stderr="x" * (cap + 3000)),
+    )
+
+    ok = codex_task._post_marker(1130, "epm:codex-task-spawned", "Codex job_id=task-x")
+
+    assert ok is True
+    err = capsys.readouterr().err
+    assert f"... (truncated at {cap} chars)" in err
+    assert "x" * cap in err  # the capped payload is forwarded...
+    assert "x" * (cap + 1) not in err  # ...and nothing beyond the cap
+
+
+# ──────────────────────────────────────────────────────────────────────
 # _marker_already_landed: matching rules.
 # ──────────────────────────────────────────────────────────────────────
 

--- a/tests/test_marker_child_stderr_forwarding.py
+++ b/tests/test_marker_child_stderr_forwarding.py
@@ -1,0 +1,122 @@
+"""Tests for the #1130 rc==0 post-marker child-stderr forwarding at the
+secondary call sites: ``spawn_session._post_duplicate_suppressed_marker``
+and ``autonomous_session_watch._forward_marker_child_stderr`` (plus its
+``_post_progress_marker`` integration).
+
+``task.py post-marker`` deliberately exits 0 while printing the
+deferred-commit ERROR and the #1100 post-commit LANDING CHECK warning to
+stderr; ``capture_output=True`` at these call sites used to discard both,
+so they reached no transcript. The forwarding writes them to the wrapper's
+stderr, prefixed and capped; control flow (rc handling, ``check=True``
+semantics, return values) is unchanged. Primary-site coverage
+(``codex_task._post_marker``) lives in ``tests/test_codex_task_post_marker.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import autonomous_session_watch as asw  # noqa: E402
+import spawn_session  # noqa: E402
+
+_LANDING_CHECK_LINE = (
+    "task.py LANDING CHECK: commit abc123 ('epm:x') is NOT reachable from refs/heads/main"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# spawn_session._post_duplicate_suppressed_marker
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_spawn_session_duplicate_marker_forwards_nonempty_stderr(monkeypatch, capsys):
+    """Non-empty child stderr → forwarded with the `[post-marker stderr]`
+    prefix (rc deliberately unchecked — best-effort post, unchanged)."""
+    calls = []
+    monkeypatch.setattr(
+        spawn_session.subprocess,
+        "run",
+        lambda *a, **k: (
+            calls.append(a) or SimpleNamespace(returncode=0, stdout="", stderr=_LANDING_CHECK_LINE)
+        ),
+    )
+
+    spawn_session._post_duplicate_suppressed_marker(1130, "sid-kept", "sid-stopped")
+
+    assert len(calls) == 1
+    err = capsys.readouterr().err
+    assert "[post-marker stderr]" in err
+    assert "task.py LANDING CHECK" in err
+
+
+def test_spawn_session_duplicate_marker_empty_stderr_silent(monkeypatch, capsys):
+    """Empty child stderr (the common case) → zero new output."""
+    monkeypatch.setattr(
+        spawn_session.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    spawn_session._post_duplicate_suppressed_marker(1130, "sid-kept", "sid-stopped")
+
+    assert capsys.readouterr().err == ""
+
+
+# ──────────────────────────────────────────────────────────────────────
+# autonomous_session_watch._forward_marker_child_stderr (unit)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_watch_helper_forwards_nonempty_stderr(capsys):
+    """Non-empty rc==0 stderr → per-line `[task.py stderr] {context}:` prefix."""
+    asw._forward_marker_child_stderr(
+        SimpleNamespace(returncode=0, stdout="", stderr=_LANDING_CHECK_LINE),
+        "epm:progress on #1130",
+    )
+
+    err = capsys.readouterr().err
+    assert "[task.py stderr] epm:progress on #1130:" in err
+    assert "task.py LANDING CHECK" in err
+
+
+def test_watch_helper_empty_or_missing_stderr_silent(capsys):
+    """Empty / None / absent stderr all forward nothing and never raise."""
+    asw._forward_marker_child_stderr(SimpleNamespace(stderr=""), "ctx")
+    asw._forward_marker_child_stderr(SimpleNamespace(stderr=None), "ctx")
+    asw._forward_marker_child_stderr(SimpleNamespace(), "ctx")  # no stderr attribute at all
+
+    assert capsys.readouterr().err == ""
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Integration: _post_progress_marker reaches the helper on rc==0.
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_watch_post_progress_marker_integration_forwards(monkeypatch, capsys):
+    """dry_run=False (the dry-run branch returns before subprocess.run) with a
+    stubbed rc==0 + non-empty-stderr child → the warning reaches the
+    watcher's stderr; exactly one subprocess invocation (check=True
+    semantics untouched — the stub does not raise)."""
+    calls = []
+    monkeypatch.setattr(
+        asw.subprocess,
+        "run",
+        lambda *a, **k: (
+            calls.append((a, k))
+            or SimpleNamespace(returncode=0, stdout="", stderr=_LANDING_CHECK_LINE)
+        ),
+    )
+
+    asw._post_progress_marker(1130, "pod-safety note", False, label="auto-stop")
+
+    assert len(calls) == 1
+    err = capsys.readouterr().err
+    assert "[task.py stderr]" in err
+    assert "task.py LANDING CHECK" in err


### PR DESCRIPTION
Closes task #1130. Forwards non-empty success-stderr (LANDING CHECK / deferred-commit warnings, #1100) from task.py post-marker children to the wrapper stderr at all 6 subprocess call sites (codex_task.py, spawn_session.py, autonomous_session_watch.py). +246/-5, tests included. Plan + reviews on tasks/completed/1130.