### PR TITLE
task #1373: fix check_v4_word_caps follow-up round crediting (plural footer + free-analysis/in-flight events legs)

### DIFF
--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -9500,32 +9500,46 @@ _V4_FOOTER_ROUND_CLAUSE_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Plural-enumeration footer form (task #1373; incident #1332 body.md:292):
+# "Two same-issue follow-up rounds, both 2026-07-15: (1) ...; (2) ...". The
+# leading number token (a number word or 1-2 digits) is REQUIRED immediately
+# before the literal phrase, so the generic plural prose the `(?!s)`
+# lookahead above excludes ("follow-up rounds also name...") stays excluded;
+# a numberless "same-issue follow-up rounds" still counts zero. The
+# enumerated items after the colon are NOT parsed — the stated N is
+# authoritative. NOTE: `_NUMBER_WORDS` stops at ten while the count clamp
+# allows 12 — the word forms eleven/twelve simply never match the
+# alternation (digit forms cover 11-12), an under-count-only asymmetry
+# consistent with the WARN-only budget.
+_V4_FOOTER_ROUND_PLURAL_RE = re.compile(
+    r"\b(?P<num>one|two|three|four|five|six|seven|eight|nine|ten|\d{1,2})"
+    r"\s+same-issue\s+follow-up\s+rounds\b",
+    re.IGNORECASE,
+)
+_NUMBER_WORDS = {
+    "one": 1,
+    "two": 2,
+    "three": 3,
+    "four": 4,
+    "five": 5,
+    "six": 6,
+    "seven": 7,
+    "eight": 8,
+    "nine": 9,
+    "ten": 10,
+}
 
-def _followup_run_marker_rounds(issue: int) -> int:
-    """Count REAL folded same-issue follow-up rounds off the task's
-    events.jsonl `epm:same-issue-followup-run` markers: distinct
-    `followup_label`s (one run marker closes a label's round) plus one per
-    unlabeled run marker, EXCLUDING markers whose `outcome` begins
-    `retroactive-close` — bookkeeping closes of ghost labels that folded
-    no new prose (they are likewise excluded from the /issue round caps,
-    SKILL.md). Returns 0 when the task id does not resolve (a plain
-    FileNotFoundError — e.g. a fixture body under a numeric tmp dir); a
-    `StaleTaskPathError` (registry corruption, a FileNotFoundError
-    SUBCLASS) still propagates — that is real corruption the gate should
-    surface, unlike an unknown id."""
+
+def _same_issue_run_rounds(events: list[dict]) -> tuple[set[str], int]:
+    """Distinct non-retroactive-close `epm:same-issue-followup-run` labels
+    plus the unlabeled-run-marker count over `events` — the extracted loop
+    body of `_followup_run_marker_rounds` (task #1373), shared with
+    `_followup_events_rounds`. Returns `(labels, unlabeled)`."""
     from explore_persona_space.task_workflow import (  # local import — matches _load_text_for_issue
         FOLLOWUP_RUN_KIND,
-        StaleTaskPathError,
-        list_events,
         parse_followup_note_field,
     )
 
-    try:
-        events = list_events(issue)
-    except StaleTaskPathError:
-        raise
-    except FileNotFoundError:
-        return 0
     labels: set[str] = set()
     unlabeled = 0
     for ev in events:
@@ -9550,7 +9564,134 @@ def _followup_run_marker_rounds(issue: int) -> int:
             labels.add(label)
         else:
             unlabeled += 1
+    return labels, unlabeled
+
+
+def _followup_run_marker_rounds(issue: int) -> int:
+    """Count REAL folded same-issue follow-up rounds off the task's
+    events.jsonl `epm:same-issue-followup-run` markers: distinct
+    `followup_label`s (one run marker closes a label's round) plus one per
+    unlabeled run marker, EXCLUDING markers whose `outcome` begins
+    `retroactive-close` — bookkeeping closes of ghost labels that folded
+    no new prose (they are likewise excluded from the /issue round caps,
+    SKILL.md). Thin wrapper over `_same_issue_run_rounds` (task #1373
+    refactor; signature + behavior unchanged). Returns 0 when the task id
+    does not resolve (a plain FileNotFoundError — e.g. a fixture body
+    under a numeric tmp dir); a `StaleTaskPathError` (registry corruption,
+    a FileNotFoundError SUBCLASS) still propagates — that is real
+    corruption the gate should surface, unlike an unknown id."""
+    from explore_persona_space.task_workflow import (  # local import — matches _load_text_for_issue
+        StaleTaskPathError,
+        list_events,
+    )
+
+    try:
+        events = list_events(issue)
+    except StaleTaskPathError:
+        raise
+    except FileNotFoundError:
+        return 0
+    labels, unlabeled = _same_issue_run_rounds(events)
     return len(labels) + unlabeled
+
+
+_V4_FREE_ANALYSIS_ABORTED_RE = re.compile(r"^aborted\b", re.IGNORECASE)
+
+
+def _free_analysis_rounds(events: list[dict], exclude_labels: set[str]) -> int:
+    """Count folded free-analysis rounds off `epm:free-analysis-followup-run`
+    markers (task #1373). A marker counts unless:
+
+    - its stripped note matches `(?i)^aborted\\b` — the SKILL.md 9a-ter
+      ABORT record (both spec'd forms begin `aborted — `) folded no prose;
+    - its full note text is byte-identical to an already-counted note —
+      a marker-retry double-post is byte-identical. `followup_ref` is NOT
+      the dedupe key: its parsed value is first-token-truncated
+      (`parse_followup_note_field`) and absent entirely in the free-prose
+      corpus shapes (#1090/#1073), so two distinct rounds sharing a first
+      title word must not collide;
+    - its parsed `followup_ref` is non-None AND in `exclude_labels` (the
+      counted same-issue run labels) — the cross-leg guard: a round that
+      closed an armed scope label AND posted a same-issue run marker for
+      it counts once.
+
+    Deliberate over-credit asymmetry: a multi-word `followup_ref` meant to
+    close an armed slug label won't exact-match retro-close class 2 (the
+    parsed ref is first-token-truncated), so that round can count via BOTH
+    this free leg and the in-flight +1 — over-credit only relaxes a
+    WARN-only, monotone-up budget."""
+    from explore_persona_space.task_workflow import (  # local import — matches _load_text_for_issue
+        FREE_ANALYSIS_RUN_KIND,
+        parse_followup_note_field,
+    )
+
+    seen_notes: set[str] = set()
+    count = 0
+    for ev in events:
+        if ev.get("kind") != FREE_ANALYSIS_RUN_KIND:
+            continue
+        note = ev.get("note") or ""
+        if _V4_FREE_ANALYSIS_ABORTED_RE.match(note.strip()):
+            continue
+        if note in seen_notes:
+            continue
+        seen_notes.add(note)
+        ref = parse_followup_note_field(note, "followup_ref")
+        if ref is not None and ref in exclude_labels:
+            continue
+        count += 1
+    return count
+
+
+def _has_inflight_round(events: list[dict]) -> bool:
+    """True iff any armed `epm:followup-scope` label group is dispatchable
+    (`task_workflow.unrun_followup_labels`) AND has NO retro-close evidence
+    (`followup_retro_close_evidence`) — an in-flight (mid-round) follow-up
+    the clean-result gate should credit as ONE round no matter how many
+    labels are armed (the caller caps at +1: the Goal says "as one round";
+    a queue of armed-but-undispatched labels is not folded prose). The
+    retro-close exclusion prevents a double count with the free-analysis
+    leg (a ghost label closed by a free-analysis `followup_ref` would
+    otherwise count via BOTH class-2 evidence and the in-flight +1);
+    undispatchable `unlabeled-<ts>` pseudo-labels never count."""
+    from explore_persona_space.task_workflow import (  # local import — matches _load_text_for_issue
+        followup_retro_close_evidence,
+        unrun_followup_labels,
+    )
+
+    for group in unrun_followup_labels(events):
+        if not group.get("dispatchable"):
+            continue
+        if followup_retro_close_evidence(events, group["followup_label"]) is None:
+            return True
+    return False
+
+
+def _followup_events_rounds(issue: int) -> int:
+    """Widened events leg for `_count_extra_followup_rounds_v4` (task
+    #1373): same-issue run rounds (distinct labels + unlabeled, via
+    `_same_issue_run_rounds`) + non-aborted deduped free-analysis rounds
+    (`_free_analysis_rounds`, cross-leg-excluded on the counted run
+    labels) + at most ONE in-flight armed-but-unclosed scope credit
+    (`_has_inflight_round`). Same failure shape as
+    `_followup_run_marker_rounds`: unknown issue id (plain
+    FileNotFoundError) returns 0; `StaleTaskPathError` (registry
+    corruption, a FileNotFoundError SUBCLASS) still propagates."""
+    from explore_persona_space.task_workflow import (  # local import — matches _load_text_for_issue
+        StaleTaskPathError,
+        list_events,
+    )
+
+    try:
+        events = list_events(issue)
+    except StaleTaskPathError:
+        raise
+    except FileNotFoundError:
+        return 0
+    labels, unlabeled = _same_issue_run_rounds(events)
+    free = _free_analysis_rounds(events, exclude_labels=labels)
+    inflight = 1 if _has_inflight_round(events) else 0
+    return len(labels) + unlabeled + free + inflight
 
 
 def _count_extra_followup_rounds_v4(body: str, issue: int | None = None) -> tuple[int, str]:
@@ -9561,12 +9702,24 @@ def _count_extra_followup_rounds_v4(body: str, issue: int | None = None) -> tupl
     case (footer: a body omitting the SPEC round clause, e.g. #685;
     events: a legacy pre-marker round whose prose IS folded, e.g. #811):
 
-    - footer: `same-issue follow-up round [`label`]` clauses inside the
+    - footer (TWO forms, max-reconciled): (a) singular
+      `same-issue follow-up round [`label`]` clauses inside the
       `**Repro:**`/`**Context:**` footer (distinct backticked labels +
-      one per unlabeled singular clause);
-    - events (when `issue` is known): non-retroactive-close
-      `epm:same-issue-followup-run` markers via
-      `_followup_run_marker_rounds`.
+      one per unlabeled singular clause); (b) the plural-enumeration
+      form `<N> same-issue follow-up rounds` (`_V4_FOOTER_ROUND_PLURAL_RE`
+      — N a number word or 1-2 digits, clamped to 12; max over matches,
+      since a repeated/updated plural sentence restates the cumulative
+      total). `footer_n = max(singular, plural)` — max, not sum, is
+      deliberate: when both forms appear they most plausibly describe the
+      SAME round set (a plural summary sentence + per-round singular
+      clauses), so max cannot double-count; a mixed-form footer may
+      under-credit, which only leaves a WARN-only budget conservative and
+      is backstopped by the events leg's own max-reconcile (task #1373);
+    - events (when `issue` is known; THREE signals, summed by
+      `_followup_events_rounds`): non-retroactive-close
+      `epm:same-issue-followup-run` markers, non-aborted deduped
+      `epm:free-analysis-followup-run` markers, and at most one in-flight
+      armed-but-unclosed `epm:followup-scope` credit.
 
     Returns `(count, source)`; `source` is one of `none` / `footer` /
     `events` / `footer+events` and names the winning signal for the WARN
@@ -9581,8 +9734,14 @@ def _count_extra_followup_rounds_v4(body: str, issue: int | None = None) -> tupl
             labels.add(m.group("label"))
         else:
             unlabeled += 1
-    footer_n = len(labels) + unlabeled
-    events_n = _followup_run_marker_rounds(issue) if issue is not None else 0
+    singular_n = len(labels) + unlabeled
+    plural_n = 0
+    for m in _V4_FOOTER_ROUND_PLURAL_RE.finditer(footer):
+        word = m.group("num").lower()
+        n = _NUMBER_WORDS.get(word) or int(word)
+        plural_n = max(plural_n, min(n, 12))
+    footer_n = max(singular_n, plural_n)
+    events_n = _followup_events_rounds(issue) if issue is not None else 0
     count = max(footer_n, events_n)
     if count == 0:
         return 0, "none"

--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -2766,6 +2766,7 @@ def _audit_record_violation(
 
 FOLLOWUP_SCOPE_KIND = "epm:followup-scope"
 FOLLOWUP_RUN_KIND = "epm:same-issue-followup-run"
+FREE_ANALYSIS_RUN_KIND = "epm:free-analysis-followup-run"
 USER_INITIATED_FOLLOWUP_SOURCES = frozenset({"user-chat", "step-10b-pick"})
 
 # An UNLABELED scope note inherits the previous entry's label ONLY when it
@@ -3137,13 +3138,11 @@ def followup_retro_close_evidence(events: list[dict], label: str) -> str | None:
                     f"epm:methodology-doc-generated at {ev.get('ts', '?')} carries extends={label}"
                 )
     for ev in events:
-        if ev.get("kind") != "epm:free-analysis-followup-run":
+        if ev.get("kind") != FREE_ANALYSIS_RUN_KIND:
             continue
         ref = parse_followup_note_field(ev.get("note") or "", "followup_ref")
         if ref == label:
-            return (
-                f"epm:free-analysis-followup-run at {ev.get('ts', '?')} has followup_ref == {label}"
-            )
+            return f"{FREE_ANALYSIS_RUN_KIND} at {ev.get('ts', '?')} has followup_ref == {label}"
     token = f"({label})"
     for ev in events:
         kind = ev.get("kind")
@@ -6105,6 +6104,7 @@ __all__ = [
     "FOLLOWUP_HELD_BLOCKED_STATUSES",
     "FOLLOWUP_RUN_KIND",
     "FOLLOWUP_SCOPE_KIND",
+    "FREE_ANALYSIS_RUN_KIND",
     "GOAL_H2_NAME",
     "KINDS",
     "PARK_STATUS",

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -7765,6 +7765,294 @@ def test_v4_round_count_graceful_when_issue_unknown(monkeypatch):
         verify_task_body._followup_run_marker_rounds(999999)
 
 
+# The verbatim #1332 body.md:292 footer clause (the task #1373 motivating
+# incident): the plural-enumeration form the singular `(?!s)` clause regex
+# deliberately excludes.
+_I1332_FOOTER_CLAUSE = (
+    "Two same-issue follow-up rounds, both 2026-07-15: (1) the 9a-ter "
+    "free-analysis directional-inference battery, 0 GPU-h; (2) the proposer "
+    "cheap-band GPU round `lowdose-grid-kill-battery` "
+    "(`source: proposer-9b-cheap`, auto-run)."
+)
+
+
+def _v4_body_with_footer_line(line: str) -> str:
+    """`_V4_GOOD_BODY` with `line` appended inside the Context footer."""
+    return _V4_GOOD_BODY.replace(
+        "- Originating prompt: origin prompt not recorded",
+        "- Originating prompt: origin prompt not recorded\n- " + line,
+    )
+
+
+def test_v4_round_count_footer_plural_enumeration():
+    """(Test 1) The verbatim #1332 footer clause -> (2, "footer") with no
+    issue id (the plural arm alone credits the stated N)."""
+    body = _v4_body_with_footer_line(_I1332_FOOTER_CLAUSE)
+    assert verify_task_body._count_extra_followup_rounds_v4(body, None) == (2, "footer")
+
+
+def test_v4_round_count_footer_plural_word_and_digit():
+    """(Test 2) Number-word and digit forms parse alike; IGNORECASE; a
+    repeated plural sentence takes max-over-matches; the count clamps at
+    12."""
+    cases = [
+        ("three same-issue follow-up rounds folded so far.", 3),
+        ("3 same-issue follow-up rounds folded so far.", 3),
+        ("Two same-issue follow-up rounds folded so far.", 2),
+        ("two SAME-ISSUE follow-up ROUNDS folded so far.", 2),
+        # Repeated/updated plural sentences restate the cumulative total:
+        # max over matches, never sum.
+        ("Two same-issue follow-up rounds; later three same-issue follow-up rounds total.", 3),
+        ("99 same-issue follow-up rounds (implausible; clamped).", 12),
+    ]
+    for line, expected in cases:
+        body = _v4_body_with_footer_line(line)
+        assert verify_task_body._count_extra_followup_rounds_v4(body, None) == (
+            expected,
+            "footer",
+        ), line
+
+
+def test_v4_round_count_footer_plural_no_generic_prose_false_positive():
+    """(Test 3) Generic spec-quoting prose and a numberless plural stay
+    excluded (preserves the `(?!s)` intent); a numbered plural sentence in
+    body prose OUTSIDE the footer counts zero (structurally inherited from
+    `_v4_footer_text`, pinned anyway)."""
+    body = _v4_body_with_footer_line(
+        "follow-up rounds also name each round's `followup_label`; "
+        "same-issue follow-up rounds are folded into this body."
+    )
+    assert verify_task_body._count_extra_followup_rounds_v4(body, None) == (0, "none")
+    # Plural-in-prose scoping: the sentence sits in Methodology prose, not
+    # the footer.
+    body2 = _V4_GOOD_BODY.replace(
+        "- **Design:**",
+        "- Two same-issue follow-up rounds folded this sweep. **Design:**",
+    )
+    assert verify_task_body._count_extra_followup_rounds_v4(body2, None) == (0, "none")
+
+
+def test_v4_round_count_footer_both_forms_max_not_sum():
+    """(Test 4) A singular clause + a plural summary sentence describe the
+    same round set: max(1, 2) == 2, never 3."""
+    body = _v4_body_with_footer_line(
+        "Two same-issue follow-up rounds: the first is the "
+        "same-issue follow-up round `round-a` (proposer-initiated)."
+    )
+    assert verify_task_body._count_extra_followup_rounds_v4(body, None) == (2, "footer")
+
+
+def test_v4_round_count_events_free_analysis_counts(monkeypatch):
+    """(Test 5) Free-analysis run markers count: a #1332-shape
+    `followup_ref=` note + a no-ref free-prose note (#1090 shape) -> 2.
+    A NON-run-kind event whose NOTE mentions the marker kind is not
+    counted (kind-keyed counting)."""
+    import explore_persona_space.task_workflow as tw
+
+    fake = [
+        {
+            "kind": "epm:free-analysis-followup-run",
+            "ts": "2026-07-15T18:51:36Z",
+            "note": "followup_ref=Directional (asymmetric) transfer predictor\n"
+            "headline_before=old title\nheadline_after=new title",
+        },
+        {
+            "kind": "epm:free-analysis-followup-run",
+            "ts": "2026-07-15T20:02:00Z",
+            "note": "inline user-chat round: re-read committed cells, folded "
+            "one takeaway into the body (no followup label).",
+        },
+        # Kind-keyed counting: a critique note MENTIONING the marker kind
+        # is not a run marker (the :7739 pattern).
+        {
+            "kind": "epm:followup-value-critique",
+            "ts": "2026-07-15T20:10:00Z",
+            "note": "screened the epm:free-analysis-followup-run proposal set",
+        },
+    ]
+    monkeypatch.setattr(tw, "list_events", lambda n: fake)
+    assert verify_task_body._followup_events_rounds(123) == 2
+    assert verify_task_body._count_extra_followup_rounds_v4(_V4_GOOD_BODY, 123) == (2, "events")
+
+
+def test_v4_round_count_events_free_analysis_excludes_aborted(monkeypatch):
+    """(Test 6) BOTH spec'd 9a-ter ABORT note forms are excluded (the
+    round folded no prose): the reclassify form AND the implementer-FAIL
+    form."""
+    import explore_persona_space.task_workflow as tw
+
+    fake = [
+        {
+            "kind": "epm:free-analysis-followup-run",
+            "ts": "2026-07-15T10:00:00Z",
+            "note": "aborted — reclassified as needs-gpu (the analysis needs new eval data)",
+        },
+        {
+            "kind": "epm:free-analysis-followup-run",
+            "ts": "2026-07-15T11:00:00Z",
+            "note": "aborted — implementer FAIL on attempt 1",
+        },
+    ]
+    monkeypatch.setattr(tw, "list_events", lambda n: fake)
+    assert verify_task_body._followup_events_rounds(123) == 0
+    assert verify_task_body._count_extra_followup_rounds_v4(_V4_GOOD_BODY, 123) == (0, "none")
+
+
+def test_v4_round_count_events_free_analysis_dedupe_and_cross_leg(monkeypatch):
+    """(Test 7) Byte-identical free-analysis notes (a marker-retry
+    double-post) count once; a free-analysis `followup_ref` matching a
+    counted same-issue run label is cross-leg-excluded; a NO-ref
+    free-prose note still counts beside a labeled run marker (the
+    explicit `ref is not None` guard). Total: run 1 + deduped no-ref
+    free 1 = 2."""
+    import explore_persona_space.task_workflow as tw
+
+    retry_note = "inline round: folded the fair-comparison re-read (retry double-post)."
+    fake = [
+        {
+            "kind": "epm:same-issue-followup-run",
+            "ts": "2026-07-15T09:00:00Z",
+            "note": "followup_label: round-x\nsource: user-chat\noutcome: folded",
+        },
+        # Cross-leg guard: ref exactly matches the counted run label.
+        {
+            "kind": "epm:free-analysis-followup-run",
+            "ts": "2026-07-15T10:00:00Z",
+            "note": "followup_ref=round-x\ngpu_hours=0\nresult: folded into body",
+        },
+        # Byte-identical double-post: counts once.
+        {
+            "kind": "epm:free-analysis-followup-run",
+            "ts": "2026-07-15T11:00:00Z",
+            "note": retry_note,
+        },
+        {
+            "kind": "epm:free-analysis-followup-run",
+            "ts": "2026-07-15T11:00:05Z",
+            "note": retry_note,
+        },
+    ]
+    monkeypatch.setattr(tw, "list_events", lambda n: fake)
+    assert verify_task_body._followup_events_rounds(123) == 2
+
+
+def test_v4_round_count_events_inflight_counts_one(monkeypatch):
+    """(Test 8) An armed dispatchable scope with no run marker and no
+    retro-close evidence credits +1; TWO armed labels still +1 (cap);
+    an unlabeled pseudo-label scope credits +0; a scope whose label has a
+    run marker adds no extra; and (guard 4) an armed label closed by a
+    free-analysis `followup_ref` counts via the free leg ONLY (in-flight
+    suppressed by retro-close evidence)."""
+    import explore_persona_space.task_workflow as tw
+
+    def _events(events):
+        monkeypatch.setattr(tw, "list_events", lambda n: list(events))
+
+    scope_a = {
+        "kind": "epm:followup-scope",
+        "ts": "2026-07-15T08:00:00Z",
+        "note": "followup_label: armed-a\nsource: proposer-9b-cheap\nest_gpu_hours: 2",
+    }
+    scope_b = {
+        "kind": "epm:followup-scope",
+        "ts": "2026-07-15T08:05:00Z",
+        "note": "followup_label: armed-b\nsource: user-chat\nest_gpu_hours: 1",
+    }
+    # (a) one armed dispatchable label, no run marker, no retro-close -> 1.
+    _events([scope_a])
+    assert verify_task_body._followup_events_rounds(123) == 1
+    # (b) TWO armed labels: the in-flight credit caps at +1 total.
+    _events([scope_a, scope_b])
+    assert verify_task_body._followup_events_rounds(123) == 1
+    # (c) an unlabeled pseudo-label scope (no correction signal) is not
+    # dispatchable and never credits.
+    _events(
+        [
+            {
+                "kind": "epm:followup-scope",
+                "ts": "2026-07-15T08:10:00Z",
+                "note": "queued follow-up idea with no label field",
+            }
+        ]
+    )
+    assert verify_task_body._followup_events_rounds(123) == 0
+    # (d) a scope whose label has a matching run marker: the run counts,
+    # no in-flight extra.
+    _events(
+        [
+            scope_a,
+            {
+                "kind": "epm:same-issue-followup-run",
+                "ts": "2026-07-15T12:00:00Z",
+                "note": "followup_label: armed-a\nsource: proposer-9b-cheap\noutcome: folded",
+            },
+        ]
+    )
+    assert verify_task_body._followup_events_rounds(123) == 1
+    # (e) guard-4 pin: an armed dispatchable label whose round completed as
+    # a free-analysis round (`followup_ref` == label, NO run marker) counts
+    # ONCE via the free leg; the retro-close evidence suppresses the
+    # in-flight +1. An implementation missing the retro-close check in
+    # `_has_inflight_round` reads 2 here.
+    _events(
+        [
+            scope_a,
+            {
+                "kind": "epm:free-analysis-followup-run",
+                "ts": "2026-07-15T09:30:00Z",
+                "note": "followup_ref=armed-a\ngpu_hours=0\nresult: folded into body",
+            },
+        ]
+    )
+    assert verify_task_body._followup_events_rounds(123) == 1
+
+
+def test_v4_round_count_issue_1332_regression(monkeypatch):
+    """(Test 9) The #1332 incident replay, BOTH states. Full state (scope +
+    run + free-analysis, the real marker shapes): events leg = run 1 +
+    free 1 = 2, and with the real plural footer the total reads
+    (2, "footer+events"). Mid-round state (run marker removed — the state
+    the clean-result gate actually saw): events leg still 2
+    (free-analysis 1 + in-flight 1)."""
+    import explore_persona_space.task_workflow as tw
+
+    free = {
+        "kind": "epm:free-analysis-followup-run",
+        "ts": "2026-07-15T18:51:36Z",
+        "version": 1,
+        "note": "followup_ref=Directional (asymmetric) transfer predictor with "
+        "registered inference\nheadline_before=Function-space map similarity "
+        "predicts marker leakage (MODERATE confidence)\nheadline_after=Directional "
+        "function-space map similarity predicts marker leakage",
+    }
+    scope = {
+        "kind": "epm:followup-scope",
+        "ts": "2026-07-15T19:37:40Z",
+        "version": 1,
+        "note": "followup_label: lowdose-grid-kill-battery\nsource: proposer-9b-cheap\n"
+        "est_gpu_hours: 8\nquestion_relation: same\nauto_run: yes",
+    }
+    run = {
+        "kind": "epm:same-issue-followup-run",
+        "ts": "2026-07-16T00:18:05Z",
+        "version": 1,
+        "note": "followup_label: lowdose-grid-kill-battery\nsource: proposer-9b-cheap\n"
+        "outcome: registered verdicts folded; re-parked awaiting_promotion",
+    }
+    body = _v4_body_with_footer_line(_I1332_FOOTER_CLAUSE)
+
+    # Full (post-round) state.
+    monkeypatch.setattr(tw, "list_events", lambda n: [free, scope, run])
+    assert verify_task_body._followup_events_rounds(123) == 2
+    assert verify_task_body._count_extra_followup_rounds_v4(body, 123) == (2, "footer+events")
+
+    # Mid-round state — the run marker has not posted yet: the armed scope
+    # is in-flight (+1) and the free-analysis round still counts (+1).
+    monkeypatch.setattr(tw, "list_events", lambda n: [free, scope])
+    assert verify_task_body._followup_events_rounds(123) == 2
+    assert verify_task_body._count_extra_followup_rounds_v4(body, 123) == (2, "footer+events")
+
+
 def test_v4_total_prose_budget_scales_with_folded_rounds():
     """(End-to-end, the #763 incident shape.) Same >800-word body: with two
     footer round clauses the total-prose WARN clears at budget 1300;


### PR DESCRIPTION
Closes task #1373.

## Summary
- Widen `_count_extra_followup_rounds_v4`'s footer leg: new `_V4_FOOTER_ROUND_PLURAL_RE` counts the plural-enumeration form ("Two same-issue follow-up rounds ...: (1) ...; (2) ..."); `footer_n = max(singular, plural)`; existing singular regex byte-unchanged.
- Widen the events leg (`_followup_events_rounds`): same-issue run markers + non-aborted deduped `epm:free-analysis-followup-run` markers + at most one in-flight armed-scope credit (`unrun_followup_labels` + retro-close evidence).
- `FREE_ANALYSIS_RUN_KIND` constant in task_workflow.py; 14 new pytest pins incl. the #1332 both-state regression replay.

## Test plan
- [x] `tests/test_verify_task_body.py` full file: 574 passed / 6 skipped
- [x] Live regression: `verify_task_body.py --issue 1332` → budget 1300 `[footer+events]` (was 1050 `[events]`)
- [x] Corpus sweep over 100 follow-up tasks: strictly monotone-up (68↑, 0↓)
- [ ] Step 9c test-verdict gate (in flight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)