### PR TITLE
issue-1180: widen wf-fix dedup title-prefix to cross-channel

### DIFF
--- a/.claude/rules/workflow-fix-on-bug.md
+++ b/.claude/rules/workflow-fix-on-bug.md
@@ -453,9 +453,11 @@ normalize(s) = s.lower(), collapse internal whitespace to single spaces, strip
 
 **Dedup KEY SURFACES:**
 
-- **PRIMARY (round-trips through `view --json` + REGISTRY):** the
-  `workflow-fix:` TITLE PREFIX (set by `task.py new --title` / a later
-  `set_title`, both update the REGISTRY snapshot) AND the `wf-fix-fp:<fp>`
+- **PRIMARY (round-trips through `view --json` + REGISTRY):** a
+  `workflow-fix:` OR `daily-fix:` TITLE PREFIX (one per filing channel —
+  orchestrator vs /daily route-2; `task_workflow.WF_FIX_TITLE_PREFIXES` is the
+  single source of truth, widened by #1180; set by `task.py new --title` / a
+  later `set_title`, both update the REGISTRY snapshot) AND the `wf-fix-fp:<fp>`
   TAG (set by `add-tag`; round-trips via `view --json .frontmatter.tags`).
 - **FALLBACK (documented, WORKING):** the body's `## Provenance`
   `workflow_fix_target: <path>` line (written verbatim by `--body-file`)
@@ -464,7 +466,8 @@ normalize(s) = s.lower(), collapse internal whitespace to single spaces, strip
   frontmatter except `paper`/`abstract`.
 
 **Dedup predicate (exact):** a candidate is a duplicate iff there exists a
-task with `kind: infra` AND a `workflow-fix:` title prefix AND a
+task with `kind: infra` AND a `workflow-fix:` or `daily-fix:` title prefix
+(`task_workflow.WF_FIX_TITLE_PREFIXES`) AND a
 `wf-fix-fp:<fp>` tag matching the candidate's fingerprint AND a
 `## Provenance` `workflow_fix_target:` line EXACTLY string-matching the
 candidate's `target_file` AND whose status is NOT in the terminal set

--- a/.claude/workflow.yaml
+++ b/.claude/workflow.yaml
@@ -3218,9 +3218,9 @@ workflow_fix_on_bug:
     durable_signal: "workflow_fix_target: line in the task body's ## Provenance block"  # survives watcher respawn (primary; task_workflow.is_workflow_fix_session)
     behavior: "A session under EITHER signal logs+notifies candidates it raises; it NEVER auto-files/spawns MORE workflow-fix tasks for its own findings (analogue of AUTO_REVIEW_DISABLED). Escape valve: such a session CAN still emit candidate blocks — they are parked/notified, not silently dropped."
   dedup_key: "(target_file, fingerprint)"        # fp = sha256(normalize(proposed_change)+'||'+normalize(bug_observed))[:12]; task_workflow.wf_fix_fingerprint
-  dedup_predicate: "A candidate is a duplicate iff an OPEN kind:infra task has a workflow-fix: title prefix AND a wf-fix-fp:<fp> tag matching the fingerprint AND a ## Provenance workflow_fix_target line EXACTLY matching target_file AND status NOT in {completed, archived}. Same file + DIFFERENT fingerprint is NOT a duplicate (it files its own task). Impl: task_workflow.is_open_workflow_fix_task; tested in tests/test_workflow_fix_dedup.py."
+  dedup_predicate: "A candidate is a duplicate iff an OPEN kind:infra task has a workflow-fix: or daily-fix: title prefix (task_workflow.WF_FIX_TITLE_PREFIXES; #1180 cross-channel) AND a wf-fix-fp:<fp> tag matching the fingerprint AND a ## Provenance workflow_fix_target line EXACTLY matching target_file AND status NOT in {completed, archived}. Same file + DIFFERENT fingerprint is NOT a duplicate (it files its own task). Impl: task_workflow.is_open_workflow_fix_task; tested in tests/test_workflow_fix_dedup.py."
   dedup_surfaces:
-    primary: "title prefix 'workflow-fix:' (via task.py new --title / set_title) + tag 'wf-fix-fp:<fp>' (via add-tag) — both round-trip through view --json / REGISTRY"
+    primary: "title prefix 'workflow-fix:' or 'daily-fix:' (task_workflow.WF_FIX_TITLE_PREFIXES, one per filing channel; via task.py new --title / set_title) + tag 'wf-fix-fp:<fp>' (via add-tag) — both round-trip through view --json / REGISTRY"
     fallback: "grep the literal 'workflow_fix_target:' line in body.md ## Provenance (written verbatim via --body-file)"
     never: "set_body — strips leading frontmatter except paper/abstract; NEVER route a dedup key through it"
   spawn_command: "uv run python scripts/spawn_session.py spawn-issue --issue <N> --auto"

