### PR TITLE
task #1413: guard ssh-string git false positives (mask single-quoted multi-statement ssh payloads)

### DIFF
--- a/scripts/guard_repo_root_branch.sh
+++ b/scripts/guard_repo_root_branch.sh
@@ -52,10 +52,20 @@
 # diverged-pod recovery, executed in the pod's own /workspace clone) is
 # WAIVED per-clause by the driver-loop ssh/grep waiver below, under its
 # fail-closed refusal ladder; grep/egrep/fgrep/rg pattern arguments get the
-# same waiver. A MULTI-STATEMENT remote string mis-splits on the
-# quoted-separator trade-off and its tail clauses still classify —
-# remediation unchanged: `git -C /workspace/... <verb>` inside the remote
-# string, a pod-side script, or the SSH MCP (which bypasses the Bash hook
+# same waiver. A MULTI-STATEMENT SINGLE-QUOTED remote string in the canonical
+# shape — the quoted payload is the clause's FINAL token, and the whole
+# candidate passes the 8-arm refusal predicate of the
+# mask_ssh_payload_separators() pre-pass (#1413: clean tail, no quote or
+# latch-arming vocabulary before it, no expansion/redirect/local-exec/
+# repo-path/WT= token) — has its intra-payload separators masked BEFORE the
+# split, so the merged clause reaches the same waiver whole (closes the
+# founding #779 false block). Every OTHER multi-statement shape —
+# double-quoted payloads, redirect-carrying payloads, trailing tokens after
+# the closing quote, wrapped/variable/abs-path ssh, quoted or
+# latch-vocabulary prefixes — still mis-splits on the quoted-separator
+# trade-off and its tail clauses still classify — remediation unchanged:
+# `git -C /workspace/... <verb>` inside the remote string, a pod-side
+# script, or the SSH MCP (which bypasses the Bash hook
 # entirely). Never waived, deliberately: an ssh clause naming the shared-repo
 # path in any covered spelling (literal / $HOME/ / ~/ + the repo basename),
 # and ANY waived-word clause in pipeline-producer / background position or
@@ -236,11 +246,38 @@
 #       refusal.
 # (xiv) (#1098) The ssh/grep-family clause waiver's residuals, BOTH sides.
 #       Fail-closed FALSE POSITIVES (harmless shapes that stay blocked):
-#       multi-statement remote strings with the gated verb in a non-first
-#       statement (`ssh pod 'cd /workspace/x && git reset --hard'` —
-#       mis-split; the tail clause lost the ssh command word); wrapped /
+#       multi-statement remote-string FPs are CLOSED for the CANONICAL shape
+#       by the mask_ssh_payload_separators() pre-pass (#1413:
+#       single-quoted, payload is the clause's final token, ladder-clean,
+#       latch-clean, quote-clean prefix — `ssh pod 'cd /workspace/x && git
+#       reset --hard'` now merges and waives); the REMAINING multi-statement
+#       FPs keep today's disposition, each with the standing remediation
+#       (`git -C /workspace/... <verb>` inside the remote string, a pod-side
+#       script, or the SSH MCP): double-quoted payloads (`\"`/expansion/
+#       nesting make the parse inexact); redirect-carrying payloads (`>`,
+#       `<`, `2>&1` — R2's blanket refusal, and the fd-dup `&` still
+#       mis-splits as BG); trailing tokens after the closing quote
+#       (`2>/dev/null`, `-v`, a second quoted arg — R1); wrapped /
 #       absolute-path / variable ssh (`timeout N ssh ...`, `/usr/bin/ssh`,
