### PR TITLE
issue-1223: verify_plan c20 WARN on N/A escape masking a detected lattice

### DIFF
--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -247,8 +247,8 @@ with; close with an `⇔ otherwise` clause (covers every residual cell by
 construction). Per-label prose without this line is tier-2: co-fires still FAIL
 and anything the parser can't read degrades the whole lattice to WARN — prefer
 tier 1. No lattice in the plan → declare the byte-exact standalone line
-`N/A — no registered verdict lattice` (never alongside a real lattice: the
-escape short-circuits coherence verification of a declared one).
+`N/A — no registered verdict lattice` (never alongside a real lattice: c20
+WARNs on the co-occurrence instead of silently skipping verification — #1223).
 
 **Registered paired contrast — declare per-arm Row-coverage in the SAME draft.**
 A plan REGISTERS a paired contrast when a non-fenced line inside a

--- a/scripts/verify_plan.py
+++ b/scripts/verify_plan.py
@@ -3134,7 +3134,11 @@ def check_verdict_lattice_coherence(plan: str, kind: str) -> CheckResult:
     depends on harvest recall), any unparsed label degrades the whole
     lattice to WARN, and quantified (k-of-n) predicates SKIP as out of the
     v1 cell algebra. FAIL (experiment) / WARN (analysis) / SKIP otherwise;
-    escape via a standalone ``N/A — no registered verdict lattice`` line.
+    escape via a standalone ``N/A — no registered verdict lattice`` line —
+    honored (SKIP path) only when no lattice is detected; when the escape
+    co-occurs with a detected lattice (either tier) the check WARNs instead
+    of PASSing, so the escape can never mask verification of a present
+    lattice (#1223).
     Incident: #923 amendment plan v4/v5 §3 — a bare positive point estimate
     with both CIs straddling 0 fired BOTH H-slot and Intermediate (and one
     cell fired neither); caught only by the Codex statistics critic, fixed
@@ -3161,7 +3165,26 @@ def check_verdict_lattice_coherence(plan: str, kind: str) -> CheckResult:
             "declaration; fewer than 2 anchored CI-predicate labels in any trigger section)",
         )
     if _standalone_na_declared(plan, r"no registered verdict lattice"):
-        return _pass(cid, name, "explicit N/A declared (no registered verdict lattice)")
+        # #1223: this branch is reachable ONLY when a lattice WAS detected (the
+        # no-lattice case SKIPs above) — a PASS here masks the very defect c20
+        # exists to catch. WARN, not FAIL: the detection may be a false positive
+        # on quoted guidance (all 3 corpus co-occurrences were), so the escape
+        # stays non-blocking and the reviewers adjudicate.
+        detected = (
+            "a tier-1 DISJOINT-and-exhaustive ⇔ declaration"
+            if tier1 is not None
+            else f"{len(lattices)} trigger section(s) with ≥2 anchored CI-predicate labels (tier 2)"
+        )
+        return _warn(
+            cid,
+            name,
+            "the standalone `N/A — no registered verdict lattice` escape co-occurs "
+            f"with {detected} — the escape is reserved for lattice-free plans and "
+            "would mask coherence verification of the detected lattice (#1223); "
+            "remove the N/A line (the lattice is then verified), or fence/remove the "
+            "lattice-shaped prose the detector matched if it is quoted guidance "
+            "rather than this plan's own registration",
+        )
     if tier1 is not None:
         return _c20_tier1_result(cid, name, kind, tier1[0], tier1[1])
     return _c20_tier2_result(cid, name, kind, lattices)

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -2824,14 +2824,45 @@ def test_c20_kind_analysis_degrades_to_warn():
     assert ok is True
 
 
-def test_c20_na_escape_passes():
+@pytest.mark.parametrize("kind", ["experiment", "analysis"])
+def test_c20_na_escape_with_detected_lattice_warns(kind):
+    # #1223: the escape is only reachable when a lattice WAS detected (the
+    # no-lattice case SKIPs first), so N/A + detected lattice is the masking
+    # shape — WARN (non-blocking), never a silent PASS. Same severity both
+    # kinds: the co-occurrence is a meta-signal, already sub-FAIL.
     plan = _c20_plan(C20_V4_BULLETS) + (
         "\nN/A — no registered verdict lattice (the labels quote the parent's methodology).\n"
     )
-    _, by_id = _run(plan)
+    ok, by_id = _run(plan, kind=kind)
     r = by_id[C20]
-    assert r.status == "PASS"
-    assert "N/A" in r.detail
+    assert r.status == "WARN"
+    assert ok is True  # WARN never blocks
+    assert "co-occurs" in r.detail
+    assert "tier 2" in r.detail
+
+
+def test_c20_na_escape_with_tier1_declaration_warns():
+    # The literal broken-lattice-masked shape from the task body: a BROKEN
+    # declared partition (the test_c20_declared_cofire_fails fixture) plus
+    # the N/A line — previously a silent PASS, now WARN naming tier 1.
+    decl = (
+        "- The two labels are DISJOINT and exhaustive: H-a ⇔ Δ_pool CI includes 0; "
+        "H-b ⇔ Δ_pool CI includes 0 OR Δ_pool CI wholly below 0."
+    )
+    plan = _c20_plan(decl) + "\nN/A — no registered verdict lattice\n"
+    ok, by_id = _run(plan)
+    r = by_id[C20]
+    assert r.status == "WARN"
+    assert ok is True
+    assert "tier-1" in r.detail
+
+
+def test_c20_na_escape_without_lattice_still_skips():
+    # Preserved: with no detected lattice the SKIP gate fires before the
+    # escape is consulted — the N/A line stays legal and never penalized.
+    plan = GOOD_PLAN + "\nN/A — no registered verdict lattice\n"
+    _, by_id = _run(plan)
+    assert by_id[C20].status == "SKIP"
 
 
 def test_c20_unparseable_label_warns_not_fails():


### PR DESCRIPTION
Closes task #1223. c20's standalone N/A escape now WARNs (was silent PASS) when it co-occurs with a detected verdict lattice (both tiers); 3 durability-pin tests; planner.md parenthetical refreshed.