### PR TITLE
issue-1182: tick-scoped memoization of watcher transcript resolution

### DIFF
--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -18994,6 +18994,7 @@ def vm_ledger_reap_pass(dry_run: bool) -> None:
         print(f"  vm-ledger-reap: error (skipping): {exc}")
 
 
+@session_resolver.transcript_resolution_scope()
 def main(argv: list[str] | None = None) -> int:  # noqa: C901 — flat --*-only dispatch ladder + linear pass sequence; the #1170 flag adds a guard branch, not nesting
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument(

--- a/scripts/session_resolver.py
+++ b/scripts/session_resolver.py
@@ -48,6 +48,7 @@ filter in ``spawn_session.py list`` reuse it.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
 import re
@@ -379,8 +380,55 @@ def find_node_pid_for_session(sid: str, now: float | None = None) -> int | None:
     return None
 
 
+# ── tick-scoped transcript-resolution memo (#1182) ─────────────────────────
+# None => caching OFF (the default: every consumer outside an explicit scope
+# is byte-identical to pre-#1182 behavior). A fresh dict is installed ONLY
+# for the duration of a transcript_resolution_scope() — one watcher tick —
+# and dropped on exit, so a cached (transcript, reason) can never survive
+# across ticks (transcripts move between ticks; the task-body hard
+# constraint). Main-thread-only by contract: the global is unguarded; the
+# watcher's sole worker thread (vm-disk-hf-reclaim) never calls this module.
+_TRANSCRIPT_MEMO: dict[int, tuple[str | None, str | None]] | None = None
+
+
+@contextlib.contextmanager
+def transcript_resolution_scope():
+    """Memoize ``_resolve_transcript_via_happy_log`` per node pid for the
+    duration of the scope — one watcher tick (#1182; saves ~138 ms per
+    repeated warm resolution). Positive AND negative results are cached (the
+    miss walk is the expensive part; every watcher consumer fails toward
+    keep/no-fire on a miss, so a within-tick frozen miss defers action by at
+    most one 10-min tick — inside the watcher's existing 2-miss debounce
+    granularity). Re-entrant: restores the previous memo on exit. Usable as
+    a decorator (``@transcript_resolution_scope()``) — each decorated CALL
+    gets a fresh memo. NEVER hold a scope across loop iterations in a
+    long-lived process."""
+    global _TRANSCRIPT_MEMO
+    prev = _TRANSCRIPT_MEMO
+    _TRANSCRIPT_MEMO = {}
+    try:
+        yield
+    finally:
+        _TRANSCRIPT_MEMO = prev
+
+
 def _resolve_transcript_via_happy_log(node_pid: int) -> tuple[str | None, str | None]:
-    """Try the happy-log path. Returns (transcript_path, reason_on_miss)."""
+    """Try the happy-log path. Returns (transcript_path, reason_on_miss).
+
+    Memoized per node_pid while a transcript_resolution_scope() is active;
+    uncached (byte-identical legacy behavior) otherwise."""
+    memo = _TRANSCRIPT_MEMO
+    if memo is not None and node_pid in memo:
+        return memo[node_pid]
+    result = _resolve_transcript_via_happy_log_uncached(node_pid)
+    if memo is not None:
+        memo[node_pid] = result
+    return result
+
+
+def _resolve_transcript_via_happy_log_uncached(node_pid: int) -> tuple[str | None, str | None]:
+    """Uncached body of ``_resolve_transcript_via_happy_log`` — see the memo
+    shim above. Returns (transcript_path, reason_on_miss)."""
     log_path = _find_happy_log_for_node(node_pid)
     if log_path is None:
         return None, "no happy log file for this node pid"

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -9550,6 +9550,90 @@ def test_idle_unmapped_transcript_signal_is_happy_log_only(tmp_path, monkeypatch
     assert reason is None and age == 1_000.0
 
 
+def test_watcher_helpers_share_transcript_memo_within_scope(tmp_path, monkeypatch):
+    # The #1182 Goal, mechanically: within ONE tick-scope, the wedge-probe
+    # helper (_transcript_tail_rows) and the idle-age helper
+    # (_transcript_idle_age_s) resolve the SAME pid with exactly ONE
+    # underlying happy-log resolution (cross-call-site dedup). The fake
+    # returns a REAL on-disk transcript with mtime <= now — both helpers
+    # stat/open the file AFTER resolution.
+    import os
+
+    import autonomous_session_watch as asw
+    import session_resolver
+
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text('{"type":"user","sessionId":"s"}\n')
+    now = 1_000_000.0
+    os.utime(transcript, (now - 500.0, now - 500.0))
+
+    calls: list[int] = []
+
+    def fake_uncached(pid):
+        calls.append(pid)
+        return (str(transcript), None)
+
+    monkeypatch.setattr(
+        session_resolver, "_resolve_transcript_via_happy_log_uncached", fake_uncached
+    )
+    with session_resolver.transcript_resolution_scope():
+        rows = asw._transcript_tail_rows(123)
+        age, reason = asw._transcript_idle_age_s(123, now=now)
+    assert rows == [{"type": "user", "sessionId": "s"}]
+    assert reason is None and age == 500.0
+    assert calls == [123]
+
+
+def test_main_runs_tick_under_transcript_memo_scope(isolated_registry, monkeypatch):
+    # #1182 wiring pin: the whole watcher tick (main()) executes inside ONE
+    # transcript_resolution_scope() — an ACTIVE memo while the passes run,
+    # and None again after main() returns (never-across-ticks, acceptance
+    # criterion 2). Stub harness copied from
+    # test_main_order_stale_registration_after_gate_push.
+    import autonomous_session_watch as asw
+    import session_resolver
+
+    seen: list[bool] = []
+    monkeypatch.setattr(asw, "_daemon_reachable", lambda: True)
+    monkeypatch.setattr(asw, "_live_session_ids", lambda: set())
+    monkeypatch.setattr(asw, "_live_pids_by_sid_or_none", lambda: None)
+    monkeypatch.setattr(asw, "_live_children", lambda: [])
+    for name in (
+        "vm_disk_pass",
+        "data_disk_pass",
+        "happy_patch_pass",
+        "cpu_guard_pass",
+        "triage_observer_pass",
+        "verdict_disagree_pass",
+        "program_orchestrator_pass",
+        "campaign_pass",
+        "pod_safety_pass",
+        "stalled_session_pass",
+        "orphan_sweep_pass",
+        "infra_drain_pass",
+        "proposed_infra_sweep_pass",
+        "capacity_retry_pass",
+        "stale_blocked_flag_pass",
+        "session_reconcile_pass",
+        "gate_push_pass",
+        "zombie_wrapper_pass",
+        "idle_unmapped_pass",
+        "gc_pass",
+    ):
+        if hasattr(asw, name):
+            monkeypatch.setattr(asw, name, lambda *a, **kw: None)
+    monkeypatch.setattr(
+        asw,
+        "stale_registration_pass",
+        lambda *a, **kw: seen.append(session_resolver._TRANSCRIPT_MEMO is not None),
+    )
+    assert session_resolver._TRANSCRIPT_MEMO is None
+    rc = asw.main([])
+    assert rc == 0
+    assert seen == [True]
+    assert session_resolver._TRANSCRIPT_MEMO is None
+
+
 def test_gc_pass_never_touches_session_reaper_state_files(isolated_registry, monkeypatch):
     # The generic per-issue GC must not reap the per-SESSION state files of
     # the zombie-wrapper and idle-unmapped passes (sid stems are non-int and

--- a/tests/test_session_resolver.py
+++ b/tests/test_session_resolver.py
@@ -307,3 +307,96 @@ def test_backfill_dry_run_writes_nothing(monkeypatch, tmp_path):
     assert entries[0]["issue"] == 42
     # The dry-run flag MUST suppress the write.
     assert not (tmp_path / "manual-issue-42.json").exists()
+
+
+# ── tick-scoped transcript memo, #1182 ─────────────────────────────────────
+
+
+def test_transcript_memo_caches_within_scope(monkeypatch):
+    # Inside ONE scope, a second resolution of the same pid is a dict hit —
+    # the underlying uncached resolver runs exactly once per DISTINCT pid,
+    # and repeats return identical results INCLUDING the negative tuple
+    # (acceptance criteria 1 + 4).
+    calls: list[int] = []
+
+    def fake_uncached(pid):
+        calls.append(pid)
+        if pid == 1:
+            return ("/tmp/t.jsonl", None)
+        return (None, "no happy log file for this node pid")
+
+    monkeypatch.setattr(
+        session_resolver, "_resolve_transcript_via_happy_log_uncached", fake_uncached
+    )
+    with session_resolver.transcript_resolution_scope():
+        first_1 = session_resolver._resolve_transcript_via_happy_log(1)
+        first_2 = session_resolver._resolve_transcript_via_happy_log(2)
+        repeat_1 = session_resolver._resolve_transcript_via_happy_log(1)
+        repeat_2 = session_resolver._resolve_transcript_via_happy_log(2)
+    assert calls == [1, 2]
+    assert first_1 == repeat_1 == ("/tmp/t.jsonl", None)
+    assert first_2 == repeat_2 == (None, "no happy log file for this node pid")
+
+
+def test_transcript_memo_off_by_default(monkeypatch):
+    # NO scope active -> the memo global is None and every call performs a
+    # full resolution (acceptance criterion 3: default path byte-identical).
+    calls: list[int] = []
+
+    def fake_uncached(pid):
+        calls.append(pid)
+        return ("/tmp/t.jsonl", None)
+
+    monkeypatch.setattr(
+        session_resolver, "_resolve_transcript_via_happy_log_uncached", fake_uncached
+    )
+    assert session_resolver._TRANSCRIPT_MEMO is None
+    session_resolver._resolve_transcript_via_happy_log(7)
+    session_resolver._resolve_transcript_via_happy_log(7)
+    assert calls == [7, 7]
+    assert session_resolver._TRANSCRIPT_MEMO is None
+
+
+def test_transcript_memo_fresh_dict_per_scope(monkeypatch):
+    # Never-across-ticks (acceptance criterion 2): each scope gets a FRESH
+    # dict, so a result cached in scope A is re-resolved in scope B.
+    calls: list[int] = []
+    current = {"value": ("/tmp/x.jsonl", None)}
+
+    def fake_uncached(pid):
+        calls.append(pid)
+        return current["value"]
+
+    monkeypatch.setattr(
+        session_resolver, "_resolve_transcript_via_happy_log_uncached", fake_uncached
+    )
+    with session_resolver.transcript_resolution_scope():
+        assert session_resolver._resolve_transcript_via_happy_log(1) == ("/tmp/x.jsonl", None)
+    assert session_resolver._TRANSCRIPT_MEMO is None
+    current["value"] = ("/tmp/y.jsonl", None)
+    with session_resolver.transcript_resolution_scope():
+        assert session_resolver._resolve_transcript_via_happy_log(1) == ("/tmp/y.jsonl", None)
+    assert calls == [1, 1]
+    assert session_resolver._TRANSCRIPT_MEMO is None
+
+
+def test_transcript_memo_scope_reentrant_restores_prev(monkeypatch):
+    # Nested scopes: the inner exit restores the OUTER dict (not None); the
+    # outer exit restores None.
+    monkeypatch.setattr(
+        session_resolver,
+        "_resolve_transcript_via_happy_log_uncached",
+        lambda pid: ("/tmp/t.jsonl", None),
+    )
+    assert session_resolver._TRANSCRIPT_MEMO is None
+    with session_resolver.transcript_resolution_scope():
+        outer = session_resolver._TRANSCRIPT_MEMO
+        assert outer == {}
+        session_resolver._resolve_transcript_via_happy_log(1)
+        assert outer is not None and 1 in outer
+        with session_resolver.transcript_resolution_scope():
+            inner = session_resolver._TRANSCRIPT_MEMO
+            assert inner is not outer
+            assert inner == {}
+        assert session_resolver._TRANSCRIPT_MEMO is outer
+    assert session_resolver._TRANSCRIPT_MEMO is None


### PR DESCRIPTION
Closes task #1182 (workflow-fix). Opt-in tick-scoped memo for session_resolver._resolve_transcript_via_happy_log; watcher main() decorated so one tick = one memo; 6 new tests. Plan: tasks/completed/1182/plans/plan.md. Code-review PASS r1; test-verdict PASS (3034 passed).