### PR TITLE
issue-1287: boot-death lane covers boot-turn refusal deaths (two-arm predicate)

### DIFF
--- a/.claude/rules/background-automation.md
+++ b/.claude/rules/background-automation.md
@@ -701,31 +701,42 @@ session-list snapshot in place; daemon-gated (`children is None` ⇒ no-op). Unr
 deletes the entry, which is self-deduping; a fresh re-registration restarts
 the clock. Durable trace: `~/.eps-autonomous/stale-registration-events.jsonl`.
 
-**Boot-death lane (#1267, `boot_death_pass`).** The die-BEFORE-turn-1
-complement of the stale-registration pass: a freshly dispatched AUTO session
+**Boot-death lane (#1267 arm 1 + #1287 arm 2, `boot_death_pass`).** The
+die-at-or-before-turn-1 complement of the stale-registration pass: a freshly
+dispatched AUTO session
 (`issue-<N>.json` only — `manual-issue-*.json` is excluded by design, a
 user-driven session is never auto-stopped) whose resolved Claude transcript
-contains ZERO response rows (`_classify_wedge_row` ∉ {assistant, api-error})
-≥30 min after `spawned_at` (`EPM_BOOT_DEATH_WINDOW_MIN`, minutes;
+EITHER (arm 1, zero-response, `shape=zero-response`) contains ZERO response
+rows (`_classify_wedge_row` ∉ {assistant, api-error}) OR (arm 2,
+boot-refusal, `shape=boot-refusal`; #1287/#1277) whose 256 KB transcript
+TAIL (`_transcript_tail_rows`) segments via `_segment_wake_turns` (#1127)
+to ≥1 completed turn with EVERY completed turn failed — a refusal-killed
+boot turn; a single visible ok turn keeps (the #1104 single-refusal guard)
+— ≥30 min after `spawned_at` (`EPM_BOOT_DEATH_WINDOW_MIN`, minutes;
 malformed/non-positive → default), with the transcript quiet ≥10 min (the
 in-flight-first-turn guard) and the sid LIVE, is STOPPED via `_stop_session`
 + surfaced (Telegram push + an anti-liveness `epm:progress` marker,
 sentinels `[autonomous_session_watch:boot-death-stop]` /
 `[...:boot-death-cap-exhausted]`) instead of waiting ~12h for the
-stale-registration unregister (incident #1251–#1256: 9-row / ~11 KB
+stale-registration unregister (incidents #1251–#1256: 9-row / ~11 KB
 transcripts frozen ~7 s post-spawn — the session died during `/issue` skill
-load; every other lane is structurally blind to the shape). Whole-file
-read bounded at 256 KB (a larger transcript cannot be a boot-death → keep);
+load; #1277: an 826 KB transcript whose boot turn ran ~74 s then died on a
+refusal before the tick cron was armed — every other lane is structurally
+blind to both shapes). Arm 1's whole-file
+read is bounded at 256 KB (a larger transcript cannot be a ZERO-RESPONSE
+boot-death → arm 1 keeps; arm 2's seek-tail read works at any size);
 every unresolvable signal fails toward keep. Action is STOP-ONLY — no
 unregister, no direct spawn: post-stop re-drive is fully owned by the
 existing arms (ACTIVE → crash-recovery, ~20 min; `proposed` → the
 proposed-infra sweep's stale-dead-registration grace, ~30–60 min). Bounds:
 per-issue per-UTC-day stop cap (`EPM_BOOT_DEATH_STOPS_PER_DAY`, default 3;
-malformed/<1 → default, never a kill switch), bumped ONCE at
+malformed/<1 → default, never a kill switch; ONE day budget SHARED across
+both arms), bumped ONCE at
 stop-initiation (a stop failure still consumes a budget unit); state at
 `~/.eps-autonomous/boot-death-<N>.json` (GC'd at `completed`/`archived`
 only), durable trace `~/.eps-autonomous/boot-death-events.jsonl` (stop rows
-carry `transcript=` + `stderr_excerpt=` forensics). There is NO episode
+carry `transcript=` + `stderr_excerpt=` + `api_error_excerpt=` forensics —
+the refusal excerpt is SIDECAR-ONLY, never in the marker/push). There is NO episode
 belt BY DESIGN — this is a stop lane, not a respawn lane; the downstream
 re-drive arms carry their own belts/caps, and the auth-outage guard
 suppresses the re-dispatch side (the infra-sweep/crash-arm spawn gates)

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -1203,11 +1203,13 @@ STALE_BLOCKED_PROGRESS_FRESH_S_DEFAULT = 2 * 3600
 # (assistant OR api-error) >= 30 min after `spawned_at` — the
 # die-BEFORE-turn-1 class (#1251-#1256: 9-row / ~11 KB transcripts frozen
 # ~7 s post-spawn, invisible to every lane until the 12h stale-registration
-# pass). The pass STOPS the session (auto registrations only) and leaves
-# re-drive to the existing arms. Same staleness-filter contract as every
-# other watcher-posted sentinel (anti-liveness is load-bearing: an
-# unsentineled note would refresh `_latest_progress_ts` and mask the
-# orphan/stalled staleness clocks).
+# pass) — OR whose 256 KB tail segments to >= 1 completed turn, ALL failed —
+# the #1287 boot-turn-refusal class (#1277: the boot turn ran and was
+# refusal-killed before the tick cron was armed). The pass STOPS the session
+# (auto registrations only) and leaves re-drive to the existing arms. Same
+# staleness-filter contract as every other watcher-posted sentinel
+# (anti-liveness is load-bearing: an unsentineled note would refresh
+# `_latest_progress_ts` and mask the orphan/stalled staleness clocks).
 _BOOT_DEATH_STOP_NOTE_SENTINEL = "[autonomous_session_watch:boot-death-stop]"
 
 # Substring stamped into the one-time "daily boot-death stop cap exhausted"
@@ -1233,7 +1235,11 @@ BOOT_DEATH_STATE_PREFIX = "boot-death-"
 # - quiet = one watcher cron interval (the in-flight-first-turn guard).
 # - tail cap == the #1104 production wedge window (256 KB): a boot-death
 #   transcript is ~11 KB (23x headroom); a LARGER transcript cannot be a
-#   boot-death, so the probe short-circuits to keep without the read.
+#   ZERO-RESPONSE boot-death, so the whole-file probe short-circuits without
+#   the read. #1287 (arm 2, boot-refusal) keeps every constant unchanged;
+#   this same cap now ALSO sizes the arm-2 seek-tail read
+#   (`_transcript_tail_rows`), deliberately equal to the #1104/#1209 wedge
+#   window so both lanes see the same evidence horizon.
 # - stop cap 3/day = #1241 parity (TICK_WEDGE_RESPAWNS_PER_DAY).
 BOOT_DEATH_WINDOW_S = 30 * 60
 BOOT_DEATH_QUIET_S = 10 * 60
@@ -2523,28 +2529,45 @@ def decide_boot_death(
     sid_alive: bool,
     entry_age_s: float | None,
     response_row_seen: bool | None,
+    all_turns_failed: bool | None,
     transcript_idle_s: float | None,
     window_s: float,
     quiet_s: float,
     stops_today: int,
     stops_per_day: int,
 ) -> str:
-    """Pure per-entry decision for the boot-death lane (#1267). Returns
-    ``"stop"`` | ``"cap-alert"`` | ``"keep"``.
+    """Pure per-entry decision for the boot-death lane (#1267 arm 1 +
+    #1287 arm 2). Returns ``"stop"`` | ``"cap-alert"`` | ``"keep"``.
 
-    Fires ONLY on: live sid + registration older than ``window_s`` + a
-    fully-read transcript with ZERO response rows (assistant OR api-error —
-    an api-error row means the session took a FAILED turn, which is the
-    #1209 family's property, not a boot-death) + transcript quiet >=
-    ``quiet_s`` (the in-flight-first-turn guard). Every unresolvable input
-    fails toward keep (the 12h stale-registration pass stays the backstop):
+    Fires ONLY on: live sid + registration older than ``window_s`` + ONE of
 
-    - ``entry_age_s is None`` — missing / zero / non-numeric ``spawned_at``;
-      a FUTURE-dated ``spawned_at`` yields a negative age -> keep too.
-    - ``response_row_seen is None`` — transcript unresolvable OR larger than
-      the tail cap (a >256 KB transcript cannot be a boot-death).
-    - ``transcript_idle_s is None`` — :func:`_transcript_idle_age_s` could
-      not resolve the transcript mtime.
+    - ARM 1 (zero-response, #1267/#1251): ``response_row_seen is False`` —
+      the whole-file read found NO response rows (assistant OR api-error);
+      the session died before turn 1.
+    - ARM 2 (boot-refusal, #1287/#1277): ``all_turns_failed is True`` —
+      the 256 KB TAIL read segmented (via :func:`_segment_wake_turns`,
+      #1127) to >= 1 completed turn with EVERY completed turn failed (last
+      response row api-error). The boot turn executed and every turn
+      failed; at a PARK status the #1209/#1127 wedge lanes are structurally
+      ineligible (``respawn_eligible = in_active and ...``), so this lane
+      owns the shape. A single visible ok turn anywhere in the tail =>
+      not boot-dead (the #1104 single-refusal guard).
+
+    + transcript quiet >= ``quiet_s`` (the in-flight-first-turn / mid-retry
+    guard: a live retrying session keeps appending rows, so mtime stays
+    fresh). Silence-anchor divergence from #1209 (deliberate — #1267
+    parity): arm 2 gates on the lane's mtime quiet (10 min), NOT #1209's
+    newest-parseable-row-ts 20-min silence anchor; the two coincide for
+    dead append-only transcripts (mtime tracks the last row), so do not
+    "fix" it in either direction. Every unresolvable input fails toward
+    keep (the 12h stale-registration pass stays the backstop):
+    ``entry_age_s`` None or negative (missing / zero / non-numeric /
+    FUTURE-dated ``spawned_at``); ``response_row_seen`` None (whole-file
+    read unresolvable OR over the cap — which does NOT veto arm 2: the
+    tail read works at any size); ``all_turns_failed`` None (tail
+    unresolvable) or False (zero completed turns — swallows stay the
+    dequeue-run's property — or an ok turn); ``transcript_idle_s`` None
+    (:func:`_transcript_idle_age_s` could not resolve the mtime).
 
     At the daily stop cap the lane stops STOPPING and returns
     ``"cap-alert"`` (the caller dedupes to one loud alert per UTC day);
@@ -2555,7 +2578,9 @@ def decide_boot_death(
         return "keep"  # dead sid: crash-recovery / sweep-grace property
     if entry_age_s is None or entry_age_s < window_s:
         return "keep"
-    if response_row_seen is None or response_row_seen:
+    boot_dead = response_row_seen is False  # arm 1 (#1267)
+    boot_refused = all_turns_failed is True  # arm 2 (#1287)
+    if not (boot_dead or boot_refused):
         return "keep"
     if transcript_idle_s is None or transcript_idle_s < quiet_s:
         return "keep"
@@ -9543,11 +9568,12 @@ def _transcript_tail_rows(pid: int, max_bytes: int = 65536) -> list[dict] | None
 def _boot_death_transcript_rows(
     pid: int, max_bytes: int = BOOT_DEATH_TAIL_BYTES
 ) -> tuple[list[dict] | None, str | None, int | None]:
-    """Whole-transcript rows for the boot-death lane (#1267), as
+    """Whole-transcript rows for the boot-death lane's ARM 1 (#1267), as
     ``(rows, transcript_path, size_bytes)`` — ``rows`` is ``None`` when the
     transcript is unresolvable OR larger than ``max_bytes`` (a >256 KB
-    transcript cannot be a boot-death — treat as not-eligible, fail toward
-    keep). ``transcript_path`` / ``size_bytes`` are best-effort forensics for
+    transcript cannot be a ZERO-RESPONSE boot-death — arm 1 treats it as
+    not-eligible; the #1287 arm-2 seek-tail read handles larger files).
+    ``transcript_path`` / ``size_bytes`` are best-effort forensics for
     the sidecar row (``None`` when unresolvable).
 
     Unlike :func:`_transcript_tail_rows`, the WHOLE-file guarantee is
@@ -18278,18 +18304,39 @@ def idle_unmapped_pass(
 
 # ─── boot-death pass (#1267) ──────────────────────────────────────────────────
 #
-# The die-BEFORE-turn-1 lane: a freshly `--auto`-dispatched session whose
-# resolved Claude transcript contains ZERO response rows (`_classify_wedge_row`
-# not in {assistant, api-error}) >= 30 min after `spawned_at`, with the
-# transcript quiet >= 10 min, a LIVE sid, auto registrations only. Incident
-# #1251-#1256: 7 live-captured boot-death transcripts, all 9 rows / 11,368 B,
-# frozen ~7 s post-spawn (the session died during `/issue` skill load — one
-# prompt row carries a `<local-command-stderr>` diagnostic); every existing
-# lane is structurally blind (no self-report => the stalled detector skips;
-# the sid is LIVE + status `proposed` => crash-recovery PARKs; the inner
-# Claude is alive-idle => zombie pass; issue-MAPPED => idle-unmapped), so the
-# only recovery was the 12h stale-registration unregister — a silent
-# dispatch -> boot-death -> 12h -> re-dispatch loop (~12.5h/cycle).
+# The die-AT-OR-BEFORE-turn-1 lane, TWO ARMS:
+#
+# - ARM 1 (zero-response, #1267): a freshly `--auto`-dispatched session whose
+#   resolved Claude transcript contains ZERO response rows
+#   (`_classify_wedge_row` not in {assistant, api-error}) >= 30 min after
+#   `spawned_at`. Incident #1251-#1256: 7 live-captured boot-death
+#   transcripts, all 9 rows / 11,368 B, frozen ~7 s post-spawn (the session
+#   died during `/issue` skill load — one prompt row carries a
+#   `<local-command-stderr>` diagnostic).
+# - ARM 2 (boot-refusal, #1287): the transcript's 256 KB TAIL
+#   (`_transcript_tail_rows`) segments via `_segment_wake_turns` (#1127) to
+#   >= 1 completed turn with EVERY completed turn failed (last response row
+#   api-error) — the refusal-killed boot turn. Incident #1277: an 826 KB
+#   transcript whose boot turn took real assistant actions for ~74 s, then
+#   died on a refusal BEFORE the /issue tick cron was armed; arm 1 keeps
+#   twice over (assistant rows exist; size over the whole-file cap), and at
+#   a PARK status the #1209/#1127 wedge lanes are structurally ineligible
+#   (`respawn_eligible = in_active and ...`), so this lane owns the shape.
+#
+# Both arms: transcript quiet >= 10 min, a LIVE sid, auto registrations
+# only. Every existing lane is structurally blind (no self-report => the
+# stalled detector skips; the sid is LIVE + status `proposed` =>
+# crash-recovery PARKs; the inner Claude is alive-idle => zombie pass;
+# issue-MAPPED => idle-unmapped), so the only recovery was the 12h
+# stale-registration unregister — a silent dispatch -> boot-death -> 12h ->
+# re-dispatch loop (~12.5h/cycle).
+#
+# BY-DESIGN misses (fall back to the 12h sweep — a future incident in either
+# shape reads as designed-miss, not regression): (a) a refusal death whose
+# transcript ends in a trailing non-api-error assistant row (the last
+# completed turn reads `ok` => arm 2 keeps); (b) a >256 KB ZERO-RESPONSE
+# transcript (arm 1's whole-file guarantee cannot be established, and arm 2
+# sees no completed turn to fail).
 #
 # Action: STOP the session via the existing `_stop_session` — NO unregister,
 # NO direct spawn. Post-stop re-drive is fully owned by existing arms:
@@ -18444,6 +18491,41 @@ def _boot_death_stderr_excerpt(rows: list[dict], cap: int = 200) -> str | None:
     return None
 
 
+def _boot_death_api_error_excerpt(rows: list[dict], cap: int = 200) -> str | None:
+    """Best-effort forensic (#1287 arm 2): the LAST ``"api-error"``-classified
+    row's message text — the refusal / API-error body that killed the boot
+    turn — whitespace-collapsed and bounded to ``cap`` chars. SIDECAR-ONLY by
+    design (refusal bodies are trigger-dense text; the excerpt never enters
+    the task marker or the Telegram push — #866/#1073/#1098 containment).
+    Returns ``None`` when no api-error row carries usable text. Pure
+    string-scanning, never raises on the dict shapes ``rows`` can hold — the
+    :func:`_boot_death_stderr_excerpt` defensive contract: a
+    present-but-non-str ``"text"`` value (``null``, an int) is skipped as
+    carrying no diagnostic text. The FIRING predicate never depends on this
+    helper — it is forensic only."""
+    for row in reversed(rows):
+        if _classify_wedge_row(row) != "api-error":
+            continue
+        msg = row.get("message")
+        content = msg.get("content") if isinstance(msg, dict) else None
+        texts: list[str] = []
+        if isinstance(content, str):
+            texts.append(content)
+        elif isinstance(content, list):
+            texts.extend(
+                b["text"]
+                for b in content
+                if isinstance(b, dict)
+                and b.get("type") == "text"
+                and isinstance(b.get("text"), str)
+            )
+        for text in texts:
+            excerpt = " ".join(text.split())
+            if excerpt:
+                return excerpt[:cap]
+    return None
+
+
 def _process_boot_death(path: Path, pids_by_sid: dict[str, int], now: float, dry_run: bool) -> None:
     """Evaluate ONE auto registration against the boot-death predicate and
     STOP its session when it verdicts ``"stop"`` (cap permitting). Every
@@ -18484,6 +18566,17 @@ def _process_boot_death(path: Path, pids_by_sid: dict[str, int], now: float, dry
         if rows is None
         else any(_classify_wedge_row(r) in ("assistant", "api-error") for r in rows)
     )
+    # ARM 2 (#1287): turn-segmented all-failed read over the 256 KB TAIL —
+    # works at ANY transcript size (#1277's transcript was 825,591 B, over
+    # arm 1's whole-file cap). Reuse the whole-file rows when they resolved
+    # (tail == whole file at <= cap; saves the second read); else seek-tail.
+    tail_rows = (
+        rows if rows is not None else _transcript_tail_rows(pid, max_bytes=BOOT_DEATH_TAIL_BYTES)
+    )
+    turns = None if tail_rows is None else _segment_wake_turns(tail_rows)
+    all_turns_failed = (
+        None if turns is None else bool(turns) and all(o == "failed" for o, _ts in turns)
+    )
     idle_s, _why = _transcript_idle_age_s(pid, now)
     state = _load_boot_death_state(issue)
     day_key = time.strftime("%Y-%m-%d", time.gmtime(now))  # the #1209/#1241 day-cap derivation
@@ -18493,6 +18586,7 @@ def _process_boot_death(path: Path, pids_by_sid: dict[str, int], now: float, dry
         sid_alive=True,
         entry_age_s=entry_age_s,
         response_row_seen=response_row_seen,
+        all_turns_failed=all_turns_failed,
         transcript_idle_s=idle_s,
         window_s=_boot_death_window_s(),
         quiet_s=BOOT_DEATH_QUIET_S,
@@ -18511,13 +18605,14 @@ def _process_boot_death(path: Path, pids_by_sid: dict[str, int], now: float, dry
             f"{_BOOT_DEATH_CAP_NOTE_SENTINEL} {stops_today} boot-death stops today hit the "
             f"daily cap ({cap}); leaving the dead registration in place (the 12h "
             f"stale-registration pass is the back-pressure); sessions for #{issue} are dying "
-            f"at skill load — investigate the dispatch path. sid={sid} task status={status}."
+            f"at or just after boot — skill-load death or refused boot turn — investigate "
+            f"the dispatch path. sid={sid} task status={status}."
         )
         print(f"  boot-death: issue #{issue} — {note}")
         _post_progress_marker(issue, note, dry_run, label="boot-death-cap-exhausted")
         _telegram_push(
             f"boot-death cap: #{issue} hit {stops_today} dead-boot stops today; "
-            f"sessions are dying at skill load — investigate the dispatch path.",
+            f"sessions are dying at or just after boot — investigate the dispatch path.",
             dry_run,
         )
         _append_boot_death_event(note, dry_run)
@@ -18531,13 +18626,27 @@ def _process_boot_death(path: Path, pids_by_sid: dict[str, int], now: float, dry
     state.update({"stop_day": day_key, "stops_today": stops_today + 1})
     _save_boot_death_state(issue, state, dry_run)
     stop_ok = _stop_session(sid, dry_run)
-    n_rows = len(rows) if rows is not None else 0
-    stderr_excerpt = _boot_death_stderr_excerpt(rows) if rows else None
+    # Arms are mutually exclusive (zero response rows => zero completed
+    # turns), so arm 1 owning the tag when it fired is unambiguous.
+    shape = "zero-response" if response_row_seen is False else "boot-refusal"
+    if shape == "zero-response":
+        evidence = (
+            f"transcript rows={len(rows)} size={size}B with ZERO response rows "
+            f"(assistant/api-error)"
+        )
+    else:
+        n_tail = len(tail_rows) if tail_rows is not None else 0
+        n_turns = len(turns) if turns else 0
+        api_error_rows = sum(1 for r in (tail_rows or []) if _classify_wedge_row(r) == "api-error")
+        evidence = (
+            f"256KB-tail rows={n_tail} (file size={size}B): {n_turns} completed "
+            f"turn(s), ALL failed ({api_error_rows} api-error row(s) — "
+            f"refusal-killed boot turn, #1287)"
+        )
     note = (
         f"{_BOOT_DEATH_STOP_NOTE_SENTINEL} stopped boot-dead session sid={sid}: "
         f"registration age {entry_age_s / 60:.0f}m >= {_boot_death_window_s() / 60:.0f}m, "
-        f"transcript rows={n_rows} size={size}B with ZERO response rows "
-        f"(assistant/api-error), idle {(idle_s or 0) / 60:.0f}m; stop_ok={stop_ok}; "
+        f"shape={shape}, {evidence}, idle {(idle_s or 0) / 60:.0f}m; stop_ok={stop_ok}; "
         f"task status={status}; stop {stops_today + 1}/{cap} today; registration kept: "
         f"crash-recovery re-drives an ACTIVE task (~20 min); the proposed-infra sweep's "
         f"stale-dead-registration grace re-dispatches a `proposed` task (~30-60 min)."
@@ -18545,12 +18654,19 @@ def _process_boot_death(path: Path, pids_by_sid: dict[str, int], now: float, dry
     print(f"  boot-death: issue #{issue} — {note}")
     _post_progress_marker(issue, note, dry_run, label="boot-death-stop")
     _telegram_push(
-        f"boot-death: stopped dead-boot session for #{issue} "
-        f"(zero response rows at {entry_age_s / 60:.0f}m; stop {stops_today + 1}/{cap} today)",
+        f"boot-death: stopped dead-boot session for #{issue} (shape={shape} at "
+        f"{entry_age_s / 60:.0f}m; stop {stops_today + 1}/{cap} today)",
         dry_run,
     )
+    # The refusal excerpt is SIDECAR-ONLY by design: refusal bodies are
+    # trigger-dense text, so it never enters the task marker or the push
+    # (#866/#1073/#1098 containment).
+    stderr_excerpt = _boot_death_stderr_excerpt(tail_rows) if tail_rows else None
+    api_error_excerpt = _boot_death_api_error_excerpt(tail_rows) if tail_rows else None
     _append_boot_death_event(
-        f"{note} transcript={transcript} stderr_excerpt={stderr_excerpt or 'none'}", dry_run
+        f"{note} transcript={transcript} stderr_excerpt={stderr_excerpt or 'none'} "
+        f"api_error_excerpt={api_error_excerpt or 'none'}",
+        dry_run,
     )
 
 
@@ -18564,8 +18680,8 @@ def boot_death_pass(
     false "live" read must not stop anything). Iterates ``issue-*.json``
     ONLY — ``manual-issue-*.json`` is EXCLUDED by design (a user-driven
     session is never auto-stopped, the #505 posture; auto registrations all
-    carry an initial prompt, so zero response rows at 30 min is unambiguous
-    death)."""
+    carry an initial prompt, so zero response rows — or an all-failed
+    completed-turn tail (#1287) — at 30 min is unambiguous death)."""
     now = now if now is not None else time.time()
     if not _boot_death_pass_enabled():
         print("boot-death: disabled via EPM_DISABLE_BOOT_DEATH_PASS; skipping")

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -16319,6 +16319,74 @@ def _boot_death_rows_fixture(*, with_stderr=True, extra_row=None):
     return rows
 
 
+# Deliberately SHORT and mild (one line): the fixture needs a refusal-SHAPED
+# api-error text for the sidecar-containment asserts, never real refusal prose.
+_BOOT_REFUSAL_TEXT = "API Error: 400 request was blocked by our usage policy"
+
+
+def _boot_refusal_rows_fixture(
+    *, trailing_ok=False, with_prompt_evidence=True, leading_ok_turn=False
+):
+    """Reduced replica of the REAL #1277 boot-refusal transcript's
+    classification sequence (#1287 plan §9 A2, verified at plan time: 40
+    rows — 14 assistant / 1 api-error / 2 prompt / 1 dequeue / 22 other,
+    sequence ``o d o o o p p o…a…a o`` with the trailing response row an
+    api-error): a dequeue + prompt delivery burst (omitted under
+    ``with_prompt_evidence=False`` — the oversize-tail shape where the
+    prompt rows are truncated out and the #1127 leading-implicit-turn rule
+    carries segmentation), interleaved ``other`` rows, 3 real assistant
+    rows (the boot turn took real actions), and a trailing api-error row
+    (row shape mirrors the live-captured #1074 api-error rows).
+    ``trailing_ok=True`` appends a final plain assistant row instead — the
+    recovered shape (last turn ``ok``). ``leading_ok_turn=True`` PREPENDS a
+    completed OK delivery burst ([dequeue, prompt, assistant]) before the
+    refusal burst — the two-burst ``[ok, failed]`` tail (the
+    reduction-discrimination shape, the plan's test 9)."""
+    rows: list[dict] = []
+    if leading_ok_turn:
+        rows += [
+            {"type": "queue-operation", "operation": "dequeue"},
+            {"type": "user", "message": {"content": "earlier prompt (ok turn)"}},
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "earlier ok delivery"}]},
+            },
+        ]
+    if with_prompt_evidence:
+        rows += [
+            {"type": "summary", "summary": "session meta"},  # other
+            {"type": "queue-operation", "operation": "dequeue"},  # delivery burst
+            {"type": "user", "message": {"content": "/issue 1277"}},  # prompt
+            {"type": "user", "message": {"content": "second prompt"}},  # prompt (same burst)
+        ]
+    else:
+        # Oversize-tail shape: the prompt-evidence rows are truncated out of
+        # the 256 KB tail; the leading response rows form one implicit turn.
+        rows += [{"type": "summary", "summary": "session meta"}]  # other
+    rows += [
+        {"type": "attachment", "attachment": {"kind": "skill"}},  # other
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "working"}]}},
+        {"type": "user", "message": {"content": [{"type": "tool_result", "content": "ok"}]}},
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "more work"}]}},
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "heartbeat"}]}},
+        {"type": "attachment", "attachment": {"kind": "file"}},  # other
+    ]
+    if trailing_ok:
+        rows.append(
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "recovered"}]}}
+        )
+    else:
+        rows.append(
+            {
+                "type": "assistant",
+                "isApiErrorMessage": True,
+                "message": {"content": [{"type": "text", "text": _BOOT_REFUSAL_TEXT}]},
+            }
+        )
+    rows.append({"type": "queue-operation", "operation": "enqueue"})  # trailing other (`…a o`)
+    return rows
+
+
 def _write_boot_death_entry(reg_dir, issue, session_id, spawned_at, *, manual=False):
     """Registration entry with an EXPLICIT spawned_at (the lane's age gate
     keys on it; `_write_autonomous_entry` pins spawned_at=now, too fresh)."""
