### PR TITLE
workflow-fix #1381: verify_plan c37 — flag false no-flags bundling claims

### DIFF
--- a/.claude/skills/adversarial-planner/SKILL.md
+++ b/.claude/skills/adversarial-planner/SKILL.md
@@ -296,7 +296,12 @@ Run the structural verifier against the plan version just persisted:
   `N/A — no numeric containment claims` (check 36 — the matched
   inside/within-range text quotes an incident or a sibling's numbers, or is not
   a claim about this plan's own committed values; a plan with a genuinely false
-  claim instead fixes the arithmetic or rewrites the prose).
+  claim instead fixes the arithmetic or rewrites the prose), and
+  `N/A — no no-flags bundling claim` (check 37 — the `--check-*` + no-flags
+  vocabulary is incidental, not this plan's own claim that a flag is bundled
+  into workflow_lint.py's no-flags default run; a plan whose bundling claim is
+  genuinely false instead corrects it, naming the explicit invocation that
+  runs the flag).
 - **FAIL → bounce to the planner** with the failed-check details (a mechanical-fix
   revision: re-spawn the planner with the FAIL list + the plan path; it patches the
   missing block and the orchestrator persists v{K+1} via `task.py new-plan-version`).

--- a/scripts/verify_plan.py
+++ b/scripts/verify_plan.py
@@ -7,11 +7,13 @@ Phase 1.5.0 BEFORE the fact-checker + critic ensemble spawn. The plan-side
 sibling of ``scripts/verify_task_body.py`` (clean-result bodies): pure
 regex / string presence checks, NO LLM calls, no network, no side effects
 (the orchestrator running the adversarial-planner skill posts the
-``epm:plan-verify`` marker — never this script). One disclosed read-only
-exception: check 34, when its trigger fires, ``stat()``s the live sizes of
+``epm:plan-verify`` marker — never this script). Two disclosed read-only
+exceptions: check 34, when its trigger fires, ``stat()``s the live sizes of
 the ratcheted workflow files the plan names and lazily imports
 ``scripts/workflow_lint.py`` for their size-cap constants — read-only, no
-writes, still no network.
+writes, still no network; and check 37, when its trigger fires, reads
+``scripts/workflow_lint.py`` SOURCE TEXT to derive main()'s no-flags
+dispatch set — read-only, no import, no network.
 
 Check catalog (id — classification — kind scope)
 ------------------------------------------------
@@ -84,12 +86,13 @@ Check catalog (id — classification — kind scope)
       verified at pin                                     analysis
   c36 numeric containment       WARN-only, conditional    experiment +
       claims                                              analysis
+  c37 no-flags bundling claim   WARN-only, conditional    infra + batch only
 
 Kind-exempt checks render as [SKIP] (first-class status, distinguishable
 from genuine passes — the calibration report needs n_skip separate from
 n_pass). Conditional checks (4, 6, 7, 10, 11, 12, 13, 14, 15, 16, 17, 18,
-19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36)
-also SKIP when their content trigger does not fire.
+19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+37) also SKIP when their content trigger does not fire.
 Check 23 runs OUTSIDE ``verify_plan_text()`` — it needs task context
 (``body.md`` + ``events.jsonl``), so ``main()`` appends it in ``--issue``
 mode only and renders it SKIP in ``--plan-file`` mode; its WARN is the one
@@ -138,6 +141,7 @@ labeled-line forms):
   - ``N/A — no verbatim ratcheted-file insertion`` (check 34)
   - ``N/A — no revision-pinned reuse`` (check 35)
   - ``N/A — no numeric containment claims`` (check 36)
+  - ``N/A — no no-flags bundling claim`` (check 37)
 
 WARN semantics: a WARN never blocks exit (exit 0). The Phase 1.5.0 wiring
 carries WARN lines verbatim into the fact-checker + critic briefs — that
@@ -5951,6 +5955,184 @@ def check_numeric_containment(plan: str, kind: str) -> CheckResult:
     return _warn(cid, name, _c36_offender_detail(offenders))
 
 
