### PR TITLE
workflow-fix #1337: step9c scratch oracle for __file__-anchored scan tests

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -8107,7 +8107,9 @@ suite directly and posts an `epm:test-verdict` event with the result.
       * `COMPARE_RC=2` → indeterminate (PYTEST_RC ∉ {0,1} — aborted/interrupted
         run; missing/empty junitxml; suite crash; unusable ledger;
         scratch-ineligible dirty oracle (residual contaminating dirt, a
-        scan-set node, or a non-sparse work root — other root dirt
+        scan-set node outside the file-anchored allowlist
+        (step9c_baseline.py FILE_ANCHORED_SCAN_TESTS, #1337), or a
+        non-sparse work root — other root dirt
         auto-falls back to a detached sparse scratch-worktree oracle at main
         HEAD, reported as JSON "pristine_oracle": "scratch-worktree"; since
         #1251 dirty in-package `src/` is neutralized via a probe-verified
@@ -9536,8 +9538,11 @@ tests BEFORE anything lands:
   the map current, #895). Attribution is FILE-grain, not junit-node grain: a
   scan test asserts per-file invariants and aggregates EVERY offender into
   ONE red node, so node-level subtraction is degenerate (baseline-red node ==
-  gated-red node would mask a NEW offender — the same reason
-  `step9c_baseline.py compare` marks scan-set nodes scratch-ineligible). Hits
+  gated-red node would mask a NEW offender — the same aggregation degeneracy
+  that makes compare's node-identity strips of scan tests carry the MF-6
+  masking WARN; compare additionally marks NON-file-anchored scan-set nodes
+  scratch-ineligible (`step9c_baseline.py` `FILE_ANCHORED_SCAN_TESTS` members
+  are scratch-resolved, still WARNed — #1337)). Hits
   = pytest-output lines naming a payload-matched path, line numbers blanked
   so main-vs-branch drift of the SAME pre-existing offense cannot fake a NEW
   line, pytest's ellipsis-truncated `E   assert ...` repr line dropped (its

--- a/scripts/select_step9c_tests.py
+++ b/scripts/select_step9c_tests.py
@@ -241,6 +241,10 @@ _DATA_DOC_SUFFIXES: frozenset[str] = frozenset(
 # the touched file "tested" for the stem map (the scan asserts a cross-cutting
 # invariant ABOUT the file, not the file's own logic), so untested_touched
 # WARNs still fire.
+# NOTE (#1337): adding an entry here does NOT make it eligible for compare's
+# scratch pristine oracle — step9c_baseline.py's R-F' rule refuses scan-set nodes
+# by default; a scan test whose scan root is Path(__file__)-derived may be opted in
+# via step9c_baseline.py::FILE_ANCHORED_SCAN_TESTS after source verification.
 GLOB_SCAN_TESTS: dict[str, tuple[str, ...]] = {
     # test_no_new_torch_before_dotenv_vm_entrypoints scan roots (#1187: its
     # _scan_targets() — every tracked scripts/**/*.py + __main__-guarded

--- a/scripts/step9c_baseline.py
+++ b/scripts/step9c_baseline.py
@@ -48,7 +48,8 @@ Exit codes (pinned by ``tests/test_step9c_baseline.py``):
              (residual contaminating dirt — ``pyproject.toml`` / ``uv.lock`` or an
              out-of-package ``src/`` path; dirty ``src/explore_persona_space/**`` is
              neutralized by the scratch PYTHONPATH shadow unless ``--no-src-shadow``
-             (#1251); a scan-set (``GLOB_SCAN_TESTS``) node; a non-sparse work
+             (#1251); a scan-set (``GLOB_SCAN_TESTS``) node outside
+             ``FILE_ANCHORED_SCAN_TESTS`` (#1337); a non-sparse work
              root; or ``--no-scratch-fallback``); scratch-worktree fallback creation
              or src-shadow probe failure; more than ``--max-pristine-files`` distinct
              pristine files ("systemic main breakage"); missing ruff binary
@@ -83,8 +84,11 @@ touched; ledger writes are flock single-flight + atomic tmp+``os.replace``.
 Residual risk of the scratch fallback: ``repo_root()``-anchored /
 installed-package-path reads resolve the MAIN root even from a scratch cwd —
 the scan-set (``GLOB_SCAN_TESTS``) exclusion covers the known class of such
-live-tree scanners; a future non-scan test that executes root files via
-``repo_root()`` would re-open that channel. The #1251 src-shadow covers
+live-tree scanners — EXCEPT ``FILE_ANCHORED_SCAN_TESTS`` members (#1337),
+scan tests source-verified to derive their scan root from ``Path(__file__)``
+so a scratch copy scans the scratch tree (anchoring drift pin in
+tests/test_step9c_baseline.py); a future non-scan test that executes root
+files via ``repo_root()`` would re-open that channel. The #1251 src-shadow covers
 *import-system* resolution only — ``repo_root()``-anchored ``src/`` file READS
 remain that documented scan-set-covered channel. PRE-EXISTING (unchanged by
 #1251) trigger gap: src-``.json``-only dirt with no dirty ``*.py`` never trips
@@ -152,6 +156,26 @@ SCRATCH_CONTAMINATION_PATHSPEC: tuple[str, ...] = ("src/", "pyproject.toml", "uv
 
 # Sparse-profile floor excludes — mirror of new_worktree.sh EXCLUDES.
 SCRATCH_EXCLUDES: tuple[str, ...] = ("eval_results", "external", "ood_eval_results")
+
+# Scan-set nodes whose scan is SOURCE-VERIFIED to anchor on the test file's own
+# location (Path(__file__)-derived root; no repo_root() / task_workflow / live-tree
+# read in the scan chain) — a scratch copy of such a test scans the SCRATCH tree,
+# so the scratch pristine oracle is trustworthy for it and R-F is relaxed to R-F'
+# (#1337; incident #1318). Hand-curated pinned literal, same curation rule as
+# select_step9c_tests.py's GLOB_SCAN_TESTS / SLOW_TESTS; the live-tree anchoring
+# drift pin is tests/test_step9c_baseline.py::test_file_anchored_scan_tests_live_tree_pin.
+# FAIL-CLOSED: a scan test absent here keeps the R-F refusal — verify anchoring
+# by reading the source BEFORE adding an entry.
+FILE_ANCHORED_SCAN_TESTS: frozenset[str] = frozenset(
+    {
+        # root = Path(__file__).resolve().parents[1] (:871); _scan_targets(root) uses
+        # root.glob(...) + `git ls-files` with cwd=root — all scratch-local (#1318).
+        "tests/test_shared_vm_thread_caps.py",
+        # REPO_ROOT = Path(__file__).resolve().parents[1] (:76); _iter_in_scope_files
+        # globs REPO_ROOT only; pure ast/re on file text, stdlib-only imports.
+        "tests/test_subprocess_env_explicit.py",
+    }
+)
 
 REQUIRED_LEDGER_KEYS: frozenset[str] = frozenset(
     {
@@ -1292,8 +1316,9 @@ def _arm_src_shadow(
             f"SCRATCH-ORACLE WARN: root dirty on non-contaminating paths "
             f"{ctx.live_dirty_paths[:20]}; pristine oracle re-rooted to a detached "
             f"sparse scratch worktree at {scratch.sha[:12]} (root venv interpreter; "
-            "contamination probe src//pyproject.toml/uv.lock was clean; scan-set "
-            "nodes and non-sparse work roots stay indeterminate)"
+            "contamination probe src//pyproject.toml/uv.lock was clean; "
+            "non-file-anchored scan-set nodes and non-sparse work roots stay "
+            "indeterminate)"
         )
     else:
         src_dirt = [p for p in contaminating if p.startswith("src/")]
@@ -1303,8 +1328,8 @@ def _arm_src_shadow(
             f"neutralized via PYTHONPATH=<scratch>/src (shadow probe verified); "
             f"pristine oracle re-rooted to a detached sparse scratch worktree at "
             f"{scratch.sha[:12]} (root venv interpreter; residual probe "
-            "pyproject.toml/uv.lock/out-of-package-src was clean; scan-set nodes "
-            "and non-sparse work roots stay indeterminate)"
+            "pyproject.toml/uv.lock/out-of-package-src was clean; non-file-anchored "
+            "scan-set nodes and non-sparse work roots stay indeterminate)"
         )
 
 
@@ -1321,10 +1346,16 @@ def _resolve_pristine_bucket(ctx: _CompareCtx, root: Path, args: argparse.Namesp
     root's HEAD — created lazily once per compare (the shadow probe runs ONCE
     at creation, fail-closed to exit 2), reused for every eligible bucketed
     file, ALWAYS removed in the ``finally``. Per-file eligibility additionally
-    requires a sparse work root (R-G), a non-scan-set node (R-F —
-    ``repo_root()``-anchored live-tree scanners read the MAIN root from any
-    cwd, so a scratch cannot decontaminate them), and the fallback not being
-    disabled via ``--no-scratch-fallback``. Everything else keeps the
+    requires a sparse work root (R-G), a non-scan-set node OR a
+    ``FILE_ANCHORED_SCAN_TESTS`` member (R-F' — ``repo_root()``-anchored
+    live-tree scanners read the MAIN root from any cwd, so a scratch cannot
+    decontaminate them; a source-verified ``__file__``-anchored scanner scans
+    its own tree, #1337), and the fallback not being disabled via
+    ``--no-scratch-fallback``. For an allowlisted scan node R-F' shifts one
+    verdict class: a scan failure caused solely by live-root strays (untracked
+    offenders absent from the HEAD-pinned scratch) now classifies NEW (rc 1)
+    instead of exit 2 — fail-closed in direction (never a silent strip), but
+    it attributes the failure to the branch. Everything else keeps the
     fail-closed MF-4c exit 2. BOTH probes re-run per file, so residual dirt
     appearing mid-loop reverts later files to the root oracle (fail-closed);
     every scratch-mode pristine call passes the shadow uniformly, so
@@ -1369,7 +1400,10 @@ def _resolve_pristine_bucket(ctx: _CompareCtx, root: Path, args: argparse.Namesp
                 and not residual  # R-B' (#1251): in-package src/ dirt is shadow-neutralized;
                 # only pyproject.toml / uv.lock / out-of-package src/ dirt still blocks
                 and wt_cones is not None  # R-G: sparse work root only
-                and test_file not in ctx.sel.GLOB_SCAN_TESTS  # R-F: scan set never scratch-resolved
+                and (
+                    test_file not in ctx.sel.GLOB_SCAN_TESTS
+                    or test_file in FILE_ANCHORED_SCAN_TESTS
+                )  # R-F' (#1337): __file__-anchored scanners scan their own (scratch) tree
                 and not args.no_scratch_fallback
             )
             if use_scratch and scratch is None:
@@ -1416,6 +1450,7 @@ def _resolve_pristine_bucket(ctx: _CompareCtx, root: Path, args: argparse.Namesp
                             f"shadowable src dirt: {shadowable[:20] or 'n/a'}; "
                             f"visible code dirt: {ctx.live_dirty_paths[:20]}; "
                             f"scan_set={test_file in ctx.sel.GLOB_SCAN_TESTS}, "
+                            f"file_anchored={test_file in FILE_ANCHORED_SCAN_TESTS}, "
                             f"sparse_wt={wt_cones is not None}) — a 'pre-existing' verdict "
                             f"for {node.file}::{node.name} from a dirty root is "
                             "untrustworthy (MF-4c); indeterminate",

--- a/tests/test_step9c_baseline.py
+++ b/tests/test_step9c_baseline.py
@@ -1532,9 +1532,10 @@ def test_compare_mid_loop_dirt_transition_fail_closed(tmp_path: Path, monkeypatc
 
 
 def test_compare_scan_set_node_never_scratch_stripped(tmp_path: Path, monkeypatch, capsys):
-    """N11 (R-F): a GLOB_SCAN_TESTS node is never scratch-resolved — live-tree
-    scanners read the MAIN root via repo_root() from any cwd, so a scratch cannot
-    decontaminate them; the node keeps the MF-4c indeterminate."""
+    """N11 (R-F'): a non-allowlisted GLOB_SCAN_TESTS node is never scratch-resolved
+    — live-tree scanners read the MAIN root via repo_root() from any cwd, so a
+    scratch cannot decontaminate them; the node keeps the MF-4c indeterminate
+    (only FILE_ANCHORED_SCAN_TESTS members are exempt, #1337)."""
     node = sb.Node(
         file="tests/test_scan_thing.py", classname="tests.test_scan_thing", name="test_x"
     )
@@ -1553,6 +1554,7 @@ def test_compare_scan_set_node_never_scratch_stripped(tmp_path: Path, monkeypatc
     assert out["indeterminate"] is True
     assert calls["scratch_created"] == []
     assert "scan_set=True" in out["reason"]
+    assert "file_anchored=False" in out["reason"]
     # The oracle ran at the ROOT (per-file granularity: only THIS node is barred).
     assert calls["pristine_detail"] == [(node.file, root, None)]
 
@@ -1575,6 +1577,46 @@ def test_compare_non_sparse_work_root_ineligible(tmp_path: Path, monkeypatch, ca
     assert out["indeterminate"] is True
     assert calls["scratch_created"] == []
     assert "sparse_wt=False" in out["reason"]
+
+
+# --- #1337: R-F' — FILE_ANCHORED_SCAN_TESTS members ARE scratch-eligible ----------
+
+
+@pytest.mark.parametrize("fails_on_main", [True, False])
+def test_compare_file_anchored_scan_node_scratch_resolved(
+    tmp_path: Path, monkeypatch, capsys, fails_on_main
+):
+    """#1337 (R-F'): a FILE_ANCHORED_SCAN_TESTS scan node on a dirty sparse root IS
+    scratch-resolved (strip-or-NEW, rc 0/1) instead of MF-4c exit 2 — the #1318 shape;
+    the MF-6 masking WARN still fires on the strip."""
+    node = sb.Node(
+        file="tests/test_scan_anchor.py", classname="tests.test_scan_anchor", name="test_x"
+    )
+    monkeypatch.setattr(sb, "FILE_ANCHORED_SCAN_TESTS", frozenset({node.file}))
+    argv, calls, root, _w = _compare_env(
+        tmp_path,
+        monkeypatch,
+        junit_cases=[(node.file, node.classname, node.name, "failed")],
+        ledger_kw={"failing": ()},
+        glob_scan={node.file: ("scripts/issue*_*.py",)},
+        touched=("scripts/issue999_wip.py",),  # matches the scan glob -> MF-6 WARN
+        live_dirty=("scripts/wip.py",),
+        pristine_failing=(node,) if fails_on_main else (),
+        extra_args=("--run-pristine",),
+    )
+    rc, out, _err = _run_json(argv, capsys)
+    assert len(calls["scratch_created"]) == 1
+    assert calls["pristine_detail"] == [(node.file, root / "scratch-fake", root)]
+    if fails_on_main:
+        assert rc == 0 and out["indeterminate"] is False
+        assert out["stripped"] == [{**node._asdict(), "via": "pristine-scratch"}]
+        assert any(
+            "MASKING WARN" in w and node.file in w and "scripts/issue999_wip.py" in w
+            for w in out["warns"]
+        )
+    else:
+        assert rc == 1
+        assert [n["name"] for n in out["new"]] == ["test_x"]
 
 
 # --- #1251: scratch PYTHONPATH src-shadow (dirty src/ no longer refuses) -----------
@@ -1802,6 +1844,33 @@ def test_load_selector_module_real_body():
     assert isinstance(mod.WORKFLOW_INVARIANT, tuple) and mod.WORKFLOW_INVARIANT
     assert isinstance(mod.GLOB_SCAN_TESTS, dict) and mod.GLOB_SCAN_TESTS
     assert callable(mod.select_tests_with_reasons) and callable(mod._matches_any)
+
+
+def test_file_anchored_scan_tests_live_tree_pin():
+    """#1337 drift pin: every FILE_ANCHORED_SCAN_TESTS member is a live GLOB_SCAN_TESTS
+    key whose source still derives its scan root from Path(__file__) and never touches
+    repo_root()/task_workflow — the source-verified basis of R-F' scratch eligibility.
+
+    Token-level, NOT dataflow-level: an imported helper that reached the live main
+    root via repo_root() would still pass these token pins — membership additions
+    stay must-ask, with a human verifying the whole scan chain by reading the source
+    (plan #1337 §10b / §11)."""
+    root = Path(sb.__file__).resolve().parents[1]
+    sel = sb.load_selector_module(root)
+    assert sb.FILE_ANCHORED_SCAN_TESTS, "allowlist unexpectedly empty"
+    # A member's `git ls-files` run with cwd inside the scratch resolves the scratch
+    # worktree's own (detached-HEAD) index, not the main index — so untracked
+    # main-root strays are invisible there (#1318 positive control).
+    for rel in sorted(sb.FILE_ANCHORED_SCAN_TESTS):
+        assert rel in sel.GLOB_SCAN_TESTS, f"{rel}: allowlisted but not a scan test"
+        src = (root / rel).read_text()
+        assert "Path(__file__).resolve().parents[1]" in src, f"{rel}: __file__ anchor gone"
+        assert "repo_root(" not in src, f"{rel}: repo_root() appeared — R-F' basis broken"
+        assert "task_workflow" not in src, f"{rel}: task_workflow import appeared"
+        # Extra negative tokens (verified 0-hit at #1337 implement time): escape
+        # channels back to the MAIN tree from a scratch cwd.
+        assert "git-common-dir" not in src, f"{rel}: git-common-dir escape appeared"
+        assert "Path.cwd()" not in src, f"{rel}: cwd-anchored scan appeared"
 
 
 def test_ruff_helpers_real_body(tmp_path: Path):


### PR DESCRIPTION
Closes task #1337.

## Summary
- Relax the step9c pristine-oracle R-F rule: `FILE_ANCHORED_SCAN_TESTS` allowlist lets __file__-anchored scan-set tests resolve via the scratch worktree oracle instead of exit-2 (MF-4c) on a dirty shared root (incident #1318).
- Fail-closed preserved: non-allowlisted scan tests keep the verbatim refusal (N11 extended, rc==2); live-tree drift-pin test guards the allowlist's factual basis; membership additions are must-ask.
- Docs synced: MF-4c `file_anchored=` token, SCRATCH-ORACLE WARN strings, module docstrings, two SKILL.md exit-2 parentheticals.

## Test plan
- [x] tests/test_step9c_baseline.py 93/93 (new parametrized behavior test + N11 extension + drift pin)
- [x] Step 9c gate: 40 files, 3548 passed / 6 skipped; compare new=[], lint ok (epm:test-verdict v1 on task #1337)

🤖 Generated with [Claude Code](https://claude.com/claude-code)