### PR TITLE
issue-1443: anchor repo-root guard cd-scope latch to clause-initial cd

### DIFF
--- a/scripts/guard_repo_root_branch.sh
+++ b/scripts/guard_repo_root_branch.sh
@@ -270,13 +270,13 @@
 #       residuals). WT-latch arm-SUPPRESSION flips are fail-CLOSED by R8
 #       (exotic shapes where a payload fragment's clause-initial `WT=`
 #       arming would have disappeared post-refusal go allow->block —
-#       acceptable direction). The pre-existing internal-`&&`-only
-#       latch-arming payload fail-open (`ssh pod 'cd /tmp/x && git fetch'`'s
-#       FIRST fragment matching the unanchored cd-latch grep — rc=0 TODAY,
-#       see the register QUALIFIER below) is a DRIVER bug independent of the
-#       mask and stays open; R6 leaves those shapes byte-identical
-#       (driver-side root fix tracked via the parked workflow-fix candidate
-#       on task #1413, 2026-07-16). Other pre-existing FPs, unchanged:
+#       acceptable direction). The former internal-`&&`-only latch-arming
+#       payload fail-open (`ssh pod 'cd /tmp/x && git reset --hard'`'s
+#       FIRST fragment matching the then-unanchored cd-latch grep) is
+#       CLOSED by #1443: the latch greps are clause-initial-anchored, so
+#       the shape fails CLOSED (blocks — joining the R6/R7/R8 cost-residual
+#       FP class, same standing remediations); a non-gated tail (a remote
+#       `git fetch`) allows via the verb gate. Other pre-existing FPs, unchanged:
 #       `${VAR}` in remote strings, incl. single-quoted
 #       forms bash would not expand (the deliberate `${` over-match);
 #       ssh clauses naming the shared-repo path in a covered spelling;
@@ -306,12 +306,12 @@
 #       stays waived), or `git -C`). Also
 #       here: `git grep '<gated>'`
 #       clauses stay blocked (clause-initial word is `git`, not
-#       grep-family) — remediation: plain `grep`. QUALIFIER for register
-#       exactness: the "tail clauses still classify" sentence is not
-#       universally true — a FIRST remote statement matching the
-#       UNANCHORED cd-latch (`ssh pod 'cd /tmp/ && git clean -fd'`) is
-#       rc=0 TODAY via the pre-existing latch, not via this waiver;
-#       pre-existing behavior, unchanged by this diff.
+#       grep-family) — remediation: plain `grep`. QUALIFIER resolved by
+#       #1443: the "tail clauses still classify" sentence is now exact for
+#       latch-vocab FIRST statements too — the anchored driver latch never
+#       arms on a payload fragment (`ssh pod 'cd /tmp/ && git clean -fd'`),
+#       so the gated tail classifies and BLOCKS fail-closed (it was rc=0
+#       via the then-unanchored latch, not via this waiver).
 #       Deliberate-only accepted FAIL-OPENS (~zero accidental probability,
 #       cooperative-agent model, same register as gaps (v)/(x)/(xii)):
 #       `ssh -F <config> host` whose ProxyCommand/LocalCommand lives in
@@ -651,11 +651,11 @@ cmd=$(strip_heredoc_bodies "$cmd")
 #       local-code-swallow hole); strict any-quote refusal, because an
 #       apostrophe-parity check misses the pre-opened-double-quote variant.
 #   R6  no cd-latch-arming vocabulary in the candidate — `cd` + /tmp/ or
-#       .claude/worktrees/ (a conservative substring superset of the driver's
-#       UNANCHORED pre-waiver latch greps below, which take `scoped=1;
-#       continue` BEFORE the waiver; also precludes the regex-WIDENING match
-#       where masking lets `cd +[^;&|]*\.claude/worktrees/` span across
-#       former statement boundaries).
+#       .claude/worktrees/ (RETAINED as defense-in-depth + disposition pin,
+#       #1443: the driver latch greps below are clause-initial-anchored, and
+#       a masked merged clause is `ssh`-initial so they can never match it;
+#       NM22/NM23 pin blocked dispositions — relaxing R6 is a non-goal; also
+#       precludes regex-WIDENING latch matches across former statement bounds).
 #   R7  no cd-latch-arming vocabulary in the PREFIX — guarantees scoped == 0
 #       at candidate entry, so the mask's removal of intra-payload separators
 #       (which today RESET `scoped` at each mis-split boundary) can never
@@ -1171,12 +1171,17 @@ while IFS=$'\t' read -r sep nextsep clause; do
   clause=$(printf '%s' "$clause" | sed -E 's/[[:space:]]#.*$//')
   [ -n "$clause" ] || continue
 
