### PR TITLE
issue-1152: harden guard_harmful_bank_read hook (3 bypass residuals + --file rider)

### DIFF
--- a/.claude/hooks/guard_harmful_bank_read.sh
+++ b/.claude/hooks/guard_harmful_bank_read.sh
@@ -16,19 +16,71 @@
 #   Grep  — deny output_mode "content" on a bank FILE or the query_banks DIR
 #           (banks are ~one item per line; a content match IS item text);
 #           files_with_matches / count modes are digests -> allowed.
-#   Bash  — whole-command raw scan (deliberately NO clause/pipe split, plan
-#           §11.3): deny text-paging verbs (cat/head/sed/awk/json.tool/...)
-#           co-occurring with a bank token, grep-family line output with
-#           PER-EXECUTABLE safe flags (grep/egrep/fgrep: -c/-q/-l/-L digests;
-#           rg: -c/-q/-l only — rg -L is --follow, it PRINTS lines) tracked
-#           PER INSTANCE (a later safe grep cannot launder an earlier unsafe
-#           one), git show/diff/log -p paging a bank (digest forms --stat /
-#           --name-only / --numstat / --oneline allowed), and jq with a
-#           non-digest filter (allowed single-word digests: keys /
-#           keys_unsorted / length / type / empty). Everything else
-#           (python/uv pipelines, cp, git add/commit, wc, sha256sum, stat,
-#           du, redirects) is allowed by default — banks exist to be consumed
-#           in-process by pipeline code.
+#   Bash  — raw scan over operator-padded word-split tokens. The DENY
+#           co-occurrence (bank token + paging verb) stays WHOLE-COMMAND
+#           (deliberately NO clause/pipe split for the deny side, plan #965
+#           §11.3 — a clause splitter fails OPEN on quoted pipes), but the
+#           per-instance grep/git/jq SAFE-FLAG attribution closes at
+#           command-unit BOUNDARIES (#1152): padded `| & ; ( )` + backtick
+#           tokens (newlines mapped to `;` via tr) latch-or-evaluate + reset the
+#           open instance, so a later unit's flags cannot launder an
+#           earlier unit's instance (`grep harmful <bank> && ls -l` denies)
+#           and a later unit's flags no longer false-deny an earlier safe
+#           one (`git log -- <bank> && mkdir -p /tmp/x` allows). `<`/`>`
+#           are NOT boundaries — redirects don't start a new command unit.
+#           GIT CARRY RULE: an UNRESOLVED git instance (in_git=1,
+#           subcommand not yet seen — e.g. the padded `(` of
+#           `git -C $(pwd) show ...` fires a boundary BEFORE the
+#           subcommand token) CARRIES across the boundary; resetting it
+#           would detach the attribution (fail-OPEN on show/log -p,
+#           false-deny on diff --stat via the bare-diff branch).
+#           Fail-closed residue of the carry: a subcommand-less git
+#           (`git add <bank> && diff x y`) can mis-attribute a later
+#           unit's show/diff/log to git — extra DENY, never extra allow.
+#           Denies: text-paging verbs (cat/head/sed/awk/comm/join/
+#           json.tool/...) co-occurring with a bank token; bare `diff`
+#           OUTSIDE a git instance (diff /dev/null <bank> prints item
+#           text; `diff` cannot join the verb regex because `git diff
+#           --stat` walks a `diff` token — the same-unit `git` precedes
+#           it, so in_git guards the digest forms); grep-family line
+#           output with PER-EXECUTABLE safe flags (grep/egrep/fgrep:
+#           -c/-q/-l/-L digests; rg: -c/-q/-l only — rg -L is --follow,
+#           it PRINTS lines) tracked PER INSTANCE (a later safe grep
+#           cannot launder an earlier unsafe one); git show/diff/log -p
+#           paging a bank (digest forms --stat / --name-only / --numstat
+#           / --oneline allowed); jq with a non-digest filter (allowed
+#           single-word digests: keys / keys_unsorted / length / type /
+#           empty); and task.py --file/--body-file on a bank file (would
+#           embed bank items into task state — events.jsonl / body.md /
+#           plans; non-task.py `--file <bank>` pipeline consumption stays
+#           allowed). Everything else (python/uv pipelines, cp, git
+#           add/commit, wc, sha256sum, stat, du, redirects) is allowed by
+#           default — banks exist to be consumed in-process by pipeline
+#           code.
+#           NOTE EXEMPTION (#1152): on a task.py-shaped command
+#           (`*task.py*` glob — matches ANY path named task.py;
+#           deliberate, acceptable under the python-allowed posture),
+#           quoted `--note` strings are blanked BEFORE the fast path:
+#           single-quoted always; double-quoted ONLY when free of $ and
+#           backtick (a note carrying $(...) / `...` DOES execute — left
+#           visible to the walk, fail-closed). Notes are DATA arguments
+#           to a Python CLI, never executed; the scrub defends against
+#           ACCIDENTAL false positives (progress notes naming a bank path
+#           + a paging verb), NOT crafted quote-splicing — deliberate
+#           evasion is already dominated by the standing python allowance
+#           + the documented escape hatch.
+#           Accepted fail-CLOSED FP shapes (extra deny, never extra
+#           allow; remediation named in the deny message): a digest flag
+#           AFTER a quoted-operator pattern (`grep -E 'foo|bar' -c
+#           <bank>` — the quoted `|` pads into a boundary that latches
+#           the still-unsafe instance; put -c/-q/-l BEFORE the pattern),
+#           the `&` inside `2>&1` when the instance is still unsafe at
+#           that point, multi-line quoted strings containing operators,
+#           and a backslash-newline continuation with the digest flag on
+#           the continuation line (the tr'd `;` closes the instance
+#           unsafe). Un-blanked note shapes (escaped quotes, $var,
+#           backticks, literal newlines) keep the pre-#1152 deny
+#           behavior — conservative, counted by the sidecar log.
 #   mcp__ssh__ssh_execute — same command-string shape; reuses the Bash arm.
 #
 # Contract: reads the PreToolUse JSON on stdin; exit 0 = allow, exit 2 =