+# ─── Check 37 — no-flags bundling claim vs workflow_lint dispatch ──────────
+
+# Trigger: a NON-fenced line carrying a `--check-<flag>` token together with
+# a CLAIM-VERB-ANCHORED no-flags bundling assertion and no negation/scoping
+# token (same-line radius — the c16 re-generat precedent: window scans sweep
+# discussion noise, and set membership already exonerates true claims
+# wherever they sit). The verb anchor is load-bearing (2026-07-16
+# calibration): bare `--check-*` + no-flags co-occurrence swept in the
+# two-command acceptance idiom ("run `--check-asks` AND the no-flags
+# default run") at 293 WARNs over 838 corpus plan versions; requiring a
+# bundling verb linking the flag list to the no-flags run drops that whole
+# class while keeping the #1322-v1 "included in the no-flags default run"
+# shape and the endemic corpus false claim "no-flags run bundles/includes
+# `--check-asks`" (corrected #1007 v1→v2).
+_C37_LINT_PATH = Path(__file__).resolve().parent / "workflow_lint.py"  # tests monkeypatch
+# Keep `args.check_X or no_flags` as workflow_lint main()'s dispatch shape —
+# c37 parses exactly this form. A dispatch-shape refactor drops the derived
+# set below _C37_MIN_PLAUSIBLE (loud SKIP here) and
+# test_c37_live_derivation_pins fails the suite, forcing a deliberate
+# re-derivation rather than a silent all-PASS.
+_C37_DISPATCH_RE = re.compile(r"args\.check_(\w+)\s+or\s+no_flags")
+_C37_MIN_PLAUSIBLE = 10  # 47 dispatch lines measured 2026-07-16; fewer ⇒ parse broken
+
+_C37_FLAG_RE = re.compile(r"--check-([a-z0-9][a-z0-9-]*)")
+# Claim anchors, both word orders. Forward: verb … no-flags ("bundled into
+# the no-flags default run", "included in the no-flags default run" — the
+# #1322 v1 shape). Inverse: no-flags … verb ("no-flags default run, which
+# bundles/includes/covers `--check-asks`"; `incl\w*` admits the corpus
+# "incl." abbreviation). Gaps exclude '.' '|' and newline (sentence stop /
+# table cell) but deliberately ADMIT ';' and '—' (the corpus false claim
+# "no-flags default run; all bundled checks must pass (incl. `--check-asks`"
+# crosses a ';'). "runs?" is deliberately NOT a verb anchor: "run" is the
+# NOUN in "no-flags default run" and anchors nearly every incidental line.
+# `bundl` is restricted to the VERB forms (bundles/bundled/bundling): the
+# bare NOUN "bundle" anchors the incidental two-command idiom "(no-flags
+# bundle) + `--check-asks` + `--check-references` green" (2026-07-16 corpus).
+_C37_CLAIM_FWD_RE = re.compile(
+    r"(?i)\b(?:includ\w*|incl\.?|bundl(?:es|ed|ing)|part of|folde?d? into)[^.|\n]{0,40}no[- ]flags"
+)
+_C37_CLAIM_INV_RE = re.compile(
+    r"(?i)no[- ]flags[^.|\n]{0,60}\b(?:includ\w*|incl\.?|bundl(?:es|ed|ing)|covers?|carri\w*)"
+)
+# Destination-skip: a flag token directly preceded by "into" is the BUNDLE
+# DESTINATION, not the claim subject — "`--check-script-refs` (also bundled
+# into `--check-references` and the no-flags default run)" claims
+# script-refs ∈ {references bundle, no-flags run}; it asserts nothing about
+# references' own no-flags membership (the reference-check-extension family:
+# #714/#753/#739/#802/#1190 all quote this workflow_lint docstring idiom).
+_C37_DEST_RE = re.compile(r"(?i)\binto\s*[`'\"]?$")
+_C37_NEG_RE = re.compile(
+    r"(?i)\bnot\b|\bnever\b|\bno longer\b|\babsent\b|\bexcluded?\b|\boutside\b"
+    r"|\bseparate(?:ly)?\b|\bonly\s+(?:in|under|when|via|on)\b|\bruns only\b"
+)
+
+
+def _c37_lint_source() -> str | None:
+    """``scripts/workflow_lint.py`` source text (same-dir resolution —
+    worktree-correct), or ``None`` when absent (``--plan-file`` off-repo).
+    Read-only, NO import: source-regex derivation skips the 540 KB /
+    ~345 ms module import c34 pays (and main()'s dispatch is procedural —
+    there is no module-level constant to import)."""
+    if not _C37_LINT_PATH.is_file():
+        return None
+    return _C37_LINT_PATH.read_text()
+
+
+def _c37_noflags_dests(src: str) -> frozenset[str] | None:
+    """argparse dests dispatched on workflow_lint.py's no-flags default run,
+    derived from ``src``. ``None`` => underivable: fewer than
+    ``_C37_MIN_PLAUSIBLE`` matches (main()'s dispatch shape changed; the
+    live-tree pin test fails the suite in that world — never a spray of
+    WARNs on a broken parse). The `no_flags = not (...)` definition block
+    alternates `or args.check_*`, never `or no_flags`, so it cannot match;
+    the parenthesized `(args.check_X or no_flags) and not
+    args.check_references` forms DO match (correctly — they are in the
+    no-flags set, since no_flags=True implies check_references=False)."""
+    dests = frozenset(_C37_DISPATCH_RE.findall(src))
+    return dests if len(dests) >= _C37_MIN_PLAUSIBLE else None
+
+
+def check_noflags_bundling_claim(plan: str, kind: str) -> CheckResult:
+    """WARN-only, conditional, ``kind: infra|batch``: a plan line asserting
+    a ``--check-<flag>`` is bundled into workflow_lint.py's no-flags default
+    run must name a flag actually dispatched there (an `args.check_<dest> or
+    no_flags` line in main()) — #1322 v1 shipped an acceptance criterion
+    claiming the pre-commit-only ``--check-references`` runs on the bare
+    invocation, so its gate could never fire as written. Trigger:
+    ``--check-<flag>`` + a claim-verb-anchored no-flags assertion on one
+    non-fenced line with no negation/scoping token; falsity = derived-set
+    non-membership, restricted to flags that EXIST in the workflow_lint
+    source (a flag with no ``--check-<flag>`` occurrence there is a
+    PROPOSED new check — "add ``--check-newthing`` to the no-flags default
+    run" is forward-looking and unfalsifiable at plan time, never an
+    offender). NEVER FAILs (the c15/c34 doctrine: trigger and derivation
+    are text heuristics). Deliberately OUT of scope (v1, disclosed): the
+    CONVERSE claim class (asserting a flag is NOT in the set when it IS —
+    the negation guard drops every negated line unadjudicated), and the
+    vocabulary-side false-negative class (a bundling claim phrased without
+    a literal "no-flags"/"no flags" token, e.g. "the bare/default
+    workflow_lint run"). Calibration (2026-07-16, 838 corpus plan versions
+    carrying ``--check-``, forced kind=infra): 174 WARN / 115 PASS /
+    549 SKIP; the 20 NEWEST infra|batch plans (the forward-looking
+    operative set) are 0 WARN; #1322 v1 WARNs while its corrected v2
+    SKIPs (positive/negative control pair, likewise #802 v1→v2). The
+    verb anchor, the into-destination skip, and the existence gate are
+    each grounded on a named corpus false-positive class (see the
+    trigger-constant comments above); the residual WARN mass is dominated
+    by the endemic genuinely-false "no-flags run bundles/includes
+    ``--check-asks``" claim (corrected #1007 v1→v2 — a true positive),
+    with ~5% incidental false WARNs on historical long mixed-clause
+    lines, acceptable at WARN-only granularity."""
+    cid, name = (
+        "c37_noflags_bundling_claim",
+        "no-flags bundling claim matches workflow_lint dispatch",
+    )
+    if kind not in ("infra", "batch"):
+        return _skip(
+            cid,
+            name,
+            "kind-exempt: --check-* bundling claims are an infra|batch (workflow-fix) shape",
+        )
+    lines = plan.splitlines()
+    mask = _fence_mask(lines)
+    hits: list[tuple[str, str]] = []
+    for line, fenced in zip(lines, mask, strict=True):
+        if fenced:
+            continue
+        if not (_C37_CLAIM_FWD_RE.search(line) or _C37_CLAIM_INV_RE.search(line)):
+            continue
+        if _C37_NEG_RE.search(line):
+            continue
+        for m in _C37_FLAG_RE.finditer(line):
+            if _C37_DEST_RE.search(line[max(0, m.start() - 12) : m.start()]):
+                continue  # "bundled into `--check-X`": X is the destination, not the subject
+            hits.append((m.group(1), line))
+    if not hits:
+        return _skip(cid, name, "no --check-* no-flags bundling claim on a non-fenced line")
+    if _standalone_na_declared(plan, r"no no[- ]flags bundling claim"):
+        return _pass(cid, name, "explicit N/A declared (incidental --check/no-flags vocabulary)")
+    src = _c37_lint_source()
+    dests = None if src is None else _c37_noflags_dests(src)
+    if dests is None:
+        return _skip(
+            cid,
+            name,
+            "no-flags dispatch set underivable — scripts/workflow_lint.py absent (--plan-file "
+            "off-repo) or _C37_DISPATCH_RE matched below the plausibility floor "
+            f"({_C37_MIN_PLAUSIBLE}); membership cannot be adjudicated",
+        )
+    offenders = [
+        (flag, line)
+        for flag, line in hits
+        # Existence gate: a flag absent from the lint source outright is a
+        # PROPOSED new check (forward-looking claim) — skip, never an offender.
+        if f"--check-{flag}" in src and flag.replace("-", "_") not in dests
+    ]
+    if not offenders:
+        return _pass(
+            cid,
+            name,
+            f"{len(hits)} no-flags bundling claim(s) — every named flag is in the live "
+            "dispatch set (or is a proposed new check, not yet in the lint source)",
+        )
+    flag, line = offenders[0]
+    more = f" (+{len(offenders) - 1} more)" if len(offenders) > 1 else ""
+    return _warn(
+        cid,
+        name,
+        f"`--check-{flag}` is NOT in workflow_lint.py main()'s no-flags dispatch set "
+        f"(no `args.check_{flag.replace('-', '_')} or no_flags` line) — the plan's bundling "
+        "claim is false; the flag runs only when passed explicitly (#1322 v1 shipped exactly "
+        f"this claim for a pre-commit-only flag). Offending line: {line.strip()[:100]!r}{more}. "
+        "Remedies: correct the claim (name the explicit invocation that runs the flag), or "
+        "declare `N/A — no no-flags bundling claim` on its own line, unwrapped "
+        "(no backticks/quotes)",
+    )
+
+
 # ─── Driver ────────────────────────────────────────────────────────────────
 
 CHECKS = [
@@ -5989,6 +6171,7 @@ CHECKS = [
     check_ratchet_headroom,
     check_pinned_revision_reuse,
     check_numeric_containment,
+    check_noflags_bundling_claim,
 ]
 
 

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -7,7 +7,10 @@ Behaviours:
 * ``--check-references`` (default in pre-commit): walk ``CLAUDE.md``,
   ``.claude/skills/issue/SKILL.md``, and ``.claude/skills/issue/markers.md``;
   every ``(see workflow.yaml § <key>)`` reference MUST resolve to a real
-  YAML key.
+  YAML key. NOT in the no-flags default run: a bare ``workflow_lint.py``
+  invocation does not run this check — it fires only when the flag is
+  passed explicitly (the pre-commit hook, /daily's reference gate, and
+  the /issue Step-10d parity legs pass it).
 * ``--emit-tables``: regenerate the auto-generated table blocks in
   ``markers.md`` and ``SKILL.md`` ("Active vs awaiting-user" table) inside
   the fenced ``<!-- workflow.yaml: AUTO-GENERATED -->`` … ``<!--

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -175,10 +175,11 @@ def test_good_plan_passes_all():
         "c34_ratchet_headroom": "SKIP",
         "c35_pinned_revision_reuse": "SKIP",
         "c36_numeric_containment": "SKIP",
+        "c37_noflags_bundling_claim": "SKIP",
     }
     actual = {cid: r.status for cid, r in by_id.items()}
     assert actual == expected
