### PR TITLE
issue-1154: add check_marker_recipe_snippets (marker-recipe doc<->code constant pins)

### DIFF
--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -394,6 +394,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import dataclasses
 import re
 import sys
 from collections import Counter
@@ -6383,6 +6384,241 @@ def check_awk_elision_parity(*, repo_root: Path | None = None) -> list[str]:
     return errors
 
 
+@dataclasses.dataclass(frozen=True)
+class _RecipePin:
+    """One (doc snippet <-> code constant) binding for
+    :func:`check_marker_recipe_snippets`.
+
+    ``doc_pattern`` runs on WHITESPACE-NORMALIZED doc text (all ``\\s+`` runs
+    collapsed to single spaces, so markdown line wraps never matter);
+    ``src_pattern`` runs on RAW source text with ``re.MULTILINE``. Each
+    pattern carries EXACTLY ONE capture group — the numeric value — pinned by
+    ``tests/test_workflow_lint.py::test_marker_recipe_pins_have_one_capture_group``.
+    """
+
+    label: str  # stable human name, appears in error messages
+    doc_rel: str  # doc path relative to repo root
+    doc_pattern: str  # regex, ONE capture group, whitespace-normalized doc text
+    src_rel: str  # source path relative to repo root
+    src_pattern: str  # regex, ONE capture group, raw source text (re.MULTILINE)
+    symbol: str  # the code symbol name, for error messages
+
+
+_MARKER_RECIPE_DOC = "docs/marker_training_recipe.md"
+_MARKER_RECIPE_RULE = ".claude/rules/marker-training-recipe.md"
+_MARKER_RECIPE_SRC_RECIPE = "src/explore_persona_space/artifacts/recipe.py"
+_MARKER_RECIPE_SRC_SFT = "src/explore_persona_space/train/sft.py"
+_MARKER_RECIPE_SRC_ORGANISMS = "src/explore_persona_space/artifacts/organisms.py"
+_MARKER_RECIPE_SRC_CALLBACKS = "src/explore_persona_space/eval/callbacks.py"
+
+# The marker-token-id doc patterns require a SPACE before the backticked
+# marker (the ` ※` form) — the wrong-token prose "Avoid bare `※` id 63680"
+# has a backtick, not a space, before ※, so 63680 is never captured (pinned by
+# test_marker_recipe_snippets_does_not_capture_wrong_token_id). The sft.py
+# pattern's trailing comma + no-word-char lookbehind exclude the
+# `marker_tail_tokens: int = 0` dataclass field (sft.py, no trailing comma).
+_MARKER_RECIPE_PINS: tuple[_RecipePin, ...] = (
+    # --- docs/marker_training_recipe.md (5 pins) ---
+    _RecipePin(
+        label="marker-token-id",
+        doc_rel=_MARKER_RECIPE_DOC,
+        doc_pattern=r"(?: ※` id|token id) (\d+)",
+        src_rel=_MARKER_RECIPE_SRC_RECIPE,
+        src_pattern=r"^MARKER_TOKEN_ID = (\d+)$",
+        symbol="MARKER_TOKEN_ID",
+    ),
+    _RecipePin(
+        label="collator-tail-tokens",
+        doc_rel=_MARKER_RECIPE_DOC,
+        doc_pattern=r"MarkerOnlyDataCollator\(tail_tokens=(\d+)\)",
+        src_rel=_MARKER_RECIPE_SRC_SFT,
+        src_pattern=r"(?<!\w)tail_tokens: int = (\d+),",
+        symbol="MarkerOnlyDataCollator.__init__ tail_tokens default",
+    ),
+    _RecipePin(
+        label="mix-reject-floor",
+        doc_rel=_MARKER_RECIPE_DOC,
+        doc_pattern=r"reject floor (0\.\d+)",
+        src_rel=_MARKER_RECIPE_SRC_ORGANISMS,
+        src_pattern=r"^MIX_MAX_REJECT_FRAC = ([0-9.]+)$",
+        symbol="MIX_MAX_REJECT_FRAC",
+    ),
+    _RecipePin(
+        label="bandstop-low",
+        doc_rel=_MARKER_RECIPE_DOC,
+        doc_pattern=r"source ΔG ∈ \[([\d.]+), [\d.]+\] nat",
+        src_rel=_MARKER_RECIPE_SRC_CALLBACKS,
+        src_pattern=r"(?<!\w)low_nats: float = ([\d.]+),",
+        symbol="MarkerBandStopCallback.__init__ low_nats default",
+    ),
+    _RecipePin(
+        label="bandstop-high",
+        doc_rel=_MARKER_RECIPE_DOC,
+        doc_pattern=r"source ΔG ∈ \[[\d.]+, ([\d.]+)\] nat",
+        src_rel=_MARKER_RECIPE_SRC_CALLBACKS,
+        src_pattern=r"(?<!\w)high_nats: float = ([\d.]+),",
+        symbol="MarkerBandStopCallback.__init__ high_nats default",
+    ),
+    # --- .claude/rules/marker-training-recipe.md (5 pins) ---
+    _RecipePin(
+        label="rule-marker-token-id",
+        doc_rel=_MARKER_RECIPE_RULE,
+        doc_pattern=r" ※` id (\d+)",
+        src_rel=_MARKER_RECIPE_SRC_RECIPE,
+        src_pattern=r"^MARKER_TOKEN_ID = (\d+)$",
+        symbol="MARKER_TOKEN_ID",
+    ),
+    _RecipePin(
+        label="rule-collator-tail-tokens",
+        doc_rel=_MARKER_RECIPE_RULE,
+        doc_pattern=r"MarkerOnlyDataCollator\(tail_tokens=(\d+)\)",
+        src_rel=_MARKER_RECIPE_SRC_SFT,
+        src_pattern=r"(?<!\w)tail_tokens: int = (\d+),",
+        symbol="MarkerOnlyDataCollator.__init__ tail_tokens default",
+    ),
+    _RecipePin(
+        label="rule-mix-reject-floor",
+        doc_rel=_MARKER_RECIPE_RULE,
+        doc_pattern=r"rejection-fraction floor \((0\.\d+)\)",
+        src_rel=_MARKER_RECIPE_SRC_ORGANISMS,
+        src_pattern=r"^MIX_MAX_REJECT_FRAC = ([0-9.]+)$",
+        symbol="MIX_MAX_REJECT_FRAC",
+    ),
+    _RecipePin(
+        label="rule-bandstop-low",
+        doc_rel=_MARKER_RECIPE_RULE,
+        doc_pattern=r"base ∈ \[([\d.]+), [\d.]+\] nat",
+        src_rel=_MARKER_RECIPE_SRC_CALLBACKS,
+        src_pattern=r"(?<!\w)low_nats: float = ([\d.]+),",
+        symbol="MarkerBandStopCallback.__init__ low_nats default",
+    ),
+    _RecipePin(
+        label="rule-bandstop-high",
+        doc_rel=_MARKER_RECIPE_RULE,
+        doc_pattern=r"base ∈ \[[\d.]+, ([\d.]+)\] nat",
+        src_rel=_MARKER_RECIPE_SRC_CALLBACKS,
+        src_pattern=r"(?<!\w)high_nats: float = ([\d.]+),",
+        symbol="MarkerBandStopCallback.__init__ high_nats default",
+    ),
+)
+
+
+def _norm_val(v: str) -> float | str:
+    """Return ``v`` as a float when it parses, else the string unchanged."""
+    try:
+        return float(v)
+    except ValueError:
+        return v
+
+
+def _values_equal(doc_val: str, src_val: str) -> bool:
+    """Float-compare when BOTH values parse as floats ('5' == '5.0',
+    '0.10' == '0.1'), else exact string equality."""
+    a, b = _norm_val(doc_val), _norm_val(src_val)
+    if isinstance(a, float) and isinstance(b, float):
+        return a == b
+    return doc_val == src_val
+
+
+def _recipe_pin_file_text(
+    cache: dict[str, str | None], path: Path, *, normalize: bool
+) -> str | None:
+    """Read + cache one pinned file for :func:`check_marker_recipe_snippets`.
+
+    ``normalize`` collapses every whitespace run to a single space (the
+    line-wrap-immune doc-matching mode); raw mode is for source files.
+    Returns None (cached) when the file is missing.
+    """
+    key = str(path)
+    if key not in cache:
+        if not path.is_file():
+            cache[key] = None
+        else:
+            text = path.read_text(encoding="utf-8")
+            cache[key] = re.sub(r"\s+", " ", text) if normalize else text
+    return cache[key]
+
+
+def check_marker_recipe_snippets(*, repo_root: Path | None = None) -> list[str]:
+    """FAIL when a frozen numeric snippet in the marker-training recipe doc
+    (docs/marker_training_recipe.md) or its sibling rule
+    (.claude/rules/marker-training-recipe.md) disagrees with the code constant
+    it cites (#1154; the drift class: a stale frozen number misleads every
+    future marker-training planner grounding hyperparameters from the doc).
+
+    Registry-driven (``_MARKER_RECIPE_PINS``) — only registered pins are ever
+    evaluated; empirical findings / frozen experiment history in the same
+    files are never parsed. Doc patterns run whitespace-normalized
+    (line-wrap-immune); src patterns run raw + MULTILINE. Values compare as
+    floats when both parse ('5' == '5.0'), else exact strings. Failure modes:
+    missing file, doc snippet not found (rot alarm — the pinned prose was
+    rephrased), code constant not found (the symbol moved/renamed), ambiguous
+    conflicting source matches, and doc-vs-code value mismatch. ``repo_root``
+    is a unit-test override hook; production callers pass None. Bundled into
+    the no-flags default run.
+    """
+    root = repo_root if repo_root is not None else _REPO_ROOT
+    errors: list[str] = []
+    doc_cache: dict[str, str | None] = {}  # normalized doc text (None = missing)
+    src_cache: dict[str, str | None] = {}  # raw source text (None = missing)
+    for pin in _MARKER_RECIPE_PINS:
+        doc_path = root / pin.doc_rel
+        src_path = root / pin.src_rel
+        doc_text = _recipe_pin_file_text(doc_cache, doc_path, normalize=True)
+        src_text = _recipe_pin_file_text(src_cache, src_path, normalize=False)
+        if doc_text is None:
+            errors.append(
+                f"{doc_path}: missing — pin '{pin.label}' binds a snippet here to "
+                f"{pin.src_rel}::{pin.symbol}; the marker-recipe doc was moved or "
+                f"deleted — update _MARKER_RECIPE_PINS in scripts/workflow_lint.py "
+                f"(#1154)."
+            )
+            continue
+        if src_text is None:
+            errors.append(
+                f"{src_path}: missing — pin '{pin.label}' expects {pin.symbol} here "
+                f"(cited by {pin.doc_rel}); the source file was moved or deleted — "
+                f"update _MARKER_RECIPE_PINS in scripts/workflow_lint.py (#1154)."
+            )
+            continue
+        doc_vals = re.findall(pin.doc_pattern, doc_text)
+        if not doc_vals:
+            errors.append(
+                f"{doc_path}: pin '{pin.label}': doc snippet not found (pattern "
+                f"{pin.doc_pattern!r}) — the pinned prose was rephrased or removed; "
+                f"update the snippet or _MARKER_RECIPE_PINS in "
+                f"scripts/workflow_lint.py (#1154)."
+            )
+            continue
+        src_vals = re.findall(pin.src_pattern, src_text, re.MULTILINE)
+        if not src_vals:
+            errors.append(
+                f"{src_path}: pin '{pin.label}': code constant {pin.symbol} not "
+                f"found (pattern {pin.src_pattern!r}) — the symbol moved or was "
+                f"renamed; update _MARKER_RECIPE_PINS in scripts/workflow_lint.py "
+                f"(#1154)."
+            )
+            continue
+        if len({_norm_val(v) for v in src_vals}) > 1:
+            errors.append(
+                f"{src_path}: pin '{pin.label}': ambiguous — {len(src_vals)} "
+                f"conflicting matches for {pin.symbol} (values "
+                f"{sorted(set(src_vals))}); tighten the pin's src_pattern in "
+                f"_MARKER_RECIPE_PINS (#1154)."
+            )
+            continue
+        src_val = src_vals[0]
+        for doc_val in dict.fromkeys(doc_vals):  # distinct values, first-seen order
+            if not _values_equal(doc_val, src_val):
+                errors.append(
+                    f"{doc_path}: pin '{pin.label}': doc cites {doc_val!r} but "
+                    f"{pin.src_rel}::{pin.symbol} is {src_val!r} — update the doc "
+                    f"snippet (or _MARKER_RECIPE_PINS if the binding itself "
+                    f"changed) so they agree (#1154)."
+                )
+    return errors
+
+
 # `--check-lessons-index`: every `.claude/rules/*.md` (except LESSONS.md
 # itself) must have exactly one matching row in `.claude/rules/LESSONS.md`, and
 # every row in LESSONS.md must point at an existing rule file. Closes the
