### PR TITLE
issue-1256: cross-issue reuse-provenance check (check 35) in verify_task_body.py

### DIFF
--- a/.claude/skills/clean-results/SPEC.md
+++ b/.claude/skills/clean-results/SPEC.md
@@ -1249,6 +1249,11 @@ Agent-facing appendix at the bottom. Required content, in order:
   (recipe match + measurement-regime fit + required conditions present).
   Format: `- Reused <kind> from [#M](...): <path> — fit: <one line>`.
   When THIS task produced every artifact, no reuse bullets are needed.
+  Cross-issue provenance pins found in committed result-JSON `metadata`
+  (`hf_rev_<M>_*` revision keys, `issue<M>_` input paths) must be
+  declared in the body (canonically this list) — `verify_task_body.py`
+  check 35 (`check_cross_issue_reuse_provenance`) FAILs an undeclared
+  pinned revision at posting time.
 - **`**Compute:**`** — wall time, GPU type/count, pod label.
 - **`**Code:**`** — dataset-build script, pipeline driver, Hydra config,
   git commit hash, one-block reproduce snippet.

--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -671,6 +671,35 @@ Generation-agnostic checks (run on v2 AND v3 — the inline-figure +
   a beat claimed "both input arms" / "one bar per re-fit item" against a
   figure rendering neither, passing every mechanical figure check. (#1255)
 
+- **check 35** (`check_cross_issue_reuse_provenance`, FAIL/WARN, v4-only,
+  #1256): cross-issue reuse pins in the committed
+  `eval_results/issue_<N>/**/*.json` result-JSON `metadata` must be
+  declared in the body (canonical slot: the footer `Reused:` bullet,
+  SPEC.md § `**Artifacts:**`). Tier 1 (FAIL): a `metadata` key matching
+  `hf_rev_<M>` / `hf_rev_<M>_<tag>` with M != N whose pinned revision has
+  no >=7-hex-char prefix token anywhere in the body (non-hex branch/tag
+  pins fall back to a `#M` / `/tasks/M` / `issue<M>_` mention). Tier 2
+  (WARN): a `\bissue<M>_` path token in `metadata.input_shas` keys/values
+  or PATH-LIKE (`/`-bearing) `metadata.args` string values, M != N, with
+  neither the `issue<M>_<slug>` segment nor a `#M` / `/tasks/M` mention in
+  the body. Graceful PASS-skips: not-v4 (forward-only), issue unknown
+  (stdin), `EPM_VERIFY_BODY_NO_EVAL_SCAN=1`, eval root unresolved
+  (is_warn, the #732 convention), no pins found. Corrupt / unreadable /
+  oversize (>50 MB stat guard) JSONs are skipped silently — `issue_810`
+  carries 138-208 MB JSONs and `issue_811` is a ~14.7 GB dir, so the
+  guard + a substring pre-filter are load-bearing. Grounding (corpus scan
+  2026-07-11, ~90,858 committed eval JSONs): the tier-1 key shape exists
+  in exactly 1 file repo-wide (the #1092 incident file), and the bare
+  `issue<M>_` pattern appears in >=10,028 files — hence the tier-2
+  restriction + WARN severity. Documented residuals: same-revision
+  multi-artifact reuse (one firing pin per round suffices; LM
+  clean-result-critic Lens 5 stays the semantic backstop), and
+  `paper: true` tasks (gated by verify_paper.py, never this verifier).
+  Incident: #1092 round 3 — `hf_rev_779_labels` pinned in
+  `transfer_reads.json` metadata with the reuse undeclared in the footer
+  survived to the LM critic. Dispatched OUTSIDE the body-only CHECKS list
+  (needs `issue` + eval-root resolution; the #732 precedent).
+
 Harmful-content carve-out: checks 18/19 accept the sanitized excerpt
 form (`[truncated — harmful-content row; verify at <path>, row <i>]`)
 exactly as checks 10/11 do today.
@@ -4908,6 +4937,312 @@ def check_judge_error_denominator(
         return CheckResult(name, True, detail, is_warn=True)
     return CheckResult(
         name, True, f"judge-error fraction below 1% (worst {worst:.1%}, pooled {pooled:.1%})"
+    )
+
+
+# ─── Check 35 (#1256): cross-issue reuse pins declared in the body ─────────
+
+# A metadata KEY that pins another issue's HF revision: `hf_rev_<M>` or
+# `hf_rev_<M>_<tag>` (observed shape: #1092's transfer_reads.json
+# metadata.args `hf_rev_779_passb` / `hf_rev_779_labels` / self-pin
+# `hf_rev_1092`). Corpus base rate: exactly 1 file among ~90,858 committed
+# eval JSONs (scan 2026-07-11) — the incident file.
+_HF_REV_PIN_KEY_RE = re.compile(r"^hf_rev_(\d+)(?:_\w+)?$")
+
+# An issue-slug path segment (`issue779_monitoring/...`) inside metadata
+# input paths. Deliberately underscore-anchored: local caches
+# (`data/issue_952/`), worktrees (`issue-952`) and self dirs
+# (`eval_results/issue_1092/`) do NOT match (underscore/hyphen precedes
+# the digits there, so `\bissue(\d+)_` cannot fire on them). The bare
+# pattern appears in >=10,028 committed eval JSONs (scan 2026-07-11), so
+# tier 2 is restricted to `input_shas` + path-like `args` values and
+# capped at WARN severity.
+_ISSUE_SLUG_RE = re.compile(r"\bissue(\d+)_[A-Za-z0-9_]*")
+
+# Hex tokens in the body that can satisfy a tier-1 revision pin by prefix.
+_BODY_HEX_TOKEN_RE = re.compile(r"\b[0-9a-fA-F]{7,40}\b")
+
+# Per-file stat guard (MANDATORY): eval_results is JSON/text-only by policy,
+# but `issue_810` carries 4 JSONs of 138-208 MB and `issue_811` is a
+# ~14.7 GB dir — a guard-less gate-time scan there would read ~750 MB+.
+_REUSE_SCAN_MAX_BYTES = 50 * 1024 * 1024
+
+
+def _iter_metadata_dicts(payload: object) -> Iterator[dict]:
+    """Yield every dict that sits under a key named `metadata`, any depth.
+
+    Measured identical to top-level-only on the whole committed corpus
+    (nested `metadata` dicts add 0 pin hits, scan 2026-07-11), but more
+    robust for nested `run_result.json` phase shapes.
+    """
+    stack = [payload]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, dict):
+            for k, v in node.items():
+                if k == "metadata" and isinstance(v, dict):
+                    yield v
+                stack.append(v)
+        elif isinstance(node, list):
+            stack.extend(node)
+
+
+def _walk_hf_rev_keys(
+    node: object, issue: int, relpath: str, tier1: list[tuple[str, str, int, str]]
+) -> None:
+    """Recursively collect tier-1 pins: `hf_rev_<M>[_<tag>]` keys with a
+    string value and M != issue, anywhere inside `node`."""
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if isinstance(k, str) and isinstance(v, str):
+                m = _HF_REV_PIN_KEY_RE.match(k)
+                if m and int(m.group(1)) != issue:
+                    tier1.append((relpath, k, int(m.group(1)), v))
+            _walk_hf_rev_keys(v, issue, relpath, tier1)
+    elif isinstance(node, list):
+        for v in node:
+            _walk_hf_rev_keys(v, issue, relpath, tier1)
+
+
+def _slug_hits(text: str, issue: int, relpath: str, tier2: list[tuple[str, int, str]]) -> None:
+    """Collect tier-2 `_ISSUE_SLUG_RE` tokens with M != issue from `text`."""
+    for m in _ISSUE_SLUG_RE.finditer(text):
+        src = int(m.group(1))
+        if src != issue:
+            tier2.append((relpath, src, m.group(0)))
+
+
+def _walk_pathlike_args(
+    node: object, issue: int, relpath: str, tier2: list[tuple[str, int, str]]
+) -> None:
+    """Recursively collect tier-2 tokens from PATH-LIKE (`"/" in v`) string
+    values under a metadata `args` subtree."""
+    if isinstance(node, dict):
+        for v in node.values():
+            _walk_pathlike_args(v, issue, relpath, tier2)
+    elif isinstance(node, list):
+        for v in node:
+            _walk_pathlike_args(v, issue, relpath, tier2)
+    elif isinstance(node, str) and "/" in node:
+        _slug_hits(node, issue, relpath, tier2)
+
+
+def _collect_metadata_pins(
+    md: dict,
+    issue: int,
+    relpath: str,
+    tier1: list[tuple[str, str, int, str]],
+    tier2: list[tuple[str, int, str]],
+) -> None:
+    """Collect cross-issue pins from ONE metadata dict into tier1/tier2.
+
+    tier1: `hf_rev_<M>[_<tag>]` keys (ALL keys, recursively) with a string
+    value and M != issue. tier2: `_ISSUE_SLUG_RE` hits in
+    `metadata["input_shas"]` keys + string values, and in PATH-LIKE
+    (`"/" in v`) string values under `metadata["args"]` (recursive),
+    M != issue. M == issue pins (the `hf_rev_1092` self-pin) never flag —
+    the self-pin is provenance, not reuse.
+    """
+    _walk_hf_rev_keys(md, issue, relpath, tier1)
+
+    input_shas = md.get("input_shas")
+    if isinstance(input_shas, dict):
+        for k, v in input_shas.items():
+            if isinstance(k, str):
+                _slug_hits(k, issue, relpath, tier2)
+            if isinstance(v, str):
+                _slug_hits(v, issue, relpath, tier2)
+
+    args = md.get("args")
+    if args is not None:
+        _walk_pathlike_args(args, issue, relpath, tier2)
+
+
+def _scan_cross_issue_reuse_pins(repo: Path, issue: int) -> dict | None:
+    """Scan committed `repo/eval_results/issue_<N>/**/*.json` metadata for
+    cross-issue provenance pins. Returns
+    ``{"tier1": [(relpath, key, M, value)], "tier2": [(relpath, M, token)]}``
+    or None when the dir is absent / no candidate files carry a pin / the
+    `EPM_VERIFY_BODY_NO_EVAL_SCAN=1` fence is set (graceful skip).
+
+    Corrupt / unreadable / oversize (`_REUSE_SCAN_MAX_BYTES` stat guard)
+    JSONs are skipped silently (the `_scan_issue_judge_errors` convention —
+    never crash the gate). A cheap substring pre-filter (`"metadata"` plus
+    `hf_rev_` or `issue<digits>_`) avoids `json.loads` on the vast majority
+    of files. `.jsonl` files are OUT of scope (parity with
+    `_scan_issue_judge_errors`).
+    """
+    if os.environ.get("EPM_VERIFY_BODY_NO_EVAL_SCAN") == "1":
+        return None
+    eval_dir = repo / "eval_results" / f"issue_{issue}"
+    if not eval_dir.is_dir():
+        return None
+
+    tier1: list[tuple[str, str, int, str]] = []
+    tier2: list[tuple[str, int, str]] = []
+    slug_probe = re.compile(r"\bissue\d+_")
+
+    for path in sorted(eval_dir.rglob("*.json")):
+        try:
+            if path.stat().st_size > _REUSE_SCAN_MAX_BYTES:
+                continue  # oversize guard — never page a 100+ MB blob at gate time
+            text = path.read_text()
+        except OSError:
+            continue
+        if '"metadata"' not in text:
+            continue
+        if "hf_rev_" not in text and not slug_probe.search(text):
+            continue
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            continue  # a corrupt artifact must not crash the gate
+        relpath = str(path.relative_to(repo))
+        for md in _iter_metadata_dicts(payload):
+            _collect_metadata_pins(md, issue, relpath, tier1, tier2)
+
+    if not tier1 and not tier2:
+        return None
+    return {"tier1": tier1, "tier2": tier2}
+
+
+def _tier1_satisfied(body_hex_tokens: set[str], value: str, M: int, body: str) -> bool:
+    """True when a tier-1 revision pin `value` (source issue M) is declared
+    in the body: a hex pin is satisfied by any >=7-hex-char body token that
+    PREFIXES it (case-insensitive — a footer short sha `5aa6de1b` satisfies
+    the metadata's 40-char pin); a non-hex pin (branch/tag) falls back to
+    an issue-level `#M` / `/tasks/M` / `issue<M>_` mention."""
+    v = value.strip().lower()
+    if re.fullmatch(r"[0-9a-f]{7,64}", v):
+        return any(v.startswith(tok) for tok in body_hex_tokens)  # lowercased, len>=7
+    # non-hex pin (branch/tag): fall back to issue-level mention
+    return bool(
+        re.search(rf"#\s?{M}(?!\d)", body)
+        or re.search(rf"/tasks/{M}(?!\d)", body)
+        or f"issue{M}_" in body
+    )
+
+
+def _tier2_satisfied(body: str, M: int, token: str) -> bool:
+    """True when a tier-2 path token (source issue M) is declared in the
+    body: the `issue<M>_<slug>` first path segment appears verbatim, or an
+    issue-level `#M` / `/tasks/M` mention does. The `(?!\\d)` digit boundary
+    prevents `#7791` satisfying M=779."""
+    seg = token.split("/")[0]  # e.g. "issue779_monitoring"
+    return bool(
+        seg in body or re.search(rf"#\s?{M}(?!\d)", body) or re.search(rf"/tasks/{M}(?!\d)", body)
+    )
+
+
+def check_cross_issue_reuse_provenance(
+    body: str,
+    *,
+    issue: int | None = None,
+    eval_root: Path | None = None,
+    body_source_path: Path | None = None,
+) -> CheckResult:
+    """Check 35 (#1256): cross-issue reuse pins in committed result-JSON
+    metadata must be declared in the body (canonical slot: the footer
+    `Reused:` bullet, SPEC.md § `**Artifacts:**`).
+
+    Verdict ladder:
+      PASS-skip — not a v4 body (forward-only) / issue unknown (stdin) /
+                  `EPM_VERIFY_BODY_NO_EVAL_SCAN=1` fence / eval root
+                  unresolved (is_warn=True, judge-error parity) / no pins
+                  found (graceful).
+      FAIL      — a tier-1 pin (M != N) whose revision value has no
+                  satisfying token in the body (`_tier1_satisfied`).
+      WARN      — a tier-2 path hit (M != N) with no satisfying body
+                  mention (`_tier2_satisfied`).
+      PASS      — every pin satisfied.
+
+    Satisfaction is checked against the WHOLE raw body text (not just the
+    footer): the goal is "provenance is reader-visible", the FAIL detail
+    points at the footer `Reused:` bullet as the canonical fix, and the LM
+    clean-result-critic Lens 5 keeps owning placement/wording quality.
+    Pins are deduped by (key, M, value) / (M, token) across files so one
+    reused artifact yields one detail line.
+
+    Documented residuals: (a) same-revision multi-artifact reuse — when two
+    reused artifacts share one repo revision, a body declaring either
+    satisfies both pins; one firing pin per round is sufficient to force
+    the declaration fix, and LM Lens 5 stays the semantic backstop
+    (#1092's `hf_rev_779_passb` was satisfied pre-fix via the declared r_B
+    bullet's shared `037fcbb` revision). (b) `paper: true` tasks are gated
+    by verify_paper.py and never reach this verifier.
+    """
+    name = "cross-issue reuse pins declared (footer Reused bullets)"
+    if not is_v4(body):
+        return CheckResult(name, True, "skipped — not a v4 body (forward-only)")
+    if issue is None:
+        return CheckResult(
+            name, True, "skipped — issue number unknown (stdin); cannot read eval_results"
+        )
+    if os.environ.get("EPM_VERIFY_BODY_NO_EVAL_SCAN") == "1":
+        return CheckResult(
+            name, True, "skipped — EPM_VERIFY_BODY_NO_EVAL_SCAN=1 (eval scan fenced off)"
+        )
+    repo = _resolve_eval_root(issue, eval_root=eval_root, body_source_path=body_source_path)
+    if repo is None:
+        return CheckResult(name, True, "skipped — eval root unresolved", is_warn=True)
+    pins = _scan_cross_issue_reuse_pins(repo, issue)
+    if pins is None:
+        return CheckResult(
+            name,
+            True,
+            "no cross-issue reuse pins in committed result-JSON metadata — graceful skip",
+        )
+
+    body_hex_tokens = {t.lower() for t in _BODY_HEX_TOKEN_RE.findall(body)}
+
+    unsatisfied_t1: list[tuple[str, str, int, str]] = []
+    seen_t1: set[tuple[str, int, str]] = set()
+    for relpath, key, src, value in pins["tier1"]:
+        dedupe = (key, src, value)
+        if dedupe in seen_t1:
+            continue
+        seen_t1.add(dedupe)
+        if not _tier1_satisfied(body_hex_tokens, value, src, body):
+            unsatisfied_t1.append((relpath, key, src, value))
+
+    unsatisfied_t2: list[tuple[str, int, str]] = []
+    seen_t2: set[tuple[int, str]] = set()
+    for relpath, src, token in pins["tier2"]:
+        dedupe = (src, token)
+        if dedupe in seen_t2:
+            continue
+        seen_t2.add(dedupe)
+        if not _tier2_satisfied(body, src, token):
+            unsatisfied_t2.append((relpath, src, token))
+
+    if unsatisfied_t1:
+        lines = [
+            f"`{relpath}` metadata key `{key}` pins #{src} @ {value[:12]} "
+            f"with no matching body declaration"
+            for relpath, key, src, value in unsatisfied_t1
+        ]
+        detail = (
+            "; ".join(lines)
+            + " — declare each reused artifact in the footer, expected shape: "
+            + "`- Reused <kind> from [#M](...): <path> @ <rev> — fit: <one line>`"
+        )
+        return CheckResult(name, False, detail)
+    if unsatisfied_t2:
+        lines = [
+            f"`{relpath}` metadata input path `{token}` references #{src} with no body mention"
+            for relpath, src, token in unsatisfied_t2
+        ]
+        detail = (
+            "; ".join(lines)
+            + " — name the source (the `issue<M>_<slug>` path segment, `#M`, or a /tasks/M "
+            + "link); canonical slot: the footer `Reused:` bullet"
+        )
+        return CheckResult(name, True, detail, is_warn=True)
+    return CheckResult(
+        name,
+        True,
+        f"all cross-issue reuse pins declared in the body "
+        f"({len(seen_t1)} tier-1, {len(seen_t2)} tier-2)",
     )
 
 
@@ -10392,6 +10727,15 @@ def verify_text(
     # PASS when the issue is unknown or no eval data is reachable.
     results.append(
         check_judge_error_denominator(
+            body, issue=issue, eval_root=eval_root, body_source_path=body_source_path
+        )
+    )
+    # Check 35 (#1256): cross-issue reuse pins in committed result-JSON
+    # metadata must be declared in the body (footer Reused bullets). Needs
+    # the issue number + eval-root resolution, so it lives outside CHECKS
+    # (the #732 check_judge_error_denominator precedent).
+    results.append(
+        check_cross_issue_reuse_provenance(
             body, issue=issue, eval_root=eval_root, body_source_path=body_source_path
         )
     )

--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -4851,7 +4851,7 @@ def _scan_issue_judge_errors(repo: Path, issue: int) -> dict | None:
     for path in sorted(eval_dir.rglob("*.json")):
         try:
             payload = json.loads(path.read_text())
-        except (json.JSONDecodeError, OSError):
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError):
             continue  # a corrupt / unreadable artifact must not crash the gate
         _descend(payload)
 
@@ -5087,7 +5087,7 @@ def _scan_cross_issue_reuse_pins(repo: Path, issue: int) -> dict | None:
             if path.stat().st_size > _REUSE_SCAN_MAX_BYTES:
                 continue  # oversize guard — never page a 100+ MB blob at gate time
             text = path.read_text()
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             continue
         if '"metadata"' not in text:
             continue

--- a/tests/sparse_cones.txt
+++ b/tests/sparse_cones.txt
@@ -22,9 +22,13 @@
 #                             (missing line surfaced as a sparse-worktree FileNotFoundError, #897)
 #   eval_results/issue_952  — test_issue952_kfold.py reads the committed
 #                             split_seed952.json (the B4≡committed-split calibration pin)
+#   eval_results/issue_1092 — test_verify_task_body.py::test_cross_issue_reuse_provenance_integration_1092
+#                             reads cross-corpus-probe-transfer/transfer_reads.json (the #1092
+#                             incident metadata pins; skip-if-absent for pre-existing worktrees)
 eval_results/issue_545
 eval_results/issue_521
 eval_results/issue_257
 eval_results/issue_276
 eval_results/issue_537
 eval_results/issue_952
+eval_results/issue_1092

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -158,18 +158,21 @@ def test_good_body_passes_all():
     # body-Parameters-⊆-doc reconciliation (PASS-skip with no doc), the v4
     # check-20 word caps (needs `issue` for the events-based round budget,
     # #921; PASS-skip: not a v4 body), the
-    # #732 judge-API-error denominator check (PASS-skip: legacy body), AND
+    # #732 judge-API-error denominator check (PASS-skip: legacy body), the
+    # check-35 cross-issue reuse-provenance check (PASS-skip: not a v4
+    # body, #1256), AND
     # the check-31 orphaned-per-unit-figures probe (needs `issue` for
     # figures-dir scoping, #1011; PASS here — the fixture's fake sha is not
     # locally reachable, so the cited SHA is silently skipped) →
-    # 48 results total (2 prepended + CHECKS[1:]=37 + 9 appended). The
+    # 49 results total (2 prepended + CHECKS[1:]=37 + 10 appended). The
     # Lens 14 / check-16 results are PASS-skips when no concerns.jsonl /
     # plans/plan.md sibling is available; check 17 and the v3/v4 checks
     # are PASS-skips on this legacy (pre-v2-sentinel) fixture.
-    assert len(results) == 48
+    assert len(results) == 49
     # By-name membership so the NEXT check addition can key by name instead
     # of re-deriving the arithmetic (#1016 methodology-reconciler Must-Fix).
     assert _HF_32_NAME in {r.name for r in results}
+    assert "cross-issue reuse pins declared (footer Reused bullets)" in {r.name for r in results}
     assert "figure prose numerics vs figure sidecar (plotted-value drift)" in {
         r.name for r in results
     }
@@ -10781,6 +10784,323 @@ def test_judge_error_denominator_sibling_issue_graceful_pass(tmp_path):
         _CHECK732_UNDISCLOSED_BODY, issue=608, eval_root=tmp_path
     )
     assert res.passed and not res.is_warn, res.render()
+
+
+# ─── Check 35 (#1256): cross-issue reuse pins declared in the body ─────────
+#
+# Signal (two tiers over committed `eval_results/issue_<N>/**/*.json`
+# metadata): tier 1 (FAIL) = `hf_rev_<M>[_<tag>]` keys, M != N, satisfied by
+# a >=7-hex-char body token prefixing the pinned revision (non-hex branch/tag
+# pins fall back to a `#M` / `/tasks/M` / `issue<M>_` mention); tier 2 (WARN)
+# = `\bissue<M>_` tokens in `metadata.input_shas` keys/values + PATH-LIKE
+# `metadata.args` string values. Grounding (corpus scan 2026-07-11): the
+# tier-1 key shape exists in exactly 1 file among ~90,858 committed eval
+# JSONs (the #1092 incident file); the bare `issue<M>_` pattern appears in
+# >=10,028 files — hence the tier-2 restriction + WARN severity.
+# Demonstrated bug class: #1092 round 3 (`hf_rev_779_labels` pinned in
+# `transfer_reads.json` metadata, reuse undeclared until the LM critic).
+
+_CHECK1256_NAME = "cross-issue reuse pins declared (footer Reused bullets)"
+
+# Synthetic 40-hex revision pin. Must NOT share a >=7-char prefix with
+# `_V4_GOOD_BODY`'s own footer hex tokens (`0123456789abcdef` / `abc123def`),
+# or the base fixture would satisfy the pin by accident.
+_CHECK1256_SYN_SHA = "deadbeefcafe4d4d9c00112233445566778899aa"
+
+# The base v4 fixture carries NO `#779` / `/tasks/779` / `issue779_` mention
+# and no hex token prefixing `_CHECK1256_SYN_SHA` — it is the undeclared body.
+_CHECK1256_UNDECLARED_BODY = _V4_GOOD_BODY
+
+# Declared body whose ONLY satisfying token is the 8-char short sha
+# `deadbeef` (a strict PREFIX of the 40-char pin) — deliberately NO `#779`
+# and NO `issue779_` string, so a PASS proves the hex-prefix predicate
+# specifically. Shaped like #1092's real inline `Reused: ... [@ <short>]`
+# footer form (NOT the SPEC dash-bullet shape — the predicate must not
+# require the literal bullet).
+_CHECK1256_DECLARED_BODY = _V4_GOOD_BODY + (
+    "\nReused: r_B trait directions [@ deadbeef]"
+    "(https://huggingface.co/datasets/superkaiba1/explore-persona-space-data/"
+    "tree/deadbeef/rb) — fit: same base model + recipe.\n"
+)
+
+
+def _make_cross_issue_pin_eval_tree(
+    root: Path,
+    issue: int,
+    *,
+    pins: dict | None = None,
+    input_shas: dict | None = None,
+):
+    """Write a synthetic `transfer_reads.json`-shaped result JSON under
+    `root/eval_results/issue_<N>/` whose `metadata.args` carries `pins`
+    (e.g. ``{"hf_rev_779_labels": "<40-hex>"}``) merged over a self-path
+    `out` arg, plus an optional `metadata.input_shas` dict — the observed
+    #1092 incident shape. Returns the eval dir."""
+    eval_dir = root / "eval_results" / f"issue_{issue}"
+    eval_dir.mkdir(parents=True, exist_ok=True)
+    args = {"out": f"eval_results/issue_{issue}/probe/", **(pins or {})}
+    metadata = {"script": "scripts/synthetic_probe.py", "args": args}
+    if input_shas is not None:
+        metadata["input_shas"] = input_shas
+    payload = {"verdict": {"ok": True}, "metadata": metadata}
+    (eval_dir / "transfer_reads.json").write_text(json.dumps(payload))
+    return eval_dir
+
+
+def test_cross_issue_reuse_provenance_undeclared_pin_fails(tmp_path):
+    """(a) MAIN / durability-pin test (SPEC.md § **Artifacts:** mechanical
+    cross-check sentence, #1256): a v4 body over an eval tree whose
+    `metadata.args` carries `hf_rev_779_labels: <40-hex>` (M=779 != N=999)
+    with the revision nowhere in the body → FAIL naming the source issue,
+    the metadata key, and the JSON relpath."""
+    _make_cross_issue_pin_eval_tree(tmp_path, 999, pins={"hf_rev_779_labels": _CHECK1256_SYN_SHA})
+    res = verify_task_body.check_cross_issue_reuse_provenance(
+        _CHECK1256_UNDECLARED_BODY, issue=999, eval_root=tmp_path
+    )
+    assert not res.passed, res.render()
+    assert "#779" in res.detail, res.render()
+    assert "hf_rev_779_labels" in res.detail, res.render()
+    assert "eval_results/issue_999/transfer_reads.json" in res.detail, res.render()
+    assert "Reused" in res.detail, res.render()  # expected declaration shape named
+
+
+def test_cross_issue_reuse_provenance_declared_short_sha_passes(tmp_path):
+    """(b) Prefix predicate: same triggering tree; the body declares the
+    reuse with ONLY an 8-char short sha (`deadbeef`) prefixing the 40-char
+    metadata pin (no `#779`, no `issue779_`) → clean PASS."""
+    _make_cross_issue_pin_eval_tree(tmp_path, 999, pins={"hf_rev_779_labels": _CHECK1256_SYN_SHA})
+    res = verify_task_body.check_cross_issue_reuse_provenance(
+        _CHECK1256_DECLARED_BODY, issue=999, eval_root=tmp_path
+    )
+    assert res.passed and not res.is_warn, res.render()
+    assert "declared" in res.detail, res.render()
+
+
+def test_cross_issue_reuse_provenance_no_pins_graceful_pass(tmp_path):
+    """(c) Graceful skip: metadata with no `hf_rev_*` keys and no
+    `issue<M>_` input paths → PASS with the graceful-skip detail (distinct
+    from the env-fence skip detail)."""
+    _make_cross_issue_pin_eval_tree(tmp_path, 999, pins={})
+    res = verify_task_body.check_cross_issue_reuse_provenance(
+        _CHECK1256_UNDECLARED_BODY, issue=999, eval_root=tmp_path
+    )
+    assert res.passed and not res.is_warn, res.render()
+    assert "graceful skip" in res.detail, res.render()
+    assert "EPM_VERIFY_BODY_NO_EVAL_SCAN" not in res.detail, res.render()
+
+
+def test_cross_issue_reuse_provenance_self_pin_never_flags(tmp_path):
+    """(d) Self-pin exemption: `hf_rev_<N>` with M == N (the observed
+    `hf_rev_1092` self-pin) is provenance, not reuse → never flags →
+    graceful-skip PASS."""
+    _make_cross_issue_pin_eval_tree(tmp_path, 999, pins={"hf_rev_999": _CHECK1256_SYN_SHA})
+    res = verify_task_body.check_cross_issue_reuse_provenance(
+        _CHECK1256_UNDECLARED_BODY, issue=999, eval_root=tmp_path
+    )
+    assert res.passed and not res.is_warn, res.render()
+    assert "graceful skip" in res.detail, res.render()
+
+
+def test_cross_issue_reuse_provenance_corrupt_json_skipped(tmp_path, monkeypatch):
+    """(e) Robustness ladder: a corrupt `.json` that PASSES the substring
+    pre-filter (so the `json.loads` skip path actually runs) + a clean
+    pin-free JSON → PASS, no crash. Dir-absent scanner branch → None.
+    `issue=None` → PASS-skip. Unresolvable root (no legs) → PASS
+    `is_warn=True` (the judge-error L4889 convention)."""
+    eval_dir = tmp_path / "eval_results" / "issue_999"
+    eval_dir.mkdir(parents=True)
+    (eval_dir / "corrupt.json").write_text('{"metadata": {"args": {"hf_rev_779_labels": ')
+    (eval_dir / "clean.json").write_text(json.dumps({"metadata": {"args": {"out": "x/y"}}}))
+    res = verify_task_body.check_cross_issue_reuse_provenance(
+        _CHECK1256_UNDECLARED_BODY, issue=999, eval_root=tmp_path
+    )
+    assert res.passed and not res.is_warn, res.render()
+    assert "graceful skip" in res.detail, res.render()
+
+    # Dir-absent scanner branch: an eval root with NO eval_results/issue_<N>.
+    empty_root = tmp_path / "empty"
+    empty_root.mkdir()
+    assert verify_task_body._scan_cross_issue_reuse_pins(empty_root, 999) is None
+
+    # issue=None (stdin) → PASS-skip before any disk read.
+    res_none = verify_task_body.check_cross_issue_reuse_provenance(
+        _CHECK1256_UNDECLARED_BODY, issue=None
+    )
+    assert res_none.passed and not res_none.is_warn, res_none.render()
+    assert "issue number unknown" in res_none.detail, res_none.render()
+
+    # Unresolvable root: no eval_root, cwd not a git repo, MAIN leg forced
+    # to None → PASS with is_warn=True (judge-error parity).
+    nongit = tmp_path / "nongit"
+    nongit.mkdir()
+    monkeypatch.chdir(nongit)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: None)
+    res_warn = verify_task_body.check_cross_issue_reuse_provenance(
+        _CHECK1256_UNDECLARED_BODY, issue=999
+    )
+    assert res_warn.passed and res_warn.is_warn, res_warn.render()
+    assert "eval root unresolved" in res_warn.detail, res_warn.render()
+
+
+def test_cross_issue_reuse_provenance_v3_body_vacuous_pass(tmp_path):
+    """(f) Forward-only generation gate: a v3-sentinel body over a
+    TRIGGERING tree → PASS "not a v4 body" (grandfathered v3/v2/legacy
+    bodies are wholly exempt; plan §11 item 6)."""
+    _make_cross_issue_pin_eval_tree(tmp_path, 999, pins={"hf_rev_779_labels": _CHECK1256_SYN_SHA})
+    res = verify_task_body.check_cross_issue_reuse_provenance(
+        _V3_GOOD_BODY, issue=999, eval_root=tmp_path
+    )
+    assert res.passed and not res.is_warn, res.render()
+    assert "not a v4 body" in res.detail, res.render()
+
+
+def test_cross_issue_reuse_provenance_tier2_input_shas_warns(tmp_path):
+    """Tier 2 (WARN): an `issue658_...` path in `metadata.input_shas` with
+    the body silent on #658 → PASS with `is_warn=True` naming #658; the
+    same body mentioning the `issue658_theory_assumptions` segment →
+    clean PASS."""
+    _make_cross_issue_pin_eval_tree(
+        tmp_path,
+        999,
+        pins={},
+        input_shas={"issue658_theory_assumptions/store/v0.pt": "46c06e89c513ca59"},
+    )
+    res = verify_task_body.check_cross_issue_reuse_provenance(
+        _CHECK1256_UNDECLARED_BODY, issue=999, eval_root=tmp_path
+    )
+    assert res.passed and res.is_warn, res.render()
+    assert "#658" in res.detail, res.render()
+    body_mentioning = _CHECK1256_UNDECLARED_BODY + (
+        "\nInputs reused from the issue658_theory_assumptions store.\n"
+    )
+    res2 = verify_task_body.check_cross_issue_reuse_provenance(
+        body_mentioning, issue=999, eval_root=tmp_path
+    )
+    assert res2.passed and not res2.is_warn, res2.render()
+
+
+def test_cross_issue_reuse_provenance_args_nonpath_tag_ignored(tmp_path):
+    """Tier-2 noise exemption: a NON-path-like `metadata.args` string value
+    (`issue404_outcome_eval`, no `/`) is the measured experiment-tag noise
+    class → not scanned → graceful-skip PASS."""
+    _make_cross_issue_pin_eval_tree(tmp_path, 999, pins={"experiment": "issue404_outcome_eval"})
+    res = verify_task_body.check_cross_issue_reuse_provenance(
+        _CHECK1256_UNDECLARED_BODY, issue=999, eval_root=tmp_path
+    )
+    assert res.passed and not res.is_warn, res.render()
+    assert "graceful skip" in res.detail, res.render()
+
+
+def test_cross_issue_reuse_provenance_nonhex_pin_issue_mention_fallback(tmp_path):
+    """Non-hex tier-1 fallback (the one predicate branch the named cases
+    miss): a branch/tag pin value (`main`) cannot use the hex-prefix
+    predicate — it falls back to an issue-level mention. Body without any
+    #779 mention → FAIL; body with a `[#779](...)` link → clean PASS."""
+    _make_cross_issue_pin_eval_tree(tmp_path, 999, pins={"hf_rev_779": "main"})
+    res = verify_task_body.check_cross_issue_reuse_provenance(
+        _CHECK1256_UNDECLARED_BODY, issue=999, eval_root=tmp_path
+    )
+    assert not res.passed, res.render()
+    assert "hf_rev_779" in res.detail and "#779" in res.detail, res.render()
+    body_mentioning = _CHECK1256_UNDECLARED_BODY + (
+        "\n- Reused labels from [#779](https://eps.superkaiba.com/tasks/779): "
+        "monitoring labels @ main — fit: same judge pin.\n"
+    )
+    res2 = verify_task_body.check_cross_issue_reuse_provenance(
+        body_mentioning, issue=999, eval_root=tmp_path
+    )
+    assert res2.passed and not res2.is_warn, res2.render()
+
+
+def test_cross_issue_reuse_provenance_integration_1092(tmp_path):
+    """Integration pair on REAL data (skip-if-absent, the #715 convention):
+    the current (fixed) #1092 body over the real
+    `eval_results/issue_1092/` tree → PASS; the same body with the round-3
+    "Also reused (cross-corpus transfer round): ..." sentence stripped
+    (the pre-fix replay) → FAIL naming `hf_rev_779_labels`. Measured
+    during planning: pre-fix `labels` unsatisfied, `passb` satisfied via
+    the shared `037fcbb` revision (documented residual)."""
+    try:
+        from explore_persona_space.task_workflow import find_task_path, repo_root
+
+        body_path = find_task_path(1092) / "body.md"
+        if not body_path.exists():
+            pytest.skip("published #1092 body absent")
+        body = body_path.read_text()
+        main_root = repo_root()
+    except Exception:
+        pytest.skip("could not resolve published #1092 body")
+    if not verify_task_body.is_v4(body):
+        pytest.skip("#1092 body is not v4 (migrated away from the incident fixture)")
+    candidates = [
+        Path(__file__).resolve().parents[1],  # this checkout (cone added per sparse_cones.txt)
+        main_root,  # MAIN
+    ]
+    eval_root = next(
+        (
+            c
+            for c in candidates
+            if (c / "eval_results" / "issue_1092" / "cross-corpus-probe-transfer").is_dir()
+        ),
+        None,
+    )
+    if eval_root is None:
+        pytest.skip("issue_1092 eval fixture absent (sparse worktree without the cone)")
+    res = verify_task_body.check_cross_issue_reuse_provenance(body, issue=1092, eval_root=eval_root)
+    assert res.passed and not res.is_warn, res.render()
+    # Pre-fix replay: strip the round-3 declaration sentence.
+    anchor = "Also reused (cross-corpus transfer round):"
+    if anchor not in body:
+        pytest.skip("anchor sentence gone — #1092 body edited since #1256; refresh the replay")
+    prefix_body = re.sub(
+        r"Also reused \(cross-corpus transfer round\):.*?recorded in `transfer_reads\.json`\)\.",
+        "",
+        body,
+        flags=re.DOTALL,
+    )
+    assert prefix_body != body, "strip did not change the body"
+    res2 = verify_task_body.check_cross_issue_reuse_provenance(
+        prefix_body, issue=1092, eval_root=eval_root
+    )
+    assert not res2.passed, res2.render()
+    assert "hf_rev_779_labels" in res2.detail and "#779" in res2.detail, res2.render()
+
+
+def test_cross_issue_reuse_provenance_env_fence(tmp_path, monkeypatch):
+    """Env fence: `EPM_VERIFY_BODY_NO_EVAL_SCAN=1` over a TRIGGERING tree →
+    PASS with the greppable fence detail (distinct from the no-pins
+    graceful skip); the scanner-level fence returns None too."""
+    _make_cross_issue_pin_eval_tree(tmp_path, 999, pins={"hf_rev_779_labels": _CHECK1256_SYN_SHA})
+    monkeypatch.setenv("EPM_VERIFY_BODY_NO_EVAL_SCAN", "1")
+    res = verify_task_body.check_cross_issue_reuse_provenance(
+        _CHECK1256_UNDECLARED_BODY, issue=999, eval_root=tmp_path
+    )
+    assert res.passed and not res.is_warn, res.render()
+    assert "EPM_VERIFY_BODY_NO_EVAL_SCAN" in res.detail, res.render()
+    assert verify_task_body._scan_cross_issue_reuse_pins(tmp_path, 999) is None
+
+
+def test_cross_issue_reuse_provenance_oversize_file_skipped(tmp_path):
+    """50 MB stat guard (MANDATORY per plan §8 — `issue_810` carries
+    138-208 MB committed JSONs): a VALID >50 MB JSON carrying an
+    undeclared cross-issue pin must be SKIPPED by the stat guard, not
+    read — without the guard this tree would FAIL, so this test is
+    discriminating for the guard itself."""
+    eval_dir = tmp_path / "eval_results" / "issue_999"
+    eval_dir.mkdir(parents=True)
+    pad = "x" * (51 * 1024 * 1024)
+    (eval_dir / "big.json").write_text(
+        '{"pad": "'
+        + pad
+        + '", "metadata": {"args": {"hf_rev_779_labels": "'
+        + _CHECK1256_SYN_SHA
+        + '"}}}'
+    )
+    res = verify_task_body.check_cross_issue_reuse_provenance(
+        _CHECK1256_UNDECLARED_BODY, issue=999, eval_root=tmp_path
+    )
+    assert res.passed and not res.is_warn, res.render()
+    assert "graceful skip" in res.detail, res.render()
 
 
 # ─── Check 15 clause-scoping (#893, incident #841) ─────────────────────────

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -10942,6 +10942,23 @@ def test_cross_issue_reuse_provenance_corrupt_json_skipped(tmp_path, monkeypatch
     assert "eval root unresolved" in res_warn.detail, res_warn.render()
 
 
+def test_cross_issue_reuse_provenance_non_utf8_json_skipped(tmp_path):
+    """(e-bis) Robustness ladder, reviewer r1 Minor: a non-UTF8 `.json`
+    <=50 MB makes `path.read_text()` raise `UnicodeDecodeError` (neither
+    `OSError` nor `json.JSONDecodeError`) — the scanner must skip the file,
+    not crash the gate → PASS (graceful skip), no exception."""
+    eval_dir = tmp_path / "eval_results" / "issue_999"
+    eval_dir.mkdir(parents=True)
+    (eval_dir / "non_utf8.json").write_bytes(
+        b'\xff\xfe{"metadata": {"args": {"hf_rev_779_x": "deadbeef"}}}'
+    )
+    res = verify_task_body.check_cross_issue_reuse_provenance(
+        _CHECK1256_UNDECLARED_BODY, issue=999, eval_root=tmp_path
+    )
+    assert res.passed and not res.is_warn, res.render()
+    assert "graceful skip" in res.detail, res.render()
+
+
 def test_cross_issue_reuse_provenance_v3_body_vacuous_pass(tmp_path):
     """(f) Forward-only generation gate: a v3-sentinel body over a
     TRIGGERING tree → PASS "not a v4 body" (grandfathered v3/v2/legacy


### PR DESCRIPTION
Closes task #1256 (workflow-fix, kind: infra).

Adds check 35: cross-issue reuse pins in committed eval-result JSON metadata (hf_rev_<M>_* revision keys -> FAIL; issue<M>_ input paths -> WARN) must be declared in the v4 clean-result body. Mechanizes the completeness half of clean-result-critic Lens 5 (incident #1092 r3). 13 new tests; corpus replay 0 FP; pre-fix #1092 replay FAILs on the incident pin. Plan 3x critic APPROVE + consistency PASS; code-review r1+r2 PASS; Step-9c test-verdict PASS.