### PR TITLE
issue-1299: step-9c selector import-map arm

### DIFF
--- a/scripts/select_step9c_tests.py
+++ b/scripts/select_step9c_tests.py
@@ -29,12 +29,45 @@ Touched-file -> test mapping (per touched file ``f``):
     selects that scanning test (tests that cover files via a directory scan
     at test time are reachable from no stem — #895). A map hit never
     suppresses the ``untested_touched`` WARN for the touched file itself.
+  * any ``tests/**/test_*.py`` whose ``Import``/``ImportFrom`` nodes name a
+    touched ``scripts/`` or ``src/explore_persona_space/`` module is
+    ADDITIONALLY selected with reason ``import-map:<touched file>`` (#1299;
+    founding incident #1286 — an importing test whose NAME shares no touched
+    stem was reachable by no arm). Unlike a glob-scan hit, an import hit DOES
+    mark the touched file tested (suppresses its ``untested_touched`` WARN):
+    the test executes the touched module's code, strictly stronger evidence
+    than the filename-substring stem glob that also sets ``matched``.
 
 ``safe-by-direction``: the broad ``*{stem}*`` glob arm deliberately OVER-matches
 on short stems (e.g. stem ``gcp`` selects ``test_gcp_backend.py``) — running a
 few extra invariant-adjacent tests is the safe failure direction. There is no
 ``else: tighten the glob`` arm: a missed mapping surfaces as an
 ``untested_touched`` WARN, never a silently-dropped file.
+
+Import-map scope + cost (#1299): the arm resolves absolute ``import X`` /
+``from M import a`` forms over the WHOLE file (``ast.walk`` — function-level
+imports count; the founding test imports 2/3 of its targets inside test
+functions). Out of scope, each miss landing in the ``untested_touched`` WARN
+(the pre-existing loud fallback): relative imports (``node.level > 0``
+skipped); dynamic imports (``importlib`` / ``spec_from_file_location`` — both
+live dynamic consumers of THIS selector are covered anyway:
+``tests/test_select_step9c_tests.py`` is stem-mapped and
+``tests/test_diff_base_origin_main_pin.py`` is WORKFLOW_INVARIANT-pinned);
+attribute access on a parent package (``import explore_persona_space`` then
+``.task_workflow``); modules outside ``scripts/`` +
+``src/explore_persona_space/``; ``conftest.py`` imports (only ``test_*.py``
+files are scanned); transitive imports (a test importing helper H is not
+selected for a diff touching a module H imports — one hop only). Known miss
+class: touching a package ``__init__.py`` resolves to the PACKAGE name only,
+so importers of its submodules are not matched. Deliberately counted as hits
+(over-selection is the safe direction): imports under ``TYPE_CHECKING`` /
+try-except guards / any conditional, and a false-positive flat-stem match (a
+test importing a PyPI package whose name equals a touched ``scripts/`` stem).
+Cost: a substring pre-filter parses only candidate-bearing files (zero file
+reads on a workflow-surface-only diff; a short / colliding stem parses extra
+files, bounded by the measured ~4-8 s whole-tree worst case), and import-map
+selections flow into :func:`recommended_timeout_s` automatically (it sizes on
+``len(tests)``).
 
 Root resolution: with no ``--repo-root``, everything (the ``git diff`` cwd,
 touched-test existence checks, stem-glob mapping, invariant presence) resolves
@@ -96,7 +129,8 @@ BACKGROUND invocation — SKILL.md 9c step 1b). ``--json`` emits
 "n_tests": <int>, "recommended_timeout_s": <int>,
 "slow_tests_selected": [...]}`` (a
 reason is ``invariant`` / ``touched-test`` / ``stem-map:<touched file>`` /
-``glob-scan:<touched file>`` — #1022). Exit 0 on success (even with WARN lines);
+``glob-scan:<touched file>`` / ``import-map:<touched file>`` — #1022, #1299).
+Exit 0 on success (even with WARN lines);
 exit 1 if an underlying ``git`` call fails irrecoverably (work-root resolution
 or the diff) or if the selection comes back EMPTY (the zero-test-gate
 refusal).
@@ -105,6 +139,7 @@ refusal).
 from __future__ import annotations
 
 import argparse
+import ast
 import fnmatch
 import json
 import subprocess
