### PR TITLE
workflow-fix #1301: v2 composer brief contract — plan_path, not plan_body

### DIFF
--- a/.claude/agents/codex-efficiency-critic.md
+++ b/.claude/agents/codex-efficiency-critic.md
@@ -62,14 +62,34 @@ This is the load-bearing constraint for the entire wrapper agent.
 Spawned by `/adversarial-planner-v2` Phase 2, in PARALLEL with the Claude
 `efficiency-critic` (plan mode). Your brief contains:
 
-- `plan_body`: the full plan text under critique.
+- `issue`: the task number `<N>` (temp-file naming + canonical-path re-derivation).
+- `plan_path`: the ABSOLUTE path to the plan version under critique —
+  `$(uv run python scripts/task.py find <N>)/plans/v<K>.md`, the versioned file for
+  THIS round (NEVER the `plan.md` symlink, which can advance mid-round). If the
+  brief passed a relative form, re-derive
+  `TASK_DIR="$(uv run python scripts/task.py find <N>)"` and join the brief's
+  `plans/v<K>.md` tail — the re-derived absolute path wins (same hardening as
+  `codex-clean-result-critic.md` Step 1b). Read the plan text from this path ONCE
+  at compose time; that text fills the `{{plan_body}}` template substitution in
+  Step 3 (the composed Codex prompt still inlines the verbatim plan text — the
+  paths-only rule governs the BRIEF, not the composed prompt). `test -s` the path
+  BEFORE composing; on a missing/empty file print
+  `BLOCKER: plan_path unresolvable at compose time — <path>` and exit (the
+  orchestrator treats this as a twin no-show → single-Claude fallback, the same
+  contract as the no-span compose gate).
+- `planned_manifest_path` (OPTIONAL): absolute path to
+  `artifacts/planned_manifest.json`. NEVER inlined; when present and non-empty,
+  pass it through as ONE path-reference line in the composed prompt (Codex has
+  file access). Omit that line when the field is absent.
 - `revision_round`: 1-indexed; max 5 (the `/adversarial-planner-v2` per-lens round cap; reconciler invocations don't count).
 - `prior_critique_summaries` (round 2+): one-line summaries across both Efficiency
   twins.
 
-**Snapshot freshness (compose-only).** Your inputs are a spawn-time snapshot; you
-do NOT re-read task state and you do NOT dispatch Codex. Pin the snapshot boundary
-into the prompt (the `SNAPSHOT NOTE` in Step 3).
+**Snapshot freshness (compose-only).** The brief hands you PATHS; the plan text you
+read from `plan_path` at compose time IS the snapshot. Read it ONCE, never re-read
+it after composing, never chase a newer plan version; you do NOT re-read task state
+and you do NOT dispatch Codex. Pin the snapshot boundary into the prompt (the
+`SNAPSHOT NOTE` in Step 3).
 
 ## Procedure
 
@@ -107,8 +127,9 @@ memory: a silently-empty rubric composes a Codex critic with no binding items.
 ### Step 3: Compose the lens-specific prompt
 
 **Composer numeric-grounding rule (load-bearing — closes the #722 fabricated-numbers
-bug).** The ONLY plan content in the prompt is the verbatim `{{plan_body}}` and the
-verbatim `{{lens_items}}` / `{{prior_critique_summaries}}`. NEVER author or inline a
+bug).** The ONLY plan content in the prompt is the verbatim `{{plan_body}}` (the
+plan text you read from `plan_path` at compose time) and the verbatim
+`{{lens_items}}` / `{{prior_critique_summaries}}`. NEVER author or inline a
 numeric value (a projected wall-time, a GPU-hour figure) the brief did not hand you.
 A missing sizing number is itself a finding. Task-reference identifiers (`#<N>`,
 `tasks/<status>/<N>`, `issue[-_]<N>` — i.e. `issue-<N>`/`issue_<N>`, hyphen AND
@@ -153,10 +174,15 @@ PLAN TEXT:
 PRIOR CRITIQUES (this lens, prior rounds):
 {{prior_critique_summaries — empty on round 1}}
 
+PLANNED MANIFEST (machine-readable conditions/metrics/figures — read it from disk
+if needed): {{planned_manifest_path — one path-reference line; omit this line when
+the brief did not provide the field}}
+
 SNAPSHOT NOTE: This prompt reflects the plan body and prior-critique timeline AS
-HANDED TO THE COMPOSER at spawn. Scope every verdict to THIS snapshot — flag a
-sizing claim ONLY against what is written above; never REVISE on the suspicion that
-newer state exists. Within-snapshot findings are not gagged by this note.
+READ BY THE COMPOSER at compose time from the handed `plan_path`. Scope every
+verdict to THIS snapshot — flag a sizing claim ONLY against what is written above;
+never REVISE on the suspicion that newer state exists. Within-snapshot findings are
+not gagged by this note.
 
 For the EFFICIENCY lens (plan mode), evaluate ONLY the following bars — the 8
 PLAN-mode REVISE bars from efficiency-critic.md plus the binding definitions of
@@ -207,7 +233,12 @@ line per residual, single exit — + re-compose on any residual; same recipe +
 rationale as `.claude/agents/codex-critic.md` Step 4, the reference implementation). The
 efficiency lens quotes sizing numbers (wall-times, GPU-hours) heavily, so pass the
 inlined §9 / guidelines substance through `{{lens_items}}` so those numbers clear