-    assert len(results) == 36
+    assert len(results) == 37
 
 
 # ─── Check 0 — plan-nonstub ────────────────────────────────────────────────
@@ -5834,12 +5835,12 @@ def test_cli_json_schema_and_exit_zero_on_pass(tmp_path):
     assert payload["issue"] is None
     assert payload["kind"] == "experiment"
     assert payload["n_fail"] == 0
-    assert payload["n_skip"] == 29
+    assert payload["n_skip"] == 30
     assert {"id", "name", "status", "detail"} <= set(payload["checks"][0])
     statuses = {c["status"] for c in payload["checks"]}
     assert statuses <= {"PASS", "WARN", "FAIL", "SKIP"}
-    assert len(payload["checks"]) == 37
-    assert len({c["id"] for c in payload["checks"]}) == 37
+    assert len(payload["checks"]) == 38
+    assert len({c["id"] for c in payload["checks"]}) == 38
     # c23 has no task context in --plan-file mode: rendered SKIP (companion
     # assert for test_cli_issue_mode_appends_goal_currency).
     c23 = next(c for c in payload["checks"] if c["id"] == "c23_goal_currency")
@@ -7274,6 +7275,180 @@ def test_c36_label_digit_not_a_candidate():
 
 def test_c36_true_word_count_claim_passes():
     assert _status(_c36_plan(C36_1353_LINE), "c36_numeric_containment") == "PASS"
