### PR TITLE
workflow-fix #1375: verify_plan.py c36 — numeric containment claims

### DIFF
--- a/.claude/skills/adversarial-planner/SKILL.md
+++ b/.claude/skills/adversarial-planner/SKILL.md
@@ -292,7 +292,11 @@ Run the structural verifier against the plan version just persisted:
   vocabulary is a git code SHA or otherwise not an HF revision pin on this plan's
   own reuse; a genuine revision-pinned reuse instead names its revision-scoped
   probe — the `revision=<pin>` kwarg on `list_repo_tree` / `list_repo_files`,
-  per named stem).
+  per named stem), and
+  `N/A — no numeric containment claims` (check 36 — the matched
+  inside/within-range text quotes an incident or a sibling's numbers, or is not
+  a claim about this plan's own committed values; a plan with a genuinely false
+  claim instead fixes the arithmetic or rewrites the prose).
 - **FAIL → bounce to the planner** with the failed-check details (a mechanical-fix
   revision: re-spawn the planner with the FAIL list + the plan path; it patches the
   missing block and the orchestrator persists v{K+1} via `task.py new-plan-version`).

--- a/scripts/verify_plan.py
+++ b/scripts/verify_plan.py
@@ -82,12 +82,14 @@ Check catalog (id — classification — kind scope)
       ratchet headroom
   c35 revision-pinned reuse     WARN-only, conditional    experiment +
       verified at pin                                     analysis
+  c36 numeric containment       WARN-only, conditional    experiment +
+      claims                                              analysis
 
 Kind-exempt checks render as [SKIP] (first-class status, distinguishable
 from genuine passes — the calibration report needs n_skip separate from
 n_pass). Conditional checks (4, 6, 7, 10, 11, 12, 13, 14, 15, 16, 17, 18,
-19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35) also
-SKIP when their content trigger does not fire.
+19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36)
+also SKIP when their content trigger does not fire.
 Check 23 runs OUTSIDE ``verify_plan_text()`` — it needs task context
 (``body.md`` + ``events.jsonl``), so ``main()`` appends it in ``--issue``
 mode only and renders it SKIP in ``--plan-file`` mode; its WARN is the one
@@ -135,6 +137,7 @@ labeled-line forms):
     ``N/A — no checkpoint ladder`` (check 33)
   - ``N/A — no verbatim ratcheted-file insertion`` (check 34)
   - ``N/A — no revision-pinned reuse`` (check 35)
+  - ``N/A — no numeric containment claims`` (check 36)
 
 WARN semantics: a WARN never blocks exit (exit 0). The Phase 1.5.0 wiring
 carries WARN lines verbatim into the fact-checker + critic briefs — that
@@ -5793,6 +5796,161 @@ def check_pinned_revision_reuse(plan: str, kind: str) -> CheckResult:
     )
 
 
