### PR TITLE
issue-1378: load_dotenv() before heavy imports in issue1073/issue1092 figure scripts

### DIFF
--- a/scripts/issue1073_fig_linear_nonlinear.py
+++ b/scripts/issue1073_fig_linear_nonlinear.py
@@ -8,10 +8,17 @@ one plot: color = decode arm, linestyle/marker = fitter class.
 import json
 from pathlib import Path
 
-import matplotlib.pyplot as plt
-from matplotlib.lines import Line2D
+from explore_persona_space.orchestrate.env import load_dotenv
 
-from explore_persona_space.analysis.paper_plots import (
+# #847: thread caps must land BEFORE the matplotlib import below — on the
+# shared VM, load_dotenv() setdefaults OMP/MKL/OPENBLAS/NUMEXPR_NUM_THREADS,
+# and the BLAS pools freeze at import time.
+load_dotenv()
+
+import matplotlib.pyplot as plt  # noqa: E402
+from matplotlib.lines import Line2D  # noqa: E402
+
+from explore_persona_space.analysis.paper_plots import (  # noqa: E402
     add_direction_arrow,
     paper_palette,
     savefig_paper,
@@ -41,8 +48,8 @@ def main() -> None:
     set_paper_style("blog")
     fig, ax = plt.subplots()
 
-    colors = dict(zip(ARM_LABELS, paper_palette(len(ARM_LABELS))))
-    for arm, arm_label in ARM_LABELS.items():
+    colors = dict(zip(ARM_LABELS, paper_palette(len(ARM_LABELS)), strict=False))
+    for arm, _arm_label in ARM_LABELS.items():
         for key, (_, ls, marker) in FITTERS.items():
             ys = [table[arm][str(layer)][key] for layer in layers]
             ax.plot(

--- a/scripts/issue1092_inline_operator_figure.py
+++ b/scripts/issue1092_inline_operator_figure.py
@@ -13,14 +13,21 @@ import json
 import sys
 from pathlib import Path
 
-import matplotlib
-
-matplotlib.use("Agg")
-import matplotlib.pyplot as plt
-import numpy as np
-
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "src"))
+from explore_persona_space.orchestrate.env import load_dotenv  # noqa: E402
+
+# #847: thread caps must land BEFORE the matplotlib/numpy imports below — on
+# the shared VM, load_dotenv() setdefaults OMP/MKL/OPENBLAS/NUMEXPR_NUM_THREADS,
+# and the BLAS pools freeze at import time.
+load_dotenv()
+
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+
 from explore_persona_space.analysis.paper_plots import (  # noqa: E402
     paper_palette_role,
     savefig_paper,


### PR DESCRIPTION
Closes task #1378. 2-line load_dotenv preamble (#847 thread-cap pattern) in scripts/issue1073_fig_linear_nonlinear.py + scripts/issue1092_inline_operator_figure.py, clearing the fleet-wide test_no_new_torch_before_dotenv_vm_entrypoints failure. Code-review PASS r1; Step 9c test-verdict PASS (new: []).