### PR TITLE
task #1147: Step-10d mapped invariant-test merge-gate leg (workflow-fix)

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -8602,7 +8602,14 @@ fast-pathed; it takes the ordinary `--rebase`.
 #931 (2026-07-04) merged a workflow-lint offender to `main`, breaking
 `tests/test_workflow_lint.py` on pristine trunk fleet-wide for most of a day
 (5 downstream sessions each burned 5-25 min classifying it as pre-existing).
-Gate the merge payload on the lint BEFORE anything lands:
+#1147 adds a mapped invariant-test leg to the same gate: GLOB_SCAN_TESTS-covered
+payloads (`scripts/issue*_*.py`, dispatcher scripts) previously landed with
+zero pytest on the experiment auto-merge path (Step 9c is
+code-change-kinds-only) — a channel through which #1144's thread-caps offenders
+accreted; sampled offenders also landed via direct-to-main
+free-analysis/analyzer commits, which this gate does NOT cover (see the Step
+9a-ter follow-up). Gate the merge payload on the lint + the mapped invariant
+tests BEFORE anything lands:
 
 - **Trigger (cheap; artifact-only merges skip).** Run the gate ONLY when the
   branch's own three-dot diff (`git -C "$WT" diff --name-only
@@ -8675,6 +8682,72 @@ Gate the merge payload on the lint BEFORE anything lands:
       --check-references --check-tables --check-asks --check-autonomous-asks \
       >> /tmp/issue-<N>-lint-gated.txt 2>&1 \
       || { rc=$?; if [ "$rc" -gt "$GATED_RC" ]; then GATED_RC=$rc; fi; }
