### PR TITLE
issue-1150: forward rc==0 task.py child stderr at 3 remaining subprocess sites

### DIFF
--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -5993,6 +5993,7 @@ def _set_status_blocked(issue: int, dry_run: bool) -> bool:
             file=sys.stderr,
         )
         return False
+    _forward_marker_child_stderr(out, f"set-status blocked on #{issue}")
     return True
 
 
@@ -8588,6 +8589,7 @@ def _repark_completed_followup_round(
             file=sys.stderr,
         )
         return False
+    _forward_marker_child_stderr(out, f"set-status awaiting_promotion on #{issue}")
     print(f"  issue #{issue}: re-parked completed follow-up round -> awaiting_promotion")
     _post_followup_run_marker(issue, events, dry_run)
     _post_progress_marker(

--- a/scripts/file_infra_task.py
+++ b/scripts/file_infra_task.py
@@ -62,7 +62,14 @@ if _SCRIPTS_DIR not in sys.path:
 #     function and the three dispatchers cannot drift apart).
 #   - AUTONOMOUS_REGISTRY_DIR / daemon_port: the registration dir + Happy
 #     daemon port, the SAME source of truth `spawn_session.py list` uses.
-from autonomous_session_watch import infra_dispatch_has_free_slot  # noqa: E402
+#   - _forward_marker_child_stderr: the shared #1130 rc==0 child-stderr
+#     forwarder (a copied forwarder is exactly the drift this import layer
+#     exists to prevent; SLF is unselected in ruff, and the #1130 tests
+#     already access it cross-module).
+from autonomous_session_watch import (  # noqa: E402
+    _forward_marker_child_stderr,
+    infra_dispatch_has_free_slot,
+)
 
 # PROJECT_ROOT is git-common-dir-resolved (canonical primary checkout, #844)
 # once the imported spawn_session copy contains the fix — a stale pre-fix
@@ -224,6 +231,10 @@ def cmd_file_infra(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return filed.returncode
+    # rc==0: task.py new deliberately exits 0 on deferred-commit / LANDING
+    # CHECK warnings — forward them so they reach the caller's transcript
+    # (#1130 helper; the rc!=0 branch above already writes stderr itself).
+    _forward_marker_child_stderr(filed, "task.py new (file_infra_task)")
     issue = _parse_new_id(filed.stdout)
     if issue is None:
         print(

--- a/tests/test_marker_child_stderr_forwarding.py
+++ b/tests/test_marker_child_stderr_forwarding.py
@@ -14,6 +14,7 @@ semantics, return values) is unchanged. Primary-site coverage
 
 from __future__ import annotations
 
+import argparse
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -23,6 +24,7 @@ if str(SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SCRIPTS))
 
 import autonomous_session_watch as asw  # noqa: E402
+import file_infra_task  # noqa: E402
 import spawn_session  # noqa: E402
 
 _LANDING_CHECK_LINE = (
@@ -120,3 +122,132 @@ def test_watch_post_progress_marker_integration_forwards(monkeypatch, capsys):
     err = capsys.readouterr().err
     assert "[task.py stderr]" in err
     assert "task.py LANDING CHECK" in err
+
+
+# ──────────────────────────────────────────────────────────────────────
+# #1150: the three remaining mutating task.py children.
+# autonomous_session_watch._set_status_blocked
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_set_status_blocked_forwards_rc0_stderr(monkeypatch, capsys):
+    """rc==0 set-status child with non-empty stderr → returns True AND the
+    warning is forwarded under the `set-status blocked on #<N>` context."""
+    monkeypatch.setattr(
+        asw.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="", stderr=_LANDING_CHECK_LINE),
+    )
+
+    assert asw._set_status_blocked(1150, dry_run=False) is True
+    err = capsys.readouterr().err
+    assert "[task.py stderr] set-status blocked on #1150:" in err
+    assert "task.py LANDING CHECK" in err
+
+
+def test_set_status_blocked_rc_nonzero_unchanged(monkeypatch, capsys):
+    """rc!=0 → returns False with the existing WARNING line; NO forwarding
+    (the rc!=0 branch already prints the stderr detail — forwarding there
+    would duplicate it)."""
+    monkeypatch.setattr(
+        asw.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="boom detail"),
+    )
+
+    assert asw._set_status_blocked(1150, dry_run=False) is False
+    err = capsys.readouterr().err
+    assert "WARNING: set-status blocked on #1150 FAILED (rc=1): boom detail" in err
+    assert "[task.py stderr]" not in err
+
+
+# ──────────────────────────────────────────────────────────────────────
+# autonomous_session_watch._repark_completed_followup_round
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_repark_forwards_rc0_stderr(monkeypatch, capsys):
+    """rc==0 set-status child with non-empty stderr → returns True AND the
+    warning is forwarded under the exact `set-status awaiting_promotion on
+    #<N>` context prefix (the stub also serves the downstream marker posts,
+    which forward under their OWN contexts — asserting the exact repark
+    context keeps those from masking the target site; events=[] makes
+    _post_followup_run_marker fail-soft with no subprocess of its own)."""
+    monkeypatch.setattr(
+        asw.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="", stderr=_LANDING_CHECK_LINE),
+    )
+
+    assert asw._repark_completed_followup_round(1150, "reason", [], dry_run=False) is True
+    err = capsys.readouterr().err
+    assert "[task.py stderr] set-status awaiting_promotion on #1150:" in err
+    assert "task.py LANDING CHECK" in err
+
+
+# ──────────────────────────────────────────────────────────────────────
+# file_infra_task.cmd_file_infra (`task.py new` child)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _file_infra_args(**overrides):
+    """Namespace with every attr cmd_file_infra consumes up to the
+    --no-dispatch early return (_build_new_argv attrs + no_dispatch)."""
+    base = dict(
+        kind="infra",
+        title="t",
+        body=None,
+        body_file=None,
+        parent=None,
+        tag=[],
+        origin_prompt=None,
+        no_dispatch=True,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def test_file_infra_task_new_forwards_rc0_stderr(monkeypatch, capsys):
+    """rc==0 `task.py new` child with non-empty stderr → exit 0 AND the
+    warning is forwarded under the `task.py new (file_infra_task)` context
+    (no_dispatch=True returns right after filing — no daemon/cap probes)."""
+    monkeypatch.setattr(
+        file_infra_task.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(
+            returncode=0, stdout="filed #123", stderr=_LANDING_CHECK_LINE
+        ),
+    )
+
+    rc = file_infra_task.cmd_file_infra(_file_infra_args())
+
+    assert rc == 0
+    out, err = capsys.readouterr()
+    assert "filed #123" in out
+    assert "[task.py stderr] task.py new (file_infra_task):" in err
+    assert "task.py LANDING CHECK" in err
+
+
+def test_file_infra_task_new_rc_nonzero_unchanged(monkeypatch, capsys):
+    """rc!=0 → exit code == child rc, the child stderr is written exactly
+    once (the existing sys.stderr.write), and NO `[task.py stderr]` prefix
+    (no double-print on the failure path)."""
+    monkeypatch.setattr(
+        file_infra_task.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="new failed detail\n"),
+    )
+
+    rc = file_infra_task.cmd_file_infra(_file_infra_args())
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert err.count("new failed detail") == 1
+    assert "task NOT filed" in err
+    assert "[task.py stderr]" not in err
+
+
+def test_file_infra_task_imports_shared_helper():
+    """Pins the no-drift decision: file_infra_task reuses the watcher's
+    forwarder rather than a copied local one (a rename fails loud here)."""
+    assert file_infra_task._forward_marker_child_stderr is asw._forward_marker_child_stderr


### PR DESCRIPTION
Closes task #1150 (workflow-fix, kind: infra).

Adds the #1130 `_forward_marker_child_stderr` call on the rc==0 success path at the watcher's two set-status subprocess sites and file_infra_task.py's `task.py new` child, so deferred-commit / LANDING CHECK warnings reach wrapper transcripts. +145/−1 across 3 files; 6 new tests; step9c gate 2967 passed / baseline compare new=[].

🤖 Generated with [Claude Code](https://claude.com/claude-code)