### PR TITLE
workflow-fix #1137: suppress repeat/noise stalled-session alerts

### DIFF
--- a/.claude/rules/background-automation.md
+++ b/.claude/rules/background-automation.md
@@ -175,7 +175,8 @@ triage-observer pass, and three session reapers — the session-vs-status
 reconcile pass, the zombie-wrapper pass, and the idle-unmapped pass.
 
 **Stall-detection hardening (#845; the five 2026-07-01 incident classes).**
-The stalled detector + the two respawn arms carry five hardening mechanisms:
+The stalled detector + the two respawn arms carry six hardening mechanisms
+(five from #845, the sixth from #1137):
 
 - *(a-i) Marker-heartbeat window.* Signal 2 (the newest non-watcher marker)
   has its OWN 2h freshness window (`EPM_STALLED_MARKER_HEARTBEAT_MIN`,
@@ -284,6 +285,26 @@ The stalled detector + the two respawn arms carry five hardening mechanisms:
   skipped them; a firing exemption vetoes the wedge), the worktree hold,
   or the fence; a wedge respawn resets `live_consecutive`. Unresolvable
   transcripts fail toward no-wedge.
+- *(f) Alert-noise dedup (#1137).* At most ONE `session-stalled-alert`
+  marker per staleness episode, across BOTH producers (decide()'s own
+  alert path and the #759 K-downgrade lane, which bypasses decide()'s
+  alerted-dedup by rewriting respawn->alert after it) — cleared on
+  self-report advancement; repeat ticks keep the stderr line + the
+  stalled-live sidecar row. And a `blocked` task whose newest
+  status-changed is corroborated by an epm:failure within the park
+  window (the halt-contract trail) is never stalled-alerted at all —
+  the gate-push pass already pushed the blocked transition (a no-trail
+  blocked task keeps the one-time alert). Accepted residual: a
+  capacity-retry-eligible `no_compute_available` blocked task carries
+  the halt trail by definition, so a re-driven session that wedges
+  before leaving `blocked` gets no stalled alert — the crash-recovery /
+  wedge / stale-registration lanes own that class. Incident #1092
+  2026-07-07: 15:33Z alert on a 1s-apart failure+blocked park;
+  20:43/21:03/21:23Z repeat alerts from the escalate→wt-hold-defer→
+  downgrade 2-tick cycle (the criterion-7 reset after a DEFERRED
+  escalation is by design — changing it would change respawn timing;
+  only the marker noise was removed). Respawn/fence/hold semantics
+  byte-identical.
 
 Per-episode state for all five rides `stalled-<N>.json`
 (`stop_pending_sid`/`stop_pending_ts`/`stop_retried`/`stop_failed_alerted`,

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -96,7 +96,11 @@ GC pass:
    reachable/unreachable daemon flap can repeatedly reset the
    K-corroboration ``live_consecutive`` counter and defer escalation,
    bounded in practice by the #845 (c) page after 2 blocked ticks plus
-   the persistent staleness re-fire.
+   the persistent staleness re-fire.  At most one stalled-alert marker
+   is posted per staleness episode across both alert producers (decide's
+   own alert path and the #759 downgrade lane), and a deliberately-parked
+   ``blocked`` task (epm:failure + status-changed halt-contract trail) is
+   never alerted (#1137).
 5. **Orphan sweep (registration-INDEPENDENT safety net).** Every other
    session pass starts from the registry files (``issue-<N>.json`` /
    ``manual-issue-<N>.json``), so an ACTIVE-status task with NO registration
@@ -9657,6 +9661,15 @@ def _apply_stalled_live_corroboration(
         return "alert", live_consecutive, note
     # Kth consecutive live stall — escalate to the canonical respawn arm and
     # reset the counter (a fresh --auto session begins a new episode).
+    # #1137 criterion-7 x wt-hold interplay (BY DESIGN, do not "fix"): when
+    # the escalated respawn is subsequently DEFERRED by the #845 (b) worktree
+    # hold / spawn grace, the counter reset below has already been persisted,
+    # so the NEXT tick is a fresh "1/K" downgrade — deliberate: preserving
+    # the count across a deferral would make the first post-hold tick respawn
+    # immediately, a respawn-timing change. The repeat-ALERT marker noise the
+    # resulting escalate/defer/downgrade cycle produced (#1092, 2026-07-07)
+    # is fixed at the marker-post site (_handle_stalled_alert's episode-total
+    # dedup), never here.
     print(
         f"  issue #{issue}: LIVE-SESSION ESCALATION — Happy id is in live_ids "
         f"but it has stalled across {live_consecutive} consecutive episodes "

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -1188,6 +1188,16 @@ def _stalled_marker_window_s() -> float:
         return float(STALLED_MARKER_WINDOW_S_DEFAULT)
 
 
+# #1137: window for the halt-contract trail behind a deliberate `blocked`
+# park — an `epm:failure` marker within this many seconds BEFORE (or
+# _BLOCKED_PARK_FAILURE_SLACK_AFTER_S after) the newest `epm:status-changed`.
+# The canonical halt sequence posts them ~1s apart (#1092: 13:21:34Z failure,
+# 13:21:35Z status-changed); 1h absorbs slow orchestrator paths (a
+# poller-posted failure classified minutes before the park).
+_BLOCKED_PARK_FAILURE_WINDOW_S = 3600.0
+_BLOCKED_PARK_FAILURE_SLACK_AFTER_S = 300.0
+
+
 # #845 (b): worktree-activity hold. A file under the issue's worktree edited
 # within this window is direct evidence an implementer/analyzer subagent is
 # mid-edit (incident #812: the killed session had edited a file 57s before the
@@ -8276,6 +8286,44 @@ def _spend_approval_skip_already_noted(events: list[dict]) -> bool:
     return False
 
 
+def _deliberate_blocked_park_reason(events: list[dict]) -> str | None:
+    """Reason string when the newest ``epm:status-changed`` is corroborated by
+    the halt-contract trail — an ``epm:failure`` marker within
+    [:data:`_BLOCKED_PARK_FAILURE_WINDOW_S` before,
+    :data:`_BLOCKED_PARK_FAILURE_SLACK_AFTER_S` after] it — i.e. the block is
+    a deliberate park (post epm:failure, set status blocked, exit: the
+    CLAUDE.md halt contract), not an unexplained freeze (#1137; #1092's
+    15:33Z alert fired 2h12m after a 1s-apart failure+blocked pair). Pure
+    over the already-loaded ``events``; the CALLER gates on ``task_status ==
+    "blocked"`` (only there is the newest status-changed the transition into
+    blocked). Fail direction: unparseable ts / no trail -> ``None`` (the
+    one-time alert still fires)."""
+    sc_ts: float | None = None
+    for ev in events:
+        if ev.get("kind") == "epm:status-changed":
+            ts = _parse_event_ts(ev.get("ts"))
+            if ts is not None and (sc_ts is None or ts > sc_ts):
+                sc_ts = ts
+    if sc_ts is None:
+        return None
+    lo = sc_ts - _BLOCKED_PARK_FAILURE_WINDOW_S
+    hi = sc_ts + _BLOCKED_PARK_FAILURE_SLACK_AFTER_S
+    for ev in events:
+        if ev.get("kind") != "epm:failure":
+            continue
+        ts = _parse_event_ts(ev.get("ts"))
+        if ts is None:
+            continue
+        if lo <= ts <= hi:
+            return (
+                "deliberately parked at status=blocked (halt-contract trail: "
+                "epm:failure within the park window of the newest "
+                "epm:status-changed); the gate-push pass already notified the "
+                "blocked transition"
+            )
+    return None
+
+
 # Anchored, case-SENSITIVE prefix of a prose user-pause hold note (incident
 # #816). All four observed hold variants (the canonical SKILL.md durable-park
 # note, the #816 incident note, the older #919 sketch, the #920 chat note)
@@ -9404,9 +9452,9 @@ def _apply_stalled_followups_exemption(
 ) -> tuple[str, int, bool]:
     """Check the alive-but-stalled exemptions for the stalled-detector pass
     (the prose USER-PAUSE hold, the over-cap spend-approval park, the
-    round-complete re-park, and the
-    followups_running-parent-waiting-on-open-child suppression); rewrite
-    ``(action, new_missed, followups_child_alerted)`` accordingly.
+    deliberate-blocked-park suppression (#1137), the round-complete re-park,
+    and the followups_running-parent-waiting-on-open-child suppression);
+    rewrite ``(action, new_missed, followups_child_alerted)`` accordingly.
 
     No-op unless ``action != "keep" or new_missed > 0`` (so the healthy-
     session hot path never pays the ``task.py list-children`` subprocess).
@@ -9468,6 +9516,23 @@ def _apply_stalled_followups_exemption(
                 label="spend-approval-skip",
             )
         return "keep", 0, followups_child_alerted
+    # Deliberate blocked park (#1137): the halt contract posts epm:failure
+    # then sets status blocked — a stalled SESSION on such a task is the
+    # EXPECTED post-park shape (the session parked and went idle by design),
+    # and the gate-push pass already phone-pushed the blocked transition.
+    # Suppress the alert (print-only, no marker: the epm:failure marker
+    # itself carries the user ask). A blocked task with NO failure trail
+    # (hand-moved / unexplained) keeps the one-time alert. #1092 15:33Z:
+    # alert fired 2h12m after a 1s-apart failure+blocked park.
+    if status == "blocked":
+        blocked_reason = _deliberate_blocked_park_reason(events)
+        if blocked_reason is not None:
+            print(
+                f"  issue #{issue}: ALIVE-BUT-STALLED exemption — {blocked_reason}; "
+                f"treating session as parked this tick (would have been "
+                f"action={action})."
+            )
+            return "keep", 0, followups_child_alerted
     # Round-complete re-park (incident #533 freeze, 2026-06-11→12): a
     # COMPLETED same-issue follow-up round stranded at followups_running
     # (session died after the final gate, before the designed re-park) is
@@ -9784,7 +9849,8 @@ def _apply_stalled_park_exemptions(
        parent parked at step 10 awaiting a user-gated child cannot be
        unblocked by respawning the parent — see
        :func:`_apply_stalled_followups_exemption` (which also carries the
-       spend-approval park and the round-complete re-park).
+       spend-approval park, the deliberate-blocked-park suppression
+       (#1137), and the round-complete re-park).
     """
     exempted = False
     if action != "keep" or new_missed > 0:

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -9337,6 +9337,25 @@ def _handle_stalled_alert(ctx: _StalledActionCtx) -> None:
         # stays stalled past that gets re-tried in the next episode.
         new_refresh_attempted = True
 
+    # #1137 one alert marker per staleness episode TOTAL, across BOTH alert
+    # producers. decide_session_stalled's alerted=True dedup covers only its
+    # own keep branch; the #759 downgrade lane rewrites respawn->alert AFTER
+    # decide() and reached this handler every eligible tick — on #1092
+    # (2026-07-07) the escalate/wt-hold-defer/downgrade 2-tick cycle posted a
+    # fresh marker every 20 min on a healthy session (20:43Z/21:03Z/21:23Z).
+    # An already-alerted episode keeps the stderr line, the downgrade lane's
+    # stalled-live sidecar row, and the state persist — only the marker post
+    # is suppressed. Cleared on self-report advancement like every other
+    # per-episode flag, so a NEW episode re-alerts.
+    if ctx.alerted:
+        print(
+            f"  issue #{ctx.issue}: repeat stalled-alert marker SUPPRESSED "
+            f"(episode already alerted; cause this tick: {reason})",
+            file=sys.stderr,
+        )
+        _persist_stalled_ctx(ctx, sid, 0, alerted=True, refresh_attempted=new_refresh_attempted)
+        return
+
     if ctx.manual:
         # Manual entries are never liveness-checked by the respawn pass, so
         # the session may be fully dead (the #505 class), not just

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -2510,6 +2510,142 @@ def test_stalled_repeat_alert_refires_on_new_episode(
     assert stops == [] and spawns == []
 
 
+# ─── #1137 fix (B): deliberate-blocked-park alert suppression ─────────────────
+# The CLAUDE.md halt contract posts epm:failure then sets status blocked (1s
+# apart on #1092); a stalled-session alert on that shape duplicates a by-design
+# park the gate-push pass already phone-pushed. A blocked task with NO failure
+# trail (hand-moved / unexplained) keeps the one-time alert (fail-open).
+
+
+def _blocked_park_events(*, with_failure_trail: bool):
+    """Events for the #1092 blocked-park shape. The ts are 1970-era so their
+    age under the fake ``now=1_000_000.0`` (~1970-01-12) is ~11.5 days — far
+    past the 2h STALLED_MARKER_WINDOW_S_DEFAULT (a 2026 ISO ts would read as
+    NEGATIVE-age fresh and the detector would vacuously keep). Both blocked
+    tests share this helper so the no-trail positive control provably runs
+    under the SAME ts scheme as the suppressed trail case."""
+    events = [{"kind": "epm:status-changed", "ts": "1970-01-01T00:00:01Z"}]
+    if with_failure_trail:
+        # 1s BEFORE the status change — the canonical halt-contract pair
+        # (#1092: 13:21:34Z epm:failure, 13:21:35Z status-changed -> blocked).
+        events.insert(0, {"kind": "epm:failure", "ts": "1970-01-01T00:00:00Z"})
+    return events
+
+
+def test_stalled_blocked_deliberate_park_suppresses_alert(
+    isolated_registry, monkeypatch, stalled_recorder
+):
+    # The #1092 15:33Z replay (acceptance 2): status=blocked with the
+    # halt-contract trail, both staleness signals stale -> the deliberate-
+    # blocked-park exemption suppresses the alert entirely (print-only, no
+    # marker — the epm:failure marker itself carries the user ask, and the
+    # gate-push pass already phone-pushed the blocked transition). Pre-#1137
+    # baseline: 1 alert marker on the 2nd miss.
+    import autonomous_session_watch as asw
+
+    stops, spawns, markers = stalled_recorder
+    _write_autonomous_entry(isolated_registry, 1092, "sess-1092", cap=24.0)
+    _patch_stale_signals(monkeypatch, asw, status="blocked")
+    monkeypatch.setattr(
+        asw, "_task_events", lambda issue: _blocked_park_events(with_failure_trail=True)
+    )
+    now = 1_000_000.0
+
+    for _ in range(3):
+        asw.stalled_session_pass(dry_run=False, threshold=2, now=now, daemon_reachable=True)
+    assert markers == []
+    assert stops == [] and spawns == []
+
+
+def test_stalled_blocked_without_failure_trail_still_alerts(
+    isolated_registry, monkeypatch, stalled_recorder
+):
+    # Fail-open positive control (acceptance 3): status=blocked with NO
+    # epm:failure trail (hand-moved / unexplained block) keeps the one-time
+    # alert — exactly ONE marker after 2 misses, then decide()'s own
+    # alerted dedup holds. Same events helper / ts scheme as the suppressed
+    # trail case above.
+    import autonomous_session_watch as asw
+
+    stops, spawns, markers = stalled_recorder
+    _write_autonomous_entry(isolated_registry, 1094, "sess-1094", cap=24.0)
+    _patch_stale_signals(monkeypatch, asw, status="blocked")
+    monkeypatch.setattr(
+        asw, "_task_events", lambda issue: _blocked_park_events(with_failure_trail=False)
+    )
+    now = 1_000_000.0
+
+    for _ in range(3):
+        asw.stalled_session_pass(dry_run=False, threshold=2, now=now, daemon_reachable=True)
+    assert markers == [(1094, "session-stalled-alert")]
+    assert stops == [] and spawns == []
+
+
+def test_deliberate_blocked_park_reason_trail_within_window():
+    # The canonical 1s-apart halt-contract pair -> reason fires.
+    import autonomous_session_watch as asw
+
+    events = [
+        {"kind": "epm:failure", "ts": "1970-01-02T00:00:00Z"},
+        {"kind": "epm:status-changed", "ts": "1970-01-02T00:00:01Z"},
+    ]
+    assert asw._deliberate_blocked_park_reason(events) is not None
+
+
+def test_deliberate_blocked_park_reason_failure_older_than_window():
+    # Failure > 3600s BEFORE the newest status change -> no trail -> None.
+    import autonomous_session_watch as asw
+
+    events = [
+        {"kind": "epm:failure", "ts": "1970-01-01T00:00:00Z"},
+        {"kind": "epm:status-changed", "ts": "1970-01-01T02:00:00Z"},
+    ]
+    assert asw._deliberate_blocked_park_reason(events) is None
+
+
+def test_deliberate_blocked_park_reason_failure_after_slack():
+    # Failure > 300s AFTER the newest status change (order inversion beyond
+    # the slack) -> None.
+    import autonomous_session_watch as asw
+
+    events = [
+        {"kind": "epm:status-changed", "ts": "1970-01-01T00:00:00Z"},
+        {"kind": "epm:failure", "ts": "1970-01-01T00:05:01Z"},
+    ]
+    assert asw._deliberate_blocked_park_reason(events) is None
+
+
+def test_deliberate_blocked_park_reason_unparseable_ts_fails_open():
+    # Unparseable ts on both rows -> None (fail-open: the alert still fires).
+    import autonomous_session_watch as asw
+
+    events = [
+        {"kind": "epm:failure", "ts": "not-a-timestamp"},
+        {"kind": "epm:status-changed", "ts": "also-garbage"},
+    ]
+    assert asw._deliberate_blocked_park_reason(events) is None
+
+
+def test_deliberate_blocked_park_reason_empty_events():
+    import autonomous_session_watch as asw
+
+    assert asw._deliberate_blocked_park_reason([]) is None
+
+
+def test_deliberate_blocked_park_reason_newest_status_change_wins():
+    # The failure trails an OLD status change; the NEWEST status change
+    # (a day later, e.g. a manual re-block) has no failure inside its
+    # window -> None (the trail must corroborate the CURRENT block).
+    import autonomous_session_watch as asw
+
+    events = [
+        {"kind": "epm:failure", "ts": "1970-01-01T00:00:00Z"},
+        {"kind": "epm:status-changed", "ts": "1970-01-01T00:00:01Z"},
+        {"kind": "epm:status-changed", "ts": "1970-01-02T00:00:00Z"},
+    ]
+    assert asw._deliberate_blocked_park_reason(events) is None
+
+
 # ─── #759 bug class b.2: STALLED_WINDOW_S raised 45 -> 60 min, env-tunable ────
 
 

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -2237,12 +2237,15 @@ def test_stalled_live_kth_episode_escalates_to_respawn(
     assert rows[1]["k"] == 2
 
 
-def test_stalled_live_k_equals_3_takes_two_alerts_then_respawn(
+def test_stalled_live_k_equals_3_takes_one_alert_then_respawn(
     isolated_registry, monkeypatch, stalled_recorder
 ):
-    # Criteria 6+7 generalized for K=3: K-1 = 2 downgrade episodes, then the
-    # 3rd escalates. Pins that the escalation tracks the env-tuned K, not a
-    # hardcoded 2.
+    # Criteria 6+7 generalized for K=3: K-1 = 2 downgrade EPISODES (both in
+    # the sidecar), then the 3rd escalates. Pins that the escalation tracks
+    # the env-tuned K, not a hardcoded 2. #1137: only the FIRST downgrade
+    # posts a session-stalled-alert marker — the second downgrade reaches
+    # the alert handler with alerted=True and its marker is suppressed
+    # (marker-only dedup; the counter/sidecar dynamics are unchanged).
     import autonomous_session_watch as asw
 
     stops, spawns, markers = stalled_recorder
@@ -2259,12 +2262,15 @@ def test_stalled_live_k_equals_3_takes_two_alerts_then_respawn(
     assert spawns == [] and markers == [(739, "session-stalled-alert")]
     assert _read_live_consecutive(isolated_registry, 739) == 1
 
-    # Tick 3: alerted=True -> respawn-wanted -> 2nd episode (2 < 3) -> alert again.
+    # Tick 3: alerted=True -> respawn-wanted -> 2nd episode (2 < 3) -> the
+    # downgrade fires again but the repeat alert MARKER is suppressed (#1137
+    # episode-total dedup); the incremented counter still persists (the dedup
+    # is marker-only, never a dynamics change).
     asw.stalled_session_pass(
         dry_run=False, threshold=2, now=now, daemon_reachable=True, live_ids={"sess-739"}
     )
     assert spawns == []
-    assert markers == [(739, "session-stalled-alert"), (739, "session-stalled-alert")]
+    assert markers == [(739, "session-stalled-alert")]
     assert _read_live_consecutive(isolated_registry, 739) == 2
 
     # Tick 4: 3rd (== K) episode -> ESCALATE to respawn, reset to 0. #845
@@ -2357,6 +2363,151 @@ def test_stalled_keep_resets_live_consecutive(isolated_registry, monkeypatch, st
         dry_run=False, threshold=2, now=now, daemon_reachable=True, live_ids={"sess-741"}
     )
     assert _read_live_consecutive(isolated_registry, 741) == 0
+
+
+# ─── #1137: episode-total alert dedup across BOTH alert producers ─────────────
+# decide_session_stalled's alerted=True dedup covers only its own keep branch;
+# the #759 downgrade lane rewrites respawn->alert AFTER decide() and used to
+# post a fresh session-stalled-alert marker every eligible tick. Incident
+# #1092 (2026-07-07): the escalate -> wt-hold-defer -> downgrade 2-tick cycle
+# posted one marker every 20 min, indefinitely, on a healthy session.
+
+
+def _read_stalled_alerted(reg_dir, issue):
+    """Return the persisted ``alerted`` flag from stalled-<issue>.json
+    (``None`` when the state file is absent)."""
+    import json
+
+    path = reg_dir / f"stalled-{issue}.json"
+    if not path.is_file():
+        return None
+    return json.loads(path.read_text()).get("alerted")
+
+
+def test_stalled_live_downgrade_repeat_alert_suppressed_across_wt_held_cycle(
+    isolated_registry, monkeypatch, stalled_recorder
+):
+    # The #1092 2026-07-07 replay (fix A acceptance 1): K=2, LIVE sid, FRESH
+    # worktree activity. Steady-state 2-tick cycle — escalate (criterion-7
+    # reset) -> #845 (b) wt-hold defer -> downgrade 1/2 -> alert — reached
+    # _handle_stalled_alert with alerted=True every other tick. Post-fix:
+    # exactly ONE session-stalled-alert marker for the whole 6-tick episode
+    # (pre-#1137 baseline: 3), zero stops, zero spawns; the sidecar
+    # downgrade/escalation observability and the alerted persist survive.
+    import autonomous_session_watch as asw
+
+    stops, spawns, markers = stalled_recorder
+    monkeypatch.delenv("EPM_STALLED_LIVE_ESCALATION_K", raising=False)  # default K=2
+    _write_autonomous_entry(isolated_registry, 1092, "sess-1092", cap=24.0)
+    _patch_stale_signals(monkeypatch, asw, status="running")
+    # Fresh worktree activity (#1092: P0's file writes kept the worktree
+    # warm) -> every escalated respawn is DEFERRED by the #845 (b) hold,
+    # which persists the already-reset counter -> the next tick is a fresh
+    # 1/2 downgrade. Re-patch AFTER the fixture's default False.
+    monkeypatch.setattr(asw, "_worktree_recent_activity", lambda *_a, **_k: True)
+    now = 1_000_000.0
+
+    for _ in range(6):
+        asw.stalled_session_pass(
+            dry_run=False, threshold=2, now=now, daemon_reachable=True, live_ids={"sess-1092"}
+        )
+
+    assert markers == [(1092, "session-stalled-alert")]  # ONE per episode (was 3)
+    assert stops == []
+    assert spawns == []
+    assert _read_stalled_alerted(isolated_registry, 1092) is True
+    rows = _read_live_escalation_events(isolated_registry)
+    assert [r["event"] for r in rows] == [
+        "stalled-live-downgrade",
+        "stalled-live-escalation",
+        "stalled-live-downgrade",
+        "stalled-live-escalation",
+        "stalled-live-downgrade",
+    ]
+
+
+def test_stalled_repeat_alert_dry_run_no_marker_no_persist(
+    isolated_registry, monkeypatch, stalled_recorder
+):
+    # Fix A dry-run discipline: drive the #1092 replay to the repeat-downgrade
+    # tick with real writes, then run the SUPPRESSED tick under dry_run=True —
+    # the new dedup path posts no marker AND persists nothing (the state file
+    # is unchanged; _persist_stalled_ctx no-ops on dry_run). The recorder's
+    # _post_progress_marker patch records regardless of dry_run, so a marker
+    # post on this tick would be visible.
+    import autonomous_session_watch as asw
+
+    stops, spawns, markers = stalled_recorder
+    monkeypatch.delenv("EPM_STALLED_LIVE_ESCALATION_K", raising=False)  # default K=2
+    _write_autonomous_entry(isolated_registry, 1092, "sess-1092", cap=24.0)
+    _patch_stale_signals(monkeypatch, asw, status="running")
+    monkeypatch.setattr(asw, "_worktree_recent_activity", lambda *_a, **_k: True)
+    now = 1_000_000.0
+
+    # Ticks 1-3 (real): miss, downgrade -> first alert, escalate -> wt-hold.
+    for _ in range(3):
+        asw.stalled_session_pass(
+            dry_run=False, threshold=2, now=now, daemon_reachable=True, live_ids={"sess-1092"}
+        )
+    assert markers == [(1092, "session-stalled-alert")]
+    state_before = (isolated_registry / "stalled-1092.json").read_text()
+
+    # Tick 4 (dry run): the repeat downgrade hits the #1137 dedup branch.
+    asw.stalled_session_pass(
+        dry_run=True, threshold=2, now=now, daemon_reachable=True, live_ids={"sess-1092"}
+    )
+    assert markers == [(1092, "session-stalled-alert")]  # no new marker
+    assert (isolated_registry / "stalled-1092.json").read_text() == state_before
+    assert stops == [] and spawns == []
+
+
+def test_stalled_repeat_alert_refires_on_new_episode(
+    isolated_registry, monkeypatch, stalled_recorder
+):
+    # Fix A is EPISODE-scoped, not permanent silence (acceptance 4): after the
+    # self-report ts ADVANCES (episode over -> alerted cleared) and a new
+    # staleness episode forms, a fresh alert fires again. K is pinned high so
+    # every respawn downgrades to alert (no stop/fence noise in the read).
+    # Episode advancement is a LEXICOGRAPHIC string compare on the raw
+    # self-report ts, so the ts sequence must be lexicographically increasing:
+    # "ts-old" -> "ts-old-2" -> "ts-old-3".
+    import autonomous_session_watch as asw
+
+    stops, spawns, markers = stalled_recorder
+    monkeypatch.setenv("EPM_STALLED_LIVE_ESCALATION_K", "99")
+    _write_autonomous_entry(isolated_registry, 1093, "sess-1093", cap=24.0)
+    _patch_stale_signals(monkeypatch, asw, status="running")
+    now = 1_000_000.0
+    signal = {"age": STALLED_WINDOW_S + 60, "ts": "ts-old"}
+    monkeypatch.setattr(
+        asw, "_self_report_age_seconds", lambda issue, now: (signal["age"], signal["ts"])
+    )
+
+    # Episode 1: miss -> downgrade -> ONE alert; the tick-3 repeat downgrade
+    # is suppressed (pure downgrade-lane shape, no wt hold needed).
+    for _ in range(3):
+        asw.stalled_session_pass(
+            dry_run=False, threshold=2, now=now, daemon_reachable=True, live_ids={"sess-1093"}
+        )
+    assert markers == [(1093, "session-stalled-alert")]
+
+    # Self-report advances + goes fresh: the episode is over, alerted clears.
+    signal["age"] = 60.0
+    signal["ts"] = "ts-old-2"
+    asw.stalled_session_pass(
+        dry_run=False, threshold=2, now=now, daemon_reachable=True, live_ids={"sess-1093"}
+    )
+    assert _read_stalled_alerted(isolated_registry, 1093) is False
+
+    # New staleness episode (a third, newer ts, stale again): re-alerts once.
+    signal["age"] = STALLED_WINDOW_S + 60
+    signal["ts"] = "ts-old-3"
+    for _ in range(3):
+        asw.stalled_session_pass(
+            dry_run=False, threshold=2, now=now, daemon_reachable=True, live_ids={"sess-1093"}
+        )
+    assert markers == [(1093, "session-stalled-alert"), (1093, "session-stalled-alert")]
+    assert stops == [] and spawns == []
 
 
 # ─── #759 bug class b.2: STALLED_WINDOW_S raised 45 -> 60 min, env-tunable ────


### PR DESCRIPTION
Closes task #1137. Fix A: episode-total stalled-alert dedup (the #759 downgrade lane bypassed the alerted dedup). Fix B: deliberate-blocked-park suppression (halt-contract trail). Fix C: docs. Plan: tasks/running/1137/plans/plan.md