-#       `$SSHCMD ...`); `${VAR}` in remote strings, incl. single-quoted
+#       `$SSHCMD ...` — not clause-initial `ssh`); IPv6-bracket hosts
+#       (`ssh [::1] '...'` — `[` stops the head scan); a comment-`#` inside
+#       the payload (the per-clause comment-tail strip truncates the merged
+#       clause — truncation cannot un-waive or create a latch match, but the
+#       shape is not guaranteed to merge); ANY quoted text before the ssh
+#       candidate (R5's strict any-quote refusal — quoted-prefix compounds
+#       keep today's disposition); latch vocabulary in payload or prefix
+#       (`cd /tmp/`, `cd ...worktrees...`, `WT=` — the R6/R7/R8 cost
+#       residuals). WT-latch arm-SUPPRESSION flips are fail-CLOSED by R8
+#       (exotic shapes where a payload fragment's clause-initial `WT=`
+#       arming would have disappeared post-refusal go allow->block —
+#       acceptable direction). The pre-existing internal-`&&`-only
+#       latch-arming payload fail-open (`ssh pod 'cd /tmp/x && git fetch'`'s
+#       FIRST fragment matching the unanchored cd-latch grep — rc=0 TODAY,
+#       see the register QUALIFIER below) is a DRIVER bug independent of the
+#       mask and stays open; R6 leaves those shapes byte-identical
+#       (driver-side root fix tracked via the parked workflow-fix candidate
+#       on task #1413, 2026-07-16). Other pre-existing FPs, unchanged:
+#       `${VAR}` in remote strings, incl. single-quoted
 #       forms bash would not expand (the deliberate `${` over-match);
 #       ssh clauses naming the shared-repo path in a covered spelling;
 #       here-string literals (`grep -q x <<<"...gated..."` — the R8b
@@ -576,6 +613,149 @@ strip_heredoc_bodies() {
     }'
 }
 cmd=$(strip_heredoc_bodies "$cmd")
