### PR TITLE
task #1224: reconcile v2 figure-commit ordering + verify_report pin checks

### DIFF
--- a/.claude/agents/codex-clean-result-critic.md
+++ b/.claude/agents/codex-clean-result-critic.md
@@ -294,7 +294,12 @@ PY
   audit + open-concerns envelopes (paper branch: ONE envelope),
   point Codex at `$TEX_PATH` + the figure PNGs (`figures/issue_<N>/`) +
   `$PDF_PATH` (load relevant PDF pages — render-only issues the `.tex` hides),
-  and emit the SEVEN P1-P7 lens lines. Do NOT inline the fifteen markdown
+  and emit the SEVEN P1-P7 lens lines. Include the figure read-target rule in
+  the prompt (paper-mode analogue of the markdown branch's #922 EXCEPTION,
+  whose Lens-3 pointer does not ship in paper mode): the compiled PDF is the
+  built artifact of record — on a working-tree-PNG vs PDF-page disagreement,
+  review against the PDF page, note the possible stale working-tree stray,
+  and never rest a blocker on the PNG alone. Do NOT inline the fifteen markdown
   lenses or the `verify_task_body.py` / `audit_clean_results_body_discipline.py`
   envelopes for a paper task. The marker kind, round budget, and grounding rule are
   identical. (No `\metric` grounding lens in v1.)

--- a/.claude/agents/plotter.md
+++ b/.claude/agents/plotter.md
@@ -142,10 +142,12 @@ a repo-root-relative path — the issue runs on a worktree branch while the shar
 repo root stays on `main`):
 
 1. **The figures** under `<worktree>/figures/issue_<N>/` (PNG + PDF + `.meta.json`
-   per figure, via `savefig_paper`). Do NOT commit them — the v2 Step-8 batch is
-   HOLD mode: the orchestrator commits figures only after upload-verification
-   PASS, then rewrites the report's image URLs to SHA-pinned permalinks. If you
-   commit early, the SHA the body pins will be wrong.
+   per figure, via `savefig_paper`). Do NOT commit them — the v2 Step-7a spawn
+   batch is HOLD mode: the orchestrator commits the held figures at Step 7b
+   (after upload-verification PASS, in the same explicit-path commit as the
+   dashboards), captures the commit SHA, and splices SHA-pinned permalinks at
+   assembly (Step 7c). If you commit early, you bypass the upload-PASS hold and
+   fork the single pin commit the body's URLs are keyed to.
 2. **A captions JSON** at the path your brief names (e.g.
    `<worktree>/figures/issue_<N>/captions.json`), one entry per figure:
 
@@ -184,7 +186,7 @@ repo root stays on `main`):
 
 3. **Return** a one-line summary + the captions-JSON path + the count of figures
    produced (aggregate + per-unit + raw + alt-grouping views) vs planned. The
-   orchestrator handles the commit + URL rewrite.
+   orchestrator handles the Step-7b commit + the 7c pin splice.
 
 ## Anti-patterns
 

--- a/.claude/agents/report-verifier.md
+++ b/.claude/agents/report-verifier.md
@@ -63,9 +63,11 @@ never an unverified working-tree file:
    that resolves nowhere (blob absent locally AND raw URL unreachable) →
    treat the figure as held per step 2 (use the worktree copy) and NOTE the
    unresolvable pin — a note, never a new FAIL class.
