### PR TITLE
issue-1422: check-30 Pattern E trailing-parenthetical file-count claims

### DIFF
--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -555,7 +555,12 @@ Generation-agnostic checks (run on v2 AND v3 — the inline-figure +
   or a backtick `dir/` sub-path token whose parenthetical OPENS with the
   count-noun, bound to the nearest preceding hex-pinned `/tree/<sha>`
   markdown link on the same footer row — bracket-free, newline-free,
-  ≤400-char gap — and probed at `<link-prefix>/<sub-path>`, #1143)
+  ≤400-char gap — and probed at `<link-prefix>/<sub-path>`, #1143; or a
+  parenthetical immediately AFTER the link that OPENS with the count-noun
+  (`[summary store](…/tree/<sha>/…) (52 files)`, the #1005 footer shape —
+  ANY distributive `per <word>` qualifier declines, and a paren
+  immediately followed by an HF markdown link is Pattern B's
+  paren-before-link shape: E declines, B wins, #1422))
   must match a files-only scoped Hub tree count at the pinned revision —
   the same bounded raw tree-endpoint probe checks 23/25 use (#733; never
   the SDK `list_repo_tree` / `list_repo_files`), counted EXHAUSTIVELY with
@@ -575,7 +580,10 @@ Generation-agnostic checks (run on v2 AND v3 — the inline-figure +
   "908 files listed per namespace" where each namespace holds 891 blobs +
   17 directory entries (#1088); task #1112 shipped "(7,372 files: …)"
   after a backtick `raw_completions/` token in the pinned-bucket footer
-  row where the scoped tree holds 7,165 files + 207 folders (#1143).
+  row where the scoped tree holds 7,165 files + 207 folders (#1143);
+  task #1005's footer claimed 51/15 in bare trailing parens right after
+  its pinned links where the pinned trees hold 52/17 — no pattern reached
+  the count-opening paren-after-link position (#1422).
 
 - **check 31** (`check_orphaned_per_unit_figures`, WARN): the INVERSE
   direction of checks 4b/22/29 (which verify what the body CITES) —
@@ -8516,7 +8524,11 @@ def check_audit_availability_claims_match_hf(body: str) -> CheckResult:
 # where the scoped tree at `<bucket>/raw_completions` holds 7,165 files
 # + 207 folders. No pattern reached a count bound to a backtick SUB-PATH
 # of a preceding link; Pattern D + the nearest-preceding-pinned-link
-# binder close that gap (#1143).
+# binder close that gap (#1143). #1005's footer then carried bare
+# trailing parens — `[summary store + manifest](…/tree/<sha>/…) (51
+# files)` — where the pinned trees hold 52/17: a count-OPENING paren
+# right after the link that matches no anchored phrase; Pattern E closes
+# that gap (#1422).
 
 # A markdown link whose target is an HF Hub URL. Two-stage extraction: match
 # the link structure first, then scan the TEXT for a count-noun and parse the
@@ -8580,6 +8592,37 @@ _FILES_PER_NAMESPACE_RE = re.compile(
 _FILES_AT_PINNED_REV_RE = re.compile(
     r"\b(?P<count>\d{1,3}(?:,\d{3})+|\d{1,6})\s+files?\s+(?:listed\s+)?"
     r"at\s+the\s+pinned\s+revision\b",
+    re.IGNORECASE,
+)
+# Pattern E (#1005, the trailing-parenthetical footer shape): the paren
+# immediately AFTER the pinned link OPENS with the count-noun —
+# `[summary store + manifest](…/tree/<sha>/…) (52 files)`. Applied via
+# .match() on the paren body captured by _HF_LINKTEXT_THEN_PAREN_RE, so the
+# same-line separator ([ \t]{0,2}) and [^()]{1,300} paren-body bounds are
+# inherited from that iterator. Wide distributive decline like Pattern D:
+# ANY "per <word>" qualifier declines — "per namespace" belongs to the #833
+# per-namespace leg; "per adapter"/"per seed" (#460 class) have per-unit
+# semantics and would compare N against the parent's total. Trailing content
+# after the count-noun is unconstrained within the paren-body bound (the
+# #1005 "(17 files incl. `f2f3/` …)" / "(50 files: 42 updated + 8 verbatim)"
+# shapes).
+_COUNT_OPEN_PAREN_AFTER_LINK_RE = re.compile(
+    r"(?P<count>\d{1,3}(?:,\d{3})+|\d{1,6})\s+(?P<noun>files?|shards?)\b"
+    r"(?!\s+(?:listed\s+)?per\s+\w+\b)",
+    re.IGNORECASE,
+)
+# B-adjacency decline for Pattern E (mirrors Pattern D's trailing negative
+# lookahead, #1143): a paren immediately followed by an HF markdown link is
+# Pattern B's paren-before-link shape — E declines rather than extracting a
+# second, differently-scoped claim from the same paren. Checked with
+# .match(stripped, pos) at the E-paren's closing position (re.Pattern.match
+# anchors at pos, no leading `^` needed). NOTE: the whitespace separators
+# (`\s{0,2}`) span newlines, so a paren at end-of-line followed by a
+# next-line HF markdown link ALSO declines — a conservative recall residue
+# (a declined claim, never a wrong one). IGNORECASE for parity with the
+# Pattern B/D link matching.
+_HF_LINK_FOLLOWS_PAREN_RE = re.compile(
+    r"\s{0,2}[:\u2013\u2014-]?\s{0,2}\[[^\]]{1,300}\]\(https?://huggingface\.co",
     re.IGNORECASE,
 )
 # A backtick directory token in link TEXT: `analysis_tensors_nonemit/` — the
@@ -8680,7 +8723,7 @@ def _gather_hf_count_claims(body: str) -> list[tuple[int, str, str, str, str, st
     shared URL regex only matches 7-40-char hex revisions, mirroring
     check 23).
 
-    Four conservative positions (precision over recall — a missed claim
+    Five conservative positions (precision over recall — a missed claim
     costs nothing, the check is a net-new WARN):
 
     - **Pattern A** — the count-noun sits INSIDE the markdown link TEXT
@@ -8709,14 +8752,31 @@ def _gather_hf_count_claims(body: str) -> list[tuple[int, str, str, str, str, st
       line (bracket-free, ≤``_SUBPATH_CLAIM_MAX_GAP``-char gap); the count
       scopes to the JOINED prefix ``<link-prefix>/<sub-path>`` at the
       link's sha — the same join the per-namespace leg uses.
+    - **Pattern E (trailing count-opening paren, #1005)** — a parenthetical
+      immediately AFTER the link that OPENS with the count-noun
+      (``[summary store + manifest](…/tree/<sha>/…) (52 files)``, the
+      #1005 footer shape), scanned via ``.match()`` on the paren body of
+      the SAME link-then-paren iterator Pattern C uses (same-line
+      separator + paren-body bounds inherited). Trailing content after
+      the count-noun is unconstrained within the paren-body bound
+      (``(17 files incl. `f2f3/` …)`` / ``(50 files: 42 updated + 8
+      verbatim)``). Two declines: ANY distributive ``per <word>``
+      qualifier (Pattern D's wide lookahead — per-namespace claims stay
+      the per-namespace leg's exclusive property; per-adapter / per-seed
+      counts have per-unit semantics), and a paren immediately followed
+      by an HF markdown link (Pattern B's paren-before-link shape wins —
+      see the E-specific sacrifices below). An at-pinned-revision paren
+      fires BOTH C and E with identical args — the shared ``seen`` key
+      collapses them to one tuple.
 
     Known recall sacrifices (each avoids a concrete false-positive class):
-    prose counts near BARE (non-markdown) HF URLs; counts AFTER the link
-    OUTSIDE a link-adjacent paren carrying one of the two anchored phrases
-    (generic post-link prose counts stay sacrificed); parentheticals where
-    the count is not leading ("(total 515 files)") unless phrase-anchored
-    per Pattern C — mirrored by Pattern D, whose count must OPEN the
-    paren; compound claims ("8 eval JSONs + 2 npz"); nouns other
+    prose counts near BARE (non-markdown) HF URLs; prose counts AFTER the
+    link OUTSIDE the link-adjacent paren (generic post-link prose counts
+    stay sacrificed); non-leading counts INSIDE the link-adjacent paren
+    ("(total 515 files)") unless phrase-anchored per Pattern C — mirrored
+    by Patterns D and E, whose counts must OPEN the paren (a leading
+    space, "( 52 files)", deliberately does not match — B/D anchor
+    parity); compound claims ("8 eval JSONs + 2 npz"); nouns other
     than file(s) / shard(s) ("rows" / "completions" are RECORD counts, not
     file counts); per-namespace-qualified counts in A/B positions (see the
     lookahead note above). Pattern-D-specific sacrifices: a claim whose
@@ -8728,11 +8788,16 @@ def _gather_hf_count_claims(body: str) -> list[tuple[int, str, str, str, str, st
     paren-before-link shape wins — D's trailing lookahead declines); a
     BARE (non-markdown) pinned HF URL in the gap neither declines nor
     rebinds — the claim binds past it to the earlier markdown link, a
-    documented recall/precision sacrifice. Lookahead ASYMMETRY (deliberate):
-    Pattern D declines ANY distributive ``per <word>`` qualifier while A/B
-    keep the narrow #833 per-namespace-only lookahead — a "per
+    documented recall/precision sacrifice. Pattern-E-specific sacrifices:
+    an E-paren immediately followed by an HF markdown link declines
+    (``_HF_LINK_FOLLOWS_PAREN_RE`` — B wins; its whitespace separators
+    span newlines, so a paren at end-of-line followed by a NEXT-LINE HF
+    markdown link also declines — a conservative recall residue, a
+    declined claim, never a wrong one). Lookahead ASYMMETRY (deliberate):
+    Patterns D and E decline ANY distributive ``per <word>`` qualifier
+    while A/B keep the narrow #833 per-namespace-only lookahead — a "per
     adapter"-style count in A/B position is a PRE-EXISTING hole outside
-    #1143's scope, left unchanged by design.
+    #1143's / #1422's scope, left unchanged by design.
     """
     kind_to_type = {"datasets": "dataset", "spaces": "space", None: "model"}
     stripped = _strip_fenced_blocks(body)
@@ -8778,9 +8843,17 @@ def _gather_hf_count_claims(body: str) -> list[tuple[int, str, str, str, str, st
             _add(cm.group("count"), cm.group("noun"), lm.group("url"))
     for pm in _COUNT_PAREN_LINK_RE.finditer(stripped):  # Pattern B: paren before link
         _add(pm.group("count"), pm.group("noun"), pm.group("url"))
-    for lm in _HF_LINKTEXT_THEN_PAREN_RE.finditer(stripped):  # Pattern C: paren after link
-        for cm in _FILES_AT_PINNED_REV_RE.finditer(lm.group("paren")):
+    for lm in _HF_LINKTEXT_THEN_PAREN_RE.finditer(stripped):  # Patterns C + E: paren after link
+        for cm in _FILES_AT_PINNED_REV_RE.finditer(lm.group("paren")):  # C (pinned-revision)
             _add(cm.group("count"), "files", lm.group("url"))
+        # Pattern E (#1005): the paren OPENS with the count-noun — .match()
+        # gives B/D-parity anchor semantics ("( 52 files)" with a leading
+        # space deliberately does not match, a documented recall sacrifice).
+        # An at-pinned-revision paren fires BOTH C and E with identical
+        # _add args — the shared `seen` key collapses them to one tuple.
+        em = _COUNT_OPEN_PAREN_AFTER_LINK_RE.match(lm.group("paren"))
+        if em is not None and _HF_LINK_FOLLOWS_PAREN_RE.match(stripped, lm.end()) is None:
+            _add(em.group("count"), em.group("noun"), lm.group("url"))
     for dm in _BACKTICK_SUBPATH_COUNT_PAREN_RE.finditer(stripped):  # Pattern D (#1143)
         lm = _nearest_preceding_pinned_tree_link(stripped, dm.start(), link_matches)
         if lm is None:
@@ -8997,13 +9070,20 @@ def check_hf_file_count_claims(body: str) -> CheckResult:
 
     Incident: task #931 shipped "528 files" / "10 shards" / "3 files" /
     "198 files" where the scoped listing at the pinned revision holds
-    515/9/2/197 — folder entries were counted as files. This check compares
+    515/9/2/197 — folder entries were counted as files. Task #1005's footer
+    then claimed 51/15 in bare trailing parentheticals right after its
+    pinned links where the pinned trees hold 52/17 — understated counts
+    invisible to Patterns A-D, so check 30 reported "no file-count claims
+    adjacent" and the miss cost a clean-result-critic round finding
+    (#1422). This check compares
     each extracted claim (``_gather_hf_count_claims`` — Pattern A count in
     link text / Pattern B paren-before-link / Pattern C anchored
     pinned-revision phrase in a paren AFTER the link / Pattern D backtick
     ``dir/`` sub-path + count-opening paren bound to the nearest preceding
     pinned link and scoped to ``<link-prefix>/<sub-path>`` (#1143, the
-    #1112 footer shape); see its docstring for
+    #1112 footer shape) / Pattern E a paren immediately AFTER the link
+    that OPENS with the count-noun (#1422, the #1005 footer shape); see
+    its docstring for
     the precision/recall trade-offs) against an EXHAUSTIVE files-only count
     of the pinned prefix (``_hf_file_count_for_prefix`` → the #733 bounded
     raw tree-endpoint probe; folders excluded).

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -2150,9 +2150,10 @@ def test_hf_check25_not_found_is_skip_not_fail(monkeypatch):
 # #733 bounded raw tree-endpoint probe stack checks 23/25 use. Claim
 # positions: Pattern A count-in-link-text, Pattern B paren-before-link,
 # Pattern C anchored paren-after-link + the per-namespace form (#1088),
-# and Pattern D backtick `dir/` sub-path + count-opening paren bound to
-# the nearest preceding pinned link (#1143, the #1112 footer shape). All
-# tests are offline: extractor tests need no stub; probe tests stub
+# Pattern D backtick `dir/` sub-path + count-opening paren bound to
+# the nearest preceding pinned link (#1143, the #1112 footer shape), and
+# Pattern E trailing count-opening paren (#1422, the #1005 footer shape).
+# All tests are offline: extractor tests need no stub; probe tests stub
 # `verify_task_body._hf_tree_get` (`_stub_tree` / inline stateful
 # closures) after removing the conftest EPM_VERIFY_BODY_NO_HF fence.
 
@@ -3072,6 +3073,237 @@ def test_hf_count_subpath_dedup_with_link_text_pattern():
     )
     claims = verify_task_body._gather_hf_count_claims(row)
     assert [(c[0], c[1], c[5]) for c in claims] == [(7, "files", "parent/sub")]
+
+
+# ─── Check 30 Pattern E: trailing count-opening paren (#1422) ───────────────
+# #1005's footer carried bare trailing parentheticals immediately after its
+# pinned /tree links — `[summary store + manifest](…/tree/<sha>/…) (52
+# files)` — a count-OPENING paren matching none of the A-D anchors; the
+# incident body claimed 51/15 where the pinned trees hold 52/17 and check 30
+# reported "no file-count claims adjacent" (the miss cost a
+# clean-result-critic round finding). Extractor tests are pure; probe tests
+# stub `_hf_tree_get` after removing the conftest fence.
+
+_I1005_SHA_R1 = "621b370c668d5a1df0c158aa522ef9d046c4b3c2"
+_I1005_SHA_R2 = "9e79ce7f2c8126de99796b0b709b3c438756ad30"
+_I1005_REPO_ID = "superkaiba1/explore-persona-space-data"
+_I1005_PREFIX = "issue1005_cot_decomposition_r1"
+
+
+def _i1005_footer_excerpt() -> str:
+    """The two verbatim count-bearing footer sentences of the #1005 incident
+    body (tasks/awaiting_promotion/1005/body.md line 185 at fix time, copied
+    verbatim into this suite — never read from the live body at test time;
+    the `_i1112_footer` precedent), joined by one space (the intervening
+    footer prose elided). First-round sentence: five pinned links at the
+    first sha — four trailing count parens + one paren-less link
+    (`[per-context error tensors]`); round-2 sentence: three pinned links at
+    a second sha, all with trailing count parens (the corrected live counts
+    52/17 — the incident's wrong 51/15 exist only in the pre-fix history and
+    are re-introduced by the mismatch test below)."""
+    return (
+        "HF data repo paths under prefix `issue1005_cot_decomposition_r1/`, verified live via `li"
+        "st_repo_tree` at write time, revision-pinned: [rollout text](https://huggingface.co/data"
+        "sets/superkaiba1/explore-persona-space-data/tree/621b370c668d5a1df0c158aa522ef9d046c4b3c"
+        "2/issue1005_cot_decomposition_r1/raw_completions/thinking_rollouts) (50 files), [summary"
+        " store + manifest](https://huggingface.co/datasets/superkaiba1/explore-persona-space-dat"
+        "a/tree/621b370c668d5a1df0c158aa522ef9d046c4b3c2/issue1005_cot_decomposition_r1/analysis_"
+        "tensors/store) (52 files), [per-context error tensors](https://huggingface.co/datasets/s"
+        "uperkaiba1/explore-persona-space-data/tree/621b370c668d5a1df0c158aa522ef9d046c4b3c2/issu"
+        "e1005_cot_decomposition_r1/analysis_tensors/decomp), [fit results](https://huggingface.c"
+        "o/datasets/superkaiba1/explore-persona-space-data/tree/621b370c668d5a1df0c158aa522ef9d04"
+        "6c4b3c2/issue1005_cot_decomposition_r1/fit_results) (17 files incl. `f2f3/` and `indiv_m"
+        "lp_control/`), [driver figures](https://huggingface.co/datasets/superkaiba1/explore-pers"
+        "ona-space-data/tree/621b370c668d5a1df0c158aa522ef9d046c4b3c2/issue1005_cot_decomposition"
+        "_r1/figures) (87 files)."
+        " "
+        "HF (same prefix, revision-pinned, verified live via scoped `list_repo_tree`): [16K rollo"
+        "ut text](https://huggingface.co/datasets/superkaiba1/explore-persona-space-data/tree/9e7"
+        "9ce7f2c8126de99796b0b709b3c438756ad30/issue1005_cot_decomposition_r1/raw_completions/thi"
+        "nking_rollouts_16k) (50 files: 42 updated + 8 verbatim), [16K summary store](https://hug"
+        "gingface.co/datasets/superkaiba1/explore-persona-space-data/tree/9e79ce7f2c8126de99796b0"
+        "b709b3c438756ad30/issue1005_cot_decomposition_r1/analysis_tensors/store/percq_summaries_"
+        "16k) (52 files), [16K fit results](https://huggingface.co/datasets/superkaiba1/explore-p"
+        "ersona-space-data/tree/9e79ce7f2c8126de99796b0b709b3c438756ad30/issue1005_cot_decomposit"
+        "ion_r1/fit_results_16k) (16 files)."
+    )
+
+
+def test_hf_count_extractor_trailing_paren_1005_shape():
+    """Pure extractor (Pattern E, #1422): the verbatim #1005 footer excerpt
+    yields EXACTLY the 7 expected claim tuples (complete 6-tuples, including
+    the repo_type field) in document order. Exact equality also pins that
+    the paren-less `[per-context error tensors]` link yields nothing."""
+    claims = verify_task_body._gather_hf_count_claims(_i1005_footer_excerpt())
+    assert claims == [
+        (
+            50,
+            "files",
+            _I1005_REPO_ID,
+            "dataset",
+            _I1005_SHA_R1,
+            f"{_I1005_PREFIX}/raw_completions/thinking_rollouts",
+        ),
+        (
+            52,
+            "files",
+            _I1005_REPO_ID,
+            "dataset",
+            _I1005_SHA_R1,
+            f"{_I1005_PREFIX}/analysis_tensors/store",
+        ),
+        (17, "files", _I1005_REPO_ID, "dataset", _I1005_SHA_R1, f"{_I1005_PREFIX}/fit_results"),
+        (87, "files", _I1005_REPO_ID, "dataset", _I1005_SHA_R1, f"{_I1005_PREFIX}/figures"),
+        (
+            50,
+            "files",
+            _I1005_REPO_ID,
+            "dataset",
+            _I1005_SHA_R2,
+            f"{_I1005_PREFIX}/raw_completions/thinking_rollouts_16k",
+        ),
+        (
+            52,
+            "files",
+            _I1005_REPO_ID,
+            "dataset",
+            _I1005_SHA_R2,
+            f"{_I1005_PREFIX}/analysis_tensors/store/percq_summaries_16k",
+        ),
+        (16, "files", _I1005_REPO_ID, "dataset", _I1005_SHA_R2, f"{_I1005_PREFIX}/fit_results_16k"),
+    ]
+
+
+def test_hf_count_extractor_trailing_paren_shapes():
+    """Pure extractor: minimal Pattern-E positives — bare `(9 files)`,
+    singular `(1 file)`, comma-grouped `(1,234 files)`, `(9 shards)`, and
+    the two trailing-content #1005 shapes (`incl.` prose, colon form)."""
+    u = f"{_I931_REPO}/tree/abc1234def/p"
+    shapes = [
+        (f"[x]({u}) (9 files)", (9, "files")),
+        (f"[x]({u}) (1 file)", (1, "file")),
+        (f"[x]({u}) (1,234 files)", (1234, "files")),
+        (f"[x]({u}) (9 shards)", (9, "shards")),
+        (f"[x]({u}) (17 files incl. `f2f3/` and `indiv_mlp_control/`)", (17, "files")),
+        (f"[x]({u}) (50 files: 42 updated + 8 verbatim)", (50, "files")),
+    ]
+    for body, (count, noun) in shapes:
+        claims = verify_task_body._gather_hf_count_claims(body)
+        assert [(c[0], c[1], c[5]) for c in claims] == [(count, noun, "p")], body
+
+
+def test_hf_count_extractor_trailing_paren_negative_cases():
+    """Shapes that must NOT extract via Pattern E (precision-first; each
+    guards a concrete false-positive class). The per-namespace arm ALSO
+    asserts the claim is not stolen from the per-namespace leg (which still
+    extracts it); `(891 files per seed)` in
+    test_hf_count_extractor_per_namespace_negative_cases is the standing
+    tripwire mechanically forcing the WIDE `per <word>` lookahead."""
+    u = f"{_I931_REPO}/tree/abc1234def/p"
+    # Distributive `per <word>` declines — E never steals the per-namespace
+    # leg's claims (that leg still extracts, with its own semantics).
+    ns_body = f"[`ns_a/` @abc1234]({_I931_REPO}/tree/abc1234def/p) (12 files per namespace)"
+    assert verify_task_body._gather_hf_count_claims(ns_body) == []
+    ns_claims = verify_task_body._gather_hf_per_namespace_claims(ns_body)
+    assert [(c[0], c[4]) for c in ns_claims] == [(12, "p")]
+    negatives = [
+        f"[x]({u}) (891 files listed per namespace)",  # per-namespace, "listed" filler
+        f"[x]({u}) (11 files per adapter, 176 files total)",  # the #460 per-unit class
+        f"[x]({u}) (verified live via list_repo_tree)",  # non-count paren
+        f"[x]({u}) (total 515 files)",  # count does not OPEN the paren
+        f"[x]({u}) ( 52 files)",  # leading space — B/D anchor parity
+        f"[x]({_I931_REPO}/tree/main/p) (9 files)",  # moving ref, not hex-pinned
+        f"[x]({_I931_REPO}/blob/abc1234def/p/f.json) (9 files)",  # /blob/ = single file
+        "[x](https://huggingface.co/superkaiba1/explore-persona-space) (11 files)",  # no /tree/
+        "[x](https://github.com/o/r/tree/abc1234def/p) (9 files)",  # non-HF link
+        f"```\n[x]({u}) (9 files)\n```",  # fenced block
+        f"[x]({u})\n(9 files)",  # newline gap — the iterator is same-line only
+        f"[x]({u})   (9 files)",  # 3-space gap — outside the separator bound
+    ]
+    for body in negatives:
+        assert verify_task_body._gather_hf_count_claims(body) == [], body
+
+
+def test_hf_count_extractor_trailing_paren_dedup_with_pinned_phrase():
+    """An at-pinned-revision paren fires BOTH Pattern C and Pattern E with
+    identical `_add` args → exactly ONE tuple (the shared `seen` dedup, not
+    a special case). The pathological colon form
+    `(50 files: 1,234 files at the pinned revision)` fires E (50) AND C
+    (1234) → TWO distinct tuples on the same prefix, each verified
+    independently (the multi-claim semantics Pattern A already has)."""
+    u = f"{_I931_REPO}/tree/abc1234def/p"
+    one = verify_task_body._gather_hf_count_claims(f"[x]({u}) (1,234 files at the pinned revision)")
+    assert [(c[0], c[1], c[5]) for c in one] == [(1234, "files", "p")]
+    patho = verify_task_body._gather_hf_count_claims(
+        f"[x]({u}) (50 files: 1,234 files at the pinned revision)"
+    )
+    assert sorted((c[0], c[1], c[5]) for c in patho) == [
+        (50, "files", "p"),
+        (1234, "files", "p"),
+    ]
+
+
+def test_hf_count_trailing_paren_b_adjacency_declines():
+    """`[x](url1) (52 files): [y](url2)` → E declines (the paren is
+    immediately followed by an HF markdown link — Pattern B's
+    paren-before-link shape) and B ALONE extracts, scoped to url2's OWN
+    prefix: exactly one tuple, never a second differently-scoped claim from
+    the same paren."""
+    body = (
+        f"[x @abc1234]({_I931_REPO}/tree/abc1234def/p) (52 files): "
+        f"[y @abc1234]({_I931_REPO}/tree/abc1234def/other)"
+    )
+    claims = verify_task_body._gather_hf_count_claims(body)
+    assert [(c[0], c[1], c[5]) for c in claims] == [(52, "files", "other")]
+
+
+def test_hf_count_trailing_paren_mismatch_warns_1005_shape(monkeypatch):
+    """The #1005 incident reconstruction: the footer's `[summary store +
+    manifest](…) (51 files)` claim (the incident's original understated
+    count) against a stubbed pinned tree of 52 files → WARN naming both
+    numbers + the subset hedge (51 < 52 may describe a subset); `passed`
+    stays True (WARN-only invariant — no `passed=False` path added)."""
+    monkeypatch.delenv("EPM_VERIFY_BODY_NO_HF", raising=False)
+    # Explicit cache hygiene: this test and its match-passes sibling share
+    # the same (repo, sha, prefix) key and `_HF_TREE_FILE_COUNT_CACHE` is
+    # module-global — clear it so the probe can never be served by a
+    # sibling's cached listing (the shard-claims one-sided precedent; the
+    # autouse fixture also clears between tests).
+    verify_task_body._HF_TREE_FILE_COUNT_CACHE.clear()
+    needle = f"{_I1005_PREFIX}/analysis_tensors/store"
+    entries = [{"path": needle, "type": "directory"}]
+    entries += [{"path": f"{needle}/f{i}.npz", "type": "file"} for i in range(52)]
+    _stub_tree(monkeypatch, status="ok", entries=entries)
+    body = (
+        f"[summary store + manifest]({_I931_REPO}/tree/{_I1005_SHA_R1}/"
+        f"{_I1005_PREFIX}/analysis_tensors/store) (51 files)"
+    )
+    r = verify_task_body.check_hf_file_count_claims(body)
+    assert r.passed and r.is_warn, r.detail
+    assert "51" in r.detail and "52 file(s)" in r.detail
+    assert "subset of the prefix" in r.detail
+
+
+def test_hf_count_trailing_paren_match_passes(monkeypatch):
+    """The same single-claim body with the CORRECT count `(52 files)` →
+    clean PASS: no WARN, no `unverified` note, `1 claim(s) checked`."""
+    monkeypatch.delenv("EPM_VERIFY_BODY_NO_HF", raising=False)
+    # Same explicit cache hygiene as the mismatch sibling above: without the
+    # clear, a cached listing on the shared key could serve this probe and
+    # make the PASS vacuous.
+    verify_task_body._HF_TREE_FILE_COUNT_CACHE.clear()
+    needle = f"{_I1005_PREFIX}/analysis_tensors/store"
+    entries = [{"path": needle, "type": "directory"}]
+    entries += [{"path": f"{needle}/f{i}.npz", "type": "file"} for i in range(52)]
+    _stub_tree(monkeypatch, status="ok", entries=entries)
+    body = (
+        f"[summary store + manifest]({_I931_REPO}/tree/{_I1005_SHA_R1}/"
+        f"{_I1005_PREFIX}/analysis_tensors/store) (52 files)"
+    )
+    r = verify_task_body.check_hf_file_count_claims(body)
+    assert r.passed and not r.is_warn, r.detail
+    assert "unverified" not in r.detail
+    assert "1 claim(s) checked" in r.detail
 
 
 # ─── Check 32: HF-adjacent backtick file claims vs the pinned tree (WARN) ──


### PR DESCRIPTION
Closes task #1422. Extends check 30 (check_hf_file_count_claims) with Pattern E: trailing count-opening parenthetical after a hex-pinned HF /tree link (the #1005 footer shape).