### PR TITLE
issue-1247: terminal-status act guard + source stamp + watcher test hermeticity

### DIFF
--- a/.claude/rules/background-automation.md
+++ b/.claude/rules/background-automation.md
@@ -350,6 +350,28 @@ safe defaults. While a fence episode is pending, the #759 K corroboration is
 skipped (its debounce already served — re-downgrading the verify ticks would
 stall the fence).
 
+**Terminal-status act guard + source stamp (#1247).** The orphan sweep and
+the stalled fence's spawn branch act only after a same-instant live-status
+re-read (`_task_status`, canonical `PROJECT_ROOT` resolver, #844) POSITIVELY
+returns an ACTIVE status — a stale pass-start snapshot can never produce a
+respawn, a marker, or a cap-consume on a terminal/parked task (2-week
+#662/#663/#867 marker loop, ~1,800 junk commits; the loop's root cause was
+the test suite's own unstubbed `_post_progress_marker`, fixed alongside, but
+the guard closes the whole stale-snapshot/TOCTOU class). Abort is loud
+(`ORPHAN-ACT-GUARD` / `STALLED-ACT-GUARD` stderr line naming snapshot vs
+live status + the aborted action); a `None` read (transient task.py failure)
+defers one tick without erasing episode state; a positive non-ACTIVE read
+clears the episode state (orphan) / the fence's `stop_pending_*` fields
+(stalled). Residual ms-scale TOCTOU between the guard read and the act is
+irreducible without locking — the guard shrinks the window from
+minutes/multi-tick to ~ms. Every orphan-respawn / orphan-alert /
+stalled-respawn marker note additionally carries a
+`[src: host=… user=… pid=… sha=… root=…]` stamp (`_source_stamp()`,
+running-checkout-derived by design — it exposes a stale worktree/clone copy)
+so any future stale-instance poster identifies itself on its first marker.
+Pinned by `tests/test_autonomous_session_watch.py::test_orphan_act_guard_*`
++ `test_stalled_fence_spawn_guard_*`.
+
 **Infra-drain pass (execute the PM dispatch queue; task #633).** The PM
 session's standing infra auto-dispatch rule (`research-pm.md` § Standing
 rule, item 4b) adjudicates which `proposed` `kind: infra|batch` tasks are

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -458,11 +458,14 @@ from __future__ import annotations
 
 import argparse
 import fcntl
+import functools
+import getpass
 import json
 import os
 import re
 import shlex
 import shutil
+import socket
 import subprocess
 import sys
 import threading
@@ -886,6 +889,41 @@ _ORPHAN_RESPAWN_NOTE_SENTINEL = "[autonomous_session_watch:orphan-respawn]"
 # failed, or the task's only registration is MANUAL (user-driven sessions are
 # never auto-respawned, #505). Same staleness-filter contract as the others.
 _ORPHAN_ALERT_NOTE_SENTINEL = "[autonomous_session_watch:orphan-alert]"
+
+
+@functools.lru_cache(maxsize=1)
+def _source_stamp() -> str:
+    """Self-identification suffix for respawn-class marker notes (#1247):
+    host + user + pid + short HEAD sha + root of the RUNNING checkout.
+
+    Deliberately ``Path(__file__)``-derived, NOT the git-common-dir-resolved
+    ``PROJECT_ROOT`` (#844) — the whole point is to expose a stale
+    worktree/clone copy of this script posting from old code (the two-week
+    #662/#663/#867 junk-marker loop had no per-marker process identity, so
+    the poster took days of forensics to attribute). ``root=`` is the primary
+    discriminator (durable after the process dies); ``pid=`` enables live
+    ``/proc`` inspection; ``sha=`` dates the build generation. Fail-soft:
+    ``sha=unknown`` on any git failure; never raises. ``lru_cache``:
+    host/user/pid/sha/root are process-constants, computed once."""
+    script_root = Path(__file__).resolve().parent.parent
+    try:
+        sha = (
+            subprocess.run(
+                ["git", "rev-parse", "--short", "HEAD"],
+                cwd=script_root,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            ).stdout.strip()
+            or "unknown"
+        )
+    except (subprocess.SubprocessError, OSError):
+        sha = "unknown"
+    return (
+        f"[src: host={socket.gethostname()} user={getpass.getuser()} "
+        f"pid={os.getpid()} sha={sha} root={script_root}]"
+    )
+
 
 # Substring stamped into the one-time alert the stalled / orphan-respawn passes
 # post when they would have respawned a ``followups_running`` parent whose own
@@ -9669,6 +9707,26 @@ def _fence_spawn_stalled(ctx: _StalledActionCtx, sid: str) -> None:
     """Verified-dead spawn branch of the stop-verify fence (the pre-#845
     respawn body): the pending sid is confirmed absent from the daemon's
     live set, so a fresh ``--auto`` session cannot race the superseded one."""
+    # #1247 terminal-status act guard (stalled-arm symmetry): the fence
+    # stop→verify→spawn spans ticks, so ctx.task_status is ≥10 min old
+    # here by construction. Same positive-ACTIVE confirmation as the
+    # orphan pass.
+    live_status = _task_status(ctx.issue)
+    if live_status not in ACTIVE:
+        print(
+            f"  STALLED-ACT-GUARD issue #{ctx.issue}: fence spawn aborted — "
+            f"live status re-read returned {live_status!r} (not ACTIVE; "
+            f"snapshot was {ctx.task_status}); no respawn, no marker (#1247).",
+            file=sys.stderr,
+        )
+        if live_status is not None and not ctx.dry_run:
+            # Positively non-ACTIVE: clear the four fence stop_pending_*/
+            # stop_* fields only (NOT the whole stalled episode state),
+            # mirroring the suppressed branch's clear below. On None
+            # (transient task.py read failure) keep the fence PENDING —
+            # re-evaluated next tick.
+            _clear_fence_state_on_disk(ctx.issue)
+        return
     cap = _stalled_cap_gpu_hours(ctx.issue)
     spawn_result = _respawn_stalled_session(ctx.issue, cap, ctx.dry_run)
     if spawn_result == "suppressed":
@@ -9709,7 +9767,7 @@ def _fence_spawn_stalled(ctx: _StalledActionCtx, sid: str) -> None:
             f"spawned a fresh `--auto` session "
             f"(respawn {new_respawn_count}/{STALLED_MAX_RESPAWNS} this "
             f"episode). Confirmed for >= {ctx.threshold} checks."
-            f"{wedge_suffix}{hold_suffix}",
+            f"{wedge_suffix}{hold_suffix} {_source_stamp()}",
             ctx.dry_run,
             label="session-auto-respawn",
         )
@@ -11864,6 +11922,36 @@ def _parse_orphan_state_counters(state: dict, day_key: str) -> tuple[int, int]:
     return missed, respawns_today
 
 
+def _orphan_act_guard(
+    issue: int, *, status: str, action: str, state: dict, dry_run: bool
+) -> str | None:
+    """#1247 terminal-status act guard: re-read the LIVE status through the
+    canonical resolver (:func:`_task_status` — ``cwd=PROJECT_ROOT``,
+    git-common-dir resolved, #844) immediately before an acting branch and
+    require POSITIVE ACTIVE confirmation. Returns the live status on
+    confirmation (the caller acts + writes marker notes against IT, not the
+    stale snapshot) or ``None`` to abort the act: no respawn, no marker, no
+    cap consumed. A positively non-ACTIVE read clears the orphan episode
+    state (matching :func:`decide_orphan`'s own ``status not in ACTIVE ->
+    clear`` semantics); a ``None`` read (transient task.py failure) keeps
+    the state and defers one tick — fail toward not-acting, never toward
+    erasing episode state on a task.py glitch. Runs under ``--dry-run`` too
+    (the read is a read-only subprocess; the state-clear is dry_run-gated)."""
+    live_status = _task_status(issue)
+    if live_status in ACTIVE:
+        return live_status
+    print(
+        f"  ORPHAN-ACT-GUARD issue #{issue}: snapshot status={status} but "
+        f"live re-read returned {live_status!r} — not ACTIVE; aborting "
+        f"action={action}: no respawn, no marker, no cap consumed "
+        f"(#1247 stale-snapshot guard).",
+        file=sys.stderr,
+    )
+    if live_status is not None and state and not dry_run:
+        _clear_orphan_state(issue)  # positively non-active: episode over
+    return None
+
+
 def _process_orphan_task(
     issue: int,
     status: str,
@@ -11982,6 +12070,21 @@ def _process_orphan_task(
                 prev=state,
             )
         return
+    # ── #1247 terminal-status act guard ─────────────────────────────────
+    # Every branch below ACTS (spawns, posts a marker, or consumes the
+    # daily cap) on the pass-start _active_status_tasks() snapshot, which
+    # can be stale (TOCTOU within a tick; a stale task-state view fed the
+    # 2-week #662/#663/#867 marker loop). Re-verify the LIVE status
+    # through the canonical resolver (cwd=PROJECT_ROOT, git-common-dir
+    # resolved, #844) immediately before acting. POSITIVE confirmation
+    # required: act only on live ∈ ACTIVE. Helper-factored to keep this
+    # function under the C901 cap.
+    live_status = _orphan_act_guard(
+        issue, status=status, action=action, state=state, dry_run=dry_run
+    )
+    if live_status is None:
+        return
+    status = live_status  # act + write marker notes against the LIVE status
     if action == "respawn":
         spawn_result = _respawn_orphan(issue, _stalled_cap_gpu_hours(issue), dry_run)
         if spawn_result == "suppressed":
@@ -12009,7 +12112,7 @@ def _process_orphan_task(
                     f"(status={status}) had no live registered session and no "
                     f"real progress marker for {gap_str}; auto-respawned via "
                     f"spawn-issue --auto (attempt {respawns_today + 1}/{max_per_day} "
-                    f"today).",
+                    f"today). {_source_stamp()}",
                     dry_run,
                     label="orphan-respawn",
                 )
@@ -12046,7 +12149,8 @@ def _process_orphan_task(
             f"{_ORPHAN_ALERT_NOTE_SENTINEL} active task (status={status}) has "
             f"no live registered session and no real progress marker for "
             f"{gap_str}; {reason}. Manual recovery: uv run python "
-            f"scripts/spawn_session.py spawn-issue --issue {issue} --auto",
+            f"scripts/spawn_session.py spawn-issue --issue {issue} --auto "
+            f"{_source_stamp()}",
             dry_run,
             label="orphan-alert",
         )

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -903,7 +903,10 @@ def _source_stamp() -> str:
     the poster took days of forensics to attribute). ``root=`` is the primary
     discriminator (durable after the process dies); ``pid=`` enables live
     ``/proc`` inspection; ``sha=`` dates the build generation. Fail-soft:
-    ``sha=unknown`` on any git failure; never raises. ``lru_cache``:
+    ``sha=unknown`` on any git failure and ``user=unknown`` when the identity
+    lookup fails (``getpass.getuser()`` raises KeyError/OSError with no
+    USER/LOGNAME env and no pw entry for the uid — stripped cron/container
+    envs); never raises. ``lru_cache``:
     host/user/pid/sha/root are process-constants, computed once."""
     script_root = Path(__file__).resolve().parent.parent
     try:
@@ -919,8 +922,15 @@ def _source_stamp() -> str:
         )
     except (subprocess.SubprocessError, OSError):
         sha = "unknown"
+    try:
+        user = getpass.getuser()
+    except (KeyError, OSError):
+        # The sanctioned fail-soft carve-out: the stamp is forensic metadata —
+        # raising at note-format time AFTER the act guard passed would kill
+        # the acting pass over a missing identity string.
+        user = "unknown"
     return (
-        f"[src: host={socket.gethostname()} user={getpass.getuser()} "
+        f"[src: host={socket.gethostname()} user={user} "
         f"pid={os.getpid()} sha={sha} root={script_root}]"
     )
 

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -1,18 +1,25 @@
 """Crash-recovery + pod-safety + stalled-detector watcher for autonomous and
 interactive issue sessions (plus campaign sessions, task #586).
 
-Fourteen passes; items 1-8 run in that order, with the CAMPAIGN pass (item 9)
-right after pass 2, the IDLE-UNMAPPED-SESSION pass (item 10) right after
-pass 7, the INFRA-DRAIN pass (item 11) between pass 5 (the orphan sweep)
-and pass 6 (session-reconcile), the CPU-GUARD pass (item 12) in the
-daemon-independent block right after the happy-patch check (order there:
-pass 1's disk checks -> data-disk -> happy-patch -> CPU-GUARD ->
-program-orchestrator recovery), the AUTH-OUTAGE GUARD pass (item 13)
-immediately after the single per-tick daemon probe and BEFORE every spawn
-arm (crash-recovery is the first spawner it must precede), and the
-STALE-BLOCKED FLAG pass (item 14) also between pass 5 and pass 6 — right
-after the capacity-retry re-drive, before session-reconcile — all before
-the GC pass:
+24 passes ("pass" = one top-level per-tick action block in ``main()``'s
+production run order; helpers invoked INSIDE a pass — e.g. the sub-floor
+disk sentinel inside pass 1 — and the ``--*-only`` debug entrypoints do
+not count; a NEW inline pass block that is not a ``*_pass``-named function
+called from ``main()`` also requires bumping ``_ASW_INLINE_PASS_BLOCKS``
+in ``scripts/workflow_lint.py``). Item numbers below are STABLE
+IDENTIFIERS (cross-referenced throughout this docstring), NOT execution
+order. The per-tick execution order is: 1 (VM disk) -> 15 (data-disk) ->
+16 (happy-patch) -> 12 (CPU-guard) -> 17 (triage-observer) ->
+18 (verdict-disagree) -> 19 (VM-ledger reap) -> 20 (program-orchestrator
+recovery) -> 13 (auth-outage guard) -> 2 (crash-recovery) -> 9 (campaign)
+-> 3 (pod-safety) -> 4 (stalled-detector) -> 5 (orphan sweep) ->
+11 (infra-drain) -> 21 (proposed-infra-sweep) -> 22 (capacity-retry) ->
+14 (stale-blocked flag) -> 6 (session-reconcile) -> 23 (gate-push) ->
+24 (stale-registration) -> 7 (zombie-wrapper) -> 10 (idle-unmapped) ->
+8 (GC). The count is lint-pinned: ``workflow_lint.py
+--check-asw-docstring-pass-count`` FAILs when the "24 passes" digit, the
+numbered-item count, or the live ``*_pass`` set in ``main()`` diverge —
+adding a pass means adding a numbered item here AND bumping the digit:
 
 1. **VM disk-headroom pass.** Watch free space on the VM root filesystem —
    the host of every orchestrator session, the worktree ``.venv``s, the uv
@@ -341,6 +348,64 @@ the GC pass:
    via the task.py subprocess). Kill switch
    ``EPM_DISABLE_STALE_BLOCKED_FLAG=1``; ``--stale-blocked-only`` runs
    just this pass (pair with ``--dry-run`` for a live smoke).
+15. **Data-disk headroom pass (#681; ESCALATE-ONLY; runs right after
+   pass 1).** A second disk-watch on the dedicated ``/mnt/eps-data``
+   mount (the relocated ``.claude/worktrees/`` tree), driving the
+   PERCENT decision helpers so the fire point is size-invariant; no
+   reclaim arm runs on the data disk. Clean no-op before the cutover or
+   when the mount is absent. (:func:`data_disk_pass`.)
+16. **Happy-patch pass (#726; escalate-only, daemon-INDEPENDENT; runs
+   right after pass 15).** Proactively surfaces a reverted/drifted Happy
+   injection patch (typically from ``npm update happy``) within ~10 min
+   — the spawn-path guard is reactive and would only catch it at the
+   next spawn. Never re-applies (that needs sudo).
+   (:func:`happy_patch_pass`.)
+17. **Triage-observer pass (#967; NON-GATING; runs right after
+   pass 12).** Post-hoc audit of the /issue Step 9 pre-dispatch
+   external-marker triage duty (origin incident #779): flags a
+   missing / 'none' triage line against a re-enumerated non-empty
+   candidate window. Sidecar rows + capped deduped pushes + capped
+   ``epm:progress`` nudges; never mutates task status.
+   (:func:`triage_observer_pass`.)
+18. **Verdict-disagree observer pass (#1170; NON-GATING; runs right
+   after pass 17).** Audits the doubled marker-mode review sites for the
+   #825 shape — the latest round whose Claude + Codex durable verdicts
+   disagree with no role-matched reconcile and no Codex no-show
+   evidence. Sidecar + one deduped push per (issue, site, round); never
+   posts a task marker. (:func:`verdict_disagree_pass`.)
+19. **VM resource-ledger reap pass (runs right after pass 18;
+   daemon-INDEPENDENT, fail-soft).** Drops expired-TTL / dead-PID claims
+   from the advisory ``~/.task-workflow/vm-ledger.json`` so a crashed
+   session's claim can never wedge the CPU/RAM off-VM routing decision.
+   (:func:`vm_ledger_reap_pass`.)
+20. **Program-orchestrator recovery pass (#660; daemon-INDEPENDENT; runs
+   right after pass 19).** Relaunches the leakage-program bash meta-loop
+   daemon (``run_program_orchestrator.sh`` in tmux ``eps-program``) if
+   it died mid-program — STOP-sentinel + deliberate-exit guarded; fails
+   toward NOT relaunching on any missing signal.
+   (:func:`program_orchestrator_pass`.)
+21. **Proposed-infra-sweep pass (#690; runs right after pass 11).**
+   Always-on backstop dispatching ripe ORPHANED ``proposed`` infra/batch
+   tasks whose filer could not self-dispatch (headless filers, crashed
+   filers, cap-full filings), bounded by the shared infra session cap.
+   (:func:`proposed_infra_sweep_pass`.)
+22. **Capacity-retry pass (#642; runs right after pass 21).** Re-drives
+   (via ``spawn-issue --auto``) the narrow subclass of ``blocked`` tasks
+   whose latest ``epm:failure`` is ``failure_class: infra`` +
+   ``reason: no_compute_available``; backoff + a per-UTC-day cap bound
+   the churn; every other ``blocked`` task stays parked.
+   (:func:`capacity_retry_pass`.)
+23. **Gate-push pass (runs right after pass 6).** Per-issue gate push
+   (fail-soft Telegram on gate-park / ``blocked`` transitions,
+   transition-deduped) + title/self-report reconcile + tick-runaway
+   force-stop; consumes ``main()``'s pre-respawn and pre-campaign
+   registration snapshots so first-tick GC reaps can't hide a
+   transition. (:func:`gate_push_pass`.)
+24. **Stale-registration pass (#845 d; daemon-gated; runs right after
+   pass 23).** Unregisters (never stops) a LIVE session's registration
+   after prolonged transcript idleness so a stale registration stops
+   holding the /issue Step 0 single-orchestrator guard; the orphan sweep
+   re-drives an ACTIVE task. (:func:`stale_registration_pass`.)
 
 Why each pass exists
 --------------------

--- a/tests/test_auth_outage_guard.py
+++ b/tests/test_auth_outage_guard.py
@@ -82,11 +82,15 @@ def _forbid_real_marker_posts(monkeypatch):
     commit on a REAL task (the two-week #662/#663/#867 incident class). A
     test-level recorder patch overrides this default; ``dry_run=True`` and
     stubbed-``subprocess.run`` calls keep the real body's behavior."""
+    import functools
     import subprocess as _sp
 
     real_post = asw._post_progress_marker
     real_run = _sp.run
 
+    # functools.wraps sets __wrapped__, so inspect.getsource() on the patched
+    # attribute still resolves the ORIGINAL body.
+    @functools.wraps(real_post)
     def _guarded(issue, note, dry_run, *, label):
         if not dry_run and _sp.run is real_run:
             raise AssertionError(
@@ -521,6 +525,9 @@ def test_stalled_gate_skips_stop_and_respawn_as_unit(watcher_roots, monkeypatch)
     )
     monkeypatch.setattr(asw, "_persist_stalled_ctx", lambda *a, **kw: None)
     monkeypatch.setattr(asw, "_post_progress_marker", lambda *a, **kw: None)
+    # #1247 fence act-guard seam: confirm-active so the guard's live re-read
+    # never shells the real `task.py view` subprocess (hermeticity).
+    monkeypatch.setattr(asw, "_task_status", lambda _i: "running")
     # Episode active, no token: NEITHER the stop NOR the respawn fires.
     asw._handle_stalled_respawn(_stalled_ctx(7, "sid-7", {"sid-7"}))
     assert stops == [] and spawns == []

--- a/tests/test_auth_outage_guard.py
+++ b/tests/test_auth_outage_guard.py
@@ -74,6 +74,31 @@ def _hermetic(monkeypatch):
     monkeypatch.setattr(asw, "_auth_outage_evidence", lambda: "churn-only")
 
 
+@pytest.fixture(autouse=True)
+def _forbid_real_marker_posts(monkeypatch):
+    """#1247 hermeticity guard (fail-loud): no test in this file may reach the
+    real ``task.py post-marker`` subprocess through ``_post_progress_marker``
+    with ``dry_run=False`` — an unpatched call posts a junk marker + git
+    commit on a REAL task (the two-week #662/#663/#867 incident class). A
+    test-level recorder patch overrides this default; ``dry_run=True`` and
+    stubbed-``subprocess.run`` calls keep the real body's behavior."""
+    import subprocess as _sp
+
+    real_post = asw._post_progress_marker
+    real_run = _sp.run
+
+    def _guarded(issue, note, dry_run, *, label):
+        if not dry_run and _sp.run is real_run:
+            raise AssertionError(
+                f"_post_progress_marker(issue={issue}, label={label!r}, dry_run=False) reached "
+                "the #1247 autouse hermeticity guard with the REAL subprocess.run still live — "
+                "monkeypatch a recorder (or stub subprocess.run) in the test."
+            )
+        return real_post(issue, note, dry_run, label=label)
+
+    monkeypatch.setattr(asw, "_post_progress_marker", _guarded)
+
+
 @pytest.fixture
 def push_counter(monkeypatch):
     """Count REAL (non-dry-run) pushes; a dry_run call sends nothing, like

--- a/tests/test_auth_outage_guard.py
+++ b/tests/test_auth_outage_guard.py
@@ -380,6 +380,10 @@ def test_main_order_auth_outage_before_respawn_loop(watcher_roots, monkeypatch):
         "happy_patch_pass",
         "cpu_guard_pass",
         "triage_observer_pass",
+        # #1247 r3: verdict_disagree_pass scans the LIVE tasks tree via
+        # task_workflow.list_events (sidecar + push sinks) — stub it like the
+        # other live-observer passes.
+        "verdict_disagree_pass",
         "vm_ledger_reap_pass",
         "program_orchestrator_pass",
         "campaign_pass",

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -105,6 +105,7 @@ def _forbid_real_marker_posts(monkeypatch):
     - only ``dry_run=False`` with the GENUINE ``subprocess.run`` still live
       fails loud, naming the offending call.
     """
+    import functools
     import subprocess as _sp
 
     import autonomous_session_watch as asw
@@ -112,6 +113,10 @@ def _forbid_real_marker_posts(monkeypatch):
     real_post = asw._post_progress_marker
     real_run = _sp.run
 
+    # functools.wraps sets __wrapped__, so inspect.getsource() on the patched
+    # attribute still resolves the ORIGINAL body (the #966 source-inspection
+    # pins keep working under this guard).
+    @functools.wraps(real_post)
     def _guarded(issue, note, dry_run, *, label):
         if not dry_run and _sp.run is real_run:
             raise AssertionError(
@@ -1710,6 +1715,25 @@ def test_pod_safety_pass_failed_snapshot_does_not_gc_state(isolated_registry, mo
 # ── daemon-reachability gates ONLY the respawn pass ──────────────────────────
 
 
+def _stub_fleet_mutating_passes(asw, monkeypatch):
+    """#1247 hermeticity for FULL-main() tests: main() runs passes that scan
+    the LIVE repo and can REALLY mutate fleet state from a unit test —
+    ``proposed_infra_sweep_pass`` + ``capacity_retry_pass`` DISPATCH real
+    ``spawn-issue --auto`` sessions via the live Happy daemon (observed
+    2026-07-10: a suite run of test_main_daemon_reachable_runs_both_passes
+    spawned a REAL session for proposed task #1227), and
+    ``program_orchestrator_pass`` (daemon-INDEPENDENT) can relaunch the real
+    #660 tmux daemon. Every test that drives the full main() pass sequence
+    stubs these; a test OF one of these passes stubs its own seams instead
+    and does not call this helper (or re-patches the pass it exercises)."""
+    for pass_name in (
+        "proposed_infra_sweep_pass",
+        "capacity_retry_pass",
+        "program_orchestrator_pass",
+    ):
+        monkeypatch.setattr(asw, pass_name, lambda *a, **kw: None)
+
+
 def test_main_daemon_unreachable_still_runs_pod_safety(isolated_registry, monkeypatch):
     # The pod-safety pass reasons about task status + the live pod list, neither
     # of which needs the Happy daemon. So a daemon outage must NOT skip it
@@ -1733,6 +1757,7 @@ def test_main_daemon_unreachable_still_runs_pod_safety(isolated_registry, monkey
     # #1021: the stale-blocked flag pass shells task.py against the LIVE
     # blocked set (daemon-independent) — never run it from a unit test.
     monkeypatch.setattr(asw, "stale_blocked_flag_pass", lambda *a, **kw: None)
+    _stub_fleet_mutating_passes(asw, monkeypatch)
 
     rc = asw.main([])
 
@@ -1770,6 +1795,9 @@ def test_main_daemon_reachable_runs_both_passes(isolated_registry, monkeypatch):
     # #1021: the stale-blocked flag pass shells task.py against the LIVE
     # blocked set (daemon-independent) — never run it from a unit test.
     monkeypatch.setattr(asw, "stale_blocked_flag_pass", lambda *a, **kw: None)
+    # #1247: with _daemon_reachable forced True, the UNSTUBBED sweep passes
+    # would dispatch REAL sessions (this exact test spawned one for #1227).
+    _stub_fleet_mutating_passes(asw, monkeypatch)
 
     rc = asw.main([])
 
@@ -3398,6 +3426,7 @@ def test_stalled_main_passes_daemon_flag(isolated_registry, monkeypatch):
     # #1021: the stale-blocked flag pass shells task.py against the LIVE
     # blocked set (daemon-independent) — never run it from a unit test.
     monkeypatch.setattr(asw, "stale_blocked_flag_pass", lambda *a, **kw: None)
+    _stub_fleet_mutating_passes(asw, monkeypatch)
 
     rc = asw.main([])
 
@@ -4646,6 +4675,240 @@ def test_orphan_old_lifecycle_marker_still_stale(isolated_registry, monkeypatch)
     ]
     respawns, _markers = _run_orphan_task(asw, monkeypatch, issue=90663, events=events, now=now)
     assert respawns == [90663]
+
+
+# ─── #1247: act-time terminal-status guard (orphan pass) ─────────────────────
+#
+# The acting branches of _process_orphan_task (respawn / alert / exemption)
+# previously trusted the pass-start _active_status_tasks() snapshot for the
+# whole tick; a stale snapshot produced respawns + junk markers + git commits
+# against TERMINAL tasks, unboundedly (the two-week #662/#663/#867 loop). The
+# guard re-reads the LIVE status via _task_status immediately before acting
+# and requires a POSITIVE ACTIVE confirmation. All tests drive the REAL
+# _process_orphan_task body via _run_orphan_task; only the subprocess-boundary
+# seams (_task_status, _task_events, _respawn_orphan, _post_progress_marker)
+# are monkeypatched.
+
+_STALE_EVENTS_90XXX = [
+    {"kind": "epm:plan", "ts": "2026-06-25T02:00:00Z", "note": "planning done long ago"}
+]
+
+
+def test_orphan_act_guard_aborts_on_terminal_live_status(isolated_registry, monkeypatch, capsys):
+    # Durability pin for #1247: snapshot says "running", the live re-read says
+    # "archived" — NO spawn, NO marker, orphan episode state CLEARED, one loud
+    # stderr line naming snapshot vs live status.
+    import autonomous_session_watch as asw
+
+    now = asw._parse_event_ts("2026-06-25T06:00:00Z")
+    respawns, markers = _run_orphan_task(
+        asw,
+        monkeypatch,
+        issue=90701,
+        events=_STALE_EVENTS_90XXX,
+        now=now,
+        task_status="archived",
+    )
+    assert respawns == []
+    assert markers == []
+    assert asw._load_orphan_state(90701) == {}  # positively non-ACTIVE: episode over
+    err = capsys.readouterr().err
+    assert "ORPHAN-ACT-GUARD" in err
+    assert "'archived'" in err and "status=running" in err and "action=respawn" in err
+
+
+def test_orphan_act_guard_aborts_on_parked_live_status(isolated_registry, monkeypatch, capsys):
+    # The PARK half of the terminal/parked list: on_hold is not ACTIVE either.
+    import autonomous_session_watch as asw
+
+    now = asw._parse_event_ts("2026-06-25T06:00:00Z")
+    respawns, markers = _run_orphan_task(
+        asw,
+        monkeypatch,
+        issue=90702,
+        events=_STALE_EVENTS_90XXX,
+        now=now,
+        task_status="on_hold",
+    )
+    assert respawns == []
+    assert markers == []
+    assert asw._load_orphan_state(90702) == {}
+    assert "ORPHAN-ACT-GUARD" in capsys.readouterr().err
+
+
+def test_orphan_act_guard_defers_on_unreadable_live_status(isolated_registry, monkeypatch, capsys):
+    # _task_status -> None (transient task.py read failure): abort the act but
+    # KEEP the episode state (missed intact) — retried next tick. Fail toward
+    # not-acting, never toward erasing episode state on a task.py glitch.
+    import autonomous_session_watch as asw
+
+    now = asw._parse_event_ts("2026-06-25T06:00:00Z")
+    respawns, markers = _run_orphan_task(
+        asw,
+        monkeypatch,
+        issue=90703,
+        events=_STALE_EVENTS_90XXX,
+        now=now,
+        task_status=None,
+    )
+    assert respawns == []
+    assert markers == []
+    assert asw._load_orphan_state(90703).get("missed") == 1  # state PRESERVED
+    assert "ORPHAN-ACT-GUARD" in capsys.readouterr().err
+
+
+def test_orphan_act_guard_allows_live_active(isolated_registry, monkeypatch):
+    # Regression floor: a positively-ACTIVE live read lets the respawn + its
+    # marker proceed. The recording seam also closes the wrong-argument hole:
+    # the guard must query the SAME issue it is about to act on.
+    import autonomous_session_watch as asw
+
+    now = asw._parse_event_ts("2026-06-25T06:00:00Z")
+    status_calls: list[int] = []
+    respawns, markers = _run_orphan_task(
+        asw,
+        monkeypatch,
+        issue=90704,
+        events=_STALE_EVENTS_90XXX,
+        now=now,
+        task_status="running",
+        status_calls=status_calls,
+    )
+    assert respawns == [90704]
+    assert len(markers) == 1 and markers[0][0] == 90704
+    assert status_calls == [90704]  # the live re-read queried the acted-on issue
+
+
+@pytest.mark.parametrize("branch", ["alert", "exemption"])
+def test_orphan_alert_and_exemption_branches_also_guarded(
+    isolated_registry, monkeypatch, capsys, branch
+):
+    # The guard sits at ONE site covering ALL acting branches: the daily-cap
+    # ALERT branch and the exemption-action dispatch are aborted the same way
+    # the respawn branch is (no marker, episode state cleared).
+    import autonomous_session_watch as asw
+
+    now = asw._parse_event_ts("2026-06-25T06:00:00Z")
+    if branch == "alert":
+        # Cap exhausted -> decide_orphan returns "alert".
+        kwargs = dict(respawns_today=asw.ORPHAN_MAX_RESPAWNS_PER_DAY_DEFAULT)
+        events = _STALE_EVENTS_90XXX
+        expect_action = "action=alert"
+    else:
+        # An old prose USER-PAUSE note as the latest word rewrites the respawn
+        # to the "user-pause-hold-skip" exemption action (#816 arm).
+        kwargs = {}
+        events = [
+            {
+                "kind": "epm:progress",
+                "ts": "2026-06-25T02:00:00Z",
+                "note": "USER PAUSE (verbatim: hold this); paused_from=running",
+            }
+        ]
+        expect_action = "action=user-pause-hold-skip"
+    respawns, markers = _run_orphan_task(
+        asw,
+        monkeypatch,
+        issue=90705,
+        events=events,
+        now=now,
+        task_status="completed",
+        **kwargs,
+    )
+    assert respawns == []
+    assert markers == []  # neither the alert nor the exemption marker posted
+    assert asw._load_orphan_state(90705) == {}
+    err = capsys.readouterr().err
+    assert "ORPHAN-ACT-GUARD" in err and expect_action in err
+
+
+def test_orphan_guard_marker_note_uses_live_status(isolated_registry, monkeypatch):
+    # Active->active drift (running -> verifying): the act proceeds and the
+    # marker note names the TRUE live status, not the stale snapshot.
+    import autonomous_session_watch as asw
+
+    now = asw._parse_event_ts("2026-06-25T06:00:00Z")
+    respawns, markers = _run_orphan_task(
+        asw,
+        monkeypatch,
+        issue=90706,
+        events=_STALE_EVENTS_90XXX,
+        now=now,
+        task_status="verifying",
+    )
+    assert respawns == [90706]
+    assert len(markers) == 1
+    assert "(status=verifying)" in markers[0][1]
+
+
+def test_orphan_respawn_note_carries_source_stamp(isolated_registry, monkeypatch):
+    # #1247 source stamp: the respawn note self-identifies the posting
+    # process (host/user/pid/sha/root) as its trailing token.
+    import re
+
+    import autonomous_session_watch as asw
+
+    now = asw._parse_event_ts("2026-06-25T06:00:00Z")
+    _respawns, markers = _run_orphan_task(
+        asw, monkeypatch, issue=90707, events=_STALE_EVENTS_90XXX, now=now
+    )
+    assert len(markers) == 1
+    assert re.search(r"\[src: host=\S+ user=\S+ pid=\d+ sha=\S+ root=/\S+\]$", markers[0][1])
+
+
+def test_source_stamp_format_and_stability():
+    # The stamp matches the documented shape, names THIS process's pid, and is
+    # stable within a process (lru_cache -> two calls compare equal).
+    import os
+    import re
+
+    import autonomous_session_watch as asw
+
+    stamp = asw._source_stamp()
+    assert re.fullmatch(r"\[src: host=\S+ user=\S+ pid=\d+ sha=\S+ root=/\S+\]", stamp)
+    assert f"pid={os.getpid()}" in stamp
+    assert asw._source_stamp() == stamp  # process-stable (cached)
+
+
+def test_orphan_act_guard_dry_run_never_mutates_state(isolated_registry, monkeypatch, capsys):
+    # --dry-run exercises the guard's read but must mutate NOTHING: no spawn,
+    # no marker, and the pre-seeded orphan state file survives unmodified
+    # (the guard's state-clear is dry_run-gated). Without this pin the §12
+    # `--dry-run` live smoke would be the first place a missing gate mutates
+    # real ~/.eps-autonomous state.
+    import autonomous_session_watch as asw
+
+    now = asw._parse_event_ts("2026-06-25T06:00:00Z")
+    respawns: list[int] = []
+    markers: list[tuple] = []
+    monkeypatch.setattr(asw, "_task_events", lambda _i: _STALE_EVENTS_90XXX)
+    monkeypatch.setattr(asw, "_stalled_cap_gpu_hours", lambda _i: 24.0)
+    monkeypatch.setattr(
+        asw, "_respawn_orphan", lambda i, cap, dry_run: respawns.append(i) or "spawned"
+    )
+    monkeypatch.setattr(asw, "_post_progress_marker", lambda *a, **k: markers.append(a))
+    monkeypatch.setattr(asw, "_task_status", lambda _i: "archived")
+    asw._save_orphan_state(
+        90708, missed=1, alerted=False, respawn_day=None, respawns_today=0, prev=None
+    )
+    state_path = asw._orphan_state_path(90708)
+    before = state_path.read_bytes()
+    asw._process_orphan_task(
+        90708,
+        "running",
+        None,
+        set(),
+        now,
+        True,  # dry_run
+        2,
+        staleness_s=asw.ORPHAN_STALENESS_S_DEFAULT,
+        max_per_day=asw.ORPHAN_MAX_RESPAWNS_PER_DAY_DEFAULT,
+        day_key="2026-06-25",
+    )
+    assert respawns == []
+    assert markers == []
+    assert state_path.read_bytes() == before  # state file untouched under dry-run
+    assert "ORPHAN-ACT-GUARD" in capsys.readouterr().err
 
 
 # ─── #866/#903: deliberate-takeover sentinel skips the orphan sweep ──────────
@@ -10315,6 +10578,9 @@ def test_infra_drain_main_wiring(isolated_registry, monkeypatch):
         "gc_pass",
     ):
         monkeypatch.setattr(asw, pass_name, rec(pass_name))
+    # #1247: with _daemon_reachable forced True, the unstubbed sweep passes
+    # would dispatch REAL sessions from this unit test.
+    _stub_fleet_mutating_passes(asw, monkeypatch)
 
     rc = asw.main([])
 
@@ -13788,6 +14054,9 @@ def test_stalled_handler_suppressed_books_nothing(isolated_registry, monkeypatch
     monkeypatch.setattr(asw, "_stalled_cap_gpu_hours", lambda i: 24.0)
     monkeypatch.setattr(asw, "_respawn_stalled_session", lambda i, cap, dry: "suppressed")
     monkeypatch.setattr(asw, "_worktree_recent_activity", lambda *_a, **_k: False)
+    # #1247 fence act-guard seam: confirm-active so the guard's live re-read
+    # never shells the real `task.py view` subprocess (hermeticity).
+    monkeypatch.setattr(asw, "_task_status", lambda _i: "running")
     markers: list[tuple] = []
     monkeypatch.setattr(asw, "_post_progress_marker", lambda *a, **k: markers.append((a, k)))
     saves: list[tuple] = []
@@ -13823,6 +14092,137 @@ def test_stalled_handler_suppressed_books_nothing(isolated_registry, monkeypatch
     assert on_disk["stop_pending_sid"] is None  # fence episode over
     assert on_disk["missed"] == 2  # ...but nothing else was booked
     assert on_disk["alerted"] is True
+
+
+# ─── #1247: act-time terminal-status guard (stalled fence spawn) ─────────────
+#
+# The fence's stop->verify->spawn spans ticks, so ctx.task_status is >=10 min
+# old at spawn time by construction. _fence_spawn_stalled now re-reads the
+# LIVE status and requires a positive ACTIVE confirmation before spawning or
+# posting the respawn marker (the stalled-arm sibling of ORPHAN-ACT-GUARD).
+# These tests drive the REAL _handle_stalled_respawn -> _fence_spawn_stalled
+# path; only subprocess-boundary seams are monkeypatched.
+
+
+def _drive_fence_spawn(asw, monkeypatch, isolated_registry, *, issue, task_status, dry_run=False):
+    """Reach the fence's verified-dead spawn branch (pending sid set, sid
+    absent from the live set) with recorder seams; returns (spawns, markers)."""
+    import json
+
+    spawns: list[int] = []
+    markers: list[tuple[int, str]] = []
+    monkeypatch.setattr(asw, "_stalled_cap_gpu_hours", lambda i: 24.0)
+    monkeypatch.setattr(asw, "_worktree_recent_activity", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        asw, "_respawn_stalled_session", lambda i, cap, dry: spawns.append(i) or "spawned"
+    )
+    monkeypatch.setattr(
+        asw,
+        "_post_progress_marker",
+        lambda i, note, dry_run, label: markers.append((i, note)),
+    )
+    monkeypatch.setattr(asw, "_task_status", lambda _i: task_status)
+    (isolated_registry / f"stalled-{issue}.json").write_text(
+        json.dumps({"missed": 2, "alerted": True, "stop_pending_sid": "sid-old"})
+    )
+    ctx = asw._StalledActionCtx(
+        issue=issue,
+        happy_session_id="sid-old",
+        prev_state={"missed": 2, "alerted": True, "stop_pending_sid": "sid-old"},
+        alerted=True,
+        respawn_count=0,
+        exhausted=False,
+        last_self_report_ts=None,
+        self_gap="3.0h",
+        marker_gap="3.0h",
+        has_pod=False,
+        task_status="running",
+        in_active=True,
+        threshold=2,
+        dry_run=dry_run,
+        live_ids=set(),  # verified dead -> fence 'spawn' branch
+        stop_pending_sid="sid-old",
+    )
+    asw._handle_stalled_respawn(ctx)
+    return spawns, markers
+
+
+def test_stalled_fence_spawn_guard_aborts_on_terminal_live_status(
+    isolated_registry, monkeypatch, capsys
+):
+    # Live re-read says "completed": no spawn, no marker, the fence's
+    # stop_pending_* fields cleared (episode over) while the rest of the
+    # stalled episode state is untouched.
+    import json
+
+    import autonomous_session_watch as asw
+
+    spawns, markers = _drive_fence_spawn(
+        asw, monkeypatch, isolated_registry, issue=90711, task_status="completed"
+    )
+    assert spawns == []
+    assert markers == []
+    on_disk = json.loads((isolated_registry / "stalled-90711.json").read_text())
+    assert on_disk["stop_pending_sid"] is None  # fence state cleared
+    assert on_disk["missed"] == 2  # episode state untouched (surgical clear)
+    err = capsys.readouterr().err
+    assert "STALLED-ACT-GUARD" in err and "'completed'" in err
+
+
+def test_stalled_fence_spawn_guard_defers_on_unreadable_live_status(
+    isolated_registry, monkeypatch, capsys
+):
+    # _task_status -> None (transient read failure): no spawn, no marker, and
+    # the fence stays PENDING on disk — re-evaluated next tick.
+    import json
+
+    import autonomous_session_watch as asw
+
+    spawns, markers = _drive_fence_spawn(
+        asw, monkeypatch, isolated_registry, issue=90712, task_status=None
+    )
+    assert spawns == []
+    assert markers == []
+    on_disk = json.loads((isolated_registry / "stalled-90712.json").read_text())
+    assert on_disk["stop_pending_sid"] == "sid-old"  # fence KEPT pending
+    assert "STALLED-ACT-GUARD" in capsys.readouterr().err
+
+
+def test_stalled_fence_spawn_guard_dry_run_never_mutates_state(
+    isolated_registry, monkeypatch, capsys
+):
+    # Dry-run sibling: the guard's state-clear is dry_run-gated — the fence
+    # file survives byte-for-byte, and nothing spawns or posts.
+    import json
+
+    import autonomous_session_watch as asw
+
+    state_path = isolated_registry / "stalled-90713.json"
+    spawns, markers = _drive_fence_spawn(
+        asw, monkeypatch, isolated_registry, issue=90713, task_status="archived", dry_run=True
+    )
+    assert spawns == []
+    assert markers == []
+    on_disk = json.loads(state_path.read_text())
+    assert on_disk["stop_pending_sid"] == "sid-old"  # untouched under dry-run
+    assert "STALLED-ACT-GUARD" in capsys.readouterr().err
+
+
+def test_stalled_fence_spawn_allows_live_active_and_note_carries_source_stamp(
+    isolated_registry, monkeypatch
+):
+    # Regression floor + stamp: a positively-ACTIVE live read lets the fence
+    # spawn proceed, and the respawn note self-identifies the posting process.
+    import re
+
+    import autonomous_session_watch as asw
+
+    spawns, markers = _drive_fence_spawn(
+        asw, monkeypatch, isolated_registry, issue=90714, task_status="running"
+    )
+    assert spawns == [90714]
+    assert len(markers) == 1 and markers[0][0] == 90714
+    assert re.search(r"\[src: host=\S+ user=\S+ pid=\d+ sha=\S+ root=/\S+\]$", markers[0][1])
 
 
 def test_capacity_retry_suppressed_consumes_no_budget(isolated_registry, monkeypatch, capsys):

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -86,6 +86,45 @@ def _no_real_stagger_sleep(monkeypatch):
     return sleeps
 
 
+@pytest.fixture(autouse=True)
+def _forbid_real_marker_posts(monkeypatch):
+    """#1247 hermeticity guard (fail-loud): no test in this file may reach the
+    REAL ``task.py post-marker`` subprocess through ``_post_progress_marker``.
+
+    The real body shells ``task.py post-marker`` at the canonical
+    ``PROJECT_ROOT``, so an unpatched call with ``dry_run=False`` posts a JUNK
+    marker + git commit on a REAL task — the two-week #662/#663/#867 incident
+    was this file's own ``_run_orphan_task`` driver leaving it live. Contract:
+
+    - a test that wants marker assertions overrides this with its own recorder
+      (a later test-level / fixture-level ``monkeypatch.setattr`` wins over
+      this autouse default);
+    - ``dry_run=True`` calls keep the real function's log-only behavior;
+    - a test that exercises the real BODY against a STUBBED ``subprocess.run``
+      (the argv-recording pass tests) stays hermetic and is allowed through;
+    - only ``dry_run=False`` with the GENUINE ``subprocess.run`` still live
+      fails loud, naming the offending call.
+    """
+    import subprocess as _sp
+
+    import autonomous_session_watch as asw
+
+    real_post = asw._post_progress_marker
+    real_run = _sp.run
+
+    def _guarded(issue, note, dry_run, *, label):
+        if not dry_run and _sp.run is real_run:
+            raise AssertionError(
+                f"_post_progress_marker(issue={issue}, label={label!r}, dry_run=False) reached "
+                "the #1247 autouse hermeticity guard with the REAL subprocess.run still live — "
+                "the real body would shell `task.py post-marker` and post a junk marker on a "
+                "real task. Monkeypatch a recorder (or stub subprocess.run) in the test."
+            )
+        return real_post(issue, note, dry_run, label=label)
+
+    monkeypatch.setattr(asw, "_post_progress_marker", _guarded)
+
+
 def _p(issue: int, pod_id: str, name: str):
     """A non-wedged 4-tuple for ``_running_managed_issue_pods`` stubs (#692).
 
@@ -4476,20 +4515,56 @@ def test_orphan_state_roundtrip_and_clear(isolated_registry):
 # and was falsely respawned. It now reads _latest_nonwatcher_event_ts.
 
 
-def _run_orphan_task(asw, monkeypatch, *, issue, events, now, missed=1):
+def _run_orphan_task(
+    asw,
+    monkeypatch,
+    *,
+    issue,
+    events,
+    now,
+    missed=1,
+    task_status="running",
+    dry_run=False,
+    respawns_today=0,
+    status_calls=None,
+):
     """Drive _process_orphan_task end-to-end through the actual marker-age call
     site (rec=None -> fully-unregistered #472 class, so it is an orphan
     candidate). Pre-seeds orphan state with ``missed`` so a stale read fires a
-    respawn on the SECOND consecutive miss (threshold default 2). Records every
-    _respawn_orphan call; returns the recorder list."""
+    respawn on the SECOND consecutive miss (threshold default 2).
+
+    #1247 hermeticity: the driver previously left ``_post_progress_marker``
+    LIVE with ``dry_run=False``, so every suite run shelled the real
+    ``task.py post-marker`` and committed a junk marker on the REAL task named
+    by ``issue`` — the two-week #662/#663/#867 marker loop. It now records
+    marker posts, seams ``_task_status`` (the #1247 act-time guard's live
+    re-read; ``task_status`` sets the returned status, ``status_calls``
+    optionally records the issue argument), and drives SYNTHETIC issue ids
+    only. Returns ``(respawns, markers)``."""
     respawns: list[int] = []
+    markers: list[tuple[int, str]] = []
     monkeypatch.setattr(asw, "_task_events", lambda _i: events)
     monkeypatch.setattr(asw, "_stalled_cap_gpu_hours", lambda _i: 24.0)
     monkeypatch.setattr(
         asw, "_respawn_orphan", lambda i, cap, dry_run: respawns.append(i) or "spawned"
     )
+    monkeypatch.setattr(
+        asw,
+        "_post_progress_marker",
+        lambda i, note, dry_run, label: markers.append((i, note)),
+    )
+    monkeypatch.setattr(
+        asw,
+        "_task_status",
+        lambda i: (status_calls.append(i) if status_calls is not None else None) or task_status,
+    )
     asw._save_orphan_state(
-        issue, missed=missed, alerted=False, respawn_day=None, respawns_today=0, prev=None
+        issue,
+        missed=missed,
+        alerted=False,
+        respawn_day="2026-06-25" if respawns_today else None,
+        respawns_today=respawns_today,
+        prev=None,
     )
     _process_orphan_task = asw._process_orphan_task
     _process_orphan_task(
@@ -4498,13 +4573,13 @@ def _run_orphan_task(asw, monkeypatch, *, issue, events, now, missed=1):
         None,  # rec=None: fully-unregistered orphan candidate
         set(),  # no live session ids
         now,
-        False,  # dry_run
+        dry_run,
         2,  # threshold
         staleness_s=asw.ORPHAN_STALENESS_S_DEFAULT,
         max_per_day=asw.ORPHAN_MAX_RESPAWNS_PER_DAY_DEFAULT,
         day_key="2026-06-25",
     )
-    return respawns
+    return respawns, markers
 
 
 def test_orphan_pre_run_lifecycle_marker_keeps_session(isolated_registry, monkeypatch):
@@ -4528,7 +4603,7 @@ def test_orphan_pre_run_lifecycle_marker_keeps_session(isolated_registry, monkey
             "note": "implemented dispatch script",
         },
     ]
-    respawns = _run_orphan_task(asw, monkeypatch, issue=661, events=events, now=now)
+    respawns, _markers = _run_orphan_task(asw, monkeypatch, issue=90661, events=events, now=now)
     assert respawns == []  # kept — the recent lifecycle marker is a sign of life
 
 
@@ -4552,8 +4627,8 @@ def test_orphan_watcher_sentinel_marker_still_ignored(isolated_registry, monkeyp
             "note": f"{asw._ORPHAN_RESPAWN_NOTE_SENTINEL} auto-respawn attempt",
         },
     ]
-    respawns = _run_orphan_task(asw, monkeypatch, issue=662, events=events, now=now)
-    assert respawns == [662]  # the watcher sentinel is filtered; real marker is stale
+    respawns, _markers = _run_orphan_task(asw, monkeypatch, issue=90662, events=events, now=now)
+    assert respawns == [90662]  # the watcher sentinel is filtered; real marker is stale
 
 
 def test_orphan_old_lifecycle_marker_still_stale(isolated_registry, monkeypatch):
@@ -4569,8 +4644,8 @@ def test_orphan_old_lifecycle_marker_still_stale(isolated_registry, monkeypatch)
             "note": "planning done long ago",
         },
     ]
-    respawns = _run_orphan_task(asw, monkeypatch, issue=663, events=events, now=now)
-    assert respawns == [663]
+    respawns, _markers = _run_orphan_task(asw, monkeypatch, issue=90663, events=events, now=now)
+    assert respawns == [90663]
 
 
 # ─── #866/#903: deliberate-takeover sentinel skips the orphan sweep ──────────
@@ -4600,16 +4675,16 @@ def test_takeover_sentinel_fresh_skips_orphan_respawn(
 
     import autonomous_session_watch as asw
 
-    (isolated_registry / "issue-866.json.paused-takeover-20260702").write_text("{}")
+    (isolated_registry / "issue-90866.json.paused-takeover-20260702").write_text("{}")
     now = time.time()
     # Marker is comfortably stale — without the sentinel this respawns (the
     # control is test_takeover_sentinel_stale_respawns below).
     events = [{"kind": "epm:plan", "ts": "2026-06-25T02:00:00Z", "note": "stale marker"}]
-    respawns = _run_orphan_task(asw, monkeypatch, issue=866, events=events, now=now)
+    respawns, _markers = _run_orphan_task(asw, monkeypatch, issue=90866, events=events, now=now)
     assert respawns == []
     # Frozen episode: the skip returns BEFORE any state read/write, so the
     # pre-seeded missed count is untouched and expiry resumes where it left off.
-    assert asw._load_orphan_state(866).get("missed") == 1
+    assert asw._load_orphan_state(90866).get("missed") == 1
 
 
 def test_takeover_sentinel_stale_respawns(isolated_registry, monkeypatch, clear_takeover_ttl_env):
@@ -4618,14 +4693,14 @@ def test_takeover_sentinel_stale_respawns(isolated_registry, monkeypatch, clear_
 
     import autonomous_session_watch as asw
 
-    sentinel = isolated_registry / "issue-867.json.paused-takeover-20260702"
+    sentinel = isolated_registry / "issue-90867.json.paused-takeover-20260702"
     sentinel.write_text("{}")
     now = time.time()
     stale = now - 7 * 3600  # past the 6h default TTL
     os.utime(sentinel, (stale, stale))
     events = [{"kind": "epm:plan", "ts": "2026-06-25T02:00:00Z", "note": "stale marker"}]
-    respawns = _run_orphan_task(asw, monkeypatch, issue=867, events=events, now=now)
-    assert respawns == [867]  # FAIL OPEN: today's behavior once the sentinel ages out
+    respawns, _markers = _run_orphan_task(asw, monkeypatch, issue=90867, events=events, now=now)
+    assert respawns == [90867]  # FAIL OPEN: today's behavior once the sentinel ages out
 
 
 def test_takeover_sentinel_manual_prefix_also_honored(
@@ -4635,9 +4710,11 @@ def test_takeover_sentinel_manual_prefix_also_honored(
 
     import autonomous_session_watch as asw
 
-    (isolated_registry / "manual-issue-868.json.paused-takeover-x").write_text("{}")
+    (isolated_registry / "manual-issue-90868.json.paused-takeover-x").write_text("{}")
     events = [{"kind": "epm:plan", "ts": "2026-06-25T02:00:00Z", "note": "stale marker"}]
-    respawns = _run_orphan_task(asw, monkeypatch, issue=868, events=events, now=time.time())
+    respawns, _markers = _run_orphan_task(
+        asw, monkeypatch, issue=90868, events=events, now=time.time()
+    )
     assert respawns == []
 
 

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -10022,6 +10022,12 @@ def test_main_runs_tick_under_transcript_memo_scope(isolated_registry, monkeypat
     monkeypatch.setattr(asw, "_live_session_ids", lambda: set())
     monkeypatch.setattr(asw, "_live_pids_by_sid_or_none", lambda: None)
     monkeypatch.setattr(asw, "_live_children", lambda: [])
+    # #1247 r3: shared hermeticity helper FIRST — covers the fleet-mutating +
+    # live-observer set incl. vm_ledger_reap_pass (absent from the loop below,
+    # which would otherwise mutate the live ~/.task-workflow/vm-ledger.json);
+    # the loop + the stale_registration_pass recorder are patched AFTER, so
+    # they win (later monkeypatch wins).
+    _stub_fleet_mutating_passes(asw, monkeypatch)
     for name in (
         "vm_disk_pass",
         "data_disk_pass",
@@ -12119,6 +12125,12 @@ def test_main_wires_stale_blocked_pass_order(isolated_registry, monkeypatch):
     monkeypatch.setattr(asw, "_live_session_ids", lambda: set())
     monkeypatch.setattr(asw, "_live_children", lambda: [])
     monkeypatch.setattr(asw, "_live_pids_by_sid_or_none", lambda: None)
+    # #1247 r3: shared hermeticity helper FIRST — adds verdict_disagree_pass
+    # (scans the LIVE tasks tree) + vm_ledger_reap_pass (mutates the live
+    # ~/.task-workflow/vm-ledger.json), both absent from the loop below; the
+    # capacity_retry / stale_blocked_flag / session_reconcile recorders are
+    # patched AFTER the helper, so they win.
+    _stub_fleet_mutating_passes(asw, monkeypatch)
     for name in (
         "vm_disk_pass",
         "data_disk_pass",
@@ -12897,6 +12909,11 @@ def test_main_runs_sweep_after_infra_drain(isolated_registry, monkeypatch):
     monkeypatch.setattr(asw, "_live_session_ids", lambda: set())
     monkeypatch.setattr(asw, "_live_children", lambda: [])
     monkeypatch.setattr(asw, "_live_pids_by_sid_or_none", lambda: None)
+    # #1247 r3: shared hermeticity helper FIRST — adds data_disk / happy_patch
+    # / cpu_guard / verdict_disagree / vm_ledger_reap (all absent from the
+    # loop below; live observer scans + a live ledger mutate); the infra_drain
+    # + proposed_infra_sweep recorders are patched AFTER, so they win.
+    _stub_fleet_mutating_passes(asw, monkeypatch)
     # Neutralize every other pass so main() runs cheaply and deterministically.
     for name in (
         "vm_disk_pass",
@@ -15861,6 +15878,11 @@ def test_main_order_stale_registration_after_gate_push(isolated_registry, monkey
     monkeypatch.setattr(asw, "_live_session_ids", lambda: set())
     monkeypatch.setattr(asw, "_live_pids_by_sid_or_none", lambda: None)
     monkeypatch.setattr(asw, "_live_children", lambda: snapshot)
+    # #1247 r3: shared hermeticity helper FIRST — adds cpu_guard /
+    # verdict_disagree / vm_ledger_reap (absent from the loop below); the
+    # helper also stubs gate_push_pass, but the gate_push recorder is patched
+    # AFTER the helper, so the recorder wins.
+    _stub_fleet_mutating_passes(asw, monkeypatch)
     for name in (
         "vm_disk_pass",
         "data_disk_pass",

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -130,6 +130,40 @@ def _forbid_real_marker_posts(monkeypatch):
     monkeypatch.setattr(asw, "_post_progress_marker", _guarded)
 
 
+@pytest.fixture(autouse=True)
+def _forbid_real_task_status_reads(monkeypatch):
+    """#1247 round-2 hermeticity guard (fail-loud): no test in this file may
+    reach the REAL ``task.py view`` subprocess through ``_task_status``.
+
+    The real body shells ``task.py view <N> --json`` at the canonical
+    ``PROJECT_ROOT``, so an unpatched call makes a unit test's behavior depend
+    on a REAL task's live status (+ ~1-2s subprocess per call — the round-1
+    review probe traced exactly this class in 6 sibling stalled-pass tests).
+    Read-only (never the junk-marker mechanism), so the guard is a
+    determinism/latency pin, not a mutation fence. Contract: a test that
+    needs a status overrides this with its own stub, e.g.
+    ``monkeypatch.setattr(asw, "_task_status", lambda issue: "running")``
+    (a later test-level / fixture-level monkeypatch wins over this autouse
+    default)."""
+    import functools
+
+    import autonomous_session_watch as asw
+
+    # functools.wraps sets __wrapped__, so inspect.getsource() on the patched
+    # attribute still resolves the ORIGINAL body (same #966-robustness note as
+    # the _forbid_real_marker_posts guard above).
+    @functools.wraps(asw._task_status)
+    def _guarded(issue):
+        raise AssertionError(
+            f"_task_status({issue}) reached the #1247 round-2 autouse hermeticity guard — the "
+            "real body shells `task.py view` against the LIVE task tree, making the test "
+            "depend on live VM state. Monkeypatch a status in the test, e.g. "
+            "monkeypatch.setattr(asw, '_task_status', lambda issue: 'running')."
+        )
+
+    monkeypatch.setattr(asw, "_task_status", _guarded)
+
+
 def _p(issue: int, pod_id: str, name: str):
     """A non-wedged 4-tuple for ``_running_managed_issue_pods`` stubs (#692).
 
@@ -1723,13 +1757,33 @@ def _stub_fleet_mutating_passes(asw, monkeypatch):
     2026-07-10: a suite run of test_main_daemon_reachable_runs_both_passes
     spawned a REAL session for proposed task #1227), and
     ``program_orchestrator_pass`` (daemon-INDEPENDENT) can relaunch the real
-    #660 tmux daemon. Every test that drives the full main() pass sequence
-    stubs these; a test OF one of these passes stubs its own seams instead
-    and does not call this helper (or re-patches the pass it exercises)."""
+    #660 tmux daemon. Round 2 (closing the
+    test-hermeticity-residual-observer-passes concern) additionally stubs the
+    escalate-only OBSERVER passes: they scan LIVE VM state (REGISTRY tasks +
+    events.jsonl via task_workflow, /proc + the earlyoom journal, the Happy
+    daemon bundle, statvfs on /mnt/eps-data) and can write REAL sidecar rows
+    under ``.claude/cache/`` + fire real Telegram pushes from a unit test —
+    plus ``vm_ledger_reap_pass``, which MUTATES the live
+    ``~/.task-workflow/vm-ledger.json`` (same live-VM-state class). Every test
+    that drives the full main() pass sequence calls this helper; a test that
+    asserts on one of these passes re-patches its own recorder AFTER the
+    helper call (a later monkeypatch wins — so call the helper before any
+    recorder you need to keep), and a test OF one of these passes stubs its
+    own seams instead and does not call this helper."""
     for pass_name in (
+        # Fleet-MUTATING sweep passes (round 1).
         "proposed_infra_sweep_pass",
         "capacity_retry_pass",
         "program_orchestrator_pass",
+        # Escalate-only observer passes against live VM state (round 2).
+        "verdict_disagree_pass",
+        "cpu_guard_pass",
+        "happy_patch_pass",
+        "data_disk_pass",
+        "gate_push_pass",
+        "gc_pass",
+        # Live ~/.task-workflow/vm-ledger.json reap (round 2).
+        "vm_ledger_reap_pass",
     ):
         monkeypatch.setattr(asw, pass_name, lambda *a, **kw: None)
 
@@ -4868,6 +4922,31 @@ def test_source_stamp_format_and_stability():
     assert re.fullmatch(r"\[src: host=\S+ user=\S+ pid=\d+ sha=\S+ root=/\S+\]", stamp)
     assert f"pid={os.getpid()}" in stamp
     assert asw._source_stamp() == stamp  # process-stable (cached)
+
+
+def test_source_stamp_never_raises_when_getuser_fails(monkeypatch):
+    # #1247 round-2 fail-soft pin: getpass.getuser() raises KeyError/OSError
+    # in an environment with no USER/LOGNAME env vars and no pw entry for the
+    # uid; the docstring claims "never raises", so the stamp must degrade to
+    # user=unknown instead of killing the acting pass at note-format time.
+    # Pre-fix this test raises OSError out of _source_stamp().
+    import re
+
+    import autonomous_session_watch as asw
+
+    def _no_user():
+        raise OSError("no USER/LOGNAME env and no pwd entry for uid")
+
+    monkeypatch.setattr(asw.getpass, "getuser", _no_user)
+    # lru_cache: clear so the stubbed getuser is actually consulted, and clear
+    # again afterwards so no later test reads the poisoned cached stamp.
+    asw._source_stamp.cache_clear()
+    try:
+        stamp = asw._source_stamp()
+    finally:
+        asw._source_stamp.cache_clear()
+    assert "user=unknown" in stamp
+    assert re.fullmatch(r"\[src: host=\S+ user=unknown pid=\d+ sha=\S+ root=/\S+\]", stamp)
 
 
 def test_orphan_act_guard_dry_run_never_mutates_state(isolated_registry, monkeypatch, capsys):
@@ -10562,6 +10641,11 @@ def test_infra_drain_main_wiring(isolated_registry, monkeypatch):
     monkeypatch.setattr(asw, "_live_session_ids", lambda: set())
     monkeypatch.setattr(asw, "_live_children", lambda: [])
     monkeypatch.setattr(asw, "_live_pids_by_sid_or_none", lambda: None)
+    # #1247: with _daemon_reachable forced True, the unstubbed sweep passes
+    # would dispatch REAL sessions from this unit test. Called BEFORE the
+    # recorder loop so the loop's own recorders (gate_push_pass / gc_pass
+    # overlap the helper's stub set) win and keep recording.
+    _stub_fleet_mutating_passes(asw, monkeypatch)
     for pass_name in (
         "vm_disk_pass",
         "triage_observer_pass",
@@ -10578,9 +10662,6 @@ def test_infra_drain_main_wiring(isolated_registry, monkeypatch):
         "gc_pass",
     ):
         monkeypatch.setattr(asw, pass_name, rec(pass_name))
-    # #1247: with _daemon_reachable forced True, the unstubbed sweep passes
-    # would dispatch REAL sessions from this unit test.
-    _stub_fleet_mutating_passes(asw, monkeypatch)
 
     rc = asw.main([])
 

--- a/tests/test_stalled_detector_and_gc.py
+++ b/tests/test_stalled_detector_and_gc.py
@@ -74,6 +74,64 @@ def _forbid_real_marker_posts(monkeypatch):
     monkeypatch.setattr(asw, "_post_progress_marker", _guarded)
 
 
+@pytest.fixture(autouse=True)
+def _forbid_real_task_status_reads(monkeypatch):
+    """#1247 round-2 hermeticity guard (fail-loud): no test in this file may
+    reach the REAL ``task.py view`` subprocess through ``_task_status`` — the
+    per-session status read in ``_process_stalled_session`` had 6 sibling
+    stalled-pass tests silently depending on task #489's LIVE status (+
+    ~1-2s subprocess per call; round-1 review probe evidence). Read-only
+    (never the junk-marker mechanism) — a determinism/latency pin. A test
+    that needs a status overrides this with its own stub (a later test-level
+    monkeypatch wins), e.g.
+    ``monkeypatch.setattr(asw, "_task_status", lambda issue: "running")``."""
+    import functools
+
+    import autonomous_session_watch as asw
+
+    # functools.wraps sets __wrapped__, so inspect.getsource() on the patched
+    # attribute still resolves the ORIGINAL body.
+    @functools.wraps(asw._task_status)
+    def _guarded(issue):
+        raise AssertionError(
+            f"_task_status({issue}) reached the #1247 round-2 autouse hermeticity guard — the "
+            "real body shells `task.py view` against the LIVE task tree, making the test "
+            "depend on live VM state. Monkeypatch a status in the test, e.g. "
+            "monkeypatch.setattr(asw, '_task_status', lambda issue: 'running')."
+        )
+
+    monkeypatch.setattr(asw, "_task_status", _guarded)
+
+
+def _stub_fleet_mutating_passes(asw, monkeypatch):
+    """#1247 hermeticity for FULL-main() tests — mirror of the same-name
+    helper in ``tests/test_autonomous_session_watch.py`` (per-file helper
+    convention, like ``isolated_registry``): main() runs passes that scan the
+    LIVE repo and can REALLY mutate fleet state from a unit test.
+    ``proposed_infra_sweep_pass`` + ``capacity_retry_pass`` DISPATCH real
+    ``spawn-issue --auto`` sessions via the live Happy daemon,
+    ``program_orchestrator_pass`` can relaunch the real #660 tmux daemon, the
+    escalate-only observer passes scan live VM state (REGISTRY tasks +
+    events.jsonl, /proc + the earlyoom journal, the Happy daemon bundle,
+    statvfs) and can write real ``.claude/cache/`` sidecar rows + Telegram
+    pushes, and ``vm_ledger_reap_pass`` mutates the live
+    ``~/.task-workflow/vm-ledger.json``. Call this helper BEFORE any
+    test-local recorder so the recorder (a later monkeypatch) wins."""
+    for pass_name in (
+        "proposed_infra_sweep_pass",
+        "capacity_retry_pass",
+        "program_orchestrator_pass",
+        "verdict_disagree_pass",
+        "cpu_guard_pass",
+        "happy_patch_pass",
+        "data_disk_pass",
+        "gate_push_pass",
+        "gc_pass",
+        "vm_ledger_reap_pass",
+    ):
+        monkeypatch.setattr(asw, pass_name, lambda *a, **kw: None)
+
+
 # ─── decide_session_stalled — pure decision matrix ────────────────────────────
 
 
@@ -610,6 +668,11 @@ def test_stalled_pass_alerts_after_two_consecutive_stale_ticks(
     )
     monkeypatch.setattr(asw, "_task_events", lambda issue: [])
     monkeypatch.setattr(asw, "_running_managed_issue_pods", lambda *_a, **_k: [])
+    # #1247 r2 hermeticity: _process_stalled_session re-reads the task status
+    # via a REAL `task.py view 489` subprocess. Stub a TERMINAL status (the
+    # value the live host historically returned for #489) so respawn stays
+    # ineligible and the pass exercises the alert-only arm this test pins.
+    monkeypatch.setattr(asw, "_task_status", lambda issue: "completed")
     monkeypatch.setattr(
         asw,
         "_post_progress_marker",
@@ -769,6 +832,8 @@ def test_stalled_pass_dedups_within_episode(
     )
     monkeypatch.setattr(asw, "_task_events", lambda issue: [])
     monkeypatch.setattr(asw, "_running_managed_issue_pods", lambda *_a, **_k: [])
+    # #1247 r2 hermeticity: terminal status (see the two-tick alert test).
+    monkeypatch.setattr(asw, "_task_status", lambda issue: "completed")
     monkeypatch.setattr(
         asw,
         "_post_progress_marker",
@@ -797,6 +862,8 @@ def test_stalled_pass_clears_alerted_when_self_report_advances(
     stale_age = STALLED_WINDOW_S + 600
     monkeypatch.setattr(asw, "_task_events", lambda issue: [])
     monkeypatch.setattr(asw, "_running_managed_issue_pods", lambda *_a, **_k: [])
+    # #1247 r2 hermeticity: terminal status (see the two-tick alert test).
+    monkeypatch.setattr(asw, "_task_status", lambda issue: "completed")
     monkeypatch.setattr(
         asw,
         "_post_progress_marker",
@@ -848,6 +915,8 @@ def test_stalled_pass_skips_when_no_self_report(
     monkeypatch.setattr(asw, "_self_report_age_seconds", lambda issue, now: (None, None))
     monkeypatch.setattr(asw, "_task_events", lambda issue: [])
     monkeypatch.setattr(asw, "_running_managed_issue_pods", lambda *_a, **_k: [])
+    # #1247 r2 hermeticity: terminal status (see the two-tick alert test).
+    monkeypatch.setattr(asw, "_task_status", lambda issue: "completed")
     monkeypatch.setattr(
         asw,
         "_post_progress_marker",
@@ -879,6 +948,8 @@ def test_stalled_pass_never_respawns_or_stops(
     )
     monkeypatch.setattr(asw, "_task_events", lambda issue: [])
     monkeypatch.setattr(asw, "_running_managed_issue_pods", lambda *_a, **_k: [])
+    # #1247 r2 hermeticity: terminal status (see the two-tick alert test).
+    monkeypatch.setattr(asw, "_task_status", lambda issue: "completed")
     monkeypatch.setattr(asw, "_respawn", lambda entry, dry_run: respawns.append(entry) or True)
     monkeypatch.setattr(asw, "_stop_pod", lambda issue, dry_run: stops.append(issue) or True)
     monkeypatch.setattr(asw, "_post_progress_marker", lambda *a, **kw: None)
@@ -960,6 +1031,8 @@ def test_stalled_pass_dry_run_no_state_write(
     )
     monkeypatch.setattr(asw, "_task_events", lambda issue: [])
     monkeypatch.setattr(asw, "_running_managed_issue_pods", lambda *_a, **_k: [])
+    # #1247 r2 hermeticity: terminal status (see the two-tick alert test).
+    monkeypatch.setattr(asw, "_task_status", lambda issue: "completed")
     monkeypatch.setattr(asw, "_post_progress_marker", lambda *a, **kw: None)
 
     asw.stalled_session_pass(dry_run=True, threshold=1, now=now)
@@ -1136,6 +1209,12 @@ def test_main_runs_stalled_and_gc_after_pod_safety(isolated_registry, monkeypatc
     import autonomous_session_watch as asw
 
     calls: list[str] = []
+    # #1247 round 2: with _daemon_reachable forced True below, the unstubbed
+    # sweep/observer passes would reach live VM state (this exact test shelled
+    # a real `task.py list-by-status --status proposed` via
+    # proposed_infra_sweep_pass). Called FIRST so the test's own gc_pass
+    # recorder below overrides the helper's stub and keeps recording.
+    _stub_fleet_mutating_passes(asw, monkeypatch)
     monkeypatch.setattr(asw, "_daemon_reachable", lambda: True)
     monkeypatch.setattr(asw, "_live_session_ids", lambda: set())
     # main() fetches the shared reaper-pass /list snapshot + the #845 wedge

--- a/tests/test_stalled_detector_and_gc.py
+++ b/tests/test_stalled_detector_and_gc.py
@@ -51,6 +51,7 @@ def _forbid_real_marker_posts(monkeypatch):
     commit on a REAL task (the two-week #662/#663/#867 incident class). A
     test-level recorder patch overrides this default; ``dry_run=True`` and
     stubbed-``subprocess.run`` calls keep the real body's behavior."""
+    import functools
     import subprocess as _sp
 
     import autonomous_session_watch as asw
@@ -58,6 +59,9 @@ def _forbid_real_marker_posts(monkeypatch):
     real_post = asw._post_progress_marker
     real_run = _sp.run
 
+    # functools.wraps sets __wrapped__, so inspect.getsource() on the patched
+    # attribute still resolves the ORIGINAL body.
+    @functools.wraps(real_post)
     def _guarded(issue, note, dry_run, *, label):
         if not dry_run and _sp.run is real_run:
             raise AssertionError(

--- a/tests/test_stalled_detector_and_gc.py
+++ b/tests/test_stalled_detector_and_gc.py
@@ -42,6 +42,34 @@ from autonomous_session_watch import (  # noqa: E402
     decide_session_stalled,
 )
 
+
+@pytest.fixture(autouse=True)
+def _forbid_real_marker_posts(monkeypatch):
+    """#1247 hermeticity guard (fail-loud): no test in this file may reach the
+    real ``task.py post-marker`` subprocess through ``_post_progress_marker``
+    with ``dry_run=False`` — an unpatched call posts a junk marker + git
+    commit on a REAL task (the two-week #662/#663/#867 incident class). A
+    test-level recorder patch overrides this default; ``dry_run=True`` and
+    stubbed-``subprocess.run`` calls keep the real body's behavior."""
+    import subprocess as _sp
+
+    import autonomous_session_watch as asw
+
+    real_post = asw._post_progress_marker
+    real_run = _sp.run
+
+    def _guarded(issue, note, dry_run, *, label):
+        if not dry_run and _sp.run is real_run:
+            raise AssertionError(
+                f"_post_progress_marker(issue={issue}, label={label!r}, dry_run=False) reached "
+                "the #1247 autouse hermeticity guard with the REAL subprocess.run still live — "
+                "monkeypatch a recorder (or stub subprocess.run) in the test."
+            )
+        return real_post(issue, note, dry_run, label=label)
+
+    monkeypatch.setattr(asw, "_post_progress_marker", _guarded)
+
+
 # ─── decide_session_stalled — pure decision matrix ────────────────────────────
 
 


### PR DESCRIPTION
Closes task #1247. Test-hermeticity fix (the junk-marker loop-stopper: _run_orphan_task drove real ids 662/663/867 with _post_progress_marker unstubbed), act-time terminal-status guard (orphan + stalled-fence), [src: ...] source stamp on respawn-class markers, background-automation.md docs.