### PR TITLE
issue-1423: extend bit_byte_identical audit regex to the -equal synonym family

### DIFF
--- a/.claude/agents/codex-clean-result-critic.md
+++ b/.claude/agents/codex-clean-result-critic.md
@@ -687,7 +687,8 @@ Emit your verdict in EXACTLY this format. No preamble, no fences:
 - `**This experiment in context:**` is the ONLY place `[#K](...)` issue
   links / bare `#K`
   appear; `## Takeaways`, `## Results`, `## Methodology` are STANDALONE (no
-  `#K`, no "byte identical" / "byte-identical", no cross-issue framing,
+  `#K`, no "byte identical" / "byte-identical" (or `bit`/`-equal`
+  variants: `bit-identical`, `byte-equal`, `bit equal`), no cross-issue framing,
   no methodology-correction framing of a prior run): PASS|FAIL with
   cited offending section
 - `## Results` has ≥1 `### <result>`; each names a story-beat /
@@ -840,8 +841,11 @@ Emit your verdict in EXACTLY this format. No preamble, no fences:
   `<!-- clean-result-v3 -->` body.)
 - `I` not `we`; no fluff transitions; plain-academic Takeaways; no
   "Standing caveats" section: PASS|FAIL with cited phrase
-- `byte identical` / `byte-identical` anywhere in body prose (banned
-  2026-W22, task #454): PASS|FAIL with cited phrase
+- `byte identical` / `byte-identical` — or the `bit` forms
+  (`bit-identical`, `bit identical`) and the `-equal` synonyms
+  (`byte-equal`, `byte equal`, `bit-equal`, `bit equal`) — anywhere in
+  body prose (byte form banned 2026-W22 #454; bit forms #642; -equal
+  synonyms #1423): PASS|FAIL with cited phrase
 - <other findings or PASS>
 
 ### Lens 7 — Statistical-framing rule

--- a/.claude/agents/codex-clean-result-critic.md
+++ b/.claude/agents/codex-clean-result-critic.md
@@ -684,13 +684,10 @@ Emit your verdict in EXACTLY this format. No preamble, no fences:
   check 3); `## Methodology` carries `**Design:**` / `**Training:**` /
   `**Evaluation:**` (+ `**Rounds:**` table when >1 round): PASS|FAIL with
   cited missing slot
-- `**This experiment in context:**` is the ONLY place `[#K](...)` issue
-  links / bare `#K`
-  appear; `## Takeaways`, `## Results`, `## Methodology` are STANDALONE (no
-  `#K`, no "byte identical" / "byte-identical" (or `bit`/`-equal`
-  variants: `bit-identical`, `byte-equal`, `bit equal`), no cross-issue framing,
-  no methodology-correction framing of a prior run): PASS|FAIL with
-  cited offending section
+- `**This experiment in context:**` is the ONLY issue-link / bare-`#K` slot;
+  `## Takeaways`, `## Results`, `## Methodology` are STANDALONE (no `#K`,
+  no byte/bit × identical/equal phrase, no cross-issue framing, no
+  prior-run methodology-correction framing): PASS|FAIL with cited section
 - `## Results` has ≥1 `### <result>`; each names a story-beat /
   states the result (no outline labels `### Headline result` /
   `### Subset checks` / `### Methodology corrections`); each STANDS
@@ -841,11 +838,8 @@ Emit your verdict in EXACTLY this format. No preamble, no fences:
   `<!-- clean-result-v3 -->` body.)
 - `I` not `we`; no fluff transitions; plain-academic Takeaways; no
   "Standing caveats" section: PASS|FAIL with cited phrase