+
+# (#1413) Mask separators inside the balanced SINGLE-QUOTED final argument of
+# a clause-initial `ssh` clause, so a MULTI-STATEMENT remote command string
+# (`ssh pod 'cd /w && git fetch && git checkout FETCH_HEAD -- f'`) is no
+# longer mis-split by the quoted-separator trade-off into a tail clause that
+# lost its ssh command word (the residual-(xiv) false-positive class;
+# founding incident #779). Single-quoted spans are the ONE place a
+# conservative parse is EXACT: bash single-quoted strings cannot contain a
+# quote at all, so '<anything-but-quote>' is the true parse — no escapes, no
+# nesting (double-quoted payloads admit all three and stay a documented
+# residual).
+#
+# Masking fires ONLY when the whole prospective clause passes an 8-arm
+# fail-closed refusal predicate; ANY refusal returns the input BYTE-IDENTICAL
+# (today's behavior). The arms (monotonicity invariant: a masked clause is
+# waived by the EXISTING #1098 ladder before classify_clause, and can neither
+# arm, ride, disarm, nor suppress-a-reset-of the driver's cd-scope / WT
+# latches — so every clause that still reaches classify_clause, and every
+# latch transition, is identical to today except the intended removal class):
+#   R1  tail after the closing quote is whitespace-only up to ; / && / || /
+#       newline / end-of-string — never a bare | or & (the ladder's PIPE/BG
+#       refusal set), never a trailing token (`2>/dev/null`, `-v`, a second
+#       quoted arg — those shapes keep today's disposition).
+#   R2  no $( / ${ / backtick / < / > / \x01 anywhere in the candidate — a
+#       strict SUPERSET of ladder conds (3)/(3b) restricted to the clause
+#       (blanket < covers <( / <<< / << / plain input redirects; \x01 is
+#       splitter-sentinel hygiene). Bare $VAR stays maskable (ladder parity).
+#   R3  no ProxyCommand / LocalCommand / KnownHostsCommand token (ssh
+#       executes all three LOCALLY — ladder cond (4) parity).
+#   R4  no shared-repo path in any covered spelling (literal / $HOME/ / ~/ +
+#       basename — cond (4) parity; the never-waived class stays never-waived).
+#   R5  no quote char (single OR double) seen anywhere BEFORE the candidate,
+#       outside previously-ACCEPTED candidates' consumed quote pairs — the
+#       scanner is quote-context-blind, so a pre-opened quote could make the
+#       scanned "payload" live LOCAL code between two strings (the
+#       local-code-swallow hole); strict any-quote refusal, because an
+#       apostrophe-parity check misses the pre-opened-double-quote variant.
+#   R6  no cd-latch-arming vocabulary in the candidate — `cd` + /tmp/ or
+#       .claude/worktrees/ (a conservative substring superset of the driver's
+#       UNANCHORED pre-waiver latch greps below, which take `scoped=1;
+#       continue` BEFORE the waiver; also precludes the regex-WIDENING match
+#       where masking lets `cd +[^;&|]*\.claude/worktrees/` span across
+#       former statement boundaries).
+#   R7  no cd-latch-arming vocabulary in the PREFIX — guarantees scoped == 0
+#       at candidate entry, so the mask's removal of intra-payload separators
+#       (which today RESET `scoped` at each mis-split boundary) can never
+#       suppress a load-bearing latch reset and skip a local gated tail.
+#   R8  no `WT=` text in the candidate — a mis-split payload fragment's
+#       clause-initial `WT=` arms/disarms `wt_bound` TODAY; masking would
+#       suppress those transitions (WT-latch state isolation).
+# The replacement token ` __EPM_SSH_SEP__ ` is space-padded word characters:
+# it cannot form a separator, a refusal pattern, a repo-path spelling, a
+# latch-regex match, or glue adjacent tokens into a `git <verb>` bigram.
+# Sentinel collision with payload text is harmless — the mask is
+# guard-internal; bash receives the ORIGINAL command either way.
+mask_ssh_payload_separators() {
+  printf '%s' "$1" | awk -v repo="$REPO" -v repo_base="$REPO_BASE" '
+    BEGIN { nrec = 0 }
+    { rec[nrec++] = $0 }
+    END {
+      # Re-join records with the newlines awk consumed (a trailing newline is
+      # stripped either way by the caller command substitution — status quo
+      # at every existing normalization stage).
+      s = ""
+      for (r = 0; r < nrec; r++) s = s (r ? "\n" : "") rec[r]
+      n = length(s)
+      i = 1; atstart = 1; out = ""; saw_quote = 0
+      while (i <= n) {
+        if (atstart && substr(s, i, 4) ~ /^ssh[ \t]/) {
+          # Candidate. Scan the head (options/host): letters, digits, and
+          # the option/host punctuation set ONLY — every quote, $, backslash,
+          # redirect, paren, bracket, and separator char stops the scan, so
+          # `ssh $(evil)`, `ssh "h"`, `ssh [::1]`, `ssh h <<EOF` never parse
+          # as candidates (refused -> byte-identical -> today\047s behavior).
+          j = i + 4
+          while (j <= n && substr(s, j, 1) ~ /[A-Za-z0-9_.@:%=+,\/ \t-]/) j++
+          if (substr(s, j, 1) == "\047") {
+            cq = index(substr(s, j + 1), "\047")   # single quotes: exact parse
+            if (cq > 0) {
+              payload = substr(s, j + 1, cq - 1)
+              after = j + 1 + cq                   # first char past closing quote
+              t = after
+              while (t <= n && substr(s, t, 1) ~ /[ \t]/) t++
+              # R1: whitespace-only tail ending in ; / && / || / NL / EOS.
+              tail_ok = (t > n)
+              if (!tail_ok) {
+                c1 = substr(s, t, 1); c2 = substr(s, t, 2)
+                tail_ok = (c1 == ";" || c1 == "\n" || c2 == "&&" || c2 == "||")
+              }
+              cand = substr(s, i, after - i)       # head + quoted payload
+              pfx  = substr(s, 1, i - 1)           # everything before candidate
+              lc   = tolower(cand)
+              if (tail_ok &&
+                  saw_quote == 0 &&
+                  index(cand, "$(") == 0 && index(cand, "${") == 0 &&
+                  index(cand, "\140") == 0 && index(cand, "<") == 0 &&
+                  index(cand, ">") == 0 && index(cand, "\001") == 0 &&
+                  index(lc, "proxycommand") == 0 &&
+                  index(lc, "localcommand") == 0 &&
+                  index(lc, "knownhostscommand") == 0 &&
+                  index(cand, repo) == 0 &&
+                  index(cand, "$HOME/" repo_base) == 0 &&
+                  index(cand, "~/" repo_base) == 0 &&
+                  !(cand ~ /cd[ \t]/ && (index(cand, "/tmp/") > 0 ||
+                                         index(cand, ".claude/worktrees/") > 0)) &&
+                  !(pfx ~ /cd[ \t]/ && (index(pfx, "/tmp/") > 0 ||
+                                        index(pfx, ".claude/worktrees/") > 0)) &&
+                  index(cand, "WT=") == 0) {
+                # arms in order: R1 tail | R5 prefix quote-state | R2 token
+                # set | R3 local-exec options | R4 repo-path spellings | R6
+                # candidate latch vocab | R7 prefix latch vocab | R8 WT-latch
+                # isolation. ACCEPTED: the ONLY rewrite the function ever
+                # performs is this separator substitution inside the payload.
+                gsub(/[;&|\n]+/, " __EPM_SSH_SEP__ ", payload)
+                out = out substr(s, i, j - i) "\047" payload "\047"
+                i = after; atstart = 0
+                # The two consumed quotes do NOT set saw_quote: by R5 they
+                # are bash\047s own balanced pair, so later candidates in a
+                # multi-candidate command (`ssh h1 \047..\047 && ssh h2
+                # \047..\047`) still compose.
+                continue
+              }
+            }
+          }
+          # REFUSED: copy the `ssh` word verbatim and fall back to the char
+          # path — the refused candidate\047s own quotes then set saw_quote,
+          # so any LATER candidate in this command also refuses (conservative
+          # composition; nested-candidate resume inside a quoted region is
+          # structurally refused by R5).
+          out = out "ssh"; i += 3; atstart = 0
+          continue
+        }
+        c = substr(s, i, 1)
+        out = out c
+        if (c == "\047" || c == "\042") saw_quote = 1
+        if (c ~ /[;|&\n]/) atstart = 1
+        else if (c !~ /[ \t]/) atstart = 0
+        i++
+      }
+      printf "%s", out
+    }'
+}
+cmd=$(mask_ssh_payload_separators "$cmd")
 
 # Only consider git checkout/switch/restore/clean/reset/merge/rebase/
 # cherry-pick/revert/am invocations at all (loose pre-filter — a cheap skip,
