### PR TITLE
issue-1396: expensive-store-before-long-fit phase-ordering rule (#825)

### DIFF
--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -385,6 +385,16 @@ Compute-sizing recipes: `.claude/rules/plan-compute-sizing.md`
 (on-demand); phase placement + GPU-width right-sizing are always-on in
 CLAUDE.md § Pods.
 
+Phase-ORDER expensive-intermediate persistence: the §9 phase sequence names
+the upload point of every regeneration-costly intermediate (extraction /
+activation store, capture, rollout set) BEFORE — or detached-concurrent
+with — any long (>~15-30 min) downstream fit/analysis/eval phase that
+consumes it (a concurrent launch counts only if fail-loud + verified landed
+independently of the fit — never fire-and-forget); `extract → long fit →
+upload` is the #825 stranding order (a hung serial fit left the turnstore
+off HF; recovery = a fresh GPU re-extraction). Full rule:
+`.claude/rules/upload-policy.md` expensive-store-before-long-fit bullet.
+
 Full template + worked examples: `.claude/rules/planner-section-reference.md`
 § 9. Resources & Parallelism — read that section (grep the heading, chunked Read) BEFORE writing
 this section.

--- a/.claude/rules/LESSONS.md
+++ b/.claude/rules/LESSONS.md
@@ -42,7 +42,7 @@ Row grammar: `- <rule>.md — <fires-when trigger>`
 - research-project-structure.md — you write result artifacts / results index / queue (one source of truth per layer).
 - selection-symmetric-nulls.md — a headline max/argmax/top-k over a free axis vs a null band (inherit selection per draw or freeze held-out; band vs DV ceiling).
 - trigger-dense-review.md — reviewing/reconciling a guard/security artifact or refusal corpus (findings by reference; verdict first; windowed reads).
