### PR TITLE
task #1360: hub.py transport-class retry on the _upload verify leg + Xet queue-full classifier

### DIFF
--- a/src/explore_persona_space/orchestrate/hub.py
+++ b/src/explore_persona_space/orchestrate/hub.py
@@ -639,7 +639,12 @@ def list_hf_files_under_path(
     relative paths); an exact FILE returns ``[path]`` (the tree endpoint 404s
     on file paths — verified on hub 0.36.2, #939 — so an
     ``EntryNotFoundError`` falls back to one ``HfApi.file_exists`` HEAD
-    probe); an absent path returns ``[]``. Repository/Revision-not-found and
+    probe, itself wrapped in ``_retry_upload``: the bare probe was the ONE
+    un-retried Hub call on the sharded-upload verify path, and a Hub
+    queue-full 429 there killed #1345's smoke upload leg after the shard had
+    already landed — att-20260715-175238; the sibling fallback in
+    ``verify_repo_paths_uploaded`` was already wrapped); an absent path
+    returns ``[]``. Repository/Revision-not-found and
     transport/auth errors PROPAGATE (the file_exists fallback only fires
     after the tree call proved repo+revision resolve, so its swallowing of
     RepositoryNotFoundError is unreachable here). Empty ``path`` raises
@@ -656,7 +661,10 @@ def list_hf_files_under_path(
             api, repo_id, repo_type=repo_type, revision=revision, path_in_repo=normalized
         )
     except EntryNotFoundError:
-        if api.file_exists(repo_id, normalized, repo_type=repo_type, revision=revision):
+        if _retry_upload(
+            lambda: api.file_exists(repo_id, normalized, repo_type=repo_type, revision=revision),
+            what=f"file_exists({repo_id}/{normalized})",
+        ):
             return [normalized]
         return []
     prefix = normalized + "/"
@@ -854,13 +862,14 @@ def _is_transient_upload_error(err: Exception) -> bool:
     false-transient (#989). The substring scan applies only to response-less
     errors (ConnectionError, timeouts).
 
-    Response-less rate-limit text ('too many requests' / 'rate limit') is
-    transient (#931: a 429 during an hf_xet transfer can cross the Rust
-    token-refresher boundary as a wrapped exception without ``.response``);
-    NEVER bare '429' (the #989 digit-triplet trap). Note: a response-less
-    PERMANENT failure whose text happens to contain one of these markers now
-    burns the full retry budget before re-raising — bounded by design
-    (``EPM_HF_RETRY_BUDGET_S``, default 1800 s)."""
+    Response-less rate-limit text ('too many requests' / 'rate limit' /
+    'queue size reached' — the HF/Xet upload-queue-saturation 429 body text,
+    #1315/#1360) is transient (#931: a 429 during an hf_xet transfer can
+    cross the Rust token-refresher boundary as a wrapped exception without
+    ``.response``); NEVER bare '429' (the #989 digit-triplet trap). Note: a
+    response-less PERMANENT failure whose text happens to contain one of
+    these markers now burns the full retry budget before re-raising —
+    bounded by design (``EPM_HF_RETRY_BUDGET_S``, default 1800 s)."""
     code = getattr(getattr(err, "response", None), "status_code", None)
     if isinstance(code, int):
         return code in (408, 429) or 500 <= code < 600
@@ -880,6 +889,12 @@ def _is_transient_upload_error(err: Exception) -> bool:
             "temporarily unavailable",
             "too many requests",  # response-less 429 text — xet Rust boundary (#931)
             "rate limit",  # matches "rate limit(ed)"; NEVER bare "429" (#989)
+            "queue size reached",  # HF/Xet upload-queue-saturation 429 body text
+            # (#1315/#1360) — can cross the hf_xet PyO3 boundary without
+            # .response and without the "too many requests" phrase. Words-only:
+            # immune to the #989 digit-triplet trap; response-BEARING errors
+            # are still decided entirely by status code (a 4xx carrying this
+            # text stays non-transient).
         )
     )
 

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -7,9 +7,10 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+import huggingface_hub
 import pytest
 from huggingface_hub.hf_api import RepoFile
