### PR TITLE
workflow-fix #1306: c15 fail-loud evidence scan accepts pytest.raises negative controls + labeled pins

### DIFF
--- a/scripts/verify_plan.py
+++ b/scripts/verify_plan.py
@@ -1952,6 +1952,23 @@ _FAILLOUD_TEST_EVIDENCE_RE = re.compile(
 # otherwise self-certify (`grep -n 'except Exception' tests/test_foo.py`).
 _FAILLOUD_GREP_LINE_RE = re.compile(r"(?i)\bgrep\b")
 
+# Evidence route 2 (#1306): a quoted pytest.raises control with a named
+# exception is intrinsically fail-loud test vocabulary — accepted WITHOUT a
+# same-line test_ identifier (#1296: the negative-control literal sits on
+# its own hard-wrapped line). Corpus-audited 2026-07-14: flips exactly the
+# two #1296 incident plans out of 119 standing infra|batch WARNs.
+_FAILLOUD_PYTEST_RAISES_RE = re.compile(r"pytest\.raises\(\s*[\w.]+")
+
+# Evidence route 3 (#1306): a deliberate labeled pin line opens a FORWARD,
+# paragraph-bounded scan for the test identifier — the labeled-line
+# convention (c31 precedent: an unlabeled c15-style loose window
+# false-satisfied all 9 of c31's incident plan versions, so the label is
+# load-bearing), made wrap-tolerant for long test paths (#1296 v2's
+# 105-char path forced the wrap). A blank line ends the paragraph; the
+# scan is capped (incident paragraph = 5 lines; 8 = 5 + margin).
+_FAILLOUD_PIN_LABEL_RE = re.compile(r"(?i)\bfail[- ]?loud (?:pin|acceptance)\b[^:\n]{0,40}:")
+_FAILLOUD_PIN_SCAN_LINES = 8
+
 # Anchor carriers that never bind: §0.0 TL;DR / §0 Plan Summary restate
 # criteria as summary prose (same rationale as c8's _tldr_ranges exclusion).
 _FAILLOUD_SUMMARY_HEAD_RE = re.compile(r"(?i)tl;dr|plan summary|^(?:§\s*)?0(?:\.0)?\b")
@@ -2011,15 +2028,37 @@ def _failloud_claim_hits(plan: str) -> list[tuple[str, str]]:
 
 
 def _failloud_test_evidence_lines(plan: str) -> list[str]:
-    """RAW-plan lines naming a committed fail-loud-exercising test: a
-    ``test_`` identifier (also matches tests/<file>.py paths) co-located with
-    fail-loud vocabulary, grep-command lines excluded."""
+    """RAW-plan lines naming a committed fail-loud-exercising test, three
+    routes (#913/#1306): (1) a ``test_`` identifier co-located with
+    fail-loud vocabulary on ONE line (the original scan); (2) a quoted
+    ``pytest.raises(<Exception>`` control — intrinsically test + raise
+    vocabulary, no identifier needed; (3) a ``Fail-loud pin:``-style
+    labeled line whose contiguous paragraph names a ``test_`` identifier
+    within ``_FAILLOUD_PIN_SCAN_LINES`` lines (wrap-tolerant labeled route;
+    unlabeled ±k windows false-satisfy — 21-29 of 119 corpus WARNs at
+    k=1-2 vs 2 genuine, measured 2026-07-14 — so the label is
+    load-bearing, the c31 lesson). Grep-command lines never count on any
+    route."""
+    lines = plan.splitlines()
     out: list[str] = []
-    for line in plan.splitlines():
+    for i, line in enumerate(lines):
         if _FAILLOUD_GREP_LINE_RE.search(line):
             continue
         if _TEST_IDENT_RE.search(line) and _FAILLOUD_TEST_EVIDENCE_RE.search(line):
             out.append(line.strip())
+            continue
+        if _FAILLOUD_PYTEST_RAISES_RE.search(line):
+            out.append(line.strip())
+            continue
+        if _FAILLOUD_PIN_LABEL_RE.search(line):
+            for j in range(i, min(len(lines), i + _FAILLOUD_PIN_SCAN_LINES)):
+                if not lines[j].strip():
+                    break
+                if _FAILLOUD_GREP_LINE_RE.search(lines[j]):
+                    continue
+                if _TEST_IDENT_RE.search(lines[j]):
+                    out.append(f"{line.strip()} … {lines[j].strip()}")
+                    break
     return out
 
 
@@ -2034,7 +2073,16 @@ def check_failloud_test_coverage(plan: str, kind: str) -> CheckResult:
     only the zero-fail-loud-test case, and PASSes a plan naming a fail-loud
     test for a different claim). Extending kind scope to ``analysis`` is a
     future calibration decision if an incident arises there (the corpus
-    replay covered infra|batch only)."""
+    replay covered infra|batch only). Evidence routes 2-3 (#1306) — a
+    quoted ``pytest.raises(<Exception>`` control and a labeled
+    ``Fail-loud pin``-style paragraph scan — were corpus-audited
+    2026-07-14 (exactly the two #1296 incident plans flip WARN→PASS out
+    of 119 standing infra|batch WARNs; unlabeled ±1/±2-line windows were
+    REJECTED at 21/29 false flips); accepted residual: a fenced
+    bug-narration ``pytest.raises(...)`` quote or a stale/nonexistent
+    test name in a labeled pin can false-satisfy — acceptable because the
+    check is WARN-only at existence granularity and per-claim coverage
+    stays with the Phase 2 critics."""
     cid, name = "c15_failloud_test_coverage", "fail-loud acceptance claim backed by a test"
     if kind not in ("infra", "batch"):
         return _skip(
@@ -2069,7 +2117,10 @@ def check_failloud_test_coverage(plan: str, kind: str) -> CheckResult:
         "tests/<file> path alongside raise/swallow/silent/except vocabulary; grep-gate lines do "
         "not count) — a run-book grep verifies the invariant once at review time, and a "
         "differently-worded re-swallow ships green past all committed tests (#913). Name the "
-        "pinning test, or declare `N/A — no fail-loud acceptance claim` / "
+        "pinning test and its raise/swallow/silent vocabulary on ONE unwrapped line "
+        "(hard-wrapped mentions do not count), quote the `pytest.raises` negative control "
+        "with its exception class, add a `Fail-loud pin` labeled line (the label, a colon, "
+        "then the test path), or declare `N/A — no fail-loud acceptance claim` / "
         "`N/A — fail-loud claim not test-backable` — each on its own line, unwrapped "
         "(no backticks/quotes)",
     )

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -2367,6 +2367,146 @@ def test_c15_acceptance_heading_containing_failure_mode_word_still_triggers():
     assert _status(plan, "c15_failloud_test_coverage", kind="infra") == "WARN"
 
 
