### PR TITLE
issue-1296: scripts_dir bootstrap before lazy runpod_api imports in backend_poll

### DIFF
--- a/scripts/backend_poll.py
+++ b/scripts/backend_poll.py
@@ -155,6 +155,21 @@ def _pin_main_lane_infra(anchor: Path | None = None) -> Path:
 if __name__ == "__main__":
     _pin_main_lane_infra()
 
+
+def _ensure_scripts_dir_on_sys_path() -> None:
+    """Insert THIS file's dir (scripts/) so a lazy ``import runpod_api`` resolves.
+
+    In script mode scripts/ is already ``sys.path[0]``; in MODULE mode (tests do
+    ``from scripts.backend_poll import main``) only the repo root is on
+    sys.path, so a bare lazy ``runpod_api`` import would raise
+    ``ModuleNotFoundError`` (#710/#1296). Mirrors the inline bootstrap at the
+    issue664_common import sites; idempotent.
+    """
+    scripts_dir = str(Path(__file__).resolve().parent)
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+
+
 # Conservative short bg-poll interval (seconds). Mirrors
 # ``scripts.poll_pipeline.POLL_INTERVAL_DEFAULT_SEC`` — kept as a local
 # literal so the fast ``--help`` path doesn't import the (heavy)
@@ -1551,6 +1566,7 @@ def _maybe_escalate_runpod_wedge(handle, result, sidecar: Path, *, now: float):
     """
     if getattr(handle, "backend", None) != "runpod":
         return result
+    _ensure_scripts_dir_on_sys_path()
     from runpod_api import get_pod_by_name  # live RunPod API (X-Team-Id baked in)
 
     info = get_pod_by_name(handle.pod_name)  # PodInfo or None
@@ -2202,6 +2218,7 @@ def _failover_wedged_runpod(*, issue: int, handle, result, sidecar: Path) -> dic
         )
 
     # 3. TERMINATE the billing leak (fail-loud; terminate_pod raises on API error).
+    _ensure_scripts_dir_on_sys_path()
     from runpod_api import get_pod_by_name, terminate_pod
 
     info = get_pod_by_name(handle.pod_name)
@@ -2377,6 +2394,7 @@ def _failover_cuda_ima_runpod(*, issue: int, handle, result, sidecar: Path) -> d
     #    we log + continue to the sentinel + fresh-host relaunch. (Part C's no-port
     #    terminate stays fail-loud BY DESIGN — that pod is genuinely RUNNING+billing,
     #    so a terminate failure there is the billing leak the wedge exists to stop.)
+    _ensure_scripts_dir_on_sys_path()
     from runpod_api import get_pod_by_name, terminate_pod
 
     info = get_pod_by_name(handle.pod_name)

--- a/tests/test_backend_poll.py
+++ b/tests/test_backend_poll.py
@@ -3105,3 +3105,81 @@ def test_gcp_queue_timeout_failover_reconstructs_from_reconnect_handle(
     # Queued GCP instance torn down; sidecar re-pointed at the RunPod handle.
     assert len(teardown_backend.teardowns) == 1
     assert read_handle_sidecar(sidecar).backend == "runpod"
+
+
+# ---------------------------------------------------------------------------
+# #710/#1296 — scripts-dir bootstrap before the lazy ``from runpod_api`` sites
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_scripts_dir_bootstrap_resolves_runpod_api_in_module_mode(monkeypatch):
+    """#1296: ``_ensure_scripts_dir_on_sys_path()`` makes a bare
+    ``import runpod_api`` resolve in MODULE mode (repo root on sys.path,
+    scripts/ NOT), with a built-in NEGATIVE CONTROL proving the pre-fix
+    ``ModuleNotFoundError`` exists once scripts/ is scrubbed. Import only —
+    no live RunPod API call is ever made."""
+    import importlib
+    import sys
+
+    import scripts.backend_poll as bp
+
+    scripts_dir = str(Path(bp.__file__).resolve().parent)
+    # Scrub every sys.path entry that resolves to scripts/ (cross-test-file
+    # inserts included). monkeypatch.setattr replaces the LIST OBJECT and
+    # restores the original at teardown, so the helper's in-test insert (into
+    # the scrubbed list) never leaks either.
+    scrubbed = [p for p in sys.path if str(Path(p or ".").resolve()) != scripts_dir]
+    monkeypatch.setattr(sys, "path", scrubbed)
+    # delitem records + restores any PRE-test runpod_api module object.
+    monkeypatch.delitem(sys.modules, "runpod_api", raising=False)
+
+    # NEGATIVE CONTROL (fail-loud claim, plan §5 kill criterion): with
+    # scripts/ scrubbed and the bootstrap not yet run, the bare import raises
+    # — the exact pre-fix failure mode at the three lazy sites.
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module("runpod_api")
+
+    bp._ensure_scripts_dir_on_sys_path()
+
+    mod = importlib.import_module("runpod_api")
+    try:
+        assert hasattr(mod, "get_pod_by_name")
+        assert hasattr(mod, "terminate_pod")
+    finally:
+        # Drop the module object THIS test just imported so it cannot alias
+        # past teardown; monkeypatch then restores the original entry (when
+        # one existed) after this pop.
+        sys.modules.pop("runpod_api", None)
+
+
+def test_every_lazy_runpod_api_import_is_bootstrap_guarded():
+    """#1296 durability pin: every INDENTED (function-local, lazy)
+    ``from runpod_api import`` line in scripts/backend_poll.py must have the
+    scripts-dir bootstrap — ``_ensure_scripts_dir_on_sys_path()`` or the
+    inline ``sys.path.insert(0, scripts_dir)`` — within the preceding ~12
+    lines, so a FUTURE bare site cannot re-introduce the module-mode
+    ModuleNotFoundError landmine. Comment lines never satisfy the guard."""
+    import scripts.backend_poll as bp
+
+    lines = Path(bp.__file__).read_text(encoding="utf-8").splitlines()
+    lazy_sites = [
+        i
+        for i, line in enumerate(lines)
+        if line.strip().startswith("from runpod_api import") and line != line.lstrip()
+    ]
+    assert lazy_sites, "expected >=1 lazy 'from runpod_api import' site in backend_poll.py"
+    for i in lazy_sites:
+        window = [
+            ln.strip()
+            for ln in lines[max(0, i - 12) : i]
+            if ln.strip() and not ln.strip().startswith("#")
+        ]
+        guarded = any(
+            "_ensure_scripts_dir_on_sys_path()" in ln or "sys.path.insert(0, scripts_dir)" in ln
+            for ln in window
+        )
+        assert guarded, (
+            f"scripts/backend_poll.py:{i + 1}: lazy 'from runpod_api import' without a "
+            f"scripts-dir bootstrap in the preceding 12 lines — call "
+            f"_ensure_scripts_dir_on_sys_path() directly above the import (#1296)"
+        )


### PR DESCRIPTION
Closes task #1296. Workflow-fix (#710 origin): module-level _ensure_scripts_dir_on_sys_path() helper + calls before the 3 lexically-bare lazy runpod_api imports; 2 regression tests.