### PR TITLE
task #1177: warn-only pod-safety check at provision/resume choke points

### DIFF
--- a/scripts/pod_lifecycle.py
+++ b/scripts/pod_lifecycle.py
@@ -1698,6 +1698,14 @@ def cmd_provision(args: argparse.Namespace) -> None:
     if args.issue is None:
         raise SystemExit("--issue <N> is required")
 
+    # Warn-only pod-safety check (#1177) — BEFORE any RunPod API call
+    # (list_team_pods below), so it prints even when the provision later
+    # fails on capacity, and covers the CPU branch, the GPU branch, AND
+    # --dry-run (deliberate divergence from the terminate guard, which
+    # skips dry-run because it BLOCKS; a warn-only line is exactly what a
+    # preview should surface).
+    _warn_on_terminal_parent_provision(args.issue)
+
     name = _canonical_pod_name(args.issue)
     legacy = f"epm-issue-{args.issue}"
 
@@ -1901,6 +1909,11 @@ def cmd_stop(args: argparse.Namespace) -> None:
 
 def cmd_resume(args: argparse.Namespace) -> None:
     """Bring a stopped pod back. New IP, same volume."""
+    # Warn-only pod-safety check (#1177): resume creates a RUNNING pod the
+    # watcher's pod-safety pass treats identically to a fresh provision
+    # (#573's stopped pods were healthy follow-up pods; resuming one on a
+    # terminal parent without signals is re-stopped ~20 min later).
+    _warn_on_terminal_parent_provision(args.issue, verb="resume")
     state = _load_state()
     pod = _find_pod_in_state(state, args.issue)
     if pod is None:
@@ -2056,6 +2069,143 @@ def cmd_resume(args: argparse.Namespace) -> None:
         )
     _restore_uv_on_pod(refreshed.host, refreshed.port)
     print(f"  pods.conf updated. Connect: ssh {name}")
