### PR TITLE
issue-1251: step9c oracle tolerates unrelated concurrent dirty src/ (PYTHONPATH scratch-shadow)

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -7981,10 +7981,14 @@ suite directly and posts an `epm:test-verdict` event with the result.
         regression (the JSON names each). FAIL.
       * `COMPARE_RC=2` → indeterminate (PYTEST_RC ∉ {0,1} — aborted/interrupted
         run; missing/empty junitxml; suite crash; unusable ledger;
-        scratch-ineligible dirty oracle (contaminating src//pyproject.toml/uv.lock
-        dirt, a scan-set node, or a non-sparse work root — other root dirt
+        scratch-ineligible dirty oracle (residual contaminating dirt, a
+        scan-set node, or a non-sparse work root — other root dirt
         auto-falls back to a detached sparse scratch-worktree oracle at main
-        HEAD, reported as JSON "pristine_oracle": "scratch-worktree");
+        HEAD, reported as JSON "pristine_oracle": "scratch-worktree"; since
+        #1251 dirty in-package `src/` is neutralized via a probe-verified
+        `PYTHONPATH=<scratch>/src` shadow (`"scratch_src_shadow": true`), so
+        only `pyproject.toml`/`uv.lock` (or out-of-package `src/`) dirt still
+        refuses);
         systemic main breakage). FAIL — never PASS on indeterminate.
         COMPARE_OUT is valid JSON on EVERY exit path under --json (exit-2
         payloads carry "indeterminate": true — an exit-2 payload's empty

--- a/scripts/step9c_baseline.py
+++ b/scripts/step9c_baseline.py
@@ -21,7 +21,8 @@ Subcommands::
                                                      [--max-pristine-files 5]
                                                      [--max-age-hours 24] [--max-code-commits 150]
                                                      [--scratch-timeout-s 120]
-                                                     [--no-scratch-fallback] [--json]
+                                                     [--no-scratch-fallback]
+                                                     [--no-src-shadow] [--json]
 
 Exit codes (pinned by ``tests/test_step9c_baseline.py``):
 
@@ -41,11 +42,13 @@ Exit codes (pinned by ``tests/test_step9c_baseline.py``):
              testcases; unusable ledger with unresolved buckets (no ``--run-pristine``);
              pristine run timeout/crash (incl. a missing root-venv interpreter); dirty
              oracle on a failing node where the scratch fallback is ineligible
-             (contaminating dirt — ANY top-level ``src/`` file, ``pyproject.toml``,
-             ``uv.lock``; a scan-set (``GLOB_SCAN_TESTS``) node; a non-sparse work
+             (residual contaminating dirt — ``pyproject.toml`` / ``uv.lock`` or an
+             out-of-package ``src/`` path; dirty ``src/explore_persona_space/**`` is
+             neutralized by the scratch PYTHONPATH shadow unless ``--no-src-shadow``
+             (#1251); a scan-set (``GLOB_SCAN_TESTS``) node; a non-sparse work
              root; or ``--no-scratch-fallback``); scratch-worktree fallback creation
-             failure; more than ``--max-pristine-files`` distinct pristine files
-             ("systemic main breakage"); missing ruff binary
+             or src-shadow probe failure; more than ``--max-pristine-files`` distinct
+             pristine files ("systemic main breakage"); missing ruff binary
 ===========  ==========================================================================
 
 Safety invariants (plan #1022 v3 R1-R7): the refresh NEVER runs ``pytest tests/``
@@ -57,9 +60,13 @@ resolved by a bounded single-file pristine-main run at CURRENT HEAD from a
 clean-code-path root; every strip of a scan-covered test carries a masking WARN
 naming the branch's touched files that scan covers; indeterminate is always a
 FAIL (exit 2), never a silent PASS; the refresh + pristine pytest subprocesses
-run the TARGET root's OWN venv interpreter with ``PYTHONPATH`` stripped (never
-the invoking ``sys.executable``, whose worktree ``.pth`` would import branch
-library code into a "pristine" run — #1022 round-2 Critical); NO subcommand
+run the TARGET root's OWN venv interpreter with inherited ``PYTHONPATH``
+stripped (never the invoking ``sys.executable``, whose worktree ``.pth`` would
+import branch library code into a "pristine" run — #1022 round-2 Critical);
+scratch-oracle mode then sets ``PYTHONPATH`` to the scratch's HEAD-pinned
+``src/`` so the scratch package shadows the root venv's static editable
+``.pth``, verified per compare by a fail-closed runtime probe
+(``assert_scratch_src_shadow``, #1251); NO subcommand
 mutates git state (reads only:
 ``rev-parse`` / ``rev-list`` / ``cat-file`` / ``diff --name-only`` /
 ``status --porcelain`` / ``ls-tree``), EXCEPT compare's bounded dirty-oracle
@@ -74,7 +81,12 @@ Residual risk of the scratch fallback: ``repo_root()``-anchored /
 installed-package-path reads resolve the MAIN root even from a scratch cwd —
 the scan-set (``GLOB_SCAN_TESTS``) exclusion covers the known class of such
 live-tree scanners; a future non-scan test that executes root files via
-``repo_root()`` would re-open that channel.
+``repo_root()`` would re-open that channel. The #1251 src-shadow covers
+*import-system* resolution only — ``repo_root()``-anchored ``src/`` file READS
+remain that documented scan-set-covered channel. PRE-EXISTING (unchanged by
+#1251) trigger gap: src-``.json``-only dirt with no dirty ``*.py`` never trips
+``live_dirty_paths`` (the ``*.py``-scoped MF-4a trigger), so the root oracle
+runs — identical before/after the shadow.
 
 Under ``--json``, EVERY compare exit path prints exactly one JSON object to
 stdout: exit 0/1 the classification result (``indeterminate: false``); exit 2
@@ -129,7 +141,10 @@ DIRTY_CODE_PATHSPEC: tuple[str, ...] = ("*.py", "pyproject.toml", "uv.lock")
 # only *.py — the *.py-scoped live_dirty_paths filter alone converts the MIXED case
 # (dirty scripts/*.py + dirty src/*.json) into a false scratch strip (#1077).
 # MF-4a's .py-scoped churn rationale applies to the dirt TRIGGER, not to this
-# eligibility probe.
+# eligibility probe. The probe still watches all three legs; since #1251 the
+# in-package src/explore_persona_space/ legs are SHADOWABLE (neutralized via the
+# probe-verified scratch PYTHONPATH shadow) while pyproject.toml / uv.lock — and
+# any out-of-package src/ path — stay residual (see residual_scratch_contamination).
 SCRATCH_CONTAMINATION_PATHSPEC: tuple[str, ...] = ("src/", "pyproject.toml", "uv.lock")
 
 # Sparse-profile floor excludes — mirror of new_worktree.sh EXCLUDES.
@@ -289,6 +304,7 @@ def run_pytest(
     extra: Iterable[str] = PYTEST_BASE_FLAGS,
     *,
     python_exe: str,
+    pythonpath: str | None = None,
 ) -> int:
     """Run one bounded, thread-capped pytest subprocess; return its exit code.
 
@@ -300,6 +316,10 @@ def run_pytest(
     regression would then fail "pristine" too and be stripped as pre-existing).
     ``PYTHONPATH`` is stripped from the child env for the same reason (an
     exported ``PYTHONPATH=<wt>/src`` would override the resolved venv).
+    Inherited ``PYTHONPATH`` is ALWAYS stripped (the #1022 vector); an
+    explicitly passed ``pythonpath`` is set afterwards and must be derived from
+    a HEAD-pinned tree (the #1251 scratch shadow) — the two are different trust
+    classes (ambient env vs caller-constructed).
     ``start_new_session=True`` + ``os.killpg`` on ``TimeoutExpired`` group-kills
     stragglers, then the ``TimeoutExpired`` is re-raised (callers exit 2 —
     NEVER a ledger write / classification from a timed-out run).
@@ -314,6 +334,8 @@ def run_pytest(
     ]
     env = thread_capped(os.environ)
     env.pop("PYTHONPATH", None)  # never let the invoking checkout's src/ shadow the root venv
+    if pythonpath is not None:
+        env["PYTHONPATH"] = pythonpath  # caller-derived from a HEAD-pinned tree (#1251)
     proc = subprocess.Popen(
         argv,
         cwd=str(cwd),
@@ -405,12 +427,35 @@ def scratch_contamination_probe(root: Path) -> list[str]:
     rides ``importlib.resources`` — plus ``pyproject.toml``/``uv.lock``,
     which the venv's installed deps derive from.
     ``git status --porcelain -- src/ pyproject.toml uv.lock``, parsed exactly
-    like ``dirty_code_paths()``. Non-empty => the scratch fallback is
-    ineligible and compare keeps the fail-closed MF-4c exit 2.
+    like ``dirty_code_paths()``. Since #1251 the in-package
+    ``src/explore_persona_space/**`` legs are shadowable (neutralized by the
+    scratch PYTHONPATH shadow — see ``residual_scratch_contamination``); the
+    residual legs (``pyproject.toml``/``uv.lock``, out-of-package ``src/``)
+    keep the fail-closed MF-4c exit 2.
     """
     return _porcelain_paths(
         _git_out(["status", "--porcelain", "--", *SCRATCH_CONTAMINATION_PATHSPEC], root)
     )
+
+
+def residual_scratch_contamination(paths: Iterable[str]) -> list[str]:
+    """The contamination-probe paths a PYTHONPATH src-shadow CANNOT neutralize (#1251).
+
+    In-package dirt (``src/explore_persona_space/**``) IS neutralized: the
+    scratch pristine pytest runs with ``PYTHONPATH=<scratch>/src``, so the
+    scratch's HEAD-pinned package shadows the root venv's static editable
+    ``.pth`` in sys.path order (verified per compare by
+    ``assert_scratch_src_shadow``); package data (query-bank ``.json``) rides
+    the winning package ``__path__`` too. ``pyproject.toml`` / ``uv.lock``
+    dirt is NOT shadowable — the venv's INSTALLED DEPS derive from them — so
+    those legs keep the fail-closed MF-4c exit 2. ANY other path is residual
+    by construction: an out-of-package ``src/`` file (e.g. an untracked
+    ``src/rogue.py``) stays importable from the root via the ``.pth``'s
+    ``<root>/src`` sys.path entry and is NOT covered by the package shadow,
+    so it blocks too (fail-closed for oddballs, incl. a top-level file
+    literally named ``src``).
+    """
+    return [p for p in paths if not p.startswith("src/explore_persona_space/")]
 
 
 # --- Scratch-worktree fallback helpers (#1077) -------------------------------------
@@ -531,6 +576,54 @@ def remove_scratch_worktree(root: Path, scratch: _ScratchTree) -> None:
             timeout=60,
         )
     shutil.rmtree(scratch.parent, ignore_errors=True)
+
+
+def assert_scratch_src_shadow(root: Path, scratch_path: Path, timeout_s: float) -> None:
+    """Verify PYTHONPATH=<scratch>/src actually WINS over root's editable install (#1251).
+
+    Runs the ROOT venv interpreter (the exact interpreter ``run_pytest`` uses)
+    with the exact child-env shape (inherited ``PYTHONPATH`` stripped, ours
+    set) and the pytest child's cwd (the scratch), and
+    ``importlib.util.find_spec``'s the package WITHOUT executing it; requires
+    the resolved origin to sit under the scratch tree. Guards against
+    editable-install styles that preempt sys.path order (meta-path finder
+    hooks; easy-install-style ``.pth`` reordering), against a
+    namespace-package refactor (``find_spec`` origin is None => fail), and
+    against a scratch missing ``src/`` (origin resolves to root => fail).
+    Raises PristineRunError on ANY failure — the caller maps it to the
+    fail-closed exit 2; a verdict never rests on an unverified shadow.
+    """
+    code = (
+        "import importlib.util, sys\n"
+        "spec = importlib.util.find_spec('explore_persona_space')\n"
+        "origin = (spec.origin or '') if spec else ''\n"
+        "sys.exit(0 if origin.startswith(sys.argv[1] + '/') else 3)\n"
+    )
+    try:
+        python_exe = resolve_root_python(root)
+    except ToolMissingError as exc:
+        raise PristineRunError(str(exc)) from exc
+    env = thread_capped(os.environ)
+    env.pop("PYTHONPATH", None)  # same shape as run_pytest: inherited stripped, ours set
+    env["PYTHONPATH"] = str(scratch_path / "src")
+    try:
+        proc = subprocess.run(
+            [python_exe, "-c", code, str(scratch_path)],
+            cwd=str(scratch_path),
+            env=env,
+            capture_output=True,
+            timeout=timeout_s,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        raise PristineRunError(f"src-shadow probe failed to run: {exc}") from exc
+    if proc.returncode != 0:
+        stderr_tail = proc.stderr.decode(errors="replace").strip()[-200:]
+        raise PristineRunError(
+            f"src-shadow probe rc={proc.returncode}: PYTHONPATH={scratch_path / 'src'} did NOT "
+            "win over the root venv's editable install — src dirt cannot be neutralized "
+            "(fail-closed; --no-src-shadow restores the #1077 eligibility)"
+            + (f"; probe stderr: {stderr_tail}" if stderr_tail else "")
+        )
 
 
 def _ruff_bin() -> str:
@@ -873,7 +966,12 @@ def cmd_status(args: argparse.Namespace) -> int:
 
 
 def run_single_file_pristine(
-    test_file: str, cwd: Path, timeout_s: float, *, venv_root: Path | None = None
+    test_file: str,
+    cwd: Path,
+    timeout_s: float,
+    *,
+    venv_root: Path | None = None,
+    pythonpath: str | None = None,
 ) -> set[Node]:
     """Run ONE test file at the pristine oracle *cwd*; return its failing nodes.
 
@@ -883,8 +981,10 @@ def run_single_file_pristine(
     "pristine" too and get stripped as pre-existing (#1022 round-2 Critical).
     ``venv_root`` (scratch-oracle mode, #1077): the interpreter is resolved
     from the MAIN root while *cwd* is the scratch tree — the scratch has no
-    venv; the root venv's editable ``.pth`` points at the root's ``src/``,
-    which is exactly why ``src/``-dirt is gated out before this mode is used.
+    venv. Scratch mode additionally passes ``pythonpath=<scratch>/src``
+    (#1251) so the scratch's HEAD-pinned package shadows the root venv's
+    editable ``.pth`` — only ``pyproject.toml``/``uv.lock`` (and
+    out-of-package ``src/``) dirt remains gated out before this mode is used.
     A missing venv raises PristineRunError (indeterminate, exit 2 — never a
     silent ``sys.executable`` fallback). Bounded + thread-capped like refresh.
     rc not in {0, 1}, a timeout, or a zero-collected run raises
@@ -907,6 +1007,7 @@ def run_single_file_pristine(
                 timeout_s=timeout_s,
                 junit_path=tmp_path,
                 python_exe=python_exe,
+                pythonpath=pythonpath,
             )
         except subprocess.TimeoutExpired as exc:
             raise PristineRunError(f"pristine run of {test_file} timed out ({timeout_s}s)") from exc
@@ -1032,6 +1133,7 @@ class _CompareCtx:
     pristine_files_run: list[str] = field(default_factory=list)
     pristine_oracle: str = "root"  # "scratch-worktree" once the #1077 fallback fires
     scratch_sha: str | None = None
+    scratch_src_shadow: bool = False  # True once the #1251 PYTHONPATH shadow is armed + probed
 
 
 def _resolve_roots(args: argparse.Namespace) -> tuple[Path, Path]:
@@ -1135,21 +1237,81 @@ def _bucket_run_failures(
             ctx.pristine_bucket.append(node)  # unknown provenance
 
 
+def _arm_src_shadow(
+    ctx: _CompareCtx,
+    root: Path,
+    scratch: _ScratchTree,
+    contaminating: list[str],
+    args: argparse.Namespace,
+) -> None:
+    """Run the once-per-compare #1251 shadow probe + record scratch-oracle provenance.
+
+    Called immediately after ``create_scratch_worktree`` (the caller assigns
+    ``scratch`` FIRST so its ``finally`` teardown covers a probe raise). With
+    the shadow armed (default), ``assert_scratch_src_shadow`` verifies
+    ``PYTHONPATH=<scratch>/src`` wins over the root venv's editable install —
+    a failure maps to the fail-closed exit 2 (a verdict never rests on an
+    unverified shadow). Under ``--no-src-shadow`` no probe runs and the
+    pre-#1251 WARN text is kept (the contamination probe was fully clean by
+    eligibility there).
+    """
+    if not args.no_src_shadow:
+        try:
+            assert_scratch_src_shadow(root, scratch.path, timeout_s=args.scratch_timeout_s)
+        except PristineRunError as exc:
+            raise _Indeterminate(
+                f"scratch src-shadow probe failed ({exc}) — dirty oracle unresolvable",
+                extra={
+                    "live_dirty_paths": ctx.live_dirty_paths,
+                    "contaminating_paths": contaminating,
+                },
+                warns=ctx.warns,
+            ) from exc
+    ctx.scratch_src_shadow = not args.no_src_shadow
+    ctx.pristine_oracle = "scratch-worktree"
+    ctx.scratch_sha = scratch.sha
+    if args.no_src_shadow:
+        ctx.warns.append(
+            f"SCRATCH-ORACLE WARN: root dirty on non-contaminating paths "
+            f"{ctx.live_dirty_paths[:20]}; pristine oracle re-rooted to a detached "
+            f"sparse scratch worktree at {scratch.sha[:12]} (root venv interpreter; "
+            "contamination probe src//pyproject.toml/uv.lock was clean; scan-set "
+            "nodes and non-sparse work roots stay indeterminate)"
+        )
+    else:
+        src_dirt = [p for p in contaminating if p.startswith("src/")]
+        ctx.warns.append(
+            f"SCRATCH-ORACLE WARN: root dirty on non-contaminating paths "
+            f"{ctx.live_dirty_paths[:20]}; src-dirt {src_dirt[:20] or 'none'} "
+            f"neutralized via PYTHONPATH=<scratch>/src (shadow probe verified); "
+            f"pristine oracle re-rooted to a detached sparse scratch worktree at "
+            f"{scratch.sha[:12]} (root venv interpreter; residual probe "
+            "pyproject.toml/uv.lock/out-of-package-src was clean; scan-set nodes "
+            "and non-sparse work roots stay indeterminate)"
+        )
+
+
 def _resolve_pristine_bucket(ctx: _CompareCtx, root: Path, args: argparse.Namespace) -> None:
     """Resolve bucketed nodes via bounded single-file pristine runs (or refuse).
 
     Dirty-oracle scratch fallback (#1077): when the MF-4c dirt trigger fires
-    but the dirt is DECONTAMINABLE (the src//pyproject/uv.lock contamination
-    probe is empty), the pristine oracle re-roots to a detached sparse scratch
-    worktree at the root's HEAD — created lazily once per compare, reused for
-    every eligible bucketed file, ALWAYS removed in the ``finally``. Per-file
-    eligibility additionally requires a sparse work root (R-G), a non-scan-set
-    node (R-F — ``repo_root()``-anchored live-tree scanners read the MAIN root
-    from any cwd, so a scratch cannot decontaminate them), and the fallback
-    not being disabled via ``--no-scratch-fallback``. Everything else keeps
-    the fail-closed MF-4c exit 2. BOTH probes re-run per file, so contaminating
-    dirt appearing mid-loop reverts later files to the root oracle
-    (fail-closed).
+    but the dirt is DECONTAMINABLE (the contamination probe has no RESIDUAL
+    legs — R-B', #1251: in-package ``src/explore_persona_space/**`` dirt is
+    neutralized by the probe-verified ``PYTHONPATH=<scratch>/src`` shadow, so
+    only ``pyproject.toml``/``uv.lock`` and out-of-package ``src/`` dirt still
+    block; ``--no-src-shadow`` restores the #1077 any-probe-hit rule), the
+    pristine oracle re-roots to a detached sparse scratch worktree at the
+    root's HEAD — created lazily once per compare (the shadow probe runs ONCE
+    at creation, fail-closed to exit 2), reused for every eligible bucketed
+    file, ALWAYS removed in the ``finally``. Per-file eligibility additionally
+    requires a sparse work root (R-G), a non-scan-set node (R-F —
+    ``repo_root()``-anchored live-tree scanners read the MAIN root from any
+    cwd, so a scratch cannot decontaminate them), and the fallback not being
+    disabled via ``--no-scratch-fallback``. Everything else keeps the
+    fail-closed MF-4c exit 2. BOTH probes re-run per file, so residual dirt
+    appearing mid-loop reverts later files to the root oracle (fail-closed);
+    every scratch-mode pristine call passes the shadow uniformly, so
+    in-package src dirt appearing mid-loop stays neutralized.
     """
     if not ctx.pristine_bucket:
         return
@@ -1180,9 +1342,15 @@ def _resolve_pristine_bucket(ctx: _CompareCtx, root: Path, args: argparse.Namesp
                 raise _Indeterminate(
                     f"dirt probe failed at {root}: {exc}", warns=ctx.warns
                 ) from exc
+            residual = (
+                list(contaminating)  # --no-src-shadow: the #1077 eligibility rule verbatim
+                if args.no_src_shadow
+                else residual_scratch_contamination(contaminating)
+            )
             use_scratch = (
                 bool(ctx.live_dirty_paths)
-                and not contaminating  # R-B: src/-wide probe, not the .py-scoped filter
+                and not residual  # R-B' (#1251): in-package src/ dirt is shadow-neutralized;
+                # only pyproject.toml / uv.lock / out-of-package src/ dirt still blocks
                 and wt_cones is not None  # R-G: sparse work root only
                 and test_file not in ctx.sel.GLOB_SCAN_TESTS  # R-F: scan set never scratch-resolved
                 and not args.no_scratch_fallback
@@ -1198,15 +1366,9 @@ def _resolve_pristine_bucket(ctx: _CompareCtx, root: Path, args: argparse.Namesp
                         extra={"live_dirty_paths": ctx.live_dirty_paths},
                         warns=ctx.warns,
                     ) from exc
-                ctx.pristine_oracle = "scratch-worktree"
-                ctx.scratch_sha = scratch.sha
-                ctx.warns.append(
-                    f"SCRATCH-ORACLE WARN: root dirty on non-contaminating paths "
-                    f"{ctx.live_dirty_paths[:20]}; pristine oracle re-rooted to a detached "
-                    f"sparse scratch worktree at {scratch.sha[:12]} (root venv interpreter; "
-                    "contamination probe src//pyproject.toml/uv.lock was clean; scan-set "
-                    "nodes and non-sparse work roots stay indeterminate)"
-                )
+                # scratch is assigned BEFORE the probe, so the finally below
+                # tears it down when the probe raises (fail-closed, no leak).
+                _arm_src_shadow(ctx, root, scratch, contaminating, args)
             timeout_s = (
                 args.pristine_timeout_s
                 if args.pristine_timeout_s is not None
@@ -1218,6 +1380,11 @@ def _resolve_pristine_bucket(ctx: _CompareCtx, root: Path, args: argparse.Namesp
                     cwd=scratch.path if use_scratch else root,
                     timeout_s=timeout_s,
                     venv_root=root if use_scratch else None,
+                    pythonpath=(
+                        str(scratch.path / "src")
+                        if use_scratch and not args.no_src_shadow
+                        else None
+                    ),
                 )
             except PristineRunError as exc:
                 raise _Indeterminate(f"{exc} — indeterminate", warns=ctx.warns) from exc
@@ -1225,9 +1392,11 @@ def _resolve_pristine_bucket(ctx: _CompareCtx, root: Path, args: argparse.Namesp
             for node in [n for n in ctx.pristine_bucket if n.file == test_file]:
                 if node in main_failing:
                     if not use_scratch and ctx.live_dirty_paths:
+                        shadowable = [p for p in contaminating if p not in residual]
                         raise _Indeterminate(  # MF-4c, fail-closed residual
                             f"pristine oracle is DIRTY "
-                            f"(contaminating: {contaminating[:20] or 'n/a'}; "
+                            f"(residual contaminating: {residual[:20] or 'n/a'}; "
+                            f"shadowable src dirt: {shadowable[:20] or 'n/a'}; "
                             f"visible code dirt: {ctx.live_dirty_paths[:20]}; "
                             f"scan_set={test_file in ctx.sel.GLOB_SCAN_TESTS}, "
                             f"sparse_wt={wt_cones is not None}) — a 'pre-existing' verdict "
@@ -1236,6 +1405,7 @@ def _resolve_pristine_bucket(ctx: _CompareCtx, root: Path, args: argparse.Namesp
                             extra={
                                 "live_dirty_paths": ctx.live_dirty_paths,
                                 "contaminating_paths": contaminating,
+                                "residual_contaminating_paths": residual,
                             },
                             warns=ctx.warns,
                         )
@@ -1273,6 +1443,7 @@ def _compare_impl(args: argparse.Namespace) -> dict:
         "pristine_files_run": ctx.pristine_files_run,
         "pristine_oracle": ctx.pristine_oracle,
         "scratch_sha": ctx.scratch_sha,
+        "scratch_src_shadow": ctx.scratch_src_shadow,
         "lint": lint,
         "ledger_sha": ledger["main_sha"] if ledger else None,
         "ledger_age_h": ledger_age_hours(ledger) if ledger else None,
@@ -1405,6 +1576,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--no-scratch-fallback",
         action="store_true",
         help="disable the scratch fallback — restore the pre-#1077 MF-4c raise on ANY dirty oracle",
+    )
+    p_compare.add_argument(
+        "--no-src-shadow",
+        action="store_true",
+        help="disable the #1251 scratch PYTHONPATH src-shadow — restore the #1077 eligibility "
+        "rule (ANY dirty src//pyproject.toml/uv.lock path keeps the fail-closed exit 2)",
     )
     p_compare.add_argument("--json", action="store_true")
     p_compare.set_defaults(func=cmd_compare)

--- a/tests/test_step9c_baseline.py
+++ b/tests/test_step9c_baseline.py
@@ -16,6 +16,13 @@ The "#1077" section pins the dirty-oracle scratch-worktree fallback + the
 JSON-on-every-exit contract (fake-based N1-N4b/N9-N12 in that section;
 real-git N5-N8 + the _work_root_sparse_cones body test in the real-body
 section at the bottom).
+
+The "#1251" section pins the scratch PYTHONPATH src-shadow (in-package dirty
+src/ no longer refuses): fake-based compare cases + the pure residual-split
+unit; the real-subprocess mechanism proof (a fresh ``--without-pip`` venv with
+a production-style single-line ``.pth``), the real ``run_pytest`` env branch,
+and the live-venv ``assert_scratch_src_shadow`` durability pin (+ its
+missing-scratch-src negative) live in the real-body section at the bottom.
 """
 
 from __future__ import annotations
@@ -198,6 +205,7 @@ def _install_compare_fakes(
     contamination_paths=(),
     wt_cones=("tests",),
     scratch_exc: Exception | None = None,
+    shadow_probe_exc: Exception | None = None,
 ) -> dict[str, list]:
     """Monkeypatch signature-conformant fakes onto the module; return the call recorder.
 
@@ -206,14 +214,17 @@ def _install_compare_fakes(
     per-call mid-loop-transition case); ``wt_cones`` fakes
     ``_work_root_sparse_cones`` (None = non-sparse work root); ``scratch_exc``
     makes the fake ``create_scratch_worktree`` raise instead of returning a
-    fake ``_ScratchTree``.
+    fake ``_ScratchTree``. #1251 knob: ``shadow_probe_exc`` makes the fake
+    ``assert_scratch_src_shadow`` raise (the probe-failure fail-closed case).
     """
     calls: dict[str, list] = {
         "pristine": [],
         "pristine_detail": [],  # (test_file, cwd, venv_root) per pristine call
         "pristine_timeout": [],  # timeout_s per pristine call (#1129 derived-default pin)
+        "pristine_pythonpath": [],  # pythonpath kwarg per pristine call (#1251 shadow pin)
         "scratch_created": [],
         "scratch_removed": [],
+        "shadow_probe": [],  # (root, scratch_path) per assert_scratch_src_shadow call (#1251)
     }
     _install_scratch_fakes(
         monkeypatch,
@@ -222,6 +233,7 @@ def _install_compare_fakes(
         contamination_paths=contamination_paths,
         wt_cones=wt_cones,
         scratch_exc=scratch_exc,
+        shadow_probe_exc=shadow_probe_exc,
     )
 
     def fake_load_selector_module(root_: Path):
@@ -240,11 +252,17 @@ def _install_compare_fakes(
         return code_commits
 
     def fake_run_single_file_pristine(
-        test_file: str, cwd: Path, timeout_s: float, *, venv_root: Path | None = None
+        test_file: str,
+        cwd: Path,
+        timeout_s: float,
+        *,
+        venv_root: Path | None = None,
+        pythonpath: str | None = None,
     ) -> set:
         calls["pristine"].append(test_file)
         calls["pristine_detail"].append((test_file, cwd, venv_root))
         calls["pristine_timeout"].append(timeout_s)
+        calls["pristine_pythonpath"].append(pythonpath)
         if pristine_exc is not None:
             raise pristine_exc
         return {n for n in pristine_failing if n.file == test_file}
@@ -271,9 +289,16 @@ def _install_compare_fakes(
 
 
 def _install_scratch_fakes(
-    monkeypatch, calls: dict[str, list], *, root: Path, contamination_paths, wt_cones, scratch_exc
+    monkeypatch,
+    calls: dict[str, list],
+    *,
+    root: Path,
+    contamination_paths,
+    wt_cones,
+    scratch_exc,
+    shadow_probe_exc=None,
 ) -> None:
-    """Install the #1077 scratch-fallback fakes (split from _install_compare_fakes)."""
+    """Install the #1077 scratch-fallback (+ #1251 shadow-probe) fakes."""
     fake_scratch = sb._ScratchTree(
         parent=root / "scratch-parent", path=root / "scratch-fake", sha="f" * 40
     )
@@ -296,10 +321,16 @@ def _install_scratch_fakes(
     def fake_remove_scratch_worktree(root_: Path, scratch) -> None:
         calls["scratch_removed"].append(scratch)
 
+    def fake_assert_scratch_src_shadow(root_: Path, scratch_path: Path, timeout_s: float) -> None:
+        calls["shadow_probe"].append((root_, scratch_path))
+        if shadow_probe_exc is not None:
+            raise shadow_probe_exc
+
     monkeypatch.setattr(sb, "scratch_contamination_probe", fake_scratch_contamination_probe)
     monkeypatch.setattr(sb, "_work_root_sparse_cones", fake_work_root_sparse_cones)
     monkeypatch.setattr(sb, "create_scratch_worktree", fake_create_scratch_worktree)
     monkeypatch.setattr(sb, "remove_scratch_worktree", fake_remove_scratch_worktree)
+    monkeypatch.setattr(sb, "assert_scratch_src_shadow", fake_assert_scratch_src_shadow)
 
 
 def _compare_env(
@@ -327,6 +358,7 @@ def _compare_env(
     contamination_paths=(),
     wt_cones=("tests",),
     scratch_exc: Exception | None = None,
+    shadow_probe_exc: Exception | None = None,
     sel_attrs: dict | None = None,
     extra_args=(),
 ):
@@ -364,6 +396,7 @@ def _compare_env(
         contamination_paths=contamination_paths,
         wt_cones=wt_cones,
         scratch_exc=scratch_exc,
+        shadow_probe_exc=shadow_probe_exc,
     )
     argv = [
         "compare",
@@ -935,7 +968,14 @@ def test_pristine_argv_interpreter_derives_from_root_not_sys_executable(tmp_path
     seen: dict = {}
 
     def fake_run_pytest(
-        files, cwd, timeout_s, junit_path, extra=sb.PYTEST_BASE_FLAGS, *, python_exe
+        files,
+        cwd,
+        timeout_s,
+        junit_path,
+        extra=sb.PYTEST_BASE_FLAGS,
+        *,
+        python_exe,
+        pythonpath=None,
     ) -> int:
         seen["python_exe"] = python_exe
         Path(junit_path).write_text(
@@ -1056,9 +1096,10 @@ def test_compare_dirty_ledger_never_blind_strips(tmp_path: Path, monkeypatch, ca
     assert out["stripped"] == [{**NODE_A._asdict(), "via": "pristine"}]
 
 
-# --- Case 19 [A2]: CONTAMINATING dirty oracle never vouches "pre-existing" -------
-# (#1077: decontaminable dirt now auto-falls back to a scratch oracle — see N1 —
-# so this exit-2 pin uses a CONTAMINATING src/ path, which keeps the MF-4c raise.)
+# --- Case 19 [A2]: RESIDUAL contaminating dirty oracle never vouches "pre-existing"
+# (#1077: decontaminable dirt auto-falls back to a scratch oracle — see N1; since
+# #1251 in-package src/ dirt is shadow-neutralized too — see the #1251 section —
+# so this exit-2 pin uses a RESIDUAL pyproject.toml leg, which keeps the MF-4c raise.)
 
 
 @pytest.mark.parametrize("fails_on_main", [True, False])
@@ -1069,24 +1110,24 @@ def test_compare_dirty_pristine_oracle(tmp_path: Path, monkeypatch, capsys, fail
         monkeypatch,
         junit_cases=[(node.file, node.classname, node.name, "failed")],
         ledger_kw={"failing": ()},
-        live_dirty=("src/explore_persona_space/wip.py",),
-        contamination_paths=("src/explore_persona_space/wip.py",),
+        live_dirty=("pyproject.toml",),  # pyproject.toml IS in DIRTY_CODE_PATHSPEC
+        contamination_paths=("pyproject.toml",),
         pristine_failing=(node,) if fails_on_main else (),
         extra_args=("--run-pristine",),
     )
     rc, out, err = _run_json(argv, capsys)
-    assert calls["scratch_created"] == []  # contaminating dirt never falls back
+    assert calls["scratch_created"] == []  # residual contaminating dirt never falls back
     if fails_on_main:
         # A "pre-existing" verdict from a contaminated oracle is untrustworthy -> exit 2.
         assert rc == 2
         assert out["indeterminate"] is True
-        assert "src/explore_persona_space/wip.py" in out["reason"]
-        assert "src/explore_persona_space/wip.py" in err
+        assert "pyproject.toml" in out["reason"]
+        assert "pyproject.toml" in err
     else:
         # A PASS on a dirty root still classifies NEW (fail-closed) -> exit 1.
         assert rc == 1
         assert out["new"] == [node._asdict()]
-        assert out["live_dirty_paths"] == ["src/explore_persona_space/wip.py"]
+        assert out["live_dirty_paths"] == ["pyproject.toml"]
         assert out["pristine_oracle"] == "root"
 
 
@@ -1354,9 +1395,11 @@ def test_compare_no_scratch_fallback_flag_restores_old_raise(tmp_path: Path, mon
     assert calls["scratch_created"] == []  # the kill switch restores the pre-#1077 raise
 
 
-def test_compare_mixed_dirt_contaminating_json_blocks_scratch(tmp_path: Path, monkeypatch, capsys):
-    """N9: dirty scripts/*.py (the visible trigger) + dirty src/*.json (invisible to
-    the .py-scoped filter) MUST stay exit-2 — the mixed case is never a scratch strip."""
+def test_compare_mixed_dirt_residual_uv_lock_blocks_scratch(tmp_path: Path, monkeypatch, capsys):
+    """N9': dirty scripts/*.py (the visible trigger) + dirty uv.lock (a RESIDUAL
+    leg the #1251 shadow cannot neutralize — installed deps derive from it) MUST
+    stay exit-2 — the mixed-residual case is never a scratch strip. (The old N9
+    premise — dirty src/*.json blocks — is superseded by the #1251 shadow test.)"""
     node = sb.Node(file="tests/test_m.py", classname="tests.test_m", name="test_x")
     argv, calls, _r, _w = _compare_env(
         tmp_path,
@@ -1364,24 +1407,26 @@ def test_compare_mixed_dirt_contaminating_json_blocks_scratch(tmp_path: Path, mo
         junit_cases=[(node.file, node.classname, node.name, "failed")],
         ledger_kw={"failing": ()},
         live_dirty=("scripts/x.py",),
-        contamination_paths=("src/explore_persona_space/artifacts/query_banks/x.json",),
+        contamination_paths=("uv.lock",),
         pristine_failing=(node,),
         extra_args=("--run-pristine",),
     )
     rc, out, _err = _run_json(argv, capsys)
     assert rc == 2
     assert out["indeterminate"] is True
-    assert out["contaminating_paths"] == ["src/explore_persona_space/artifacts/query_banks/x.json"]
+    assert out["contaminating_paths"] == ["uv.lock"]
+    assert out["residual_contaminating_paths"] == ["uv.lock"]
     assert calls["scratch_created"] == []
 
 
 def test_compare_mid_loop_dirt_transition_fail_closed(tmp_path: Path, monkeypatch, capsys):
-    """N10: contamination appearing MID-LOOP reverts later files to the root oracle;
-    a fail-on-main node there goes indeterminate (fail-closed), while file1's
-    scratch provenance rides the exit-2 warns."""
+    """N10: RESIDUAL contamination appearing MID-LOOP reverts later files to the
+    root oracle; a fail-on-main node there goes indeterminate (fail-closed),
+    while file1's scratch provenance rides the exit-2 warns. (#1251 repointed
+    the transition dirt from src/*.json — now shadowable — to uv.lock.)"""
     n1 = sb.Node(file="tests/test_a1.py", classname="tests.test_a1", name="test_x")
     n2 = sb.Node(file="tests/test_a2.py", classname="tests.test_a2", name="test_x")
-    contamination_seq = iter([[], ["src/explore_persona_space/x.json"]])
+    contamination_seq = iter([[], ["uv.lock"]])
     argv, calls, root, _w = _compare_env(
         tmp_path,
         monkeypatch,
@@ -1399,7 +1444,7 @@ def test_compare_mid_loop_dirt_transition_fail_closed(tmp_path: Path, monkeypatc
     assert len(calls["scratch_created"]) == 1
     assert calls["pristine_detail"][0] == (n1.file, root / "scratch-fake", root)
     assert calls["pristine_detail"][1] == (n2.file, root, None)
-    assert out["contaminating_paths"] == ["src/explore_persona_space/x.json"]
+    assert out["contaminating_paths"] == ["uv.lock"]
     assert any("SCRATCH-ORACLE WARN" in w for w in out["warns"])
     assert calls["scratch_removed"], "finally teardown must run"
 
@@ -1448,6 +1493,193 @@ def test_compare_non_sparse_work_root_ineligible(tmp_path: Path, monkeypatch, ca
     assert out["indeterminate"] is True
     assert calls["scratch_created"] == []
     assert "sparse_wt=False" in out["reason"]
+
+
+# --- #1251: scratch PYTHONPATH src-shadow (dirty src/ no longer refuses) -----------
+
+
+@pytest.mark.parametrize("fails_on_main", [True, False])
+def test_compare_src_dirt_shadowed_scratch_strip_or_new(
+    tmp_path: Path, monkeypatch, capsys, fails_on_main
+):
+    """#1251 (the #1190 regression pin): unrelated concurrent dirty IN-PACKAGE
+    src/ at the shared root no longer refuses (rc=2) — the scratch oracle arms
+    with a probe-verified PYTHONPATH=<scratch>/src shadow and resolves the node
+    strip-or-NEW (rc 0/1). Covers .py AND package-data .json dirt (the #1077
+    mixed case the shadow now neutralizes via the package __path__)."""
+    node = sb.Node(file="tests/test_m.py", classname="tests.test_m", name="test_x")
+    argv, calls, root, _w = _compare_env(
+        tmp_path,
+        monkeypatch,
+        junit_cases=[(node.file, node.classname, node.name, "failed")],
+        ledger_kw={"failing": ()},
+        live_dirty=("src/explore_persona_space/wip.py",),  # the #1190 dirt class
+        contamination_paths=(
+            "src/explore_persona_space/wip.py",
+            "src/explore_persona_space/artifacts/query_banks/x.json",
+        ),
+        pristine_failing=(node,) if fails_on_main else (),
+        extra_args=("--run-pristine",),
+    )
+    rc, out, _err = _run_json(argv, capsys)
+    assert len(calls["scratch_created"]) == 1
+    assert calls["shadow_probe"] == [(root, root / "scratch-fake")]  # probe ran ONCE
+    assert calls["pristine_pythonpath"] == [str(root / "scratch-fake" / "src")]
+    assert out["pristine_oracle"] == "scratch-worktree"
+    assert out["scratch_src_shadow"] is True
+    # The WARN names the neutralized src paths.
+    assert any("src/explore_persona_space/wip.py" in w and "neutralized" in w for w in out["warns"])
+    if fails_on_main:
+        assert rc == 0
+        assert out["indeterminate"] is False
+        assert out["stripped"] == [{**node._asdict(), "via": "pristine-scratch"}]
+    else:
+        assert rc == 1
+        assert out["new"] == [node._asdict()]
+
+
+def test_compare_no_src_shadow_flag_restores_1077_eligibility(tmp_path: Path, monkeypatch, capsys):
+    """--no-src-shadow restores the #1077 rule: ANY dirty src/ path keeps the
+    fail-closed exit 2 (no scratch); scripts-only dirt stays scratch-eligible
+    with the shadow DISARMED (scratch_src_shadow false, pre-#1251 WARN text)."""
+    node = sb.Node(file="tests/test_m.py", classname="tests.test_m", name="test_x")
+    argv, calls, _r, _w = _compare_env(
+        tmp_path,
+        monkeypatch,
+        junit_cases=[(node.file, node.classname, node.name, "failed")],
+        ledger_kw={"failing": ()},
+        live_dirty=("src/explore_persona_space/wip.py",),
+        contamination_paths=("src/explore_persona_space/wip.py",),
+        pristine_failing=(node,),
+        extra_args=("--run-pristine", "--no-src-shadow"),
+    )
+    rc, out, _err = _run_json(argv, capsys)
+    assert rc == 2
+    assert out["indeterminate"] is True
+    assert calls["scratch_created"] == []
+    assert "src/explore_persona_space/wip.py" in out["reason"]
+    # Scripts-only dirt under --no-src-shadow: the #1077 fallback still fires,
+    # shadow disarmed — no probe, no PYTHONPATH, scratch_src_shadow false.
+    argv, calls, _root, _w = _compare_env(
+        tmp_path,
+        monkeypatch,
+        junit_cases=[(node.file, node.classname, node.name, "failed")],
+        ledger_kw={"failing": ()},
+        live_dirty=("scripts/wip.py",),
+        pristine_failing=(node,),
+        extra_args=("--run-pristine", "--no-src-shadow"),
+    )
+    rc, out, _err = _run_json(argv, capsys)
+    assert rc == 0
+    assert out["stripped"] == [{**node._asdict(), "via": "pristine-scratch"}]
+    assert out["scratch_src_shadow"] is False
+    assert calls["shadow_probe"] == []
+    assert calls["pristine_pythonpath"] == [None]
+    assert any(
+        "contamination probe src//pyproject.toml/uv.lock was clean" in w for w in out["warns"]
+    )
+
+
+def test_compare_shadow_probe_failure_indeterminate(tmp_path: Path, monkeypatch, capsys):
+    """A failing src-shadow probe is fail-closed: exit 2, the scratch is torn
+    down, and NO oracle run rests on the unverified shadow."""
+    node = sb.Node(file="tests/test_m.py", classname="tests.test_m", name="test_x")
+    argv, calls, _r, _w = _compare_env(
+        tmp_path,
+        monkeypatch,
+        junit_cases=[(node.file, node.classname, node.name, "failed")],
+        ledger_kw={"failing": ()},
+        live_dirty=("src/explore_persona_space/wip.py",),
+        contamination_paths=("src/explore_persona_space/wip.py",),
+        shadow_probe_exc=sb.PristineRunError(
+            "src-shadow probe rc=3: PYTHONPATH did NOT win over the root venv's editable install"
+        ),
+        pristine_failing=(node,),
+        extra_args=("--run-pristine",),
+    )
+    rc, out, _err = _run_json(argv, capsys)
+    assert rc == 2
+    assert out["indeterminate"] is True
+    assert "src-shadow probe" in out["reason"]
+    assert calls["scratch_removed"], "finally teardown must run on a probe failure"
+    assert calls["pristine"] == []  # no verdict rested on an unverified shadow
+
+
+def test_compare_mid_loop_src_dirt_does_not_revert(tmp_path: Path, monkeypatch, capsys):
+    """The N10 contrast pin: IN-PACKAGE src dirt appearing MID-LOOP does NOT
+    revert later files to the root oracle — the shadow is armed uniformly on
+    every scratch pristine call, so both files stay scratch-resolved (rc 0)."""
+    n1 = sb.Node(file="tests/test_a1.py", classname="tests.test_a1", name="test_x")
+    n2 = sb.Node(file="tests/test_a2.py", classname="tests.test_a2", name="test_x")
+    contamination_seq = iter([[], ["src/explore_persona_space/late.py"]])
+    argv, calls, root, _w = _compare_env(
+        tmp_path,
+        monkeypatch,
+        junit_cases=[(n.file, n.classname, n.name, "failed") for n in (n1, n2)],
+        ledger_kw={"failing": ()},
+        live_dirty=("scripts/x.py",),  # non-empty at file 1 or use_scratch never arms
+        contamination_paths=lambda: next(contamination_seq),
+        pristine_failing=(n1, n2),
+        extra_args=("--run-pristine",),
+    )
+    rc, out, _err = _run_json(argv, capsys)
+    assert rc == 0
+    assert out["indeterminate"] is False
+    assert len(calls["scratch_created"]) == 1
+    # BOTH files scratch-resolved under the shadow (hermetic against the transition).
+    assert [d[1] for d in calls["pristine_detail"]] == [root / "scratch-fake"] * 2
+    assert calls["pristine_pythonpath"] == [str(root / "scratch-fake" / "src")] * 2
+    assert {s["via"] for s in out["stripped"]} == {"pristine-scratch"}
+    assert out["scratch_src_shadow"] is True
+
+
+def test_resolve_pristine_threads_pythonpath(tmp_path: Path, monkeypatch):
+    """run_single_file_pristine threads the pythonpath kwarg verbatim into
+    run_pytest (default None) — the #1251 sibling of the interpreter-threading
+    pin above."""
+    root = tmp_path / "root"
+    (root / "tests").mkdir(parents=True)
+    venv_py = root / ".venv" / "bin" / "python"
+    venv_py.parent.mkdir(parents=True)
+    venv_py.write_text("")
+    seen: list = []
+
+    def fake_run_pytest(
+        files,
+        cwd,
+        timeout_s,
+        junit_path,
+        extra=sb.PYTEST_BASE_FLAGS,
+        *,
+        python_exe,
+        pythonpath=None,
+    ) -> int:
+        seen.append(pythonpath)
+        Path(junit_path).write_text(
+            _junit_xml([("tests/test_probe.py", "tests.test_probe", "test_x", "failed")])
+        )
+        return 1
+
+    monkeypatch.setattr(sb, "run_pytest", fake_run_pytest)
+    sb.run_single_file_pristine("tests/test_probe.py", cwd=root, timeout_s=30.0, pythonpath="X")
+    sb.run_single_file_pristine("tests/test_probe.py", cwd=root, timeout_s=30.0)
+    assert seen == ["X", None]
+
+
+def test_residual_scratch_contamination_split():
+    """Pure unit: only in-package src/explore_persona_space/ paths are shadowable;
+    pyproject.toml / uv.lock / out-of-package src/ / oddballs stay residual."""
+    assert sb.residual_scratch_contamination(
+        [
+            "src/explore_persona_space/a.py",
+            "src/explore_persona_space/d/x.json",
+            "pyproject.toml",
+            "uv.lock",
+            "srcfile",
+            "src/rogue.py",
+        ]
+    ) == ["pyproject.toml", "uv.lock", "srcfile", "src/rogue.py"]
+    assert sb.residual_scratch_contamination([]) == []
 
 
 # --- status subcommand ------------------------------------------------------------
@@ -1715,6 +1947,125 @@ def test_work_root_sparse_cones_real_git(tmp_path: Path):
     not_a_repo = tmp_path / "not-a-repo"
     not_a_repo.mkdir()
     assert sb._work_root_sparse_cones(not_a_repo) is None
+
+
+# --- #1251 real-subprocess mechanism + live-venv durability pins -------------------
+
+
+def _make_probe_pkg(base: Path, where: str) -> Path:
+    """Write <base>/src/probe_pkg/__init__.py with WHERE=<where>; return <base>/src."""
+    pkg = base / "src" / "probe_pkg"
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "__init__.py").write_text(f'WHERE = "{where}"\n')
+    return base / "src"
+
+
+def test_real_pythonpath_shadow_wins_over_static_editable_pth(tmp_path: Path):
+    """Mechanism proof (real venv machinery): a single-line static ``.pth``
+    (byte-style-identical to the production ``__editable__.*.pth``) resolves the
+    root copy WITHOUT PYTHONPATH (control arm — proves the .pth engages, guards
+    a vacuous pass), and PYTHONPATH=<scratch>/src WINS over it (the #1251
+    shadow's load-bearing sys.path-precedence claim)."""
+    venvroot = tmp_path / "venvroot"
+    subprocess.run(
+        [sys.executable, "-m", "venv", "--without-pip", str(venvroot)],
+        check=True,
+        capture_output=True,
+        timeout=120,
+    )
+    py = str(venvroot / "bin" / "python")
+    # Locate the tmp venv's site-packages portably (sysconfig, not a hardcoded pythonX.Y).
+    site_pkgs = Path(
+        subprocess.run(
+            [py, "-c", "import sysconfig; print(sysconfig.get_paths()['purelib'])"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=60,
+        ).stdout.strip()
+    )
+    root_src = _make_probe_pkg(tmp_path / "root", "root")
+    scratch_src = _make_probe_pkg(tmp_path / "scratch", "scratch")
+    (site_pkgs / "__editable__.probe_pkg.pth").write_text(f"{root_src}\n")
+    code = "import probe_pkg, sys; sys.stdout.write(probe_pkg.WHERE)"
+    env_base = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+    # (a) control: WITHOUT PYTHONPATH the .pth engages -> the root copy resolves.
+    proc_a = subprocess.run(
+        [py, "-c", code], env=env_base, capture_output=True, text=True, timeout=60
+    )
+    assert proc_a.returncode == 0, proc_a.stderr
+    assert proc_a.stdout == "root"
+    # (b) WITH PYTHONPATH=<scratch>/src the shadow wins over the .pth entry.
+    proc_b = subprocess.run(
+        [py, "-c", code],
+        env={**env_base, "PYTHONPATH": str(scratch_src)},
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc_b.returncode == 0, proc_b.stderr
+    assert proc_b.stdout == "scratch"
+
+
+def test_real_run_pytest_pythonpath_env(tmp_path: Path, monkeypatch):
+    """Real-subprocess coverage of run_pytest's #1251 env branch: an explicitly
+    passed ``pythonpath`` reaches the pytest child (the probe test imports the
+    scratch copy and passes), while an AMBIENT PYTHONPATH is still stripped
+    (the #1022 vector: the same run WITHOUT the kwarg cannot import probe_pkg
+    even with PYTHONPATH exported in the parent env)."""
+    scratch_src = _make_probe_pkg(tmp_path / "scratch", "scratch")
+    tree = tmp_path / "tree"
+    (tree / "tests").mkdir(parents=True)
+    (tree / "pyproject.toml").write_text('[tool.pytest.ini_options]\naddopts = ""\n')
+    (tree / "tests" / "test_probe_env.py").write_text(
+        "import probe_pkg\n\n\ndef test_where():\n    assert probe_pkg.WHERE == 'scratch'\n"
+    )
+    junit = tmp_path / "junit-shadow.xml"
+    rc = sb.run_pytest(
+        files=["tests/test_probe_env.py"],
+        cwd=tree,
+        timeout_s=180.0,
+        junit_path=junit,
+        python_exe=sys.executable,
+        pythonpath=str(scratch_src),
+    )
+    assert rc == 0
+    failing, summary = sb.parse_junit(junit)
+    assert failing == []  # the scratch copy resolved: probe_pkg.WHERE == 'scratch'
+    assert summary["tests"] == 1
+    # Strip pin: ambient PYTHONPATH (no kwarg) never reaches the child (#1022).
+    monkeypatch.setenv("PYTHONPATH", str(scratch_src))
+    junit2 = tmp_path / "junit-strip.xml"
+    rc2 = sb.run_pytest(
+        files=["tests/test_probe_env.py"],
+        cwd=tree,
+        timeout_s=180.0,
+        junit_path=junit2,
+        python_exe=sys.executable,
+    )
+    assert rc2 != 0  # probe_pkg unimportable -> the inherited PYTHONPATH was stripped
+
+
+def test_live_venv_src_shadow_probe_passes(tmp_path: Path):
+    """Durability pin: the REAL assert_scratch_src_shadow body against THIS
+    repo's actual venv + editable install — goes red the day the editable
+    style changes to a PYTHONPATH-preempting mechanism (finder hook /
+    reordering .pth), the exact early warning #1251 wants."""
+    scratch = tmp_path / "scratch"
+    pkg = scratch / "src" / "explore_persona_space"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("")
+    sb.assert_scratch_src_shadow(sb.main_repo_root(), scratch, timeout_s=60.0)  # no raise
+
+
+def test_live_venv_src_shadow_probe_fails_on_missing_scratch_src(tmp_path: Path):
+    """Companion negative (real body): a scratch MISSING src/explore_persona_space
+    makes the probe resolve the root package instead -> PristineRunError (the
+    fail-closed missing-scratch-src path)."""
+    scratch = tmp_path / "empty-scratch"
+    scratch.mkdir()
+    with pytest.raises(sb.PristineRunError, match="src-shadow probe"):
+        sb.assert_scratch_src_shadow(sb.main_repo_root(), scratch, timeout_s=60.0)
 
 
 def test_main_repo_root_and_resolve_work_root_real_body(monkeypatch):


### PR DESCRIPTION
Closes task #1251. Plan v2 (PYTHONPATH scratch-shadow, probe-verified, fail-closed residuals). Code-review PASS r1.