### PR TITLE
issue-1403: Step 10d residual merge conflicts dispatch to a fresh worktree-scoped subagent

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -10136,11 +10136,28 @@ else
     fi
   done < /tmp/issue-<N>-recovery-figures.txt
 fi
-# THIS task's own tasks/*/<N>/ conflicts and all remaining non-tasks/ conflicts (figures/ resolved above):
-# resolve in the worktree (keep main's version of anything outside this
-# task's deliverables), then:
-git -C "$WT" add <each resolved file>
-git -C "$WT" commit --no-edit
+# Residual conflicts — THIS task's own tasks/*/<N>/ paths and all remaining
+# non-tasks/ paths (foreign tasks/ and figures/ were resolved MECHANICALLY
+# above, with zero conflict-body reads). The orchestrator NEVER reads
+# residual conflict bodies inline here — that inline read killed #1338
+# ("Prompt is too long", no recovery turn): Step 10d/9b merges run
+# late-session by construction, and a session cannot introspect its own
+# context headroom. Materialize the residual list (exclusive-arm `if ! ...`
+# producer shape, #1184/#1243):
+if ! git -C "$WT" -c core.quotePath=false diff --name-only --diff-filter=U \
+    > /tmp/issue-<N>-recovery-residual.txt; then
+  echo "recovery: residual conflicted-paths diff FAILED — do NOT resolve blind; epm:merge-failed"
+  false
+elif [ -s /tmp/issue-<N>-recovery-residual.txt ]; then
+  echo "recovery: $(wc -l < /tmp/issue-<N>-recovery-residual.txt) residual content conflict(s) — dispatch the residual-conflict subagent (subsection below); do NOT read conflict bodies inline"
+  # Halt the inline fence at this branch (loud false — a naive one-shot
+  # execution must not fall through to the commit/certification below);
+  # re-enter at the post-resolution certification block once the
+  # subagent's resolution commit lands.
+  false
+else
+  git -C "$WT" commit --no-edit   # every conflict was resolved mechanically above
+fi
 # Post-resolution certification (the #1128 verification): the branch tree
 # must now be IDENTICAL to the captured snapshot over tasks/, modulo this
 # task's own folder. ONE fused if/elif chain (Guard 1's `if ! ...` shape,
