### PR TITLE
issue-1156: poller WARN on stale pid file vs run-launched marker

### DIFF
--- a/.claude/rules/pod-side-reporting.md
+++ b/.claude/rules/pod-side-reporting.md
@@ -204,10 +204,15 @@ relaunch, a watch-session correction — not just first launches:
    to rewrite the pid file with 11636 and re-post `epm:run-launched` — an
    entire extra round whose only content was this contract.
 
-Residual honesty: this contract is prose, not a runtime detector — a future
-relaunch that violates it can still produce the same silent false-dead shape;
-the poller's marker-pid OR-probe remains the only mechanical rescue, and only
-while the newest marker's pid is itself alive.
+Residual honesty: this contract now HAS a WARN-only runtime detector (#1156 —
+`poll_pipeline.py` warns on every tick, and sets the tick-JSON flag
+`pid_file_stale_vs_marker`, when the pid file's pod-clock mtime predates the
+newest `epm:run-launched` marker by more than
+`EPM_POLL_PID_MARKER_SLACK_SEC`, default 600 s), so a rewrite-skipping
+relaunch is named in the poll log instead of left to manual archaeology. The
+detector never changes a verdict: the poller's marker-pid OR-probe remains
+the only VERDICT-bearing mechanical rescue, and only while the newest
+marker's pid is itself alive.
 
 ### Pod-side preflight gates (behind-origin/main false positive — LEGACY post-#554)
 

