### PR TITLE
issue-1255: figure-text sidecar capture + verifier drift checks (workflow-fix #1255)

### DIFF
--- a/.claude/skills/paper-plots/SKILL.md
+++ b/.claude/skills/paper-plots/SKILL.md
@@ -136,7 +136,7 @@ ax.legend([CONDITION_LABELS[k] for k in series_keys])
 
 If the data source's keys ARE already plain English, pass them through directly. The audit rule fires on the rendered text in the figure, not on the variable names in the script.
 
-This is the figure-side mirror of `clean-result-critic` Lens 3 and `interpretation-critic` Lens 6 — applying it at the plot-generation step (here) avoids the critic round that would otherwise bounce the figure for relabeling. The bare condition slug appears ONLY in the `.meta.json` sidecar (provenance, not reader-facing) and in commit messages / launch commands.
+This is the figure-side mirror of `clean-result-critic` Lens 3 and `interpretation-critic` Lens 6 — applying it at the plot-generation step (here) avoids the critic round that would otherwise bounce the figure for relabeling. Bare condition slugs remain fine in the sidecar's *provenance keys* (`commit`, `argv`, `script`, …) and in commit messages / launch commands — but the figure's RENDERED text (titles, axis labels, legends, series names, annotations, tick labels) is now serialized into the sidecar under `text` and mechanically scanned by `verify_task_body.py` checks 24/28/34, so a slug in a title / legend WARNs at body-verification time instead of waiting for the multimodal critic. Expect a check-28 WARN uptick on NEW figures whose tick labels carry 3-segment slugs — that is the plain-English rule firing correctly (forward-observable only; old sidecars carry no `text` block and are unaffected).
 
 ### 3.6. Consistent encoding across facets
 
@@ -226,7 +226,7 @@ plt.close(fig)
 `savefig_paper` writes:
 - `figures/aim5/pre_post_alignment.png` (300 DPI, commit-tagged via pnginfo)
 - `figures/aim5/pre_post_alignment.pdf` (vector, commit-tagged via PDF metadata)
-- `figures/aim5/pre_post_alignment.meta.json` (commit + timestamp + figsize **+ the figure's per-point data**)
+- `figures/aim5/pre_post_alignment.meta.json` (commit + timestamp + figsize **+ the figure's per-point data + its rendered text**)
 
 The sidecar `.meta.json` is what makes figure provenance auditable later.
 
@@ -256,6 +256,24 @@ Implications:
   a `data_path` pointer (repo-relative, under `eval_results/` or `figures/`) to
   the sidecar yourself — the viewer follows it. In-sidecar embeds are capped at
   2000 rows (recorded via `data_truncated` + `total_points`).
+
+**The sidecar also auto-carries the figure's RENDERED TEXT (default).** At
+save time `savefig_paper` reads every piece of text the figure renders —
+suptitle, per-axes titles (including the house `loc="left"` style +
+`set_title_subtitle`'s annotation subtitle), x/y axis labels, legend labels +
+legend title, series names (legend-eligible artist labels), free-floating
+annotations, and tick labels — and embeds it under a `text` key
+(`_extract_fig_text`; values are only strings / null / lists, so the
+dashboard viewer can never mistake the block for data rows). Two
+consequences: (1) `verify_task_body.py` checks 24 (stale tokens/fractions),
+28 (opaque config-code slugs / `@L` pins), and 34 (beat-phrase
+series-structure claims) mechanically scan it — the §3.5 plain-English rule
+is now machine-checked on rendered text, not just critic-reviewed; (2)
+`embed_text=False` opts out (independent of `embed_data` — an
+`embed_data=False` huge-data figure still gets its cheap text captured by
+default). Capture is best-effort like the data embed: a failure omits the
+key, never fails the save. Forward-only: sidecars committed before this
+landed carry no `text` block and are never retroactively flagged.
 
 **Commit + push BEFORE referencing the figure in a clean-result body.**
 The EPS dashboard renders the body's `![alt](url)` images, but it does NOT
@@ -297,6 +315,8 @@ defer to that file if they ever diverge.
 - [ ] No microscopic text. Squint test: readable on a video call at 75% zoom.
 - [ ] Colorblind-friendly palette (use `paper_palette(n)`).
 - [ ] Both `.png` and `.pdf` written. Sidecar `.meta.json` exists.
+- [ ] Sidecar `text` block present (new `savefig_paper` output does this
+      automatically; only deliberate `embed_text=False` opt-outs lack it).
 - [ ] Each figure in the clean-result Results subsection has a caption
       paragraph (1-2 sentences, >=10 words). REQUIRED by
       `verify_clean_result.py:check_results_figure_captions`. Caption states

--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -7038,7 +7038,17 @@ def _sidecar_kind_row_groups(meta: dict) -> tuple[Counter, dict[str, set], set] 
     index, and the writer emits it only on multi-artist figures
     (``_build_sidecar_data``: ``multi = len(artifacts) > 1``) — so a
     single-artist sidecar has NO groups anywhere.
+
+    Returns None for a TRUNCATED sidecar (``data_truncated`` — the writer's
+    top-level flag — or a legacy top-level ``truncated``):
+    ``_build_sidecar_data`` truncates the concatenated per-artist rows
+    HEAD-FIRST (``points[:_MAX_SIDECAR_ROWS]``), so a first artist with
+    >= the cap drops every LATER artist/kind from the stored payload —
+    per-kind / per-``_group`` counts over stored rows are then not figure
+    truth (the ``_sidecar_plotted_values`` sibling convention, check 33).
     """
+    if meta.get("data_truncated") or meta.get("truncated"):
+        return None
     pts = meta.get("points")
     if not isinstance(pts, list):
         pts = meta.get("rows")
@@ -7083,6 +7093,17 @@ def _both_claim_bases(
     ``{basis name: count}`` dict — each key present only when that basis has
     actual labels/rows (a zero-count kind is UNAVAILABLE, never a
     contradiction). See ``_beat_claim_warnings`` for the basis semantics."""
+    if len(all_groups) == 1:
+        # A 1-value group set means exactly ONE artist contributed rows in a
+        # MULTI-artist figure (`_group` is only emitted when
+        # `len(artifacts) > 1`, so a sibling artist yielded zero rows). That
+        # is indistinguishable from the single-artist no-`_group` case: the
+        # lone data-bearing artist (scatter especially) may encode >=2 arms
+        # per-point, so the group evidence is treated as ABSENT, never as a
+        # 1-count basis. (`_line_artist_count` is unaffected — its
+        # no-groups fallback reads the same 1.)
+        kind_groups = {}
+        all_groups = set()
     bases: dict[str, int] = {}
     text_block = meta.get("text")
     tb = text_block if isinstance(text_block, dict) else {}
@@ -7137,6 +7158,9 @@ def _beat_claim_warnings(claims: dict, meta: dict, basename: str) -> list[str]:
       the claim is skipped);
     - total distinct ``_group`` across ALL rows (leniency-only: a mixed
       line+scatter two-artist figure satisfies "both arms" across kinds).
+      A 1-value group set (exactly one artist contributed rows — a rowless
+      sibling in a multi-artist figure) is treated as ABSENT group evidence
+      (``_both_claim_bases``), the same skip as the lone unlabeled scatter.
 
     WARN only when >=1 basis is available AND every available basis reads
     <=1. Class B ("one bar per X") ⇒ claimed >=2 elements of the mapped kind;
@@ -7145,9 +7169,15 @@ def _beat_claim_warnings(claims: dict, meta: dict, basename: str) -> list[str]:
     points payload (no payload → skip); WARN when the basis reads <=1 (kind
     absent entirely, or a single aggregate element where the prose claims
     per-unit multiplicity — the #1092 "one bar per re-fit item" degenerate
-    class). ``data_truncated`` sidecars are safe for both classes: truncation
-    implies >=`_MAX_SIDECAR_ROWS` STORED rows, so the <=1 test cannot
-    misfire.
+    class). TRUNCATED sidecars (``data_truncated`` / legacy ``truncated``)
+    carry NO points-derived basis: ``_build_sidecar_data`` truncates the
+    concatenated rows HEAD-FIRST, so a first artist with >= the
+    ``_MAX_SIDECAR_ROWS`` cap drops every LATER artist/kind from the stored
+    payload — stored-row counts are not figure truth there
+    (``_sidecar_kind_row_groups`` returns None, the check-33
+    ``_sidecar_plotted_values`` convention). Class B therefore SKIPS on a
+    truncated sidecar; Class A falls back to the truncation-immune TEXT
+    bases (series / legend labels), skipping when none is available.
     """
     warns: list[str] = []
     rows = _sidecar_kind_row_groups(meta)
@@ -7239,9 +7269,11 @@ def check_figure_beat_claims_vs_sidecar_text(body: str) -> CheckResult:
 
     False-negative envelope (accepted by design): ``embed_text=False``
     figures never carry ``text`` and are never checked; ``embed_data=False``
-    figures lack every points-derived basis, so only their series / legend
-    labels can ground a Class-A read and Class B always skips; paraphrased
-    claims ("each arm", "two models") miss the registered regexes.
+    AND truncated (``data_truncated``) figures lack every points-derived
+    basis (head-first row truncation can drop entire later artists/kinds
+    from the stored payload), so only their series / legend labels can
+    ground a Class-A read and Class B always skips; paraphrased claims
+    ("each arm", "two models") miss the registered regexes.
 
     WARN, never FAIL (heuristic text parsing over natural prose — the
     24/28/33 severity convention; FAIL is reserved for check 26's provable

--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -648,6 +648,29 @@ Generation-agnostic checks (run on v2 AND v3 — the inline-figure +
   figure plotted 0.231 / a -4.53-clipped bar; checks 24 (rendered text) and
   26 (structure) are blind to plotted-NUMBER drift by construction.
 
+- **check 34** (`check_figure_beat_claims_vs_sidecar_text`, WARN,
+  FORWARD-ONLY): beat-1 series-structure claims — "both <up to 3 words>
+  arms/series/conditions/models/lines/curves" and "one
+  bar/point/dot/marker/line/curve per <unit>" (the two literal #1092
+  defect-(b) phrasings; paraphrases miss by design) — must not contradict
+  the series structure the figure's sha-pinned sidecar demonstrably
+  renders. Fires ONLY when the sidecar carries the `meta["text"]`
+  rendered-text block the current `savefig_paper` writes (pre-capture
+  sidecars silently skip — no retroactive WARN on existing bodies).
+  Contradiction-only: Class A WARNs only when >=1 evidence basis is
+  available AND every available basis reads <=1 (series labels / legend
+  entries / bar point-rows — never `n_series`, one `BarContainer` holds a
+  whole bar pair — / distinct line artists / distinct scatter artists /
+  total artist groups); a figure with no basis (e.g. an unlabeled
+  single-artist scatter) SKIPS. Class B requires a points payload and
+  WARNs when the mapped `_kind` renders <=1 element (line/curve counted as
+  distinct ARTISTS via `_group` — vertex rows are unsound). Window =
+  check 33's narrow `_beat1_prose_window`. WARN never FAIL; silent skip on
+  missing / unparsable / text-less sidecars (check-24 convention); NO-OP
+  PASS offline / stdin / no inline figures. Incident: #1092 (9a-bis r1) —
+  a beat claimed "both input arms" / "one bar per re-fit item" against a
+  figure rendering neither, passing every mechanical figure check. (#1255)
+
 Harmful-content carve-out: checks 18/19 accept the sanitized excerpt
 form (`[truncated — harmful-content row; verify at <path>, row <i>]`)
 exactly as checks 10/11 do today.
@@ -6039,6 +6062,14 @@ def check_figure_text_vs_body_tokens(body: str) -> CheckResult:
     most one ``git show`` per unique figure URL, all fail-soft, so the check
     adds negligible latency on a normal body (no figure sidecars with text →
     one cheap git probe per figure, then skip).
+
+    Sidecars written by the current ``savefig_paper`` additionally carry the
+    figure's RENDERED text (titles / axis labels / legends / series names /
+    annotations / tick labels) under a ``text`` key — its strings enter this
+    check's scans automatically via ``_flatten_meta_strings`` (forward-only:
+    older sidecars simply lack the key), so a stale fraction in the actual
+    rendered TITLE is now catchable, not just one echoed in an ad-hoc
+    ``description``.
     """
     label = "figure text vs body prose (figure-text staleness)"
     section = _figure_scan_section(body)
@@ -6474,12 +6505,22 @@ def check_figure_label_codes(body: str) -> CheckResult:
     deferred it as a cosmetic nit.
 
     Coverage = sidecar-CARRIED strings only: string values (provenance
-    subtrees pruned) plus whitespace-bearing dict keys. Known residuals,
-    accepted by design: (i) a slug-bearing figure TITLE with no ad-hoc
-    sidecar echo is invisible — the canonical ``savefig_paper`` writer never
-    serializes titles (PNG-pixel text stays the multimodal critics'
-    substantive read); (ii) a bare slug used as a whitespace-free column KEY
-    is unscanned; (iii) a slug or ``@L`` pin inside a path-shaped word (or a
+    subtrees pruned) plus whitespace-bearing dict keys. The current
+    ``savefig_paper`` serializes the figure's RENDERED text (suptitle, axes
+    titles incl. ``loc="left"``, axis labels, legend entries, series names,
+    annotations, tick labels) under ``meta["text"]``, whose string VALUES
+    enter this walk automatically — so a slug-bearing figure TITLE / legend /
+    series name in NEW sidecars IS scanned (the #1092 defect-(a) class); the
+    ``text`` block's own structural key names (``suptitle``,
+    ``legend_labels``, …) are whitespace-free identifier keys and are never
+    collected. Known residuals, accepted by design: (i) rendered-text
+    blindness persists for sidecars written BEFORE the ``meta["text"]``
+    capture landed (forward-only) AND for figures saved via plain
+    ``fig.savefig`` scripts that never get a sidecar at all — for those,
+    PNG-pixel text stays the multimodal critics' substantive read; (ii) a
+    bare slug used as a whitespace-free column KEY is unscanned (tick labels
+    now arrive as scanned VALUES in new sidecars, narrowing this residual to
+    key names); (iii) a slug or ``@L`` pin inside a path-shaped word (or a
     whole path-shaped string) is exempt — the path exemption covers BOTH
     token classes. WARN,
     never FAIL; fail-soft on missing / unparsable sidecars (the check-24
@@ -6924,6 +6965,342 @@ def check_figure_prose_numerics_vs_sidecar(body: str) -> CheckResult:
         label,
         True,
         f"{scanned} figure(s): all bolded what-is-plotted decimals present among sidecar values",
+    )
+
+
+# ─── Check 34: beat-phrase series-structure claims vs sidecar rendered text ─
+#
+# Fifth sibling of checks 24/26/28/33 (same figure iteration, same
+# `_read_figure_meta_json` sidecar read, same fail-soft skip conventions;
+# reuses check 33's narrow `_beat1_prose_window`). Checks 24/28 scan the
+# sidecar's rendered STRINGS and check 26 its `_kind` STRUCTURE against
+# explicit panel/overlay claims — none compares a beat-1 SERIES-STRUCTURE
+# claim ("shows both input arms", "one bar per re-fit item") against what the
+# figure demonstrably renders, so #1092's defect (b) passed every mechanical
+# figure check. Check 34 closes that gap for the two literal #1092 claim
+# classes, contradiction-only, FORWARD-ONLY (fires only when the sidecar
+# carries the `meta["text"]` rendered-text block the current `savefig_paper`
+# writes — the writer-version marker).
+
+# Class A: "both <up to 3 words> arms/series/conditions/models/lines/curves".
+_BEAT_BOTH_RE = re.compile(
+    r"\bboth\b(?:\s+[\w-]+){0,3}\s+(?:arms?|series|conditions?|models?|lines?|curves?)\b",
+    re.IGNORECASE,
+)
+# Class B: "one bar|point|dot|marker|line|curve per <unit>".
+_BEAT_ONE_PER_RE = re.compile(
+    r"\bone\s+(bar|point|dot|marker|line|curve)s?\s+per\s+[\w-]+", re.IGNORECASE
+)
+_BEAT_WORD_TO_KIND = {
+    "bar": "bar",
+    "point": "scatter",
+    "dot": "scatter",
+    "marker": "scatter",
+    "line": "line",
+    "curve": "line",
+}
+
+
+def _beat_series_claims(prose: str) -> dict:
+    """Parse the two registered check-34 claim classes out of a figure's
+    beat-1 prose window::
+
+        {"both":    [<matched phrase>, ...],           # Class A
+         "one_per": [(<matched phrase>, <kind>), ...]} # Class B, kind mapped
+                                                       # via _BEAT_WORD_TO_KIND
+
+    Deliberately NARROW (the check's FP containment): only the two literal
+    #1092 defect phrasings are registered — paraphrases ("each arm", "two
+    models", "per-source bars") miss by design (a documented false-negative,
+    not a bug). Class-B phrases are de-duplicated preserving order.
+    """
+    claims: dict = {"both": [], "one_per": []}
+    for bm in _BEAT_BOTH_RE.finditer(prose):
+        claims["both"].append(bm.group(0))
+    seen: set[tuple[str, str]] = set()
+    for om in _BEAT_ONE_PER_RE.finditer(prose):
+        pair = (om.group(0).casefold(), _BEAT_WORD_TO_KIND[om.group(1).lower()])
+        if pair not in seen:
+            seen.add(pair)
+            claims["one_per"].append((om.group(0), pair[1]))
+    return claims
+
+
+def _sidecar_kind_row_groups(meta: dict) -> tuple[Counter, dict[str, set], set] | None:
+    """Per-kind point-row counts, per-kind distinct ``_group`` sets, and the
+    all-rows ``_group`` set from a parsed sidecar's ``points``/``rows`` list —
+    or None when the sidecar carries no recognizable point list.
+
+    Same reading convention as ``_sidecar_kind_group_aggregate`` (``points``
+    canonical, ``rows`` legacy; non-dict rows skipped), but check 34's line /
+    scatter ARTIST counting needs the per-KIND group split the aggregate does
+    not expose. ``_group`` is a per-ARTIST (per-series) index, NOT a per-panel
+    index, and the writer emits it only on multi-artist figures
+    (``_build_sidecar_data``: ``multi = len(artifacts) > 1``) — so a
+    single-artist sidecar has NO groups anywhere.
+    """
+    pts = meta.get("points")
+    if not isinstance(pts, list):
+        pts = meta.get("rows")
+    if not isinstance(pts, list) or not pts:
+        return None
+    kinds: Counter = Counter()
+    kind_groups: dict[str, set] = {}
+    all_groups: set = set()
+    for p in pts:
+        if not isinstance(p, dict):
+            continue
+        k = p.get("_kind")
+        kind = k.strip().lower() if isinstance(k, str) and k.strip() else None
+        if kind is not None:
+            kinds[kind] += 1
+        g = p.get("_group")
+        if g is not None:
+            all_groups.add(g)
+            if kind is not None:
+                kind_groups.setdefault(kind, set()).add(g)
+    if not kinds and not all_groups:
+        return None
+    return kinds, kind_groups, all_groups
+
+
+def _line_artist_count(kinds: Counter, kind_groups: dict[str, set]) -> int | None:
+    """Distinct line ARTISTS rendered, or None when the sidecar has no line
+    rows (basis unavailable). Distinct ``_group`` values among line-kind rows;
+    a single-artist sidecar carries no ``_group`` at all, so line rows with no
+    groups count as ONE artist (one ``Line2D`` trace = one series — a line's
+    point rows are VERTICES, so the raw row count is unsound for lines)."""
+    if kinds.get("line", 0) <= 0:
+        return None
+    groups = kind_groups.get("line", set())
+    return len(groups) if groups else 1
+
+
+def _both_claim_bases(
+    meta: dict, kinds: Counter, kind_groups: dict[str, set], all_groups: set
+) -> dict[str, int]:
+    """The Class-A ("both … arms") evidence bases AVAILABLE in ``meta``, as a
+    ``{basis name: count}`` dict — each key present only when that basis has
+    actual labels/rows (a zero-count kind is UNAVAILABLE, never a
+    contradiction). See ``_beat_claim_warnings`` for the basis semantics."""
+    bases: dict[str, int] = {}
+    text_block = meta.get("text")
+    tb = text_block if isinstance(text_block, dict) else {}
+    series = tb.get("series")
+    if isinstance(series, list) and series:
+        bases["series labels"] = len(series)
+    axes_block = tb.get("axes")
+    legend_counts = []
+    if isinstance(axes_block, list):
+        for ax_d in axes_block:
+            if not isinstance(ax_d, dict):
+                continue
+            labs = ax_d.get("legend_labels")
+            if isinstance(labs, list) and labs:
+                legend_counts.append(len(labs))
+    if legend_counts:
+        bases["legend entries"] = max(legend_counts)
+    if kinds.get("bar", 0) > 0:
+        bases["bar rows"] = kinds["bar"]
+    line_n = _line_artist_count(kinds, kind_groups)
+    if line_n is not None:
+        bases["line artists"] = line_n
+    scatter_groups = kind_groups.get("scatter", set())
+    if scatter_groups:
+        bases["scatter artists"] = len(scatter_groups)
+    if all_groups:
+        bases["artist groups"] = len(all_groups)
+    return bases
+
+
+def _beat_claim_warnings(claims: dict, meta: dict, basename: str) -> list[str]:
+    """Return the check-34 WARN messages for ONE figure's parsed ``claims``
+    against its parsed sidecar ``meta``. Empty list = no demonstrable
+    contradiction (which includes "no evidence basis available" — absence of
+    evidence never fires).
+
+    Class A ("both … arms") ⇒ claimed >=2 rendered elements. Evidence bases,
+    each AVAILABLE only when it has actual labels/rows, all max'd:
+
+    - ``len(text["series"])`` — fig-GLOBAL legend-eligible artist labels
+      (deliberately conservative: a multi-panel figure with one series per
+      panel and >=2 distinct labels satisfies "both arms");
+    - ``max(len(ax["legend_labels"]))`` over axes;
+    - bar-kind point-ROW count (one bar row per bar — NEVER ``n_series``,
+      which counts artist GROUPS: a two-arm bar pair lives in ONE
+      ``BarContainer`` and would false-fire);
+    - distinct line ARTISTS (``_line_artist_count``);
+    - distinct scatter ARTISTS (distinct ``_group`` among scatter rows) — NO
+      single-artist fallback, unlike lines: one scatter artist can encode >=2
+      arms via per-point colors the extractor cannot see, so a lone unlabeled
+      scatter is never a demonstrable contradiction (it yields NO basis and
+      the claim is skipped);
+    - total distinct ``_group`` across ALL rows (leniency-only: a mixed
+      line+scatter two-artist figure satisfies "both arms" across kinds).
+
+    WARN only when >=1 basis is available AND every available basis reads
+    <=1. Class B ("one bar per X") ⇒ claimed >=2 elements of the mapped kind;
+    basis per kind: bar/scatter → point-row count of that ``_kind``;
+    line/curve → distinct line ARTISTS (vertex rows are unsound). Requires a
+    points payload (no payload → skip); WARN when the basis reads <=1 (kind
+    absent entirely, or a single aggregate element where the prose claims
+    per-unit multiplicity — the #1092 "one bar per re-fit item" degenerate
+    class). ``data_truncated`` sidecars are safe for both classes: truncation
+    implies >=`_MAX_SIDECAR_ROWS` STORED rows, so the <=1 test cannot
+    misfire.
+    """
+    warns: list[str] = []
+    rows = _sidecar_kind_row_groups(meta)
+    kinds, kind_groups, all_groups = rows if rows is not None else (Counter(), {}, set())
+
+    if claims["both"]:
+        bases = _both_claim_bases(meta, kinds, kind_groups, all_groups)
+        if bases and max(bases.values()) <= 1:
+            detail = ", ".join(f"{k}={v}" for k, v in bases.items())
+            warns.append(
+                f"`{basename}`: beat-1 prose claims `{claims['both'][0]}` but every "
+                f"available sidecar basis renders <=1 element ({detail}) — regenerate "
+                f"the figure or fix the prose; if the claim is genuinely satisfied "
+                f"(e.g. two arms encoded inside one artist), acknowledge in body to ship"
+            )
+
+    if claims["one_per"] and rows is not None:
+        for phrase, kind in claims["one_per"]:
+            if kind == "line":
+                n = _line_artist_count(kinds, kind_groups) or 0
+            else:
+                n = kinds.get(kind, 0)
+            if n <= 1:
+                warns.append(
+                    f"`{basename}`: beat-1 prose claims `{phrase}` but the sidecar "
+                    f"renders {n} `{kind}` element(s) — regenerate the figure or fix "
+                    f"the prose; a legitimate n=1 (e.g. `one bar per source` on a "
+                    f"genuinely single-source panel) is acknowledgeable in body"
+                )
+    return warns
+
+
+def _beat_claims_for_one_figure(
+    repo: Path, m: re.Match, rlines: list[str], img_idx: int, json_cache: dict
+) -> tuple[list[str], bool]:
+    """Process ONE same-repo figure for check 34 (the check-26/33 per-figure
+    shape). Returns ``(warn_msgs, scanned)`` — ``scanned`` True only when a
+    text-bearing sidecar was actually compared against a registered claim;
+    mutates ``json_cache`` (per-URL parsed-sidecar cache) in place.
+    """
+    window = _beat1_prose_window(rlines, img_idx)
+    if window is None:
+        return [], False  # no per-result H3 above — no scoped window
+    claims = _beat_series_claims(window)
+    if not claims["both"] and not claims["one_per"]:
+        return [], False  # no registered claim → nothing to check (never over-fire)
+    url = m.group(0)
+    if url not in json_cache:
+        json_cache[url] = _read_figure_meta_json(repo, m.group("sha"), m.group("path"))
+    meta = json_cache[url]
+    if meta is None:
+        return [], False  # no sidecar at that sha — check-24 fail-soft convention
+    if not isinstance(meta.get("text"), dict):
+        # THE forward-only gate: absence of `text` is the expected state of
+        # every sidecar written before the `savefig_paper` rendered-text
+        # capture landed — silent skip, never a loud FAIL (check 26's loud
+        # missing-sidecar FAIL exists for a silently-uncommitted sidecar; a
+        # loud branch HERE would retroactively flag every old body).
+        return [], False
+    basename = m.group("path").rsplit("/", 1)[-1]
+    return _beat_claim_warnings(claims, meta, basename), True
+
+
+def check_figure_beat_claims_vs_sidecar_text(body: str) -> CheckResult:
+    """Check 34 (WARN): a figure's beat-1 series-structure claim — "shows
+    both <…> arms/series/conditions/models/lines/curves" or "one
+    bar/point/dot/marker/line/curve per <unit>" — must not contradict the
+    series structure the figure's ``.meta.json`` sidecar demonstrably
+    renders. FORWARD-ONLY: fires ONLY when the sidecar carries the
+    ``meta["text"]`` rendered-text block (written by the current
+    ``savefig_paper``); every pre-capture sidecar silently skips, so no
+    existing body can retroactively WARN.
+
+    The prose window is check 33's narrow previous-figure-bounded beat-1
+    slice (``_beat1_prose_window`` — no cross-figure bleed, the #778
+    false-WARN class). Both claim classes fire CONTRADICTION-ONLY: Class A
+    ("both … arms") WARNs only when >=1 evidence basis is available AND every
+    available basis reads <=1 (series labels / legend entries / bar rows /
+    line artists / scatter artists / total artist groups — see
+    ``_beat_claim_warnings``; a figure with no basis at all, e.g. an
+    unlabeled single-artist scatter with no points payload signal, SKIPS —
+    absence of evidence is never a contradiction). Class B ("one bar per X")
+    requires a points payload and WARNs when the mapped kind renders <=1
+    element. Deliberately NOT built (FP containment; may be added later
+    behind the same forward-only gate): numeric-count claims ("three bars"),
+    panel-count claims (the sidecar has no panel signal — see check 26),
+    unit-NAME matching against series labels, and prose-vs-tick-label
+    comparison.
+
+    False-negative envelope (accepted by design): ``embed_text=False``
+    figures never carry ``text`` and are never checked; ``embed_data=False``
+    figures lack every points-derived basis, so only their series / legend
+    labels can ground a Class-A read and Class B always skips; paraphrased
+    claims ("each arm", "two models") miss the registered regexes.
+
+    WARN, never FAIL (heuristic text parsing over natural prose — the
+    24/28/33 severity convention; FAIL is reserved for check 26's provable
+    structural contradictions). Silent skip (check-24 convention): missing /
+    unparsable sidecar, no ``text`` block, no ``### `` H3 above the figure,
+    no registered claim phrase in the window, non-same-repo URL. NO-OP PASS
+    offline / ``--body-stdin`` / no figure section / no inline figures.
+    Incident #1092 (clean-result-critic 9a-bis r1): a beat claimed "both
+    input arms" / "one bar per re-fit item" contradicting the plotted
+    series/bar structure and passed every mechanical figure check.
+    """
+    label = "figure beat claims vs sidecar rendered text (series-structure drift)"
+    section = _figure_scan_section(body)
+    text = section_text(body, section)
+    if text is None:
+        return CheckResult(label, True, f"no `## {section}` section to scan")
+    rlines = text.splitlines()
+    fig_at: list[tuple[str, int]] = []
+    for idx, line in enumerate(rlines):
+        for im in _IMAGE_RE.finditer(line):
+            url = im.group(1).strip()
+            url = url.split(None, 1)[0] if url else url
+            if url:
+                fig_at.append((url, idx))
+    if not fig_at:
+        return CheckResult(label, True, "no inline figures to scan")
+    repo = _resolve_repo_root()
+    if repo is None:
+        return CheckResult(label, True, "skipped — repo root unresolved (offline / stdin)")
+    warns: list[str] = []
+    scanned = 0
+    json_cache: dict[str, dict | None] = {}
+    for url, img_idx in fig_at:
+        m = _RAW_GITHUB_FIGURE_RE.match(url)
+        if m is None or (m.group("owner").lower(), m.group("repo").lower()) != _THIS_REPO_SLUG:
+            continue  # only same-repo sha-pinned figures resolve from git
+        fig_warns, did_scan = _beat_claims_for_one_figure(repo, m, rlines, img_idx, json_cache)
+        warns.extend(fig_warns)
+        if did_scan:
+            scanned += 1
+    if warns:
+        preview = "; ".join(warns[:3]) + (" …" if len(warns) > 3 else "")
+        return CheckResult(
+            label,
+            True,
+            f"{len(warns)} beat-claim contradiction(s) across {scanned} scanned "
+            f"figure(s): {preview}",
+            is_warn=True,
+        )
+    if scanned == 0:
+        return CheckResult(
+            label,
+            True,
+            "no beat-phrase claim with a text-bearing sidecar — nothing to compare",
+        )
+    return CheckResult(
+        label,
+        True,
+        f"{scanned} figure(s): beat-phrase claims consistent with the rendered structure",
     )
 
 
@@ -9812,6 +10189,9 @@ CHECKS = [
     check_hf_adjacent_file_claims,  # check 32 (WARN) — adjacent file claims are tree members (#952)
     # check 33 (WARN) — bolded what-is-plotted decimals vs sidecar plotted values (#1107, #825 r1):
     check_figure_prose_numerics_vs_sidecar,
+    # check 34 (WARN, forward-only) — beat-phrase series-structure claims vs the sidecar's
+    # rendered-text block (fires only when meta["text"] is present; #1255, #1092 defect (b)):
+    check_figure_beat_claims_vs_sidecar_text,
     # Check 31 (`check_orphaned_per_unit_figures`, WARN, generation-agnostic)
     # is NOT here either — like check 20 (v4) it needs the issue number (for
     # figures-dir scoping), so it is dispatched separately in `verify_text`

--- a/src/explore_persona_space/analysis/paper_plots.py
+++ b/src/explore_persona_space/analysis/paper_plots.py
@@ -973,6 +973,116 @@ def _build_sidecar_data(
     }
 
 
+_MAX_TEXT_ITEMS = 100  # per-axes cap on annotations / tick labels (+ the series list)
+
+
+def _artist_text(t) -> str:
+    """The stripped text of a matplotlib ``Text``-like artist, or ``""`` when
+    the artist is None / unreadable (best-effort — never raises)."""
+    try:
+        return t.get_text().strip() if t is not None else ""
+    except Exception:
+        return ""
+
+
+def _axes_text_and_series(ax) -> tuple[dict[str, object], list[str]]:
+    """Rendered text of ONE ``Axes`` for ``_extract_fig_text``: the per-axes
+    text dict (titles at all three locs — the house style renders at
+    ``loc="left"`` — axis labels, legend labels + title, annotations, tick
+    labels) plus the axes' legend-eligible artist labels (series names).
+    May raise on a pathological Axes; the caller's per-axes try/except skips
+    it (one bad Axes never sinks the capture)."""
+    ax_d: dict[str, object] = {}
+    for loc in ("center", "left", "right"):
+        t = ax.get_title(loc=loc)
+        if t.strip():
+            ax_d["title" if loc == "center" else f"title_{loc}"] = t.strip()
+    for key, val in (("xlabel", ax.get_xlabel()), ("ylabel", ax.get_ylabel())):
+        if val.strip():
+            ax_d[key] = val.strip()
+    leg = ax.get_legend()
+    if leg is not None:
+        labs = [s for s in (_artist_text(t) for t in leg.get_texts()) if s]
+        if labs:
+            ax_d["legend_labels"] = labs
+        lt = _artist_text(leg.get_title())
+        if lt:
+            ax_d["legend_title"] = lt
+    # set_title_subtitle's subtitle is an ax.annotate → lands in ax.texts,
+    # alongside free-floating point labels — both rendered text.
+    ann = [s for s in (_artist_text(t) for t in ax.texts) if s]
+    if ann:
+        ax_d["annotations"] = ann[:_MAX_TEXT_ITEMS]
+    for key, ticks in (
+        ("xticklabels", ax.get_xticklabels()),
+        ("yticklabels", ax.get_yticklabels()),
+    ):
+        tl = [s for s in (_artist_text(t) for t in ticks) if s]
+        if tl:
+            ax_d[key] = tl[:_MAX_TEXT_ITEMS]
+    # Series names: legend-eligible artist labels ('_'-prefixed =
+    # matplotlib's no-legend convention, excluded).
+    labels: list[str] = []
+    for art in (*ax.get_lines(), *ax.containers, *ax.collections):
+        lab = str(art.get_label() or "")
+        if lab and not lab.startswith("_"):
+            labels.append(lab)
+    return ax_d, labels
+
+
+def _extract_fig_text(fig: plt.Figure) -> dict[str, object] | None:
+    """Best-effort capture of the figure's RENDERED text for the sidecar.
+
+    Returns ``{"suptitle": str|None, "fig_texts": [str], "series": [str],
+    "axes": [{...}]}`` or ``None`` when nothing was captured. Values are ONLY
+    ``str`` / ``None`` / ``list`` — never nested dicts-of-dicts — so the
+    dashboard viewer's ``normalizeToRows`` fallback can never mistake the
+    block for data rows (``dashboard/lib/task-data.ts``: ``isPlainObject``
+    excludes arrays/null, and the object-of-objects fallback descends at most
+    two levels, so a ``text`` dict whose values are str/None/list never
+    matches). Never raises: any unreadable artist/axes is skipped (the
+    ``_extract_axes_data`` contract). The block is what lets
+    ``scripts/verify_task_body.py`` checks 24/28/34 mechanically scan the
+    figure's titles / legends / series names (incident #1092: bare cell slugs
+    as panel titles + a beat claiming an unrendered series structure passed
+    every mechanical figure check because the sidecar carried no rendered
+    text).
+    """
+    suptitle_obj = getattr(fig, "_suptitle", None)
+    supx_obj = getattr(fig, "_supxlabel", None)
+    supy_obj = getattr(fig, "_supylabel", None)
+    # On matplotlib 3.10 the suptitle AND supx/supy labels all appear in
+    # `fig.texts`; exclude them by identity so they are not duplicated into
+    # `fig_texts` (suptitle gets its own key; supx/supy are re-added exactly
+    # once below, AFTER the cap, so a text-dense figure cannot truncate them
+    # away).
+    special = {id(suptitle_obj), id(supx_obj), id(supy_obj)}
+    out: dict[str, object] = {"suptitle": _artist_text(suptitle_obj) or None}
+    fig_texts = [s for s in (_artist_text(t) for t in fig.texts if id(t) not in special) if s]
+    fig_texts = fig_texts[:_MAX_TEXT_ITEMS]
+    fig_texts += [s for s in (_artist_text(supx_obj), _artist_text(supy_obj)) if s]
+    out["fig_texts"] = fig_texts
+
+    # `series` is fig-GLOBAL, deduplicated across axes.
+    series: list[str] = []
+    axes_out: list[dict[str, object]] = []
+    for ax in fig.get_axes():
+        try:
+            ax_d, labels = _axes_text_and_series(ax)
+        except Exception:
+            continue  # one bad Axes never sinks the capture
+        series.extend(labels)
+        if ax_d:
+            axes_out.append(ax_d)
+    if axes_out:
+        out["axes"] = axes_out
+    dedup = list(dict.fromkeys(series))[:_MAX_TEXT_ITEMS]
+    if dedup:
+        out["series"] = dedup
+    has_content = out["suptitle"] or out["fig_texts"] or axes_out or dedup
+    return out if has_content else None
+
+
 def _git_commit_hash() -> str:
     """Return the current git commit short hash, or ``"uncommitted"`` on failure."""
     try:
@@ -997,6 +1107,7 @@ def savefig_paper(
     dir: str | Path = "figures/",
     formats: tuple[str, ...] = ("png", "pdf"),
     embed_data: bool = True,
+    embed_text: bool = True,
 ) -> dict[str, Path]:
     """Save ``fig`` to ``<dir>/<stem>.<fmt>`` for every ``fmt`` in ``formats``.
 
@@ -1004,7 +1115,8 @@ def savefig_paper(
     ``pnginfo``. Also writes a sidecar ``<dir>/<stem>.meta.json`` containing
     commit hash, ISO-8601 UTC timestamp, figure size (inches), AND — when
     ``embed_data`` is true (the default) — the figure's per-point data under a
-    ``points`` key.
+    ``points`` key, plus — when ``embed_text`` is true (the default) — the
+    figure's rendered text under a ``text`` key.
 
     **Per-point data (dashboard data viewer).** The plotted data is read back
     off the rendered matplotlib artists (``_extract_axes_data``): scatter point
@@ -1028,7 +1140,12 @@ def savefig_paper(
     The clean-result-critic Lens 3 and interpretation-critic Lens 6 enforce
     this on review; doing it here avoids a regenerate-the-figure bounce. Because
     the axis labels also become the sidecar's column names, plain-English labels
-    make the data viewer's columns readable too.
+    make the data viewer's columns readable too. The rendered labels are ALSO
+    serialized into the sidecar under ``text`` (``_extract_fig_text``; opt out
+    with ``embed_text=False``) and mechanically scanned by
+    ``scripts/verify_task_body.py`` checks 24/28/34, so an opaque slug in a
+    title / legend / series name now WARNs at body-verification time instead
+    of waiting for the multimodal critics.
 
     Parameters
     ----------
@@ -1046,6 +1163,14 @@ def savefig_paper(
         the sidecar under ``points``. Set false to write a provenance-only
         sidecar (e.g. for a figure whose data is huge or already exposed via a
         committed ``data_path`` the caller adds afterward).
+    embed_text
+        When true (default), capture the figure's rendered text (suptitle,
+        per-axes titles incl. the house ``loc="left"`` style, axis labels,
+        legend labels + title, series names, annotations, tick labels) into
+        the sidecar under ``text`` (``_extract_fig_text``). Independent of
+        ``embed_data`` — a huge-data ``embed_data=False`` figure still gets
+        its cheap text captured. Best-effort: a capture failure omits the
+        key, never fails the save.
 
     Returns
     -------
@@ -1103,6 +1228,17 @@ def savefig_paper(
             meta["total_points"] = payload["total_points"]
             if payload["truncated"]:
                 meta["data_truncated"] = True
+
+    # Rendered-text capture (verifier + review window into figure text).
+    # Best-effort, same contract as the data embed above: a text-extraction
+    # failure NEVER fails the save — the key is simply omitted.
+    if embed_text:
+        try:
+            fig_text = _extract_fig_text(fig)
+        except Exception:
+            fig_text = None
+        if fig_text is not None:
+            meta["text"] = fig_text
 
     meta_path.write_text(json.dumps(meta, indent=2) + "\n")
     written["meta"] = meta_path

--- a/tests/test_paper_plots.py
+++ b/tests/test_paper_plots.py
@@ -429,7 +429,9 @@ def test_sidecar_multi_series_tags_group(tmp_path: Path) -> None:
 
 
 def test_sidecar_embed_data_opt_out(tmp_path: Path) -> None:
-    """embed_data=False writes a provenance-only sidecar (no `points`)."""
+    """embed_data=False writes a data-less sidecar (no `points`). The rendered
+    TEXT capture is independent of the data opt-out (numeric tick labels are
+    still rendered text), so `text` IS present by default."""
     set_paper_style("blog")
     fig, ax = plt.subplots()
     ax.scatter([1, 2, 3], [4, 5, 6])
@@ -437,12 +439,13 @@ def test_sidecar_embed_data_opt_out(tmp_path: Path) -> None:
     plt.close(fig)
 
     meta = json.loads(written["meta"].read_text())
-    assert set(meta.keys()) == {"commit", "created", "figsize"}
+    assert set(meta.keys()) == {"commit", "created", "figsize", "text"}
     assert "points" not in meta
 
 
 def test_sidecar_imshow_falls_back_to_provenance_only(tmp_path: Path) -> None:
-    """A figure with no extractable point data keeps the provenance-only sidecar."""
+    """A figure with no extractable point data keeps a data-less sidecar (no
+    `points`); the rendered-TEXT capture still applies (tick labels)."""
     import numpy as np
 
     set_paper_style("neurips")
@@ -453,7 +456,7 @@ def test_sidecar_imshow_falls_back_to_provenance_only(tmp_path: Path) -> None:
 
     meta = json.loads(written["meta"].read_text())
     assert "points" not in meta
-    assert {"commit", "created", "figsize"} == set(meta.keys())
+    assert {"commit", "created", "figsize", "text"} == set(meta.keys())
 
 
 def _reject_js_invalid_constants(c: str) -> object:
@@ -513,3 +516,175 @@ def test_sidecar_bar_nan_height_serializes_as_json_null(tmp_path: Path) -> None:
     pts = meta["points"]
     assert pts[1]["rate"] is None
     assert pts[0]["rate"] == 0.5
+
+
+# ---------------------------------------------------------------------------
+# savefig_paper — rendered-text capture into the sidecar (`meta["text"]`)
+# ---------------------------------------------------------------------------
+
+
+def test_sidecar_text_captures_titles_labels_legend(tmp_path: Path) -> None:
+    """Suptitle, `set_title_subtitle` (the house `loc="left"` title + its
+    annotation subtitle), axis labels, legend labels + title, and series names
+    all land in `meta["text"]`."""
+    set_paper_style("blog")
+    fig, ax = plt.subplots()
+    fig.suptitle("Overall headline")
+    set_title_subtitle(ax, "Finding lede", subtitle="context under the lede")
+    ax.plot([0, 1], [0, 1], label="trained")
+    ax.bar(["a", "b"], [0.2, 0.4], label="base")
+    ax.set_xlabel("condition")
+    ax.set_ylabel("agreement rate")
+    ax.legend(title="arm")
+    written = savefig_paper(fig, "textcap", dir=tmp_path)
+    plt.close(fig)
+
+    meta = json.loads(written["meta"].read_text())
+    text = meta["text"]
+    assert text["suptitle"] == "Overall headline"
+    ax_d = text["axes"][0]
+    assert ax_d["title_left"] == "Finding lede"  # the house loc="left" render path
+    assert "context under the lede" in ax_d["annotations"]  # subtitle = ax.annotate
+    assert ax_d["xlabel"] == "condition"
+    assert ax_d["ylabel"] == "agreement rate"
+    assert ax_d["legend_labels"] == ["trained", "base"]
+    assert ax_d["legend_title"] == "arm"
+    assert set(text["series"]) == {"trained", "base"}
+    # Category tick labels are rendered text too (closes check 28's residual
+    # (ii) for bar category labels).
+    assert "a" in ax_d["xticklabels"] and "b" in ax_d["xticklabels"]
+
+
+def test_sidecar_text_series_excludes_underscore_labels(tmp_path: Path) -> None:
+    """Unlabeled artists (matplotlib's `_child0` no-legend convention) never
+    appear in `series`."""
+    set_paper_style("blog")
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])  # unlabeled → auto `_child0`
+    ax.scatter([0.5], [0.5])  # unlabeled collection
+    written = savefig_paper(fig, "noseries", dir=tmp_path)
+    plt.close(fig)
+
+    meta = json.loads(written["meta"].read_text())
+    assert "series" not in meta["text"]
+
+
+def test_sidecar_text_omitted_when_empty(tmp_path: Path) -> None:
+    """A figure rendering NO text at all (no titles / labels / legend / ticks)
+    omits the `text` key entirely — no empty-noise key."""
+    set_paper_style("blog")
+    fig, ax = plt.subplots()
+    # 3 vertices: an unlabeled <=2-vertex line is skipped by the DATA
+    # extractor as a leader/reference segment, and this test also pins that
+    # the data embed is unaffected by the empty TEXT capture.
+    ax.plot([0, 1, 2], [0, 1, 4])
+    ax.set_xticks([])
+    ax.set_yticks([])
+    written = savefig_paper(fig, "notext", dir=tmp_path)
+    plt.close(fig)
+
+    meta = json.loads(written["meta"].read_text())
+    assert "text" not in meta
+    assert "points" in meta  # the data embed is unaffected
+
+
+def test_sidecar_text_extraction_failure_never_fails_save(tmp_path: Path, monkeypatch) -> None:
+    """A raising `_extract_fig_text` must NOT fail the save — the `text` key
+    is simply omitted (the `_extract_axes_data` best-effort contract)."""
+    from explore_persona_space.analysis import paper_plots as pp
+
+    def _boom(fig):
+        raise RuntimeError("synthetic extraction failure")
+
+    monkeypatch.setattr(pp, "_extract_fig_text", _boom)
+    fig = _make_simple_fig()
+    written = savefig_paper(fig, "textfail", dir=tmp_path)
+    plt.close(fig)
+
+    assert written["png"].exists() and written["meta"].exists()
+    meta = json.loads(written["meta"].read_text())
+    assert "text" not in meta
+    assert "points" in meta  # data embed unaffected by the text failure
+
+
+def test_sidecar_text_embed_text_false_opts_out(tmp_path: Path) -> None:
+    """`embed_text=False` writes no `text` key while `points` stays."""
+    fig = _make_simple_fig()
+    written = savefig_paper(fig, "textopt", dir=tmp_path, embed_text=False)
+    plt.close(fig)
+
+    meta = json.loads(written["meta"].read_text())
+    assert "text" not in meta
+    assert "points" in meta
+
+
+def test_sidecar_text_schema_shape_dashboard_safe(tmp_path: Path) -> None:
+    """Every `meta["text"]` value is str | None | list, and every `axes[i]`
+    entry maps str -> (str | list[str]). This pins the dashboard-viewer
+    safety invariant: `dashboard/lib/task-data.ts` `normalizeToRows` prefers
+    INLINE_ROW_KEYS (`points` wins when present) and its object-of-objects
+    fallback requires >=2 plain-OBJECT values at a visited level while
+    descending at most two levels — `isPlainObject` excludes arrays/null, so
+    a `text` dict whose values are only str/None/list can never be misread
+    as data rows."""
+    set_paper_style("blog")
+    fig, ax = plt.subplots()
+    fig.suptitle("Headline")
+    set_title_subtitle(ax, "Lede", subtitle="sub", source="Source: eval_results/x")
+    ax.plot([0, 1], [0, 1], label="trained")
+    ax.legend()
+    ax.set_xlabel("x")
+    ax.set_ylabel("y")
+    written = savefig_paper(fig, "schema", dir=tmp_path)
+    plt.close(fig)
+
+    text = json.loads(written["meta"].read_text())["text"]
+    assert isinstance(text, dict)
+    for v in text.values():
+        assert v is None or isinstance(v, (str, list)), v
+    for ax_d in text.get("axes", []):
+        assert isinstance(ax_d, dict)
+        for v in ax_d.values():
+            assert isinstance(v, (str, list)), v
+            if isinstance(v, list):
+                assert all(isinstance(s, str) for s in v), v
+
+
+def test_sidecar_text_tick_labels_capped(tmp_path: Path) -> None:
+    """Per-axes tick-label lists are capped at `_MAX_TEXT_ITEMS` (sidecar size
+    containment)."""
+    from explore_persona_space.analysis.paper_plots import _MAX_TEXT_ITEMS
+
+    set_paper_style("blog")
+    fig, ax = plt.subplots()
+    n = _MAX_TEXT_ITEMS + 50
+    ax.bar(range(n), [1.0] * n)
+    ax.set_xticks(range(n), [f"cat {i}" for i in range(n)])
+    written = savefig_paper(fig, "manyticks", dir=tmp_path, embed_data=False)
+    plt.close(fig)
+
+    text = json.loads(written["meta"].read_text())["text"]
+    assert len(text["axes"][0]["xticklabels"]) == _MAX_TEXT_ITEMS
+
+
+def test_sidecar_text_no_suptext_duplication(tmp_path: Path) -> None:
+    """On matplotlib 3.10 the suptitle AND supx/supy labels are all members of
+    `fig.texts`, so the identity-exclusion set in `_extract_fig_text` is
+    LOAD-BEARING: the suptitle string appears ONLY under `text["suptitle"]`
+    (never in `fig_texts`), and the supx/supy strings appear EXACTLY ONCE
+    each in `fig_texts` (via the post-cap explicit re-add, not doubled
+    through the `fig.texts` walk)."""
+    set_paper_style("blog")
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+    fig.suptitle("The headline")
+    fig.supxlabel("Source: eval_results/issue_999")
+    fig.supylabel("shared y label")
+    written = savefig_paper(fig, "suptext", dir=tmp_path, embed_data=False)
+    plt.close(fig)
+
+    text = json.loads(written["meta"].read_text())["text"]
+    assert text["suptitle"] == "The headline"
+    assert "The headline" not in text["fig_texts"]
+    assert text["fig_texts"].count("Source: eval_results/issue_999") == 1
+    assert text["fig_texts"].count("shared y label") == 1

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -10361,6 +10361,42 @@ def test_check34_both_arms_unlabeled_scatter_silent_skip(tmp_path, monkeypatch):
     assert res.passed and not res.is_warn, res.render()
 
 
+def test_check34_truncated_sidecar_class_b_silent_skip(tmp_path, monkeypatch):
+    """(m) Regression, r1 Major `check34-truncated-sidecar-false-warn`: a
+    `data_truncated` sidecar carries NO points-derived basis — the writer
+    truncates concatenated rows HEAD-FIRST, so a first artist with >= the cap
+    drops all LATER artists/kinds from the stored payload. The r1 demo shape
+    (two LABELED line artists; stored rows all `_group` 0 because artist 2 was
+    truncated away) + "one line per seed" fired a false Class-B WARN pre-fix;
+    post-fix Class B silently skips (stored rows are not figure truth)."""
+    pts = [{"x": float(i), "y": float(i), "_kind": "line", "_group": 0} for i in range(12)]
+    meta = _check34_sidecar(points=pts, series=["seed 0", "seed 1"])
+    meta["data_truncated"] = True
+    repo, sha = _make_repo_with_figure_meta(tmp_path, meta)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = _check33_body("Plotted: one line per seed.").replace("0123456789abcdef", sha)
+    res = verify_task_body.check_figure_beat_claims_vs_sidecar_text(body)
+    assert res.passed and not res.is_warn, res.render()
+
+
+def test_check34_truncated_sidecar_class_a_text_basis_pass(tmp_path, monkeypatch):
+    """(n) Companion to (m): the TEXT bases are truncation-IMMUNE (rendered
+    text is captured separately from the points payload) — the same truncated
+    sidecar WITH 2 legend labels + a Class-A claim still scans and PASSes via
+    the legend basis; truncation removes only the points-derived bases."""
+    pts = [{"x": float(i), "y": float(i), "_kind": "line", "_group": 0} for i in range(12)]
+    meta = _check34_sidecar(points=pts, legend_labels=["trained", "base"])
+    meta["data_truncated"] = True
+    repo, sha = _make_repo_with_figure_meta(tmp_path, meta)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = _check33_body("Plotted: mean agreement for both trained and base models.").replace(
+        "0123456789abcdef", sha
+    )
+    res = verify_task_body.check_figure_beat_claims_vs_sidecar_text(body)
+    assert res.passed and not res.is_warn, res.render()
+    assert "consistent" in res.detail
+
+
 def test_check34_text_and_points_leave_checks26_33_unchanged(tmp_path, monkeypatch):
     """(l) A sidecar carrying BOTH `text` and `points` changes nothing for the
     sibling checks: check 33 still matches its bolded decimals against the
@@ -10466,11 +10502,41 @@ def test_check34_beat_claim_warnings_comparator():
         {"x": 1.0, "y": 1.0, "_kind": "line", "_group": 1},
     ]
     assert fn(both, _meta(points=mixed), "f.png") == []
+    # A lone data-contributing scatter artist in a MULTI-artist figure (a
+    # rowless sibling left `_group` on the rows): the 1-value group set is
+    # treated as ABSENT group evidence — same skip as the no-`_group` lone
+    # scatter above (the artist may encode >=2 arms per-point). r1 Minor.
+    lone_group_scatter = [
+        {"x": 0.1 * i, "y": 0.2 * i, "_kind": "scatter", "_group": 0} for i in range(5)
+    ]
+    assert fn(both, _meta(points=lone_group_scatter), "f.png") == []
     # Class B without a points payload → skip (basis unavailable).
     one_per = {"both": [], "one_per": [("one bar per source", "bar")]}
     assert fn(one_per, _meta(text=text_two_series), "f.png") == []
     # Class B: claimed kind entirely absent (0 bar rows) → warn.
     assert len(fn(one_per, _meta(points=lone_scatter), "f.png")) == 1
+
+    # TRUNCATED sidecars (r1 Major): stored rows are head-truncated, so they
+    # are NOT figure truth — every points-derived basis is unavailable.
+    def _trunc(m):
+        m["data_truncated"] = True
+        return m
+
+    # Class B on a truncated sidecar → skip (both the <=1-artist read AND the
+    # zeroed-out claimed kind: the missing bar rows may sit past the cap).
+    one_line_grouped = [
+        {"x": float(i), "y": float(i), "_kind": "line", "_group": 0} for i in range(10)
+    ]
+    line_per = {"both": [], "one_per": [("one line per seed", "line")]}
+    assert fn(line_per, _trunc(_meta(points=one_line_grouped)), "f.png") == []
+    assert fn(one_per, _trunc(_meta(points=one_line_grouped)), "f.png") == []
+    # Class A on a truncated sidecar: points-derived bases gone, but the TEXT
+    # bases are truncation-immune and still FIRE — a single fig-global series
+    # label with "both arms" claimed warns exactly as it does untruncated.
+    text_one_series = {"suptitle": None, "fig_texts": [], "series": ["a"]}
+    assert len(fn(both, _trunc(_meta(points=one_line_grouped, text=text_one_series)), "f.png")) == 1
+    # ... and with no text basis at all, a truncated Class A yields NO basis → skip.
+    assert fn(both, _trunc(_meta(points=one_line_grouped)), "f.png") == []
 
 
 #

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -104,7 +104,7 @@ def test_good_body_passes_all():
     ok, results = verify_task_body.verify_text(GOOD_BODY)
     assert ok, [r.render() for r in results if not r.passed]
     assert all(r.passed for r in results)
-    # CHECKS has 36 body-only functions: the 20 pre-v3 body-only checks
+    # CHECKS has 37 body-only functions: the 20 pre-v3 body-only checks
     # (incl. the sentinel-gated `check_tldr_nested_structure` and the
     # check-8b Reproducibility artifact-URL existence probe), the four
     # v3-gated body-only checks (check 18 `check_data_shape`, check 19
@@ -115,7 +115,7 @@ def test_good_body_passes_all():
     # 21 `check_v4_results_beat` WARN, check 27
     # `check_v4_no_bare_issue_refs`; check 20 v4 `check_v4_word_caps`
     # moved to the appended-outside set — it needs `issue`, #921) — each
-    # a PASS-skip on this non-v3/non-v4 fixture — PLUS the NINE
+    # a PASS-skip on this non-v3/non-v4 fixture — PLUS the TEN
     # generation-agnostic checks: check 22
     # (`check_figure_url_sha_matches_repro`), a NO-OP PASS here because
     # this fixture's `## Reproducibility` carries no figure-sha claim,
@@ -142,12 +142,15 @@ def test_good_body_passes_all():
     # the fence, and check 33 (`check_figure_prose_numerics_vs_sidecar`,
     # WARN), a NO-OP PASS here for the same fake-sha / no-sidecar reason
     # as checks 24/28 (no value-bearing sidecar resolves, so no bolded
-    # decimal is ever compared).
+    # decimal is ever compared), and check 34
+    # (`check_figure_beat_claims_vs_sidecar_text`, WARN, forward-only), a
+    # NO-OP PASS here for the same fake-sha / no-sidecar reason (and no
+    # `meta["text"]` block could resolve even if a sidecar did).
     # check 25 (`check_audit_availability_claims_match_hf`)
     # is a vacuous PASS here because this fixture carries no
     # availability-denial-near-artifact line. verify_text prepends check 0
     # (body-nonstub) + check 0b (no-duplicate-frontmatter), runs CHECKS[1:]
-    # (36 functions), then appends the Goal soft check, the H1↔frontmatter-
+    # (37 functions), then appends the Goal soft check, the H1↔frontmatter-
     # title sync check (#1110; PASS-skip: not a sentinelled body), the
     # Lens 14
     # concerns-audit, the check-16 lr-matches-plan reconciliation, the
@@ -159,15 +162,18 @@ def test_good_body_passes_all():
     # the check-31 orphaned-per-unit-figures probe (needs `issue` for
     # figures-dir scoping, #1011; PASS here — the fixture's fake sha is not
     # locally reachable, so the cited SHA is silently skipped) →
-    # 47 results total (2 prepended + CHECKS[1:]=36 + 9 appended). The
+    # 48 results total (2 prepended + CHECKS[1:]=37 + 9 appended). The
     # Lens 14 / check-16 results are PASS-skips when no concerns.jsonl /
     # plans/plan.md sibling is available; check 17 and the v3/v4 checks
     # are PASS-skips on this legacy (pre-v2-sentinel) fixture.
-    assert len(results) == 47
+    assert len(results) == 48
     # By-name membership so the NEXT check addition can key by name instead
     # of re-deriving the arithmetic (#1016 methodology-reconciler Must-Fix).
     assert _HF_32_NAME in {r.name for r in results}
     assert "figure prose numerics vs figure sidecar (plotted-value drift)" in {
+        r.name for r in results
+    }
+    assert "figure beat claims vs sidecar rendered text (series-structure drift)" in {
         r.name for r in results
     }
 
@@ -4597,7 +4603,7 @@ def test_checks_list_size():
     v3-gated checks added 2026-W24 are — check 18
     (`check_data_shape`), check 19 (`check_data_subset_disclosure`),
     check 19b (`check_data_unwrapped_example_table`, WARN), check 20
-    (`check_v3_word_caps`) — PLUS the TEN generation-agnostic checks:
+    (`check_v3_word_caps`) — PLUS the ELEVEN generation-agnostic checks:
     check 22 (`check_figure_url_sha_matches_repro`: inline figure URL sha
     vs the `## Reproducibility` per-figure commit claim), check 23
     (`check_hf_url_resolves`: HF Hub revision-pin existence via a bounded
@@ -4633,7 +4639,13 @@ def test_checks_list_size():
     sidecar's plotted values, under rounding / sign / percent /
     sci-notation tolerance; per-figure `<!-- prose-numerics: derived -->`
     opt-out; silent skip on missing / truncated sidecars; incident #825 r1,
-    #1107). The
+    #1107), and check 34 (`check_figure_beat_claims_vs_sidecar_text`, WARN,
+    FORWARD-ONLY: beat-1 series-structure claims — "both … arms/…" and "one
+    bar/… per <unit>" — vs the series structure the sidecar demonstrably
+    renders; fires only when the sidecar carries the `meta["text"]`
+    rendered-text block, so every pre-capture sidecar silently skips;
+    contradiction-only, absence of evidence never fires; incident #1092
+    defect (b), #1255). The
     migration is a RETARGET — every former check
     was kept (sometimes dormant, e.g. `check_figure_caption`) so downstream
     tests stay valid; the v3 checks PASS-skip on non-v3 bodies.
@@ -4649,15 +4661,16 @@ def test_checks_list_size():
     denominator check (needs eval JSONs), and the check-31
     orphaned-per-unit-figures probe (needs `issue` for figures-dir
     scoping, #1011).
-    So `verify_text` returns 46 results (2 prepended + CHECKS[1:]=36 +
-    8 appended — see `test_good_body_passes_all`), but `CHECKS` stays
-    at 37.
+    So `verify_text` returns 48 results (2 prepended + CHECKS[1:]=37 +
+    9 appended — see `test_good_body_passes_all`), but `CHECKS` stays
+    at 38.
     """
-    assert len(verify_task_body.CHECKS) == 37
+    assert len(verify_task_body.CHECKS) == 38
     # By-name membership so the NEXT check addition can key by name instead
     # of re-deriving the arithmetic (#1016 methodology-reconciler Must-Fix).
     assert verify_task_body.check_hf_adjacent_file_claims in verify_task_body.CHECKS
     assert verify_task_body.check_figure_prose_numerics_vs_sidecar in verify_task_body.CHECKS
+    assert verify_task_body.check_figure_beat_claims_vs_sidecar_text in verify_task_body.CHECKS
 
 
 # ─── Check 14: MDX-safe prose (regex layer + real-parse backstop) ───
@@ -8949,6 +8962,30 @@ def test_check24_repo_unresolved_is_noop_pass(monkeypatch):
     assert "repo root unresolved" in res.detail
 
 
+def test_check24_stale_token_in_text_suptitle_warns(tmp_path, monkeypatch):
+    """The `meta["text"]` rendered-text block (new `savefig_paper` output) is
+    scanned by check 24 with ZERO scan-code change: a configured stale token
+    sitting in the actual rendered SUPTITLE → WARN (`_flatten_meta_strings`
+    walks all non-provenance strings, so the new subtree enters
+    automatically; forward-only — old sidecars simply lack the key)."""
+    repo, sha = _make_repo_with_figure_meta(
+        tmp_path,
+        {
+            "created": "2026-07-10T00:00:00Z",
+            "text": {
+                "suptitle": "Cosine recipe shows a geometrically real separation",
+                "fig_texts": [],
+                "axes": [{"xlabel": "condition"}],
+            },
+        },
+    )
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = _CHECK24_BODY.replace("0123456789abcdef", sha)
+    res = verify_task_body.check_figure_text_vs_body_tokens(body)
+    assert res.passed and res.is_warn, res.render()
+    assert "geometrically real" in res.detail
+
+
 def test_check24_user_token_file_extends_list(tmp_path, monkeypatch):
     """`~/.eps-stale-tokens.json` extends the built-in list, read fail-soft."""
     home = tmp_path / "home"
@@ -9517,6 +9554,62 @@ def test_check28_slash_separated_label_warns(tmp_path, monkeypatch):
     res = verify_task_body.check_figure_label_codes(body)
     assert res.passed and res.is_warn, res.render()
     assert "ctx_blk_max" in res.detail and "ans_uhdr_max" in res.detail
+
+
+def test_check28_slug_in_text_axes_title_warns(tmp_path, monkeypatch):
+    """The #1092 defect-(a) regression: a bare cell slug rendered as a PANEL
+    TITLE now reaches check 28 through the `meta["text"]` block the current
+    `savefig_paper` writes — `_iter_meta_label_values` collects the text
+    subtree's string VALUES with zero scan-code change, while the block's
+    structural key names (`suptitle`, `axes`, `fig_texts`, …) are
+    whitespace-free identifier keys and are never collected."""
+    repo, sha = _make_repo_with_figure_meta(
+        tmp_path,
+        {
+            "created": "2026-07-10T00:00:00Z",
+            "text": {
+                "suptitle": None,
+                "fig_texts": [],
+                "axes": [{"title": "ctx_blk_max@L12 vs ans_uhdr_max@L12"}],
+            },
+        },
+    )
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = _CHECK24_BODY.replace("0123456789abcdef", sha)
+    res = verify_task_body.check_figure_label_codes(body)
+    assert res.passed and res.is_warn, res.render()
+    assert "ctx_blk_max@L12" in res.detail
+
+
+def test_check28_plain_english_text_block_clean(tmp_path, monkeypatch):
+    """A plain-English `meta["text"]` block (suptitle / titles / labels /
+    legend / series / tick labels) → clean PASS: the new subtree opens no
+    false-positive channel on well-labeled figures."""
+    repo, sha = _make_repo_with_figure_meta(
+        tmp_path,
+        {
+            "created": "2026-07-10T00:00:00Z",
+            "text": {
+                "suptitle": "Alignment holds across seeds",
+                "fig_texts": ["Source: evaluation results for task 999"],
+                "series": ["trained", "base"],
+                "axes": [
+                    {
+                        "title_left": "Trained vs base agreement",
+                        "xlabel": "condition",
+                        "ylabel": "agreement rate",
+                        "legend_labels": ["trained", "base"],
+                        "legend_title": "arm",
+                        "xticklabels": ["baseline", "tulu-25"],
+                    }
+                ],
+            },
+        },
+    )
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = _CHECK24_BODY.replace("0123456789abcdef", sha)
+    res = verify_task_body.check_figure_label_codes(body)
+    assert res.passed and not res.is_warn, res.render()
 
 
 # ─── Check 33: bolded what-is-plotted numerics vs sidecar plotted values ───
@@ -10089,7 +10182,297 @@ def test_check33_bold_prose_decimals_extraction():
     assert len(out) == 4, out
 
 
-# ─── #732: check_judge_error_denominator — gate silent judge-API-error EM ──
+# ─── Check 34: beat-phrase series-structure claims vs sidecar rendered text ─
+#
+# Fifth sibling of checks 24/26/28/33: the two literal #1092 defect-(b)
+# phrasings ("both … arms/…", "one bar/… per <unit>") must not contradict the
+# series structure the sidecar demonstrably renders. FORWARD-ONLY: fires only
+# when the sidecar carries the `meta["text"]` rendered-text block the current
+# `savefig_paper` writes; contradiction-only (absence of evidence never
+# fires). WARN never FAIL.
+
+_CHECK34_NAME = "figure beat claims vs sidecar rendered text (series-structure drift)"
+
+
+def _check34_sidecar(*, points=None, series=None, legend_labels=None, n_series=None):
+    """A sidecar carrying the `meta["text"]` block (the check-34 forward-only
+    gate), with optional `points` rows, fig-global `series` labels, and
+    per-axes `legend_labels`."""
+    ax_d: dict = {"xlabel": "condition", "ylabel": "agreement rate"}
+    if legend_labels:
+        ax_d["legend_labels"] = list(legend_labels)
+    text: dict = {"suptitle": None, "fig_texts": [], "axes": [ax_d]}
+    if series:
+        text["series"] = list(series)
+    meta: dict = {"created": "2026-07-10T00:00:00Z", "text": text}
+    if points is not None:
+        meta["points"] = points
+    if n_series is not None:
+        meta["n_series"] = n_series
+    return meta
+
+
+def test_check34_both_arms_single_series_warns(tmp_path, monkeypatch):
+    """(a) "both trained and base models" vs a sidecar whose ONLY available
+    basis is a single series label → WARN (passed=True, is_warn=True) naming
+    the claim phrase; the WARN never flips the body's overall verdict."""
+    repo, sha = _make_repo_with_figure_meta(tmp_path, _check34_sidecar(series=["trained"]))
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = _check33_body("Plotted: mean agreement for both trained and base models.").replace(
+        "0123456789abcdef", sha
+    )
+    _ok, results = verify_task_body.verify_text(body)
+    res = _results_by_name(results)[_CHECK34_NAME]
+    assert res.passed and res.is_warn, res.render()
+    assert "both trained and base models" in res.detail
+    assert _CHECK34_NAME not in {r.name for r in results if not r.passed}
+
+
+def test_check34_both_arms_two_legend_labels_pass(tmp_path, monkeypatch):
+    """(b) The same claim vs 2 legend entries → clean PASS (the legend basis
+    reads 2, so the claim is satisfiable)."""
+    repo, sha = _make_repo_with_figure_meta(
+        tmp_path, _check34_sidecar(legend_labels=["trained", "base"])
+    )
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = _check33_body("Plotted: mean agreement for both trained and base models.").replace(
+        "0123456789abcdef", sha
+    )
+    res = verify_task_body.check_figure_beat_claims_vs_sidecar_text(body)
+    assert res.passed and not res.is_warn, res.render()
+    assert "consistent" in res.detail
+
+
+def test_check34_both_arms_two_bar_rows_one_container_pass(tmp_path, monkeypatch):
+    """(c) Two BAR ROWS in ONE container (`n_series` = 1, no `_group`) satisfy
+    "both arms" → PASS. Pins the n_series-NOT-used decision: a two-arm bar
+    pair lives in one `BarContainer`, so an `n_series` basis would read 1 and
+    false-fire on the most common two-arm bar chart."""
+    pts = [
+        {"category": "trained", "rate": 0.7, "_kind": "bar"},
+        {"category": "base", "rate": 0.4, "_kind": "bar"},
+    ]
+    repo, sha = _make_repo_with_figure_meta(tmp_path, _check34_sidecar(points=pts, n_series=1))
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = _check33_body("Plotted: agreement for both trained and base arms.").replace(
+        "0123456789abcdef", sha
+    )
+    res = verify_task_body.check_figure_beat_claims_vs_sidecar_text(body)
+    assert res.passed and not res.is_warn, res.render()
+
+
+def test_check34_one_bar_per_single_bar_warns(tmp_path, monkeypatch):
+    """(d) The #1092 degenerate class: "one bar per re-fit item" vs a single
+    rendered bar row → WARN, with the n=1 acknowledgeable remedy named."""
+    pts = [{"category": "only", "rate": 0.7, "_kind": "bar"}]
+    repo, sha = _make_repo_with_figure_meta(tmp_path, _check34_sidecar(points=pts))
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = _check33_body("Plotted: one bar per re-fit item.").replace("0123456789abcdef", sha)
+    res = verify_task_body.check_figure_beat_claims_vs_sidecar_text(body)
+    assert res.passed and res.is_warn, res.render()
+    assert "one bar per re-fit" in res.detail
+    assert "acknowledgeable" in res.detail
+
+
+def test_check34_one_bar_per_five_bars_pass(tmp_path, monkeypatch):
+    """(e) "one bar per source" vs 5 bar rows → clean PASS."""
+    pts = [{"category": f"s{i}", "rate": 0.1 * i, "_kind": "bar"} for i in range(5)]
+    repo, sha = _make_repo_with_figure_meta(tmp_path, _check34_sidecar(points=pts))
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = _check33_body("Plotted: one bar per source persona.").replace("0123456789abcdef", sha)
+    res = verify_task_body.check_figure_beat_claims_vs_sidecar_text(body)
+    assert res.passed and not res.is_warn, res.render()
+
+
+def test_check34_one_line_per_single_line_artist_warns(tmp_path, monkeypatch):
+    """(f) "one line per seed" vs a SINGLE line artist with many vertex rows →
+    WARN. Pins the distinct-`_group` per-ARTIST basis: a line's point rows are
+    VERTICES (30 rows here), so a raw row count would read 30 and never fire;
+    `_group` is per-ARTIST (per-series), not per-panel, and a single-artist
+    sidecar carries no `_group` at all → 1 artist."""
+    pts = [{"x": float(i), "y": float(i), "_kind": "line"} for i in range(30)]
+    repo, sha = _make_repo_with_figure_meta(tmp_path, _check34_sidecar(points=pts))
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = _check33_body("Plotted: one line per seed.").replace("0123456789abcdef", sha)
+    res = verify_task_body.check_figure_beat_claims_vs_sidecar_text(body)
+    assert res.passed and res.is_warn, res.render()
+    assert "1 `line` element(s)" in res.detail
+
+
+def test_check34_no_text_sidecar_silent_skip(tmp_path, monkeypatch):
+    """(g) THE forward-only pin: a claiming prose window + a sidecar WITHOUT
+    the `meta["text"]` block (every sidecar committed before the capture
+    landed) → NO-OP silent skip, never a WARN and never check 26's loud
+    missing-sidecar FAIL — no existing body can retroactively flag."""
+    meta = {
+        "created": "2026-06-01T00:00:00Z",
+        "points": [{"category": "only", "rate": 0.7, "_kind": "bar"}],
+    }
+    repo, sha = _make_repo_with_figure_meta(tmp_path, meta)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = _check33_body("Plotted: one bar per re-fit item.").replace("0123456789abcdef", sha)
+    res = verify_task_body.check_figure_beat_claims_vs_sidecar_text(body)
+    assert res.passed and not res.is_warn, res.render()
+    assert "nothing to compare" in res.detail
+
+
+def test_check34_missing_sidecar_silent_skip(tmp_path, monkeypatch):
+    """(h) A same-repo figure with NO `.meta.json` sibling → silent-skip PASS
+    (check-24 fail-soft convention), even with a claiming window."""
+    repo, sha = _make_repo_with_figure(tmp_path)  # commits hero.png but no sidecar
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = _check33_body("Plotted: one bar per re-fit item.").replace("0123456789abcdef", sha)
+    res = verify_task_body.check_figure_beat_claims_vs_sidecar_text(body)
+    assert res.passed and not res.is_warn, res.render()
+    assert "nothing to compare" in res.detail
+
+
+def test_check34_repo_unresolved_is_noop_pass(monkeypatch):
+    """(i) Offline / repo root unresolved → NO-OP PASS."""
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: None)
+    body = _check33_body("Plotted: one bar per re-fit item.")
+    res = verify_task_body.check_figure_beat_claims_vs_sidecar_text(body)
+    assert res.passed and not res.is_warn
+    assert "repo root unresolved" in res.detail
+
+
+def test_check34_no_claim_in_prose_pass(tmp_path, monkeypatch):
+    """(j) A window with NO registered claim phrase → "nothing to compare"
+    PASS even against a text-bearing sidecar (never over-fire)."""
+    repo, sha = _make_repo_with_figure_meta(tmp_path, _check34_sidecar(series=["trained"]))
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = _CHECK33_BODY.replace("0123456789abcdef", sha)  # bolded decimals, no beat claim
+    res = verify_task_body.check_figure_beat_claims_vs_sidecar_text(body)
+    assert res.passed and not res.is_warn, res.render()
+    assert "nothing to compare" in res.detail
+
+
+def test_check34_both_arms_unlabeled_scatter_silent_skip(tmp_path, monkeypatch):
+    """(k) The one real FP channel, closed by basis AVAILABILITY: "both arms"
+    over an UNLABELED single-artist scatter (no series, no legend, no bar/line
+    rows, no `_group` anywhere — a lone scatter artist can encode two arms via
+    per-point colors the extractor cannot see) → NO available basis → skip,
+    NOT a contradiction."""
+    pts = [{"x": 0.1 * i, "y": 0.2 * i, "_kind": "scatter"} for i in range(6)]
+    repo, sha = _make_repo_with_figure_meta(tmp_path, _check34_sidecar(points=pts))
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = _check33_body("Plotted: agreement for both input arms.").replace("0123456789abcdef", sha)
+    res = verify_task_body.check_figure_beat_claims_vs_sidecar_text(body)
+    assert res.passed and not res.is_warn, res.render()
+
+
+def test_check34_text_and_points_leave_checks26_33_unchanged(tmp_path, monkeypatch):
+    """(l) A sidecar carrying BOTH `text` and `points` changes nothing for the
+    sibling checks: check 33 still matches its bolded decimals against the
+    `points` values (clean PASS), and check 26 still finds no panel/series
+    prose claim (NO-OP PASS) — the `text` key is invisible to both by
+    construction (check 26/33 read `points`/`rows` only)."""
+    meta = _bar_values_sidecar(0.704, 0.879)
+    meta["text"] = {
+        "suptitle": "Alignment per condition",
+        "fig_texts": [],
+        "axes": [{"xlabel": "condition", "ylabel": "alignment"}],
+    }
+    repo, sha = _make_repo_with_figure_meta(tmp_path, meta)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = _CHECK33_BODY.replace("0123456789abcdef", sha)
+    res33 = verify_task_body.check_figure_prose_numerics_vs_sidecar(body)
+    assert res33.passed and not res33.is_warn, res33.render()
+    assert "all bolded what-is-plotted decimals present" in res33.detail
+    res26 = verify_task_body.check_figure_panel_prose_vs_sidecar(body)
+    assert res26.passed and not res26.is_warn, res26.render()
+    assert "no panel/series prose claims" in res26.detail
+
+
+def test_check34_beat_series_claims_inventory():
+    """Pure-parser inventory for `_beat_series_claims`: the two registered
+    claim classes match their literal #1092 phrasings; paraphrases miss BY
+    DESIGN (the documented false-negative envelope)."""
+    fn = verify_task_body._beat_series_claims
+    # Class A — matches.
+    assert fn("shows both input arms")["both"] == ["both input arms"]
+    assert fn("both fine-tuned and base models are shown")["both"] == [
+        "both fine-tuned and base models"
+    ]
+    assert fn("both trained and base conditions")["both"]
+    assert fn("Both curves overlap")["both"]  # case-insensitive
+    # Class B — matches, kind-mapped, de-duplicated.
+    one = fn("one bar per re-fit item; one bar per re-fit item")["one_per"]
+    assert one == [("one bar per re-fit", "bar")]
+    assert fn("one line per seed")["one_per"] == [("one line per seed", "line")]
+    assert fn("one curve per layer")["one_per"][0][1] == "line"
+    assert fn("one dot per persona")["one_per"][0][1] == "scatter"
+    assert fn("one point per context")["one_per"][0][1] == "scatter"
+    assert fn("one marker per cell")["one_per"][0][1] == "scatter"
+    # Non-matches (paraphrases / other nouns) — the FN envelope.
+    for miss in (
+        "each arm gets its own panel",
+        "two models are compared",
+        "both of these approaches work",  # 'approaches' is not a registered noun
+        "bars per source",  # no leading 'one'
+        "one bar for each source",  # 'for each', not 'per'
+    ):
+        got = fn(miss)
+        assert not got["both"] and not got["one_per"], (miss, got)
+
+
+def test_check34_beat_claim_warnings_comparator():
+    """Pure-comparator inventory for `_beat_claim_warnings`, pinning the
+    per-ARTIST (not per-panel) `_group` semantics and the basis-availability
+    rules. `_group` indexes artist GROUPS (`_build_sidecar_data`: one index
+    per extracted artist, emitted only on multi-artist figures) — a 4-panel
+    figure with 22 artists has 22 groups, so no basis here ever reads panel
+    counts."""
+    fn = verify_task_body._beat_claim_warnings
+    both = {"both": ["both arms"], "one_per": []}
+
+    def _meta(points=None, text=None):
+        m: dict = {"created": "t"}
+        if points is not None:
+            m["points"] = points
+        m["text"] = text if text is not None else {"suptitle": None, "fig_texts": []}
+        return m
+
+    # Two line ARTISTS (distinct _group) satisfy "both" — no warn.
+    two_lines = [
+        {"x": 0.0, "y": 0.0, "_kind": "line", "_group": 0},
+        {"x": 1.0, "y": 1.0, "_kind": "line", "_group": 0},
+        {"x": 0.0, "y": 0.5, "_kind": "line", "_group": 1},
+        {"x": 1.0, "y": 1.5, "_kind": "line", "_group": 1},
+    ]
+    assert fn(both, _meta(points=two_lines), "f.png") == []
+    # ONE line artist (vertices, single-artist sidecar → no _group) → warn.
+    one_line = [{"x": float(i), "y": float(i), "_kind": "line"} for i in range(10)]
+    assert len(fn(both, _meta(points=one_line), "f.png")) == 1
+    # Fig-GLOBAL series labels: a multi-panel figure with one series per panel
+    # and >=2 distinct labels satisfies "both arms" — DELIBERATELY
+    # conservative (never false-fire on per-panel single-series layouts).
+    text_two_series = {"suptitle": None, "fig_texts": [], "series": ["a", "b"]}
+    assert fn(both, _meta(text=text_two_series), "f.png") == []
+    # Two scatter ARTISTS (distinct _group) → no warn; a single unlabeled
+    # scatter artist (no _group) yields NO basis → no warn either (skip).
+    two_scatter = [
+        {"x": 0.1, "y": 0.2, "_kind": "scatter", "_group": 0},
+        {"x": 0.3, "y": 0.4, "_kind": "scatter", "_group": 1},
+    ]
+    assert fn(both, _meta(points=two_scatter), "f.png") == []
+    lone_scatter = [{"x": 0.1, "y": 0.2, "_kind": "scatter"} for _ in range(5)]
+    assert fn(both, _meta(points=lone_scatter), "f.png") == []
+    # Mixed line+scatter TWO-artist figure: the total artist-groups basis
+    # reads 2 → "both arms" satisfiable across kinds → no warn.
+    mixed = [
+        {"x": 0.1, "y": 0.2, "_kind": "scatter", "_group": 0},
+        {"x": 0.0, "y": 0.0, "_kind": "line", "_group": 1},
+        {"x": 1.0, "y": 1.0, "_kind": "line", "_group": 1},
+    ]
+    assert fn(both, _meta(points=mixed), "f.png") == []
+    # Class B without a points payload → skip (basis unavailable).
+    one_per = {"both": [], "one_per": [("one bar per source", "bar")]}
+    assert fn(one_per, _meta(text=text_two_series), "f.png") == []
+    # Class B: claimed kind entirely absent (0 bar rows) → warn.
+    assert len(fn(one_per, _meta(points=lone_scatter), "f.png")) == 1
+
+
 #
 # A NEW mechanical check that FAILs/WARNs when a clean-result body states a
 # BARE LLM-judge denominator (`n=N` / "N completions/EM") in a judge-context


### PR DESCRIPTION
Closes task #1255.

- savefig_paper: rendered-text capture into .meta.json under meta["text"] (embed_text=True, best-effort)
- verify_task_body.py: checks 24/28 auto-pickup + NEW check 34 (WARN, forward-only) beat-claim vs series-structure drift
- paper-plots SKILL.md sidecar-contract docs; 29 new tests
- Forward-only proven: 0/2101 committed sidecars carry the key; calibration 0 fires on 172 bodies