@@ -1162,9 +1342,16 @@ while IFS=$'\t' read -r sep nextsep clause; do
   #       executes a preprocessor command per file, locally).
   # NO LATCH: the waiver covers THIS clause only — it reads the clause's
   # own command word, so no arming/propagation separator proof is needed
-  # (unlike the cd/WT latches, no state crosses clauses). A quoted
-  # multi-statement remote string (`ssh pod 'cd /w && git reset --hard'`)
-  # is mis-split by the quoted-separator trade-off and its TAIL clause
+  # (unlike the cd/WT latches, no state crosses clauses). A single-quoted
+  # multi-statement remote string in the CANONICAL shape (payload is the
+  # clause's final token; quote-, latch- and ladder-clean per the R1-R8
+  # predicate) is merged into ONE clause by the
+  # mask_ssh_payload_separators() pre-pass (#1413) BEFORE the split, so it
+  # reaches this waiver whole — the pre-pass grants nothing itself; the
+  # merged clause still walks every refusal above. Any OTHER
+  # multi-statement remote string (double quotes, trailing tokens,
+  # redirects, wrapped ssh, quoted or latch-vocabulary prefixes) is still
+  # mis-split by the quoted-separator trade-off and its TAIL clause
   # (which lost the ssh command word) still classifies — fail-closed,
   # residual gap (xiv); remediation unchanged: single-statement
   # `git -C /workspace/... <verb>` inside the remote string (the -C waiver
