### PR TITLE
issue-1235: nightly /daily invoker for the #1196 title-sync drift sweep

### DIFF
--- a/.claude/skills/daily/SKILL.md
+++ b/.claude/skills/daily/SKILL.md
@@ -225,7 +225,7 @@ NO LONGER an allowed write target for this skill.
 
 ### Living-docs consolidation passes (folded in from /weekly, #713)
 
-Two nightly consolidation checks that used to live in `/weekly` (which is now a
+Nightly consolidation checks — the first two used to live in `/weekly` (which is now a
 manual deep-dive nothing depends on — see `.claude/skills/weekly/SKILL.md`). Both
 run every nightly `/daily`, both PROPOSE only (`docs/open_questions.md` mutations
 are user-gated — the `living_docs_update` gate is user-only), both are deduped by
@@ -355,6 +355,31 @@ self-describing per workflow-fix-on-bug.md § Markers.
 
 Future sweeps skip routed candidates mechanically — see the enumerator's
 suppression predicate (`scripts/sweep_parked_wf_candidates.py --help`).
+
+**4. Clean-result title-sync drift sweep (Step D).** Run the read-only
+corpus-wide H1-vs-frontmatter-title drift sweep (#1196) so the drift report
+surfaces nightly:
+
+```
+uv run python scripts/audit_clean_results_body_discipline.py --title-sync-sweep
+    # read-only (bodies are NOT modified); WARN-only — ALWAYS exits 0
+    # (~2 s at the current ~1,200-body corpus). A NONZERO exit is a CRASH
+    # (the sweep never FAILs by design): note it as a problem in
+    # ## Other problems & notes — never treat it as a drift signal, and
+    # never let it fail the daily run.
+```
+
+A `PASS:` headline (zero WARN rows) → nothing to record. Otherwise copy each
+`- #<N> (<status>): ...` WARN row into `## Other problems & notes` as its own
+bullet, verbatim — each row already carries both title values AND both
+remediation commands (`task.py set-title` vs re-`set-body`). Which side is
+the fresher intent is a HUMAN call: NEVER run the remediation from /daily
+(same discipline as "never `living_docs.py apply`"); Thomas or the PM runs
+the command from the note. No-spam variant: if the row set is IDENTICAL to
+the previous daily file's, replace the verbatim copies with one line —
+`- title-sync drift unchanged (<K> rows — see logs/daily/<prev-date>.md)`
+(LLM judgment against yesterday's file; no new dedup state, matching Step
+B's no-spam skip discipline).
 
 **Dedup mechanism (Step F).** A filesystem event-stream
 `.claude/cache/nightly-consolidation-events.jsonl` (a local, gitignored durable

--- a/tests/test_daily_three_route_classifier_doc.py
+++ b/tests/test_daily_three_route_classifier_doc.py
@@ -308,3 +308,19 @@ def test_route2_wf_fix_false_variant_documented(daily_skill_text: str):
         "the drop-tags route-2 variant would be prose-only again, unreachable "
         "through the batch driver daily_drive_filings.py (#1228)"
     )
+
+
+# ── Step D: nightly title-sync drift sweep invoker (#1196 → #1235) ────────────
+
+
+def test_title_sync_sweep_pass_present(daily_skill_text: str):
+    """The nightly /daily invoker for the #1196 title-sync drift sweep survives
+    (task #1235): the command, its WARN-only/exit-0 contract, and the
+    surface-only routing must not be silently dropped by a later edit."""
+    assert (
+        "scripts/audit_clean_results_body_discipline.py --title-sync-sweep" in daily_skill_text
+    ), "the Step D title-sync sweep command is missing from daily/SKILL.md"
+    assert "title-sync drift sweep (Step D)" in daily_skill_text, (
+        "the Step D pass header is missing — the nightly title-sync invoker "
+        "(#1235) may have been dropped"
+    )


### PR DESCRIPTION
Closes task #1235. Adds Step D (title-sync drift sweep) to /daily SKILL.md + durability-pin test.