### PR TITLE
task #1149: ensemble_verdicts_present mechanical no-show predicate

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -2339,6 +2339,31 @@ single-reviewer decision:
    version — `epm:code-review[-codex] v<n>`, `epm:interp-critique[-codex]
    v<n>`, `epm:clean-result-critique[-codex] v<n>`,
    `epm:followup-value-critique[-codex]`, or `epm:review-reconcile v<n>`.
+   The mechanical form of this check is
+   `task_workflow.ensemble_verdicts_present` (precedent:
+   `stage_dispatch_should_skip` for the dispatch side) — run it, do not
+   eyeball the events scan:
+
+   ```bash
+   uv run python - <<'PY'
+   import json
+   from explore_persona_space.task_workflow import ensemble_verdicts_present, list_events
+   print(json.dumps(ensemble_verdicts_present(
+       list_events(<N>), ["epm:code-review", "epm:code-review-codex"], <n>)))
+   PY
+   ```
+
+   (Substitute the site's marker kinds; for a reconciler read pass
+   `reconcile_role="<role under adjudication>"` so a same-round reconcile
+   for a DIFFERENT role never satisfies the check.) `present: false` →
+   proceed to item 2; `present: true, verdict: null` → the marker EXISTS
+   but is malformed — item 3's malformed-output handling, NEVER a
+   no-show; `present: true` with a verdict token → the reviewer RETURNED.
+   Before acting on a returned verdict token, confirm the adopted note's
+   head sentinel names THIS round (the predicate already treats the
+   sentinel as authoritative over the drift-prone `version` field; the
+   confirm is the cheap orchestrator-side double-check against a
+   stale-round adoption).
 2. If no marker: check the role's durable output file — the EXACT
    `--output-file` path this round's dispatch config named
    (role+round-specific conventions:

--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -81,7 +81,7 @@ import re
 import shutil
 import subprocess
 import time
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -1625,6 +1625,117 @@ def stage_dispatch_should_skip(
         f"breadcrumb at {events[crumb_idx].get('ts', '')}, effective age {age_minutes:.1f}m "
         f"< window {window_minutes}m{refreshed}"
     )
+
+
+# --- Ensemble verdict presence (#1149; mechanizes SKILL.md Step 5b ---
+# --- durable-verdict-first rule items 1 + 3)                        ---
+
+_RECONCILE_KIND = "epm:review-reconcile"
+
+
+def _sentinel_round(note: str, kind: str) -> int | None:
+    """Round named by a note-head ``<!-- <kind> v<n> -->`` sentinel, else None.
+
+    Anchored at the lstripped note HEAD (a copy-pasted sentinel mid-note never
+    matches); the kind must match exactly, so a ``-codex`` sibling's sentinel
+    never satisfies its base kind.
+    """
+    match = re.match(rf"<!--\s*{re.escape(kind)}\s+v(\d+)\s*-->", note.lstrip())
+    return int(match.group(1)) if match else None
+
+
+def ensemble_verdicts_present(
+    events: list[dict],
+    kinds: Sequence[str],
+    round_n: int,
+    *,
+    reconcile_role: str | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Per-kind durable-verdict presence for one ensemble round (#1149).
+
+    Mechanizes items 1 + 3 of the /issue Step 5b durable-verdict-first
+    rule: BEFORE any reviewer no-show decision, the orchestrator asks
+    whether the round's expected verdict markers exist on events.jsonl and
+    whether each carries a parseable ``Verdict:`` field. For each queried
+    kind returns ``{"present": bool, "verdict": str | None,
+    "ts": str | None}``:
+
+    - ``present=False`` -> proceed to the rule's item 2 (durable output
+      file), then item 4 (no-show handling).
+    - ``present=True, verdict=None`` -> the marker EXISTS but its note has
+      no parseable ``Verdict:`` field: malformed-output handling (rule
+      item 3), NEVER a no-show (#810 r4: a posted verdict misread as a
+      total no-show is the incident class this predicate closes).
+    - ``present=True, verdict=<token>`` -> the reviewer RETURNED; apply
+      the normal ensemble rule. The token is returned RAW (per-site
+      pass/fail vocabularies live in workflow.yaml § ensemble_review).
+
+    Round matching: a note-head ``<!-- <kind> v<n> -->`` sentinel is
+    AUTHORITATIVE when present — the event matches iff the sentinel names
+    ``round_n``; a sentinel naming a DIFFERENT round suppresses any
+    top-level ``version``-field match (version/round divergence is real in
+    the wild: #480 non-monotonicity, defaulted re-spawn auto-bump). With
+    no sentinel, non-reconcile kinds fall back to
+    ``event["version"] == round_n``. ``epm:review-reconcile`` NEVER
+    matches on the ``version`` field — it is round-MEANINGLESS there
+    (auto-derived max+1 per kind while the sentinel names the ROUND; live
+    proof: #1092's reconcile is version 1 with sentinel v5) — so a
+    sentinel-less reconcile falls back to the note's ``**Round:**`` field,
+    else never matches. The LATEST matching event wins (re-spawns post at
+    the same v<n>). When ``kind`` is ``epm:review-reconcile`` and
+    ``reconcile_role`` is given, the note's ``**Role under
+    adjudication:**`` field must equal it — a same-round reconcile for a
+    DIFFERENT role, or a reconcile note MISSING the role field entirely,
+    never satisfies a role-scoped query (deliberate: fail toward the
+    rule's output-file probe rather than adopt an unattributable
+    adjudication). Verdict / role / round parsing reuses
+    :func:`parse_followup_note_field` (bold, bullet, ``; ``-joined and
+    escaped-newline note shapes, incl. the bold-wrapped
+    ``**Verdict: PASS**`` Codex-twin shape). Known false-ABSENT residual:
+    a sentinel-less terse note whose ``version`` drifted from the round
+    (a defaulted re-spawn that omitted the sentinel) reads absent — rule
+    item 2 (the durable output-FILE probe) is the prose backstop for that
+    path. Pure function over :func:`list_events` output — no I/O; the
+    rule's item 2 (output-file probe) and precedence clauses stay
+    orchestrator prose.
+    """
+    out: dict[str, dict[str, Any]] = {}
+    for kind in kinds:
+        match: dict | None = None
+        for event in events:  # chronological; latest match wins
+            if event.get("kind", "") != kind:
+                continue
+            note = event.get("note", "") or ""
+            head_round = _sentinel_round(note, kind)
+            if kind == _RECONCILE_KIND:
+                # The reconcile version field never carries the round
+                # (#1092: version 1 / sentinel v5) — sentinel, then the
+                # note's **Round:** field, else no match.
+                if head_round is not None:
+                    if head_round != round_n:
+                        continue
+                else:
+                    round_field = parse_followup_note_field(note, "Round")
+                    if round_field is None or not round_field.isdigit():
+                        continue
+                    if int(round_field) != round_n:
+                        continue
+            elif head_round is not None:
+                if head_round != round_n:
+                    continue  # sentinel authoritative — suppress the version match
+            elif event.get("version") != round_n:
+                continue
+            if kind == _RECONCILE_KIND and reconcile_role is not None:
+                role = parse_followup_note_field(note, "Role under adjudication")
+                if role != reconcile_role:
+                    continue
+            match = event
+        if match is None:
+            out[kind] = {"present": False, "verdict": None, "ts": None}
+        else:
+            verdict = parse_followup_note_field(match.get("note", "") or "", "Verdict")
+            out[kind] = {"present": True, "verdict": verdict, "ts": match.get("ts")}
+    return out
 
 
 # Canonical PASS-verdict pattern for an epm:upload-verification note

--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -1699,43 +1699,58 @@ def ensemble_verdicts_present(
     rule's item 2 (output-file probe) and precedence clauses stay
     orchestrator prose.
     """
+    if isinstance(kinds, str):
+        # A bare string iterates per-character, mechanically producing false
+        # no-shows — the exact class this predicate exists to close.
+        raise TypeError("kinds must be a sequence of marker-kind strings, not a bare str")
     out: dict[str, dict[str, Any]] = {}
     for kind in kinds:
         match: dict | None = None
         for event in events:  # chronological; latest match wins
-            if event.get("kind", "") != kind:
-                continue
-            note = event.get("note", "") or ""
-            head_round = _sentinel_round(note, kind)
-            if kind == _RECONCILE_KIND:
-                # The reconcile version field never carries the round
-                # (#1092: version 1 / sentinel v5) — sentinel, then the
-                # note's **Round:** field, else no match.
-                if head_round is not None:
-                    if head_round != round_n:
-                        continue
-                else:
-                    round_field = parse_followup_note_field(note, "Round")
-                    if round_field is None or not round_field.isdigit():
-                        continue
-                    if int(round_field) != round_n:
-                        continue
-            elif head_round is not None:
-                if head_round != round_n:
-                    continue  # sentinel authoritative — suppress the version match
-            elif event.get("version") != round_n:
-                continue
-            if kind == _RECONCILE_KIND and reconcile_role is not None:
-                role = parse_followup_note_field(note, "Role under adjudication")
-                if role != reconcile_role:
-                    continue
-            match = event
+            if _ensemble_event_matches(event, kind, round_n, reconcile_role):
+                match = event
         if match is None:
             out[kind] = {"present": False, "verdict": None, "ts": None}
         else:
             verdict = parse_followup_note_field(match.get("note", "") or "", "Verdict")
             out[kind] = {"present": True, "verdict": verdict, "ts": match.get("ts")}
     return out
+
+
+def _ensemble_event_matches(
+    event: dict, kind: str, round_n: int, reconcile_role: str | None
+) -> bool:
+    """True iff ``event`` is a round-``round_n`` verdict marker of ``kind``.
+
+    Round matching is sentinel-authoritative: a head sentinel naming a
+    DIFFERENT round suppresses the version-field match, and the reconcile
+    kind never matches on its round-meaningless ``version`` field (#1092:
+    version 1 / sentinel v5) — sentinel first, then the note's
+    ``**Round:**`` field, else no match. Role scoping applies to the
+    reconcile kind only.
+    """
+    if event.get("kind", "") != kind:
+        return False
+    note = event.get("note", "") or ""
+    head_round = _sentinel_round(note, kind)
+    if kind == _RECONCILE_KIND:
+        if head_round is not None:
+            if head_round != round_n:
+                return False
+        else:
+            round_field = parse_followup_note_field(note, "Round")
+            if round_field is None or not round_field.isdigit() or int(round_field) != round_n:
+                return False
+    elif head_round is not None:
+        if head_round != round_n:
+            return False  # sentinel authoritative — suppress the version match
+    elif event.get("version") != round_n:
+        return False
+    if kind == _RECONCILE_KIND and reconcile_role is not None:
+        role = parse_followup_note_field(note, "Role under adjudication")
+        if role != reconcile_role:
+            return False
+    return True
 
 
 # Canonical PASS-verdict pattern for an epm:upload-verification note

--- a/tests/test_ensemble_verdicts_present.py
+++ b/tests/test_ensemble_verdicts_present.py
@@ -16,6 +16,8 @@ bold-wrapped ``**Verdict: PASS**`` Codex-twin shape).
 
 from __future__ import annotations
 
+import pytest
+
 import explore_persona_space.task_workflow as tw
 
 
@@ -293,3 +295,10 @@ def test_reconcile_missing_role_field():
     assert scoped["epm:review-reconcile"] == _ABSENT
     unscoped = tw.ensemble_verdicts_present(events, kinds, 2)
     assert unscoped["epm:review-reconcile"]["present"] is True
+
+
+def test_bare_str_kinds_raises():
+    # Reviewer-round pin: a bare string for `kinds` would iterate
+    # per-character and mechanically produce false no-shows — reject loudly.
+    with pytest.raises(TypeError, match="bare str"):
+        tw.ensemble_verdicts_present([], "epm:code-review", 1)

--- a/tests/test_ensemble_verdicts_present.py
+++ b/tests/test_ensemble_verdicts_present.py
@@ -1,0 +1,295 @@
+"""Tests for the ensemble durable-verdict presence predicate (#1149).
+
+``ensemble_verdicts_present`` is the mechanical form of items 1 + 3 of the
+/issue Step 5b durable-verdict-first rule: before any reviewer no-show
+decision, the orchestrator asks whether the round's expected verdict markers
+exist on events.jsonl and whether each carries a parseable ``Verdict:`` field
+(incident #810 r4: a posted ``epm:code-review v4`` PASS was misread as a
+total no-show after the reviewer's summary turn died, and a unilateral FAIL
+was adopted from the surviving Codex verdict alone). Fixtures replay real
+note shapes from task #1092 (a reconcile marker whose top-level ``version``
+is 1 while its head sentinel says ``v5`` — the version field is
+round-meaningless on reconcile markers) and task #1090 (the terse
+sentinel-less Claude critique with no ``**Verdict:**`` line; the
+bold-wrapped ``**Verdict: PASS**`` Codex-twin shape).
+"""
+
+from __future__ import annotations
+
+import explore_persona_space.task_workflow as tw
+
+
+def _ev(ts: str, kind: str, note: str = "", version: int = 1, by: str = "test") -> dict:
+    return {"ts": ts, "kind": kind, "version": version, "by": by, "note": note}
+
+
+# Real #1092 reconcile shape (subset, verbatim head): top-level version 1,
+# sentinel + **Round:** both naming round 5.
+_RECONCILE_1092 = (
+    "<!-- epm:review-reconcile v5 -->\n\n"
+    "## Reconciler Verdict — FAIL\n\n"
+    "**Role under adjudication:** code-reviewer\n"
+    "**Round:** 5\n"
+    "**Verdict:** FAIL\n"
+    "**Claude verdict:** PASS\n"
+    "**Codex verdict:** FAIL\n"
+)
+
+# Real #1090 terse Claude-critique shape: no sentinel, no **Verdict:** line.
+_TERSE_1090 = (
+    "Round 1: PASS — v4 body is structurally complete, register-clean, and "
+    "every load-bearing number reconciles against eval_results/issue_1090 "
+    "ground truth"
+)
+
+# Reconcile note with NO head sentinel — round carried only by **Round:**.
+_RECONCILE_NO_SENTINEL = (
+    "## Reconciler Verdict — PASS\n\n"
+    "**Role under adjudication:** interpretation-critic\n"
+    "**Round:** 3\n"
+    "**Verdict:** PASS\n"
+)
+
+# Reconcile note with NO **Role under adjudication:** field.
+_RECONCILE_NO_ROLE = "<!-- epm:review-reconcile v2 -->\n\n**Round:** 2\n**Verdict:** PASS\n"
+
+_ABSENT = {"present": False, "verdict": None, "ts": None}
+
+
+def test_both_present_verdicts_parsed():
+    events = [
+        _ev(
+            "2026-07-07T10:00:00Z",
+            "epm:code-review",
+            "<!-- epm:code-review v2 -->\n\n**Verdict:** FAIL\n\n### Blockers\n- b1",
+            version=2,
+        ),
+        _ev(
+            "2026-07-07T10:01:00Z",
+            "epm:code-review-codex",
+            "<!-- epm:code-review-codex v2 -->\n\n**Verdict:** PASS\n",
+            version=2,
+        ),
+    ]
+    out = tw.ensemble_verdicts_present(events, ["epm:code-review", "epm:code-review-codex"], 2)
+    assert out["epm:code-review"] == {
+        "present": True,
+        "verdict": "FAIL",
+        "ts": "2026-07-07T10:00:00Z",
+    }
+    assert out["epm:code-review-codex"] == {
+        "present": True,
+        "verdict": "PASS",
+        "ts": "2026-07-07T10:01:00Z",
+    }
+
+
+def test_one_missing():
+    events = [
+        _ev(
+            "2026-07-07T10:00:00Z",
+            "epm:code-review",
+            "<!-- epm:code-review v2 -->\n\n**Verdict:** PASS\n",
+            version=2,
+        ),
+    ]
+    out = tw.ensemble_verdicts_present(events, ["epm:code-review", "epm:code-review-codex"], 2)
+    assert out["epm:code-review"]["present"] is True
+    assert out["epm:code-review-codex"] == _ABSENT
+
+
+def test_wrong_round_version():
+    # The stale-prior-round trap of rule item 2: markers exist only at round 3.
+    events = [
+        _ev(
+            "2026-07-07T10:00:00Z",
+            "epm:code-review",
+            "<!-- epm:code-review v3 -->\n\n**Verdict:** PASS\n",
+            version=3,
+        ),
+        _ev(
+            "2026-07-07T10:01:00Z",
+            "epm:code-review-codex",
+            "<!-- epm:code-review-codex v3 -->\n\n**Verdict:** PASS\n",
+            version=3,
+        ),
+    ]
+    out = tw.ensemble_verdicts_present(events, ["epm:code-review", "epm:code-review-codex"], 4)
+    assert out["epm:code-review"] == _ABSENT
+    assert out["epm:code-review-codex"] == _ABSENT
+
+
+def test_malformed_note_no_verdict_line():
+    # Real #1090 terse shape: present-but-malformed route — NEVER a no-show,
+    # and NEVER a fabricated verdict token (forbids a strict-Verdict
+    # presence test).
+    events = [_ev("2026-07-07T06:26:20Z", "epm:clean-result-critique", _TERSE_1090, version=1)]
+    out = tw.ensemble_verdicts_present(events, ["epm:clean-result-critique"], 1)
+    assert out["epm:clean-result-critique"] == {
+        "present": True,
+        "verdict": None,
+        "ts": "2026-07-07T06:26:20Z",
+    }
+
+
+def test_reconcile_role_scoped():
+    # Real #1092 shape: version field 1, sentinel v5 — also exercises the
+    # sentinel round read and the multi-word role-field parse.
+    events = [_ev("2026-07-07T13:20:13Z", "epm:review-reconcile", _RECONCILE_1092, version=1)]
+    kinds = ["epm:review-reconcile"]
+    scoped = tw.ensemble_verdicts_present(events, kinds, 5, reconcile_role="code-reviewer")
+    assert scoped["epm:review-reconcile"] == {
+        "present": True,
+        "verdict": "FAIL",
+        "ts": "2026-07-07T13:20:13Z",
+    }
+    wrong_role = tw.ensemble_verdicts_present(
+        events, kinds, 5, reconcile_role="interpretation-critic"
+    )
+    assert wrong_role["epm:review-reconcile"] == _ABSENT
+    unscoped = tw.ensemble_verdicts_present(events, kinds, 5)
+    assert unscoped["epm:review-reconcile"]["present"] is True
+
+
+def test_empty_events():
+    out = tw.ensemble_verdicts_present([], ["epm:code-review", "epm:review-reconcile"], 1)
+    assert out["epm:code-review"] == _ABSENT
+    assert out["epm:review-reconcile"] == _ABSENT
+
+
+def test_sentinel_fallback_on_version_divergence():
+    # Defaulted re-spawn auto-bump (#480 class): version landed at max+1=5
+    # while the sentinel names the true round 4.
+    events = [
+        _ev(
+            "2026-07-07T10:00:00Z",
+            "epm:code-review",
+            "<!-- epm:code-review v4 -->\n\n**Verdict:** PASS\n",
+            version=5,
+        ),
+    ]
+    out = tw.ensemble_verdicts_present(events, ["epm:code-review"], 4)
+    assert out["epm:code-review"]["present"] is True
+    assert out["epm:code-review"]["verdict"] == "PASS"
+
+
+def test_sentinel_authoritative_suppresses_version_match():
+    # Same event as above queried at its VERSION number (5): the sentinel
+    # names round 4, so the version-field match is suppressed — a
+    # stale/drifted version never reads as this round's verdict.
+    events = [
+        _ev(
+            "2026-07-07T10:00:00Z",
+            "epm:code-review",
+            "<!-- epm:code-review v4 -->\n\n**Verdict:** PASS\n",
+            version=5,
+        ),
+    ]
+    out = tw.ensemble_verdicts_present(events, ["epm:code-review"], 5)
+    assert out["epm:code-review"] == _ABSENT
+
+
+def test_respawn_duplicate_latest_wins():
+    # A re-spawn posts at the SAME v<n> (rule item 4): the chronologically
+    # latest match carries the verdict + ts.
+    events = [
+        _ev(
+            "2026-07-07T10:00:00Z",
+            "epm:code-review",
+            "<!-- epm:code-review v3 -->\n\n**Verdict:** FAIL\n",
+            version=3,
+        ),
+        _ev(
+            "2026-07-07T11:00:00Z",
+            "epm:code-review",
+            "<!-- epm:code-review v3 -->\n\n**Verdict:** PASS\n",
+            version=3,
+        ),
+    ]
+    out = tw.ensemble_verdicts_present(events, ["epm:code-review"], 3)
+    assert out["epm:code-review"] == {
+        "present": True,
+        "verdict": "PASS",
+        "ts": "2026-07-07T11:00:00Z",
+    }
+
+
+def test_versionless_single_pass_site():
+    # epm:followup-value-critique[-codex] is the single-pass site (always
+    # effectively round 1); hyphenated verdict token parses whole.
+    events = [
+        _ev(
+            "2026-07-07T10:00:00Z",
+            "epm:followup-value-critique-codex",
+            "**Verdict:** not-redundant\n**Proposals screened:** 3",
+            version=1,
+        ),
+    ]
+    out = tw.ensemble_verdicts_present(events, ["epm:followup-value-critique-codex"], 1)
+    assert out["epm:followup-value-critique-codex"]["present"] is True
+    assert out["epm:followup-value-critique-codex"]["verdict"] == "not-redundant"
+
+
+def test_non_verdict_kinds_ignored():
+    # Noise rows at the queried version never satisfy a queried kind —
+    # kind equality is exact.
+    events = [
+        _ev("2026-07-07T10:00:00Z", "epm:progress", "stage-dispatch stage=review round=2", 2),
+        _ev("2026-07-07T10:01:00Z", "epm:codex-task-completed", "Codex job phase=done", 2),
+    ]
+    out = tw.ensemble_verdicts_present(events, ["epm:code-review", "epm:code-review-codex"], 2)
+    assert out["epm:code-review"] == _ABSENT
+    assert out["epm:code-review-codex"] == _ABSENT
+
+
+def test_codex_bold_wrapped_verdict():
+    # The dominant real Codex-twin shape (#1090): bold wraps field AND value.
+    events = [
+        _ev(
+            "2026-07-07T10:00:00Z",
+            "epm:clean-result-critique-codex",
+            "<!-- epm:clean-result-critique-codex v1 -->\n**Verdict: PASS**\n",
+            version=1,
+        ),
+    ]
+    out = tw.ensemble_verdicts_present(events, ["epm:clean-result-critique-codex"], 1)
+    assert out["epm:clean-result-critique-codex"]["verdict"] == "PASS"
+
+
+def test_reconcile_version_field_never_matches():
+    # Critic-ensemble amendment pin (a): a reconcile whose version field
+    # equals the queried round but whose sentinel names a DIFFERENT round is
+    # NOT matched — the reconcile version field is round-meaningless.
+    events = [_ev("2026-07-07T13:20:13Z", "epm:review-reconcile", _RECONCILE_1092, version=4)]
+    kinds = ["epm:review-reconcile"]
+    at_version = tw.ensemble_verdicts_present(events, kinds, 4, reconcile_role="code-reviewer")
+    assert at_version["epm:review-reconcile"] == _ABSENT
+    at_sentinel = tw.ensemble_verdicts_present(events, kinds, 5, reconcile_role="code-reviewer")
+    assert at_sentinel["epm:review-reconcile"]["present"] is True
+
+
+def test_reconcile_round_field_fallback():
+    # Critic-ensemble amendment pin (b): sentinel absent — the reconcile is
+    # matched via the note's **Round:** field, never via version.
+    events = [_ev("2026-07-07T13:20:13Z", "epm:review-reconcile", _RECONCILE_NO_SENTINEL, 1)]
+    kinds = ["epm:review-reconcile"]
+    by_round_field = tw.ensemble_verdicts_present(
+        events, kinds, 3, reconcile_role="interpretation-critic"
+    )
+    assert by_round_field["epm:review-reconcile"]["present"] is True
+    assert by_round_field["epm:review-reconcile"]["verdict"] == "PASS"
+    by_version = tw.ensemble_verdicts_present(events, kinds, 1)
+    assert by_version["epm:review-reconcile"] == _ABSENT
+
+
+def test_reconcile_missing_role_field():
+    # Deliberate, docstring-pinned behavior: a role-scoped query against a
+    # reconcile note with NO **Role under adjudication:** field reads absent
+    # (fail toward the rule's output-file probe, never adopt an
+    # unattributable adjudication); an unscoped query still sees it.
+    events = [_ev("2026-07-07T13:20:13Z", "epm:review-reconcile", _RECONCILE_NO_ROLE, version=1)]
+    kinds = ["epm:review-reconcile"]
+    scoped = tw.ensemble_verdicts_present(events, kinds, 2, reconcile_role="code-reviewer")
+    assert scoped["epm:review-reconcile"] == _ABSENT
+    unscoped = tw.ensemble_verdicts_present(events, kinds, 2)
+    assert unscoped["epm:review-reconcile"]["present"] is True


### PR DESCRIPTION
Closes task #1149. Adds task_workflow.ensemble_verdicts_present (mechanical predicate for the /issue Step 5b durable-verdict-first reviewer no-show check, mechanizing rule items 1+3) + the SKILL.md recipe citation + 16 tests. Plan v1 approved (3x APPROVE + consistency PASS); code-review r1 PASS; test-verdict PASS (2880 passed, compare clean).