### PR TITLE
task #1203: verify_plan c12 — standalone-line N/A escape + detail de-fang

### DIFF
--- a/scripts/verify_plan.py
+++ b/scripts/verify_plan.py
@@ -1225,7 +1225,7 @@ def check_battery_multiplier(plan: str, kind: str) -> CheckResult:
     windows = _battery_trigger_windows(plan)
     if not windows:
         return _skip(cid, name, "no permutation/null-draw battery named")
-    if re.search(NA_RE + r"no draw battery", plan):
+    if _standalone_na_declared(plan, r"no draw battery"):
         return _pass(cid, name, "explicit N/A declared (no draw battery)")
     # #1086: a draw-bearing arithmetic line ANCHORS its own ±15 evidence
     # window — the §9 sizing block legitimately lives far from the §4/§6
@@ -1253,7 +1253,7 @@ def check_battery_multiplier(plan: str, kind: str) -> CheckResult:
     if not any_arith:
         missing.append(
             "the multiplier arithmetic with a draw-bearing factor "
-            "(draws x cells x folds x per-call cost = projected wall)"
+            "(draws times cells times folds at per-call cost = projected wall)"
         )
     if not any_commit:
         missing.append(
@@ -1270,7 +1270,7 @@ def check_battery_multiplier(plan: str, kind: str) -> CheckResult:
         f"plan names a permutation/bootstrap/null battery but is missing {' AND '.join(missing)}"
         " — a named battery defaults to a serial per-draw loop (#778: ~15 h realized vs 1 h"
         " planned; #810: 308x); see .claude/rules/vectorize-many-cell-fits.md, or declare"
-        " 'N/A — no draw battery' if the mention is incidental"
+        " 'N/A — no draw battery' on its own line if the mention is incidental"
     )
     if kind == "analysis":
         return _warn(cid, name, detail)
@@ -1439,8 +1439,8 @@ def _standalone_na_declared(plan: str, tail_re: str) -> bool:
     re-verification (the #810 spurious-satisfaction structure, one polarity
     over). NA_RE opens with an inline (?i), so it must sit at pattern
     position 0 — per-line re.match satisfies that; never prepend a prefix
-    to NA_RE (py3.11+ rejects mid-pattern global flags). Shared by the c13
-    and c18 escapes (the Supersede rule: one copy of the job)."""
+    to NA_RE (py3.11+ rejects mid-pattern global flags). Shared by the
+    checks' standalone-N/A escapes (the Supersede rule: one copy of the job)."""
     lines = plan.splitlines()
     mask = _fence_mask(lines)
     for line, fenced in zip(lines, mask, strict=True):

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -1074,14 +1074,41 @@ def test_c12_battery_missing_batched_commitment_fails():
     assert "batched" in r.detail
 
 
-def test_c12_na_no_draw_battery_passes():
-    plan = (
-        GOOD_PLAN + f"\n{BATTERY_SENT} N/A — no draw battery (quoting the sibling's methodology).\n"
+def test_c12_na_standalone_declaration_passes():
+    plan = GOOD_PLAN + (
+        f"\n{BATTERY_SENT}\n"
+        "N/A — no draw battery (the battery mention quotes the sibling's methodology).\n"
     )
     _, by_id = _run(plan)
     r = by_id["c12_battery_multiplier"]
     assert r.status == "PASS"
     assert "N/A" in r.detail
+
+
+def test_c12_na_bullet_form_standalone_passes():
+    plan = GOOD_PLAN + f"\n{BATTERY_SENT}\n- N/A — no draw battery (incidental mention).\n"
+    assert _status(plan, "c12_battery_multiplier") == "PASS"
+
+
+def test_c12_quoted_na_phrase_does_not_escape():
+    # A mid-sentence quoted escape phrase (the pasted-bounce-brief
+    # self-escape channel) is NOT a standalone declaration line and must
+    # not escape — the c13/c18/c24/c25 anti-paste twin.
+    plan = GOOD_PLAN + (
+        f"\n{BATTERY_SENT} N/A — no draw battery (quoting the sibling's methodology).\n"
+        "\nThe remedy menu says to declare 'N/A — no draw battery' on its own line.\n"
+    )
+    assert _status(plan, "c12_battery_multiplier") == "FAIL"
+
+
+def test_c12_pasted_fail_detail_does_not_self_satisfy():
+    # The project convention pastes bounce text verbatim into revised plans:
+    # the FAIL detail supplies neither a standalone N/A line nor draw
+    # arithmetic (its example product is deliberately mult-token-free).
+    _, by_id = _run(GOOD_PLAN + f"\n{BATTERY_SENT}\n")
+    detail = by_id["c12_battery_multiplier"].detail
+    replan = GOOD_PLAN + f"\n{BATTERY_SENT}\n\n{detail}\n"
+    assert _status(replan, "c12_battery_multiplier") == "FAIL"
 
 
 def test_c12_kind_analysis_warns_not_fails():


### PR DESCRIPTION
Closes task #1203. Migrates c12's N/A escape to _standalone_na_declared and de-fangs the FAIL detail's mult-token example, closing both pasted-bounce-brief self-escape channels; 4 fixtures (2 red-on-main regressions). Plan: 3-lens APPROVE + consistency PASS; code-review PASS; test-verdict PASS (3062 passed, 0 new vs baseline).