-from huggingface_hub.utils import HfHubHTTPError
+from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError
 from requests.exceptions import ConnectionError
 
 from explore_persona_space.orchestrate import hub
@@ -506,6 +507,18 @@ class TestRetryUpload:
         assert _is_transient_upload_error(_storage_403()) is False
         assert _is_transient_upload_error(ValueError("bad args")) is False
 
+    def test_predicate_queue_size_reached_response_less_transient(self):
+        """#1315/#1360: the HF/Xet upload-queue-saturation body text ('maximum
+        queue size reached') classifies transient when response-LESS (the #931
+        PyO3-boundary shape); a response-BEARING 4xx carrying the same phrase
+        stays non-transient — the decision is made ENTIRELY by status code
+        (the #989 code-wins-over-substring guard intact)."""
+        err = RuntimeError(
+            "Data processing error: CAS service error ... maximum queue size reached"
+        )
+        assert _is_transient_upload_error(err) is True
+        assert _is_transient_upload_error(_http_err(400, "queue size reached")) is False
+
     def test_4xx_digit_triplet_in_message_not_retried(self):
         """A 404 whose MESSAGE embeds a digit triplet ('issue504_raw') must NOT
         retry: a real 4xx status code decides non-transient BEFORE the fuzzy
@@ -686,6 +699,119 @@ class TestListRepoFilesRetry:
 
 
 # ---------------------------------------------------------------------------
+# #1360 — _upload's verify leg rides _retry_upload (the #1315 p11 429 escape)
+# ---------------------------------------------------------------------------
+
+
+class _VerifyRetryApi:
+    """Signature-conformant HfApi fake for the ``_upload`` verify-leg tests.
+
+    Mirrors hub.py's exact call shapes (the #906 one-production-body rule —
+    the REAL ``_upload`` body runs end to end; the fake sits only at the
+    network boundary): ``upload_file`` succeeds, the scoped tree walk 404s on
+    the exact-file path (``EntryNotFoundError``), and ``file_exists`` raises
+    its scripted transport errors in order before returning
+    ``file_exists_result``.
+    """
+
+    def __init__(self, *, file_exists_raises=None, file_exists_result=True):
+        self._file_exists_raises = list(file_exists_raises or [])
+        self.file_exists_result = file_exists_result
+        self.upload_file_calls = 0
+        self.file_exists_calls = 0
+
+    def __call__(self, token=None):  # factory shim: hub calls HfApi(token=...)
+        return self
+
+    def create_repo(self, repo_id, *, repo_type=None, private=False, exist_ok=False):
+        pass
+
+    def upload_file(self, *, path_or_fileobj, repo_id, path_in_repo, repo_type):
+        self.upload_file_calls += 1
+
+    def upload_folder(self, *, folder_path, repo_id, path_in_repo, repo_type, ignore_patterns=None):
+        raise AssertionError("folder branch must not fire on a single-file upload")
+
+    def list_repo_tree(
+        self, *, repo_id, repo_type=None, revision=None, recursive=False, path_in_repo=None
+    ):
+        raise EntryNotFoundError(f"entry {path_in_repo} not found")
+
+    def file_exists(self, repo_id, path, *, repo_type=None, revision=None):
+        self.file_exists_calls += 1
+        if self._file_exists_raises:
+            raise self._file_exists_raises.pop(0)
+        return self.file_exists_result
+
+
+def _queue_429() -> HfHubHTTPError:
+    """The #1315 p11 kill shape: an HTTP 429 whose body carries the HF/Xet
+    upload-queue-saturation text."""
+    return _http_err(
+        429, "429 Client Error: Too Many Requests for url: ... maximum queue size reached"
+    )
+
+
+class TestUploadVerifyTransportRetry:
+    """#1360 integration: ``_upload``'s verify leg (the exact-file
+    ``file_exists`` fallback in ``list_hf_files_under_path``) rides
+    ``_retry_upload``, exercised through the REAL ``_upload`` body with HfApi
+    faked at the network boundary (the test_hub_filecount_fallback.py
+    pattern). Return contract preserved: "" only after retry exhaustion."""
+
+    DEST = "issue1360_test/run_config.json"
+    REPO = "owner/data-repo"
+
+    @pytest.fixture
+    def src_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HF_TOKEN", "t")
+        f = tmp_path / "run_config.json"
+        f.write_text("{}")
+        return f
+
+    def test_upload_single_file_returns_path_after_verify_429_then_success(
+        self, src_file, monkeypatch
+    ):
+        """upload_file succeeds; the tree walk 404s (exact-file path); the
+        file_exists probe 429s once then True -> the verified path returns
+        (pre-fix: the 429 propagated to _upload's log-and-return-\"\" arm)."""
+        api = _VerifyRetryApi(file_exists_raises=[_queue_429()], file_exists_result=True)
+        monkeypatch.setattr(huggingface_hub, "HfApi", api)
+        with patch("explore_persona_space.orchestrate.hub.time.sleep") as mock_sleep:
+            result = hub._upload(src_file, self.REPO, "dataset", self.DEST, upload_as_file=True)
+        assert result == f"{self.REPO}/{self.DEST}"
+        assert api.upload_file_calls == 1
+        assert api.file_exists_calls == 2
+        mock_sleep.assert_called_once()
+
+    def test_upload_returns_empty_only_after_verify_retry_exhaustion(self, src_file, monkeypatch):
+        """A PERSISTENT verify 429 under the budget kill switch (=0) exhausts
+        the 6-call attempt floor, then — and only then — _upload returns the
+        no-path signal callers fail-fast on."""
+        monkeypatch.setenv("EPM_HF_RETRY_BUDGET_S", "0")
+        api = _VerifyRetryApi(file_exists_raises=[_queue_429() for _ in range(6)])
+        monkeypatch.setattr(huggingface_hub, "HfApi", api)
+        with patch("explore_persona_space.orchestrate.hub.time.sleep"):
+            result = hub._upload(src_file, self.REPO, "dataset", self.DEST, upload_as_file=True)
+        assert result == ""
+        assert api.file_exists_calls == 6
+
+    def test_file_path_without_flag_valueerror_unretried(self, src_file, monkeypatch):
+        """The #595 fail-loud guard (file path without upload_as_file=True)
+        still propagates un-retried with zero sleeps — content classes are
+        byte-unchanged by the #1360 wrap."""
+        api = _VerifyRetryApi()
+        monkeypatch.setattr(huggingface_hub, "HfApi", api)
+        with (
+            patch("explore_persona_space.orchestrate.hub.time.sleep") as mock_sleep,
+            pytest.raises(ValueError, match="upload_as_file"),
+        ):
+            hub._upload(src_file, self.REPO, "dataset", self.DEST)
+        assert api.upload_file_calls == 0
+        mock_sleep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # #988 — scoped post-upload verifies + list_hub_datasets prefix dispatch
 # ---------------------------------------------------------------------------
 
@@ -701,7 +827,6 @@ class TestUploadVerifyScoped:
     def test_file_upload_verify_uses_file_exists_fallback(self, tmp_path):
         """An exact-file dest 404s on the tree endpoint (EntryNotFoundError)
         and resolves via ONE file_exists probe."""
-        from huggingface_hub.utils import EntryNotFoundError
 
         from explore_persona_space.orchestrate.hub import _upload
 
@@ -743,7 +868,6 @@ class TestUploadVerifyScoped:
     def test_absent_dest_returns_empty_not_success(self, tmp_path):
         """An absent dest (EntryNotFoundError + file_exists False) keeps the
         existing '0 files found ... NOT marking as successful' branch."""
-        from huggingface_hub.utils import EntryNotFoundError
 
         from explore_persona_space.orchestrate.hub import _upload
 
@@ -1113,7 +1237,6 @@ class TestVerifyRepoPathsUploaded:
         """A prefix absent on the repo (EntryNotFoundError during the scoped
         walk) returns ALL expected paths — the caller's fail-loud fires with
         the full list."""
-        from huggingface_hub.utils import EntryNotFoundError
 
         api = Mock()
         api.list_repo_tree = Mock(side_effect=EntryNotFoundError("tree bucket not found"))
@@ -1159,7 +1282,6 @@ class TestVerifyRepoPathsUploaded:
         helper must fall back to a ``file_exists`` probe — a successfully-
         uploaded file must NOT be reported missing. Pre-fix this returned
         ``["bucket/x.json"]`` (EntryNotFoundError => all expected missing)."""
-        from huggingface_hub.utils import EntryNotFoundError
 
         api = Mock()
         api.list_repo_tree = Mock(side_effect=EntryNotFoundError("tree 404s on file paths"))
@@ -1174,7 +1296,6 @@ class TestVerifyRepoPathsUploaded:
         """The False variant: tree 404s AND ``file_exists`` is False -> the
         exact file IS missing (the caller's fail-loud still fires on a
         genuinely absent file)."""
-        from huggingface_hub.utils import EntryNotFoundError
 
         api = Mock()
         api.list_repo_tree = Mock(side_effect=EntryNotFoundError("tree 404s on file paths"))
@@ -1188,7 +1309,6 @@ class TestVerifyRepoPathsUploaded:
         """The ``file_exists`` fallback is a fresh Hub call on the verify path
         — a transient 500 on the probe retries instead of crashing the verify
         leg (the #920 class must not re-enter through the fallback)."""
-        from huggingface_hub.utils import EntryNotFoundError
 
         api = Mock()
         api.list_repo_tree = Mock(side_effect=EntryNotFoundError("tree 404s on file paths"))
@@ -1205,7 +1325,6 @@ class TestVerifyRepoPathsUploaded:
         """A directory-like prefix (no expected path EQUAL to it) keeps the
         all-missing semantics on EntryNotFoundError — the file_exists fallback
         never fires."""
-        from huggingface_hub.utils import EntryNotFoundError
 
         api = Mock()
         api.list_repo_tree = Mock(side_effect=EntryNotFoundError("tree bucket not found"))

--- a/tests/test_hub_artifacts_and_refusal.py
+++ b/tests/test_hub_artifacts_and_refusal.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from huggingface_hub.hf_api import RepoFile, RepoFolder
-from huggingface_hub.utils import EntryNotFoundError, RepositoryNotFoundError
+from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError, RepositoryNotFoundError
 
 from explore_persona_space.eval.refusal import detect_refusal, filter_refusals
 from explore_persona_space.orchestrate.hub import (
@@ -76,6 +76,15 @@ class TestListRepoFilesComplete:
 # ── list_hf_files_under_path (the shared scoped-listing helper, #988) ────────
 
 
+def _http_err(code: int, msg: str | None = None) -> HfHubHTTPError:
+    """HfHubHTTPError whose .response.status_code == code (mirrors
+    tests/test_hub.py's helper) so the classifier's status-code branch is
+    exercised as in prod."""
+    r = MagicMock()
+    r.status_code = code
+    return HfHubHTTPError(msg or f"{code} error", response=r)
+
+
 class _ProbeApi:
     """Signature-mirroring ``HfApi`` stand-in for the exact-file fallback tests.
 
@@ -83,11 +92,22 @@ class _ProbeApi:
     ``file_exists``), never a bare ``MagicMock`` — the real helper body runs
     end to end against them (code-style rule: one production-body test per
     seam-stubbed function, #906).
+
+    ``file_exists_raises`` scripts transport errors for the #1360 retry tests:
+    each ``file_exists`` call pops + raises the next exception in order, then
+    later calls return ``file_exists_result``.
     """
 
-    def __init__(self, *, tree_raises: Exception, file_exists_result: bool = False):
+    def __init__(
+        self,
+        *,
+        tree_raises: Exception,
+        file_exists_result: bool = False,
+        file_exists_raises: list[Exception] | None = None,
+    ):
         self._tree_raises = tree_raises
         self.file_exists_result = file_exists_result
+        self._file_exists_raises = list(file_exists_raises or [])
         self.tree_calls: list[dict] = []
         self.file_exists_calls: list[dict] = []
 
@@ -114,6 +134,8 @@ class _ProbeApi:
                 "revision": revision,
             }
         )
+        if self._file_exists_raises:
+            raise self._file_exists_raises.pop(0)
         return self.file_exists_result
 
     def list_repo_files(self, *args, **kwargs):  # pragma: no cover - must never run
@@ -176,6 +198,59 @@ class TestListHfFilesUnderPath:
         with pytest.raises(RepositoryNotFoundError):
             list_hf_files_under_path(api, "owner/ghost", "a/b")
         assert api.file_exists_calls == []
+
+    def test_exact_file_fallback_retries_transient_429_then_succeeds(self):
+        """#1360: the exact-file ``file_exists`` fallback rides ``_retry_upload``
+        — a transient HF 429 ('maximum queue size reached', the #1315 p11 kill
+        shape) retries instead of propagating to _upload's
+        log-and-return-\"\" arm."""
+        api = _ProbeApi(
+            tree_raises=EntryNotFoundError("entry a/b/x.json not found"),
+            file_exists_result=True,
+            file_exists_raises=[
+                _http_err(429, "429 Client Error: Too Many Requests ... maximum queue size reached")
+            ],
+        )
+        with patch("explore_persona_space.orchestrate.hub.time.sleep") as mock_sleep:
+            result = list_hf_files_under_path(api, "owner/repo", "a/b/x.json", repo_type="dataset")
+        assert result == ["a/b/x.json"]
+        assert len(api.file_exists_calls) == 2
+        mock_sleep.assert_called_once()
+
+    def test_exact_file_fallback_exhausts_and_propagates(self, monkeypatch):
+        """A PERSISTENT 429 exhausts the attempt floor (wall-clock budget kill
+        switch = 0) and re-raises fail-loud after exactly 6 calls (the #735
+        contract) — never a silent swallow."""
+        monkeypatch.setenv("EPM_HF_RETRY_BUDGET_S", "0")
+        err = _http_err(429, "429 Client Error: Too Many Requests")
+        api = _ProbeApi(
+            tree_raises=EntryNotFoundError("entry ghost not found"),
+            file_exists_raises=[err] * 6,
+        )
+        with (
+            patch("explore_persona_space.orchestrate.hub.time.sleep"),
+            pytest.raises(HfHubHTTPError),
+        ):
+            list_hf_files_under_path(api, "owner/repo", "ghost", repo_type="dataset")
+        assert len(api.file_exists_calls) == 6
+
+    def test_exact_file_fallback_content_class_immediate_reraise(self):
+        """The persistent storage-quota-403 (content-class) re-raises on call 1
+        with zero sleeps — the wrap must not delay the #564 overflow-routing /
+        fail-loud semantics."""
+        api = _ProbeApi(
+            tree_raises=EntryNotFoundError("entry a/b/x.json not found"),
+            file_exists_raises=[
+                _http_err(403, "403 Forbidden: You have exceeded your public storage space")
+            ],
+        )
+        with (
+            patch("explore_persona_space.orchestrate.hub.time.sleep") as mock_sleep,
+            pytest.raises(HfHubHTTPError),
+        ):
+            list_hf_files_under_path(api, "owner/repo", "a/b/x.json", repo_type="dataset")
+        assert len(api.file_exists_calls) == 1
+        mock_sleep.assert_not_called()
 
 
 # ── verify_artifacts_exist ────────────────────────────────────────────────────


### PR DESCRIPTION
Closes task #1360. Wraps the bare api.file_exists verify fallback in _retry_upload (byte-matched to issue-1345's 181c6326d8) + adds the 'queue size reached' response-less transient substring. Plan: tasks/*/1360/plans/v3.md.