### PR TITLE
issue-1421: check 39 — Sample-slot Disclosure: N of M count reconciliation

### DIFF
--- a/.claude/skills/clean-results/SPEC.md
+++ b/.claude/skills/clean-results/SPEC.md
@@ -544,6 +544,9 @@ Boldface-led slots, in order:
   random sample` / `cherry-picked for illustration` / `first N of M` / the
   harmful-content sanitized form) AND followed/preceded by a **pinned link
   to the complete artifact** (HF Hub `/tree/<sha>`, GitHub `/blob/<sha>`).
+  When the disclosure carries an explicit count claim in the
+  `Disclosure: N of M` form, N must equal the number of example items
+  actually shown below it (check 39 reconciles; overstating N is a FAIL).
   Harmful-content corpora ship SANITIZED (see § Harmful-content below).
 
 **Per-condition quantitative numbers live in PLOTS (in `## Results`), not
@@ -987,6 +990,20 @@ Forward-only: each check branches on the sentinel. The v4 checks
     class (dense 4–5-sentence paragraphs burning an LM critic round).
     (Numbered 36 because 28–35 are taken by the generation-agnostic
     checks, #1368.)
+39. **Sample-slot disclosure count** (`check_v4_sample_disclosure_count`,
+    v4 only): an explicit `Disclosure: N of M` count claim in the Sample
+    slot must reconcile with the example items actually shown in that
+    claim's group — overclaim (N exceeds EVERY counting basis: sample /
+    fenced / `<details>` blocks, top-level list items, GFM table data
+    rows, blockquote groups, and their disjoint-media sum) is a FAIL;
+    any other mismatch is a WARN; no count claim / no countable
+    presentation = skip (never guess). One `Disclosure:` line covers the
+    items from the line after it to the next `Disclosure:` line (or slot
+    end). The broad check-19 phrasings (`K of M rows`, `first N of M`)
+    never trigger reconciliation — only the `Disclosure:` prefix does.
+    (Numbered 39 because 37–38 are taken by the footer-reuse-pin and
+    linked-not-embedded WARN checks, #1421; incident #1005 claimed
+    `Disclosure: 8 of 2,400` while showing 6.)
 
 Generation-agnostic checks (v2 AND v3 AND v4): figure-URL-sha-matches
 (check 22), HF-URL-resolves (check 23), figure-sidecar opaque

--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -9717,6 +9717,216 @@ def check_data_subset_disclosure(body: str) -> CheckResult:
     return CheckResult(label, True, f"{len(samples)} `## Data` example block(s) disclosed")
 
 
