### PR TITLE
issue-1280: Guard 1 foreign-tasks trigger diff -> three-dot own-commits scoping

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -8724,9 +8724,20 @@ task at the wrong status, AND a branch based on another still-unmerged
 rebase-merged. Three guards:
 
 1. **Foreign-`tasks/` guard (strip whole foreign task folders before the
-   merge).** `git diff --name-only "$MAIN_SHA" HEAD -- tasks/` — against the
-   freshly captured `main` snapshot (`MAIN_SHA`, captured in the block
-   below) — MUST be empty except THIS task's own folder (`tasks/*/<N>/`).
+   merge).** `git diff --name-only "$MAIN_SHA"...HEAD -- tasks/` — the
+   THREE-DOT form: merge-base..HEAD, i.e. only paths the branch's OWN
+   replayed commits touch (#1280) — MUST be empty except THIS task's own
+   folder (`tasks/*/<N>/`). Main-side advancement since the merge-base is
+   BENIGN and must NOT trigger the strip: the `--rebase` merge replays only
+   the branch's commits, so files the branch never touched keep `main`'s
+   version. The retired two-endpoint endpoints (`"$MAIN_SHA" HEAD`) listed
+   every path the fleet's marker churn advanced on `main` since the fork
+   (#1271: 33 false positives on a branch whose replayed commits touched
+   ZERO `tasks/` paths), and stripping those stages main-advancement content
+   into a NEW branch commit whose server-side replay conflicts with main's
+   further advancement — creating the very #1128-shape conflict the strip
+   exists to prevent. The strip TARGET stays the freshly captured `main`
+   snapshot (`MAIN_SHA`, captured in the block below).
    For any FOREIGN `tasks/` path in that diff — a `tasks/*/<M>/…` file for
    `M != <N>`, whether `events.jsonl`, `comments.jsonl`, `body.md`, or any
    other file — reset it to that snapshot BEFORE merging so the server-side
@@ -8782,9 +8793,18 @@ rebase-merged. Three guards:
      git -C "$WT" fetch origin main --quiet \
        || echo "Guard 1 WARN: fetch origin main failed — stripping against last-fetched origin/main (conflict-prone; Known failure shape 2 is the recovery)"
      MAIN_SHA=$(git -C "$WT" rev-parse origin/main)
-     if ! git -C "$WT" -c core.quotePath=false diff --name-only "$MAIN_SHA" HEAD -- 'tasks/' \
+     # Three-dot (#1280): merge-base..HEAD = paths the branch's OWN replayed
+     # commits touch. Two-endpoint ("$MAIN_SHA" HEAD) read main-side
+     # advancement as foreign (33 false positives on #1271) and its strip
+     # staged main content into a new branch commit that CREATED the
+     # #1128-shape server-side conflict. The [ -z ] pre-check keeps an empty
+     # MAIN_SHA fail-LOUD: an empty sha collapses the fused token to
+     # '...HEAD' (= HEAD...HEAD, an EMPTY diff, exit 0 — silent fail-open),
+     # where the old quoted empty argument made git error out.
+     if [ -z "$MAIN_SHA" ] \
+        || ! git -C "$WT" -c core.quotePath=false diff --name-only "$MAIN_SHA"...HEAD -- 'tasks/' \
          > /tmp/issue-<N>-guard1-tasks-diff.txt; then
-       echo "Guard 1: git diff \$MAIN_SHA HEAD -- tasks/ FAILED (bad ref or empty MAIN_SHA) — cannot certify no foreign tasks/ paths; do NOT merge"
+       echo "Guard 1: git diff \$MAIN_SHA...HEAD -- tasks/ FAILED (bad ref or empty MAIN_SHA) — cannot certify no foreign tasks/ paths; do NOT merge"
        GUARD1_STATE=diff-failed
        break
      # Work arm: two-command elif list — mapfile fills FOREIGN from the FILE
@@ -8831,9 +8851,15 @@ rebase-merged. Three guards:
        # Un-stage AND restore the working tree for ONLY this attempt's paths
        # so the retry re-splits clean (never a bare `reset -- tasks/`, which
        # could touch own-task staged state). checkout HEAD restores index AND
-       # working tree, so a path that DROPS OUT of attempt-2's FOREIGN (main
-       # caught up to the branch for it) leaves no uncommitted foreign litter
-       # behind — litter a later shape-1 worktree merge could refuse on.
+       # working tree. Under the three-dot trigger (#1280) FOREIGN itself is
+       # fork-point-stable into attempt 2 on a RESTORED attempt — the
+       # pre-commit-failure case this arm handles: a fresh fetch moves the
+       # pin, not the merge-base, and this restore leaves HEAD unchanged —
+       # what refreshes on attempt 2 is the SPLIT (a fresh MAIN_SHA can
+       # re-class a path on-main vs branch-only when main moves the folder)
+       # and the strip TARGET content, so the restore must still leave no
+       # uncommitted foreign litter behind — litter a later shape-1 worktree
+       # merge could refuse on.
        git -C "$WT" checkout HEAD -- "${FOREIGN[@]}"
      else
        GUARD1_STATE=ok   # no foreign tasks/ paths — nothing to strip
@@ -8855,10 +8881,15 @@ rebase-merged. Three guards:
    `main` silently. So when `STRIPPED_FOREIGN=yes`, the safe-case block below
    MUST push the strip commit to the PR head ref BEFORE calling `gh pr merge`.
 
-   This is idempotent (a re-run finds `FOREIGN` empty and no-ops; a FAILED
-   trigger diff fails loud (echo + `false`) instead of reading as
-   no-foreign-files, leaving `STRIPPED_FOREIGN=no` while the block exits
-   non-zero (#1184)) and never
+   This is idempotent at the commit gate (#1280): after a successful strip a
+   re-run's three-dot diff can still list an on-main foreign path (HEAD holds
+   the OLD pin's content, which differs from the merge-base) — the re-run
+   re-checkouts the FRESH snapshot and the `diff --cached --quiet` gate skips
+   the commit when main has not advanced, or refreshes the strip to the newer
+   pin when it has; branch-ADDED foreign paths drop out of the diff entirely
+   once rm-ed. A FAILED trigger diff fails loud (echo + `false`) instead of
+   reading as no-foreign-files, leaving `STRIPPED_FOREIGN=no` while the block
+   exits non-zero (#1184), and the guard never
    touches THIS task's own `tasks/*/<N>/` folder (the `grep -Ev
    "^tasks/[^/]+/<N>/"` carve-out). Never let a behind-`main` branch revert
    another task's `events.jsonl` / `comments.jsonl`. (Incident 2026-06-01:
@@ -9891,6 +9922,13 @@ git -C "$WT" commit --no-edit
 # certification passed VACUOUSLY (fail-OPEN into the push). Here a
 # failed producer takes the terminal arm and the residual check is
 # structurally unreachable:
+# Two-endpoint ("$MAIN_SHA" HEAD) DELIBERATELY, not Guard 1's three-dot
+# (#1280): this certifies TREE IDENTITY against the captured snapshot AFTER
+# the merge brought MAIN_SHA's content in — both endpoints fixed, so
+# main-side advancement cannot false-positive here, and the form stays
+# correct even when the merge produced no commit. Guard 1's PRE-merge
+# trigger is the site where two-endpoint misread main advancement as
+# foreign touches.
 if ! git -C "$WT" -c core.quotePath=false diff --name-only "$MAIN_SHA" HEAD -- 'tasks/' \
     > /tmp/issue-<N>-recovery-tasks-verify.txt; then
   echo "recovery: tasks/ verification diff FAILED — do NOT push"

--- a/tests/test_issue_skill_merge_resnapshot_pin.py
+++ b/tests/test_issue_skill_merge_resnapshot_pin.py
@@ -12,6 +12,11 @@ Guard-1 snapshot and the server-side merge (the #1128 incident class):
    foreign `tasks/` conflicts to it, and certifies the result via a
    `diff "$MAIN_SHA" HEAD -- 'tasks/'` before pushing.
 
+Task #1280 later scoped Guard 1's TRIGGER diff to the branch's own replayed
+commits (three-dot "$MAIN_SHA"...HEAD, with an empty-sha fail-loud
+pre-check); the recovery certification in (3) deliberately KEEPS the
+two-endpoint form (post-merge tree identity against the captured snapshot).
+
 REGION-SCOPED by design: Edits (1) and (3) deliberately share byte-identical
 strings (`MAIN_SHA=$(git -C "$WT" rev-parse origin/main)`, pinned checkouts),
 so whole-file substring asserts would cross-satisfy and miss the deletion of
@@ -124,8 +129,9 @@ def test_guard1_consumes_movable_ref_only_at_fetch_and_capture():
     assert 'git -C "$WT" fetch origin main --quiet' in guards, (
         "Guard 1 must fetch origin main fresh before capturing MAIN_SHA"
     )
-    assert "diff --name-only \"$MAIN_SHA\" HEAD -- 'tasks/'" in guards, (
-        "the Guard-1 trigger diff must run against the captured MAIN_SHA"
+    assert "diff --name-only \"$MAIN_SHA\"...HEAD -- 'tasks/'" in guards, (
+        "the Guard-1 trigger diff must run against the captured MAIN_SHA "
+        "(three-dot: the branch's own replayed commits, #1280)"
     )
     assert 'cat-file -e "$MAIN_SHA:$p"' in guards, (
         "the Guard-1 existence probe must run against the captured MAIN_SHA"
@@ -292,8 +298,14 @@ def test_step10d_path_list_producers_disable_quotepath():
             "> /tmp/issue-<N>-own-diff.txt",
             "P2",
         ),
-        # P3 — Guard 1's foreign-tasks trigger diff.
-        (guards, f'if ! git -C "$WT" {flag} diff --name-only "$MAIN_SHA" HEAD -- \'tasks/\'', "P3"),
+        # P3 — Guard 1's foreign-tasks trigger diff (three-dot own-commits
+        # form, #1280; the `if !` producer prefix moved to the empty-sha
+        # pre-check line, so the pin anchors the `|| !` continuation).
+        (
+            guards,
+            f'|| ! git -C "$WT" {flag} diff --name-only "$MAIN_SHA"...HEAD -- \'tasks/\'',
+            "P3",
+        ),
         # P4 — the recovery's conflicted-path producer.
         (
             recovery,
@@ -342,4 +354,39 @@ def test_guard1_bounded_refetch_repin_retry():
     assert term != -1, "the post-loop terminal disposition arm must exist"
     assert "\n     false\n   fi" in guards[term : term + 400], (
         "the post-loop terminal arm must end in a terminal false (do NOT merge)"
+    )
+
+
+def test_guard1_trigger_diff_scopes_to_own_commits_three_dot():
+    """#1280: Guard 1's trigger diff is the THREE-DOT form ("$MAIN_SHA"...HEAD
+    = merge-base..HEAD, the branch's own replayed commits). The two-endpoint
+    form read main-side advancement as foreign touches (33 false positives on
+    #1271, zero own tasks/ touches) and its strip STAGED main-advancement
+    content into a new branch commit whose server-side replay conflicts (the
+    #1128 shape). The empty-MAIN_SHA pre-check keeps the fused token
+    fail-LOUD (an empty sha collapses '...HEAD' to HEAD...HEAD = empty diff,
+    exit 0 — fail-open). The recovery certification DELIBERATELY stays
+    two-endpoint (post-merge tree identity against the captured snapshot —
+    a different invariant than Guard 1's)."""
+    text = _skill_text()
+    guards = _merge_guards_region(text)
+    recovery = _recovery_region(text)
+    assert "diff --name-only \"$MAIN_SHA\"...HEAD -- 'tasks/'" in guards, (
+        "the Guard-1 trigger diff must use the three-dot own-commits form"
+    )
+    assert 'diff --name-only "$MAIN_SHA" HEAD' not in guards, (
+        "the two-endpoint Guard-1 trigger form must be gone (#1271 false positives)"
+    )
+    assert 'if [ -z "$MAIN_SHA" ]' in guards, (
+        "the empty-MAIN_SHA pre-check must precede the fused three-dot token"
+    )
+    assert r"git diff \$MAIN_SHA...HEAD -- tasks/ FAILED" in guards, (
+        "the Guard-1 diff-failure echo must name the three-dot trigger form (#1280)"
+    )
+    assert _RECOVERY_CERT_DIFF in recovery, (
+        "the recovery certification stays two-endpoint (tree identity)"
+    )
+    assert 'Two-endpoint ("$MAIN_SHA" HEAD) DELIBERATELY' in recovery, (
+        "the recovery site must carry the comment distinguishing it from "
+        "Guard 1's three-dot trigger (#1280)"
     )


### PR DESCRIPTION
Closes task #1280. Workflow-fix: scope /issue Step 10d Guard 1's FOREIGN set to the branch's own commits (three-dot diff) + [ -z ] pre-check + test pins.