### PR TITLE
issue-1388: waive 3 hub-verify lint offenders (locally retry-wrapped list_repo_tree calls)

### DIFF
--- a/scripts/issue1073_greedy_cloud_distribution.py
+++ b/scripts/issue1073_greedy_cloud_distribution.py
@@ -99,6 +99,7 @@ def stage_store(max_workers: int = 6) -> None:
     want: list[str] = []
     entries = I._retry(
         lambda: list(
+            # HUB_VERIFY_RETRY_EXEMPT: wrapped in issue1073_common._retry (bounded, re-raises)
             api.list_repo_tree(
                 DATA_REPO,
                 path_in_repo=f"{HF_PREFIX}/v_store",

--- a/scripts/issue1092_inline_operator_stage.py
+++ b/scripts/issue1092_inline_operator_stage.py
@@ -89,6 +89,7 @@ def main() -> None:
     for cell in CELLS:
         tree = _retry(
             lambda cell=cell: list(
+                # HUB_VERIFY_RETRY_EXEMPT: wrapped in local _retry (6 tries, capped backoff)
                 list_repo_tree(
                     REPO,
                     repo_type="dataset",

--- a/scripts/issue1345_framing_dashboard.py
+++ b/scripts/issue1345_framing_dashboard.py
@@ -138,6 +138,7 @@ def resolve_story_files(revision: str) -> list[str]:
     api = HfApi()
     for attempt in range(4):
         try:
+            # HUB_VERIFY_RETRY_EXEMPT: inline 4-attempt retry loop + documented filename fallback
             tree = api.list_repo_tree(
                 HF_DATA_REPO,
                 path_in_repo=STORY_PREFIX,


### PR DESCRIPTION
Closes task #1388. Comment-only: 3 HUB_VERIFY_RETRY_EXEMPT waiver lines silencing the check_hub_verify_retry offenders that fail tests/test_workflow_lint.py on pristine main fleet-wide. Plan: tasks/completed/1388/plans/plan.md. Code-review PASS; Step 9c test-verdict PASS (no new failures vs baseline ledger).