### PR TITLE
task #1424: caption italic-lead-claim check (check 5 family)

### DIFF
--- a/.claude/skills/clean-results/SPEC.md
+++ b/.claude/skills/clean-results/SPEC.md
@@ -941,7 +941,10 @@ Forward-only: each check branches on the sentinel. The v4 checks
 4. At least one `![alt](url)` image inline under `## Results`.
 4b. Figure URLs resolvable AND existing under `## Results` (same offline
    `git cat-file` / HTTP HEAD probe as v3).
-5. (Soft) Figure-caption sanity — vacuously satisfied.
+5. (Soft, WARN) Figure-caption shape — each non-empty blockquote caption
+   after an inline figure under `## Results` opens
+   `**Figure.** *italic lead claim.*` (§ Figure caption shape). WARN never
+   FAIL; captionless figures exempt (check 21 + Lens 3 own presence).
 6. Confidence — for v4 the H1 title tag is the source of truth; PASSes
    when the title carries the `(... confidence)` tag, NO body Confidence
    sentence required. Gated on `is_titletag_confidence()` = v2 OR v3 OR v4.
@@ -1553,8 +1556,9 @@ listed under § Grandfathered shape. The v3 checks:
 4b. Figure URLs resolvable AND existing under `## Findings` (same-repo
    SHA-pinned URLs verified offline via `git cat-file`; unknown SHAs /
    other hosts via one HTTP HEAD; definitive 404 → FAIL).
-5. (Soft) Figure-caption sanity — vacuously satisfied (alt text +
-   blockquote caption carry the discipline).
+5. (Soft) Figure-caption sanity — vacuously satisfied for v3 (alt text +
+   blockquote caption carry the discipline); the italic-lead-claim WARN
+   is v4-only (forward-only).
 6. Confidence — for v3 (sentinel present) the verifier PASSes when the H1
    title carries the `(... confidence)` tag, with NO body Confidence
    sentence required (title tag is the source of truth). Gated on

--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -82,12 +82,12 @@ checks (3/3b) run on the v2 sentinel; v3-only checks (v3 structure +
     FAIL); unknown SHAs / other hosts fall back to one HTTP HEAD per
     unique URL (definitive 404 → FAIL; network error / timeout →
     `unverified` note on the PASS line, never a FAIL).
-5. Figure caption sanity — vacuously satisfied under the new spec
-   (inline-image alt text + blockquote caption inside each result H3
-   carry the discipline; the analyzer is instructed to write
-   descriptive alt text). Retained as a hook for future tightening; in
-   the current revision the check always PASSes because the retired
-   `## Figure` H2 is now a check 2 FAIL.
+5. Figure caption sanity — v4-only WARN: each non-empty blockquote
+   caption after an inline figure under `## Results` must open
+   `**Figure.** *italic lead claim.*` (SPEC § Figure caption shape;
+   incident #1005 r1, #1424). Captionless figures + v3/v2/legacy
+   bodies exempt. Formerly a vacuous hook (kept in place so CHECKS
+   indices never shift).
 6. Confidence sentence matches title — for v2 nested-design bodies
    (`<!-- clean-result-v2 -->` sentinel present) the H1 title tag is
    the single source of truth; the check PASSes when the title carries
@@ -2713,24 +2713,80 @@ def check_linked_not_embedded_figures(body: str, *, issue: int | None = None) ->
     )
 
 