+
+
+# ---------------------------------------------------------------------------
+# Pod-safety pre-provision warn (#1177)
+# ---------------------------------------------------------------------------
+
+# These three sets MIRROR the watcher's pod-safety auto-stop predicate
+# (autonomous_session_watch.py: POD_SAFETY_AUTO_STOP,
+# _POD_FOLLOWUP_SIGNAL_KINDS, _DONE_TRANSITION_KINDS) so the warning fires
+# exactly when the watcher would auto-stop. Parity is pinned by
+# tests/test_pod_lifecycle.py::test_provision_pod_safety_constants_match_watcher
+# (constant-set equality) and
+# tests/test_pod_lifecycle.py::test_provision_freshness_behavioral_parity_with_watcher
+# (comparison semantics) — update BOTH sides together (never refactor the
+# watcher from here; it is read-only from this module's perspective).
+_POD_SAFETY_AUTO_STOP_STATUSES = frozenset(
+    {"completed", "awaiting_promotion", "archived", "on_hold"}
+)
+_POD_FOLLOWUP_SIGNAL_KINDS = frozenset(
+    {"epm:run-launched", "epm:followup-scope", "epm:free-analysis-followup-run"}
+)
+_POD_DONE_TRANSITION_KINDS = frozenset({"epm:promoted", "epm:status-changed"})
+_KEEP_RUNNING_TAG = "keep-running"
+
+
+def _parse_marker_ts(ts: object) -> float | None:
+    """Epoch seconds for an events.jsonl ISO-8601 ``ts``
+    (``task_workflow._utcnow_iso`` format ``%Y-%m-%dT%H:%M:%SZ``); ``None`` on
+    any unparseable value — the event is then treated as absent (conservative
+    toward warning, never a crash)."""
+    try:
+        return dt.datetime.fromisoformat(str(ts).replace("Z", "+00:00")).timestamp()
+    except (ValueError, TypeError):
+        return None
+
+
+def _latest_marker_ts(events: list[dict], kinds: frozenset[str]) -> float | None:
+    """Newest parseable ts among ``events`` whose ``kind`` is in ``kinds``,
+    else ``None``. Mirrors ``autonomous_session_watch._latest_event_ts``
+    semantics."""
+    best: float | None = None
+    for ev in events:
+        if ev.get("kind") not in kinds:
+            continue
+        ts = _parse_marker_ts(ev.get("ts"))
+        if ts is not None and (best is None or ts > best):
+            best = ts
+    return best
+
+
+def _fresh_followup_signal(events: list[dict]) -> bool:
+    """True iff a follow-up signal marker is STRICTLY newer than the latest
+    done-transition — byte-for-byte the watcher's ``_task_followup_active``
+    comparison (signal missing -> False; done-transition missing -> False)."""
+    sig = _latest_marker_ts(events, _POD_FOLLOWUP_SIGNAL_KINDS)
+    if sig is None:
+        return False
+    done = _latest_marker_ts(events, _POD_DONE_TRANSITION_KINDS)
+    if done is None:
+        return False
+    return sig > done
+
+
+def _terminal_parent_warning_text(issue: int, status: str, verb: str) -> str:
+    """The pod-safety two-signal warning body (#1177) — quotes the exact
+    remedy commands so a session that never consulted the CLAUDE.md
+    two-signal bullet can still fix the state at the terminal."""
+    return (
+        f"[pod_lifecycle] WARNING (pod-safety, #1177): task #{issue} is at status "
+        f"'{status}' — inside the watcher's pod-safety AUTO-STOP set "
+        f"(completed / awaiting_promotion / archived / on_hold) — with NO "
+        f"keep-running tag and NO fresh follow-up signal marker "
+        f"(epm:run-launched / epm:followup-scope / epm:free-analysis-followup-run "
+        f"newer than the latest epm:promoted / epm:status-changed).\n"
+        f"  The autonomous-session watcher will AUTO-STOP this pod ~20 min after "
+        f"it starts RUNNING (2-miss accumulation; incidents #573 / #779: healthy "
+        f"pods repeatedly stopped mid-bootstrap and misdiagnosed as flaky hosts).\n"
+        f"  Two-signal recipe (CLAUDE.md 'Routing experiment intent'):\n"
+        f"    1. BEFORE provisioning — or RIGHT NOW (the tag is "
+        f"timestamp-independent and still shields an already-running pod):\n"
+        f"         uv run python scripts/task.py add-tag {issue} keep-running\n"
+        f"    2. Post epm:run-launched on #{issue} immediately once the pod exists:\n"
+        f"         uv run python scripts/task.py post-marker {issue} "
+        f"epm:run-launched --note '<pod name + purpose>'\n"
+        f"    3. Remove the tag when the run completes so the auto-stop re-arms:\n"
+        f"         uv run python scripts/task.py remove-tag {issue} keep-running\n"
+        f"  Proceeding with {verb} (warn-only check)."
+    )
+
+
+def _warn_on_terminal_parent_provision(issue: int, *, verb: str = "provision") -> bool:
+    """Warn-only pod-safety pre-provision check (#1177). Returns True iff the
+    warning fired (for tests); NEVER blocks, NEVER raises on task-state
+    problems — an unresolvable task (ad-hoc pod, registry miss, branch-guard
+    fire) proceeds with a one-line NOTE. Mirrors the watcher's auto-stop
+    predicate so the warning predicts exactly what the pod-safety pass will
+    do. Provision-time only: a task that ENTERS the auto-stop set after
+    provision is never warned — the watcher remains the runtime backstop (do
+    not read the warning's absence as a safety guarantee).
+    """
+    try:
+        from explore_persona_space.task_workflow import get_task, list_events
+    except ImportError:
+        print(
+            f"[pod_lifecycle] NOTE: pod-safety pre-{verb} check skipped for "
+            f"issue #{issue}: task_workflow module unavailable. Proceeding.",
+            file=sys.stderr,
+        )
+        return False
+    # Narrow fail-open set, grounded in the terminate guard above:
+    # FileNotFoundError = task not in registry/on disk (ad-hoc pods);
+    # RuntimeError = task_workflow branch-guard on non-main HEAD / git missing;
+    # ValueError = malformed frontmatter / corrupt REGISTRY.json
+    # (JSONDecodeError is a ValueError); OSError = unreadable events.jsonl.
+    # Anything else (KeyboardInterrupt, MemoryError, a programming bug)
+    # propagates — fail-fast rule.
+    try:
+        task = get_task(issue)
+        status = task.get("status") or ""
+        if status not in _POD_SAFETY_AUTO_STOP_STATUSES:
+            return False
+        tags = (task.get("frontmatter") or {}).get("tags") or []
+        if _KEEP_RUNNING_TAG in tags:
+            return False
+        events = list_events(issue)
+    except (FileNotFoundError, RuntimeError, ValueError, OSError) as exc:
+        print(
+            f"[pod_lifecycle] NOTE: pod-safety pre-{verb} check skipped for "
+            f"issue #{issue}: could not read task state "
+            f"({type(exc).__name__}: {exc}). Proceeding.",
+            file=sys.stderr,
+        )
+        return False
+    if _fresh_followup_signal(events):
+        return False
+    print(_terminal_parent_warning_text(issue, status, verb), file=sys.stderr)
+    return True
 
 
 def _has_upload_verification_pass(issue: int) -> bool:

