### PR TITLE
issue-1294: producer-side in-place-regeneration bullet (upload-policy) + item-(j) cross-ref

### DIFF
--- a/.claude/rules/artifact-reuse.md
+++ b/.claude/rules/artifact-reuse.md
@@ -371,6 +371,11 @@ The planner verifies, before recording an artifact as reused in §10/§11:
   assert after a full GCE cycle. Sibling class: the #601 pinned-pair
   COVERAGE mismatch —
   `.claude/agent-memory/experiment-implementer/feedback_pinned_artifact_pair_mutual_inconsistency.md`.)
+  The PRODUCER-side half of this rule — a regeneration must version-bump the
+  path or record the regeneration note this check reads (an in-artifact
+  `reconstruction` field, or a same-commit `<name>.regeneration.json`
+  sidecar) — is `.claude/rules/upload-policy.md`
+  § "Regenerating a published artifact in place".
 
 A failing check other than (i)/(h)(iv) → retrain / regenerate; a failing
 throughput check (i) → fix the SOURCE module (batch / parametrize / scope it

--- a/.claude/rules/upload-policy.md
+++ b/.claude/rules/upload-policy.md
@@ -160,6 +160,38 @@ incident: #779's extraction driver (`issue779_extract_rb.py`) reduced kept
 rollouts to `r_B` and dropped the rollout text (wrote it only as judge input,
 not under `raw_completions/`), so a sibling arm had to regenerate.
 
+**Regenerating a published artifact in place requires a version-bumped path or
+a regeneration note (#922/#779).** Re-uploading / reconstructing an
+already-published artifact at the SAME path can silently invalidate every
+capture another task made under the original bytes — activations,
+teacher-forced reads, judge outputs, adapters trained on the mix. Each pair
+member still
+resolves and sha-verifies individually, so only the consumer-side pairwise
+provenance-coherence check (`.claude/rules/artifact-reuse.md` item (j))
+detects the incoherence — after the fact, at the cost of a wasted run.
+Producer duty, one of two forms:
+
+1. **Version-bump the path** — publish the regenerated artifact at a NEW path
+   (`issueN_<slug>/v2/...`, or a new filename), so the original path keeps
+   resolving to the bytes existing captures were made under. Prefer this form
+   whenever a dependent capture is known or plausible.
+2. **Record a regeneration note the artifact itself carries** — a
+   `reconstruction` / regeneration metadata field inside the artifact (or a
+   sidecar `<name>.regeneration.json` uploaded in the same commit) stating the
+   regeneration date, the reason (a bug-fix regeneration invalidates the old
+   bytes; a byte-equivalent rebuild does not), and any KNOWN dependent
+   captures (task ids / capture paths). Item (j) already reads exactly this
+   field (#922's question artifact documented its own regeneration); the note
+   is what lets a consumer choose between item (j)'s two remedies —
+   re-capture under the current input, or pin the input at the
+   pre-regeneration revision. This form is the floor when the path must stay
+   stable (a canonical bucket consumers resolve by convention).
+
+(Incident: #779 regenerated published question artifacts in place — HF commit
+`9578892ef4`, 2026-07-02 — AFTER #922's dependent `cx.pt` activation capture,
+`a8060198a4`, 2026-07-01; every per-member check passed and the run crashed at
+a parity assert after a full GCE cycle.)
+
 **Resume-critical pipeline INPUTS must upload before any deliberate
 `pod.py stop` that expects a later resume.** The same logic extends
 upstream of analysis: generated training rows (`R_train` caches,


### PR DESCRIPTION
Closes task #1294.

## Summary
- Adds the producer-side "Regenerating a published artifact in place requires a version-bumped path or a regeneration note (#922/#779)" bullet to `.claude/rules/upload-policy.md` (two-form duty feeding artifact-reuse.md item (j)'s reconstruction-field read + remedy fork).
- Appends a one-sentence producer-pointer cross-ref to `.claude/rules/artifact-reuse.md` item (j).

## Test plan
- [x] workflow_lint no-flags baseline/postedit diff empty; --check-lessons-index PASS
- [x] acceptance greps exactly 1 in each file (phrase on one line)
- [x] step9c gate: 3351 passed / 6 skipped; compare new=[]

🤖 Generated with [Claude Code](https://claude.com/claude-code)