### PR TITLE
issue-1237: anchor the 9 remaining doc-global N/A escapes to standalone lines

### DIFF
--- a/.claude/skills/adversarial-planner/SKILL.md
+++ b/.claude/skills/adversarial-planner/SKILL.md
@@ -159,7 +159,11 @@ Run the structural verifier against the plan version just persisted:
   satisfy a check it is legitimately exempt from — and instruct the planner that the
   plan's own declaration line must be UNWRAPPED plain text at line start (leading list
   markers fine): the backtick-wrapped renderings below are deliberate anti-paste armor
-  and are NOT recognized by `verify_plan.py::_standalone_na_declared` (#1238)):
+  and are NOT recognized by `verify_plan.py::_standalone_na_declared` (#1238)): Every
+  phrase satisfies its check ONLY when written as a standalone declaration line in the
+  plan (leading `-`/`>`/`*` list markers tolerated); a phrase quoted mid-sentence — e.g.
+  inside a pasted bounce brief — does not count (exceptions: check 7 matches its bare
+  phrase in prose by design; check 31 uses its labeled-line forms) (#1237).
   `N/A — no behavioral construct`
   (check 2), `N/A — no model training` / `N/A — no training hyperparameters` (check 1),
   `N/A — not a replication` (check 7), `N/A — no artifact reuse` (check 6),

--- a/scripts/verify_plan.py
+++ b/scripts/verify_plan.py
@@ -82,7 +82,10 @@ mode only and renders it SKIP in ``--plan-file`` mode; its WARN is the one
 the adversarial-planner Phase 1.5.0 consumer treats as a mechanical redraft
 bounce (SKILL.md § Goal-currency gate), not a brief-forwarded WARN.
 
-Canonical N/A escape phrases (quote verbatim in bounce briefs):
+Canonical N/A escape phrases (quote verbatim in bounce briefs; each
+satisfies its check ONLY as a standalone declaration line — see
+``_standalone_na_declared``; exceptions: check 7 matches its bare
+phrase in prose by design, check 31 uses its labeled-line forms):
 
   - ``N/A — no model training`` / ``N/A — no training hyperparameters``
     (check 1)
@@ -545,8 +548,8 @@ def check_source_grounding(plan: str, kind: str) -> CheckResult:
         plan, ("decision rationale", "hyperparameter grounding", "decision grounding")
     )
     scope = sect if sect is not None else plan
-    if re.search(
-        NA_RE + r"no (?:model )?(?:training )?(?:model training|hyperparameters|training)", scope
+    if _standalone_na_declared(
+        scope, r"no (?:model )?(?:training )?(?:model training|hyperparameters|training)"
     ):
         return _pass(
             cid, name, "explicit N/A declared (no model training / no training hyperparameters)"
@@ -562,9 +565,10 @@ def check_source_grounding(plan: str, kind: str) -> CheckResult:
         return _fail(
             cid,
             name,
-            "no Decision Rationale / grounding section and zero Source: entries — every "
+            "no Decision Rationale / grounding section and zero Source entries — every "
             "load-bearing hyperparameter needs a Source (planner.md §11); if the plan trains "
-            "no model, declare `N/A — no model training` / `N/A — no training hyperparameters`",
+            "no model, declare `N/A — no model training` / `N/A — no training hyperparameters` "
+            "— each on its own line",
         )
     if blank:
         return _fail(
@@ -585,8 +589,8 @@ def check_source_grounding(plan: str, kind: str) -> CheckResult:
         return _fail(
             cid,
             name,
-            "§11-style section present but zero Source entries (inline `Source:` label or "
-            "a `Source` table column)",
+            "§11-style section present but zero Source entries (an inline source label — "
+            "`Source` followed by a colon — or a `Source` table column)",
         )
     ungrounded = [s for s in sources if "ungrounded" in s.lower()]
     return _pass(
@@ -609,7 +613,7 @@ def check_measurement_validity(plan: str, kind: str) -> CheckResult:
     cid, name = "c2_measurement_validity", "per-DV measurement validity"
     if kind != "experiment":
         return _skip(cid, name, "kind-exempt: analysis|infra|batch|survey have no behavioral DV")
-    if re.search(NA_RE + r"no behavioral construct", plan):
+    if _standalone_na_declared(plan, r"no behavioral construct"):
         return _pass(cid, name, "explicit N/A declared (no behavioral construct)")
     text = strip_fences(plan)
     mv_headings = [h for h in _headings(plan) if "measurement validity" in h.text.casefold()]
@@ -644,7 +648,7 @@ def check_measurement_validity(plan: str, kind: str) -> CheckResult:
         name,
         "no measurement-validity declaration (planner.md §6 required block: per-DV construct "
         "+ metric + on-distribution status; non-behavioral plans declare "
-        "`N/A — no behavioral construct`)",
+        "`N/A — no behavioral construct` on its own line)",
     )
 
 
@@ -825,7 +829,7 @@ def check_reuse_fitness(plan: str, kind: str) -> CheckResult:
     reuse_heading = any(re.search(r"(?i)reuse|reused[- ]artifact", h.text) for h in _headings(plan))
     if not (reuse_near_hf or reuse_heading):
         return _skip(cid, name, "no HF-artifact reuse detected")
-    if re.search(NA_RE + r"no (?:artifact )?reuse", text):
+    if _standalone_na_declared(plan, r"no (?:artifact )?reuse"):
         return _pass(cid, name, "explicit no-reuse declaration (N/A — no artifact reuse)")
     fitness = re.search(r"(?i)fitness", text)
     letters = {m.group(1) for m in re.finditer(r"\(([a-j])\)", text)}
@@ -1089,7 +1093,7 @@ def check_dryrun_test_coverage(plan: str, kind: str) -> CheckResult:
         )
     if not _DRYRUN_FLAG_RE.search(plan):
         return _skip(cid, name, "no --dry-run smoke/verification command detected")
-    if re.search(NA_RE + r"no dry-?run smoke", plan):
+    if _standalone_na_declared(plan, r"no dry-?run smoke"):
         return _pass(cid, name, "explicit N/A declared (no dry-run smoke)")
     evidence = _dryrun_test_evidence_lines(plan)
     if evidence:
@@ -1098,9 +1102,10 @@ def check_dryrun_test_coverage(plan: str, kind: str) -> CheckResult:
         cid,
         name,
         "plan names a `--dry-run` smoke/verification command but the test list has no test "
-        "exercising `dry_run=True` on the new code path — a broken dry_run thread turns the "
-        "final smoke into a real mutation (#596/#607/#633 pattern); add the test, or declare "
-        "`N/A — no dry-run smoke` if the flag mention is incidental",
+        "exercising the dry-run kwarg thread on the new code path — a broken dry-run kwarg "
+        "thread turns the final smoke into a real mutation (#596/#607/#633 pattern); add the "
+        "test, or declare `N/A — no dry-run smoke` on its own line if the flag mention is "
+        "incidental",
     )
 
 
@@ -1865,10 +1870,6 @@ _FAILLOUD_SUMMARY_HEAD_RE = re.compile(r"(?i)tl;dr|plan summary|^(?:§\s*)?0(?:\
 
 _FAILLOUD_WINDOW_LINES = 30
 
-_FAILLOUD_NA_RE = re.compile(
-    NA_RE + r"(?:no fail[- ]?loud acceptance claim|fail[- ]?loud claim not test-backable)"
-)
-
 
 def _failloud_claim_hits(plan: str) -> list[tuple[str, str]]:
     """(section heading, matched vocabulary) per acceptance/success anchor
@@ -1927,7 +1928,9 @@ def check_failloud_test_coverage(plan: str, kind: str) -> CheckResult:
     hits = _failloud_claim_hits(plan)
     if not hits:
         return _skip(cid, name, "no fail-loud claim in an acceptance/success-criteria window")
-    if _FAILLOUD_NA_RE.search(plan):
+    if _standalone_na_declared(
+        plan, r"(?:no fail[- ]?loud acceptance claim|fail[- ]?loud claim not test-backable)"
+    ):
         return _pass(
             cid, name, "explicit N/A declared (incidental vocabulary or not test-backable)"
         )
@@ -1950,7 +1953,7 @@ def check_failloud_test_coverage(plan: str, kind: str) -> CheckResult:
         "not count) — a run-book grep verifies the invariant once at review time, and a "
         "differently-worded re-swallow ships green past all committed tests (#913). Name the "
         "pinning test, or declare `N/A — no fail-loud acceptance claim` / "
-        "`N/A — fail-loud claim not test-backable`",
+        "`N/A — fail-loud claim not test-backable` — each on its own line",
     )
 
 
@@ -2017,7 +2020,6 @@ _C16_NONREPLACE_RE = re.compile(
     r"(?:headline[- ])?replac\w*[^.;]{0,80}?(?:headline|committed)"
     r"|(?:never|not)\s+(?:silently\s+)?replac\w*[^.;]{0,60}?headline"
 )
-_C16_NA_RE = re.compile(NA_RE + r"no re-?extracted reference arms")
 
 
 def check_reference_headline_distinction(plan: str, kind: str) -> CheckResult:
@@ -2051,7 +2053,7 @@ def check_reference_headline_distinction(plan: str, kind: str) -> CheckResult:
             "re-extraction vocabulary present but the plan does not read as a "
             "same-issue follow-up folding into an existing clean-result",
         )
-    if _C16_NA_RE.search(text):
+    if _standalone_na_declared(plan, r"no re-?extracted reference arms"):
         return _pass(cid, name, "explicit N/A declared (no re-extracted reference arms)")
     if (
         _C16_SAMEPASS_RE.search(text)
@@ -2067,12 +2069,13 @@ def check_reference_headline_distinction(plan: str, kind: str) -> CheckResult:
         cid,
         name,
         "plan re-extracts prior-headline reference arms AND folds into an existing "
-        "clean-result, but no sentence distinguishes same-pass comparator values from "
+        "clean-result, but no sentence distinguishes same-pass-comparator values from "
         "the prior committed headline values — state which values adjudicate this "
-        "round's NEW comparison vs which remain the committed headline, and that a "
+        "round's NEW comparison vs which are still the committed headline, and that a "
         "flipped reference CALL is reported as replication-stability evidence rather "
-        "than replacing the headline (#811 v3 §6 incident; the committed-cells-"
-        "remain-evidence rule), or declare `N/A — no re-extracted reference arms`",
+        "than replacing the headline (#811 v3 §6 incident; the kept-cells-"
+        "stay-evidence rule), or declare `N/A — no re-extracted reference arms` "
+        "on its own line",
     )
 
 
@@ -2571,7 +2574,7 @@ def check_ood_folds(plan: str, kind: str) -> CheckResult:
     cid, name = "c19_ood_folds", "OOD generalization folds (held-out predictive DV)"
     if kind not in ("experiment", "analysis"):
         return _skip(cid, name, "kind-exempt: infra|batch|survey plans have no predictive DV")
-    if re.search(NA_RE + r"no held-?out predictive DV", plan):
+    if _standalone_na_declared(plan, r"no held-?out predictive DV"):
         return _pass(cid, name, "explicit N/A declared (no held-out predictive DV)")
     text = strip_fences(plan)
     solo = _C19_SOLO_FOLD_RE.search(text)
@@ -2604,10 +2607,11 @@ def check_ood_folds(plan: str, kind: str) -> CheckResult:
     return _warn(
         cid,
         name,
-        "held-out predictive-DV vocabulary detected but no GROUP-level fold (LOFO / "
-        "leave-one-family-out / corpus transfer), no iid argument, and no "
-        "`N/A — no held-out predictive DV` escape — pointwise LOO can REORDER "
-        "cross-context claims (#810: read-out rho 0.909 → 0.285 under LOFO); "
+        "held-out predictive-DV vocabulary detected but no group-scoped fold "
+        "(leave-one-<family>-out / a fit-on-one-corpus-score-on-another arm), no "
+        "independence (i-i-d) argument, and no `N/A — no held-out predictive DV` escape "
+        "declared on its own line — pointwise LOO can REORDER cross-context claims "
+        "(#810: read-out rho 0.909 → 0.285 under the family-level fold); "
         ".claude/rules/ood-generalization-folds.md; Statistics critic must gate this",
     )
 
@@ -3245,8 +3249,6 @@ _C21_AST_EVIDENCE_RE = re.compile(
     r"(?i)ast\.(?:walk|parse)|\bAST[- ](?:based|arity|audit|walker)|libcst"
 )
 
-_C21_NA_RE = re.compile(NA_RE + r"no arity acceptance gate")
-
 
 def check_grep_arity_gate(plan: str, kind: str) -> CheckResult:
     """Plans registering a grep/`wc -l`-based signature-ARITY acceptance
@@ -3284,7 +3286,7 @@ def check_grep_arity_gate(plan: str, kind: str) -> CheckResult:
             hits.append((i, line.strip()))
     if not hits:
         return _skip(cid, name, "no grep-based call-arity pass condition detected")
-    if _C21_NA_RE.search(plan):
+    if _standalone_na_declared(plan, r"no arity acceptance gate"):
         return _pass(
             cid, name, "explicit N/A declared (flagged grep is not an arity pass condition)"
         )
@@ -3306,7 +3308,7 @@ def check_grep_arity_gate(plan: str, kind: str) -> CheckResult:
         "(split-line and keyword-argument calls carry no same-line comma; #1024 plan v1/v2). "
         "Register an AST arity audit instead: ast.parse each target file, ast.walk over Call "
         "nodes matching the function, count len(node.args) + len(node.keywords), whitelist "
-        "named exceptions — or declare `N/A — no arity acceptance gate`",
+        "named exceptions — or declare `N/A — no arity acceptance gate` on its own line",
     )
 
 
@@ -4722,7 +4724,7 @@ def check_realized_keys(plan: str, kind: str) -> CheckResult:
     )
     if not reuse_near_bundle:
         return _skip(cid, name, "no multi-field bundle reuse detected")
-    if re.search(NA_RE + r"no multi-?field bundle reuse", text):
+    if _standalone_na_declared(plan, r"no multi-?field bundle reuse"):
         return _pass(cid, name, "explicit no-bundle-reuse declaration")
     if _C30_SATISFIER_RE.search(plan):  # raw plan: fenced commands count
         return _pass(
@@ -4846,7 +4848,8 @@ def check_skillmd_prose_pin(plan: str, kind: str) -> CheckResult:
         "pin — protection prose with no pytest asserting its presence/shape is silently "
         "droppable by any later SKILL.md edit (lineage: #884/#1045/#1134). Add one line "
         "`Durability pin: tests/test_<file>.py::test_<name>` (a standing pin test, or a NEW "
-        "pin test this plan adds), or declare `Durability pin: N/A — <one-line reason>`",
+        "pin test this plan adds), or declare `Durability pin: N/A` followed on the same "
+        "line by an em dash and a one-line reason (a bare `Durability pin: N/A` still WARNs)",
     )
 
 

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -296,6 +296,36 @@ def test_c1_section_present_zero_sources_fails():
     assert "zero source entries" in r.detail.lower()
 
 
+def test_c1_pasted_fail_detail_does_not_self_satisfy():
+    # Anti-paste guard (#4.2 c1 de-fang): pre-fix, the pasted FAIL detail
+    # both matched the doc-global escape (its quoted `N/A — no model
+    # training`) and yielded an evidence-valued `Source:` capture via
+    # "zero Source: entries — ...". Exercises the doc-global scope fallback
+    # (no recognizable §11 heading → scope = whole plan).
+    base = GOOD_PLAN.replace("## 11. Decision Rationale (§11)", "## 11. Notes").replace(
+        "Source:", "Ref:"
+    )
+    _, by_id = _run(base)
+    r = by_id["c1_source_grounding"]
+    assert r.status == "FAIL"
+    pasted = base + f"\n{r.detail}\n"
+    assert _status(pasted, "c1_source_grounding") == "FAIL"
+
+
+def test_c1_section_present_zero_sources_pasted_detail_does_not_self_satisfy():
+    # The sibling FAIL branch's red twin: §11 heading KEPT, all sources
+    # renamed → FAIL via the section-present-zero-sources branch. Pre-fix
+    # its detail's "(inline `Source:` label or ...)" wording yielded an
+    # evidence-valued capture when pasted INTO the §11 section (the last
+    # section, so an appended paste lands in the section slice).
+    base = GOOD_PLAN.replace("Source:", "Ref:")
+    _, by_id = _run(base)
+    r = by_id["c1_source_grounding"]
+    assert r.status == "FAIL"
+    pasted = base + f"\n{r.detail}\n"
+    assert _status(pasted, "c1_source_grounding") == "FAIL"
+
+
 def test_c1_sources_without_recognizable_section_warns():
     plan = GOOD_PLAN.replace("## 11. Decision Rationale (§11)", "## 11. Notes")
     _, by_id = _run(plan)
@@ -388,6 +418,18 @@ def test_c2_na_no_behavioral_construct_passes():
     r = by_id["c2_measurement_validity"]
     assert r.status == "PASS"
     assert "N/A" in r.detail
+
+
+def test_c2_pasted_fail_detail_does_not_self_satisfy():
+    # Anti-paste guard: the FAIL detail quotes its escape phrase as a remedy
+    # option — pre-fix, the doc-global escape search matched it when the
+    # detail was pasted back into the plan (FAIL → PASS).
+    base = _plan_without_mv()
+    _, by_id = _run(base)
+    r = by_id["c2_measurement_validity"]
+    assert r.status == "FAIL"
+    pasted = base + f"\n{r.detail}\n"
+    assert _status(pasted, "c2_measurement_validity") == "FAIL"
 
 
 def test_c2_heading_without_content_warns():
@@ -737,11 +779,29 @@ def test_c6_fitness_with_few_letters_warns():
 
 
 def test_c6_na_no_artifact_reuse_passes():
+    # Standalone-line escape (the mid-line form was the self-escape shape —
+    # repurposed into test_c6_quoted_na_phrase_does_not_escape below).
     plan = (
         GOOD_PLAN
-        + "\nPrior adapters at superkaiba1/explore-persona-space exist; reuse was considered and rejected. N/A — no artifact reuse.\n"
+        + "\nPrior adapters at superkaiba1/explore-persona-space exist; reuse was considered and rejected.\n"
+        + "\nN/A — no artifact reuse (adapters exist but this design retrains).\n"
     )
     assert _status(plan, "c6_reuse_fitness") == "PASS"
+
+
+def test_c6_quoted_na_phrase_does_not_escape():
+    # Anti-paste guard: a mid-sentence quote of the escape phrase (the shape a
+    # pasted remedy menu produces) must not satisfy the standalone-line escape.
+    base = (
+        GOOD_PLAN
+        + "\nWe reuse the parent adapters from superkaiba1/explore-persona-space for the base arm.\n"
+    )
+    assert _status(base, "c6_reuse_fitness") == "WARN"
+    quoted = base + (
+        "\nReuse was considered and rejected: N/A — no artifact reuse. The remedy menu "
+        "says to declare `N/A — no artifact reuse` on its own line.\n"
+    )
+    assert _status(quoted, "c6_reuse_fitness") == "WARN"
 
 
 def test_c6_heading_triggers():
@@ -961,7 +1021,7 @@ def test_c11_smoke_without_dryrun_test_warns():
     _, by_id = _run(plan, kind="infra")
     r = by_id["c11_dryrun_test_coverage"]
     assert r.status == "WARN"
-    assert "dry_run" in r.detail
+    assert "dry-run kwarg" in r.detail
     assert "#633" in r.detail
 
 
@@ -1017,14 +1077,28 @@ def test_c11_smoke_sentence_mentioning_test_suite_does_not_self_certify():
 
 
 def test_c11_na_escape_passes():
+    # Standalone-line escape (the mid-line form was the self-escape shape).
     plan = (
         GOOD_PLAN
-        + "\nworktree_audit.py already supports --dry-run; this plan does not touch that path. N/A — no dry-run smoke.\n"
+        + "\nworktree_audit.py already supports --dry-run; this plan does not touch that path.\n"
+        + "\nN/A — no dry-run smoke.\n"
     )
     _, by_id = _run(plan, kind="infra")
     r = by_id["c11_dryrun_test_coverage"]
     assert r.status == "PASS"
     assert "N/A" in r.detail
+
+
+def test_c11_pasted_warn_detail_does_not_self_satisfy():
+    # Anti-paste guard (#4.2 c11 de-fang): pre-fix, the WARN detail's own
+    # `dry_run=True` wording satisfied the kwarg evidence branch when pasted
+    # back into the plan; the reworded detail must not.
+    base = GOOD_PLAN + DRYRUN_SMOKE
+    _, by_id = _run(base, kind="infra")
+    r = by_id["c11_dryrun_test_coverage"]
+    assert r.status == "WARN"
+    pasted = base + f"\n{r.detail}\n"
+    assert _status(pasted, "c11_dryrun_test_coverage", kind="infra") == "WARN"
 
 
 # ─── Check 12 — battery multiplier + batched commitment ────────────────────
@@ -1859,16 +1933,29 @@ def test_c15_identifier_internal_vocab_passes():
 
 
 def test_c15_na_escape_incidental_passes():
+    # Standalone-line escape (the mid-line form was the self-escape shape).
     plan = (
         GOOD_PLAN
         + FAILLOUD_ACCEPT
-        + "\nThe 'silently' sentence above narrates the pre-fix defect. "
-        "N/A — no fail-loud acceptance claim.\n"
+        + "\nThe 'silently' sentence above narrates the pre-fix defect.\n"
+        + "\nN/A — no fail-loud acceptance claim.\n"
     )
     _, by_id = _run(plan, kind="infra")
     r = by_id["c15_failloud_test_coverage"]
     assert r.status == "PASS"
     assert "N/A" in r.detail
+
+
+def test_c15_pasted_warn_detail_does_not_self_satisfy():
+    # Anti-paste guard: the WARN detail quotes BOTH escape phrases as remedy
+    # options — pre-fix, the doc-global escape search matched them when the
+    # detail was pasted back into the plan.
+    base = GOOD_PLAN + FAILLOUD_ACCEPT
+    _, by_id = _run(base, kind="infra")
+    r = by_id["c15_failloud_test_coverage"]
+    assert r.status == "WARN"
+    pasted = base + f"\n{r.detail}\n"
+    assert _status(pasted, "c15_failloud_test_coverage", kind="infra") == "WARN"
 
 
 def test_c15_na_escape_doc_target_passes():
@@ -2015,7 +2102,19 @@ def test_c16_811_v3_clause_shape_warns():
     _, by_id = _run(C16_INCIDENT)
     r = by_id[C16]
     assert r.status == "WARN"
-    assert "same-pass comparator" in r.detail
+    assert "same-pass-comparator" in r.detail
+
+
+def test_c16_pasted_warn_detail_does_not_self_satisfy():
+    # Anti-paste guard (#4.2 c16 de-fang): pre-fix, the WARN detail's own
+    # "same-pass comparator" wording satisfied _C16_SAMEPASS_RE (and its
+    # committed-headline prose satisfied _C16_DISTINCTION_RE) when pasted
+    # back into the plan; the reworded detail must not.
+    _, by_id = _run(C16_INCIDENT)
+    r = by_id[C16]
+    assert r.status == "WARN"
+    pasted = C16_INCIDENT + f"\n{r.detail}\n"
+    assert _status(pasted, C16) == "WARN"
 
 
 def test_c16_distinguishing_sentence_passes():
@@ -2780,6 +2879,27 @@ def test_c19_na_escape_passes():
     assert "N/A" in res.detail
 
 
+def test_c19_na_bullet_form_standalone_passes():
+    # Pins the helper's lstrip(" \t>*-") on the Goal-named site: a bullet-form
+    # standalone declaration still counts (the only other lstrip pin is c12's).
+    plan = _predictive_plan() + "- N/A — no held-out predictive DV (no predictor in this design).\n"
+    assert _status(plan, "c19_ood_folds") == "PASS"
+
+
+def test_c19_pasted_warn_detail_does_not_self_satisfy():
+    # THE #974 guard (#4.2 c19 de-fang): pre-fix, the pasted WARN detail
+    # satisfied FOUR channels at once — the doc-global NA escape, the
+    # group-fold vocabulary ("GROUP-level fold" / "corpus transfer"), the
+    # leave-one-family-out unit capture, and the iid regex via "no iid
+    # argument" (the lookbehind does not cover "no ").
+    base = _predictive_plan()
+    _, by_id = _run(base)
+    r = by_id["c19_ood_folds"]
+    assert r.status == "WARN"
+    pasted = base + f"\n{r.detail}\n"
+    assert _status(pasted, "c19_ood_folds") == "WARN"
+
+
 def test_c19_kind_analysis_triggers():
     # Scope pin: kind=analysis is IN scope (the #810/#761/#763 predictor
     # line lives in analysis follow-ups), same WARN-only severity.
@@ -3178,6 +3298,19 @@ def test_c21_na_escape_passes():
     r = by_id[C21]
     assert r.status == "PASS"
     assert "N/A" in r.detail
+
+
+def test_c21_quoted_na_phrase_does_not_escape():
+    # Anti-paste guard: a mid-sentence quote of the escape phrase (the shape
+    # a pasted remedy menu produces) must not satisfy the standalone-line
+    # escape. Quoted-phrase form, not full-detail paste — the AST-evidence
+    # channel of the pasted detail is a disclosed residual (plan §8 row 6).
+    base = GOOD_PLAN + C21_PIPELINE_GATE
+    assert _status(base, C21, kind="infra") == "WARN"
+    quoted = base + (
+        "\nThe remedy menu says to declare 'N/A — no arity acceptance gate' on its own line.\n"
+    )
+    assert _status(quoted, C21, kind="infra") == "WARN"
 
 
 def test_c21_discovery_grep_does_not_trigger():
@@ -5349,15 +5482,32 @@ def test_c30_consumer_loader_declaration_passes():
 
 
 def test_c30_na_escape_passes():
+    # Standalone-line escape (the mid-line form was the self-escape shape —
+    # repurposed into test_c30_quoted_na_phrase_does_not_escape below).
     plan = (
         GOOD_PLAN
         + "\nThe parent produced analysis_tensors bundles (.pt) but this design does not "
-        + "reuse them: N/A — no multi-field bundle reuse.\n"
+        + "reuse them.\n"
+        + "\nN/A — no multi-field bundle reuse.\n"
     )
     _, by_id = _run(plan)
     r = by_id["c30_realized_keys"]
     assert r.status == "PASS"
     assert "no-bundle-reuse declaration" in r.detail
+
+
+def test_c30_quoted_na_phrase_does_not_escape():
+    # Anti-paste guard: the old mid-line escape shape must not satisfy the
+    # standalone-line escape. Quoted-phrase form, not full-detail paste — the
+    # satisfier-name channel of the pasted detail is a disclosed residual
+    # (plan §8 row 6).
+    base = GOOD_PLAN + C30_BUNDLE_REUSE
+    assert _status(base, "c30_realized_keys") == "WARN"
+    quoted = base + (
+        "\nThe parent produced analysis_tensors bundles (.pt) but this design does not "
+        "reuse them: N/A — no multi-field bundle reuse.\n"
+    )
+    assert _status(quoted, "c30_realized_keys") == "WARN"
 
 
 def test_c30_kind_infra_skips():
@@ -5422,6 +5572,19 @@ def test_c31_skillmd_edit_without_pin_warns():
 
 def test_c31_kind_batch_triggers():
     assert _status(GOOD_PLAN + C31_SKILL_EDIT, "c31_skillmd_prose_pin", kind="batch") == "WARN"
+
+
+def test_c31_pasted_warn_detail_does_not_self_satisfy():
+    # Anti-paste guard (#4.2 c31 de-fang): pre-fix, the WARN detail's quoted
+    # example `Durability pin: N/A — <one-line reason>` satisfied
+    # _C31_PIN_NA_RE when pasted back into the plan (`<` meets the \S
+    # requirement); the reworded detail closes the backtick right after N/A.
+    base = GOOD_PLAN + C31_SKILL_EDIT
+    _, by_id = _run(base, kind="infra")
+    r = by_id["c31_skillmd_prose_pin"]
+    assert r.status == "WARN"
+    pasted = base + f"\n{r.detail}\n"
+    assert _status(pasted, "c31_skillmd_prose_pin", kind="infra") == "WARN"
 
 
 def test_c31_pin_line_passes():
@@ -5834,3 +5997,51 @@ def test_c33_warn_never_fails():
     ok, by_id = _run(C33_LADDER_S9)
     assert by_id["c33_ladder_retention"].status == "WARN"
     assert ok is True
+
+
+# ─── Anti-paste composite + SKILL.md documentation pin (#1237) ─────────────
+
+
+def test_composite_bounce_brief_paste_does_not_improve_any_check():
+    # A composite bounce brief — several checks' LIVE FAIL/WARN details
+    # concatenated into one paste block (the shape a mechanical-bounce
+    # revision produces) — appended to each triggering base plan must not
+    # improve any check's status. Self-updating: the details are captured
+    # live, so a future detail reword that re-opens a self-satisfaction
+    # channel fails here without touching the fixture.
+    cases = [
+        (
+            GOOD_PLAN.replace("## 11. Decision Rationale (§11)", "## 11. Notes").replace(
+                "Source:", "Ref:"
+            ),
+            "c1_source_grounding",
+            "experiment",
+            "FAIL",
+        ),
+        (_plan_without_mv(), "c2_measurement_validity", "experiment", "FAIL"),
+        (GOOD_PLAN + DRYRUN_SMOKE, "c11_dryrun_test_coverage", "infra", "WARN"),
+        (C16_INCIDENT, "c16_reference_headline_distinction", "experiment", "WARN"),
+        (_predictive_plan(), "c19_ood_folds", "experiment", "WARN"),
+    ]
+    details = []
+    for base, cid, kind, expected in cases:
+        _, by_id = _run(base, kind=kind)
+        assert by_id[cid].status == expected, cid
+        details.append(by_id[cid].detail)
+    blob = "\n" + "\n".join(details) + "\n"
+    for base, cid, kind, expected in cases:
+        assert _status(base + blob, cid, kind=kind) == expected, cid
+
+
+def test_skillmd_canonical_escapes_documents_standalone_line():
+    # Durability pin (plan §4.3b): the adversarial-planner SKILL.md
+    # canonical-escapes bullet must carry the standalone-declaration-line
+    # sentence — without it, post-migration bounce loops recur (a planner
+    # told to "quote verbatim" pastes the phrase mid-sentence and bounces
+    # again).
+    skill_md = (REPO_ROOT / ".claude" / "skills" / "adversarial-planner" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    idx = skill_md.index("Canonical N/A escape phrases")
+    bullet = skill_md[idx : idx + 2500]
+    assert "standalone declaration line" in bullet


### PR DESCRIPTION
Closes task #1237 (workflow-fix: migrate remaining verify_plan doc-global N/A escapes).

## Summary
- Migrates the 9 remaining doc-global `NA_RE` escape sites in `scripts/verify_plan.py` (c1, c2, c6, c11, c15, c16, c19, c21, c30) to the line-anchored `_standalone_na_declared` helper, closing the pasted-bounce-brief self-escape channel (#1203 closed c12 only); delivers the c19 anti-paste guard deferred from #974.
- De-fangs detail strings that self-satisfied their own checks (c1 both FAIL branches, c11 both occurrences, c16 three tokens, c19 four tokens, c31 backtick closure); deletes 3 single-consumer compiled patterns; documents the standalone-line requirement (docstring + adversarial-planner SKILL.md, escape phrases byte-identical).
- Tests: 577 pass file-scoped; 13 new anti-paste/pin guards each verified red on pre-fix code (incl. a composite bounce-brief fixture); Step 9c gate 3151 passed / compare new=[].

## Test plan
- [x] `uv run pytest tests/test_verify_plan.py` (577 passed on the rebased tree)
- [x] Step 9c touched-scope gate + baseline compare (PASS, new=[])
- [x] Pre-push workflow-lint gate (pass; TG legs 19/19 both trees)

🤖 Generated with [Claude Code](https://claude.com/claude-code)