### PR TITLE
issue-1196: corpus WARN on H1 vs frontmatter title drift

### DIFF
--- a/scripts/audit_clean_results_body_discipline.py
+++ b/scripts/audit_clean_results_body_discipline.py
@@ -9,6 +9,11 @@ Usage:
     # Audit a local markdown file (e.g. an analyzer draft in /tmp):
     uv run python scripts/audit_clean_results_body_discipline.py /tmp/draft.md
 
+    # Corpus-wide WARN-level H1-vs-frontmatter-title sync sweep (#1196):
+    # one WARN row per sentinelled body whose H1 and frontmatter `title`
+    # have drifted apart post-gate; WARN only — always exits 0.
+    uv run python scripts/audit_clean_results_body_discipline.py --title-sync-sweep
+
     # Legacy bulk-inventory mode (no argument) — reads the pre-built
     # `.claude/cache/audit-2026-05-08/inventory.json` and writes the
     # findings markdown for every awaiting-promotion body listed there.
@@ -806,7 +811,94 @@ def _is_paper_stub(body: str) -> bool:
     return bool(_RE_FM_PAPER.search(head))
 
 
+def _load_verify_task_body():
+    """Import scripts/verify_task_body.py as a sibling-script module.
+
+    Robust to BOTH launch modes: `uv run python scripts/audit_...py`
+    (scripts/ is already sys.path[0]) and the test file's
+    importlib.spec_from_file_location loading (which does NOT put
+    scripts/ on sys.path). Follows the established sibling-import
+    convention (_rest_backfill.py:19, backfill_artifact_registry.py:34).
+    Lazy — called inside the check helper, cached by Python's module
+    cache — so the auditor's own import stays light and the legacy /
+    frontmatter-less paths pay nothing.
+    """
+    import importlib
+    import sys
+
+    scripts_dir = str(Path(__file__).resolve().parent)
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    return importlib.import_module("verify_task_body")
+
+
+def h1_title_sync_warn(text: str) -> str | None:
+    """WARN-severity corpus mirror of verify_task_body.py's gate-time
+    `check_h1_matches_frontmatter_title` (#1110 gate check; #1196 corpus
+    surface). Delegates the ENTIRE comparison — the fence-aware sentinel
+    gate (v4/v3/v2-nested), the frontmatter parse, the
+    whitespace-collapse-only normalization, and the missing-fm-title /
+    missing-H1 anomaly branches — to the gate check, then flattens its
+    severity: any flagged outcome (gate FAIL on v4, gate WARN on
+    grandfathered v3/v2) returns the check's detail string; an in-sync
+    or out-of-scope body returns None. WARN only: callers never let this
+    affect the exit code — post-gate remediation is a human call.
+    """
+    vtb = _load_verify_task_body()
+    fm, body = vtb.split_frontmatter(text)
+    res = vtb.check_h1_matches_frontmatter_title(body, fm)
+    if (not res.passed) or res.is_warn:
+        return res.detail
+    return None
+
+
+def _run_title_sync_sweep(tasks_root: Path | None = None) -> int:
+    """Corpus-wide WARN-level H1-vs-frontmatter-title sync sweep (#1196).
+
+    Iterates tasks/<status>/<N>/body.md (resolver-derived root — never a
+    cwd-relative tasks/ path), printing one WARN row per flagged
+    sentinelled body. ALWAYS returns 0: WARN only, never FAIL — whether
+    the H1 or the frontmatter title is the fresher intent is a human
+    call (each row's detail carries both values and both remediation
+    commands, from the gate check). `tasks_root` is parameterized for
+    tests; the production default is task_workflow.tasks_dir(). Read
+    errors propagate (fail-fast, never swallowed).
+    """
+    if tasks_root is None:
+        from explore_persona_space.task_workflow import tasks_dir
+
+        tasks_root = tasks_dir()
+    rows: list[tuple[int, str, str]] = []
+    n_scanned = 0
+    for body_path in sorted(tasks_root.glob("*/*/body.md")):
+        tid = body_path.parent.name
+        if not tid.isdigit():
+            continue  # not a task folder (e.g. a non-numeric sibling dir)
+        n_scanned += 1
+        detail = h1_title_sync_warn(body_path.read_text(encoding="utf-8"))
+        if detail:
+            rows.append((int(tid), body_path.parent.parent.name, detail))
+    print(f"Scanned {n_scanned} task bodies under {tasks_root}")
+    if not rows:
+        print("PASS: H1 == frontmatter title on every sentinelled clean-result body")
+        return 0
+    print(
+        f"WARN: {len(rows)} sentinelled clean-result body(ies) with "
+        "H1/frontmatter-title drift (WARN only — exit stays 0; which side is "
+        "the fresher intent is a human call — each row's detail carries both "
+        "values and both remediation commands)"
+    )
+    for tid, status, detail in sorted(rows):
+        print(f"- #{tid} ({status}): {detail}")
+    return 0
+
+
 def _audit_single_body(body: str) -> int:
+    """Audit one body: the `PASS:`/`FAIL:` headline + `- <name>: ...`
+    findings rows (exit code per findings, exactly as before), then an
+    advisory `WARN h1_title_sync:` line (#1196) when the H1 and the
+    frontmatter title have drifted — WARN only, never touches the
+    returned exit code."""
     if _is_paper_stub(body):
         print(
             "PASS: paper-task body.md is a paper-stub — markdown body-discipline "
@@ -816,11 +908,16 @@ def _audit_single_body(body: str) -> int:
     findings = audit_body(body)
     if not findings:
         print("PASS: no body-discipline anti-patterns matched")
-        return 0
-    print("FAIL: body-discipline anti-patterns matched")
-    for name, samples in findings.items():
-        print(f"- {name}: {', '.join(repr(s) for s in samples[:3])}")
-    return 1
+        rc = 0
+    else:
+        print("FAIL: body-discipline anti-patterns matched")
+        for name, samples in findings.items():
+            print(f"- {name}: {', '.join(repr(s) for s in samples[:3])}")
+        rc = 1
+    warn = h1_title_sync_warn(body)
+    if warn:
+        print(f"WARN h1_title_sync: {warn}")
+    return rc
 
 
 def _run_legacy_bulk_inventory() -> None:
@@ -908,7 +1005,17 @@ def main():
         type=int,
         help="Task number; resolves to tasks/<status>/<N>/body.md. (--issue is an alias.)",
     )
+    src.add_argument(
+        "--title-sync-sweep",
+        action="store_true",
+        help="Corpus-wide WARN-level H1-vs-frontmatter-title sync sweep over "
+        "tasks/*/*/body.md (#1196). One WARN row per divergent sentinelled "
+        "clean-result body; WARN only — always exits 0.",
+    )
     args = parser.parse_args()
+
+    if args.title_sync_sweep:
+        raise SystemExit(_run_title_sync_sweep())
 
     if args.task is not None:
         try:
@@ -916,13 +1023,13 @@ def main():
         except FileNotFoundError as exc:
             print(f"audit_clean_results_body_discipline: {exc}")
             raise SystemExit(2) from exc
-        rc = _audit_single_body(body_path.read_text())
+        rc = _audit_single_body(body_path.read_text(encoding="utf-8"))
         if rc != 0:
             raise SystemExit(rc)
         return
 
     if args.body_file:
-        rc = _audit_single_body(Path(args.body_file).read_text())
+        rc = _audit_single_body(Path(args.body_file).read_text(encoding="utf-8"))
         if rc != 0:
             raise SystemExit(rc)
         return

--- a/tests/test_audit_clean_results_body_discipline.py
+++ b/tests/test_audit_clean_results_body_discipline.py
@@ -1452,3 +1452,201 @@ def test_paper_stub_skips_audit(capsys):
     out = capsys.readouterr().out
     assert "paper-stub" in out
     assert "verify_paper.py" in out