-- upload-policy.md — you write training/Hub/sweep code (Hub-API verification + verify-path transport retry, delete-after-eval persist, quota-403 recovery, upload-wedge ladder).
+- upload-policy.md — you write training/Hub/sweep code, or sequence phases around a regeneration-costly store (Hub-API verification + verify-path transport retry, delete-after-eval persist, store-upload-before-long-fit ordering #825, quota-403 recovery, upload-wedge ladder).
 - vectorize-many-cell-fits.md — many-cell GD, dense fits (svd/eigh/lstsq/ridge), or a perm/bootstrap/null-draw battery over a fixed pool (VECTORIZE first; detached+checkpointed VM fits; Supersede contract incl. mid-run ≥2×-deviation + width re-eval).
 - workflow-fix-on-bug.md — any agent hits a bug from a gap in the workflow surface itself (emit a `workflow-fix-candidate`).
 - agents-vs-skills.md — you create/restructure anything under `.claude/` (decide agent vs skill).

--- a/.claude/rules/critic-lens-reference.md
+++ b/.claude/rules/critic-lens-reference.md
@@ -250,6 +250,19 @@ composer copies the requested lens's items VERBATIM and IN FULL from this file.
       never needed to hold (2026-06-09: pod-518 ran 1h+ of pure-CPU permutation/bootstrap scoring
       with all 8 H100s at 0%, pod-523 ran a CPU-only metrics phase ~6h on idle GPUs — ~$48/hr of
       idle burn).
+      Sequencing clause (b) ALSO runs as a DATA-SAFETY ordering, not only a
+      billing one (and it fires for GPU fit phases too — the consuming
+      phase's device does not narrow it): when a long (>~15-30 min)
+      fit/analysis/eval phase CONSUMES a regeneration-costly intermediate
+      (extraction / activation store, capture, rollout set), REVISE a plan
+      whose phase sequence leaves that store unpersisted through the fit —
+      the store uploads (or a detached/backgrounded upload launches,
+      fail-loud + verified landed independently of the fit, never
+      fire-and-forget) BEFORE the long fit begins (#825: `extract → serial
+      CPU fit (hung) → upload` stranded the turnstore off HF; recovery cost
+      a full fresh GPU re-extraction).
+      Rule: `.claude/rules/upload-policy.md` expensive-store-before-long-fit
+      bullet; plan-side mirror: `planner.md` §9.
     - **(ii) Oversized footprint placed on the VM (disk/RAM safety).** REVISE when the plan routes the
       phase to the VM (the off-pod default) but its estimated local footprint exceeds
       `VM_ANALYSIS_FOOTPRINT_GB_MAX = 50` GB — `downloaded_inputs_gb +

--- a/.claude/rules/experiment-guidelines.md
+++ b/.claude/rules/experiment-guidelines.md
@@ -76,9 +76,13 @@ pressure, uploaded INCREMENTALLY in shards so a store larger than the disk
 quota still persists. NO policy ceiling. A discard fires ONLY when main AND
 overflow are exhausted, always with an alert + a regen recipe; model
 generations / rollout text are NEVER discardable.
+Sequence the upload of any regeneration-costly store BEFORE — or concurrent
+with — a long fit/analysis phase that consumes it: a fit hang must never
+strand the store (#825).
 Full recipe: `.claude/rules/upload-policy.md` (v2 § upload-by-default).
 **Owner:** `upload-verifier` (v2 mode — 100% reconciliation, undeclared
-missing = FAIL) + `efficiency-critic` (shard-upload sequencing, #664).
+missing = FAIL) + `efficiency-critic` (shard-upload sequencing, #664;
+expensive-store-before-long-fit ordering, #825).
 
 ## 6. Contrastive negatives for behavior implantation
 

--- a/.claude/rules/upload-policy.md
+++ b/.claude/rules/upload-policy.md
@@ -331,6 +331,36 @@ terminate fires only when the per-cell three-state gate finds zero partial
 cells. Reference impl: `scripts/issue664_dispatch.py` `_upload_cell_artifacts` /
 `_classify_cell_hub_state` / `_cell_done_anywhere`.
 
+**Expensive stores upload BEFORE — or detached-concurrent with — any long
+fit/analysis phase; a fit hang must never strand the store (#825).** When a
+run produces a regeneration-costly intermediate (an extraction / activation
+store, a teacher-forced capture, an on-policy rollout set — anything whose
+recreation costs GPU re-extraction rather than cheap CPU recompute) and a
+DOWNSTREAM fit/analysis/eval phase consumes it, the store's upload is
+sequenced BEFORE any long (>~15-30 min) downstream phase begins, or the
+upload is LAUNCHED concurrently with the fit (detached/backgrounded — HF
+`upload_folder` costs no GPU and overlaps a CPU fit freely). A concurrent
+launch counts as persistence ONLY when it is fail-loud and its completion
+is VERIFIED independently of the fit's completion — an exit-status check on
+the detached upload, or `hub.verify_repo_paths_uploaded` against the
+expected file set, BEFORE the fit's result is consumed; a fire-and-forget
+launch (never confirmed landed) does NOT satisfy this rule — a silently
+wedged upload plus a hung fit strands the store exactly as #825 did (the
+#931 wedge ladder above is the hung-upload remedy; this clause is what
+makes the ladder reachable before the pod is gone). The default
+order `extract → fit → upload` parks the entire fit's hang/crash/OOM-kill
+risk between the expensive artifact's creation and its persistence: #825
+Track-S run 2 hung in a serial CPU MLP fit before `[phase=upload]`,
+stranding the turnstore off HF — recovery cost a full fresh GPU
+re-extraction. This is the INTRA-RUN sibling of the two #664 sequencing
+rules: per-cell upload (bullet above) persists each sweep cell the moment
+it completes; pod-release before the final bulk upload (v2 § below) frees
+the GPU — this bullet orders store-persist ahead of long fits WITHIN one
+run's phase sequence. Plan-side mirror: `planner.md` §9 (the phase sequence
+names the upload point of every regeneration-costly intermediate relative
+to long fit phases); review enforcement: Methodology lens item 10(i)
+data-safety sequencing clause (`.claude/rules/critic-lens-reference.md`).
+
 **Inline-upload fence `EPM_SKIP_INLINE_CHECKPOINT_UPLOAD`.** `_finalize_phase`
 auto-uploads merged checkpoints to WandB Artifacts; orchestrators doing their own
 tagged upload set the env in `try/finally` to prevent double-uploads.
@@ -587,3 +617,6 @@ policy ceiling (Thomas's call). Everything above still holds; v2 tightens it to:
 
 - **#664 sequencing unchanged.** The GPU pod is released before the FINAL bulk
   upload; incremental shard uploads may overlap compute (they cost no GPU).
+  The #825 intra-run ordering bullet (main body above) binds v2 unchanged:
+  an expensive extraction store uploads before — or concurrent with — any
+  long fit/analysis phase that consumes it.

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -8863,8 +8863,10 @@ _LESSONS_ROW_GRANDFATHER_MAX_HEADROOM_BYTES = 40
 # Measured 5,780 B at the #1269 row-grammar migration; ratchet = measured
 # + ~220 (<= _LESSONS_RATCHET_MAX_HEADROOM_BYTES). #1366 grew the
 # artifact-reuse row (parent-lineage trigger, (a)-(k)): measured 6,046 B;
-# ratchet = measured + ~34.
-_LESSONS_RATCHET_BYTES = 6080
+# ratchet = measured + ~34. #1396 grew the upload-policy row
+# (phase-sequencing trigger, store-before-long-fit #825): measured 6,147 B;
+# ratchet = measured + ~253 (<= _LESSONS_RATCHET_MAX_HEADROOM_BYTES).
+_LESSONS_RATCHET_BYTES = 6400
 _LESSONS_RATCHET_MAX_HEADROOM_BYTES = 400
 
 


### PR DESCRIPTION
Closes task #1396.

Adds the expensive-store-before-long-fit phase-ordering rule to upload-policy.md (with fail-loud + verified-landed concurrent-upload clause), mirrors it in planner.md §9, adds the critic-lens-reference item 10(i) data-safety REVISE hook, widens the LESSONS.md trigger row (+ _LESSONS_RATCHET_BYTES 6080->6400), and indexes it in experiment-guidelines guideline 5. Driving incident: #825 (fit hang stranded the turnstore off HF; recovery = fresh GPU re-extraction).