@@ -47,7 +99,7 @@ STEM_RE='(advbench|strongreject|betley_main8|wang44|broad_em_train|sensitive_inf
 BANK_RE="(^|/)query_banks/${STEM_RE}[^/]*\.json\$"
 BARE_RE="(^|/)${STEM_RE}[^/]*\.json\$"
 BANKDIR_RE='(^|/)query_banks/?$'
-DENY_VERBS_RE='^(cat|tac|nl|head|tail|sed|awk|cut|sort|uniq|rev|strings|less|more|most|bat|od|xxd|hexdump|base64|fold|fmt|pr|column|paste|json\.tool)$'
+DENY_VERBS_RE='^(cat|tac|nl|head|tail|sed|awk|cut|sort|uniq|rev|strings|less|more|most|bat|od|xxd|hexdump|base64|fold|fmt|pr|column|paste|comm|join|json\.tool)$'
 JQ_DIGEST_RE='^(keys|keys_unsorted|length|type|empty)$'
 GUARD_LOG="${EPM_BANK_GUARD_LOG:-/home/thomasjiralerspong/explore-persona-space/.claude/cache/bank-guard-denies.log}"
 
@@ -122,24 +174,58 @@ cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) |
 # Inline escape hatch.
 case "$cmd" in *EPM_ALLOW_BANK_READ=1*) exit 0 ;; esac
 
-# Fast path: no bank-stem-shaped token anywhere -> allow (hook runs on EVERY
-# Bash call; this single grep is the common-case cost).
-printf '%s' "$cmd" | grep -qE "${STEM_RE}[^/[:space:]]*\.json" || exit 0
+# (c) task.py --note quoted-prose exemption (#1152): a --note string on a
+# task.py invocation is a DATA argument to a Python CLI, never executed —
+# blank it before scanning so purely descriptive prose naming a bank path
+# and/or a paging verb cannot false-positive (the #965 FP-watch shape).
+# Blank single-quoted notes always; blank double-quoted notes ONLY when
+# free of $ and backtick (a note carrying $(...) / `...` DOES execute —
+# left visible to the walk, fail-closed). Line-based sed: a multi-line
+# quoted note stays un-blanked (conservative — the old FP persists there,
+# never a new allow). See the header for the *task.py* gate + scope notes.
+# Gate = two in-shell case globs — zero added cost on the common path.
+cmd_scan="$cmd"
+taskpy_shape=0
+case "$cmd" in *task.py*) taskpy_shape=1 ;; esac
+if [ "$taskpy_shape" = 1 ]; then
+  case "$cmd" in
+    *--note*)
+      cmd_scan=$(printf '%s' "$cmd" | sed -E \
+        -e "s/--note(=|[[:space:]]+)'[^']*'/--note ''/g" \
+        -e 's/--note(=|[[:space:]]+)"[^"$`]*"/--note ""/g')
+      ;;
+  esac
+fi
 
