### PR TITLE
workflow-fix #1204: pre-spawn Codex quota-sentinel check before composer spawns

### DIFF
--- a/.claude/skills/adversarial-planner-v2/SKILL.md
+++ b/.claude/skills/adversarial-planner-v2/SKILL.md
@@ -182,6 +182,12 @@ Consistency-checker + the (implementation-side) plan-adherence lens are
 Claude-only. Pass each subagent the PATH to `plans/vN.md` + `planned_manifest.json`,
 never the bodies (429 pacing).
 
+**Quota-sentinel pre-check first (#1204, CLAUDE.md § Codex ensemble
+review):** when LIVE, the batch is the 3 Claude critics +
+consistency-checker only — all 3 codex twins skipped as instant
+confirmed no-shows (single-Claude per lens), one `epm:progress` note per
+round.
+
 ### 2. Per-lens ensemble decision + reconciler
 
 Per twinned lens (statistics / methodology-baselines / efficiency), combine the
@@ -252,6 +258,9 @@ DRAFT (Step 1):
 
 CRITIQUE (Step 3, post-approval):
   loop (cap 5):
+    # pre: #1204 quota-sentinel check (CLAUDE.md § Codex ensemble review) —
+    #      if LIVE, spawn Claude critics + consistency-checker only;
+    #      codex twins = instant no-show per lens.
     spawn batch: statistics-critic + codex twin
                ∥ methodology-baselines-critic + codex twin
                ∥ efficiency-critic + codex twin

--- a/.claude/skills/adversarial-planner/SKILL.md
+++ b/.claude/skills/adversarial-planner/SKILL.md
@@ -253,6 +253,14 @@ between Claude and Codex twins is resolved by the `reconciler` agent in
 `.claude/workflow.yaml § ensemble_review.doubled_steps[critic]` and
 `.claude/agents/reconciler.md` § "Two Output Modes".
 