-  # A `cd` into a worktree / /tmp latches scope forward ONLY across a following
-  # `&&` clause. Latch and continue — this clause runs the `cd`, not a git
-  # command, and it must NOT scope EARLIER clauses (those were classified
-  # before it).
-  if echo "$clause" | grep -qE 'cd +[^;&|]*\.claude/worktrees/' \
-     || echo "$clause" | grep -qE 'cd +/tmp/'; then
+  # A CLAUSE-INITIAL `cd` into a worktree / /tmp latches scope forward ONLY
+  # across a following `&&` clause. Latch and continue — this clause runs the
+  # `cd`, not a git command, and it must NOT scope EARLIER clauses (those were
+  # classified before it). The greps are ^-anchored (#1443): the splitter
+  # strips leading whitespace from every clause (L833), so a legit post-split
+  # `&& cd /tmp/x` fragment is clause-initial by construction, while quoted
+  # latch-vocab text mid-clause — an ssh payload fragment, echo'd prose, or a
+  # superstring like `cdx .claude/worktrees/` — never arms. (`cd<TAB>` never
+  # armed pre- or post-anchor: `cd +` matches spaces only — pre-existing.)
+  if echo "$clause" | grep -qE '^cd +[^;&|]*\.claude/worktrees/' \
+     || echo "$clause" | grep -qE '^cd +/tmp/'; then
     scoped=1
     continue
   fi

--- a/tests/test_guard_repo_root_branch.py
+++ b/tests/test_guard_repo_root_branch.py
@@ -1690,6 +1690,65 @@ def test_ssh_masking_refusal_ladder_blocks(cmd):
     assert _run(cmd) == 2
 
 
+# ==== #1443 — clause-initial anchoring of the cd-scope latch ================
+#
+# The driver's literal-path cd-scope latch greps are ^-anchored (#1443): only
+# a clause whose COMMAND WORD is `cd` arms `scoped`. Latch vocabulary buried
+# mid-clause — a quoted ssh remote-payload fragment ahead of an internal `&&`
+# (the mask's R6 arm deliberately leaves such payloads byte-identical, so
+# they mis-split), or an echo'd string — must never mutate local scoping
+# state. The splitter strips leading whitespace from every clause
+# (split_and_label, guard L833), so post-split `&& cd /tmp/...` clauses stay
+# clause-initial and keep arming. All four block fixtures were verified rc=0
+# against the pre-#1443 guard (the fail-open this section closes); both
+# allow fixtures were verified rc=0 pre-fix and must stay rc=0.
+
+
+@on_main
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        pytest.param(
+            "ssh pod-779 'cd /tmp/x && git reset --hard'",
+            id="L1-ssh_payload_tmp_fragment_no_latch",
+        ),
+        pytest.param(
+            "ssh pod-779 'cd .claude/worktrees/w && git checkout -b tmp'",
+            id="L2-ssh_payload_worktrees_fragment_no_latch",
+        ),
+        pytest.param(
+            "echo 'cd /tmp/x' && git reset --hard",
+            id="L3-echo_quoted_tmp_text_no_latch",
+        ),
+        pytest.param(
+            "echo 'cd .claude/worktrees/x' && git restore .",
+            id="L4-echo_quoted_worktrees_text_no_latch",
+        ),
+    ],
+)
+def test_mid_clause_cd_text_does_not_latch(cmd):
+    """Latch vocabulary mid-clause (payload/prose) never arms local scope."""
+    assert _run(cmd) == 2
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        pytest.param(
+            "mkdir -p /tmp/s && cd /tmp/s && git clean -fd",
+            id="L5-post_split_clause_initial_tmp_arms",
+        ),
+        pytest.param(
+            'cd "$ROOT/.claude/worktrees/issue-9" && git restore .',
+            id="L6-quoted_prefix_worktrees_arms",
+        ),
+    ],
+)
+def test_clause_initial_cd_still_arms(cmd):
+    """Anchoring must not regress the intended clause-initial latch allows."""
+    assert _run(cmd) == 0
+
+
 # ==== #1128 — branch-merge fence (the #1090 conflict-marker incident class) ====
 #
 # A `git merge <ref>` at the SHARED repo root strands conflict markers in the


### PR DESCRIPTION
Closes task #1443.

## Summary
- Anchor both cd-scope latch greps in `scripts/guard_repo_root_branch.sh` to clause-initial `cd` (`^cd +...`) so quoted latch-vocabulary text mid-clause (ssh payload fragments, echo'd strings) can no longer arm local scope across `&&`.
- Sync the 4 register/comment spans that documented the hole as open (#1413 residual (xiv)).
- 6 regression fixtures (4 must-not-latch, 2 must-still-arm) in `tests/test_guard_repo_root_branch.py`; red→green demonstrated.

## Test plan
- [x] Pre-fix RED: 4 block fixtures fail on unmodified guard; post-fix 6/6 pass
- [x] Full guard suite: 449 passed / 0 skipped
- [x] Step 9c gate: 4106 passed, 6 skipped; compare vs main baseline: 0 new failures
- [x] ruff + workflow_lint: clean / rc=0 no FAIL lines