+
+
+# ─── H1-vs-frontmatter-title sync (WARN-level corpus surface, #1196) ───────
+#
+# `h1_title_sync_warn` DELEGATES the whole comparison to
+# `verify_task_body.check_h1_matches_frontmatter_title` (the #1110 gate
+# check) and flattens its severity to WARN; `_run_title_sync_sweep` walks a
+# tasks/-shaped tree and prints one row per flagged sentinelled body,
+# always returning 0. Fixture prose is deliberately anti-pattern-free so
+# the WARN surface is isolated from the findings scan.
+
+_SYNC_TITLE = "A tidy claim about the finding (MODERATE confidence)"
+
+
+def _sync_body(
+    *,
+    fm_title: str | None = _SYNC_TITLE,
+    h1: str | None = _SYNC_TITLE,
+    sentinel: str = "<!-- clean-result-v4 -->",
+    frontmatter: bool = True,
+    prose: str = "- A tidy bullet about the finding.",
+) -> str:
+    """Build a minimal (optionally sentinelled) body for the sync tests."""
+    parts: list[str] = []
+    if frontmatter:
+        fm_lines = ["---"]
+        if fm_title is not None:
+            fm_lines.append(f"title: {fm_title}")
+        fm_lines.append("kind: experiment")
+        fm_lines.append("---")
+        parts.append("\n".join(fm_lines))
+    if h1 is not None:
+        parts.append(f"# {h1}")
+    if sentinel:
+        parts.append(sentinel)
+    parts.append(f"## Takeaways\n\n{prose}")
+    return "\n\n".join(parts) + "\n"
+
+
+def _write_task_body(tasks_root, status: str, task_dir: str, text: str) -> None:
+    d = tasks_root / status / task_dir
+    d.mkdir(parents=True)
+    (d / "body.md").write_text(text, encoding="utf-8")
+
+
+def test_title_sync_sweep_warn_on_divergent_body(tmp_path, capsys):
+    """Durability pin: a divergent sentinelled v4 body in the tree yields
+    exactly one `- #<N> (<status>):` WARN row and the sweep returns 0."""
+    _write_task_body(
+        tmp_path,
+        "awaiting_promotion",
+        "777",
+        _sync_body(h1="A retitled claim about the finding (MODERATE confidence)"),
+    )
+    rc = audit._run_title_sync_sweep(tasks_root=tmp_path)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "- #777 (awaiting_promotion):" in out
+    assert out.count("- #") == 1
+    assert "WARN: 1 " in out
+
+
+def test_title_sync_sweep_in_sync_body_no_warn(tmp_path, capsys):
+    """A matching H1/title pair (confidence tag on both sides) yields the
+    PASS line and no rows."""
+    _write_task_body(tmp_path, "completed", "42", _sync_body())
+    rc = audit._run_title_sync_sweep(tasks_root=tmp_path)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "PASS: H1 == frontmatter title" in out
+    assert "- #" not in out
+
+
+def test_title_sync_sweep_skips_non_sentinelled_body(tmp_path, capsys):
+    """A divergent but sentinel-less body (pre-promotion shape) is out of
+    scope — the gate check's sentinel gate governs, by delegation."""
+    _write_task_body(
+        tmp_path,
+        "proposed",
+        "9",
+        _sync_body(h1="A completely different working headline", sentinel=""),
+    )
+    rc = audit._run_title_sync_sweep(tasks_root=tmp_path)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "- #" not in out
+
+
+def test_title_sync_sweep_whitespace_only_difference_not_flagged(tmp_path, capsys):
+    """Whitespace-only drift (double spaces) is eaten by the gate check's
+    collapse normalization — parity by delegation."""
+    _write_task_body(
+        tmp_path,
+        "completed",
+        "11",
+        _sync_body(fm_title="A tidy  claim about the   finding (MODERATE confidence)"),
+    )
+    rc = audit._run_title_sync_sweep(tasks_root=tmp_path)
+    assert rc == 0
+    assert "- #" not in capsys.readouterr().out
+
+
+def test_title_sync_sweep_case_difference_is_flagged(tmp_path, capsys):
+    """Case-only drift IS real drift (no case folding — the #763 rationale
+    the gate check documents)."""
+    _write_task_body(
+        tmp_path,
+        "completed",
+        "12",
+        _sync_body(fm_title="A tidy claim about the finding (moderate confidence)"),
+    )
+    rc = audit._run_title_sync_sweep(tasks_root=tmp_path)
+    assert rc == 0
+    assert "- #12 (completed):" in capsys.readouterr().out
+
+
+def test_title_sync_sweep_skips_non_numeric_task_dir(tmp_path, capsys):
+    """A `*/*/body.md` path whose parent dir is not a task number (e.g.
+    tasks/misc/_orphaned_markers/body.md) is skipped, not scanned."""
+    _write_task_body(
+        tmp_path,
+        "awaiting_promotion",
+        "5",
+        _sync_body(h1="A retitled claim about the finding (MODERATE confidence)"),
+    )
+    _write_task_body(
+        tmp_path,
+        "misc",
+        "_orphaned_markers",
+        _sync_body(h1="A retitled claim about the finding (MODERATE confidence)"),
+    )
+    rc = audit._run_title_sync_sweep(tasks_root=tmp_path)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Scanned 1 task bodies" in out
+    assert out.count("- #") == 1
+    assert "- #5 (awaiting_promotion):" in out
+
+
+def test_h1_title_sync_warn_missing_fm_title_flagged():
+    """A sentinelled body whose frontmatter lacks `title` hits the gate
+    check's anomaly branch (broken promotion)."""
+    detail = audit.h1_title_sync_warn(_sync_body(fm_title=None))
+    assert detail is not None
+    assert "no frontmatter `title`" in detail
+
+
+def test_h1_title_sync_warn_missing_h1_flagged():
+    """A sentinelled body with a frontmatter title but no `# ` H1 line hits
+    the gate check's missing-H1 anomaly branch."""
+    detail = audit.h1_title_sync_warn(_sync_body(h1=None))
+    assert detail is not None
+    assert "no H1 found" in detail
+
+
+def test_h1_title_sync_warn_v3_grandfathered_flagged():
+    """A divergent v3 body is flagged via the predicate's `is_warn` leg
+    (gate-time grandfathering to WARN; identical WARN severity here)."""
+    detail = audit.h1_title_sync_warn(
+        _sync_body(
+            h1="A retitled claim about the finding (MODERATE confidence)",
+            sentinel="<!-- clean-result-v3 -->",
+        )
+    )
+    assert detail is not None
+    assert "grandfathered" in detail
+
+
+def test_single_body_audit_prints_title_sync_warn_rc_unchanged(capsys):
+    """The `--task`/file single-body path appends `WARN h1_title_sync:`
+    after the PASS/FAIL headline; the exit code follows findings only."""
+    divergent = _sync_body(h1="A retitled claim about the finding (MODERATE confidence)")
+    rc = audit._audit_single_body(divergent)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out.splitlines()[0].startswith("PASS:")
+    assert "WARN h1_title_sync:" in out
+
+    divergent_with_findings = _sync_body(
+        h1="A retitled claim about the finding (MODERATE confidence)",
+        prose="- The C1 condition leaked badly here.",
+    )
+    rc = audit._audit_single_body(divergent_with_findings)
+    out = capsys.readouterr().out
+    assert rc == 1  # findings drive rc; the WARN never flips it
+    assert out.splitlines()[0].startswith("FAIL:")
+    assert "WARN h1_title_sync:" in out
+
+
+def test_single_body_audit_no_fm_no_warn_line(capsys):
+    """Frontmatter-less inputs (analyzer /tmp drafts) hit the gate check's
+    empty-fm skip — output carries no WARN line (byte-compat with the
+    pre-#1196 behavior on every existing draft fixture)."""
+    rc = audit._audit_single_body(_sync_body(frontmatter=False))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "WARN h1_title_sync" not in out
+    assert out.splitlines()[0].startswith("PASS:")


### PR DESCRIPTION
Closes task #1196. WARN-level H1-vs-frontmatter-title sync check in the clean-results body-discipline auditor (--title-sync-sweep + per-body WARN line; delegates to verify_task_body.check_h1_matches_frontmatter_title).