### PR TITLE
task #1274: per-task stream grouping — routed-records suppress across duplicate status folders

### DIFF
--- a/scripts/sweep_parked_wf_candidates.py
+++ b/scripts/sweep_parked_wf_candidates.py
@@ -14,17 +14,26 @@ sweep's suppression rule (1) keys on.
 
 Suppression rules (a candidate is SUPPRESSED == already routed):
 
-1. **Same-stream filed record** — a LATER row (aware-UTC ts > candidate ts)
-   in the SAME stream with kind ``epm:workflow-fix-task-filed*`` matching the
-   candidate: fp-computable candidates match ONLY on the fingerprint (same
-   ``target_file`` + different fp is NOT a duplicate — workflow-fix-on-bug.md
-   § Dedup) — EXCEPT that a record carrying NO usable fingerprint (field
-   absent, or non-fp-shaped, e.g. ``n/a (prose park)``) falls back to
-   ``origin_candidate_ts`` equality with a ``target_file`` prefix-compatibility
-   veto (#1248); a record carrying a real, DIFFERING 12-hex fp still never
-   suppresses. Accepted residual: two same-second candidate rows on the SAME
-   file in one stream are indistinguishable to the ts+target_file key, so one
-   n/a-fp record would close both; fp-less (prose) parks match on the record's
+1. **Same-task filed record** — a LATER row (aware-UTC ts > candidate ts)
+   with kind ``epm:workflow-fix-task-filed*`` in ANY events.jsonl of the same
+   SOURCE, matching the candidate. All ``tasks/*/<id>/events.jsonl`` status
+   folders of one task id merge into ONE logical stream (source
+   ``task:<id>``), so a routed-record posted on ANY folder of a task closes
+   the park's copies in EVERY folder — a stale duplicate status folder (the
+   #644/#1253 class) otherwise re-enumerates an already-routed park nightly
+   (incident #1196/#1274); the cache file stays its own source. The emitted
+   ``suppressed_by.kind`` string stays ``same-stream-filed`` for output
+   compatibility. Matching: fp-computable candidates match ONLY on the
+   fingerprint (same ``target_file`` + different fp is NOT a duplicate —
+   workflow-fix-on-bug.md § Dedup) — EXCEPT that a record carrying NO usable
+   fingerprint (field absent, or non-fp-shaped, e.g. ``n/a (prose park)``)
+   falls back to ``origin_candidate_ts`` equality with a ``target_file``
+   prefix-compatibility veto (#1248); a record carrying a real, DIFFERING
+   12-hex fp still never suppresses. Accepted residual: two same-second
+   candidate rows on the SAME file in one TASK are indistinguishable to the
+   ts+target_file key, so one n/a-fp record would close both — grouping
+   widens this corner from same-file to same-task fork copies, failing toward
+   suppression only there; fp-less (prose) parks match on the record's
    ``origin_candidate_ts`` (PRIMARY key), falling back to a ``target_file``
    string match ONLY when the record carries no ``origin_candidate_ts``
    (legacy/backfill records).
@@ -35,8 +44,10 @@ Suppression rules (a candidate is SUPPRESSED == already routed):
    ts (first parseable events.jsonl row) POSTdates the candidate ts — a
    candidate that predates the closed fix was subsumed by it; one raised
    after it closed is a genuine re-raise and stays enumerated.
-3. **Row dedup** — identical (stream, ts, content-hash) rows collapse to one
-   (observed verbatim duplication in #1100's events.jsonl).
+3. **Row dedup** — identical (source, ts, content-hash) rows collapse to one;
+   the dedup set is shared across all status folders of one task id, so
+   byte-identical fork copies collapse too (observed verbatim duplication in
+   #1100's events.jsonl; cross-folder fork copies in #1196).
 
 fp-less prose parks are NEVER auto-suppressed on file-only matches (the
 #622-class distinct-bug-on-a-hot-file hazard); instead the advisory field
@@ -398,16 +409,23 @@ def _open_wf_fix_on_file(
     return None
 
 
-def _load_stream(path: Path, source: str) -> tuple[list[tuple[dict, datetime, str]], int]:
+def _load_stream(
+    path: Path, source: str, seen: set[tuple[str, str, str]] | None = None
+) -> tuple[list[tuple[dict, datetime, str]], int]:
     """Parse one JSONL stream into relevant (row, ts, raw_ts) tuples, row-deduped.
 
     Only candidate/filed-kind rows are kept (others are irrelevant, not
     malformed). Returns (rows, skipped) where skipped counts unparseable JSON
     lines and relevant rows with a missing/unparseable ts.
+
+    ``seen`` is the row-dedup set; pass ONE shared set across all events.jsonl
+    paths of a single source (task id) so byte-identical copies in duplicate
+    status folders collapse (#1274). None -> fresh per-call set.
     """
     skipped = 0
     rows: list[tuple[dict, datetime, str]] = []
-    seen: set[tuple[str, str, str]] = set()
+    if seen is None:
+        seen = set()
     try:
         # split("\n"), NEVER splitlines(): splitlines() splits on U+2028/U+2029
         # etc. and shreds valid JSONL rows whose note strings carry them
@@ -450,11 +468,21 @@ def sweep(
     include_routed: bool = False,
 ) -> dict:
     """Enumerate parked, unrouted workflow-fix candidates across all streams."""
-    streams: list[tuple[str, Path]] = []
+    # One logical stream PER TASK ID: all tasks/*/<id>/events.jsonl status
+    # folders merge, so a routed-record posted on ANY folder of a task closes
+    # the park's copies in EVERY folder, and byte-identical fork copies
+    # row-dedup (#1274; incident #1196: a stale duplicate status folder — the
+    # #644/#1253 class — re-enumerated an already-routed park nightly). The
+    # cache file stays its own group: filed records never match across
+    # task/cache boundaries (the fp-less primary key is bare
+    # origin_candidate_ts equality, so a global pool could false-suppress a
+    # same-second park on a DIFFERENT task).
+    grouped: dict[str, list[Path]] = {}
     for events in sorted(tasks_root.glob("*/*/events.jsonl")):
-        streams.append((f"task:{events.parent.name}", events))
+        grouped.setdefault(f"task:{events.parent.name}", []).append(events)
+    streams: list[tuple[str, list[Path]]] = list(grouped.items())
     if cache_file is not None and cache_file.exists():
-        streams.append(("cache", cache_file))
+        streams.append(("cache", [cache_file]))
 
     skipped_rows = 0
     candidates: list[Candidate] = []
@@ -462,9 +490,13 @@ def sweep(
     cutoff = now - timedelta(days=window_days) if window_days > 0 else None
     bodies: list[tuple[int, str, Path, str, dict]] | None = None  # loaded lazily, ONCE
 
-    for source, path in streams:
-        rows, skipped = _load_stream(path, source)
-        skipped_rows += skipped
+    for source, paths in streams:
+        rows: list[tuple[dict, datetime, str]] = []
+        seen: set[tuple[str, str, str]] = set()
+        for path in paths:
+            path_rows, skipped = _load_stream(path, source, seen)
+            rows.extend(path_rows)
+            skipped_rows += skipped
         filed = [(r, ts) for r, ts, _raw in rows if _row_kind(r).startswith(FILED_KIND_PREFIX)]
         for row, ts, ts_raw in rows:
             if not _row_kind(row).startswith(CANDIDATE_KIND_PREFIX):

--- a/tests/test_sweep_parked_wf_candidates.py
+++ b/tests/test_sweep_parked_wf_candidates.py
@@ -648,3 +648,123 @@ def test_issue1248_comma_separated_record_target_file_is_prefix_compatible(
     c = only(run_sweep(tmp_path, include_routed=True))
     assert c["suppressed"] is True
     assert c["suppressed_by"]["kind"] == "same-stream-filed"
+
+
+# ── 18. #1274 regressions: per-task stream grouping across duplicate folders ─
+#
+# Byte-verbatim fixture rows from the live #1196 events.jsonl (the #644/#1253
+# stale-duplicate-status-folder class): the 2026-07-09 fp-less prose park sits
+# byte-identically in BOTH tasks/completed/1196 (canonical) and the stale
+# tasks/reviewing/1196 fork, while the 2026-07-10 routed-record
+# (filed_task: #1235) lives ONLY in the canonical folder. Pre-#1274 each
+# status folder was its OWN stream, so the stale folder's copy escaped
+# suppression rule 1 and re-enumerated nightly (incident 2026-07-10,
+# hand-deduped as `deduped:#1235`).
+
+_RAW_1196_CAND = r"""{"ts": "2026-07-09T20:54:25Z", "kind": "epm:workflow-fix-candidate", "version": 1, "by": "unknown", "note": "parked — running under workflow_fix_target Provenance (recursion guard, see workflow-fix-on-bug.md § Recursion guard). target_file: .claude/skills/daily/SKILL.md. proposed_change: invoke 'uv run python scripts/audit_clean_results_body_discipline.py --title-sync-sweep' from the nightly /daily skill (one bullet + command) so the H1/title drift report surfaces without a manual run. bug_observed: the #1196 sweep is manually-invoked only; no scheduled invoker. confidence: medium. related_task: #1196. routed: parked: EPM_WORKFLOW_FIX_SESSION"}"""  # noqa: E501
+_RAW_1196_REC = r"""{"ts": "2026-07-10T06:57:53Z", "kind": "epm:workflow-fix-task-filed", "version": 1, "by": "unknown", "note": "filed_task: #1235 / target_file: .claude/skills/daily/SKILL.md / fingerprint: n/a (prose park) / session_spawned: false / source: daily-parked-candidate-sweep / origin_candidate_ts: 2026-07-09T20:54:25Z / origin_candidate: parked — running under workflow_fix_target Provenance (recursion guard, see workflow-fix-on-bug.md § Recursion guard). target_file: .claude/skills/daily/SKILL.md. proposed_change: "}"""  # noqa: E501
+
+
+def test_issue1196_stale_duplicate_status_folder_filed_record_suppresses_both_copies(
+    tmp_path: Path,
+) -> None:
+    """#1274 red-green: one task id in two status folders (#644/#1253 class).
+
+    tasks/reviewing/1196 is a stale fork carrying a byte-identical copy of the
+    fp-less prose park but NOT the later routed-record; tasks/completed/1196
+    (canonical) carries both. The record must close BOTH copies and the
+    identical fork copies must collapse to ONE output row.
+    """
+    # round-trip guard: the embedded fixture lines are single valid JSON rows
+    assert json.loads(_RAW_1196_CAND)["ts"] == "2026-07-09T20:54:25Z"
+    assert json.loads(_RAW_1196_REC)["ts"] == "2026-07-10T06:57:53Z"
+    make_task(tmp_path, 1196, "completed", raw_event_lines=[_RAW_1196_CAND, _RAW_1196_REC])
+    make_task(tmp_path, 1196, "reviewing", raw_event_lines=[_RAW_1196_CAND])  # stale fork copy
+    assert run_sweep(tmp_path)["candidates"] == []  # RED pre-fix: the stale copy escapes
+    c = only(run_sweep(tmp_path, include_routed=True))  # RED pre-fix: 2 rows, no collapse
+    assert c["source"] == "task:1196"
+    assert c["fingerprint"] is None  # prose park; fp-less origin-ts key decided
+    assert c["suppressed"] is True
+    assert c["suppressed_by"] == {"kind": "same-stream-filed", "ref": "#1235"}
+
+
+def test_issue1196_record_in_stale_folder_also_closes_canonical_copy(tmp_path: Path) -> None:
+    """Reverse direction: the merged per-task pool is order-symmetric — a
+    routed-record living ONLY in the stale fork still closes the canonical
+    folder's copy (pins the docstring's 'ANY events.jsonl of the task' claim)."""
+    make_task(tmp_path, 1196, "completed", raw_event_lines=[_RAW_1196_CAND])
+    make_task(tmp_path, 1196, "reviewing", raw_event_lines=[_RAW_1196_CAND, _RAW_1196_REC])
+    assert run_sweep(tmp_path)["candidates"] == []
+    c = only(run_sweep(tmp_path, include_routed=True))
+    assert c["suppressed"] is True
+    assert c["suppressed_by"] == {"kind": "same-stream-filed", "ref": "#1235"}
+
+
+def test_filed_record_on_different_task_never_suppresses_same_second_park(
+    tmp_path: Path,
+) -> None:
+    """Grain pin (plan §4.2 alt 1 hazard): the filed-record pool is PER TASK,
+    never global. An fp-less park on task 4001 must not be closed by ANOTHER
+    task's routed-record carrying the same bare-ts origin_candidate_ts (the
+    fp-less PRIMARY key has no target_file check, so a global pool could
+    false-suppress a same-second park on a different task)."""
+    make_task(tmp_path, 4001, "completed", events=[cand_row(T0, PROSE_NOTE)])
+    make_task(
+        tmp_path,
+        4002,
+        "completed",
+        events=[
+            filed_row(
+                T1,
+                "filed_task: #96 / target_file: scripts/codex_task.py / "
+                f"fingerprint: n/a (prose park) / origin_candidate_ts: {T0}",
+            )
+        ],
+    )
+    c = only(run_sweep(tmp_path))
+    assert c["source"] == "task:4001"
+    assert c["suppressed"] is False
+
+
+def test_distinct_candidate_rows_in_duplicate_folders_both_enumerate(tmp_path: Path) -> None:
+    """Grain pin: row dedup collapses only identical (source, ts_raw,
+    content-hash) rows — two DISTINCT parks split across a task's duplicate
+    status folders both stay enumerated."""
+    make_task(tmp_path, 4003, "completed", events=[cand_row(T0, PROSE_NOTE)])
+    make_task(tmp_path, 4003, "reviewing", events=[cand_row(T1, PROSE_NOTE)])
+    result = run_sweep(tmp_path)
+    assert len(result["candidates"]) == 2, result["candidates"]
+    assert [c["ts"] for c in result["candidates"]] == [T0, T1]
+    assert all(c["source"] == "task:4003" for c in result["candidates"])
+
+
+def test_cache_park_not_closed_by_task_stream_record_at_matching_origin_ts(
+    tmp_path: Path,
+) -> None:
+    """Grain pin: the cache file stays its OWN group — a task-stream
+    routed-record with a matching bare-ts origin key must not close an
+    fp-less structured cache park."""
+    root = tmp_path / "tasks"
+    make_task(
+        root,
+        4004,
+        "completed",
+        events=[
+            filed_row(
+                T1,
+                "filed_task: #97 / target_file: g/h.md / "
+                f"fingerprint: n/a (prose park) / origin_candidate_ts: {T0}",
+            )
+        ],
+    )
+    cache = tmp_path / "workflow-fix-events.jsonl"
+    cache_park = {
+        "ts": T0,
+        "marker": "epm:workflow-fix-candidate v1",
+        "target_file": "g/h.md",
+        "routed": "parked: EPM_WORKFLOW_FIX_SESSION",
+    }
+    cache.write_text(json.dumps(cache_park) + "\n")
+    c = only(run_sweep(root, cache))
+    assert c["source"] == "cache"
+    assert c["suppressed"] is False


### PR DESCRIPTION
Closes task #1274 (daily-fix: sweep misses routed-record for prior-night park).

## Summary
- `scripts/sweep_parked_wf_candidates.py`: group all `tasks/*/<id>/events.jsonl` status folders of one task id into ONE logical stream (shared row-dedup set + cross-folder filed-record pool; cache file stays its own group) so a routed-record on ANY status folder suppresses parked-candidate copies in EVERY folder — the #1196 stale-duplicate-folder shape (#644/#1253 class).
- `tests/test_sweep_parked_wf_candidates.py`: section 18 — byte-verbatim #1196 red-green fixture + reverse-direction variant + 2 grain pins + cache-isolation pin.

## Test plan
- [x] RED pre-fix (2 fixture tests fail), GREEN post-fix (32/32)
- [x] Step 9c gate: 3433 passed; 1 pre-existing main red stripped via pristine oracle (COMPARE_RC=0)
- [x] Live read-only smoke: task:1196 exactly once, suppressed by #1235
- [x] ruff + workflow_lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)