### PR TITLE
issue-1277: migrate verify_plan.py c4 N/A escape to _standalone_na_declared

### DIFF
--- a/.claude/skills/adversarial-planner/SKILL.md
+++ b/.claude/skills/adversarial-planner/SKILL.md
@@ -208,6 +208,9 @@ Run the structural verifier against the plan version just persisted:
   `N/A — no behavioral construct`
   (check 2), `N/A — no model training` / `N/A — no training hyperparameters` (check 1),
   `N/A — not a replication` (check 7), `N/A — no artifact reuse` (check 6),
+  `N/A — not a behavior-implantation` (check 4 — the implant/marker vocabulary hit is
+  incidental or quotes a sibling's design, not this plan's own implantation; a genuine
+  implantation plan instead names its contrastive-negative set or a named exemption),
   `N/A — no dry-run smoke` (check 11 — kind: infra|batch plans where a `--dry-run`
   mention is incidental, not the plan's own acceptance smoke), `N/A — no draw battery`
   (check 12), `N/A — no empirical-null gate` (check 13),

--- a/scripts/verify_plan.py
+++ b/scripts/verify_plan.py
@@ -96,6 +96,7 @@ labeled-line forms):
   - ``N/A — no model training`` / ``N/A — no training hyperparameters``
     (check 1)
   - ``N/A — no behavioral construct`` (check 2)
+  - ``N/A — not a behavior-implantation`` (check 4)
   - ``N/A — no artifact reuse`` (check 6)
   - ``N/A — not a replication`` (check 7)
   - ``N/A — no dry-run smoke`` (check 11)
@@ -712,8 +713,12 @@ def check_contrastive_negatives(plan: str, kind: str) -> CheckResult:
             name,
             "not detected as behavior-implantation (no implant/leakage-marker vocabulary)",
         )
-    if re.search(r"(?i)not a behavior[- ]implantation", text):
-        return _pass(cid, name, "explicit N/A declared (not a behavior-implantation)")
+    if _standalone_na_declared(plan, r"not a behavior[- ]implantation"):
+        return _pass(
+            cid,
+            name,
+            "explicit N/A declared on its own line, unwrapped (not a behavior-implantation)",
+        )
     if re.search(r"(?i)contrastive[- ]negatives?", text):
         lowered = text.lower()
         found = [t for t in ("panel", "ratio", "1:1", "disjoint") if t in lowered]
@@ -738,7 +743,8 @@ def check_contrastive_negatives(plan: str, kind: str) -> CheckResult:
         name,
         "behavior-implantation vocabulary detected but no contrastive-negative set or named "
         "exemption — .claude/rules/contrastive-negatives.md (panel + ratio + disjointness); "
-        "Methodology critic must gate this",
+        "Methodology critic must gate this; or declare `N/A — not a behavior-implantation` "
+        "on its own line, unwrapped (no backticks/quotes)",
     )
 
 

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -525,11 +525,40 @@ def test_c4_named_exemption_passes():
     assert _status(plan, "c4_contrastive_negatives") == "PASS"
 
 
-def test_c4_na_line_passes():
+def test_c4_standalone_na_line_passes():
+    # Standalone-line escape (the mid-line form was the self-escape shape —
+    # repurposed into test_c4_midprose_phrase_does_not_escape below).
+    plan = (
+        GOOD_PLAN
+        + "\nThe word implant appears in a quoted sibling methodology.\n"
+        + "\nN/A — not a behavior-implantation (the implant vocabulary is incidental).\n"
+    )
+    _, by_id = _run(plan)
+    r = by_id["c4_contrastive_negatives"]
+    assert r.status == "PASS"
+    assert "on its own line, unwrapped" in r.detail
+
+
+def test_c4_midprose_phrase_does_not_escape():
+    # #1277 red-pin (c4 twin of #1262's c7 pin): the phrase mid-prose (the
+    # #810 structure, one polarity over) must not escape c4.
+    # Pre-fix: doc-global re.search -> PASS. This is the former
+    # test_c4_na_line_passes fixture, polarity flipped.
     plan = (
         GOOD_PLAN + "\nThe word implant appears but this is not a behavior-implantation design.\n"
     )
-    assert _status(plan, "c4_contrastive_negatives") == "PASS"
+    assert _status(plan, "c4_contrastive_negatives") == "WARN"
+
+
+def test_c4_backtick_wrapped_escape_does_not_escape():
+    # Mirror of test_c7_backtick_wrapped_escape_does_not_escape: the pasted
+    # bounce-brief bullet shape must not escape.
+    plan = (
+        GOOD_PLAN
+        + "\nWe implant a refusal behavior into the source persona.\n"
+        + "- `N/A — not a behavior-implantation` (declare per the bounce brief).\n"
+    )
+    assert _status(plan, "c4_contrastive_negatives") == "WARN"
 
 
 def test_c4_kind_infra_skips():
@@ -1273,7 +1302,7 @@ def test_skillmd_canonical_escape_block_never_self_escapes():
     # not literally `plan` (or that uses r'...' quoting) is silently
     # uncovered by this pin while the floor stays green; the floor catches
     # shrinkage, not omission.
-    assert len(tails) >= 22, tails  # extraction guard: 22 plan-arg call sites at pin time (#1262)
+    assert len(tails) >= 23, tails  # extraction guard: 23 plan-arg call sites (#1262; c4 #1277)
     text = (REPO_ROOT / ".claude/skills/adversarial-planner/SKILL.md").read_text()
     for tail in tails:
         assert not verify_plan._standalone_na_declared(text, tail), tail
@@ -1315,11 +1344,11 @@ def test_skillmd_canonical_escapes_sync_with_docstring():
     doc = verify_plan.__doc__
     section = doc[doc.index("Canonical N/A escape phrases") : doc.index("WARN semantics")]
     phrases = re.findall(r"``((?:N/A —|Durability pin: N/A)[^`]+?)``", section)
-    # Extraction guard (never-self-escapes precedent, :1232): 28 phrases at
+    # Extraction guard (never-self-escapes precedent, :1232): 29 phrases at
     # pin time. A shrinking count means the docstring format drifted and the
     # parser silently under-covers — fix the regex; never lower this floor
     # except for a deliberate check retirement (state which check).
-    assert len(phrases) >= 28, (len(phrases), phrases)
+    assert len(phrases) >= 29, (len(phrases), phrases)  # c4 registered (#1277)
     # Code->docstring leg: every `_standalone_na_declared` call-site tail must
     # match somewhere in the docstring section, so a new check's recognizer
     # cannot land unregistered (the SKILL.md asserts below then propagate the
@@ -1361,7 +1390,7 @@ def test_own_line_remedies_carry_unwrapped_clarifier():
         else:
             offenders.append((node.lineno, node.value[:90]))
     assert not offenders, f"own-line remedies missing the unwrapped clarifier: {offenders}"
-    # 19 sites (#1263) + the c34 exemplar + c7's remedy/pass-detail (#1262 merge) = 22 live
+    # 19 sites (#1263) + c34 exemplar + c7's remedy/pass-detail (#1262) + c4's (#1277) = 24 live
     assert clarified >= 20
 
 


### PR DESCRIPTION
Closes task #1277. Migrates check-4's N/A escape from a bare doc-global regex to the house standalone-line recognizer (mirrors #1262's c7 migration); registers the phrase in both canonical escape lists; red/green/wrapped fixtures; extraction floors 22→23, 28→29.