### PR TITLE
issue-1327: spawn_session.py unregister subcommand

### DIFF
--- a/.claude/rules/background-automation.md
+++ b/.claude/rules/background-automation.md
@@ -796,6 +796,23 @@ verified kill-by-pid recipe (or SIGTERMs it under `--kill`; comm re-verified,
 never auto-SIGKILL). Stale sentinels are GC'd after `max(7 days, the
 configured TTL)`.
 
+**Deliberate registration removal (`spawn_session.py unregister`; #1327).**
+Deliberately removing an `issue-<N>.json` / `manual-issue-<N>.json` /
+`campaign-<N>.json` registration (collision-yield, deliberate-stop cleanup)
+goes through `spawn_session.py unregister` — never a hand `rm` on
+`~/.eps-autonomous/` (the #952 shape: an unguarded rm can strip crash-recovery
+from the healthy owner). Sid-matched by default: `unregister --issue N`
+removes only files recording the CALLING session's Happy id
+(ancestry-inferred, the `register-current` walk), so a yielding duplicate can
+never delete the true owner's entry — a `KEPT-SID-MISMATCH` line is the guard
+working, not a bug. Third-party cleanup of a DEAD session's file:
+`unregister --issue N --session-id <dead-sid>` (removes only entries recording
+that sid; no daemon-liveness check), or `unregister --force --issue N` for
+unconditional operator cleanup (`--force` requires `--issue` and is refused
+with `--session-id`). Takeover sentinels (`*.paused-takeover-*`) and
+non-registration siblings (`dispatch-lease-*`, `campaign-watch-*`,
+`pm-session.json`) are never touched by any invocation form.
+
 **Program-orchestrator recovery pass (#660 leakage-program bash daemon).** The
 leakage-theory program (#660) is sequenced by a BASH DAEMON
 (`scripts/run_program_orchestrator.sh` in tmux `eps-program`), NOT a Happy

--- a/scripts/spawn_session.py
+++ b/scripts/spawn_session.py
@@ -2238,6 +2238,148 @@ def cmd_register_current(args: argparse.Namespace) -> None:
     print(f"Registered session {sid} as driver of issue #{issue}: {dest} [{semantics}]")
 
 
+# ─── unregister (inverse of register-current; #1327) ─────────────────────────
+#
+# Strict filename shape of the THREE registration kinds — and ONLY those.
+# The registry dir holds many sibling file classes (`dispatch-lease-*.json`,
+# `campaign-watch-*.json`, `pm-session.json`, `*.paused-takeover-*` sentinels,
+# watcher state files); the `\.json$`-anchored full-match regex cannot scrape
+# any of them (a takeover sentinel whose free-form suffix itself ends in
+# `.json` still fails the `<prefix>-<digits>.json` full match).
+_REGISTRATION_NAME_RE = re.compile(r"^(issue|manual-issue|campaign)-(\d+)\.json$")
+_KIND_TO_PREFIX = {"auto": "issue", "manual": "manual-issue", "campaign": "campaign"}
+
+
+def unregister_paths(
+    *,
+    issue: int | None,
+    session_id: str | None,
+    force: bool = False,
+    kind: str | None = None,
+    registry_dir: Path | None = None,
+) -> list[tuple[str, Path, str]]:
+    """Remove issue/manual/campaign registration files, sid-match-guarded.
+
+    Returns ``[(action, path, detail)]`` with ``action`` in ``{"removed",
+    "kept-sid-mismatch", "kept-unreadable", "missing"}``. Without ``force`` a
+    file is removed IFF its recorded ``happy_session_id`` string-equals
+    ``session_id``; an unreadable / garbled / missing-``happy_session_id``
+    entry is KEPT (fail toward keep, mirroring the watcher's unresolvable-
+    input posture). Never touches takeover sentinels or non-registration
+    siblings: the ``--issue`` form targets the ≤3 exact filenames, the scan
+    form filters through :data:`_REGISTRATION_NAME_RE`. Removal is a single
+    atomic ``unlink(missing_ok=True)`` — the watcher re-globs each pass.
+    RAISES ``ValueError`` when ``force`` is set without ``issue`` (a forced
+    whole-registry scan is refused at the helper layer too)."""
+    if force and issue is None:
+        raise ValueError("force=True requires issue (a forced whole-registry scan is refused)")
+    reg = registry_dir if registry_dir is not None else AUTONOMOUS_REGISTRY_DIR
+    prefixes = [_KIND_TO_PREFIX[kind]] if kind else list(_KIND_TO_PREFIX.values())
+    scan_mode = issue is None
+    if not scan_mode:
+        candidates = [reg / f"{p}-{issue}.json" for p in prefixes]
+    else:
+        candidates = sorted(
+            p
+            for p in (reg.glob("*.json") if reg.is_dir() else [])
+            if (m := _REGISTRATION_NAME_RE.match(p.name)) and m.group(1) in prefixes
+        )
+    rows: list[tuple[str, Path, str]] = []
+    for path in candidates:
+        recorded: str | None = None
+        readable = False
+        try:
+            entry = json.loads(path.read_text())
+        except FileNotFoundError:
+            if not scan_mode:
+                rows.append(("missing", path, ""))
+            continue
+        except (OSError, ValueError):
+            pass
+        else:
+            sid_field = entry.get("happy_session_id") if isinstance(entry, dict) else None
+            if isinstance(sid_field, str) and sid_field:
+                recorded = sid_field
+                readable = True
+        if force:
+            path.unlink(missing_ok=True)
+            detail = (
+                f"recorded sid {recorded} (forced)"
+                if readable
+                else "recorded sid unreadable (forced)"
+            )
+            rows.append(("removed", path, detail))
+        elif not readable:
+            # Garbled JSON / OSError / missing or non-string happy_session_id:
+            # fail toward keep (only --force --issue may remove it).
+            if not scan_mode:
+                rows.append(
+                    ("kept-unreadable", path, "garbled/unreadable entry — refusing without --force")
+                )
+        elif recorded == session_id:
+            path.unlink(missing_ok=True)  # atomic; watcher re-globs each pass
+            rows.append(("removed", path, f"recorded sid {recorded}"))
+        elif not scan_mode:
+            rows.append(("kept-sid-mismatch", path, f"recorded sid {recorded!r} != {session_id!r}"))
+    return rows
+
+
+def cmd_unregister(args: argparse.Namespace) -> None:
+    """Inverse of ``register-current``: remove this session's registration file(s).
+
+    For collision-yield and deliberate-stop paths — replaces the hand-rolled
+    `rm ~/.eps-autonomous/issue-<N>.json` (#952). Sid-matched by default:
+    without ``--session-id`` the caller's own Happy id is inferred from the
+    process ancestry (the ``register-current`` walk), so a yielding duplicate
+    can never delete the true owner's entry — a mismatch prints
+    ``KEPT-SID-MISMATCH`` and exits 0 (that line is the guard working, not a
+    bug). Third-party cleanup of a DEAD session's file: pass
+    ``--session-id <dead-sid>`` (no daemon-liveness requirement — the sid
+    being removed is typically dead/yielding, the validation is against the
+    FILE), or ``--force --issue N`` for unconditional operator removal.
+    Takeover sentinels are never touched. No task marker is posted — the
+    yield paths post their own breadcrumb; ``--reason`` is echoed per line
+    for the transcript."""
+    if args.force and args.session_id:
+        sys.exit(
+            "--force and --session-id are mutually exclusive (--force means "
+            "'skip the sid match'); pass --issue with exactly one of them."
+        )
+    if args.force and args.issue is None:
+        sys.exit("--force requires --issue (a forced whole-registry scan is refused).")
+    sid = args.session_id
+    if sid is None and not args.force:
+        # Same ancestry walk as cmd_register_current; NO liveness requirement
+        # on the sid being removed, but inference itself needs the daemon's
+        # live-children list (we're finding OUR OWN sid).
+        children = _live_children()
+        pid_to_sid = {
+            c["pid"]: c["happySessionId"]
+            for c in children
+            if isinstance(c.get("pid"), int) and isinstance(c.get("happySessionId"), str)
+        }
+        matches = [pid_to_sid[p] for p in _ancestor_pids() if p in pid_to_sid]
+        if not matches:
+            sys.exit(
+                "could not infer this session's Happy id from the process "
+                "ancestry; pass --session-id explicitly (or --force with "
+                "--issue for an unconditional operator removal)."
+            )
+        sid = matches[0]
+    if args.issue is None and sid is None:
+        sys.exit("nothing to select: pass --issue and/or --session-id.")
+    rows = unregister_paths(issue=args.issue, session_id=sid, force=args.force, kind=args.kind)
+    for action, path, detail in rows:
+        line = f"{action.upper():<18} {path}"
+        if detail:
+            line += f" ({detail})"
+        if args.reason:
+            line += f" [reason: {args.reason}]"
+        print(line)
+    if not any(action == "removed" for action, _, _ in rows):
+        print("nothing removed")
+
+
 def cmd_register_pm(args: argparse.Namespace) -> None:
     """Register an EXISTING live session as the PM session.
 
@@ -2783,6 +2925,62 @@ def main(argv: list[str] | None = None) -> None:
         ),
     )
     p_reg.set_defaults(fn=cmd_register_current)
+
+    p_unreg = sub.add_parser(
+        "unregister",
+        help=(
+            "remove this session's issue/manual/campaign registration file(s) — the "
+            "inverse of register-current, for collision-yield and deliberate-stop "
+            "paths (never hand-rm ~/.eps-autonomous files). Sid-matched by default: "
+            "only files recording the calling session's Happy id (ancestry-inferred "
+            "or --session-id) are removed, so a yielding duplicate can never delete "
+            "the true owner's entry (a KEPT-SID-MISMATCH line is the guard working, "
+            "not a bug). Third-party cleanup of a DEAD session's file: "
+            "`unregister --issue N --session-id <dead-sid>` (removes only entries "
+            "recording that sid; no liveness check), or `unregister --force "
+            "--issue N` for unconditional operator cleanup. Takeover sentinels "
+            "(*.paused-takeover-*) are never touched."
+        ),
+    )
+    p_unreg.add_argument(
+        "--issue",
+        type=int,
+        default=None,
+        help=(
+            "issue number whose registration file(s) to remove (exact filenames "
+            "issue-N.json / manual-issue-N.json / campaign-N.json)"
+        ),
+    )
+    p_unreg.add_argument(
+        "--session-id",
+        default=None,
+        help=(
+            "only remove entries recording this Happy session id (works for a DEAD "
+            "sid — third-party cleanup validates against the FILE, not the daemon); "
+            "omit to infer this session's own id from the process ancestry. With no "
+            "--issue, scans all registrations for this sid."
+        ),
+    )
+    p_unreg.add_argument(
+        "--kind",
+        choices=("auto", "manual", "campaign"),
+        default=None,
+        help="narrow to one registration kind (default: all three)",
+    )
+    p_unreg.add_argument(
+        "--force",
+        action="store_true",
+        help="skip the sid match (requires --issue; mutually exclusive with --session-id)",
+    )
+    p_unreg.add_argument(
+        "--reason",
+        default=None,
+        help=(
+            "free-form audit string echoed in each output line (transcript "
+            "breadcrumb; no task marker is posted)"
+        ),
+    )
+    p_unreg.set_defaults(fn=cmd_unregister)
 
     p_reg_pm = sub.add_parser(
         "register-pm",

--- a/tests/test_spawn_session_unregister.py
+++ b/tests/test_spawn_session_unregister.py
@@ -1,0 +1,237 @@
+"""Tests for the #1327 `unregister` subcommand in ``scripts/spawn_session.py``.
+
+What this pins (the inverse of ``register-current``, for collision-yield and
+deliberate-stop paths — replacing the hand-rolled #952 ``rm``):
+
+1. **Sid-matched removal by default.** Without ``--force`` a registration file
+   is removed IFF its recorded ``happy_session_id`` string-equals the caller's
+   sid; a mismatch KEEPS the file (``KEPT-SID-MISMATCH``), so a yielding
+   duplicate can never delete the true owner's entry.
+2. **Fail toward keep.** Garbled / unreadable / missing-``happy_session_id``
+   entries are KEPT without ``--force`` (``KEPT-UNREADABLE``); missing files
+   are tolerated (``MISSING``, exit 0).
+3. **Strict targeting.** The ``--issue`` form builds exact filenames; the scan
+   form filters through the strict ``^(issue|manual-issue|campaign)-(\\d+)\\.json$``
+   regex — takeover sentinels (``*.paused-takeover-*``) and non-registration
+   siblings (``dispatch-lease-*``, ``campaign-watch-*``, ``pm-session.json``)
+   are never removed by ANY invocation form.
+4. **Flag surface.** ``--force`` requires ``--issue`` and excludes
+   ``--session-id`` (cmd layer AND the pure helper); no selectors + failed
+   ancestry inference exits loud; ``--kind`` narrows targeting.
+5. **CLI wiring.** One end-to-end invocation through the REAL argparse parser
+   (``spawn_session.main([...])``) asserting the ``KEPT-SID-MISMATCH``
+   breadcrumb line on stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import spawn_session  # noqa: E402
+
+_MY_SID = "happy-sess-1327-mine"
+_OTHER_SID = "happy-sess-1327-owner"
+
+
+def _write_entry(reg: Path, name: str, sid: str) -> Path:
+    """A minimal registration entry carrying ``happy_session_id`` (the only
+    field the sid match reads)."""
+    path = reg / name
+    path.write_text(json.dumps({"issue": 5, "happy_session_id": sid, "spawned_at": 1.0}))
+    return path
+
+
+def _ns(**overrides) -> argparse.Namespace:
+    """A full `unregister` Namespace (every attribute cmd_unregister reads)."""
+    ns = argparse.Namespace(issue=None, session_id=None, kind=None, force=False, reason=None)
+    for k, v in overrides.items():
+        setattr(ns, k, v)
+    return ns
+
+
+# ── 1. sid-matched removal (issue form) ──────────────────────────────────────
+
+
+def test_issue_form_removes_only_matching_sid(tmp_path, monkeypatch):
+    """Case 1: writer-produced entry for MY sid is removed; the other kinds'
+    files recording OTHER sids are untouched."""
+    # Construct the auto entry through the production writer itself (the
+    # #1287 predicate-trace requirement — not hand-mocked JSON).
+    monkeypatch.setattr(spawn_session, "AUTONOMOUS_REGISTRY_DIR", tmp_path)
+    spawn_session._register_autonomous_session(5, _MY_SID, "/tmp/cwd", 100.0, force=True)
+    manual = _write_entry(tmp_path, "manual-issue-5.json", _OTHER_SID)
+    campaign = _write_entry(tmp_path, "campaign-5.json", _OTHER_SID)
+
+    rows = spawn_session.unregister_paths(issue=5, session_id=_MY_SID, registry_dir=tmp_path)
+    actions = {p.name: a for a, p, _ in rows}
+    assert actions["issue-5.json"] == "removed"
+    assert actions["manual-issue-5.json"] == "kept-sid-mismatch"
+    assert actions["campaign-5.json"] == "kept-sid-mismatch"
+    assert not (tmp_path / "issue-5.json").exists()
+    assert manual.exists() and campaign.exists()
+
+
+def test_sid_mismatch_keeps_file_content_unchanged(tmp_path):
+    """Case 2: the owner's entry survives a wrong-sid removal byte-for-byte."""
+    path = _write_entry(tmp_path, "issue-5.json", _OTHER_SID)
+    before = path.read_text()
+    rows = spawn_session.unregister_paths(issue=5, session_id=_MY_SID, registry_dir=tmp_path)
+    assert [a for a, _, _ in rows if a == "removed"] == []
+    assert ("kept-sid-mismatch", path) in [(a, p) for a, p, _ in rows]
+    assert path.read_text() == before
+
+
+def test_missing_files_tolerated(tmp_path):
+    """Case 3: nothing on disk -> three `missing` rows, no exception."""
+    rows = spawn_session.unregister_paths(issue=7, session_id=_MY_SID, registry_dir=tmp_path)
+    assert [a for a, _, _ in rows] == ["missing", "missing", "missing"]
+
+
+# ── 4/5. force + garbled entries ─────────────────────────────────────────────
+
+
+def test_force_removes_all_kinds_regardless_of_sid(tmp_path):
+    """Case 4: --force removes all three kind files incl. a garbled one."""
+    _write_entry(tmp_path, "issue-5.json", _OTHER_SID)
+    _write_entry(tmp_path, "manual-issue-5.json", _OTHER_SID)
+    (tmp_path / "campaign-5.json").write_text("{not json")
+    rows = spawn_session.unregister_paths(
+        issue=5, session_id=None, force=True, registry_dir=tmp_path
+    )
+    assert [a for a, _, _ in rows] == ["removed", "removed", "removed"]
+    assert list(tmp_path.glob("*.json")) == []
+
+
+def test_garbled_without_force_kept(tmp_path):
+    """Case 5: garbled JSON without --force -> kept-unreadable, file intact."""
+    garbled = tmp_path / "issue-5.json"
+    garbled.write_text("{not json")
+    rows = spawn_session.unregister_paths(issue=5, session_id=_MY_SID, registry_dir=tmp_path)
+    assert ("kept-unreadable", garbled) in [(a, p) for a, p, _ in rows]
+    assert garbled.exists()
+
+
+def test_missing_sid_field_without_force_kept(tmp_path):
+    """An entry with no happy_session_id fails toward keep (never matches)."""
+    path = tmp_path / "issue-5.json"
+    path.write_text(json.dumps({"issue": 5}))
+    rows = spawn_session.unregister_paths(issue=5, session_id=_MY_SID, registry_dir=tmp_path)
+    assert ("kept-unreadable", path) in [(a, p) for a, p, _ in rows]
+    assert path.exists()
+
+
+def test_helper_force_without_issue_raises(tmp_path):
+    """Critic concern 1: the pure helper asserts force-requires-issue itself."""
+    with pytest.raises(ValueError, match="force=True requires issue"):
+        spawn_session.unregister_paths(
+            issue=None, session_id=None, force=True, registry_dir=tmp_path
+        )
+
+
+# ── 6/7. scan form + never-touch siblings ────────────────────────────────────
+
+
+def test_scan_form_removes_matching_and_skips_siblings(tmp_path):
+    """Case 6: scan removes MY entries across issues/kinds, silently skips
+    other-sid registrations, and never scrapes non-registration siblings."""
+    mine_a = _write_entry(tmp_path, "issue-5.json", _MY_SID)
+    mine_b = _write_entry(tmp_path, "manual-issue-9.json", _MY_SID)
+    other = _write_entry(tmp_path, "campaign-5.json", _OTHER_SID)
+    lease = _write_entry(tmp_path, "dispatch-lease-7.json", _MY_SID)
+    pm = _write_entry(tmp_path, "pm-session.json", _MY_SID)
+    watch = _write_entry(tmp_path, "campaign-watch-5.json", _MY_SID)
+    # The suffix-ends-in-.json takeover edge: full name fails the strict regex.
+    sentinel_json = _write_entry(tmp_path, "issue-5.json.paused-takeover-x.json", _MY_SID)
+
+    rows = spawn_session.unregister_paths(issue=None, session_id=_MY_SID, registry_dir=tmp_path)
+    removed = {p.name for a, p, _ in rows if a == "removed"}
+    assert removed == {"issue-5.json", "manual-issue-9.json"}
+    assert not mine_a.exists() and not mine_b.exists()
+    # Other-sid registration skipped SILENTLY in scan mode (no per-file noise).
+    assert [a for a, p, _ in rows if p.name == "campaign-5.json"] == []
+    for survivor in (other, lease, pm, watch, sentinel_json):
+        assert survivor.exists(), survivor
+
+
+def test_takeover_sentinel_survives_every_form(tmp_path):
+    """Case 7: `issue-5.json.paused-takeover-abc` survives issue / scan /
+    force forms (matching sid inside changes nothing)."""
+    sentinel = tmp_path / "issue-5.json.paused-takeover-abc"
+    sentinel.write_text(json.dumps({"happy_session_id": _MY_SID}))
+    spawn_session.unregister_paths(issue=5, session_id=_MY_SID, registry_dir=tmp_path)
+    spawn_session.unregister_paths(issue=None, session_id=_MY_SID, registry_dir=tmp_path)
+    spawn_session.unregister_paths(issue=5, session_id=None, force=True, registry_dir=tmp_path)
+    assert sentinel.exists()
+
+
+def test_kind_narrows_targeting(tmp_path):
+    """Case 8: --kind auto targets issue-N.json only."""
+    auto = _write_entry(tmp_path, "issue-5.json", _MY_SID)
+    manual = _write_entry(tmp_path, "manual-issue-5.json", _MY_SID)
+    rows = spawn_session.unregister_paths(
+        issue=5, session_id=_MY_SID, kind="auto", registry_dir=tmp_path
+    )
+    assert [(a, p.name) for a, p, _ in rows] == [("removed", "issue-5.json")]
+    assert not auto.exists() and manual.exists()
+
+
+# ── 9/10. cmd-level flag surface + ancestry inference ────────────────────────
+
+
+def test_cmd_force_with_session_id_exits():
+    with pytest.raises(SystemExit):
+        spawn_session.cmd_unregister(_ns(issue=5, session_id=_MY_SID, force=True))
+
+
+def test_cmd_force_without_issue_exits():
+    with pytest.raises(SystemExit):
+        spawn_session.cmd_unregister(_ns(force=True))
+
+
+def test_cmd_no_selectors_failed_inference_exits(monkeypatch):
+    """Case 9: no --issue/--session-id and the ancestry walk resolves nothing."""
+    monkeypatch.setattr(spawn_session, "_live_children", lambda *a, **k: [])
+    monkeypatch.setattr(spawn_session, "_ancestor_pids", lambda *a, **k: [123])
+    with pytest.raises(SystemExit):
+        spawn_session.cmd_unregister(_ns(issue=5))
+
+
+def test_cmd_ancestry_inference_removes_own_entry(tmp_path, monkeypatch, capsys):
+    """Case 10: happy path — inferred sid removes this session's own entry."""
+    monkeypatch.setattr(spawn_session, "AUTONOMOUS_REGISTRY_DIR", tmp_path)
+    _write_entry(tmp_path, "issue-5.json", _MY_SID)
+    monkeypatch.setattr(
+        spawn_session,
+        "_live_children",
+        lambda *a, **k: [{"pid": 4242, "happySessionId": _MY_SID}],
+    )
+    monkeypatch.setattr(spawn_session, "_ancestor_pids", lambda *a, **k: [4242])
+    spawn_session.cmd_unregister(_ns(issue=5, reason="yield test"))
+    out = capsys.readouterr().out
+    assert "REMOVED" in out and "[reason: yield test]" in out
+    assert not (tmp_path / "issue-5.json").exists()
+
+
+# ── CLI end-to-end through the real argparse parser ──────────────────────────
+
+
+def test_cli_end_to_end_sid_mismatch_breadcrumb(tmp_path, monkeypatch, capsys):
+    """Critic concern 2: the REAL parser wires `unregister` to cmd_unregister,
+    and a third-party sid mismatch prints the KEPT-SID-MISMATCH breadcrumb
+    (exit 0 — the function returns normally)."""
+    monkeypatch.setattr(spawn_session, "AUTONOMOUS_REGISTRY_DIR", tmp_path)
+    _write_entry(tmp_path, "issue-5.json", _OTHER_SID)
+    spawn_session.main(["unregister", "--issue", "5", "--session-id", "x"])
+    out = capsys.readouterr().out
+    assert "KEPT-SID-MISMATCH" in out
+    assert "nothing removed" in out
+    assert (tmp_path / "issue-5.json").exists()


### PR DESCRIPTION
Closes task #1327. Adds the `unregister` subcommand (sid-matched registry removal for collision-yield / deliberate-stop paths) + tests + docs paragraph.