+# ─── Check 36 — numeric containment claims (WARN-only; experiment + analysis) ─
+
+_C36_NUM = r"(?:\d+(?:\.\d+)?|\.\d+)"
+# Range operand pair. Two alternatives:
+#   (a) en/em-dash or "to" separator, signed operands allowed ("-0.5 to 0.3");
+#   (b) unspaced ASCII hyphen, UNSIGNED operands only ("2-4", "0.25-0.5") —
+#       a signed/hyphen mix ("-0.5-0.3") is ambiguous between range and
+#       negative pair and is NEVER parsed (accepted false negative).
+# The leading lookbehind blocks matching the tail of a larger number or a
+# signed token; \b after operands blocks partial-digit backtracks (the c28
+# :4487 convention — without it "150-330 band" mis-parses); (?!-\d) on the
+# hyphen form rejects date/version chains ("2026-07-15").
+_C36_RANGE = (
+    rf"(?P<lo>(?<![\d.\-−+])[+\-−]?{_C36_NUM})%?\s*(?:[–—]|\bto\b)\s*"  # noqa: RUF001 — en dash is real plan text
+    rf"(?P<hi>[+\-−]?{_C36_NUM})"  # noqa: RUF001 — U+2212 minus is real plan text
+    rf"|(?P<lo2>(?<![\d.\-−+]){_C36_NUM})-(?P<hi2>{_C36_NUM}(?!-\d))"  # noqa: RUF001
+)
+# Containment claim: verb + bounded filler + range + bounded tail + range-noun,
+# all on ONE line. Filler excludes .;:| so a claim never crosses a sentence,
+# clause-label, or table-cell boundary; the post-range lookahead rejects
+# compound count modifiers ("10-20-draw random band", #816 v1 L227).
+# "estimate" and "guidance" are deliberately NOT range-nouns (the #825
+# aggregate-delta and t-SNE-guidance corpus shapes are accepted false
+# negatives — both FP-prone).
+_C36_CLAIM_RE = re.compile(
+    rf"\b(?:inside|within)\b(?P<fill>[^.;:|\n]{{0,45}}?)(?:{_C36_RANGE})\b"
+    rf"(?![–-][A-Za-z])\s*%?(?P<tail>[^.;|\n]{{0,18}}?)"  # noqa: RUF001 — en dash is real plan text
+    rf"\b(?:spread|band|range|window|interval|CIs?)\b",
+    re.IGNORECASE,
+)
+# Candidate claimed values: numbers in the same clause BEFORE the verb. The
+# leading lookbehind kills identifier digits ("H2", "#508", "Tier-1",
+# "checkpoint-20", "coef-0"); the trailing lookahead kills hex/sha and
+# unit-glued tokens ("48de22...", "13h").
+_C36_CAND_RE = re.compile(
+    rf"(?<![A-Za-z#\d.\-−+/])[+\-−]?{_C36_NUM}%?(?![A-Za-z0-9])"  # noqa: RUF001
+)
+_C36_NEG_RE = re.compile(r"(?i)\b(?:not|never|no longer|nor|outside)\b")
+
+
+def _c36_frac(tok: str) -> Fraction:
+    """Exact ``Fraction`` from a claim/operand token: strips a trailing %, a
+    leading +, maps U+2212 minus to ASCII, then delegates to ``_c28_frac``
+    (the leading-dot-tolerant c13/c28 parse convention — cross-check helper
+    reuse per the c28 <-> ``_C13_GATE_SECTION_RE`` precedent)."""
+    return _c28_frac(tok.rstrip("%").lstrip("+").replace("−", "-"))  # noqa: RUF001
+
+
+def _c36_na_escape_declared(plan: str) -> bool:
+    """Standalone ``N/A — no numeric containment claims`` escape (see
+    ``_standalone_na_declared`` for the anti-paste rationale)."""
+    return _standalone_na_declared(plan, r"no numeric containment claims?")
+
+
+def _c36_offender_detail(offenders: list[tuple[str, Fraction, Fraction, list[Fraction]]]) -> str:
+    """Bounded WARN detail (c28 conventions: at most 3 offenders shown,
+    90-char line snippets): per offender the line snippet, the candidate
+    claimed values, and the bounds none of them lands in. Ends with the
+    #1315 incident anchor and the remedy menu. The anchor + remedy prose
+    is deliberately NON-matching (the c28 detail-inertness precedent): it
+    phrases containment without an inside/within verb + range + range-noun
+    co-occurrence, so a verbatim paste of this detail into a revised plan
+    cannot re-trigger the check by itself (the 90-char offender snippet may
+    still quote the plan's own claim — the remedy menu names the
+    blockquote/fence move for exactly that)."""
+    parts: list[str] = []
+    for line, lo, hi, cands in offenders[:3]:
+        vals = ", ".join(f"{float(v):.3g}" for v in cands)
+        parts.append(
+            f'line "{line[:90]}" - no candidate value (~ {vals}) lies in '
+            f"[{float(lo):.3g}, {float(hi):.3g}]"
+        )
+    shown = "; ".join(parts)
+    if len(offenders) > 3:
+        shown += "; ..."
+    return (
+        f"{shown} - an explicit numeric containment claim must be arithmetically "
+        "true (#1315 v4 L66 asserted containment of 0.724 in a 0.737-0.820 "
+        "spread; verify_plan PASSed 0/0 - caught only at the critic layer). "
+        "Remedy: fix the arithmetic, rewrite the prose (e.g. '0.013 BELOW the "
+        "... spread', the #1315 v5 correction), move a quoted incident line "
+        "into a blockquote or fence, or declare `N/A - no numeric containment "
+        "claims` on its own line, unwrapped (no backticks/quotes); the semantic "
+        "verdict - WHICH number the prose attributes - stays with the "
+        "Statistics critic"
+    )
+
+
+def check_numeric_containment(plan: str, kind: str) -> CheckResult:
+    """WARN-only, conditional: an explicit numeric containment claim —
+    a claimed number, a containment verb (inside/within), and an explicit
+    numeric A-B range with a range-noun (spread/band/range/window/
+    interval/CI) on one line — must be arithmetically true: some
+    attributable claimed number in the same clause lies in [A, B]
+    (boundary-inclusive; reversed bounds normalized). NEVER FAILs (the
+    c14/c28 doctrine: a heuristic free-prose check must not hard-block);
+    the semantic verdict — WHICH number the prose attributes — stays with
+    the Statistics critic. Incident: #1315 plan v4 L66 (0.724 asserted
+    inside 0.737-0.820; verify_plan PASSed 0/0; two critics caught it by
+    hand -> #1375). Accepted false negatives (v1, named): claims whose
+    subject sits in a previous sentence/clause; a decoy same-clause number
+    inside the range masking a false claim; %-vs-unitless mixed units;
+    scientific notation; noun-before-range word order ("the band
+    0.6-0.8"); "estimate"/"guidance" nouns; ± tolerance forms (not
+    ranges); signed hyphen ranges; bare-"in" containment ("N in the
+    A-B band") and "between A and B" phrasings (both FP-prone; the
+    {inside, within} verb set is deliberate).
+    """
+    cid, name = "c36_numeric_containment", "numeric containment claims"
+    if kind not in ("experiment", "analysis"):
+        return _skip(
+            cid, name, "kind-exempt: containment-claim prose is an experiment|analysis plan shape"
+        )
+    lines = plan.splitlines()
+    mask = _fence_mask(lines)
+    n_claims = 0
+    offenders: list[tuple[str, Fraction, Fraction, list[Fraction]]] = []
+    for line, fenced in zip(lines, mask, strict=True):
+        if fenced or line.lstrip(" \t").startswith(">"):
+            continue  # fenced code + blockquotes: quoted text, not claims
+        blanked = line  # length-preserving blank of prior match spans
+        for m in _C36_CLAIM_RE.finditer(line):
+            lo_s = m.group("lo") or m.group("lo2")
+            hi_s = m.group("hi") or m.group("hi2")
+            lo, hi = _c36_frac(lo_s), _c36_frac(hi_s)
+            if lo > hi:
+                lo, hi = hi, lo  # reversed bounds: normalize, still verify
+            pre = blanked[: m.start()]
+            cut = max(pre.rfind("|"), pre.rfind(":"), pre.rfind(";"))
+            seg = pre[cut + 1 :]  # clause/cell-bounded candidate window
+            blanked = blanked[: m.start()] + " " * (m.end() - m.start()) + blanked[m.end() :]
+            if _C36_NEG_RE.search(seg[-24:]):
+                continue  # negated/outside claims: out of scope
+            rng_pct = "%" in line[m.start() : m.end()]
+            cands = [
+                _c36_frac(t.group(0))
+                for t in _C36_CAND_RE.finditer(seg)
+                if t.group(0).endswith("%") == rng_pct
+            ]
+            if not cands:
+                continue  # no attributable claimed value -> not a claim
+            n_claims += 1
+            if not any(lo <= c <= hi for c in cands):
+                offenders.append((line.strip(), lo, hi, cands))
+    if n_claims == 0 and not offenders:
+        return _skip(cid, name, "no numeric containment claims detected")
+    if _c36_na_escape_declared(plan):
+        return _pass(
+            cid, name, "explicit N/A declared (no numeric containment claims of this plan's own)"
+        )
+    if not offenders:
+        return _pass(cid, name, f"{n_claims} numeric containment claim(s) arithmetically coherent")
+    return _warn(cid, name, _c36_offender_detail(offenders))
+
+
 # ─── Driver ────────────────────────────────────────────────────────────────
 
 CHECKS = [
@@ -5830,6 +5988,7 @@ CHECKS = [
     check_ladder_retention,
     check_ratchet_headroom,
     check_pinned_revision_reuse,
+    check_numeric_containment,
 ]
 
 

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -174,10 +174,11 @@ def test_good_plan_passes_all():
         "c33_ladder_retention": "SKIP",
         "c34_ratchet_headroom": "SKIP",
         "c35_pinned_revision_reuse": "SKIP",
+        "c36_numeric_containment": "SKIP",
     }
     actual = {cid: r.status for cid, r in by_id.items()}
     assert actual == expected
