### PR TITLE
workflow-fix #1288: Step 10d squash-first merge routing for infra fleets + Known failure shape 0

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -8873,10 +8873,10 @@ rebase-merged. Three guards:
    ```
 
    The `STRIPPED_FOREIGN` flag is load-bearing: the strip commit above is a
-   LOCAL worktree commit, but the safe-case `gh pr merge --rebase` below
-   rebases the commits on the PR head ref as it exists on
+   LOCAL worktree commit, but the safe-case `gh pr merge $MERGE_FORM` below
+   merges the PR head ref as it exists on
    `origin/issue-<N>` (server-side), NOT the local worktree HEAD. An unpushed
-   strip commit is therefore INVISIBLE to that server-side rebase — the
+   strip commit is therefore INVISIBLE to that server-side merge — the
    foreign `tasks/*` reverts would remain in the replayed history and land on
    `main` silently. So when `STRIPPED_FOREIGN=yes`, the safe-case block below
    MUST push the strip commit to the PR head ref BEFORE calling `gh pr merge`.
@@ -8896,7 +8896,8 @@ rebase-merged. Three guards:
    #458's merge branch, 1,146 commits behind main, silently rewound
    `tasks/running/448/events.jsonl`.) The `--rebase` merge form below replays
    the branch's commits on top of current `main`, so files the branch never
-   committed keep `main`'s version — this is what keeps the clean-result body
+   committed keep `main`'s version (the `--squash` form lands the same
+   own-diff content as one commit) — this is what keeps the clean-result body
    (committed to `main` by `task.py`, never in the worktree) safe across the
    merge.
 2. **Status already off `running`.** By both trigger points the status is
@@ -8933,7 +8934,8 @@ rebase-merged. Three guards:
 
    ```bash
    # The branch's OWN commits (merge-base..HEAD) — with ON_MAINLINE=yes
-   # this is exactly what `gh pr merge --rebase` will replay onto main.
+   # this is exactly what `gh pr merge --rebase` will replay onto main
+   # (the `--squash` form lands the same own-diff content as one commit).
    # quotePath=false: each $f below feeds a literal `git log ... -- "$f"`
    # pathspec — a `"`-quoted non-ASCII path matches nothing, non_sync reads
    # empty, and the file is misread as "imported from main" (fail-open).
@@ -8982,7 +8984,8 @@ rebase-merged. Three guards:
    rebase-merge regardless of `BEHIND`: the rebase replays only these commits,
    and files the branch never committed keep `main`'s version.
 
-   In the unsafe case, do NOT run `gh pr merge --rebase` — fall through
+   In the unsafe case, do NOT run the safe-case `gh pr merge` (any
+   `$MERGE_FORM`) — fall through
    to the **artifact-confirmed merge** procedure below. The Guard 1
    foreign-`tasks/` checkout is necessary but not sufficient: it covers
    `tasks/`, but a branch based on a still-unmerged parent branch also
@@ -9001,14 +9004,14 @@ rebase-merged. Three guards:
 
 #### Fast-path routing pre-check (workflow-fix / small-ADDED-diff far-behind branches)
 
-Run this AFTER guards 1-3 and BEFORE the safe-case `gh pr merge --rebase`
+Run this AFTER guards 1-3 and BEFORE the safe-case `gh pr merge $MERGE_FORM`
 call. For a workflow-fix / small-diff branch that is very far behind `main`,
 a server-side `--rebase` predictably conflicts on churn even after Guard 1
 strips foreign folders (GitHub replays the branch's own commits across
 thousands of intervening main commits, and cannot use this repo's
 `merge=union`). When the branch's OWN diff is small, entirely in-scope, AND
-consists ONLY of ADDED files, skip the doomed `--rebase` and route DIRECTLY to
-the surgical additive checkout below.
+consists ONLY of ADDED files, skip the doomed server-side merge and route
+DIRECTLY to the surgical additive checkout below.
 
 **Why the ADDED-only conjunct is load-bearing (do NOT drop it).** The
 surgical additive checkout does a WHOLESALE `git checkout issue-<N> -- <path>`
@@ -9020,7 +9023,7 @@ overwrite silently discards `main`'s newer content with NO conflict surfacing
 the surgical checkout only ever CREATES files that do not yet exist on
 `main`, so it can never clobber a concurrently-advanced one. A branch that
 MODIFIES a workflow-surface file (status M) is NOT fast-path-eligible and
-takes the ordinary `gh pr merge --rebase` path, whose server-side 3-way merge
+takes the ordinary `gh pr merge $MERGE_FORM` path, whose server-side 3-way merge
 either merges main's changes cleanly or surfaces a real conflict for the
 recovery sub-procedure. (This is exactly why #787 itself — which MODIFIES
 `SKILL.md` — is not fast-path-eligible.)
@@ -9084,7 +9087,7 @@ if [ "$TASK_KIND" = "infra" ] \
 fi
 ```
 
-If `FAST_PATH=yes`: SKIP the `gh pr merge --rebase` call and jump straight to
+If `FAST_PATH=yes`: SKIP the safe-case `gh pr merge $MERGE_FORM` call and jump straight to
 the **surgical additive checkout** (the "One or more deliverables missing"
 branch of the artifact-confirmed procedure below). The surgical checkout
 lands this branch's own ADDED files onto `main` directly, with no rebase.
@@ -9093,11 +9096,11 @@ true, surgical_checkout: true, fast_path: true, reason: "wf-fix branch
 BEHIND=<BEHIND> > 1000, own diff <=15 in-scope ADDED-only files — skipped
 doomed server-side rebase", files: [...]}`.
 
-If `FAST_PATH=no`: proceed to the safe-case `gh pr merge --rebase` (or the
+If `FAST_PATH=no`: proceed to the safe-case `gh pr merge $MERGE_FORM` (or the
 artifact-confirmed path if Guard 3 said UNSAFE) exactly as before — this
 pre-check adds NO new behavior for normal branches. A branch that MODIFIES a
 workflow-surface file (status M ⇒ `ADDED_ONLY=no`) is deliberately not
-fast-pathed; it takes the ordinary `--rebase`.
+fast-pathed; it takes the ordinary `$MERGE_FORM` merge.
 
 #### Pre-push workflow-lint gate (runs before every merge form lands)
 
@@ -9650,9 +9653,10 @@ else
   # block and run the artifact-confirmed merge below instead.
   #
   # Push the Guard-1 strip commit to the PR head ref FIRST, so the
-  # server-side rebase in `gh pr merge` below sees the stripped branch tip,
+  # server-side merge in `gh pr merge` below (rebase replay or squash)
+  # sees the stripped branch tip,
   # not the pre-strip commit. The strip commit is a LOCAL worktree commit and
-  # is otherwise invisible to server-side rebase — leaving the foreign
+  # is otherwise invisible to the server-side merge — leaving the foreign
   # tasks/* reverts in the replayed history and landing them on main silently
   # (Codex code-review round-1 blocker, task #787). Push retry mirrors
   # CLAUDE.md § "Concurrent repo-root committers": pull --rebase=merges
@@ -9683,6 +9687,27 @@ else
       || { git -C "$WT" pull --rebase=merges --autostash \
            && git -C "$WT" push origin issue-<N>; }
   fi
+  # Merge-form routing (#1288): infra-fleet code branches (kind infra|batch —
+  # the watcher's INFRA_DRAIN_KINDS, the population same-batch racing this
+  # step by construction) default to --squash: server-side --rebase was 0/4
+  # first-try on 2026-07-12 (10/24 sessions on 07-11) under fleet churn, and
+  # every failed session landed on --squash anyway after burning the failed
+  # rebase + its retry ladder. GitHub mergeability is merge-method-
+  # independent, but --rebase can ADDITIONALLY fail ("can't be rebased",
+  # #1041) where --squash succeeds — so squash-first strictly dominates for
+  # a single-logical-change branch, and it reverts as ONE commit (the only
+  # grain that exists on such a branch). Experiments (Step 9b trigger) keep
+  # --rebase: heterogeneous per-item commits retain per-commit revert value
+  # and the empirical record does not cover them. An unreadable kind falls
+  # to --rebase (fail-open to today's behavior). REPO_ROOT is re-derived
+  # inline — fenced blocks are separate shells, and the guards block's
+  # derivation is not in scope here:
+  REPO_ROOT=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")
+  MERGE_FORM=--rebase
+  TASK_KIND=$(uv run python "$REPO_ROOT/scripts/task.py" view <N> --json \
+    | uv run python -c 'import sys,json; print(json.load(sys.stdin).get("frontmatter",{}).get("kind",""))' \
+    || echo "")
+  case "$TASK_KIND" in infra|batch) MERGE_FORM=--squash ;; esac
   # Pre-push workflow-lint gate (subsection above) — run its executable
   # block FIRST as ONE BACKGROUND Bash call, read the verdict file in a
   # fresh foreground call when it completes (completion-read, gate
@@ -9698,10 +9723,10 @@ else
      && [ -n "$(sed -n 2p /tmp/issue-<N>-lint-verdict.txt 2>/dev/null)" ] \
      && [ "$(sed -n 2p /tmp/issue-<N>-lint-verdict.txt 2>/dev/null)" = "$(git -C "$WT" rev-parse HEAD)" ]; then
     gh pr ready <PR>
-    if gh pr merge <PR> --rebase --delete-branch=false; then
+    if gh pr merge <PR> $MERGE_FORM --delete-branch=false; then
       rm -f /tmp/issue-<N>-lint-verdict.txt   # consume on MERGE SUCCESS — the verdict certified exactly the tip that landed
     else
-      echo "MERGE FAILED — classify the gh error text: (1) \"can't be rebased\" -> the #1041 --squash retry (Known failure shape 1 below; SHA-bound verdict remains valid for the SAME tip); (2) \"Pull Request has merge conflicts\" (mergePullRequest) -> the #1128 re-snapshot-and-retry-once (Known failure shape 2 below); (3) anything else -> the Failure bullet (merge-conflict recovery ONCE, then epm:merge-failed). Do NOT hand-write the verdict file."
+      echo "MERGE FAILED — classify the gh error text: (0) \"Base branch was modified\" -> transient base-advance (Known failure shape 0 below): wait ~20s, re-enter this SAME conditional (same tip, verdict still valid; max 2 same-tip retries); (1) \"can't be rebased\" (--rebase form only) -> the #1041 --squash retry (Known failure shape 1 below; SHA-bound verdict remains valid for the SAME tip); (2) \"Pull Request has merge conflicts\" -> the #1128 re-snapshot-and-retry-once (Known failure shape 2 below); (3) anything else -> the Failure bullet (merge-conflict recovery ONCE, then epm:merge-failed). Do NOT hand-write the verdict file."
       false
     fi
   else
@@ -9719,6 +9744,32 @@ a scratch worktree (the root guard blocks a repo-root revert, #1234) (vs.
 revert control after the fact — that is what makes a no-prompt merge safe
 here. The worktree is deliberately NOT removed (`--delete-branch=false`,
 no `git worktree remove`).
+
+For `kind: infra|batch` branches `$MERGE_FORM` is `--squash` (#1288):
+the branch is a single logical change by construction, the squash lands
+it as ONE independently-revertible commit, and the empirical record
+(0/4 first-try rebases 2026-07-12; 10/24 sessions 07-11; every failure
+landing on --squash anyway) makes the rebase attempt a pure wall-time
+tax under fleet churn. Shape 1 cannot fire on the --squash path (the
+error is rebase-specific); shapes 0/2/else apply to both forms.
+
+**Known failure shape 0 — base branch advanced mid-merge (`Base branch
+was modified`, #1288).** Substring-match `Base branch was modified` (the
+full wording — `Base branch was modified. Review and try the merge
+again.` — is transcript-mined and may drift). GitHub recomputed the
+merge against a base that moved DURING the API call — a pure timing
+transient under fleet marker churn (~100+ tasks/ commits/hr on main):
+no content conflict, nothing to fix. Recovery: wait ~20 s (≈ one churn
+interval, letting gh's mergeability recompute settle), then re-enter
+the SAME gated merge conditional with the SAME `$MERGE_FORM` — the
+branch tip is unchanged, so the SHA-bound verdict re-certifies it
+(consume-on-merge-success survives this failure by design; never
+hand-write the verdict file, #1082). Bounded at TWO same-tip retries
+per Step 10d invocation; a third consecutive hit is no longer plausibly
+timing — reclassify by error text per shapes 1/2/else. Before #1288
+this shape fell through to "(3) anything else" and burned a full
+~16-min scratch-worktree recovery on a transient (one of the three
+error shapes in the 2026-07-12 fleet's 4/4 first-attempt failures).
 
 **Known failure shape 1 — branch carries a merge commit (`can't be
 rebased`, #1041).** A branch that CARRIES A MERGE COMMIT (e.g. after a
@@ -9793,7 +9844,7 @@ fi
 # the NEW tip (never hand-write it, #1082). If the tip did NOT change
 # (push-only fix), the still-valid verdict re-certifies it — the
 # conditional's sha arm enforces this mechanically either way. Then
-# re-enter the SAME gated merge conditional (--rebase form) exactly
+# re-enter the SAME gated merge conditional (the task's $MERGE_FORM) exactly
 # once. Classify a SECOND refusal by its error text per the failure
 # echo: a "can't be rebased" refusal takes the shape-1 --squash retry
 # (the retried rebase replays the FIRST, stale strip commit per-commit
@@ -9811,10 +9862,14 @@ fix the server-side view and the retry is warranted; the tip is then
 unchanged, so the still-valid SHA-bound verdict re-certifies it and no
 gate re-run is needed.)
 
-- **Success:** post `epm:merged v1` with the list of merge SHAs. Update
+- **Success:** post `epm:merged v1` with the list of merge SHAs plus
+  `merge_form: squash|rebase` and `merge_attempts: <n>` (note-token
+  convention — no schema change, #1288). Update
   the chat title with `merged`. Then run the **post-merge stale-task-folder
   guard** below (it runs on every merge form).
 - **Failure** (rebase conflict, non-mergeable PR, non-fast-forward): for
+  the `Base branch was modified` shape (substring match), run the
+  shape-0 wait-and-retry (Known failure shape 0 above, max 2) FIRST; for
   the `Pull Request has merge conflicts` shape (substring match), FIRST
   run the **re-snapshot-and-retry** (Known failure shape 2 above) ONCE;
   if it is skipped (nothing changed), run the **merge-conflict recovery**
@@ -9947,10 +10002,11 @@ fi
 # before this gated push). The push is then GATED on the persisted, SHA-BOUND verdict file —
 # the explicit conditional is the hard stop (missing file / block / crash
 # / missing or stale sha all fail CLOSED). The verdict is consumed only
-# AFTER `gh pr merge` SUCCEEDS: this branch now CARRIES A MERGE COMMIT,
-# so the --rebase merge routinely fails with the #1041 rebase refusal —
-# the surviving verdict certifies the documented --squash retry of the
-# SAME tip (never hand-write the verdict file, #1082):
+# AFTER `gh pr merge` SUCCEEDS (never hand-write the verdict file,
+# #1082). The recovery just added a merge commit, so --rebase is
+# documented-doomed here (#1041 — the old flow burned that attempt, then
+# took the --squash substitution). Go straight to --squash for ALL kinds
+# (#1288):
 if grep -qxE 'pass|skip-artifact-only' /tmp/issue-<N>-lint-verdict.txt 2>/dev/null \
    && [ -n "$(sed -n 2p /tmp/issue-<N>-lint-verdict.txt 2>/dev/null)" ] \
    && [ "$(sed -n 2p /tmp/issue-<N>-lint-verdict.txt 2>/dev/null)" = "$(git -C "$WT" rev-parse HEAD)" ]; then
@@ -9958,10 +10014,10 @@ if grep -qxE 'pass|skip-artifact-only' /tmp/issue-<N>-lint-verdict.txt 2>/dev/nu
   # gh recomputes mergeability asynchronously after a push — it can be
   # momentarily stale. Re-check before concluding failure:
   gh pr view <PR> --json mergeable -q .mergeable   # brief wait/retry until MERGEABLE
-  if gh pr merge <PR> --rebase --delete-branch=false; then
+  if gh pr merge <PR> --squash --delete-branch=false; then
     rm -f /tmp/issue-<N>-lint-verdict.txt   # consume on MERGE SUCCESS — the verdict certified exactly the tip that landed
   else
-    echo "MERGE FAILED post-push (the recovery's merge commit typically refuses server-side rebase — the #1041 shape). The SHA-bound verdict REMAINS VALID for the same-tip retry: re-enter this conditional with --squash substituted for --rebase (Known failure shape 1 above); the rm fires on THAT retry's success. Do NOT hand-write the verdict file."
+    echo "MERGE FAILED post-push — classify: (0) \"Base branch was modified\" -> shape-0 same-tip retry (verdict survives); anything else -> epm:merge-failed (do NOT hand-write the verdict file)."
     false
   fi
 else
@@ -10386,13 +10442,13 @@ Decision tree:
   with the error, surface ONE line in chat (branch + worktree path +
   one-line reason), CONTINUE. Same fail-fast policy as the safe case.
 
-Never blind-`gh pr merge --rebase` a branch that tripped guard 3 — that
-is the exact #458 / #479 incident class this section exists to prevent.
+Never blind-`gh pr merge` (any `$MERGE_FORM`) a branch that tripped guard 3
+— that is the exact #458 / #479 incident class this section exists to prevent.
 
 #### Post-merge stale-task-folder guard (runs after EVERY merge form lands)
 
 Run this AFTER any of the three merge forms above lands (safe-case
-`gh pr merge --rebase`, the merge-conflict-recovery retry, or the
+`gh pr merge $MERGE_FORM`, the merge-conflict-recovery retry, or the
 artifact-confirmed / surgical-additive checkout). A merge commit — most
 often the recovery's `git merge origin/main`, but also any improvised
 merge taken when `--rebase` keeps being refused — can import THIS task's
@@ -10403,7 +10459,7 @@ reads the stale folder as a live task and respawns the session
 indefinitely (incident #644, 2026-06-16: an orphan-respawn cap-2-per-day
 cycle ran ~8h; #643 hit the same class at archive time). Guard 1 above
 catches FOREIGN tasks' folders but not this task's own old-status
-duplicate, and it only runs on the `--rebase` form. Keep exactly ONE
+duplicate, and it only runs on the safe-case (`$MERGE_FORM`) path. Keep exactly ONE
 folder for this task on `main`:
 
 ```bash

--- a/tests/test_issue_skill_step10d_merge_form.py
+++ b/tests/test_issue_skill_step10d_merge_form.py
@@ -1,0 +1,44 @@
+"""Pin the #1288 Step 10d merge-form protections in .claude/skills/issue/SKILL.md.
+
+Task #1288 (2026-07-13) changed Step 10d so that:
+
+1. The safe-case merge routes by task kind — ``MERGE_FORM=--squash`` for
+   ``kind: infra|batch`` (the watcher's INFRA_DRAIN_KINDS, the population that
+   same-batch races Step 10d by construction; server-side ``--rebase`` went
+   0/4 first-try in the 2026-07-12 fleet), ``--rebase`` retained as the
+   default / fail-open form (experiments, unreadable kind).
+2. The safe-case merge call uses the ``$MERGE_FORM`` variable, not a
+   hardcoded form.
+3. A "Known failure shape 0" documents the transient GitHub error
+   ``Base branch was modified`` (wait ~20 s, same-tip retry, max 2) instead
+   of routing it into the ~16-min scratch-worktree conflict recovery.
+
+These tests fail the suite if a later SKILL.md editor drops any of the three
+protections (plan #1288 §5 durability pin).
+"""
+
+from pathlib import Path
+
+SKILL = Path(__file__).resolve().parents[1] / ".claude" / "skills" / "issue" / "SKILL.md"
+
+
+def _step10d_span() -> str:
+    """Return the SKILL.md text from the (unique) `### Step 10d` heading onward."""
+    text = SKILL.read_text()
+    return text[text.index("### Step 10d") :]
+
+
+def test_merge_form_routing_present():
+    span = _step10d_span()
+    assert "MERGE_FORM=--rebase" in span  # default preserved (fail-open arm)
+    assert 'case "$TASK_KIND" in infra|batch) MERGE_FORM=--squash ;; esac' in span
+
+
+def test_safe_case_merge_uses_merge_form_variable():
+    assert "gh pr merge <PR> $MERGE_FORM --delete-branch=false" in _step10d_span()
+
+
+def test_known_failure_shape_0_present():
+    span = _step10d_span()
+    assert "Known failure shape 0" in span
+    assert "Base branch was modified" in span

--- a/tests/test_step10d_guard3.py
+++ b/tests/test_step10d_guard3.py
@@ -151,11 +151,12 @@ def test_guard1_own_folder_carveout_present():
 # Sub-fix 2 (round-2 fix) — push the Guard-1 strip commit BEFORE gh pr merge
 # --------------------------------------------------------------------------
 # The Guard-1 strip commit is a LOCAL worktree commit; the safe-case
-# `gh pr merge --rebase` rebases the PR head ref on origin/issue-<N>
-# (server-side), so an unpushed strip commit is invisible to that rebase and
-# the foreign tasks/* reverts would land on main silently. The safe case must
-# push the strip commit (guarded by STRIPPED_FOREIGN=yes) before merging, and
-# that push must APPEAR BEFORE the safe-case gh pr merge line in the file.
+# `gh pr merge $MERGE_FORM` (#1288 merge-form routing) operates on the PR
+# head ref at origin/issue-<N> (server-side), so an unpushed strip commit is
+# invisible to that merge and the foreign tasks/* reverts would land on main
+# silently. The safe case must push the strip commit (guarded by
+# STRIPPED_FOREIGN=yes) before merging, and that push must APPEAR BEFORE the
+# safe-case gh pr merge line in the file.
 
 
 def test_guard1_tracks_stripped_foreign_flag():
@@ -173,8 +174,8 @@ def test_safe_case_pushes_strip_commit_gated_on_stripped_foreign():
     text = _skill_text()
     assert 'git -C "$WT" push origin issue-<N>' in text, (
         "the safe-case block must push the branch to the PR head ref before "
-        "gh pr merge --rebase (otherwise the strip commit is invisible to the "
-        "server-side rebase)"
+        "gh pr merge $MERGE_FORM (otherwise the strip commit is invisible to "
+        "the server-side merge)"
     )
     assert '[ "$STRIPPED_FOREIGN" = "yes" ]' in text, (
         "the safe-case push must be gated on STRIPPED_FOREIGN=yes so it fires "
@@ -183,15 +184,16 @@ def test_safe_case_pushes_strip_commit_gated_on_stripped_foreign():
 
 
 def test_safe_case_push_appears_before_gh_pr_merge():
-    """The push must SEQUENCE before the safe-case gh pr merge --rebase call,
-    so the server-side rebase sees the stripped branch tip."""
+    """The push must SEQUENCE before the safe-case gh pr merge $MERGE_FORM
+    call (#1288), so the server-side merge sees the stripped branch tip."""
     text = _skill_text()
     # Scope the search to the safe-case block: the #1138 canonical
     # "Bare push / merge snippets" subsection (inserted earlier in Step 10d)
-    # contains both literals, so first-occurrence pins would retarget it.
+    # contains the bare push literal (plus a merge snippet), so
+    # first-occurrence pins would retarget it.
     base = text.find("#### The auto-merge procedure (safe case")
     assert base != -1, "safe-case auto-merge heading not found in SKILL.md"
-    merge_line = "gh pr merge <PR> --rebase --delete-branch=false"
+    merge_line = "gh pr merge <PR> $MERGE_FORM --delete-branch=false"
     push_line = 'git -C "$WT" push origin issue-<N>'
     merge_offset = text.find(merge_line, base)
     push_offset = text.find(push_line, base)
@@ -582,7 +584,12 @@ _SHA_CHECK = (
     ' = "$(git -C "$WT" rev-parse HEAD)" ]'
 )
 _NONEMPTY_SHA_CHECK = '[ -n "$(sed -n 2p /tmp/issue-<N>-lint-verdict.txt 2>/dev/null)" ]'
-_MERGE_SUCCESS_IF = "if gh pr merge <PR> --rebase --delete-branch=false; then"
+# #1288 merge-form routing: the safe case merges via the kind-derived
+# $MERGE_FORM variable; the merge-conflict recovery block is hard-pinned to
+# --squash (its just-added merge commit makes --rebase documented-doomed,
+# #1041). Each consumer is pinned to ITS OWN success-checked merge form.
+_MERGE_SUCCESS_IF_SAFE = "if gh pr merge <PR> $MERGE_FORM --delete-branch=false; then"
+_MERGE_SUCCESS_IF_RECOVERY = "if gh pr merge <PR> --squash --delete-branch=false; then"
 
 
 def test_gate_verdict_sha_bound_at_write_and_both_consumers():
@@ -601,8 +608,8 @@ def test_gate_verdict_sha_bound_at_write_and_both_consumers():
     probe = "grep -qxE 'pass|skip-artifact-only' /tmp/issue-<N>-lint-verdict.txt"
     first = text.find(probe)
     second = text.find(probe, first + 1)
-    m1 = text.find(_MERGE_SUCCESS_IF, first)
-    m2 = text.find(_MERGE_SUCCESS_IF, second)
+    m1 = text.find(_MERGE_SUCCESS_IF_SAFE, first)
+    m2 = text.find(_MERGE_SUCCESS_IF_RECOVERY, second)
     assert -1 < first < m1, "safe case: the success-checked merge must follow its conditional"
     assert -1 < second < m2, "recovery: the success-checked merge must follow its conditional"
     assert _SHA_CHECK in text[first:m1], (
@@ -634,8 +641,8 @@ def test_gate_verdict_consumed_only_after_merge_success():
     first = text.find(probe)
     second = text.find(probe, first + 1)
     ready = text.find("gh pr ready <PR>")
-    m1 = text.find(_MERGE_SUCCESS_IF, first)
-    m2 = text.find(_MERGE_SUCCESS_IF, second)
+    m1 = text.find(_MERGE_SUCCESS_IF_SAFE, first)
+    m2 = text.find(_MERGE_SUCCESS_IF_RECOVERY, second)
     assert -1 < first < ready < m1, "safe case: conditional -> gh pr ready -> success-checked merge"
     assert text.find(rm_line, first, m1) == -1, (
         "safe case: NO rm may sit between the verdict conditional and the merge attempt "


### PR DESCRIPTION
Closes task #1288. Step 10d merge-form routing (--squash for kind infra|batch), new Known failure shape 0 (Base branch was modified transient), recovery straight-to-squash, epm:merged note tokens, durability pin test.