-# Normalize shell control operators BEFORE the token walk so unspaced forms
-# tokenize (`cat <bank>|grep foo`, `cat <bank>&&echo`, `cat <bank>;echo`,
-# trailing `)`s) — otherwise the operator glues to the path token and the
-# $-anchored .json match fails open. Padding inside quoted strings only
-# affects tokenization, never execution (we never rewrite the command).
-cmd_norm=$(printf '%s' "$cmd" | sed 's/[|;&<>()]/ & /g')
+# Fast path: no bank-stem-shaped token anywhere in the (note-scrubbed)
+# command -> allow (hook runs on EVERY Bash call; this single grep is the
+# common-case cost). A command whose ONLY bank token lived in note prose
+# exits 0 right here.
+printf '%s' "$cmd_scan" | grep -qE "${STEM_RE}[^/[:space:]]*\.json" || exit 0
 
-# Whole-command raw scan (deliberately NO clause split — plan §11.3):
-# word-split; find a bank token; if present, deny on any text-paging verb
-# token, on grep-family line output (per-executable safe flags, per-instance
-# tracking), on git show/diff/log -p paging (per-instance), or on jq with a
-# non-digest filter (per-instance). Everything else (python/uv pipelines,
-# cp, git add/commit, wc, sha256sum, stat, du, redirects) is allowed by
-# default.
+# Normalize BEFORE the token walk: newlines map to ';' (a newline separates
+# command units exactly like ';'), then shell control operators are padded
+# so unspaced forms tokenize (`cat <bank>|grep foo`, `cat <bank>&&echo`,
+# `cat <bank>;echo`, trailing `)`s) — otherwise the operator glues to the
+# path token and the $-anchored .json match fails open. Backticks pad too
+# (#1152): a backtick substitution glues to its verb + closing path token
+# exactly as `$( )` would without the paren padding — the pre-#1152
+# tokenizer failed OPEN on a bare backtick-cat of a bank. Padding inside
+# quoted strings only affects tokenization, never execution (we never
+# rewrite the command).
+cmd_norm=$(printf '%s' "$cmd_scan" | tr '\n' ';' | sed 's/[|;&<>()`]/ & /g')
+
+# Raw scan: word-split; find a bank token; if present, deny on any
+# text-paging verb token, on bare diff outside a git instance, on
+# grep-family line output (per-executable safe flags, per-instance
+# tracking), on git show/diff/log -p paging (per-instance), on jq with a
+# non-digest filter (per-instance), or on a task.py --file/--body-file
+# bank argument. The DENY co-occurrence stays WHOLE-COMMAND (deliberately
+# NO clause split — plan #965 §11.3); padded operator tokens `| & ; ( )`
+# + backtick are INSTANCE BOUNDARIES only (close_instances): they stop safe-flag /
+# attribution state from crossing command units, never detach the verb
+# from the bank. Everything else (python/uv pipelines, cp, git
+# add/commit, wc, sha256sum, stat, du, redirects) is allowed by default.
 set -f
 # shellcheck disable=SC2086
 set -- $cmd_norm
@@ -154,6 +240,7 @@ done
 has_grep=0 grep_safe=0 grep_kind="" grep_any_unsafe=0
 has_jq=0 jq_filter="" jq_seen=0
 in_git=0 git_sub="" git_safe=0 git_log_patch=0