-the multiset. Temp files only — no Codex dispatch, no polling loop, no marker.
+the multiset. **Handed-span clarification (binding):** the brief-handed PATH
+strings (`plan_path` + `planned_manifest_path`) count as handed spans for the
+numeric-leak multiset — write BOTH into the handed-span files — so numeric atoms
+inside a path (the `v<K>` plan-version number, the task id in
+`tasks/<status>/<N>/...`) never surface as false-positive composer-authored
+residuals. Temp files only — no Codex dispatch, no polling loop, no marker.
 
 ### Step 5: Return to orchestrator
 
@@ -242,7 +273,8 @@ retry, or return the marker body.
 6. **`background: true`.**
 7. **Fail loud, not silent.** Missing plugin / malformed compose → `BLOCKER: ...`, exit.
 8. **No verdict softening.** Return whatever Codex returns; the reconciler adjudicates.
-9. **Numbers come only from `plan_body`** (+ `lens_items` / `prior_critique_summaries`).
+9. **Numbers come only from `plan_body`** (the plan text read from `plan_path`;
+   + `lens_items` / `prior_critique_summaries`).
 10. **Pin the snapshot boundary; do not chase fresher state.**
 
 ## Memory Usage

--- a/.claude/agents/codex-methodology-baselines-critic.md
+++ b/.claude/agents/codex-methodology-baselines-critic.md
@@ -59,14 +59,34 @@ This is the load-bearing constraint for the entire wrapper agent.
 Spawned by `/adversarial-planner-v2` Phase 2, in PARALLEL with the Claude
 `methodology-baselines-critic`. Your brief contains:
 
-- `plan_body`: the full plan text under critique.
+- `issue`: the task number `<N>` (temp-file naming + canonical-path re-derivation).
+- `plan_path`: the ABSOLUTE path to the plan version under critique —
+  `$(uv run python scripts/task.py find <N>)/plans/v<K>.md`, the versioned file for
+  THIS round (NEVER the `plan.md` symlink, which can advance mid-round). If the
+  brief passed a relative form, re-derive
+  `TASK_DIR="$(uv run python scripts/task.py find <N>)"` and join the brief's
+  `plans/v<K>.md` tail — the re-derived absolute path wins (same hardening as
+  `codex-clean-result-critic.md` Step 1b). Read the plan text from this path ONCE
+  at compose time; that text fills the `{{plan_body}}` template substitution in
+  Step 3 (the composed Codex prompt still inlines the verbatim plan text — the
+  paths-only rule governs the BRIEF, not the composed prompt). `test -s` the path
+  BEFORE composing; on a missing/empty file print
+  `BLOCKER: plan_path unresolvable at compose time — <path>` and exit (the
+  orchestrator treats this as a twin no-show → single-Claude fallback, the same
+  contract as the no-span compose gate).
+- `planned_manifest_path` (OPTIONAL): absolute path to
+  `artifacts/planned_manifest.json`. NEVER inlined; when present and non-empty,
+  pass it through as ONE path-reference line in the composed prompt (Codex has
+  file access). Omit that line when the field is absent.
 - `revision_round`: 1-indexed; max 5 (the `/adversarial-planner-v2` per-lens round cap; reconciler invocations don't count).
 - `prior_critique_summaries` (round 2+): one-line summaries across both Methodology
   & Baselines twins.
 
-**Snapshot freshness (compose-only).** Your inputs are a spawn-time snapshot; you
-do NOT re-read task state and you do NOT dispatch Codex. Pin the snapshot boundary
-into the prompt (the `SNAPSHOT NOTE` in Step 3).
+**Snapshot freshness (compose-only).** The brief hands you PATHS; the plan text you
+read from `plan_path` at compose time IS the snapshot. Read it ONCE, never re-read
+it after composing, never chase a newer plan version; you do NOT re-read task state
+and you do NOT dispatch Codex. Pin the snapshot boundary into the prompt (the
+`SNAPSHOT NOTE` in Step 3).
 
 ## Procedure
 
@@ -107,8 +127,9 @@ memory: a silently-empty rubric composes a Codex critic with no binding items.
 ### Step 3: Compose the lens-specific prompt
 
 **Composer numeric-grounding rule (load-bearing — closes the #722 fabricated-numbers
-bug).** The ONLY plan content in the prompt is the verbatim `{{plan_body}}` and the
-verbatim `{{lens_items}}` / `{{prior_critique_summaries}}`. NEVER author or inline a
+bug).** The ONLY plan content in the prompt is the verbatim `{{plan_body}}` (the
+plan text you read from `plan_path` at compose time) and the verbatim
+`{{lens_items}}` / `{{prior_critique_summaries}}`. NEVER author or inline a
 numeric value the brief did not hand you. A missing number is itself a finding.
 Task-reference identifiers (`#<N>`, `tasks/<status>/<N>`, `issue[-_]<N>` — i.e.
 `issue-<N>`/`issue_<N>`, hyphen AND underscore) are provenance, not result numbers —
