### PR TITLE
issue-1188: pair task.py set-title with every re-fold H1 retitle site

### DIFF
--- a/.claude/agents/analyzer.md
+++ b/.claude/agents/analyzer.md
@@ -445,7 +445,11 @@ over a stub body.
 
 **Same-issue follow-up re-entry (re-fold, not re-promote).** On an
 `epm:followup-scope v1` re-spawn the body is ALREADY a clean-result: fold
-the new round in, re-verify, `set-body` WITHOUT `--snapshot`. (1) Add the
+the new round in, re-verify, `set-body` WITHOUT `--snapshot`, then — if the
+fold retitled the H1 — `task.py set-title <SOURCE-N> "<new H1 text>"`
+(set-body preserves the old frontmatter `title`; the #1110 H1==frontmatter
+verifier check FAILs the next gate otherwise — same set-body-then-set-title
+order as Step 6 above). (1) Add the
 round's `### <result>` sections; (2) REWRITE `## Takeaways` to the current
 cross-round belief (mandatory) + retitle the H1 if the headline moved; (3)
 note the round under `**Design:**` + a per-round hyperparameter column +

--- a/.claude/rules/analyzer-paper-mode.md
+++ b/.claude/rules/analyzer-paper-mode.md
@@ -234,7 +234,14 @@ NOT migrate to markdown):
 4. Re-spawn `methodology-writer` in EXTEND mode for the new arm's Methods +
    Appendix recipe; splice its additions in.
 5. Re-run `build_paper.py` + `verify_paper.py`; write the stub (without
-   `--snapshot` — the original is already preserved) only on PASS.
+   `--snapshot` — the original is already preserved) only on PASS — and if
+   step 2 retitled the stub, follow the stub write with
+   `task.py set-title <N> "<new stub H1>"` — pass the stub's H1 line minus
+   the leading `# ` (same argument spec as the markdown re-fold,
+   analyzer-section-reference.md § Same-issue follow-up re-entry) —
+   (set-body preserves the old frontmatter `title`, so the
+   REGISTRY/dashboard title would keep the stale headline — the same
+   pairing the main paper Step 6 sequence already prescribes).
 
 ## After submission (paper-task)
 

--- a/.claude/rules/analyzer-section-reference.md
+++ b/.claude/rules/analyzer-section-reference.md
@@ -54,7 +54,7 @@ Before analyzing, write down — in your scratch context — what the hypothesis
 - <what this changes / next decision>
 ```
 
-**`## Takeaways` is the ROLLING cross-round synthesis** — it ALWAYS reflects the current cross-round belief. On a same-issue follow-up round you REWRITE it to integrate the later round (see Step 6 § Same-issue follow-up re-entry); a `## Takeaways` that describes only round 1 after round 2 landed is a critic FAIL. The H1 title stays the one-sentence claim + confidence tag; retitle it if the headline moved.
+**`## Takeaways` is the ROLLING cross-round synthesis** — it ALWAYS reflects the current cross-round belief. On a same-issue follow-up round you REWRITE it to integrate the later round (see Step 6 § Same-issue follow-up re-entry); a `## Takeaways` that describes only round 1 after round 2 landed is a critic FAIL. The H1 title stays the one-sentence claim + confidence tag; retitle it if the headline moved (on a re-fold, pair the H1 retitle with `task.py set-title <N> "<new H1 text>"` — see § Same-issue follow-up re-entry).
 
 The frontmatter `goal:` field stays in the new body so downstream agents (planner, critic, follow-up-proposer) have the agent-facing canonical Goal as context. The Goal motivation folds into the `## Goal` section's TWO required parts — `**This experiment in context:**` (what THIS experiment tests + how it relates to the other experiments in its line; the ONLY place prior-issue links appear) and `**Broader narrative:**` (the project-level / `docs/open_questions.md` question it serves) — both rewritten in plain English, not pasted verbatim. If the result substantively diverged from the Goal, that's a signal the experiment didn't answer the question it set out to answer — surface it in the relevant result's interpretation prose rather than papering over it.
 