+**Quota-sentinel pre-check first (#1204).** Run the canonical check
+(CLAUDE.md § Codex ensemble review). `CODEX_QUOTA_LIVE` → spawn ONLY the
+3 Claude lens critics (+ consistency-checker when riding the batch) and
+skip all 3 `codex-critic` composer spawns this round; record each lens
+as an instant confirmed Codex no-show (single-Claude per the Phase-2
+no-show row — no output-file probe) and log one line (+ one
+`epm:progress` note on #N when run from /issue Step 2).
+
 **Consistency-checker rides the same spawn batch (when invoked from
 `/issue` Step 2).** The orchestrator spawns the `consistency-checker`
 agent CONCURRENTLY with the 6 critics (7 parallel spawns in one
@@ -394,7 +402,9 @@ reconciler once; if still none, do NOT adjudicate the disagreement
 yourself — adopt the MORE SEVERE of the two lens verdicts as a
 fail-safe (biasing toward revision, never toward shipping) and record
 the unresolved reconcile in the merged critique handed to the
-plan-approval gate.
+plan-approval gate. A #1204 sentinel-skip is exempt from this probe —
+the composer never ran, so no prompt/output file exists for the round;
+the skip itself is the confirmed no-show.
 
 **Cross-lens merge (after per-lens reconciliation):**
 
@@ -524,6 +534,9 @@ if "WRONG" in verifier_result:
 #    NOT bg-dispatch themselves (CLAUDE.md § "Codex task dispatch": only
 #    the orchestrator's direct bg-Bash invocation delivers a real
 #    notification when Codex terminates).
+# 4-pre. Quota-sentinel pre-check (#1204, CLAUDE.md § Codex ensemble review):
+#    if LIVE, skip the three *_codex spawns below (instant no-show per lens);
+#    Claude spawns + c_check unchanged.
 m_claude = Agent(subagent_type="critic",       prompt="[Methodology lens] Critique:\n\n{corrected_plan}",   run_in_background=True)
 m_codex  = Agent(subagent_type="codex-critic", prompt="lens=methodology\nplan_body:\n{corrected_plan}",     run_in_background=True)
 s_claude = Agent(subagent_type="critic",       prompt="[Statistics lens] Critique:\n\n{corrected_plan}",    run_in_background=True)

--- a/.claude/skills/issue-v2/SKILL.md
+++ b/.claude/skills/issue-v2/SKILL.md
@@ -190,6 +190,13 @@ CLAUDE.md § 429 token-pacing):
 - `efficiency-critic` ∥ its Codex twin `codex-efficiency-critic`
 - `consistency-checker` (Claude-only, no twin)
 
+**Quota-sentinel pre-check first (#1204, CLAUDE.md § Codex ensemble
+review):** when LIVE, spawn only `statistics-critic` ∥
+`methodology-baselines-critic` ∥ `efficiency-critic` ∥
+`consistency-checker` — skip all 3 codex-twin composer spawns this round
+(instant confirmed no-show per lens, single-Claude decision), one
+`epm:progress` note per round.
+
 The Codex twins are prompt-composers; **the orchestrator bg-dispatches each via
 `scripts/codex_task.py`** exactly as CLAUDE.md § "Codex ensemble review"
 prescribes (the wrapper never self-dispatches Codex — orphan-job anti-pattern
@@ -285,6 +292,11 @@ event-driven, no ask site).
   **multi-GPU: launch commands demonstrably shard across every provisioned GPU**).
 - `efficiency-critic` (implementation mode) — the Claude side of the same
   efficiency checks.
+
+**Quota-sentinel pre-check first (#1204, CLAUDE.md § Codex ensemble
+review):** when LIVE, skip the `codex-code-reviewer` twin spawn;
+`code-correctness-critic` proceeds Claude-only per the v1 Step 5d
+no-show fallback (applied verbatim here).
 
 Ensemble decision, reconciler on disagreement, mechanical-strip, and **round cap
 5** are IDENTICAL to v1 (`.claude/skills/issue/SKILL.md` § "Step 5: Code review

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -2116,6 +2116,13 @@ Copy the verbatim forms from Step 10d § "Bare push / merge snippets".
 
 **5a. Spawn both reviewers in parallel (fresh contexts, single message).**
 
+**Quota-sentinel pre-check first (#1204).** Run the canonical pre-spawn
+check (CLAUDE.md § Codex ensemble review). `CODEX_QUOTA_LIVE` → spawn
+ONLY the Claude `code-reviewer` this round; record the Codex twin as an
+instant confirmed no-show per the Step 5d no-show fallback (no
+durable-verdict probe — nothing was dispatched) and post the one-line
+`epm:progress` note.
+
 **Spec-freshness check first (worktree-cwd sessions; applies at EVERY
 ensemble/agent fan-out — here, the Step 9a analyzer + critic ensembles,
 and 9a-bis).** The Agent tool loads agent specs (and Skill playbooks)
@@ -2650,7 +2657,12 @@ Step 5b rule; NEVER adopt a unilateral decision from the surviving
 reviewer (incident #810 r4). An `epm:codex-task-failed` note carrying
 `codex-quota-exhausted` is the org-quota outage short-circuit (#1126):
 treat as an instant no-show (Claude-only), do not re-dispatch or
-investigate; the sentinel self-expires at the stated reset.
+investigate; the sentinel self-expires at the stated reset. The Step 5a
+pre-spawn sentinel check (#1204) makes this fallback fire WITHOUT
+spawning the composer: a sentinel-skip recorded at spawn time is a
+confirmed no-show — do NOT run the durable-verdict probe for a round
+whose composer was never spawned, and do not wait for any
+`epm:codex-task-*` marker (none will exist).
 
 ##### Step 5.bis: Pre-dispatch checks (compute-deviation + whack-a-mole)
 
@@ -5692,6 +5704,11 @@ discarded by Step 8's gap-fill decision rule).
      — same 7 lenses (lens 6 plot-prose works on Codex multimodal).
      Posts `epm:interp-critique-codex v1`.
 
+   Quota-sentinel pre-check first (#1204, CLAUDE.md § Codex ensemble
+   review): when LIVE, spawn only the Claude critic; instant confirmed
+   Codex no-show per the decision-table no-show row + one `epm:progress`
+   note.
+
    Neither sees the analyzer's reasoning. Independence is load-bearing.
 
 3. **Apply ensemble decision rule** (see
@@ -6213,7 +6230,11 @@ dispatching this round's critics.
 
 2. Spawn `codex-clean-result-critic` (Codex twin) in parallel on
    every round (all-rounds ensemble as of 2026-06-12; previously
-   round 1 only). Brief contract (matches
+   round 1 only). Quota-sentinel pre-check first (#1204, CLAUDE.md
+   § Codex ensemble review): when LIVE, skip this twin's composer
+   spawn — instant confirmed Codex no-show per this step's no-show
+   handling (Claude-only ensemble decision) + one `epm:progress`
+   note. Brief contract (matches
    `.claude/agents/codex-clean-result-critic.md` § "Your brief
    contains" + Step 1b): pass the ABSOLUTE
    `$(task.py find <N>)/body.md` as `clean_result_body_path` and
@@ -6806,7 +6827,11 @@ autonomous block step 2-bis, and Step 10b):
 >    four twin sites (CLAUDE.md § "Codex ensemble review"); the twin agent
 >    NEVER dispatches Codex itself (orphan-job anti-pattern, #533). Post
 >    `epm:followup-value-critique v1` (Claude) + `epm:followup-value-critique-codex`
->    (Codex) on this task's `events.jsonl`.
+>    (Codex) on this task's `events.jsonl`. Quota-sentinel pre-check
+>    first (#1204, CLAUDE.md § Codex ensemble review): when LIVE, spawn
+>    only the Claude `follow-up-critic`; the merge in step 3 proceeds
+>    Claude-only per the existing no-show contract, + one `epm:progress`
+>    note.
 > 3. **Merge the verdicts PER PROPOSAL** (single pass — no round loop;
 >    `single_pass: true`). For each proposal: both `not-redundant` →
 >    `not-redundant`. Both `redundant` → `redundant` (the merged
@@ -9636,6 +9661,11 @@ investigate and optionally `task.py set-status <N> blocked`.
 
 **Resume correctness per active state** (the key benefit of having
 dedicated "working" statuses):
+
+Every "re-spawn `codex-*` … only" action in this table is subject to the
+#1204 pre-spawn sentinel check (CLAUDE.md § Codex ensemble review): when
+LIVE, record the instant confirmed no-show instead of re-spawning the
+composer.
 
 | Status at resume | `epm:*` events present | Interpretation | Action |
 |------------------|------------------------|----------------|--------|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,31 @@ Bash(run_in_background=true,
     --prompt-file /tmp/codex-prompt-issue-<N>.md --output-file /tmp/codex-output-issue-<N>.md")
 ```
 
-Helper posts `epm:codex-task-spawned`, then `epm:codex-task-completed`/`epm:codex-task-failed`. On marker-post failure: retry once, then drop to `tasks/_orphaned_markers/`. Orchestrator posts the verdict marker after reading the output file. On a hard org usage-limit failure the helper writes `.claude/cache/codex-quota-exhausted-until` and short-circuits every later dispatch until the parsed reset (exit 9, note reason `codex-quota-exhausted`); delete the sentinel to force a probe dispatch (#1126). If the wrapper/session is killed leaving the Codex job running (an `epm:codex-task-spawned` with no terminal marker), first confirm the wrapper is actually dead (`pgrep -f 'codex_task.py.*<job-id>'` empty — a live wrapper would double-poll, duplicate markers, and cross-cancel on signal), then re-attach instead of re-dispatching: `uv run python scripts/codex_task.py --issue <N> --reattach <job-id> --output-file <same path>`; the helper's bounded result-fetch retry also absorbs transient `No job found` registry blips (#1020).
+Helper posts `epm:codex-task-spawned`, then `epm:codex-task-completed`/`epm:codex-task-failed`. On marker-post failure: retry once, then drop to `tasks/_orphaned_markers/`. Orchestrator posts the verdict marker after reading the output file. On a hard org usage-limit failure the helper writes `.claude/cache/codex-quota-exhausted-until` and short-circuits every later dispatch until the parsed reset (exit 9, note reason `codex-quota-exhausted`); delete the sentinel to force a probe dispatch (#1126).
+
+**Pre-spawn sentinel check (#1204) — check BEFORE composing.** The exit-9 short-circuit fires at DISPATCH time, but the thin `codex-*` composers spawn in the same batch as the Claude reviewers BEFORE any dispatch — during a known outage each round burns 1–3 composer spawns whose prompts are discarded (≥9 sessions, 2026-07-08; #1135/#1146 show the intended skip done ad hoc). Before spawning any `codex-*` prompt-composer in a review round, run the canonical check below. If it prints `CODEX_QUOTA_LIVE`, SKIP every `codex-*` composer spawn that round: treat each twin as an INSTANT CONFIRMED no-show (single-Claude decision per that site's existing no-show fallback — no durable-verdict / output-file probe: nothing was composed or dispatched), log ONE chat line, and post ONE `epm:progress` note per skipped round when a task is in scope (`codex composers skipped — quota sentinel live until <until_iso> (#1204 pre-spawn check); single-Claude per no-show fallback`). NEVER fabricate `epm:codex-task-failed` or a twin verdict marker — those belong to the helper/twin. FAIL-OPEN: sentinel absent / unreadable / corrupt / expired / implausibly far-future, or `EPM_SKIP_CODEX_QUOTA_SENTINEL=1` → spawn normally (the dispatch-time exit-9 short-circuit stays the arbiter and backstop). The decision keys on the TWO-SIDED window `now < until_unix <= now + 45 d` — the upper bound is the helper's `QUOTA_MAX_PLAUSIBLE_SECS` plausibility ceiling (`codex_task.py:295`), so a hand-seeded or corrupt far-future timestamp can never wedge composer spawning off permanently (it prints CLEAR and the next dispatch's `_quota_sentinel_active` deletes it). A `parse_ok: false` sentinel with a plausible future `until_unix` (the helper's 24h fallback TTL) is honored the same as a parsed one.
+
+```bash
+# Canonical pre-spawn quota check (#1204): CODEX_QUOTA_LIVE until=<iso> | CODEX_QUOTA_CLEAR
+ROOT="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"   # main checkout, worktree-safe
+uv run python -c '
+import json, os, sys, time
+p = os.environ.get("EPM_CODEX_QUOTA_SENTINEL_PATH") or sys.argv[1]
+try:
+    assert os.environ.get("EPM_SKIP_CODEX_QUOTA_SENTINEL") != "1"
+    d = json.load(open(p))
+    now = time.time()
+    until = float(d["until_unix"])
+    assert now < until <= now + 45 * 86400   # QUOTA_MAX_PLAUSIBLE_SECS parity (codex_task.py:295)
+    print("CODEX_QUOTA_LIVE until=" + str(d.get("until_iso", "?")))
+except Exception:
+    print("CODEX_QUOTA_CLEAR")
+' "$ROOT/.claude/cache/codex-quota-exhausted-until"
+```
+
+(Read-only check: unlike `_quota_sentinel_active` it never deletes an expired/corrupt/far-future sentinel — lifecycle stays with the helper.)
+
+If the wrapper/session is killed leaving the Codex job running (an `epm:codex-task-spawned` with no terminal marker), first confirm the wrapper is actually dead (`pgrep -f 'codex_task.py.*<job-id>'` empty — a live wrapper would double-poll, duplicate markers, and cross-cancel on signal), then re-attach instead of re-dispatching: `uv run python scripts/codex_task.py --issue <N> --reattach <job-id> --output-file <same path>`; the helper's bounded result-fetch retry also absorbs transient `No job found` registry blips (#1020).
 
 ## Context hygiene
 


### PR DESCRIPTION
Closes task #1204.

Adds the canonical pre-spawn quota-sentinel check (CLAUDE.md § Codex ensemble review) + pointers at every codex-* composer spawn site (issue / adversarial-planner / adversarial-planner-v2 / issue-v2 SKILL.md). Skip fires only inside the two-sided plausibility window (now < until_unix <= now+45d, QUOTA_MAX_PLAUSIBLE_SECS parity); fail-open otherwise; exit-9 dispatch short-circuit stays the backstop. scripts/codex_task.py untouched.

Plan: tasks/completed/1204/plans/plan.md · code-review PASS · test-verdict PASS (2864 passed).