@@ -146,10 +167,15 @@ PLAN TEXT:
 PRIOR CRITIQUES (this lens, prior rounds):
 {{prior_critique_summaries — empty on round 1}}
 
+PLANNED MANIFEST (machine-readable conditions/metrics/figures — read it from disk
+if needed): {{planned_manifest_path — one path-reference line; omit this line when
+the brief did not provide the field}}
+
 SNAPSHOT NOTE: This prompt reflects the plan body and prior-critique timeline AS
-HANDED TO THE COMPOSER at spawn. Scope every verdict to THIS snapshot — flag a
-claim ONLY against what is written above; never REVISE on the suspicion that newer
-state exists. Within-snapshot findings are not gagged by this note.
+READ BY THE COMPOSER at compose time from the handed `plan_path`. Scope every
+verdict to THIS snapshot — flag a claim ONLY against what is written above; never
+REVISE on the suspicion that newer state exists. Within-snapshot findings are not
+gagged by this note.
 
 For the METHODOLOGY & BASELINES lens, evaluate ONLY the following items — copied
 VERBATIM from `.claude/rules/critic-lens-reference.md` § Methodology lens
@@ -198,8 +224,13 @@ fail-strict; THEN tokenize atoms splitting hyphenated ranges / slash pairs;
 multiset-subtract `plan_body`+`lens_items`+`prior_critique_summaries`; set-clear the
 scaffold allowlist `{0, 1, 2, 3, 4, 5, 500}`; fail loud collect-all — one BLOCKER
 line per residual, single exit — + re-compose on any residual; same recipe +
-rationale as `.claude/agents/codex-critic.md` Step 4, the reference implementation). Temp
-files only — no Codex dispatch, no polling loop, no marker.
+rationale as `.claude/agents/codex-critic.md` Step 4, the reference implementation).
+**Handed-span clarification (binding):** the brief-handed PATH strings (`plan_path`
++ `planned_manifest_path`) count as handed spans for the numeric-leak multiset —
+write BOTH into the handed-span files — so numeric atoms inside a path (the `v<K>`
+plan-version number, the task id in `tasks/<status>/<N>/...`) never surface as
+false-positive composer-authored residuals. Temp files only — no Codex dispatch, no
+polling loop, no marker.
 
 ### Step 5: Return to orchestrator
 
@@ -232,7 +263,8 @@ retry, or return the marker body.
 5. **`background: true`.**
 6. **Fail loud, not silent.** Missing plugin / malformed compose → `BLOCKER: ...`, exit.
 7. **No verdict softening.** Return whatever Codex returns; the reconciler adjudicates.
-8. **Numbers come only from `plan_body`** (+ `lens_items` / `prior_critique_summaries`).
+8. **Numbers come only from `plan_body`** (the plan text read from `plan_path`;
+   + `lens_items` / `prior_critique_summaries`).
 9. **Pin the snapshot boundary; do not chase fresher state.**
 
 ## Memory Usage