+
+
+# ─── Check 37 — no-flags bundling claim vs workflow_lint dispatch ──────────
+
+# The #1322 v1 incident shape (verbatim clause structure): an acceptance
+# criterion asserting the pre-commit-only reference check rides the bare run.
+C37_FALSE_CLAIM = (
+    "2. `uv run python scripts/workflow_lint.py` (no-flags default run) passes — this "
+    "includes `--check-references` (which walks CLAUDE.md; both new cross-refs must resolve)."
+)
+C37_TRUE_CLAIM = (
+    "1. `uv run python scripts/workflow_lint.py` (no-flags default run, which bundles "
+    "`--check-lessons-index`) passes."
+)
+
+
+def _c37_plan(*extra: str) -> str:
+    return GOOD_PLAN + "\n" + "\n\n".join(extra) + ("\n" if extra else "")
+
+
+def test_c37_kind_experiment_skips():
+    r_by = _run(_c37_plan(C37_FALSE_CLAIM), kind="experiment")[1]["c37_noflags_bundling_claim"]
+    assert r_by.status == "SKIP"
+    assert "kind-exempt" in r_by.detail
+
+
+def test_c37_false_claim_warns():
+    _, by_id = _run(_c37_plan(C37_FALSE_CLAIM), kind="infra")
+    r = by_id["c37_noflags_bundling_claim"]
+    assert r.status == "WARN"
+    assert "`--check-references`" in r.detail
+    assert "args.check_references" in r.detail
+
+
+def test_c37_true_claim_passes():
+    # `--check-lessons-index` IS dispatched on the no-flags run
+    # (workflow_lint.py `args.check_lessons_index or no_flags`).
+    assert _status(_c37_plan(C37_TRUE_CLAIM), "c37_noflags_bundling_claim", kind="infra") == "PASS"
+
+
+def test_c37_negated_line_does_not_trigger():
+    # The corrected #1322 v2 / workflow_lint-docstring phrasing: the claim
+    # anchor is present ("bundled into the no-flags") but the negation guard
+    # drops the line — asserted-negative mentions are never adjudicated.
+    plan = _c37_plan(
+        "`--check-references` is NOT bundled into the no-flags default run — pass it explicitly."
+    )
+    assert _status(plan, "c37_noflags_bundling_claim", kind="infra") == "SKIP"
+
+
+def test_c37_space_spelling_no_flags_warns():
+    # The "no flags" (space) vocabulary form survives the verb-anchored
+    # narrowing — pinned per the critic-round ask.
+    plan = _c37_plan("Run `workflow_lint.py` (no flags — bundles `--check-references`) as a gate.")
+    assert _status(plan, "c37_noflags_bundling_claim", kind="infra") == "WARN"
+
+
+def test_c37_two_command_idiom_does_not_trigger():
+    # Calibration FP class 1 (155+ corpus instances pre-narrowing): two
+    # separate invocations listed on one line make no bundling claim.
+    plan = _c37_plan(
+        "- `uv run python scripts/workflow_lint.py --check-asks` and the no-flags "
+        "default `uv run python scripts/workflow_lint.py` both exit 0."
+    )
+    assert _status(plan, "c37_noflags_bundling_claim", kind="infra") == "SKIP"
+
+
+def test_c37_into_destination_flag_not_flagged():
+    # Calibration FP class 2 (the reference-check-extension family,
+    # #714/#753/#739/#802/#1190): "bundled into `--check-references` and the
+    # no-flags default run" claims the SUBJECT flag's membership, not the
+    # destination bundle's — the subject (in-set) PASSes, the destination is
+    # never adjudicated.
+    plan = _c37_plan(
+        "New check `--check-lessons-index` (also bundled into `--check-references` "
+        "and the no-flags default run) walks the rules index."
+    )
+    assert _status(plan, "c37_noflags_bundling_claim", kind="infra") == "PASS"
+
+
+def test_c37_proposed_new_flag_passes():
+    # Calibration FP class 3 (forward-looking extension plans): a flag with
+    # no occurrence in the workflow_lint source is a PROPOSED new check —
+    # unfalsifiable at plan time, never an offender.
+    plan = _c37_plan(
+        "Add `--check-notyetbuilt`, bundled into the no-flags default run, to workflow_lint."
+    )
+    assert _status(plan, "c37_noflags_bundling_claim", kind="infra") == "PASS"
+
+
+def test_c37_fenced_claim_does_not_trigger():
+    plan = GOOD_PLAN + "\n```\n" + C37_FALSE_CLAIM + "\n```\n"
+    assert _status(plan, "c37_noflags_bundling_claim", kind="infra") == "SKIP"
+
+
+def test_c37_no_vocab_skips():
+    assert _status(GOOD_PLAN, "c37_noflags_bundling_claim", kind="infra") == "SKIP"
+
+
+def test_c37_na_escape_passes():
+    plan = _c37_plan(C37_FALSE_CLAIM, "N/A — no no-flags bundling claim")
+    _, by_id = _run(plan, kind="infra")
+    r = by_id["c37_noflags_bundling_claim"]
+    assert r.status == "PASS"
+    assert "declared" in r.detail
+
+
+def test_c37_quoted_na_phrase_does_not_escape():
+    # Anti-paste convention (#810/#1238 lineage, the c36 precedent): the
+    # phrase quoted mid-sentence / backtick-wrapped does not count.
+    plan = _c37_plan(
+        C37_FALSE_CLAIM,
+        "The bounce brief quotes `N/A — no no-flags bundling claim` as the check-37 escape.",
+    )
+    assert _status(plan, "c37_noflags_bundling_claim", kind="infra") == "WARN"
+
+
+def test_c37_pasted_warn_detail_does_not_retrigger_or_satisfy():
+    # The WARN detail leads with the negated truth (NOT) so a verbatim paste
+    # can neither re-trigger (negation guard) nor self-satisfy (the escape
+    # phrase in the detail is backtick-wrapped).
+    _, by_id = _run(_c37_plan(C37_FALSE_CLAIM), kind="infra")
+    detail = by_id["c37_noflags_bundling_claim"].detail
+    clean_plus_detail = _c37_plan(detail)
+    assert _status(clean_plus_detail, "c37_noflags_bundling_claim", kind="infra") == "SKIP"
+    offending_plus_detail = _c37_plan(C37_FALSE_CLAIM, detail)
+    assert _status(offending_plus_detail, "c37_noflags_bundling_claim", kind="infra") == "WARN"
+
+
+def test_c37_live_derivation_pins():
+    # Live-tree pin: the source-regex derivation stays plausible and keeps
+    # the ground-truth memberships. A workflow_lint main() dispatch-shape
+    # refactor fails HERE (forcing a deliberate _C37_DISPATCH_RE update)
+    # while the check itself only SKIPs.
+    src = verify_plan._c37_lint_source()
+    assert src is not None
+    dests = verify_plan._c37_noflags_dests(src)
+    assert dests is not None and len(dests) >= 40, dests
+    assert "references" not in dests  # the founding #1322 ground truth
+    assert "lessons_index" in dests
+    # The parenthesized `(args.check_X or no_flags) and not
+    # args.check_references` dispatch form parses too:
+    assert "marker_registry" in dests
+
+
+def test_c37_underivable_source_skips(tmp_path, monkeypatch):
+    # A stub lint file with zero dispatch lines → below the plausibility
+    # floor → loud SKIP, never a spray of WARNs (c34's missing-file pattern).
+    stub = tmp_path / "workflow_lint.py"
+    stub.write_text("def main():\n    pass\n")
+    monkeypatch.setattr(verify_plan, "_C37_LINT_PATH", stub)
+    _, by_id = _run(_c37_plan(C37_FALSE_CLAIM), kind="infra")
+    r = by_id["c37_noflags_bundling_claim"]
+    assert r.status == "SKIP"
+    assert "underivable" in r.detail
+
+
+def test_c37_missing_lint_file_skips(tmp_path, monkeypatch):
+    # --plan-file mode off-repo: workflow_lint.py absent → SKIP, no crash.
+    monkeypatch.setattr(verify_plan, "_C37_LINT_PATH", tmp_path / "workflow_lint.py")
+    _, by_id = _run(_c37_plan(C37_FALSE_CLAIM), kind="infra")
+    assert by_id["c37_noflags_bundling_claim"].status == "SKIP"
+
+
+def test_c37_phrase_listed_in_skillmd():
+    # Durability pin (the c34 test shape): the canonical escape phrase is
+    # registered backtick-wrapped in the adversarial-planner SKILL.md escape
+    # block; the generative sync test separately propagates the docstring
+    # registration.
+    text = (REPO_ROOT / ".claude" / "skills" / "adversarial-planner" / "SKILL.md").read_text()
+    anchor = text.index("Canonical N/A escape phrases")
+    block = text[anchor : text.index("bounce to the planner", anchor)]
+    assert "`N/A — no no-flags bundling claim`" in block
+    assert "check 37" in block
 
 
 def test_canonical_json_parse_snippet_pinned():

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -7325,6 +7325,14 @@ def test_c37_negated_line_does_not_trigger():
     assert _status(plan, "c37_noflags_bundling_claim", kind="infra") == "SKIP"
 
 