+    # MAPPED INVARIANT-TEST LEG (#1147). GLOB_SCAN_TESTS-covered payloads
+    # (scripts/issue*_*.py, dispatcher scripts) land via this gate with ZERO
+    # pytest on the experiment auto-merge path (Step 9c is code-change-kinds-
+    # only) — #1144: 34 thread-caps offenders accreted this way. Map the
+    # own-diff to its scanning tests via the selector's single-source map;
+    # empty map => leg skipped (no pytest run).
+    TG_RC=0; TG_BASE_RC=0; TG_CRASH=no
+    : > /tmp/issue-<N>-tg-new.txt
+    if ! uv run python "$REPO_ROOT/scripts/select_step9c_tests.py" \
+        --map-files /tmp/issue-<N>-own-diff.txt --repo-root "$WT" \
+        > /tmp/issue-<N>-tg-map.txt 2>/tmp/issue-<N>-tg-map-err.txt; then
+      TG_CRASH=yes   # helper failure: cannot classify the payload — fail CLOSED
+    fi
+    if [ "$TG_CRASH" = no ] && [ -s /tmp/issue-<N>-tg-map.txt ]; then
+      # matched payload paths (attribution grep list) + gated test list:
+      cut -f2 /tmp/issue-<N>-tg-map.txt | sort -u > /tmp/issue-<N>-tg-files.txt
+      mapfile -t TG_TESTS < <(cut -f1 /tmp/issue-<N>-tg-map.txt | sort -u)
+      # BASELINE leg — root copy on the payload-free main tree (each scan
+      # test derives its scan root from its own __file__, so the root copy
+      # scans the root tree). Only tests present on the baseline tree run
+      # there: a branch-NEW scan test has no baseline, so its gated hits are
+      # NEW by construction (correct — block).
+      mapfile -t TG_BASE_TESTS < <(uv run python \
+        "$REPO_ROOT/scripts/select_step9c_tests.py" \
+        --map-files /tmp/issue-<N>-own-diff.txt --repo-root "$REPO_ROOT" \
+        2>/dev/null | cut -f1 | sort -u)
+      if [ "${#TG_BASE_TESTS[@]}" -gt 0 ]; then
+        ( cd "$REPO_ROOT" && timeout --kill-after=30s 300s \
+          env OMP_NUM_THREADS=8 MKL_NUM_THREADS=8 OPENBLAS_NUM_THREADS=8 \
+              NUMEXPR_NUM_THREADS=8 \
+          uv run pytest "${TG_BASE_TESTS[@]}" -q -p no:cacheprovider ) \
+          > /tmp/issue-<N>-tg-baseline.txt 2>&1 || TG_BASE_RC=$?
+      else
+        : > /tmp/issue-<N>-tg-baseline.txt
+      fi
+      # GATED leg — worktree copy on the payload-bearing branch-tip tree:
+      ( cd "$WT" && timeout --kill-after=30s 300s \
+        env OMP_NUM_THREADS=8 MKL_NUM_THREADS=8 OPENBLAS_NUM_THREADS=8 \
+            NUMEXPR_NUM_THREADS=8 \
+        uv run pytest "${TG_TESTS[@]}" -q -p no:cacheprovider ) \
+        > /tmp/issue-<N>-tg-gated.txt 2>&1 || TG_RC=$?
+      # rc 0 = green, 1 = test failures (attributable); ANY other rc
+      # (timeout 124, collection/internal/usage error 2-5) = crash-class.
+      if [ "$TG_RC" -gt 1 ] || [ "$TG_BASE_RC" -gt 1 ]; then TG_CRASH=yes; fi
+      # FILE-grain payload attribution: a scan test asserts per-file
+      # invariants and aggregates every offender into ONE red node, so
+      # node-level subtraction is degenerate (baseline-red node == gated-red
+      # node masks a NEW offender). Attribution = output lines naming a
+      # payload-matched path; line numbers blanked so main-vs-branch drift of
+      # the SAME pre-existing offense cannot fake a NEW line. (The third sed
+      # clause blanks test_subprocess_env_explicit.py's check-1
+      # `- <path>:<ln> (fn=...)` format.) pytest's own `E   assert ...` repr
+      # line is DROPPED: its ellipsis-truncated offender-list repr is
+      # unstable across trees (unrelated dirt in ONE tree changes it ->
+      # false NEW line on an innocent payload); every real offense also
+      # emits its dedicated per-file evidence line, which survives.
+      for leg in baseline gated; do
+        grep -F -f /tmp/issue-<N>-tg-files.txt "/tmp/issue-<N>-tg-$leg.txt" \
+          | grep -vE '^E +assert ' \
+          | sed -E 's/at line [0-9]+/at line N/g; s/:[0-9]+:/::/g; s/:[0-9]+([^0-9]|$)/:N\1/g' \
+          | sort -u \
+          > "/tmp/issue-<N>-tg-$leg-hits.txt" || true
+      done
+      comm -23 /tmp/issue-<N>-tg-gated-hits.txt \
+        /tmp/issue-<N>-tg-baseline-hits.txt > /tmp/issue-<N>-tg-new.txt
+    fi
     # Normalize failure lines: keep per-error `workflow_lint: <err>` lines,
     # DROP the PASS / `FAIL (N error(s))` summary lines (their COUNT changes
     # even when the failure identities match — a payload that fixes one
@@ -8705,12 +8778,13 @@ Gate the merge payload on the lint BEFORE anything lands:
     # one (rc=1 WITH lines) blocks only when payload-attributed (an
     # own-diff-named failure line OR a non-empty NEW set); rc=1 with lines
     # but none own-diff/NEW stays `pass` (pre-existing red — WARN).
-    if [ "$GATED_RC" -gt 1 ] || [ "$BASE_RC" -gt 1 ] \
+    if [ "$GATED_RC" -gt 1 ] || [ "$BASE_RC" -gt 1 ] || [ "$TG_CRASH" = "yes" ] \
        || { [ "$GATED_RC" -ne 0 ] && [ ! -s /tmp/issue-<N>-lint-gated-norm.txt ]; } \
        || { [ "$BASE_RC" -ne 0 ] && [ ! -s /tmp/issue-<N>-lint-baseline-norm.txt ]; }; then
       echo crash > /tmp/issue-<N>-lint-verdict.txt
-    elif [ "$GATED_RC" -ne 0 ] \
-       && { [ -s /tmp/issue-<N>-lint-owndiff.txt ] || [ -s /tmp/issue-<N>-lint-new.txt ]; }; then
+    elif { [ "$GATED_RC" -ne 0 ] \
+       && { [ -s /tmp/issue-<N>-lint-owndiff.txt ] || [ -s /tmp/issue-<N>-lint-new.txt ]; }; } \
+       || { [ "$TG_RC" -ne 0 ] && [ -s /tmp/issue-<N>-tg-new.txt ]; }; then
       echo block > /tmp/issue-<N>-lint-verdict.txt
     else
       echo pass > /tmp/issue-<N>-lint-verdict.txt