--- a/.claude/agents/codex-statistics-critic.md
+++ b/.claude/agents/codex-statistics-critic.md
@@ -65,15 +65,35 @@ This is the load-bearing constraint for the entire wrapper agent.
 Spawned by `/adversarial-planner-v2` Phase 2, in PARALLEL with the Claude
 `statistics-critic`. Your brief contains:
 
-- `plan_body`: the full plan text under critique (markdown, may be v1 or a revised v<n>).
+- `issue`: the task number `<N>` (temp-file naming + canonical-path re-derivation).
+- `plan_path`: the ABSOLUTE path to the plan version under critique —
+  `$(uv run python scripts/task.py find <N>)/plans/v<K>.md`, the versioned file for
+  THIS round (NEVER the `plan.md` symlink, which can advance mid-round). If the
+  brief passed a relative form, re-derive
+  `TASK_DIR="$(uv run python scripts/task.py find <N>)"` and join the brief's
+  `plans/v<K>.md` tail — the re-derived absolute path wins (same hardening as
+  `codex-clean-result-critic.md` Step 1b). Read the plan text from this path ONCE
+  at compose time; that text fills the `{{plan_body}}` template substitution in
+  Step 3 (the composed Codex prompt still inlines the verbatim plan text — the
+  paths-only rule governs the BRIEF, not the composed prompt). `test -s` the path
+  BEFORE composing; on a missing/empty file print
+  `BLOCKER: plan_path unresolvable at compose time — <path>` and exit (the
+  orchestrator treats this as a twin no-show → single-Claude fallback, the same
+  contract as the no-span compose gate).
+- `planned_manifest_path` (OPTIONAL): absolute path to
+  `artifacts/planned_manifest.json`. NEVER inlined; when present and non-empty,
+  pass it through as ONE path-reference line in the composed prompt (Codex has
+  file access). Omit that line when the field is absent.
 - `revision_round`: 1-indexed; max 5 per the `/adversarial-planner-v2` per-lens round cap (reconciler invocations don't count).
 - `prior_critique_summaries` (round 2+): one-line summaries of prior critique rounds
   across both the Claude AND Codex Statistics twins.
 
-**Snapshot freshness (compose-only).** Your inputs are a point-in-time snapshot the
-orchestrator handed you; you do NOT re-read task state and you do NOT dispatch Codex.
-Pin the snapshot boundary into the composed prompt (the `SNAPSHOT NOTE` in Step 3)
-so Codex scopes its verdict to what it was given.
+**Snapshot freshness (compose-only).** The brief hands you PATHS; the plan text you
+read from `plan_path` at compose time IS the point-in-time snapshot. Read it ONCE,
+never re-read it after composing, and never chase a newer plan version; you do NOT
+re-read task state and you do NOT dispatch Codex. Pin the snapshot boundary into the
+composed prompt (the `SNAPSHOT NOTE` in Step 3) so Codex scopes its verdict to what
+it was given.
 
 ## Procedure
 
@@ -110,7 +130,8 @@ memory: a silently-empty rubric composes a Codex critic with no binding items.
 
 **Composer numeric-grounding rule (load-bearing — closes the #722 fabricated-numbers
 bug).** The ONLY plan content you place in the prompt is the verbatim `{{plan_body}}`
-and the verbatim `{{lens_items}}` / `{{prior_critique_summaries}}`. NEVER author,
+(the plan text you read from `plan_path` at compose time) and the verbatim
+`{{lens_items}}` / `{{prior_critique_summaries}}`. NEVER author,
 paraphrase, or inline ANY numeric / predicted / effect-size value you sourced from
 your own context, memory, or an artifact the brief did not hand you. Codex critiques
 the plan AS WRITTEN; a number not in `plan_body` is not the plan's claim. A missing
@@ -151,8 +172,13 @@ PLAN TEXT:
 PRIOR CRITIQUES (this lens, prior rounds):
 {{prior_critique_summaries — empty on round 1}}
 
+PLANNED MANIFEST (machine-readable conditions/metrics/figures — read it from disk
+if needed): {{planned_manifest_path — one path-reference line; omit this line when
+the brief did not provide the field}}
+
 SNAPSHOT NOTE: This prompt reflects the plan body and prior-critique timeline AS
-HANDED TO THE COMPOSER at spawn. It MAY be behind on-disk state by the time your
+READ BY THE COMPOSER at compose time from the handed `plan_path`. It MAY be behind
+on-disk state by the time your
 verdict is read. Scope every verdict to THIS snapshot — flag a number/claim ONLY
 against what is written above; never REVISE on the suspicion that newer state
 exists. Within-snapshot findings (flaws you CAN see in this plan text) are not
@@ -216,7 +242,12 @@ task ref or numeric atom), fail loud collect-all (one `BLOCKER: composer-authore
 number <n> not traceable ...` line per residual, single exit) and re-compose from
 the handed inputs alone — never hand-edit the offending number in.
 (Same recipe + rationale as `.claude/agents/codex-critic.md` Step 4; that file is
-the reference implementation.)
+the reference implementation.) **Handed-span clarification (binding):** the
+brief-handed PATH strings (`plan_path` + `planned_manifest_path`) count as handed
+spans for the numeric-leak multiset — write BOTH into the handed-span files — so
+numeric atoms inside a path (the `v<K>` plan-version number, the task id in
+`tasks/<status>/<N>/...`) never surface as false-positive composer-authored
+residuals.
 
 ### Step 5: Return to orchestrator
 
