### PR TITLE
issue-1304: guard scripts-local lazy imports (backend_poll + pod_config), widen #1296 pin test

### DIFF
--- a/scripts/backend_poll.py
+++ b/scripts/backend_poll.py
@@ -1381,6 +1381,7 @@ def _crash_signature_has_our_code_frame(text: str | None) -> bool:
     """
     if not text:
         return False
+    _ensure_scripts_dir_on_sys_path()
     from failure_classifier import OUR_CODE_FRAME
 
     return bool(OUR_CODE_FRAME.search(text))

--- a/scripts/pod_config.py
+++ b/scripts/pod_config.py
@@ -49,6 +49,22 @@ if TYPE_CHECKING:
     # keeps the cheap ``--list`` / ``--check`` paths free of the eager load.
     from runpod_api import PodInfo
 
+
+def _ensure_scripts_dir_on_sys_path() -> None:
+    """Insert THIS file's dir (scripts/) so a lazy ``import runpod_api`` resolves.
+
+    In script mode scripts/ is already ``sys.path[0]``; in MODULE mode
+    (``from scripts.pod_config import parse_pods_conf``) only the repo root is
+    on sys.path, so a bare lazy ``runpod_api`` import raises
+    ``ModuleNotFoundError`` (#1296/#1304). Mirrors scripts/backend_poll.py's
+    helper; idempotent; called ONLY on the lazy paths so the cheap
+    ``--list``/``--check`` paths and library imports never mutate sys.path.
+    """
+    scripts_dir = str(Path(__file__).resolve().parent)
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+
+
 # ---------------------------------------------------------------------------
 # Paths -- resolved to the MAIN repo regardless of which worktree this
 # module is loaded from. ``pods.conf`` and ``pods_ephemeral.json`` are
@@ -572,6 +588,7 @@ def _guard_against_dropping_running(dropped: set[str], on_disk_rows: dict[str, P
     """
     # Lazy import — ``runpod_api`` is heavy (loads RunPod GraphQL config
     # from .env at import time).
+    _ensure_scripts_dir_on_sys_path()
     try:
         from runpod_api import RunPodError, list_team_pods
     except ImportError:  # pragma: no cover - only if repo is malformed
@@ -1546,6 +1563,7 @@ def cmd_refresh_from_api(pods: list[Pod], pod_name: str | None) -> None:
     # Import lazily — ``runpod_api`` is the heavy module and importing at
     # module top would force every ``pod_config --check`` / ``--list`` to
     # eagerly load it. The lazy import keeps the cheap subcommands cheap.
+    _ensure_scripts_dir_on_sys_path()
     from runpod_api import list_team_pods
 
     live_pods = list_team_pods()

--- a/tests/test_backend_poll.py
+++ b/tests/test_backend_poll.py
@@ -3108,7 +3108,7 @@ def test_gcp_queue_timeout_failover_reconstructs_from_reconnect_handle(
 
 
 # ---------------------------------------------------------------------------
-# #710/#1296 — scripts-dir bootstrap before the lazy ``from runpod_api`` sites
+# #710/#1296/#1304 — scripts-dir bootstrap before lazy scripts-local imports
 # ---------------------------------------------------------------------------
 
 
@@ -3152,34 +3152,104 @@ def test_ensure_scripts_dir_bootstrap_resolves_runpod_api_in_module_mode(monkeyp
         sys.modules.pop("runpod_api", None)
 
 
-def test_every_lazy_runpod_api_import_is_bootstrap_guarded():
-    """#1296 durability pin: every INDENTED (function-local, lazy)
-    ``from runpod_api import`` line in scripts/backend_poll.py must have the
-    scripts-dir bootstrap — ``_ensure_scripts_dir_on_sys_path()`` or the
-    inline ``sys.path.insert(0, scripts_dir)`` — within the preceding ~12
+def _inside_type_checking_block(lines: list[str], i: int) -> bool:
+    """True iff ``lines[i]`` sits INSIDE an ``if TYPE_CHECKING:`` block.
+
+    BLOCK MEMBERSHIP, not raw-window presence (#1304 review concern): walk
+    upward to the NEAREST non-blank, non-comment line at STRICTLY LOWER
+    indentation — the enclosing block opener. Only a literal
+    ``if TYPE_CHECKING:`` / ``if typing.TYPE_CHECKING:`` opener exempts; a
+    runtime lazy import that merely sits within a few lines of a
+    TYPE_CHECKING mention is NOT exempt (an ``else:``/``try:``/``def`` opener
+    returns False).
+    """
+    indent_i = len(lines[i]) - len(lines[i].lstrip())
+    for j in range(i - 1, -1, -1):
+        stripped = lines[j].strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent_j = len(lines[j]) - len(lines[j].lstrip())
+        if indent_j < indent_i:
+            return stripped.startswith(("if TYPE_CHECKING", "if typing.TYPE_CHECKING"))
+    return False
+
+
+def test_every_lazy_scripts_local_import_is_bootstrap_guarded():
+    """#1296/#1304 durability pin, WIDENED to the scripts-local module CLASS
+    (renames + supersedes the #1296
+    ``test_every_lazy_runpod_api_import_is_bootstrap_guarded``, which pinned
+    only ``from runpod_api import`` in backend_poll.py — a fixed module name
+    is exactly what let the unguarded ``failure_classifier`` site slip past
+    it, #1304): every INDENTED (function-local, lazy) import of a
+    scripts-local module — any stem of ``scripts/*.py``, derived DYNAMICALLY
+    so a future scripts-local module is auto-covered — in
+    scripts/backend_poll.py AND scripts/pod_config.py must have the
+    scripts-dir bootstrap (``_ensure_scripts_dir_on_sys_path()`` or the
+    inline ``sys.path.insert(0, scripts_dir)``) within the preceding ~12
     lines, so a FUTURE bare site cannot re-introduce the module-mode
-    ModuleNotFoundError landmine. Comment lines never satisfy the guard."""
+    ModuleNotFoundError landmine. Scan scope is these TWO files — the ones
+    with known module-mode lazy sites (the poller + pod_config's module-mode
+    consumers, e.g. ``backends/runpod.py``); a future widening starts from
+    them. Both import forms are matched: ``from X import ...`` (undotted
+    module names only, so module-mode-safe ``from scripts.pod_config import
+    ...`` consumers are excluded by construction) and
+    ``import X [as Y][, Z [as W]]``. Comment lines never satisfy the guard;
+    an ``if TYPE_CHECKING:`` block member is exempt by BLOCK MEMBERSHIP only
+    (``_inside_type_checking_block``)."""
+    import re
+    import sys
+
     import scripts.backend_poll as bp
 
-    lines = Path(bp.__file__).read_text(encoding="utf-8").splitlines()
-    lazy_sites = [
-        i
-        for i, line in enumerate(lines)
-        if line.strip().startswith("from runpod_api import") and line != line.lstrip()
-    ]
-    assert lazy_sites, "expected >=1 lazy 'from runpod_api import' site in backend_poll.py"
-    for i in lazy_sites:
-        window = [
-            ln.strip()
-            for ln in lines[max(0, i - 12) : i]
-            if ln.strip() and not ln.strip().startswith("#")
-        ]
-        guarded = any(
-            "_ensure_scripts_dir_on_sys_path()" in ln or "sys.path.insert(0, scripts_dir)" in ln
-            for ln in window
-        )
-        assert guarded, (
-            f"scripts/backend_poll.py:{i + 1}: lazy 'from runpod_api import' without a "
-            f"scripts-dir bootstrap in the preceding 12 lines — call "
-            f"_ensure_scripts_dir_on_sys_path() directly above the import (#1296)"
+    scripts_dir = Path(bp.__file__).resolve().parent
+    stems = {p.stem for p in scripts_dir.glob("*.py")}
+    # Sanity-guard the dynamic stems set: a scripts/*.py whose stem shadows a
+    # stdlib module would make this scan flag stdlib imports (verified empty
+    # today; installed-package shadowing is left unchecked by design — there
+    # is no cheap authoritative enumeration of installed top-level names).
+    stdlib_overlap = stems & set(sys.stdlib_module_names)
+    assert not stdlib_overlap, (
+        f"scripts/*.py stems shadow stdlib modules {sorted(stdlib_overlap)}; "
+        f"the dynamic scripts-local stems scan cannot distinguish them"
+    )
+
+    from_re = re.compile(r"\s+from ([A-Za-z_]\w*) import\b")
+    import_re = re.compile(
+        r"\s+import ([A-Za-z_]\w*(?:\s+as\s+\w+)?"
+        r"(?:\s*,\s*[A-Za-z_]\w*(?:\s+as\s+\w+)?)*)\s*(#.*)?$"
+    )
+
+    for fname in ("backend_poll.py", "pod_config.py"):
+        lines = (scripts_dir / fname).read_text(encoding="utf-8").splitlines()
+        n_flagged = 0
+        for i, line in enumerate(lines):
+            m = from_re.match(line)
+            if m:
+                names = [m.group(1)]
+            else:
+                m2 = import_re.match(line)
+                names = [seg.split()[0] for seg in m2.group(1).split(",")] if m2 else []
+            if not any(n in stems for n in names):
+                continue
+            if _inside_type_checking_block(lines, i):
+                continue  # type-checking-only import; no runtime effect
+            n_flagged += 1
+            window = [
+                ln.strip()
+                for ln in lines[max(0, i - 12) : i]
+                if ln.strip() and not ln.strip().startswith("#")
+            ]
+            guarded = any(
+                "_ensure_scripts_dir_on_sys_path()" in ln or "sys.path.insert(0, scripts_dir)" in ln
+                for ln in window
+            )
+            assert guarded, (
+                f"scripts/{fname}:{i + 1}: lazy scripts-local import ({line.strip()!r}) "
+                f"without a scripts-dir bootstrap in the preceding 12 lines — call "
+                f"_ensure_scripts_dir_on_sys_path() directly above the import "
+                f"(#1296/#1304)"
+            )
+        assert n_flagged, (
+            f"expected >=1 flagged lazy scripts-local import site in scripts/{fname} "
+            f"(non-vacuity: the scan went blind if this fires)"
         )

--- a/tests/test_pod_config_refresh_from_api.py
+++ b/tests/test_pod_config_refresh_from_api.py
@@ -536,3 +536,48 @@ def test_refresh_does_not_fabricate_unmanaged_rows(
     assert written is not None
     by_name = {p.name for p in written}
     assert by_name == {"pod-763"}, by_name
+
+
+# ---------------------------------------------------------------------------
+# #1304 — scripts-dir bootstrap before the lazy ``from runpod_api`` sites
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_scripts_dir_bootstrap_enables_runpod_api_import(monkeypatch):
+    """#1304: ``pod_config._ensure_scripts_dir_on_sys_path()`` makes a bare
+    ``import runpod_api`` resolve in MODULE mode (repo root on sys.path,
+    scripts/ NOT), with a built-in NEGATIVE CONTROL proving the pre-fix
+    ``ModuleNotFoundError`` exists once scripts/ is scrubbed. Mirror of
+    tests/test_backend_poll.py's #1296 behavioral test
+    (``test_ensure_scripts_dir_bootstrap_resolves_runpod_api_in_module_mode``).
+    Import only — no live RunPod API call is ever made."""
+    import importlib
+
+    scripts_dir = str(Path(pod_config.__file__).resolve().parent)
+    # Scrub every sys.path entry that resolves to scripts/ (cross-test-file
+    # inserts included, e.g. this file's own module-top insert).
+    # monkeypatch.setattr replaces the LIST OBJECT and restores the original
+    # at teardown, so the helper's in-test insert (into the scrubbed list)
+    # never leaks either.
+    scrubbed = [p for p in sys.path if str(Path(p or ".").resolve()) != scripts_dir]
+    monkeypatch.setattr(sys, "path", scrubbed)
+    # delitem records + restores the PRE-test runpod_api module object (this
+    # file imports PodInfo from it at module top, so one exists).
+    monkeypatch.delitem(sys.modules, "runpod_api", raising=False)
+
+    # NEGATIVE CONTROL (fail-loud claim): with scripts/ scrubbed and the
+    # bootstrap not yet run, the bare import raises — the exact pre-fix
+    # failure mode at pod_config's two lazy runtime sites.
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module("runpod_api")
+
+    pod_config._ensure_scripts_dir_on_sys_path()
+
+    mod = importlib.import_module("runpod_api")
+    try:
+        assert hasattr(mod, "list_team_pods")
+    finally:
+        # Drop the module object THIS test just imported so it cannot alias
+        # past teardown; monkeypatch then restores the original entry after
+        # this pop.
+        sys.modules.pop("runpod_api", None)


### PR DESCRIPTION
Closes task #1304 (daily-fix: guard backend_poll failure_classifier import).

## Summary
- Guard the unguarded scripts-local lazy import `from failure_classifier import OUR_CODE_FRAME` in `scripts/backend_poll.py` (`_crash_signature_has_our_code_frame`, CUDA-IMA escalation path) with `_ensure_scripts_dir_on_sys_path()`.
- Add a mirrored local `_ensure_scripts_dir_on_sys_path()` helper to `scripts/pod_config.py`, called above both `runpod_api` lazy sites — the try/except-wrapped never-drop-RUNNING guard site stops masking healthy module-mode imports; the bare `cmd_refresh_from_api` site stops crashing with module-mode ModuleNotFoundError.
- Rename + widen the #1296 pin test to the scripts-local module class: dynamic `scripts/*.py` stems, both import forms, both files, block-membership TYPE_CHECKING exemption, per-file non-vacuity, stdlib-shadow assert. New behavioral bootstrap test for pod_config.

## Test plan
- [x] Step 9c touched-scope gate: 4411 passed / 6 skipped / 0 failed (exit 0)
- [x] step9c_baseline compare: new=[], lint clean on touched files (repo-wide ruff delta −14)
- [x] Fail-loud probe: reverting one guard makes the widened test FAIL naming file:line
- [x] Module-mode spot-probe: `from scripts.pod_config import _ensure_scripts_dir_on_sys_path; f(); import runpod_api` → ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)