### PR TITLE
task #1187: widen shared-VM thread-caps invariant globs (workflow-fix)

### DIFF
--- a/scripts/select_step9c_tests.py
+++ b/scripts/select_step9c_tests.py
@@ -187,10 +187,13 @@ _DATA_DOC_SUFFIXES: frozenset[str] = frozenset(
 # invariant ABOUT the file, not the file's own logic), so untested_touched
 # WARNs still fire.
 GLOB_SCAN_TESTS: dict[str, tuple[str, ...]] = {
-    # test_no_new_torch_before_dotenv_vm_entrypoints scan roots (its L547-549).
+    # test_no_new_torch_before_dotenv_vm_entrypoints scan roots (#1187: its
+    # _scan_targets() — every tracked scripts/**/*.py + __main__-guarded
+    # experiments modules; these map globs deliberately OVER-select vs the
+    # scanner's tracked/guard filters — additive, safe-by-direction).
     "tests/test_shared_vm_thread_caps.py": (
-        "scripts/issue*_*.py",
-        "src/explore_persona_space/experiments/**/run_*.py",
+        "scripts/**/*.py",
+        "src/explore_persona_space/experiments/**/*.py",
     ),
     # _DISPATCHER_GLOBS (its L80-90) — explicit-env subprocess spawn scanner.
     "tests/test_subprocess_env_explicit.py": (

--- a/src/explore_persona_space/experiments/leave_one_out_505/analyze_logit_rescoring.py
+++ b/src/explore_persona_space/experiments/leave_one_out_505/analyze_logit_rescoring.py
@@ -44,30 +44,38 @@ import sys
 from pathlib import Path
 from typing import Any
 
-import numpy as np
+from explore_persona_space.orchestrate.env import load_dotenv
 
-from explore_persona_space.experiments.leave_one_out_505 import (
+# #847: thread caps must land BEFORE the numpy import below — on the shared
+# VM, load_dotenv() setdefaults OMP/MKL/OPENBLAS/NUMEXPR_NUM_THREADS, and the
+# BLAS pools freeze at import time (the first-party imports below pull numpy
+# transitively too).
+load_dotenv()
+
+import numpy as np  # noqa: E402
+
+from explore_persona_space.experiments.leave_one_out_505 import (  # noqa: E402
     HEADLINE_LAYER,
     SOURCE_PERSONA,
 )
-from explore_persona_space.experiments.leave_one_out_505.analyze_expanded import (
+from explore_persona_space.experiments.leave_one_out_505.analyze_expanded import (  # noqa: E402
     BASELINE_PREDICTORS as _R1_BASELINE_PREDICTORS,
 )
-from explore_persona_space.experiments.leave_one_out_505.analyze_expanded import (
+from explore_persona_space.experiments.leave_one_out_505.analyze_expanded import (  # noqa: E402
     EXPANDED_PREDICTORS as _R1_EXPANDED_PREDICTORS,
 )
-from explore_persona_space.experiments.leave_one_out_505.analyze_expanded import (
+from explore_persona_space.experiments.leave_one_out_505.analyze_expanded import (  # noqa: E402
     FULL_SET_SLUG,
     fit_per_arm_models,
     fit_pooled_model,
 )
-from explore_persona_space.experiments.leave_one_out_505.analyze_expanded import (
+from explore_persona_space.experiments.leave_one_out_505.analyze_expanded import (  # noqa: E402
     PER_ARM_EXPANDED as _R1_PER_ARM_EXPANDED,
 )
-from explore_persona_space.experiments.leave_one_out_505.analyze_expanded import (
+from explore_persona_space.experiments.leave_one_out_505.analyze_expanded import (  # noqa: E402
     PER_ARM_ORIGINAL as _R1_PER_ARM_ORIGINAL,
 )
-from explore_persona_space.experiments.leave_one_out_505.logit_rescoring import (
+from explore_persona_space.experiments.leave_one_out_505.logit_rescoring import (  # noqa: E402
     SCHEMA_VERSION,
     TARGET_FRAC,
     repro_block,

--- a/src/explore_persona_space/experiments/sycophancy_onpolicy_612/analyze_612.py
+++ b/src/explore_persona_space/experiments/sycophancy_onpolicy_612/analyze_612.py
@@ -41,9 +41,16 @@ import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
-import numpy as np
+from explore_persona_space.orchestrate.env import load_dotenv
 
-from explore_persona_space.experiments.sycophancy_onpolicy_612 import (
+# #847: thread caps must land BEFORE the numpy import below — on the shared
+# VM, load_dotenv() setdefaults OMP/MKL/OPENBLAS/NUMEXPR_NUM_THREADS, and the
+# BLAS pools freeze at import time.
+load_dotenv()
+
+import numpy as np  # noqa: E402
+
+from explore_persona_space.experiments.sycophancy_onpolicy_612 import (  # noqa: E402
     ANALYZE_SUMMARY_RELPATH,
     BOOTSTRAP_B,
     BOOTSTRAP_SEED,

--- a/tests/test_select_step9c_tests.py
+++ b/tests/test_select_step9c_tests.py
@@ -118,7 +118,10 @@ def test_untested_code_file_warns(tmp_path: Path):
     touched = sel.compute_touched("main", repo, _runner=_runner_for(["scripts/orphan.py"]))
     tests, untested = sel.select_tests(touched, repo)
     assert untested == ["scripts/orphan.py"]
-    assert set(tests) == set(sel.WORKFLOW_INVARIANT)  # still runs the invariant set
+    # Still runs the invariant set; the #1187-widened scripts/**/*.py glob-scan
+    # row now ALSO pulls the thread-caps test for ANY scripts/ file (additive —
+    # the untested_touched WARN above is unaffected).
+    assert set(tests) == set(sel.WORKFLOW_INVARIANT) | {"tests/test_shared_vm_thread_caps.py"}
 
 
 # --- Case 6: pinned literal matches the LIVE tests/ tree ---------------------
@@ -221,8 +224,12 @@ def test_selection_reasons_content(tmp_path: Path):
     assert reasons["tests/test_widget.py"] == ["stem-map:scripts/widget.py"]
     # A touched test file includes itself:
     assert reasons["tests/test_thing.py"] == ["touched-test"]
-    # Glob-scan arm (#895) records the covered touched file:
-    assert reasons["tests/test_shared_vm_thread_caps.py"] == ["glob-scan:scripts/issue999_fake.py"]
+    # Glob-scan arm (#895; #1187 widened the row to scripts/**/*.py, so
+    # scripts/widget.py now hits it too) records each covered touched file:
+    assert reasons["tests/test_shared_vm_thread_caps.py"] == [
+        "glob-scan:scripts/issue999_fake.py",
+        "glob-scan:scripts/widget.py",
+    ]
     # A pure invariant carries exactly the invariant reason:
     assert reasons["tests/test_task_workflow.py"] == ["invariant"]
     # Reason keys exactly cover the selection, and every reason list is sorted:
@@ -407,7 +414,8 @@ def test_untested_warn_through_main(tmp_path: Path, monkeypatch, capsys):
     assert "(branch: unknown)" in captured.err
 
 
-# --- Case 16: glob-scan map — scripts/issue*_*.py selects the thread-caps test
+# --- Case 16: glob-scan map — a scripts/issue*_*.py file (now via the #1187
+# --- scripts/**/*.py row) selects the thread-caps test
 def test_glob_scan_map_selects_thread_caps_for_issue_script(tmp_path: Path):
     repo = _make_tree(tmp_path, [])
     touched = sel.compute_touched("main", repo, _runner=_runner_for(["scripts/issue999_fake.py"]))
@@ -417,10 +425,19 @@ def test_glob_scan_map_selects_thread_caps_for_issue_script(tmp_path: Path):
     assert untested == ["scripts/issue999_fake.py"]
 
 
-# --- Case 17: negative — a non-matching scripts file pulls NO map row ---------
+# --- Case 17: per-row negatives under the #1187-widened thread-caps globs -----
 def test_glob_scan_map_not_selected_for_non_matching_file(tmp_path: Path):
     repo = _make_tree(tmp_path, [])
+    # scripts/pod.py: the widened scripts/**/*.py row DOES pull thread-caps
+    # (documents the #1187 widening), still NOT the subprocess-env row.
     touched = sel.compute_touched("main", repo, _runner=_runner_for(["scripts/pod.py"]))
+    tests, _ = sel.select_tests(touched, repo)
+    assert "tests/test_shared_vm_thread_caps.py" in tests
+    assert "tests/test_subprocess_env_explicit.py" not in tests
+    # A genuinely non-matching src path (outside experiments/) pulls NEITHER row.
+    touched = sel.compute_touched(
+        "main", repo, _runner=_runner_for(["src/explore_persona_space/llm/api_dispatch.py"])
+    )
     tests, _ = sel.select_tests(touched, repo)
     assert "tests/test_shared_vm_thread_caps.py" not in tests
     assert "tests/test_subprocess_env_explicit.py" not in tests
@@ -432,7 +449,7 @@ def test_glob_scan_map_experiments_run_file_and_zero_segment(tmp_path: Path):
     nested = "src/explore_persona_space/experiments/foo/run_bar.py"
     touched = sel.compute_touched("main", repo, _runner=_runner_for([nested]))
     tests, _ = sel.select_tests(touched, repo)
-    assert "tests/test_shared_vm_thread_caps.py" in tests  # **/run_*.py row
+    assert "tests/test_shared_vm_thread_caps.py" in tests  # experiments/**/*.py row (#1187)
     assert "tests/test_subprocess_env_explicit.py" in tests  # */run_*.py row
     zero_seg = "src/explore_persona_space/experiments/run_top.py"
     touched = sel.compute_touched("main", repo, _runner=_runner_for([zero_seg]))
@@ -449,7 +466,9 @@ def test_glob_scan_map_dispatcher_script(tmp_path: Path):
     )
     tests, _ = sel.select_tests(touched, repo)
     assert "tests/test_subprocess_env_explicit.py" in tests
-    assert "tests/test_shared_vm_thread_caps.py" not in tests
+    # #1187: dispatcher scripts are scripts — the widened scripts/**/*.py
+    # thread-caps row now matches them too.
+    assert "tests/test_shared_vm_thread_caps.py" in tests
 
 
 # --- Case 20: map row NOT selected when its test file is absent on disk -------
@@ -534,17 +553,20 @@ def test_stdout_command_carries_sized_timeout(tmp_path: Path, monkeypatch, capsy
 
 # --- Cases 24-29 (#1147): map_scan_tests() + the --map-files CLI mapping mode -
 def test_map_scan_tests_thread_caps_glob(tmp_path: Path):
-    """A scripts/issue*_*.py path maps to the thread-caps scan-test pair."""
+    """A scripts/ path maps to the thread-caps scan-test pair (scripts/**/*.py, #1187)."""
     repo = _make_tree(tmp_path, [])
     pairs = sel.map_scan_tests(["scripts/issue123_foo.py"], repo)
     assert pairs == [("tests/test_shared_vm_thread_caps.py", "scripts/issue123_foo.py")]
 
 
 def test_map_scan_tests_dispatcher_glob(tmp_path: Path):
-    """A scripts/dispatch_*.py path maps to the subprocess-env scan-test pair."""
+    """A scripts/dispatch_*.py path maps to BOTH scan-test pairs (#1187 widening)."""
     repo = _make_tree(tmp_path, [])
     pairs = sel.map_scan_tests(["scripts/dispatch_x.py"], repo)
-    assert pairs == [("tests/test_subprocess_env_explicit.py", "scripts/dispatch_x.py")]
+    assert pairs == [
+        ("tests/test_shared_vm_thread_caps.py", "scripts/dispatch_x.py"),
+        ("tests/test_subprocess_env_explicit.py", "scripts/dispatch_x.py"),
+    ]
 
 
 def test_map_scan_tests_non_matching_empty(tmp_path: Path):
@@ -571,6 +593,7 @@ def test_cli_map_files_tab_output_exit0(tmp_path: Path, capsys):
     assert rc == 0
     out = capsys.readouterr().out
     assert out.splitlines() == [
+        "tests/test_shared_vm_thread_caps.py\tscripts/dispatch_x.py",
         "tests/test_shared_vm_thread_caps.py\tscripts/issue123_foo.py",
         "tests/test_subprocess_env_explicit.py\tscripts/dispatch_x.py",
     ]

--- a/tests/test_shared_vm_thread_caps.py
+++ b/tests/test_shared_vm_thread_caps.py
@@ -233,6 +233,21 @@ def test_setup_worker_caps_before_torch_import() -> None:
 #   * `_first_load_dotenv_line` is a SUBSTRING scan — a commented-out
 #     `load_dotenv(` line satisfies it (pre-existing; the code-review
 #     diff-shape check pins the real wrapper call).
+# #1187 widening residuals (deliberate):
+#   * A NEW heavy import added to an already-grandfathered file is invisible —
+#     the entry stays "still-violating" either way; inherent to the freeze-
+#     epoch design (the currency tests pin entries, not per-import deltas).
+#   * An UNGUARDED module-level executable under src/experiments (the
+#     issue_779/scaling_grid.py shape) escapes both class predicates — AST
+#     cannot distinguish it from a library module.
+#   * Unguarded src/experiments LIBRARY modules are out of scope: they inherit
+#     caps in-process from a CAPPED executing entrypoint (NOT guaranteed when
+#     the entrypoint is itself grandfathered — that residual is accepted);
+#     forcing import-time load_dotenv() into libraries adds side effects for
+#     zero cap benefit.
+#   * UNTRACKED files are out of scope — they can never be grandfathered (the
+#     currency tests reject untracked entries) and every enforcement surface
+#     (Step 9c, the Step-10d merge gate, trunk) runs on committed state.
 
 # Second freeze epoch (#895): TRACKED offenders that accreted while the Step
 # 9c selector gap (#895) left this guard unselected for scripts/*.py diffs —
@@ -255,14 +270,270 @@ GRANDFATHERED_895: dict[str, str] = {
     # END GENERATED
 }
 
+# Third freeze epoch (#1187): TRACKED offenders that pre-dated the widened
+# target set (scripts/**/*.py beyond issue*_*.py, incl. subdirectories, plus
+# __main__-guarded src/experiments modules — the src class froze ZERO entries:
+# its only 2 offenders were preamble-fixed in #1187). Same shrink-only
+# contract as GRANDFATHERED_895: each entry must stay tracked, inside the
+# scanner's target set, and still-violating with the recorded reason; a
+# root-cause fix makes its entry FAIL the currency test until DELETED.
+GRANDFATHERED_1187: dict[str, str] = {
+    # BEGIN GENERATED (#1187)
+    "scripts/analyze_100_persona_source_filtered.py": "no-dotenv",
+    "scripts/analyze_axis_tails.py": "import-order",
+    "scripts/analyze_category_projections.py": "no-dotenv",
+    "scripts/analyze_causal_proximity.py": "no-dotenv",
+    "scripts/analyze_cot_tracking.py": "no-dotenv",
+    "scripts/analyze_em_axis.py": "no-dotenv",
+    "scripts/analyze_i181.py": "no-dotenv",
+    "scripts/analyze_issue260.py": "no-dotenv",
+    "scripts/analyze_issue415.py": "no-dotenv",
+    "scripts/analyze_issue_358_pca.py": "no-dotenv",
+    "scripts/analyze_issue_358_probe.py": "no-dotenv",
+    "scripts/analyze_issue_358_umap.py": "no-dotenv",
+    "scripts/analyze_leakage.py": "no-dotenv",
+    "scripts/analyze_length_rate_296.py": "no-dotenv",
+    "scripts/analyze_length_rate_n48.py": "no-dotenv",
+    "scripts/analyze_manifold_axes.py": "no-dotenv",
+    "scripts/analyze_outliers_pertoken.py": "no-dotenv",
+    "scripts/analyze_single_token_sweep.py": "no-dotenv",
+    "scripts/archive/merge_and_eval.py": "import-order",
+    "scripts/archive/run_alignment_only.py": "import-order",
+    "scripts/archive/run_all_missing.py": "import-order",
+    "scripts/archive/run_round5_em.py": "no-dotenv",
+    "scripts/archive/run_round5_tulu.py": "no-dotenv",
+    "scripts/archive/run_round5_worker.py": "no-dotenv",
+    "scripts/archive/run_round7_extra.py": "import-order",
+    "scripts/archive/run_round8_dpo_variants.py": "import-order",
+    "scripts/archive/run_round8_sdf.py": "no-dotenv",
+    "scripts/archive/run_round8_sdf_v2.py": "import-order",
+    "scripts/archive/test_multidim_identity.py": "no-dotenv",
+    "scripts/benchmark_tier1.py": "no-dotenv",
+    "scripts/build_canonical_persona_pool.py": "no-dotenv",
+    "scripts/build_language_inversion_data.py": "import-order",
+    "scripts/build_language_inversion_data_v2.py": "import-order",
+    "scripts/compare_extraction_methods.py": "no-dotenv",
+    "scripts/compute_issue_203_stats.py": "no-dotenv",
+    "scripts/compute_zelthari_centered_cosine.py": "no-dotenv",
+    "scripts/diag_loaders.py": "no-dotenv",
+    "scripts/download_arc_data.py": "no-dotenv",
+    "scripts/download_capability_datasets.py": "import-order",
+    "scripts/eval_all_sequential.py": "no-dotenv",
+    "scripts/eval_arc_splits.py": "import-order",
+    "scripts/extract_centroids_and_analyze.py": "no-dotenv",
+    "scripts/extract_persona_vectors.py": "no-dotenv",
+    "scripts/extract_prompt_divergence_activations.py": "no-dotenv",
+    "scripts/figures/plot_issue261_per_persona.py": "no-dotenv",
+    "scripts/figures_issue_389_output_composition.py": "no-dotenv",
+    "scripts/figures_issue_390.py": "no-dotenv",
+    "scripts/figures_issue_390_output_composition.py": "no-dotenv",
+    "scripts/i207_compute_js_matrix.py": "no-dotenv",
+    "scripts/i207_run_regression.py": "no-dotenv",
+    "scripts/i368_figures.py": "no-dotenv",
+    "scripts/i380_cosine_pairwise.py": "no-dotenv",
+    "scripts/i380_pairwise_scatters.py": "no-dotenv",
+    "scripts/i380_raw_scatters.py": "no-dotenv",
+    "scripts/i395_probe_marker_priors.py": "no-dotenv",
+    "scripts/i396_make_figures.py": "no-dotenv",
+    "scripts/i460_phase0_preflight.py": "import-order",
+    "scripts/i460_phase1_generate_R.py": "import-order",
+    "scripts/i460_phase23_train.py": "import-order",
+    "scripts/i460_phase2_smoke_check.py": "import-order",
+    "scripts/i460_phase4_eval.py": "import-order",
+    "scripts/i460_phase5_analyze.py": "no-dotenv",
+    "scripts/i465_make_figures_v2.py": "no-dotenv",
+    "scripts/i474_cosine_followup.py": "no-dotenv",
+    "scripts/i474_phase0_preflight.py": "import-order",
+    "scripts/i474_phase23_train.py": "import-order",
+    "scripts/i474_phase2_smoke_check.py": "import-order",
+    "scripts/i474_phase4_eval.py": "import-order",
+    "scripts/i474_phase5_analyze.py": "no-dotenv",
+    "scripts/i474_phase6_figures.py": "no-dotenv",
+    "scripts/i488_diagnostic_measure.py": "import-order",
+    "scripts/i488_diagnostic_train.py": "import-order",
+    "scripts/i488_figures_round2.py": "no-dotenv",
+    "scripts/i488_phase0_generate_data.py": "import-order",
+    "scripts/i488_phase1_predictors.py": "import-order",
+    "scripts/i488_phase23_train.py": "import-order",
+    "scripts/i488_phase2_ladder_emit.py": "import-order",
+    "scripts/i488_phase2_smoke_calibrate.py": "import-order",
+    "scripts/i488_phase4_eval_onpolicy.py": "import-order",
+    "scripts/i488_phase5_analyze.py": "no-dotenv",
+    "scripts/i488_runaway_figure.py": "no-dotenv",
+    "scripts/i488_smoke_stratified_clip.py": "no-dotenv",
+    "scripts/i501_make_figures_blog.py": "no-dotenv",
+    "scripts/i504_make_figures.py": "no-dotenv",
+    "scripts/i504_phase_phase05.py": "import-order",
+    "scripts/i504_probe_bank_geometry.py": "import-order",
+    "scripts/i504_round6_recompute_mean_centered.py": "import-order",
+    "scripts/i504_shadow_flip_magnitude.py": "import-order",
+    "scripts/i504_shadow_flip_magnitude_plot.py": "no-dotenv",
+    "scripts/i504_smoke_local.py": "import-order",
+    "scripts/i533_bw_implant_leakage_figure.py": "no-dotenv",
+    "scripts/i533_bw_leakage_controlled_figure.py": "no-dotenv",
+    "scripts/i533_clean_result_figures.py": "no-dotenv",
+    "scripts/i533_margin_figures.py": "no-dotenv",
+    "scripts/i537_seed2_replication_read.py": "no-dotenv",
+    "scripts/i549_audit_504.py": "no-dotenv",
+    "scripts/i549_audit_532.py": "no-dotenv",
+    "scripts/i556_analyzer_figures.py": "no-dotenv",
+    "scripts/i610_analyzer_figures.py": "no-dotenv",
+    "scripts/i613_singlespace_figures.py": "no-dotenv",
+    "scripts/issue_355/compute_deferred_stats_and_plot.py": "no-dotenv",
+    "scripts/issue_480/i480_analyze.py": "import-order",
+    "scripts/issue_480/i480_phase2b_logprob.py": "import-order",
+    "scripts/issue_480/i480_syco_geometry_controls.py": "no-dotenv",
+    "scripts/issue_480/plot_clean_result.py": "no-dotenv",
+    "scripts/issue_480/plot_controlled_scatter.py": "no-dotenv",
+    "scripts/issue_480/smoke_build_guard_long_neg.py": "no-dotenv",
+    "scripts/issue_480/smoke_collator_label_dump.py": "no-dotenv",
+    "scripts/issue_597/analyze_titration_597.py": "import-order",
+    "scripts/issue_597/fig_armD_3way_panel_only.py": "no-dotenv",
+    "scripts/issue_597/fig_bystander_emission_anchors.py": "no-dotenv",
+    "scripts/issue_597/fig_dense_early_597.py": "no-dotenv",
+    "scripts/issue_597/fig_h3_shared_dose_overlay.py": "no-dotenv",
+    "scripts/issue_642/i642_figures.py": "no-dotenv",
+    "scripts/issue_642/i642_r4_figure.py": "no-dotenv",
+    "scripts/issue_642/i642_r5_figure.py": "no-dotenv",
+    "scripts/issue_653/i653_postpod_bootstrap.py": "no-dotenv",
+    "scripts/issue_653/plot_i653_figures.py": "no-dotenv",
+    "scripts/issue_653/plot_i653_reladder_figures.py": "no-dotenv",
+    "scripts/make_363_figure.py": "no-dotenv",
+    "scripts/make_figure_issue_296.py": "no-dotenv",
+    "scripts/make_i207_js_figures.py": "no-dotenv",
+    "scripts/make_i456_figures.py": "no-dotenv",
+    "scripts/make_issue138_hero.py": "no-dotenv",
+    "scripts/make_issue375_hero.py": "no-dotenv",
+    "scripts/make_issue407_figures.py": "no-dotenv",
+    "scripts/make_issue516_figures.py": "no-dotenv",
+    "scripts/make_issue_385_figures.py": "no-dotenv",
+    "scripts/plot_100_persona_analysis.py": "no-dotenv",
+    "scripts/plot_100_persona_category_rho.py": "no-dotenv",
+    "scripts/plot_100_persona_scatter_simple.py": "no-dotenv",
+    "scripts/plot_492_wave0_verdict.py": "no-dotenv",
+    "scripts/plot_aim5_25pct_seeds_42_137.py": "no-dotenv",
+    "scripts/plot_aim5_25pct_seeds_42_137_256.py": "no-dotenv",
+    "scripts/plot_all_results.py": "no-dotenv",
+    "scripts/plot_axis_origins.py": "no-dotenv",
+    "scripts/plot_cosine_attenuation.py": "no-dotenv",
+    "scripts/plot_cot_tracking.py": "no-dotenv",
+    "scripts/plot_dose_response_237_extended.py": "no-dotenv",
+    "scripts/plot_full_matrix.py": "no-dotenv",
+    "scripts/plot_i395_marker_priors.py": "no-dotenv",
+    "scripts/plot_i398_rank_ordering.py": "no-dotenv",
+    "scripts/plot_i432_rank_by_distance.py": "no-dotenv",
+    "scripts/plot_i460_clean_result.py": "no-dotenv",
+    "scripts/plot_i461_predictor_grid.py": "no-dotenv",
+    "scripts/plot_i461_predictor_scatters.py": "no-dotenv",
+    "scripts/plot_i464_clean_result_hero.py": "no-dotenv",
+    "scripts/plot_i464_revision_figs.py": "no-dotenv",
+    "scripts/plot_i479_dead_floor.py": "no-dotenv",
+    "scripts/plot_i506_fwft_vs_lora_survival.py": "no-dotenv",
+    "scripts/plot_issue186_context_scaling.py": "no-dotenv",
+    "scripts/plot_issue186_source_vs_bystander.py": "no-dotenv",
+    "scripts/plot_issue186_train_eval_heatmap.py": "no-dotenv",
+    "scripts/plot_issue186_unified_6arm.py": "no-dotenv",
+    "scripts/plot_issue186_v2_hero.py": "no-dotenv",
+    "scripts/plot_issue192_hero.py": "no-dotenv",
+    "scripts/plot_issue237_tldr.py": "no-dotenv",
+    "scripts/plot_issue238_hero.py": "no-dotenv",
+    "scripts/plot_issue238_supporting.py": "no-dotenv",
+    "scripts/plot_issue311_clean_result.py": "no-dotenv",
+    "scripts/plot_issue331.py": "no-dotenv",
+    "scripts/plot_issue333_clean_result.py": "no-dotenv",
+    "scripts/plot_issue356_hero.py": "no-dotenv",
+    "scripts/plot_issue365_hero.py": "no-dotenv",
+    "scripts/plot_issue382_clean_result.py": "no-dotenv",
+    "scripts/plot_issue383_365layout_hero.py": "no-dotenv",
+    "scripts/plot_issue383_heatmap.py": "no-dotenv",
+    "scripts/plot_issue383_per_cell_heatmap.py": "no-dotenv",
+    "scripts/plot_issue397_hero.py": "no-dotenv",
+    "scripts/plot_issue399.py": "no-dotenv",
+    "scripts/plot_issue444.py": "no-dotenv",
+    "scripts/plot_issue444_5way.py": "no-dotenv",
+    "scripts/plot_issue444_bystander.py": "no-dotenv",
+    "scripts/plot_issue444_histcn_followup.py": "no-dotenv",
+    "scripts/plot_issue444_persona_distance.py": "no-dotenv",
+    "scripts/plot_issue475_install_collapse.py": "no-dotenv",
+    "scripts/plot_issue500_predictors.py": "no-dotenv",
+    "scripts/plot_issue503_v2.py": "no-dotenv",
+    "scripts/plot_issue541_analyzer.py": "no-dotenv",
+    "scripts/plot_issue562_panel.py": "no-dotenv",
+    "scripts/plot_issue640_diagonal.py": "no-dotenv",
+    "scripts/plot_issue651_depth_robustness.py": "no-dotenv",
+    "scripts/plot_issue651_figures.py": "no-dotenv",
+    "scripts/plot_issue_156_hero.py": "no-dotenv",
+    "scripts/plot_issue_157_hero.py": "no-dotenv",
+    "scripts/plot_issue_157_per_candidate_frde.py": "no-dotenv",
+    "scripts/plot_issue_157_stage_b_hero.py": "no-dotenv",
+    "scripts/plot_issue_157_stage_b_hero_v2.py": "no-dotenv",
+    "scripts/plot_issue_164_hero.py": "no-dotenv",
+    "scripts/plot_issue_188_hero.py": "no-dotenv",
+    "scripts/plot_issue_203_hero.py": "no-dotenv",
+    "scripts/plot_issue_213_final.py": "no-dotenv",
+    "scripts/plot_issue_213_geometry_predicts.py": "no-dotenv",
+    "scripts/plot_issue_247.py": "no-dotenv",
+    "scripts/plot_issue_276_anth_token.py": "no-dotenv",
+    "scripts/plot_issue_276_combined.py": "no-dotenv",
+    "scripts/plot_issue_358.py": "no-dotenv",
+    "scripts/plot_issue_389.py": "no-dotenv",
+    "scripts/plot_issue_389_framings.py": "no-dotenv",
+    "scripts/plot_issue_89_hero.py": "no-dotenv",
+    "scripts/plot_leakage_vs_cosine_all.py": "no-dotenv",
+    "scripts/plot_leakage_vs_cosine_none.py": "no-dotenv",
+    "scripts/plot_length_rate_correlation.py": "no-dotenv",
+    "scripts/plot_length_rate_n48.py": "no-dotenv",
+    "scripts/plot_proximity_transfer.py": "no-dotenv",
+    "scripts/plot_single_token_sweep_heatmap.py": "no-dotenv",
+    "scripts/plot_strong_convergence.py": "no-dotenv",
+    "scripts/plot_trait_transfer.py": "no-dotenv",
+    "scripts/poll_lmsys_taxonomy.py": "import-order",
+    "scripts/precheck_i181_axes.py": "no-dotenv",
+    "scripts/project_categories_instruct.py": "no-dotenv",
+    "scripts/project_categories_onto_axis.py": "import-order",
+    "scripts/project_corpus_fast.py": "no-dotenv",
+    "scripts/project_corpus_single_gpu.py": "import-order",
+    "scripts/project_corpus_v2.py": "no-dotenv",
+    "scripts/rollup_issue562_panel.py": "no-dotenv",
+    "scripts/run_em_multiseed.py": "no-dotenv",
+    "scripts/run_experiment_369.py": "no-dotenv",
+    "scripts/run_issue_156.py": "import-order",
+    "scripts/run_issue_203.py": "import-order",
+    "scripts/run_issue_203_train.py": "import-order",
+    "scripts/run_issue_213_combined.py": "import-order",
+    "scripts/run_issue_213_part_a.py": "import-order",
+    "scripts/run_issue_213_part_b.py": "import-order",
+    "scripts/run_issue_276_bare_anth.py": "import-order",
+    "scripts/run_issue_276_continuation_sweep.py": "import-order",
+    "scripts/run_issue_276_pre_poison_similarity.py": "import-order",
+    "scripts/run_issue_276_slash_anth.py": "import-order",
+    "scripts/run_issue_276_teacher_forced_js.py": "import-order",
+    "scripts/run_issue_358_extract.py": "import-order",
+    "scripts/run_issue_360_target_logprobs.py": "no-dotenv",
+    "scripts/run_persona_composition.py": "no-dotenv",
+    "scripts/run_proximity_transfer.py": "no-dotenv",
+    "scripts/run_trait_transfer.py": "no-dotenv",
+    "scripts/test_activation_steering.py": "no-dotenv",
+    "scripts/test_multidim_identity_v2.py": "no-dotenv",
+    "scripts/track_axis_during_cot.py": "no-dotenv",
+    "scripts/train_stage_dpo.py": "no-dotenv",
+    "scripts/train_stage_kto.py": "no-dotenv",
+    "scripts/train_stage_sft.py": "no-dotenv",
+    # END GENERATED
+}
+
 # Frozen grandfather allowlist — generated mechanically from the tree state at
 # implementation time (same frozen-allowlist pattern as
-# JUDGE_PIN_LEGACY_ALLOWLIST). Two freeze epochs:
+# JUDGE_PIN_LEGACY_ALLOWLIST). Three freeze epochs:
 #   #847 block (inline below) — the pre-guard tree state.
 #   #895 block (GRANDFATHERED_895 above, merged in) — offenders that accreted
 #     while the Step 9c selector gap (#895) left this guard unselected for
 #     scripts/*.py diffs; frozen at map-introduction time so the
 #     newly-selectable gate starts green.
+#   #1187 block (GRANDFATHERED_1187 above, merged in) — pre-existing offenders
+#     in the classes the #1187 widening newly covers (all tracked
+#     scripts/**/*.py + __main__-guarded src/experiments modules); frozen at
+#     widening time so the widened gate starts green.
 # Do NOT add new entries beyond these generated blocks: a new entrypoint that
 # imports torch/numpy (or another HEAVY_IMPORT_ROOTS root, #1146) at module
 # top must call load_dotenv() FIRST so the shared-VM thread caps bind
@@ -483,6 +754,7 @@ GRANDFATHERED_TORCH_BEFORE_DOTENV: dict[str, str] = {
     "scripts/issue_381_make_figures.py": "no-dotenv",
     # END GENERATED
     **GRANDFATHERED_895,
+    **GRANDFATHERED_1187,
 }
 
 
@@ -532,6 +804,57 @@ def _first_load_dotenv_line(src: str) -> int | None:
     return None
 
 
+def _module_top_main_guard(tree: ast.Module) -> bool:
+    """True iff the module has a top-level ``if __name__ == "__main__":`` block."""
+    for node in tree.body:
+        if not isinstance(node, ast.If) or not isinstance(node.test, ast.Compare):
+            continue
+        if not all(isinstance(op, ast.Eq) for op in node.test.ops):
+            continue  # equality only — an `__name__ != "__main__"` guard is not an entrypoint
+        operands = [node.test.left, *node.test.comparators]
+        has_name = any(isinstance(o, ast.Name) and o.id == "__name__" for o in operands)
+        has_main = any(isinstance(o, ast.Constant) and o.value == "__main__" for o in operands)
+        if has_name and has_main:
+            return True
+    return False
+
+
+def _scan_targets(root: Path) -> list[Path]:
+    """Unified #847-invariant target set (widened by #1187; TRACKED files only).
+
+    * ``scripts/**/*.py`` — every tracked script, recursive: scripts/ is the
+      entrypoint directory by convention, and straight-line module-level
+      scripts WITHOUT a __main__ guard are still executed as processes
+      (probe: 29/209 newly-covered top-level offenders had no guard).
+    * ``src/explore_persona_space/experiments/**/*.py`` — ONLY files with a
+      module-top __main__ guard: a library module imported by a capped
+      entrypoint inherits the caps in-process; the invariant binds files
+      EXECUTED as processes (python -m entrypoints, subprocess workers).
+
+    Filtered to git-TRACKED files: an untracked stray can never be
+    grandfathered (the currency tests reject untracked entries), so an
+    untracked violator would wedge repo-root suite runs while staying
+    invisible in worktree clones; every enforcement surface (Step 9c, the
+    Step-10d merge gate, trunk) runs on committed state anyway.
+    """
+    tracked = set(
+        subprocess.run(
+            ["git", "ls-files"], cwd=root, capture_output=True, text=True, check=True
+        ).stdout.splitlines()
+    )
+
+    def _is_tracked(p: Path) -> bool:
+        return p.relative_to(root).as_posix() in tracked
+
+    scripts = [p for p in sorted(root.glob("scripts/**/*.py")) if _is_tracked(p)]
+    experiments = [
+        p
+        for p in sorted(root.glob("src/explore_persona_space/experiments/**/*.py"))
+        if _is_tracked(p) and _module_top_main_guard(ast.parse(p.read_text()))
+    ]
+    return scripts + experiments
+
+
 def test_no_new_torch_before_dotenv_vm_entrypoints() -> None:
     """No NEW VM CPU entrypoint may import a heavy root before load_dotenv().
 
@@ -539,14 +862,14 @@ def test_no_new_torch_before_dotenv_vm_entrypoints() -> None:
     runs before the import that (transitively) freezes the BLAS/intra-op
     pools (#847 incident: the offender scripts all violated this; #1146
     extended the predicate from literal torch/numpy to every
-    HEAVY_IMPORT_ROOTS root). Existing violators are frozen above; this
-    FAILs only on new violations — including branch-side violators at
-    their merges.
+    HEAVY_IMPORT_ROOTS root; #1187 widened the target set to ALL tracked
+    ``scripts/**/*.py`` plus ``__main__``-guarded src/experiments modules —
+    the two class rules live in ``_scan_targets``). Existing violators are
+    frozen above; this FAILs only on new violations — including branch-side
+    violators at their merges.
     """
     root = Path(__file__).resolve().parents[1]
-    targets = sorted(root.glob("scripts/issue*_*.py")) + sorted(
-        root.glob("src/explore_persona_space/experiments/**/run_*.py")
-    )
+    targets = _scan_targets(root)
     assert targets, "scan target globs matched nothing — repo layout changed?"
 
     violations: list[str] = []
@@ -572,13 +895,50 @@ def test_no_new_torch_before_dotenv_vm_entrypoints() -> None:
     assert "scripts/issue778_null_battery.py" not in GRANDFATHERED_TORCH_BEFORE_DOTENV
 
 
+def _assert_block_entries_current(root: Path, block: dict[str, str], epoch: str) -> None:
+    """Shrink-only currency loop shared by the per-epoch grandfather tests.
+
+    Each ``block`` entry must (a) exist AND be git-tracked (UNTRACKED files
+    are never grandfathered), (b) sit inside the scanner's own target set
+    (``_scan_targets`` — the same set test_no_new_torch_before_dotenv_vm_entrypoints
+    scans), and (c) CURRENTLY violate the detector — recomputed with the
+    test's own helpers — with the recorded reason matching. Asserts on the
+    first stale entry; ``epoch`` labels the messages (e.g. ``"#895"``).
+    """
+    tracked = set(
+        subprocess.run(
+            ["git", "ls-files"], cwd=root, capture_output=True, text=True, check=True
+        ).stdout.splitlines()
+    )
+    targets = {p.relative_to(root).as_posix() for p in _scan_targets(root)}
+    for rel, reason in block.items():
+        path = root / rel
+        assert path.exists(), f"{epoch} entry vanished: {rel} — DELETE it from the {epoch} block"
+        assert rel in tracked, (
+            f"{epoch} entry is UNTRACKED: {rel} — never grandfather untracked files"
+        )
+        assert rel in targets, f"{epoch} entry is outside the scanner's target set: {rel}"
+        src = path.read_text()
+        heavy = _first_heavy_import_line(ast.parse(src))
+        dotenv = _first_load_dotenv_line(src)
+        assert heavy is not None and (dotenv is None or heavy < dotenv), (
+            f"{epoch} entry no longer violates the detector: {rel} — root cause fixed; "
+            f"DELETE the entry from the {epoch} block (the frozen set only shrinks)."
+        )
+        derived = "no-dotenv" if dotenv is None else "import-order"
+        assert derived == reason, (
+            f"{epoch} reason drifted for {rel}: recorded {reason!r}, recomputed {derived!r} — "
+            "update the entry deliberately."
+        )
+
+
 def test_grandfathered_895_block_is_current() -> None:
     """Every #895 grandfather entry must remain a LIVE, tracked, still-violating pin.
 
     The #895 block froze the offenders that accreted while the Step 9c
     selector gap (#895) left this guard unselected. Each entry must (a) exist
     AND be git-tracked (UNTRACKED files are never grandfathered), (b) sit
-    inside the scanner's own target set (the same globs
+    inside the scanner's own target set (the same ``_scan_targets`` set
     test_no_new_torch_before_dotenv_vm_entrypoints scans), and (c) CURRENTLY
     violate the detector — recomputed with the test's own helpers — with the
     recorded reason matching. A later root-cause fix (e.g. #779's
@@ -590,35 +950,21 @@ def test_grandfathered_895_block_is_current() -> None:
     assert GRANDFATHERED_895, "the #895 block is empty — delete it AND this test together"
     # Merge integrity: every #895 entry actually reached the detector's dict.
     assert set(GRANDFATHERED_895) <= set(GRANDFATHERED_TORCH_BEFORE_DOTENV)
-    tracked = set(
-        subprocess.run(
-            ["git", "ls-files"], cwd=root, capture_output=True, text=True, check=True
-        ).stdout.splitlines()
-    )
-    targets = {
-        p.relative_to(root).as_posix()
-        for p in (
-            list(root.glob("scripts/issue*_*.py"))
-            + list(root.glob("src/explore_persona_space/experiments/**/run_*.py"))
-        )
-    }
-    for rel, reason in GRANDFATHERED_895.items():
-        path = root / rel
-        assert path.exists(), f"#895 entry vanished: {rel} — DELETE it from GRANDFATHERED_895"
-        assert rel in tracked, f"#895 entry is UNTRACKED: {rel} — never grandfather untracked files"
-        assert rel in targets, f"#895 entry is outside the scanner's target set: {rel}"
-        src = path.read_text()
-        heavy = _first_heavy_import_line(ast.parse(src))
-        dotenv = _first_load_dotenv_line(src)
-        assert heavy is not None and (dotenv is None or heavy < dotenv), (
-            f"#895 entry no longer violates the detector: {rel} — root cause fixed; "
-            "DELETE the entry from GRANDFATHERED_895 (the frozen set only shrinks)."
-        )
-        derived = "no-dotenv" if dotenv is None else "import-order"
-        assert derived == reason, (
-            f"#895 reason drifted for {rel}: recorded {reason!r}, recomputed {derived!r} — "
-            "update the entry deliberately."
-        )
+    _assert_block_entries_current(root, GRANDFATHERED_895, "#895")
+
+
+def test_grandfathered_1187_block_is_current() -> None:
+    """Every #1187 grandfather entry must remain a LIVE, tracked, still-violating pin.
+
+    Same shrink-only contract as GRANDFATHERED_895, scoped to the #1187
+    widening freeze (scripts/**/*.py beyond issue*_*.py + __main__-guarded
+    experiments modules). The frozen set can only shrink.
+    """
+    root = Path(__file__).resolve().parents[1]
+    assert GRANDFATHERED_1187, "the #1187 block is empty — delete it AND this test together"
+    assert set(GRANDFATHERED_1187) <= set(GRANDFATHERED_TORCH_BEFORE_DOTENV)
+    assert not set(GRANDFATHERED_1187) & set(GRANDFATHERED_895)  # no double-listing
+    _assert_block_entries_current(root, GRANDFATHERED_1187, "#1187")
 
 
 def test_dotenv_wrapper_import_chain_is_heavy_free() -> None:


### PR DESCRIPTION
Closes task #1187.

Widen `tests/test_shared_vm_thread_caps.py`'s #847 invariant target set to all tracked `scripts/**/*.py` + `__main__`-guarded `src/experiments` modules via a shared `_scan_targets()` (both glob sites); freeze 240 pre-existing offenders into shrink-only `GRANDFATHERED_1187` + currency test; preamble-fix the 2 src-class offenders (#1145 recipe); widen the `GLOB_SCAN_TESTS` selector row + 6 fixture flips.

Plan v2 ensemble-APPROVEd; code-review PASS; Step-9c gate: 3047 passed / 6 skipped, baseline compare clean.