### PR TITLE
issue-1318: fix 4 workflow_lint FAILs (hub-verify + filecount guard)

### DIFF
--- a/scripts/issue1092_corpus_dashboard.py
+++ b/scripts/issue1092_corpus_dashboard.py
@@ -137,24 +137,36 @@ def _load_json(path: Path) -> dict:
 
 
 def load_own_answer_map() -> dict[str, str]:
-    """row_id -> instruct-model on-policy own answer, from the cell_inst_own shards."""
+    """row_id -> instruct-model on-policy own answer, from the cell_inst_own shards.
+
+    Raises FileNotFoundError when no cell_inst_own_ shards resolve under the
+    prefix (fail-loud parity with the old bare listing, which raised on an
+    absent prefix).
+    """
     from huggingface_hub import HfApi
 
+    from explore_persona_space.orchestrate.hub import list_hf_files_under_path
+
     api = HfApi()
-    entries = api.list_repo_tree(
+    # Scoped, retried, files-only listing (#920/#997) — replaces the bare
+    # api.list_repo_tree call; the helper returns repo-root-relative FILE
+    # paths, subsuming the old RepoFolder filter.
+    files = list_hf_files_under_path(
+        api,
         HF_DATA_REPO,
-        path_in_repo=f"{HF_PREFIX}/raw_completions/instruct",
+        f"{HF_PREFIX}/raw_completions/instruct",
         repo_type="dataset",
-        recursive=True,
         revision="main",
     )
     shard_rel = [
-        "/".join(e.path.split("/")[1:])  # strip the leading HF_PREFIX segment for _fetch
-        for e in entries
-        if e.__class__.__name__ != "RepoFolder"
-        and Path(e.path).name.startswith("cell_inst_own_")
-        and e.path.endswith(".jsonl")
+        "/".join(p.split("/")[1:])  # strip the leading HF_PREFIX segment for _fetch
+        for p in files
+        if Path(p).name.startswith("cell_inst_own_") and p.endswith(".jsonl")
     ]
+    if not shard_rel:
+        raise FileNotFoundError(
+            f"no cell_inst_own_ shards under {HF_PREFIX}/raw_completions/instruct"
+        )
     answer: dict[str, str] = {}
     for rel in sorted(shard_rel):
         for row in _load_jsonl(_fetch(rel)):

--- a/scripts/issue825_map_alignment.py
+++ b/scripts/issue825_map_alignment.py
@@ -646,27 +646,33 @@ def _make_figures(results: dict, fig_root: str) -> None:
 # collides with the production full-extraction cache).
 # ===========================================================================
 def _extract_first_shard(stem: str, dl_dir: Path) -> Path:
-    from huggingface_hub import hf_hub_download, list_repo_tree
+    from huggingface_hub import HfApi, hf_hub_download
+
+    from explore_persona_space.orchestrate.hub import list_hf_files_under_path
 
     npz_path = dl_dir / f"{stem}.smoke.npz"
     if npz_path.exists():
         return npz_path
     dl_dir.mkdir(parents=True, exist_ok=True)
     tok = os.environ.get("HF_TOKEN")
-    tree = list(
-        list_repo_tree(
-            HF_DATA_REPO,
-            path_in_repo=HF_PREFIX,
-            repo_type="dataset",
-            revision=HF_REV,
-            recursive=False,
-            token=tok,
-        )
+    # Scoped, retried listing (#920/#997) — replaces the bare list_repo_tree
+    # call (recursive=False, token=tok).
+    files = list_hf_files_under_path(
+        HfApi(token=tok),
+        HF_DATA_REPO,
+        path=HF_PREFIX,
+        repo_type="dataset",
+        revision=HF_REV,
     )
+    _prefix = HF_PREFIX.strip("/")
     shard_files = sorted(
-        os.path.basename(t.path)
-        for t in tree
-        if os.path.basename(t.path).startswith(f"{stem}_shard") and t.path.endswith(".pt")
+        p.rsplit("/", 1)[1]
+        for p in files
+        # preserve the old recursive=False semantics: direct children of
+        # HF_PREFIX only (the helper's scoped walk is recursive)
+        if p.rsplit("/", 1)[0] == _prefix
+        and p.rsplit("/", 1)[1].startswith(f"{stem}_shard")
+        and p.endswith(".pt")
     )
     if not shard_files:
         raise FileNotFoundError(f"no shards for {stem} at {HF_PREFIX}@{HF_REV}")

--- a/scripts/issue952_china_topup_gpu.py
+++ b/scripts/issue952_china_topup_gpu.py
@@ -517,7 +517,16 @@ def phase_upload(out_base: pathlib.Path) -> None:
     R.log_phase("topup_upload")
     from huggingface_hub import HfApi
 
+    from explore_persona_space.orchestrate.hub import (
+        assert_hub_dir_filecounts,
+        list_hf_files_under_path,
+    )
+
     api = HfApi()
+    # Pre-count guard (#658/#1190): fail loud BEFORE any network I/O if any
+    # target repo dir would receive >10k files in one commit. Deliberately
+    # OUTSIDE any transient-retry wrapper (a guard raise is deterministic).
+    assert_hub_dir_filecounts(out_base, HF_PREFIX)
     api.upload_folder(
         folder_path=str(out_base),
         repo_id=REPO,
@@ -525,11 +534,15 @@ def phase_upload(out_base: pathlib.Path) -> None:
         path_in_repo=HF_PREFIX,
         commit_message=f"issue #952 china-politics top-up ({TOPUP_TAG}) — GPU leg artifacts",
     )
-    # Verify: scoped tree listing of the uploaded prefix (never a full-repo list).
-    tree = list(
-        api.list_repo_tree(REPO, path_in_repo=HF_PREFIX, repo_type="dataset", recursive=True)
-    )
-    files = [getattr(t, "path", str(t)) for t in tree if getattr(t, "size", None) is not None]
+    # Verify: scoped tree listing of the uploaded prefix (never a full-repo
+    # list) — retried via the orchestrate.hub helper (#920/#997); files-only
+    # by construction, subsuming the old `size is not None` filter.
+    files = list_hf_files_under_path(api, REPO, HF_PREFIX, repo_type="dataset")
+    if not files:
+        raise RuntimeError(
+            f"post-upload verify: no files listed under {REPO}/{HF_PREFIX} "
+            "after upload_folder (fail-loud parity with the old bare listing)"
+        )
     logger.info("[topup-upload] %d files under %s/%s", len(files), REPO, HF_PREFIX)
     for f in sorted(files):
         logger.info("  hf: %s", f)


### PR DESCRIPTION
Closes task #1318. Routes 3 bare list_repo_tree calls through orchestrate.hub.list_hf_files_under_path and adds an assert_hub_dir_filecounts guard before the issue952 upload_folder. Pure lint hygiene; live equivalence probes confirm identical listings.