### PR TITLE
issue-1262: migrate c7 N/A escape to _standalone_na_declared

### DIFF
--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -169,7 +169,7 @@ Given a task description (from the `/adversarial-planner` skill or the main sess
    recipe — match the paper's data + recipe FIRST, change ONLY the one
    deliberately tested variable, name forced deviations in §12 Assumptions.
    Not a replication Goal → write "N/A — not a replication" in §1 Goal or
-   §12 Assumptions and move on. (Relocated verbatim from this spec, #829.)
+   §12 Assumptions as a standalone line and move on. (Relocated verbatim from this spec, #829.)
 
 ## Plan Format
 

--- a/.claude/rules/critic-lens-reference.md
+++ b/.claude/rules/critic-lens-reference.md
@@ -83,7 +83,7 @@ composer copies the requested lens's items VERBATIM and IN FULL from this file.
    that is explicitly named in §12 Assumptions as forced by a project constraint (judge model, GPU
    budget, model size) AND carried as a scope caveat — the plan owns the deviation, you accept it;
    (b) a Goal that is not a replication (the plan should write "N/A — not a replication" in §1 or
-   §12 and you accept that). Cross-check: a faithful positive-only replication is the named
+   §12 as a standalone line and you accept that). Cross-check: a faithful positive-only replication is the named
    contrastive-negatives exemption (b) above — do not double-bounce on item 6 for the same plan.
 8. **Few-shot / ICL demonstration content (any plan with in-context-example demos).** If the plan's
    §4 Design includes a fixed bank of in-context-example / few-shot / ICL demonstrations

--- a/.claude/skills/adversarial-planner/SKILL.md
+++ b/.claude/skills/adversarial-planner/SKILL.md
@@ -203,8 +203,8 @@ Run the structural verifier against the plan version just persisted:
   and are NOT recognized by `verify_plan.py::_standalone_na_declared` (#1238)): Every
   phrase satisfies its check ONLY when written as a standalone declaration line in the
   plan (leading `-`/`>`/`*` list markers tolerated); a phrase quoted mid-sentence — e.g.
-  inside a pasted bounce brief — does not count (exceptions: check 7 matches its bare
-  phrase in prose by design; check 31 uses its labeled-line forms) (#1237).
+  inside a pasted bounce brief — does not count (exception: check 31 uses its
+  labeled-line forms) (#1237, #1262).
   `N/A — no behavioral construct`
   (check 2), `N/A — no model training` / `N/A — no training hyperparameters` (check 1),
   `N/A — not a replication` (check 7), `N/A — no artifact reuse` (check 6),

--- a/scripts/verify_plan.py
+++ b/scripts/verify_plan.py
@@ -90,8 +90,8 @@ bounce (SKILL.md § Goal-currency gate), not a brief-forwarded WARN.
 
 Canonical N/A escape phrases (quote verbatim in bounce briefs; each
 satisfies its check ONLY as a standalone declaration line — see
-``_standalone_na_declared``; exceptions: check 7 matches its bare
-phrase in prose by design, check 31 uses its labeled-line forms):
+``_standalone_na_declared``; exception: check 31 uses its
+labeled-line forms):
 
   - ``N/A — no model training`` / ``N/A — no training hyperparameters``
     (check 1)
@@ -878,8 +878,8 @@ def check_replication_fidelity(plan: str, kind: str) -> CheckResult:
     if goal is None or not re.search(r"(?i)replicat", goal):
         return _skip(cid, name, "Goal does not mention replication")
     text = strip_fences(plan)
-    if re.search(r"(?i)not a replication", text):
-        return _pass(cid, name, "explicit N/A declared (not a replication)")
+    if _standalone_na_declared(plan, r"not a replication"):
+        return _pass(cid, name, "explicit N/A declared on its own line (not a replication)")
     if re.search(
         r"(?i)paper'?s (?:data|recipe|corpus)|faithful|replication[- ]fidelity|deviation", text
     ):
@@ -891,9 +891,9 @@ def check_replication_fidelity(plan: str, kind: str) -> CheckResult:
     return _warn(
         cid,
         name,
-        "Goal mentions replication but no fidelity vocabulary (paper's data/recipe, "
-        "faithful, deviations) — CLAUDE.md replication rule: match the paper's data + "
-        "recipe FIRST, name every deviation",
+        "Goal mentions replication but no fidelity vocabulary — match the data + recipe of "
+        "the source paper FIRST and name every divergence (replication rule, CLAUDE.md); "
+        "or declare `N/A — not a replication` on its own line",
     )
 
 
@@ -1460,11 +1460,12 @@ def _standalone_na_declared(plan: str, tail_re: str) -> bool:
 
     Wrapped declarations (a backtick/quote-wrapped paste of a remedy's
     quoted form) are DELIBERATELY unrecognized (#1238 reasoned no-change):
-    the adversarial-planner SKILL.md canonical-phrases block renders nine
-    escape phrases backtick-wrapped at line start, four of which route
-    through THIS helper (c20/c24/c25/c32), so every trailing-tolerant
-    wrapper widening lets a verbatim block paste self-declare four
-    checks' escapes at once; requiring a balanced closing wrapper does
+    the adversarial-planner SKILL.md canonical-phrases block renders its
+    escape phrases backtick-wrapped at line start, nearly all of them
+    helper-routed since the #1237/#1262 migrations, so every
+    trailing-tolerant wrapper widening lets a verbatim block paste
+    self-declare many checks' escapes at once; requiring a balanced
+    closing wrapper does
     not discriminate (the block's wrappers are balanced by construction),
     and the strict phrase-alone-on-line variant rejects the one shape
     that measurably BOUNCED (#1090 plans/v1.md:369, trailing scope

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -852,6 +852,49 @@ def test_c7_na_not_a_replication_passes():
     assert _status(plan, "c7_replication_fidelity") == "PASS"
 
 
+def test_c7_midprose_phrase_does_not_escape():
+    # #1262 red-pin: the phrase mid-prose (the #810 structure, one polarity
+    # over) must not escape c7. Pre-fix: doc-global re.search → PASS.
+    plan = (
+        _replication_goal_plan()
+        + "\nThis experiment is not a replication of prior work; we test a new dose axis.\n"
+    )
+    assert _status(plan, "c7_replication_fidelity") == "WARN"
+
+
+def test_c7_backtick_wrapped_escape_does_not_escape():
+    # Mirror of test_c12_backtick_wrapped_escape_at_bullet_start_does_not_escape:
+    # the pasted bounce-brief bullet shape must not escape.
+    plan = (
+        _replication_goal_plan()
+        + "\n- `N/A — not a replication` (declare on its own line per the bounce brief).\n"
+    )
+    assert _status(plan, "c7_replication_fidelity") == "WARN"
+
+
+def test_c7_pasted_warn_detail_does_not_self_satisfy():
+    # Anti-paste guard (#1237 de-fang class): pre-fix, the WARN detail's own
+    # "paper's data + recipe" wording satisfied the vocabulary branch when
+    # pasted back into the plan (WARN → PASS).
+    base = _replication_goal_plan()
+    _, by_id = _run(base)
+    r = by_id["c7_replication_fidelity"]
+    assert r.status == "WARN"
+    pasted = base + f"\n{r.detail}\n"
+    assert _status(pasted, "c7_replication_fidelity") == "WARN"
+
+
+def test_c7_na_bulleted_standalone_passes():
+    # Green pin (#1262, stats-lens concern): the planner.md documented
+    # bulleted declaration form is recognized (leading list markers
+    # lstripped, trailing prose tolerated by re.match).
+    plan = (
+        _replication_goal_plan()
+        + "\n- N/A — not a replication (the Goal's word refers to restarts).\n"
+    )
+    assert _status(plan, "c7_replication_fidelity") == "PASS"
+
+
 def test_c7_kind_infra_skips():
     assert _status(_replication_goal_plan(), "c7_replication_fidelity", kind="infra") == "SKIP"
 
@@ -1191,9 +1234,9 @@ def test_standalone_na_wrapped_forms_stay_unrecognized():
     # #1238 reasoned no-change red-pin: wrapped declarations are
     # DELIBERATELY unrecognized — every trailing-tolerant wrapper widening
     # lets a verbatim paste of the adversarial-planner SKILL.md
-    # canonical-phrases block (nine line-start backtick-wrapped phrases,
-    # FOUR of them helper-routed: c20/c24/c25/c32) self-declare four
-    # escapes at once (the #810 polarity). See the helper docstring for
+    # canonical-phrases block (line-start backtick-wrapped phrases, nearly
+    # all helper-routed since #1237/#1262) self-declare many escapes at
+    # once (the #810 polarity). See the helper docstring for
     # the full analysis before "fixing" this.
     for line in [
         # the live #1090 plans/v1.md:369 shape (trailing scope prose):
@@ -1229,7 +1272,7 @@ def test_skillmd_canonical_escape_block_never_self_escapes():
     # not literally `plan` (or that uses r'...' quoting) is silently
     # uncovered by this pin while the floor stays green; the floor catches
     # shrinkage, not omission.
-    assert len(tails) >= 12, tails  # extraction guard: 12 call sites at pin time
+    assert len(tails) >= 22, tails  # extraction guard: 22 plan-arg call sites at pin time (#1262)
     text = (REPO_ROOT / ".claude/skills/adversarial-planner/SKILL.md").read_text()
     for tail in tails:
         assert not verify_plan._standalone_na_declared(text, tail), tail
@@ -1251,6 +1294,18 @@ def test_skillmd_canonical_block_states_unwrapped_contract():
     text = (REPO_ROOT / ".claude/skills/adversarial-planner/SKILL.md").read_text()
     assert "must be UNWRAPPED" in text
     assert "_standalone_na_declared" in text
+
+
+def test_skillmd_c7_exception_clause_retired():
+    # Durability pin (#1262): the c7 bare-phrase exception is retired from
+    # BOTH documentation surfaces; only the check-31 exception remains
+    # DOCUMENTED (c4's same-class escape is an undocumented bug tracked as
+    # its own workflow-fix candidate, deliberately NOT documented as an
+    # exception — do not use the words "matches its bare" anywhere new).
+    for path in (_SCRIPT, REPO_ROOT / ".claude/skills/adversarial-planner/SKILL.md"):
+        text = path.read_text()
+        assert "matches its bare" not in text, path
+        assert "check 31" in text, path
 
 
 def test_c12_kind_analysis_warns_not_fails():


### PR DESCRIPTION
Closes task #1262. Routes c7's doc-global 'not a replication' escape through the standalone-line recognizer (the #1237 pattern); red-green fixtures; docs updated.