### PR TITLE
task #1372: opaque snake_case slug detection in body-discipline audit

### DIFF
--- a/.claude/skills/clean-results/SPEC.md
+++ b/.claude/skills/clean-results/SPEC.md
@@ -1536,8 +1536,8 @@ paragraph — RETIRES for v3).
 
 ## Anti-pattern audit (`audit_clean_results_body_discipline.py`)
 
-Catches prose-level violations the verifier doesn't (unchanged across
-generations):
+Catches prose-level violations the verifier doesn't (mostly unchanged across
+generations; the snake_case-slug category is v4-only):
 
 - Pre-registration mentions
 - Effect-size names in prose (Cohen's d, η², r-as-effect-size,
@@ -1546,6 +1546,10 @@ generations):
   exact, Mann-Whitney, Wilcoxon, bootstrap test)
 - Inline `value ± err` credence intervals (chart error bars fine)
 - Project-internal condition labels (`C1`, `C2`, `C2'`, `H1`, `P1`)
+- Backticked 3+-segment snake_case condition/cell slugs (`neg_reph_curious`)
+  in v4 reader-facing prose (Takeaways/Goal/Results; footer, captions,
+  tables, Methodology, field-name allowlist exempt; digit-leading segments
+  + bare unbackticked slugs stay LM-critic territory) — v4-only (#1372)
 - Math-style subscripts/superscripts in prose
 - GCG / PAIR / `H_a` / `REJECTED` / letter labels / `Bin A/B/C`
 - **`byte identical` / `byte-identical`** — banned phrasing.

--- a/scripts/audit_clean_results_body_discipline.py
+++ b/scripts/audit_clean_results_body_discipline.py
@@ -33,6 +33,42 @@ OUT_DIR = Path(".claude/cache/audit-2026-05-08")
 FINDINGS_PATH = OUT_DIR / "findings.md"
 INVENTORY_PATH = OUT_DIR / "inventory.json"
 
+# Field / API / config identifiers that legitimately appear backticked in
+# reader-facing v4 prose. Seeded from the 2026-07-15 corpus dry-run (#1372);
+# extensible — a false positive at the Step 9a-bis gate adds its token here
+# with a one-line reason. Exact-token match only (the regex closes the
+# lookahead with a backtick), so `logp_pos_mean_v2` still flags.
+_SNAKE_SLUG_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "add_special_tokens",  # HF tokenizer kwarg
+        "apply_chat_template",  # HF tokenizer API
+        "est_gpu_hours",  # follow-up proposal field
+        "has_clean_result",  # task frontmatter field
+        "list_repo_files",  # huggingface_hub API (upload-verification prose)
+        "list_repo_tree",  # huggingface_hub API
+        "logp_pos_mean",  # dual-DV companion field (llm-judging.md rule 20)
+        "max_model_len",  # vLLM engine kwarg
+        "max_new_tokens",  # generation kwarg
+        "output_hidden_states",  # HF forward kwarg
+        "span_seam_counts",  # per-row provenance field (#1315's legitimate neighbor)
+    }
+)
+
+# Backticked bare 3+-segment lowercase snake_case token. Tight backtick
+# anchoring structurally excludes filenames (`mix_meta.json`), paths, calls
+# (`train_lora()`), flags (`--x_y_z`), and assignments (`a=b_c_d`); the
+# `test_` lookahead excludes pytest test names (#672 class); the allowlist
+# lookahead is exact-token (it closes with a backtick). Known residual, by
+# design (the task Goal's verbatim regex): the first two segments are
+# `[a-z]`-only, so digit-leading-segment slugs (`c1_evil_wrong_em`,
+# `d1_seed42`-style heads) and bare UNbackticked slugs are not matched —
+# both stay LM-critic territory.
+_SNAKE_SLUG_PATTERN = (
+    "`(?!test_)(?!(?:"
+    + "|".join(sorted(re.escape(t) for t in _SNAKE_SLUG_ALLOWLIST))
+    + ")`)[a-z]+_[a-z]+(?:_[a-z0-9]+)+`"
+)
+
 PATTERNS: dict[str, tuple[str, str]] = {
     # name: (regex, plain-English description)
     "pre_reg": (
@@ -160,6 +196,15 @@ PATTERNS: dict[str, tuple[str, str]] = {
         "Plan-internal per-cell / extraction-method / judge / gate tags (BS_E*, Z_*, G*, "
         "Method A/B, M1) — replace with plain English; tags go in "
         "<details>Setup details</details>",
+    ),
+    "opaque_snake_slugs": (
+        _SNAKE_SLUG_PATTERN,
+        "Backticked 3+-segment snake_case condition/cell/outcome slugs in v4 "
+        "reader-facing prose (## Takeaways / ## Goal / ## Results) — replace "
+        "with plain-English names; slugs belong in the condition table, the "
+        "**Repro:** footer, and launch-command examples. Digit-leading "
+        "segments (`c1_evil_wrong_em`) and bare unbackticked slugs stay "
+        "LM-critic territory (#1315/#1372)",
     ),
     "experimental_arm": (
         # "arm" / "arms" used as a project-internal experiment-strand label.
@@ -671,6 +716,53 @@ def _restrict_pre_reg_to_prose_sections(body: str, text: str) -> str:
     return "\n".join(out)
 
 
+# The v4 reader-facing prose sections the `opaque_snake_slugs` category scans.
+# Methodology is deliberately OUT of scope (#1372 §4.6): it is the
+# field-name-dense "everything required to understand the results" section,
+# and the no-opaque-codes rule targets NARRATIVE prose; a slug appearing ONLY
+# in Methodology prose stays LM-critic territory.
+_SNAKE_SLUG_PROSE_H2S: frozenset[str] = frozenset({"takeaways", "goal", "results"})
+_REPRO_LABEL_RE = re.compile(r"^(?:[-*]\s+)?\*\*\s*Repro\s*:", re.IGNORECASE)
+
+
+def _restrict_snake_slugs_to_v4_reader_prose(body: str, text: str) -> str:
+    """Scan source for `opaque_snake_slugs` (#1372, incident #1315).
+
+    v4-sentinel bodies ONLY — v3/v2/legacy bodies return "" (category
+    inactive): forward-only, per CLAUDE.md § Experiment Report Structure
+    ("grandfathered bodies are NEVER newly hard-FAILed by a v4 rule").
+    Within a v4 body, keep only lines inside `## Takeaways` / `## Goal` /
+    `## Results`; blank everything from the `**Repro:**` footer label
+    onward (the footer + launch commands are the SANCTIONED slug surfaces
+    — planner §5 / SPEC.md); blank blockquote (`>`) lines (figure captions
+    naming the plotted cell by slug — same carve-out family as
+    `interval_inline`'s). `text` must be the `strip_fenced_code_only`
+    chain WITH table rows blanked (inline backticks kept — `strip_code`
+    would erase the very spans this category reads; the #667 precedent).
+    Degradation: a mis-detected boundary means a line is scanned or
+    blanked, never a crash; a defensive later H2 re-evaluates the footer
+    cut.
+    """
+    if "<!-- clean-result-v4 -->" not in body:
+        return ""
+    out: list[str] = []
+    keep = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        h2 = _H2_RE.match(stripped)
+        if h2:
+            keep = h2.group("title").strip().lower() in _SNAKE_SLUG_PROSE_H2S
+            out.append("")
+            continue
+        if _REPRO_LABEL_RE.match(stripped):
+            keep = False  # footer runs to EOF (next H2 re-evaluates, defensively)
+        if keep and stripped.startswith(">"):
+            out.append("")
+            continue
+        out.append(line if keep else "")
+    return "\n".join(out)
+
+
 def is_v2(body: str) -> bool:
     """Return True when a body is treated as a "current spec" body for
     the legacy bulk-inventory audit.
@@ -752,6 +844,13 @@ def audit_body(body: str) -> dict[str, list[str]]:
     `## Data` / `## Reproducibility` prose no longer fires a false
     positive (incident #623); v2 / legacy bodies keep the prior whole-body
     `pre_reg` behavior.
+
+    `opaque_snake_slugs` scans a v4-ONLY reader-prose source via
+    `_restrict_snake_slugs_to_v4_reader_prose`: the inline-backtick-keeping
+    chain (like `interval_inline`) with GFM table rows blanked, restricted
+    to `## Takeaways` / `## Goal` / `## Results` lines, with the
+    `**Repro:**` footer onward and blockquote caption lines blanked;
+    v3/v2/legacy bodies get an empty scan source (forward-only, #1372).
     """
     findings: dict[str, list[str]] = {}
     cleaned = strip_code(
@@ -770,15 +869,22 @@ def audit_body(body: str) -> dict[str, list[str]]:
     interval_cleaned = strip_fenced_code_only(
         strip_data_example_blocks(strip_context_blockquotes(strip_frontmatter(body)))
     )
-    interval_scan_source = _strip_interval_inline_exempt_lines(_blank_table_rows(interval_cleaned))
+    interval_table_blanked = _blank_table_rows(interval_cleaned)
+    interval_scan_source = _strip_interval_inline_exempt_lines(interval_table_blanked)
     # `pre_reg` scans a generation-scoped source: v4 = whole body minus
     # table rows; v3 = the three Lens 7 prose sections; v2/legacy = whole body.
     pre_reg_scan_source = _restrict_pre_reg_to_prose_sections(body, cleaned)
+    # `opaque_snake_slugs` reuses the inline-backtick-keeping table-blanked
+    # chain (backticks are the match anchor — `strip_code` would erase them),
+    # restricted to v4 reader-facing prose (#1372).
+    snake_slug_scan_source = _restrict_snake_slugs_to_v4_reader_prose(body, interval_table_blanked)
     for name, (pattern, _) in PATTERNS.items():
         if name == "interval_inline":
             scan_source = interval_scan_source
         elif name == "pre_reg":
             scan_source = pre_reg_scan_source
+        elif name == "opaque_snake_slugs":
+            scan_source = snake_slug_scan_source
         elif name in _TABLE_CELL_EXEMPT_CATEGORIES:
             scan_source = cleaned_table_blanked
         else:

--- a/tests/test_audit_clean_results_body_discipline.py
+++ b/tests/test_audit_clean_results_body_discipline.py
@@ -1666,3 +1666,204 @@ def test_single_body_audit_no_fm_no_warn_line(capsys):
     out = capsys.readouterr().out
     assert "WARN h1_title_sync" not in out
     assert out.splitlines()[0].startswith("PASS:")
+
+
+# ─── opaque_snake_slugs: backticked 3+-segment snake_case slugs (#1372) ──
+#
+# Incident #1315: `` `neg_reph_curious` `` sat in Methodology Data-extraction
+# AND Results prose; `--task 1315` printed PASS and only the LM critic caught
+# it. The category scans v4 reader-facing prose ONLY (`## Takeaways` /
+# `## Goal` / `## Results`), over the inline-backtick-keeping chain (like
+# `interval_inline`), with the `**Repro:**` footer onward, blockquote
+# captions, GFM table rows, fenced code, `test_*` names, and the exact-token
+# field-name allowlist exempt. Tests mutate V4_BODY_CLEAN via targeted
+# `.replace()` with a body != fixture guard, matching the pre_reg section.
+
+_RESULTS_PROSE_LINE = "The lift holds at every seed in the held-out evaluation."
+
+
+def test_snake_slug_in_v4_results_prose_is_flagged():
+    """The #1315 Results-prose shape: a backticked 3-segment slug in
+    `## Results` prose on a v4 body trips `opaque_snake_slugs`."""
+    body = V4_BODY_CLEAN.replace(
+        _RESULTS_PROSE_LINE,
+        "The lift holds at every seed; one panel context (`neg_reph_curious`) drives it.",
+    )
+    assert body != V4_BODY_CLEAN
+    findings = audit.audit_body(body)
+    assert "opaque_snake_slugs" in findings, findings
+    assert "`neg_reph_curious`" in findings["opaque_snake_slugs"], findings
+
+
+def test_snake_slug_in_v4_takeaways_prose_is_flagged():
+    """A backticked slug in a `## Takeaways` bullet flags — the mentor-facing
+    narrative surface the no-opaque-codes rule most directly protects."""
+    body = V4_BODY_CLEAN.replace(
+        "- Headline finding: the implant installs cleanly across three seeds.",
+        "- Headline finding: `tf_rev_default` installs cleanly across three seeds.",
+    )
+    assert body != V4_BODY_CLEAN
+    findings = audit.audit_body(body)
+    assert "opaque_snake_slugs" in findings, findings
+
+
+def test_snake_slug_in_v4_goal_prose_is_flagged():
+    """A backticked slug in `## Goal` prose flags — pins that `goal` is in
+    `_SNAKE_SLUG_PROSE_H2S` (reviewer concern on #1372's plan)."""
+    body = V4_BODY_CLEAN.replace(
+        "**Broader narrative:** which context factors predict fine-tuning leakage.",
+        "**Broader narrative:** whether `imp_icl_ft_neg` leakage tracks geometry.",
+    )
+    assert body != V4_BODY_CLEAN
+    findings = audit.audit_body(body)
+    assert "opaque_snake_slugs" in findings, findings
+
+
+def test_snake_slug_in_v4_methodology_prose_is_exempt():
+    """A slug appearing ONLY in `## Methodology` prose does NOT flag — the
+    field-name-dense section is deliberately out of scope (#1372 §4.6); the
+    residual stays LM-critic territory."""
+    body = V4_BODY_CLEAN.replace(
+        "**Design:** three seeds; baseline vs treatment; the single variable is the data mix.",
+        "**Design:** three seeds; one panel context (`neg_reph_curious`) is the treatment.",
+    )
+    assert body != V4_BODY_CLEAN
+    findings = audit.audit_body(body)
+    assert "opaque_snake_slugs" not in findings, findings
+
+
+def test_snake_slug_in_repro_footer_is_exempt():
+    """Slugs in the `**Repro:**` footer (the #1315 remediation destination —
+    the sanctioned slug surface) do NOT flag: the walker blanks the footer
+    label line onward."""
+    body = V4_BODY_CLEAN.replace(
+        "**Repro:** 1x A100, 47 min; code at commit deadbeef.",
+        "**Repro:** 1x A100, 47 min; adapters `tf_default_contra_d1` and\n"
+        "`neg_reph_curious`; code at commit deadbeef.",
+    )
+    assert body != V4_BODY_CLEAN
+    findings = audit.audit_body(body)
+    assert "opaque_snake_slugs" not in findings, findings
+
+
+def test_snake_slug_in_figure_caption_blockquote_is_exempt():
+    """A slug in a figure-caption blockquote inside `## Results` does NOT
+    flag — a caption naming the plotted cell is provenance, not narrative
+    (same carve-out family as `interval_inline`'s)."""
+    body = V4_BODY_CLEAN.replace(
+        _RESULTS_PROSE_LINE,
+        _RESULTS_PROSE_LINE + "\n\n> **Figure.** *Per-seed lift for the "
+        "`tf_default_contra_d1_seed42` cell.*",
+    )
+    assert body != V4_BODY_CLEAN
+    findings = audit.audit_body(body)
+    assert "opaque_snake_slugs" not in findings, findings
+
+
+def test_snake_slug_in_condition_table_and_fenced_code_is_exempt():
+    """Slugs in a GFM condition-table cell and in a fenced launch command
+    inside `## Results` do NOT flag — the condition table and command
+    examples are exactly where slugs belong."""
+    body = V4_BODY_CLEAN.replace(
+        _RESULTS_PROSE_LINE,
+        _RESULTS_PROSE_LINE + "\n\n"
+        "| Condition | Config slug |\n"
+        "|---|---|\n"
+        "| query-rephrase panel | `neg_reph_curious` |\n\n"
+        "```bash\n"
+        "uv run python scripts/eval.py condition=neg_reph_curious seed=42\n"
+        "```\n",
+    )
+    assert body != V4_BODY_CLEAN
+    findings = audit.audit_body(body)
+    assert "opaque_snake_slugs" not in findings, findings
+
+
+def test_snake_slug_allowlist_field_names_not_flagged():
+    """Allowlisted field/API identifiers in Results prose do NOT flag
+    (`logp_pos_mean`, `span_seam_counts` — legitimate 3+-segment names)."""
+    body = V4_BODY_CLEAN.replace(
+        _RESULTS_PROSE_LINE,
+        "The `logp_pos_mean` companion tracks the rate; `span_seam_counts` is clean.",
+    )
+    assert body != V4_BODY_CLEAN
+    findings = audit.audit_body(body)
+    assert "opaque_snake_slugs" not in findings, findings
+
+
+def test_snake_slug_allowlist_is_exact_token_not_prefix():
+    """The allowlist lookahead closes with a backtick, so an allowlisted
+    PREFIX does not exempt a longer token: `logp_pos_mean_v2` flags."""
+    body = V4_BODY_CLEAN.replace(
+        _RESULTS_PROSE_LINE,
+        "The `logp_pos_mean_v2` variant tracks the rate at every seed.",
+    )
+    assert body != V4_BODY_CLEAN
+    findings = audit.audit_body(body)
+    assert "opaque_snake_slugs" in findings, findings
+    assert "`logp_pos_mean_v2`" in findings["opaque_snake_slugs"], findings
+
+
+def test_snake_slug_two_segment_and_filename_forms_not_flagged():
+    """Structural exclusions: 2-segment tokens, filenames (extension before
+    the closing backtick), calls, and assignments never match — the tight
+    backtick anchoring carries these classes without allowlist entries."""
+    body = V4_BODY_CLEAN.replace(
+        _RESULTS_PROSE_LINE,
+        "Per-row `span_seam` provenance from `mix_meta.json` and "
+        "`training_mix_v2.jsonl`, built by `train_lora()` under "
+        "`condition=c1_evil_wrong_em`.",
+    )
+    assert body != V4_BODY_CLEAN
+    findings = audit.audit_body(body)
+    assert "opaque_snake_slugs" not in findings, findings
+
+
+def test_snake_slug_test_names_not_flagged():
+    """Backticked pytest names in Results prose do NOT flag (the `test_`
+    lookahead; #672's two hits are real code identifiers, never slugs)."""
+    body = V4_BODY_CLEAN.replace(
+        _RESULTS_PROSE_LINE,
+        "The pin is `test_watchdog_terminates_only_when_both_probes_fail`.",
+    )
+    assert body != V4_BODY_CLEAN
+    findings = audit.audit_body(body)
+    assert "opaque_snake_slugs" not in findings, findings
+
+
+def test_snake_slug_inactive_on_v3_bodies():
+    """Forward-only: the same slug in a v3-sentinel body's Findings prose
+    produces NO `opaque_snake_slugs` finding — grandfathered bodies are
+    never newly hard-FAILed by a v4 rule."""
+    body = V3_BODY_WITH_DATA_CODES.replace(
+        "The lift holds at every seed in the held-out evaluation.",
+        "The lift holds at every seed; one panel context (`neg_reph_curious`) drives it.",
+    )
+    assert body != V3_BODY_WITH_DATA_CODES
+    findings = audit.audit_body(body)
+    assert "opaque_snake_slugs" not in findings, findings
+
+
+def test_snake_slug_regression_issue_1315_shape():
+    """REGRESSION PIN (#1315 r1 shape): the Methodology Data-extraction
+    sentence AND the Results sentence that shipped in #1315's round-1 body.
+    The extended audit fires with `` `neg_reph_curious` `` sampled from the
+    Results prose; the legitimate `span_seam` / `span_seam_counts` neighbors
+    appear in NO sample (Methodology is out of scope; `span_seam` is
+    2-segment; `span_seam_counts` is allowlisted)."""
+    body = V4_BODY_CLEAN.replace(
+        "**Evaluation:** judge-scored rate on the held-out probes.",
+        "**Evaluation:** judge-scored rate on the held-out probes.\n\n"
+        "**Data extraction:** One panel context (`neg_reph_curious`) carries "
+        "per-row `span_seam` provenance (`span_seam_counts` = 100 exact / "
+        "20 prefix / 0 context).",
+    ).replace(
+        _RESULTS_PROSE_LINE,
+        "The lift holds at every seed; one panel context (`neg_reph_curious`) "
+        "sits on a BPE merge seam.",
+    )
+    assert body != V4_BODY_CLEAN
+    findings = audit.audit_body(body)
+    assert "opaque_snake_slugs" in findings, findings
+    assert "`neg_reph_curious`" in findings["opaque_snake_slugs"], findings
+    assert not any("span_seam" in s for s in findings["opaque_snake_slugs"]), findings


### PR DESCRIPTION
Closes task #1372 (kind: infra, workflow-fix).

Adds an `opaque_snake_slugs` category to `scripts/audit_clean_results_body_discipline.py`: backticked 3+-segment snake_case condition/cell slugs (`neg_reph_curious` class, incident #1315) now FAIL the audit in v4 reader-facing prose (Takeaways/Goal/Results), with an 11-entry field-name allowlist, v4-only activation, and footer/caption/table/fence exemptions. 13 new tests incl. a #1315-shape regression pin; 3-line SPEC.md doc touch.

Plan: tasks/completed/1372/plans/plan.md (3× critic APPROVE, consistency PASS, fact-checker 11/11 CONFIRMED). Code-review PASS r1. Step 9c test-verdict PASS (compare rc=0; 4 pre-existing trunk-red stripped).