### PR TITLE
issue-1405: paper-plots §3.9 interim/user-facing figure defaults

### DIFF
--- a/.claude/skills/paper-plots/SKILL.md
+++ b/.claude/skills/paper-plots/SKILL.md
@@ -210,6 +210,75 @@ across rounds — a follow-up experiment can shift the headline. A caption
 regen. Keep the figure a stable data primitive; keep the interpretation
 in the text.
 
+For interim-figure decoration defaults (hatching, per-bar n, estimated-value markers, tick rotation), see §3.9.
+
+### 3.9. Interim / user-facing figure defaults
+
+These are DEFAULTS for any figure shown to the user outside a final
+paper — chat figures, mid-run result summaries, pull-request previews,
+or any interim figure sent before the clean-result promotes. A user
+request to add hatching, per-bar counts, or an estimated-value marker
+overrides these defaults for that figure; absent an explicit ask, apply
+them silently.
+
+**Default-off decoration (absent a user request, omit all of these):**
+
+- **No hatching.** Fill bars with solid color only. Hatching adds
+  visual noise and often fails accessibility checks at small sizes;
+  if ≥6 conditions need distinguishing, split into two panels (P7)
+  rather than defaulting to hatching. (Evidence: 09f28ede 2026-07-15.)
+- **No per-bar n-annotations.** Do not auto-label bars with their
+  sample count (`n=200`, `n=4998`). Report N in the caption or the
+  prose; on the figure it competes with the data labels and misleads
+  when n is a total that conflates train/held-out sizes.
+  (Evidence: 09f28ede + b7150177 2026-07-15.)
+- **No estimated / "guess" value markers.** Do not add a marker, band,
+  or annotation showing a model's best-guess or estimated value unless
+  the user explicitly requests it. Estimated values are interpretation;
+  they belong in the caption or prose, not on the artist.
+  (Evidence: 09f28ede 2026-07-15.)
+- **No gratuitous tick-label rotation.** Only rotate tick labels
+  (≤ 30°) when labels genuinely overlap at the figure's default width.
+  `plt.setp(ax.get_xticklabels(), rotation=15, ha="right")` is in the
+  pattern files as a WHEN-NEEDED example, not a standing default; omit
+  it when labels fit horizontally. (Evidence: 09f28ede 2026-07-15.)
+
+**CV / cross-validated metric figures — fold structure in the caption
+(REQUIRED):**
+
+Any figure whose y-axis reports a cross-validated metric (R², ρ,
+accuracy, loss averaged across folds) MUST state in its caption ALL of:
+`n_contexts=<K>` (total units / observations), `k=<F>` folds,
+`held-out=<H>` (held-out set size or fraction per fold). Use plain
+English: *"cross-validated over 5 folds, n=4998 total contexts
+(∼1000 held-out per fold)"* is the target register. Without this, an
+aggregate n is routinely misread as the training set size.
+(Evidence: b7150177 2026-07-15, "n=4998" caption.)
+
+**Interim figures — mapping arm + per-behavior disaggregation in the
+caption/setup line (REQUIRED):**
+
+This is the figure-side mirror of the CLAUDE.md "Ad-hoc results
+summaries state per-arm provenance in their setup line" rule. Every
+interim figure caption or setup-line MUST state:
+
+1. **The mapping arm(s) shown:** *prefix-based* (everything before the
+   user query) or *context-based* (prefix + user query), or *both* if
+   the figure overlays them. Never label an arm as just "activations"
+   or "representations."
+2. **Per-behavior disaggregation:** if the figure aggregates across
+   behaviors (sycophancy, refusal, EM, …), say so; if it shows a
+   single behavior or a subset, name them. Never ship a figure where the
+   reader must infer which behavior(s) contributed.
+
+Example caption opener: *"Prefix-based mapping, sycophancy + refusal
+behaviors, base model, k=5 LOFO folds."* (Evidence: 28d0874a
+2026-07-15 06:36-06:44.)
+
+This guidance targets interim figures (pre-clean-result), which
+`verify_task_body.py` does not scan. A future mechanization that checks
+figure sidecar captions is a natural extension but out of scope here.
+
 ### 4. Run & save
 
 ```python

--- a/.claude/skills/paper-plots/patterns/P1-bar-comparison.md
+++ b/.claude/skills/paper-plots/patterns/P1-bar-comparison.md
@@ -89,6 +89,6 @@ caption.
   bars (two bars side-by-side per x-tick) instead.
 - **Don't label bars with `0.912` when the metric is a proportion.** Show
   `91.2%` — more readable. (Call `f"{v * 100:.1f}%"`.)
-- **Don't use > 5 colors.** If you have 6+ conditions, group them into
-  related pairs with the same fill color + different hatch, or split into
-  two panels (P7).
+- **Don't use > 5 colors.** If you have 6+ conditions, split into two
+  panels (P7). Hatching is a user-request opt-in (§3.9) — do not add
+  it as a default fallback.


### PR DESCRIPTION
Closes task #1405 (daily-fix: paper-plots interim-figure defaults). Adds §3.9 interim-figure decoration defaults + CV fold-structure and mapping-arm caption rules; P1 hatch recommendation downgraded to opt-in.