+# ─── v4 Sample-slot disclosure-count check (39) ─────────────────────────────
+
+# Explicit shown-count claim inside the v4 Sample slot — the `Disclosure:
+# N of M` convention (#928/#1005). Deliberately keyed on the `Disclosure:`
+# prefix ONLY: the broad `_SUBSET_DISCLOSURE_RE` phrasings (`K of M rows`,
+# `first N of M`) routinely count table ROWS inside one block (e.g. the
+# `_V4_GOOD_BODY` test fixture's `5 of 2,000 rows, random sample` over a
+# 1-row table) and must NOT trigger count reconciliation (#1421).
+_DISCLOSURE_COUNT_RE = re.compile(
+    r"(?im)\bdisclosure:\s*(?:the\s+|first\s+|showing\s+|top\s+)*"
+    r"(\d[\d,]*)\s+of\s+(?:the\s+)?(\d[\d,]*)"
+)
+
+# A top-level markdown list item: `- ` / `* ` / `+ ` / `1. ` / `1) ` at
+# indent ≤3 (the CommonMark top-level bound), with a non-space payload.
+_LIST_ITEM_RE = re.compile(r"^ {0,3}(?:[-*+]|\d{1,3}[.)])\s+\S")
+
+
+def _iter_unfenced_lines(text: str):
+    """Yield the lines of `text` that sit OUTSIDE fenced code blocks.
+
+    ``` / ~~~ delimiter lines toggle the fence state and are not yielded
+    themselves (the same relaxed CommonMark toggle `find_h2_sections`
+    uses)."""
+    in_fence = False
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("```") or s.startswith("~~~"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        yield line
+
+
+def _count_top_level_list_items(text: str) -> int:
+    """Count top-level markdown list items outside fenced code blocks.
+
+    Indent ≤3 counts as top-level per CommonMark, so a 2-space-indented
+    nested sub-bullet ALSO counts — an INFLATION-ONLY bias by design: it
+    can only raise the max/summed counting bases (masking an overclaim on
+    a sub-bulleted group, never manufacturing a false FAIL, since FAIL
+    requires N to exceed EVERY basis). Do NOT tighten the indent bound to
+    0 — legitimately indented top-level items would then undercount and
+    turn this basis into a false-positive source (#1421)."""
+    return sum(1 for line in _iter_unfenced_lines(text) if _LIST_ITEM_RE.match(line))
+
+
+def _count_gfm_table_data_rows(text: str) -> int:
+    """Count GFM table DATA rows outside fenced code blocks.
+
+    Per contiguous run of `|`-starting lines: the rows AFTER the first
+    delimiter row (`_GFM_DELIM_RE` multi-column / `_SINGLE_COL_DELIM_RE`
+    single-column), excluding any further delimiter rows. A run with no
+    delimiter row counts 0 (not a table). Sums over runs."""
+
+    def _is_delim(line: str) -> bool:
+        return bool(_GFM_DELIM_RE.match(line) or _SINGLE_COL_DELIM_RE.match(line))
+
+    total = 0
+    run: list[str] = []
+
+    def _flush() -> None:
+        nonlocal total
+        delim_idx = next((i for i, row in enumerate(run) if _is_delim(row)), None)
+        if delim_idx is not None:
+            total += sum(1 for row in run[delim_idx + 1 :] if not _is_delim(row))
+        run.clear()
+
+    for line in _iter_unfenced_lines(text):
+        if line.lstrip().startswith("|"):
+            run.append(line)
+        else:
+            _flush()
+    _flush()
+    return total
+
+
+def _count_blockquote_groups(text: str) -> int:
+    """Count maximal runs of `>`-starting lines outside fenced code
+    blocks; each contiguous run counts 1 (a blockquote-formatted example
+    list — cheap insurance, the Figure-caption style is Results-only)."""
+    total = 0
+    prev_quote = False
+    for line in _iter_unfenced_lines(text):
+        is_quote = line.lstrip().startswith(">")
+        if is_quote and not prev_quote:
+            total += 1
+        prev_quote = is_quote
+    return total
+
+
+def _count_disjoint_media_sum(group: str) -> int:
+    """Summed disjoint-media counting basis for check 39 (#1421): merged
+    fenced + `<details>` block regions (span-deduped — a fence nested in
+    a `<details>` block, or vice versa, counts once via the merged outer
+    region) PLUS top-level list items and GFM table data rows counted
+    only OUTSIDE those block regions, so each shown item enters the sum
+    exactly once. Strictly generosity-increasing: it adds one more value
+    N may legitimately match (the mixed-media presentation — e.g. 3 table
+    rows + 3 fenced completions for `Disclosure: 6 of M`) and can only
+    raise max(bases); it can never manufacture a false FAIL."""
+    raw = [(m.start(), m.end()) for m in _FENCED_RE.finditer(group)]
+    raw += [(m.start(), m.end()) for m in _DETAILS_BLOCK_RE.finditer(group)]
+    raw.sort()
+    merged: list[list[int]] = []
+    for s, e in raw:
+        if merged and s < merged[-1][1]:
+            merged[-1][1] = max(merged[-1][1], e)
+        else:
+            merged.append([s, e])
+    chars = list(group)
+    for s, e in merged:
+        for i in range(s, e):
+            if chars[i] != "\n":
+                chars[i] = " "
+    remainder = "".join(chars)
+    return (
+        len(merged) + _count_top_level_list_items(remainder) + _count_gfm_table_data_rows(remainder)
+    )
+
+
+def check_v4_sample_disclosure_count(body: str) -> CheckResult:
+    """Check 39 (v4 only): every explicit `Disclosure: N of M` count
+    claim in the `## Methodology` Sample slot reconciles with the number
+    of example items actually shown in that claim's group (#1421;
+    incident #1005: claimed `Disclosure: 8 of 2,400`, showed 6).
+
+    Group semantics: one `Disclosure:` line covers the text from the
+    FIRST NEWLINE after its match to the START OF THE LINE carrying the
+    next `Disclosure:` claim (or slot end) — the claim line's own tail
+    (`— 3 well-formed … plus 3 cap-truncated …`) never enters the counted
+    group, and a bullet wrapping a `Disclosure:` line (`- Disclosure: …`)
+    is excluded from BOTH its own group and the previous one.
+
+    Counting bases per group (zero-valued bases dropped): sample-like
+    blocks (`_iter_sample_blocks` — check 19's enumeration), ALL raw
+    fenced + `<details>` blocks, top-level list items
+    (`_count_top_level_list_items` — indent ≤3, inflation-only), GFM
+    table data rows, blockquote groups, and the summed disjoint-media
+    basis (`_count_disjoint_media_sum` — mixed-media presentations).
+      - N matches ANY basis          -> PASS (presentation-medium agnostic)
+      - N > max(bases), bases != {}  -> FAIL (overclaim — the incident class)
+      - other mismatch               -> WARN (is_warn=True)
+      - bases == {}                  -> PASS-skip (unrecognized
+                                        presentation; never guess)
+    PASS-skips on non-v4 bodies (forward-only; no grandfathered body
+    carries the `Disclosure:` convention — repo grep 2026-07-16, #1421).
+    """
+    label = "Sample-slot disclosure count (v4)"
+    if not is_v4(body):
+        return CheckResult(label, True, "skipped — not a v4 body")
+    methodology = section_text(body, "Methodology")
+    if methodology is None:
+        return CheckResult(label, True, "## Methodology missing — check 18 will report")
+    slot = _v4_methodology_sample_slot(methodology)
+    if slot is None:
+        return CheckResult(label, True, "no Sample slot — check 18 will report")
+    matches = list(_DISCLOSURE_COUNT_RE.finditer(slot))
+    if not matches:
+        return CheckResult(label, True, "no `Disclosure: N of M` count claim in the Sample slot")
+    fails: list[str] = []
+    warns: list[str] = []
+    n_skipped = 0
+    for i, m in enumerate(matches):
+        n_claimed = int(m.group(1).replace(",", ""))
+        nl = slot.find("\n", m.end())
+        group_start = nl + 1 if nl != -1 else len(slot)
+        if i + 1 < len(matches):
+            group_end = slot.rfind("\n", 0, matches[i + 1].start()) + 1
+        else:
+            group_end = len(slot)
+        group = slot[group_start:group_end] if group_start < group_end else ""
+        bases = {
+            "sample blocks": len(_iter_sample_blocks(group)),
+            "fenced/<details> blocks": (
+                len(list(_FENCED_RE.finditer(group))) + len(list(_DETAILS_BLOCK_RE.finditer(group)))
+            ),
+            "top-level list items": _count_top_level_list_items(group),
+            "table data rows": _count_gfm_table_data_rows(group),
+            "blockquote groups": _count_blockquote_groups(group),
+            "summed disjoint media": _count_disjoint_media_sum(group),
+        }
+        nonzero = {k: v for k, v in bases.items() if v > 0}
+        if not nonzero:
+            n_skipped += 1  # unrecognized presentation medium — never guess
+            continue
+        if n_claimed in nonzero.values():
+            continue
+        desc = (
+            f"`Disclosure: {m.group(1)} of {m.group(2)}` claims {n_claimed} shown "
+            f"but its group carries at most {max(nonzero.values())} "
+            f"({', '.join(f'{v} {k}' for k, v in nonzero.items())})"
+        )
+        (fails if n_claimed > max(nonzero.values()) else warns).append(desc)
+    if fails:
+        return CheckResult(label, False, "; ".join(fails + warns))
+    if warns:
+        return CheckResult(
+            label,
+            True,
+            "; ".join(warns) + " — count mismatch (not an overclaim)",
+            is_warn=True,
+        )
+    detail = f"{len(matches) - n_skipped} disclosure count claim(s) reconcile"
+    if n_skipped:
+        detail += f"; {n_skipped} claim(s) skipped — no countable presentation (never guess)"
+    return CheckResult(label, True, detail)
+
+
 # ─── v3 word-cap check (20) ──────────────────────────────────────────────────
 
 
@@ -11140,6 +11350,9 @@ CHECKS = [
     # check 37 (WARN, v4, #1370) — footer `- Reused ... from [#M](...)` bullets carry a
     # revision/path pin (body-text-only sibling of check 35's metadata-side trigger):
     check_footer_reuse_bullets_pinned,
+    # check 39 (v4) — `Disclosure: N of M` count claim in the Sample slot
+    # reconciles with the example items actually shown (#1421; incident #1005):
+    check_v4_sample_disclosure_count,
     # generation-agnostic checks (v2 AND v3 AND v4):
     check_figure_url_sha_matches_repro,  # check 22
     check_hf_url_resolves,  # check 23

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -104,7 +104,7 @@ def test_good_body_passes_all():
     ok, results = verify_task_body.verify_text(GOOD_BODY)
     assert ok, [r.render() for r in results if not r.passed]
     assert all(r.passed for r in results)
-    # CHECKS has 38 body-only functions: the 20 pre-v3 body-only checks
+    # CHECKS has 39 body-only functions: the 20 pre-v3 body-only checks
     # (incl. the sentinel-gated `check_tldr_nested_structure` and the
     # check-8b Reproducibility artifact-URL existence probe), the four
     # v3-gated body-only checks (check 18 `check_data_shape`, check 19
@@ -152,7 +152,7 @@ def test_good_body_passes_all():
     # is a vacuous PASS here because this fixture carries no
     # availability-denial-near-artifact line. verify_text prepends check 0
     # (body-nonstub) + check 0b (no-duplicate-frontmatter), runs CHECKS[1:]
-    # (39 functions), then appends the Goal soft check, the H1↔frontmatter-
+    # (40 functions), then appends the Goal soft check, the H1↔frontmatter-
     # title sync check (#1110; PASS-skip: not a sentinelled body), the
     # Lens 14
     # concerns-audit, the check-16 lr-matches-plan reconciliation, the
@@ -168,17 +168,19 @@ def test_good_body_passes_all():
     # locally reachable, so the cited SHA is silently skipped), AND the
     # check-38 linked-not-embedded-figures scan (needs `issue` for
     # own-figures-dir scoping, #1371; PASS-skip: not a v4 body) →
-    # 52 results total (2 prepended + CHECKS[1:]=39 + 11 appended; check 36
-    # `check_v4_result_paragraph_sentences` (#1368) and check 37
-    # `check_footer_reuse_bullets_pinned` (#1370) ride CHECKS and PASS-skip
+    # 53 results total (2 prepended + CHECKS[1:]=40 + 11 appended; check 36
+    # `check_v4_result_paragraph_sentences` (#1368), check 37
+    # `check_footer_reuse_bullets_pinned` (#1370), and check 39
+    # `check_v4_sample_disclosure_count` (#1421) ride CHECKS and PASS-skip
     # here — not a v4 body). The
     # Lens 14 / check-16 results are PASS-skips when no concerns.jsonl /
     # plans/plan.md sibling is available; check 17 and the v3/v4 checks
     # are PASS-skips on this legacy (pre-v2-sentinel) fixture.
-    assert len(results) == 52
+    assert len(results) == 53
     # By-name membership so the NEXT check addition can key by name instead
     # of re-deriving the arithmetic (#1016 methodology-reconciler Must-Fix).
     assert _HF_32_NAME in {r.name for r in results}
+    assert "Sample-slot disclosure count (v4)" in {r.name for r in results}
     assert "cross-issue reuse pins declared (footer Reused bullets)" in {r.name for r in results}
     assert "footer Reused bullets carry a revision/path pin" in {r.name for r in results}
     assert "figure prose numerics vs figure sidecar (plotted-value drift)" in {
@@ -4674,13 +4676,15 @@ def test_checks_list_size():
     denominator check (needs eval JSONs), and the check-31
     orphaned-per-unit-figures probe (needs `issue` for figures-dir
     scoping, #1011).
-    So `verify_text` returns 51 results (2 prepended + CHECKS[1:]=39 +
+    So `verify_text` returns 52 results (2 prepended + CHECKS[1:]=40 +
     10 appended — see `test_good_body_passes_all`), but `CHECKS` stays
-    at 40 (check 36 `check_v4_result_paragraph_sentences` (#1368) and
+    at 41 (check 36 `check_v4_result_paragraph_sentences` (#1368),
     check 37 `check_footer_reuse_bullets_pinned` — the body-only
-    footer-side reuse-pin sibling of check 35, #1370 — ride CHECKS).
+    footer-side reuse-pin sibling of check 35, #1370 — and check 39
+    `check_v4_sample_disclosure_count` — the Sample-slot
+    `Disclosure: N of M` count reconciliation, #1421 — ride CHECKS).
     """
-    assert len(verify_task_body.CHECKS) == 40
+    assert len(verify_task_body.CHECKS) == 41
     # By-name membership so the NEXT check addition can key by name instead
     # of re-deriving the arithmetic (#1016 methodology-reconciler Must-Fix).
     assert verify_task_body.check_hf_adjacent_file_claims in verify_task_body.CHECKS
@@ -4688,6 +4692,7 @@ def test_checks_list_size():
     assert verify_task_body.check_figure_beat_claims_vs_sidecar_text in verify_task_body.CHECKS
     assert verify_task_body.check_v4_result_paragraph_sentences in verify_task_body.CHECKS
     assert verify_task_body.check_footer_reuse_bullets_pinned in verify_task_body.CHECKS
+    assert verify_task_body.check_v4_sample_disclosure_count in verify_task_body.CHECKS
 
 
 # ─── Check 14: MDX-safe prose (regex layer + real-parse backstop) ───
@@ -7034,6 +7039,209 @@ def test_v4_check19b_emits_v4_label_only():
     by_name = _results_by_name(results)
     assert "Methodology unwrapped example table (v4)" in by_name
     assert "Data unwrapped example table (v3)" not in by_name
+
+
+# ─── Check 39: Sample-slot `Disclosure: N of M` count reconciliation (#1421) ─
+# Incident #1005: the clean-result claimed `Disclosure: 8 of 2,400` while only
+# 6 example bullets followed (pre-fix revision preserved at 8926c25db5).
+# Assertions call the check directly (plus one verify_text by-name read) —
+# the `_V4_GOOD_BODY` convention: fake SHAs fail the existence probes, so
+# overall PASS is not assertable.
+
+_CHECK39_NAME = "Sample-slot disclosure count (v4)"
+
+# Six top-level bullets structurally copied from #1005's Sample slot shape
+# (markdown links + em-dashes, no fenced blocks, no tables).
+_SIX_I1005_STYLE_BULLETS = (
+    "- [naturalistic_s57](https://huggingface.co/datasets/x/tree/abc/rc/s57.json) — "
+    "well-formed single-turn rollout; direct answer to the probe.\n"
+    "- [naturalistic_s61](https://huggingface.co/datasets/x/tree/abc/rc/s61.json) — "
+    "well-formed; hedged framing.\n"
+    "- [naturalistic_s74](https://huggingface.co/datasets/x/tree/abc/rc/s74.json) — "
+    "well-formed; list-style answer.\n"
+    "- [chat_s12](https://huggingface.co/datasets/x/tree/abc/rc/s12.json) — "
+    "well-formed multi-turn rollout.\n"
+    "- [chat_s19](https://huggingface.co/datasets/x/tree/abc/rc/s19.json) — "
+    "well-formed; short reply.\n"
+    "- [chat_s23](https://huggingface.co/datasets/x/tree/abc/rc/s23.json) — "
+    "cap-truncated rollout (ends mid-sentence).\n"
+)
+
+
+def _v4_body_with_sample_slot(slot_md: str) -> str:
+    """Return a `_V4_GOOD_BODY` variant whose `## Methodology` Sample-slot
+    CONTENT (everything after the slot label line, up to `## Results`) is
+    replaced by ``slot_md``. The slot label line itself stays."""
+    start = _V4_GOOD_BODY.index("<details open>")
+    end = _V4_GOOD_BODY.index("## Results")
+    return _V4_GOOD_BODY[:start] + slot_md.rstrip() + "\n\n" + _V4_GOOD_BODY[end:]
+
+
+def test_v4_sample_disclosure_count_overclaim_fails():
+    """Durability pin + the real-#1005-shape regression: a Sample slot
+    claiming `Disclosure: 8 of 2,400` over exactly 6 top-level bullets
+    (the pre-fix #1005 revision, `8926c25db5`) FAILs, naming 8 (claimed)
+    and 6 (shown). The disclosure line's own em-dash tail (`— 5
+    well-formed … plus 3 cap-truncated`) never enters the counted group
+    (group starts at the first newline after the claim)."""
+    slot = (
+        "Disclosure: 8 of 2,400 rollouts — 5 well-formed responses plus 3 "
+        "cap-truncated, drawn at random for illustration.\n\n" + _SIX_I1005_STYLE_BULLETS
+    )
+    res = verify_task_body.check_v4_sample_disclosure_count(_v4_body_with_sample_slot(slot))
+    assert res.passed is False
+    assert "claims 8 shown" in res.detail
+    assert "at most 6" in res.detail
+
+
+def test_v4_sample_disclosure_count_match_passes():
+    """The #928 / post-fix-#1005 shape: `Disclosure: 6 of 2,400` over 6
+    top-level bullets reconciles → PASS, no WARN."""
+    slot = "Disclosure: 6 of 2,400 rollouts, drawn at random.\n\n" + _SIX_I1005_STYLE_BULLETS
+    res = verify_task_body.check_v4_sample_disclosure_count(_v4_body_with_sample_slot(slot))
+    assert res.passed is True
+    assert res.is_warn is False
+    assert "reconcile" in res.detail
+
+
+def test_v4_sample_disclosure_no_count_claim_skips():
+    """A Sample slot disclosed via the broad check-19 vocabulary only
+    (`5 of 2,000 rows, random sample` inside a `<summary>`, the
+    `_V4_GOOD_BODY` shape — no `Disclosure:` keyword) does not engage the
+    check; the shared good fixture stays green under verify_text."""
+    res = verify_task_body.check_v4_sample_disclosure_count(_V4_GOOD_BODY)
+    assert res.passed is True
+    assert res.is_warn is False
+    assert "no `Disclosure: N of M` count claim" in res.detail
+    _ok, results = verify_task_body.verify_text(_V4_GOOD_BODY)
+    by_name = _results_by_name(results)
+    assert by_name[_CHECK39_NAME].passed
+    assert not by_name[_CHECK39_NAME].is_warn
+
+
+def test_v4_sample_disclosure_thousands_separator_parses():
+    """`Disclosure: 1,000 of 2,400` parses N=1000 (thousands separators on
+    both sides), and the M-side separator does not break the incident
+    parse (8 of 2,400 + 6 bullets still FAILs)."""
+    m = verify_task_body._DISCLOSURE_COUNT_RE.search("Disclosure: 1,000 of 2,400 rows shown.")
+    assert m is not None
+    assert int(m.group(1).replace(",", "")) == 1000
+    assert m.group(2) == "2,400"
+    slot = "Disclosure: 8 of 2,400 rollouts, drawn at random.\n\n" + _SIX_I1005_STYLE_BULLETS
+    res = verify_task_body.check_v4_sample_disclosure_count(_v4_body_with_sample_slot(slot))
+    assert res.passed is False
+
+
+def test_v4_sample_disclosure_table_rows_basis_passes():
+    """`Disclosure: 5 of 2,000 training rows` in a `<details><summary>`
+    whose table carries 5 data rows PASSes via the table-row basis (the
+    one-table-of-N-rows form must not false-FAIL)."""
+    slot = (
+        "<details>\n"
+        "<summary>Disclosure: 5 of 2,000 training rows, random sample</summary>\n\n"
+        "| Row | System | User | Assistant |\n"
+        "|---|---|---|---|\n"
+        "| 1 | sys | q | a |\n"
+        "| 2 | sys | q | a |\n"
+        "| 3 | sys | q | a |\n"
+        "| 4 | sys | q | a |\n"
+        "| 5 | sys | q | a |\n\n"
+        "</details>\n"
+    )
+    res = verify_task_body.check_v4_sample_disclosure_count(_v4_body_with_sample_slot(slot))
+    assert res.passed is True
+    assert res.is_warn is False
+
+
+def test_v4_sample_disclosure_undercount_warns():
+    """An UNDERCOUNT (`Disclosure: 2 of 2,400` over 4 bullets) is a
+    mismatch but not an overclaim → WARN (`is_warn=True`), never FAIL."""
+    four_bullets = "".join(_SIX_I1005_STYLE_BULLETS.splitlines(keepends=True)[:4])
+    slot = "Disclosure: 2 of 2,400 rollouts, drawn at random.\n\n" + four_bullets
+    res = verify_task_body.check_v4_sample_disclosure_count(_v4_body_with_sample_slot(slot))
+    assert res.passed is True
+    assert res.is_warn is True
+    assert "not an overclaim" in res.detail
+
+
+def test_v4_sample_disclosure_unrecognized_presentation_skips():
+    """A count claim followed only by plain paragraphs (no bullets /
+    blocks / tables / quotes) has no countable basis → PASS-skip (never
+    guess)."""
+    slot = (
+        "Disclosure: 3 of 500 examples, described narratively below.\n\n"
+        "A plain paragraph describing the worked examples in prose without "
+        "any bullets, tables, fenced blocks, or blockquotes.\n"
+    )
+    res = verify_task_body.check_v4_sample_disclosure_count(_v4_body_with_sample_slot(slot))
+    assert res.passed is True
+    assert res.is_warn is False
+    assert "no countable presentation" in res.detail
+
+
+def test_v3_body_disclosure_line_not_checked():
+    """Grandfathering regression: a v3 body carrying a `Disclosure: 8 of
+    2,400` line (with example bullets) PASS-skips — the check is v4-only
+    by construction."""
+    body = _V3_GOOD_BODY + "\nDisclosure: 8 of 2,400 rollouts.\n\n- one example\n- two example\n"
+    res = verify_task_body.check_v4_sample_disclosure_count(body)
+    assert res.passed is True
+    assert "not a v4 body" in res.detail
+
+
+def test_v4_sample_disclosure_two_groups_second_overclaim_fails():
+    """TWO `Disclosure:` lines in one Sample slot: the first group
+    reconciles (3 over 3 bullets), the second overclaims (9 over 4
+    bullets) → FAIL naming the SECOND group's numbers. Also pins the
+    group boundary: the second claim's own bolded-bullet prefix
+    (`- **Disclosure: …`) never counts into the FIRST group (each group
+    ends at the START of the line carrying the next claim)."""
+    slot = (
+        "Disclosure: 3 of 2,400 rollouts, drawn at random.\n\n"
+        "- [a](https://x/a) — first rollout\n"
+        "- [b](https://x/b) — second rollout\n"
+        "- [c](https://x/c) — third rollout\n\n"
+        "- **Disclosure: 9 of 2,400 judge rows, drawn at random.**\n\n"
+        "- [d](https://x/d) — fourth\n"
+        "- [e](https://x/e) — fifth\n"
+        "- [f](https://x/f) — sixth\n"
+        "- [g](https://x/g) — seventh\n"
+    )
+    res = verify_task_body.check_v4_sample_disclosure_count(_v4_body_with_sample_slot(slot))
+    assert res.passed is False
+    assert "claims 9 shown" in res.detail
+    assert "at most 4" in res.detail
+    # The reconciling FIRST group (3 == 3) is not flagged.
+    assert "Disclosure: 3 of" not in res.detail
+
+
+def test_v4_sample_disclosure_bulleted_claim_excludes_own_bullet():
+    """A `Disclosure:` claim nested inside a bullet (`- Disclosure: 6 of
+    2,400 …`) excludes its OWN bullet line from the group count: 6
+    following bullets reconcile at exactly 6 (a 7-count would WARN)."""
+    slot = "- Disclosure: 6 of 2,400 rollouts, drawn at random:\n" + _SIX_I1005_STYLE_BULLETS
+    res = verify_task_body.check_v4_sample_disclosure_count(_v4_body_with_sample_slot(slot))
+    assert res.passed is True
+    assert res.is_warn is False
+
+
+def test_v4_sample_disclosure_mixed_media_summed_basis_passes():
+    """SUMMED disjoint-media basis: a mixed-media group showing 3 table
+    data rows + 3 fenced completions for `Disclosure: 6 of 2,400` PASSes
+    via the summed basis (3 blocks + 3 out-of-block rows = 6) even though
+    no single-medium basis equals 6 (strictly generosity-increasing)."""
+    fence = "```text\nUser: q?\nAssistant: a.\n```\n"
+    slot = (
+        "Disclosure: 6 of 2,400 rows and completions, drawn at random.\n\n"
+        "| Row | System | User |\n"
+        "|---|---|---|\n"
+        "| 1 | sys | q |\n"
+        "| 2 | sys | q |\n"
+        "| 3 | sys | q |\n\n" + fence + "\n" + fence + "\n" + fence
+    )
+    res = verify_task_body.check_v4_sample_disclosure_count(_v4_body_with_sample_slot(slot))
+    assert res.passed is True
+    assert res.is_warn is False
 
 
 # ─── Check 17 (v4 lineage-token sub-check, #1014) ──────────────────────────


### PR DESCRIPTION
Closes task #1421. Adds check_v4_sample_disclosure_count (check 39) to scripts/verify_task_body.py + 11 tests + SPEC.md entry 39.