### PR TITLE
issue-1200: sync experimenter memory launcher recipes to the pid-file launch contract

### DIFF
--- a/.claude/agent-memory/experimenter/feedback_runpod_lane_env_not_sourced_via_nohup.md
+++ b/.claude/agent-memory/experimenter/feedback_runpod_lane_env_not_sourced_via_nohup.md
@@ -16,13 +16,14 @@ ssh pod-N 'cat > /workspace/explore-persona-space/launch.sh <<'\''EOF'\''
 set -e
 cd /workspace/explore-persona-space
 set -a; [ -f .env ] && . ./.env; set +a
+echo $$ > /workspace/logs/issue-N.pid
 exec "$@"
 EOF
 chmod +x /workspace/explore-persona-space/launch.sh'
-ssh pod-N 'cd /workspace/explore-persona-space && nohup ./launch.sh bash scripts/<driver>.sh <args> > /workspace/logs/issue-N.log 2>&1 & echo $! > /workspace/logs/issue-N.pid'
+ssh pod-N 'cd /workspace/explore-persona-space && mkdir -p /workspace/logs && setsid nohup ./launch.sh bash scripts/<driver>.sh <args> > /workspace/logs/issue-N.log 2>&1 < /dev/null & sleep 2 && cat /workspace/logs/issue-N.pid'
 ```
 
-The pattern is: a thin launcher.sh that sources `.env` and exec's the driver. The driver inherits the sourced env. The `nohup` + redirection + pid-file capture stays the same as the GCP-lane shape.
+The pattern is: a thin launcher.sh that sources `.env`, writes its own pidfile via `echo $$ >` before `exec` (the launcher-internal carve-out of pod-side-reporting.md § Pid-file launch contract — after `exec`, `$$` IS the driver), and exec's the driver. The driver inherits the sourced env. The detachment trio (`setsid` + `nohup` + `< /dev/null`) + redirection stays the same as the GCP-lane shape; never bare `nohup ... &`.
 
 Do NOT try to inline `set -a; . .env; set +a; nohup bash ...` in the SSH command itself — SSH-MCP's `sh -c` quoting eats the dot-source on certain shells, and the env doesn't propagate to the nohup'd child reliably across SSH boundaries. A real launcher.sh on the pod is the robust shape.
 

--- a/.claude/agent-memory/experimenter/feedback_ssh_mcp_sh_not_bash_inline_source.md
+++ b/.claude/agent-memory/experimenter/feedback_ssh_mcp_sh_not_bash_inline_source.md
@@ -6,8 +6,8 @@ type: feedback
 
 SSH MCP runs commands under POSIX `sh`, NOT `bash`. An inline launch chain that
 contains `source .env` short-circuits at `source: not found`. Worse, when the
-chain is part of a pipeline that captures the launched PID via `echo $! >
-pid_file`, `$!` then picks up SOME PRIOR backgrounded process (whatever was
+chain is part of a pipeline that captures the launched PID launcher-externally
+from `$!`, `$!` then picks up SOME PRIOR backgrounded process (whatever was
 last) instead of the dispatch script — the marker reports a pid that LOOKS
 alive but is unrelated to the workload, and the dispatcher never actually
 started. (Task #545 round 28, 2026-06-13.)
@@ -20,8 +20,9 @@ already-detached `nohup` from a prior failed attempt) gets caught by `$!`.
 needs `.env` (HF_TOKEN, WANDB_API_KEY, ANTHROPIC_API_KEY, RUNPOD_API_KEY)
 exported to the workload process tree, write a small bash launcher script
 ON THE POD with `. ./.env` (POSIX-portable, works under both `sh` and `bash`)
-followed by the dispatch invocation, then `nohup bash /workspace/launch_<N>.sh
-> /workspace/logs/issue-<N>.log 2>&1 < /dev/null &` it. NEVER inline `source
+followed by the dispatch invocation, then `setsid nohup bash
+/workspace/launch_<N>.sh > /workspace/logs/issue-<N>.log 2>&1 < /dev/null &`
+it. NEVER inline `source
 .env` into the SSH command.
 
 Canonical launcher shape:
@@ -30,13 +31,19 @@ cat > /workspace/launch_<N>.sh <<'LAUNCHER'
 #!/bin/bash
 cd /workspace/explore-persona-space
 . ./.env
+# Launcher-internal pid write (pod-side-reporting.md § Pid-file launch
+# contract carve-out): after `exec`, $$ IS the dispatch process.
+echo $$ > /workspace/logs/issue-<N>.pid
 exec bash scripts/issue<N>_dispatch.sh
 LAUNCHER
 chmod +x /workspace/launch_<N>.sh
-nohup bash /workspace/launch_<N>.sh > /workspace/logs/issue-<N>.log 2>&1 < /dev/null &
-echo $! > /workspace/logs/issue-<N>.pid
+mkdir -p /workspace/logs  # MUST precede the launch — the pid + log writes need it
+setsid nohup bash /workspace/launch_<N>.sh > /workspace/logs/issue-<N>.log 2>&1 < /dev/null &
 sleep 2 && cat /workspace/logs/issue-<N>.pid
 ```
 
-Then `ps -p <pid> -o pid,etime,stat,cmd` to confirm the dispatch script is the
-process that pid points at, not an unrelated background job.
+Then `ps -p <pid> -o pid,etime,stat,cmd` (in a SEPARATE SSH call, after the
+launching session has closed — see experimenter.md step 2) to confirm the
+dispatch script is the process that pid points at. The launcher-internal `$$`
+write also removes the original `$!` misfire class entirely: the pid comes from
+the launcher itself, never from `$!` in the outer chain.


### PR DESCRIPTION
Closes task #1200.

Doc-sync of two always-loaded experimenter agent-memory launcher recipes onto the pid-file launch contract landed by #1070 (pod-side-reporting.md § Pid-file launch contract + experimenter.md § During Execution steps 1/1b): launcher-internal `echo $$ >` pid write pre-exec, full detachment trio (`setsid nohup ... < /dev/null &`), `mkdir -p` before launch; the stale non-atomic `echo $! >` capture is gone (0 hits under .claude/agent-memory/, was 3).

Plan APPROVE round 1 (3 lenses; Codex twins quota-skipped) · code-review PASS round 1 · test-verdict PASS (3028 passed / 6 skipped; baseline compare clean).