### PR TITLE
issue-1399: filing-time advisory for recently-closed wf-fix siblings

### DIFF
--- a/.claude/rules/workflow-fix-on-bug.md
+++ b/.claude/rules/workflow-fix-on-bug.md
@@ -515,6 +515,25 @@ re-route — while a candidate parked AFTER the fix closed is a genuine
 re-raise and stays enumerated; see
 `scripts/sweep_parked_wf_candidates.py`.)
 
+**Recently-closed-sibling ADVISORY (#1399 — advisory only, never a block).**
+The predicate above is exact-`(target_file, fingerprint)` over OPEN tasks, so
+a JUST-MERGED sibling with different wording is invisible by design
+(2026-07-15: #1350 was filed 25 min after #1329 merged the same fix, and
+#1330 duplicated #1309's already-landed guidance — two pipeline sessions
+burned). At filing time `scripts/file_infra_task.py` therefore prints a
+stderr advisory listing wf-fix/daily-fix tasks CLOSED (completed/archived)
+within the last ~7 days that overlap the candidate — by `workflow_fix_target:`
+path token, or by informative title token
+(`task_workflow.recent_closed_workflow_fix_tasks`) — capped at the 10 most
+recent. The filer eyeballs the list before letting the spawned session run.
+ADVISORY ONLY: it never blocks the filing, never changes exit codes, and
+fails soft with a printed diagnostic — the rule above is unchanged (a closed
+fix still never blocks a genuine re-raise). Because the wrapper's stderr
+arrives after it has already filed and best-effort-spawned, an agent consumer
+that spots a just-merged duplicate in the list applies the post-hoc remedy:
+archive the just-filed task (`task.py set-status <id> archived`) and stop its
+spawned session (`spawn_session.py stop --session-id <sid>`).
+
 ## Recursion guard
 
 A workflow-fix `/issue` session must NOT auto-file MORE workflow-fix

--- a/scripts/file_infra_task.py
+++ b/scripts/file_infra_task.py
@@ -94,7 +94,11 @@ from spawn_session import (  # noqa: E402
 # The shared wf-fix title-prefix set (single source of truth, one prefix per
 # filing channel — task_workflow.py). Same package-import pattern as
 # daily_drive_filings.py; the `uv run` env has the editable install.
-from explore_persona_space.task_workflow import WF_FIX_TITLE_PREFIXES  # noqa: E402
+from explore_persona_space.task_workflow import (  # noqa: E402
+    WF_FIX_TITLE_PREFIXES,
+    recent_closed_workflow_fix_tasks,
+    wf_fix_extract_target,
+)
 
 # The auto-dispatchable pure-code/ops kinds. `experiment`/`analysis`/
 # `campaign` are rejected: analysis needs the `agent-ok` opt-in + PM triage;
@@ -269,6 +273,62 @@ def _warn_missing_wf_fix_title_prefix(args: argparse.Namespace) -> None:
     )
 
 
+# Measured: 27 same-target closures/7d on the hottest file; the recency-desc
+# cap keeps the just-merged incident class on top (#1399).
+_ADVISORY_MAX_ROWS = 10
+
+
+def _advise_recent_closed_wf_fix_siblings(args: argparse.Namespace) -> None:
+    """#1399 warn-only advisory: before filing a wf-fix-shaped task, list
+    recently-closed (7-day) wf-fix/daily-fix siblings overlapping the candidate
+    by workflow_fix_target path token or by title token — the open-only
+    exact-(target_file, fingerprint) dedup is blind to a just-merged sibling
+    with different wording (2026-07-15: #1350 dup of #1329 merged 25 min
+    earlier; #1330 dup of #1309). ADVISORY ONLY (the task body frames this as
+    an advisory rather than a hard block): never blocks, never changes exit
+    codes, never skips the filing (a closed fix deliberately never blocks a
+    genuine re-raise); the whole leg is fail-soft — any exception prints a
+    one-line diagnostic and filing proceeds (#1173/#1283 precedent, hardened
+    to a full try/except per the #1399 task-body constraint)."""
+    try:
+        body_text = args.body
+        if body_text is None and args.body_file is not None:
+            try:
+                body_text = Path(args.body_file).read_text(encoding="utf-8")
+            except OSError:
+                body_text = None
+        target = wf_fix_extract_target(body_text or "")
+        # wf-fix-shaped: the tag (the #1173/#1283 gate) OR a target line.
+        if "wf-fix" not in (args.tag or []) and target is None:
+            return
+        hits = recent_closed_workflow_fix_tasks(target, args.title, days=7.0)
+        if not hits:
+            return
+        print(
+            f"file_infra_task: ADVISORY — {len(hits)} wf-fix sibling(s) closed within "
+            "7 days overlap this filing. Closed tasks never block a re-raise "
+            "(.claude/rules/workflow-fix-on-bug.md § Dedup, #1399) — eyeball for a "
+            "just-merged duplicate before letting the spawned session run:",
+            file=sys.stderr,
+        )
+        for h in hits[:_ADVISORY_MAX_ROWS]:
+            print(
+                f"  #{h['id']}  {h['status']}  closed {h['closed_at'][:10]}  "
+                f"[{'; '.join(h['matched'])}]  {h['title']}",
+                file=sys.stderr,
+            )
+        if len(hits) > _ADVISORY_MAX_ROWS:
+            print(
+                f"  ... and {len(hits) - _ADVISORY_MAX_ROWS} more within the window",
+                file=sys.stderr,
+            )
+    except Exception as e:  # deliberate fail-soft: advisory must never break filing (#1399)
+        print(
+            f"file_infra_task: advisory leg failed ({e!r}); filing proceeds (#1399 fail-soft)",
+            file=sys.stderr,
+        )
+
+
 def cmd_file_infra(args: argparse.Namespace) -> int:
     """File a ripe `kind: infra`/`batch` task, then best-effort dispatch it.
 
@@ -278,9 +338,10 @@ def cmd_file_infra(args: argparse.Namespace) -> int:
     here would make callers think filing failed)."""
     # 0. Warn-only pre-filing backstops (stderr only; exit codes and filing
     # behavior unchanged): #1173 durable-recursion-guard line, #1283 dedup
-    # title-prefix surface.
+    # title-prefix surface, #1399 recently-closed-sibling advisory.
     _warn_missing_wf_fix_provenance(args)
     _warn_missing_wf_fix_title_prefix(args)
+    _advise_recent_closed_wf_fix_siblings(args)
 
     # 1. File first (the durable, must-succeed half).
     new_argv = _build_new_argv(args)

--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -83,7 +83,7 @@ import subprocess
 import time
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -1094,6 +1094,187 @@ def is_workflow_fix_session(task_id: int) -> bool:
     except (FileNotFoundError, OSError):
         return False
     return "workflow_fix_target:" in body
+
+
+# Terminal statuses for the #1399 recently-closed advisory (the complement of
+# _WF_FIX_NONTERMINAL above — a task at one of these no longer blocks dedup,
+# but a JUST-closed one is exactly what the advisory surfaces).
+_WF_FIX_TERMINAL: tuple[str, ...] = ("completed", "archived")
+# Closure-class event kinds: set_status appends epm:status-changed and promote
+# appends epm:promoted — together the done-transition pair the watcher's
+# pod-safety predicate already keys on (CLAUDE.md).
+_WF_FIX_CLOSURE_EVENT_KINDS: tuple[str, ...] = ("epm:status-changed", "epm:promoted")
+# Small stopword set for the title-token overlap arm (len >= 4 tokens only, so
+# short glue words are already excluded; these are the frequent len>=4 ones).
+_WF_FIX_TITLE_STOPWORDS: frozenset[str] = frozenset(
+    {"the", "for", "and", "with", "must", "that", "from", "into", "when", "only", "over"}
+)
+_WF_FIX_TARGET_LINE_RE = re.compile(r"^\s*-?\s*workflow_fix_target:\s*(.+?)\s*$", re.M)
+
+
+def wf_fix_extract_target(body_text: str) -> str | None:
+    """Value of the first anchored ``workflow_fix_target:`` body line, else None.
+
+    Anchored at line start (optional ``- `` bullet) so prose MENTIONS of the
+    key (e.g. a Constraints bullet naming the ``workflow_fix_target:``
+    Provenance line mid-sentence) never match — verified against #1350's real
+    body, where line 55 is prose and line 59 is the Provenance line.
+    """
+    m = _WF_FIX_TARGET_LINE_RE.search(body_text or "")
+    return m.group(1).strip() if m else None
+
+
+def _wf_fix_closed_at(task_dir: Path) -> datetime | None:
+    """Closure timestamp: ts of the LAST closure-class event in events.jsonl.
+
+    Closure-class = epm:status-changed (set_status) or epm:promoted (promote)
+    — the two done-transition kinds (CLAUDE.md watcher predicate). Unreadable
+    file / no closure event / unparseable or tz-naive ts -> None (the caller
+    EXCLUDES the task: recency cannot be established, and an advisory must not
+    present unknown-age tasks as 'recent').
+    """
+    try:
+        text = (task_dir / "events.jsonl").read_text()
+    except OSError:
+        return None
+    ts = None
+    # split("\n") not splitlines(): raw U+2028/U+2029/NEL inside JSON strings
+    # would shred records under splitlines (gotchas.md jsonl-splitlines).
+    for line in text.split("\n"):
+        # Cheap substring prefilter before json.loads (events files are long).
+        if '"epm:status-changed"' not in line and '"epm:promoted"' not in line:
+            continue
+        try:
+            d = json.loads(line)
+        except ValueError:
+            continue
+        if d.get("kind") in _WF_FIX_CLOSURE_EVENT_KINDS and d.get("ts"):
+            ts = d["ts"]
+    if ts is None:
+        return None
+    try:
+        dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        # A tz-naive ts cannot be compared against the tz-aware window
+        # (TypeError); exclude this task rather than kill the whole scan.
+        return None
+    return dt
+
+
+def _wf_fix_target_tokens(target_file: str) -> set[str]:
+    """Comma-split a target_file value into exact path tokens (backticks/space stripped).
+
+    A glob token is treated as an OPAQUE string (matches only an identical
+    glob) — measured 2/595 corpus target lines carry a glob; fnmatch expansion
+    is deliberately out of scope (documented limitation).
+    """
+    return {p.strip().strip("`") for p in (target_file or "").split(",") if p.strip().strip("`")}
+
+
+def _wf_fix_title_tokens(title: str) -> set[str]:
+    """Informative title tokens: lowercase, channel prefix removed, split on
+    non-word chars keeping ``-``/``_`` inside tokens, each token stripped of
+    edge ``-``/``_`` (so ``--workload-cmd`` == ``workload-cmd``), length >= 4,
+    minus a small stopword set."""
+    t = (title or "").lower()
+    for p in WF_FIX_TITLE_PREFIXES:
+        t = t.removeprefix(p)
+    out: set[str] = set()
+    for w in re.split(r"[^a-z0-9_\-]+", t):
+        w = w.strip("-_")
+        if len(w) >= 4 and w not in _WF_FIX_TITLE_STOPWORDS:
+            out.add(w)
+    return out
+
+
+def recent_closed_workflow_fix_tasks(
+    target_file: str | None,
+    candidate_title: str | None = None,
+    *,
+    days: float = 7.0,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """CLOSED wf-fix siblings within ``days`` overlapping the candidate (#1399).
+
+    The ADVISORY complement of :func:`is_open_workflow_fix_task`: that
+    predicate blocks exact-(target_file, fingerprint) duplicates among OPEN
+    tasks; this helper only SURFACES recently-closed topical siblings for the
+    filer to eyeball — advisory rather than a hard block, so a closed task
+    still never blocks a re-raise (.claude/rules/workflow-fix-on-bug.md
+    § Dedup, unchanged).
+
+    A task matches iff kind==infra AND status in {completed, archived} AND
+    title startswith WF_FIX_TITLE_PREFIXES AND its closure ts (last
+    epm:status-changed/epm:promoted in events.jsonl) is within ``days`` of
+    ``now`` AND at least one arm overlaps:
+      - 'target': candidate target_file path-token set (comma-split) intersects
+        the task's anchored ``workflow_fix_target:`` line token set;
+      - 'title:<tokens>': candidate title shares >=1 informative token
+        (len>=4, stopword-filtered) with the task title.
+    Returns [{'id', 'title', 'status', 'target', 'closed_at', 'matched'}, ...]
+    sorted by closed_at DESC. Read-only: no mutation, no commit, no lock.
+    Per-task failures (missing folder, non-numeric registry key, unreadable
+    body) skip that task — one broken entry never kills the whole scan.
+    """
+    now = now or datetime.now(UTC)
+    cutoff = now - timedelta(days=days)
+    # Window is TWO-SIDED: cutoff <= closed_at <= now. The upper bound makes a
+    # retrospective query (the plan-§4.6 smoke, window tests with a historical
+    # now=) filing-time-exact — without it, tasks closed AFTER `now` would
+    # surface in retrospective smokes. At a LIVE filing nothing is closed in
+    # the future, so the bound is inert in production.
+    cand_targets = _wf_fix_target_tokens(target_file) if target_file else set()
+    cand_tokens = _wf_fix_title_tokens(candidate_title) if candidate_title else set()
+    if not cand_targets and not cand_tokens:
+        return []
+    hits: list[dict[str, Any]] = []
+    for tid_str, entry in _load_registry().get("tasks", {}).items():
+        if entry.get("kind") != "infra":
+            continue
+        if (entry.get("status") or "") not in _WF_FIX_TERMINAL:
+            continue
+        title = str(entry.get("title", ""))
+        if not title.startswith(WF_FIX_TITLE_PREFIXES):
+            continue
+        try:
+            tid = int(tid_str)
+            task_dir = find_task_path(tid)
+        except (FileNotFoundError, ValueError):
+            # Non-numeric registry key or missing folder: skip this entry.
+            continue
+        matched: list[str] = []
+        task_targets: set[str] = set()
+        if cand_targets:
+            try:
+                _, body = _read_body(task_dir / "body.md")
+            except (FileNotFoundError, ValueError):
+                body = ""  # fail-soft: target arm silently unavailable for this task
+            for m in _WF_FIX_TARGET_LINE_RE.finditer(body):
+                task_targets |= _wf_fix_target_tokens(m.group(1))
+            if cand_targets & task_targets:
+                matched.append("target")
+        shared = cand_tokens & _wf_fix_title_tokens(title)
+        if shared:
+            matched.append("title:" + ",".join(sorted(shared)))
+        if not matched:
+            continue
+        closed = _wf_fix_closed_at(task_dir)
+        if closed is None or closed < cutoff or closed > now:
+            continue
+        hits.append(
+            {
+                "id": tid,
+                "title": title,
+                "status": entry.get("status"),
+                "target": ", ".join(sorted(task_targets)) or None,
+                "closed_at": closed.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "matched": matched,
+            }
+        )
+    hits.sort(key=lambda h: h["closed_at"], reverse=True)
+    return hits
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_file_infra_task.py
+++ b/tests/test_file_infra_task.py
@@ -59,6 +59,16 @@ def _no_real_stagger(monkeypatch):
     return recorded
 
 
+@pytest.fixture(autouse=True)
+def _no_real_recent_closed(monkeypatch):
+    """Hermeticity for the #1399 recently-closed-sibling advisory: default the
+    helper to "no recent closures" so pre-existing wf-fix-shaped filings in
+    these tests never scan the LIVE task registry (whose contents — e.g. a
+    just-closed sibling title containing 'workflow_fix_target' — would make
+    stderr assertions time-dependent). Advisory-specific tests override it."""
+    monkeypatch.setattr(fit, "recent_closed_workflow_fix_tasks", lambda *a, **k: [])
+
+
 def _install_run_recorder(
     monkeypatch,
     *,
@@ -634,3 +644,116 @@ def test_title_prefix_guard_reads_shared_constant(monkeypatch, capsys, tmp_path)
     rc = fit.main(["--title", "workflow-fix: x", "--tag", "wf-fix", "--body-file", str(body)])
     assert rc == 0
     assert "--title lacks a" in capsys.readouterr().err
+
+
+# ── #1399: recently-closed-sibling advisory (warn-only, fail-soft) ────────────
+
+_CANNED_HIT = {
+    "id": 1309,
+    "title": "workflow-fix: honor an explicit marker output file",
+    "status": "completed",
+    "target": ".claude/skills/issue/SKILL.md",
+    "closed_at": "2026-07-14T08:49:34Z",
+    "matched": ["target"],
+}
+
+
+def test_wf_fix_filing_prints_closed_sibling_advisory(monkeypatch, capsys, tmp_path):
+    # A wf-fix-shaped filing prints the #1399 stderr advisory listing
+    # recently-closed siblings; filing + dispatch behavior and exit code are
+    # unchanged. The recorder ALSO pins the (target, title) args the filer
+    # passes: the body-file's anchored Provenance target + the verbatim
+    # --title (a silently-broken wf_fix_extract_target cannot pass).
+    calls = _install_run_recorder(monkeypatch, new_id="#771")
+    _healthy_dispatch_env(monkeypatch)
+    seen = {}
+
+    def _fake_recent(target, title, *, days):
+        seen["args"] = (target, title, days)
+        return [dict(_CANNED_HIT)]
+
+    monkeypatch.setattr(fit, "recent_closed_workflow_fix_tasks", _fake_recent)
+    body = tmp_path / "body.md"
+    body.write_text(_PREFIXED_PROVENANCE_BODY, encoding="utf-8")
+
+    rc = fit.main(["--title", "workflow-fix: x", "--tag", "wf-fix", "--body-file", str(body)])
+
+    assert rc == 0
+    assert len(_new_calls(calls)) == 1  # filing proceeded
+    assert len(_spawn_calls(calls)) == 1  # dispatch behavior unchanged
+    err = capsys.readouterr().err
+    assert "ADVISORY" in err
+    assert "#1309" in err
+    # _PREFIXED_PROVENANCE_BODY carries `- workflow_fix_target: CLAUDE.md`.
+    assert seen["args"] == ("CLAUDE.md", "workflow-fix: x", 7.0)
+
+
+def test_advisory_leg_fail_soft_never_breaks_filing(monkeypatch, capsys, tmp_path):
+    # Any exception inside the advisory leg prints a one-line diagnostic and
+    # filing + dispatch proceed with rc unchanged (#1399 fail-soft constraint).
+    calls = _install_run_recorder(monkeypatch, new_id="#771")
+    _healthy_dispatch_env(monkeypatch)
+
+    def _boom(target, title, *, days):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(fit, "recent_closed_workflow_fix_tasks", _boom)
+    body = tmp_path / "body.md"
+    body.write_text(_PREFIXED_PROVENANCE_BODY, encoding="utf-8")
+
+    rc = fit.main(["--title", "workflow-fix: x", "--tag", "wf-fix", "--body-file", str(body)])
+
+    assert rc == 0
+    assert len(_new_calls(calls)) == 1  # filing still happened
+    assert len(_spawn_calls(calls)) == 1  # dispatch behavior unchanged
+    assert "advisory leg failed" in capsys.readouterr().err
+
+
+def test_non_wf_fix_filing_skips_advisory(monkeypatch, capsys, tmp_path):
+    # A plain infra filing (no wf-fix tag, no anchored target line) never
+    # invokes the helper and prints no advisory.
+    calls = _install_run_recorder(monkeypatch, new_id="#771")
+    _healthy_dispatch_env(monkeypatch)
+    called: list[tuple] = []
+    monkeypatch.setattr(
+        fit, "recent_closed_workflow_fix_tasks", lambda *a, **k: called.append(a) or []
+    )
+    body = tmp_path / "body.md"
+    body.write_text("## Goal\n\nordinary infra\n", encoding="utf-8")
+
+    rc = fit.main(["--title", "ordinary infra task", "--body-file", str(body)])
+
+    assert rc == 0
+    assert len(_new_calls(calls)) == 1
+    assert called == []
+    assert "ADVISORY" not in capsys.readouterr().err
+
+
+def test_advisory_caps_rows_and_prints_more_line(monkeypatch, capsys, tmp_path):
+    # >_ADVISORY_MAX_ROWS hits: exactly 10 rows print plus the "... and K
+    # more" summary line (the helper's recency-desc order keeps the
+    # just-merged incident class inside the cap).
+    _install_run_recorder(monkeypatch, new_id="#771")
+    _healthy_dispatch_env(monkeypatch)
+    hits = [
+        {
+            "id": 1400 + i,
+            "title": f"workflow-fix: sibling {i}",
+            "status": "completed",
+            "target": "CLAUDE.md",
+            "closed_at": f"2026-07-{15 - i:02d}T00:00:00Z",
+            "matched": ["target"],
+        }
+        for i in range(12)
+    ]
+    monkeypatch.setattr(fit, "recent_closed_workflow_fix_tasks", lambda *a, **k: list(hits))
+    body = tmp_path / "body.md"
+    body.write_text(_PREFIXED_PROVENANCE_BODY, encoding="utf-8")
+
+    rc = fit.main(["--title", "workflow-fix: x", "--tag", "wf-fix", "--body-file", str(body)])
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    row_lines = [ln for ln in err.splitlines() if ln.startswith("  #")]
+    assert len(row_lines) == fit._ADVISORY_MAX_ROWS == 10
+    assert "... and 2 more within the window" in err

--- a/tests/test_workflow_fix_dedup.py
+++ b/tests/test_workflow_fix_dedup.py
@@ -21,8 +21,10 @@ covered. The ``fake_repo`` fixture mirrors ``tests/test_task_workflow.py``.
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -327,3 +329,219 @@ def test_title_prefix_roundtrips_view_json(fake_repo):
     # Frontmatter on body.md agrees.
     fm, _ = tw._read_body(tw.find_task_path(tid) / "body.md")
     assert fm["title"].startswith("workflow-fix:")
+
+
+# ─── #1399: recently-closed-sibling advisory helper ─────────────────────────
+
+
+def test_wf_fix_extract_target_anchored_line_only():
+    """The anchored regex matches a Provenance line (with or without the `- `
+    bullet) but never a prose MENTION of the key mid-sentence (the #1350 body
+    shape: line 55 is prose, line 59 is the Provenance line)."""
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+    import explore_persona_space.task_workflow as tw
+
+    bullet = "## Provenance\n\n- workflow_fix_target: CLAUDE.md\n"
+    assert tw.wf_fix_extract_target(bullet) == "CLAUDE.md"
+    bare = "workflow_fix_target: scripts/task.py\n"
+    assert tw.wf_fix_extract_target(bare) == "scripts/task.py"
+    prose = "- This session carries a `workflow_fix_target:` Provenance line.\n"
+    assert tw.wf_fix_extract_target(prose) is None
+    assert tw.wf_fix_extract_target("") is None
+
+
+def test_wf_fix_closed_at_tz_naive_ts_excluded(tmp_path):
+    """A tz-naive closure ts resolves to None (task excluded) rather than a
+    naive datetime that would TypeError against the tz-aware window — one
+    malformed events row must never kill the whole advisory scan."""
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+    import explore_persona_space.task_workflow as tw
+
+    (tmp_path / "events.jsonl").write_text(
+        json.dumps({"kind": "epm:status-changed", "ts": "2026-07-14T08:49:34"}) + "\n"
+    )
+    assert tw._wf_fix_closed_at(tmp_path) is None
+    # An aware ts on the same shape parses fine (control).
+    (tmp_path / "events.jsonl").write_text(
+        json.dumps({"kind": "epm:status-changed", "ts": "2026-07-14T08:49:34Z"}) + "\n"
+    )
+    closed = tw._wf_fix_closed_at(tmp_path)
+    assert closed is not None and closed.tzinfo is not None
+
+
+def test_recent_closed_sibling_same_target_within_window(fake_repo):
+    """A completed AND an archived same-target sibling both surface, each with
+    'target' in matched and its terminal status reported."""
+    _, tw = fake_repo
+    target = ".claude/skills/issue/SKILL.md"
+    completed = _file_wf_fix_task(
+        tw, target, tw.wf_fix_fingerprint("Fix A.", "bug A"), proposed_change="Fix A."
+    )
+    tw.set_status(completed, "completed")
+    archived = _file_wf_fix_task(
+        tw, target, tw.wf_fix_fingerprint("Fix B.", "bug B"), proposed_change="Fix B."
+    )
+    tw.set_status(archived, "archived")
+
+    hits = tw.recent_closed_workflow_fix_tasks(target)
+    by_id = {h["id"]: h for h in hits}
+    assert set(by_id) == {completed, archived}
+    assert "target" in by_id[completed]["matched"]
+    assert by_id[completed]["status"] == "completed"
+    assert "target" in by_id[archived]["matched"]
+    assert by_id[archived]["status"] == "archived"
+
+
+def test_recent_closed_sibling_outside_window_excluded(fake_repo):
+    """A sibling closed now falls outside a 7-day window queried 8 days later."""
+    _, tw = fake_repo
+    target = "CLAUDE.md"
+    tid = _file_wf_fix_task(tw, target, tw.wf_fix_fingerprint("Fix the gate.", "gate wrong"))
+    tw.set_status(tid, "completed")
+    future = datetime.now(UTC) + timedelta(days=8)
+    assert tw.recent_closed_workflow_fix_tasks(target, now=future) == []
+
+
+def test_recent_closed_excludes_open_tasks(fake_repo):
+    """The advisory is closed-only: a task left at `proposed` never surfaces
+    (the OPEN surface stays is_open_workflow_fix_task's)."""
+    _, tw = fake_repo
+    target = "CLAUDE.md"
+    _file_wf_fix_task(tw, target, tw.wf_fix_fingerprint("Fix the gate.", "gate wrong"))
+    assert tw.recent_closed_workflow_fix_tasks(target) == []
+
+
+def test_recent_closed_excludes_non_wf_fix_titles(fake_repo):
+    """A completed kind:infra task whose title lacks a wf-fix channel prefix
+    is ignored even with a matching workflow_fix_target line."""
+    _, tw = fake_repo
+    target = "CLAUDE.md"
+    fp = tw.wf_fix_fingerprint("Fix the gate.", "gate wrong")
+    tid = tw.create_task(
+        tw.NewTaskRequest(
+            kind="infra",
+            title="refactor: tidy the gate",
+            body=_wf_fix_body(target, fp, "Fix the gate."),
+            tags=["wf-fix", f"wf-fix-fp:{fp}"],
+        )
+    )
+    tw.set_status(tid, "completed")
+    assert tw.recent_closed_workflow_fix_tasks(target) == []
+
+
+def test_recent_closed_target_overlap_comma_list(fake_repo):
+    """Per-token comma-list semantics: candidate 'a.md, b.md' matches a
+    sibling whose target is 'a.md'; candidate 'c.md' does not (133/595 corpus
+    target lines are comma-lists)."""
+    _, tw = fake_repo
+    tid = _file_wf_fix_task(
+        tw, "a.md", tw.wf_fix_fingerprint("Fix a.md.", "a.md wrong"), proposed_change="Fix a.md."
+    )
+    tw.set_status(tid, "completed")
+
+    hits = tw.recent_closed_workflow_fix_tasks("a.md, b.md")
+    assert [h["id"] for h in hits] == [tid]
+    assert "target" in hits[0]["matched"]
+    assert tw.recent_closed_workflow_fix_tasks("c.md") == []
+
+
+def test_recent_closed_title_token_overlap_fires_on_1329_1350_shape(fake_repo):
+    """Incident regression pin (durability pin, #1399): the REAL pair-1 shape
+    (#1329 -> #1350) has DIFFERENT target files, so only the title-token arm
+    can fire — via the shared 'workload-cmd' token after edge-strip
+    ('--workload-cmd' == 'workload-cmd')."""
+    _, tw = fake_repo
+    fp = tw.wf_fix_fingerprint("Lint lane env vars.", "workload-cmd env unset")
+    sibling = tw.create_task(
+        tw.NewTaskRequest(
+            kind="infra",
+            title="daily-fix: lint lane-specific env vars in workload-cmd",
+            body=_wf_fix_body("scripts/dispatch_issue.py", fp, "Lint lane env vars."),
+            tags=["wf-fix", f"wf-fix-fp:{fp}"],
+        )
+    )
+    tw.set_status(sibling, "completed")
+
+    cand_title = (
+        "workflow-fix: lane-portable REPO_ROOT guidance for --workload-cmd "
+        "(WORKLOAD_ROOT is GCE-only)"
+    )
+    hits = tw.recent_closed_workflow_fix_tasks(".claude/skills/issue/SKILL.md", cand_title)
+    assert len(hits) == 1
+    assert hits[0]["id"] == sibling
+    assert hits[0]["matched"] == ["title:workload-cmd"]
+
+
+def test_recent_closed_fail_soft_on_missing_body(fake_repo):
+    """A sibling whose body.md is gone does not kill the scan: the intact
+    sibling still surfaces via the target arm, and the broken one can still
+    match via the title arm (its target arm is silently unavailable)."""
+    _, tw = fake_repo
+    intact = _file_wf_fix_task(
+        tw,
+        "x.md",
+        tw.wf_fix_fingerprint("Fix alpha.", "alpha bug"),
+        proposed_change="alpha-arm gate fix",
+    )
+    tw.set_status(intact, "completed")
+    broken = _file_wf_fix_task(
+        tw,
+        "x.md",
+        tw.wf_fix_fingerprint("Fix beta.", "beta bug"),
+        proposed_change="broken-body probe fix",
+    )
+    tw.set_status(broken, "completed")
+    (tw.find_task_path(broken) / "body.md").unlink()
+
+    hits = tw.recent_closed_workflow_fix_tasks("x.md", "workflow-fix: broken-body sweep")
+    by_id = {h["id"]: h for h in hits}
+    assert "target" in by_id[intact]["matched"]
+    assert by_id[broken]["matched"] == ["title:broken-body"]
+
+
+def test_recent_closed_empty_when_no_candidate_keys(fake_repo, monkeypatch):
+    """(None, None) returns [] BEFORE the registry scan even starts (no
+    per-task reads)."""
+    _, tw = fake_repo
+
+    def _boom():
+        raise AssertionError("registry scan must not run with no candidate keys")
+
+    monkeypatch.setattr(tw, "_load_registry", _boom)
+    assert tw.recent_closed_workflow_fix_tasks(None, None) == []
+
+
+def test_recent_closed_upper_bound_excludes_future_closures(fake_repo):
+    """Two-sided window: a task closed AFTER the query's `now` never surfaces
+    (keeps retrospective / filing-moment queries exact)."""
+    _, tw = fake_repo
+    target = "CLAUDE.md"
+    tid = _file_wf_fix_task(tw, target, tw.wf_fix_fingerprint("Fix the gate.", "gate wrong"))
+    tw.set_status(tid, "completed")
+    past = datetime.now(UTC) - timedelta(hours=1)
+    assert tw.recent_closed_workflow_fix_tasks(target, now=past) == []
+
+
+def test_recent_closed_hits_sorted_closed_at_desc(fake_repo, monkeypatch):
+    """Hits are sorted most-recently-closed FIRST (the just-merged incident
+    class sorts to the top of the filer's capped list)."""
+    _, tw = fake_repo
+    target = "CLAUDE.md"
+    now = datetime.now(UTC)
+    tids = []
+    for i in range(3):
+        tid = _file_wf_fix_task(
+            tw,
+            target,
+            tw.wf_fix_fingerprint(f"Fix {i}.", f"bug {i}"),
+            proposed_change=f"Fix {i}.",
+        )
+        tw.set_status(tid, "completed")
+        tids.append(tid)
+    # Deterministic distinct closure times: tids[0] oldest ... tids[2] newest
+    # (real set_status ts land within the same second, so pin them here).
+    closed = {tw.find_task_path(tid): now - timedelta(hours=3 - i) for i, tid in enumerate(tids)}
+    monkeypatch.setattr(tw, "_wf_fix_closed_at", lambda task_dir: closed[task_dir])
+
+    hits = tw.recent_closed_workflow_fix_tasks(target, now=now)
+    assert [h["id"] for h in hits] == list(reversed(tids))

--- a/tests/test_workflow_fix_dedup.py
+++ b/tests/test_workflow_fix_dedup.py
@@ -522,6 +522,28 @@ def test_recent_closed_upper_bound_excludes_future_closures(fake_repo):
     assert tw.recent_closed_workflow_fix_tasks(target, now=past) == []
 
 
+def test_recent_closed_skips_non_numeric_registry_key(fake_repo):
+    """A non-numeric registry key (corrupt entry) skips that entry — it never
+    aborts the whole advisory scan (per-task hardening, #1399)."""
+    repo, tw = fake_repo
+    target = "CLAUDE.md"
+    tid = _file_wf_fix_task(tw, target, tw.wf_fix_fingerprint("Fix the gate.", "gate wrong"))
+    tw.set_status(tid, "completed")
+    reg_path = repo / "tasks" / "REGISTRY.json"
+    reg = json.loads(reg_path.read_text())
+    reg["tasks"]["not-a-number"] = {
+        "path": "tasks/completed/999",
+        "title": "workflow-fix: bogus corrupt entry",
+        "kind": "infra",
+        "status": "completed",
+        "has_clean_result": False,
+    }
+    reg_path.write_text(json.dumps(reg))
+
+    hits = tw.recent_closed_workflow_fix_tasks(target)
+    assert [h["id"] for h in hits] == [tid]
+
+
 def test_recent_closed_hits_sorted_closed_at_desc(fake_repo, monkeypatch):
     """Hits are sorted most-recently-closed FIRST (the just-merged incident
     class sorts to the top of the filer's capped list)."""


### PR DESCRIPTION
Closes task #1399. Adds recent_closed_workflow_fix_tasks + wf_fix_extract_target (task_workflow.py), the warn-only fail-soft stderr advisory leg in file_infra_task.py (step-0, before filing/spawn), the workflow-fix-on-bug.md § Dedup advisory paragraph, and 16 tests. Advisory only — never blocks; open-task dedup predicate behaviorally unchanged.