### PR TITLE
issue-1406: cross-issue protocol-delta citation rule (SPEC + Lens 7 + analyzer duty + pin test)

### DIFF
--- a/.claude/agents/analyzer.md
+++ b/.claude/agents/analyzer.md
@@ -377,6 +377,13 @@ written inline, never `see #M`) / `## Results` (one
   ground truth (training script at the Code SHA / `run_result.json` / plan
   §11), never typed from memory (#489: a 50x lr misprint; check 16). For
   no-training tasks: `**N/A — no model training.**`
+- **Cross-issue protocol delta (SPEC.md §`## Goal` (v4) / §`## Results`
+  (v4)):** when quoting a sibling issue's headline number measured under
+  a different eval protocol (e.g. split scheme, fold structure,
+  layer-selection rule, eval distribution, judge/DV recipe), state the
+  protocol delta inline next to the number + a comparability verdict
+  ("— not directly comparable"); in `## Results`/captions use the
+  descriptive no-`#K` form. Lens 7 FAILs a bare side-by-side.
 - **The Artifacts-grounding rule (`**Repro:**` footer):** GROUND every
   path-specific artifact claim in a live Hub listing at write time via
   `huggingface_hub.list_repo_files` (the `hf` CLI has no `api` subcommand,

--- a/.claude/rules/clean-result-critic-lens-reference.md
+++ b/.claude/rules/clean-result-critic-lens-reference.md
@@ -214,7 +214,10 @@ this lens is the substantive read on top. (v3: the five-flat-H2 shape
   a recap of the earlier run's superseded eval rig / negatives / panel
   / judge. `**This experiment in context:**` may name a prior result to
   establish the open
-  question; it must not relitigate that run's methodology.
+  question; it must not relitigate that run's methodology (a
+  cross-issue protocol delta stated next to a cited number per Lens 7
+  § Cross-issue protocol comparability is comparability qualification,
+  NOT correction framing).
 
 **`## Methodology`:** (v3: the one-line recipes lived in the
 `**Design:**` / `**Training:**` / `**Eval:**` slots of `## What I ran`;
@@ -681,6 +684,29 @@ PASSes vacuously when the result is not a content-behavior
 leakage/implant, or when both DVs (+ validation) are reported with the
 rate primary. (Mirrors CLAUDE.md § Measurement validity, analyzer.md
 gate check 3, interpretation-critic Lens 1, critic Statistics item 10.)
+
+**Cross-issue protocol comparability (citation discipline, FAIL).** When
+the body or a figure cites a sibling issue's headline number (R², ρ,
+rate, margin) measured under a DIFFERENT eval protocol — e.g. split
+scheme (single split vs k-fold), fold structure, layer-selection rule
+(steering-selected vs predictivity-selected), eval distribution,
+judge/DV recipe, or any other material eval-protocol dimension — the
+protocol delta MUST be stated inline next to the number, with a
+comparability verdict where the protocols differ materially ("— not
+directly comparable" is the typical verdict; a justified comparability
+verdict is equally legitimate). A protocol delta stated to qualify a
+cited number is comparability qualification, NOT Lens 2's banned
+correction framing. FAIL when two protocol-mismatched headlines sit
+side by side (e.g. in `## Takeaways`, `## Goal` context prose, a
+caption, or interpretation prose) with no delta stated —
+mentor-facing incident: #779 vs #823 R² headlines (single-split vs
+k-fold, different layer-selection rules) needed ~6 clarifying
+questions. PASS vacuously when no sibling headline is quoted, the cited
+protocol matches this issue's, or the delta (+ a comparability verdict
+where the protocols differ materially) is stated.
+Forward-only: binds v4 bodies and follow-up rounds folding onto older
+bodies (migrate-on-fold makes them v4); never newly FAIL a parked
+v3/v2/legacy body.
 
 ### Lens 8 — Mentor-facing title
 

--- a/.claude/skills/clean-results/SPEC.md
+++ b/.claude/skills/clean-results/SPEC.md
@@ -474,6 +474,19 @@ required boldface-led parts:
   `#K`-linked). **Do NOT stage the writeup as a methodology correction of
   a prior run** — describe the open question and what this run did; never
   "the prior run used X, this run uses Y".
