### PR TITLE
issue-1302: couple mbc inline Alt capsule to critic-lens-reference

### DIFF
--- a/.claude/agents/methodology-baselines-critic.md
+++ b/.claude/agents/methodology-baselines-critic.md
@@ -103,9 +103,10 @@ answer its own question. Be sparing.
 ## Methodology & Baselines lens
 
 **Canonical-heading anchor (#1292 — the v2 sibling of #1282; incident #1265).**
-The grep target is ALWAYS the canonical heading `### Methodology lens` in
+The grep targets are ALWAYS the canonical headings `### Methodology lens` and —
+for item 2's absorbed screen — `### Alternative Explanations lens`, both in
 `.claude/rules/critic-lens-reference.md` — never a brief-supplied or paraphrased
-variant. If that grep returns NO span, STOP and re-grep (e.g. case-insensitive
+variant. If a grep returns NO span, STOP and re-grep (e.g. case-insensitive
 on a distinctive fragment like `Methodology`) to locate a renamed heading —
 never review from the item capsule in this spec alone: the binding REVISE bars,
 N/A escapes, and incident citations would silently never load (the #1265
@@ -124,7 +125,10 @@ efficiency-critic's). The items I own:
    alternative explanation for a positive result that (a) the design does not rule
    out AND (b) no downstream weigher can weigh from reported diagnostics? Only
    fatal-and-unweighable confounds trigger REVISE. **This item absorbs the
-   Alternative Explanations lens's fatal-confound screen (v1 Alt items 1-3):** for
+   fatal-confound screen from `### Alternative Explanations lens` (v1 Alt
+   items 1-3) in `.claude/rules/critic-lens-reference.md` — grep that heading
+   too and Read its short span alongside the Methodology span; on divergence
+   the reference wins and this capsule gets re-synced:** for
    each predicted positive result, name the simplest alternative that does NOT
    require the claimed mechanism, and REVISE only when the design cannot
    distinguish it. **Controls & baselines** live here: REVISE a missing control /

--- a/tests/test_adversarial_planner_lens_brief_headings.py
+++ b/tests/test_adversarial_planner_lens_brief_headings.py
@@ -11,6 +11,8 @@ composers cite their canonical headings backticked-verbatim, the Claude
 agents carry the STOP-and-re-grep anchor rule, the composers carry the
 no-span compose gate, and every `.claude/agents/*.md` consumer of
 critic-lens-reference.md is pinned or explicitly allowlisted.
+(5) #1302: the mbc inline Alt capsule cites its source heading + carries the
+reference-wins re-sync coupling.
 """
 
 from pathlib import Path
@@ -62,7 +64,10 @@ def test_critic_md_grep_target_is_canonical_never_brief_supplied():
 # test_v2_cited_headings_are_canonical_and_exist_in_lens_reference tautological.
 V2_FILES_TO_HEADINGS = {
     ".claude/agents/statistics-critic.md": ("### Statistics & Measurement lens",),
-    ".claude/agents/methodology-baselines-critic.md": ("### Methodology lens",),
+    ".claude/agents/methodology-baselines-critic.md": (
+        "### Methodology lens",
+        "### Alternative Explanations lens",
+    ),
     ".claude/agents/efficiency-critic.md": ("### Methodology lens",),
     ".claude/agents/codex-statistics-critic.md": ("### Statistics & Measurement lens",),
     ".claude/agents/codex-methodology-baselines-critic.md": (
@@ -96,6 +101,23 @@ def test_v2_codex_composers_carry_no_span_compose_gate():
         text = (REPO_ROOT / rel).read_text(encoding="utf-8")
         assert "No-span compose gate" in text, rel
         assert "STOP and return a BLOCKER" in _norm(text), rel
+
+
+def test_mbc_alt_capsule_is_coupled_to_reference_span():
+    """#1302: the mbc item-2 Alt capsule is an ADAPTED absorption (not a verbatim
+    copy), so the pin is a cross-reference assertion — the capsule cites the
+    canonical heading verbatim (covered by V2_FILES_TO_HEADINGS assertions) AND
+    carries the read-alongside / reference-wins load instruction. Deleting the
+    coupling sentence, or renaming the source heading, fails a test. NOTE: the
+    first needle hardcodes the heading string, so a heading-rename commit must
+    update this test too (loud by design)."""
+    rel = ".claude/agents/methodology-baselines-critic.md"
+    text_norm = _norm((REPO_ROOT / rel).read_text(encoding="utf-8"))
+    assert (
+        _norm("absorbs the fatal-confound screen from `### Alternative Explanations lens`")
+        in text_norm
+    )
+    assert "on divergence the reference wins" in text_norm
 
 
 # Discovery pin — every .claude/agents/*.md consumer of critic-lens-reference.md


### PR DESCRIPTION
Closes task #1302 (workflow-fix, kind: infra).

Couples the inline Alternative-Explanations capsule in .claude/agents/methodology-baselines-critic.md to its source span ### Alternative Explanations lens in .claude/rules/critic-lens-reference.md: verbatim heading citation + read-alongside/reference-wins load instruction, V2_FILES_TO_HEADINGS extension, and a new coupling test (test_mbc_alt_capsule_is_coupled_to_reference_span). Extends the #1282/#1292 pin pattern; closes the #1265-class silent-drift gap for the one remaining inline capsule.

Gate evidence: code-review PASS (r1), test-verdict PASS (3370 passed, COMPARE_RC=0, lint clean).