### PR TITLE
issue-1428: load_dotenv() before heavy imports in 11 figure scripts (#847)

### DIFF
--- a/.claude/agent-memory/implementer/reference_ruff_ruf002_unicode_docstring.md
+++ b/.claude/agent-memory/implementer/reference_ruff_ruf002_unicode_docstring.md
@@ -15,3 +15,14 @@ set (×, ×→x; en/em-dashes; smart quotes), not all non-ASCII.
 NOT a `# noqa: RUF002` — the codebase has zero RUF002-noqa precedent and the
 ASCII form reads identically. Plans that paste GPU-shape prose (`8×H100`,
 `2×A100`) verbatim into a docstring will hit this; swap to `x` at write time.
+
+**RUF001 (strings) addendum (#1428, 2026-07-16):** en dash `–` and MINUS SIGN
+`−` in figure-label STRINGS are RUF001-flagged; em dash `—` is NOT confusable
+(passes clean). For deliberate typographic chars in rendered figure text the
+fix IS a line-level `# noqa: RUF001 -- reason` (repo precedent:
+plot_aim5_25pct_*.py) — never swap the char (changes rendered figures). E501
+interplay: the noqa comment counts toward the 100-char limit, so on a ~95-char
+line wrap the call per-arg (magic trailing comma keeps ruff-format stable) and
+put the noqa on the label line. Also verified: `# noqa: C901 -- reason`
+trailing text parses fine, and an underscore prefix (`_lab`, `_null_lo`)
+silences B007/F841 with the assignment kept.

--- a/scripts/issue1092_inline_compose_chain_figure.py
+++ b/scripts/issue1092_inline_compose_chain_figure.py
@@ -14,10 +14,17 @@ import json
 import sys
 from pathlib import Path
 
-import matplotlib.pyplot as plt
-
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "src"))
+from explore_persona_space.orchestrate.env import load_dotenv  # noqa: E402
+
+# #847: thread caps must land BEFORE the matplotlib import below — on the
+# shared VM, load_dotenv() setdefaults OMP/MKL/OPENBLAS/NUMEXPR_NUM_THREADS,
+# and the BLAS pools freeze at import time.
+load_dotenv()
+
+import matplotlib.pyplot as plt  # noqa: E402
+
 from explore_persona_space.analysis.paper_plots import (  # noqa: E402
     paper_palette_role,
     savefig_paper,

--- a/scripts/issue1092_inline_fair_comparison_agreement_fig.py
+++ b/scripts/issue1092_inline_fair_comparison_agreement_fig.py
@@ -20,14 +20,20 @@ import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
-import matplotlib
-
-matplotlib.use("Agg")
-import matplotlib.pyplot as plt
-import numpy as np
-
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "src"))
+from explore_persona_space.orchestrate.env import load_dotenv  # noqa: E402
+
+# #847: thread caps must land BEFORE the matplotlib/numpy imports below — on
+# the shared VM, load_dotenv() setdefaults OMP/MKL/OPENBLAS/NUMEXPR_NUM_THREADS,
+# and the BLAS pools freeze at import time.
+load_dotenv()
+
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
 
 from explore_persona_space.analysis.paper_plots import (  # noqa: E402
     paper_palette_role,

--- a/scripts/issue1092_inline_fair_comparison_fig.py
+++ b/scripts/issue1092_inline_fair_comparison_fig.py
@@ -25,14 +25,20 @@ import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
-import matplotlib
-
-matplotlib.use("Agg")
-import matplotlib.pyplot as plt
-import numpy as np
-
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "src"))
+from explore_persona_space.orchestrate.env import load_dotenv  # noqa: E402
+
+# #847: thread caps must land BEFORE the matplotlib/numpy imports below — on
+# the shared VM, load_dotenv() setdefaults OMP/MKL/OPENBLAS/NUMEXPR_NUM_THREADS,
+# and the BLAS pools freeze at import time.
+load_dotenv()
+
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
 
 from explore_persona_space.analysis.paper_plots import (  # noqa: E402
     paper_palette_role,

--- a/scripts/issue1092_offvm_refit_figures.py
+++ b/scripts/issue1092_offvm_refit_figures.py
@@ -25,10 +25,17 @@ import json
 import math
 from pathlib import Path
 
-import matplotlib.pyplot as plt
-import numpy as np
+from explore_persona_space.orchestrate.env import load_dotenv
 
-from explore_persona_space.analysis.paper_plots import (
+# #847: thread caps must land BEFORE the matplotlib/numpy imports below — on
+# the shared VM, load_dotenv() setdefaults OMP/MKL/OPENBLAS/NUMEXPR_NUM_THREADS,
+# and the BLAS pools freeze at import time.
+load_dotenv()
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+
+from explore_persona_space.analysis.paper_plots import (  # noqa: E402
     paper_palette,
     savefig_paper,
     set_paper_style,

--- a/scripts/issue1315_bare_plots.py
+++ b/scripts/issue1315_bare_plots.py
@@ -22,7 +22,14 @@ import json
 import sys
 from pathlib import Path
 
-import matplotlib.pyplot as plt
+from explore_persona_space.orchestrate.env import load_dotenv
+
+# #847: thread caps must land BEFORE the matplotlib import below — on the
+# shared VM, load_dotenv() setdefaults OMP/MKL/OPENBLAS/NUMEXPR_NUM_THREADS,
+# and the BLAS pools freeze at import time.
+load_dotenv()
+
+import matplotlib.pyplot as plt  # noqa: E402
 
 _SCRIPTS_DIR = Path(__file__).resolve().parent
 if str(_SCRIPTS_DIR) not in sys.path:

--- a/scripts/issue1315_bare_plots.py
+++ b/scripts/issue1315_bare_plots.py
@@ -117,7 +117,7 @@ def fig_hero(own: dict, tf: dict) -> None:
 
     # Panel B — matched-80-row rank (mean ± sd over 100 draws).
     ax = axes[1]
-    for (c, lab), col, dx in zip(SCAFFOLDED, colors, jit, strict=True):
+    for (c, _lab), col, dx in zip(SCAFFOLDED, colors, jit, strict=True):
         ax.errorbar(
             [dx],
             [ss[c]["rank_k_at_90_mean"]],
@@ -136,7 +136,12 @@ def fig_hero(own: dict, tf: dict) -> None:
         color="black",
         capsize=3,
     )
-    ax.axhspan(*SYCO_80ROW_BAND, color="tab:gray", alpha=0.25, label="sycophancy band (48–50)")
+    ax.axhspan(
+        *SYCO_80ROW_BAND,
+        color="tab:gray",
+        alpha=0.25,
+        label="sycophancy band (48–50)",  # noqa: RUF001 -- typographic en dash in label
+    )
     ax.set_xticks([0, 1], ["scaffolded (7)", "bare"])
     ax.set_xlim(-0.6, 1.6)
     ax.set_ylim(26, 54)
@@ -146,12 +151,15 @@ def fig_hero(own: dict, tf: dict) -> None:
 
     # Panel C — shared-text rank at L14 (V4).
     ax = axes[2]
-    for (c, lab), col, dx in zip(SCAFFOLDED, colors, jit, strict=True):
+    for (c, _lab), col, dx in zip(SCAFFOLDED, colors, jit, strict=True):
         ax.plot([dx], [rec(r_tf, c, "response", L14)["rank_k_at_90"]], "o", ms=8, color=col)
     ax.plot([1.0], [rec(r_tf, BARE, "response", L14)["rank_k_at_90"]], "*", ms=16, color="black")
     ax.axhline(COLLAPSE_BAR, ls="--", lw=1.2, color="black", label="collapse bar (30)")
     ax.axhspan(
-        *SYCO_SHARED_SPAN, color="tab:gray", alpha=0.25, label="sycophancy shared span (27–35)"
+        *SYCO_SHARED_SPAN,
+        color="tab:gray",
+        alpha=0.25,
+        label="sycophancy shared span (27–35)",  # noqa: RUF001 -- typographic en dash in label
     )
     ax.set_xticks([0, 1], ["scaffolded (7)", "bare"])
     ax.set_xlim(-0.6, 1.6)

--- a/scripts/issue1336_analyzer_figures.py
+++ b/scripts/issue1336_analyzer_figures.py
@@ -23,13 +23,20 @@ for _p in (str(_SCRIPT_DIR), str(_REPO_ROOT / "src")):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
-import matplotlib
+from explore_persona_space.orchestrate.env import load_dotenv  # noqa: E402
+
+# #847: thread caps must land BEFORE the matplotlib/numpy imports below — on
+# the shared VM, load_dotenv() setdefaults OMP/MKL/OPENBLAS/NUMEXPR_NUM_THREADS,
+# and the BLAS pools freeze at import time.
+load_dotenv()
+
+import matplotlib  # noqa: E402
 
 matplotlib.use("Agg")
-import matplotlib.pyplot as plt
-import numpy as np
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
 
-from explore_persona_space.analysis.paper_plots import (
+from explore_persona_space.analysis.paper_plots import (  # noqa: E402
     paper_palette,
     savefig_paper,
     set_paper_style,

--- a/scripts/issue1336_analyzer_figures.py
+++ b/scripts/issue1336_analyzer_figures.py
@@ -88,7 +88,7 @@ def fig_hero(decision: dict) -> None:
             color=colors[si],
             label=lab,
         )
-        for x, p in zip(xs + (si - 1) * width, pts):
+        for x, p in zip(xs + (si - 1) * width, pts, strict=False):
             if abs(p) > 0.01:
                 ax.text(x, p + (0.006 if p > 0 else -0.012), f"{p:+.3f}", ha="center", fontsize=7)
     ax.axhline(0.0, color="0.3", lw=0.8)
@@ -134,7 +134,7 @@ def fig_hero(decision: dict) -> None:
             linestyle="none",
             label=lab,
         )
-        for x, p in zip(xs2 + off, pts):
+        for x, p in zip(xs2 + off, pts, strict=False):
             ax.text(x + 0.06, p, f"{p:+.4f}", fontsize=7, va="center")
     ax.axhline(0.0, color="0.3", lw=0.8)
     band = decision["verdict_lattice"]["elicit_band"]
@@ -166,7 +166,7 @@ def fig_within_vs_comp() -> None:
         xs = np.arange(3)
         ax.bar(xs - 0.18, within, 0.34, color=colors[0], label="within-stage map")
         ax.bar(xs + 0.18, comp, 0.34, color=colors[1], label="base map, reparameterized")
-        for x, w, c in zip(xs, within, comp):
+        for x, w, c in zip(xs, within, comp, strict=False):
             ax.text(x - 0.18, w + 0.008, f"{w:.3f}", ha="center", fontsize=7.5)
             ax.text(x + 0.18, c + 0.008, f"{c:.3f}", ha="center", fontsize=7.5)
         ax.set_xticks(xs)
@@ -198,7 +198,7 @@ def fig_saga(verdict: dict, g1: dict) -> None:
     cols = ["#b5443c", "#c99a3c", "#3c7fb5"]
     xs = np.arange(3)
     ax.bar(xs, vals, 0.55, color=cols)
-    for x, v in zip(xs, vals):
+    for x, v in zip(xs, vals, strict=False):
         ax.text(x, v + (0.03 if v > 0 else -0.07), f"{v:+.3f}", ha="center", fontsize=9)
     ax.axhline(li["bar_r"], color="0.2", lw=1.1, ls="--")
     ax.text(
@@ -227,7 +227,7 @@ def fig_saga(verdict: dict, g1: dict) -> None:
     xs = np.arange(2)
     vals2 = [v["committed_anchor"], v["s_qwen_recal"]]
     ax.bar(xs, vals2, 0.5, color=["0.6", "#3c7fb5"])
-    for x, val in zip(xs, vals2):
+    for x, val in zip(xs, vals2, strict=False):
         ax.text(x, val + 0.008, f"{val:.4f}", ha="center", fontsize=9)
     ax.set_xticks(xs)
     ax.set_xticklabels(
@@ -318,14 +318,15 @@ def fig_lambda_degeneracy() -> None:
         ax.plot(
             xs + (si - 1) * 0.08, vals, "o", label=slab, markersize=7, color=paper_palette(3)[si]
         )
-        for x, v in zip(xs + (si - 1) * 0.08, vals):
+        for x, v in zip(xs + (si - 1) * 0.08, vals, strict=False):
             ax.text(x + 0.06, v * 1.15, f"{v:.1e}" if v < 1e-3 else f"{v:.3f}", fontsize=6.5)
     ax.set_yscale("log")
     ax.set_xticks(xs)
     ax.set_xticklabels([lab for _, lab in EVAL_SETS], fontsize=8)
     ax.set_ylabel("|gap| (recal, layer 30, log scale)")
     ax.set_title(
-        "On GSM8K test every fit sits at the $\\lambda$ floor:\nthe composition reproduces the within map exactly",
+        "On GSM8K test every fit sits at the $\\lambda$ floor:\n"
+        "the composition reproduces the within map exactly",
         pad=12,
         fontsize=10,
     )
@@ -353,14 +354,15 @@ def fig_dose() -> None:
             his.append(L["gap_recal_bootstrap"]["ci_hi"] - L["gap_recal"])
         off = (oi - 0.5) * 0.26
         ax.bar(xs + off, pts, 0.24, yerr=[los, his], capsize=3, color=colors[oi], label=lab)
-        for x, p in zip(xs + off, pts):
+        for x, p in zip(xs + off, pts, strict=False):
             ax.text(x, p + (0.006 if p > 0 else -0.014), f"{p:+.3f}", ha="center", fontsize=7.5)
     ax.axhline(0, color="0.3", lw=0.8)
     ax.set_xticks(xs)
     ax.set_xticklabels([lab for _, lab in sets3], fontsize=9)
     ax.set_ylabel("Reparameterization gap (recal, layer 30)")
     ax.set_title(
-        "Longer-RLVR dose arm (descriptive; different kept-row set,\ndifferent $\\lambda$ regime on LMSYS)",
+        "Longer-RLVR dose arm (descriptive; different kept-row set,\n"
+        "different $\\lambda$ regime on LMSYS)",
         pad=12,
         fontsize=10,
     )

--- a/scripts/issue1336_dedup_figure.py
+++ b/scripts/issue1336_dedup_figure.py
@@ -102,7 +102,7 @@ def main() -> None:
             markersize=8,
             label=label,
         )
-        for x, v in zip(xb + (j - 0.5) * 2 * off, vals):
+        for x, v in zip(xb + (j - 0.5) * 2 * off, vals, strict=False):
             ax_b.text(x, v + 0.004, f"{v:.3f}", ha="center", fontsize=9)
     ax_b.axhline(bar_r, color="0.25", lw=1.2, ls=":")
     ax_b.text(0.98, bar_r + 0.003, "usable-strength bar", ha="right", fontsize=9, color="0.25")

--- a/scripts/issue1336_dedup_figure.py
+++ b/scripts/issue1336_dedup_figure.py
@@ -17,10 +17,17 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import matplotlib.pyplot as plt
-import numpy as np
+from explore_persona_space.orchestrate.env import load_dotenv
 
-from explore_persona_space.analysis.paper_plots import (
+# #847: thread caps must land BEFORE the matplotlib/numpy imports below — on
+# the shared VM, load_dotenv() setdefaults OMP/MKL/OPENBLAS/NUMEXPR_NUM_THREADS,
+# and the BLAS pools freeze at import time.
+load_dotenv()
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+
+from explore_persona_space.analysis.paper_plots import (  # noqa: E402
     paper_palette,
     savefig_paper,
     set_paper_style,

--- a/scripts/issue1336_increments_figure.py
+++ b/scripts/issue1336_increments_figure.py
@@ -17,10 +17,17 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import matplotlib.pyplot as plt
-import numpy as np
+from explore_persona_space.orchestrate.env import load_dotenv
 
-from explore_persona_space.analysis.paper_plots import (
+# #847: thread caps must land BEFORE the matplotlib/numpy imports below — on
+# the shared VM, load_dotenv() setdefaults OMP/MKL/OPENBLAS/NUMEXPR_NUM_THREADS,
+# and the BLAS pools freeze at import time.
+load_dotenv()
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+
+from explore_persona_space.analysis.paper_plots import (  # noqa: E402
     paper_palette,
     savefig_paper,
     set_paper_style,

--- a/scripts/issue1336_increments_figure.py
+++ b/scripts/issue1336_increments_figure.py
@@ -72,7 +72,7 @@ def main() -> None:
             capsize=3,
             label=label,
         )
-        for x, v in zip(pos, pts):
+        for x, v in zip(pos, pts, strict=False):
             ax.text(
                 x,
                 v + (0.006 if v >= 0 else -0.012),

--- a/scripts/issue1345_clear_figs.py
+++ b/scripts/issue1345_clear_figs.py
@@ -276,7 +276,8 @@ def plot_result2_withinregime_chat_vs_notemplate() -> dict:
         "The context→answer map holds with and without the chat template "
         "(instruct, context arm, layer 19)",
         "Within-regime held-out $R^2$ with 95% bootstrap CI (Qwen2.5-7B-Instruct). Both framings "
-        "sit ~0.6, far above the answer-mean baseline ($R^2=0$) and the shuffle-null — removing the "
+        "sit ~0.6, far above the answer-mean baseline ($R^2=0$) and the shuffle-null — "
+        "removing the "
         "chat template barely changes the map's predictive power.",
         -0.1,
     )

--- a/scripts/issue1345_clear_figs.py
+++ b/scripts/issue1345_clear_figs.py
@@ -41,12 +41,19 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import matplotlib.pyplot as plt
-import numpy as np
-from matplotlib.colors import TwoSlopeNorm
-from matplotlib.patches import Rectangle
+from explore_persona_space.orchestrate.env import load_dotenv
 
-from explore_persona_space.analysis.paper_plots import (
+# #847: thread caps must land BEFORE the matplotlib/numpy imports below — on
+# the shared VM, load_dotenv() setdefaults OMP/MKL/OPENBLAS/NUMEXPR_NUM_THREADS,
+# and the BLAS pools freeze at import time.
+load_dotenv()
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+from matplotlib.colors import TwoSlopeNorm  # noqa: E402
+from matplotlib.patches import Rectangle  # noqa: E402
+
+from explore_persona_space.analysis.paper_plots import (  # noqa: E402
     paper_palette_role,
     savefig_paper,
     set_paper_style,

--- a/scripts/issue825_turndyn_figures.py
+++ b/scripts/issue825_turndyn_figures.py
@@ -16,10 +16,17 @@ import json
 import sys
 from pathlib import Path
 
-import matplotlib.pyplot as plt
-import numpy as np
+from explore_persona_space.orchestrate.env import load_dotenv
 
-from explore_persona_space.analysis.paper_plots import (
+# #847: thread caps must land BEFORE the matplotlib/numpy imports below — on
+# the shared VM, load_dotenv() setdefaults OMP/MKL/OPENBLAS/NUMEXPR_NUM_THREADS,
+# and the BLAS pools freeze at import time.
+load_dotenv()
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+
+from explore_persona_space.analysis.paper_plots import (  # noqa: E402
     paper_palette_blog,
     savefig_paper,
     set_paper_style,

--- a/scripts/issue825_turndyn_figures.py
+++ b/scripts/issue825_turndyn_figures.py
@@ -65,7 +65,7 @@ def per_turn_series(
     return turns, r2, folds, null_hi, ns
 
 
-def main() -> None:
+def main() -> None:  # noqa: C901 -- pre-existing complexity; refactor out of scope
     results_path = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_RESULTS
     d = load(results_path)
     p = d["parts"]
@@ -74,13 +74,13 @@ def main() -> None:
     out.mkdir(parents=True, exist_ok=True)
     c = paper_palette_blog(6)
     col_g, col_r_own, col_r_log = c[0], c[1], c[2]
-    col_mlp, col_ridge = c[3], c[0]
+    col_mlp, _col_ridge = c[3], c[0]
 
     # ------------------------------------------------------------------
     # Figure 1 (hero): per-turn held-out R2 at flat n≈5000, all arms
     # ------------------------------------------------------------------
     fig, axes = plt.subplots(1, 2, figsize=(11.5, 4.6), sharey=True)
-    for ax, model in zip(axes, MODELS):
+    for ax, model in zip(axes, MODELS, strict=False):
         arms = [
             (
                 f"cells_armG_{model}",
@@ -109,7 +109,7 @@ def main() -> None:
             (f"cells_armG_{model}", "pfx", col_g, "--", "o", "prefix arm (simulated)"),
             (f"cells_armR_own_{model}", "pfx", col_r_own, "--", "s", "prefix arm (real, own)"),
         ]
-        null_lo, null_hi_all = [], []
+        _null_lo, null_hi_all = [], []
         for key, mapping, col, ls, mk, label in arms:
             turns, r2, folds, null_hi, ns = per_turn_series(p[key], mapping)
             if key.startswith("cells_armR_logged"):
@@ -129,7 +129,7 @@ def main() -> None:
                 alpha=1.0 if ls == "-" else 0.55,
                 label=label,
             )
-            for t, fl in zip(turns, folds):
+            for t, fl in zip(turns, folds, strict=False):
                 ax.plot(
                     [t] * len(fl),
                     fl,
@@ -163,7 +163,7 @@ def main() -> None:
     # Figure 2: real logged deep tail (t13-30), decaying n
     # ------------------------------------------------------------------
     fig, axes = plt.subplots(1, 2, figsize=(11.5, 4.2), sharey=True)
-    for ax, model in zip(axes, MODELS):
+    for ax, model in zip(axes, MODELS, strict=False):
         turns, r2, folds, null_hi, ns = per_turn_series(p[f"cells_armR_logged_{model}"], "ctx")
         keep = [i for i, t in enumerate(turns) if 13 <= t <= 30]
         t_, r_, nh_, n_ = ([x[i] for i in keep] for x in (turns, r2, null_hi, ns))
@@ -178,7 +178,7 @@ def main() -> None:
             label="real logged conversations, logged answers",
         )
         ax.plot(t_, nh_, ":", color="0.45", lw=1.4, label="shuffled-answer null (max of 200 draws)")
-        for t, r, n in zip(t_, r_, n_):
+        for t, r, n in zip(t_, r_, n_, strict=False):
             ax.text(
                 t,
                 r + 0.12,
@@ -202,7 +202,7 @@ def main() -> None:
     # Figure 3: cross-turn transfer matrices (arm G)
     # ------------------------------------------------------------------
     fig, axes = plt.subplots(1, 2, figsize=(11.8, 4.9))
-    for ax, model in zip(axes, MODELS):
+    for ax, model in zip(axes, MODELS, strict=False):
         tr = p[f"transfer_armG_{model}"]
         turns = tr["turns"]
         m = np.full((len(turns), len(turns)), np.nan)
@@ -227,7 +227,7 @@ def main() -> None:
     # ------------------------------------------------------------------
     fig, axes = plt.subplots(1, 2, figsize=(11.5, 4.4), sharey=True)
     row_cols = paper_palette_blog(5)
-    for ax, model in zip(axes, MODELS):
+    for ax, model in zip(axes, MODELS, strict=False):
         tr = p[f"transfer_armG_{model}"]
         turns = tr["turns"]
         diag = [tr["r2"][f"{j}->{j}"] for j in turns]
@@ -256,7 +256,7 @@ def main() -> None:
     # Figure 5: reach — turn-1 context predicting turn-k answers
     # ------------------------------------------------------------------
     fig, axes = plt.subplots(1, 2, figsize=(11.5, 4.4), sharey=True)
-    for ax, model in zip(axes, MODELS):
+    for ax, model in zip(axes, MODELS, strict=False):
         for arm, col, mk, lab in [
             (f"reach_armG_{model}", col_g, "o", "simulated continuations"),
             (f"reach_armR_own_{model}", col_r_own, "s", "real logged context, own answers"),
@@ -335,7 +335,7 @@ def main() -> None:
     ax.axhspan(-0.10, 0.10, color="0.88", alpha=0.6, zorder=0)
     ax.axhline(0, color="0.6", lw=0.8)
     ax.set_xlabel("Assistant turn depth")
-    ax.set_ylabel("R² delta: simulated − real (same conversations)")
+    ax.set_ylabel("R² delta: simulated − real (same conversations)")  # noqa: RUF001 -- minus sign
     ax.set_title("Simulated-vs-real bridge (seed intersection, ±0.10 band)")
     ax.legend(fontsize=8, loc="upper left")
 
@@ -370,7 +370,7 @@ def main() -> None:
     # Figure 7: operator similarity vs within-turn resample ceiling (arm G)
     # ------------------------------------------------------------------
     fig, axes = plt.subplots(1, 2, figsize=(11.5, 4.4), sharey=True)
-    for ax, model in zip(axes, MODELS):
+    for ax, model in zip(axes, MODELS, strict=False):
         o = p[f"operators_armG_{model}"]
         turns = o["turns"]
         ceil = [o["selfsim_ceiling"][str(t)]["raw_cos_mean"] for t in turns]

--- a/scripts/issue952_divtrain_figures.py
+++ b/scripts/issue952_divtrain_figures.py
@@ -21,11 +21,18 @@ import logging
 import pathlib
 import sys
 
-import matplotlib
+from explore_persona_space.orchestrate.env import load_dotenv
+
+# #847: thread caps must land BEFORE the matplotlib/numpy imports below — on
+# the shared VM, load_dotenv() setdefaults OMP/MKL/OPENBLAS/NUMEXPR_NUM_THREADS,
+# and the BLAS pools freeze at import time.
+load_dotenv()
+
+import matplotlib  # noqa: E402
 
 matplotlib.use("Agg")
-import matplotlib.pyplot as plt
-import numpy as np
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 if str(_REPO_ROOT / "scripts") not in sys.path:


### PR DESCRIPTION
Closes task #1428. Fleet invariant test test_no_new_torch_before_dotenv_vm_entrypoints RED on main: 11 main-resident figure scripts imported heavy modules before load_dotenv(). Applied the #1284/#1319/#1378 recipe + absolute ruff-clean of touched files. Code-review PASS (r1+r2); Step 9c PASS (0 new failures, lint leg clean).