-    assert len(results) == 35
+    assert len(results) == 36
 
 
 # ─── Check 0 — plan-nonstub ────────────────────────────────────────────────
@@ -1581,7 +1582,8 @@ def test_own_line_remedies_carry_unwrapped_clarifier():
         else:
             offenders.append((node.lineno, node.value[:90]))
     assert not offenders, f"own-line remedies missing the unwrapped clarifier: {offenders}"
-    # 19 sites (#1263) + c34 exemplar + c7's remedy/pass-detail (#1262) + c4's (#1277) = 24 live
+    # 19 sites (#1263) + c34 exemplar + c7's remedy/pass-detail (#1262) + c4's (#1277)
+    # + c36's remedy (#1375) = 25 live
     assert clarified >= 20
 
 
@@ -5832,12 +5834,12 @@ def test_cli_json_schema_and_exit_zero_on_pass(tmp_path):
     assert payload["issue"] is None
     assert payload["kind"] == "experiment"
     assert payload["n_fail"] == 0
-    assert payload["n_skip"] == 28
+    assert payload["n_skip"] == 29
     assert {"id", "name", "status", "detail"} <= set(payload["checks"][0])
     statuses = {c["status"] for c in payload["checks"]}
     assert statuses <= {"PASS", "WARN", "FAIL", "SKIP"}