+# ─── Check 15 — evidence routes 2-3 calibration (#1306) ────────────────────
+
+# Verbatim corpus literals from the #1296 incident, EMBEDDED as constants —
+# committed tests never read real tasks/ plan files (the c13 suite's
+# convention). No `test_` identifier appears in the raises lines, so the
+# fixture isolates evidence route 2 (the pytest.raises literal).
+C15_1296_RAISES_LINES = (  # tasks/completed/1296/plans/v2.md:135-137, verbatim
+    "\n   - **negative control:** `with pytest.raises(ModuleNotFoundError):\n"
+    '     importlib.import_module("runpod_api")` — proves the scrub is real and\n'
+    "     the pre-fix failure mode exists;\n"
+)
+
+# The wrapped labeled-pin paragraph: the 105-char test path forced a hard
+# wrap, splitting the identifier (line 3) from the label (line 1) and the
+# raise vocabulary (lines 1/4) — the same-line route cannot see it, so the
+# fixture isolates evidence route 3 (the labeled forward paragraph scan).
+C15_1296_PIN_PARAGRAPH = (  # tasks/completed/1296/plans/v2.md:285-289, verbatim
+    "\nFail-loud acceptance (check 15): the pytest-backed fail-loud claim is the\n"
+    "negative control in\n"
+    "`tests/test_backend_poll.py::test_ensure_scripts_dir_bootstrap_resolves_runpod_api_in_module_mode`\n"
+    "(asserts `ModuleNotFoundError` is raised when `scripts/` is scrubbed and the\n"
+    "bootstrap has not run).\n"
+)
+
+
+def test_c15_pytest_raises_negative_control_passes():
+    # Route 2 regression fixture (#1306): the quoted raises control alone —
+    # no test_ identifier anywhere in the added lines — satisfies c15.
+    plan = GOOD_PLAN + FAILLOUD_ACCEPT + C15_1296_RAISES_LINES
+    assert _status(plan, "c15_failloud_test_coverage", kind="infra") == "PASS"
+
+
+def test_c15_wrapped_prose_regression_1296_passes():
+    # Route 3 regression fixture (#1306, the Durability pin): the labeled
+    # satisfier paragraph #1296 v2 carried — label line, identifier two
+    # lines below, contiguous — satisfies c15 despite the hard wrap.
+    plan = GOOD_PLAN + FAILLOUD_ACCEPT + C15_1296_PIN_PARAGRAPH
+    assert _status(plan, "c15_failloud_test_coverage", kind="infra") == "PASS"
+
+
+def test_c15_bare_pytest_raises_without_exception_does_not_satisfy():
+    # Pins route 2's named-exception requirement (`[\w.]+` after the paren):
+    # a bare `pytest.raises()` mention is prose, not a control.
+    plan = GOOD_PLAN + FAILLOUD_ACCEPT + "\nThe fix uses pytest.raises() somewhere.\n"
+    assert _status(plan, "c15_failloud_test_coverage", kind="infra") == "WARN"
+
+
+def test_c15_pytest_raises_on_grep_line_does_not_satisfy():
+    # Pins the grep-line exclusion on route 2.
+    plan = (
+        GOOD_PLAN
+        + FAILLOUD_ACCEPT
+        + "\n- Gate: grep -rn 'pytest.raises(ValueError' tests/ returns hits.\n"
+    )
+    assert _status(plan, "c15_failloud_test_coverage", kind="infra") == "WARN"
+
+
+def test_c15_failloud_pin_label_wrapped_paragraph_passes():
+    # Synthetic minimal route-3 shape: label line, identifier two lines
+    # below, contiguous paragraph. The identifier carries no fail-loud
+    # vocabulary, so the same-line route cannot satisfy — route 3 only.
+    plan = (
+        GOOD_PLAN
+        + FAILLOUD_ACCEPT
+        + "\nFail-loud pin (wrapped): the committed negative control lives in\n"
+        "the backend-poll suite at\n"
+        "`tests/test_backend_poll.py::test_module_mode_import_guard` and runs in CI.\n"
+    )
+    assert _status(plan, "c15_failloud_test_coverage", kind="infra") == "PASS"
+
+
+def test_c15_failloud_pin_label_blank_separated_test_does_not_satisfy():
+    # Pins the paragraph bound: a blank line ends the route-3 forward scan.
+    plan = (
+        GOOD_PLAN
+        + FAILLOUD_ACCEPT
+        + "\nFail-loud pin (wrapped): to be named in a later revision.\n"
+        "\n"
+        "Tests: test_foo_behavior.\n"
+    )
+    assert _status(plan, "c15_failloud_test_coverage", kind="infra") == "WARN"
+
+
+def test_c15_failloud_pin_label_beyond_cap_does_not_satisfy():
+    # Pins _FAILLOUD_PIN_SCAN_LINES: an identifier 9 lines below the label
+    # (beyond the 8-line cap) does not satisfy route 3.
+    filler = "".join(f"filler row {k} of the pin paragraph.\n" for k in range(8))
+    plan = (
+        GOOD_PLAN
+        + FAILLOUD_ACCEPT
+        + "\nFail-loud pin (wrapped): the committed negative control lives in\n"
+        + filler
+        + "`tests/test_backend_poll.py::test_module_mode_import_guard` and runs in CI.\n"
+    )
+    assert _status(plan, "c15_failloud_test_coverage", kind="infra") == "WARN"
+
+
+def test_c15_pin_label_grep_line_in_paragraph_does_not_satisfy():
+    # Route-3 inner grep exclusion: a labeled paragraph whose ONLY test_
+    # identifier sits on a grep line inside the paragraph does not satisfy
+    # (pins the inner _FAILLOUD_GREP_LINE_RE continue).
+    plan = (
+        GOOD_PLAN + FAILLOUD_ACCEPT + "\nFail-loud pin (verify): the invariant is checked by\n"
+        "grep -n 'test_scrub_guard' tests/test_backend_poll.py returning a hit.\n"
+    )
+    assert _status(plan, "c15_failloud_test_coverage", kind="infra") == "WARN"
+
+
+def test_c15_unrelated_test_two_lines_from_silent_vocab_still_warns():
+    # Anti-window pin (the rejected-mechanism regression, distilled from the
+    # plan-time pilot's #876/#996 false-flip shape): fail-loud vocabulary
+    # two contiguous lines from UNRELATED test identifiers — no label, no
+    # pytest.raises — must NOT satisfy (the :4956 class stays out).
+    plan = (
+        GOOD_PLAN
+        + FAILLOUD_ACCEPT
+        + "\nThe cache read is silent on a miss by design and the loader\n"
+        "continues; see the loader table.\n"
+        "Suite: test_loader_roundtrip, test_loader_cache_hit.\n"
+    )
+    assert _status(plan, "c15_failloud_test_coverage", kind="infra") == "WARN"
+
+
+def test_c15_true_positive_still_warns():
+    # Post-change restatement of the #913 true positive: a fail-loud claim
+    # with only success-path tests named still WARNs, and the updated detail
+    # keeps the pinned substrings plus the new remedy wording.
+    plan = (
+        GOOD_PLAN
+        + FAILLOUD_ACCEPT
+        + "\nTests: `test_drain_dispatches_ripe_tasks`, `test_drain_respects_concurrency_cap`.\n"
+    )
+    _, by_id = _run(plan, kind="infra")
+    r = by_id["c15_failloud_test_coverage"]
+    assert r.status == "WARN"
+    assert "#913" in r.detail
+    assert "grep" in r.detail
+    assert "ONE unwrapped line" in r.detail
+
+
 # ─── Check 16 — re-extracted reference vs committed headline ───────────────
 
 # Near-verbatim #811 v3 shapes (task #937 incident): the synthetic fixtures


### PR DESCRIPTION
Closes task #1306.

## Summary
- verify_plan.py c15 evidence scan gains two corpus-audited routes: D1 `pytest.raises(<Exc>` literal acceptance + D2 labeled `Fail-loud pin/acceptance` forward paragraph scan (≤8 lines, blank-bounded, grep-excluded)
- 10 new fixtures incl. verbatim #1296 v2 regression (red pre-change / green post-change); 21 existing c15 pins byte-unchanged
- Corpus replay over 1,923 plans: zero non-c15 changes, flips exactly #1296 v1+v2 (WARN→PASS), c15 WARN 119→117

## Test plan
- [x] `pytest tests/test_verify_plan.py` — 631 passed
- [x] Step-9c gate: 3390 passed / 6 skipped; compare vs baseline ledger: 0 new, 0 lint regression
- [x] Corpus replay hard acceptance PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)