@@ -1208,5 +1395,5 @@ To LAND a branch onto main: gh pr merge <PR> --rebase (server-side, the /issue S
 To recover an in-progress root merge/rebase/cherry-pick/revert/am: git merge --abort / git rebase --abort / git cherry-pick --abort / git revert --abort / git am --abort (all allowed; --quit likewise). For a worktree fast-forward: git -C <worktree> merge --ff-only main.
 For marker-note text mentioning git commands, use --file <path.md> instead of --note; for commit messages, use git commit -F <file>.
 NOTE: this deny blocked your ENTIRE compound command — earlier clauses did NOT run either; regenerate any files/state those clauses were meant to produce before retrying the safe form (incident class #813/#1056).
-For a POD-side remote git op, a single-statement ssh <host> 'git <verb> ...' remote command is allowed (#1098); a multi-statement remote string mis-splits — put git -C /workspace/<repo> <verb> inside the remote string, or use a pod-side script / the SSH MCP." >&2
+For a POD-side remote git op, a single-statement ssh <host> 'git <verb> ...' remote command is allowed (#1098), and a SINGLE-QUOTED multi-statement remote string is allowed when the quoted payload is the clause's final token and nothing quote- or latch-ambiguous precedes it (#1413); other shapes (double quotes, redirects, trailing tokens, wrapped ssh, quoted/latch-vocabulary prefixes) still need git -C /workspace/<repo> <verb> inside the remote string, a pod-side script, or the SSH MCP." >&2
 exit 2

--- a/tests/test_guard_repo_root_branch.py
+++ b/tests/test_guard_repo_root_branch.py
@@ -33,6 +33,14 @@ As of #1098 the guard WAIVES, per-clause and under a fail-closed refusal ladder
 output redirects, ssh local-exec options, shared-repo path spellings,
 ``rg --pre``), clauses whose command word is ``ssh`` (remote execution) or
 ``grep``/``egrep``/``fgrep``/``rg`` (read-only pattern argument).
+As of #1413 a pre-split masking pass (``mask_ssh_payload_separators``) merges
+the CANONICAL single-quoted multi-statement ssh payload — the quoted payload
+is the clause's final token and the whole candidate passes an 8-arm
+fail-closed refusal predicate (R1-R8) — into ONE clause, so it reaches the
+#1098 waiver whole (closes residual (xiv)'s mis-split false positive for
+that shape; the former block fixture N1 moved to the masking allow list as
+M9). Any refused candidate leaves the input byte-identical, keeping today's
+disposition.
 """
 
 from __future__ import annotations
@@ -1278,10 +1286,11 @@ def test_grep_pattern_clause_waiver_allows(cmd):
 @pytest.mark.parametrize(
     "cmd",
     [
-        pytest.param(
-            "ssh pod-779 'cd /workspace/explore-persona-space && git reset --hard origin/main'",
-            id="N1-multi_statement_mis_split_residual_fp",
-        ),
+        # N1-multi_statement_mis_split_residual_fp MOVED (#1413) to the
+        # masking allow list below as M9-former_N1_residual_closed: N1 was
+        # the pin OF the residual-(xiv) mis-split false positive that the
+        # mask_ssh_payload_separators() pre-pass closes for the canonical
+        # single-quoted shape — the flip is Goal-mandated, not a regression.
         pytest.param('ssh host "$(git reset --hard)"', id="N2-cmdsub_executes_locally"),
         pytest.param('ssh host "`git clean -fd`"', id="N3-backtick_executes_locally"),
         pytest.param(
@@ -1429,6 +1438,255 @@ def test_grep_pattern_clause_waiver_allows(cmd):
 )
 def test_remote_waiver_fail_closed_blocks(cmd):
     """Every waiver refusal arm keeps its locally-executing lookalike at exit 2."""
+    assert _run(cmd) == 2
+
+
+# ==== #1413 — ssh multi-statement single-quoted payload masking =============
+#
+# mask_ssh_payload_separators() neutralizes the separators INSIDE the
+# balanced single-quoted FINAL argument of a clause-initial ssh clause, so
+# the canonical multi-statement remote string reaches the #1098 waiver as
+# ONE clause instead of mis-splitting (residual (xiv)'s first arm, closed
+# for that shape; founding incident #779). Masking fires ONLY when the whole
+# candidate passes the 8-arm fail-closed refusal predicate — R1
+# whitespace-only tail to ;/&&/||/NL/EOS; R2 no expansion/redirect/sentinel
+# char; R3 no ssh local-exec option token; R4 no shared-repo path spelling;
+# R5 no quote char before the candidate; R6/R7 no cd + /tmp/ or
+# .claude/worktrees/ latch vocabulary in candidate/prefix; R8 no WT= text —
+# and ANY refusal leaves the input byte-identical, so every refused shape
+# keeps today's disposition (all 27 NM fixtures below were verified rc=2
+# against the UNMODIFIED guard before the mask landed — the pre-change
+# red-team gate). The allow side is NOT @on_main (a masked-and-waived
+# clause must pass in either repo state, matching the #1098 convention).
+# Where a predicate arm overlaps a #1098 ladder refusal, the block fixture
+# uses an allow-arm-anchored CONTAMINATION payload: a mid-payload
+# `git switch feature-x` (whose ONLY detector carries the end-anchored
+# `switch main` allow-arm) followed by a payload-FINAL `git switch main` —
+# under a single dropped predicate arm the merged clause reaches
+# classify_clause and the trailing quote-tolerant allow-arm swallows the
+# block, turning the fixture RED. A destructive payload cannot detect that
+# bug class: the reset/checkout detectors span masked text via their
+# [^;&|]* gaps and stay green, so those fixtures serve as disposition pins
+# only.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        pytest.param(
+            "ssh pod-77965 'cd /workspace/explore-persona-space && git fetch origin"
+            " && git checkout FETCH_HEAD -- scripts/'",
+            id="M1-incident_779_fetch_head_checkout",
+        ),
+        pytest.param(
+            "ssh pod-779 'cd /workspace/x; git reset --hard origin/main'",
+            id="M2-semicolon_chain",
+        ),
+        pytest.param(
+            "ssh pod-779 'cd /workspace/x && git checkout -b scratch'",
+            id="M3-verb_in_tail_statement",
+        ),
+        pytest.param("ssh pod-779 'git fetch || git reset --hard'", id="M4-or_connector_payload"),
+        pytest.param(
+            "ssh pod-779 'git fetch origin\ngit checkout FETCH_HEAD'",
+            id="M5-newline_in_payload",
+        ),
+        pytest.param(
+            "ssh pod-779 'cd /w && git reset --hard' && echo done",
+            id="M6-benign_local_tail_and",
+        ),
+        pytest.param(
+            # Prefix is quote- and latch-clean, so the SEQ-preceded candidate
+            # still masks (clause-initial tracking mirrors the splitter).
+            "echo starting; ssh pod-779 'cd /w && git reset --hard'",
+            id="M7-clause_initial_after_seq",
+        ),
+        pytest.param(
+            "ssh -p 40052 root@157.157.221.29 'cd /workspace/x && git checkout FETCH_HEAD'",
+            id="M8-options_host_head",
+        ),
+        pytest.param(
+            # The former N1-multi_statement_mis_split_residual_fp block
+            # fixture: its (xiv) mis-split residual is what #1413 closes.
+            # /workspace/explore-persona-space matches NONE of cond (4)'s
+            # covered shared-repo spellings, so the merged clause waives.
+            "ssh pod-779 'cd /workspace/explore-persona-space && git reset --hard origin/main'",
+            id="M9-former_N1_residual_closed",
+        ),
+    ],
+)
+def test_ssh_multi_statement_payload_masking_allows(cmd):
+    """Canonical single-quoted multi-statement ssh payloads mask and waive (#779)."""
+    assert _run(cmd) == 0
+
+
+@on_main
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        pytest.param(
+            # Double quotes never mask (escapes/expansion/nesting make the
+            # parse inexact) — documented residual.
+            'ssh pod-779 "cd /workspace/x && git reset --hard origin/main"',
+            id="NM1-double_quoted_multi_statement",
+        ),
+        pytest.param(
+            # Constraint-1 ambiguity (no closing quote) stays blocked.
+            "ssh pod-779 'cd /workspace/x && git reset --hard origin/main",
+            id="NM2-unbalanced_quote_fail_closed",
+        ),
+        pytest.param(
+            # R4 disposition pin: the $HOME/ shared-repo spelling never masks.
+            "ssh vm 'cd $HOME/explore-persona-space && git reset --hard'",
+            id="NM3-repo_path_home_spelling",
+        ),
+        pytest.param(
+            # R4 disposition pin: the literal shared-repo spelling never masks.
+            "ssh vm 'cd /home/thomasjiralerspong/explore-persona-space && git reset --hard'",
+            id="NM4-repo_path_literal_spelling",
+        ),
+        pytest.param(
+            "timeout 240 ssh pod-779 'cd /w && git reset --hard'",
+            id="NM5-wrapped_ssh_multi_statement",
+        ),
+        pytest.param(
+            "$SSHCMD pod-779 'cd /w && git reset --hard'",
+            id="NM6-variable_ssh_multi_statement",
+        ),
+        pytest.param(
+            "/usr/bin/ssh pod-779 'cd /w && git reset --hard'",
+            id="NM7-abs_path_ssh_multi_statement",
+        ),
+        pytest.param(
+            # R1 disposition pin: pipeline-producer position stays classifying.
+            "ssh host 'echo x && git reset --hard' | bash",
+            id="NM8-pipe_after_candidate",
+        ),
+        pytest.param(
+            # R1 disposition pin: background position stays classifying.
+            "ssh host 'cd /w && git reset --hard' &",
+            id="NM9-bg_after_candidate",
+        ),
+        pytest.param(
+            # Payload `>` refuses via R2 (remote-redirect residual, parity
+            # with N29); the /tmp/x path alone does not trip R6's
+            # conjunction — no `cd` before it — the `>` arm is what refuses.
+            "ssh pod-779 'git status > /tmp/x && git checkout -b scratch'",
+            id="NM10-redirect_in_payload",
+        ),
+        pytest.param(
+            "ssh pod-779 'cd /w && git reset --hard' -v",
+            id="NM11-trailing_token_after_quote",
+        ),
+        pytest.param(
+            # Parity with N4: the deliberate ${ over-match refuses.
+            "ssh pod-779 'cd /w && git reset --hard ${REF}'",
+            id="NM12-brace_expansion_in_payload",
+        ),
+        pytest.param(
+            # Parity with N17; plain input-`<` shares R2's blanket `<` branch.
+            "ssh pod-779 'cd /w && git reset --hard' <<< input",
+            id="NM13-here_string_tail",
+        ),
+        pytest.param(
+            # Parity with N7: local-exec option token refuses (R3).
+            "ssh -o ProxyCommand=evil host 'cd /w && git reset --hard'",
+            id="NM14-proxycommand_head_multi_statement",
+        ),
+        pytest.param(
+            # Masking is clause-local: the LOCAL tail still blocks (N11 parity).
+            "ssh pod-779 'cd /w && git fetch'; git reset --hard",
+            id="NM15-local_gated_clause_after_masked",
+        ),
+        pytest.param(
+            # ~/ shared-repo spelling as a CONTAMINATION shape: today the
+            # mid-payload `git switch feature-x` fragment blocks; a dropped
+            # ~/ arm masks -> the merged clause repo-path-glob classifies ->
+            # the trailing `switch main` allow-arm would swallow -> RED.
+            "ssh vm 'cd ~/explore-persona-space; git switch feature-x; git switch main'",
+            id="NM16-repo_path_tilde_contamination",
+        ),
+        pytest.param(
+            # The LOCAL head clause still blocks (a scanner bug swallowing
+            # the prefix goes red).
+            "git reset --hard; ssh pod-779 'cd /workspace/x && git fetch'",
+            id="NM17-local_gated_clause_before_masked",
+        ),
+        pytest.param(
+            # Pins R2's $( branch with contamination power.
+            "ssh pod-779 'echo $(hostname); git switch feature-x; git switch main'",
+            id="NM18-cmdsub_payload_contamination",
+        ),
+        pytest.param(
+            # Pins R2's backtick branch with contamination power.
+            "ssh pod-779 'echo `hostname`; git switch feature-x; git switch main'",
+            id="NM19-backtick_payload_contamination",
+        ),
+        pytest.param(
+            # Today the mid-payload gated fragment blocks; a broken R1 masks
+            # -> merged clause has nextsep=PIPE -> the ladder refuses the
+            # waiver -> classifies MERGED text -> the trailing `switch main`
+            # allow-arm would swallow -> RED (the exact contamination
+            # mechanism the mask-then-let-ladder-refuse design rejects).
+            "ssh host 'echo x; git switch feature-x; git switch main' | bash",
+            id="NM20-pipe_position_contamination",
+        ),
+        pytest.param(
+            # BG-position twin of NM20.
+            "ssh host 'echo x; git switch feature-x; git switch main' &",
+            id="NM21-bg_position_contamination",
+        ),
+        pytest.param(
+            # Today the payload's `;` resets `scoped` and the && tail
+            # BLOCKS; without R6 the merged clause would match the
+            # pre-waiver `cd +/tmp/` grep -> scoped=1; continue -> the LOCAL
+            # tail is skipped -> RED.
+            "ssh pod-779 'cd /tmp/scratch; git fetch' && git reset --hard",
+            id="NM22-latch_arming_payload_and_tail",
+        ),
+        pytest.param(
+            # `cd` and the worktrees path in DIFFERENT payload statements:
+            # without R6 the mask removes the [;&|] chars guarding
+            # `cd +[^;&|]*\.claude/worktrees/`, the widened grep matches the
+            # merged clause, and the local tail is skipped -> RED.
+            "ssh pod-779 'cd /data && echo .claude/worktrees/x' && git reset --hard",
+            id="NM23-latch_regex_widening_split_payload",
+        ),
+        pytest.param(
+            # `scoped` armed by the LOCAL prefix; today the payload's `;`
+            # resets it and the tail BLOCKS; without R7 the merged clause
+            # rides scoped=1 and the tail is skipped -> RED.
+            "cd /tmp/scratch && ssh pod-779 'git fetch; git status' && git reset --hard",
+            id="NM24-prefix_latch_then_masked_and_tail",
+        ),
+        pytest.param(
+            # The scanner's "payload" would be live LOCAL code between two
+            # strings; today the local gated clause BLOCKS; without R5 it is
+            # masked into a waived ^ssh clause -> RED.
+            "echo 'x; ssh h '; git switch feature-x; echo '; y'",
+            id="NM25-preopened_single_quote_swallow",
+        ),
+        pytest.param(
+            # Double-quote variant: raw-apostrophe-parity would pass it; the
+            # strict any-quote R5 refuses -> without R5, RED.
+            'echo "x; ssh h \'"; git switch feature-x; echo "\';"',
+            id="NM26-preopened_double_quote_swallow",
+        ),
+        pytest.param(
+            # Today the payload's clause-initial WT=x' fragment DISARMS
+            # wt_bound and the tail BLOCKS; without R8 the disarm is
+            # suppressed, cd "$WT" latches, and the tail is skipped -> RED.
+            "WT=.claude/worktrees/w; ssh pod-779 'echo a; WT=x'; cd \"$WT\" && git checkout -b tmp",
+            id="NM27-wt_payload_disarm_suppression",
+        ),
+    ],
+)
+def test_ssh_masking_refusal_ladder_blocks(cmd):
+    """Every mask-predicate refusal arm leaves its shape byte-identical (exit 2).
+
+    All 27 fixtures were verified rc=2 against the UNMODIFIED guard before
+    the mask landed (the plan's pre-change red-team gate), so each pins a
+    today-blocked disposition the monotonicity invariant quantifies over.
+    """
     assert _run(cmd) == 2
 
 


### PR DESCRIPTION
Closes task #1413.

Adds mask_ssh_payload_separators() to scripts/guard_repo_root_branch.sh — a fail-closed awk pre-pass that stops the clause splitter descending into the balanced single-quoted final argument of a clause-initial ssh clause (documented residual (xiv); founding incident #779). Gated on the 8-arm refusal predicate R1-R8 extending the monotonicity invariant over the driver latch state machine. 9 allow + 27 must-block fixtures (each verified rc=2 pre-change) + the one Goal-mandated N1 flip.

Pipeline: plan v3 (3-lens critic REVISE round addressed), code-review PASS r1, Step 9c gate 4024 passed / 1 pre-existing stripped.