@@ -7443,6 +7679,17 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         "legitimately differ. Bundled into the no-flags default run.",
     )
     parser.add_argument(
+        "--check-marker-recipe-snippets",
+        action="store_true",
+        help="FAIL when a frozen numeric snippet in docs/marker_training_recipe.md "
+        "or .claude/rules/marker-training-recipe.md disagrees with the code "
+        "constant it cites (registry _MARKER_RECIPE_PINS: marker token id 83399, "
+        "the MarkerOnlyDataCollator tail_tokens default, MIX_MAX_REJECT_FRAC, the "
+        "MarkerBandStopCallback default band). Registry-driven — empirical "
+        "findings / frozen experiment history are never parsed. Bundled into the "
+        "no-flags default run (#1154).",
+    )
+    parser.add_argument(
         "--check-judge-model-pins",
         action="store_true",
         help="Walk scripts/**/*.py, scripts/**/*.sh, "
@@ -7592,6 +7839,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         or args.check_smoke_output_hygiene
         or args.check_vm_thread_cap_guidance
         or args.check_awk_elision_parity
+        or args.check_marker_recipe_snippets
         or args.check_judge_model_pins
         or args.check_no_literal_round_marker_versions
         or args.check_agent_spec_size
@@ -7690,6 +7938,8 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         errors.extend(check_vm_thread_cap_guidance())
     if args.check_awk_elision_parity or no_flags:
         errors.extend(check_awk_elision_parity())
+    if args.check_marker_recipe_snippets or no_flags:
+        errors.extend(check_marker_recipe_snippets())
     if args.check_judge_model_pins or no_flags:
         errors.extend(check_judge_model_pins())
     if args.check_no_literal_round_marker_versions or no_flags:

--- a/tests/test_workflow_lint.py
+++ b/tests/test_workflow_lint.py
@@ -19,6 +19,7 @@ Also covers the ``--check-script-refs`` mode: every
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -35,9 +36,11 @@ if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
 from workflow_lint import (  # noqa: E402
+    _MARKER_RECIPE_PINS,
     BATCH_JUDGE_LEGACY_ALLOWLIST,
     _iter_ask_target_files,
     _other_worktree_prefix,
+    _values_equal,
     check_agent_model_pins,
     check_asks,
     check_autonomous_asks,
@@ -51,6 +54,7 @@ from workflow_lint import (  # noqa: E402
     check_hollow_verification_gate_review_lens,
     check_lessons_index,
     check_long_loop_restartability_review_lens,
+    check_marker_recipe_snippets,
     check_marker_registry,
     check_no_literal_round_marker_versions,
     check_no_workflow_improver_spawn,
@@ -4014,6 +4018,240 @@ def test_vm_thread_cap_guidance_bundled_in_no_flags(tmp_path, capsys, monkeypatc
         f"the #891 vm-thread-cap diagnostic (naming code-style.md) is missing "
         f"from the no-flags default run's stderr — the check is not bundled "
         f"into no_flags:\n{err}"
+    )
+
+
+# --- #1154 marker-recipe snippet-pin tests -----------------------------------
+
+# Minimal conforming fixture tree: the two pinned doc files carry one verbatim
+# snippet per registered pin (the bandstop snippet deliberately WRAPS across a
+# line break — the reflow proof for the whitespace-normalized matching — and
+# both docs carry the bare-`※` 63680 decoy that must never be captured); the
+# four src files carry the constant lines from the live tree, including the
+# `marker_tail_tokens` decoy field the sft pattern must not match.
+_MARKER_RECIPE_FIXTURE_FILES: dict[str, str] = {
+    "docs/marker_training_recipe.md": (
+        "# marker training recipe (fixture)\n"
+        "` ※` (Qwen-2.5-7B token id 83399). DV = on-policy log P(marker).\n"
+        "| Marker | ` ※` id 83399 (assert encoding) | single rare token |\n"
+        "Constraint: marker-only loss (`MarkerOnlyDataCollator(tail_tokens=0)`).\n"
+        "| Loss mask | marker-only (`MarkerOnlyDataCollator(tail_tokens=0)`) | keeps R |\n"
+        "7. Run a pre-sweep anchor smoke. Confirm source ΔG ∈ [5, 12]\n"
+        "   nat AND bystanders below the argmax ceiling.\n"
+        "| #906 | completed | render-exact gate (4/200 rows dropped, reject floor 0.10) |\n"
+        "Avoid bare `※` id 63680 (wrong token).\n"
+    ),
+    ".claude/rules/marker-training-recipe.md": (
+        "# marker-training-recipe rule (fixture)\n"
+        "Loss via `MarkerOnlyDataCollator(tail_tokens=0)`, response frozen.\n"
+        "- Fail-loud above a rejection-fraction floor (0.10).\n"
+        "> Stop when source log P over base ∈ [5, 12] nat (gate on bystanders).\n"
+        '` ※` id 83399 only (assert `encode(" ※") == [83399]`). Avoid bare `※` id 63680.\n'
+    ),
+    "src/explore_persona_space/artifacts/recipe.py": "MARKER_TOKEN_ID = 83399\n",
+    "src/explore_persona_space/train/sft.py": (
+        "class MarkerOnlyDataCollator:\n"
+        "    def __init__(\n"
+        "        self,\n"
+        "        tail_tokens: int = 0,\n"
+        "    ) -> None:\n"
+        "        pass\n"
+        "\n"
+        "\n"
+        "class TrainLoraConfig:\n"
+        "    marker_tail_tokens: int = 0\n"
+    ),
+    "src/explore_persona_space/artifacts/organisms.py": "MIX_MAX_REJECT_FRAC = 0.10\n",
+    "src/explore_persona_space/eval/callbacks.py": (
+        "class MarkerBandStopCallback:\n"
+        "    def __init__(\n"
+        "        self,\n"
+        "        low_nats: float = 5.0,\n"
+        "        high_nats: float = 12.0,\n"
+        "    ) -> None:\n"
+        "        pass\n"
+    ),
+}
+
+
+def _write_marker_recipe_fixture(
+    root: Path,
+    overrides: dict[str, str] | None = None,
+    omit: tuple[str, ...] = (),
+) -> None:
+    """Write the #1154 pinned doc + src files at the registry's exact rel-paths
+    under ``root``. ``overrides`` swap in mutated file contents (seeded drift);
+    rel-paths in ``omit`` are not written at all (the missing-file case)."""
+    contents = dict(_MARKER_RECIPE_FIXTURE_FILES)
+    contents.update(overrides or {})
+    for rel, text in contents.items():
+        if rel in omit:
+            continue
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(text, encoding="utf-8")
+
+
+def test_marker_recipe_snippets_live_tree_passes() -> None:
+    """The real tree's pinned doc snippets agree with the code constants
+    (launch invariant: 0 false positives; the live drift gate going forward)."""
+    assert check_marker_recipe_snippets() == []
+
+
+def test_marker_recipe_snippets_fixture_tree_passes(tmp_path) -> None:
+    """The conforming fixture tree passes — pins the fixture itself so every
+    mutation test below fails for its seeded drift, not fixture rot."""
+    _write_marker_recipe_fixture(tmp_path)
+    assert check_marker_recipe_snippets(repo_root=tmp_path) == []
+
+
+def test_marker_recipe_snippets_flags_code_drift(tmp_path) -> None:
+    """Mutating a bound code constant (MARKER_TOKEN_ID 83399 -> 99999) FAILs
+    BOTH token-id pins, each naming the pin label and both values."""
+    _write_marker_recipe_fixture(
+        tmp_path,
+        overrides={"src/explore_persona_space/artifacts/recipe.py": "MARKER_TOKEN_ID = 99999\n"},
+    )
+    errors = check_marker_recipe_snippets(repo_root=tmp_path)
+    assert len(errors) == 2, errors
+    for label in ("marker-token-id", "rule-marker-token-id"):
+        matching = [e for e in errors if f"pin '{label}'" in e]
+        assert len(matching) == 1, errors
+        assert "'83399'" in matching[0] and "'99999'" in matching[0], errors
+
+
+def test_marker_recipe_snippets_flags_doc_drift(tmp_path) -> None:
+    """The doc citing a stale value (reject floor 0.12 vs code 0.10) FAILs with
+    exactly one error whose subject is the doc and which names both values."""
+    drifted = _MARKER_RECIPE_FIXTURE_FILES["docs/marker_training_recipe.md"].replace(
+        "reject floor 0.10", "reject floor 0.12"
+    )
+    _write_marker_recipe_fixture(tmp_path, overrides={"docs/marker_training_recipe.md": drifted})
+    errors = check_marker_recipe_snippets(repo_root=tmp_path)
+    assert len(errors) == 1, errors
+    subject = errors[0].split(": ", 1)[0]
+    assert subject.endswith("docs/marker_training_recipe.md"), errors
+    assert "'0.12'" in errors[0] and "'0.10'" in errors[0], errors
+
+
+def test_marker_recipe_snippets_flags_missing_doc_snippet(tmp_path) -> None:
+    """Rephrasing a pinned doc sentence away from its pattern FAILs loud
+    ('doc snippet not found' — the rot alarm), naming the pin."""
+    rephrased = _MARKER_RECIPE_FIXTURE_FILES["docs/marker_training_recipe.md"].replace(
+        "reject floor 0.10", "rejection cutoff 0.10"
+    )
+    _write_marker_recipe_fixture(tmp_path, overrides={"docs/marker_training_recipe.md": rephrased})
+    errors = check_marker_recipe_snippets(repo_root=tmp_path)
+    assert len(errors) == 1, errors
+    assert "doc snippet not found" in errors[0], errors
+    assert "pin 'mix-reject-floor'" in errors[0], errors
+
+
+def test_marker_recipe_snippets_flags_missing_code_symbol(tmp_path) -> None:
+    """Removing a bound symbol from its source file FAILs every pin citing it
+    ('code constant ... not found' — the rename/move alarm)."""
+    _write_marker_recipe_fixture(
+        tmp_path,
+        overrides={"src/explore_persona_space/artifacts/organisms.py": "OTHER_CONST = 1\n"},
+    )
+    errors = check_marker_recipe_snippets(repo_root=tmp_path)
+    assert len(errors) == 2, errors  # the docs pin + the rule pin both cite organisms.py
+    for e in errors:
+        assert "not found" in e and "MIX_MAX_REJECT_FRAC" in e, errors
+
+
+def test_marker_recipe_snippets_flags_ambiguous_src(tmp_path) -> None:
+    """A second, conflicting `tail_tokens: int = 5,` signature in sft.py makes
+    the collator pins ambiguous -> FAIL (the doc citation genuinely became
+    ambiguous; the registry pattern must be tightened)."""
+    ambiguous = _MARKER_RECIPE_FIXTURE_FILES["src/explore_persona_space/train/sft.py"] + (
+        "\n"
+        "\n"
+        "class OtherCollator:\n"
+        "    def __init__(\n"
+        "        self,\n"
+        "        tail_tokens: int = 5,\n"
+        "    ) -> None:\n"
+        "        pass\n"
+    )
+    _write_marker_recipe_fixture(
+        tmp_path, overrides={"src/explore_persona_space/train/sft.py": ambiguous}
+    )
+    errors = check_marker_recipe_snippets(repo_root=tmp_path)
+    assert len(errors) == 2, errors  # the docs pin + the rule pin both cite sft.py
+    for e in errors:
+        assert "ambiguous" in e and "tail_tokens" in e, errors
+
+
+def test_marker_recipe_snippets_flags_missing_file(tmp_path) -> None:
+    """A missing pinned doc file is itself an error — once per pin bound to it
+    (5 rule-file pins)."""
+    _write_marker_recipe_fixture(tmp_path, omit=(".claude/rules/marker-training-recipe.md",))
+    errors = check_marker_recipe_snippets(repo_root=tmp_path)
+    assert len(errors) == 5, errors
+    for e in errors:
+        assert "missing" in e, errors
+        assert e.split(": ", 1)[0].endswith("marker-training-recipe.md"), errors
+
+
+def test_marker_recipe_snippets_does_not_capture_wrong_token_id() -> None:
+    """On the LIVE tree, the token-id pins capture only 83399 — never the
+    bare-`※` wrong-token id 63680 (docs line ~196 / rule line ~236 mention it
+    with a backtick, not a space, before ※ — the space anchor skips it)."""
+    import workflow_lint as wl
+
+    for pin in _MARKER_RECIPE_PINS:
+        if "token-id" not in pin.label:
+            continue
+        doc_text = (wl._REPO_ROOT / pin.doc_rel).read_text(encoding="utf-8")
+        captures = re.findall(pin.doc_pattern, re.sub(r"\s+", " ", doc_text))
+        assert captures, f"pin '{pin.label}': no live doc matches"
+        assert "63680" not in captures, (pin.label, captures)
+        assert set(captures) == {"83399"}, (pin.label, captures)
+
+
+def test_marker_recipe_pins_have_one_capture_group() -> None:
+    """Registry invariant: every pin's doc_pattern AND src_pattern compile with
+    exactly ONE capture group (findall then returns bare value strings)."""
+    for pin in _MARKER_RECIPE_PINS:
+        assert re.compile(pin.doc_pattern).groups == 1, pin.label
+        assert re.compile(pin.src_pattern).groups == 1, pin.label
+
+
+def test_marker_recipe_values_equal_float_forms() -> None:
+    """Value comparison is float-based when both sides parse ('5' == '5.0' —
+    the doc band vs the callbacks.py float defaults), else exact-string."""
+    assert _values_equal("5", "5.0") is True
+    assert _values_equal("0.10", "0.1") is True
+    assert _values_equal("83399", "83399") is True
+    assert _values_equal("83399", "99999") is False
+    assert _values_equal("abc", "abc") is True
+    assert _values_equal("abc", "abd") is False
+
+
+def test_marker_recipe_snippets_bundled_in_no_flags(tmp_path, capsys, monkeypatch) -> None:
+    """The no-flags default run actually DISPATCHES the #1154 check — deleting
+    its ``or no_flags`` branch must fail this test (mutation-visible), closing
+    the dead-tripwire gap where all direct-call tests stay green while the CLI
+    never runs the check. Same mechanism as
+    ``test_vm_thread_cap_guidance_bundled_in_no_flags``: a seeded code drift,
+    ``_REPO_ROOT`` monkeypatched to the fixture, ``main([])`` in-process.
+    Other bundled checks contribute unrelated errors on the minimal tree, so
+    the assertion keys on the #1154 diagnostic + the offending doc path."""
+    import workflow_lint as wl
+
+    _write_marker_recipe_fixture(
+        tmp_path,
+        overrides={"src/explore_persona_space/artifacts/recipe.py": "MARKER_TOKEN_ID = 99999\n"},
+    )
+    monkeypatch.setattr(wl, "_REPO_ROOT", tmp_path)
+    rc = wl.main([])
+    err = capsys.readouterr().err
+    assert rc != 0, f"no-flags default run exited 0 on a drifted tree:\n{err}"
+    assert "#1154" in err and "marker_training_recipe.md" in err, (
+        f"the #1154 marker-recipe diagnostic (naming marker_training_recipe.md) "
+        f"is missing from the no-flags default run's stderr — the check is not "
+        f"bundled into no_flags:\n{err}"
     )
 
 


### PR DESCRIPTION
Closes task #1154. workflow-fix: registry-driven lint check that frozen numeric snippets in docs/marker_training_recipe.md + .claude/rules/marker-training-recipe.md stay consistent with the code constants they cite (4 constants / 10 pins). Docs byte-untouched.