### PR TITLE
issue-1132: /daily parked workflow-fix-candidate routing pass (Step C)

### DIFF
--- a/.claude/rules/workflow-fix-on-bug.md
+++ b/.claude/rules/workflow-fix-on-bug.md
@@ -473,7 +473,12 @@ duplicate. The library helper
 `task_workflow.is_open_workflow_fix_task(target_file, fingerprint) -> int | None`
 is the canonical, tested implementation (`tests/test_workflow_fix_dedup.py`).
 A closed (`completed`/`archived`) workflow-fix task does NOT block a
-re-raise of the same bug.
+re-raise of the same bug. (The /daily Step C parked-candidate sweep applies
+this temporally: a swept PARKED candidate that PREdates a closed matching fix
+task's creation is treated as subsumed by it — suppressed, pure churn to
+re-route — while a candidate parked AFTER the fix closed is a genuine
+re-raise and stays enumerated; see
+`scripts/sweep_parked_wf_candidates.py`.)
 
 ## Recursion guard
 
@@ -497,7 +502,9 @@ see § Recursion guard`) and surfaces it as a notification.
 
 **Escape valve (never silently lost):** such a session CAN still emit
 candidate blocks — they get parked/notified, not auto-routed, so its own
-workflow-fix bug is parked for the next human/orchestrator pass exactly
+workflow-fix bug is parked for the nightly /daily parked-candidate routing
+pass (Step C in `.claude/skills/daily/SKILL.md`; enumerator
+`scripts/sweep_parked_wf_candidates.py`) exactly
 as `AUTO_REVIEW_DISABLED`-suppressed candidates are. The cost is a
 one-cycle delay, not a dropped bug. The recursion-guard predicate is
 executable-tested (`tests/test_workflow_fix_dedup.py`

--- a/.claude/skills/daily/SKILL.md
+++ b/.claude/skills/daily/SKILL.md
@@ -275,6 +275,62 @@ for each still-open parked item:
 (consistent with the "do not move statuses unless the user asks" rule in
 "Other rules" below).
 
+**3. Parked workflow-fix-candidate routing pass (Step C).** Route the
+recursion-guard escape valve (`.claude/rules/workflow-fix-on-bug.md`
+§ Recursion guard): a workflow-fix session parks its candidates
+(`epm:workflow-fix-candidate` with a `parked …` note) instead of auto-routing
+them — THIS pass is the owning "next orchestrator pass". The /daily
+orchestrator is NOT under the recursion guard (no `workflow_fix_target:`
+Provenance line, no `EPM_WORKFLOW_FIX_SESSION=1`), so routing here cannot
+recurse.
+
+```
+sweep = run("uv run python scripts/sweep_parked_wf_candidates.py")
+    # one JSON object; UNBOUNDED window by default, already
+    # routed-suppressed + row-deduped (suppression is what bounds re-scans)
+for c in sweep["candidates"]:
+    # fields: formal <!-- workflow-fix-candidate v1 --> block → verbatim;
+    # prose park → SYNTHESIZE proposed_change/bug_observed per
+    # workflow-fix-on-bug.md (prose-synthesis rule), then
+    # fp = wf_fix_fingerprint(proposed_change, bug_observed)
+    if an open OR closed infra task already addresses this bug
+       (c["open_wf_fix_on_file"] advisory, the wf-fix-fp tag, or content match):
+        post the routed-record below with note `deduped against #<M>`; continue
+    route through the THREE-ROUTE classifier (the "Triage each problem"
+    section BELOW this pass), with two overrides:
+      - c["park_form"] == "architectural" → ALWAYS route 3 (needs-human);
+        never route 2 (architectural greenlight is user-only)
+      - DEFAULT route 2: a parked candidate is by construction a
+        behavior-change proposal; route 1 only for a pure prose/doc change
+        with no behavior effect (the route-1 litmus verbatim)
+    file through the durable filing dir + daily_drive_filings.py as usual
+      (route 2 tags: wf-fix + wf-fix-fp:<fp> + daily-auto-filed)
+    post the ROUTED-RECORD that closes the loop — for EVERY disposition
+    (route 1 self-apply, route 2 filing, route 3 needs-human filing, AND
+    dedup), no new marker kind:
+      - candidate parked on task #N:
+        task.py post-marker N epm:workflow-fix-task-filed --note
+        "filed_task: #<M or 'n/a (route 1; commit <sha>)'> / target_file: <tf> /
+         fingerprint: <fp or 'n/a (prose park)'> / session_spawned: <bool> /
+         source: daily-parked-candidate-sweep / origin_candidate_ts: <c.ts> /
+         origin_candidate: <first ~200 chars of the candidate note, abridged>"
+      - cache-borne candidate: append the equivalent JSON row to
+        .claude/cache/workflow-fix-events.jsonl (existing convention)
+    record it in ## Applied workflow improvements ("filed for review #<M>") /
+      ## Other problems & notes (route 3), exactly as routes 2/3 prescribe.
+```
+
+Routes 1 and 3 post the routed-record too — a route-3 needs-human filing DOES
+have a real `filed_task: #<M>`; route 1 records the commit sha in place of a
+task id. Without a record for every disposition, a route-3 architectural park
+would re-enumerate nightly; the record makes each disposition
+sweep-idempotent. `origin_candidate_ts` is the suppression key for fp-less
+parks; `origin_candidate` (abridged verbatim) keeps the marker
+self-describing per workflow-fix-on-bug.md § Markers.
+
+Future sweeps skip routed candidates mechanically — see the enumerator's
+suppression predicate (`scripts/sweep_parked_wf_candidates.py --help`).
+
 **Dedup mechanism (Step F).** A filesystem event-stream
 `.claude/cache/nightly-consolidation-events.jsonl` (a local, gitignored durable
 trace following the existing `.claude/cache/disk-guard-events.jsonl` /

--- a/scripts/sweep_parked_wf_candidates.py
+++ b/scripts/sweep_parked_wf_candidates.py
@@ -278,7 +278,10 @@ def _task_creation_ts(task_dir: Path) -> datetime | None:
     """First parseable events.jsonl row ts (the task's creation time); None if unreadable."""
     events = task_dir / "events.jsonl"
     try:
-        lines = events.read_text(encoding="utf-8").splitlines()
+        # split("\n"), NEVER splitlines(): splitlines() splits on U+2028/U+2029
+        # etc. and shreds valid JSONL rows whose note strings carry them
+        # (.claude/rules/gotchas.md "splitlines shreds JSONL", #950).
+        lines = events.read_text(encoding="utf-8").split("\n")
     except OSError:
         return None
     for line in lines:
@@ -351,7 +354,10 @@ def _load_stream(path: Path, source: str) -> tuple[list[tuple[dict, datetime, st
     rows: list[tuple[dict, datetime, str]] = []
     seen: set[tuple[str, str, str]] = set()
     try:
-        lines = path.read_text(encoding="utf-8").splitlines()
+        # split("\n"), NEVER splitlines(): splitlines() splits on U+2028/U+2029
+        # etc. and shreds valid JSONL rows whose note strings carry them
+        # (.claude/rules/gotchas.md "splitlines shreds JSONL", #950).
+        lines = path.read_text(encoding="utf-8").split("\n")
     except OSError:
         return rows, skipped
     for line in lines:

--- a/scripts/sweep_parked_wf_candidates.py
+++ b/scripts/sweep_parked_wf_candidates.py
@@ -251,8 +251,15 @@ def _filed_ref(record: dict) -> str:
     return str(record.get("ts") or "")
 
 
-def _iter_task_bodies(tasks_root: Path):
-    """Yield (task_id, status, body_path, body_text) across every status folder."""
+def _load_task_bodies(tasks_root: Path) -> list[tuple[int, str, Path, str, dict]]:
+    """(task_id, status, body_path, body_text, frontmatter) across every status folder.
+
+    Loaded ONCE per sweep and shared by the fp-tag scan + the open-wf-fix
+    advisory — re-reading ~10^3 bodies (plus a YAML parse each) per candidate
+    blew the <30 s wall-time bound on the live tree (109 candidates x ~1.3k
+    bodies on the first unbounded audit).
+    """
+    bodies: list[tuple[int, str, Path, str, dict]] = []
     for body_path in sorted(tasks_root.glob("*/*/body.md")):
         status = body_path.parent.parent.name
         try:
@@ -263,7 +270,8 @@ def _iter_task_bodies(tasks_root: Path):
             text = body_path.read_text(encoding="utf-8")
         except OSError:
             continue
-        yield tid, status, body_path, text
+        bodies.append((tid, status, body_path, text, _read_frontmatter(text)))
+    return bodies
 
 
 def _task_creation_ts(task_dir: Path) -> datetime | None:
@@ -286,7 +294,9 @@ def _task_creation_ts(task_dir: Path) -> datetime | None:
     return None
 
 
-def _fp_tag_scan(tasks_root: Path, fp: str, cand_ts: datetime) -> dict | None:
+def _fp_tag_scan(
+    bodies: list[tuple[int, str, Path, str, dict]], fp: str, cand_ts: datetime
+) -> dict | None:
     """Suppression rule 2: an infra task carrying this fp (tag or Provenance line).
 
     Non-terminal hit -> suppress unconditionally; terminal hit -> suppress only
@@ -294,8 +304,7 @@ def _fp_tag_scan(tasks_root: Path, fp: str, cand_ts: datetime) -> dict | None:
     subsumed by the fix). An unreadable creation ts fails toward ENUMERATION
     (treated as a re-raise), never toward a silent drop.
     """
-    for tid, status, body_path, text in _iter_task_bodies(tasks_root):
-        fm = _read_frontmatter(text)
+    for tid, status, body_path, text, fm in bodies:
         if fm.get("kind") != "infra":
             continue
         if f"wf-fix-fp:{fp}" not in text and f"fingerprint: {fp}" not in text:
@@ -308,19 +317,20 @@ def _fp_tag_scan(tasks_root: Path, fp: str, cand_ts: datetime) -> dict | None:
     return None
 
 
-def _open_wf_fix_on_file(tasks_root: Path, target_file: str) -> int | None:
+def _open_wf_fix_on_file(
+    bodies: list[tuple[int, str, Path, str, dict]], target_file: str
+) -> int | None:
     """Advisory mirror of ``task_workflow.is_open_workflow_fix_task(target_file, None)``.
 
-    Same predicate, keyed on ``tasks_root`` so test fixtures exercise it: kind
-    infra + non-terminal status + ``workflow-fix:`` TITLE PREFIX + a Provenance
-    ``workflow_fix_target: <target_file>`` line. Title-prefix-bound and hence
-    BLIND to ``daily-fix:``-titled open filings — advisory only (see module
-    docstring); the /daily LLM's content dedup is the real check.
+    Same predicate, keyed on the scanned tree so test fixtures exercise it:
+    kind infra + non-terminal status + ``workflow-fix:`` TITLE PREFIX + a
+    Provenance ``workflow_fix_target: <target_file>`` line. Title-prefix-bound
+    and hence BLIND to ``daily-fix:``-titled open filings — advisory only (see
+    module docstring); the /daily LLM's content dedup is the real check.
     """
-    for tid, status, _body_path, text in _iter_task_bodies(tasks_root):
+    for tid, status, _body_path, text, fm in bodies:
         if status in TERMINAL_STATUSES:
             continue
-        fm = _read_frontmatter(text)
         if fm.get("kind") != "infra":
             continue
         if not str(fm.get("title") or "").startswith("workflow-fix:"):
@@ -389,6 +399,7 @@ def sweep(
     candidates: list[Candidate] = []
     now = datetime.now(UTC)
     cutoff = now - timedelta(days=window_days) if window_days > 0 else None
+    bodies: list[tuple[int, str, Path, str, dict]] | None = None  # loaded lazily, ONCE
 
     for source, path in streams:
         rows, skipped = _load_stream(path, source)
@@ -418,13 +429,18 @@ def sweep(
                     cand.suppressed = True
                     cand.suppressed_by = {"kind": "same-stream-filed", "ref": _filed_ref(record)}
                     break
+            needs_bodies = (not cand.suppressed and cand.fingerprint is not None) or bool(
+                cand.target_file
+            )
+            if needs_bodies and bodies is None:
+                bodies = _load_task_bodies(tasks_root)
             if not cand.suppressed and cand.fingerprint is not None:
-                hit = _fp_tag_scan(tasks_root, cand.fingerprint, cand.ts)
+                hit = _fp_tag_scan(bodies or [], cand.fingerprint, cand.ts)
                 if hit is not None:
                     cand.suppressed = True
                     cand.suppressed_by = hit
             if cand.target_file:
-                cand.open_wf_fix_on_file = _open_wf_fix_on_file(tasks_root, cand.target_file)
+                cand.open_wf_fix_on_file = _open_wf_fix_on_file(bodies or [], cand.target_file)
             candidates.append(cand)
 
     candidates.sort(key=lambda c: (c.source, c.ts_raw))

--- a/scripts/sweep_parked_wf_candidates.py
+++ b/scripts/sweep_parked_wf_candidates.py
@@ -1,0 +1,484 @@
+"""Read-only enumerator of PARKED workflow-fix candidates (/daily Step C input).
+
+Scans every ``tasks/*/*/events.jsonl`` (ALL statuses — both evidence parks live
+on terminal tasks: #1100 completed, #1101 archived) plus the outside-task
+fallback stream ``.claude/cache/workflow-fix-events.jsonl`` for
+``epm:workflow-fix-candidate`` rows whose note/``routed`` field marks them
+PARKED (the recursion-guard escape valve,
+``.claude/rules/workflow-fix-on-bug.md`` § Recursion guard), and prints ONE
+JSON object to stdout listing the candidates no later routed-record has
+closed. The /daily "Parked workflow-fix-candidate routing pass (Step C)"
+(``.claude/skills/daily/SKILL.md``) routes each through the three-route
+classifier and posts the ``epm:workflow-fix-task-filed`` routed-record this
+sweep's suppression rule (1) keys on.
+
+Suppression rules (a candidate is SUPPRESSED == already routed):
+
+1. **Same-stream filed record** — a LATER row (aware-UTC ts > candidate ts)
+   in the SAME stream with kind ``epm:workflow-fix-task-filed*`` matching the
+   candidate: fp-computable candidates match ONLY on the fingerprint (same
+   ``target_file`` + different fp is NOT a duplicate — workflow-fix-on-bug.md
+   § Dedup); fp-less (prose) parks match on the record's
+   ``origin_candidate_ts`` (PRIMARY key), falling back to a ``target_file``
+   string match ONLY when the record carries no ``origin_candidate_ts``
+   (legacy/backfill records).
+2. **fp-tag scan** (fingerprint computable only) — a ``kind: infra`` task
+   whose ``body.md`` carries ``wf-fix-fp:<fp>`` (tag) or ``fingerprint: <fp>``
+   (Provenance line). A NON-terminal hit suppresses unconditionally; a
+   TERMINAL (completed/archived) hit suppresses only when the task's creation
+   ts (first parseable events.jsonl row) POSTdates the candidate ts — a
+   candidate that predates the closed fix was subsumed by it; one raised
+   after it closed is a genuine re-raise and stays enumerated.
+3. **Row dedup** — identical (stream, ts, content-hash) rows collapse to one
+   (observed verbatim duplication in #1100's events.jsonl).
+
+fp-less prose parks are NEVER auto-suppressed on file-only matches (the
+#622-class distinct-bug-on-a-hot-file hazard); instead the advisory field
+``open_wf_fix_on_file`` is emitted for the /daily LLM's content-level dedup.
+NOTE: that advisory mirrors ``task_workflow.is_open_workflow_fix_task``
+semantics and is therefore ``workflow-fix:``-TITLE-PREFIX-BOUND — it is BLIND
+to ``daily-fix:``-titled open filings (which carry no ``workflow-fix:`` title;
+see ``daily_drive_filings.find_open_fp_duplicate``). Advisory only; the
+LLM-side content dedup in Step C is the real check.
+
+Timestamp discipline: every ts is normalized to an AWARE-UTC datetime before
+any comparison (the cache file carries ``-07:00`` offset rows alongside
+``Z``-form; string comparison misorders them). A naive-parsing ts is assumed
+UTC. A JSONL line that fails to parse, or a candidate/filed row whose ts is
+missing/unparseable, is SKIPPED and COUNTED in the top-level ``skipped_rows``
+(never a crash, never a silent drop). Exit code is 0 always — this is an
+enumerator, not a gate.
+
+Usage:
+    uv run python scripts/sweep_parked_wf_candidates.py [--window-days 0]
+        [--include-routed] [--tasks-root PATH] [--cache-file PATH]
+
+``--window-days 0`` (the DEFAULT) is UNBOUNDED; a positive N scopes an audit
+to candidates parked within the last N days. Default output lists only
+UNSUPPRESSED candidates; ``--include-routed`` includes suppressed ones too.
+``--tasks-root`` / ``--cache-file`` are test overrides (an explicit override
+that does not exist fails loud; the DEFAULT cache file is skipped when absent).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import yaml
+
+from explore_persona_space.task_workflow import repo_root, tasks_dir, wf_fix_fingerprint
+
+CANDIDATE_KIND_PREFIX = "epm:workflow-fix-candidate"
+FILED_KIND_PREFIX = "epm:workflow-fix-task-filed"
+TERMINAL_STATUSES = ("completed", "archived")
+
+_PARKED_LEAD_RE = re.compile(r"\s*parked\b", re.IGNORECASE)
+_PARKED_ROUTED_RE = re.compile(r"routed:\s*parked\b", re.IGNORECASE)
+_ARCHITECTURAL_RE = re.compile(r"parked:\s*architectural", re.IGNORECASE)
+_BLOCK_RE = re.compile(
+    r"<!--\s*workflow-fix-candidate v1\s*-->(.*?)<!--\s*/workflow-fix-candidate\s*-->",
+    re.DOTALL,
+)
+_TARGET_FILE_RE = re.compile(r"target_file:\s*([^\s,;]+)")
+_ORIGIN_TS_RE = re.compile(r"origin_candidate_ts:\s*(\S+)")
+_FILED_TASK_RE = re.compile(r"filed_task:\s*(#?\d+)")
+
+
+def parse_ts(raw: object) -> datetime | None:
+    """Parse an ISO-8601-ish timestamp to an AWARE-UTC datetime; None on failure.
+
+    Accepts ``Z``-suffix, explicit-offset, and naive forms (naive is assumed
+    UTC — the project's marker rows are written in UTC). Returns None for a
+    missing / non-string / unparseable value so callers can skip-and-count.
+    """
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    text = raw.strip().rstrip(".,;")
+    try:
+        dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+def _read_frontmatter(text: str) -> dict:
+    """Best-effort YAML frontmatter of a body.md; {} when absent/unparseable."""
+    if not text.startswith("---"):
+        return {}
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {}
+    try:
+        fm = yaml.safe_load(parts[1])
+    except yaml.YAMLError:
+        return {}
+    return fm if isinstance(fm, dict) else {}
+
+
+@dataclass
+class Candidate:
+    """One parked workflow-fix candidate row, normalized across row shapes."""
+
+    source: str
+    ts_raw: str
+    ts: datetime
+    note: str
+    target_file: str | None
+    fingerprint: str | None
+    park_form: str
+    formal_block: bool
+    suppressed: bool = False
+    suppressed_by: dict | None = None
+    open_wf_fix_on_file: int | None = None
+
+    def to_json(self) -> dict:
+        return {
+            "source": self.source,
+            "ts": self.ts_raw,
+            "target_file": self.target_file,
+            "fingerprint": self.fingerprint,
+            "park_form": self.park_form,
+            "formal_block": self.formal_block,
+            "note": self.note,
+            "suppressed": self.suppressed,
+            "suppressed_by": self.suppressed_by,
+            "open_wf_fix_on_file": self.open_wf_fix_on_file,
+        }
+
+
+def _row_kind(row: dict) -> str:
+    """The row's marker kind under EITHER key ('kind' events.jsonl / 'marker' cache rows).
+
+    None-guarded: 43 of the live cache file's 88 rows lack a 'kind' key (some
+    carry 'marker', some neither) — a bare row['kind'] would crash the scan.
+    """
+    return str(row.get("kind") or row.get("marker") or "")
+
+
+def _row_is_parked(row: dict) -> bool:
+    """Parked-ness from EITHER surface: the note text or a structured 'routed' field."""
+    note = str(row.get("note") or "")
+    if _PARKED_LEAD_RE.match(note) or _PARKED_ROUTED_RE.search(note):
+        return True
+    routed = row.get("routed")
+    return isinstance(routed, str) and "parked" in routed.lower()
+
+
+def _park_form(row: dict) -> str:
+    surface = f"{row.get('note') or ''}\n{row.get('routed') or ''}"
+    return "architectural" if _ARCHITECTURAL_RE.search(surface) else "recursion-guard"
+
+
+def _extract_fields(row: dict) -> tuple[str | None, str | None, bool]:
+    """(target_file, fingerprint, formal_block) for one candidate row.
+
+    Structured (marker-key) cache rows carry their fields as JSON keys; a
+    note embedding a formal candidate block is parsed verbatim; a prose park
+    gets a best-effort target_file regex and fingerprint None (the /daily LLM
+    synthesizes the fields + fp at route time, per the prose-synthesis rule).
+    """
+    note = str(row.get("note") or "")
+    m = _BLOCK_RE.search(note)
+    if m:
+        block = m.group(1)
+
+        def block_field(name: str) -> str | None:
+            fm = re.search(rf"^{name}:\s*(.+)$", block, re.MULTILINE)
+            return fm.group(1).strip() if fm else None
+
+        target_file = block_field("target_file")
+        proposed = block_field("proposed_change")
+        bug = block_field("bug_observed")
+        fp = wf_fix_fingerprint(proposed, bug) if proposed and bug else None
+        return target_file, fp, True
+    if "note" not in row and ("proposed_change" in row or "target_file" in row):
+        target_file = row.get("target_file") or None
+        proposed, bug = row.get("proposed_change"), row.get("bug_observed")
+        fp = wf_fix_fingerprint(str(proposed), str(bug)) if proposed and bug else None
+        return target_file, fp, False
+    tf_match = _TARGET_FILE_RE.search(note)
+    target_file = tf_match.group(1).rstrip(".,;:!?") if tf_match else None
+    return target_file, None, False
+
+
+def _filed_record_matches(cand: Candidate, record: dict) -> bool:
+    """Does this same-stream filed record close this candidate? (suppression rule 1)."""
+    note = str(record.get("note") or "")
+    if cand.fingerprint is not None:
+        # fp-aware: ONLY the candidate's own fingerprint suppresses; a
+        # file-matching record with a different fp is a DIFFERENT bug.
+        if cand.fingerprint in note:
+            return True
+        return cand.fingerprint in str(record.get("fingerprint") or "")
+    # fp-less (prose park): PRIMARY key = origin_candidate_ts equality.
+    origin_raw = None
+    om = _ORIGIN_TS_RE.search(note)
+    if om:
+        origin_raw = om.group(1)
+    elif record.get("origin_candidate_ts"):
+        origin_raw = str(record["origin_candidate_ts"])
+    if origin_raw is not None:
+        origin_dt = parse_ts(origin_raw)
+        return origin_dt is not None and origin_dt == cand.ts
+    # Legacy record with NO origin_candidate_ts: fall back to target_file match.
+    if not cand.target_file:
+        return False
+    rec_tf = record.get("target_file")
+    if not rec_tf:
+        tm = _TARGET_FILE_RE.search(note)
+        rec_tf = tm.group(1).rstrip(".,;:!?") if tm else None
+    return rec_tf == cand.target_file
+
+
+def _filed_ref(record: dict) -> str:
+    note = str(record.get("note") or "")
+    fm = _FILED_TASK_RE.search(note)
+    if fm:
+        ref = fm.group(1)
+        return ref if ref.startswith("#") else f"#{ref}"
+    filed = record.get("filed_task")
+    if filed:
+        return str(filed) if str(filed).startswith("#") else f"#{filed}"
+    return str(record.get("ts") or "")
+
+
+def _iter_task_bodies(tasks_root: Path):
+    """Yield (task_id, status, body_path, body_text) across every status folder."""
+    for body_path in sorted(tasks_root.glob("*/*/body.md")):
+        status = body_path.parent.parent.name
+        try:
+            tid = int(body_path.parent.name)
+        except ValueError:
+            continue
+        try:
+            text = body_path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        yield tid, status, body_path, text
+
+
+def _task_creation_ts(task_dir: Path) -> datetime | None:
+    """First parseable events.jsonl row ts (the task's creation time); None if unreadable."""
+    events = task_dir / "events.jsonl"
+    try:
+        lines = events.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        dt = parse_ts(row.get("ts"))
+        if dt is not None:
+            return dt
+    return None
+
+
+def _fp_tag_scan(tasks_root: Path, fp: str, cand_ts: datetime) -> dict | None:
+    """Suppression rule 2: an infra task carrying this fp (tag or Provenance line).
+
+    Non-terminal hit -> suppress unconditionally; terminal hit -> suppress only
+    when the task's creation ts POSTdates the candidate (the candidate was
+    subsumed by the fix). An unreadable creation ts fails toward ENUMERATION
+    (treated as a re-raise), never toward a silent drop.
+    """
+    for tid, status, body_path, text in _iter_task_bodies(tasks_root):
+        fm = _read_frontmatter(text)
+        if fm.get("kind") != "infra":
+            continue
+        if f"wf-fix-fp:{fp}" not in text and f"fingerprint: {fp}" not in text:
+            continue
+        if status not in TERMINAL_STATUSES:
+            return {"kind": "fp-tag-open", "ref": f"#{tid}"}
+        created = _task_creation_ts(body_path.parent)
+        if created is not None and created > cand_ts:
+            return {"kind": "fp-tag-closed", "ref": f"#{tid}"}
+    return None
+
+
+def _open_wf_fix_on_file(tasks_root: Path, target_file: str) -> int | None:
+    """Advisory mirror of ``task_workflow.is_open_workflow_fix_task(target_file, None)``.
+
+    Same predicate, keyed on ``tasks_root`` so test fixtures exercise it: kind
+    infra + non-terminal status + ``workflow-fix:`` TITLE PREFIX + a Provenance
+    ``workflow_fix_target: <target_file>`` line. Title-prefix-bound and hence
+    BLIND to ``daily-fix:``-titled open filings — advisory only (see module
+    docstring); the /daily LLM's content dedup is the real check.
+    """
+    for tid, status, _body_path, text in _iter_task_bodies(tasks_root):
+        if status in TERMINAL_STATUSES:
+            continue
+        fm = _read_frontmatter(text)
+        if fm.get("kind") != "infra":
+            continue
+        if not str(fm.get("title") or "").startswith("workflow-fix:"):
+            continue
+        if f"workflow_fix_target: {target_file}" in text:
+            return tid
+    return None
+
+
+def _load_stream(path: Path, source: str) -> tuple[list[tuple[dict, datetime, str]], int]:
+    """Parse one JSONL stream into relevant (row, ts, raw_ts) tuples, row-deduped.
+
+    Only candidate/filed-kind rows are kept (others are irrelevant, not
+    malformed). Returns (rows, skipped) where skipped counts unparseable JSON
+    lines and relevant rows with a missing/unparseable ts.
+    """
+    skipped = 0
+    rows: list[tuple[dict, datetime, str]] = []
+    seen: set[tuple[str, str, str]] = set()
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return rows, skipped
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            skipped += 1
+            continue
+        if not isinstance(row, dict):
+            skipped += 1
+            continue
+        kind = _row_kind(row)
+        if not (kind.startswith(CANDIDATE_KIND_PREFIX) or kind.startswith(FILED_KIND_PREFIX)):
+            continue
+        ts_raw = str(row.get("ts") or "")
+        ts = parse_ts(ts_raw)
+        if ts is None:
+            skipped += 1
+            continue
+        content = str(row.get("note") or "") or json.dumps(row, sort_keys=True)
+        dedup_key = (source, ts_raw, hashlib.sha256(content.encode()).hexdigest())
+        if dedup_key in seen:
+            continue
+        seen.add(dedup_key)
+        rows.append((row, ts, ts_raw))
+    return rows, skipped
+
+
+def sweep(
+    tasks_root: Path,
+    cache_file: Path | None,
+    window_days: int = 0,
+    include_routed: bool = False,
+) -> dict:
+    """Enumerate parked, unrouted workflow-fix candidates across all streams."""
+    streams: list[tuple[str, Path]] = []
+    for events in sorted(tasks_root.glob("*/*/events.jsonl")):
+        streams.append((f"task:{events.parent.name}", events))
+    if cache_file is not None and cache_file.exists():
+        streams.append(("cache", cache_file))
+
+    skipped_rows = 0
+    candidates: list[Candidate] = []
+    now = datetime.now(UTC)
+    cutoff = now - timedelta(days=window_days) if window_days > 0 else None
+
+    for source, path in streams:
+        rows, skipped = _load_stream(path, source)
+        skipped_rows += skipped
+        filed = [(r, ts) for r, ts, _raw in rows if _row_kind(r).startswith(FILED_KIND_PREFIX)]
+        for row, ts, ts_raw in rows:
+            if not _row_kind(row).startswith(CANDIDATE_KIND_PREFIX):
+                continue
+            if not _row_is_parked(row):
+                continue
+            if cutoff is not None and ts < cutoff:
+                continue
+            target_file, fingerprint, formal_block = _extract_fields(row)
+            note = str(row.get("note") or "") or json.dumps(row, sort_keys=True)
+            cand = Candidate(
+                source=source,
+                ts_raw=ts_raw,
+                ts=ts,
+                note=note,
+                target_file=target_file,
+                fingerprint=fingerprint,
+                park_form=_park_form(row),
+                formal_block=formal_block,
+            )
+            for record, record_ts in filed:
+                if record_ts > cand.ts and _filed_record_matches(cand, record):
+                    cand.suppressed = True
+                    cand.suppressed_by = {"kind": "same-stream-filed", "ref": _filed_ref(record)}
+                    break
+            if not cand.suppressed and cand.fingerprint is not None:
+                hit = _fp_tag_scan(tasks_root, cand.fingerprint, cand.ts)
+                if hit is not None:
+                    cand.suppressed = True
+                    cand.suppressed_by = hit
+            if cand.target_file:
+                cand.open_wf_fix_on_file = _open_wf_fix_on_file(tasks_root, cand.target_file)
+            candidates.append(cand)
+
+    candidates.sort(key=lambda c: (c.source, c.ts_raw))
+    listed = candidates if include_routed else [c for c in candidates if not c.suppressed]
+    return {
+        "generated_at": now.isoformat(),
+        "window_days": window_days,
+        "skipped_rows": skipped_rows,
+        "candidates": [c.to_json() for c in listed],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint: print the sweep JSON to stdout; exit 0 always."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--window-days",
+        type=int,
+        default=0,
+        help="0 (default) = unbounded; a positive N scopes an audit to the last N days",
+    )
+    parser.add_argument(
+        "--include-routed",
+        action="store_true",
+        help="include suppressed (already-routed) candidates in the output",
+    )
+    parser.add_argument("--tasks-root", type=Path, default=None, help="test override")
+    parser.add_argument("--cache-file", type=Path, default=None, help="test override")
+    args = parser.parse_args(argv)
+
+    if args.tasks_root is not None:
+        tasks_root = args.tasks_root
+        if not tasks_root.is_dir():
+            raise FileNotFoundError(f"--tasks-root does not exist: {tasks_root}")
+    else:
+        tasks_root = tasks_dir()
+
+    if args.cache_file is not None:
+        cache_file: Path | None = args.cache_file
+        if not cache_file.is_file():
+            raise FileNotFoundError(f"--cache-file does not exist: {cache_file}")
+    else:
+        default_cache = repo_root() / ".claude" / "cache" / "workflow-fix-events.jsonl"
+        cache_file = default_cache if default_cache.exists() else None
+
+    result = sweep(
+        tasks_root,
+        cache_file,
+        window_days=args.window_days,
+        include_routed=args.include_routed,
+    )
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sweep_parked_wf_candidates.py
+++ b/tests/test_sweep_parked_wf_candidates.py
@@ -1,0 +1,398 @@
+"""Tests for scripts/sweep_parked_wf_candidates.py — the /daily Step C enumerator.
+
+Exercises the REAL module body (``sweep()`` / ``main(argv)``) against synthetic
+tmp task trees + tmp cache files via the documented ``--tasks-root`` /
+``--cache-file`` overrides (no fakes of production functions; the only fixture
+is the filesystem input, per the #906 body-coverage discipline). The 15-case
+matrix mirrors plan §7 of task #1132.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = REPO_ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import sweep_parked_wf_candidates as spc  # noqa: E402
+
+from explore_persona_space.task_workflow import wf_fix_fingerprint  # noqa: E402
+
+CAND_KIND = "epm:workflow-fix-candidate"
+FILED_KIND = "epm:workflow-fix-task-filed"
+
+T0 = "2026-07-07T07:34:50Z"
+T1 = "2026-07-07T08:00:00Z"
+T2 = "2026-07-07T09:00:00Z"
+
+
+def cand_row(ts: str, note: str, kind: str = CAND_KIND) -> dict:
+    return {"ts": ts, "kind": kind, "version": 1, "by": "unknown", "note": note}
+
+
+def filed_row(ts: str, note: str) -> dict:
+    return {"ts": ts, "kind": FILED_KIND, "version": 1, "by": "unknown", "note": note}
+
+
+def block_note(target_file: str, bug: str, change: str) -> str:
+    """A recursion-guard park note embedding a formal candidate block (#1101 shape)."""
+    return (
+        "parked — running under EPM_WORKFLOW_FIX_SESSION / workflow_fix_target, "
+        "see workflow-fix-on-bug.md § Recursion guard.\n\n"
+        "<!-- workflow-fix-candidate v1 -->\n"
+        f"target_file: {target_file}\n"
+        f"bug_observed: {bug}\n"
+        "why_workflow_gap: the workflow surface lacks the guardrail\n"
+        f"proposed_change: {change}\n"
+        "diff_sketch: |\n  + add the guardrail\n"
+        "confidence: medium\n"
+        "related_task: #999\n"
+        "<!-- /workflow-fix-candidate -->\n"
+    )
+
+
+PROSE_NOTE = (
+    "parked — running under workflow_fix_target recursion guard (see "
+    ".claude/rules/workflow-fix-on-bug.md § Recursion guard). Candidate surfaced by the "
+    "reconciler: the wrapper discards success-stderr. Proposed change: forward it. "
+    "target_file: scripts/codex_task.py. confidence: medium. related_task: #1100. "
+    "NOT auto-filed (recursion guard); next human/orchestrator pass routes it."
+)
+
+
+def make_task(
+    root: Path,
+    tid: int,
+    status: str,
+    *,
+    kind: str = "infra",
+    title: str = "some task",
+    body_extra: str = "",
+    events: list[dict] | tuple = (),
+    raw_event_lines: list[str] | tuple = (),
+) -> Path:
+    """Write a minimal tasks/<status>/<tid>/ fixture (body.md + events.jsonl)."""
+    d = root / status / str(tid)
+    d.mkdir(parents=True)
+    fm = yaml.safe_dump({"kind": kind, "title": title}, sort_keys=False)
+    (d / "body.md").write_text(f"---\n{fm}---\n\n## Overview\n\n{body_extra}\n", encoding="utf-8")
+    lines = [json.dumps(r) for r in events]
+    lines.extend(raw_event_lines)
+    (d / "events.jsonl").write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    return d
+
+
+def run_sweep(root: Path, cache: Path | None = None, **kw) -> dict:
+    return spc.sweep(root, cache, **kw)
+
+
+def only(result: dict) -> dict:
+    assert len(result["candidates"]) == 1, result["candidates"]
+    return result["candidates"][0]
+
+
+# ── 1. formal-block park → enumerated with computed fp ─────────────────────
+
+
+def test_formal_block_park_enumerated_with_fp(tmp_path: Path) -> None:
+    bug = "The sweep mined the claim but not its correction."
+    change = "Scan subsequent events for a retraction before filing."
+    make_task(
+        tmp_path,
+        1101,
+        "archived",
+        events=[cand_row(T0, block_note(".claude/skills/daily/SKILL.md", bug, change))],
+    )
+    c = only(run_sweep(tmp_path))
+    assert c["source"] == "task:1101"
+    assert c["formal_block"] is True
+    assert c["target_file"] == ".claude/skills/daily/SKILL.md"
+    assert c["fingerprint"] == wf_fix_fingerprint(change, bug)
+    assert c["park_form"] == "recursion-guard"
+    assert c["suppressed"] is False
+
+
+# ── 2. prose park (#1100 shape) → fp null, target_file parsed (+ advisory) ─
+
+
+def test_prose_park_enumerated_fp_null_target_parsed(tmp_path: Path) -> None:
+    make_task(tmp_path, 1100, "completed", events=[cand_row(T0, PROSE_NOTE)])
+    make_task(
+        tmp_path,
+        50,
+        "running",
+        title="workflow-fix: forward success-stderr",
+        body_extra="## Provenance\n\n- workflow_fix_target: scripts/codex_task.py\n",
+        events=[{"ts": T1, "kind": "epm:created", "note": "x"}],
+    )
+    c = only(run_sweep(tmp_path))
+    assert c["fingerprint"] is None
+    assert c["formal_block"] is False
+    # trailing punctuation stripped from the prose regex capture
+    assert c["target_file"] == "scripts/codex_task.py"
+    # the title-prefix-bound advisory sees the open workflow-fix: task
+    assert c["open_wf_fix_on_file"] == 50
+
+
+# ── 3. later same-stream filed record with MATCHING fp → suppressed ────────
+
+
+def test_same_stream_filed_with_matching_fp_suppresses(tmp_path: Path) -> None:
+    bug, change = "bug one.", "change one."
+    fp = wf_fix_fingerprint(change, bug)
+    make_task(
+        tmp_path,
+        7,
+        "completed",
+        events=[
+            cand_row(T0, block_note("a/b.md", bug, change)),
+            filed_row(T1, f"filed_task: #1131 / target_file: a/b.md / fingerprint: {fp}"),
+        ],
+    )
+    assert run_sweep(tmp_path)["candidates"] == []
+    c = only(run_sweep(tmp_path, include_routed=True))
+    assert c["suppressed"] is True
+    assert c["suppressed_by"] == {"kind": "same-stream-filed", "ref": "#1131"}
+
+
+# ── 4. fp-less candidate + legacy record (no origin ts) → target_file match ─
+
+
+def test_fp_less_candidate_suppressed_by_target_file_only_record(tmp_path: Path) -> None:
+    make_task(
+        tmp_path,
+        8,
+        "completed",
+        events=[
+            cand_row(T0, PROSE_NOTE),
+            filed_row(T1, "filed_task: #1130 / target_file: scripts/codex_task.py"),
+        ],
+    )
+    assert run_sweep(tmp_path)["candidates"] == []
+    c = only(run_sweep(tmp_path, include_routed=True))
+    assert c["suppressed_by"]["kind"] == "same-stream-filed"
+
+
+# ── 5. open infra task with wf-fix-fp tag in body → suppressed ─────────────
+
+
+def test_open_infra_task_with_fp_tag_suppresses(tmp_path: Path) -> None:
+    bug, change = "bug two.", "change two."
+    fp = wf_fix_fingerprint(change, bug)
+    make_task(tmp_path, 9, "archived", events=[cand_row(T0, block_note("a/b.md", bug, change))])
+    make_task(tmp_path, 60, "running", body_extra=f"tags carry wf-fix-fp:{fp} here")
+    assert run_sweep(tmp_path)["candidates"] == []
+    c = only(run_sweep(tmp_path, include_routed=True))
+    assert c["suppressed_by"] == {"kind": "fp-tag-open", "ref": "#60"}
+
+
+# ── 6. terminal fp-tag task: created AFTER → suppressed; BEFORE → not ───────
+
+
+def test_terminal_fp_task_created_after_candidate_suppresses(tmp_path: Path) -> None:
+    bug, change = "bug three.", "change three."
+    fp = wf_fix_fingerprint(change, bug)
+    make_task(tmp_path, 10, "archived", events=[cand_row(T0, block_note("a/b.md", bug, change))])
+    make_task(
+        tmp_path,
+        61,
+        "completed",
+        body_extra=f"- fingerprint: {fp}\n",
+        events=[{"ts": T2, "kind": "epm:created", "note": "created after the park"}],
+    )
+    c = only(run_sweep(tmp_path, include_routed=True))
+    assert c["suppressed_by"] == {"kind": "fp-tag-closed", "ref": "#61"}
+
+
+def test_terminal_fp_task_created_before_candidate_is_re_raise(tmp_path: Path) -> None:
+    bug, change = "bug four.", "change four."
+    fp = wf_fix_fingerprint(change, bug)
+    make_task(tmp_path, 11, "archived", events=[cand_row(T2, block_note("a/b.md", bug, change))])
+    make_task(
+        tmp_path,
+        62,
+        "completed",
+        body_extra=f"- fingerprint: {fp}\n",
+        events=[{"ts": T0, "kind": "epm:created", "note": "created before the park"}],
+    )
+    c = only(run_sweep(tmp_path))
+    assert c["suppressed"] is False
+
+
+# ── 7. window filter: excluded at --window-days 2, included at 0 ────────────
+
+
+def test_window_filter_excludes_old_candidate(tmp_path: Path) -> None:
+    old_ts = "2026-01-01T00:00:00Z"
+    make_task(tmp_path, 12, "completed", events=[cand_row(old_ts, PROSE_NOTE)])
+    assert run_sweep(tmp_path, window_days=2)["candidates"] == []
+    assert len(run_sweep(tmp_path, window_days=0)["candidates"]) == 1
+
+
+# ── 8. non-park routed candidate + mid-note "parked" → NOT enumerated ──────
+
+
+def test_non_park_and_mid_note_parked_not_enumerated(tmp_path: Path) -> None:
+    make_task(
+        tmp_path,
+        13,
+        "running",
+        events=[
+            cand_row(T0, "routed: filed #123 — target_file: a/b.md"),
+            cand_row(T1, "routing note: stopped-on-parked-task cleanup ran; nothing parked here"),
+        ],
+    )
+    assert run_sweep(tmp_path, include_routed=True)["candidates"] == []
+
+
+# ── 9. identical duplicate rows dedupe to one (#1100 duplication) ───────────
+
+
+def test_duplicate_rows_dedupe_to_one(tmp_path: Path) -> None:
+    row = cand_row(T0, PROSE_NOTE)
+    make_task(tmp_path, 1100, "completed", events=[row, row])
+    assert len(run_sweep(tmp_path)["candidates"]) == 1
+
+
+# ── 10. cache-file park enumerated; cache-file filed row suppresses ─────────
+
+
+def test_cache_file_park_and_filed_suppression(tmp_path: Path) -> None:
+    root = tmp_path / "tasks"
+    root.mkdir()
+    cache = tmp_path / "workflow-fix-events.jsonl"
+    bug, change = "cache bug.", "cache change."
+    fp = wf_fix_fingerprint(change, bug)
+    cache.write_text(json.dumps(cand_row(T0, block_note("c/d.md", bug, change))) + "\n")
+    c = only(run_sweep(root, cache))
+    assert c["source"] == "cache"
+    assert c["fingerprint"] == fp
+    with cache.open("a") as fh:
+        fh.write(json.dumps(filed_row(T1, f"filed_task: #77 / fingerprint: {fp}")) + "\n")
+    assert run_sweep(root, cache)["candidates"] == []
+
+
+# ── 11. heterogeneous cache rows: kind-less, marker-key parked / filed ──────
+
+
+def test_heterogeneous_cache_rows(tmp_path: Path) -> None:
+    root = tmp_path / "tasks"
+    root.mkdir()
+    cache = tmp_path / "workflow-fix-events.jsonl"
+    rows = [
+        # kind-less row (no 'kind'/'marker' key) — must not crash the scan
+        {"ts": T0, "note": "misc row about a parked pod, no kind key"},
+        # marker-key STRUCTURED candidate, routed contains 'parked' → enumerated
+        {
+            "ts": T1,
+            "marker": "epm:workflow-fix-candidate v1",
+            "target_file": "e/f.md",
+            "proposed_change": "structured change.",
+            "bug_observed": "structured bug.",
+            "routed": "parked: EPM_WORKFLOW_FIX_SESSION",
+            "source": "candidate-block",
+        },
+        # marker-key structured candidate already routed → NOT enumerated
+        {
+            "ts": T2,
+            "marker": "epm:workflow-fix-candidate v1",
+            "target_file": "g/h.md",
+            "proposed_change": "other change.",
+            "bug_observed": "other bug.",
+            "routed": "filed #456",
+            "source": "candidate-block",
+        },
+    ]
+    cache.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    result = run_sweep(root, cache, include_routed=True)
+    c = only(result)
+    assert c["target_file"] == "e/f.md"
+    assert c["fingerprint"] == wf_fix_fingerprint("structured change.", "structured bug.")
+    assert c["formal_block"] is False
+    assert result["skipped_rows"] == 0
+
+
+# ── 12. fp mismatch: file-matching record with a DIFFERENT fp ≠ suppression ─
+
+
+def test_fp_mismatch_record_does_not_suppress(tmp_path: Path) -> None:
+    bug, change = "bug five.", "change five."
+    other_fp = wf_fix_fingerprint("unrelated change.", "unrelated bug.")
+    make_task(
+        tmp_path,
+        14,
+        "completed",
+        events=[
+            cand_row(T0, block_note("a/b.md", bug, change)),
+            filed_row(T1, f"filed_task: #90 / target_file: a/b.md / fingerprint: {other_fp}"),
+        ],
+    )
+    c = only(run_sweep(tmp_path))
+    assert c["suppressed"] is False
+
+
+# ── 13. two distinct fp-less parks, same file: ts-keyed record hits ONLY A ──
+
+
+def test_ts_keyed_record_suppresses_only_matching_fp_less_park(tmp_path: Path) -> None:
+    park_a = cand_row(T0, PROSE_NOTE)
+    park_b = cand_row(T1, PROSE_NOTE.replace("forward it", "a DISTINCT second bug"))
+    record = filed_row(
+        T2,
+        "filed_task: #91 / target_file: scripts/codex_task.py / "
+        f"fingerprint: n/a (prose park) / origin_candidate_ts: {T0}",
+    )
+    make_task(tmp_path, 15, "completed", events=[park_a, park_b, record])
+    result = run_sweep(tmp_path, include_routed=True)
+    by_ts = {c["ts"]: c for c in result["candidates"]}
+    assert by_ts[T0]["suppressed"] is True
+    assert by_ts[T1]["suppressed"] is False
+
+
+# ── 14. mixed ts formats compare under aware-UTC, not string order ──────────
+
+
+def test_mixed_ts_formats_aware_utc_ordering(tmp_path: Path) -> None:
+    bug, change = "bug six.", "change six."
+    fp = wf_fix_fingerprint(change, bug)
+    # candidate at 09:00 -07:00 == 16:00Z; the filed record at 10:00Z is
+    # EARLIER in UTC (string comparison would misorder it as later) → no
+    # suppression; a second record at 17:00Z IS later → suppression.
+    cand = cand_row("2026-07-07T09:00:00-07:00", block_note("a/b.md", bug, change))
+    early = filed_row("2026-07-07T10:00:00Z", f"filed_task: #92 / fingerprint: {fp}")
+    make_task(tmp_path, 16, "completed", events=[cand, early])
+    assert only(run_sweep(tmp_path))["suppressed"] is False
+
+    late = filed_row("2026-07-07T17:00:00Z", f"filed_task: #93 / fingerprint: {fp}")
+    make_task(tmp_path / "b", 17, "completed", events=[cand, early, late])
+    c = only(run_sweep(tmp_path / "b", include_routed=True))
+    assert c["suppressed"] is True
+
+
+# ── 15. malformed rows: skipped + counted, CLI exit 0 ───────────────────────
+
+
+def test_malformed_rows_skipped_counted_exit_0(tmp_path: Path, capsys) -> None:
+    root = tmp_path / "tasks"
+    make_task(
+        root,
+        18,
+        "running",
+        events=[cand_row(T0, PROSE_NOTE), {"kind": CAND_KIND, "note": "parked — but no ts"}],
+        raw_event_lines=["{this is not json"],
+    )
+    cache = tmp_path / "cache.jsonl"
+    cache.write_text("also not json\n")
+    rc = spc.main(["--tasks-root", str(root), "--cache-file", str(cache)])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    # 1 corrupt task line + 1 ts-less candidate row + 1 corrupt cache line
+    assert out["skipped_rows"] == 3
+    assert len(out["candidates"]) == 1
+    assert out["candidates"][0]["ts"] == T0

--- a/tests/test_sweep_parked_wf_candidates.py
+++ b/tests/test_sweep_parked_wf_candidates.py
@@ -396,3 +396,38 @@ def test_malformed_rows_skipped_counted_exit_0(tmp_path: Path, capsys) -> None:
     assert out["skipped_rows"] == 3
     assert len(out["candidates"]) == 1
     assert out["candidates"][0]["ts"] == T0
+
+
+# ── 16. raw U+2028 inside a note must not shred the JSONL row (#950 gotcha) ─
+
+
+def test_u2028_note_parses_as_one_row_enumerates_and_suppresses(tmp_path: Path) -> None:
+    """A VALID JSONL row whose note carries a literal U+2028 (as marker notes
+    written with ensure_ascii=False do — two live rows in tasks/completed/1032)
+    must (a) parse as ONE row, (b) enumerate the parked candidate, and
+    (c) leave skipped_rows at 0. splitlines() shredded it pre-fix."""
+    sep = "\u2028"  # LINE SEPARATOR, escape form so no invisible char lives in source
+    bug, change = "bug with separator prose.", "change with separator prose."
+    fp = wf_fix_fingerprint(change, bug)
+    note = block_note("a/b.md", bug, change).replace(
+        "see workflow-fix-on-bug.md", f"see{sep}workflow-fix-on-bug.md"
+    )
+    raw = json.dumps(cand_row(T0, note), ensure_ascii=False)
+    assert sep in raw and "\n" not in raw  # one physical line carrying a literal U+2028
+    make_task(tmp_path, 19, "completed", raw_event_lines=[raw])
+    result = run_sweep(tmp_path)
+    assert result["skipped_rows"] == 0
+    c = only(result)
+    assert c["suppressed"] is False
+    assert c["fingerprint"] == fp
+
+    # Twin: a U+2028-bearing FILED record still suppresses (rule 1) — a shredded
+    # filed record would otherwise let the candidate re-enumerate (double-file).
+    filed_note = f"routing{sep}record / filed_task: #94 / fingerprint: {fp}"
+    filed_raw = json.dumps(filed_row(T1, filed_note), ensure_ascii=False)
+    assert sep in filed_raw
+    make_task(tmp_path / "b", 20, "completed", raw_event_lines=[raw, filed_raw])
+    result_b = run_sweep(tmp_path / "b", include_routed=True)
+    assert result_b["skipped_rows"] == 0
+    c_b = only(result_b)
+    assert c_b["suppressed"] is True


### PR DESCRIPTION
Closes task #1132. New /daily Step C pass + scripts/sweep_parked_wf_candidates.py enumerator + 17 tests + workflow-fix-on-bug.md cross-edits. Code-review v2 PASS; Step 9c test-verdict PASS.