@@ -251,7 +282,8 @@ for this lens this round. You do NOT validate, retry, or return the marker body.
 6. **Fail loud, not silent.** Missing plugin / malformed compose → print `BLOCKER:
    ...` and exit.
 7. **No verdict softening.** Return whatever Codex returns; the reconciler adjudicates.
-8. **Numbers come only from `plan_body`** (+ `lens_items` / `prior_critique_summaries`).
+8. **Numbers come only from `plan_body`** (the plan text read from `plan_path`;
+   + `lens_items` / `prior_critique_summaries`).
    A missing number is a finding, not something you supply.
 9. **Pin the snapshot boundary; do not chase fresher state.**
 

--- a/.claude/agents/efficiency-critic.md
+++ b/.claude/agents/efficiency-critic.md
@@ -35,7 +35,7 @@ tools:
 > (`methodology-baselines-critic`), correctness (`code-correctness-critic`), and
 > plan-adherence (`plan-adherence-critic`).
 
-**Detect your mode from the brief.** A `plan_body` / plan-path brief spawned by
+**Detect your mode from the brief.** A plan-path brief spawned by
 `/adversarial-planner-v2` → PLAN MODE. A `worktree` + `revision_round` brief on
 the implementation panel → IMPLEMENTATION MODE. If both are present, review the
 plan's compute section AND the diff (rare; state which you did).

