### PR TITLE
issue-1169: document #1021 stale-blocked flag pass + GC fixture coverage

### DIFF
--- a/.claude/rules/background-automation.md
+++ b/.claude/rules/background-automation.md
@@ -169,7 +169,8 @@ themselves in a worktree.
 
 Passes: crash-recovery respawn, pod-safety reconciliation, stalled-session
 detector, orphan-file sweep, the infra-drain pass, the capacity-retry pass,
-the gate-push pass, the program-orchestrator recovery pass, the
+the stale-blocked flag pass, the gate-push pass, the program-orchestrator
+recovery pass, the
 stale-registration pass, the CPU/memory-pressure guard pass, the
 triage-observer pass, and three session reapers — the session-vs-status
 reconcile pass, the zombie-wrapper pass, and the idle-unmapped pass.
@@ -447,6 +448,40 @@ markers carry the `[autonomous_session_watch:capacity-retry]` /
 orphan/stalled staleness clocks. Kill switch: `EPM_DISABLE_CAPACITY_RETRY=1`.
 `--capacity-retry-only` runs just this pass (pair with `--dry-run` for a live
 smoke against the real blocked-task set).
+
+**Stale-blocked flag pass (flag — never flip — a stale `blocked` on a task
+whose relaunch succeeded; task #1021, incident #742).** The capacity-retry
+pass's non-spawning sibling: both scan the `blocked` set, but this pass is
+daemon-INDEPENDENT — it spawns nothing (marker posts go via the `task.py`
+subprocess). A crash-fix relaunch that succeeds on a task an earlier failed
+round parked at `blocked` leaves the status stale: the run is healthy while
+the folder says `blocked` (#742 ran healthy ~35h at status `blocked`,
+2026-07-01→07-02). The orchestrator-side fix is the SKILL.md "A successful
+relaunch also reconciles a stale `blocked`" rule; this pass is the
+watcher-side BACKSTOP. Predicate (`decide_stale_blocked_flag`, every
+missing signal failing toward silence): status `blocked` AND the latest
+`epm:run-launched` NEWER than the transition into `blocked` (the normal
+fail→block ordering keeps a deliberately-parked task quiet — only a launch
+AFTER the block flags) AND real (non-watcher, non-deliberate-stop) progress
+AT OR AFTER that launch within `EPM_STALE_BLOCKED_PROGRESS_FRESH_S`
+(default 2h; malformed/non-positive values fall back to the default). On a
+hit it FLAGS — one deduped `epm:progress` marker naming the reconcile
+command (`task.py set-status <N> running`), one row in the durable sidecar
+`~/.eps-autonomous/stale-blocked-events.jsonl` (the `.jsonl` suffix keeps
+it out of the GC's `stale-blocked-*.json` glob), and one Telegram digest
+line — and NEVER mutates status (false alert cheap, false flip dangerous;
+the same conservative posture as the pod-safety alerts). Dedup is per
+launch episode: `~/.eps-autonomous/stale-blocked-<N>.json` records the
+flagged `epm:run-launched` ts, so the same launch never re-alerts while a
+NEWER launch does; the state file is reaped by the generalized GC at
+`completed`/`archived` only (`blocked` is deliberately NOT in
+`TERMINAL_FOR_GC`, so a live episode's dedup state is never reset
+mid-episode). Marker notes carry the
+`[autonomous_session_watch:stale-blocked-flag]` sentinel so they never
+reset the orphan/stalled staleness clocks. Kill switch:
+`EPM_DISABLE_STALE_BLOCKED_FLAG=1`. `--stale-blocked-only` runs just this
+pass (pair with `--dry-run` for a live smoke against the real blocked-task
+set).
 
 **Gate-push pass (2026-06-12 anti-stall redesign).** Telegram phone push on
 gate-park/`blocked` transitions via the my-goat `telegram_push.sh` channel

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -1,16 +1,18 @@
 """Crash-recovery + pod-safety + stalled-detector watcher for autonomous and
 interactive issue sessions (plus campaign sessions, task #586).
 
-Thirteen passes; items 1-8 run in that order, with the CAMPAIGN pass (item 9)
+Fourteen passes; items 1-8 run in that order, with the CAMPAIGN pass (item 9)
 right after pass 2, the IDLE-UNMAPPED-SESSION pass (item 10) right after
 pass 7, the INFRA-DRAIN pass (item 11) between pass 5 (the orphan sweep)
 and pass 6 (session-reconcile), the CPU-GUARD pass (item 12) in the
 daemon-independent block right after the happy-patch check (order there:
 pass 1's disk checks -> data-disk -> happy-patch -> CPU-GUARD ->
-program-orchestrator recovery), and the AUTH-OUTAGE GUARD pass (item 13)
+program-orchestrator recovery), the AUTH-OUTAGE GUARD pass (item 13)
 immediately after the single per-tick daemon probe and BEFORE every spawn
-arm (crash-recovery is the first spawner it must precede), all before the
-GC pass:
+arm (crash-recovery is the first spawner it must precede), and the
+STALE-BLOCKED FLAG pass (item 14) also between pass 5 and pass 6 — right
+after the capacity-retry re-drive, before session-reconcile — all before
+the GC pass:
 
 1. **VM disk-headroom pass.** Watch free space on the VM root filesystem —
    the host of every orchestrator session, the worktree ``.venv``s, the uv
@@ -319,6 +321,26 @@ GC pass:
    ``.claude/cache/auth-outage-events.jsonl``. Kill switch
    ``EPM_DISABLE_AUTH_OUTAGE_GUARD=1``; ``--auth-outage-only`` runs just
    this pass (pair with ``--dry-run`` for a live smoke).
+14. **Stale-blocked flag pass (task #1021; the #742 incident class; runs
+   right after the capacity-retry re-drive, between pass 5 and pass 6).**
+   FLAG — never flip — a ``blocked`` task whose events show a live healthy
+   run: an ``epm:run-launched`` NEWER than the transition into ``blocked``
+   PLUS real (non-watcher, non-deliberate-stop) post-launch progress
+   within ``EPM_STALE_BLOCKED_PROGRESS_FRESH_S`` (default 2h). The
+   watcher-side backstop of the SKILL.md "A successful relaunch also
+   reconciles a stale ``blocked``" orchestrator rule (#742 ran healthy
+   ~35h at status ``blocked``, 2026-07-01→07-02). One flag per launch
+   episode — the dedup state ``stale-blocked-<N>.json`` keys on the
+   flagged launch ts, so the same launch never re-alerts while a NEWER
+   launch does — emitting a deduped ``epm:progress`` marker naming the
+   reconcile command, a sidecar row in
+   ``~/.eps-autonomous/stale-blocked-events.jsonl``, and one Telegram
+   digest line. Every missing signal fails toward silence; the status
+   flip stays with the orchestrator/human (false alert cheap, false flip
+   dangerous). Daemon-INDEPENDENT — it spawns nothing (marker posts go
+   via the task.py subprocess). Kill switch
+   ``EPM_DISABLE_STALE_BLOCKED_FLAG=1``; ``--stale-blocked-only`` runs
+   just this pass (pair with ``--dry-run`` for a live smoke).
 
 Why each pass exists
 --------------------

--- a/tests/test_stalled_detector_and_gc.py
+++ b/tests/test_stalled_detector_and_gc.py
@@ -34,6 +34,7 @@ if str(SCRIPTS) not in sys.path:
 import spawn_session  # noqa: E402
 from autonomous_session_watch import (  # noqa: E402
     MAX_ENTRY_AGE_S,
+    STALE_BLOCKED_STATE_PREFIX,
     STALLED_MARKER_WINDOW_S_DEFAULT,
     STALLED_STATE_PREFIX,
     STALLED_WINDOW_S,
@@ -938,8 +939,9 @@ def test_stalled_pass_dry_run_no_state_write(
 
 
 def _populate_gc_targets(reg_dir: Path, issue: int) -> dict[str, Path]:
-    """Drop one file under each GC target prefix for ``issue`` and return the
-    paths so the test can assert presence/absence."""
+    """Drop one file under a representative subset of the GC target prefixes
+    for ``issue`` and return the paths so the test can assert
+    presence/absence."""
     paths: dict[str, Path] = {}
     # manual-issue-<N>.json — top level
     paths["manual"] = reg_dir / f"manual-issue-{issue}.json"
@@ -947,6 +949,11 @@ def _populate_gc_targets(reg_dir: Path, issue: int) -> dict[str, Path]:
     # stalled-<N>.json — top level
     paths["stalled"] = reg_dir / f"{STALLED_STATE_PREFIX}{issue}.json"
     paths["stalled"].write_text(json.dumps({"issue": issue, "missed": 0}))
+    # stale-blocked-<N>.json — top level (#1021 flag-pass dedup state)
+    paths["stale_blocked"] = reg_dir / f"{STALE_BLOCKED_STATE_PREFIX}{issue}.json"
+    paths["stale_blocked"].write_text(
+        json.dumps({"flagged_run_launched_ts": 1.0, "alerted_ts": 2.0})
+    )
     # issue-progress/<N>.json — nested
     (reg_dir / "issue-progress").mkdir(exist_ok=True)
     paths["progress"] = reg_dir / "issue-progress" / f"{issue}.json"
@@ -967,11 +974,11 @@ def test_gc_reaps_all_targets_for_terminal_status(isolated_registry, monkeypatch
 
     counts = asw._gc_orphaned_eps_autonomous_files(now=time.time(), dry_run=False)
 
-    # All four target paths should be gone.
+    # All five target paths should be gone.
     for p in paths.values():
         assert not p.exists(), f"{p} should have been reaped"
     # Counts dict should account for at least one drop per prefix.
-    assert sum(counts.values()) == 4
+    assert sum(counts.values()) == 5
 
 
 @pytest.mark.parametrize(
@@ -1008,7 +1015,7 @@ def test_gc_dry_run_does_not_delete(isolated_registry, monkeypatch):
     counts = asw._gc_orphaned_eps_autonomous_files(now=time.time(), dry_run=True)
 
     # Counts report what WOULD have been cleared, but the files still exist.
-    assert sum(counts.values()) == 4
+    assert sum(counts.values()) == 5
     for p in paths.values():
         assert p.exists()
 


### PR DESCRIPTION
Closes task #1169 (kind: infra, workflow-fix).

## Summary
- `scripts/autonomous_session_watch.py` docstring: inventory item 14 for the #1021 stale-blocked flag pass; header "Thirteen passes" → "Fourteen passes" with ordering prose.
- `.claude/rules/background-automation.md`: capacity-retry-style paragraph for the pass + "Passes:" enumeration entry.
- `tests/test_stalled_detector_and_gc.py`: `stale-blocked-<N>.json` GC fixture line + count assertions 4→5 (reap/keep/dry-run/age-backstop coverage for the #1021 prefix).

## Test plan
- [x] `uv run pytest tests/test_stalled_detector_and_gc.py -q` — 87/87
- [x] Step 9c touched-scope gate — 3069 passed, compare 0 new
- [x] ruff check + format clean; workflow_lint no-flags PASS (gated tree clean on both legs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)