### PR TITLE
task #1391: watcher dead-owner fast path — orphan-sweep re-drive without a registration file

### DIFF
--- a/.claude/rules/background-automation.md
+++ b/.claude/rules/background-automation.md
@@ -394,6 +394,26 @@ so any future stale-instance poster identifies itself on its first marker.
 Pinned by `tests/test_autonomous_session_watch.py::test_orphan_act_guard_*`
 + `test_stalled_fence_spawn_guard_*`.
 
+**Orphan-sweep dead-owner fast path (#1391; lineage #1090-fu5).** The orphan
+sweep's 90-min staleness floor exists because "no live registered session"
+cannot distinguish a dead driver from a live-but-unregistered one (the
+routine follow-up-round state). When the sweep has POSITIVE proof the task's
+last recorded owner session is dead — the #720 `last-mapped-terminal-<sid>`
+breadcrumb binds a sid to the issue, that sid was observed live on an
+earlier tick (state-carried in `orphan-<N>.json` as `owner_sid`, surviving
+the breadcrumb GC) or its breadcrumb still exists this tick, and it is now
+absent from a successfully-fetched daemon live set — plus a recent driver
+witness (a follow-up-round-only marker kind or a `stage-dispatch`
+breadcrumb) and no live-owner veto (fresh worktree activity, a live daemon
+child with an `issue-<N>` worktree cwd, any breadcrumb owner still live),
+the effective floor fed to `decide_orphan` drops to
+`EPM_ORPHAN_DEAD_OWNER_STALENESS_MIN` (default 20 min, clamp >= 10 min, `0`
+disables) — the #1090-fu5 shape (session dies mid-follow-up-round with its
+registration already deleted) is auto-respawned in ~35-50 min instead of
+~105. Every uncertain input fails toward the 90-min slow path; the 2-miss
+debounce, daily cap, manual-only alert (#505), act-time guard (#1247), and
+all four exemption actions bind unchanged.
+
 **Infra-drain pass (execute the PM dispatch queue; task #633).** The PM
 session's standing infra auto-dispatch rule (`research-pm.md` § Standing
 rule, item 4b) adjudicates which `proposed` `kind: infra|batch` tasks are

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -128,7 +128,20 @@ adding a pass means adding a numbered item here AND bumping the digit:
    registration is MANUAL (user-driven — never auto-respawn, #505), degrade
    to a one-time loud alert marker. Daemon-gated like the respawn pass
    (liveness is unknowable during an outage; a mass respawn would duplicate
-   pods).
+   pods). **Dead-owner fast path (#1391):** an unregistered candidate with a
+   recent driver witness and POSITIVE proof its last recorded owner session
+   is dead (the #720 ``last-mapped-terminal-<sid>`` breadcrumb sid —
+   state-carried in ``orphan-<N>.json`` as ``owner_sid`` across ticks —
+   absent from a successfully-fetched live set) gets the SHORTER
+   ``EPM_ORPHAN_DEAD_OWNER_STALENESS_MIN`` floor (default 20 min; ``0``
+   disables) instead of the 90-min default; every uncertain signal fails
+   toward the slow path. The 2-consecutive-tick requirement rides on
+   :func:`decide_orphan`'s missed-reset-on-keep semantics — a refactor of
+   that reset must not silently remove the partial-``/list``-flap bound.
+   Fail-toward-slow eligibility-flap corner: a death BEFORE any
+   live-observation tick has breadcrumb-only eligibility on the
+   death-observing tick and the slow path thereafter (the GC unlinks the
+   breadcrumb; no ``owner_sid`` was ever state-carried).
 6. **Session-reconcile pass (sessions-vs-status; AUTO-STOP by default).**
    Mirror of the pod-safety auto-stop arm for Happy SESSIONS: a live
    session mapped to an issue (registry entry, or an ``issue-<N>``
@@ -11934,6 +11947,41 @@ def _orphan_max_respawns_per_day() -> int:
         return ORPHAN_MAX_RESPAWNS_PER_DAY_DEFAULT
 
 
+# #1391: dead-owner fast path — the SHORTER marker-staleness floor applied when
+# the task's last recorded owner session is PROVABLY dead (see
+# :func:`decide_dead_owner_fast_path` / :func:`_orphan_effective_staleness`).
+# 20 min: > the 16.2-min max healthy inter-marker gap measured in #1090's
+# unregistered fu5 window (05:33-06:27Z), >= the 15-min worktree-activity hold
+# window (WT_ACTIVITY_FRESH_S_DEFAULT), and 2x the 10-min tick cadence; with
+# the 2-miss threshold the effective silence-to-respawn is >= ~30 min.
+ORPHAN_DEAD_OWNER_STALENESS_S_DEFAULT = 20 * 60
+
+# Clamp floor for the env knob: below one 10-min tick + the 2-miss debounce a
+# floor cannot interact with the cadence meaningfully; an operator typo (e.g.
+# `2`) must not create a fire-on-first-gap configuration.
+ORPHAN_DEAD_OWNER_STALENESS_S_MIN = 10 * 60
+
+
+def _orphan_dead_owner_staleness_s() -> float | None:
+    """Dead-owner fast-path staleness floor in seconds (env
+    ``EPM_ORPHAN_DEAD_OWNER_STALENESS_MIN``, minutes; default
+    :data:`ORPHAN_DEAD_OWNER_STALENESS_S_DEFAULT`). ``0`` (or negative)
+    DISABLES the fast path (returns ``None`` — the kill switch); a MALFORMED
+    value falls back to the default (an accelerator typo must not disable
+    the fast path, matching :func:`_orphan_staleness_s`'s convention);
+    positive values clamp to >= :data:`ORPHAN_DEAD_OWNER_STALENESS_S_MIN`."""
+    raw = os.environ.get("EPM_ORPHAN_DEAD_OWNER_STALENESS_MIN")
+    if not raw:
+        return float(ORPHAN_DEAD_OWNER_STALENESS_S_DEFAULT)
+    try:
+        val = float(raw) * 60.0
+    except ValueError:
+        return float(ORPHAN_DEAD_OWNER_STALENESS_S_DEFAULT)
+    if val <= 0:
+        return None
+    return max(val, float(ORPHAN_DEAD_OWNER_STALENESS_S_MIN))
+
+
 def decide_orphan(
     status: str | None,
     mapped_alive: bool,
@@ -11986,6 +12034,71 @@ def decide_orphan(
     return ("respawn", 0)
 
 
+def decide_dead_owner_fast_path(
+    *,
+    has_registration: bool,
+    breadcrumb_owner_sids: frozenset[str],
+    live_ids: frozenset[str],
+    recorded_owner_sid: str | None,
+    driver_witness_age_s: float | None,
+    witness_lookback_s: float,
+    wt_activity_fresh: bool,
+    live_cwd_owner: bool | None,
+    fast_floor_s: float | None,
+) -> tuple[bool, str]:
+    """#1391 dead-owner fast path: pure ``(eligible, reason)`` gate deciding
+    whether the orphan sweep may feed :func:`decide_orphan` the SHORT
+    staleness floor (:func:`_orphan_dead_owner_staleness_s`) instead of the
+    90-min default. :func:`decide_orphan` itself is unchanged — this only
+    modulates its ``staleness_s`` input.
+
+    Eligible iff ALL of: the fast path is enabled (``fast_floor_s`` not
+    ``None``); the task has NO registration (``rec is None`` strictly — a
+    registered-but-dead entry is the crash-recovery pass's territory, and
+    the #505 manual-only alert requires ``rec``, so that guard structurally
+    cannot co-occur with this path); a recent DRIVER witness exists within
+    ``witness_lookback_s`` (== the SLOW floor, so the fast path hands over
+    to the slow path exactly when the witness expires); no fresh worktree
+    activity (nobody mid-edit); the worktree-cwd probe POSITIVELY found no
+    live daemon child inside the issue worktree (``None`` == probe
+    unavailable -> ineligible); no breadcrumb-recorded ex-owner sid is
+    still live; and there is POSITIVE proof of owner death — a
+    state-carried ``recorded_owner_sid`` absent from the live set, or a
+    non-empty breadcrumb owner set fully absent from it.
+
+    EVERY uncertain input fails toward ``(False, <why>)`` — the slow path.
+    Pure + hermetic (#1247 seams): the caller gathers every signal."""
+    if fast_floor_s is None:
+        return (False, "disabled (EPM_ORPHAN_DEAD_OWNER_STALENESS_MIN=0)")
+    if has_registration:
+        return (False, "registration present")
+    if driver_witness_age_s is None:
+        return (False, "no driver witness on record")
+    if driver_witness_age_s >= witness_lookback_s:
+        return (False, "driver witness older than the lookback")
+    if wt_activity_fresh:
+        return (False, "fresh worktree activity")
+    if live_cwd_owner is None:
+        return (False, "worktree-cwd probe unavailable")
+    if live_cwd_owner:
+        return (False, "a live session's cwd is inside the issue worktree")
+    if breadcrumb_owner_sids & live_ids:
+        return (False, "a breadcrumb-recorded owner sid is still live")
+    if recorded_owner_sid is not None and recorded_owner_sid not in live_ids:
+        return (
+            True,
+            f"owner sid {recorded_owner_sid[:12]} (state-carried; observed live on a "
+            f"prior tick) absent from the live set",
+        )
+    if breadcrumb_owner_sids:
+        sids = ",".join(sorted(s[:12] for s in breadcrumb_owner_sids))
+        return (
+            True,
+            f"breadcrumb owner sid(s) {sids} (last-mapped-terminal) absent from the live set",
+        )
+    return (False, "no positive owner-death evidence")
+
+
 def _orphan_state_path(issue: int) -> Path:
     return AUTONOMOUS_REGISTRY_DIR / f"{ORPHAN_STATE_PREFIX}{issue}.json"
 
@@ -12012,6 +12125,8 @@ def _save_orphan_state(
     respawn_day: str,
     respawns_today: int,
     followups_child_alerted: bool = False,
+    owner_sid: str | None = None,
+    owner_last_live_ts: float | None = None,
     prev: dict | None = None,
 ) -> None:
     """Persist the per-issue orphan-sweep state atomically (temp + rename),
@@ -12021,12 +12136,23 @@ def _save_orphan_state(
     one-time "followups_running parent waiting on open child" suppression
     alert (see :func:`_followups_awaiting_child_reason`); ``first_seen``
     carries forward so the GC age backstop measures the original episode
-    start."""
+    start. ``owner_sid`` / ``owner_last_live_ts`` (#1391 dead-owner fast
+    path) record the breadcrumb-recorded owner sid last observed IN the
+    daemon live set; when NOT supplied they carry forward from ``prev`` (the
+    ``first_seen`` pattern) so existing call sites need no change and the
+    death proof survives the #720 breadcrumb GC. Pre-existing state files
+    without the fields load as ``None`` (type-guarded)."""
     AUTONOMOUS_REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
     dest = _orphan_state_path(issue)
     prev_first_seen = (prev or {}).get("first_seen")
     if not isinstance(prev_first_seen, int | float):
         prev_first_seen = time.time()
+    if owner_sid is None:
+        prev_sid = (prev or {}).get("owner_sid")
+        owner_sid = prev_sid if isinstance(prev_sid, str) and prev_sid else None
+    if owner_last_live_ts is None:
+        prev_live_ts = (prev or {}).get("owner_last_live_ts")
+        owner_last_live_ts = float(prev_live_ts) if isinstance(prev_live_ts, int | float) else None
     payload = {
         "missed": missed,
         "alerted": alerted,
@@ -12034,6 +12160,8 @@ def _save_orphan_state(
         "respawns_today": respawns_today,
         "followups_child_alerted": followups_child_alerted,
         "first_seen": prev_first_seen,
+        "owner_sid": owner_sid,
+        "owner_last_live_ts": owner_last_live_ts,
     }
     tmp = dest.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(payload, indent=2))
@@ -12177,6 +12305,82 @@ def _issue_registrations() -> dict[int, dict]:
     return out
 
 
+def _issue_breadcrumb_owner_sids(issue: int) -> set[str]:
+    """sids of ``last-mapped-terminal-<sid>.json`` breadcrumbs (#720) that
+    record THIS issue — the dead-owner fast path's owner-evidence source
+    (#1391). Reuses :func:`_last_mapped_terminal` for validation (garbled /
+    non-terminal / non-int-issue files never contribute); any read failure
+    yields the empty set (fail toward the slow path)."""
+    out: set[str] = set()
+    if not AUTONOMOUS_REGISTRY_DIR.is_dir():
+        return out
+    try:
+        paths = list(AUTONOMOUS_REGISTRY_DIR.glob(f"{LAST_MAPPED_TERMINAL_PREFIX}*.json"))
+    except OSError:
+        return out
+    for path in paths:
+        sid = path.name[len(LAST_MAPPED_TERMINAL_PREFIX) : -len(".json")]
+        if not sid:
+            continue
+        crumb = _last_mapped_terminal(sid)
+        if crumb is not None and crumb[1] == issue:
+            out.add(sid)
+    return out
+
+
+def _latest_driver_witness_age_s(events: list[dict], now: float) -> float | None:
+    """Age (s) of the newest DRIVER-attributable event (#1391): a kind in
+    :data:`_FOLLOWUP_ROUND_WITNESS_KINDS` (markers only an EXECUTING pipeline
+    round posts), or an ``epm:progress`` note beginning ``stage-dispatch ``
+    (the dispatch-breadcrumb contract; ANY stage counts — the manual 07:25Z
+    recovery breadcrumb in #1090 was a non-``followup-`` stage). The
+    watcher's own notes begin ``[autonomous_session_watch:`` and can never
+    match, and ``by=`` is deliberately NOT consulted — #1090's 06:12Z
+    breadcrumb carried ``by="unknown"``. ``None`` when absent (fail toward
+    the slow path)."""
+    best: float | None = None
+    for ev in events:
+        note = ev.get("note") or ""
+        is_witness = ev.get("kind") in _FOLLOWUP_ROUND_WITNESS_KINDS or (
+            ev.get("kind") == "epm:progress" and note.startswith("stage-dispatch ")
+        )
+        if not is_witness:
+            continue
+        ts = _parse_event_ts(ev.get("ts"))
+        if ts is not None and (best is None or ts > best):
+            best = ts
+    if best is None:
+        return None
+    return now - best
+
+
+def _any_live_child_in_issue_worktree(issue: int, live_pids: dict[str, int] | None) -> bool | None:
+    """True iff any live daemon child's ``/proc/<pid>/cwd`` resolves under
+    the issue's worktree (``issue-<N>`` or an ``issue-<N>-<suffix>``
+    follow-up worktree; :data:`_WORKTREE_ISSUE_RE`'s full digit-run capture
+    gives the component boundary — ``issue-109`` never matches
+    ``issue-1090``). ``None`` when ``live_pids`` is ``None`` (the ``/list``
+    pid probe failed — uncertain, the caller vetoes the fast path) or a
+    same-uid readlink fails for a LIVE pid (PermissionError etc. — also
+    uncertain). A VANISHED pid (``FileNotFoundError`` /
+    ``ProcessLookupError``) is skipped: dead != owner. Used ONLY as a VETO
+    (#1391): a cwd heuristic lying toward alive fails toward the slow path —
+    the safe direction — never as a liveness claim (the #518 lesson)."""
+    if live_pids is None:
+        return None
+    for pid in live_pids.values():
+        try:
+            cwd = os.readlink(f"/proc/{pid}/cwd")
+        except (FileNotFoundError, ProcessLookupError):
+            continue
+        except OSError:
+            return None
+        m = _WORKTREE_ISSUE_RE.search(cwd)
+        if m and int(m.group(1)) == issue:
+            return True
+    return False
+
+
 def _respawn_orphan(issue: int, cap_gpu_hours: float, dry_run: bool) -> str:
     """Spawn a fresh ``--auto`` session for an orphaned active task. Mirrors
     :func:`_respawn_stalled_session` but with an ``RESPAWNED-ORPHAN`` log
@@ -12227,6 +12431,7 @@ def orphan_sweep_pass(
     *,
     daemon_reachable: bool | None = None,
     live_ids: set[str] | None = None,
+    live_pids: dict[str, int] | None = None,
 ) -> None:
     """Registration-independent safety net: cross-check ACTIVE-status tasks
     against live REGISTERED sessions; recover (or loudly alert on) any active
@@ -12238,7 +12443,14 @@ def orphan_sweep_pass(
     freshness (a superseded driver generation kept #518's self-report fresh
     for 7.4h of real marker silence on 2026-06-10). Daemon-gated like the
     respawn pass: during an outage liveness is unknowable and a mass respawn
-    would duplicate pods."""
+    would duplicate pods.
+
+    ``live_pids`` (#1391): the daemon's ``{sid: wrapper pid}`` map for the
+    dead-owner fast path's worktree-cwd VETO probe — snapshotted once per
+    tick via :func:`_live_pids_by_sid_or_none` when not supplied by the
+    caller (main() reuses its stalled-pass snapshot). ``None`` from a failed
+    probe keeps the fast path ineligible (fail toward the 90-min slow
+    path); the cwd signal is only ever a veto, never a liveness claim."""
     now = now if now is not None else time.time()
     if daemon_reachable is None:
         daemon_reachable = _daemon_reachable()
@@ -12250,6 +12462,8 @@ def orphan_sweep_pass(
         return
     if live_ids is None:
         live_ids = _live_session_ids()
+    if live_pids is None:
+        live_pids = _live_pids_by_sid_or_none()
     active = _active_status_tasks()
     regs = _issue_registrations()
     staleness_s = _orphan_staleness_s()
@@ -12283,6 +12497,7 @@ def orphan_sweep_pass(
             max_per_day=max_per_day,
             day_key=day_key,
             pod_active_issues=pod_active_issues,
+            live_pids=live_pids,
         )
 
 
@@ -12659,6 +12874,65 @@ def _orphan_act_guard(
     return None
 
 
+def _orphan_effective_staleness(
+    issue: int,
+    *,
+    rec: dict | None,
+    events: list[dict],
+    live_ids: set[str],
+    live_pids: dict[str, int] | None,
+    state: dict,
+    now: float,
+    slow_s: float,
+) -> tuple[float, str | None, dict]:
+    """#1391: the per-task EFFECTIVE marker-staleness floor for
+    :func:`decide_orphan` — ``(staleness_s, fast_reason, owner_updates)``.
+
+    ``staleness_s`` is the FAST floor (:func:`_orphan_dead_owner_staleness_s`)
+    when :func:`decide_dead_owner_fast_path` finds positive proof the task's
+    last recorded owner session is dead, else ``slow_s`` unchanged (with
+    ``fast_reason=None`` — the byte-identical slow path). ``owner_updates``
+    is ``{}`` or ``{"owner_sid": sid, "owner_last_live_ts": now}`` whenever a
+    breadcrumb-recorded owner sid is observed IN the live set THIS tick (the
+    healthy #472/#1090 unregistered-round window) — the caller threads it
+    into the keep-branch :func:`_save_orphan_state` so the death proof
+    survives the #720 breadcrumb GC
+    (:func:`_gc_orphan_last_mapped_terminal` unlinks the file on the first
+    daemon tick after the sid leaves the live set; ``orphan_sweep_pass``
+    runs BEFORE ``idle_unmapped_pass`` in main(), so the death-observing
+    tick still sees the file either way).
+
+    Cheap short-circuits keep the per-tick cost flat: the worktree-activity
+    walk + ``/proc`` cwd probes run only when the fast path is enabled AND
+    owner evidence exists AND no recorded ex-owner is still live (the
+    common healthy-round case exits before any probe)."""
+    crumbs = _issue_breadcrumb_owner_sids(issue)
+    live_crumb_sids = sorted(crumbs & live_ids)
+    owner_updates: dict = (
+        {"owner_sid": live_crumb_sids[0], "owner_last_live_ts": now} if live_crumb_sids else {}
+    )
+    fast_floor = _orphan_dead_owner_staleness_s()
+    recorded = state.get("owner_sid")
+    if not (isinstance(recorded, str) and recorded):
+        recorded = None
+    if fast_floor is None or live_crumb_sids or (recorded is None and not crumbs):
+        return slow_s, None, owner_updates
+    eligible, reason = decide_dead_owner_fast_path(
+        has_registration=rec is not None,
+        breadcrumb_owner_sids=frozenset(crumbs),
+        live_ids=frozenset(live_ids),
+        recorded_owner_sid=recorded,
+        driver_witness_age_s=_latest_driver_witness_age_s(events, now),
+        witness_lookback_s=slow_s,
+        wt_activity_fresh=_worktree_recent_activity(issue, now, _wt_activity_fresh_s()),
+        live_cwd_owner=_any_live_child_in_issue_worktree(issue, live_pids),
+        fast_floor_s=fast_floor,
+    )
+    if eligible:
+        return fast_floor, reason, owner_updates
+    return slow_s, None, owner_updates
+
+
 def _process_orphan_task(
     issue: int,
     status: str,
@@ -12672,11 +12946,15 @@ def _process_orphan_task(
     max_per_day: int,
     day_key: str,
     pod_active_issues: set[int] | None = None,
+    live_pids: dict[str, int] | None = None,
 ) -> None:
     """Apply one active-status task's orphan decision (gather signals ->
     :func:`decide_orphan` -> act). ``rec`` is the task's registration record
     from :func:`_issue_registrations` (or ``None`` for the fully-unregistered
-    #472 class). Honours dry_run (logs but never mutates / spawns).
+    #472 class). ``live_pids`` is the daemon's ``{sid: wrapper pid}`` map for
+    the #1391 dead-owner fast path's cwd VETO probe (``None`` == probe
+    unavailable -> fast path ineligible). Honours dry_run (logs but never
+    mutates / spawns).
 
     #866/#903: a FRESH ``paused-takeover`` sentinel (a deliberate session
     takeover renamed the registration away) skips the issue ENTIRELY before
@@ -12705,6 +12983,9 @@ def _process_orphan_task(
     # exemption helper so we don't pay a second `task.py view` per tick.
     marker_age_s: float | None = None
     events: list[dict] = []
+    staleness_eff = staleness_s
+    fast_reason: str | None = None
+    owner_updates: dict = {}
     is_candidate = not mapped_alive and not (
         entry_age_s is not None and entry_age_s < ORPHAN_SPAWN_GRACE_S
     )
@@ -12721,6 +13002,21 @@ def _process_orphan_task(
         # sibling).
         latest = _latest_nonwatcher_event_ts(events)
         marker_age_s = (now - latest) if latest is not None else None
+        # #1391 dead-owner fast path: drop the staleness floor to
+        # EPM_ORPHAN_DEAD_OWNER_STALENESS_MIN (default 20 min) ONLY on
+        # positive proof the last recorded owner session is dead; every
+        # uncertain signal keeps the 90-min slow path (fast_reason=None,
+        # staleness_eff == staleness_s — byte-identical behavior).
+        staleness_eff, fast_reason, owner_updates = _orphan_effective_staleness(
+            issue,
+            rec=rec,
+            events=events,
+            live_ids=live_ids,
+            live_pids=live_pids,
+            state=state,
+            now=now,
+            slow_s=staleness_s,
+        )
 
     action, new_missed = decide_orphan(
         status,
@@ -12731,7 +13027,7 @@ def _process_orphan_task(
         missed,
         respawns_today=respawns_today,
         threshold=threshold,
-        staleness_s=staleness_s,
+        staleness_s=staleness_eff,
         max_respawns_per_day=max_per_day,
     )
     gap_str = f"{marker_age_s / 60:.1f}m" if marker_age_s is not None else "none"
@@ -12758,7 +13054,7 @@ def _process_orphan_task(
         f"manual_only={manual_only} marker_gap={gap_str} "
         f"missed={missed}->{new_missed} respawns_today={respawns_today}/{max_per_day} "
         f"alerted={alerted} followups_child_alerted={followups_child_alerted} "
-        f"action={action}"
+        f"action={action} fast_path={fast_reason or 'no'}"
     )
 
     if action == "clear":
@@ -12775,6 +13071,7 @@ def _process_orphan_task(
                 respawns_today=respawns_today,
                 followups_child_alerted=followups_child_alerted,
                 prev=state,
+                **owner_updates,
             )
         return
     # ── #1247 terminal-status act guard ─────────────────────────────────
@@ -12813,13 +13110,23 @@ def _process_orphan_task(
                 prev=state,
             )
             if attempted_ok:
+                # #1391: when the dead-owner fast path set the floor, the
+                # respawn marker names its evidence + the effective floor —
+                # BEFORE the _source_stamp() (which stays terminal, #1247).
+                fast_note = (
+                    f"dead-owner fast path: {fast_reason}; effective "
+                    f"staleness floor {staleness_eff / 60:.0f}m "
+                    f"(EPM_ORPHAN_DEAD_OWNER_STALENESS_MIN). "
+                    if fast_reason is not None
+                    else ""
+                )
                 _post_progress_marker(
                     issue,
                     f"{_ORPHAN_RESPAWN_NOTE_SENTINEL} active task "
                     f"(status={status}) had no live registered session and no "
                     f"real progress marker for {gap_str}; auto-respawned via "
                     f"spawn-issue --auto (attempt {respawns_today + 1}/{max_per_day} "
-                    f"today). {_source_stamp()}",
+                    f"today). {fast_note}{_source_stamp()}",
                     dry_run,
                     label="orphan-respawn",
                 )
@@ -20890,14 +21197,17 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 — flat --*-only 
     # pod-safety so the `_running_managed_issue_pods` call is fresh
     # (poll_pipeline-posted progress markers from any auto-stopped pod
     # won't accidentally bias the "has_pod" flag).
+    # #845 (e) + #1391: ONE {sid: wrapper pid} /list snapshot per tick,
+    # shared by the stalled pass's prompt-wedge transcript probe and the
+    # orphan sweep's dead-owner cwd-veto probe (one extra /list RPC, only
+    # on daemon-up ticks).
+    live_pids_by_sid = _live_pids_by_sid_or_none() if daemon_reachable else None
     stalled_session_pass(
         args.dry_run,
         args.threshold,
         daemon_reachable=daemon_reachable,
         live_ids=live_ids if daemon_reachable else None,
-        # #845 (e): the {sid: wrapper pid} map for the prompt-wedge
-        # transcript probe (one extra /list RPC, only on daemon-up ticks).
-        pids_by_sid=_live_pids_by_sid_or_none() if daemon_reachable else None,
+        pids_by_sid=live_pids_by_sid,
     )
 
     # Orphan sweep: registration-INDEPENDENT cross-check of ACTIVE-status
@@ -20906,12 +21216,15 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 — flat --*-only 
     # all (#472, 2026-06-10 — entry deleted at a TERMINAL park, task revived
     # by a same-issue follow-up, driver died unobserved for 10.5h). Runs
     # AFTER the respawn + stalled passes so a same-tick recovery by either
-    # one is visible via its fresh registry write (the spawn-grace window).
+    # one is visible via its fresh registry write (the spawn-grace window),
+    # and BEFORE idle_unmapped_pass so the death-observing tick still sees
+    # the #720 breadcrumb its GC would unlink (#1391 dead-owner fast path).
     orphan_sweep_pass(
         args.dry_run,
         args.threshold,
         daemon_reachable=daemon_reachable,
         live_ids=live_ids if daemon_reachable else None,
+        live_pids=live_pids_by_sid,
     )
 
     # Infra-drain: execute the PM session's adjudicated infra dispatch queue

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -5122,6 +5122,63 @@ def test_dead_owner_fast_path_state_carried_sid_is_sufficient():
     assert "state-carried" in reason
 
 
+def test_latest_driver_witness_age_s_arms_and_exclusions():
+    # Arm 1: a stage-dispatch epm:progress breadcrumb (by= deliberately NOT
+    # consulted — the #1090 06:12Z row carried by="unknown"); arm 2: a
+    # _FOLLOWUP_ROUND_WITNESS_KINDS kind. Watcher-sentinel'd notes and plain
+    # progress notes never count as a driver witness.
+    import autonomous_session_watch as asw
+
+    now = asw._parse_event_ts("2026-07-15T07:00:00Z")
+    events = [
+        {
+            "kind": "epm:progress",
+            "ts": "2026-07-15T06:12:03Z",
+            "by": "unknown",
+            "note": "stage-dispatch stage=followup-implementing round=1",
+        },
+        {
+            "kind": "epm:smoke-architecture-check",
+            "ts": "2026-07-15T06:27:45Z",
+            "note": "verdict: PASS_UNIFIED",
+        },
+        # NEWER but non-witness rows must not shrink the age:
+        {
+            "kind": "epm:progress",
+            "ts": "2026-07-15T06:50:00Z",
+            "note": f"{asw._ORPHAN_ALERT_NOTE_SENTINEL} watcher post",
+        },
+        {"kind": "epm:progress", "ts": "2026-07-15T06:55:00Z", "note": "plain note"},
+    ]
+    age = asw._latest_driver_witness_age_s(events, now)
+    assert age == now - asw._parse_event_ts("2026-07-15T06:27:45Z")
+    no_witness = [{"kind": "epm:progress", "ts": "2026-07-15T06:55:00Z", "note": "plain"}]
+    assert asw._latest_driver_witness_age_s(no_witness, now) is None
+
+
+def test_any_live_child_in_issue_worktree_probe_branches(monkeypatch):
+    # Real-body probe coverage: None map -> uncertain; a vanished pid is
+    # SKIPPED (dead != owner -> False); a readlink'd cwd inside the issue
+    # worktree matches on the FULL digit run (component boundary: issue-109
+    # never matches issue-1090); an unreadable live pid -> uncertain (None).
+    import autonomous_session_watch as asw
+
+    assert asw._any_live_child_in_issue_worktree(1391, None) is None
+    # pid beyond the kernel pid space: /proc/<pid>/cwd -> FileNotFoundError.
+    assert asw._any_live_child_in_issue_worktree(1391, {"sid": 2**22 + 424242}) is False
+    monkeypatch.setattr(
+        asw.os, "readlink", lambda _p: "/x/.claude/worktrees/issue-1090-fu5/scripts"
+    )
+    assert asw._any_live_child_in_issue_worktree(1090, {"sid": 1}) is True
+    assert asw._any_live_child_in_issue_worktree(109, {"sid": 1}) is False
+
+    def _perm(_p):
+        raise PermissionError("unreadable /proc entry")
+
+    monkeypatch.setattr(asw.os, "readlink", _perm)
+    assert asw._any_live_child_in_issue_worktree(1090, {"sid": 1}) is None
+
+
 def test_dead_owner_fast_path_env_zero_disables(monkeypatch):
     import autonomous_session_watch as asw
 

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -4594,6 +4594,11 @@ def _run_orphan_task(
     dry_run=False,
     respawns_today=0,
     status_calls=None,
+    snapshot_status="running",
+    live_pids=None,
+    live_ids=None,
+    rec=None,
+    wt_activity=False,
 ):
     """Drive _process_orphan_task end-to-end through the actual marker-age call
     site (rec=None -> fully-unregistered #472 class, so it is an orphan
@@ -4607,11 +4612,19 @@ def _run_orphan_task(
     marker posts, seams ``_task_status`` (the #1247 act-time guard's live
     re-read; ``task_status`` sets the returned status, ``status_calls``
     optionally records the issue argument), and drives SYNTHETIC issue ids
-    only. Returns ``(respawns, markers)``."""
+    only. Returns ``(respawns, markers)``.
+
+    #1391 plumbing: ``live_pids`` threads into the dead-owner fast path's
+    cwd-veto probe (default ``None`` == probe unavailable == fast path
+    ineligible — the pre-#1391 behavior for every existing test);
+    ``snapshot_status`` sets the pass-start snapshot status; ``live_ids``
+    the daemon live set (default empty); ``rec`` the registration record;
+    ``wt_activity`` the seamed worktree-activity probe result."""
     respawns: list[int] = []
     markers: list[tuple[int, str]] = []
     monkeypatch.setattr(asw, "_task_events", lambda _i: events)
     monkeypatch.setattr(asw, "_stalled_cap_gpu_hours", lambda _i: 24.0)
+    monkeypatch.setattr(asw, "_worktree_recent_activity", lambda *_a, **_k: wt_activity)
     monkeypatch.setattr(
         asw, "_respawn_orphan", lambda i, cap, dry_run: respawns.append(i) or "spawned"
     )
@@ -4636,15 +4649,16 @@ def _run_orphan_task(
     _process_orphan_task = asw._process_orphan_task
     _process_orphan_task(
         issue,
-        "running",
-        None,  # rec=None: fully-unregistered orphan candidate
-        set(),  # no live session ids
+        snapshot_status,
+        rec,  # default None: fully-unregistered orphan candidate
+        live_ids if live_ids is not None else set(),
         now,
         dry_run,
         2,  # threshold
         staleness_s=asw.ORPHAN_STALENESS_S_DEFAULT,
         max_per_day=asw.ORPHAN_MAX_RESPAWNS_PER_DAY_DEFAULT,
         day_key="2026-06-25",
+        live_pids=live_pids,
     )
     return respawns, markers
 
@@ -4972,6 +4986,586 @@ def test_orphan_act_guard_dry_run_never_mutates_state(isolated_registry, monkeyp
     assert markers == []
     assert state_path.read_bytes() == before  # state file untouched under dry-run
     assert "ORPHAN-ACT-GUARD" in capsys.readouterr().err
+
+
+# ─── #1391: dead-owner fast path (orphan sweep) ──────────────────────────────
+#
+# The 90-min orphan staleness floor exists because "no live registered
+# session" cannot distinguish a dead driver from a live-but-unregistered one
+# (the routine follow-up-round state). When the sweep has POSITIVE proof the
+# task's last recorded owner session is dead (#720 last-mapped-terminal
+# breadcrumb sid — state-carried in orphan-<N>.json across ticks — absent
+# from the live set), the floor fed to decide_orphan drops to
+# EPM_ORPHAN_DEAD_OWNER_STALENESS_MIN (default 20 min). decide_orphan itself
+# is byte-unchanged; EVERY uncertain input fails toward the slow path.
+
+
+def _fast_path_kwargs(**overrides):
+    """All-eligible baseline kwargs for decide_dead_owner_fast_path
+    (breadcrumb owner dead, fresh witness, every veto clear); tests override
+    one input at a time to pin each fail-toward-slow direction."""
+    kw = dict(
+        has_registration=False,
+        breadcrumb_owner_sids=frozenset({"sid-dead"}),
+        live_ids=frozenset(),
+        recorded_owner_sid=None,
+        driver_witness_age_s=30 * 60.0,
+        witness_lookback_s=90 * 60.0,
+        wt_activity_fresh=False,
+        live_cwd_owner=False,
+        fast_floor_s=20 * 60.0,
+    )
+    kw.update(overrides)
+    return kw
+
+
+def test_dead_owner_fast_path_baseline_eligible():
+    # Sanity anchor for the veto tests below: the all-clear baseline IS
+    # eligible and the reason names the breadcrumb evidence.
+    import autonomous_session_watch as asw
+
+    eligible, reason = asw.decide_dead_owner_fast_path(**_fast_path_kwargs())
+    assert eligible is True
+    assert "absent from the live set" in reason
+
+
+def test_dead_owner_fast_path_requires_positive_owner_evidence():
+    # No breadcrumb AND no state-carried sid -> ineligible even with every
+    # veto clear (absence of evidence is never death proof).
+    import autonomous_session_watch as asw
+
+    eligible, reason = asw.decide_dead_owner_fast_path(
+        **_fast_path_kwargs(breadcrumb_owner_sids=frozenset(), recorded_owner_sid=None)
+    )
+    assert eligible is False
+    assert "no positive owner-death evidence" in reason
+
+
+def test_dead_owner_fast_path_vetoed_by_live_breadcrumb_owner():
+    # The recorded ex-owner is STILL LIVE (the healthy #472/#1090
+    # unregistered-round state) -> ineligible, even when a STALE
+    # state-carried sid looks dead.
+    import autonomous_session_watch as asw
+
+    eligible, reason = asw.decide_dead_owner_fast_path(
+        **_fast_path_kwargs(
+            live_ids=frozenset({"sid-dead"}), recorded_owner_sid="sid-older-generation"
+        )
+    )
+    assert eligible is False
+    assert "still live" in reason
+
+
+def test_dead_owner_fast_path_vetoed_by_registration_present():
+    # rec is None STRICTLY: a registered-but-dead entry is the
+    # crash-recovery pass's territory (and #505 manual-only semantics
+    # require rec, so the alert guard can never co-occur with this path).
+    import autonomous_session_watch as asw
+
+    eligible, reason = asw.decide_dead_owner_fast_path(**_fast_path_kwargs(has_registration=True))
+    assert eligible is False
+    assert "registration present" in reason
+
+
+def test_dead_owner_fast_path_vetoed_by_fresh_worktree_activity():
+    import autonomous_session_watch as asw
+
+    eligible, reason = asw.decide_dead_owner_fast_path(**_fast_path_kwargs(wt_activity_fresh=True))
+    assert eligible is False
+    assert "worktree activity" in reason
+
+
+def test_dead_owner_fast_path_vetoed_by_live_worktree_cwd_session():
+    import autonomous_session_watch as asw
+
+    eligible, reason = asw.decide_dead_owner_fast_path(**_fast_path_kwargs(live_cwd_owner=True))
+    assert eligible is False
+    assert "cwd" in reason
+
+
+def test_dead_owner_fast_path_cwd_probe_unavailable_fails_toward_slow():
+    # live_pids=None (failed /list pid probe) surfaces as live_cwd_owner=None:
+    # uncertain -> ineligible (fail toward the 90-min slow path).
+    import autonomous_session_watch as asw
+
+    eligible, reason = asw.decide_dead_owner_fast_path(**_fast_path_kwargs(live_cwd_owner=None))
+    assert eligible is False
+    assert "probe unavailable" in reason
+
+
+def test_dead_owner_fast_path_requires_recent_driver_witness():
+    # Witness absent, or at/older than the lookback (== the SLOW floor, so
+    # the fast path hands over exactly when the witness expires) -> ineligible.
+    import autonomous_session_watch as asw
+
+    eligible, reason = asw.decide_dead_owner_fast_path(
+        **_fast_path_kwargs(driver_witness_age_s=None)
+    )
+    assert eligible is False
+    assert "witness" in reason
+    eligible, reason = asw.decide_dead_owner_fast_path(
+        **_fast_path_kwargs(driver_witness_age_s=90 * 60.0)  # == lookback: expired
+    )
+    assert eligible is False
+    assert "witness" in reason
+
+
+def test_dead_owner_fast_path_state_carried_sid_is_sufficient():
+    # The breadcrumb GC'd (empty crumb set) but a state-carried owner_sid is
+    # dead -> eligible; the reason names the state-carry evidence.
+    import autonomous_session_watch as asw
+
+    eligible, reason = asw.decide_dead_owner_fast_path(
+        **_fast_path_kwargs(breadcrumb_owner_sids=frozenset(), recorded_owner_sid="sid-dead-owner")
+    )
+    assert eligible is True
+    assert "state-carried" in reason
+
+
+def test_dead_owner_fast_path_env_zero_disables(monkeypatch):
+    import autonomous_session_watch as asw
+
+    monkeypatch.setenv("EPM_ORPHAN_DEAD_OWNER_STALENESS_MIN", "0")
+    assert asw._orphan_dead_owner_staleness_s() is None
+    monkeypatch.setenv("EPM_ORPHAN_DEAD_OWNER_STALENESS_MIN", "-5")
+    assert asw._orphan_dead_owner_staleness_s() is None
+    # And the pure gate honors the disable regardless of evidence:
+    eligible, reason = asw.decide_dead_owner_fast_path(**_fast_path_kwargs(fast_floor_s=None))
+    assert eligible is False
+    assert "disabled" in reason
+
+
+def test_dead_owner_fast_path_env_malformed_falls_back_default(monkeypatch):
+    # A typo must NOT disable the fast path (matches _orphan_staleness_s).
+    import autonomous_session_watch as asw
+
+    monkeypatch.setenv("EPM_ORPHAN_DEAD_OWNER_STALENESS_MIN", "twenty")
+    assert asw._orphan_dead_owner_staleness_s() == float(asw.ORPHAN_DEAD_OWNER_STALENESS_S_DEFAULT)
+    monkeypatch.delenv("EPM_ORPHAN_DEAD_OWNER_STALENESS_MIN", raising=False)
+    assert asw._orphan_dead_owner_staleness_s() == float(asw.ORPHAN_DEAD_OWNER_STALENESS_S_DEFAULT)
+
+
+def test_dead_owner_fast_path_env_clamped_to_min_floor(monkeypatch):
+    # A "2" (minutes) typo clamps to the 10-min floor, never a
+    # fire-on-first-gap configuration; sane values pass through.
+    import autonomous_session_watch as asw
+
+    monkeypatch.setenv("EPM_ORPHAN_DEAD_OWNER_STALENESS_MIN", "2")
+    assert asw._orphan_dead_owner_staleness_s() == float(asw.ORPHAN_DEAD_OWNER_STALENESS_S_MIN)
+    monkeypatch.setenv("EPM_ORPHAN_DEAD_OWNER_STALENESS_MIN", "45")
+    assert asw._orphan_dead_owner_staleness_s() == 45 * 60.0
+
+
+def _fu5_incident_events(asw):
+    """The REAL #1090 fu5 marker sequence (2026-07-15; fact-checked recount):
+    the 05:31:37Z followup-scope that armed the round + the 10 rows
+    05:33:47-06:27:45Z, incl. the by="unknown" 06:12:03Z stage-dispatch
+    breadcrumb (NO pid= field) and the 06:27:45Z smoke marker — the last
+    marker before the unregistered driver died ~06:30Z."""
+
+    def _ev(kind, ts, note="", by="unknown"):
+        return {"kind": kind, "ts": ts, "by": by, "note": note}
+
+    return [
+        _ev(
+            "epm:followup-scope",
+            "2026-07-15T05:31:37Z",
+            "<!-- epm:followup-scope v1 -->\nsource: user-chat\n"
+            "followup_label: finish-impolite-bare-and-formatting-rank",
+            by="pm-chat",
+        ),
+        _ev(
+            "epm:status-changed",
+            "2026-07-15T05:33:47Z",
+            "fu5 round start (finish-impolite-bare-and-formatting-rank, source: user-chat)",
+            by="task.py",
+        ),
+        _ev(
+            "epm:plan-verify",
+            "2026-07-15T05:49:59Z",
+            "verify_plan.py: PASS, n_fail=0, n_warn=3",
+        ),
+        _ev(
+            "epm:progress",
+            "2026-07-15T05:58:19Z",
+            "codex composers skipped -- quota sentinel live (#1204 pre-spawn check)",
+        ),
+        _ev("epm:consistency", "2026-07-15T06:09:17Z", "fu5 plan v7 consistency check: PASS"),
+        _ev("epm:plan", "2026-07-15T06:09:18Z", "Plan v7 written to tasks/<status>/1090/plans"),
+        _ev(
+            "epm:plan-approved",
+            "2026-07-15T06:09:19Z",
+            "Auto-approved by the code-enforced autonomous plan-gate",
+            by="autonomous-gate",
+        ),
+        _ev(
+            "epm:workflow-fix-candidate",
+            "2026-07-15T06:10:27Z",
+            "source: prose-followup (Methodology critic, fu5 plan-critique round)",
+        ),
+        _ev(
+            "epm:workflow-fix-task-filed",
+            "2026-07-15T06:10:28Z",
+            "filed_task: #1314; target_file: scripts/verify_plan.py",
+        ),
+        _ev(
+            "epm:progress",
+            "2026-07-15T06:12:03Z",
+            "stage-dispatch stage=followup-implementing round=1 "
+            "subagent=experiment-implementer label=finish-impolite-bare-and-formatting-rank "
+            "worktree=.claude/worktrees/issue-1090-fu5",
+        ),
+        _ev(
+            "epm:smoke-architecture-check",
+            "2026-07-15T06:27:45Z",
+            "verdict: PASS_UNIFIED notes: fu5 round",
+        ),
+    ]
+
+
+def test_dead_owner_fast_path_incident_replay_1090_fu5(isolated_registry, monkeypatch):
+    # DURABILITY PIN (#1391 acceptance criterion 1): replay the #1090 fu5
+    # incident through the PRODUCTION entry — orphan_sweep_pass with
+    # live_pids left at its production default (the pass's own
+    # _live_pids_by_sid_or_none snapshot; a dropped live_pids thread in the
+    # wiring makes the fast path inert and FAILS this test) — and assert the
+    # dead-owner fast path respawns within 50 min of the last driver marker
+    # (06:27:45Z) vs ~105-120 min on the slow path. The breadcrumb file is
+    # GC'd at the first post-death tick (simulating
+    # _gc_orphan_last_mapped_terminal, which runs AFTER the orphan sweep in
+    # main()), so eligibility at the miss ticks flows SOLELY through the
+    # state-carried owner_sid — a broken owner_updates thread into
+    # _save_orphan_state fails the replay instead of passing green via the
+    # breadcrumb disjunct.
+    import autonomous_session_watch as asw
+
+    issue = 91090
+    owner_sid = "sid-1090-fu5-owner"
+    events = _fu5_incident_events(asw)
+    # The 04:48:34Z terminal park wrote the #720 breadcrumb for the
+    # still-live sid (crash-arm action=="delete" branch).
+    asw._record_last_mapped_terminal(
+        owner_sid,
+        issue,
+        "awaiting_promotion",
+        dry_run=False,
+        now=asw._parse_event_ts("2026-07-15T04:48:34Z"),
+    )
+    respawns: list[tuple[int, float]] = []
+    markers: list[tuple[int, str]] = []
+    tick_now = {"now": 0.0}
+    monkeypatch.setattr(asw, "_active_status_tasks", lambda: {issue: "followups_running"})
+    monkeypatch.setattr(asw, "_running_managed_issue_pods", lambda *_a, **_k: [])
+    monkeypatch.setattr(asw, "_live_pids_by_sid_or_none", lambda: {})
+    monkeypatch.setattr(asw, "_task_events", lambda _i: events)
+    monkeypatch.setattr(asw, "_task_status", lambda _i: "followups_running")
+    monkeypatch.setattr(asw, "_task_children", lambda _i: [])
+    monkeypatch.setattr(asw, "_stalled_cap_gpu_hours", lambda _i: 24.0)
+    monkeypatch.setattr(asw, "_worktree_recent_activity", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        asw,
+        "_respawn_orphan",
+        lambda i, cap, dry_run: respawns.append((i, tick_now["now"])) or "spawned",
+    )
+    monkeypatch.setattr(
+        asw, "_post_progress_marker", lambda i, note, dry_run, label: markers.append((i, note))
+    )
+
+    death_ts = asw._parse_event_ts("2026-07-15T06:30:00Z")
+    last_marker_ts = asw._parse_event_ts("2026-07-15T06:27:45Z")
+    crumb_path = asw._last_mapped_terminal_path(owner_sid)
+    ticks = [
+        asw._parse_event_ts(f"2026-07-15T{hhmm}:00Z")
+        for hhmm in (
+            "05:43", "05:53", "06:03", "06:13", "06:23",  # owner live (healthy window)
+            "06:33",  # first post-death tick: sweep still sees the breadcrumb
+            "06:43", "06:53", "07:03",  # breadcrumb GC'd: state-carry only
+        )
+    ]  # fmt: skip
+    for now in ticks:
+        tick_now["now"] = now
+        alive = now < death_ts
+        asw.orphan_sweep_pass(
+            False,
+            2,
+            now=now,
+            daemon_reachable=True,
+            live_ids={owner_sid} if alive else set(),
+        )
+        if alive:
+            assert respawns == [], f"respawned during the healthy window at now={now}"
+        if not alive and crumb_path.exists():
+            # Simulate _gc_orphan_last_mapped_terminal: the GC (in
+            # idle_unmapped_pass, AFTER the orphan sweep) unlinks the
+            # breadcrumb on the first daemon tick after the sid left the
+            # live set — the death-observing tick above still saw it.
+            crumb_path.unlink()
+            # The healthy window's keep-branch saves state-carried the owner:
+            state = asw._load_orphan_state(issue)
+            assert state.get("owner_sid") == owner_sid
+
+    assert len(respawns) == 1, f"expected exactly one respawn, got {respawns}"
+    respawn_ts = respawns[0][1]
+    assert respawn_ts - last_marker_ts <= 50 * 60, (
+        f"respawn took {(respawn_ts - last_marker_ts) / 60:.1f} min after the last "
+        f"driver marker; acceptance bound is 50 min"
+    )
+    # Eligibility at the respawn tick flowed through the state-carry (the
+    # breadcrumb was unlinked well before it):
+    assert not crumb_path.exists()
+    note = next(n for i, n in markers if asw._ORPHAN_RESPAWN_NOTE_SENTINEL in n)
+    assert "dead-owner fast path" in note
+
+
+def test_dead_owner_fast_path_healthy_round_never_respawns(isolated_registry, monkeypatch):
+    # The #535 pin / acceptance criterion 2: the SAME fixture with the owner
+    # sid LIVE at every tick — including a 55-min silent stage (> the 20-min
+    # fast floor, < the 90-min slow floor) — must NEVER respawn: the
+    # live-owner veto holds the slow path.
+    import autonomous_session_watch as asw
+
+    issue = 91091
+    owner_sid = "sid-1090-fu5-owner"
+    events = _fu5_incident_events(asw)
+    asw._record_last_mapped_terminal(
+        owner_sid,
+        issue,
+        "awaiting_promotion",
+        dry_run=False,
+        now=asw._parse_event_ts("2026-07-15T04:48:34Z"),
+    )
+    respawns: list[int] = []
+    markers: list[tuple[int, str]] = []
+    monkeypatch.setattr(asw, "_active_status_tasks", lambda: {issue: "followups_running"})
+    monkeypatch.setattr(asw, "_running_managed_issue_pods", lambda *_a, **_k: [])
+    monkeypatch.setattr(asw, "_live_pids_by_sid_or_none", lambda: {})
+    monkeypatch.setattr(asw, "_task_events", lambda _i: events)
+    monkeypatch.setattr(asw, "_task_status", lambda _i: "followups_running")
+    monkeypatch.setattr(asw, "_task_children", lambda _i: [])
+    monkeypatch.setattr(asw, "_stalled_cap_gpu_hours", lambda _i: 24.0)
+    monkeypatch.setattr(asw, "_worktree_recent_activity", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        asw, "_respawn_orphan", lambda i, cap, dry_run: respawns.append(i) or "spawned"
+    )
+    monkeypatch.setattr(
+        asw, "_post_progress_marker", lambda i, note, dry_run, label: markers.append((i, note))
+    )
+    # Ticks through 07:23 — 55.6 min after the last marker (06:27:45Z).
+    ticks = [
+        asw._parse_event_ts(f"2026-07-15T{hhmm}:00Z")
+        for hhmm in (
+            "05:43", "05:53", "06:03", "06:13", "06:23",
+            "06:33", "06:43", "06:53", "07:03", "07:13", "07:23",
+        )
+    ]  # fmt: skip
+    for now in ticks:
+        asw.orphan_sweep_pass(False, 2, now=now, daemon_reachable=True, live_ids={owner_sid})
+    assert respawns == []
+    assert markers == []  # every tick keep — no respawn, no alert
+    # The slow path also never accumulated misses (55 min < 90-min floor):
+    assert asw._load_orphan_state(issue).get("missed", 0) == 0
+
+
+def _seed_dead_owner_fixture(asw, monkeypatch, issue, now):
+    """Driver-level dead-owner shape: a breadcrumb for a DEAD sid + a witness
+    event 30 min old (>= the 20-min fast floor, < the 90-min slow floor —
+    the discriminating regime: the slow path keeps, the fast path acts)."""
+    asw._record_last_mapped_terminal(
+        "sid-dead-owner", issue, "awaiting_promotion", dry_run=False, now=now - 7200
+    )
+    return [
+        {
+            "kind": "epm:experiment-implementation",
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now - 30 * 60)),
+            "note": "fu round implementing",
+        }
+    ]
+
+
+def test_dead_owner_fast_path_respawn_consumes_daily_cap(isolated_registry, monkeypatch):
+    # The daily attempt cap binds the fast path exactly as the slow path:
+    # with respawns_today already at the cap, the third would-be fast respawn
+    # degrades to the one-time ALERT (cap path unchanged).
+    import autonomous_session_watch as asw
+
+    now = asw._parse_event_ts("2026-06-25T06:00:00Z")
+    events = _seed_dead_owner_fixture(asw, monkeypatch, 91092, now)
+    respawns, markers = _run_orphan_task(
+        asw,
+        monkeypatch,
+        issue=91092,
+        events=events,
+        now=now,
+        live_pids={},
+        respawns_today=asw.ORPHAN_MAX_RESPAWNS_PER_DAY_DEFAULT,
+    )
+    assert respawns == []
+    assert len(markers) == 1
+    assert asw._ORPHAN_ALERT_NOTE_SENTINEL in markers[0][1]
+    assert "cap exhausted" in markers[0][1]
+
+
+def test_dead_owner_fast_path_act_guard_still_aborts(isolated_registry, monkeypatch, capsys):
+    # #1247 act-time guard binds the fast path unchanged: the live status
+    # re-read returns a terminal status -> no respawn, no marker, no cap
+    # consumed (episode state cleared on the positive non-ACTIVE read).
+    import autonomous_session_watch as asw
+
+    now = asw._parse_event_ts("2026-06-25T06:00:00Z")
+    events = _seed_dead_owner_fixture(asw, monkeypatch, 91093, now)
+    respawns, markers = _run_orphan_task(
+        asw,
+        monkeypatch,
+        issue=91093,
+        events=events,
+        now=now,
+        live_pids={},
+        task_status="awaiting_promotion",
+    )
+    assert respawns == []
+    assert markers == []
+    assert asw._load_orphan_state(91093) == {}
+    assert "ORPHAN-ACT-GUARD" in capsys.readouterr().err
+
+
+def test_dead_owner_fast_path_exemptions_still_intercept(isolated_registry, monkeypatch):
+    # The followups-awaiting-child exemption diverts a fast-path respawn to
+    # alert-only exactly as it diverts a slow-path one (no respawn, no cap).
+    import autonomous_session_watch as asw
+
+    now = asw._parse_event_ts("2026-06-25T06:00:00Z")
+    asw._record_last_mapped_terminal(
+        "sid-dead-owner", 91094, "awaiting_promotion", dry_run=False, now=now - 7200
+    )
+    events = [
+        {
+            "kind": "epm:experiment-implementation",
+            "ts": "2026-06-25T05:20:00Z",  # witness + newest marker: 40 min old
+            "note": "fu round implementing",
+        },
+        _make_step_completed_event(step="10", exit_kind="parked", ts="2026-06-25T05:25:00Z"),
+    ]
+    monkeypatch.setattr(
+        asw, "_task_children", lambda _i: [{"id": 546, "status": "awaiting_promotion"}]
+    )
+    respawns, markers = _run_orphan_task(
+        asw,
+        monkeypatch,
+        issue=91094,
+        events=events,
+        now=now,
+        live_pids={},
+        snapshot_status="followups_running",
+        task_status="followups_running",
+    )
+    assert respawns == []
+    assert len(markers) == 1
+    assert asw._FOLLOWUPS_AWAITING_CHILD_NOTE_SENTINEL in markers[0][1]
+    # The exemption never consumes the daily respawn budget:
+    assert asw._load_orphan_state(91094).get("respawns_today", 0) == 0
+
+
+def test_dead_owner_fast_path_marker_note_records_evidence_and_source_stamp(
+    isolated_registry, monkeypatch
+):
+    # The respawn marker names the fast-path evidence + the effective floor,
+    # BEFORE the #1247 source stamp (which stays the trailing token).
+    import re
+
+    import autonomous_session_watch as asw
+
+    now = asw._parse_event_ts("2026-06-25T06:00:00Z")
+    events = _seed_dead_owner_fixture(asw, monkeypatch, 91095, now)
+    respawns, markers = _run_orphan_task(
+        asw, monkeypatch, issue=91095, events=events, now=now, live_pids={}
+    )
+    assert respawns == [91095]
+    assert len(markers) == 1
+    note = markers[0][1]
+    assert "dead-owner fast path" in note
+    assert "EPM_ORPHAN_DEAD_OWNER_STALENESS_MIN" in note
+    assert re.search(r"\[src: host=\S+ user=\S+ pid=\d+ sha=\S+ root=/\S+\]$", note)
+    assert note.index("dead-owner fast path") < note.index("[src:")
+
+
+def test_orphan_state_owner_fields_roundtrip_and_carry_forward(isolated_registry):
+    import autonomous_session_watch as asw
+
+    asw._save_orphan_state(
+        91096,
+        missed=0,
+        alerted=False,
+        respawn_day="2026-06-25",
+        respawns_today=0,
+        owner_sid="sid-a",
+        owner_last_live_ts=123.0,
+        prev=None,
+    )
+    state = asw._load_orphan_state(91096)
+    assert state["owner_sid"] == "sid-a"
+    assert state["owner_last_live_ts"] == 123.0
+    # Not supplied -> carried forward from prev (the first_seen pattern), so
+    # existing call sites keep the death proof alive across ticks:
+    asw._save_orphan_state(
+        91096,
+        missed=1,
+        alerted=False,
+        respawn_day="2026-06-25",
+        respawns_today=0,
+        prev=state,
+    )
+    state2 = asw._load_orphan_state(91096)
+    assert state2["owner_sid"] == "sid-a"
+    assert state2["owner_last_live_ts"] == 123.0
+    # A pre-existing (pre-#1391) state file without the fields loads clean
+    # and saves clean (type-guarded None defaults):
+    (isolated_registry / "orphan-91097.json").write_text(
+        json.dumps(
+            {
+                "missed": 1,
+                "alerted": False,
+                "respawn_day": "2026-06-25",
+                "respawns_today": 0,
+                "first_seen": 1.0,
+            }
+        )
+    )
+    legacy = asw._load_orphan_state(91097)
+    asw._save_orphan_state(
+        91097, missed=2, alerted=False, respawn_day="2026-06-25", respawns_today=0, prev=legacy
+    )
+    assert asw._load_orphan_state(91097)["owner_sid"] is None
+
+
+def test_dead_owner_fast_path_slow_path_byte_identical_when_ineligible(
+    isolated_registry, monkeypatch
+):
+    # With the knob at its default but NO owner evidence, decide_orphan
+    # receives EXACTLY ORPHAN_STALENESS_S_DEFAULT (recording seam) and the
+    # 30-min-quiet candidate is KEPT — the pre-#1391 slow path, byte-identical.
+    import autonomous_session_watch as asw
+
+    now = asw._parse_event_ts("2026-06-25T06:00:00Z")
+    events = [
+        {
+            "kind": "epm:experiment-implementation",
+            "ts": "2026-06-25T05:30:00Z",  # 30 min old: fast-stale, slow-fresh
+            "note": "fu round implementing",
+        }
+    ]
+    seen: list[float] = []
+    real_decide = asw.decide_orphan
+    monkeypatch.setattr(
+        asw,
+        "decide_orphan",
+        lambda *a, **k: seen.append(k["staleness_s"]) or real_decide(*a, **k),
+    )
+    respawns, markers = _run_orphan_task(
+        asw, monkeypatch, issue=91098, events=events, now=now, live_pids={}
+    )
+    assert seen == [asw.ORPHAN_STALENESS_S_DEFAULT]
+    assert respawns == []
+    assert markers == []
 
 
 # ─── #866/#903: deliberate-takeover sentinel skips the orphan sweep ──────────


### PR DESCRIPTION
Closes task #1391.

## Summary
- Dead-owner fast path for the watcher orphan sweep: when an ACTIVE-status (incl. followups_running) task has no registration file, a recent driver witness, and POSITIVE proof its last recorded owner session is dead, the staleness floor fed to decide_orphan drops 90 min → EPM_ORPHAN_DEAD_OWNER_STALENESS_MIN (default 20 min, clamp ≥10, 0 disables).
- decide_orphan byte-unchanged; every uncertain input fails toward the slow path; cap / manual-only (#505) / daemon gate / #1247 act guard preserved and test-pinned.
- 17 new tests incl. the #1090-fu5 incident replay entering via the production orphan_sweep_pass path (durability pin, with kill-switch negative control).

## Test plan
- [x] uv run pytest tests/test_autonomous_session_watch.py (973 + 98 pass)
- [x] Step 9c gate: 53 files, 4409 passed; 2 pre-existing-on-main reds stripped by baseline compare
- [x] ruff + workflow_lint clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)