--- a/.claude/skills/adversarial-planner-v2/SKILL.md
+++ b/.claude/skills/adversarial-planner-v2/SKILL.md
@@ -180,7 +180,9 @@ orchestrator bg-runs via `scripts/codex_task.py`:
 Efficiency EARNS its Codex twin here (Thomas's multi-GPU emphasis).
 Consistency-checker + the (implementation-side) plan-adherence lens are
 Claude-only. Pass each subagent the PATH to `plans/vN.md` + `planned_manifest.json`,
-never the bodies (429 pacing).
+never the bodies (429 pacing); each Codex composer reads the plan from the handed
+path at compose time and inlines the verbatim plan text into its composed Codex
+prompt — `{{plan_body}}` is a compose-time substitution, not a brief field.
 
 **Quota-sentinel pre-check first (#1204, CLAUDE.md § Codex ensemble
 review):** when LIVE, the batch is the 3 Claude critics +

--- a/tests/test_v2_composer_plan_path_brief.py
+++ b/tests/test_v2_composer_plan_path_brief.py
@@ -1,0 +1,95 @@
+"""Pin #1301: the three v2 Codex composer briefs are plan_path-based (paths-only).
+
+Pins the reconciliation of the v2 composer brief contract with
+`.claude/skills/adversarial-planner-v2/SKILL.md`'s paths-only rule ("Pass each
+subagent the PATH to `plans/vN.md` + `planned_manifest.json`, never the bodies"):
+
+1. Each of the three v2 Codex composer specs declares `plan_path` as a brief
+   field and NO LONGER declares `plan_body` as one (the declaration-line form
+   ``- `plan_body`:`` is banned; `{{plan_body}}` survives ONLY as the
+   compose-time template substitution filled from the text read at
+   `plan_path`).
+2. Each composer carries the compose-time-read linkage, the fail-loud
+   `BLOCKER: plan_path unresolvable at compose time` clause, and the
+   "NEVER the `plan.md` symlink" versioned-file clause.
+3. The v2 skill carries the one-contract clarifying clause.
+4. `efficiency-critic.md`'s mode detection no longer names a `plan_body`
+   brief (the token that would re-seed the drift this task removed).
+
+Shape-token pins only (per plan #1301 §4-F / §8): future rewording of the
+surrounding prose is free as long as the contract tokens survive.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+V2_COMPOSERS = (
+    ".claude/agents/codex-statistics-critic.md",
+    ".claude/agents/codex-methodology-baselines-critic.md",
+    ".claude/agents/codex-efficiency-critic.md",
+)
+
+V2_SKILL = ".claude/skills/adversarial-planner-v2/SKILL.md"
+
+# The banned brief-field DECLARATION form (a markdown list bullet declaring
+# `plan_body` as a brief field). `{{plan_body}}` mentions elsewhere are fine.
+PLAN_BODY_BRIEF_FIELD_DECL = re.compile(r"^\s*-\s*`plan_body`\s*:", re.MULTILINE)
+
+
+def _read(rel: str) -> str:
+    return (REPO_ROOT / rel).read_text(encoding="utf-8")
+
+
+def _norm(text: str) -> str:
+    return " ".join(text.split())
+
+
+def test_composers_declare_plan_path_not_plan_body():
+    for rel in V2_COMPOSERS:
+        text = _read(rel)
+        assert "`plan_path`" in text, rel  # (a) plan_path declared
+        assert not PLAN_BODY_BRIEF_FIELD_DECL.search(text), (
+            f"{rel} still declares `plan_body` as a brief field"
+        )  # (b)
+
+
+def test_composers_retain_plan_body_template_substitution():
+    # (c) the template-substitution name is retained, not renamed — the Step-4
+    # numeric-leak verifier and the v1 reference implementation cite it.
+    for rel in V2_COMPOSERS:
+        assert "{{plan_body}}" in _read(rel), rel
+
+
+def test_composers_carry_compose_time_read_linkage():
+    # (d) the plan text is read from plan_path at compose time.
+    for rel in V2_COMPOSERS:
+        text = _norm(_read(rel))
+        assert "plan_path" in text, rel
+        assert "compose time" in text, rel
+
+
+def test_composers_fail_loud_on_unresolvable_plan_path():
+    # Reviewer-carried constraint: the fail-loud clause is present per spec.
+    for rel in V2_COMPOSERS:
+        text = _norm(_read(rel))
+        assert "BLOCKER: plan_path unresolvable at compose time" in text, rel
+
+
+def test_composers_pin_versioned_file_never_the_symlink():
+    # Reviewer-carried constraint: the versioned plans/v<K>.md file, never the
+    # plan.md symlink (which can advance mid-round).
+    for rel in V2_COMPOSERS:
+        text = _norm(_read(rel))
+        assert "NEVER the `plan.md` symlink" in text, rel
+
+
+def test_v2_skill_paths_only_clause_present():
+    text = _norm(_read(V2_SKILL))
+    assert "never the bodies" in text
+    assert "reads the plan from the handed path at compose time" in text
+
+
+def test_efficiency_critic_mode_detection_drops_plan_body_token():
+    assert "`plan_body` / plan-path brief" not in _read(".claude/agents/efficiency-critic.md")


### PR DESCRIPTION
Closes task #1301.

Reconciles the three v2 Codex composer specs' brief contract (was: brief carries `plan_body`, the full plan text) with the v2 skill's paths-only rule: the brief hands `plan_path` (+ optional `planned_manifest_path`); the composer reads the versioned `plans/v<K>.md` at compose time and inlines it as the `{{plan_body}}` substitution.

- `.claude/agents/codex-{statistics,methodology-baselines,efficiency}-critic.md`: path-based brief contract, compose-time-read snapshot semantics, Step-4 handed-span clarification, fail-loud BLOCKER on unresolvable plan_path
- `.claude/skills/adversarial-planner-v2/SKILL.md`: one-contract clarifying clause
- `.claude/agents/efficiency-critic.md`: stale `plan_body` token dropped
- NEW `tests/test_v2_composer_plan_path_brief.py` (7-test durability pin)

Plan: 3× critic APPROVE + consistency PASS. Code-review: PASS (r1).