--- a/scripts/daily_drive_filings.py
+++ b/scripts/daily_drive_filings.py
@@ -308,9 +308,14 @@ def find_open_fp_duplicate(tasks_root: Path, fp: str) -> Path | None:
     """First NON-terminal task body.md carrying ``wf-fix-fp:<fp>`` (route-2 dedup).
 
     Same predicate as the proven ad-hoc driver: a tag-scan over non-``completed``/
-    ``archived`` statuses. ``task_workflow.is_open_workflow_fix_task`` is NOT usable
-    here — it requires the ``workflow-fix:`` title prefix; daily filings use
-    ``daily-fix:`` titles.
+    ``archived`` statuses. Deliberately COARSER than
+    ``task_workflow.is_open_workflow_fix_task`` (which since #1180 DOES see
+    ``daily-fix:`` titles via ``WF_FIX_TITLE_PREFIXES``): this scan keys on the
+    fingerprint tag ALONE — any title, any kind, no ``workflow_fix_target:``
+    requirement, filesystem-only (no REGISTRY read) — so a same-fp task filed
+    by EITHER channel blocks a daily re-file even when its registry row or
+    Provenance line is malformed. Kept (not delegated) for that coarser grain
+    and for the ``tasks_root`` injection the test fixtures use.
     """
     needle = f"wf-fix-fp:{fp}"
     for body in sorted(tasks_root.glob("*/*/body.md")):