+  **Cross-issue protocol comparability:** when this slot quotes a
+  sibling issue's headline NUMBER measured under a DIFFERENT eval
+  protocol (split scheme, fold structure, layer-selection rule, eval
+  distribution, judge/DV recipe), state the protocol delta inline next
+  to the number, with a comparability verdict where the protocols
+  differ materially — e.g.
+  "[#823](https://eps.superkaiba.com/tasks/823) reported R²=0.63
+  (k-fold, predictivity-selected layer) vs this issue's 0.71 (single
+  split, steering layer) — not directly comparable". A protocol delta
+  stated to QUALIFY a quoted number is comparability qualification,
+  not the banned correction framing above. Two protocol-mismatched
+  headlines side by side with no delta stated is a critic FAIL
+  (Lens 7).
 - **`**Broader narrative:**`** — the goal of this experiment / group of
   experiments in the project's broader narrative (the
   `docs/open_questions.md` anchor / project-level question it serves).
@@ -561,6 +574,14 @@ One `### <result>` H3 per result. Each result is STANDALONE — a reader can
 land on it directly and understand it. Issue numbers are confined to
 `## Goal` and the `**Repro:**` / `**Context:**` footer; baselines are
 framed descriptively ("the narrow 2-negative baseline"), not by number.
+When a descriptively-framed baseline (in prose, a caption, or a figure
+reference line) quotes a sibling experiment's headline number measured
+under a DIFFERENT eval protocol, the protocol delta rides inline next
+to the number in the same beat — descriptive form, no `#K` (e.g. "the
+sibling k-fold, predictivity-selected estimate (R²=0.63) vs this run's
+single-split, steering-layer 0.71 — not directly comparable"). When
+the 60-word caption cap binds, the delta rides the what-is-plotted
+prose instead of the caption.
 
 Per-result skeleton — the strict three-beat (THIS is the v4 contract):
 

--- a/.claude/skills/clean-results/iterations.md
+++ b/.claude/skills/clean-results/iterations.md
@@ -674,6 +674,17 @@ Companion rule added to the migration prompt's cluster-analysis instructions: **
 
 ---
 
+## 2026-07-16 — task #1406 (cross-issue protocol-comparability citation rule)
+
+### Two protocol-mismatched sibling R² headlines sat side by side in mentor-facing prose with no comparability qualifier
+
+- **Before:** mentor-facing prose quoted #779's and #823's R² headlines side by side with no qualifier, though they were measured under different eval protocols (single split vs k-fold; different layer-selection rules) — untangling which numbers were comparable took ~6 clarifying questions. No SPEC.md rule governed how a sibling issue's headline number is qualified when cited.
+- **After:** a sibling issue's headline cited under a different eval protocol carries the protocol delta inline next to the number plus a comparability verdict, e.g. "[#823](https://eps.superkaiba.com/tasks/823) reported R²=0.63 (k-fold, predictivity-selected layer) vs this issue's 0.71 (single split, steering layer) — not directly comparable"; in `## Results`/captions the delta rides the descriptive no-`#K` form (and the what-is-plotted prose when the 60-word caption cap binds).
+- **Rule:** Cross-issue protocol comparability — when a body or figure cites a sibling issue's headline number measured under a DIFFERENT eval protocol (e.g. split scheme, fold structure, layer-selection rule, eval distribution, judge/DV recipe), state the protocol delta inline next to the number, with a comparability verdict where the protocols differ materially. A delta stated to qualify a cited number is comparability qualification, not Lens 2's banned correction framing. Forward-only: binds v4 bodies + follow-up rounds folding onto older bodies; enforcement is Lens 7.
+- **Folded into:** `.claude/skills/clean-results/SPEC.md` (§ `## Goal` (v4) `**This experiment in context:**` bullet + § `## Results` (v4) descriptive-baseline guidance); `.claude/rules/clean-result-critic-lens-reference.md` (Lens 7 enforcement paragraph + Lens 2 carve-out cross-ref); `.claude/agents/analyzer.md` (Step 4 drafting-duty bullet); `tests/test_cross_issue_protocol_comparability_prose.py` (pin test).
+
+---
+
 ## How to add a new entry
 
 When iterating on a clean-result with the user, after applying their correction:

--- a/tests/test_cross_issue_protocol_comparability_prose.py
+++ b/tests/test_cross_issue_protocol_comparability_prose.py
@@ -1,0 +1,46 @@
+"""Durability pin for the cross-issue protocol-comparability citation rule (#1406).
+
+The rule is enforcement PROSE only (no mechanical verifier check -- protocol
+identity is semantic, not greppable), so a later spec-trim pass could silently
+drop it while every lint stays green. This pin fails loud if any of the three
+prose surfaces loses its clause: SPEC.md (the source of truth), the
+clean-result-critic Lens 7 rubric, and the analyzer drafting duty. Origin
+incident: #779 vs #823 protocol-mismatched R-squared headlines quoted side by
+side in mentor-facing prose. Family precedent:
+tests/test_analyzer_language_intrusion_duty.py.
+"""
+
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+
+
+def test_protocol_delta_clause_present() -> None:
+    """SPEC.md, Lens 7, and analyzer.md all carry the protocol-delta clause."""
+    spec = (_REPO / ".claude" / "skills" / "clean-results" / "SPEC.md").read_text(encoding="utf-8")
+    # (a) SPEC.md: both v4 anchors (## Goal slot + ## Results descriptive baseline)
+    assert spec.count("not directly comparable") >= 2, (
+        "SPEC.md lost a 'not directly comparable' worked example "
+        "(need one in the ## Goal (v4) slot and one in ## Results (v4))"
+    )
+    assert spec.count("Cross-issue protocol comparability") >= 1, (
+        "SPEC.md lost the Cross-issue protocol comparability clause"
+    )
+
+    # (b) lens-reference: the enforcement paragraph lives inside the Lens 7 span
+    lens_ref = (_REPO / ".claude" / "rules" / "clean-result-critic-lens-reference.md").read_text(
+        encoding="utf-8"
+    )
+    lens7_start = lens_ref.index("### Lens 7")
+    lens8_start = lens_ref.index("### Lens 8")
+    assert lens7_start < lens8_start, "Lens 7/8 heading order broke"
+    lens7_span = lens_ref[lens7_start:lens8_start]
+    assert "Cross-issue protocol comparability" in lens7_span, (
+        "Lens 7 lost the Cross-issue protocol comparability enforcement paragraph"
+    )
+
+    # (c) analyzer drafting duty
+    analyzer = (_REPO / ".claude" / "agents" / "analyzer.md").read_text(encoding="utf-8")
+    assert "Cross-issue protocol delta" in analyzer, (
+        "analyzer.md lost the Cross-issue protocol delta drafting-duty bullet"
+    )


### PR DESCRIPTION
Closes task #1406.

Workflow-fix (kind: infra, wf-fix): when a clean-result body or figure cites a sibling issue's headline measured under a different eval protocol, the protocol delta is stated inline next to the number.

- SPEC.md: v4 `## Goal` slot clause + v4 `## Results` descriptive-baseline clause
- clean-result-critic lens reference: Lens 7 enforcement paragraph + Lens 2 carve-out cross-ref
- analyzer.md: drafting-duty bullet
- iterations.md: correction entry
- new pin test `tests/test_cross_issue_protocol_comparability_prose.py`

Plan v2 (3×APPROVE ensemble, consistency WARN resolved); code-review PASS; test-verdict PASS (compare exit 0).