+def test_c37_included_in_forward_form_warns():
+    # The #1322 v1 emitter phrasing verbatim ("included in the no-flags
+    # default run") — the FORWARD verb…no-flags word order must survive any
+    # future trigger narrowing (critic-round pin).
+    plan = _c37_plan("`--check-references` is included in the no-flags default run.")
+    assert _status(plan, "c37_noflags_bundling_claim", kind="infra") == "WARN"
+
+
 def test_c37_space_spelling_no_flags_warns():
     # The "no flags" (space) vocabulary form survives the verb-anchored
     # narrowing — pinned per the critic-round ask.


### PR DESCRIPTION
Closes task #1381.

- New verify_plan.py check c37 `check_noflags_bundling_claim` (WARN-only, infra|batch): flags plan text claiming a `--check-*` flag is in workflow_lint.py main()'s no-flags default run when it is absent from the source-derived dispatch set (47 dests, plausibility floor 10, SKIP-on-underivable, N/A escape).
- workflow_lint.py docstring: `--check-references` bullet now states it is NOT in the no-flags default run.
- Escape phrase registered in the adversarial-planner SKILL.md canonical block (#1264 sync test).
- 18 new `test_c37_*` tests; gate: 3811 passed, 0 new failures vs the known-red main baseline.

Founding incident: #1322 plan v1's false bundling claim about `--check-references` (v1 WARNs, corrected v2 SKIPs — verified live).