@@ -407,20 +442,172 @@ def compute_touched(
     return [line.strip() for line in out.splitlines() if line.strip()]
 
 
+# --- Import-map arm (#1299). ---------------------------------------------------
+# Founding incident #1286: tests/test_issue810_uh_pack_validation.py imports
+# issue810_common but shares no filename stem with it, so NO arm selected it and
+# 4/5 touched scripts landed in the untested_touched WARN. The import arm selects
+# any tests/**/test_*.py whose Import/ImportFrom nodes name a touched module, so
+# touched-module coverage no longer depends on test-file NAMING.
+
+
+def touched_module_names(touched: list[str]) -> dict[str, set[str]]:
+    """Importable module names -> the touched files that resolve to them (#1299).
+
+    Eligible touched files: suffix ``.py``, under ``scripts/`` or
+    ``src/explore_persona_space/`` (never ``tests/`` — the touched-test arm owns
+    those). Resolution::
+
+        scripts/X.py             -> {"X", "scripts.X"}   (flat via the
+                                     sys.path.insert pattern — the #1286 shape,
+                                     174 test files; dotted — scripts/ is a
+                                     package, ~25 test files)
+        scripts/pkg/__init__.py  -> {"pkg", "scripts.pkg"}
+        src/explore_persona_space/a/b.py        -> {"explore_persona_space.a.b"}
+        src/explore_persona_space/a/__init__.py -> {"explore_persona_space.a"}
+
+    Multi-maps on collision: two touched files resolving one name are both
+    listed under it. ``scripts/__init__.py`` itself maps to no flat name (the
+    dotted ``scripts`` package marker carries no per-module signal).
+    """
+    out: dict[str, set[str]] = {}
+
+    def _record(name: str, f: str) -> None:
+        out.setdefault(name, set()).add(f)
+
+    for f in touched:
+        p = Path(f)
+        if p.suffix != ".py":
+            continue
+        parts = p.parts
+        tail = () if p.name == "__init__.py" else (p.stem,)
+        if parts[0] == "scripts" and len(parts) > 1:
+            rel = parts[1:-1] + tail
+            if not rel:
+                continue  # scripts/__init__.py: the package marker itself
+            flat = ".".join(rel)
+            _record(flat, f)
+            _record(f"scripts.{flat}", f)
+        elif parts[:2] == ("src", "explore_persona_space"):
+            rel = parts[1:-1] + tail  # keeps the leading explore_persona_space
+            _record(".".join(rel), f)
+    return out
+
+
+def _import_names(tree: ast.AST) -> set[str]:
+    """Every dotted name any ``Import``/``ImportFrom`` node references, ANYWHERE
+    in the file (``ast.walk`` — function-level imports count: the founding test
+    imports 2 of its 3 target modules inside test functions, #1286 L138/L178).
+
+    ``import X.Y as z`` -> ``{"X.Y"}``; ``from M import a, b`` -> ``{"M",
+    "M.a", "M.b"}`` (the ``M.a`` join catches ``from
+    explore_persona_space.foo import bar`` naming touched module
+    ``...foo.bar``). Relative imports (``node.level > 0``) are SKIPPED —
+    ``tests/`` is not a package here, so a relative form cannot name a
+    ``scripts/`` / ``src/`` module.
+    """
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and not node.level and node.module:
+            names.add(node.module)
+            names.update(f"{node.module}.{alias.name}" for alias in node.names)
+    return names
+
+
+def import_map_hits(touched: list[str], work_root: Path) -> tuple[dict[str, set[str]], set[str]]:
+    """Scan ``tests/**/test_*.py`` for imports of touched modules (#1299).
+
+    Returns ``({test_relpath: {touched files it imports}}, {touched files with
+    >= 1 importing test})``. Subdir tests (``tests/experiments/``) are in scope
+    (sorted ``rglob`` — pytest collects them and the touched-test arm already
+    admits their paths), so the import arm matches that scope.
+
+    Cost bound: an empty module map (workflow-surface-only diff) returns
+    immediately with ZERO file reads. Otherwise each test file's raw text is
+    read and a SUBSTRING PRE-FILTER applies: the file is ``ast``-parsed only
+    when its text contains the last dotted component of at least one candidate
+    module name — any absolute import of module M must literally spell M's last
+    component, so the filter is over-inclusive (never a false negative).
+    Typical touched sets parse a handful of files; worst case the whole tree
+    (~500 files, measured ~4-8 s under shared-VM load — module docstring).
+
+    Fail-soft (#1299 rationale R5): a file that cannot be read / decoded /
+    parsed (``OSError``, ``SyntaxError``, ``ValueError`` incl.
+    ``UnicodeDecodeError``) emits ONE stderr WARN and is SKIPPED for the import
+    arm — never crashes the selector. The selection stays well-defined for
+    every other file, and if the broken file is itself part of the diff the
+    touched-test arm still selects it (pytest collection then fails loud at the
+    right surface). When parse failures exceed 5% of the scanned files, ONE
+    additional aggregate WARN flags the systemic tests/ breakage.
+    """
+    hits: dict[str, set[str]] = {}
+    tested: set[str] = set()
+    module_map = touched_module_names(touched)
+    if not module_map:
+        return hits, tested
+    tests_dir = work_root / "tests"
+    if not tests_dir.is_dir():
+        return hits, tested
+    tokens = {name.rsplit(".", 1)[-1] for name in module_map}
+    n_scanned = 0
+    n_failed = 0
+    for test_path in sorted(tests_dir.rglob("test_*.py")):
+        n_scanned += 1
+        rel = test_path.relative_to(work_root).as_posix()
+        try:
+            text = test_path.read_text(encoding="utf-8")
+            if not any(tok in text for tok in tokens):
+                continue
+            imported = _import_names(ast.parse(text))
+        except (OSError, SyntaxError, ValueError) as exc:
+            n_failed += 1
+            print(
+                f"select_step9c_tests: WARN — import-map cannot parse {rel}: {exc}; "
+                "file skipped for the import arm",
+                file=sys.stderr,
+            )
+            continue
+        for name, files in module_map.items():
+            if name in imported:
+                hits.setdefault(rel, set()).update(files)
+                tested.update(files)
+    if n_scanned and n_failed / n_scanned > 0.05:
+        print(
+            f"select_step9c_tests: WARN — import-map parse failures on "
+            f"{n_failed}/{n_scanned} scanned test files (>5%): systemic tests/ breakage; "
+            "the import arm may under-select",
+            file=sys.stderr,
+        )
+    return hits, tested
+
+
+def _seed_import_reasons(import_hits: dict[str, set[str]]) -> dict[str, set[str]]:
+    """Initial ``{test: reasons}`` mapping seeded from import-map hits (#1299)."""
+    return {t: {f"import-map:{f}" for f in files} for t, files in import_hits.items()}
+
+
 def select_tests_with_reasons(
     touched: list[str], work_root: Path
 ) -> tuple[list[str], list[str], dict[str, list[str]]]:
     """Superset of :func:`select_tests`: also returns ``{test: sorted reasons}``.
 
     A reason is ``'invariant' | 'touched-test' | 'stem-map:<touched file>' |
-    'glob-scan:<touched file>'``; a test may carry several (e.g. an invariant
-    that is also stem-mapped from a touched file). Selection behavior is
-    IDENTICAL to :func:`select_tests` — same tests, same ``untested_touched``
-    WARN list, same sorted ordering (#1022: the reasons feed
-    ``step9c_baseline.py compare``'s diff-linked-ness read, which must come
-    from the SAME mapping logic that selected the run's tests).
+    'glob-scan:<touched file>' | 'import-map:<touched file>'``; a test may
+    carry several (e.g. an invariant that is also stem-mapped from a touched
+    file). Selection behavior is IDENTICAL to :func:`select_tests` — same
+    tests, same ``untested_touched`` WARN list, same sorted ordering (#1022:
+    the reasons feed ``step9c_baseline.py compare``'s diff-linked-ness read,
+    which must come from the SAME mapping logic that selected the run's tests).
     """
-    selected: dict[str, set[str]] = {}
+    # Import-map arm (#1299): seeds the selection — additive by construction
+    # (it only ever adds tests/reasons here and, via the ``matched`` seed
+    # below, removes entries from the untested WARN list; no code path drops a
+    # stem-map / glob-scan / invariant / touched-test selection, so selection
+    # only GROWS). Ordering is irrelevant: the terminal sorted() reads below
+    # keep the output deterministic.
+    import_hits, import_tested = import_map_hits(touched, work_root)
+    selected: dict[str, set[str]] = _seed_import_reasons(import_hits)
     untested: list[str] = []
 
     def _add(test: str, reason: str) -> None:
@@ -446,7 +633,12 @@ def select_tests_with_reasons(
         # Code files (.py anywhere): map stem -> test_<stem>.py + test_*<stem>*.py.
         if p.suffix == ".py":
             stem = p.stem
-            matched = False
+            # An import-map hit marks the touched file tested (#1299): the
+            # importing test executes the touched module's code — strictly
+            # stronger evidence than the stem-map filename glob that also sets
+            # ``matched``. (The glob-scan arm deliberately does NOT — a scan
+            # asserts a cross-cutting invariant ABOUT the file.)
+            matched = f in import_tested
             exact = work_root / "tests" / f"test_{stem}.py"
             if exact.exists():
                 _add(f"tests/test_{stem}.py", f"stem-map:{f}")

--- a/tests/test_select_step9c_tests.py
+++ b/tests/test_select_step9c_tests.py
@@ -809,3 +809,287 @@ def test_resolve_base_fetch_failure_degrades_to_stale_origin_main(
     err = capsys.readouterr().err
     assert "git fetch origin main failed" in err
     assert seen["fetch_kwargs"]["timeout"] == sel.FETCH_TIMEOUT_S  # the bounded fetch
+
+
+# --- Cases 36+ (#1299): the import-map arm -------------------------------------
+# Fixtures write REAL import statements into tmp-tree test files (the shared
+# _make_tree stubs contain no imports and no touched-stem substrings, so the
+# new arm no-ops on every pre-existing fixture by construction).
+
+
+def _make_import_tree(tmp_path: Path, files: dict[str, str]) -> Path:
+    """_make_tree plus tests/-relative files with real (import-bearing) content."""
+    repo = _make_tree(tmp_path, [])
+    for rel, content in files.items():
+        p = repo / "tests" / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    return repo
+
+
+# --- Case 36: THE durability pin — the #1286 fixture shape ---------------------
+def test_import_map_selects_unrelated_filename(tmp_path: Path):
+    """An importing test whose NAME shares no touched stem is selected (#1299).
+
+    Durability pin. Founding incident #1286:
+    tests/test_issue810_uh_pack_validation.py imports issue810_common but was
+    reachable by no selection arm ("uh_pack_validation" contains no touched
+    stem), so #1286 hand-appended it to the gate command.
+    """
+    repo = _make_import_tree(
+        tmp_path, {"test_uh_pack_validation.py": "from issue810_common import validate\n"}
+    )
+    tests, untested, reasons = sel.select_tests_with_reasons(["scripts/issue810_common.py"], repo)
+    assert "tests/test_uh_pack_validation.py" in tests
+    assert reasons["tests/test_uh_pack_validation.py"] == ["import-map:scripts/issue810_common.py"]
+    assert untested == []  # the import hit marks the touched file tested
+
+
+# --- Case 37: function-level import (ast.walk, not module-top-only) ------------
+def test_import_map_function_level_import_selected(tmp_path: Path):
+    """Mirrors the real file's L138/L178: the ONLY import is inside a test body."""
+    repo = _make_import_tree(
+        tmp_path,
+        {
+            "test_uh_pack.py": (
+                "def test_x():\n    import issue810_fit_readout as fr\n    assert fr\n"
+            )
+        },
+    )
+    tests, untested, reasons = sel.select_tests_with_reasons(
+        ["scripts/issue810_fit_readout.py"], repo
+    )
+    assert "tests/test_uh_pack.py" in tests
+    assert reasons["tests/test_uh_pack.py"] == ["import-map:scripts/issue810_fit_readout.py"]
+    assert untested == []
+
+
+# --- Case 38: dotted scripts.X import (scripts/ is a package) ------------------
+def test_import_map_dotted_scripts_import(tmp_path: Path):
+    repo = _make_import_tree(tmp_path, {"test_consumer.py": "from scripts.widgetlib import x\n"})
+    tests, untested, reasons = sel.select_tests_with_reasons(["scripts/widgetlib.py"], repo)
+    assert "tests/test_consumer.py" in tests
+    assert reasons["tests/test_consumer.py"] == ["import-map:scripts/widgetlib.py"]
+    assert untested == []
+
+
+# --- Case 39: src/explore_persona_space dotted package modules -----------------
+def test_import_map_src_package_module(tmp_path: Path):
+    repo = _make_import_tree(
+        tmp_path,
+        {
+            # the M.a candidate-join form: touched ...foo/bar.py, import from ...foo
+            "test_pkg_consumer.py": "from explore_persona_space.foo import bar\n",
+            "test_flat_consumer.py": "from explore_persona_space.task_widget import x\n",
+        },
+    )
+    tests, untested, reasons = sel.select_tests_with_reasons(
+        [
+            "src/explore_persona_space/foo/bar.py",
+            "src/explore_persona_space/task_widget.py",
+        ],
+        repo,
+    )
+    assert "tests/test_pkg_consumer.py" in tests
+    assert reasons["tests/test_pkg_consumer.py"] == [
+        "import-map:src/explore_persona_space/foo/bar.py"
+    ]
+    assert "tests/test_flat_consumer.py" in tests
+    assert reasons["tests/test_flat_consumer.py"] == [
+        "import-map:src/explore_persona_space/task_widget.py"
+    ]
+    assert untested == []
+
+
+# --- Case 40: an import hit suppresses the untested_touched WARN ----------------
+def test_import_map_marks_touched_file_tested(tmp_path: Path):
+    """Touched module with an importing test and NO stem-named test -> no WARN."""
+    repo = _make_import_tree(tmp_path, {"test_something_else.py": "import orphanlib\n"})
+    tests, untested, _ = sel.select_tests_with_reasons(["scripts/orphanlib.py"], repo)
+    assert "tests/test_something_else.py" in tests
+    assert untested == []
+
+
+# --- Case 41: monotonicity — the arm only ever GROWS the selection --------------
+def test_import_map_only_grows_selection(tmp_path: Path):
+    """Same touched set, tree WITH vs WITHOUT the importing test file:
+    WITH-selection is a superset and every WITHOUT reason list is preserved
+    verbatim (the plan's acceptance criterion (b))."""
+    touched = ["scripts/widgetlib.py", "scripts/orphan.py"]
+    repo_without = _make_tree(tmp_path / "without", ["test_widgetlib.py"])
+    t_without, u_without, r_without = sel.select_tests_with_reasons(touched, repo_without)
+    repo_with = _make_tree(tmp_path / "with", ["test_widgetlib.py"])
+    (repo_with / "tests" / "test_importer.py").write_text("import widgetlib\n")
+    t_with, u_with, r_with = sel.select_tests_with_reasons(touched, repo_with)
+    assert set(t_with) >= set(t_without)
+    for test, rs in r_without.items():
+        assert r_with[test] == rs  # pre-existing reason lists preserved verbatim
+    assert "tests/test_importer.py" in t_with
+    # orphan.py has no test in either tree; widgetlib.py is stem-mapped in both.
+    assert u_without == ["scripts/orphan.py"]
+    assert u_with == ["scripts/orphan.py"]
+
+
+# --- Case 42: a broken test file WARNs + is skipped; never crashes ---------------
+def test_import_map_broken_test_file_warns_not_crash(tmp_path: Path, capsys):
+    repo = _make_import_tree(
+        tmp_path,
+        {
+            "test_good_importer.py": "import widgetlib\n",
+            # contains the pre-filter token, so it IS parsed — and fails.
+            "test_broken.py": "import widgetlib\ndef broken(:\n",
+        },
+    )
+    tests, untested, _ = sel.select_tests_with_reasons(["scripts/widgetlib.py"], repo)
+    assert "tests/test_good_importer.py" in tests  # the valid hit still selected
+    assert "tests/test_broken.py" not in tests  # broken file not import-selected
+    assert untested == []
+    err = capsys.readouterr().err
+    assert err.count("import-map cannot parse") == 1
+    assert "test_broken.py" in err
+    # 1 failure over the ~41-file fixture tree is < 5%: no aggregate WARN.
+    assert "systemic tests/ breakage" not in err
+
+
+# --- Case 43: undecodable file WARNs via the same fail-soft path ----------------
+def test_import_map_undecodable_file_warns_when_scanning(tmp_path: Path, capsys):
+    """A read/decode failure (UnicodeDecodeError, a ValueError) takes the same
+    WARN-and-skip path as a SyntaxError — the positive control for case 44's
+    zero-read proof (the raw read happens BEFORE the substring pre-filter)."""
+    repo = _make_import_tree(tmp_path, {"test_ok.py": "import widgetlib\n"})
+    (repo / "tests" / "test_undecodable.py").write_bytes(b"import widgetlib\n\xff\xfe bad")
+    tests, _, _ = sel.select_tests_with_reasons(["scripts/widgetlib.py"], repo)
+    assert "tests/test_ok.py" in tests
+    err = capsys.readouterr().err
+    assert "import-map cannot parse" in err
+    assert "test_undecodable.py" in err
+
+
+# --- Case 44: workflow-surface-only diff -> ZERO file reads (early return) ------
+def test_import_map_no_eligible_touched_skips_scan(tmp_path: Path, capsys):
+    """No import-map-eligible touched file -> the scan never reads tests/.
+
+    Proof: an undecodable test file is planted; any scan pass reads raw text
+    BEFORE the pre-filter (case 43 shows that read WARNs), so the absence of a
+    WARN here proves the zero-read early return.
+    """
+    repo = _make_import_tree(tmp_path, {})
+    (repo / "tests" / "test_undecodable.py").write_bytes(b"import widgetlib\n\xff\xfe bad")
+    hits, tested = sel.import_map_hits([".claude/skills/issue/SKILL.md", "notes.md"], repo)
+    assert hits == {} and tested == set()
+    tests, untested, _ = sel.select_tests_with_reasons([".claude/skills/issue/SKILL.md"], repo)
+    err = capsys.readouterr().err
+    assert "import-map cannot parse" not in err  # zero reads: never touched the bad file
+    assert set(tests) == set(sel.WORKFLOW_INVARIANT)
+    assert untested == []
+
+
+# --- Case 45: subdir tests (tests/experiments/) are in the rglob scope ----------
+def test_import_map_subdir_test_selected(tmp_path: Path):
+    repo = _make_import_tree(tmp_path, {"experiments/test_sub.py": "import widgetlib\n"})
+    tests, _, reasons = sel.select_tests_with_reasons(["scripts/widgetlib.py"], repo)
+    assert "tests/experiments/test_sub.py" in tests
+    assert reasons["tests/experiments/test_sub.py"] == ["import-map:scripts/widgetlib.py"]
+
+
+# --- Case 46: precision — an UNRELATED import is not selected -------------------
+def test_import_map_unrelated_import_not_selected(tmp_path: Path):
+    repo = _make_import_tree(
+        tmp_path, {"test_bystander.py": "import numpy\nfrom otherlib import thing\n"}
+    )
+    tests, _, _ = sel.select_tests_with_reasons(["scripts/widgetlib.py"], repo)
+    assert "tests/test_bystander.py" not in tests
+
+
+# --- Case 47: precision — relative imports (node.level > 0) are skipped ---------
+def test_import_map_relative_import_skipped(tmp_path: Path):
+    # The text CONTAINS the pre-filter token, so the file IS parsed; the level
+    # check (not the pre-filter) is what excludes it.
+    repo = _make_import_tree(
+        tmp_path, {"test_relative.py": "from . import widgetlib\nfrom .widgetlib import x\n"}
+    )
+    tests, _, _ = sel.select_tests_with_reasons(["scripts/widgetlib.py"], repo)
+    assert "tests/test_relative.py" not in tests
+
+
+# --- Case 48: aggregate parse-failure WARN (systemic-breakage signal) -----------
+def test_import_map_aggregate_parse_failure_warn(tmp_path: Path, capsys):
+    """>5% of scanned test files failing to parse emits ONE extra summary WARN."""
+    files = {f"test_broken_{i}.py": "import widgetlib\ndef broken(:\n" for i in range(3)}
+    files["test_ok.py"] = "import widgetlib\n"
+    repo = _make_import_tree(tmp_path, files)  # 3 broken / ~43 scanned ≈ 7% > 5%
+    tests, _, _ = sel.select_tests_with_reasons(["scripts/widgetlib.py"], repo)
+    assert "tests/test_ok.py" in tests
+    err = capsys.readouterr().err
+    assert err.count("import-map cannot parse") == 3  # one per-file WARN each
+    assert err.count("systemic tests/ breakage") == 1  # exactly one aggregate WARN
+
+
+# --- Case 49: touched_module_names resolution rules ------------------------------
+def test_touched_module_names_resolution():
+    m = sel.touched_module_names(
+        [
+            "scripts/issue810_common.py",
+            "scripts/pkg/__init__.py",
+            "src/explore_persona_space/a/b.py",
+            "src/explore_persona_space/a/__init__.py",
+            "tests/test_foo.py",  # never eligible — the touched-test arm owns tests/
+            "scripts/__init__.py",  # the scripts package marker itself: no name
+            "other/module.py",  # outside the two eligible roots
+            "scripts/notes.md",  # not .py
+        ]
+    )
+    assert m["issue810_common"] == {"scripts/issue810_common.py"}
+    assert m["scripts.issue810_common"] == {"scripts/issue810_common.py"}
+    assert m["pkg"] == {"scripts/pkg/__init__.py"}
+    assert m["scripts.pkg"] == {"scripts/pkg/__init__.py"}
+    assert m["explore_persona_space.a.b"] == {"src/explore_persona_space/a/b.py"}
+    assert m["explore_persona_space.a"] == {"src/explore_persona_space/a/__init__.py"}
+    ineligible = {"test_foo", "module", "notes", "scripts"}
+    assert not any(name.rsplit(".", 1)[-1] in ineligible for name in m)
+
+
+# --- Case 50: end-to-end through main() --json — schema unchanged, reason carried
+def test_cli_json_carries_import_map_reason(tmp_path: Path, monkeypatch, capsys):
+    repo = _make_import_tree(tmp_path, {"test_uh_pack.py": "import widgetlib\n"})
+    monkeypatch.setattr(sel, "_resolve_work_root", lambda _arg: repo)
+    monkeypatch.setattr(sel, "compute_touched", lambda *_a, **_k: ["scripts/widgetlib.py"])
+    rc = sel.main(["--json", "--no-fetch", "--repo-root", str(repo)])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload) == {  # --json key set byte-compatible (acceptance (c))
+        "tests",
+        "untested_touched",
+        "base",
+        "missing_invariants",
+        "selection_reasons",
+        "n_tests",
+        "recommended_timeout_s",
+        "slow_tests_selected",
+    }
+    assert "tests/test_uh_pack.py" in payload["tests"]
+    assert payload["selection_reasons"]["tests/test_uh_pack.py"] == [
+        "import-map:scripts/widgetlib.py"
+    ]
+    assert payload["untested_touched"] == []
+
+
+# --- Case 51: LIVE-tree pin of the founding incident (#1286) ---------------------
+def test_import_map_live_tree_issue1286_shape():
+    """No fixtures: the real tree's test_issue810_uh_pack_validation.py is
+    selected for a diff touching issue810_common + issue810_fit_readout, with
+    BOTH import-map reasons (fit_readout is a function-level import — pins the
+    ast.walk extension on the real tree), and neither file is WARNed untested.
+
+    If a future cleanup removes scripts/issue810_*.py or the target test, this
+    pin fails loud — repoint it at another committed import-relationship pair.
+    """
+    repo_root = Path(sel.__file__).resolve().parents[1]
+    touched = ["scripts/issue810_common.py", "scripts/issue810_fit_readout.py"]
+    tests, untested, reasons = sel.select_tests_with_reasons(touched, repo_root)
+    target = "tests/test_issue810_uh_pack_validation.py"
+    assert target in tests
+    assert "import-map:scripts/issue810_common.py" in reasons[target]
+    assert "import-map:scripts/issue810_fit_readout.py" in reasons[target]
+    assert "scripts/issue810_common.py" not in untested
+    assert "scripts/issue810_fit_readout.py" not in untested


### PR DESCRIPTION
Closes task #1299 (workflow-fix: step-9c selector import-map arm).

Adds an additive import-map selection arm to scripts/select_step9c_tests.py: ast-scan of tests/**/test_*.py Import/ImportFrom nodes naming a touched scripts// src/explore_persona_space/ module selects the importing test (reason `import-map:<touched file>`); an import hit marks the touched file tested. Selection grows only; --map-files/--json/timeout sizing byte-compatible. 16 new pins incl. the live-tree #1286 durability pin.

Plan: tasks/*/1299/plans/v3.md (critics 3x APPROVE, consistency PASS). Code-review v1 PASS. Step 9c gate: 3431 passed / 6 skipped; compare exit 0.