--- a/scripts/sweep_parked_wf_candidates.py
+++ b/scripts/sweep_parked_wf_candidates.py
@@ -36,10 +36,10 @@ fp-less prose parks are NEVER auto-suppressed on file-only matches (the
 #622-class distinct-bug-on-a-hot-file hazard); instead the advisory field
 ``open_wf_fix_on_file`` is emitted for the /daily LLM's content-level dedup.
 NOTE: that advisory mirrors ``task_workflow.is_open_workflow_fix_task``
-semantics and is therefore ``workflow-fix:``-TITLE-PREFIX-BOUND — it is BLIND
-to ``daily-fix:``-titled open filings (which carry no ``workflow-fix:`` title;
-see ``daily_drive_filings.find_open_fp_duplicate``). Advisory only; the
-LLM-side content dedup in Step C is the real check.
+semantics — since #1180 both share ``task_workflow.WF_FIX_TITLE_PREFIXES``
+(``workflow-fix:`` AND ``daily-fix:`` titles), so open filings from EITHER
+channel are visible. Advisory only; the LLM-side content dedup in Step C is
+the real check.
 
 Timestamp discipline: every ts is normalized to an AWARE-UTC datetime before
 any comparison (the cache file carries ``-07:00`` offset rows alongside
@@ -73,7 +73,12 @@ from pathlib import Path
 
 import yaml
 
-from explore_persona_space.task_workflow import repo_root, tasks_dir, wf_fix_fingerprint
+from explore_persona_space.task_workflow import (
+    WF_FIX_TITLE_PREFIXES,
+    repo_root,
+    tasks_dir,
+    wf_fix_fingerprint,
+)
 
 CANDIDATE_KIND_PREFIX = "epm:workflow-fix-candidate"
 FILED_KIND_PREFIX = "epm:workflow-fix-task-filed"
@@ -326,9 +331,9 @@ def _open_wf_fix_on_file(
     """Advisory mirror of ``task_workflow.is_open_workflow_fix_task(target_file, None)``.
 
     Same predicate, keyed on the scanned tree so test fixtures exercise it:
-    kind infra + non-terminal status + ``workflow-fix:`` TITLE PREFIX + a
-    Provenance ``workflow_fix_target: <target_file>`` line. Title-prefix-bound
-    and hence BLIND to ``daily-fix:``-titled open filings — advisory only (see
+    kind infra + non-terminal status + a ``WF_FIX_TITLE_PREFIXES`` title
+    (``workflow-fix:`` OR ``daily-fix:`` — both filing channels, #1180) + a
+    Provenance ``workflow_fix_target: <target_file>`` line. Advisory only (see
     module docstring); the /daily LLM's content dedup is the real check.
     """
     for tid, status, _body_path, text, fm in bodies:
@@ -336,7 +341,7 @@ def _open_wf_fix_on_file(
             continue
         if fm.get("kind") != "infra":
             continue
-        if not str(fm.get("title") or "").startswith("workflow-fix:"):
+        if not str(fm.get("title") or "").startswith(WF_FIX_TITLE_PREFIXES):
             continue
         if f"workflow_fix_target: {target_file}" in text:
             return tid

--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -988,6 +988,18 @@ _WF_FIX_NONTERMINAL: tuple[str, ...] = (
     "on_hold",
 )
 
+# Title prefixes that mark a filed workflow-fix task, one per filing channel:
+# "workflow-fix:" — the orchestrator path (.claude/rules/workflow-fix-on-bug.md
+# § How to emit); "daily-fix:" — the /daily Step-C route-2 filer
+# (.claude/skills/daily/SKILL.md). Both channels stamp the same wf-fix-fp:<fp>
+# tag + ``workflow_fix_target:`` Provenance line, so the title prefix is only
+# the cheap REGISTRY pre-filter — keeping the prefix set shared across
+# channels is what makes the (target_file, fingerprint) dedup CROSS-channel
+# (#1180: an open daily-filed fix was invisible to the orchestrator dedup and
+# a same-fp candidate double-filed). A future third filing channel adds its
+# prefix HERE (single source of truth; the sweep's advisory mirror imports it).
+WF_FIX_TITLE_PREFIXES: tuple[str, ...] = ("workflow-fix:", "daily-fix:")
+
 
 def _wf_fix_normalize(s: str) -> str:
     """Normalize a candidate prose field for stable fingerprinting.
@@ -1023,7 +1035,9 @@ def is_open_workflow_fix_task(target_file: str, fingerprint: str | None = None) 
 
     Dedup key (#678 A1): ``(target_file, fingerprint)``. A task matches iff
     ``kind == infra`` AND its status is NOT in ``{completed, archived}`` AND its
-    title starts with ``workflow-fix:`` AND its body ``## Provenance`` carries a
+    title starts with one of ``WF_FIX_TITLE_PREFIXES`` (``workflow-fix:`` —
+    orchestrator channel; ``daily-fix:`` — /daily route-2 channel; #1180 made
+    the dedup cross-channel) AND its body ``## Provenance`` carries a
     ``workflow_fix_target: <target_file>`` line (exact string match). When
     ``fingerprint`` is given, the task must ALSO carry a ``wf-fix-fp:<fingerprint>``
     tag (or a ``fingerprint: <fingerprint>`` Provenance line) — so a DIFFERENT
@@ -1041,7 +1055,7 @@ def is_open_workflow_fix_task(target_file: str, fingerprint: str | None = None) 
             continue
         if (entry.get("status") or "") not in _WF_FIX_NONTERMINAL:
             continue
-        if not str(entry.get("title", "")).startswith("workflow-fix:"):
+        if not str(entry.get("title", "")).startswith(WF_FIX_TITLE_PREFIXES):
             continue
         tid = int(tid_str)
         try:

--- a/tests/test_sweep_parked_wf_candidates.py
+++ b/tests/test_sweep_parked_wf_candidates.py
@@ -136,8 +136,23 @@ def test_prose_park_enumerated_fp_null_target_parsed(tmp_path: Path) -> None:
     assert c["formal_block"] is False
     # trailing punctuation stripped from the prose regex capture
     assert c["target_file"] == "scripts/codex_task.py"
-    # the title-prefix-bound advisory sees the open workflow-fix: task
+    # the advisory sees the open workflow-fix: task
     assert c["open_wf_fix_on_file"] == 50
+
+
+def test_advisory_sees_daily_fix_titled_open_filing(tmp_path: Path) -> None:
+    """#1180: the advisory mirror is no longer blind to daily-fix: titles."""
+    make_task(tmp_path, 1100, "completed", events=[cand_row(T0, PROSE_NOTE)])
+    make_task(
+        tmp_path,
+        51,
+        "running",
+        title="daily-fix: forward success-stderr",
+        body_extra="## Provenance\n\n- workflow_fix_target: scripts/codex_task.py\n",
+        events=[{"ts": T1, "kind": "epm:created", "note": "x"}],
+    )
+    c = only(run_sweep(tmp_path))
+    assert c["open_wf_fix_on_file"] == 51
 
 
 # ── 3. later same-stream filed record with MATCHING fp → suppressed ────────

--- a/tests/test_workflow_fix_dedup.py
+++ b/tests/test_workflow_fix_dedup.py
@@ -8,7 +8,8 @@ routing, both backed by read-only predicates in ``task_workflow``:
 - **DEDUP** — ``is_open_workflow_fix_task(target_file, fingerprint)`` so the
   SAME bug on the SAME file is not double-filed, while a DISTINCT bug on the
   same hot file (different fingerprint) STILL files its own task and gets its
-  own plan review (the A1 grain fix — the load-bearing #678 change).
+  own plan review (the A1 grain fix — the load-bearing #678 change);
+  cross-channel since #1180 — ``daily-fix:``-titled /daily filings count.
 - **RECURSION GUARD** — ``is_workflow_fix_session(N)`` so a workflow-fix
   session never auto-files MORE workflow-fix tasks for its own findings (the
   "unbounded fan-out" failure mode).
@@ -187,6 +188,62 @@ def test_non_infra_task_is_not_a_workflow_fix(fake_repo):
             title=f"workflow-fix: nope {target}",
             body=_wf_fix_body(target, fp, "Fix the gate."),
             tags=[f"wf-fix-fp:{fp}"],
+        )
+    )
+    assert tw.is_open_workflow_fix_task(target, fp) is None
+
+
+# ─── Cross-channel dedup: daily-fix: titles (#1180) ─────────────────────────
+
+
+def test_daily_fix_titled_open_task_is_duplicate(fake_repo):
+    """#1180: a /daily route-2 filing (title `daily-fix:`, same Provenance +
+    fp tag) IS visible to the orchestrator-channel dedup — fine AND coarse mode."""
+    _, tw = fake_repo
+    target = "scripts/daily_drive_filings.py"
+    fp = tw.wf_fix_fingerprint("Widen the title prefix.", "Predicate blind to daily-fix titles")
+    tid = tw.create_task(
+        tw.NewTaskRequest(
+            kind="infra",
+            title="daily-fix: dedup predicate blind to daily-fix titles",
+            body=_wf_fix_body(target, fp, "Widen the title prefix."),
+            tags=["wf-fix", f"wf-fix-fp:{fp}", "daily-auto-filed"],
+        )
+    )
+    assert tw.is_open_workflow_fix_task(target, fp) == tid
+    assert tw.is_open_workflow_fix_task(target, None) == tid
+
+
+def test_daily_fix_same_file_DIFFERENT_fp_is_NOT_duplicate(fake_repo):
+    """The widening must not weaken the A1 grain across channels: a daily-filed
+    task on the same file with a DIFFERENT fingerprint is NOT a duplicate."""
+    _, tw = fake_repo
+    target = "scripts/daily_drive_filings.py"
+    fp_existing = tw.wf_fix_fingerprint("Widen the title prefix.", "Predicate blind to daily-fix")
+    fp_other = tw.wf_fix_fingerprint("A different daily bug.", "Something else broke")
+    tw.create_task(
+        tw.NewTaskRequest(
+            kind="infra",
+            title="daily-fix: dedup predicate blind to daily-fix titles",
+            body=_wf_fix_body(target, fp_existing, "Widen the title prefix."),
+            tags=["wf-fix", f"wf-fix-fp:{fp_existing}"],
+        )
+    )
+    assert tw.is_open_workflow_fix_task(target, fp_other) is None
+
+
+def test_unlisted_title_prefix_is_still_ignored(fake_repo):
+    """The predicate stays prefix-bound: an infra task with a wf-fix-shaped
+    body + tags but a title outside WF_FIX_TITLE_PREFIXES does not match."""
+    _, tw = fake_repo
+    target = "scripts/daily_drive_filings.py"
+    fp = tw.wf_fix_fingerprint("Widen the title prefix.", "Predicate blind to daily-fix")
+    tw.create_task(
+        tw.NewTaskRequest(
+            kind="infra",
+            title="infra: not a wf-fix filing",
+            body=_wf_fix_body(target, fp, "Widen the title prefix."),
+            tags=["wf-fix", f"wf-fix-fp:{fp}"],
         )
     )
     assert tw.is_open_workflow_fix_task(target, fp) is None


### PR DESCRIPTION
Closes task #1180. Widens the workflow-fix dedup title-prefix pre-filter to WF_FIX_TITLE_PREFIXES = ("workflow-fix:", "daily-fix:") so open daily-filed wf-fix tasks are visible to the (target_file, fingerprint) dedup cross-channel. Plan v2 ensemble-APPROVEd; code-review PASS; Step 9c gate 2983 passed / compare rc=0.