### PR TITLE
task #1138: verbatim bare push/merge snippets in /issue SKILL.md

### DIFF
--- a/.claude/agents/experiment-implementer.md
+++ b/.claude/agents/experiment-implementer.md
@@ -689,7 +689,13 @@ such corpora or banks:
    `.claude/rules/code-style.md`
    § One production-body test per seam-stubbed function.
 10. **Commit + push** on branch `issue-<N>`. Use the repo's commit-message
-    convention (`git log --oneline -10` for style).
+    convention (`git log --oneline -10` for style). Run the push BARE with
+    its exit code checked — `git push origin issue-<N>` from the worktree —
+    NEVER piped through `tail`/`grep`/`head`: the `guard_piped_git_push.sh`
+    PreToolUse hook blocks the piped shape, and a pipe masks a rejected
+    push (#957). For a commit message that MENTIONS a piped-push pattern,
+    use the heredoc recipe or `git commit -F <file>` (the hook
+    blanket-allows heredocs).
 11. **Post the report** as `<!-- epm:experiment-implementation v<n> -->` on
     issue #N (see Report Format below). The `/issue` skill reads this marker
     and spawns `code-reviewer`.

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -123,7 +123,7 @@ section wins on invocation form.
 - **Never skip steps.** If a test fails, investigate — don't disable it.
 - **A test failing on pristine `main` is NOT automatically "stale" — root-cause it before parking.** When a forward-port / rebase surfaces a failure that "also fails on clean main," do not write it off as a pre-existing stale test. If the test pins a documented invariant or gotcha (grep `.claude/rules/gotchas.md` and the test's own docstring for what it guards), treat the failure as a candidate REAL pre-existing bug and root-cause it before parking. (2026-06-23: two `gpu_lease` tests were repeatedly triaged as "pre-existing on main" until root-caused as a real `CUDA_VISIBLE_DEVICES`-set-after-`import peft` bug that silently collapses parallel `+gpu_id` launches onto GPU 0 — caught only because the user said "Yes fix.")
 - **Commit messages: follow repo convention.** Check `git log --oneline -10` for style.
-- **ALL code edits on local VM.** Never edit code directly on pods. If pods need the change, commit + push, then experimenter `git pull`s.
+- **ALL code edits on local VM.** Never edit code directly on pods. If pods need the change, commit + push, then experimenter `git pull`s. Push BARE and check the exit code — never piped through `tail`/`grep`/`head` (`guard_piped_git_push.sh` blocks it; a pipe masks a rejected push).
 
 ### Content hygiene for harmful-content data files (EM corpora, refusal-bait, safety-benchmark banks)
 

--- a/.claude/rules/LESSONS.md
+++ b/.claude/rules/LESSONS.md
@@ -32,7 +32,7 @@ update this index (lint: `--check-lessons-index`).
 - **[ood-generalization-folds](ood-generalization-folds.md)** — fires when: a held-out predictive DV (R²/ρ) over grouped samples (require a GROUP-level fold — LOFO/transfer, not pointwise LOO; #810).
 - **[persona-distance-metrics](persona-distance-metrics.md)** — fires when: you write base-model persona-distance predictor code (canonical KL/JS/cosine defs; #404/#458 line).
 - **[persona-vectors-recipe](persona-vectors-recipe.md)** — fires when: a plan elects persona vectors / a mean-difference contrastive direction (reproduce arXiv 2507.21509 EXCEPT logit scoring).
-- **[plan-compute-sizing](plan-compute-sizing.md)** — fires when: a plan sizes §9 compute (HBM capture, merge disk, sentinel lanes, store/IO, VM-CPU RAM/RSS routing, wall-time floors/costing incl. the MEASURED 1-cell pilot basis for per-cell fit loops, p90 fence sizing).
+- **[plan-compute-sizing](plan-compute-sizing.md)** — fires when: a plan sizes §9 compute (HBM capture, merge disk + ladder ckpt retention, sentinel lanes, store/IO, VM-CPU RAM/RSS routing, wall-time floors/costing incl. the MEASURED 1-cell pilot basis for per-cell fit loops, p90 fence sizing).
 - **[planner-section-reference](planner-section-reference.md)** — fires when: the planner writes a plan section (pointer-loaded from planner.md).
 - **[pod-config](pod-config.md)** — fires when: pod SSH/MCP keeps failing or you touch the pod scripts/pods.conf (live-API vs pods.conf authority split).
 - **[pod-side-reporting](pod-side-reporting.md)** — fires when: writing pod-side dispatcher / sentinel / poll_pipeline.py-facing code, or (re)launching ANY detached pod/VM workload (pid-file rewrite contract, #813).

--- a/.claude/rules/critic-lens-reference.md
+++ b/.claude/rules/critic-lens-reference.md
@@ -459,7 +459,27 @@ composer copies the requested lens's items VERBATIM and IN FULL from this file.
     result — a feasibility failure, not a cheaper-variant suggestion (#653 round 4: the
     `select_checkpoint` phase merged a ~15 GB copy per probed dose checkpoint × 12 content cells × 9
     dose ckpts = ~1.6 TB worst case on a 130 GB quota with no cleanup between probes; the run hit
-    the quota and died, the fix was atomic merge-read-delete per probe). Plan-time storage-budget
+    the quota and died, the fix was atomic merge-read-delete per probe).
+    LADDER-RETENTION EXTENSION (#1133, from incident #1112): when the phase is
+    a dose-ladder / multi-rung checkpoint phase (per-rung checkpoints persisted
+    for later selection — dose-to-band grids, band-stop ladders, per-step save
+    grids), ALSO verify §9 states the checkpoint-retention policy (default:
+    keep dose-selected + latest, delete ruled-out rungs between rungs — per
+    `.claude/rules/plan-compute-sizing.md` § Dose-ladder / multi-rung
+    checkpoint retention) and sizes disk to the RETAINED set + in-flight rung.
+    REVISE when the ladder plan's disk estimate assumes keeping every rung on
+    local disk without an explicit justification that (a) says why the rungs
+    must coexist, (b) sizes the FULL ladder at realized per-rung size (weights
+    + optimizer state), and (c) declares the requirement in the launch flags
+    (`--boot-disk-gb`, arming the #1118 thread-or-refuse) — a keep-all bound
+    that merely fits the PLANNED lane's disk is NOT sufficient (#1112: a
+    compliant 575 GB keep-all bound under a planned 750 GB GCP boot disk
+    ENOSPC'd at rung 24/30 when the GCP→RunPod failover delivered the ft-7b
+    default 200 GB volume). The fits-quota escape below does NOT cover ladder
+    phases; the ladder escapes are a stated retention policy + retained-set
+    sizing, the justified keep-all above, or "N/A — no multi-rung checkpoint
+    phase". Upload-before-delete unchanged (declared §10 discard OR
+    upload-first before any between-rung deletion). Plan-time storage-budget
     check only, never a mid-run gate. Not a REVISE when no phase materializes transient
     full-precision artifacts at scale (single merged copy, or merges that fit the quota with
     headroom — the plan's §9 "N/A — no transient full-precision merges" or a bound under quota

--- a/.claude/rules/plan-compute-sizing.md
+++ b/.claude/rules/plan-compute-sizing.md
@@ -1,5 +1,5 @@
 ---
-description: Planner §9 compute-sizing recipes — activation-capture HBM sizing, merge-disk budget, sentinel-signaling lane pins, the floor cross-check for long / many-call phases (planned_wall_h > 4 OR >~500 serial calls), the measured 1-cell fit-pilot basis for per-cell fit / factorization / GD phases (#1060), the store-heavy / IO-heavy phase recipe (measured per-item serialization+upload wall-time; compression-default-OFF for fp16→Xet), the CPU-phase RAM/RSS routing gate (projected peak RSS per VM-placed phase; ≥~16 GB single-or-summed routes off the shared VM), and costing wall-time against the machine the router will ACTUALLY provision + p90-based fence sizing, and the external-stream >~1h presumption for network-bound streaming/harvest phases (#1092) (loads at plan time via plan-file paths; relocated verbatim from planner.md §9, #829)
+description: Planner §9 compute-sizing recipes — activation-capture HBM sizing, merge-disk budget, sentinel-signaling lane pins, the floor cross-check for long / many-call phases (planned_wall_h > 4 OR >~500 serial calls), the measured 1-cell fit-pilot basis for per-cell fit / factorization / GD phases (#1060), the store-heavy / IO-heavy phase recipe (measured per-item serialization+upload wall-time; compression-default-OFF for fp16→Xet), the CPU-phase RAM/RSS routing gate (projected peak RSS per VM-placed phase; ≥~16 GB single-or-summed routes off the shared VM), the dose-ladder checkpoint-retention default (keep dose-selected + latest, clean ruled-out rungs between rungs; size disk to the RETAINED set, #1133), and costing wall-time against the machine the router will ACTUALLY provision + p90-based fence sizing, and the external-stream >~1h presumption for network-bound streaming/harvest phases (#1092) (loads at plan time via plan-file paths; relocated verbatim from planner.md §9, #829)
 paths:
   - ".claude/plans/**"
   - "tasks/**/plans/**"
@@ -7,11 +7,14 @@ paths:
 
 # Plan compute sizing (planner §9 relocated recipes)
 
-These eight recipes are the planner-specific §9 sizing blocks — five relocated
+These ten recipes are the planner-specific §9 sizing blocks — five relocated
 verbatim from `.claude/agents/planner.md` (#829), plus the
 store-heavy / IO-heavy phase recipe (#910, from incident #813), the
-CPU-phase RAM/RSS routing gate (#1031, from incidents #778/#833), and the
-per-cell fit-phase pilot basis (#1060, from incidents #811/#931/#823). The planner
+CPU-phase RAM/RSS routing gate (#1031, from incidents #778/#833), the
+per-cell fit-phase pilot basis (#1060, from incidents #811/#931/#823), the
+external-stream floor presumption (#1092 — present since #1092, first counted
+here), and the dose-ladder checkpoint-retention default (#1133, from incident
+#1112). The planner
 applies each when its trigger matches; the compute-projection table spec +
 stratification spec stay inline in planner.md §9.
 
@@ -59,6 +62,61 @@ full-precision copy per probed dose checkpoint × 12 content cells × 9 dose
 ckpts = ~1.6 TB worst case on a 130 GB quota, with no cleanup between
 probes — the run died at the quota; the fix was atomic merge-read-delete
 per probe). This is a plan-time storage-budget check, NOT a mid-run gate.
+Per-rung checkpoint LADDERS additionally carry the retention DEFAULT of the
+next block — for a ladder phase, a keep-all-rungs bound that happens to fit
+the planned quota is no longer sufficient on its own.
+
+
+**Dose-ladder / multi-rung checkpoint retention — keep the dose-selected +
+latest rungs only; size disk to the RETAINED set, never the full ladder.**
+Any training phase that persists per-rung checkpoints for later selection —
+a dose-to-band checkpoint ladder (earliest-rung-in-band), a band-stop grid,
+a dose-matching checkpoint grid, any long run saving every k steps for a
+later pick — MUST state its checkpoint-retention policy in §9. DEFAULT:
+retain only (i) the dose-selected rung(s) (or the current selection
+candidate while the read is pending), (ii) the latest rung (crash-resume),
+and (iii) rungs the selection read has not yet covered; every ruled-out
+rung is deleted BETWEEN rungs, not in one sweep after the ladder completes.
+Three implementations bound the on-disk ladder: an online per-rung
+selection read (the deterministic log-prob band-stop callback is the
+marker-recipe case — `.claude/rules/marker-training-recipe.md`);
+upload-as-you-go then delete locally (select against the Hub copies,
+re-download only the selected rung — pricing in Hub storage headroom, the
+#541/#552 quota exposure); or a coarse+refine two-pass grid
+(sparse saves that fit, judge, deterministic retrain to the bracketing
+steps — #1112's own RunPod contingency). A design whose selection read
+runs only AFTER the full ladder has no between-rung deletion point —
+carve-out (iii) would cover every rung, degenerating the default to
+keep-all — so a post-hoc-selection ladder MUST adopt one of the bounding
+implementations above or take the justified keep-all exception below;
+it cannot ride carve-out (iii). Deletion composes with the Upload
+Policy UNCHANGED: a non-selected rung is deleted only when covered by a
+plan §10 `discarded_artifacts:` entry ({name, reason, regen_recipe} —
+non-selected rungs of a deterministic retrain from pinned data + commit +
+seed are the canonical candidate, #1112's own declared discard) OR
+uploaded first; selected / headline-carrying checkpoints keep the full
+upload-before-delete invariant (never delete an unuploaded, undeclared
+checkpoint). The §9 disk estimate sizes to the RETAINED set plus the
+transient high-water mark (`retained_rungs × per_rung_gb +
+in_flight_rung_gb + concurrent transients`), with `per_rung_gb` grounded
+on what the trainer ACTUALLY writes — weights + optimizer state, so a
+full-FT rung can run well past the bf16 weights (#1112 planned ~15 GB/rung;
+realized rungs ran ≥15 GB, up to ~28 GB per the incident filing). Keeping
+every rung locally is the JUSTIFIED
+EXCEPTION, not the default: the plan must say why the rungs must coexist,
+size the disk to the FULL ladder at realized per-rung size, and DECLARE
+that requirement in the launch flags (`--boot-disk-gb`) so the #1118
+volume-threading / typed refusal engages on a lane failover. A merge-disk
+bound that fits the PLANNED lane's disk is NOT sufficient on its own
+(#1112: a compliant 575 GB keep-all bound sat under the planned 750 GB GCP
+boot disk; the GCP→RunPod failover delivered the `ft-7b` default 200 GB
+volume and the run ENOSPC'd — errno 28 mid-safetensors-write — at rung
+24/30: crash + terminate + a fresh 800 GB recovery pod, billing ~$16/hr
+per the incident filing. The same design's retention-bounded footprint is
+~2–3 rungs ≈ 30–85 GB and fits every lane). Critic enforcement:
+Methodology lens item 16
+(`.claude/rules/critic-lens-reference.md`) REVISEs a ladder plan whose
+disk estimate assumes keeping every rung without this justification.
 
 
 **Sentinel-signaling workloads need a /workspace-contract lane — never

--- a/.claude/rules/planner-section-reference.md
+++ b/.claude/rules/planner-section-reference.md
@@ -346,10 +346,12 @@ any reason a smaller pod was chosen anyway (rare — e.g. "data is too small
 to amortize 8× setup"). If the answer is "no parallelism axis applies,"
 say so — silence is not acceptable.
 
-> **Compute-sizing recipes (HBM sizing / merge-disk / sentinel lanes / floor
-> cross-check / store-IO / CPU-phase RAM/RSS routing / machine costing +
-> p90 fence sizing)** — when sizing any §9 phase (activation capture, adapter
-> merges, sentinel-signaling workloads, long-phase wall-time floors,
+> **Compute-sizing recipes (HBM sizing / merge-disk + ladder-checkpoint
+> retention / sentinel lanes / floor cross-check + external-stream
+> presumption / fit-phase pilot basis / store-IO / CPU-phase RAM/RSS
+> routing / machine costing + p90 fence sizing)** — when sizing any §9
+> phase (activation capture, adapter merges, dose-ladder rung checkpoints,
+> sentinel-signaling workloads, long-phase wall-time floors,
 > store-heavy writes, VM-placed CPU-phase RAM, per-machine wall-time costing,
 > a deliberate GCP fence), READ
 > `.claude/rules/plan-compute-sizing.md` IN FULL before writing the table.

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -2107,6 +2107,13 @@ disagreement (PASS-class vs FAIL), a `reconciler` agent (Claude) issues
 a binding tie-break. See (see workflow.yaml § ensemble_review) for the
 canonical contract.
 
+**Round push hygiene.** Any branch push run during this loop — yours
+between rounds, or the implementer's per its spec — is BARE with its exit
+code checked: `git -C "$WT" push origin issue-<N>`. NEVER pipe a
+push/merge through `tail`/`grep`/`head` (the `guard_piped_git_push.sh`
+PreToolUse hook blocks the piped shape; a pipe masks a rejected push).
+Copy the verbatim forms from Step 10d § "Bare push / merge snippets".
+
 **5a. Spawn both reviewers in parallel (fresh contexts, single message).**
 
 **Spec-freshness check first (worktree-cwd sessions; applies at EVERY
@@ -4771,7 +4778,11 @@ When this skill is re-invoked in `running`:
       `.claude/agent-memory/<owning_agent>/` plus a one-line
       `MEMORY.md` index entry, then commit BY EXPLICIT PATH on `main`
       from the repo root and push (auto, no approval gate — same
-      standing rule 2026-06-02 as workflow fixes). The point is
+      standing rule 2026-06-02 as workflow fixes). Push BARE —
+      `git push origin main || uv run python scripts/sync_repo_root.py` —
+      never piped (Step 10d § "Bare push / merge snippets";
+      sync_repo_root exit 0 can mean in-flight — landing not guaranteed,
+      see the canonical block's caveat). The point is
       same-day cross-session sharing: a sibling session's next agent
       spawn loads the memory within minutes, instead of waiting for the
       nightly `/daily` sweep (on 2026-06-11, #537 and #545 re-hit
@@ -6054,7 +6065,11 @@ explicit eval-data path):
    `src/explore_persona_space/analysis/` — over the existing eval
    JSONs. Regenerate any affected figures (the analyzer's
    `figures/issue_<N>/` outputs); commit + push to `main` so the body
-   can SHA-pin them per the existing analyzer.md Step 3 rule.
+   can SHA-pin them per the existing analyzer.md Step 3 rule. Push BARE:
+   `git push origin main || uv run python scripts/sync_repo_root.py` —
+   never piped (Step 10d § "Bare push / merge snippets"; sync_repo_root
+   exit 0 can mean in-flight — landing not guaranteed, see the canonical
+   block's caveat).
 4. **Capture the headline before / after.** Read the current `body.md`
    H1 title before the re-spawn and the analyzer-produced H1 after,
    plus the LOW / MODERATE / HIGH confidence tag in each.
@@ -6735,7 +6750,11 @@ loaded). The chat-side prompt below remains the durable record.
 
 **Auto-merge the worktree now (experiments).** The instant the task
 lands at `awaiting_promotion`, run the **Step 10d auto-merge procedure**
-(rebase-merge `issue-<N>` -> `main`, no prompt, keep the worktree). The
+(rebase-merge `issue-<N>` -> `main`, no prompt, keep the worktree).
+Execute it with the Step 10d command blocks VERBATIM — bare,
+exit-code-checked push/merge, never piped through `tail`/`grep`/`head`
+(Step 10d § "Bare push / merge snippets"; the `guard_piped_git_push.sh`
+hook blocks piped variants). The
 code / figures / `eval_results` the run produced land on `main`
 immediately so the next experiment inheriting from `main` gets any
 shared-infra fix this branch carried (this is the #456 -> #466 fix). The
@@ -8217,6 +8236,52 @@ reaped later by the daily stale-worktree audit (`worktree_audit.py`,
 **Idempotent.** Skip the whole step if `epm:merged` already exists on the
 task (an experiment that merged at Step 9b is a no-op here). Also skip if
 no PR exists or the branch is already merged into `main`.
+
+#### Bare push / merge snippets (canonical — copy verbatim, never compose a piped variant)
+
+Every `git push` / `git merge` / `gh pr merge|create` in this skill — and any
+IMPROVISED recovery around one — runs BARE with its exit code checked. Never
+pipe one through `tail` / `grep` / `head` / any filter: bash makes a
+pipeline's exit status the LAST stage's, so the pipe masks a rejected push
+and the session proceeds on a merge that never landed (#957; 4 sessions
+2026-07-02). The `guard_piped_git_push.sh` PreToolUse hook BLOCKS the piped
+shape anyway, so composing it just wastes a turn (~10 blocks across ≥8
+sessions on 2026-07-07, #1138). Push/merge output is a few lines — it needs
+no trimming. Copy these forms; the earlier composition sites (Step 5 round
+pushes, the failure-lesson memory persist, Step 9a-ter re-analysis commits,
+the Step 9b auto-merge trigger) point here:
+
+```bash
+# (1) Worktree branch push, rebase-retry on reject (the safe-case form):
+git -C "$WT" push origin issue-<N> \
+  || { git -C "$WT" pull --rebase=merges --autostash \
+       && git -C "$WT" push origin issue-<N>; }
+
+# (2) Repo-root push to main, single-flight recovery on reject
+#     (sync_repo_root exit 0 can mean "another sync in flight — your push
+#      has NOT landed"; for guard-critical pushes use the landing-verified
+#      form in the post-merge duplicate-folder guard below):
+git push origin main || uv run python scripts/sync_repo_root.py
+
+# (3) PR merge (for sites OUTSIDE Step 10d/9b — those two run the full
+#     lint-verdict-gated blocks below, never this bare form) — branch the
+#     flow on the EXIT CODE, never on filtered output:
+if gh pr merge <PR> --rebase --delete-branch=false; then
+  echo "merged"
+else
+  echo "merge failed — route to the Step 10d failure handling"; false
+fi
+
+# (4) Need to bound long output? Redirect to a FILE and read the FILE in a
+#     SEPARATE command — the push itself stays bare:
+git push origin main > /tmp/issue-<N>-push.log 2>&1; PUSH_RC=$?
+tail -20 /tmp/issue-<N>-push.log
+[ "$PUSH_RC" -eq 0 ] || { echo "PUSH FAILED (rc=$PUSH_RC)"; false; }
+```
+
+Inside Step 10d itself, use the full executable blocks below (they wrap
+forms (1)/(3) in the pre-push workflow-lint verdict gate); this subsection
+is the copy source for every OTHER site.
 
 #### Merge safety guards (run before the merge commands)
 

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -8260,7 +8260,7 @@ git -C "$WT" push origin issue-<N> \
 # (2) Repo-root push to main, single-flight recovery on reject
 #     (sync_repo_root exit 0 can mean "another sync in flight — your push
 #      has NOT landed"; for guard-critical pushes use the landing-verified
-#      form in the post-merge duplicate-folder guard below):
+#      form in the post-merge stale-task-folder guard below):
 git push origin main || uv run python scripts/sync_repo_root.py
 
 # (3) PR merge (for sites OUTSIDE Step 10d/9b — those two run the full

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -6451,10 +6451,10 @@ AGENT_SPEC_SIZE_GRANDFATHER: dict[str, int] = {
     # + <=~1 KB. Prior: 47,930 B post-#881)
     # #948: seam-stubbed production-body lens (Step 3.8)
     "codex-code-reviewer.md": 51_600,
-    # measured 63,424 B post-#1115 (read-hygiene context-budget section —
-    # plan-mandated growth; cap = measured + <=~1 KB. Prior: 62,500 —
-    # measured 61,733 B post-#1102)
-    "experiment-implementer.md": 64_000,
+    # measured 64,360 B post-#1138 (bare-push guidance append —
+    # plan-mandated growth; cap = measured + <=~1 KB. Prior: 64,000 —
+    # measured 63,942 B post-#1115)
+    "experiment-implementer.md": 65_300,
     # measured 65,540 B post-#1081 r2 (D3 crash-fix-relaunch addendum:
     # disposition-conditional resume-glob confirm — plan-mandated growth;
     # cap = measured + <=~1 KB. Prior: 65,500 — measured 62,672 B)

--- a/tests/test_step10d_guard3.py
+++ b/tests/test_step10d_guard3.py
@@ -168,10 +168,15 @@ def test_safe_case_push_appears_before_gh_pr_merge():
     """The push must SEQUENCE before the safe-case gh pr merge --rebase call,
     so the server-side rebase sees the stripped branch tip."""
     text = _skill_text()
+    # Scope the search to the safe-case block: the #1138 canonical
+    # "Bare push / merge snippets" subsection (inserted earlier in Step 10d)
+    # contains both literals, so first-occurrence pins would retarget it.
+    base = text.find("#### The auto-merge procedure (safe case")
+    assert base != -1, "safe-case auto-merge heading not found in SKILL.md"
     merge_line = "gh pr merge <PR> --rebase --delete-branch=false"
     push_line = 'git -C "$WT" push origin issue-<N>'
-    merge_offset = text.find(merge_line)
-    push_offset = text.find(push_line)
+    merge_offset = text.find(merge_line, base)
+    push_offset = text.find(push_line, base)
     assert merge_offset != -1, "safe-case gh pr merge line not found in SKILL.md"
     assert push_offset != -1, "safe-case strip-commit push line not found in SKILL.md"
     assert push_offset < merge_offset, (


### PR DESCRIPTION
Closes task #1138 (kind: infra, workflow-fix).

## Summary
- Adds ONE canonical `#### Bare push / merge snippets` subsection at /issue SKILL.md Step 10d (4 verbatim GOOD-form snippets: worktree branch push w/ rebase-retry; repo-root push w/ sync_repo_root recovery; exit-code-branched gh pr merge; no-pipe output-bounding recipe) + 6 one-line pointers (Step 5 intro, Step 9b trigger, failure-lesson persist, Step 9a-ter, experiment-implementer.md item 10, implementer.md).
- Plan-v3 amendments: AGENT_SPEC_SIZE_GRANDFATHER bump for experiment-implementer.md (64,000 → 65,300, precedent comment format); test_step10d_guard3.py safe-case ordering pin scoped to its heading (canonical block would have silently captured the first-occurrence find()).

## Test plan
- [x] hook self-test PASS; 25 added fenced lines all ALLOW through guard_piped_git_push.sh (hook-as-oracle)
- [x] no-flags workflow_lint.py PASS on the edited tree
- [x] Step 9c gate: 3076 passed / 6 skipped; step9c_baseline compare clean (new=[], stripped=[])
- [x] Claude code-review PASS (Codex twin: org-quota no-show, #1126)

🤖 Generated with [Claude Code](https://claude.com/claude-code)