### PR TITLE
task #1446: widen closed-sibling advisory to ordinary infra tasks

### DIFF
--- a/.claude/rules/workflow-fix-on-bug.md
+++ b/.claude/rules/workflow-fix-on-bug.md
@@ -461,9 +461,14 @@ with fragment/substring greps of the claimed text as the fallback, run
 REPO-WIDE (`grep -rn '<fragment>' src/ scripts/ .claude/`) so a guard landed
 in a sibling file is not missed — AND record a landed-fix history check on
 the target file (`git log --oneline --since='7 days ago' -- <target_file>`),
-because the dedup predicate (OPEN tasks only, by design) and the #1399
-recently-closed-sibling advisory (`workflow-fix:`/`daily-fix:` title
-prefixes only) are BOTH blind to an ordinary landed infra fix (#1386 filed +
+because the dedup predicate (OPEN tasks only, by design) is blind to an
+ordinary landed infra fix, and the #1399 recently-closed-sibling advisory
+covers it only partially: since #1446 its widened pass also scans ordinary
+(non-prefixed) closed `kind: infra` tasks (≥2 shared informative title
+tokens, or a candidate target path named in the task body), but it fires
+only at filing time, within its 7-day window, and only on overlap — a fix
+landed with no task at all remains invisible to it, so the git-log +
+semantic-probe duties here STAY required (#1386 filed +
 a session spawned ~9h after #1360 landed the shorter substring
 `'queue size reached'` in `orchestrate/hub.py` at merge `289ad17572`; the
 filer's verbatim grep for `'maximum queue size'` read 0 hits and was
@@ -548,9 +553,12 @@ a JUST-MERGED sibling with different wording is invisible by design
 (2026-07-15: #1350 was filed 25 min after #1329 merged the same fix, and
 #1330 duplicated #1309's already-landed guidance — two pipeline sessions
 burned). At filing time `scripts/file_infra_task.py` therefore prints a
-stderr advisory listing wf-fix/daily-fix tasks CLOSED (completed/archived)
-within the last ~7 days that overlap the candidate — by `workflow_fix_target:`
-path token, or by informative title token
+stderr advisory listing recently-closed (completed/archived, last ~7 days)
+siblings that overlap the candidate: `workflow-fix:`/`daily-fix:`-prefixed
+tasks by `workflow_fix_target:` path token or by informative title token,
+and — since #1446 — ordinary (non-prefixed) `kind: infra` tasks by ≥2
+shared informative title tokens (`infra-title:`) or by a candidate target
+path appearing in the task body (`infra-target`)
 (`task_workflow.recent_closed_workflow_fix_tasks`) — capped at the 10 most
 recent. The filer eyeballs the list before letting the spawned session run.
 ADVISORY ONLY: it never blocks the filing, never changes exit codes, and
@@ -752,7 +760,7 @@ homepage rendering of the fallback is unimplemented.)
 | File a body whose bug claim (call sites, site counts, paths) was never re-verified by grep at filing time (#1221/#1229/#1249: 3 stale-claim filings in 2 days, each burning a spawned session's verification rounds) | Run the grep at body-compose time; record `verified-at-filing: <cmd> → <hits>` (or `n/a — <reason>`) in `## Workflow gap` |
 | Record a real grep that does not BIND to the claim — a repo-wide pattern grep beside a named target_file with 0 hits for the claimed site (#1290), or a single-path probe backing a "no longer exists" claim (#1296) | State per-target hits for each file named in target_file (presence claim + 0-hit target ⇒ re-grep repo-wide, correct target_file, re-verify before filing); back any nonexistence claim with a recorded repo-wide relocation grep |
 | Bind a presence grep on hit COUNT alone when the hit's surrounding context already implements the proposed change (#1330 filed over the landed #1309 fix) | Read each presence-hit's surrounding lines before filing; a hit that IS the fix = already landed — dedup, don't file |
-| Accept a verbatim-literal 0-hit grep as absence evidence for a TEXT-MATCHING guard (#1386 filed+spawned ~9h after #1360 landed the shorter `'queue size reached'` substring; the grep searched the full `'maximum queue size'`) | Semantic probe (clause (a')): run the predicate against the claimed text and/or grep fragments/substrings of it repo-wide, PLUS `git log --oneline --since='7 days ago' -- <target_file>` for a just-landed fix — open-task dedup + the #1399 advisory are both blind to an ordinary landed infra fix |
+| Accept a verbatim-literal 0-hit grep as absence evidence for a TEXT-MATCHING guard (#1386 filed+spawned ~9h after #1360 landed the shorter `'queue size reached'` substring; the grep searched the full `'maximum queue size'`) | Semantic probe (clause (a')): run the predicate against the claimed text and/or grep fragments/substrings of it repo-wide, PLUS `git log --oneline --since='7 days ago' -- <target_file>` for a just-landed fix — open-task dedup stays blind to an ordinary landed infra fix by design, and the advisory's widened pass (#1446) covers ordinary closed infra tasks only window-bounded + overlap-matched, so the git-log landed-fix check remains the backstop |
 
 ## Composition with other rules
 

--- a/scripts/file_infra_task.py
+++ b/scripts/file_infra_task.py
@@ -289,7 +289,10 @@ def _advise_recent_closed_wf_fix_siblings(args: argparse.Namespace) -> None:
     codes, never skips the filing (a closed fix deliberately never blocks a
     genuine re-raise); the whole leg is fail-soft — any exception prints a
     one-line diagnostic and filing proceeds (#1173/#1283 precedent, hardened
-    to a full try/except per the #1399 task-body constraint)."""
+    to a full try/except per the #1399 task-body constraint). Since #1446 the
+    enumerator's widened pass also surfaces ordinary (non-prefixed) closed
+    kind:infra siblings, labeled `infra-title:`/`infra-target` in the matched
+    column (the #1386-over-#1360 gap)."""
     try:
         body_text = args.body
         if body_text is None and args.body_file is not None:
@@ -305,7 +308,7 @@ def _advise_recent_closed_wf_fix_siblings(args: argparse.Namespace) -> None:
         if not hits:
             return
         print(
-            f"file_infra_task: ADVISORY — {len(hits)} wf-fix sibling(s) closed within "
+            f"file_infra_task: ADVISORY — {len(hits)} closed sibling task(s) within "
             "7 days overlap this filing. Closed tasks never block a re-raise "
             "(.claude/rules/workflow-fix-on-bug.md § Dedup, #1399) — eyeball for a "
             "just-merged duplicate before letting the spawned session run:",

--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -1109,6 +1109,13 @@ _WF_FIX_CLOSURE_EVENT_KINDS: tuple[str, ...] = ("epm:status-changed", "epm:promo
 _WF_FIX_TITLE_STOPWORDS: frozenset[str] = frozenset(
     {"the", "for", "and", "with", "must", "that", "from", "into", "when", "only", "over"}
 )
+# Widened-pass (#1446) title arm needs >=2 shared informative tokens (vs >=1
+# for the self-selected topical prefixed population): measured 2026-07-17 on
+# the live 7-day closed non-prefixed infra window (28 tasks) — the real #1386
+# candidate title yields exactly 2 hits at >=2 (incl. #1360, the true
+# duplicate) and 0 junk, while a generic stress title yields 5 hits at >=1
+# vs 0 at >=2.
+_WF_FIX_PLAIN_TITLE_MIN_SHARED = 2
 _WF_FIX_TARGET_LINE_RE = re.compile(r"^\s*-?\s*workflow_fix_target:\s*(.+?)\s*$", re.M)
 
 
@@ -1189,14 +1196,15 @@ def _wf_fix_title_tokens(title: str) -> set[str]:
     return out
 
 
-def recent_closed_workflow_fix_tasks(
+def recent_closed_workflow_fix_tasks(  # noqa: C901 — two-population scan; branch shape + gating order pinned by plan #1446 §4.1(c)
     target_file: str | None,
     candidate_title: str | None = None,
     *,
     days: float = 7.0,
     now: datetime | None = None,
+    include_plain_infra: bool = True,
 ) -> list[dict[str, Any]]:
-    """CLOSED wf-fix siblings within ``days`` overlapping the candidate (#1399).
+    """CLOSED infra siblings within ``days`` overlapping the candidate (#1399, #1446).
 
     The ADVISORY complement of :func:`is_open_workflow_fix_task`: that
     predicate blocks exact-(target_file, fingerprint) duplicates among OPEN
@@ -1205,18 +1213,47 @@ def recent_closed_workflow_fix_tasks(
     still never blocks a re-raise (.claude/rules/workflow-fix-on-bug.md
     § Dedup, unchanged).
 
-    A task matches iff kind==infra AND status in {completed, archived} AND
-    title startswith WF_FIX_TITLE_PREFIXES AND its closure ts (last
-    epm:status-changed/epm:promoted in events.jsonl) is within ``days`` of
-    ``now`` AND at least one arm overlaps:
-      - 'target': candidate target_file path-token set (comma-split) intersects
-        the task's anchored ``workflow_fix_target:`` line token set;
+    Two populations are scanned, both requiring kind==infra AND status in
+    {completed, archived} AND a closure ts (last epm:status-changed /
+    epm:promoted in events.jsonl) within ``days`` of ``now``:
+
+    - PREFIXED pass (title startswith WF_FIX_TITLE_PREFIXES) — the original
+      #1399 population; behavior preserved except the declared body-read
+      catch-tuple widening ((FileNotFoundError, ValueError) ->
+      (OSError, ValueError); fact-check 2026-07-17: a non-FNF OSError from
+      read_text() escaped the old tuple). Arms:
+      - 'target': candidate target_file path-token set (comma-split)
+        intersects the task's anchored ``workflow_fix_target:`` line tokens;
       - 'title:<tokens>': candidate title shares >=1 informative token
         (len>=4, stopword-filtered) with the task title.
+    - WIDENED pass (#1446; NON-prefixed titles; opt out via
+      ``include_plain_infra=False``) — ordinary closed infra tasks, where
+      functional fixes routinely land (#1386 was filed over the
+      already-landed non-prefixed #1360, invisible to the prefixed pass by
+      construction). Higher-precision arms:
+      - 'infra-title:<tokens>': >=_WF_FIX_PLAIN_TITLE_MIN_SHARED shared
+        informative title tokens (the broad plain-infra population needs a
+        higher bar than the self-selected topical prefixed one);
+      - 'infra-target': a candidate target path token appears as a substring
+        of the task's ``body.md`` (the FULL path, never the basename —
+        bare basenames matched 11/28 in-window bodies vs 0-6 for full
+        paths, measured 2026-07-17).
+      The closure-window check runs BEFORE the body read on this pass (only
+      in-window tasks are ever body-read), and a registry-only precheck
+      skips entries where no widened arm could possibly fire. Limitation: a
+      short directory-less target path (e.g. ``CLAUDE.md``) substring-matches
+      more bodies than the measured directory-bearing range; the row cap +
+      the distinct ``infra-*`` labels + the advisory-only contract bound
+      that downside.
+
     Returns [{'id', 'title', 'status', 'target', 'closed_at', 'matched'}, ...]
-    sorted by closed_at DESC. Read-only: no mutation, no commit, no lock.
-    Per-task failures (missing folder, non-numeric registry key, unreadable
-    body) skip that task — one broken entry never kills the whole scan.
+    sorted by closed_at DESC. The ``target`` field differs per population:
+    prefixed rows carry the task's own ``workflow_fix_target:`` tokens;
+    widened rows carry the candidate path token(s) actually FOUND in the
+    task body (the overlap the filer wants to see). Read-only: no mutation,
+    no commit, no lock. Per-task failures (missing folder, non-numeric
+    registry key, unreadable body) skip that task — one broken entry never
+    kills the whole scan.
     """
     now = now or datetime.now(UTC)
     cutoff = now - timedelta(days=days)
@@ -1236,7 +1273,13 @@ def recent_closed_workflow_fix_tasks(
         if (entry.get("status") or "") not in _WF_FIX_TERMINAL:
             continue
         title = str(entry.get("title", ""))
-        if not title.startswith(WF_FIX_TITLE_PREFIXES):
+        prefixed = title.startswith(WF_FIX_TITLE_PREFIXES)
+        if not prefixed and not include_plain_infra:
+            continue
+        shared = cand_tokens & _wf_fix_title_tokens(title)
+        if not prefixed and len(shared) < _WF_FIX_PLAIN_TITLE_MIN_SHARED and not cand_targets:
+            # Widened pass (#1446): no arm can possibly fire — skip before
+            # any per-task file read (registry-only precheck).
             continue
         try:
             tid = int(tid_str)
@@ -1246,23 +1289,52 @@ def recent_closed_workflow_fix_tasks(
             continue
         matched: list[str] = []
         task_targets: set[str] = set()
-        if cand_targets:
-            try:
-                _, body = _read_body(task_dir / "body.md")
-            except (FileNotFoundError, ValueError):
-                body = ""  # fail-soft: target arm silently unavailable for this task
-            for m in _WF_FIX_TARGET_LINE_RE.finditer(body):
-                task_targets |= _wf_fix_target_tokens(m.group(1))
-            if cand_targets & task_targets:
-                matched.append("target")
-        shared = cand_tokens & _wf_fix_title_tokens(title)
-        if shared:
-            matched.append("title:" + ",".join(sorted(shared)))
-        if not matched:
-            continue
-        closed = _wf_fix_closed_at(task_dir)
-        if closed is None or closed < cutoff or closed > now:
-            continue
+        if prefixed:
+            # ── Prefixed pass: #1399 logic, output-identical except the
+            # declared catch-tuple widening below ──
+            if cand_targets:
+                try:
+                    _, body = _read_body(task_dir / "body.md")
+                except (OSError, ValueError):
+                    # widened per fact-check 2026-07-17: a non-FNF OSError
+                    # from read_text() escaped the old
+                    # (FileNotFoundError, ValueError) tuple
+                    body = ""  # fail-soft: target arm silently unavailable
+                for m in _WF_FIX_TARGET_LINE_RE.finditer(body):
+                    task_targets |= _wf_fix_target_tokens(m.group(1))
+                if cand_targets & task_targets:
+                    matched.append("target")
+            if shared:
+                matched.append("title:" + ",".join(sorted(shared)))
+            if not matched:
+                continue
+            closed = _wf_fix_closed_at(task_dir)
+            if closed is None or closed < cutoff or closed > now:
+                continue
+        else:
+            # ── Widened pass (#1446): ordinary closed infra tasks. The
+            # window check runs BEFORE the body read (cost gate: only the
+            # ~tens of in-window tasks are ever body-read; measured 28
+            # in-window on 2026-07-17 vs 199 non-prefixed terminal total).
+            closed = _wf_fix_closed_at(task_dir)
+            if closed is None or closed < cutoff or closed > now:
+                continue
+            if len(shared) >= _WF_FIX_PLAIN_TITLE_MIN_SHARED:
+                matched.append("infra-title:" + ",".join(sorted(shared)))
+            if cand_targets:
+                try:
+                    _, body = _read_body(task_dir / "body.md")
+                except (OSError, ValueError):
+                    # same widened catch tuple as the prefixed pass above
+                    body = ""  # fail-soft: target arm silently unavailable
+                # Full candidate path token as a body substring (NOT the
+                # basename: bare 'SKILL.md' matches 11/28 in-window bodies,
+                # while full paths measured 0-6; glob tokens stay opaque).
+                task_targets = {t for t in cand_targets if t in body}
+                if task_targets:
+                    matched.append("infra-target")
+            if not matched:
+                continue
         hits.append(
             {
                 "id": tid,

--- a/tests/test_workflow_fix_dedup.py
+++ b/tests/test_workflow_fix_dedup.py
@@ -411,9 +411,12 @@ def test_recent_closed_excludes_open_tasks(fake_repo):
     assert tw.recent_closed_workflow_fix_tasks(target) == []
 
 
-def test_recent_closed_excludes_non_wf_fix_titles(fake_repo):
-    """A completed kind:infra task whose title lacks a wf-fix channel prefix
-    is ignored even with a matching workflow_fix_target line."""
+def test_recent_closed_plain_infra_included_via_target_body_match(fake_repo):
+    """#1446 widened pass: a completed kind:infra task WITHOUT a wf-fix channel
+    prefix now surfaces when a candidate target path appears in its body (the
+    `workflow_fix_target:` line makes the path a body substring — the widened
+    arm needs no anchored line). No candidate title is passed, so `matched`
+    is exactly the target arm."""
     _, tw = fake_repo
     target = "CLAUDE.md"
     fp = tw.wf_fix_fingerprint("Fix the gate.", "gate wrong")
@@ -426,7 +429,142 @@ def test_recent_closed_excludes_non_wf_fix_titles(fake_repo):
         )
     )
     tw.set_status(tid, "completed")
-    assert tw.recent_closed_workflow_fix_tasks(target) == []
+    hits = tw.recent_closed_workflow_fix_tasks(target)
+    assert [h["id"] for h in hits] == [tid]
+    assert hits[0]["matched"] == ["infra-target"]
+    assert hits[0]["target"] == "CLAUDE.md"
+
+
+def test_recent_closed_plain_infra_opt_out(fake_repo):
+    """`include_plain_infra=False` reproduces the pre-#1446 population: the
+    same non-prefixed completed task is ignored even with a matching
+    workflow_fix_target line (the old exclusion semantics behind the kwarg)."""
+    _, tw = fake_repo
+    target = "CLAUDE.md"
+    fp = tw.wf_fix_fingerprint("Fix the gate.", "gate wrong")
+    tid = tw.create_task(
+        tw.NewTaskRequest(
+            kind="infra",
+            title="refactor: tidy the gate",
+            body=_wf_fix_body(target, fp, "Fix the gate."),
+            tags=["wf-fix", f"wf-fix-fp:{fp}"],
+        )
+    )
+    tw.set_status(tid, "completed")
+    assert tw.recent_closed_workflow_fix_tasks(target, include_plain_infra=False) == []
+
+
+def test_recent_closed_plain_infra_fires_on_1360_1386_shape(fake_repo):
+    """Incident regression pin (durability pin, #1446): the REAL #1386-over-
+    #1360 shape — #1360 was a genuinely ordinary infra task (no channel
+    prefix, no wf-fix tags, no anchored `workflow_fix_target:` line) whose
+    body named `src/explore_persona_space/orchestrate/hub.py` in prose. The
+    widened pass surfaces it via BOTH arms: shared informative title tokens
+    {queue-full, retry} (exactly the >=2 bar) and the candidate target path
+    as a body substring."""
+    _, tw = fake_repo
+    sibling = tw.create_task(
+        tw.NewTaskRequest(
+            kind="infra",
+            title=(
+                "hub.py::_upload: bounded transport-class retry (429/Xet queue-full) "
+                "before no-path return"
+            ),
+            body=(
+                "## Goal\n\n"
+                "Add a bounded retry for transport-class upload failures in\n"
+                "src/explore_persona_space/orchestrate/hub.py before the no-path return.\n"
+            ),
+        )
+    )
+    tw.set_status(sibling, "completed")
+
+    hits = tw.recent_closed_workflow_fix_tasks(
+        "src/explore_persona_space/orchestrate/hub.py",
+        "daily-fix: hub Xet queue-full transient retry",
+    )
+    assert [h["id"] for h in hits] == [sibling]
+    assert "infra-title:queue-full,retry" in hits[0]["matched"]
+    assert "infra-target" in hits[0]["matched"]
+    assert hits[0]["target"] == "src/explore_persona_space/orchestrate/hub.py"
+
+
+def test_recent_closed_plain_infra_title_arm_needs_two_tokens(fake_repo):
+    """AC4 differential: the widened title arm requires >=2 shared informative
+    tokens (1 shared token -> no widened hit), while the SAME 1-token overlap
+    WITH a wf-fix channel prefix still surfaces via the prefixed pass's >=1
+    bar — proving the prefixed bar is untouched."""
+    _, tw = fake_repo
+    plain = tw.create_task(
+        tw.NewTaskRequest(
+            kind="infra",
+            title="watcher retry backstop for pod polling",
+            body="## Goal\n\nplain infra sibling\n",
+        )
+    )
+    tw.set_status(plain, "completed")
+    # Prefixed CONTROL: same words behind the workflow-fix: channel prefix
+    # (_file_wf_fix_task builds the title as f"workflow-fix: {...}").
+    prefixed = _file_wf_fix_task(
+        tw,
+        "scripts/pod_watch.py",
+        tw.wf_fix_fingerprint("Watcher retry backstop.", "watcher retry gap"),
+        proposed_change="watcher retry backstop for pod polling",
+    )
+    tw.set_status(prefixed, "completed")
+
+    hits = tw.recent_closed_workflow_fix_tasks(None, "workflow-fix: retry advisory widening")
+    assert [h["id"] for h in hits] == [prefixed]
+    assert hits[0]["matched"] == ["title:retry"]
+
+
+def test_recent_closed_plain_infra_body_read_window_gated(fake_repo, monkeypatch):
+    """AC5 cost gate: on the widened pass the closure-window check precedes
+    the body read — an out-of-window non-prefixed task is never body-read.
+    Single-task fixture (a prefixed task with a candidate target would
+    legitimately body-read before its window check)."""
+    _, tw = fake_repo
+    tid = tw.create_task(
+        tw.NewTaskRequest(
+            kind="infra",
+            title="refactor: tidy the gate",
+            body="## Goal\n\nnames CLAUDE.md in prose\n",
+        )
+    )
+    tw.set_status(tid, "completed")
+
+    real_read_body = tw._read_body
+    calls: list = []
+
+    def _recording_read_body(path):
+        calls.append(path)
+        return real_read_body(path)
+
+    monkeypatch.setattr(tw, "_read_body", _recording_read_body)
+    future = datetime.now(UTC) + timedelta(days=8)
+    assert tw.recent_closed_workflow_fix_tasks("CLAUDE.md", None, now=future) == []
+    assert calls == []
+
+
+def test_recent_closed_plain_infra_fail_soft_missing_body(fake_repo):
+    """Widened-pass fail-soft: a non-prefixed task whose body.md is gone still
+    surfaces via the infra-title arm (its infra-target arm is silently
+    unavailable) — mirrors the prefixed-pass missing-body pin."""
+    _, tw = fake_repo
+    tid = tw.create_task(
+        tw.NewTaskRequest(
+            kind="infra",
+            title="widen advisory scan for closed infra",
+            body="## Goal\n\nbody to be deleted\n",
+        )
+    )
+    tw.set_status(tid, "completed")
+    (tw.find_task_path(tid) / "body.md").unlink()
+
+    hits = tw.recent_closed_workflow_fix_tasks("CLAUDE.md", "workflow-fix: widen advisory")
+    assert [h["id"] for h in hits] == [tid]
+    assert hits[0]["matched"] == ["infra-title:advisory,widen"]
+    assert hits[0]["target"] is None
 
 
 def test_recent_closed_target_overlap_comma_list(fake_repo):


### PR DESCRIPTION
Closes task #1446. Widen the #1399 recently-closed-sibling filing advisory (task_workflow.recent_closed_workflow_fix_tasks) to also surface ordinary (non-prefixed) closed kind:infra tasks — the mechanical half of the #1386-over-#1360 duplicate filing.