+expect_taskfile=0
 
 git_check() {  # evaluate the accumulated git instance; deny on unsafe paging.
   [ -n "$git_sub" ] || return 0
@@ -174,10 +261,54 @@ jq_check() {  # evaluate the accumulated jq instance; deny on non-digest filter.
   return 0
 }
 
+close_instances() {  # at a command-unit boundary (`| & ; ( )` + backtick;
+  # newlines arrive as `;` via tr): latch/evaluate each open instance, then
+  # reset it —
+  # a later unit's flags must never mark an earlier unit's instance safe.
+  # grep: an instance still unsafe at its unit's end stays unsafe (sticky).
+  if [ "$has_grep" = 1 ] && [ "$grep_safe" = 0 ]; then grep_any_unsafe=1; fi
+  has_grep=0; grep_safe=0; grep_kind=""
+  # git: attribution-based deny (show/diff/log deny only via in_git/git_sub),
+  # so an UNRESOLVED instance (in_git=1, git_sub empty — e.g. the padded `(`
+  # of `git -C $(pwd) show ...` fires a boundary BEFORE the subcommand token)
+  # must CARRY across the boundary or the attribution detaches: the executing
+  # `git show` would page the bank while the walk sees a bare orphan `show`
+  # (fail-OPEN), and `git -C $(pwd) diff --stat` would false-deny via the
+  # bare-diff branch. Carrying is fail-closed both ways: worst case a real
+  # boundary after a subcommand-less git (e.g. `git add <bank> && diff x y`)
+  # mis-attributes the next unit's show/diff/log to git -> extra DENY, never
+  # extra allow. A RESOLVED instance (git_sub set) evaluates + resets here,
+  # which is what fixes the `git log -- <bank> && mkdir -p /tmp/x` FP.
+  if [ "$in_git" = 1 ] && [ -z "$git_sub" ]; then
+    :  # carry the unresolved git instance across the boundary
+  else
+    git_check   # denies here if the closing unit paged a bank via git
+    in_git=0; git_sub=""; git_safe=0; git_log_patch=0
+  fi
+  jq_check    # denies here on a non-digest jq filter
+  has_jq=0; jq_filter=""; jq_seen=0
+  expect_taskfile=0
+}
+
 for tok in "$@"; do
+  # Command-unit boundary: close every open instance, consume the token.
+  # Backticks bound command substitutions exactly as `( )` do (a distinct
+  # command unit runs inside). `<`/`>` are deliberately NOT boundaries —
+  # redirects don't start a new command unit, and flags legitimately
+  # follow redirects.
+  case "$tok" in
+    '|' | '&' | ';' | '(' | ')' | '`') close_instances; continue ;;
+  esac
   base="${tok##*/}"
   if printf '%s' "$base" | grep -qE "$DENY_VERBS_RE"; then
     deny "'$base' on a bank file" "$bank"
+  fi
+  # Bare `diff` OUTSIDE a git instance pages bank content (`diff /dev/null
+  # <bank>` prints every item). `diff` cannot join DENY_VERBS_RE because
+  # `git diff --stat` walks a `diff` token; the same-unit `git` precedes
+  # it (in_git=1 there), so this fires only for standalone diff.
+  if [ "$base" = diff ] && [ "$in_git" = 0 ]; then
+    deny "'diff' paging a bank file (diff /dev/null <bank> prints item text; for tracked changes use git diff --stat / --name-only)" "$bank"
   fi
   case "$base" in
     grep | egrep | fgrep | rg)
@@ -228,11 +359,33 @@ for tok in "$@"; do
         ;;
     esac
   fi
+  # task.py --file/--body-file rider (#1152): embedding a bank into task
+  # state (events.jsonl note body / body.md / plans) defeats the
+  # digest-only rule with delay. Gated on the task.py shape so legitimate
+  # pipeline consumption (`scripts/eval.py --file <bank>`) stays allowed.
+  # expect_taskfile resets at boundaries (close_instances) — `--file`
+  # followed by an operator never attributes the NEXT unit's token.
+  if [ "$taskpy_shape" = 1 ]; then
+    if [ "$expect_taskfile" = 1 ]; then
+      if is_bank_path "$tok"; then
+        deny "task.py --file/--body-file on a bank file (would embed bank items into task state)" "$tok"
+      fi
+      expect_taskfile=0
+    fi
+    case "$tok" in
+      --file | --body-file) expect_taskfile=1 ;;
+      --file=* | --body-file=*)
+        if is_bank_path "${tok#*=}"; then
+          deny "task.py --file/--body-file on a bank file (would embed bank items into task state)" "${tok#*=}"
+        fi
+        ;;
+    esac
+  fi
 done
 
 if [ "$has_grep" = 1 ] && [ "$grep_safe" = 0 ]; then grep_any_unsafe=1; fi
 if [ "$grep_any_unsafe" = 1 ]; then