@@ -10200,6 +10217,79 @@ else
   false
 fi
 ```
+
+##### Residual-conflict subagent dispatch (context-hygiene branch)
+
+When the residual list is NON-EMPTY, dispatch the conflict investigation +
+resolution to a fresh worktree-scoped subagent — never an inline
+orchestrator read. UNCONDITIONAL: no file-count or context-fullness
+threshold. Step 10d/9b merges run after the full pipeline, so late-session
+is guaranteed; a session cannot introspect its own headroom; and the
+lethal variable is conflict-body BYTES, not file count (#1338: 4 files
+paged inline killed the session with no recovery turn — one conflicted
+eval script can be just as large). The mechanical passes above absorb the
+common classes, so this branch fires rarely. The failure-arm echoes above
+("resolve by hand per the prose below") route HERE — "by hand" means via
+this dispatch; do NOT read conflict bodies inline.
+
+1. Post the stage-dispatch breadcrumb FIRST (Step 9 entry-guard
+   convention): an `epm:progress` marker whose note BEGINS with the
+   literal `stage-dispatch ` prefix (required by
+   `task_workflow.stage_dispatch_should_skip` / `_breadcrumb_fields` —
+   a prefix-less note is invisible to the dedup + resume machinery):
+   `stage-dispatch stage=step10d-conflict-resolve worktree=<abs $WT> paths=<count>`.
+   Resume/dedup predicate for a successor session: breadcrumb present AND
+   `git -C "$WT" diff --name-only --diff-filter=U` empty AND a resolution
+   commit on the branch tip ⇒ resolution landed, skip to certification;
+   breadcrumb present but worktree still conflicted AND no prior subagent
+   verdict recorded ⇒ re-dispatch ONCE, counted as the SAME single
+   attempt; otherwise fall to the Failure bullet. Never two concurrent
+   dispatches.
+2. Spawn ONE fresh `implementer`-class subagent with
+   `env=scrub_subagent_env(os.environ)` (standing convention). If the
+   residual list file is missing at dispatch time (a successor session, a
+   swept /tmp), re-run the `--diff-filter=U` producer above rather than
+   assuming the file exists. The brief is LEAN — paths and pins by
+   reference, never conflict bodies
+   (`.claude/rules/trigger-dense-review.md` disciplines 1/3/4 — findings
+   by reference, windowed reads, minimal return text;
+   `.claude/rules/diff-size-budget.md`):
+   - task id, branch name, absolute worktree path `$WT`;
+   - the captured `$MAIN_SHA` — the subagent PINS every resolution to it
+     and never re-fetches or re-snapshots (#1128 shared-ref race);
+   - the residual list file `/tmp/issue-<N>-recovery-residual.txt` + count
+     (the subagent reads paths from the file);
+   - the resolution contract, verbatim: (a) a residual FOREIGN tasks/ path
+     is pinned to `$MAIN_SHA` — checkout the on-main, `git rm -f` the
+     gone-on-main (the mechanical pass's own split); (b) a residual binary
+     figures/ path resolves newer-regeneration-wins per the recipe above;
+     (c) THIS task's own tasks/*/<N>/ and non-tasks/ paths: keep main's
+     version of anything outside this task's deliverables; for the task's
+     own deliverables keep the branch's content, merging hunk-by-hunk only
+     where both sides carry real content;
+   - read discipline: size any diff body before reading (300 KB budget);
+     read conflicted files individually, windowed around conflict markers;
+   - completion duties: `git -C "$WT" add` each resolved path,
+     `git -C "$WT" commit --no-edit`, verify zero `--diff-filter=U` paths;
+   - return contract: verdict `resolved` | `unresolvable: <one line>`, the
+     resolution commit sha, per-class path counts, path NAMES only — NEVER
+     conflict hunks, bodies, or diff text in the return (an oversized
+     return kills the parent this dispatch protects).
+3. On `resolved`: verify cheaply (`--diff-filter=U` empty; `rev-parse
+   HEAD` matches the reported sha), spot-check the keep-main contract on a
+   sample — a residual path OUTSIDE this task's deliverables should be
+   byte-identical to the snapshot (`git -C "$WT" diff "$MAIN_SHA" HEAD --
+   <path>` empty) — then re-enter the fence above AT the post-resolution
+   certification block and run certification → lint gate → push → merge
+   YOURSELF. The subagent never pushes and never runs the lint gate — the
+   fail-closed verdict-file contract is unchanged.
+4. On `unresolvable`, a dead/refused subagent (after step 1's single
+   no-verdict-recorded re-dispatch, or immediately when a verdict WAS
+   recorded), or certification FAIL on the subagent's commit: fall to the
+   Failure bullet (`epm:merge-failed v1`, continue). The dispatch lives
+   INSIDE the one-recovery-attempt cap — never a second dispatch (the
+   step-1 no-verdict re-dispatch is the SAME attempt; a second death
+   falls here), never an inline fallback read.
 
 One recovery attempt per Step 10d invocation. If the re-checked
 mergeability never recovers or the retried merge is refused again, fall

--- a/tests/test_issue_skill_conflict_subagent_dispatch_pin.py
+++ b/tests/test_issue_skill_conflict_subagent_dispatch_pin.py
@@ -1,0 +1,137 @@
+"""Content-invariant pins for the #1403 residual-conflict subagent dispatch.
+
+Task #1403 replaced the Step-9b/10d merge-conflict recovery's inline
+manual-resolution step in `.claude/skills/issue/SKILL.md` with a
+context-hygiene branch: the orchestrator materializes the residual
+`--diff-filter=U` conflicted-path list to a file (exclusive-arm `if !`
+producer, #1184/#1243); a NON-EMPTY list routes to ONE fresh
+worktree-scoped `implementer`-class subagent (lean by-reference brief;
+verdict + resolution commit sha + per-class counts + path NAMES back —
+never conflict hunks), while an EMPTY list commits inline
+(`git commit --no-edit`). The orchestrator never reads residual conflict
+bodies inline; certification / lint gate / push / merge stay
+orchestrator-side, and the dispatch lives inside the one-recovery-attempt
+cap.
+
+REGION-SCOPED per the `test_issue_skill_binary_figures_recovery_pin.py`
+precedent (slice `#### Merge-conflict recovery` -> `#### The
+artifact-confirmed merge procedure`, fail-loud anchors). Prose pins
+normalize whitespace AND strip `# ` comment prefixes (rationale prose
+wraps across comment lines inside the fenced bash block).
+
+Origin incident: #1338 (2026-07-15, session bc8a308f): 4-file real content
+conflicts at a Step 10d squash-merge; the conflict diff was paged inline
+into a near-full orchestrator context; "Prompt is too long", no recovery
+turn.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SKILL = _REPO_ROOT / ".claude" / "skills" / "issue" / "SKILL.md"
+
+_RESIDUAL_LIST_TOKEN = "recovery-residual.txt"
+_DISPATCH_HEADING = "##### Residual-conflict subagent dispatch"
+# Assert-4 positive token: the fence's non-empty-residual dispatch branch.
+_FENCE_BRANCH_TOKEN = "elif [ -s /tmp/issue-<N>-recovery-residual.txt"
+# Assert-4 negative token: the removed inline manual-add placeholder
+# (unique to the replaced step; NOT `keep main's version of anything
+# outside this task's deliverables`, which the subagent brief deliberately
+# reuses as its resolution contract).
+_REMOVED_MANUAL_ADD = 'git -C "$WT" add <each resolved file>'
+
+
+def _skill_text() -> str:
+    return _SKILL.read_text(encoding="utf-8")
+
+
+def _recovery_region(text: str) -> str:
+    """The merge-conflict recovery slice (the dispatch branch's home)."""
+    start_marker = "#### Merge-conflict recovery"
+    end_marker = "#### The artifact-confirmed merge procedure"
+    start = text.find(start_marker)
+    end = text.find(end_marker)
+    assert start != -1, "Merge-conflict recovery heading not found in SKILL.md"
+    assert end != -1, "artifact-confirmed merge heading not found in SKILL.md"
+    assert start < end, "recovery region must precede the artifact-confirmed merge"
+    return text[start:end]
+
+
+def _normalized_prose(text: str) -> str:
+    """Whitespace-collapse AND strip leading `#` comment prefixes per line —
+    rationale prose wraps across bash comment lines and numbered-list
+    continuation lines, so pins on spanning phrases need the prefixes
+    removed and the lines joined."""
+    words: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            stripped = stripped.lstrip("#").strip()
+        words.extend(stripped.split())
+    return " ".join(words)
+
+
+def test_recovery_region_carries_residual_dispatch_branch():
+    """Assert 1: the recovery region materializes the residual conflicted-path
+    list to a file AND carries the residual-conflict subagent dispatch
+    subsection (the context-hygiene branch a non-empty list routes to)."""
+    recovery = _recovery_region(_skill_text())
+    assert _RESIDUAL_LIST_TOKEN in recovery, (
+        "the recovery must materialize the residual conflicted-path list "
+        "to /tmp/issue-<N>-recovery-residual.txt"
+    )
+    assert _DISPATCH_HEADING in recovery, (
+        "the recovery region must carry the residual-conflict subagent "
+        "dispatch subsection (##### heading)"
+    )
+
+
+def test_recovery_prose_bans_inline_conflict_body_reads():
+    """Assert 2: the normalized region prose bans inline conflict-body reads
+    (the #1338 context bomb) on BOTH sides — the orchestrator's dispatch
+    branch (`do NOT read conflict bodies inline`) and the subagent's return
+    contract (`NEVER conflict hunks`, bodies, or diff text in the return)."""
+    prose = _normalized_prose(_recovery_region(_skill_text()))
+    assert "do NOT read conflict bodies inline" in prose, (
+        "the dispatch branch must ban inline orchestrator reads of residual "
+        "conflict bodies (the #1338 context bomb)"
+    )
+    assert "NEVER conflict hunks" in prose, (
+        "the subagent return contract must ban conflict hunks/bodies/diff "
+        "text in the return (an oversized return kills the parent)"
+    )
+
+
+def test_dispatch_lives_inside_one_attempt_cap():
+    """Assert 3: the dispatch lives INSIDE the one-recovery-attempt cap
+    (never a second dispatch, never an inline fallback read) and the
+    subagent pins every resolution to the captured $MAIN_SHA snapshot
+    (never re-fetches or re-snapshots — the #1128 shared-ref race)."""
+    prose = _normalized_prose(_recovery_region(_skill_text()))
+    assert "never a second dispatch" in prose, (
+        "the dispatch must live inside the one-recovery-attempt cap (never a second dispatch)"
+    )
+    assert "never re-fetches or re-snapshots" in prose, (
+        "the subagent brief must pin resolutions to the captured $MAIN_SHA "
+        "(never re-fetches or re-snapshots, #1128)"
+    )
+
+
+def test_fence_branch_replaces_inline_manual_resolution():
+    """Assert 4 (FENCE-DISCRIMINATING, plan-r1 Statistics Must-Fix): without
+    this pin the suite is satisfiable with the subsection (Edit B) present
+    but the fence branch (Edit A) missing — a vacuous PASS that leaves the
+    old inline manual-resolution path executed. Positive: the fence carries
+    the non-empty-residual dispatch branch. Negative: the removed inline
+    manual-add placeholder is gone from the region."""
+    recovery = _recovery_region(_skill_text())
+    assert _FENCE_BRANCH_TOKEN in recovery, (
+        "the recovery fence must branch on a non-empty residual list "
+        "(elif [ -s /tmp/issue-<N>-recovery-residual.txt ...) — Edit A"
+    )
+    assert _REMOVED_MANUAL_ADD not in recovery, (
+        "the inline manual-resolution step (git add <each resolved file>) "
+        "must be gone — residual conflicts dispatch to the subagent instead"
+    )


### PR DESCRIPTION
Closes task #1403.

Workflow-fix (kind: infra, /daily-filed): the Step 10d merge-conflict recovery in .claude/skills/issue/SKILL.md gains a residual-conflict subagent-dispatch branch so the orchestrator never pages conflict bodies into a near-full context (incident #1338: 'Prompt is too long' death mid-recovery). Adds a region-scoped pin test with a fence-discrimination assert.

Pipeline: plan v3 (critic ensemble: APPROVE/REVISE-addressed/APPROVE; consistency PASS) -> implementer 34ad3eea -> code-review PASS (round 1).