### PR TITLE
task #1364: analyzer Step 3.7 language-intrusion audit over judged install-instrument pools

### DIFF
--- a/.claude/agents/analyzer.md
+++ b/.claude/agents/analyzer.md
@@ -321,6 +321,38 @@ Full text: `analyzer-section-reference.md`
 § Step 3.6: Raw-text sample selection (MANDATORY, per load-bearing condition)
 (grep heading, chunked Read).
 
+### Step 3.7: Language-intrusion audit (Qwen-family under a non-CJK eval — MANDATORY)
+
+Whenever the evaluated completions come from a Qwen-family model (the
+project's Qwen-2.5-7B base or any finetune/adapter of it) under a non-CJK
+eval (prompts + expected outputs in English or another non-CJK-script
+language), run the per-arm CJK scan over BOTH substrates BEFORE writing the
+body — auditing only (a) is the incident class (#1090 fu4, then #1315: the
+judged pools carried 11.5-18% CJK intrusion (18/100, 16/100, 23/200) that flipped two parity PASSes
+under zeroed bounds while the greedy capture rollouts were clean at 2/120;
+Lens 7 caught it post-hoc both times):
+
+- **(a) capture/geometry substrate rollouts** (greedy or sampled), AND
+- **(b) EVERY judged install-instrument pool** — each temp>0 completion set
+  joined with its judge scores (e.g. #1315's Tier-1/Tier-2/parity temp-1.0
+  pools joined with `all_scores`) — that any PASS/WARN install/parity
+  adjudication, band-placement claim, or headline-rate claim rests on.
+
+Per arm (trained AND base/control arms alike), report NEXT TO the adjudication it supports (never only in an
+appendix): `intruded/total` (a row is intruded iff its completion matches
+`[\u4e00-\u9fff\u3400-\u4dbf\uf900-\ufaff\u3040-\u30ff\uac00-\ud7af]`),
+fired-overlap (intrusion × judge-positive cross-tab), and the
+zeroed-intrusion + excluded-intrusion recounts of the pool's headline rate.
+An adjudication that flips under either recount is labeled
+convention-dependent in the body — never silently kept PASS. The scan is
+pure counting: only aggregate counts enter context; cite intruded rows by
+file + row index, never quoted text (full recipe + the script-swap variant
+for non-CJK intrusion scripts: `interpretation-critic.md` Lens 7 item 3b,
+the #1312 scan). Escapes — write `Language-intrusion audit: N/A — <reason>`
+in the fact sheet: CJK-context eval (per-ARM inside a mixed-language eval,
+not per-task), non-Qwen evaluated model, or a DV with no on-policy
+generation (teacher-forced margins, fixed-completion log-P).
+
 ### Step 4: Write the clean-result body
 
 **SPEC.md § "v4 body shape" is authoritative** (+ the exemplar

--- a/.claude/agents/interpretation-critic.md
+++ b/.claude/agents/interpretation-critic.md
@@ -327,6 +327,13 @@ If the figure doesn't show what the caption claims, flag it. Common failures:
       fixed-completion log-P). If a different intrusion script surfaces in
       step 2's samples (e.g. Cyrillic), rerun the same recipe with that
       script's block ranges swapped in.
+    - **Upstream analyzer duty (cross-ref):** the analyzer owes this same
+      scan over BOTH substrates — capture rollouts AND every judged
+      install-instrument pool — BEFORE the body is written (`analyzer.md`
+      Step 3.7, #1364). A body resting a PASS/WARN install/parity
+      adjudication on a judged pool with no adjacent intrusion counts +
+      zeroed/excluded bounds is a missing-analyzer-duty REVISE finding
+      (name Step 3.7 in the finding), not only a critic-side recompute.
 4. **Cross-check the body's sample-output blocks**: the body MUST include ≥3 firing + ≥3 non-firing examples per Result. Verify those examples are actually drawn from the eval JSON (not fabricated) and are representative (not cherry-picked extreme cases).
 
 If the body's sample-output blocks are missing, contain only firing examples (no non-firing), or include examples not findable in the raw JSON, flag it.

--- a/tests/test_analyzer_language_intrusion_duty.py
+++ b/tests/test_analyzer_language_intrusion_duty.py
@@ -1,0 +1,44 @@
+"""Durability pin for the analyzer.md Step 3.7 language-intrusion audit duty (#1364).
+
+analyzer.md sits above the 28 KB agent-spec size-WARN budget, so future trim
+passes are likely; this pin fails loud if a trim drops the duty. Without it
+the #1090 fu4 -> #1315 recurrence class (judged install-instrument pools
+carrying 11.5-18% CJK intrusion (18/100, 16/100, 23/200) invisible in the
+draft body) has no upstream defense. Family precedent: T11 in
+tests/test_workflow_lint_no_repo_root_git_reset_hard.py (analyzer.md
+hard-rule prose pin).
+"""
+
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+
+
+def test_analyzer_md_carries_language_intrusion_duty() -> None:
+    """The Step 3.7 duty text keeps its load-bearing elements."""
+    text = (_REPO / ".claude" / "agents" / "analyzer.md").read_text(encoding="utf-8")
+    low = text.lower()
+    # the step heading
+    assert "language-intrusion audit" in low, "duty heading dropped"
+    # trigger condition
+    assert "qwen-family" in low and "non-cjk" in low, "trigger condition dropped"
+    # substrate (b): judged pools, not only capture rollouts
+    assert "judged install-instrument pool" in low, "substrate (b) dropped"
+    # the three per-arm report elements + adjacency
+    assert "intruded/total" in low, "intruded/total report element dropped"
+    assert "fired-overlap" in low, "fired-overlap report element dropped"
+    assert "zeroed-intrusion" in low, "zeroed-intrusion bound dropped"
+    assert "pass/warn" in low, "PASS/WARN adjacency requirement dropped"
+    # incident lineage
+    assert "#1090" in text and "#1315" in text, "incident citations dropped"
+    # decision semantics + the NFC-safe escaped char class (Statistics r1)
+    assert "excluded-intrusion" in low, "excluded-intrusion recount dropped"
+    assert "convention-dependent" in low, "convention-dependent labeling dropped"
+    assert r"\u4e00-\u9fff" in low, "escaped CJK class dropped (NFC-safe form required)"
+
+
+def test_interpretation_critic_lens7_cross_ref() -> None:
+    """Lens 7 3b keeps the upstream-duty cross-ref to analyzer.md Step 3.7."""
+    text = (_REPO / ".claude" / "agents" / "interpretation-critic.md").read_text(encoding="utf-8")
+    assert "Step 3.7" in text, "Lens 7 upstream-duty cross-ref dropped"
+    assert "missing-analyzer-duty" in text, "missing-analyzer-duty routing dropped"


### PR DESCRIPTION
Closes task #1364 (workflow-fix, kind: infra). Adds the analyzer-side language-intrusion audit duty (Qwen-family under non-CJK evals; both substrates: capture rollouts + judged install-instrument pools), the Lens 7 3b upstream-duty cross-ref, and a durability pin test. Plan v3; code-review r1 PASS; step9c gate 3404 passed / compare clean.