--- a/tests/test_pod_lifecycle.py
+++ b/tests/test_pod_lifecycle.py
@@ -1561,3 +1561,237 @@ def test_resolve_spec_partial_flag_without_intent_fails_loud(gpu_type, gpu_count
 def test_resolve_spec_nothing_given_fails_loud():
     with pytest.raises(SystemExit, match="Must pass either --intent"):
         pod_lifecycle._resolve_spec(None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# cmd_provision — pod-safety terminal-parent warn (#1177)
+# ---------------------------------------------------------------------------
+
+
+def _fm(status: str, tags: tuple[str, ...] = (), kind: str = "experiment") -> dict:
+    """Build the ``get_task()`` return shape the #1177 guard reads: top-level
+    ``status`` (folder name) + ``frontmatter.tags``."""
+    return {
+        "id": 0,
+        "status": status,
+        "frontmatter": {"kind": kind, "tags": list(tags)},
+        "body": "",
+    }
+
+
+def _ev(kind: str, ts: str | None) -> dict:
+    """Build a minimal events.jsonl row (ts/kind are all the guard reads)."""
+    return {"ts": ts, "kind": kind, "version": 1, "by": "test", "note": ""}
+
+
+def _patch_task_state(monkeypatch, task, events) -> None:
+    """Monkeypatch ``task_workflow.get_task`` / ``.list_events`` (lazily
+    imported inside the #1177 guard) with fixed returns; pass an Exception
+    instance for either to make that read raise (fail-open tests)."""
+
+    def fake_get_task(issue):
+        if isinstance(task, Exception):
+            raise task
+        return dict(task, id=issue)
+
+    def fake_list_events(issue):
+        if isinstance(events, Exception):
+            raise events
+        return list(events)
+
+    monkeypatch.setattr("explore_persona_space.task_workflow.get_task", fake_get_task)
+    monkeypatch.setattr("explore_persona_space.task_workflow.list_events", fake_list_events)
+
+
+_T1 = "2026-07-01T00:00:00Z"
+_T2 = "2026-07-02T00:00:00Z"
+
+
+def test_provision_warns_on_completed_status_no_signals(monkeypatch, capsys):
+    """The primary trigger: completed + untagged + only a done-transition
+    event -> the warning fires with all five acceptance substrings."""
+    _patch_task_state(monkeypatch, _fm("completed"), [_ev("epm:status-changed", _T1)])
+
+    assert pod_lifecycle._warn_on_terminal_parent_provision(664) is True
+
+    err = capsys.readouterr().err
+    for needle in (
+        "pod-safety",
+        "AUTO-STOP",
+        "add-tag 664 keep-running",
+        "epm:run-launched",
+        "Proceeding",
+    ):
+        assert needle in err, f"warning missing acceptance substring: {needle!r}"
+    # All three recipe commands are quoted.
+    assert "post-marker 664 epm:run-launched" in err
+    assert "remove-tag 664 keep-running" in err
+
+
+@pytest.mark.parametrize("status", ["completed", "awaiting_promotion", "archived", "on_hold"])
+def test_provision_warn_fires_for_each_auto_stop_status(monkeypatch, capsys, status):
+    _patch_task_state(monkeypatch, _fm(status), [_ev("epm:status-changed", _T1)])
+    assert pod_lifecycle._warn_on_terminal_parent_provision(1) is True
+    assert "WARNING" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "status", ["running", "followups_running", "approved", "blocked", "proposed"]
+)
+def test_provision_silent_on_active_statuses(monkeypatch, capsys, status):
+    """Sanctioned paths (incl. the followups_running follow-up loop) must
+    print NOTHING — false-positive rate 0 on this matrix."""
+    _patch_task_state(monkeypatch, _fm(status), [_ev("epm:status-changed", _T1)])
+    assert pod_lifecycle._warn_on_terminal_parent_provision(1) is False
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert captured.out == ""
+
+
+def test_provision_silent_with_keep_running_tag(monkeypatch, capsys):
+    _patch_task_state(
+        monkeypatch, _fm("completed", tags=("keep-running",)), [_ev("epm:status-changed", _T1)]
+    )
+    assert pod_lifecycle._warn_on_terminal_parent_provision(1) is False
+    assert capsys.readouterr().err == ""
+
+
+@pytest.mark.parametrize(
+    "signal_kind",
+    ["epm:run-launched", "epm:followup-scope", "epm:free-analysis-followup-run"],
+)
+def test_provision_silent_with_fresh_followup_signal(monkeypatch, capsys, signal_kind):
+    """A follow-up signal STRICTLY newer than the latest done-transition is
+    the watcher's live-follow-up exemption -> no warning."""
+    events = [_ev("epm:status-changed", _T1), _ev(signal_kind, _T2)]
+    _patch_task_state(monkeypatch, _fm("completed"), events)
+    assert pod_lifecycle._warn_on_terminal_parent_provision(1) is False
+    assert capsys.readouterr().err == ""
+
+
+def test_provision_warns_on_stale_followup_signal(monkeypatch, capsys):
+    """A signal OLDER than the latest done-transition means the follow-up
+    finished (the watcher's re-arm semantics, strict >) -> warn fires."""
+    events = [_ev("epm:followup-scope", _T1), _ev("epm:status-changed", _T2)]
+    _patch_task_state(monkeypatch, _fm("completed"), events)
+    assert pod_lifecycle._warn_on_terminal_parent_provision(1) is True
+    assert "WARNING" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "exc", [FileNotFoundError("gone"), RuntimeError("branch"), ValueError("bad")]
+)
+def test_provision_failopen_on_unresolvable_task(monkeypatch, capsys, exc):
+    """An unresolvable task (ad-hoc pod / registry miss / branch-guard fire)
+    proceeds with a one-line NOTE — never a block, never an exception."""
+    _patch_task_state(monkeypatch, exc, [])
+    assert pod_lifecycle._warn_on_terminal_parent_provision(9999) is False
+    err = capsys.readouterr().err
+    assert "skipped" in err
+    assert "WARNING" not in err
+
+
+def test_provision_failopen_on_unparseable_ts(monkeypatch, capsys):
+    """Garbage/absent ts values never crash: the events are treated as absent
+    (conservative toward warning), so the warn fires here."""
+    events = [_ev("epm:run-launched", None), _ev("epm:status-changed", "not-a-timestamp")]
+    _patch_task_state(monkeypatch, _fm("completed"), events)
+    assert pod_lifecycle._warn_on_terminal_parent_provision(1) is True
+    assert "WARNING" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "signal_kind",
+    ["epm:run-launched", "epm:followup-scope", "epm:free-analysis-followup-run"],
+)
+def test_provision_warns_on_signal_without_done_transition(monkeypatch, capsys, signal_kind):
+    """A signal with NO done-transition ever posted -> warn fires (the
+    watcher's conservative missing-done -> False branch,
+    autonomous_session_watch._task_followup_active). A sign inversion here
+    would silently drop the warn on a watcher-stopped class."""
+    _patch_task_state(monkeypatch, _fm("completed"), [_ev(signal_kind, _T2)])
+    assert pod_lifecycle._warn_on_terminal_parent_provision(1) is True
+    assert "WARNING" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [OSError("io"), FileNotFoundError("gone"), RuntimeError("branch"), ValueError("bad")],
+)
+def test_provision_failopen_on_list_events_raising(monkeypatch, capsys, exc):
+    """get_task succeeds (completed, untagged) but list_events raises — the
+    events read is where OSError specifically joins the fail-open set."""
+    _patch_task_state(monkeypatch, _fm("completed"), exc)
+    assert pod_lifecycle._warn_on_terminal_parent_provision(1) is False
+    err = capsys.readouterr().err
+    assert "skipped" in err
+    assert "WARNING" not in err
+
+
+def test_provision_pod_safety_constants_match_watcher():
+    """Parity pin: the local mirror constants equal the watcher's — a watcher
+    change to any of the three sets breaks this test and forces a same-round
+    re-sync (plan §11: local mirror + parity test, zero coupling)."""
+    import autonomous_session_watch as asw
+
+    assert frozenset(asw.POD_SAFETY_AUTO_STOP) == pod_lifecycle._POD_SAFETY_AUTO_STOP_STATUSES
+    assert pod_lifecycle._POD_FOLLOWUP_SIGNAL_KINDS == asw._POD_FOLLOWUP_SIGNAL_KINDS
+    assert pod_lifecycle._POD_DONE_TRANSITION_KINDS == asw._DONE_TRANSITION_KINDS
+
+
+def test_provision_freshness_behavioral_parity_with_watcher():
+    """Parity pin on the comparison SEMANTICS (strict >, missing-signal ->
+    False, missing-done -> False) — the constants test alone cannot catch
+    comparison-logic drift. The watcher accepts an injected events list."""
+    import autonomous_session_watch as asw
+
+    matrices = {
+        "fresh-signal": [_ev("epm:status-changed", _T1), _ev("epm:run-launched", _T2)],
+        "stale-signal": [_ev("epm:followup-scope", _T1), _ev("epm:status-changed", _T2)],
+        "signal-only-no-done": [_ev("epm:free-analysis-followup-run", _T2)],
+        "done-only": [_ev("epm:promoted", _T1)],
+        "empty": [],
+    }
+    for label, evts in matrices.items():
+        assert pod_lifecycle._fresh_followup_signal(evts) == asw._task_followup_active(
+            1, events=evts
+        ), f"freshness parity diverged from the watcher on {label!r}"
+
+
+def test_provision_dry_run_calls_check(monkeypatch, capsys, isolated_state, stub_list_team_pods):
+    """Wiring: cmd_provision --dry-run on a completed-status task prints the
+    warning BEFORE the dry-run return (i.e. before any create call)."""
+    _patch_task_state(monkeypatch, _fm("completed"), [_ev("epm:status-changed", _T1)])
+    stub_list_team_pods.return_value = []
+    ns = argparse.Namespace(
+        list_intents=False,
+        issue=664,
+        intent="debug",
+        gpu_type=None,
+        gpu_count=None,
+        dry_run=True,
+        volume_gb=200,
+        container_disk_gb=50,
+    )
+
+    pod_lifecycle.cmd_provision(ns)
+
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.err and "pod-safety" in captured.err
+    assert "[dry-run]" in captured.out
+
+
+def test_resume_calls_check(monkeypatch, capsys, isolated_state, stub_list_team_pods):
+    """Wiring: cmd_resume --dry-run runs the same check with verb='resume'
+    as its FIRST statement (before _load_state)."""
+    pod_name = _register_pod_for_issue(664)
+    stub_list_team_pods.return_value = [_info(pod_name, desired_status="EXITED")]
+    _patch_task_state(monkeypatch, _fm("completed"), [_ev("epm:status-changed", _T1)])
+    ns = argparse.Namespace(issue=664, dry_run=True)
+
+    pod_lifecycle.cmd_resume(ns)
+
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.err and "pod-safety" in captured.err
+    assert "Proceeding with resume" in captured.err
+    assert "[dry-run]" in captured.out


### PR DESCRIPTION
## Summary
- Warn-only, fail-open pod-safety pre-provision check in `scripts/pod_lifecycle.py`: fires when provisioning/resuming a pod for a task in the watcher's auto-stop set ({completed, awaiting_promotion, archived, on_hold}) with neither the `keep-running` tag nor a fresh follow-up signal marker — printing the exact two-signal remedy commands BEFORE any RunPod API call (#573/#779 class: healthy pods auto-stopped mid-bootstrap).
- Predicate is a local mirror of the watcher's `_task_followup_active`, pinned by two parity tests (constant sets + behavioral freshness comparison on synthetic event lists). Never blocks, never raises past its body.
- 14 new tests (30 instances) in `tests/test_pod_lifecycle.py`; 98/98 file-local, 3051-test Step 9c gate green, compare new=[].

Closes task #1177 (kind: infra, workflow-fix; plan v3 critic-ensemble reviewed; code-review PASS; test-verdict PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)