@@ -685,7 +685,18 @@ after a same-issue follow-up run (SKILL.md Step 9b § Same-issue
 follow-up loop), the body is ALREADY a clean-result. Fold the new round
 in per these rules, then re-run the verifier and call `set-body` WITHOUT
 `--snapshot` (`original-body.md` already preserves the pre-promotion
-original; a second snapshot would overwrite it). The
+original; a second snapshot would overwrite it). If the fold retitled the
+H1 (step 2 below), follow the `set-body` with
+`task.py set-title <N> "<new H1 text>"` — pass the H1 line minus the
+leading `# `, INCLUDING the `(LOW|MODERATE|HIGH confidence)` tag,
+character-exact (the verifier compares whitespace-collapsed with no
+case/Unicode/punctuation folding, and `set_title` also refreshes the
+REGISTRY snapshot the dashboard list view reads). `set_body` deliberately
+preserves frontmatter, so skipping this leaves the frontmatter `title` on
+the OLD headline and `verify_task_body.py::check_h1_matches_frontmatter_title`
+FAILs the body at the very 9a-bis gate that re-runs next (FAIL on v4;
+migrate-on-fold makes every folded body v4). Same set-body-then-set-title
+order as the main promotion sequence above. The
 clean-result-critique gate (9a-bis) then re-runs on the updated body.
 
 1. **Add the new round's result(s)** as additional `### <result>`
@@ -695,7 +706,9 @@ clean-result-critique gate (9a-bis) then re-runs on the updated body.
    after a follow-up round it MUST integrate the later round, not just
    describe round 1. A Takeaways that describes only round 1 after
    round 2 landed is a critic FAIL (Takeaways-quality lens). **Retitle
-   the H1** (claim + confidence tag) if the headline moved.
+   the H1** (claim + confidence tag) if the headline moved — and pair the
+   retitle with the `task.py set-title` call named in the preamble above
+   (an H1 edit + `set-body` alone leaves the frontmatter title stale).
 3. **Note the round in `## Methodology` + add the round's params + footer.**
    Add a per-round note (or a `**Rounds:**` table) under `**Design:**`,
    and a per-round COLUMN to the `**Training:**` hyperparameter table for

--- a/.claude/skills/clean-results/SPEC.md
+++ b/.claude/skills/clean-results/SPEC.md
@@ -745,7 +745,10 @@ Same as v3:
 1. **`## Takeaways` is the rolling synthesis.** After every round, rewrite
    it to the current cross-round belief and retitle the H1 if the headline
    moved. A Takeaways describing only round 1 after round 2 landed is a
-   critic FAIL.
+   critic FAIL. A retitled H1 is synced to frontmatter via
+   `task.py set-title <N> "<new H1 text>"` after the `set-body` (set-body
+   preserves frontmatter; `check_h1_matches_frontmatter_title` FAILs a
+   diverged v4 body).
 2. **Round visibility.** `## Methodology → **Design:**` gains a per-round
    note (or a `**Rounds:**` table) when >1 round; `**Context:**` keeps
    per-round followup_labels + verbatim prompts. The complete

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -6078,7 +6078,11 @@ explicit eval-data path):
    the existing clean-result body (typically updating one
    `### <finding>` H3 and possibly the H1 title / confidence tag),
    re-runs `verify_task_body.py` (must still PASS), and writes the
-   revised body via `task.py set-body <N> --file ...`. The analyzer's
+   revised body via `task.py set-body <N> --file ...`, followed by
+   `task.py set-title <N> "<new H1 text>"` whenever the fold changed
+   the H1 (set-body preserves the old frontmatter `title`; the
+   H1==frontmatter verifier check FAILs the 9a-bis re-gate otherwise).
+   The analyzer's
    Step 6.5 still fires on this re-run, but the loop guard above
    prevents another 9a-ter dispatch within the same task. (**`paper:
    true`?** The re-spawned analyzer re-authors the `.tex` in place —
@@ -7354,7 +7358,10 @@ orchestrators driving one round is the #778 root cause.
      H3s), updating the H1 title / confidence tag if the result moves the
      headline. The
      `set-body` call passes NO `--snapshot` — `original-body.md`
-     already preserves the pre-promotion original (see analyzer.md §
+     already preserves the pre-promotion original — and a moved headline
+     is followed by `task.py set-title <N> "<new H1 text>"` (set-body
+     preserves the old frontmatter `title`; the H1==frontmatter verifier
+     check FAILs the 9a-bis re-gate otherwise; see analyzer.md §
      Same-issue follow-up re-entry).
    - `clean-result-critic` re-gates the UPDATED body (9a-bis as
      normal), then 9a-quater and the `awaiting_promotion` park run as


### PR DESCRIPTION
Closes task #1188 (workflow-fix). 8 prose hunks / 5 workflow-surface files adding the paired `task.py set-title` sync wherever a same-issue follow-up re-fold licenses an H1 retitle (set_body preserves frontmatter; the #1110 verifier check FAILs the diverged body otherwise). Plan: tasks/running/1188/plans/v2.md.