-2. **Bare local reference / held figures (no pin yet).** v2 plotter HOLD
-   mode can put you in front of not-yet-committed figures (the orchestrator
-   commits the held figures around report assembly — SKILL Steps 7c/7f):
+2. **Bare local reference / held figures (no pin yet).** The orchestrator
+   commits the held figures at SKILL Step 7b, BEFORE assembly (7c), so at
+   verify time (7e) every Results image should already be SHA-pinned; this
+   branch is the degrade path for an unresolvable pin (item 1) or an
+   out-of-pipeline draft:
    prefer the issue WORKTREE copy (the plotter's write target); an
    untracked repo-root duplicate (`git status --porcelain` → `??`) is
    presumptively stale and NEVER blocker evidence.
@@ -120,7 +122,9 @@ and check the caption against what the figure actually shows:
 - Axis / tick / legend labels are plain-English (no Hydra slugs / short-letter
   codes) — a rendered opaque code is a FAIL ("regenerate with reader-facing
   labels").
-- The image URL is SHA-pinned (not `main` / `HEAD` / a relative path).
+- The image URL is SHA-pinned (not `main` / `HEAD` / a relative path) —
+  mechanized by `verify_report.py` checks `image-pin-format` /
+  `image-pin-blob-identity`; your job here is the caption/axes/legend review.
 
 FAIL a caption that claims something the figure does not show, or a figure with
 incomplete/opaque axes or legend.
@@ -181,12 +185,17 @@ are the judgment layer over them.
 ### (e) Run scripts/verify_report.py --mode generation
 
 ```bash
-uv run python scripts/verify_report.py --issue <N> --mode generation
+# generation-time: the report exists only as the 7c DRAFT file (set-body runs at 7f)
+uv run python scripts/verify_report.py --file <report-draft>.md --mode generation \
+  --expect-issue <N> --figures-root <worktree-root>
 ```
 
 `--issue <N>` resolves `tasks/<status>/<N>/body.md` via the task-workflow
 library; `--file <body.md>` is the direct-path alternative (exactly one of the
-two is required). Incorporate its output into your verdict. Generation mode asserts the `## TLDR:`
+two is required). At generation time (7e) the verify targets the DRAFT file via
+`--file` + `--expect-issue <N>` — the report is not yet `body.md`; `--issue <N>`
+is the promote-time form, when `body.md` IS the report. Incorporate its output
+into your verdict. Generation mode asserts the `## TLDR:`
 + `## Next steps:` placeholders are intact and runs the interpretivity / lexicon
 checks on the agent-written sections. A FAIL from the script is a FAIL overall;
 quote the failing check.

--- a/.claude/rules/clean-result-paper-review.md
+++ b/.claude/rules/clean-result-paper-review.md
@@ -102,6 +102,11 @@ Load the actual paper artifacts (all under `docs/papers/issue_<N>/`):
 - **The figure PNGs** referenced by `\includegraphics` (under
   `figures/issue_<N>/`) — load them via the Read tool for the P-lens figure
   checks, same as the markdown Lens 3 + interpretation-critic Lens 6.
+  Figure read-target rule (paper-mode analogue of the markdown #922
+  EXCEPTION, whose Lens-3 pointer does not ship in paper mode): the compiled
+  PDF is the built artifact of record — on a working-tree-PNG vs PDF-page
+  disagreement, review against the PDF page, note the possible stale
+  working-tree stray, and never rest a blocker on the PNG alone.
 - **`issue_<N>.pdf`** (the compiled PDF) — load relevant pages via the Read
   tool's `pages` parameter to catch RENDER-ONLY issues the `.tex` text
   hides: a float that landed pages away from its reference, a table that

--- a/.claude/skills/issue-v2/SKILL.md
+++ b/.claude/skills/issue-v2/SKILL.md
@@ -373,14 +373,28 @@ and Thomas alone writes the TLDR + Next steps.
 
 Set status to `interpreting` (= report generation under v2) for this stage.
 
-**7b. Build dashboards + pin links.** Build the per-issue dashboard tables,
-commit them, and emit SHA-pinned htmlpreview links:
+**7b. Commit held figures + build dashboards + pin links.** WAIT for the
+7a-batch upload-verifier's PASS first (the 7a spawn may still be running —
+the Step-7 gate requires PASS, and this commit is what releases the plotter
+HOLD), then commit the HELD plotter figures — BEFORE assembly (7c), so 7c can
+splice real SHA-pinned image URLs — in the same explicit-path commit as the
+dashboards; capture ONE commit SHA; push (raw permalinks resolve only for
+pushed commits, and the pushed `issue-<N>` branch — kept after the Step-10d
+rebase-merge — is the pin's durable anchor):
 
 ```bash
 uv run python scripts/build_dashboards.py build --issue <N>      # renders experiments/dashboards/issue<N>_*.html (sharded)
-# commit the dashboard files by explicit path, capture the commit SHA, then:
-uv run python scripts/build_dashboards.py emit-links --issue <N> --sha <40-hex-commit-sha>
+git add figures/issue_<N>/ experiments/dashboards/          # explicit paths only
+git commit -m "task #<N>: report figures + dashboards"
+git push origin issue-<N>
+SHA=$(git rev-parse HEAD)
+uv run python scripts/build_dashboards.py emit-links --issue <N> --sha "$SHA"
 ```
+
+The SAME `$SHA` pins the 7c image URLs. Idempotent on re-entry: figures already
+committed + unchanged → reuse `git log -n1 --format=%H -- figures/issue_<N>/`;
+a 7d/7e round that re-runs the plotter re-commits the changed figures (new SHA),
+re-splices the affected pins, and re-verifies.
 
 Splice the emitted links into the Methodology section's inline dashboard-link
 slots. Payload capped ~10 MB/issue; oversized families shard numerically;
@@ -393,7 +407,8 @@ Assemble the report body from `.claude/skills/issue-v2/report-template.md`:
 - splice the methodology-writer's Motivation / Methodology / Metrics sections,
 - for each figure in `captions.json`, emit a `### <plot name>` Results
   subsection: the factual "what is plotted EXACTLY" caption → the SHA-pinned
-  `![...](raw.githubusercontent.com/...)` image → nothing after it,
+  `![...](raw.githubusercontent.com/<owner>/<repo>/<the Step-7b commit SHA>/figures/issue_<N>/...)`
+  image → nothing after it,
 - leave `## TLDR:` and `## Next steps:` as the literal `*(Thomas fills in)*`
   placeholders,
 - keep the `# Experiment: <question>` H1 with NO confidence tag (Thomas appends
@@ -418,9 +433,16 @@ report-template.md § "The interpretivity rule"); and (e) runs the mechanical
 gate:
 
 ```bash
-uv run python scripts/verify_report.py --issue <N> --mode generation \
+# the report exists only as the 7c draft file until 7f's set-body — verify the DRAFT:
+uv run python scripts/verify_report.py --file <report-draft>.md --mode generation \
+  --expect-issue <N> --figures-root <worktree-root> \
   --manifest <path>/planned_manifest.json
 ```
+
+(`<report-draft>.md` = the file 7c assembles and 7f's `set-body --file` consumes —
+same path both places; e.g. the task's `artifacts/report-draft.md` or a
+worktree-local draft. The promote-mode invocation `--issue <N> --mode promote`
+is unchanged — `body.md` IS the report by then.)
 
 Generation mode REQUIRES the TLDR + Next-steps placeholders intact and runs the
 interpretivity / lexicon checks on the AGENT-written sections only. On findings,
@@ -428,14 +450,14 @@ re-run the plotter / methodology-writer / assembly as needed and re-verify. Post
 `epm:report-verified` on PASS. Round cap 5; at the cap with a substantive
 residual, interactive → surface, autonomous → `epm:failure` + block.
 
-**7f. Commit + park.** After `verify_report.py --mode generation` PASSes, commit
-the held plotter figures, then write the report body and park:
+**7f. Write body + park.** After `verify_report.py --mode generation` PASSes
+(figures were committed + pinned at Step 7b), write the report body and park:
 
 ```bash
 # --allow-goal-drop is DELIBERATE: the report-v1 skeleton carries `## Motivation:`,
 # not `## Goal` (the `goal:` frontmatter is preserved by set_body), so the Goal-H2
 # drop guard (#1112) must be explicitly overridden here.
-uv run python scripts/task.py set-body <N> --file <report>.md --snapshot --allow-goal-drop
+uv run python scripts/task.py set-body <N> --file <report-draft>.md --snapshot --allow-goal-drop
 uv run python scripts/task.py set-title <N> "Experiment: <one-line question>"   # NO confidence tag — Thomas adds it at promote
 uv run python scripts/task.py set-clean-result <N>                              # accepts the report-v1 sentinel
 uv run python scripts/task.py post-marker <N> epm:report --note "report-v1 generated + verified; awaiting Thomas TLDR"

--- a/scripts/verify_report.py
+++ b/scripts/verify_report.py
@@ -23,6 +23,23 @@ Required structure (both modes):
     ``--figures-root``; default: the git-repo root of ``--file``).
   - Every ``htmlpreview.github.io`` link embeds a full 40-hex SHA
     ``raw.githubusercontent`` URL (well-formedness only, no network).