-    assert len(payload["checks"]) == 36
-    assert len({c["id"] for c in payload["checks"]}) == 36
+    assert len(payload["checks"]) == 37
+    assert len({c["id"] for c in payload["checks"]}) == 37
     # c23 has no task context in --plan-file mode: rendered SKIP (companion
     # assert for test_cli_issue_mode_appends_goal_currency).
     c23 = next(c for c in payload["checks"] if c["id"] == "c23_goal_currency")
@@ -7089,6 +7091,189 @@ def test_c35_phrase_listed_in_skillmd():
     assert "no revision-pinned reuse" in block
     assert "check 35" in block
     assert "`N/A — no revision-pinned reuse`" in block
+
+
+# ─── Check 36 — numeric containment claims ─────────────────────────────────
+
+# Verbatim corpus literals — embedded as literals, NEVER read from tasks/ at
+# test runtime (tasks move between status folders; the c28 fixture
+# convention). C36_1315_LINE is the founding incident sentence,
+# tasks/*/1315/plans/v4.md L66 (the "Install: …" sentence; the leading
+# "Weights: …" clause of the physical line is trimmed — the plan-#1375 §6
+# fixture spec names the sentence). Its FIRST containment claim is TRUE
+# (0.724 in [0.60, 0.85]); the SECOND is arithmetically FALSE
+# (0.724 < 0.737) — verify_plan PASSed 0/0 on it and two critics caught it
+# by hand (-> #1375).
+C36_1315_LINE = (
+    "Install: Tier-1 0.663 in band at step 20, Tier-2 confirm 0.724 — inside the registered "
+    "0.60–0.85 band and inside the siblings' realized 0.737–0.820 spread (install-strength "
+    "control satisfied without dose-matching work)."
+)
+# #1315 v5 L68 (the corrected prose; trailing parenthetical trimmed at the
+# c28 precedent) — the true-negative sibling of the founding line.
+C36_1315_V5_LINE = (
+    "Install: Tier-1 0.663 in band at step 20, Tier-2 confirm 0.724 — inside the registered "
+    "0.60–0.85 band, 0.013 BELOW the siblings' realized 0.737–0.820 spread (install-strength "
+    "control satisfied via the registered band without dose-matching work)."
+)
+# #1315 v4 L126 (trimmed): "next to" is not a containment verb.
+C36_1315_NEXT_TO_LINE = (
+    "install-band control (0.724 in band next to siblings 0.737–0.820; per-cell realized "
+    "install reported next to every geometry DV)"
+)
+# #1315 v4 L274 verbatim: a ± tolerance is not a range.
+C36_1315_PLUSMINUS_LINE = (
+    "1. Parity probe: judged rate within 0.724 ± 0.15 AND application check ≥ 0.5 nat — or "
+    "the named retrain-from-frozen-mix fallback lands in band."
+)
+# #816 v1 L227 (trimmed): "10-20-draw" is a compound count modifier, not a range claim.
+C36_816_LINE = (
+    "- **Exp 4 — kills** if: a norm-matched random-direction preventative finetune reduces "
+    "the post-ft trait score as much as the real vector (real's reduction inside the "
+    "10–20-draw random band, given the p-floor)."
+)
+# #514 v1 L175 verbatim: table row — cross-cell numbers must never be attributed.
+C36_514_ROW = (
+    "| Dense lever, 30% epoch | Whether stopping just past the #508 FT-light cell catches a "
+    "clean cell above 9 nat | Budget resolution within the 0.25-0.5 epoch window | "
+    "`ft_dense_b30` |"
+)
+# #597 v2 L33 (trimmed): "H2" is a label digit, not a claimed value.
+C36_597_LINE = (
+    "- **H2 (rotation + gate collapse at the cliff).** The consecutive-checkpoint "
+    "top-direction cosine has its minimum inside steps 12–40 (the cliff/onset window), and "
+    "the gate ρ trajectory drops from its early value toward ~0 across the same window, in "
+    "most sources."
+)
+# #1353 v1 L52 (trimmed): a TRUE claim that also pins the \b partial-digit
+# operand boundaries (without them "150-330 band" garbage-parses).
+C36_1353_LINE = (
+    "(~300 words — inside the siblings' 150–330 band. Register elements checked against "
+    "L282/L283: bold headline sentence · explicit RULE: clauses · sibling cross-reference.)"
+)
+
+
+def _c36_plan(*extra: str) -> str:
+    """GOOD_PLAN + ``extra`` lines appended (the ``_c28_plan`` pattern)."""
+    return GOOD_PLAN + "\n" + "\n\n".join(extra) + ("\n" if extra else "")
+
+
+def test_c36_1315_v4_false_claim_warns():
+    _, by_id = _run(_c36_plan(C36_1315_LINE))
+    r = by_id["c36_numeric_containment"]
+    assert r.status == "WARN"
+    assert "0.737" in r.detail and "0.724" in r.detail  # the false pair
+
+
+def test_c36_true_claim_same_sentence_not_flagged():
+    # The L66 first half only — the TRUE claim (0.724 in [0.60, 0.85]).
+    plan = _c36_plan("Tier-2 confirm 0.724 — inside the registered 0.60–0.85 band")
+    assert _status(plan, "c36_numeric_containment") == "PASS"
+
+
+def test_c36_corrected_v5_line_passes():
+    assert _status(_c36_plan(C36_1315_V5_LINE), "c36_numeric_containment") == "PASS"
+
+
+def test_c36_next_to_non_fire():
+    # No containment verb -> no claim detected at all.
+    assert _status(_c36_plan(C36_1315_NEXT_TO_LINE), "c36_numeric_containment") == "SKIP"
+
+
+def test_c36_plusminus_tolerance_non_fire():
+    # "within 0.724 ± 0.15" is a tolerance, not an A-B range.
+    assert _status(_c36_plan(C36_1315_PLUSMINUS_LINE), "c36_numeric_containment") == "SKIP"
+
+
+def test_c36_fenced_false_claim_skips():
+    plan = GOOD_PLAN + "\n```\n" + C36_1315_LINE + "\n```\n"
+    assert _status(plan, "c36_numeric_containment") == "SKIP"
+
+
+def test_c36_blockquoted_false_claim_skips():
+    assert _status(_c36_plan("> " + C36_1315_LINE), "c36_numeric_containment") == "SKIP"
+
+
+@pytest.mark.parametrize("kind", ["infra", "batch", "survey"])
+def test_c36_kind_exempt_skips(kind):
+    # The self-reference-trap pin: workflow-fix plans quoting the incident
+    # are kind: infra and never scanned (plan-#1375 §4.7 layer 1).
+    assert _status(_c36_plan(C36_1315_LINE), "c36_numeric_containment", kind=kind) == "SKIP"
+
+
+def test_c36_na_escape_passes():
+    plan = _c36_plan(C36_1315_LINE, "N/A — no numeric containment claims")
+    _, by_id = _run(plan)
+    r = by_id["c36_numeric_containment"]
+    assert r.status == "PASS"
+    assert "declared" in r.detail
+
+
+def test_c36_quoted_na_phrase_does_not_escape():
+    # Anti-paste convention (#810/#1238 lineage): the phrase quoted
+    # mid-sentence (e.g. inside a pasted bounce brief) does not count.
+    plan = _c36_plan(
+        C36_1315_LINE,
+        "The bounce brief quotes `N/A — no numeric containment claims` as the check-36 escape.",
+    )
+    assert _status(plan, "c36_numeric_containment") == "WARN"
+
+
+def test_c36_boundary_equality_inside():
+    # Fraction-exact boundary inclusion: N == A counts as inside.
+    plan = _c36_plan("The realized install of 0.60 sits within the registered 0.60–0.85 band.")
+    assert _status(plan, "c36_numeric_containment") == "PASS"
+
+
+def test_c36_reversed_bounds_normalized():
+    # A reversed range is a prose-order quirk, not an exemption: [0.60, 0.85]
+    # is still verified after normalization.
+    ok_plan = _c36_plan("The confirm read 0.75 sits inside the 0.85–0.60 band.")
+    assert _status(ok_plan, "c36_numeric_containment") == "PASS"
+    bad_plan = _c36_plan("The confirm read 0.50 sits inside the 0.85–0.60 band.")
+    assert _status(bad_plan, "c36_numeric_containment") == "WARN"
+
+
+def test_c36_hyphen_range_parses():
+    # Unspaced ASCII hyphen with unsigned operands is a range.
+    plan = _c36_plan("The mix uses 4 negatives, within the 2-4 range.")
+    assert _status(plan, "c36_numeric_containment") == "PASS"
+
+
+def test_c36_negative_hyphen_ambiguity_never_parses():
+    # A signed/hyphen mix is ambiguous between range and negative pair.
+    plan = _c36_plan("The shift 0.1 lands within the -0.5-0.3 band under this recipe.")
+    assert _status(plan, "c36_numeric_containment") == "SKIP"
+
+
+def test_c36_percent_unit_segregation():
+    # %-flagged candidates compare only against %-flagged ranges.
+    pct_plan = _c36_plan("72% of judged rows sit within the 60–85% range.")
+    assert _status(pct_plan, "c36_numeric_containment") == "PASS"
+    # Mixed units: the only candidate is %-flagged, the range unitless ->
+    # no attributable claimed value -> no claim.
+    mixed_plan = _c36_plan("The 30% rate sits within the 0.25–0.5 window.")
+    assert _status(mixed_plan, "c36_numeric_containment") == "SKIP"
+
+
+def test_c36_compound_count_modifier_non_fire():
+    assert _status(_c36_plan(C36_816_LINE), "c36_numeric_containment") == "SKIP"
+
+
+def test_c36_table_cell_bleed_non_fire():
+    # Candidate window cut at the last `|`: the sibling cell's "9 nat" is
+    # never attributed to the "0.25-0.5 epoch window" claim.
+    assert _status(_c36_plan(C36_514_ROW), "c36_numeric_containment") == "SKIP"
+
+
+def test_c36_label_digit_not_a_candidate():
+    # "H2" is killed by the candidate lookbehind; a candidate-less match
+    # does not count as a claim.
+    assert _status(_c36_plan(C36_597_LINE), "c36_numeric_containment") == "SKIP"
+
+
+def test_c36_true_word_count_claim_passes():
+    assert _status(_c36_plan(C36_1353_LINE), "c36_numeric_containment") == "PASS"
 
 
 def test_canonical_json_parse_snippet_pinned():


### PR DESCRIPTION
Closes task #1375. Adds WARN-only check c36 (arithmetic verification of numeric containment claims) to verify_plan.py + 21 tests + the SKILL.md escape-phrase entry. Origin: #1315 plan v4 false claim.