@@ -8731,6 +8805,46 @@ Gate the merge payload on the lint BEFORE anything lands:
   cat /tmp/issue-<N>-lint-verdict.txt   # line 1: pass | block | crash | skip-artifact-only; line 2: certified branch-tip sha
   ```
 
+- **Mapped invariant-test leg (#1147).** A second, trigger-gated leg of the
+  SAME gate: when the payload (the own-diff / additive list) matches any
+  `GLOB_SCAN_TESTS` glob, the executable block runs the MAPPED scan tests on
+  the payload-bearing tree and subtracts a payload-free baseline run. The
+  trigger is the helper map — `select_step9c_tests.py --map-files <list-file>
+  [--repo-root <tree>]` prints `scan_test<TAB>matched_path` pairs; empty
+  output = leg skipped entirely (zero pytest runs added). The helper is the
+  SINGLE SOURCE of the glob→test mapping — never hardcode the globs in this
+  file (the selector's drift pins in `tests/test_select_step9c_tests.py` keep
+  the map current, #895). Attribution is FILE-grain, not junit-node grain: a
+  scan test asserts per-file invariants and aggregates EVERY offender into
+  ONE red node, so node-level subtraction is degenerate (baseline-red node ==
+  gated-red node would mask a NEW offender — the same reason
+  `step9c_baseline.py compare` marks scan-set nodes scratch-ineligible). Hits
+  = pytest-output lines naming a payload-matched path, line numbers blanked
+  so main-vs-branch drift of the SAME pre-existing offense cannot fake a NEW
+  line, pytest's ellipsis-truncated `E   assert ...` repr line dropped (its
+  content is unstable across trees; every real offense also emits a dedicated
+  per-file evidence line); NEW = gated hits − baseline hits (`comm -23`,
+  `/tmp/issue-<N>-tg-new.txt`). Each pytest leg is bounded at 300 s
+  (`timeout --kill-after=30s`; measured basis ~12.6 s for both mapped tests,
+  2026-07-08) — a timeout / pytest rc>1 / helper failure on either leg is
+  crash-class: verdict `crash`, fail CLOSED, the same "re-run the gate ONCE →
+  `epm:merge-failed`" recovery as the lint legs (Verdict bullet case 3). On
+  form (iii) this leg is structurally DORMANT today — the surgical additive
+  pathspec set excludes `scripts/` / `src/`, so its trigger map is empty by
+  construction; it arms automatically if that set ever grows. Known residuals
+  (accepted, documented): (a) path-(i) test-VERSION drift — the gated leg
+  runs the branch-tip copy of the scan test, so a check added on `main` after
+  the branch forked is not enforced there (fail-safe direction; the same
+  residual as the lint's path (i)); (b) the baseline leg runs on the
+  always-dirty shared root — dirt biases toward PASS, never a false block: an
+  untracked concurrent-session file (including an untracked same-path draft
+  of the payload file at the root, which the directory scan picks up
+  tracked-or-not) can only ENLARGE the baseline hit set and mask, a residual
+  inherited from the lint gate's baseline leg; (c) a payload that DEEPENS an
+  offense in an already-red payload-touched file normalizes to the same
+  per-file line and is subtracted — a false-pass window that vanishes once
+  #1145 greens the baseline (the file is already post-freeze red; low harm).
+
 - **Verdict — payload-attributed via failure-LINE-SET subtraction; NEVER
   blocks an innocent merge on pre-existing red.** Exit codes alone are
   vacuous when `main` is already red for an unrelated reason; attribution
@@ -8747,7 +8861,13 @@ Gate the merge payload on the lint BEFORE anything lands:
   pass/skip verdict certifies ONLY while the CURRENT branch tip equals the
   certified sha, so any new commit since certification fails CLOSED too
   (re-run the gate) and a hand-written verdict without the correct sha is
-  useless (anti-self-attestation). The file is REMOVED only once it can no
+  useless (anti-self-attestation). The mapped invariant-test leg (#1147)
+  contributes into this SAME verdict file: `crash` on either test leg's
+  crash-class outcome (pytest rc>1 / timeout / helper failure), `block` on a
+  payload-attributed NEW test hit (`/tmp/issue-<N>-tg-new.txt` non-empty with
+  a red gated run); a gated-red-but-no-NEW-hit test outcome (pre-existing
+  trunk red) stays `pass`, and the `epm:merged` WARN note records the tg tail
+  alongside the lint tail. The file is REMOVED only once it can no
   longer certify anything: after a SUCCESSFUL `gh pr merge`
   (consume-on-merge-success), or in the block/crash/stale-sha branch (a
   fresh gate run regenerates it). A merge that fails for a NON-lint
@@ -8783,7 +8903,11 @@ Gate the merge payload on the lint BEFORE anything lands:
      worktree, re-run the gate ONCE; still crashing → the SAME
      `epm:merge-failed v1` handling as case 1. Never merge/push on `crash`.
 - **Baseline semantics per binding form (the baseline is ALWAYS a
-  payload-free tree).** (i) Safe case: gated = the WORKTREE copy
+  payload-free tree).** The mapped invariant-test legs (#1147) follow the
+  IDENTICAL per-form baseline placement as the lint legs — (i) gated = the
+  `$WT` copy on the branch-tip tree / baseline = the root copy; (ii) gated =
+  the post-merge worktree copy / baseline = the root copy; (iii) baseline
+  BEFORE the checkout, gated after, BOTH the root copy. (i) Safe case: gated = the WORKTREE copy
   (branch-tip tree); baseline = the repo-root copy (main tree, payload
   absent); bind immediately before `gh pr ready` / `gh pr merge`. Note:
   path-(i) lint-VERSION drift can also FALSE-BLOCK (a check retired/loosened
@@ -9180,6 +9304,30 @@ Decision tree:
       >> /tmp/issue-<N>-lint-baseline.txt 2>&1 \
       || { rc=$?; if [ "$rc" -gt "$BASE_RC" ]; then BASE_RC=$rc; fi; }
   fi
+  # MAPPED INVARIANT-TEST LEG (#1147) — form (iii), DORMANT TODAY by
+  # construction: the additive pathspec set above excludes scripts/ and src/,
+  # so no additive payload can match a GLOB_SCAN_TESTS glob and the trigger
+  # map is empty. The leg exists as defense-in-depth should that pathspec set
+  # ever grow; it costs one ~1 s helper call per surgical landing. Sequencing
+  # mirrors the lint legs: TG BASELINE runs BEFORE the checkout (the payload
+  # lands in the ROOT tree — a post-checkout "baseline" would be a degenerate
+  # self-compare), TG GATED after; BOTH legs run the ROOT copy.
+  TG_RC=0; TG_BASE_RC=0; TG_CRASH=no
+  : > /tmp/issue-<N>-tg-new.txt
+  if ! uv run python "$REPO_ROOT/scripts/select_step9c_tests.py" \
+      --map-files /tmp/issue-<N>-additive-files.txt --repo-root "$REPO_ROOT" \
+      > /tmp/issue-<N>-tg-map.txt 2>/tmp/issue-<N>-tg-map-err.txt; then
+    TG_CRASH=yes   # helper failure: cannot classify the payload — fail CLOSED
+  fi
+  if [ "$TG_CRASH" = no ] && [ -s /tmp/issue-<N>-tg-map.txt ]; then
+    cut -f2 /tmp/issue-<N>-tg-map.txt | sort -u > /tmp/issue-<N>-tg-files.txt
+    mapfile -t TG_TESTS < <(cut -f1 /tmp/issue-<N>-tg-map.txt | sort -u)
+    ( cd "$REPO_ROOT" && timeout --kill-after=30s 300s \
+      env OMP_NUM_THREADS=8 MKL_NUM_THREADS=8 OPENBLAS_NUM_THREADS=8 \
+          NUMEXPR_NUM_THREADS=8 \
+      uv run pytest "${TG_TESTS[@]}" -q -p no:cacheprovider ) \
+      > /tmp/issue-<N>-tg-baseline.txt 2>&1 || TG_BASE_RC=$?
+  fi
   # `-C "$REPO_ROOT"` is the repo-root guard's designed deliberate-override
   # (#897): the hook's working-tree-revert detector would bounce the bare
   # `checkout <branch> -- <paths>` form; the `-C` names the tree explicitly.
@@ -9226,6 +9374,37 @@ Decision tree:
        && { [ -s /tmp/issue-<N>-lint-owndiff.txt ] || [ -s /tmp/issue-<N>-lint-new.txt ]; }; then
       GATE_VERDICT=block
     fi
+  fi
+  # TG GATED leg (#1147) — the root tree now carries the payload; same
+  # grep -> line-number-blank -> comm -23 subtraction as the shared gate's
+  # executable block (own-diff here = the additive-files list; structurally
+  # unreachable today, see the dormancy comment above the TG baseline leg).
+  if [ "$TG_CRASH" = no ] && [ -s /tmp/issue-<N>-tg-map.txt ]; then
+    ( cd "$REPO_ROOT" && timeout --kill-after=30s 300s \
+      env OMP_NUM_THREADS=8 MKL_NUM_THREADS=8 OPENBLAS_NUM_THREADS=8 \
+          NUMEXPR_NUM_THREADS=8 \
+      uv run pytest "${TG_TESTS[@]}" -q -p no:cacheprovider ) \
+      > /tmp/issue-<N>-tg-gated.txt 2>&1 || TG_RC=$?
+    if [ "$TG_RC" -gt 1 ] || [ "$TG_BASE_RC" -gt 1 ]; then TG_CRASH=yes; fi
+    for leg in baseline gated; do
+      grep -F -f /tmp/issue-<N>-tg-files.txt "/tmp/issue-<N>-tg-$leg.txt" \
+        | grep -vE '^E +assert ' \
+        | sed -E 's/at line [0-9]+/at line N/g; s/:[0-9]+:/::/g; s/:[0-9]+([^0-9]|$)/:N\1/g' \
+        | sort -u \
+        > "/tmp/issue-<N>-tg-$leg-hits.txt" || true
+    done
+    comm -23 /tmp/issue-<N>-tg-gated-hits.txt \
+      /tmp/issue-<N>-tg-baseline-hits.txt > /tmp/issue-<N>-tg-new.txt
+  fi
+  # Fold the TG verdict into the SAME GATE_VERDICT the stage/commit/push
+  # consumes below — crash-class first (fail CLOSED; never downgraded), then
+  # the payload-attributed block arm; block/crash reuse the existing cleanup
+  # + hard-stop path verbatim:
+  if [ "$TG_CRASH" = "yes" ]; then
+    GATE_VERDICT=crash
+  elif [ "$TG_RC" -ne 0 ] && [ -s /tmp/issue-<N>-tg-new.txt ] \
+     && [ "$GATE_VERDICT" != "crash" ]; then
+    GATE_VERDICT=block
   fi
   # HARD STOP: stage/commit/push run ONLY on a pass verdict; a block cleans
   # the payload back out of the shared root (index + working tree).

--- a/scripts/select_step9c_tests.py
+++ b/scripts/select_step9c_tests.py
@@ -56,6 +56,15 @@ benign.
 Usage::
 
     uv run python scripts/select_step9c_tests.py [--base main] [--repo-root <path>] [--json]
+    uv run python scripts/select_step9c_tests.py --map-files <file> [--repo-root <path>]
+
+``--map-files FILE`` (the ``/issue`` Step 10d merge-gate mapping mode, #1147):
+read newline-delimited repo-relative paths from FILE and print one
+``<scan_test>\\t<matched_path>`` line per :data:`GLOB_SCAN_TESTS` hit
+(:func:`map_scan_tests`), skipping the diff-based selection entirely. A scan
+test absent from the work root is dropped with a stderr WARN. Empty stdout on
+no match is a SUCCESS (exit 0 — the gate's skip signal); exit 1 only when FILE
+is unreadable (the gate fails CLOSED on an unclassifiable payload).
 
 Default output: the exact gate invocation
 ``timeout --kill-after=60s <T>s uv run pytest <files...> -v --tb=short`` on
@@ -253,6 +262,27 @@ def _matches_any(path: str, globs: tuple[str, ...]) -> bool:
     return False
 
 
+def _scan_pairs(files: list[str]) -> set[tuple[str, str]]:
+    """All ``(scan_test, matched_file)`` pairs per :data:`GLOB_SCAN_TESTS` (no existence filter)."""
+    return {
+        (scan_test, f)
+        for f in files
+        for scan_test, scan_globs in GLOB_SCAN_TESTS.items()
+        if _matches_any(f, scan_globs)
+    }
+
+
+def map_scan_tests(files: list[str], work_root: Path) -> list[tuple[str, str]]:
+    """Map *files* to ``(scan_test, matched_file)`` pairs via :data:`GLOB_SCAN_TESTS`.
+
+    Pure path arithmetic over the pinned map (no git); a scan test absent
+    from *work_root* is dropped (the caller's tree cannot run it). Returns
+    sorted unique pairs. This is the ``--map-files`` backing function the
+    ``/issue`` Step 10d pre-push merge gate consumes (#1147).
+    """
+    return sorted(p for p in _scan_pairs(files) if (work_root / p[0]).exists())
+
+
 def compute_touched(
     base: str,
     work_root: Path,
@@ -422,6 +452,18 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument("--json", action="store_true", help="emit a JSON object")
+    parser.add_argument(
+        "--map-files",
+        default=None,
+        metavar="FILE",
+        help=(
+            "newline-delimited repo-relative paths: print one "
+            "'scan_test<TAB>matched_path' line per GLOB_SCAN_TESTS hit and exit "
+            "(the /issue Step 10d merge-gate mapping mode, #1147 — skips the "
+            "diff-based selection entirely; empty stdout on no match is a "
+            "SUCCESS, the gate's skip signal)"
+        ),
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -445,6 +487,33 @@ def main(argv: list[str] | None = None) -> int:
         f"select_step9c_tests: work root {work_root} (branch: {_current_branch(work_root)})",
         file=sys.stderr,
     )
+
+    if args.map_files is not None:
+        # Mapping mode (#1147): pure GLOB_SCAN_TESTS lookup over an explicit
+        # file list — no git diff, no invariant set, no timeout sizing. The
+        # Step 10d merge gate consumes the tab-separated stdout; empty output
+        # + exit 0 means "no scan-covered payload" (the gate skips its test
+        # leg). Only an unreadable input file is an error (exit 1) — the gate
+        # must fail CLOSED when it cannot classify the payload.
+        try:
+            raw = Path(args.map_files).read_text()
+        except OSError as exc:
+            print(
+                f"select_step9c_tests: cannot read --map-files input: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+        files = [line.strip() for line in raw.splitlines() if line.strip()]
+        pairs = map_scan_tests(files, work_root)
+        for scan_test, f in sorted(_scan_pairs(files) - set(pairs)):
+            print(
+                f"select_step9c_tests: WARN — scan test {scan_test} (matched by {f}) "
+                f"absent from {work_root}; pair dropped",
+                file=sys.stderr,
+            )
+        for scan_test, f in pairs:
+            print(f"{scan_test}\t{f}")
+        return 0
 
     try:
         touched = compute_touched(args.base, work_root)

--- a/tests/test_select_step9c_tests.py
+++ b/tests/test_select_step9c_tests.py
@@ -530,3 +530,76 @@ def test_stdout_command_carries_sized_timeout(tmp_path: Path, monkeypatch, capsy
     line = captured.out.strip().splitlines()[-1]
     assert line.startswith(f"timeout --kill-after=60s {t}s uv run pytest ")
     assert f"recommended-timeout-s={t}" in captured.err
+
+
+# --- Cases 24-29 (#1147): map_scan_tests() + the --map-files CLI mapping mode -
+def test_map_scan_tests_thread_caps_glob(tmp_path: Path):
+    """A scripts/issue*_*.py path maps to the thread-caps scan-test pair."""
+    repo = _make_tree(tmp_path, [])
+    pairs = sel.map_scan_tests(["scripts/issue123_foo.py"], repo)
+    assert pairs == [("tests/test_shared_vm_thread_caps.py", "scripts/issue123_foo.py")]
+
+
+def test_map_scan_tests_dispatcher_glob(tmp_path: Path):
+    """A scripts/dispatch_*.py path maps to the subprocess-env scan-test pair."""
+    repo = _make_tree(tmp_path, [])
+    pairs = sel.map_scan_tests(["scripts/dispatch_x.py"], repo)
+    assert pairs == [("tests/test_subprocess_env_explicit.py", "scripts/dispatch_x.py")]
+
+
+def test_map_scan_tests_non_matching_empty(tmp_path: Path):
+    """Paths outside every GLOB_SCAN_TESTS glob map to no pairs at all."""
+    repo = _make_tree(tmp_path, [])
+    files = ["tasks/running/1/body.md", ".claude/skills/issue/SKILL.md", "docs/foo.md"]
+    assert sel.map_scan_tests(files, repo) == []
+
+
+def test_map_scan_tests_missing_test_dropped(tmp_path: Path):
+    """A glob hit whose scan test is absent from the work root is dropped."""
+    bare = tmp_path / "bare"  # no tests/ tree at all
+    bare.mkdir()
+    assert sel.map_scan_tests(["scripts/issue123_foo.py"], bare) == []
+
+
+def test_cli_map_files_tab_output_exit0(tmp_path: Path, capsys):
+    """--map-files prints sorted `test<TAB>path` lines to stdout, rc 0; a
+    non-matching list yields EMPTY stdout, still rc 0 (the gate's skip signal)."""
+    repo = _make_tree(tmp_path, [])
+    listing = tmp_path / "payload.txt"
+    listing.write_text("scripts/issue123_foo.py\nscripts/dispatch_x.py\n")
+    rc = sel.main(["--map-files", str(listing), "--repo-root", str(repo)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert out.splitlines() == [
+        "tests/test_shared_vm_thread_caps.py\tscripts/issue123_foo.py",
+        "tests/test_subprocess_env_explicit.py\tscripts/dispatch_x.py",
+    ]
+    # Non-matching payload: empty stdout, rc 0 — NOT an error.
+    listing.write_text("docs/foo.md\ntasks/running/1/body.md\n")
+    rc = sel.main(["--map-files", str(listing), "--repo-root", str(repo)])
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_cli_map_files_unreadable_exit1(tmp_path: Path, capsys):
+    """An unreadable --map-files input is exit 1 + one stderr line (fail CLOSED)."""
+    repo = _make_tree(tmp_path, [])
+    rc = sel.main(["--map-files", str(tmp_path / "nope.txt"), "--repo-root", str(repo)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "cannot read --map-files input" in err
+
+
+def test_cli_map_files_missing_test_warns(tmp_path: Path, capsys):
+    """A glob hit whose scan test is absent from the work root drops the pair
+    WITH a stderr WARN naming it (never a silent shrink)."""
+    bare = tmp_path / "bare"
+    bare.mkdir()
+    listing = tmp_path / "payload.txt"
+    listing.write_text("scripts/issue123_foo.py\n")
+    rc = sel.main(["--map-files", str(listing), "--repo-root", str(bare)])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "WARN — scan test tests/test_shared_vm_thread_caps.py" in captured.err
+    assert "pair dropped" in captured.err


### PR DESCRIPTION
Closes task #1147 (kind: infra, workflow-fix; auto-filed from #1145's Alternatives critic).

## Summary
- Adds a trigger-gated, baseline-subtracted `GLOB_SCAN_TESTS`-mapped invariant-test leg to the Step-10d pre-push merge gate in `.claude/skills/issue/SKILL.md` — live at the safe-case + recovery merge forms (the zero-pytest experiment auto-merge channel that let #1144's thread-caps offenders accrete), dormant defense-in-depth at the surgical additive checkout.
- Adds `map_scan_tests()` + `--map-files` CLI to `scripts/select_step9c_tests.py` (single-sources the glob→test mapping) + 7 unit tests.
- Pre-existing trunk red never blocks (file-grain payload attribution, line-number-blanked `comm -23` subtraction); crash-class fails closed into the existing SHA-bound verdict file (name/values/consumers unchanged).

## Test plan
- [x] Step 9c touched-scope gate: 2933 passed / 6 skipped / 0 failed (11:05); step9c_baseline compare: new=[], lint delta clean
- [x] Five-case dry-run harness against live conditions: block / pass / skip / pass / crash (acceptance criteria 1-4)
- [x] `workflow_lint.py --check-asks` + `--check-references --check-tables` PASS; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)