+  - ``image-pin-format``: every ``## Results:`` image is a well-formed
+    ``https://raw.githubusercontent.com/<owner>/<repo>/<40-hex-sha>/figures/issue_<N>/...``
+    pin, all Results images name ONE issue number (== ``--expect-issue`` /
+    ``--issue`` when known). Images outside Results are exempt from the pin
+    requirement and the issue-number match, but a raw.githubusercontent image
+    there still gets format well-formedness + the identity ladder.
+  - ``image-pin-blob-identity``: each well-formed pin is verified against the
+    LOCAL git object DB — ``git hash-object <local>`` vs
+    ``git rev-parse <sha>:<path>`` — read-only local git, NO network. The
+    degrade ladder is mode-split: non-git checkout → WARN (both modes);
+    unresolvable pinned commit → FAIL in generation (the pin commit was just
+    created locally; unresolvable = fabricated SHA) / WARN in promote
+    (unfetched clone plausible); commit present but path absent → FAIL (both);
+    blob mismatch → FAIL in generation / WARN in promote (post-merge local
+    drift — the pin is the record, #922); pin resolves with no local copy →
+    WARN in generation / PASS-note in promote. Mixed SHAs across Results pins
+    are fine per-pin (the 7b re-entry / partial-re-splice shape).
 
 Mode-specific:
   - ``generation``: TLDR AND Next steps content MUST be exactly the placeholder
@@ -59,6 +76,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -104,6 +122,23 @@ _IMAGE_RE = re.compile(r"!\[[^\]]*\]\(([^)]+)\)")
 # A URL token (used to find htmlpreview links).
 _URL_RE = re.compile(r"https?://[^\s)\]<>\"']+")
 _SHA40_RE = re.compile(r"[0-9a-fA-F]{40}")
+# A SHA-pinned raw.githubusercontent permalink: owner / repo / 40-hex sha / path.
+_RAW_PIN_RE = re.compile(
+    r"^https://raw\.githubusercontent\.com/([^/]+)/([^/]+)/([0-9a-fA-F]{40})/(.+)$"
+)
+# The repo-relative figure path a Results pin must carry.
+_FIGURES_ISSUE_RE = re.compile(r"^figures/issue_(\d+)/")
+
+
+def _git(repo: Path, *args: str) -> tuple[int, str]:
+    """Run a READ-ONLY git command in ``repo``; return (returncode, stripped stdout).
+
+    Used by the image-pin blob-identity check — local object-DB lookups only
+    (``rev-parse`` / ``cat-file`` / ``hash-object``), never a network call.
+    """
+    proc = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
+    return proc.returncode, proc.stdout.strip()
+
 
 _SCHEMA_PATH = (
     Path(__file__).resolve().parent.parent
@@ -403,6 +438,160 @@ def check_htmlpreview(body: str) -> CheckResult:
     return CheckResult("htmlpreview-sha", True, f"{len(urls)} htmlpreview link(s) SHA-pinned")
 
 
+# ─── Image-pin checks (#1224 mechanization; both modes, no network) ─────────
+
+
+def _check_pin_blob_identity(
+    pins: list[tuple[str, str, str]], *, mode: str, figures_root: Path
+) -> CheckResult:
+    """Verify each well-formed ``(url, sha, path)`` pin against the LOCAL git
+    object DB (read-only ``_git`` calls, never a network fetch).
+
+    Mode-split degrade ladder (see the module docstring): generation is strict
+    (the pipeline path where the pin commit + local copies exist by
+    construction at 7e), promote is lenient (fresh-clone / post-merge shapes).
+    Returns ONE CheckResult: FAIL if any pin fails, else WARN if any pin
+    warned, else PASS.
+    """
+    name = "image-pin-blob-identity"
+    if not pins:
+        return CheckResult(name, True, "no well-formed pins to verify (N/A)")
+    rc, _ = _git(figures_root, "rev-parse", "--git-dir")
+    if rc != 0:
+        return CheckResult(
+            name,
+            True,
+            f"{figures_root} is not a git checkout; blob identity unverifiable",
+            is_warn=True,
+        )
+    fails: list[str] = []
+    warns: list[str] = []
+    notes: list[str] = []
+    for _url, sha, path in pins:
+        rc, _ = _git(figures_root, "cat-file", "-e", f"{sha}^{{commit}}")
+        if rc != 0:
+            # At 7e the pin commit was JUST created in this worktree / shared
+            # object DB, so an unresolvable SHA is definitively wrong (the
+            # fabricated-SHA class); post-merge an unfetched clone is plausible.
+            msg = f"pinned commit {sha[:12]} unresolvable in the local object DB ({path})"
+            if mode == "generation":
+                fails.append(msg)
+            else:
+                warns.append(msg + "; unfetched clone possible post-merge, identity unverifiable")
+            continue
+        rc, blob_id = _git(figures_root, "rev-parse", f"{sha}:{path}")
+        if rc != 0:
+            fails.append(f"pinned commit {sha[:12]} does not contain {path}")
+            continue
+        local = figures_root / path
+        if not local.is_file():
+            # At 7e every Results figure should have a just-plotted local copy;
+            # its absence is suspicious (e.g. a wrong-path pin colliding with a
+            # previously-committed figure name). Post-merge it is expected.
+            msg = f"{path}@{sha[:12]} resolves in object DB; no local copy to compare"
+            if mode == "generation":
+                warns.append(msg)
+            else:
+                notes.append(msg)
+            continue
+        rc, local_id = _git(figures_root, "hash-object", str(local))
+        if rc != 0 or not local_id:
+            warns.append(f"git hash-object failed on local copy {path}; identity unverifiable")
+            continue
+        if local_id != blob_id:
+            msg = f"local {path} differs from the blob pinned at {sha[:12]}"
+            if mode == "generation":
+                fails.append(msg)
+            else:
+                warns.append(msg + " (post-merge local drift; the pin is the record)")
+        else:
+            notes.append(f"{path}@{sha[:12]} matches local copy")
+    if fails:
+        detail = "; ".join(fails)
+        if warns:
+            detail += "; warn: " + "; ".join(warns)
+        return CheckResult(name, False, detail)
+    if warns:
+        return CheckResult(name, True, "; ".join(warns), is_warn=True)
+    return CheckResult(name, True, "; ".join(notes) or f"{len(pins)} pin(s) verified")
+
+
+def check_image_pins(
+    sections: list[Section],
+    blanked_body: str,
+    *,
+    mode: str,
+    figures_root: Path,
+    expect_issue: int | None = None,
+) -> list[CheckResult]:
+    """``image-pin-format`` + ``image-pin-blob-identity`` (#1224).
+
+    Runs on the BLANKED body (fenced/blockquote example images are DATA and
+    exempt — the same discipline as ``check_image_files``). Every image inside
+    ``## Results:`` must be a well-formed
+    ``raw.githubusercontent.com/<owner>/<repo>/<40-hex>/figures/issue_<N>/...``
+    pin; all Results-image issue numbers must be identical (and equal to
+    ``expect_issue`` when provided). Images OUTSIDE Results are exempt from the
+    pin requirement and the issue-number match (a legitimate non-blockquoted
+    cross-issue prior-figure reference in Motivation must not FAIL); when they
+    ARE raw.githubusercontent URLs they still get format well-formedness + the
+    identity ladder. Mixed SHAs across pins are fine per-pin.
+    """
+    results_sec = section_map(sections).get("## Results:")
+    results_imgs = _images_in(results_sec.content) if results_sec is not None else []
+    outside_imgs = list(_images_in(blanked_body))
+    for u in results_imgs:
+        if u in outside_imgs:
+            outside_imgs.remove(u)
+
+    format_problems: list[str] = []
+    pins: list[tuple[str, str, str]] = []  # (url, sha, repo-relative path)
+    results_issue_nums: set[str] = set()
+
+    for url in results_imgs:
+        m = _RAW_PIN_RE.match(url)
+        fig_m = _FIGURES_ISSUE_RE.match(m.group(4)) if m else None
+        if m is None or fig_m is None:
+            format_problems.append(
+                f"Results image '{url}' is not a well-formed "
+                "raw.githubusercontent.com/<owner>/<repo>/<40-hex-sha>/figures/issue_<N>/... pin"
+            )
+            continue
+        pins.append((url, m.group(3), m.group(4)))
+        results_issue_nums.add(fig_m.group(1))
+
+    if len(results_issue_nums) > 1:
+        format_problems.append(
+            "Results pins name multiple issue numbers: " + ", ".join(sorted(results_issue_nums))
+        )
+    if expect_issue is not None and results_issue_nums - {str(expect_issue)}:
+        format_problems.append(
+            f"Results pin issue number(s) {sorted(results_issue_nums)} "
+            f"!= expected issue {expect_issue}"
+        )
+
+    for url in outside_imgs:
+        if "raw.githubusercontent.com" not in url:
+            continue
+        m = _RAW_PIN_RE.match(url)
+        if m is None:
+            format_problems.append(
+                f"non-Results raw.githubusercontent image '{url}' is not a "
+                "well-formed 40-hex-SHA pin"
+            )
+            continue
+        pins.append((url, m.group(3), m.group(4)))
+
+    if format_problems:
+        fmt = CheckResult("image-pin-format", False, "; ".join(format_problems))
+    elif pins:
+        fmt = CheckResult("image-pin-format", True, f"{len(pins)} pinned image(s) well-formed")
+    else:
+        fmt = CheckResult("image-pin-format", True, "no pinned images (N/A)")
+
+    return [fmt, _check_pin_blob_identity(pins, mode=mode, figures_root=figures_root)]
+
+
 # ─── Interpretive-lexicon check (agent sections; both modes) ────────────────
 
 
@@ -567,6 +756,7 @@ def verify_report_text(
     mode: str,
     figures_root: Path,
     manifest_path: Path | None = None,
+    expect_issue: int | None = None,
 ) -> tuple[bool, list[CheckResult]]:
     """Run all checks for ``mode``; return (overall_pass, results)."""
     if mode not in ("generation", "promote"):
@@ -588,6 +778,11 @@ def verify_report_text(
     results.append(check_results_subsections(sections))
     results.append(check_image_files(blanked_body, figures_root))
     results.append(check_htmlpreview(body))
+    results.extend(
+        check_image_pins(
+            sections, blanked_body, mode=mode, figures_root=figures_root, expect_issue=expect_issue
+        )
+    )
     results.append(check_lexicon(sections))
 
     if mode == "generation":
@@ -631,7 +826,20 @@ def main(argv: list[str] | None = None) -> int:
         "--figures-root",
         help="root for resolving local image paths (default: the git-repo root of the body)",
     )
+    parser.add_argument(
+        "--expect-issue",
+        type=int,
+        help=(
+            "issue number the ## Results: image pins must name (figures/issue_<N>/). "
+            "Only meaningful with --file; with --issue the number is already known."
+        ),
+    )
     args = parser.parse_args(argv)
+
+    if args.issue is not None and args.expect_issue is not None:
+        parser.error(
+            "--issue and --expect-issue are mutually exclusive: --issue already names the issue"
+        )
 
     if args.issue is not None:
         # Resolve via the workflow library — NEVER hand-build tasks/<status>/<N>
@@ -668,8 +876,13 @@ def main(argv: list[str] | None = None) -> int:
             print(f"verify_report: --manifest not found: {args.manifest}", file=sys.stderr)
             return 2
 
+    expect = args.issue if args.issue is not None else args.expect_issue
     overall, results = verify_report_text(
-        raw, mode=args.mode, figures_root=figures_root, manifest_path=manifest_path
+        raw,
+        mode=args.mode,
+        figures_root=figures_root,
+        manifest_path=manifest_path,
+        expect_issue=expect,
     )
     print(f"verify_report — {file_path} (mode={args.mode})")
     for r in results:

--- a/tests/test_issue_v2_skill_figure_pin_contract.py
+++ b/tests/test_issue_v2_skill_figure_pin_contract.py
@@ -1,0 +1,99 @@
+"""Durability pins for the #1224 figure-commit ordering contract (Option A).
+
+The v2 report pipeline commits the HELD plotter figures ONCE at issue-v2
+SKILL.md Step 7b (after upload-verification PASS, BEFORE assembly at 7c), so
+7c splices real SHA-pinned image URLs and 7f only writes the body + parks.
+These shape asserts pin that single ordering across the four prose surfaces
+(SKILL.md / plotter.md / report-verifier.md / the paper-mode critics) so a
+future prose edit cannot silently reintroduce the 7c-vs-7f contradiction or
+the plotter's retired "rewrite the URLs after commit" third variant.
+
+Paths resolve via git from this file's directory (worktree-safe, cwd-free).
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    """The repo/worktree root of THIS checkout, resolved via git (never cwd)."""
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=Path(__file__).resolve().parent,
+    )
+    return Path(out.stdout.strip())
+
+
+def _norm(text: str) -> str:
+    """Collapse whitespace so line-wrapped prose matches single-space needles."""
+    return " ".join(text.split()).lower()
+
+
+def _read(rel: str) -> str:
+    return (_repo_root() / rel).read_text()
+
+
+def _step_block(skill_norm: str, step: str, next_step: str) -> str:
+    """The normalized text between ``**<step>.`` and ``**<next_step>.``."""
+    m = re.search(
+        re.escape(f"**{step}.") + r"(.*?)" + re.escape(f"**{next_step}."),
+        skill_norm,
+        re.DOTALL,
+    )
+    assert m, f"could not locate the {step}..{next_step} block in issue-v2 SKILL.md"
+    return m.group(1)
+
+
+def test_figure_commit_lives_at_7b_not_7f():
+    skill = _norm(_read(".claude/skills/issue-v2/SKILL.md"))
+    block_7b = _step_block(skill, "7b", "7c")
+    block_7f = skill.split("**7f.", 1)[1]
+
+    # 7b owns the figure commit: held figures committed BEFORE assembly, one SHA.
+    assert "commit held figures" in skill.split("**7b.", 1)[1][:80]
+    assert "commit the held plotter figures" in block_7b
+    assert "before assembly" in block_7b
+    assert "git add figures/issue_<n>/" in block_7b
+    # 7f no longer commits figures — it only writes the body and parks.
+    assert "write body + park" in block_7f[:40]
+    assert "commit the held" not in block_7f
+    assert "figures were committed + pinned at step 7b" in block_7f
+
+
+def test_plotter_and_report_verifier_agree_on_7b():
+    plotter = _norm(_read(".claude/agents/plotter.md"))
+    verifier = _norm(_read(".claude/agents/report-verifier.md"))
+
+    # plotter.md: the retired "rewrite the report's image URLs" third variant
+    # is gone; the orchestrator commits at Step 7b and splices pins at 7c.
+    assert "rewrites the report" not in plotter
+    assert "commits the held figures at step 7b" in plotter
+    assert "step-7b commit + the 7c pin splice" in plotter
+
+    # report-verifier.md: the "around report assembly — Steps 7c/7f" hedge is
+    # gone; item 2 states the 7b ordering, and check (e) verifies the DRAFT.
+    assert "around report assembly" not in verifier
+    assert "commits the held figures at skill step 7b" in verifier
+    assert "--file <report-draft>.md --mode generation" in verifier
+    assert "--expect-issue <n>" in verifier
+
+
+def test_codex_paper_branch_carries_figure_read_target_rule():
+    needle = (
+        "the compiled pdf is the built artifact of record — on a working-tree-png "
+        "vs pdf-page disagreement, review against the pdf page, note the possible "
+        "stale working-tree stray, and never rest a blocker on the png alone"
+    )
+    codex = _norm(_read(".claude/agents/codex-clean-result-critic.md"))
+    assert needle in codex, "codex paper branch lost the figure read-target rule"
+    # The Claude-side paper path reads .claude/rules/clean-result-paper-review.md
+    # IN FULL (clean-result-critic.md's paper branch delegates there), so the
+    # same sentence must live in the rule file's read-target list.
+    rule = _norm(_read(".claude/rules/clean-result-paper-review.md"))
+    assert needle in rule, "clean-result-paper-review.md lost the figure read-target rule"

--- a/tests/test_verify_report.py
+++ b/tests/test_verify_report.py
@@ -28,11 +28,22 @@ _spec.loader.exec_module(verify_report)  # type: ignore[union-attr]
 
 PLACEHOLDER = verify_report.PLACEHOLDER
 
+# The default Results image is a WELL-FORMED SHA pin (#1224 Option A: figures
+# commit at Step 7b, before assembly, so a valid report always pins). The SHA
+# is synthetic — in a non-git tmp figures-root the blob-identity check degrades
+# to WARN (which counts as PASS overall).
+_PIN_SHA = "a" * 40
+_PINNED_IMAGE = f"https://raw.githubusercontent.com/o/r/{_PIN_SHA}/figures/issue_5/f.png"
+
+
+def _pin(sha: str, path: str = "figures/issue_5/f.png") -> str:
+    return f"https://raw.githubusercontent.com/o/r/{sha}/{path}"
+
 
 # ─── Body builders ──────────────────────────────────────────────────────────
 
 
-def _default_sections(*, image: str = "figures/f.png") -> list[tuple[str, str]]:
+def _default_sections(*, image: str = _PINNED_IMAGE) -> list[tuple[str, str]]:
     """The six required sections, in order, with a valid Results subsection."""
     return [
         ("## TLDR:", PLACEHOLDER),
@@ -66,6 +77,14 @@ def _assemble(
     return "\n".join(lines) + "\n"
 
 
+def _promote_sections(**kw) -> list[tuple[str, str]]:
+    """Default sections with TLDR + Next steps filled (valid at promote time)."""
+    sections = _default_sections(**kw)
+    sections[0] = ("## TLDR:", "Thomas takeaway: the effect held.")
+    sections[-1] = ("## Next steps:", "Run more seeds.")
+    return sections
+
+
 @pytest.fixture
 def figs_root(tmp_path: Path) -> Path:
     """A figures-root with the default image present on disk."""
@@ -74,13 +93,45 @@ def figs_root(tmp_path: Path) -> Path:
     return tmp_path
 
 
+def _git_run(repo: Path, *args: str) -> str:
+    r = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True, check=True)
+    return r.stdout.strip()
+
+
+@pytest.fixture
+def git_figs_repo(tmp_path: Path) -> tuple[Path, str]:
+    """A REAL git repo with figures/issue_5/f.png committed; returns (root, head_sha)."""
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True, capture_output=True)
+    _git_run(tmp_path, "config", "user.email", "test@test.test")
+    _git_run(tmp_path, "config", "user.name", "Test")
+    _git_run(tmp_path, "config", "commit.gpgsign", "false")
+    figs = tmp_path / "figures" / "issue_5"
+    figs.mkdir(parents=True)
+    (figs / "f.png").write_bytes(b"\x89PNG\r\n\x1a\nreal-figure-bytes")
+    _git_run(tmp_path, "add", "figures/issue_5/f.png")
+    _git_run(tmp_path, "commit", "-q", "-m", "add figure")
+    head = _git_run(tmp_path, "rev-parse", "HEAD")
+    return tmp_path, head
+
+
 def _by_name(results, name):
     return next(r for r in results if r.name == name)
 
 
-def _run(body: str, *, mode: str, figs_root: Path, manifest_path: Path | None = None):
+def _run(
+    body: str,
+    *,
+    mode: str,
+    figs_root: Path,
+    manifest_path: Path | None = None,
+    expect_issue: int | None = None,
+):
     return verify_report.verify_report_text(
-        body, mode=mode, figures_root=figs_root, manifest_path=manifest_path
+        body,
+        mode=mode,
+        figures_root=figs_root,
+        manifest_path=manifest_path,
+        expect_issue=expect_issue,
     )
 
 
@@ -168,7 +219,7 @@ def test_banned_lexeme_in_results_fails(figs_root):
     sections = _default_sections()
     sections[4] = (
         "## Results:",
-        "### rate\nThis suggests the treatment worked.\n![rate](figures/f.png)",
+        f"### rate\nThis suggests the treatment worked.\n![rate]({_PINNED_IMAGE})",
     )
     ok, results = _run(_assemble(sections), mode="generation", figs_root=figs_root)
     assert not ok
@@ -470,7 +521,9 @@ def test_issue_resolves_body_via_library(issue_repo):
     repo = issue_repo
     task_dir = repo / "tasks" / "proposed" / "777"
     task_dir.mkdir(parents=True)
-    (task_dir / "body.md").write_text(_assemble(_default_sections()))
+    # --issue 777 implies expect_issue=777, so the Results pin must name issue_777.
+    body = _assemble(_default_sections(image=_pin(_PIN_SHA, "figures/issue_777/f.png")))
+    (task_dir / "body.md").write_text(body)
     # figures-root defaults to the git-repo root of the resolved body.md.
     (repo / "figures").mkdir()
     (repo / "figures" / "f.png").write_bytes(b"\x89PNG\r\n")
@@ -562,3 +615,224 @@ def test_manifest_condition_substring_not_covered(figs_root, tmp_path):
     assert not ok
     cond = _by_name(results, "manifest-conditions")
     assert not cond.passed and "leak" in cond.detail
+
+
+# ─── image-pin-format (#1224 mechanization) ───────────────────────────────
+
+
+def test_pinned_image_wellformed_passes(figs_root):
+    ok, results = _run(_assemble(_default_sections()), mode="generation", figs_root=figs_root)
+    fmt = _by_name(results, "image-pin-format")
+    ident = _by_name(results, "image-pin-blob-identity")
+    assert fmt.passed and not fmt.is_warn
+    assert ident.passed and ident.is_warn  # non-git tmp figures-root → WARN (counts as PASS)
+    assert ok, [r.render() for r in results if not r.passed]
+
+
+def test_unpinned_relative_results_image_fails(figs_root):
+    # A relative-path Results image violates the pin contract in BOTH modes.
+    for mode, builder in (("generation", _default_sections), ("promote", _promote_sections)):
+        ok, results = _run(
+            _assemble(builder(image="figures/f.png")), mode=mode, figs_root=figs_root
+        )
+        assert not ok
+        assert not _by_name(results, "image-pin-format").passed
+
+
+def test_main_ref_image_fails(figs_root):
+    sections = _default_sections(
+        image="https://raw.githubusercontent.com/o/r/main/figures/issue_5/f.png"
+    )
+    ok, results = _run(_assemble(sections), mode="generation", figs_root=figs_root)
+    assert not ok
+    assert not _by_name(results, "image-pin-format").passed
+
+
+def test_non_figures_path_pin_fails(figs_root):
+    sections = _default_sections(image=_pin(_PIN_SHA, "docs/x.png"))
+    ok, results = _run(_assemble(sections), mode="generation", figs_root=figs_root)
+    assert not ok
+    assert not _by_name(results, "image-pin-format").passed
+
+
+def test_expect_issue_mismatch_fails(figs_root):
+    sections = _default_sections(image=_pin(_PIN_SHA, "figures/issue_7/f.png"))
+    ok, results = _run(_assemble(sections), mode="generation", figs_root=figs_root, expect_issue=5)
+    assert not ok
+    fmt = _by_name(results, "image-pin-format")
+    assert not fmt.passed and "expected issue 5" in fmt.detail
+
+
+def test_outside_results_raw_image_exempt_from_issue_match(figs_root):
+    # A well-formed CROSS-ISSUE pin outside Results with expect_issue=5:
+    # the issue-number match is Results-scoped → NO format FAIL.
+    sections = _default_sections()
+    sections[2] = (
+        "## Methodology:",
+        "We trained under two conditions. Prior figure: "
+        f"![prior]({_pin('c' * 40, 'figures/issue_9/x.png')})",
+    )
+    ok, results = _run(_assemble(sections), mode="generation", figs_root=figs_root, expect_issue=5)
+    assert _by_name(results, "image-pin-format").passed
+    assert ok, [r.render() for r in results if not r.passed]
+    # A MALFORMED raw URL outside Results (short SHA) still fails well-formedness.
+    sections[2] = (
+        "## Methodology:",
+        "Prior figure: "
+        "![prior](https://raw.githubusercontent.com/o/r/abc123/figures/issue_9/x.png)",
+    )
+    ok, results = _run(_assemble(sections), mode="generation", figs_root=figs_root, expect_issue=5)
+    assert not ok
+    assert not _by_name(results, "image-pin-format").passed
+
+
+# ─── image-pin-blob-identity (#1224 mechanization) ────────────────────────
+
+
+def test_pin_blob_identity_match_passes(git_figs_repo):
+    repo, head = git_figs_repo
+    ok, results = _run(
+        _assemble(_default_sections(image=_pin(head))), mode="generation", figs_root=repo
+    )
+    ident = _by_name(results, "image-pin-blob-identity")
+    assert ident.passed and not ident.is_warn
+    assert ok, [r.render() for r in results if not r.passed]
+
+
+def test_pin_blob_identity_mismatch_fails_generation(git_figs_repo):
+    # At 7e the worktree copy IS the just-plotted figure; a pin whose blob
+    # differs is the exact wrong-SHA bug class → generation FAIL.
+    repo, head = git_figs_repo
+    (repo / "figures" / "issue_5" / "f.png").write_bytes(b"\x89PNG modified-after-commit")
+    ok, results = _run(
+        _assemble(_default_sections(image=_pin(head))), mode="generation", figs_root=repo
+    )
+    assert not ok
+    ident = _by_name(results, "image-pin-blob-identity")
+    assert not ident.passed and "differs" in ident.detail
+
+
+def test_pin_blob_identity_mismatch_warns_promote(git_figs_repo):
+    # Post-merge local drift is a stray; the pin is the record (#922) → WARN.
+    repo, head = git_figs_repo
+    (repo / "figures" / "issue_5" / "f.png").write_bytes(b"\x89PNG modified-after-commit")
+    ok, results = _run(
+        _assemble(_promote_sections(image=_pin(head))), mode="promote", figs_root=repo
+    )
+    ident = _by_name(results, "image-pin-blob-identity")
+    assert ident.passed and ident.is_warn
+    assert ok, [r.render() for r in results if not r.passed]
+
+
+def test_pin_commit_lacks_path_fails(git_figs_repo):
+    # Commit resolves but does not contain the pinned path → a wrong pin,
+    # definitively — FAIL in BOTH modes.
+    repo, head = git_figs_repo
+    ghost = _pin(head, "figures/issue_5/ghost.png")
+    ok, results = _run(_assemble(_default_sections(image=ghost)), mode="generation", figs_root=repo)
+    assert not ok
+    ident = _by_name(results, "image-pin-blob-identity")
+    assert not ident.passed and "does not contain" in ident.detail
+    ok_p, results_p = _run(
+        _assemble(_promote_sections(image=ghost)), mode="promote", figs_root=repo
+    )
+    assert not ok_p
+    assert not _by_name(results_p, "image-pin-blob-identity").passed
+
+
+def test_pin_unresolvable_sha_fails_generation_warns_promote(git_figs_repo):
+    # At 7e the pin commit was JUST created locally, so an unresolvable SHA is
+    # the fabricated/hallucinated-SHA class → generation FAIL; at promote an
+    # unfetched clone is plausible → WARN.
+    repo, _head = git_figs_repo
+    ok, results = _run(
+        _assemble(_default_sections(image=_pin("b" * 40))), mode="generation", figs_root=repo
+    )
+    assert not ok
+    ident = _by_name(results, "image-pin-blob-identity")
+    assert not ident.passed and "unresolvable" in ident.detail
+    ok_p, results_p = _run(
+        _assemble(_promote_sections(image=_pin("b" * 40))), mode="promote", figs_root=repo
+    )
+    ident_p = _by_name(results_p, "image-pin-blob-identity")
+    assert ident_p.passed and ident_p.is_warn
+    assert ok_p, [r.render() for r in results_p if not r.passed]
+
+
+def test_non_git_checkout_degrades_to_warn(figs_root):
+    ok, results = _run(_assemble(_default_sections()), mode="generation", figs_root=figs_root)
+    ident = _by_name(results, "image-pin-blob-identity")
+    assert ident.passed and ident.is_warn and "not a git checkout" in ident.detail
+    assert ok, [r.render() for r in results if not r.passed]
+
+
+def test_mixed_sha_results_pins_both_valid_pass(git_figs_repo):
+    # Two Results pins at DIFFERENT real SHAs (the 7b re-entry /
+    # partial-re-splice shape): each pin verifies independently; only the
+    # issue NUMBER must be identical across Results images, never the SHA.
+    repo, sha1 = git_figs_repo
+    (repo / "figures" / "issue_5" / "g.png").write_bytes(b"\x89PNG second-figure-bytes")
+    _git_run(repo, "add", "figures/issue_5/g.png")
+    _git_run(repo, "commit", "-q", "-m", "add second figure")
+    sha2 = _git_run(repo, "rev-parse", "HEAD")
+    assert sha1 != sha2
+    sections = _default_sections()
+    sections[4] = (
+        "## Results:",
+        "### rate by condition\n"
+        "Bar chart of the agreement rate per condition.\n"
+        f"![rate]({_pin(sha1)})\n"
+        "### rate per unit\n"
+        "Per-unit points behind the aggregate.\n"
+        f"![points]({_pin(sha2, 'figures/issue_5/g.png')})",
+    )
+    ok, results = _run(_assemble(sections), mode="generation", figs_root=repo)
+    assert _by_name(results, "image-pin-format").passed
+    ident = _by_name(results, "image-pin-blob-identity")
+    assert ident.passed and not ident.is_warn
+    assert ok, [r.render() for r in results if not r.passed]
+
+
+def test_pin_resolves_no_local_copy_warns_generation(git_figs_repo):
+    # Pin resolves in the object DB but the local copy is gone: at 7e every
+    # Results figure should have a just-plotted local copy → generation WARN;
+    # post-merge that is expected → promote PASS-note.
+    repo, head = git_figs_repo
+    (repo / "figures" / "issue_5" / "f.png").unlink()
+    ok, results = _run(
+        _assemble(_default_sections(image=_pin(head))), mode="generation", figs_root=repo
+    )
+    ident = _by_name(results, "image-pin-blob-identity")
+    assert ident.passed and ident.is_warn and "no local copy" in ident.detail
+    assert ok, [r.render() for r in results if not r.passed]
+    ok_p, results_p = _run(
+        _assemble(_promote_sections(image=_pin(head))), mode="promote", figs_root=repo
+    )
+    ident_p = _by_name(results_p, "image-pin-blob-identity")
+    assert ident_p.passed and not ident_p.is_warn and "no local copy" in ident_p.detail
+    assert ok_p, [r.render() for r in results_p if not r.passed]
+
+
+def test_cli_expect_issue_flag(figs_root, tmp_path):
+    good = tmp_path / "good.md"
+    good.write_text(_assemble(_default_sections()))
+    base = [
+        sys.executable,
+        str(_SCRIPT),
+        "--file",
+        str(good),
+        "--mode",
+        "generation",
+        "--figures-root",
+        str(figs_root),
+    ]
+    r_ok = subprocess.run([*base, "--expect-issue", "5"], capture_output=True, text=True)
+    assert r_ok.returncode == 0, r_ok.stdout + r_ok.stderr
+    r_mismatch = subprocess.run([*base, "--expect-issue", "7"], capture_output=True, text=True)
+    assert r_mismatch.returncode == 1, r_mismatch.stdout + r_mismatch.stderr
+    assert "image-pin-format" in r_mismatch.stdout
+    # --issue + --expect-issue together is an argparse usage error (exit 2):
+    # silently ignoring one of them would be a footgun.
+    with pytest.raises(SystemExit) as exc:
+        verify_report.main(["--issue", "1", "--expect-issue", "5", "--mode", "generation"])
+    assert exc.value.code == 2


### PR DESCRIPTION
Closes task #1224. Option A (commit-then-assemble at 7b) + verify_report.py image-pin-format/blob-identity checks + paper-mode figure read-target rule. Plan: tasks/running/1224/plans/plan.md (v3).