--- a/scripts/poll_pipeline.py
+++ b/scripts/poll_pipeline.py
@@ -666,6 +666,13 @@ ZOMBIE_CPU_RATE_MIN_DT_SEC = int(os.environ.get("EPM_ZOMBIE_CPU_RATE_MIN_DT_SEC"
 # a restart for an ops flip to take effect.
 OUTPUT_MTIME_FOLD_ENABLED = os.environ.get("EPM_POLL_OUTPUT_MTIME_FOLD", "1") != "0"
 
+# #1156: slack for the stale-pid-file-vs-marker WARN. Must exceed the normal
+# launch->marker-post latency (the pid file is written BEFORE epm:run-launched
+# posts — experimenter.md steps 1/1b; worst observed normal-family gap 516 s,
+# the #813 v5 relaunch, so 600 s carries ~16% margin) while staying well under
+# the >=30 min inter-launch gap of a genuine stale file.
+PID_FILE_MARKER_SLACK_SEC = int(os.environ.get("EPM_POLL_PID_MARKER_SLACK_SEC", "600"))
+
 
 def _output_find_timeout_sec() -> int:
     """The bounded ``timeout`` (seconds) around the pod-side output ``find``.
@@ -875,6 +882,83 @@ def _run_launched_age_sec(issue: int, now_epoch: float) -> float | None:
     return now_epoch - launched.timestamp()
 
 
+def _pid_file_predates_marker(
+    *,
+    pid_file_mtime_epoch: int,
+    pod_now_epoch: int,
+    run_age_sec: float | None,
+    slack_sec: int | None = None,
+) -> bool:
+    """True iff the pod-side pid file's mtime predates the newest
+    epm:run-launched marker by more than ``slack_sec`` (#1156).
+
+    Same-clock differences only (#704): ``pod_now_epoch - pid_file_mtime_epoch``
+    is pod-clock, ``run_age_sec`` is VM-clock — never a cross-clock subtraction.
+    Inert (False) on any missing input: ``pid_file_mtime_epoch <= 0`` (absent /
+    stat failed / legacy probe), ``pod_now_epoch <= 0`` (no drift-free basis),
+    ``run_age_sec is None`` (no marker / unparseable ts). Pure; unit-tested
+    directly with no SSH.
+    """
+    if slack_sec is None:
+        slack_sec = PID_FILE_MARKER_SLACK_SEC
+    if pid_file_mtime_epoch <= 0 or pod_now_epoch <= 0 or run_age_sec is None:
+        return False
+    pid_file_age_sec = pod_now_epoch - pid_file_mtime_epoch
+    return pid_file_age_sec > run_age_sec + slack_sec
+
+
+def _maybe_warn_stale_pid_file(
+    *,
+    issue: int,
+    pod: str,
+    pid_file: str,
+    probe: dict[str, str],
+    run_age_sec: float | None,
+    pid_file_missing: bool,
+) -> bool:
+    """Fail-soft #1156 WARN emitter; returns the observability flag.
+
+    WARN-only by contract: never contributes to status / stall / dead.
+    ``pid_file_missing`` short-circuits (the #521 absent-file WARN already
+    covers that case — no double-fire). Any exception is swallowed to DEBUG:
+    the flag is WARN-only observability feeding no verdict, and every live
+    poll loop fleet-wide runs this hot shared script, so a broken backstop
+    must never break a tick — a deliberate, narrow exception to fail-fast
+    (the parse tolerance itself comes from the #1033 r2 defensive-scalar
+    pattern).
+    """
+    try:
+        if pid_file_missing:
+            return False
+        pod_now_epoch = _parse_output_mtime_epoch(probe.get("pod_now_epoch"))
+        pid_file_mtime_epoch = _parse_output_mtime_epoch(probe.get("pid_file_mtime_epoch"))
+        stale = _pid_file_predates_marker(
+            pid_file_mtime_epoch=pid_file_mtime_epoch,
+            pod_now_epoch=pod_now_epoch,
+            run_age_sec=run_age_sec,
+        )
+        if stale:
+            pid_age = pod_now_epoch - pid_file_mtime_epoch
+            log.warning(
+                "pid file %s on pod %s predates the newest epm:run-launched marker "
+                "for #%d (pid-file age %ds vs marker age %.0fs, slack %ds) — possible "
+                "stale pid from a prior launch masking a dead relaunch (#813 pid-file "
+                "rewrite contract). WARN-only; status verdict unchanged. Recovery: "
+                "rewrite the pid file with the live workload pid and re-post "
+                "epm:run-launched (pod-side-reporting.md § Pid-file launch contract).",
+                pid_file,
+                pod,
+                issue,
+                pid_age,
+                run_age_sec,
+                PID_FILE_MARKER_SLACK_SEC,
+            )
+        return stale
+    except Exception as exc:
+        log.debug("stale-pid-file-vs-marker check failed (ignored, #1156): %s", exc)
+        return False
+
+
 # Schema version the poller knows how to parse. Bump in lockstep with the
 # pod-side writer (currently ``run_experiment_<N>.py::SENTINEL_SCHEMA_VERSION``).
 # Newer schemas are skipped + logged, never silently mis-parsed.
@@ -1080,6 +1164,12 @@ class PollResult:
     # regardless of the once-per-episode dedup (an already-advised episode
     # still reports what it sees). Empty when no episode is active.
     post_done_phase_lines: tuple[str, ...] = ()
+    # True when the pod-side pid file's mtime predates the newest
+    # epm:run-launched marker by > PID_FILE_MARKER_SLACK_SEC (#1156 — the
+    # #813 stale-pid-after-relaunch shape). Observability only; status
+    # routing unchanged. Defaulted so cross-backend PollResult(...) call
+    # sites need no change.
+    pid_file_stale_vs_marker: bool = False
 
 
 def _ssh_probe(
@@ -1110,6 +1200,10 @@ def _ssh_probe(
       tick collapsed "file absent, marker-pid fallback in effect" into
       a bare ``pid_alive=False``). ``"0"`` on the SSH-failure fail-safe
       path — transport failure means "unknown", not "missing".
+    * ``pid_file_mtime_epoch`` — pod-clock mtime (``stat -c %Y``) of
+      ``pid_file``, feeding the #1156 stale-pid-file-vs-marker WARN.
+      ``"0"`` (always inert) when the file is absent / ``stat`` failed /
+      SSH failed / a legacy probe replay omits the line.
     * ``marker_pid_alive`` — liveness of ``marker_pid`` (the PID carried
       by the latest epm:run-launched marker) when one is supplied. The
       marker-pid probe is the self-correction path for a stale pidfile.
@@ -1518,6 +1612,7 @@ def _ssh_probe(
         f"LOG_PATH={log_path}; "
         f"if [ -f {pid_file} ]; then "
         f"  echo PID_FILE_MISSING=0; PID=$(cat {pid_file}); "
+        f"  echo PID_FILE_MTIME_EPOCH=$(stat -c %Y {pid_file} 2>/dev/null || echo 0); "
         f"  if ps -p $PID > /dev/null 2>&1; then echo PID_ALIVE=1; else echo PID_ALIVE=0; fi; "
         f"else echo PID_FILE_MISSING=1; echo PID_ALIVE=0; fi; "
         f"{marker_probe}"
@@ -1556,6 +1651,7 @@ def _ssh_probe(
         return {
             "pid_alive": "0",
             "pid_file_missing": "0",
+            "pid_file_mtime_epoch": "0",
             "marker_pid_alive": "0",
             "mtime_epoch": "0",
             "pod_now_epoch": "0",
@@ -1586,6 +1682,7 @@ def _ssh_probe(
 _PROBE_SCALAR_KEYS: tuple[str, ...] = (
     "PID_ALIVE",
     "PID_FILE_MISSING",
+    "PID_FILE_MTIME_EPOCH",
     "MARKER_PID_ALIVE",
     "MTIME_EPOCH",
     "POD_NOW_EPOCH",
@@ -1613,6 +1710,7 @@ def _parse_probe_stdout(stdout: str) -> dict[str, str]:
     parsed: dict[str, str] = {
         "pid_alive": "0",
         "pid_file_missing": "0",
+        "pid_file_mtime_epoch": "0",
         "marker_pid_alive": "0",
         "mtime_epoch": "0",
         "pod_now_epoch": "0",
@@ -4310,8 +4408,11 @@ def _parse_output_mtime_epoch(raw: str | None) -> int:
     line — must fail INERT, not kill the tick: return ``0``, which
     ``_log_staleness_secs`` maps to the ``10**9`` absent sentinel (the
     pre-#1033 no-fold behavior). Every numeric value parses exactly as the
-    previous inline ``int(raw or "0")`` did. Guards ONLY this new #1033 key —
-    the sibling probe ints keep their long-standing strict parses.
+    previous inline ``int(raw or "0")`` did. Guards ONLY the tolerant-parse
+    keys — this #1033 ``OUTPUT_MTIME_EPOCH`` scalar and the #1156 reads inside
+    ``_maybe_warn_stale_pid_file`` (``PID_FILE_MTIME_EPOCH`` + its
+    ``POD_NOW_EPOCH`` basis) — the sibling probe ints keep their
+    long-standing strict parses.
     """
     try:
         return int(raw or "0")
@@ -4735,6 +4836,18 @@ def poll_once(
     # ``prev_state`` (zombie_streak scoping is out of #1033's scope; the
     # post-done guard has its own natural epoch).
     run_age_sec = _run_launched_age_sec(issue, now_epoch)
+    # ── #1156 stale-pid-file-vs-marker WARN (observability-only) ─────────
+    # Placed here (not at the #521 pid_file_missing block above) so it
+    # reuses run_age_sec — keeping the "one events.jsonl read per tick"
+    # invariant. Never contributes to status / stall / dead.
+    pid_file_stale_vs_marker = _maybe_warn_stale_pid_file(
+        issue=issue,
+        pod=pod,
+        pid_file=pid_file,
+        probe=probe,
+        run_age_sec=run_age_sec,
+        pid_file_missing=pid_file_missing,
+    )
     tripwire_state, tripwire_run_epoch = _tripwire_run_scope(
         prev_state, run_age_sec=run_age_sec, now_epoch=now_epoch
     )
@@ -5027,6 +5140,7 @@ def poll_once(
         last_log_mtime_sec_ago=min(last_mtime_ago, 10**9),
         pid_alive=pid_alive,
         pid_file_missing=pid_file_missing,
+        pid_file_stale_vs_marker=pid_file_stale_vs_marker,
         log_tail_excerpt=tail_excerpt,
         gate=gate,
         sentinels_processed=sentinels_processed,
@@ -5106,6 +5220,7 @@ def main(argv: list[str] | None = None) -> int:
                 "last_log_mtime_sec_ago": result.last_log_mtime_sec_ago,
                 "pid_alive": result.pid_alive,
                 "pid_file_missing": result.pid_file_missing,
+                "pid_file_stale_vs_marker": result.pid_file_stale_vs_marker,
                 "log_tail_excerpt": result.log_tail_excerpt,
                 "gate": result.gate,
                 "sentinels_processed": result.sentinels_processed,

--- a/tests/test_poll_pipeline_stale_pid_warn.py
+++ b/tests/test_poll_pipeline_stale_pid_warn.py
@@ -1,0 +1,502 @@
+"""Stale-pid-file-vs-marker WARN backstop (#1156).
+
+A relaunch that skips the pid-file rewrite contract
+(`.claude/rules/pod-side-reporting.md` § Pid-file launch contract, #813 v5)
+leaves a PRIOR launch's dead pid in ``/workspace/logs/issue-<N>.pid``. A
+PRESENT-but-stale pid file is worse than a missing one: the #521
+``pid_file_missing`` WARN covers only absence, so the stale file is silently
+probed every tick. ``poll_pipeline`` now compares the pid file's pod-clock
+AGE (``POD_NOW_EPOCH - PID_FILE_MTIME_EPOCH``, drift-free per #704) against
+the VM-clock age of the newest ``epm:run-launched`` marker and WARNs — plus
+sets the observability-only ``pid_file_stale_vs_marker`` tick-JSON flag —
+when the pid file predates the marker by more than
+``PID_FILE_MARKER_SLACK_SEC`` (600 s default, env
+``EPM_POLL_PID_MARKER_SLACK_SEC``). Never a verdict change.
+
+These tests pin:
+
+* the pure predicate ``_pid_file_predates_marker`` — normal launch ordering
+  (pid file written BEFORE the marker, small positive delta) stays silent;
+  a prior-launch-aged pid file fires; the boundary is a strict ``>``;
+  missing inputs are inert; the marker-first (GCP pre-launch-signal)
+  ordering never fires;
+* the ``poll_once`` integration — the WARN + flag fire on the #813 shape
+  with the verdict untouched, under a 14 h pod-vs-VM drift in EITHER
+  direction (drift-free same-clock arithmetic); missing pid file / missing
+  marker / malformed mtime are silent and never crash the tick (the
+  fail-loud-acceptance backing for the fail-soft contract);
+* the probe heredoc emits ``PID_FILE_MTIME_EPOCH`` inside the ``[ -f ]``
+  branch; the ``main()`` JSON line surfaces the flag.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import logging
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_script_module(filename: str, alias: str):
+    """Load a ``scripts/*.py`` file as a module (mirrors
+    ``tests/test_poll_pipeline_clock_skew.py``'s loader)."""
+    spec = importlib.util.spec_from_file_location(alias, REPO_ROOT / "scripts" / filename)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[alias] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+pp = _load_script_module("poll_pipeline.py", "poll_pipeline_stale_pid_under_test")
+
+# The new WARN's identifying substring (asserted present/absent in caplog; the
+# #521 absent-file WARN says "absent on pod" and never matches this).
+_WARN_SUBSTR = "predates the newest epm:run-launched"
+
+# A non-`done`, non-`gate` tail so the verdict is the normal liveness path.
+_RUNNING_TAIL = "2026-07-09 00:00:01 [phase=training step=5/100]"
+# 14h pod-vs-VM drift: a cross-clock implementation would mis-read ages by
+# ~50400s in one direction or the other (tests 6 / 7 / 7b bracket both).
+_DRIFT_SEC = 14 * 3600
+
+
+# ── probe builder ──────────────────────────────────────────────────────────────
+
+
+def _probe_stdout(
+    *,
+    mtime_epoch: int,
+    pod_now_epoch: int | None,
+    tail: str,
+    gpu_util: str,
+    pid_file_missing: int = 0,
+    pid_alive: int = 1,
+    marker_pid_alive: int | None = None,
+    pid_file_mtime_epoch: int | str | None = None,
+    session_cpu: str = "unknown",
+) -> str:
+    """Probe stdout in the shape ``_parse_probe_stdout`` expects.
+
+    ``pod_now_epoch=None`` / ``pid_file_mtime_epoch=None`` /
+    ``marker_pid_alive=None`` OMIT the corresponding line entirely (legacy /
+    absent-branch replays); any value emits it. ``pid_file_mtime_epoch``
+    accepts a str so the malformed-scalar case is expressible.
+    """
+    lines = [f"PID_FILE_MISSING={pid_file_missing}"]
+    if pid_file_mtime_epoch is not None:
+        lines.append(f"PID_FILE_MTIME_EPOCH={pid_file_mtime_epoch}")
+    lines.append(f"PID_ALIVE={pid_alive}")
+    if marker_pid_alive is not None:
+        lines.append(f"MARKER_PID_ALIVE={marker_pid_alive}")
+    lines.append(f"MTIME_EPOCH={mtime_epoch}")
+    if pod_now_epoch is not None:
+        lines.append(f"POD_NOW_EPOCH={pod_now_epoch}")
+    lines += [
+        "TAIL_START",
+        tail,
+        "TAIL_END",
+        "CELL_MTIME_EPOCH=0",
+        "CELL_TAIL_START",
+        "CELL_TAIL_END",
+        "PHASE_LOG_MTIME_EPOCH=0",
+        "SHARD_LOG_MTIME_EPOCH=0",
+        f"GPU_UTIL={gpu_util}",
+        "ZOMBIE_GPU_PIDS=",
+        f"SESSION_CPU_SECS={session_cpu}",
+        "RESULTS_SENTINEL_PRESENT=0",
+    ]
+    return "\n".join(lines)
+
+
+def _patch_pod(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    probe_kwargs: dict[str, Any],
+    marker_pid: int | None = None,
+    run_age_sec: float | None = 10800.0,
+) -> None:
+    """Monkeypatch poll_pipeline's I/O boundary with a fully-controlled probe.
+
+    Mirrors ``tests/test_poll_pipeline_clock_skew.py::_patch_pod`` — the
+    sentinel-drain SSH call returns empty; the probe call returns the
+    controlled stdout; ``_marker_pid`` / ``_run_launched_age_sec`` (both
+    events.jsonl reads) are stubbed with the given values.
+    """
+
+    def _fake_run(cmd: list[str], **kwargs: Any):
+        import subprocess
+
+        remote = cmd[-1]
+        stdout = "" if "SENTINEL_START" in remote else _probe_stdout(**probe_kwargs)
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", _fake_run)
+    monkeypatch.setattr(pp, "post_event", MagicMock())
+    monkeypatch.setattr(pp, "_marker_pid", lambda issue: marker_pid)
+    monkeypatch.setattr(pp, "_run_launched_age_sec", lambda issue, now_epoch: run_age_sec)
+
+
+def _poll(tmp_path: Path):
+    """Run ``poll_once`` with the standard fixture args."""
+    return pp.poll_once(
+        issue=9813,
+        pod="pod-9813",
+        log_path="/workspace/logs/issue-9813.log",
+        pid_file="/workspace/logs/issue-9813.pid",
+        state_file=tmp_path / "poll-state.json",
+    )
+
+
+# ── 1-5. pure predicate (no SSH) ───────────────────────────────────────────────
+
+
+def test_predicate_normal_launch_ordering_no_warn() -> None:
+    """The EXPECTED ordering — pid file written 90 s before the marker posts
+    (pid_age = marker_age + 90) — must NOT fire: delta > 0 on EVERY healthy
+    launch, so a slack-0-like regression would warn on every tick."""
+    pod_now = 1_800_000_000
+    assert (
+        pp._pid_file_predates_marker(
+            pid_file_mtime_epoch=pod_now - 3690,  # pid_age 3690 = marker_age + 90
+            pod_now_epoch=pod_now,
+            run_age_sec=3600.0,
+            slack_sec=600,
+        )
+        is False
+    )
+
+
+def test_predicate_stale_prior_launch_pid_warns() -> None:
+    """A 2h-older pid file (the #813 prior-launch shape) fires."""
+    pod_now = 1_800_000_000
+    assert (
+        pp._pid_file_predates_marker(
+            pid_file_mtime_epoch=pod_now - (3600 + 7200),  # pid_age = marker_age + 7200
+            pod_now_epoch=pod_now,
+            run_age_sec=3600.0,
+            slack_sec=600,
+        )
+        is True
+    )
+
+
+def test_predicate_boundary_at_slack_no_warn() -> None:
+    """pid_age exactly marker_age + slack is silent (strict ``>`` — pins the
+    boundary so a future ``>=`` regression is caught)."""
+    pod_now = 1_800_000_000
+    assert (
+        pp._pid_file_predates_marker(
+            pid_file_mtime_epoch=pod_now - (3600 + 600),  # pid_age = marker_age + slack
+            pod_now_epoch=pod_now,
+            run_age_sec=3600.0,
+            slack_sec=600,
+        )
+        is False
+    )
+
+
+def test_predicate_missing_inputs_never_warn() -> None:
+    """Each missing input — pid-file mtime 0, pod-now 0, marker age None —
+    is inert even when every OTHER input reads as stale."""
+    pod_now = 1_800_000_000
+    stale_mtime = pod_now - (3600 + 7200)
+    assert (
+        pp._pid_file_predates_marker(
+            pid_file_mtime_epoch=0,
+            pod_now_epoch=pod_now,
+            run_age_sec=3600.0,
+            slack_sec=600,
+        )
+        is False
+    )
+    assert (
+        pp._pid_file_predates_marker(
+            pid_file_mtime_epoch=stale_mtime,
+            pod_now_epoch=0,
+            run_age_sec=3600.0,
+            slack_sec=600,
+        )
+        is False
+    )
+    assert (
+        pp._pid_file_predates_marker(
+            pid_file_mtime_epoch=stale_mtime,
+            pod_now_epoch=pod_now,
+            run_age_sec=None,
+            slack_sec=600,
+        )
+        is False
+    )
+
+
+def test_predicate_marker_newer_than_pid_file_no_warn() -> None:
+    """Marker posted BEFORE the workload booted (pid_age < marker_age — the
+    GCP pre-launch-signal ordering) never fires."""
+    pod_now = 1_800_000_000
+    assert (
+        pp._pid_file_predates_marker(
+            pid_file_mtime_epoch=pod_now - 120,  # pid_age 120 < marker_age 3600
+            pod_now_epoch=pod_now,
+            run_age_sec=3600.0,
+            slack_sec=600,
+        )
+        is False
+    )
+
+
+# ── 6-10. poll_once integration (SSH boundary faked) ───────────────────────────
+
+
+def test_poll_once_stale_pid_warns_sets_field_keeps_verdict(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The exact #813 shape under a 14h drift (pod clock BEHIND the VM):
+    stale pid file (3h-old on the pod clock vs a 1h-old marker), dead
+    pidfile pid rescued by a live marker pid. The WARN + flag fire and the
+    verdict stays ``running`` (acceptance criterion 1) with
+    ``pid_alive=True`` — the backstop never touches status routing."""
+    vm_now = int(time.time())
+    pod_now = vm_now - _DRIFT_SEC
+    _patch_pod(
+        monkeypatch,
+        probe_kwargs=dict(
+            mtime_epoch=pod_now - 30,  # fresh log on the pod clock
+            pod_now_epoch=pod_now,
+            tail=_RUNNING_TAIL,
+            gpu_util="95",
+            pid_alive=0,  # pid-file pid dead (the stale prior-launch pid)
+            marker_pid_alive=1,  # live relaunch pid via the marker OR-probe
+            pid_file_mtime_epoch=pod_now - 10800,  # 3h-old pid file
+        ),
+        marker_pid=12345,
+        run_age_sec=3600.0,  # marker 1h old → pid_age exceeds by 7200 > 600
+    )
+    with caplog.at_level(logging.WARNING, logger="poll_pipeline"):
+        result = _poll(tmp_path)
+    assert any(_WARN_SUBSTR in rec.message for rec in caplog.records), [
+        rec.message for rec in caplog.records
+    ]
+    assert result.pid_file_stale_vs_marker is True
+    assert result.status == "running", result
+    assert result.pid_alive is True
+
+
+def test_poll_once_normal_ordering_no_warn_under_drift(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Normal ordering (delta = 90 s) under the same 14h pod-BEHIND drift:
+    no WARN, flag False. A cross-clock implementation would read the pid-file
+    age as ~+14h here and FALSE-FIRE (this test + the pod-AHEAD sibling
+    bracket both drift directions — acceptance criterion 4)."""
+    vm_now = int(time.time())
+    pod_now = vm_now - _DRIFT_SEC
+    _patch_pod(
+        monkeypatch,
+        probe_kwargs=dict(
+            mtime_epoch=pod_now - 30,
+            pod_now_epoch=pod_now,
+            tail=_RUNNING_TAIL,
+            gpu_util="95",
+            pid_file_mtime_epoch=pod_now - 3690,  # pid_age 3690 = marker_age + 90
+        ),
+        run_age_sec=3600.0,
+    )
+    with caplog.at_level(logging.WARNING, logger="poll_pipeline"):
+        result = _poll(tmp_path)
+    assert not any(_WARN_SUBSTR in rec.message for rec in caplog.records), [
+        rec.message for rec in caplog.records
+    ]
+    assert result.pid_file_stale_vs_marker is False
+
+
+def test_poll_once_normal_ordering_no_warn_pod_clock_ahead(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Opposite drift sign — pod clock 14h AHEAD of the VM — on the same
+    normal-ordering case: still silent, flag False, tick completes. Pins the
+    false-SILENCE direction of a cross-clock bug (a VM-clock pid-file age
+    would read hugely NEGATIVE here, so any implementation whose behavior
+    depends on the drift sign — mis-firing on negatives, or crashing —
+    is caught; the same-clock arithmetic is sign-invariant)."""
+    vm_now = int(time.time())
+    pod_now = vm_now + _DRIFT_SEC  # pod clock AHEAD of the VM clock
+    _patch_pod(
+        monkeypatch,
+        probe_kwargs=dict(
+            mtime_epoch=pod_now - 30,
+            pod_now_epoch=pod_now,
+            tail=_RUNNING_TAIL,
+            gpu_util="95",
+            pid_file_mtime_epoch=pod_now - 3690,  # pid_age 3690 = marker_age + 90
+        ),
+        run_age_sec=3600.0,
+    )
+    with caplog.at_level(logging.WARNING, logger="poll_pipeline"):
+        result = _poll(tmp_path)
+    assert not any(_WARN_SUBSTR in rec.message for rec in caplog.records), [
+        rec.message for rec in caplog.records
+    ]
+    assert result.pid_file_stale_vs_marker is False
+
+
+def test_poll_once_missing_pid_file_no_stale_warn(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A MISSING pid file short-circuits the new WARN (the #521 absent-file
+    WARN owns that case — no double-fire), even when a stale-looking mtime
+    scalar rides the probe stdout. Asserts on the NEW substring only (the
+    #521 WARN legitimately fires here)."""
+    vm_now = int(time.time())
+    pod_now = vm_now
+    _patch_pod(
+        monkeypatch,
+        probe_kwargs=dict(
+            mtime_epoch=pod_now - 30,
+            pod_now_epoch=pod_now,
+            tail=_RUNNING_TAIL,
+            gpu_util="95",
+            pid_file_missing=1,
+            pid_alive=0,
+            marker_pid_alive=1,
+            pid_file_mtime_epoch=pod_now - 10800,  # would fire if not short-circuited
+        ),
+        marker_pid=12345,
+        run_age_sec=3600.0,
+    )
+    with caplog.at_level(logging.WARNING, logger="poll_pipeline"):
+        result = _poll(tmp_path)
+    assert not any(_WARN_SUBSTR in rec.message for rec in caplog.records), [
+        rec.message for rec in caplog.records
+    ]
+    assert result.pid_file_stale_vs_marker is False
+
+
+def test_poll_once_no_marker_no_warn(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """No epm:run-launched marker (``_run_launched_age_sec`` → None): the
+    predicate is inert — no WARN, flag False, no crash."""
+    vm_now = int(time.time())
+    pod_now = vm_now
+    _patch_pod(
+        monkeypatch,
+        probe_kwargs=dict(
+            mtime_epoch=pod_now - 30,
+            pod_now_epoch=pod_now,
+            tail=_RUNNING_TAIL,
+            gpu_util="95",
+            pid_file_mtime_epoch=pod_now - 10800,  # 3h-old pid file, but no marker
+        ),
+        marker_pid=None,
+        run_age_sec=None,
+    )
+    with caplog.at_level(logging.WARNING, logger="poll_pipeline"):
+        result = _poll(tmp_path)
+    assert not any(_WARN_SUBSTR in rec.message for rec in caplog.records), [
+        rec.message for rec in caplog.records
+    ]
+    assert result.pid_file_stale_vs_marker is False
+
+
+def test_poll_once_malformed_mtime_fail_soft(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A garbled probe scalar (``PID_FILE_MTIME_EPOCH=garbage``) must fail
+    INERT: the tick completes normally (no exception — this test + the
+    missing-pid-file / no-marker tests are the test-enforced fail-soft
+    contract, plan check 15), flag False."""
+    vm_now = int(time.time())
+    _patch_pod(
+        monkeypatch,
+        probe_kwargs=dict(
+            mtime_epoch=vm_now - 30,
+            pod_now_epoch=vm_now,
+            tail=_RUNNING_TAIL,
+            gpu_util="95",
+            pid_file_mtime_epoch="garbage",
+        ),
+        run_age_sec=3600.0,
+    )
+    result = _poll(tmp_path)
+    assert result.status == "running", result
+    assert result.pid_file_stale_vs_marker is False
+
+
+# ── 11. heredoc emits the new capture line ──────────────────────────────────────
+
+
+def test_heredoc_emits_pid_file_mtime_epoch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The probe heredoc emits ``PID_FILE_MTIME_EPOCH=$(stat -c %Y ...)``
+    INSIDE the ``[ -f ]`` branch — after ``PID_FILE_MISSING=0`` and before
+    the ``else`` arm. Capture scoped to ``cmd[0] == "ssh"`` (mirrors the
+    clock-skew heredoc test — ``poll_once`` also runs non-ssh subprocesses
+    through the mocked ``subprocess.run``)."""
+    captured: dict[str, str] = {}
+    vm_now = int(time.time())
+
+    def _fake_run(cmd: list[str], **kwargs: Any):
+        import subprocess
+
+        remote = cmd[-1]
+        if "SENTINEL_START" in remote:
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+        if cmd[0] == "ssh":
+            captured["heredoc"] = remote
+        stdout = _probe_stdout(
+            mtime_epoch=vm_now - 30,
+            pod_now_epoch=vm_now,
+            tail=_RUNNING_TAIL,
+            gpu_util="95",
+        )
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(pp.subprocess, "run", _fake_run)
+    monkeypatch.setattr(pp, "post_event", MagicMock())
+    monkeypatch.setattr(pp, "_marker_pid", lambda issue: None)
+    monkeypatch.setattr(pp, "_run_launched_age_sec", lambda issue, now_epoch: 10800.0)
+
+    _poll(tmp_path)
+    assert "heredoc" in captured, "probe ssh call was never made"
+    heredoc = captured["heredoc"]
+    m = re.search(r"PID_FILE_MTIME_EPOCH=\$\(stat -c %Y", heredoc)
+    assert m, heredoc
+    present_idx = heredoc.index("PID_FILE_MISSING=0")
+    absent_idx = heredoc.index("else echo PID_FILE_MISSING=1")
+    assert present_idx < m.start() < absent_idx, heredoc
+
+
+# ── 12. main() JSON line surfaces the flag ──────────────────────────────────────
+
+
+def test_main_json_line_surfaces_stale_flag(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``main()`` surfaces ``pid_file_stale_vs_marker`` in the tick JSON
+    (the machine-readable channel the orchestrator consumes)."""
+    fake_result = pp.PollResult(
+        status="running",
+        current_phase="training",
+        new_milestone=False,
+        last_log_mtime_sec_ago=30,
+        pid_alive=True,
+        pid_file_missing=False,
+        log_tail_excerpt="",
+        pid_file_stale_vs_marker=True,
+    )
+    monkeypatch.setattr(pp, "poll_once", lambda **kwargs: fake_result)
+    rc = pp.main(["--issue", "1", "--pod", "p", "--log", "l", "--pid-file", "f"])
+    assert rc == 0
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["pid_file_stale_vs_marker"] is True


### PR DESCRIPTION
Closes task #1156. WARN-only backstop: poll_pipeline.py warns when the pod-side pid file's mtime predates the newest epm:run-launched marker by > 600s (env EPM_POLL_PID_MARKER_SLACK_SEC). Never a verdict change. 13 new tests; plan/critics/code-review/test-verdict all PASS on the task record.