### PR TITLE
issue-1374: floor GCP boot-disk at DLVM image minimum (100 GB, #1336)

### DIFF
--- a/src/explore_persona_space/backends/gcp.py
+++ b/src/explore_persona_space/backends/gcp.py
@@ -258,6 +258,19 @@ DEFAULT_IMAGE_FAMILY = "pytorch-2-9-cu129-ubuntu-2204-nvidia-580"
 #: DLVM project for the image family above.
 DEFAULT_IMAGE_PROJECT = "deeplearning-platform-release"
 
+#: Minimum boot-disk size accepted by a create against the pinned DLVM
+#: image — GCP rejects any smaller disk ("Requested disk size cannot be
+#: smaller than the image size (100 GB)"; incident #1336: --boot-disk-gb 60
+#: failed the rung and exhausted the auto chain). render_create_argv clamps
+#: UP to this floor (never down — a plan footprint is a minimum requirement,
+#: so a bigger disk always satisfies it), mirroring the RunPod floors
+#: (runpod.py _CPU_CONTAINER_DISK_FLOOR_GB / _GPU_VOLUME_FLOOR_GB). This is
+#: a property of the IMAGE, not the config — if DEFAULT_IMAGE_FAMILY is ever
+#: re-pinned, re-verify (family is a POSITIONAL arg, not --family=):
+#:   gcloud --configuration=eps-gcp compute images describe-from-family
+#:     <FAMILY> --project=<PROJECT> --format='value(diskSizeGb)'
+_GCP_IMAGE_MIN_BOOT_DISK_GB = 100
+
 #: Canonical public HTTPS clone URL. The repo is open, so the CLONE is
 #: tokenless; PUSH auth comes from the #1205 env-reading credential
 #: helper the workload_cmd branch configures when GITHUB_TOKEN was
@@ -2809,7 +2822,9 @@ def render_create_argv(
       janitor age reap is the credit-leak backstop, not this fence.
     * ``--image-family`` / ``--image-project`` — the DLVM image with
       pre-installed CUDA/driver.
-    * ``--boot-disk-size`` / ``--boot-disk-type`` — 300 GB pd-ssd default.
+    * ``--boot-disk-size`` / ``--boot-disk-type`` — 300 GB pd-ssd default;
+      a plan override below the DLVM image minimum is clamped UP to
+      100 GB (#1336).
     * ``--scopes=cloud-platform`` — broad VM-scope so the in-VM workload
       can push to GCS / WandB / HF without per-API token wrangling.
     * ``--metadata-from-file startup-script=<path>,KEY=<path>`` — the
@@ -2847,7 +2862,16 @@ def render_create_argv(
         )
     max_run = spec.extra.get("max_run_duration") or config.default_max_run_duration
     _assert_max_run_within_flex_cap(max_run=max_run, provisioning=provisioning)
-    boot_disk_gb = int(spec.extra.get("boot_disk_gb") or config.default_boot_disk_gb)
+    requested_boot_disk_gb = int(spec.extra.get("boot_disk_gb") or config.default_boot_disk_gb)
+    boot_disk_gb = max(_GCP_IMAGE_MIN_BOOT_DISK_GB, requested_boot_disk_gb)
+    if boot_disk_gb != requested_boot_disk_gb:
+        logger.warning(
+            "boot-disk clamped UP to the DLVM image minimum: requested %d GB < %d GB "
+            "(GCP rejects disks smaller than the image, #1336); provisioning %d GB.",
+            requested_boot_disk_gb,
+            _GCP_IMAGE_MIN_BOOT_DISK_GB,
+            boot_disk_gb,
+        )
     boot_disk_type = spec.extra.get("boot_disk_type") or config.default_boot_disk_type
     target_zone = zone or config.primary_zone
     name = instance_name_for(spec.issue, lane_suffix_for(spec))

--- a/tests/test_gcp_backend.py
+++ b/tests/test_gcp_backend.py
@@ -550,6 +550,64 @@ def test_render_create_argv_cpu_bigmem_boot_disk_override() -> None:
     assert "--boot-disk-size=500GB" in argv
 
 
+def test_render_create_argv_boot_disk_clamped_to_image_minimum(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """#1374: a plan-stated boot disk below the DLVM image size (100 GB) is
+    clamped UP so the create cannot fail GCP's image-size validation
+    (incident #1336: --boot-disk-gb 60 failed the rung; chain exhausted)."""
+    cfg = _test_config()
+    with caplog.at_level(logging.WARNING, logger="explore_persona_space.backends.gcp"):
+        argv = render_create_argv(
+            spec=_spec("cpu-mid", extra={"boot_disk_gb": 60}),
+            config=cfg,
+            attempt_id="att-fixed-001",
+            startup_script="#!/bin/bash\n",
+            secret_files=_TEST_SECRET_FILES,
+        )
+    assert "--boot-disk-size=100GB" in argv
+    assert "--boot-disk-size=60GB" not in argv
+    clamp_lines = [r for r in caplog.records if "clamped" in r.getMessage()]
+    assert len(clamp_lines) == 1, clamp_lines
+    assert "60" in clamp_lines[0].getMessage() and "100" in clamp_lines[0].getMessage()
+
+
+def test_render_create_argv_boot_disk_default_path_emits_no_clamp_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """#1374 control: the default (300 GB) path renders as today and logs
+    NO clamp line — the warning fires only when a stated value is raised."""
+    cfg = _test_config()
+    with caplog.at_level(logging.WARNING, logger="explore_persona_space.backends.gcp"):
+        argv = render_create_argv(
+            spec=_spec("cpu-bigmem"),
+            config=cfg,
+            attempt_id="att-fixed-001",
+            startup_script="#!/bin/bash\n",
+            secret_files=_TEST_SECRET_FILES,
+        )
+    assert "--boot-disk-size=300GB" in argv
+    assert not any("clamped" in r.getMessage() for r in caplog.records)
+
+
+def test_render_create_argv_boot_disk_exactly_at_image_minimum_no_clamp(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """#1374 boundary: an override EXACTLY at the 100 GB floor passes
+    through unchanged and emits no clamp warning (max() is a no-op)."""
+    cfg = _test_config()
+    with caplog.at_level(logging.WARNING, logger="explore_persona_space.backends.gcp"):
+        argv = render_create_argv(
+            spec=_spec("cpu-mid", extra={"boot_disk_gb": 100}),
+            config=cfg,
+            attempt_id="att-fixed-001",
+            startup_script="#!/bin/bash\n",
+            secret_files=_TEST_SECRET_FILES,
+        )
+    assert "--boot-disk-size=100GB" in argv
+    assert not any("clamped" in r.getMessage() for r in caplog.records)
+
+
 def test_render_create_argv_gpu_intent_still_terminate() -> None:
     """#677 control: the conditional did NOT regress the GPU path —
     an accelerator intent still emits --maintenance-policy=TERMINATE."""


### PR DESCRIPTION
Closes task #1374. Clamp render_create_argv boot-disk UP to the 100 GB DLVM image minimum; warning on raise; 3 pin tests.