-  deny "grep-family line output on a bank file (matching lines ARE items; use grep -c / -q / -l; note rg -L is --follow, NOT files-without-match)" "$bank"
+  deny "grep-family line output on a bank file (matching lines ARE items; use grep -c / -q / -l, and place -c/-q/-l BEFORE the pattern in compound commands; note rg -L is --follow, NOT files-without-match)" "$bank"
 fi
 git_check
 jq_check

--- a/tests/test_guard_harmful_bank_read.py
+++ b/tests/test_guard_harmful_bank_read.py
@@ -524,3 +524,213 @@ class TestSettingsWiring:
     def test_configured_command_allows_digest_bash(self) -> None:
         r = _run_bash(f"jq 'length' {BANK_ABS}", script=self._configured_command())
         _assert_allowed(r)
+
+
+# ---------------------------------------------------------------------------
+# #1152 (a) DENY — cross-unit flag laundering closed (plan #1152 §6 cases 1-8)
+#
+# Operator tokens `| & ; ( )` + backtick (newlines tr'd to `;`) are INSTANCE
+# BOUNDARIES: per-instance grep/git/jq safe-flag state closes there, so a
+# later command unit's flags can no longer mark an earlier unit's instance
+# safe. The DENY co-occurrence (bank + verb) stays whole-command (#965 §11.3).
+# ---------------------------------------------------------------------------
+TASKPY = "uv run python scripts/task.py"
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        f"grep harmful {BANK_ABS} && ls -l",  # 1: `ls -l` laundered the grep pre-#1152
+        f"grep harmful {BANK_ABS}; ls -l",  # 2: `;` separator
+        f"grep harmful {BANK_ABS} | wc -l",  # 3: `wc -l` laundered through the pipe
+        f"rg foo {BANK_ABS} || echo -l",  # 4: `||` separator, rg family
+        f"git show HEAD:{BANK_REL} && ls --stat",  # 5: later --stat laundered git show
+        f"grep harmful {BANK_ABS}\nls -l",  # 6: real newline boundary (tr maps to `;`)
+        # 7: pins that the DENY side stayed WHOLE-COMMAND (#965 §11.3 invariant —
+        # this deliberate-FP shape must remain a deny after the boundary change).
+        f"jq 'length' {BANK_ABS} && jq '.foo' /tmp/other.json",
+        # 8: pins the accepted new FP as intentional (plan #1152 §8): a digest flag
+        # AFTER a quoted alternation — the quoted `|` pads into a boundary that
+        # latches the still-unsafe instance. Remediation: put -c before the pattern.
+        f"grep -E 'foo|bar' -c {BANK_ABS}",
+    ],
+)
+def test_bash_boundary_laundering_denied(cmd: str) -> None:
+    _assert_denied(_run_bash(cmd))
+
+
+# ---------------------------------------------------------------------------
+# #1152 (a) ALLOW — no new FPs on documented digests (§6 cases 9-14)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        f"grep -c foo {BANK_ABS} && ls -l",  # 9: safe latched before the boundary
+        f"grep -q foo {BANK_ABS} && grep -c bar {BANK_ABS}",  # 10: two safe instances
+        f"grep -cE 'foo|bar' {BANK_ABS}",  # 11: flag latched before the quoted `|`
+        f"git diff --stat -- {BANK_ABS} && git log --oneline -- {BANK_ABS}",  # 12
+        f"git log -- {BANK_ABS} && mkdir -p /tmp/x",  # 13: cross-command -p FALSE-DENY fixed
+        f"wc -l {BANK_ABS} && echo done",  # 14
+    ],
+)
+def test_bash_boundary_no_new_false_positives(cmd: str) -> None:
+    _assert_allowed(_run_bash(cmd))
+
+
+# ---------------------------------------------------------------------------
+# #1152 (b) — bare diff / comm / join page bank content (§6 cases 15-19, 21;
+# case 20 `git diff --stat -- {B}` is already parametrized in
+# test_bash_digest_ops_allowed above and stays untouched)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        f"diff /dev/null {BANK_ABS}",  # 15: prints every item
+        f"diff {BANK_ABS} /tmp/other.json",  # 16
+        f"comm {BANK_ABS} /dev/null",  # 17
+        f"join {BANK_ABS} /tmp/x",  # 18
+        # 19: (a)+(b) compose — the resolved git instance closes at the
+        # boundary, so the second unit's diff is bare (in_git=0).
+        f"git log --oneline -- {BANK_ABS} && diff /dev/null {BANK_ABS}",
+    ],
+)
+def test_bash_bare_diff_comm_join_denied(cmd: str) -> None:
+    _assert_denied(_run_bash(cmd))
+
+
+def test_bash_git_prefixed_diff_digest_allowed() -> None:
+    # 21: the in_git guard keeps git-prefixed diff digests out of the
+    # bare-diff deny (the same-unit `git` token precedes its `diff` token).
+    _assert_allowed(_run_bash(f"git -C /tmp diff --numstat -- {BANK_ABS}"))
+
+
+# ---------------------------------------------------------------------------
+# #1152 (a)-v2 — unresolved-git-instance CARRY across boundaries (§6 35-38)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        # 35: the padded `(` of $(pwd) fires a boundary BETWEEN `git` and its
+        # subcommand — a naive reset would detach the attribution (fail-OPEN).
+        f"git -C $(pwd) show HEAD:{BANK_REL}",
+        # 36: backslash-continuation newline -> `;` boundary mid-instance;
+        # bash executes this as ONE `git show`.
+        f"git \\\n show HEAD:{BANK_REL}",
+        # 37
+        f"git -C $(pwd) log -p -- {BANK_ABS}",
+    ],
+)
+def test_bash_git_carry_denies_paging(cmd: str) -> None:
+    _assert_denied(_run_bash(cmd))
+
+
+def test_bash_git_carry_preserves_diff_stat_digest() -> None:
+    # 38: the carry also restores the digest allow a naive boundary reset
+    # would false-deny via the bare-diff branch.
+    _assert_allowed(_run_bash(f"git -C $(pwd) diff --stat -- {BANK_ABS}"))
+
+
+# ---------------------------------------------------------------------------
+# #1152 boundary robustness (§6 cases 39-44) + backtick-substitution padding
+# ---------------------------------------------------------------------------
+def test_bash_pipe_amp_boundary_denied() -> None:
+    # 39: `|&` pads to two consecutive boundary tokens.
+    _assert_denied(_run_bash(f"grep harmful {BANK_ABS} |& wc -l"))
+
+
+def test_bash_unsafe_grep_in_last_unit_denied() -> None:
+    # 41: reverse direction — the unsafe grep is the LAST unit, closed by the
+    # pre-existing end-of-walk latch rather than a boundary.
+    _assert_denied(_run_bash(f"ls -l && grep harmful {BANK_ABS}"))
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        f"jq 'length' {BANK_ABS} && echo done",  # 40: digest jq closes clean
+        f"grep -c foo {BANK_ABS} 2>&1",  # 42: redirect tokens after a latched safe flag
+        f"if grep -q foo {BANK_ABS}; then echo hit; fi",  # 43: shell-keyword units
+        f"n=$(grep -c foo {BANK_ABS})",  # 44: digest inside command substitution
+        f"n=`grep -c foo {BANK_ABS}`",  # backtick substitution of a digest grep
+    ],
+)
+def test_bash_boundary_shapes_allowed(cmd: str) -> None:
+    _assert_allowed(_run_bash(cmd))
+
+
+def test_bash_backtick_substitution_paging_denied() -> None:
+    # Backticks pad + bound like `$( )` parens: pre-#1152 the backtick glued
+    # to the verb and to the closing path token, so the walk saw neither the
+    # verb nor a bank token and failed OPEN on a bare backtick-cat of a bank.
+    _assert_denied(_run_bash(f"echo `cat {BANK_ABS}`"))
+
+
+# ---------------------------------------------------------------------------
+# #1152 (c) ALLOW — task.py --note quoted-prose exemption (§6 cases 22-26).
+# Notes are DATA arguments to a Python CLI, never executed: quoted --note
+# strings on a task.py-shaped command are blanked before the fast path.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        # 22: double-quoted descriptive note naming a paging verb + a bank path
+        f'{TASKPY} post-marker 999 epm:progress --note "ran sed over {BANK_REL} digest"',
+        # 23: single-quoted note
+        f"{TASKPY} post-marker 999 epm:progress --note 'grep pass over {BANK_REL}: 0 hits'",
+        # 24: set-status --note (identical flag on the identical CLI)
+        f'{TASKPY} set-status 42 blocked --note "cat of {BANK_REL} denied by guard"',
+        # 25: --note= glued form
+        f'{TASKPY} post-marker 1 epm:x --note="sed over {BANK_REL}"',
+        # 26: the ONLY bank token lives in the note -> scrubbed fast path allows
+        f'sed -i s/a/b/ /tmp/f.txt && {TASKPY} post-marker 1 epm:x --note "checked {BANK_REL}"',
+    ],
+)
+def test_bash_taskpy_note_prose_allowed(cmd: str) -> None:
+    _assert_allowed(_run_bash(cmd))
+
+
+# ---------------------------------------------------------------------------
+# #1152 (c) DENY — the note exemption is not launderable (§6 cases 27-30)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        # 27: verb + bank OUTSIDE the note survive the scrub
+        f'cat {BANK_ABS} && {TASKPY} post-marker 1 epm:x --note "done"',
+        # 28: $(...) inside a double-quoted note EXECUTES -> never blanked
+        f'{TASKPY} post-marker 1 epm:x --note "summary: $(cat {BANK_ABS})"',
+        # 29: backtick substitution inside a note EXECUTES -> never blanked
+        f'{TASKPY} post-marker 1 epm:x --note "summary: `cat {BANK_ABS}`"',
+        # 30: no task.py in the command -> the scrub gate never fires (pins
+        # the GATE, not just the sed)
+        f'echo --note "{BANK_REL}" | xargs -n1 cat',
+    ],
+)
+def test_bash_taskpy_note_exemption_not_launderable(cmd: str) -> None:
+    _assert_denied(_run_bash(cmd))
+
+
+# ---------------------------------------------------------------------------
+# #1152 rider — task.py --file/--body-file on a bank denies (§6 cases 31-34):
+# it would embed bank items into task state (events.jsonl / body.md / plans).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        f"{TASKPY} post-marker 1 epm:x --file {BANK_ABS}",  # 31
+        f"{TASKPY} post-marker 1 epm:x --file={BANK_ABS}",  # 32: glued form
+    ],
+)
+def test_bash_taskpy_file_on_bank_denied(cmd: str) -> None:
+    _assert_denied(_run_bash(cmd))
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        f"{TASKPY} post-marker 1 epm:x --file /tmp/note.md",  # 33: non-bank file
+        f"uv run python scripts/eval.py --file {BANK_ABS}",  # 34: non-task.py untouched
+    ],
+)
+def test_bash_taskpy_file_non_bank_or_non_taskpy_allowed(cmd: str) -> None:
+    _assert_allowed(_run_bash(cmd))


### PR DESCRIPTION
Closes task #1152 (workflow-fix, auto-filed from #965 code-review residuals).

## Summary
- Close grep/git/jq guard instances at operator boundaries (`| & ; ( )` + backtick + newline) with the plan-v2 unresolved-git carry — stops cross-command safe-flag laundering.
- Deny bare `diff` (in_git-guarded; `git diff --stat` digest forms preserved) and `comm`/`join` as bank-paging channels.
- task.py-shape-gated `--note` quoted-prose scrub (fail-closed on `$`/backtick) + `--file`/`--body-file` bank-deny rider.
- 45 new pytest cases pinning boundary laundering, git-carry, diff/comm/join, note scrub, and the rider.

## Test plan
- [x] Step 9c gate: 3009 passed / 6 skipped / 0 failed; compare rc=0 (no new failures, no lint regression)
- [x] Pre-push workflow-lint gate: pass (no-flags + parity legs), SHA-bound 8495d84
- [x] Code-review r1 PASS (Claude-only; Codex quota-skipped per sentinel)

🤖 Generated with [Claude Code](https://claude.ai/code)