### PR TITLE
issue-1384: per-arm-class smoke-coverage clause in experiment-implementer.md

### DIFF
--- a/.claude/agents/experiment-implementer.md
+++ b/.claude/agents/experiment-implementer.md
@@ -427,6 +427,28 @@ such corpora or banks:
    This catches the bulk of "experimenter discovers it crashes at
    startup / at eval" failures before the pod is even provisioned.
 
+   **Per ARM CLASS, not just per phase.** When a phase's driver spans
+   MULTIPLE ARM CLASSES (distinct source-context classes / recipe
+   branches — e.g. persona-context vs bare-context arms), the tiny
+   smoke covers AT LEAST ONE cell of EACH arm class, not one arm
+   overall: per-arm seams (source-context construction, negative-panel
+   assembly, `ModelOrganism` wiring) are invisible to a single-arm
+   smoke however tiny-real its seams (#1090 fu5: a formatting-arm-only
+   smoke passed; all 3 bare-context arms then died on the #527/#538
+   panel-disjointness assert after a full 4×A100 GCE cycle). This is a
+   coverage-BREADTH duty on whichever smoke FORM runs — under a
+   unified smoke-IS-sweep architecture, run the one-cell smoke once
+   per arm class; under the GPU-bound-phase carve-out below, the
+   CPU-runnable portion covers each arm class. Record the coverage on
+   one line inside each phase's `### <phase-name>` sub-section —
+   `arm classes covered: <list>` (write `single arm class` when the
+   driver has one, so a MISSING line reads as a forgotten duty, never
+   as "single-arm by design"). Recipe: `.claude/rules/gotchas.md` "A
+   single-arm smoke is blind to per-arm seams". The Step 6d.0-bis gate
+   reads "once at tiny N" as once PER ARM CLASS and stays the
+   downstream backstop (phase-keyed mechanics unchanged) — this
+   checklist item is the implementer-side prevention.
+
    **GPU-bound-phase carve-out.** When a phase requires multi-GPU or
    GPU-mandatory runtime (`accelerate launch` + ZeRO-3, vLLM batched
    eval, ≥7B HF model load in bf16, TP=8 inference) and the local VM

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -9099,11 +9099,11 @@ AGENT_SPEC_SIZE_GRANDFATHER: dict[str, int] = {
     # post-#1254 (Step 3.9 copy-list bullet + inlined-rubric slot),
     # 51,600 — measured 50,642 B post-#948, 47,930 B post-#881)
     "codex-code-reviewer.md": 56_800,
-    # measured 67,472 B post-#1363 (MALLOC_ARENA_MAX=2 in the VM-launch cap
-    # prefix + the #1315 arena parenthetical — plan-mandated growth; cap =
-    # measured + <=~1 KB. Prior: 67,400 — measured 66,574 B post-#1349,
-    # 66,300 — measured 65,548 B post-#1311)
-    "experiment-implementer.md": 67_900,
+    # measured 68,888 B post-#1384 (per-arm-class smoke-coverage clause in
+    # checklist item 3 — plan-mandated growth; cap = measured + <=~1 KB.
+    # Prior: 67,900 — measured 67,472 B post-#1363, 67,400 — measured
+    # 66,574 B post-#1349, 66,300 — measured 65,548 B post-#1311)
+    "experiment-implementer.md": 69_800,
     # measured 65,540 B post-#1081 r2 (D3 crash-fix-relaunch addendum:
     # disposition-conditional resume-glob confirm — plan-mandated growth;
     # cap = measured + <=~1 KB. Prior: 65,500 — measured 62,672 B)


### PR DESCRIPTION
Closes task #1384 (workflow-fix, kind: infra).

## Summary
- Adds the per-arm-class smoke-coverage paragraph to `.claude/agents/experiment-implementer.md` checklist item 3 (§ "End-to-end smoke run PER PHASE"): a driver spanning multiple ARM CLASSES smokes ≥1 cell of EACH class, recorded via an unconditional `arm classes covered:` line per phase sub-section (#1090 fu5 incident; third surface after #1340's gotchas.md:251 + SKILL.md Step 6d.0-bis).
- Companion (plan-mandated): `AGENT_SPEC_SIZE_GRANDFATHER["experiment-implementer.md"]` 67_900 → 69_800 (measured 68,888 B post-edit; 912 B headroom, ≤ ratchet budget 70_200).

## Test plan
- [x] Step 9c gate: 3793 passed; 5 failures stripped as pre-existing-on-main (compare exit 0, new=[])
- [x] workflow_lint --check-asks PASS; no-flags failure set byte-identical pre/post; ruff clean
- [x] Region-scoped vocabulary check clean (8/8 tokens); item boundaries 18/18

🤖 Generated with [Claude Code](https://claude.com/claude-code)