-- `byte identical` / `byte-identical` — or the `bit` forms
-  (`bit-identical`, `bit identical`) and the `-equal` synonyms
-  (`byte-equal`, `byte equal`, `bit-equal`, `bit equal`) — anywhere in
-  body prose (byte form banned 2026-W22 #454; bit forms #642; -equal
-  synonyms #1423): PASS|FAIL with cited phrase
+- any byte/bit × identical/equal phrase, spaced or hyphenated, in body
+  prose (#454; #642; -equal #1423): PASS|FAIL with cited phrase
 - <other findings or PASS>
 
 ### Lens 7 — Statistical-framing rule

--- a/.claude/rules/clean-result-critic-lens-reference.md
+++ b/.claude/rules/clean-result-critic-lens-reference.md
@@ -127,12 +127,15 @@ clean, so this passes."
   `## Data` verbatim example blocks; cell-letter codes anywhere in
   `## Takeaways`, `## What I ran`, `## Findings`, or a `## Data` capsule.)
   (Incident: #382 round 1.)
-- **Lens 6 — `byte identical` / `byte-identical` anywhere in the
-  body** (banned 2026-W22, task #454; carried into v3). The phrase
-  reads as AI-slop in research writing. Use plain English: "the two
-  files matched exactly", "every byte agreed", "no diff between the
-  runs". Flagged by `audit_clean_results_body_discipline.py`; FAIL on
-  any occurrence outside fenced code blocks.
+- **Lens 6 — `byte identical` / `byte-identical` — or the `bit` forms
+  (`bit-identical`, `bit identical`) and the `-equal` synonyms
+  (`byte-equal`, `byte equal`, `bit-equal`, `bit equal`) — anywhere in
+  the body** (byte form banned 2026-W22 #454; bit forms #642; -equal
+  synonyms #1423). The phrase reads as AI-slop in research writing. Use
+  plain English: "the two files matched exactly", "every byte agreed",
+  "no diff between the runs". Flagged by
+  `audit_clean_results_body_discipline.py`; FAIL on any occurrence
+  outside fenced code blocks.
 
 **Procedure.** Before writing any "Lens N: PASS" line for Lenses 2, 3,
 6, 7, 8, 9, 10, 12, work through the bullets above first. If a bullet's
@@ -233,7 +236,7 @@ training rows / probes lived in `## Data`.)
   `## Methodology → **Training:**`, the full training rows / probes live
   in the Methodology data slots, and the compute / code SHA / pinned
   links live in the `**Repro:**` footer. No cross-issue
-  framing, no `byte identical` / `byte-identical`.
+  framing, no `byte identical` / `byte-identical` (or `bit`/`-equal` variants).
 - Plain language, accessible to a non-specialist. No jargon undefined
   before it is used.
 
@@ -631,9 +634,11 @@ this lens owns its REGISTER and its CROSS-ROUND SYNTHESIS CURRENCY.
   `### <finding>` read prose.)
 - No abandoned-metric prose ("we considered X but went with Y" when
   Y is the only metric reported).
-- **Never write `byte identical` or `byte-identical`** anywhere in
-  the body (banned 2026-W22, task #454; carried into v3 and v4; flagged
-  by
+- **Never write `byte identical` or `byte-identical`** — nor the `bit`
+  forms (`bit-identical`, `bit identical`) or the `-equal` synonyms
+  (`byte-equal`, `byte equal`, `bit-equal`, `bit equal`) — anywhere in
+  the body (byte form banned 2026-W22 #454; bit forms #642; -equal
+  synonyms #1423; carried into v3 and v4; flagged by
   `audit_clean_results_body_discipline.py`). FAIL on any occurrence
   outside fenced code blocks. Use plain English: "the two files
   matched exactly", "every byte agreed", "no diff between the runs".

--- a/.claude/skills/clean-results/SPEC.md
+++ b/.claude/skills/clean-results/SPEC.md
@@ -914,7 +914,8 @@ Otherwise identical to v3:
   `## Takeaways` bullet.
 - Inline math `\(...\)`, display math `\[...\]`. Keep math out of plot
   labels and captions.
-- **Never write `byte identical` or `byte-identical`** anywhere.
+- **Never write `byte identical` or `byte-identical`** — nor the `bit …` /
+  `… equal` variants (`bit-identical`, `byte-equal`, `bit equal`) — anywhere.
 - **Statistical-framing discipline** carries over (enforced by
   `audit_clean_results_body_discipline.py` + clean-result-critic): no
   pre-registration mentions, no effect-size names in prose, no named
@@ -1525,9 +1526,10 @@ Three discipline points:
   `Confidence:` sentence to carry them).
 - Inline math `\(...\)`, display math `\[...\]`. Keep math out of plot
   labels and figure captions.
-- **Never write `byte identical` or `byte-identical`** anywhere in the
-  body. Use plain English: "the two files matched exactly", "every byte
-  agreed", "no diff between the runs".
+- **Never write `byte identical` or `byte-identical`** — nor the `bit …` /
+  `… equal` variants (`bit-identical`, `byte-equal`, `bit equal`) — anywhere
+  in the body. Use plain English: "the two files matched exactly", "every
+  byte agreed", "no diff between the runs".
 - **Statistical-framing discipline** carries over from v2 (enforced by
   `audit_clean_results_body_discipline.py` + clean-result-critic Lens 7):
   no pre-registration mentions, no effect-size names in prose, no named
@@ -1640,7 +1642,7 @@ generations; the snake_case-slug category is v4-only):
   + bare unbackticked slugs stay LM-critic territory) — v4-only (#1372)
 - Math-style subscripts/superscripts in prose
 - GCG / PAIR / `H_a` / `REJECTED` / letter labels / `Bin A/B/C`
-- **`byte identical` / `byte-identical`** — banned phrasing.
+- **`byte identical` / `byte-identical` (incl. `bit` and `-equal` variants)** — banned phrasing.
 
 Exemption: blockquoted lines inside the `## Reproducibility`
 `**Context:**` row are NOT scanned (the verbatim originating-prompt /

--- a/scripts/audit_clean_results_body_discipline.py
+++ b/scripts/audit_clean_results_body_discipline.py
@@ -250,13 +250,19 @@ PATTERNS: dict[str, tuple[str, str]] = {
         # the body carried `bit-identical` AND `byte-identical`, but the
         # byte-only regex flagged only the latter; the clean-result-critic
         # Lens 6 bans both forms as the same voice violation, so the audit
-        # must catch both under one rule). Use plain English: "the two files
-        # matched exactly", "every byte agreed", "no diff between the runs".
-        r"\b(?:byte|bit)[\s-]identical\b",
+        # must catch both under one rule). The 'equal' synonym family
+        # (byte-equal / byte equal / bit-equal / bit equal) was added
+        # 2026-W29 (task #1423: issue #1005's body carried "inherited
+        # byte-equal (sha-asserted)", which the -identical-only regex missed;
+        # the clean-result-critic caught it manually). Use plain English:
+        # "the two files matched exactly", "every byte agreed", "no diff
+        # between the runs".
+        r"\b(?:byte|bit)[\s-](?:identical|equal)\b",
         (
             "Use plain English ('the two files matched exactly', 'every byte agreed', "
             "'no diff') instead of 'byte identical' / 'byte-identical' / 'bit identical' / "
-            "'bit-identical' — the phrase reads as AI-slop in research prose"
+            "'bit-identical' — or their '-equal' synonyms ('byte-equal', 'bit equal', ...) — "
+            "the phrase reads as AI-slop in research prose"
         ),
     ),
 }

--- a/tests/test_audit_clean_results_body_discipline.py
+++ b/tests/test_audit_clean_results_body_discipline.py
@@ -1295,6 +1295,9 @@ def test_verdict_caps_code_spans_not_flagged():
 # critic Lens 6 caught the `bit-identical` slip manually. The rule was
 # renamed `bit_byte_identical` and broadened to `\b(?:byte|bit)[\s-]identical\b`
 # so both same-family voice violations are caught under one mechanical rule.
+# Task #1423 extended the family to the `equal` synonyms (byte-equal /
+# byte equal / bit-equal / bit equal) after issue #1005's body carried
+# "inherited byte-equal (sha-asserted)" past the -identical-only regex.
 
 
 def test_byte_identical_still_flagged_under_new_key():
@@ -1336,6 +1339,70 @@ def test_bit_byte_identical_no_false_positive_on_unrelated_words():
     clean = V3_BODY_WITH_DATA_CODES.replace(
         "The lift holds at every seed in the held-out evaluation.",
         "The arbiter compiled the bytecode and a bite-sized summary.",
+    )
+    findings = audit.audit_body(clean)
+    assert "bit_byte_identical" not in findings, findings
+
+
+def test_byte_equal_is_flagged():
+    """The `-equal` synonym family trips the rule (task #1423): `byte-equal`
+    and `byte equal` are the same voice violation as `byte-identical`."""
+    hyphen = V3_BODY_WITH_DATA_CODES.replace(
+        "The lift holds at every seed in the held-out evaluation.",
+        "The two stores were byte-equal after the rerun.",
+    )
+    findings = audit.audit_body(hyphen)
+    assert "bit_byte_identical" in findings, findings
+    assert any("byte-equal" in s for s in findings["bit_byte_identical"]), findings
+    space = V3_BODY_WITH_DATA_CODES.replace(
+        "The lift holds at every seed in the held-out evaluation.",
+        "The two stores were byte equal after the rerun.",
+    )
+    space_findings = audit.audit_body(space)
+    assert "bit_byte_identical" in space_findings, "space form not flagged"
+    assert any("byte equal" in s for s in space_findings["bit_byte_identical"]), space_findings
+
+
+def test_bit_equal_is_flagged():
+    """The `bit-equal` / `bit equal` synonyms trip the rule too (task #1423)."""
+    hyphen = V3_BODY_WITH_DATA_CODES.replace(
+        "The lift holds at every seed in the held-out evaluation.",
+        "The loss surface was held bit-equal across all three arms.",
+    )
+    findings = audit.audit_body(hyphen)
+    assert "bit_byte_identical" in findings, findings
+    assert any("bit-equal" in s for s in findings["bit_byte_identical"]), findings
+    space = V3_BODY_WITH_DATA_CODES.replace(
+        "The lift holds at every seed in the held-out evaluation.",
+        "The loss surface was held bit equal across all three arms.",
+    )
+    space_findings = audit.audit_body(space)
+    assert "bit_byte_identical" in space_findings, "space form not flagged"
+    assert any("bit equal" in s for s in space_findings["bit_byte_identical"]), space_findings
+
+
+def test_byte_equal_incident_1005_phrasing_is_flagged():
+    """Regression anchor: the verbatim #1005 incident phrasing — "inherited
+    byte-equal (sha-asserted)" — trips the rule (the -identical-only regex
+    missed it and an LM critic round had to catch it manually)."""
+    body = V3_BODY_WITH_DATA_CODES.replace(
+        "The lift holds at every seed in the held-out evaluation.",
+        "The adapter was inherited byte-equal (sha-asserted) from the parent.",
+    )
+    findings = audit.audit_body(body)
+    assert "bit_byte_identical" in findings, findings
+    assert any("byte-equal" in s for s in findings["bit_byte_identical"]), findings
+
+
+def test_bit_byte_equal_no_false_positive_on_boundary_words():
+    """Boundary negatives for the `-equal` arm (task #1423): `byte equality`
+    (suffix blocks the trailing \\b), `bytes equal` (plural blocks `[\\s-]`),
+    `bitwise equal` (`bitwise` != `bit`), and capitalized `Byte-equal` (the
+    category scans case-sensitively, pre-existing semantics) must NOT trip."""
+    clean = V3_BODY_WITH_DATA_CODES.replace(
+        "The lift holds at every seed in the held-out evaluation.",
+        "I assert byte equality; the bytes equal to the header match, and "
+        "bitwise equal outputs held. Byte-equal casing stays untouched.",
     )
     findings = audit.audit_body(clean)
     assert "bit_byte_identical" not in findings, findings


### PR DESCRIPTION
Closes task #1423 (workflow-fix, kind: infra).

Extends the `bit_byte_identical` banned-phrase regex in `scripts/audit_clean_results_body_discipline.py` to the `-equal` synonym family (`\b(?:byte|bit)[\s-](?:identical|equal)\b`), syncs the enumerating doc surfaces (SPEC.md, clean-result-critic-lens-reference.md, codex-clean-result-critic.md), and adds 4 pin tests incl. the verbatim #1005 incident regression anchor. r2 compresses the codex agent rows back under the 74,000-byte ratchet cap.

Origin: clean-result-critic #1005 r1 mechanizable finding. Gate: epm:test-verdict v2 PASS (compare exit 0; 2 pre-existing main reds stripped via pristine oracle).