### PR TITLE
issue-1382: fix two red workflow tests (stale-entry fallback contract + v<k>. stamp parser tolerance)

### DIFF
--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -3004,7 +3004,11 @@ def parse_followup_note_field(note: str, field: str) -> str | None:
     run-marker shape, e.g. #537/#552). Each segment is anchored exactly
     like a line-core: a mid-segment mention (``(source: user-chat)``, the
     #685 prose shape) still parses ``None``, and ``word;field: x`` (no
-    whitespace after the ``;``) never splits. The value is the first
+    whitespace after the ``;``) never splits. A leading lowercase version
+    stamp (``v<k>.`` + REQUIRED whitespace, e.g. ``v1. followup_label: x``
+    — the #1092 run-note shape) is stripped as decoration, same class as
+    bullets/bold; parsing stays field-only (#1111 — no label inference).
+    The value is the first
     whitespace token of the remainder, stripped of backticks / quotes /
     ``*`` and a trailing comma or semicolon (#664 ships a backtick-wrapped
     bold value; #841's run markers carry ``label;`` when the line is read
@@ -3054,6 +3058,13 @@ def parse_followup_note_field(note: str, field: str) -> str | None:
             # One regex pass strips any interleaved mix of whitespace, bullet
             # dashes/stars, and bold markers (unchanged from the line-core rule).
             core = re.sub(r"^[\s\-*]+", "", seg)
+            # Leading version stamp (`v1. ` — the #1092 run-note shape, an
+            # emitter echoing the marker's `v<k>` grammar into the note head):
+            # decorative prefix, same class as bullets/bold — strip it so the
+            # field anchor still binds. Lowercase `v` + digits + `.` +
+            # REQUIRED whitespace only; anything else is prose and stays
+            # unparseable (field-only parsing per #1111 — no label inference).
+            core = re.sub(r"^v\d+\.\s+", "", core)
             if core.startswith(f"{field}:") or core.startswith(f"{field}="):
                 rest = core[len(field) + 1 :].lstrip("*").strip()
                 tokens = rest.split()

--- a/tests/test_living_docs.py
+++ b/tests/test_living_docs.py
@@ -504,46 +504,54 @@ def test_check_exempts_intentionally_unmapped(fixture):
 # ─── check() degrades on registry/filesystem inconsistency (#725) ──────────
 
 
-def test_check_degrades_on_drifted_registry_path(fixture):
-    """Mode A: a registry entry points at a directory that does not exist.
+def test_check_degrades_on_drifted_registry_path(fixture, caplog):
+    """Mode A (post-#898 stale-entry envelope): a registry entry points at a
+    missing dir while the task exists at exactly ONE on-disk status.
 
-    ``find_task_path`` raises ``FileNotFoundError``; ``check()`` must
-    surface the drifted task as a problem (NOT raise), AND the surviving
-    check axes must still run against the registry-trimmed index.
-    Reproduces tonight's documented crash (task #725 body / #696).
+    ``find_task_path`` no longer raises — it falls back to the on-disk path
+    with a logged drift WARNING (READ path; the registry is never rewritten
+    here — repair happens on the task's next registry-writing mutation or
+    ``task.py audit --repair --apply``). ``check()`` therefore reports NO
+    drift line and the check axes run against the FULL index; the drift is
+    still surfaced, via the WARNING.
     """
     import json
+    import logging
 
     repo, paths = fixture
     # Drift #207's registry path to a nonexistent dir. The on-disk
     # tasks/completed/207/ still exists; only the registry POINTS somewhere
-    # else — exactly find_task_path's entry-present-but-dir-missing branch.
+    # else — exactly find_task_path's 1-hit stale-entry fallback branch.
     reg_path = repo / "tasks" / "REGISTRY.json"
     reg = json.loads(reg_path.read_text())
     reg["tasks"]["207"]["path"] = "tasks/approved/207"  # nonexistent
     reg_path.write_text(json.dumps(reg, indent=2, sort_keys=True) + "\n")
     tw.invalidate_cache()  # drop the cached registry so the new path is read
 
-    # (1) Must not raise.
-    report = ld.check(paths=paths)
+    with caplog.at_level(logging.WARNING, logger="explore_persona_space.task_workflow"):
+        report = ld.check(paths=paths)
 
-    # (2) Drift finding present, names #207.
-    drift_lines = [p for p in report.problems if "registry/filesystem inconsistent" in p]
-    assert any("#207" in p for p in drift_lines), report.problems
-    # The fixture has #208 still well-formed → exactly one drift line.
-    assert len(drift_lines) == 1, drift_lines
+    # (1) No drift line — the fallback resolved #207 to tasks/completed/207.
+    assert not any("registry/filesystem inconsistent" in p for p in report.problems)
 
-    # (3) Surviving axes still ran: #207's name still appears in a1's evidence
-    # in open_questions.md, but #207 is no longer in the relates-to index, so
-    # the bidirectional check (axis a) MUST flag a missing-backlink finding
-    # for #207 vs a1.
-    nondrift = [p for p in report.problems if "registry/filesystem inconsistent" not in p]
-    assert any("207" in p and "a1" in p for p in nondrift), (
-        f"axis (a) bidirectional should have flagged #207 vs a1 after the "
-        f"drift trimmed it from the relates index; got non-drift problems: {nondrift}"
-    )
-    # report.ok must be False (drift present).
-    assert not report.ok
+    # (2) Index intact: #207 still contributes relates_to + coverage, so the
+    # otherwise-clean fixture stays clean end to end.
+    assert report.ok, report.problems
+
+    # (3) The drift IS surfaced, via the find_task_path WARNING naming the
+    # task, the stale registry path, and the on-disk path. Both indexers
+    # resolve #207, so assert >=1 matching record — the count is an
+    # implementation detail, never pinned.
+    drift_warnings = [
+        r
+        for r in caplog.records
+        if "REGISTRY says" in r.getMessage() and "found on disk at" in r.getMessage()
+    ]
+    assert drift_warnings, caplog.text
+    assert any(
+        "tasks/approved/207" in r.getMessage() and "tasks/completed/207" in r.getMessage()
+        for r in drift_warnings
+    ), [r.getMessage() for r in drift_warnings]
 
 
 def test_check_degrades_on_missing_body_md(fixture):
@@ -573,6 +581,56 @@ def test_check_degrades_on_missing_body_md(fixture):
     # was Mode A or Mode B.
     nondrift = [p for p in report.problems if "registry/filesystem inconsistent" not in p]
     assert any("207" in p and "a1" in p for p in nondrift), nondrift
+    assert not report.ok
+
+
+def test_check_degrades_on_dir_missing_everywhere(fixture):
+    """Mode C: the registry entry is intact but the task dir is gone from
+    EVERY status folder — ``find_task_path``'s 0-hit branch still raises
+    ``FileNotFoundError``, and ``check()`` must degrade + flag (the #725
+    contract survives the #898 envelope for genuinely-unresolvable entries).
+    """
+    import shutil
+
+    repo, paths = fixture
+    shutil.rmtree(repo / "tasks" / "completed" / "207")
+
+    # (1) Must not raise.
+    report = ld.check(paths=paths)
+
+    # (2) Drift finding present, names #207; #208 stays well-formed → the
+    # two indexers' findings dedup to exactly one drift line.
+    drift_lines = [p for p in report.problems if "registry/filesystem inconsistent" in p]
+    assert any("#207" in p for p in drift_lines), report.problems
+    assert len(drift_lines) == 1, drift_lines
+
+    # (3) Surviving axes still ran: #207's drop from the relates index leaves
+    # a1's evidence backlink dangling — same downstream effect as Mode B.
+    nondrift = [p for p in report.problems if "registry/filesystem inconsistent" not in p]
+    assert any("207" in p and "a1" in p for p in nondrift), nondrift
+    assert not report.ok
+
+
+def test_check_degrades_on_multi_status_stale_entry(fixture):
+    """Mode D (≥2-hit): the registry entry is stale AND the task exists at
+    TWO on-disk statuses — ``find_task_path`` raises ``StaleTaskPathError``
+    (a ``FileNotFoundError`` subclass), and ``check()`` degrades + flags
+    exactly as for any unresolvable entry.
+    """
+    import json
+    import shutil
+
+    repo, paths = fixture
+    shutil.copytree(repo / "tasks" / "completed" / "207", repo / "tasks" / "running" / "207")
+    reg_path = repo / "tasks" / "REGISTRY.json"
+    reg = json.loads(reg_path.read_text())
+    reg["tasks"]["207"]["path"] = "tasks/approved/207"  # nonexistent
+    reg_path.write_text(json.dumps(reg, indent=2, sort_keys=True) + "\n")
+    tw.invalidate_cache()
+
+    report = ld.check(paths=paths)  # (1) no raise
+    drift_lines = [p for p in report.problems if "registry/filesystem inconsistent" in p]
+    assert any("#207" in p for p in drift_lines), report.problems  # (2) flagged
     assert not report.ok
 
 

--- a/tests/test_workflow_followup_labels.py
+++ b/tests/test_workflow_followup_labels.py
@@ -376,6 +376,30 @@ _NOTE_841_RUN_V2 = (
     "ody; re-parked at awaiting_promotion."
 )
 
+# The corpus's ONLY version-stamp-led run note (VERBATIM #1092 run marker,
+# 2026-07-11T00:06:50Z): a `; `-joined single-line run note whose FIRST
+# segment leads with the marker-version stamp `v1. ` before the
+# `followup_label:` field — field-led modulo the decorative stamp (unlike
+# the prose-led #1090 fu1 note above, which carries no fields at all).
+_NOTE_1092_RUN_V1 = (
+    "v1. followup_label: cross-corpus-probe-transfer; source: proposer-9b-chea"
+    "p; round: 1; est_gpu_hours: 8 (planned) / ~0 realized (all-VM analysis on"
+    " existing artifacts, no GPU provisioned); outcome: PARTIAL — downgrade_pr"
+    "econdition_met=false. Cross-corpus probe transfer of the #1092 UltraChat-"
+    "fit context-map ridge probes: dirA (UltraChat probes -> LMSYS/pass_a targ"
+    "ets) blocked from a DOWNGRADE read by the LMSYS alignment-gate ceiling fa"
+    "ilure (part-4 reliability ceiling below the pre-registered floor), dirB ("
+    "realistic-corpus probes -> UltraChat targets) hallucination transfer Δr ="
+    " -0.128 (negative; sycophancy positive), pass_a arm transfers. Folded int"
+    "o the clean-result body (new ### result + Takeaways bullet + Methodology "
+    "extension + footer Reused: provenance @ run-recorded SHAs); clean-result-"
+    "critic re-gate rounds 1-4, final PASS (Claude-only per codex-quota no-sho"
+    "w fallback). Artifacts: eval_results/issue_1092/cross-corpus-probe-transf"
+    "er/ + figures (merged to main eaef62f632); HF issue1092_realistic_crossin"
+    "g/cross_corpus_transfer (13 files, verified). Methodology doc EXTEND expo"
+    "rted (main 4644e8aad2, gist refreshed). Cheap-band count: 1/2."
+)
+
 
 def test_label_parse_semicolon_inline_scope_1090():
     # VERBATIM #1090 scope v1 (2026-07-07T07:19:09Z) + v2 (11:05:01Z): the
@@ -409,6 +433,42 @@ def test_label_parse_semicolon_inline_run_841():
     # EOL-trailing semicolon on a line-initial field (no whitespace after the
     # `;`, so no split fires): the rstrip(",;") leg strips it.
     assert parse_followup_note_field("followup_label: foo;", "followup_label") == "foo"
+
+
+def test_label_parse_version_stamp_led_run_1092():
+    # VERBATIM #1092 run marker (2026-07-11T00:06:50Z): the first segment
+    # leads with the marker-version stamp `v1. `; the stamp strips as
+    # decoration and the explicit fields parse — pre-fix the label parsed
+    # None, leaving cross-corpus-probe-transfer a dispatchable ghost-unrun
+    # the Step 0 dispatcher could re-dispatch (the #658 ghost-label class).
+    assert (
+        parse_followup_note_field(_NOTE_1092_RUN_V1, "followup_label")
+        == "cross-corpus-probe-transfer"
+    )
+    assert parse_followup_note_field(_NOTE_1092_RUN_V1, "source") == "proposer-9b-cheap"
+    assert parse_followup_note_field(_NOTE_1092_RUN_V1, "round") == "1"
+    assert parse_followup_note_field(_NOTE_1092_RUN_V1, "outcome") == "PARTIAL"
+
+
+def test_version_stamp_anchoring_negatives():
+    # (i) The prose-led #1090 fu1 note stays None — the stamp tolerance is
+    # decoration-stripping on a field-led segment, NOT label inference
+    # (field-only parsing per #1111, re-asserted next to the new tolerance).
+    assert parse_followup_note_field(_NOTE_1090_RUN_FU1_PROSE, "followup_label") is None
+    # (ii) Mid-segment mention: the stamp strip is anchored at segment start
+    # and never re-anchors the field search mid-text.
+    assert (
+        parse_followup_note_field("the v1. followup_label: was missing", "followup_label") is None
+    )
+    # (iii) No whitespace after the dot → not a stamp, stays prose.
+    assert parse_followup_note_field("v1.followup_label: x", "followup_label") is None
+    # (iv) A field VALUE beginning with a stamp is untouched (the core starts
+    # with `plan:`, so the stamp regex never fires).
+    assert parse_followup_note_field("plan: v1. adjust", "plan") == "v1."
+    # (v) Composes with the bullet strip (bullet stripped first, then the
+    # stamp) and with the `; `-split.
+    assert parse_followup_note_field("- v2. followup_label: y; source: z", "followup_label") == "y"
+    assert parse_followup_note_field("- v2. followup_label: y; source: z", "source") == "z"
 
 
 def test_semicolon_split_anchoring_negatives():
@@ -1095,6 +1155,9 @@ def _run_labels(events: list[dict]) -> set[str]:
 # `_followup_run_marker_rounds` counts this prose-led marker as an unlabeled
 # round, so #1090's round count reads one high (3 where 2 completed). Any
 # NEW unparseable run marker still fails the corpus-replay test below.
+# (#1092's `v1. `-stamp-led run note is deliberately NOT allowlisted — its
+# fields are explicit, and the parser strips the leading version stamp as
+# decoration; see `parse_followup_note_field`.)
 KNOWN_MALFORMED_RUN_MARKERS = {(1090, "2026-07-07T09:54:27Z")}
 
 
@@ -1103,7 +1166,7 @@ def test_corpus_replay_all_historical_markers():
     # epm:same-issue-followup-run marker in the checkout must parse a
     # followup_label (covers the 15 `=`-form markers + all colon forms —
     # minus the documented KNOWN_MALFORMED_RUN_MARKERS allowlist), and
-    # the hand-checked #763/#658/#537/#552 expectations must hold.
+    # the hand-checked #763/#658/#825/#537/#552/#1092 expectations must hold.
     import pytest
 
     if _tasks_root() is None:
@@ -1188,6 +1251,15 @@ def test_corpus_replay_all_historical_markers():
         unrun = {g["followup_label"] for g in unrun_followup_labels(by_task[task_id])}
         for label in closed_labels:
             assert label not in unrun, f"#{task_id} {label} must be closed by its run marker"
+
+    # #1092 (the version-stamp-led run note, this fix's driving incident):
+    # the 2026-07-11 run marker parses its label and closes the round —
+    # pre-fix it parsed None and left the round a dispatchable ghost-unrun
+    # (events are append-only, so this pin is stable).
+    if 1092 in by_task:
+        assert "cross-corpus-probe-transfer" in _run_labels(by_task[1092])
+        unrun_1092 = {g["followup_label"] for g in unrun_followup_labels(by_task[1092])}
+        assert "cross-corpus-probe-transfer" not in unrun_1092
 
 
 def test_corpus_replay_retro_close_verdicts():


### PR DESCRIPTION
Closes task #1382.

Fixes two pre-existing red workflow-invariant tests on main:
1. tests/test_living_docs.py::test_check_degrades_on_drifted_registry_path — rewritten to the #898 find_task_path stale-entry read-path fallback contract; new Mode C (0-hit raise still degrades+flags) + Mode D (>=2-hit StaleTaskPathError) companions.
2. tests/test_workflow_followup_labels.py::test_corpus_replay_all_historical_markers — root-caused to parse_followup_note_field rejecting a v<k>.-stamped field-led note; one narrow decoration-strip added (field-only parsing preserved per #1111). Closes the live #1092 ghost-unrun re-dispatch hazard.

Pipeline: plan APPROVE x3 + consistency PASS; code-review PASS; step9c gate 4528 passed, compare NEW=[].