### PR TITLE
issue-1293: source-pin the piped-git-push no-flags bundling test

### DIFF
--- a/tests/test_workflow_lint.py
+++ b/tests/test_workflow_lint.py
@@ -2409,16 +2409,26 @@ def test_workflow_lint_check_piped_git_push_cli_exits_zero():
     )
 
 
-def test_workflow_lint_piped_git_push_bundled_in_no_flags():
-    """`check_piped_git_push` is wired into the no-flags default run
-    (bundled, same policy as `check_pipe_python`): a bare `workflow_lint.py`
-    invocation exercises it. The committed tree is clean, so the no-flags
-    run exits 0 — a planted offender in a tmp scripts dir is caught by the
-    function tests above; here we assert the bundling holds via a clean
-    exit."""
-    result = _run()
-    assert result.returncode == 0, (
-        f"workflow_lint (no flags) failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+def test_piped_git_push_bundled_in_no_flags_source_pin():
+    """NON-VACUOUS no-flags bundling pin (#1293, the #1233 exemplar-2
+    shape; the #712 §4f opt-in-not-bundled shipping class):
+    `check_piped_git_push` must be dispatched by the BARE
+    ``workflow_lint.py`` run. Source-inspection assert on the dispatch
+    branch + the no_flags detection-tuple membership — the prior
+    exit-0-on-a-clean-tree assert was vacuous (a clean tree exits 0
+    whether or not the check is dispatched) and burned a redundant full
+    no-flags subprocess run (``test_workflow_lint_default_exits_zero``
+    keeps the behavioral clean-tree cover; the ``check_piped_git_push``
+    function tests above and the ``_PIPED_PUSH_SHARED`` hook/lint
+    agreement suite below cover detection)."""
+    src = _LINT.read_text(encoding="utf-8")
+    assert re.search(
+        r"if args\.check_piped_git_push or no_flags:\s*\n"
+        r"\s*errors\.extend\(check_piped_git_push\(\)\)",
+        src,
+    ), "check_piped_git_push is not dispatched on the no-flags branch"
+    assert "or args.check_piped_git_push" in src, (
+        "--check-piped-git-push is missing from the no_flags detection tuple"
     )
 
 


### PR DESCRIPTION
Closes task #1293.

Replaces the vacuous exit-0-on-clean-tree test `test_workflow_lint_piped_git_push_bundled_in_no_flags` (tests/test_workflow_lint.py:2412) with the non-vacuous source-dispatch pin `test_piped_git_push_bundled_in_no_flags_source_pin` — regex on the dispatch branch (scripts/workflow_lint.py:10520-10521) + tuple-membership substring (:10427), the #1233 exemplar-2 pattern. workflow_lint.py byte-untouched.

Gates: plan-verify PASS · 3/3 plan critics APPROVE · code-review PASS · test-verdict PASS (3351 passed / 0 failed; baseline compare new=[]).