### PR TITLE
issue-1308: planner.md §12 incident-trace rule for detection/trigger-lane predicates

### DIFF
--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -435,6 +435,25 @@ For each assumption, state:
 
 Be exhaustive. Wrong assumptions are the #1 cause of wasted GPU time.
 
+**Detection / trigger-lane predicate plans — trace the predicate against
+the motivating incident's REAL artifact (#1287).** When the plan designs
+or modifies a predicate that classifies a persisted artifact's shape to
+decide an automated action (a watcher lane's fire/keep, a guard's
+block/allow, a janitor's reap, a failure classifier's class) and the
+motivating incident left a persisted artifact (transcript, log, events
+row, sidecar), §12 MUST carry one assumption row tracing EVERY predicate
+arm — including the read/ingest path that feeds it — against that
+artifact: name it by path, evaluate each arm on values MEASURED from it
+at plan time (row counts, byte sizes, field values — read, never
+recalled), and state the traced outcome. The predicate MUST fire on its
+own motivating incident; "would not fire" is a design defect to fix
+before returning the plan (#1287 v1: both arms read `keep` on the very
+#1277 transcript it was built to catch — 14 assistant rows defeat the
+zero-response arm, 825,591 B defeats the 262,144 B read cap). Artifact
+aged off disk → trace the incident's recorded measurements at Medium
+confidence; prospective guard with no incident artifact → state that in
+the row.
+
 ## Goal-currency guard (re-read the Goal before returning — #922)
 
 The user can amend the canonical Goal WHILE you draft: on #922 two

--- a/tests/test_planner_incident_trace_guidance.py
+++ b/tests/test_planner_incident_trace_guidance.py
@@ -1,0 +1,48 @@
+"""Pins the planner.md SS12 incident-trace authoring guidance (#1308): a plan
+that designs/modifies a detection/trigger-lane predicate must trace every
+predicate arm -- including its read/ingest path -- against the motivating
+incident's REAL persisted artifact, with measured values, and the predicate
+must fire on that incident. planner.md sits in the lint size-WARN band, so
+trim pressure is real; this pin fails loud if the paragraph is deleted, moved
+out of SS12, or has its must-fire sentence / incident numbers reworded away.
+
+Modeled on tests/test_planner_row_coverage_guidance.py (no verify_plan
+execution half -- this rule has no mechanical verifier; the Phase-1.5
+fact-checker stays the semantic backstop).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+PLANNER = REPO / ".claude" / "agents" / "planner.md"
+
+# Whitespace-normalized phrase pins (re-wrapping the paragraph must not break
+# them; rewording the load-bearing clauses away must).
+PINNED_PHRASES = (
+    # the rule's title / trigger anchor
+    "motivating incident's REAL artifact (#1287)",
+    # the must-fire requirement
+    "The predicate MUST fire on its own motivating incident",
+    # the worked example stays grounded in the real measured numbers
+    "825,591 B defeats the 262,144 B read cap",
+    # the read/ingest-path clause (half the #1287 defect was a read-path defect)
+    "including the read/ingest path",
+)
+
+
+def test_planner_md_has_incident_trace_guidance():
+    text = PLANNER.read_text(encoding="utf-8")
+    norm = " ".join(text.split())
+    for phrase in PINNED_PHRASES:
+        assert phrase in norm, f"pinned phrase missing from planner.md: {phrase!r}"
+    # Placement (raw text): the rule lives INSIDE `### 12. Assumptions`,
+    # before the `## Goal-currency guard` H2 -- not stranded elsewhere.
+    # The `## ` prefix is deliberate: a prose `§ Goal-currency guard`
+    # cross-reference exists earlier in the file and must not match.
+    assert (
+        text.index("### 12. Assumptions")
+        < text.index("REAL artifact (#1287)")
+        < text.index("## Goal-currency guard")
+    ), "incident-trace rule is not placed inside SS12 before the Goal-currency guard H2"


### PR DESCRIPTION
Closes task #1308. Adds the §12 rule requiring detection/trigger-lane predicate plans to trace the predicate against the motivating incident's real artifact (+ pin test). Plan: tasks/running/1308/plans/plan.md