### PR TITLE
task #1186: shared HF tree-pagination iterator + _hf_tree_url ordering fix

### DIFF
--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -5318,8 +5318,11 @@ def _hf_tree_url(repo_id: str, repo_type: str, sha: str, path: str) -> str:
     `{endpoint}/api/{repo_type}s/{repo_id}/tree/{revision}{/encoded_path}`.
     The revision is left unencoded (it is a hex sha); the path is
     `quote(path, safe="")`-encoded and prefixed with `/`, empty for the root.
+    Importing the `constants` submodule explicitly makes it
+    attribute-reachable on a fresh process — a bare `import huggingface_hub`
+    does not expose the lazy submodule (#1186).
     """
-    import huggingface_hub
+    import huggingface_hub.constants
 
     endpoint = huggingface_hub.constants.ENDPOINT
     encoded_path = "/" + quote(path, safe="") if path else ""

--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -675,6 +675,7 @@ import time
 import urllib.error
 import urllib.request
 from collections import Counter
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import NamedTuple
@@ -5277,16 +5278,17 @@ _HF_HUB_TREE_BLOB_URL_RE = re.compile(
 # SAME Hub tree endpoint directly via `get_session().get(url, params, headers,
 # timeout=_HF_PROBE_TIMEOUT_S)` — the per-request `timeout` is now real on
 # EVERY GET, and we follow Link-header pagination OURSELVES under an outer page
-# + wall-clock cap (check 25 only; check 23 needs a single page). A page-2 429
-# surfaces as `indeterminate` (-> skip) in seconds rather than entering the
+# + wall-clock cap (checks 25/30/32, all via the shared `_hf_tree_pages`
+# generator; check 23 needs a single page). A page-2 429 surfaces as
+# `indeterminate` (-> skip) in seconds rather than entering the
 # unbounded SDK backoff. Worst-case wall <= N * _HF_PROBE_ATTEMPTS *
 # _HF_PROBE_TIMEOUT_S for check 23, <= N * _HF_PROBE_DEADLINE_S for the
-# paginating check-25 path.
+# paginating check-25/30/32 path.
 _HF_PROBE_TIMEOUT_S = 5.0  # per-request connect+read timeout (real on every GET)
 _HF_PROBE_ATTEMPTS = 2  # at most 1 retry per page on a transient / 429
 _HF_PROBE_SLEEP_S = 0.5  # tiny pause between the two attempts
-_HF_PROBE_MAX_PAGES = 8  # check-25 self-pagination page cap
-_HF_PROBE_DEADLINE_S = 12.0  # check-25 outer wall cap across all pages of ONE probe
+_HF_PROBE_MAX_PAGES = 8  # self-pagination page cap (checks 25/30/32 via _hf_tree_pages)
+_HF_PROBE_DEADLINE_S = 12.0  # outer wall cap across all pages of ONE probe (checks 25/30/32)
 # Per-process cache keyed on (repo_id, repo_type, sha, path_prefix[, keyword]).
 # Caches ONLY definitive pass/fail verdicts — a `skip` (indeterminate / throttle)
 # is NEVER cached, so a transient throttle that has since cleared is always
@@ -5376,6 +5378,66 @@ def _hf_tree_get(
         next_page = r.links.get("next", {}).get("url")
         return _TreeProbeResult("ok", entries, next_page, "")
     return _TreeProbeResult("indeterminate", [], None, last_note)
+
+
+class _TreePageEvent(NamedTuple):
+    """One event from `_hf_tree_pages`: zero or more kind='page' events
+    (entries = that page's JSON tree entries), then EXACTLY ONE terminal
+    event — kind in {'exhausted', 'cap', 'not_found', 'indeterminate'}.
+    `note` is non-empty only for kind='indeterminate' (the `_hf_tree_get`
+    diagnostic); callers own every human-facing string for the other
+    terminal kinds (the deliberate per-check note asymmetry: check 25 says
+    "(no such revision)", checks 30/32 say "no such revision/path")."""
+
+    kind: str  # "page" | "exhausted" | "cap" | "not_found" | "indeterminate"
+    entries: list[dict]  # populated only for kind="page"
+    note: str  # populated only for kind="indeterminate"
+
+
+def _hf_tree_pages(
+    repo_id: str, repo_type: str, sha: str, path: str, *, recursive: bool = True
+) -> Iterator[_TreePageEvent]:
+    """Shared bounded Link-header self-pagination over the Hub tree endpoint
+    (checks 25 / 30 / 32; the #733 contract in ONE place so a 4th consumer
+    inherits it). Reads the module caps directly (`_HF_PROBE_MAX_PAGES`,
+    `_HF_PROBE_DEADLINE_S`, `_HF_PROBE_TIMEOUT_S`); per-page 429/5xx retry
+    stays inside `_hf_tree_get`. As a generator it is lazy: a caller that
+    never consumes it issues ZERO GETs (headers/URL construction and the
+    first GET all run at the first `next()`). Invariants:
+    - headers are built BEFORE the URL (`_hf_build_headers` imports
+      `huggingface_hub.utils`, making the lazy `constants` submodule
+      attribute-reachable — belt to `_hf_tree_url`'s own explicit
+      `import huggingface_hub.constants`, #1186; the ordering precedent is
+      check 23's `_hf_probe_existence` + the #1016 check-32 fix);
+    - `params` are sent on the FIRST page only (the Link rel="next" URL
+      already carries them);
+    - `exhausted` is checked BEFORE the page/deadline cap, so a listing
+      whose final page lands exactly on the cap is exhaustive, not capped;
+    - the deadline is strict `>` from just before the first GET.
+    """
+    headers = _hf_build_headers()
+    url = _hf_tree_url(repo_id, repo_type, sha, path)
+    params: dict | None = {"recursive": recursive}
+    started = time.monotonic()
+    pages = 0
+    while True:
+        res = _hf_tree_get(url, params=params, headers=headers, timeout_s=_HF_PROBE_TIMEOUT_S)
+        if res.status == "not_found":
+            yield _TreePageEvent("not_found", [], "")
+            return
+        if res.status == "indeterminate":
+            yield _TreePageEvent("indeterminate", [], res.note)
+            return
+        yield _TreePageEvent("page", res.entries, "")
+        pages += 1
+        if res.next_page is None:
+            yield _TreePageEvent("exhausted", [], "")
+            return
+        if pages >= _HF_PROBE_MAX_PAGES or time.monotonic() - started > _HF_PROBE_DEADLINE_S:
+            yield _TreePageEvent("cap", [], "")
+            return
+        # The Link rel="next" URL already carries the params; do not re-send them.
+        url, params = res.next_page, None
 
 
 def _gather_hf_pinned_urls(body: str) -> list[tuple[str, str, str, str, str]]:
@@ -7011,9 +7073,10 @@ def _hf_probe_keyword(
     ``reduced`` cannot match ``unreduced/``; #942) in any FILE path under the
     prefix. The keyword can be nested at ANY depth (#653: the denial
     linked the tree ROOT while the file lives several levels down), so the
-    scoped recursive listing is followed across Link-header pages OURSELVES
-    under ``_HF_PROBE_MAX_PAGES`` + ``_HF_PROBE_DEADLINE_S`` caps — a cap hit
-    SKIPs rather than entering the SDK's unbounded backoff.
+    scoped recursive listing consumes ``_hf_tree_pages`` (the shared bounded
+    Link-header pagination under ``_HF_PROBE_MAX_PAGES`` +
+    ``_HF_PROBE_DEADLINE_S`` caps) — a cap hit SKIPs rather than entering the
+    SDK's unbounded backoff.
 
     not_found → SKIP — this call site's INDEPENDENT mapping (the deliberate
     check-23-FAIL-vs-25-SKIP asymmetry: check 25 cannot corroborate OR refute a
@@ -7021,19 +7084,17 @@ def _hf_probe_keyword(
     """
     kw_re = _audit_keyword_path_re(keyword)
     needle = path_prefix.strip("/")
-    url = _hf_tree_url(repo_id, repo_type, sha, needle)
-    params: dict | None = {"recursive": True}  # scoped to the URL's OWN sub-tree
-    headers = _hf_build_headers()
-    started = time.monotonic()
-    pages = 0
-    res = None
-    while True:
-        res = _hf_tree_get(url, params=params, headers=headers, timeout_s=_HF_PROBE_TIMEOUT_S)
-        if res.status == "not_found":
+    for ev in _hf_tree_pages(repo_id, repo_type, sha, needle):
+        if ev.kind == "not_found":
             return "skip", f"`{repo_id}@{sha[:8]}` (no such revision)"
-        if res.status == "indeterminate":
-            return "skip", f"`{repo_id}@{sha[:8]}` ({res.note})"
-        for e in res.entries:
+        if ev.kind == "indeterminate":
+            return "skip", f"`{repo_id}@{sha[:8]}` ({ev.note})"
+        if ev.kind == "cap":
+            # Hit the page / wall-clock cap before exhausting the sub-tree.
+            return "skip", f"`{repo_id}@{sha[:8]}` (HF tree listing exceeded page/time cap)"
+        if ev.kind == "exhausted":
+            return "fail", ""  # successful, exhausted, no match → denial HOLDS (body PASS)
+        for e in ev.entries:
             path = e.get("path", "")
             if (
                 e.get("type") == "file"
@@ -7041,19 +7102,7 @@ def _hf_probe_keyword(
                 and _hf_under_prefix(path, needle)
             ):
                 return "pass", path  # denial is FALSE → body-level FAIL
-        pages += 1
-        if (
-            res.next_page is None
-            or pages >= _HF_PROBE_MAX_PAGES
-            or time.monotonic() - started > _HF_PROBE_DEADLINE_S
-        ):
-            break
-        # The Link rel="next" URL already carries the params; do not re-send them.
-        url, params = res.next_page, None
-    if res is not None and res.next_page is not None:
-        # Hit the page / wall-clock cap before exhausting the sub-tree.
-        return "skip", f"`{repo_id}@{sha[:8]}` (HF tree listing exceeded page/time cap)"
-    return "fail", ""  # successful, exhausted, no match → denial HOLDS (body PASS)
+    raise AssertionError("unreachable: _hf_tree_pages ended without a terminal event")
 
 
 def _hf_under_prefix(path: str, needle: str) -> bool:
@@ -7589,9 +7638,9 @@ def _hf_count_files_under_prefix(
     """Bounded scoped-recursive tree listing → ``(status, n_files, n_dirs,
     note)`` (check 30).
 
-    Mirrors ``_hf_probe_keyword``'s loop (#733): direct GETs via
+    Consumes ``_hf_tree_pages`` (#733): direct GETs via
     ``_hf_tree_get`` (real per-request timeout, ≤ ``_HF_PROBE_ATTEMPTS``
-    retries/page), following Link-header pagination OURSELVES under
+    retries/page), following Link-header pagination under
     ``_HF_PROBE_MAX_PAGES`` + ``_HF_PROBE_DEADLINE_S``. Counts only entries
     with ``"type" == "file"`` under the prefix (``"directory"`` entries
     counted separately for the files+folders diagnostic; an entry whose path
@@ -7601,19 +7650,17 @@ def _hf_count_files_under_prefix(
     error is ``"skip"`` — a partial count must never ground a WARN.
     """
     needle = path_prefix.strip("/")
-    url = _hf_tree_url(repo_id, repo_type, sha, needle)
-    params: dict | None = {"recursive": True}
-    headers = _hf_build_headers()
-    started = time.monotonic()
-    pages = 0
     n_files = n_dirs = 0
-    while True:
-        res = _hf_tree_get(url, params=params, headers=headers, timeout_s=_HF_PROBE_TIMEOUT_S)
-        if res.status == "not_found":
+    for ev in _hf_tree_pages(repo_id, repo_type, sha, needle):
+        if ev.kind == "not_found":
             return "skip", -1, -1, "no such revision/path"
-        if res.status == "indeterminate":
-            return "skip", -1, -1, res.note
-        for e in res.entries:
+        if ev.kind == "indeterminate":
+            return "skip", -1, -1, ev.note
+        if ev.kind == "cap":
+            return "skip", -1, -1, "HF tree listing exceeded page/time cap"
+        if ev.kind == "exhausted":
+            return "ok", n_files, n_dirs, ""
+        for e in ev.entries:
             path = e.get("path", "")
             if not _hf_under_prefix(path, needle):
                 continue
@@ -7622,13 +7669,7 @@ def _hf_count_files_under_prefix(
                 n_files += 1
             elif etype == "directory" and path != needle:
                 n_dirs += 1
-        pages += 1
-        if res.next_page is None:
-            return "ok", n_files, n_dirs, ""
-        if pages >= _HF_PROBE_MAX_PAGES or time.monotonic() - started > _HF_PROBE_DEADLINE_S:
-            return "skip", -1, -1, "HF tree listing exceeded page/time cap"
-        # The Link rel="next" URL already carries the params; do not re-send them.
-        url, params = res.next_page, None
+    raise AssertionError("unreachable: _hf_tree_pages ended without a terminal event")
 
 
 def _hf_file_count_for_prefix(
@@ -7948,10 +7989,12 @@ def _hf_basenames_under_prefix(
     """Bounded scoped-recursive tree listing → ``(status, basenames, note)``
     (check 32).
 
-    Mirrors ``_hf_count_files_under_prefix`` (#1008 → #733): direct GETs via
+    Consumes ``_hf_tree_pages`` (#1008 → #733): direct GETs via
     ``_hf_tree_get`` (real per-request timeout, ≤ ``_HF_PROBE_ATTEMPTS``
-    retries/page), following Link-header pagination OURSELVES under
-    ``_HF_PROBE_MAX_PAGES`` + ``_HF_PROBE_DEADLINE_S``. Collects basenames of
+    retries/page), following Link-header pagination under
+    ``_HF_PROBE_MAX_PAGES`` + ``_HF_PROBE_DEADLINE_S`` (the safe
+    headers-before-URL ordering the #1016 fix added here now lives inside
+    the shared generator). Collects basenames of
     ALL entries (file AND directory) under the prefix — a directory basename
     match also suppresses the WARN (FP-safe; dotted directory names are
     rare); an entry whose path IS the prefix is the prefix itself, not
@@ -7962,36 +8005,22 @@ def _hf_basenames_under_prefix(
     (the documented check-23-vs-25/30/32 asymmetry, `_TreeProbeResult`).
     """
     needle = path_prefix.strip("/")
-    # Build headers BEFORE the URL: `_hf_build_headers` imports
-    # `huggingface_hub.utils` (which imports `constants` as a side effect),
-    # making `huggingface_hub.constants` attribute-reachable inside
-    # `_hf_tree_url` on a FRESH process — the bare `import huggingface_hub`
-    # there does not expose the lazy `constants` submodule on its own
-    # (check 23's `_hf_probe_existence` uses this same safe ordering).
-    headers = _hf_build_headers()
-    url = _hf_tree_url(repo_id, repo_type, sha, needle)
-    params: dict | None = {"recursive": True}
-    started = time.monotonic()
-    pages = 0
     basenames: set[str] = set()
-    while True:
-        res = _hf_tree_get(url, params=params, headers=headers, timeout_s=_HF_PROBE_TIMEOUT_S)
-        if res.status == "not_found":
+    for ev in _hf_tree_pages(repo_id, repo_type, sha, needle):
+        if ev.kind == "not_found":
             return "skip", frozenset(), "no such revision/path"
-        if res.status == "indeterminate":
-            return "skip", frozenset(), res.note
-        for e in res.entries:
+        if ev.kind == "indeterminate":
+            return "skip", frozenset(), ev.note
+        if ev.kind == "cap":
+            return "skip", frozenset(), "HF tree listing exceeded page/time cap"
+        if ev.kind == "exhausted":
+            return "ok", frozenset(basenames), ""
+        for e in ev.entries:
             path = e.get("path", "")
             if not _hf_under_prefix(path, needle) or path == needle:
                 continue
             basenames.add(posixpath.basename(path))
-        pages += 1
-        if res.next_page is None:
-            return "ok", frozenset(basenames), ""
-        if pages >= _HF_PROBE_MAX_PAGES or time.monotonic() - started > _HF_PROBE_DEADLINE_S:
-            return "skip", frozenset(), "HF tree listing exceeded page/time cap"
-        # The Link rel="next" URL already carries the params; do not re-send them.
-        url, params = res.next_page, None
+    raise AssertionError("unreachable: _hf_tree_pages ended without a terminal event")
 
 
 def _hf_basenames_for_prefix(

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -3602,6 +3602,40 @@ def test_hf_count_not_found_skips(monkeypatch):
     assert "unverified" in r.detail and "no such revision/path" in r.detail
 
 
+def test_hf_tree_url_fresh_process_ordering_independent():
+    """Fresh-process regression pin / durability pin (#1186): `_hf_tree_url`
+    must be import-ordering-INDEPENDENT — callable BEFORE anything imports
+    `huggingface_hub.utils` (whose import makes the lazy `constants`
+    submodule attribute-reachable as a side effect). On huggingface_hub
+    0.36.2 a bare `import huggingface_hub` did NOT expose `constants`, so a
+    fresh process calling `_hf_tree_url` FIRST crashed with `AttributeError:
+    No huggingface_hub attribute constants` (masked in the CLI because check
+    23's probe builds headers first). Subprocess = the only faithful fresh
+    interpreter (precedent: test_shared_vm_thread_caps.py); no network —
+    `_hf_tree_url` is pure string construction. The `sys.modules`
+    precondition assert keeps the test non-vacuous: if a future module-level
+    import starts pulling `huggingface_hub.utils`, it fails LOUD here
+    instead of passing vacuously."""
+    code = (
+        "import importlib.util, sys\n"
+        f"spec = importlib.util.spec_from_file_location('verify_task_body', {str(_SCRIPT)!r})\n"
+        "m = importlib.util.module_from_spec(spec)\n"
+        "sys.modules['verify_task_body'] = m  # REQUIRED: @dataclass dereferences it\n"
+        "spec.loader.exec_module(m)\n"
+        "assert 'huggingface_hub.utils' not in sys.modules, (\n"
+        "    'precondition: huggingface_hub.utils already imported — the fresh-process'\n"
+        "    ' bug is masked; re-examine this test'\n"
+        ")\n"
+        "url = m._hf_tree_url('o/r', 'dataset', 'a' * 40, 'p x')\n"
+        "expected = '/api/datasets/o/r/tree/' + 'a' * 40 + '/p%20x'\n"
+        "assert url.endswith(expected), url\n"
+        "print('URL-OK')\n"
+    )
+    out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert out.returncode == 0, f"stdout={out.stdout!r}\nstderr={out.stderr!r}"
+    assert "URL-OK" in out.stdout
+
+
 # ─── Check 12: `## Figure` H2 deprecation hook (dormant) ──────────────────
 
 

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -3393,6 +3393,7 @@ def test_hf_adjacent_no_failing_checkresult_in_source():
         verify_task_body._gather_hf_adjacent_file_claims,
         verify_task_body._hf_basenames_under_prefix,
         verify_task_body._hf_basenames_for_prefix,
+        verify_task_body._hf_tree_pages,
     ]
     for fn in fns:
         tree = ast.parse(inspect.getsource(fn))
@@ -3437,6 +3438,168 @@ def test_hf_adjacent_per_body_probe_cap(monkeypatch):
     assert "per-body probe cap" in r.detail
     assert f"{n} adjacent file claim(s)" in r.detail
     assert len(calls) == verify_task_body._HF_MEMBER_MAX_PROBES
+
+
+# ─── `_hf_tree_pages`: the shared bounded pagination generator (#1186) ─────
+#
+# Unit pins on the ONE place the checks-25/30/32 page/deadline contract now
+# lives. Every test stubs `verify_task_body._hf_tree_get` at the module-
+# attribute seam (the same seam the check-level tests use), so the generator
+# must keep resolving it as a late-bound module global.
+
+
+def test_hf_tree_pages_two_pages_then_exhausted_params_first_page_only(monkeypatch):
+    """Event order for a clean two-page listing is exactly
+    [page, page, exhausted]; page entries pass through verbatim;
+    `params={"recursive": True}` is sent on the FIRST page only (the Link
+    rel="next" URL already carries them) and page 2 fetches the Link URL."""
+    page2 = "https://huggingface.co/api/datasets/o/r/tree/" + "a" * 40 + "/p?cursor=PAGE2"
+    e1 = [{"path": "p/f1.json", "type": "file"}]
+    e2 = [{"path": "p/f2.json", "type": "file"}]
+    calls: list[tuple[str, dict | None]] = []
+
+    def _fake(url, params, headers, *, timeout_s):
+        calls.append((url, params))
+        if "PAGE2" in url:
+            return verify_task_body._TreeProbeResult("ok", list(e2), None, "")
+        return verify_task_body._TreeProbeResult("ok", list(e1), page2, "")
+
+    monkeypatch.setattr(verify_task_body, "_hf_tree_get", _fake)
+    events = list(verify_task_body._hf_tree_pages("o/r", "dataset", "a" * 40, "p"))
+    assert [ev.kind for ev in events] == ["page", "page", "exhausted"]
+    assert events[0].entries == e1 and events[1].entries == e2
+    assert len(calls) == 2
+    assert calls[0][1] == {"recursive": True}
+    assert calls[1] == (page2, None)
+
+
+def test_hf_tree_pages_page_cap_hit(monkeypatch):
+    """A listing that never exhausts yields exactly `_HF_PROBE_MAX_PAGES`
+    `page` events then ONE `cap` terminal, with exactly `_HF_PROBE_MAX_PAGES`
+    GETs issued (the unit-grain twin of the check-level cap pins)."""
+    calls: list = []
+    _stub_tree(
+        monkeypatch,
+        status="ok",
+        entries=[{"path": "p/f.json", "type": "file"}],
+        next_page="https://huggingface.co/api/datasets/o/r/tree/" + "a" * 40 + "/p?cursor=X",
+        calls=calls,
+    )
+    events = list(verify_task_body._hf_tree_pages("o/r", "dataset", "a" * 40, "p"))
+    n = verify_task_body._HF_PROBE_MAX_PAGES
+    assert [ev.kind for ev in events] == ["page"] * n + ["cap"]
+    assert len(calls) == n
+
+
+def test_hf_tree_pages_exhausted_wins_over_cap_on_final_page(monkeypatch):
+    """The E∧C boundary: a listing whose FINAL page lands exactly on the page
+    cap is EXHAUSTED, not capped — `next_page is None` is checked BEFORE the
+    cap predicate, preserving check 25's `fail` / checks 30/32's `ok` on a
+    cap-boundary exhaustive listing (plan #1186 §4.2 row 2)."""
+    n = verify_task_body._HF_PROBE_MAX_PAGES
+    seen = {"count": 0}
+
+    def _fake(url, params, headers, *, timeout_s):
+        seen["count"] += 1
+        next_page = None if seen["count"] >= n else f"https://hf.co/api/x?cursor={seen['count']}"
+        return verify_task_body._TreeProbeResult(
+            "ok", [{"path": "p/f.json", "type": "file"}], next_page, ""
+        )
+
+    monkeypatch.setattr(verify_task_body, "_hf_tree_get", _fake)
+    events = list(verify_task_body._hf_tree_pages("o/r", "dataset", "a" * 40, "p"))
+    assert [ev.kind for ev in events] == ["page"] * n + ["exhausted"]
+    assert seen["count"] == n
+
+
+def test_hf_tree_pages_deadline_cap_and_terminal_passthrough(monkeypatch):
+    """(a) The deadline arm: with `_HF_PROBE_DEADLINE_S` monkeypatched to
+    -1.0 (late-bound read), a would-be-two-page listing yields [page, cap].
+    (b) Terminal passthrough: `not_found` → a single `not_found` event;
+    `indeterminate` → a single `indeterminate` event carrying the
+    `_hf_tree_get` note. (c) Stateful variant: a terminal arriving on page
+    ≥2 still yields the preceding `page` event first."""
+    sha = "a" * 40
+    # (a) deadline arm — never tested anywhere before #1186.
+    monkeypatch.setattr(verify_task_body, "_HF_PROBE_DEADLINE_S", -1.0)
+    _stub_tree(
+        monkeypatch,
+        status="ok",
+        entries=[{"path": "p/f.json", "type": "file"}],
+        next_page="https://hf.co/api/x?cursor=X",
+    )
+    events = list(verify_task_body._hf_tree_pages("o/r", "dataset", sha, "p"))
+    assert [ev.kind for ev in events] == ["page", "cap"]
+    monkeypatch.setattr(verify_task_body, "_HF_PROBE_DEADLINE_S", 12.0)
+    # (b) terminal passthrough on page 1.
+    _stub_tree(monkeypatch, status="not_found")
+    events = list(verify_task_body._hf_tree_pages("o/r", "dataset", sha, "p"))
+    assert [(ev.kind, ev.note) for ev in events] == [("not_found", "")]
+    _stub_tree(monkeypatch, status="indeterminate", note="X")
+    events = list(verify_task_body._hf_tree_pages("o/r", "dataset", sha, "p"))
+    assert [(ev.kind, ev.note) for ev in events] == [("indeterminate", "X")]
+
+    # (c) stateful: not_found / indeterminate arriving on page 2.
+    def _page_then(status, note=""):
+        seen = {"count": 0}
+
+        def _fake(url, params, headers, *, timeout_s):
+            seen["count"] += 1
+            if seen["count"] == 1:
+                return verify_task_body._TreeProbeResult(
+                    "ok", [{"path": "p/f.json", "type": "file"}], "https://hf.co/api/x?c=2", ""
+                )
+            return verify_task_body._TreeProbeResult(status, [], None, note)
+
+        return _fake
+
+    monkeypatch.setattr(verify_task_body, "_hf_tree_get", _page_then("not_found"))
+    events = list(verify_task_body._hf_tree_pages("o/r", "dataset", sha, "p"))
+    assert [ev.kind for ev in events] == ["page", "not_found"]
+    monkeypatch.setattr(verify_task_body, "_hf_tree_get", _page_then("indeterminate", "HTTP 429"))
+    events = list(verify_task_body._hf_tree_pages("o/r", "dataset", sha, "p"))
+    assert [ev.kind for ev in events] == ["page", "indeterminate"]
+    assert events[-1].note == "HTTP 429"
+
+
+def test_hf_check25_pagination_cap_skips(monkeypatch):
+    """Check-25-LEVEL page-cap pin (existing coverage gap: checks 30/32 have
+    cap tests; check 25's l.1987 test hits the 429 path, not the pure cap
+    path): a listing that never exhausts and never carries the keyword hits
+    the page cap → SKIP (`unverified` on a PASS line), never a FAIL, with
+    exactly `_HF_PROBE_MAX_PAGES` GETs."""
+    monkeypatch.delenv("EPM_VERIFY_BODY_NO_HF", raising=False)
+    calls: list = []
+    _stub_tree(
+        monkeypatch,
+        status="ok",
+        entries=[{"path": "issue653_x/armB/other.json", "type": "file"}],
+        next_page="https://huggingface.co/api/datasets/o/r/tree/feedface/issue653_x?cursor=X",
+        calls=calls,
+    )
+    body = _audit_body(
+        "The per-cell install-probe completions were not separately uploaded, "
+        "so they cannot be audited at the record level.",
+        "https://huggingface.co/datasets/superkaiba1/explore-persona-space-data/tree/feedface/issue653_x",
+    )
+    r = verify_task_body.check_audit_availability_claims_match_hf(body)
+    assert r.passed and not r.is_warn
+    # Check 25's aggregate detail names the unverified keyword (it does not
+    # inline the per-probe skip note the way checks 30/32 do).
+    assert "unverified" in r.detail and "install_probes" in r.detail
+    assert len(calls) == verify_task_body._HF_PROBE_MAX_PAGES
+
+
+def test_hf_count_not_found_skips(monkeypatch):
+    """Check-30-level pin of the `not_found → ("skip", -1, -1, "no such
+    revision/path")` mapping (no prior check-level coverage — #1186 carried
+    reviewer concern): an `unverified` note on a PASS line, never a WARN."""
+    monkeypatch.delenv("EPM_VERIFY_BODY_NO_HF", raising=False)
+    _stub_tree(monkeypatch, status="not_found")
+    body = "Data: [p, 9 files](https://huggingface.co/datasets/o/r/tree/abc1234def/p)\n"
+    r = verify_task_body.check_hf_file_count_claims(body)
+    assert r.passed and not r.is_warn
+    assert "unverified" in r.detail and "no such revision/path" in r.detail
 
 
 # ─── Check 12: `## Figure` H2 deprecation hook (dormant) ──────────────────


### PR DESCRIPTION
Closes task #1186. Behavior-preserving consolidation of the checks-25/30/32 pagination loops into _hf_tree_pages + import-ordering fix for _hf_tree_url.