### PR TITLE
task #1292: v2 lens critics pin the canonical rubric heading (anchor-loss hardening)

### DIFF
--- a/.claude/agents/codex-efficiency-critic.md
+++ b/.claude/agents/codex-efficiency-critic.md
@@ -94,6 +94,16 @@ the vectorization triggers in `.claude/rules/vectorize-many-cell-fits.md` — in
 their SUBSTANCE (not the whole files) as the batch-vs-sync + batching bars. The
 composed content fills `{{lens_items}}` in Step 3.
 
+**No-span compose gate (#1292; incident #1265, compose-time form).** If the
+heading grep resolves NO span in `.claude/rules/critic-lens-reference.md` for
+`### Methodology lens` (items 10 / 13 / 16 only), STOP and return a BLOCKER line
+(`BLOCKER: canonical lens heading not found in critic-lens-reference.md —
+heading drift; fix the reference/spec citation before dispatch`) instead of a
+composed prompt — the orchestrator treats this as a twin no-show
+(single-Claude fallback per the existing ensemble contract). NEVER fill
+`{{lens_items}}` with an empty span, a paraphrase, or items reconstructed from
+memory: a silently-empty rubric composes a Codex critic with no binding items.
+
 ### Step 3: Compose the lens-specific prompt
 
 **Composer numeric-grounding rule (load-bearing — closes the #722 fabricated-numbers

--- a/.claude/agents/codex-methodology-baselines-critic.md
+++ b/.claude/agents/codex-methodology-baselines-critic.md
@@ -93,6 +93,17 @@ items 1-3 (fatal confound / simplest alternative). Read the "Output Format" CRIT
 REPORT schema from `.claude/agents/methodology-baselines-critic.md`. The items fill
 `{{lens_items}}` in Step 3.
 
+**No-span compose gate (#1292; incident #1265, compose-time form).** If the
+heading grep resolves NO span in `.claude/rules/critic-lens-reference.md` for
+EITHER `### Methodology lens` (copied minus items 10 / 13 / 16) OR
+`### Alternative Explanations lens` (items 1-3), STOP and return a BLOCKER line
+(`BLOCKER: canonical lens heading not found in critic-lens-reference.md —
+heading drift; fix the reference/spec citation before dispatch`) instead of a
+composed prompt — the orchestrator treats this as a twin no-show
+(single-Claude fallback per the existing ensemble contract). NEVER fill
+`{{lens_items}}` with an empty span, a paraphrase, or items reconstructed from
+memory: a silently-empty rubric composes a Codex critic with no binding items.
+
 ### Step 3: Compose the lens-specific prompt
 
 **Composer numeric-grounding rule (load-bearing — closes the #722 fabricated-numbers

--- a/.claude/agents/codex-statistics-critic.md
+++ b/.claude/agents/codex-statistics-critic.md
@@ -96,6 +96,16 @@ IN FULL (the list grows over time — take all current items, never a frozen sub
 Also read the "Output Format" CRITIC REPORT schema from `.claude/agents/statistics-critic.md`.
 The items fill the `{{lens_items}}` placeholder in Step 3.
 
+**No-span compose gate (#1292; incident #1265, compose-time form).** If the
+heading grep resolves NO span in `.claude/rules/critic-lens-reference.md` for
+`### Statistics & Measurement lens`, STOP and return a BLOCKER line
+(`BLOCKER: canonical lens heading not found in critic-lens-reference.md —
+heading drift; fix the reference/spec citation before dispatch`) instead of a
+composed prompt — the orchestrator treats this as a twin no-show
+(single-Claude fallback per the existing ensemble contract). NEVER fill
+`{{lens_items}}` with an empty span, a paraphrase, or items reconstructed from
+memory: a silently-empty rubric composes a Codex critic with no binding items.
+
 ### Step 3: Compose the lens-specific prompt
 
 **Composer numeric-grounding rule (load-bearing — closes the #722 fabricated-numbers

--- a/.claude/agents/efficiency-critic.md
+++ b/.claude/agents/efficiency-critic.md
@@ -84,6 +84,17 @@ APPROVE / PASS.** Be sparing.
 
 ## PLAN MODE
 
+**Canonical-heading anchor (#1292 — the v2 sibling of #1282; incident #1265).**
+The grep target is ALWAYS the canonical heading `### Methodology lens` in
+`.claude/rules/critic-lens-reference.md` — never a brief-supplied or paraphrased
+variant (the span read stays scoped to items 10 / 13 / 16). If that grep
+returns NO span, STOP and re-grep (e.g. case-insensitive on a distinctive
+fragment like `Methodology`) to locate a renamed heading — never review from
+the item capsule in this spec alone: the binding REVISE bars, N/A escapes, and
+incident citations would silently never load (the #1265 anchor-loss failure
+mode). Name the heading drift in your verdict so the rename gets fixed at the
+source.
+
 Review the plan's §9 (Resources & Parallelism) and its compute-projection table.
 The binding definitions for the three inherited Methodology-lens items live in
 `.claude/rules/critic-lens-reference.md` § Methodology lens items 10, 13, 16 —

--- a/.claude/agents/methodology-baselines-critic.md
+++ b/.claude/agents/methodology-baselines-critic.md
@@ -102,6 +102,16 @@ answer its own question. Be sparing.
 
 ## Methodology & Baselines lens
 
+**Canonical-heading anchor (#1292 — the v2 sibling of #1282; incident #1265).**
+The grep target is ALWAYS the canonical heading `### Methodology lens` in
+`.claude/rules/critic-lens-reference.md` — never a brief-supplied or paraphrased
+variant. If that grep returns NO span, STOP and re-grep (e.g. case-insensitive
+on a distinctive fragment like `Methodology`) to locate a renamed heading —
+never review from the item capsule in this spec alone: the binding REVISE bars,
+N/A escapes, and incident citations would silently never load (the #1265
+anchor-loss failure mode). Name the heading drift in your verdict so the rename
+gets fixed at the source.
+
 Core question: can this design, as written, answer the stated Goal — and will it
 run? The binding item definitions (REVISE bar, N/A escape, incident citations)
 live in `.claude/rules/critic-lens-reference.md` § Methodology lens — Grep that

--- a/.claude/agents/statistics-critic.md
+++ b/.claude/agents/statistics-critic.md
@@ -106,6 +106,16 @@ is noise. Be sparing.
 
 ## Statistics & Measurement lens
 
+**Canonical-heading anchor (#1292 — the v2 sibling of #1282; incident #1265).**
+The grep target is ALWAYS the canonical heading `### Statistics & Measurement lens`
+in `.claude/rules/critic-lens-reference.md` — never a brief-supplied or
+paraphrased variant. If that grep returns NO span, STOP and re-grep (e.g.
+case-insensitive on a distinctive fragment like `Measurement lens`) to locate a
+renamed heading — never review from the item capsule in this spec alone: the
+binding REVISE bars, N/A escapes, and incident citations would silently never
+load (the #1265 anchor-loss failure mode). Name the heading drift in your
+verdict so the rename gets fixed at the source.
+
 Core question: does the measurement plan measure the Goal's construct with
 interpretable power? The binding item definitions (REVISE bar, N/A escape,
 incident citations) live in `.claude/rules/critic-lens-reference.md` § Statistics

--- a/tests/test_adversarial_planner_lens_brief_headings.py
+++ b/tests/test_adversarial_planner_lens_brief_headings.py
@@ -1,11 +1,16 @@
-"""Pin #1282: critic briefs keep the canonical lens-heading anchor.
+"""Pin #1282 (v1) + #1292 (v2): critic briefs keep the canonical lens-heading anchor.
 
 Pins (incident #1265): (1) each adversarial-planner Phase 2 lens template
 carries a `Canonical rubric:` line citing critic-lens-reference.md plus the
 VERBATIM lens heading; (2) critic.md makes the canonical capsule heading the
 only legal grep target, with STOP-and-re-grep on a no-span result; (3) the
 pinned heading strings are the ACTUAL headings in critic-lens-reference.md
-(a heading rename must update templates + capsules in the same commit).
+(a heading rename must update templates + capsules in the same commit);
+(4) #1292 v2 pins: the three v2 lens-critic agents + their three Codex
+composers cite their canonical headings backticked-verbatim, the Claude
+agents carry the STOP-and-re-grep anchor rule, the composers carry the
+no-span compose gate, and every `.claude/agents/*.md` consumer of
+critic-lens-reference.md is pinned or explicitly allowlisted.
 """
 
 from pathlib import Path
@@ -48,3 +53,71 @@ def test_critic_md_grep_target_is_canonical_never_brief_supplied():
     critic_norm = _norm(CRITIC)
     assert "NEVER a brief-supplied translated or adapted title" in critic_norm
     assert "re-grep with the canonical heading" in critic_norm
+
+
+# --- #1292: v2 lens-critic pins (the v2 sibling of the #1282 pins above) ---
+
+# Deliberately hardcodes heading strings independently of HEADINGS: deriving the
+# values from HEADINGS would make assertion (a) of
+# test_v2_cited_headings_are_canonical_and_exist_in_lens_reference tautological.
+V2_FILES_TO_HEADINGS = {
+    ".claude/agents/statistics-critic.md": ("### Statistics & Measurement lens",),
+    ".claude/agents/methodology-baselines-critic.md": ("### Methodology lens",),
+    ".claude/agents/efficiency-critic.md": ("### Methodology lens",),
+    ".claude/agents/codex-statistics-critic.md": ("### Statistics & Measurement lens",),
+    ".claude/agents/codex-methodology-baselines-critic.md": (
+        "### Methodology lens",
+        "### Alternative Explanations lens",
+    ),
+    ".claude/agents/codex-efficiency-critic.md": ("### Methodology lens",),
+}
+V2_CLAUDE_AGENTS = tuple(k for k in V2_FILES_TO_HEADINGS if "/codex-" not in k)
+V2_CODEX_COMPOSERS = tuple(k for k in V2_FILES_TO_HEADINGS if "/codex-" in k)
+
+
+def test_v2_cited_headings_are_canonical_and_exist_in_lens_reference():
+    for rel, headings in V2_FILES_TO_HEADINGS.items():
+        text_norm = _norm((REPO_ROOT / rel).read_text(encoding="utf-8"))
+        for heading in headings:
+            assert heading in HEADINGS, (rel, heading)  # (a) cited heading is canonical
+            assert f"\n{heading}\n" in LENS_REF, heading  # (b) and live in the reference
+            assert _norm(f"`{heading}`") in text_norm, (rel, heading)  # (c) cited verbatim
+
+
+def test_v2_claude_agents_carry_stop_and_regrep_rule():
+    for rel in V2_CLAUDE_AGENTS:
+        text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        assert "Canonical-heading anchor" in text, rel
+        assert "returns NO span, STOP" in _norm(text), rel
+
+
+def test_v2_codex_composers_carry_no_span_compose_gate():
+    for rel in V2_CODEX_COMPOSERS:
+        text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        assert "No-span compose gate" in text, rel
+        assert "STOP and return a BLOCKER" in _norm(text), rel
+
+
+# Discovery pin — every .claude/agents/*.md consumer of critic-lens-reference.md
+# must be a pinned v1/v2 file or an explicitly-allowlisted mention-only file, so
+# a future lens agent cannot land citing the reference unpinned.
+PINNED_V1 = (".claude/agents/critic.md", ".claude/agents/codex-critic.md")
+MENTION_ONLY_ALLOWLIST = (
+    # These two cite `.claude/rules/clean-result-critic-lens-reference.md` — a
+    # DIFFERENT reference file whose name contains "critic-lens-reference" as a
+    # substring. Verified at #1292 implementation time: neither loads
+    # `.claude/rules/critic-lens-reference.md` itself.
+    ".claude/agents/clean-result-critic.md",
+    ".claude/agents/codex-clean-result-critic.md",
+)
+
+
+def test_lens_reference_consumers_are_pinned():
+    known = set(PINNED_V1) | set(V2_FILES_TO_HEADINGS) | set(MENTION_ONLY_ALLOWLIST)
+    for path in sorted((REPO_ROOT / ".claude/agents").glob("*.md")):
+        if "critic-lens-reference" in path.read_text(encoding="utf-8"):
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            assert rel in known, (
+                f"{rel} cites critic-lens-reference.md but is not pinned in "
+                "V2_FILES_TO_HEADINGS / PINNED_V1 / MENTION_ONLY_ALLOWLIST"
+            )


### PR DESCRIPTION
Closes task #1292. Ports #1282's verbatim-heading-citation fix to the v2 lens-critic surfaces: Canonical-heading anchor (STOP-and-re-grep) in the 3 v2 Claude lens agents, No-span compose gates in the 3 codex twin composers, 4 new pinning tests. adversarial-planner-v2/SKILL.md deflected (path-only briefs, no rubric-composition channel).