### PR TITLE
issue-1244: Guard 1 — fix self-reverting FOREIGN_BRANCH_ONLY strip (#1210)

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -8708,8 +8708,14 @@ rebase-merged. Three guards:
      done
      [ "${#FOREIGN_ON_MAIN[@]}" -gt 0 ] \
        && git -C "$WT" checkout "$MAIN_SHA" -- "${FOREIGN_ON_MAIN[@]}"
+     # rm WITHOUT --cached (#1244): the strip commit below is PATHSPEC-limited,
+     # and a pathspec commit records WORKING-TREE content for the named paths
+     # (git-commit(1) --only default) — an index-only deletion (the old
+     # --cached form) is resurrected by it (#1210: 19 resurrected paths). The
+     # working-tree copies are stale duplicates of foreign tasks/ state; main
+     # is authoritative.
      [ "${#FOREIGN_BRANCH_ONLY[@]}" -gt 0 ] \
-       && git -C "$WT" rm --cached -f --ignore-unmatch -- "${FOREIGN_BRANCH_ONLY[@]}"
+       && git -C "$WT" rm -f --ignore-unmatch -- "${FOREIGN_BRANCH_ONLY[@]}"
      # Commit the reset/removal so the branch diff no longer touches them,
      # but only if anything actually changed (idempotent: a re-run finds
      # nothing staged and skips the commit). Record that a strip commit was

--- a/tests/test_step10d_guard3.py
+++ b/tests/test_step10d_guard3.py
@@ -10,7 +10,9 @@ The four #787 sub-fixes these tests guard:
 
 1. `.gitattributes` (NEW) — `merge=union` on the append-only task JSONL logs.
 2. Guard-1 — strip FOREIGN task folders before the merge, split by whether the
-   path exists on `origin/main` (checkout vs `git rm --cached`).
+   path exists on `origin/main` (checkout vs `git rm -f` — index AND working
+   tree, #1244; an index-only `rm --cached` self-reverts under the
+   pathspec-limited strip commit).
 3. Fast-path pre-check — a FIVE-conjunct predicate (incl. `ADDED_ONLY=yes`)
    that routes far-behind small ADDED-only workflow-fix branches straight to
    the surgical additive checkout, plus the surgical compute block's
@@ -116,10 +118,23 @@ def test_guard1_foreign_present_vs_added_split_present():
 
 
 def test_guard1_branch_added_foreign_dropped_not_checked_out():
+    """#1244: the drop must remove index AND working tree (`git rm -f`), never
+    index-only (`git rm --cached`) — Guard 1's strip commit is PATHSPEC-limited
+    and records WORKING-TREE content for the named paths (git-commit(1) --only
+    default), so an index-only deletion is committed right back and silently
+    never lands (#1210: 19 resurrected paths)."""
     text = _skill_text()
-    assert "rm --cached -f --ignore-unmatch" in text, (
-        "Guard-1 must drop branch-added foreign paths via git rm --cached -f "
-        "--ignore-unmatch (a checkout would crash with pathspec-did-not-match)"
+    region = _merge_guards_region(text)
+    assert 'git -C "$WT" rm -f --ignore-unmatch -- "${FOREIGN_BRANCH_ONLY[@]}"' in region, (
+        "Guard-1 must drop branch-added foreign paths via git rm -f "
+        "--ignore-unmatch (index AND working tree; a checkout would crash with "
+        "pathspec-did-not-match, and an index-only rm --cached self-reverts "
+        "under the pathspec-limited strip commit — #1210/#1244)"
+    )
+    assert "rm --cached" not in region, (
+        "index-only `git rm --cached` must not appear in the merge-guards "
+        "region — the pathspec-limited strip commit records working-tree "
+        "content and would resurrect the paths (#1210/#1244)"
     )
 
 


### PR DESCRIPTION
Closes task #1244. Guard 1's FOREIGN_BRANCH_ONLY arm staged deletions index-only (git rm --cached) while the pathspec-limited strip commit records working-tree content, silently resurrecting foreign tasks/ paths (observed live: #1210, 19 resurrected paths). Fix: drop --cached (deletion lands in index AND working tree) + updated pin test.