@@ -16339,9 +16407,16 @@ def _write_boot_death_entry(reg_dir, issue, session_id, spawned_at, *, manual=Fa
     )
 
 
-def _boot_death_env(monkeypatch, asw, *, rows, idle_s=30 * 60, status="proposed", size=11368):
+def _boot_death_env(
+    monkeypatch, asw, *, rows, tail_rows="mirror", idle_s=30 * 60, status="proposed", size=11368
+):
     """Common signal monkeypatching for the boot-death pass tests. Returns
-    the telegram-push recorder list."""
+    the telegram-push recorder list. ``tail_rows`` stubs the arm-2 (#1287)
+    ``_transcript_tail_rows`` seek-tail read; the default mirrors ``rows``
+    (tail == whole file at <= cap), preserving every pre-#1287 call site's
+    behavior."""
+    if tail_rows == "mirror":
+        tail_rows = rows
     monkeypatch.setattr(asw, "_provision_in_flight_reason", lambda issue, now: None)
     monkeypatch.setattr(asw, "_worktree_recent_activity", lambda *_a, **_k: False)
     monkeypatch.setattr(asw, "_task_status", lambda issue: status)
@@ -16351,6 +16426,7 @@ def _boot_death_env(monkeypatch, asw, *, rows, idle_s=30 * 60, status="proposed"
         "_boot_death_transcript_rows",
         lambda pid, max_bytes=None: (rows, "/fake/transcripts/boot-death.jsonl", size),
     )
+    monkeypatch.setattr(asw, "_transcript_tail_rows", lambda pid, max_bytes=None: tail_rows)
     pushes: list[tuple] = []
     monkeypatch.setattr(
         asw, "_telegram_push", lambda msg, dry_run: bool(pushes.append((msg, dry_run)))
@@ -16360,7 +16436,8 @@ def _boot_death_env(monkeypatch, asw, *, rows, idle_s=30 * 60, status="proposed"
 
 def test_decide_boot_death_fires_on_incident_shape():
     # Plan §6 acceptance 1: live sid + age 31 min + zero response rows +
-    # idle 30 min + 0 stops today -> "stop".
+    # idle 30 min + 0 stops today -> "stop". (Zero response rows => zero
+    # completed turns => arm 2 reads False; the arms are mutually exclusive.)
     import autonomous_session_watch as asw
 
     assert (
@@ -16368,6 +16445,7 @@ def test_decide_boot_death_fires_on_incident_shape():
             sid_alive=True,
             entry_age_s=31 * 60,
             response_row_seen=False,
+            all_turns_failed=False,
             transcript_idle_s=30 * 60,
             window_s=asw.BOOT_DEATH_WINDOW_S,
             quiet_s=asw.BOOT_DEATH_QUIET_S,
@@ -16390,6 +16468,7 @@ def test_decide_boot_death_keeps_young_entry(entry_age_s):
             sid_alive=True,
             entry_age_s=entry_age_s,
             response_row_seen=False,
+            all_turns_failed=False,
             transcript_idle_s=30 * 60,
             window_s=asw.BOOT_DEATH_WINDOW_S,
             quiet_s=asw.BOOT_DEATH_QUIET_S,
@@ -16402,9 +16481,10 @@ def test_decide_boot_death_keeps_young_entry(entry_age_s):
 
 def test_decide_boot_death_keeps_on_response_row():
     # ANY response row (assistant — the healthy #1251 re-dispatch shape — OR
-    # api-error, the #1209 family's property) means NOT a boot-death; the
-    # row-level classification of both variants is pinned in
-    # test_boot_death_rows_incident_fixture_zero_response.
+    # api-error) defeats ARM 1; the all-completed-turns-failed shape is ARM
+    # 2's property (#1287, pinned by test_decide_boot_death_fires_on_
+    # all_turns_failed + the boot-refusal pass tests). With arm 2 reading
+    # False (an ok turn / zero completed turns), a response row keeps.
     import autonomous_session_watch as asw
 
     assert (
@@ -16412,6 +16492,7 @@ def test_decide_boot_death_keeps_on_response_row():
             sid_alive=True,
             entry_age_s=31 * 60,
             response_row_seen=True,
+            all_turns_failed=False,
             transcript_idle_s=30 * 60,
             window_s=asw.BOOT_DEATH_WINDOW_S,
             quiet_s=asw.BOOT_DEATH_QUIET_S,
@@ -16423,8 +16504,11 @@ def test_decide_boot_death_keeps_on_response_row():
 
 
 def test_decide_boot_death_keeps_on_unresolvable_transcript():
-    # response_row_seen=None: transcript unresolvable OR over the tail cap —
-    # fail toward keep (the 12h stale-registration pass stays the backstop).
+    # response_row_seen=None + all_turns_failed=None: BOTH reads
+    # unresolvable — fail toward keep (the 12h stale-registration pass
+    # stays the backstop). The over-the-cap case where the TAIL still
+    # resolves is arm 2's stop (test_decide_boot_death_fires_on_all_turns_
+    # failed pins response_row_seen=None + all_turns_failed=True -> stop).
     import autonomous_session_watch as asw
 
     assert (
@@ -16432,6 +16516,7 @@ def test_decide_boot_death_keeps_on_unresolvable_transcript():
             sid_alive=True,
             entry_age_s=31 * 60,
             response_row_seen=None,
+            all_turns_failed=None,
             transcript_idle_s=30 * 60,
             window_s=asw.BOOT_DEATH_WINDOW_S,
             quiet_s=asw.BOOT_DEATH_QUIET_S,
@@ -16454,6 +16539,7 @@ def test_decide_boot_death_keeps_within_quiet_window(transcript_idle_s):
             sid_alive=True,
             entry_age_s=31 * 60,
             response_row_seen=False,
+            all_turns_failed=False,
             transcript_idle_s=transcript_idle_s,
             window_s=asw.BOOT_DEATH_WINDOW_S,
             quiet_s=asw.BOOT_DEATH_QUIET_S,
@@ -16473,6 +16559,7 @@ def test_decide_boot_death_keeps_dead_sid():
             sid_alive=False,
             entry_age_s=31 * 60,
             response_row_seen=False,
+            all_turns_failed=False,
             transcript_idle_s=30 * 60,
             window_s=asw.BOOT_DEATH_WINDOW_S,
             quiet_s=asw.BOOT_DEATH_QUIET_S,
@@ -16499,6 +16586,7 @@ def test_decide_boot_death_cap_exhausted_returns_cap_alert(stops_today, expected
             sid_alive=True,
             entry_age_s=31 * 60,
             response_row_seen=False,
+            all_turns_failed=False,
             transcript_idle_s=30 * 60,
             window_s=asw.BOOT_DEATH_WINDOW_S,
             quiet_s=asw.BOOT_DEATH_QUIET_S,
@@ -16589,6 +16677,9 @@ def test_boot_death_rows_incident_fixture_zero_response():
         extra_row={"type": "assistant", "isApiErrorMessage": True, "message": {}}
     )
     assert any(asw._classify_wedge_row(r) in ("assistant", "api-error") for r in refused)
+    # #1287 arm mutual exclusivity: zero response rows => zero completed
+    # turns => arm 2 reads False on exactly the shape arm 1 owns.
+    assert asw._segment_wake_turns(_boot_death_rows_fixture()) == []
 
 
 def test_boot_death_stderr_excerpt_bounded():
@@ -16662,6 +16753,7 @@ def test_boot_death_pass_stops_and_posts_marker(isolated_registry, monkeypatch):
     assert [(i, la) for i, la, _n, _d in markers] == [(990, "boot-death-stop")]
     note = markers[0][2]
     assert asw._BOOT_DEATH_STOP_NOTE_SENTINEL in note
+    assert "shape=zero-response" in note  # #1287 shape tag: arm 1 owns this fixture
     assert "status=proposed" in note and "registration kept" in note
     assert len(pushes) == 1
     assert (isolated_registry / "issue-990.json").exists()  # KEPT, never unlinked
@@ -16878,6 +16970,295 @@ def test_boot_death_pass_fresh_worktree_keeps(isolated_registry, monkeypatch):
         now=_BOOT_DEATH_NOW,
     )
     assert stops == []
+
+
+# ── #1287 boot-death lane arm 2 (boot-refusal) ────────────────────────────────
+# The #1277 shape: the boot turn RAN (assistant rows exist) then died on a
+# refusal, on an 826 KB transcript over arm 1's whole-file cap. Arm 2 reads
+# the 256 KB tail via _transcript_tail_rows + _segment_wake_turns and fires
+# on >= 1 completed turn with EVERY completed turn failed.
+
+
+def test_boot_refusal_fixture_segments_to_one_failed_turn():
+    # Pure (#1287 plan test 1): the fixture segments to exactly ONE completed
+    # turn, outcome "failed", for BOTH with_prompt_evidence=True AND False
+    # (the oversize-tail shape — prompt rows truncated out, the #1127
+    # leading-implicit-turn rule carries it — the real #1277 tail path);
+    # trailing_ok=True flips the last (only) turn to "ok".
+    import autonomous_session_watch as asw
+
+    for wpe in (True, False):
+        turns = asw._segment_wake_turns(_boot_refusal_rows_fixture(with_prompt_evidence=wpe))
+        assert [o for o, _ts in turns] == ["failed"], f"with_prompt_evidence={wpe}: {turns}"
+    turns_ok = asw._segment_wake_turns(_boot_refusal_rows_fixture(trailing_ok=True))
+    assert [o for o, _ts in turns_ok] == ["ok"]
+
+
+@pytest.mark.parametrize(
+    ("response_row_seen", "all_turns_failed", "expected"),
+    [
+        (True, True, "stop"),  # arm 2 fires past arm 1's response-row keep
+        (True, None, "keep"),  # tail unresolvable -> fail toward keep
+        (True, False, "keep"),  # an ok turn / zero completed turns
+        (None, True, "stop"),  # oversize: arm 1's unresolvable whole-file read does NOT veto arm 2
+    ],
+)
+def test_decide_boot_death_fires_on_all_turns_failed(response_row_seen, all_turns_failed, expected):
+    # Pure (#1287 plan test 2): the arm-2 predicate at age 31 min / idle
+    # 30 min / 0 stops today.
+    import autonomous_session_watch as asw
+
+    assert (
+        asw.decide_boot_death(
+            sid_alive=True,
+            entry_age_s=31 * 60,
+            response_row_seen=response_row_seen,
+            all_turns_failed=all_turns_failed,
+            transcript_idle_s=30 * 60,
+            window_s=asw.BOOT_DEATH_WINDOW_S,
+            quiet_s=asw.BOOT_DEATH_QUIET_S,
+            stops_today=0,
+            stops_per_day=3,
+        )
+        == expected
+    )
+
+
+def test_boot_death_pass_fires_on_boot_refusal_oversize_transcript(isolated_registry, monkeypatch):
+    # THE #1277 REGRESSION TEST (#1287 plan test 3): an oversize transcript
+    # (rows=None at 825,591 B — arm 1 unresolvable) whose 256 KB tail
+    # segments to one implicit completed turn, failed. The pass stops the
+    # sid, tags the note shape=boot-refusal with the ALL-failed evidence,
+    # bumps the day counter, and confines the refusal excerpt to the
+    # SIDECAR (never the marker note, never the push).
+    import json
+
+    import autonomous_session_watch as asw
+
+    stops: list[tuple] = []
+    monkeypatch.setattr(
+        asw, "_stop_session", lambda sid, dry_run: bool(stops.append((sid, dry_run))) or True
+    )
+    markers: list[tuple] = []
+    monkeypatch.setattr(
+        asw,
+        "_post_progress_marker",
+        lambda issue, note, dry_run, label: markers.append((issue, label, note)),
+    )
+    tail = _boot_refusal_rows_fixture(with_prompt_evidence=False)
+    pushes = _boot_death_env(monkeypatch, asw, rows=None, tail_rows=tail, size=825_591)
+    _write_boot_death_entry(isolated_registry, 992, "sess-992", _BOOT_DEATH_NOW - 31 * 60)
+    asw.boot_death_pass(
+        dry_run=False,
+        children=[{"happySessionId": "sess-992", "pid": 4244}],
+        now=_BOOT_DEATH_NOW,
+    )
+
+    assert stops == [("sess-992", False)]
+    assert [(i, la) for i, la, _n in markers] == [(992, "boot-death-stop")]
+    note = markers[0][2]
+    assert asw._BOOT_DEATH_STOP_NOTE_SENTINEL in note
+    assert "shape=boot-refusal" in note
+    assert "ALL failed" in note and "1 api-error row(s)" in note
+    assert "task status=proposed" in note  # the real PARK-status shape recorded
+    assert len(pushes) == 1 and "shape=boot-refusal" in pushes[0][0]
+    # Sidecar-only containment: the refusal text reaches the sidecar's
+    # api_error_excerpt= field and NOTHING else.
+    assert _BOOT_REFUSAL_TEXT not in note
+    assert _BOOT_REFUSAL_TEXT not in pushes[0][0]
+    state = json.loads((isolated_registry / "boot-death-992.json").read_text())
+    assert state["stops_today"] == 1
+    events = (isolated_registry / "boot-death-events.jsonl").read_text().splitlines()
+    assert len(events) == 1
+    row = json.loads(events[0])
+    assert f"api_error_excerpt={_BOOT_REFUSAL_TEXT[:20]}" in row["note"]
+    assert (isolated_registry / "issue-992.json").exists()  # registration KEPT
+
+
+def test_boot_death_pass_fires_on_boot_refusal_small_transcript(isolated_registry, monkeypatch):
+    # Whole-file variant (#1287 plan test 4): at <= cap the whole-file rows
+    # RESOLVE (arm 1 keeps: response_row_seen=True) and arm 2 fires on the
+    # SAME rows — tail_rows is stubbed to None here, so a fire PROVES the
+    # caller reused the resolved whole-file rows instead of the second read.
+    import autonomous_session_watch as asw
+
+    stops: list = []
+    monkeypatch.setattr(asw, "_stop_session", lambda sid, dry_run: bool(stops.append(sid)) or True)
+    markers: list[tuple] = []
+    monkeypatch.setattr(
+        asw,
+        "_post_progress_marker",
+        lambda issue, note, dry_run, label: markers.append((label, note)),
+    )
+    rows = _boot_refusal_rows_fixture()
+    _boot_death_env(monkeypatch, asw, rows=rows, tail_rows=None)
+    _write_boot_death_entry(isolated_registry, 992, "sess-992", _BOOT_DEATH_NOW - 31 * 60)
+    asw.boot_death_pass(
+        dry_run=False,
+        children=[{"happySessionId": "sess-992", "pid": 4244}],
+        now=_BOOT_DEATH_NOW,
+    )
+    assert stops == ["sess-992"]
+    assert [la for la, _n in markers] == ["boot-death-stop"]
+    assert "shape=boot-refusal" in markers[0][1]
+
+
+@pytest.mark.parametrize("age_s", [31 * 60, 7 * 24 * 3600])
+@pytest.mark.parametrize("shape", ["trailing_ok", "assistant_only"])
+def test_boot_death_pass_keeps_on_trailing_ok_turn(isolated_registry, monkeypatch, shape, age_s):
+    # Must-NOT-fire (#1287 plan test 5): (a) the recovered shape — the tail's
+    # last completed turn is "ok" (trailing_ok fixture); (b) plain
+    # assistant-row-only rows (one implicit ok turn). Parametrized over an
+    # OLD entry age (7 days) too: arm 2 makes the lane reachable at ANY age,
+    # so the healthy-long-lived-session keep is pinned, not only young ones.
+    import autonomous_session_watch as asw
+
+    stops: list = []
+    monkeypatch.setattr(asw, "_stop_session", lambda sid, dry_run: bool(stops.append(sid)))
+    markers: list = []
+    monkeypatch.setattr(
+        asw, "_post_progress_marker", lambda issue, note, dry_run, label: markers.append(label)
+    )
+    if shape == "trailing_ok":
+        rows = _boot_refusal_rows_fixture(trailing_ok=True)
+    else:
+        rows = [
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": f"t{i}"}]}}
+            for i in range(3)
+        ]
+    _boot_death_env(monkeypatch, asw, rows=rows)
+    _write_boot_death_entry(isolated_registry, 993, "sess-993", _BOOT_DEATH_NOW - age_s)
+    asw.boot_death_pass(
+        dry_run=False,
+        children=[{"happySessionId": "sess-993", "pid": 4245}],
+        now=_BOOT_DEATH_NOW,
+    )
+    assert stops == [] and markers == []
+    assert not (isolated_registry / "boot-death-993.json").exists()  # no state write
+    assert not (isolated_registry / "boot-death-events.jsonl").exists()  # no sidecar
+
+
+def test_boot_death_pass_refusal_keeps_within_quiet_window(isolated_registry, monkeypatch):
+    # #1287 plan test 6: the mtime-quiet guard is wired for arm 2 — a
+    # refusal-shaped tail with a FRESH transcript (idle 5 min < 10 min quiet)
+    # keeps: a live retrying session keeps appending rows.
+    import autonomous_session_watch as asw
+
+    stops: list = []
+    monkeypatch.setattr(asw, "_stop_session", lambda sid, dry_run: bool(stops.append(sid)))
+    markers: list = []
+    monkeypatch.setattr(
+        asw, "_post_progress_marker", lambda issue, note, dry_run, label: markers.append(label)
+    )
+    _boot_death_env(monkeypatch, asw, rows=_boot_refusal_rows_fixture(), idle_s=5 * 60)
+    _write_boot_death_entry(isolated_registry, 993, "sess-993", _BOOT_DEATH_NOW - 31 * 60)
+    asw.boot_death_pass(
+        dry_run=False,
+        children=[{"happySessionId": "sess-993", "pid": 4245}],
+        now=_BOOT_DEATH_NOW,
+    )
+    assert stops == [] and markers == []
+
+
+def test_boot_death_pass_keeps_when_both_arms_unresolvable(isolated_registry, monkeypatch):
+    # #1287 plan test 7: whole-file read unresolvable (rows=None) AND tail
+    # read unresolvable (tail_rows=None) -> keep; no state write, no marker.
+    import autonomous_session_watch as asw
+
+    stops: list = []
+    monkeypatch.setattr(asw, "_stop_session", lambda sid, dry_run: bool(stops.append(sid)))
+    markers: list = []
+    monkeypatch.setattr(
+        asw, "_post_progress_marker", lambda issue, note, dry_run, label: markers.append(label)
+    )
+    _boot_death_env(monkeypatch, asw, rows=None, tail_rows=None, size=None)
+    _write_boot_death_entry(isolated_registry, 993, "sess-993", _BOOT_DEATH_NOW - 31 * 60)
+    asw.boot_death_pass(
+        dry_run=False,
+        children=[{"happySessionId": "sess-993", "pid": 4245}],
+        now=_BOOT_DEATH_NOW,
+    )
+    assert stops == [] and markers == []
+    assert not (isolated_registry / "boot-death-993.json").exists()
+    assert not (isolated_registry / "boot-death-events.jsonl").exists()
+
+
+def test_boot_death_api_error_excerpt_bounded():
+    # #1287 plan test 8 — mirrors test_boot_death_stderr_excerpt_bounded for
+    # the arm-2 forensic helper: LAST api-error row wins when two exist;
+    # 200-char bound + whitespace collapse; None when no api-error rows / no
+    # usable text; present-but-non-str "text" skipped without raising;
+    # plain-str content handled.
+    import autonomous_session_watch as asw
+
+    excerpt = asw._boot_death_api_error_excerpt(_boot_refusal_rows_fixture())
+    assert excerpt == _BOOT_REFUSAL_TEXT
+    assert len(excerpt) <= 200 and "\n" not in excerpt
+    two = [
+        {
+            "type": "assistant",
+            "isApiErrorMessage": True,
+            "message": {"content": [{"type": "text", "text": "API Error: first"}]},
+        },
+        {
+            "type": "assistant",
+            "isApiErrorMessage": True,
+            "message": {"content": "API Error:   second\nline"},  # plain-str content
+        },
+    ]
+    assert asw._boot_death_api_error_excerpt(two) == "API Error: second line"
+    long_rows = [
+        {
+            "type": "assistant",
+            "isApiErrorMessage": True,
+            "message": {"content": "API  Error: " + "x " * 300},
+        },
+    ]
+    assert len(asw._boot_death_api_error_excerpt(long_rows)) == 200
+    # No api-error rows at all (the zero-response fixture) -> None.
+    assert asw._boot_death_api_error_excerpt(_boot_death_rows_fixture()) is None
+    nonstr_rows = [
+        {
+            "type": "assistant",
+            "isApiErrorMessage": True,
+            "message": {"content": [{"type": "text", "text": None}]},
+        },
+        {
+            "type": "assistant",
+            "isApiErrorMessage": True,
+            "message": {"content": [{"type": "text", "text": 42}]},
+        },
+    ]
+    assert asw._boot_death_api_error_excerpt(nonstr_rows) is None
+
+
+def test_boot_death_pass_keeps_on_leading_ok_turn_then_failed(isolated_registry, monkeypatch):
+    # #1287 plan test 9 — the reduction-discrimination must-not-fire (round-1
+    # Statistics Must-Fix): a two-burst [ok, failed] tail is the ONE
+    # configuration that distinguishes the correct all(outcome == "failed")
+    # reduction from the rejected any(failed) / last-turn-failed
+    # over-triggers (the #1104 single-refusal guard): an ok turn NOT last
+    # must keep.
+    import autonomous_session_watch as asw
+
+    stops: list = []
+    monkeypatch.setattr(asw, "_stop_session", lambda sid, dry_run: bool(stops.append(sid)))
+    markers: list = []
+    monkeypatch.setattr(
+        asw, "_post_progress_marker", lambda issue, note, dry_run, label: markers.append(label)
+    )
+    tail = _boot_refusal_rows_fixture(leading_ok_turn=True)
+    assert [o for o, _ts in asw._segment_wake_turns(tail)] == ["ok", "failed"]
+    _boot_death_env(monkeypatch, asw, rows=None, tail_rows=tail, size=825_591)
+    _write_boot_death_entry(isolated_registry, 994, "sess-994", _BOOT_DEATH_NOW - 31 * 60)
+    asw.boot_death_pass(
+        dry_run=False,
+        children=[{"happySessionId": "sess-994", "pid": 4246}],
+        now=_BOOT_DEATH_NOW,
+    )
+    assert stops == [] and markers == []
+    assert not (isolated_registry / "boot-death-994.json").exists()  # no state write
+    assert not (isolated_registry / "boot-death-events.jsonl").exists()  # no sidecar
 
 
 def test_boot_death_sentinels_in_watcher_note_sentinels():


### PR DESCRIPTION
Closes task #1287.

## Summary
- `decide_boot_death` becomes a two-arm predicate: arm 1 (zero-response, #1267) byte-equivalent; arm 2 (boot-refusal, NEW) fires when the 256 KB transcript tail segments to >=1 completed turn with EVERY completed turn failed (`_transcript_tail_rows` + `_segment_wake_turns`, call-only) — the #1277 boot-turn-refusal shape that previously took ~12.5 h to recover.
- Stop-only, shared 3/issue/UTC-day cap, fail-toward-keep on every unresolvable input; refusal forensics confined to the sidecar (never task markers / pushes).
- 9 new tests + fixture (incl. the #1277 oversize-transcript regression test and the [ok, failed] reduction-discrimination must-not-fire test); doc sync in `.claude/rules/background-automation.md`.

## Test plan
- [x] `pytest tests/test_autonomous_session_watch.py` (938 passed)
- [x] `pytest tests/test_autonomous_session_watch_wedge.py` (69 passed)
- [x] `pytest tests/test_auth_outage_guard.py` (32 passed)
- [x] Step 9c touched-scope gate: 3435 passed / 6 skipped; baseline compare new=[] stripped=[]
- [x] ruff check + format; workflow_lint PASS; `--boot-death-only --dry-run` smoke clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)