### PR TITLE
issue-1153: workflow_lint check_awk_elision_parity (#1153)

### DIFF
--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -371,6 +371,18 @@ Behaviours:
   the positive tokens are the primary defense). Paragraph-scoped: the span
   runs from the anchor to the first blank line, so a mid-paragraph split
   FAILs loudly (#963).
+* ``--check-awk-elision-parity`` (also bundled into the no-flags default
+  run): FAIL if the ban-gate awk elision program — the single-quoted awk
+  program on the unique ``f=!f`` anchor line — drifts between its two
+  full-text homes (/issue SKILL.md Step 9a-humanize;
+  analyzer-section-reference.md Step 4.5), or a home is missing / has 0 or
+  >1 anchor lines / carries an anchor line whose total single-quote count is
+  not exactly 2 (a program that gained a shell quote-escape would truncate
+  the extraction at the first quote in both homes, hiding drift past the
+  truncation point) / yields no extractable ``awk '...'`` span. Pins the
+  quoted PROGRAM only — the surrounding invocation lines (paths, fencing,
+  indentation) legitimately differ — and parity is not correctness: an
+  identical-but-broken edit applied to both homes passes by design (#1153).
 
 Exit codes:
 
@@ -6286,6 +6298,91 @@ def check_vm_thread_cap_guidance(*, repo_root: Path | None = None) -> list[str]:
     return errors
 
 
+_AWK_ELISION_ANCHOR = "f=!f"
+
+# The two FULL-TEXT homes of the ban-gate awk elision program (#1153, origin
+# #998): the /issue SKILL.md Step 9a-humanize gate and the analyzer's
+# Step 4.5 mirror. A future third full-text copy must be added here.
+_AWK_ELISION_HOMES = (
+    ".claude/skills/issue/SKILL.md",
+    ".claude/rules/analyzer-section-reference.md",
+)
+
+_AWK_ELISION_PROGRAM_RE = re.compile(r"awk '([^']*)'")
+
+
+def check_awk_elision_parity(*, repo_root: Path | None = None) -> list[str]:
+    """FAIL if the ban-gate awk elision program drifts between its two
+    full-text homes (#1153, origin #998).
+
+    The elision program is executable text agents copy-paste at run time
+    (/issue SKILL.md Step 9a-humanize; analyzer-section-reference.md Step
+    4.5), so a divergent copy makes the humanize ban-gate behave differently
+    depending on which file the agent read. Per home the check fails loud
+    when the file is missing, when the ``f=!f`` anchor matches 0 or >1
+    lines, when the anchor line's total single-quote count is not exactly 2
+    (a program that gained a shell quote-escape would truncate the
+    extraction at the first quote IDENTICALLY in both homes, hiding drift
+    past the truncation point — so any non-2 count fails instead), or when
+    no single ``awk '...'`` span is extractable; then the two extracted
+    PROGRAMS must compare equal. Scope: the quoted PROGRAM only — the
+    surrounding invocation (input/output paths, fencing, indentation,
+    continuation lines) legitimately differs between homes. Parity is not
+    correctness: an identical-but-broken edit applied to BOTH homes passes
+    by design. A future third full-text copy must be added to
+    ``_AWK_ELISION_HOMES``. ``repo_root`` is a unit-test override hook;
+    production callers pass None. Bundled into the no-flags default run.
+    """
+    root = repo_root if repo_root is not None else _REPO_ROOT
+    errors: list[str] = []
+    programs: list[tuple[str, str]] = []
+    for rel in _AWK_ELISION_HOMES:
+        p = root / rel
+        if not p.is_file():
+            errors.append(
+                f"{p}: missing — a ban-gate awk elision home must exist; if the "
+                f"program deliberately moved, update _AWK_ELISION_HOMES (#1153)."
+            )
+            continue
+        anchor_lines = [
+            ln for ln in p.read_text(encoding="utf-8").split("\n") if _AWK_ELISION_ANCHOR in ln
+        ]
+        if len(anchor_lines) != 1:
+            errors.append(
+                f"{p}: expected exactly 1 line containing the awk elision anchor "
+                f"{_AWK_ELISION_ANCHOR!r}, found {len(anchor_lines)} — a moved, "
+                f"deleted, or duplicated copy must not silently pass (#1153)."
+            )
+            continue
+        line = anchor_lines[0]
+        n_quotes = line.count("'")
+        if n_quotes != 2:
+            errors.append(
+                f"{p}: the awk elision anchor line carries {n_quotes} single-quote "
+                f"character(s), expected exactly 2 — a reflowed program or a gained "
+                f"quote-escape would silently truncate the extraction; keep the "
+                f"program one plain `awk '...'` span on one line, or update this "
+                f"lint (#1153)."
+            )
+            continue
+        progs = _AWK_ELISION_PROGRAM_RE.findall(line)
+        if len(progs) != 1:
+            errors.append(
+                f"{p}: could not extract exactly one single-quoted awk program from "
+                f"the anchor line (found {len(progs)}) — keep the program a single "
+                f"`awk '...'` span on one line, or update this lint (#1153)."
+            )
+            continue
+        programs.append((rel, progs[0]))
+    if not errors and len(programs) == 2 and programs[0][1] != programs[1][1]:
+        errors.append(
+            f"{programs[0][0]} vs {programs[1][0]}: the ban-gate awk elision programs "
+            f"DIFFER — the two full-text homes must stay byte-identical; edit both "
+            f"homes identically (#1153)."
+        )
+    return errors
+
+
 # `--check-lessons-index`: every `.claude/rules/*.md` (except LESSONS.md
 # itself) must have exactly one matching row in `.claude/rules/LESSONS.md`, and
 # every row in LESSONS.md must point at an existing rule file. Closes the
@@ -7333,6 +7430,19 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         "(incident #779). Bundled into the no-flags default run.",
     )
     parser.add_argument(
+        "--check-awk-elision-parity",
+        action="store_true",
+        help="FAIL if the ban-gate awk elision program (the single-quoted awk "
+        "program on the unique f=!f anchor line) drifts between its two "
+        "byte-identical full-text homes — the /issue SKILL.md Step "
+        "9a-humanize gate and analyzer-section-reference.md Step 4.5 — or a "
+        "home is missing, has 0 or >1 anchor lines, carries a non-2 total "
+        "single-quote count on the anchor line (quote-escape truncation "
+        "guard), or yields no extractable awk '...' span (#1153). Compares "
+        "the quoted PROGRAM only; the surrounding invocation lines "
+        "legitimately differ. Bundled into the no-flags default run.",
+    )
+    parser.add_argument(
         "--check-judge-model-pins",
         action="store_true",
         help="Walk scripts/**/*.py, scripts/**/*.sh, "
@@ -7481,6 +7591,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         or args.check_stale_label_disposition
         or args.check_smoke_output_hygiene
         or args.check_vm_thread_cap_guidance
+        or args.check_awk_elision_parity
         or args.check_judge_model_pins
         or args.check_no_literal_round_marker_versions
         or args.check_agent_spec_size
@@ -7577,6 +7688,8 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         errors.extend(check_smoke_output_hygiene())
     if args.check_vm_thread_cap_guidance or no_flags:
         errors.extend(check_vm_thread_cap_guidance())
+    if args.check_awk_elision_parity or no_flags:
+        errors.extend(check_awk_elision_parity())
     if args.check_judge_model_pins or no_flags:
         errors.extend(check_judge_model_pins())
     if args.check_no_literal_round_marker_versions or no_flags:

--- a/tests/test_workflow_lint.py
+++ b/tests/test_workflow_lint.py
@@ -41,6 +41,7 @@ from workflow_lint import (  # noqa: E402
     check_agent_model_pins,
     check_asks,
     check_autonomous_asks,
+    check_awk_elision_parity,
     check_batch_judge_client,
     check_compute_shape_review_lens,
     check_dispatcher_cvd_pin,
@@ -4208,6 +4209,200 @@ def test_stale_label_disposition_clause_dedicated_flag_isolated(tmp_path, capsys
     err = capsys.readouterr().err
     assert rc == 0, (
         f"--check-stale-label-disposition ran more than the (conforming) stale-label "
+        f"check — no_flags mis-computed True, i.e. the flag's membership in the "
+        f"no_flags tuple in workflow_lint.main() is missing:\n{err}"
+    )
+
+
+# --- #1153 awk elision-program parity tests ----------------------------------
+
+# A program with the ``f=!f`` anchor and no single quotes (matches the live
+# program's shape at the time of writing; the check compares homes against
+# EACH OTHER, so tests only need SOME shared program).
+_AWK_ELISION_TEST_PROGRAM = (
+    "/^```/{f=!f; next} f{next} /^<details/{d=1} d{if(/<\\/details>/)d=0; next} "
+    "/^>/{next} {print} END{if(f||d) exit 3}"
+)
+
+_AWK_HOME_SKILL = ".claude/skills/issue/SKILL.md"
+_AWK_HOME_ANALYZER = ".claude/rules/analyzer-section-reference.md"
+
+
+def _write_awk_home(root: Path, rel: str, body: str) -> None:
+    """Write ``rel`` under ``root`` with ``body`` (parents created)."""
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+
+
+def _awk_skill_body(program: str = _AWK_ELISION_TEST_PROGRAM) -> str:
+    """SKILL.md-shaped home: the program inside a FENCED bash block, 3-space
+    indent, with its own input/output continuation line."""
+    return (
+        "# issue skill\n\nStep 9a-humanize ban gate:\n\n"
+        "```bash\n"
+        f"   awk '{program}' \\\n"
+        "     body.md > elided.md\n"
+        "```\n"
+    )
+
+
+def _awk_analyzer_body(
+    program: str = _AWK_ELISION_TEST_PROGRAM, anchor_line: str | None = None
+) -> str:
+    """analyzer-section-reference.md-shaped home: the program in a 4-space
+    INDENTED block with DIFFERENT surroundings/paths than the skill home.
+    ``anchor_line`` replaces the whole program line (malformed-line cases)."""
+    line = anchor_line if anchor_line is not None else f"    awk '{program}' \\"
+    return f"# analyzer section reference\n\nStep 4.5:\n\n{line}\n        draft.md > out.md\n"
+
+
+def test_awk_elision_parity_live_tree_passes() -> None:
+    """The real tree carries ONE anchor line per home, 2 quotes each, with
+    byte-identical extracted programs (#1153)."""
+    assert check_awk_elision_parity() == []
+
+
+def test_awk_elision_parity_conforming_tmp_tree_passes(tmp_path) -> None:
+    """Same program, DIFFERENT surroundings — one fenced ```bash block, one
+    4-space-indented block, different in/out paths on the continuation
+    lines — PASSes: pins that the check tolerates the homes' real
+    formatting differences and compares the quoted PROGRAM only."""
+    _write_awk_home(tmp_path, _AWK_HOME_SKILL, _awk_skill_body())
+    _write_awk_home(tmp_path, _AWK_HOME_ANALYZER, _awk_analyzer_body())
+    assert check_awk_elision_parity(repo_root=tmp_path) == []
+
+
+def test_awk_elision_parity_flags_drift(tmp_path) -> None:
+    """One home's program mutated (END clause dropped) -> exactly one error
+    naming BOTH paths + the edit-both-homes remediation."""
+    _write_awk_home(tmp_path, _AWK_HOME_SKILL, _awk_skill_body())
+    drifted = _AWK_ELISION_TEST_PROGRAM.replace(" END{if(f||d) exit 3}", "")
+    assert drifted != _AWK_ELISION_TEST_PROGRAM
+    _write_awk_home(tmp_path, _AWK_HOME_ANALYZER, _awk_analyzer_body(program=drifted))
+    errors = check_awk_elision_parity(repo_root=tmp_path)
+    assert len(errors) == 1, errors
+    assert _AWK_HOME_SKILL in errors[0] and _AWK_HOME_ANALYZER in errors[0], errors
+    assert "identically" in errors[0], errors
+
+
+def test_awk_elision_parity_flags_missing_file(tmp_path) -> None:
+    """A missing home is itself an error — a moved/deleted copy must not
+    silently pass (#1153)."""
+    _write_awk_home(tmp_path, _AWK_HOME_SKILL, _awk_skill_body())
+    errors = check_awk_elision_parity(repo_root=tmp_path)
+    assert len(errors) == 1, errors
+    assert errors[0].split(": ", 1)[0].endswith("analyzer-section-reference.md"), errors
+    assert "missing" in errors[0], errors
+
+
+def test_awk_elision_parity_flags_zero_anchor(tmp_path) -> None:
+    """A home present but with NO anchor line (program removed) FAILs."""
+    _write_awk_home(tmp_path, _AWK_HOME_SKILL, _awk_skill_body())
+    _write_awk_home(tmp_path, _AWK_HOME_ANALYZER, "# analyzer section reference\n\nno program\n")
+    errors = check_awk_elision_parity(repo_root=tmp_path)
+    assert len(errors) == 1, errors
+    assert errors[0].split(": ", 1)[0].endswith("analyzer-section-reference.md"), errors
+    assert "found 0" in errors[0], errors
+
+
+def test_awk_elision_parity_flags_duplicate_anchor(tmp_path) -> None:
+    """TWO anchor lines in one home FAIL — span identity is load-bearing
+    (which copy would the parity read?)."""
+    _write_awk_home(tmp_path, _AWK_HOME_SKILL, _awk_skill_body())
+    _write_awk_home(tmp_path, _AWK_HOME_ANALYZER, _awk_analyzer_body() + _awk_analyzer_body())
+    errors = check_awk_elision_parity(repo_root=tmp_path)
+    assert len(errors) == 1, errors
+    assert "found 2" in errors[0], errors
+
+
+@pytest.mark.parametrize(
+    ("anchor_line", "expected_token"),
+    [
+        pytest.param(
+            "    awk '/^```/{f=!f; next} f{next} \\",
+            "expected exactly 2",
+            id="reflow-mid-program-one-quote",
+        ),
+        pytest.param(
+            "    awk '/{f=!f}/'\\''x' \\",
+            "expected exactly 2",
+            id="gained-quote-escape",
+        ),
+        pytest.param(
+            "    awk '/{f=!f}/' | awk '{print}' \\",
+            "expected exactly 2",
+            id="second-quoted-span",
+        ),
+        pytest.param(
+            "    the 'f=!f' toggle (no awk program) \\",
+            "could not extract",
+            id="two-quotes-no-awk-span",
+        ),
+    ],
+)
+def test_awk_elision_parity_flags_malformed_anchor_line(
+    tmp_path, anchor_line: str, expected_token: str
+) -> None:
+    """A malformed anchor line FAILs loudly per home: a mid-program reflow
+    (1 quote), a gained shell quote-escape (5 quotes — the truncation
+    false-PASS window the exactly-2-quotes assert closes), a second quoted
+    span on the line (4 quotes), and a 2-quote line with no ``awk '...'``
+    span (extraction finds 0)."""
+    _write_awk_home(tmp_path, _AWK_HOME_SKILL, _awk_skill_body())
+    _write_awk_home(tmp_path, _AWK_HOME_ANALYZER, _awk_analyzer_body(anchor_line=anchor_line))
+    errors = check_awk_elision_parity(repo_root=tmp_path)
+    assert len(errors) == 1, errors
+    assert errors[0].split(": ", 1)[0].endswith("analyzer-section-reference.md"), errors
+    assert expected_token in errors[0], errors
+
+
+def test_awk_elision_parity_bundled_in_no_flags(tmp_path, capsys, monkeypatch) -> None:
+    """The no-flags default run actually DISPATCHES the #1153 check —
+    deleting its dispatch branch (``if args.check_awk_elision_parity or
+    no_flags:``) or its ``or no_flags`` disjunct must fail this test
+    (mutation-visible). House pattern:
+    ``test_vm_thread_cap_guidance_bundled_in_no_flags`` — drifted tree,
+    ``_REPO_ROOT`` monkeypatched to the fixture, ``main([])`` in-process;
+    other bundled checks contribute unrelated errors on the minimal tree, so
+    the assertion keys on the #1153 drift diagnostic."""
+    import workflow_lint as wl
+
+    _write_awk_home(tmp_path, _AWK_HOME_SKILL, _awk_skill_body())
+    drifted = _AWK_ELISION_TEST_PROGRAM.replace(" END{if(f||d) exit 3}", "")
+    _write_awk_home(tmp_path, _AWK_HOME_ANALYZER, _awk_analyzer_body(program=drifted))
+    monkeypatch.setattr(wl, "_REPO_ROOT", tmp_path)
+    rc = wl.main([])
+    err = capsys.readouterr().err
+    assert rc != 0, f"no-flags default run exited 0 on a drifted tree:\n{err}"
+    assert "#1153" in err and "identically" in err, (
+        f"the #1153 awk-elision-parity drift diagnostic is missing from the "
+        f"no-flags default run's stderr — the check is not bundled into "
+        f"no_flags:\n{err}"
+    )
+
+
+def test_awk_elision_parity_dedicated_flag_isolated(tmp_path, capsys, monkeypatch) -> None:
+    """The dedicated ``--check-awk-elision-parity`` flag runs ONLY this check
+    (``no_flags`` computes False): on a minimal tree where the two awk homes
+    CONFORM but the full default bundle FAILs (other bundled checks miss
+    their files), the dedicated-flag invocation exits 0 — pins the
+    ``or args.check_awk_elision_parity`` membership in the ``no_flags``
+    tuple, the leg the ``main([])`` wiring test above cannot pin (house
+    pattern: ``test_stale_label_disposition_clause_dedicated_flag_isolated``)."""
+    import workflow_lint as wl
+
+    _write_awk_home(tmp_path, _AWK_HOME_SKILL, _awk_skill_body())
+    _write_awk_home(tmp_path, _AWK_HOME_ANALYZER, _awk_analyzer_body())
+    monkeypatch.setattr(wl, "_REPO_ROOT", tmp_path)
+    # Precondition: the FULL default bundle FAILs on this minimal tree, so a
+    # no_flags mis-computation below is observable as rc != 0.
+    assert wl.main([]) != 0, "precondition: the default bundle PASSed on the minimal tree"
+    capsys.readouterr()  # discard the precondition run's output
+    rc = wl.main(["--check-awk-elision-parity"])
+    err = capsys.readouterr().err
+    assert rc == 0, (
+        f"--check-awk-elision-parity ran more than the (conforming) awk-elision "
         f"check — no_flags mis-computed True, i.e. the flag's membership in the "
         f"no_flags tuple in workflow_lint.main() is missing:\n{err}"
     )


### PR DESCRIPTION
Closes task #1153. Adds check_awk_elision_parity to scripts/workflow_lint.py (pins the ban-gate awk elision program byte-identical across its two workflow-surface homes) + 12-test cluster.