-def check_figure_caption(body: str) -> CheckResult:
-    """Check 5: figure caption sanity (vacuous under the 2-content-section spec).
+# Check 5 (v4): caption opens `**Figure.** *italic lead claim.*` (SPEC
+# § Figure caption shape). Tolerates `**Figure**` (no period), a short
+# figure designator (`**Figure 1.**`), a period outside the bold close,
+# and underscore italics. `\*(?!\*)` keeps a bold `**…**` run from
+# masquerading as the italic lead.
+_CAPTION_BOLD_PREFIX_RE = re.compile(r"^\*\*Figure(?:\s+[^*\n]{1,16})?\.?\*\*\.?")
+_CAPTION_LEAD_CLAIM_RE = re.compile(
+    r"^\*\*Figure(?:\s+[^*\n]{1,16})?\.?\*\*\.?\s*(?:\*(?!\*)[^*]+\*|_[^_]+_)"
+)
 
-    Under the 2-content-section spec (2026-W22, task #454) a stray
-    `## Figure` H2 is rejected by check 2 as a hard FAIL, so this check
-    has nothing to scan and always PASSes. Figure captions inside each
-    result H3 wrap in markdown blockquotes (`> **Figure.** *...* ...`)
-    by analyzer convention; `clean-result-critic` enforces the
-    blockquote shape semantically. Retained as a hook for future
-    tightening; deleting it would shift CHECKS indices and break
-    downstream tests.
+
+def check_figure_caption(body: str) -> CheckResult:
+    """Check 5 (v4-only, WARN): every non-empty blockquote caption after an
+    inline figure under `## Results` opens `**Figure.** *italic lead
+    claim.*` (SPEC § "Figure caption shape"). WARN never FAIL — caption
+    checks are advisory (60-word cap, check 21) and grandfathered bodies
+    must never be newly hard-FAILed. PASS-skips on v3/v2/legacy bodies
+    (forward-only; the v3 SPEC documents the same shape but frozen v3
+    bodies keep their prior verification output). Captionless figures —
+    no contiguous blockquote run after the image (blank lines between
+    image and caption are skipped, so a blank-line-separated caption IS
+    scanned) — are exempt here: caption PRESENCE is owned by check 21 +
+    clean-result-critic Lens 3. This is a SHAPE proxy only — the
+    semantic quality of the lead claim stays LM-critic-owned (Lens 3).
+    Incident #1005 r1: all 7 captions missing the italic lead were
+    caught only by the LM critic round (#1424).
     """
-    del body
-    return CheckResult(
-        "Figure caption sanity",
-        True,
-        "no `## Figure` H2 expected — captions live in blockquote form under each result H3",
+    name = "Figure caption sanity"
+    if not is_v4(body):
+        return CheckResult(name, True, "skipped — not a v4 body (italic-lead WARN is v4-only)")
+    results = _v4_results_body(body)
+    if results is None:
+        return CheckResult(name, True, "## Results missing — check 2 will report")
+    rlines = results.splitlines()
+    h3s = _collect_tldr_h3_names(results)
+    flagged: list[str] = []
+    n_caps = 0
+    in_fence = False
+    for i, ln in enumerate(rlines):
+        s = ln.strip()
+        if s.startswith("```") or s.startswith("~~~"):
+            in_fence = not in_fence
+            continue
+        if in_fence or not _IMAGE_RE.search(ln):
+            continue
+        caption = _figure_caption_after(rlines, i)
+        if not caption:
+            continue  # captionless figure: check 21 / critic Lens 3 own presence
+        n_caps += 1
+        if _CAPTION_LEAD_CLAIM_RE.match(caption):
+            continue
+        h3 = next((nm for nm, ln_no in reversed(h3s) if ln_no < i), "<no result H3>")
+        missing = (
+            "the italic lead claim"
+            if _CAPTION_BOLD_PREFIX_RE.match(caption)
+            else "the `**Figure.**` bold prefix + italic lead claim"
+        )
+        flagged.append(f"'{h3[:48]}' caption missing {missing}")
+    if flagged:
+        preview = "; ".join(flagged[:3]) + (" …" if len(flagged) > 3 else "")
+        return CheckResult(
+            name,
+            True,
+            f"{len(flagged)} of {n_caps} `## Results` caption(s) do not open "
+            f"`> **Figure.** *one-sentence lead claim.*` "
+            f"(SPEC § Figure caption shape): {preview}",
+            is_warn=True,
+        )
+    detail = (
+        f"all {n_caps} `## Results` caption(s) open `**Figure.** *lead claim.*`"
+        if n_caps
+        else "no blockquote captions under `## Results` to check"
     )
+    return CheckResult(name, True, detail)
 
 
 def is_v2_nested_design(body: str) -> bool:

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -4662,7 +4662,8 @@ def test_checks_list_size():
     contradiction-only, absence of evidence never fires; incident #1092
     defect (b), #1255). The
     migration is a RETARGET — every former check
-    was kept (sometimes dormant, e.g. `check_figure_caption`) so downstream
+    was kept (some dormant for a period — e.g. `check_figure_caption`,
+    vacuous until #1424 tightened it) so downstream
     tests stay valid; the v3 checks PASS-skip on non-v3 bodies.
 
     Checks appended OUTSIDE CHECKS inside `verify_text` (they need
@@ -10045,6 +10046,156 @@ def test_check24_caption_after_helper():
     assert "Interpretation prose" not in cap
     # No blockquote after the image → empty.
     assert verify_task_body._figure_caption_after(["![a](u)", "plain prose"], 0) == ""
+
+
+# ─── Check 5: figure-caption italic lead claim (v4-only WARN, #1424) ────────
+
+
+def _v4_minimal_results_body(results_content: str) -> str:
+    """Minimal v4-sentinel body wrapping `results_content` under `## Results`
+    (no footer) — direct-call fixture for `check_figure_caption`."""
+    return f"# T (LOW confidence)\n\n<!-- clean-result-v4 -->\n\n## Results\n\n{results_content}\n"
+
+
+def test_caption_lead_conformant_v4_passes():
+    """A conformant v4 body (caption opens `**Figure.** *lead claim.*`)
+    passes check 5 with no WARN."""
+    res = verify_task_body.check_figure_caption(_V4_GOOD_BODY)
+    assert res.passed is True
+    assert res.is_warn is False
+    assert "all 1" in res.detail
+
+
+def test_caption_missing_italic_lead_v4_warns():
+    """DURABILITY PIN (#1424): a v4 caption carrying the bold `**Figure.**`
+    prefix but NO italic lead claim WARNs (passed stays True — never FAIL),
+    naming the enclosing result H3 and quoting the expected shape."""
+    body = _V4_GOOD_BODY.replace(
+        "> **Figure.** *Tulu-25 lifts alignment ~17 pts over baseline at every seed.* "
+        "Baseline gray, tulu-25 blue; error bars 95% Wald CIs.",
+        "> **Figure.** Plain prose lead without italics.",
+    )
+    assert body != _V4_GOOD_BODY  # the replace actually fired
+    res = verify_task_body.check_figure_caption(body)
+    assert res.passed is True
+    assert res.is_warn is True
+    assert "A clean +17-pt lift" in res.detail  # enclosing H3 named
+    assert "missing the italic lead claim" in res.detail
+    assert "**Figure.** *one-sentence lead claim.*" in res.detail
+
+
+def test_caption_missing_bold_prefix_v4_warns():
+    """A v4 caption with NO bold `**Figure.**` prefix at all WARNs and the
+    detail attributes the missing bold prefix (not just the italic lead)."""
+    body = _V4_GOOD_BODY.replace(
+        "> **Figure.** *Tulu-25 lifts alignment ~17 pts over baseline at every seed.* "
+        "Baseline gray, tulu-25 blue; error bars 95% Wald CIs.",
+        "> *Italic lead only.* Rest of caption.",
+    )
+    assert body != _V4_GOOD_BODY
+    res = verify_task_body.check_figure_caption(body)
+    assert res.passed is True
+    assert res.is_warn is True
+    assert "bold prefix" in res.detail
+
+
+def test_caption_lead_check_skips_non_v4():
+    """Forward-only: a non-conformant caption in a v3 or legacy body never
+    WARNs — check 5 PASS-skips on every non-v4 body."""
+    for fixture in (_V3_GOOD_BODY, GOOD_BODY):
+        body = fixture.replace(
+            "**Figure.** *Tulu-25 lifts alignment ~17 pts over baseline at every seed.*",
+            "**Figure.** Plain prose lead.",
+        )
+        assert body != fixture
+        res = verify_task_body.check_figure_caption(body)
+        assert res.passed is True
+        assert res.is_warn is False
+        assert "skipped — not a v4 body" in res.detail
+
+
+def test_caption_lead_no_figures_passes():
+    """A v4 body whose `## Results` has an H3 + prose but no image passes
+    vacuously (no captions to check)."""
+    body = _v4_minimal_results_body("### A result\n\nProse only, no image here.")
+    res = verify_task_body.check_figure_caption(body)
+    assert res.passed is True
+    assert res.is_warn is False
+    assert "no blockquote captions" in res.detail
+
+
+def test_caption_lead_captionless_figure_exempt():
+    """An image followed directly by plain prose (no blockquote caption) is
+    exempt — caption PRESENCE is owned by check 21 + critic Lens 3."""
+    body = _v4_minimal_results_body(
+        "### A result\n\n![alt](https://x/y.png)\n\nPlain interpretation prose, no blockquote."
+    )
+    res = verify_task_body.check_figure_caption(body)
+    assert res.passed is True
+    assert res.is_warn is False
+
+
+def test_caption_lead_period_variants_pass():
+    """Tolerance arms: `**Figure**` (no period) and `**Figure 1.**` (short
+    designator) both satisfy the bold-prefix + italic-lead shape."""
+    for cap in (
+        "> **Figure** *Lead claim.* rest of caption.",
+        "> **Figure 1.** *Lead claim.* rest of caption.",
+    ):
+        body = _v4_minimal_results_body(f"### A result\n\n![alt](https://x/y.png)\n\n{cap}")
+        res = verify_task_body.check_figure_caption(body)
+        assert res.passed is True
+        assert res.is_warn is False, cap
+
+
+def test_caption_lead_bold_not_italic_warns():
+    """A bold `**…**` run after the prefix must NOT masquerade as the italic
+    lead (the `(?!\\*)` lookahead guard)."""
+    body = _v4_minimal_results_body(
+        "### A result\n\n![alt](https://x/y.png)\n\n> **Figure.** **Bold, not italic.** rest."
+    )
+    res = verify_task_body.check_figure_caption(body)
+    assert res.passed is True
+    assert res.is_warn is True
+    assert "missing the italic lead claim" in res.detail
+
+
+def test_caption_lead_fenced_image_ignored():
+    """A non-conformant image + caption pair inside a fenced code block under
+    `## Results` is never scanned."""
+    body = _v4_minimal_results_body(
+        "### A result\n\nProse.\n\n```markdown\n"
+        "![alt](https://x/y.png)\n\n> **Figure.** No italic lead here.\n```"
+    )
+    res = verify_task_body.check_figure_caption(body)
+    assert res.passed is True
+    assert res.is_warn is False
+
+
+def test_caption_lead_issue1074_verbatim_caption_warns():
+    """Extra missing-lead fixture: the verbatim first caption of #1074's
+    committed body (bold prefix, no italic lead) — the plan-time audit's
+    known-missing-lead spot-check."""
+    cap = (
+        "> **Figure.** Judge-accepted fraction of generated positives per class and "
+        "generator, Wilson 95% intervals, floor dashed. Claude bars are the parent run's "
+        "yields under a three-way recipe bundle (generator, injection style, variant "
+        "count), context only. Only the abliterated arm on harmful compliance clears its "
+        "floor (177 of 215)."
+    )
+    body = _v4_minimal_results_body(f"### Yield per class\n\n![alt](https://x/y.png)\n\n{cap}")
+    res = verify_task_body.check_figure_caption(body)
+    assert res.passed is True
+    assert res.is_warn is True
+    assert "missing the italic lead claim" in res.detail
+
+
+def test_check_figure_caption_position_stable():
+    """Index-stability pin (#1424): `check_figure_caption` stays at CHECKS
+    position 7 and the CHECKS count is unchanged (belt-and-suspenders beside
+    the migration-history `len(CHECKS)` pin)."""
+    assert verify_task_body.CHECKS[7] is verify_task_body.check_figure_caption
+    assert len(verify_task_body.CHECKS) == 41
 
 
 # ─── Check 26: figure panel/series prose vs figure sidecar (panel drift) ───


### PR DESCRIPTION
Closes task #1424. WARN-grade v4-only italic-lead-claim caption check replacing the vacuous check_figure_caption body in place; SPEC.md v4+v3 checks-list item 5 updated; 11 new tests.