### PR TITLE
workflow-lint: fs-roots carve-out for SKILL_REF_RE false positive (#1445)

### DIFF
--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -698,14 +698,53 @@ SKILL_REF_ALLOWLIST: frozenset[str] = frozenset(
         "log",  # `/log` dashboard feed
         "sessions",  # `/sessions` dashboard page
         "updates",  # `/updates` dashboard MDX editor route
-        # --- Non-skill prose/path tokens the backtick form still catches ---
-        "workspace",  # `/workspace` pod path written inside backticks (RunPod `/workspace`)
+        # --- Non-skill prose tokens the backtick form still catches ---
+        # (pure-PATH tokens live in SKILL_REF_FS_ROOTS below; `log` stays
+        #  here on its dashboard-route justification)
         "intent",  # `/intent` — a phase/arg token in prose
         "absent",  # `/absent` — a marker-state token in prose
         "override",  # `/override subset` prose (experiment-implementer.md)
         "binary",  # `.npz/binary` prose (uploader.md)
         "terminal",  # `blocked/terminal` prose (background-automation.md)
         "expensive-band",  # `auto_run/expensive-band` prose (issue/SKILL.md)
+    }
+)
+
+# `--check-skill-refs`: bare single-segment backticked absolute PATHS.
+# SKILL_REF_RE's trailing lookahead rejects multi-segment paths (`/tmp/x`
+# — the next char is `/`) but a bare root (`/tmp`) closes on a backtick
+# and matches, so ordinary filesystem paths mis-fired the check (#1445;
+# the allowlist had grown ad-hoc path workarounds like `workspace`).
+# Members: the Linux FHS top-level directories + the RunPod `/workspace`
+# volume convention — PATH tokens, never slash-commands. Kept SEPARATE
+# from SKILL_REF_ALLOWLIST so that list keeps its "justify every entry
+# as a legitimate slash-command" contract. INVARIANT (pinned by
+# tests/test_workflow_lint.py::test_skill_ref_fs_roots_disjoint_from_live_skills_and_allowlist
+# and by the in-function collision guard in check_skill_references):
+# no member may name a live .claude/skills/ dir — a colliding entry
+# would silently disable rot detection for that skill.
+SKILL_REF_FS_ROOTS: frozenset[str] = frozenset(
+    {
+        "bin",
+        "boot",
+        "dev",
+        "etc",
+        "home",
+        "lib",
+        "lib64",
+        "media",
+        "mnt",
+        "opt",
+        "proc",
+        "root",
+        "run",
+        "sbin",
+        "srv",
+        "sys",
+        "tmp",
+        "usr",
+        "var",
+        "workspace",  # RunPod volume root (migrated from SKILL_REF_ALLOWLIST)
     }
 )
 
@@ -2715,13 +2754,21 @@ def _live_skill_names(skills_dir: Path) -> set[str]:
     return {p.name for p in skills_dir.iterdir() if p.is_dir()}
 
 
-def _skill_ref_resolves(ref: str, live: set[str], allow: frozenset[str]) -> bool:
+def _skill_ref_resolves(
+    ref: str,
+    live: set[str],
+    allow: frozenset[str],
+    fs_roots: frozenset[str] = SKILL_REF_FS_ROOTS,
+) -> bool:
     """A backticked ``/<ref>`` resolves iff it names a live skill dir, an
-    allowlisted exact token, or (when namespaced ``<plugin>:<skill>``) a token
-    whose ``<plugin>:`` prefix is allowlisted."""
+    allowlisted exact token, a bare filesystem root (a backticked PATH like
+    ``/tmp`` — see :data:`SKILL_REF_FS_ROOTS`), or (when namespaced
+    ``<plugin>:<skill>``) a token whose ``<plugin>:`` prefix is allowlisted."""
     if ref in live:  # live project skill dir
         return True
     if ref in allow:  # allowlisted exact token
+        return True
+    if ref in fs_roots:  # bare backticked fs path, not a slash-command (#1445)
         return True
     if ":" in ref:  # plugin-namespaced: prefix match
         return (ref.split(":", 1)[0] + ":") in allow
@@ -2733,6 +2780,7 @@ def check_skill_references(
     roots: list[Path] | None = None,
     skills_dir: Path | None = None,
     allowlist: frozenset[str] | None = None,
+    fs_roots: frozenset[str] | None = None,
 ) -> list[str]:
     """Walk the workflow-doc surface (agents + skills + rules + CLAUDE.md +
     workflow.yaml) and FAIL on any backtick-delimited ``/<skill-name>`` token
@@ -2750,13 +2798,29 @@ def check_skill_references(
     Plugin-namespaced refs resolve via the allowlist prefix set (or,
     forward-compat, an on-disk ``<plugin>:<skill>/`` dir).
 
-    ``roots`` / ``skills_dir`` / ``allowlist`` are unit-test override hooks;
-    production callers pass None.
+    Bare filesystem roots (``/tmp``, ``/workspace``;
+    :data:`SKILL_REF_FS_ROOTS`) are carved out as paths, never
+    slash-commands (#1445). An fs-root member that names a LIVE skill dir
+    is itself reported as a lint error — the carve-out would silently
+    disable rot detection for that skill (remedy: drop the colliding
+    member from ``SKILL_REF_FS_ROOTS``).
+
+    ``roots`` / ``skills_dir`` / ``allowlist`` / ``fs_roots`` are unit-test
+    override hooks; production callers pass None.
     """
     errors: list[str] = []
     sk_dir = skills_dir if skills_dir is not None else _REPO_ROOT / ".claude" / "skills"
     live = _live_skill_names(sk_dir)
     allow = allowlist if allowlist is not None else SKILL_REF_ALLOWLIST
+    fsr = fs_roots if fs_roots is not None else SKILL_REF_FS_ROOTS
+    collisions = sorted(fsr & live)
+    if collisions:
+        errors.append(
+            f"SKILL_REF_FS_ROOTS collides with live skill dir(s) {collisions}: the "
+            f"fs-root carve-out would silently disable skill-reference rot detection "
+            f"for them (#1445). Drop the colliding member(s) from SKILL_REF_FS_ROOTS "
+            f"in scripts/workflow_lint.py."
+        )
     for path in _resolve_skill_ref_target_files(roots):
         in_fence = False
         for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
@@ -2767,7 +2831,7 @@ def check_skill_references(
                 continue
             for match in SKILL_REF_RE.finditer(line):
                 ref = match.group(1)
-                if _skill_ref_resolves(ref, live, allow):
+                if _skill_ref_resolves(ref, live, allow, fsr):
                     continue
                 errors.append(
                     f"{path}:{lineno}: unresolved skill reference '/{ref}' — not a "

--- a/tests/test_workflow_lint.py
+++ b/tests/test_workflow_lint.py
@@ -39,7 +39,10 @@ from workflow_lint import (  # noqa: E402
     _MARKER_RECIPE_PINS,
     BATCH_JUDGE_LEGACY_ALLOWLIST,
     HUB_VERIFY_LEGACY_ALLOWLIST,
+    SKILL_REF_ALLOWLIST,
+    SKILL_REF_FS_ROOTS,
     _iter_ask_target_files,
+    _live_skill_names,
     _other_worktree_prefix,
     _values_equal,
     check_agent_model_pins,
@@ -782,6 +785,95 @@ def test_check_skill_refs_matches_legit_ref_after_boundary(tmp_path):
     assert len(errors) == 1, f"expected exactly one error (the dangling /ghost), got: {errors}"
     assert "/ghost" in errors[0], f"expected the /ghost ref flagged, got: {errors}"
     assert "a.md:6" in errors[0], f"expected the error anchored to the /ghost line, got: {errors}"
+
+
+@pytest.mark.parametrize("fs_root", sorted(SKILL_REF_FS_ROOTS))
+def test_check_skill_refs_pass_bare_fs_root_backticked(fs_root, tmp_path):
+    """Regression (#1445): a bare single-segment backticked filesystem root
+    (`/tmp`, `/workspace`, `/mnt`, ...) closes on a backtick, so SKILL_REF_RE's
+    trailing lookahead cannot reject it; the SKILL_REF_FS_ROOTS carve-out must
+    resolve EVERY member — zero FPs with an empty skills dir + empty allowlist
+    (acceptance criterion 1, pinned per member). The fs_roots-off arm proves
+    the CARVE-OUT (not a regex non-match) is what resolves each member."""
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text(f"Write it under `/{fs_root}` first.\n")
+    errors = check_skill_references(roots=[docs], skills_dir=skills, allowlist=frozenset())
+    assert errors == [], f"expected PASS (bare fs root `/{fs_root}` carved out), got: {errors}"
+    errors_off = check_skill_references(
+        roots=[docs], skills_dir=skills, allowlist=frozenset(), fs_roots=frozenset()
+    )
+    assert len(errors_off) == 1, (
+        f"expected exactly one error with fs_roots emptied (proves SKILL_REF_RE "
+        f"extracts `/{fs_root}` and only the carve-out resolves it), got: {errors_off}"
+    )
+    assert f"/{fs_root}" in errors_off[0]
+
+
+def test_check_skill_refs_fs_root_carveout_is_load_bearing(tmp_path):
+    """The same bare `/tmp` token FAILs when fs_roots is emptied via the
+    override hook — proving the carve-out (not the regex/allowlist) resolves it."""
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text("Write it under `/tmp` first.\n")
+    errors = check_skill_references(
+        roots=[docs], skills_dir=skills, allowlist=frozenset(), fs_roots=frozenset()
+    )
+    assert len(errors) == 1, f"expected exactly one error, got: {errors}"
+    assert "/tmp" in errors[0]
+
+
+def test_check_skill_refs_fail_dead_ref_with_production_fs_roots(tmp_path):
+    """True-positive power preserved (#1445): a genuinely dead `/ghost-skill`
+    still FAILs — as the ONE error — with the production fs-roots default
+    active and a carved-out `/tmp` on the same line."""
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text("Run `/ghost-skill` here, then clean `/tmp` up.\n")
+    errors = check_skill_references(roots=[docs], skills_dir=skills, allowlist=frozenset())
+    assert len(errors) == 1, f"expected exactly one error, got: {errors}"
+    assert "/ghost-skill" in errors[0]
+
+
+def test_skill_ref_fs_roots_disjoint_from_live_skills_and_allowlist():
+    """Collision guard (#1445): an fs-root entry naming a live
+    .claude/skills/ dir would silently disable rot detection for that skill;
+    double-membership with SKILL_REF_ALLOWLIST would blur the two sets'
+    contracts. Both intersections must stay empty. REMEDY on failure: drop
+    the colliding member(s) from SKILL_REF_FS_ROOTS (scripts/workflow_lint.py)
+    — do NOT delete this test (plan #1445 §6)."""
+    live = _live_skill_names(_REPO_ROOT / ".claude" / "skills")
+    assert SKILL_REF_FS_ROOTS & live == set(), (
+        "fs-root carve-out member(s) name a live skill dir — drop them from "
+        f"SKILL_REF_FS_ROOTS in scripts/workflow_lint.py: {sorted(SKILL_REF_FS_ROOTS & live)}"
+    )
+    assert set() == SKILL_REF_FS_ROOTS & SKILL_REF_ALLOWLIST, (
+        "fs-root carve-out member(s) double-listed in SKILL_REF_ALLOWLIST — keep "
+        "each token in exactly one set (scripts/workflow_lint.py): "
+        f"{sorted(SKILL_REF_FS_ROOTS & SKILL_REF_ALLOWLIST)}"
+    )
+
+
+def test_check_skill_refs_flags_fs_root_live_skill_collision(tmp_path):
+    """The in-function collision guard (#1445): a live skill dir named like an
+    fs-root member is reported by check_skill_references itself, so the
+    no-flags lint run catches the collision without pytest. REMEDY: drop the
+    colliding member from SKILL_REF_FS_ROOTS (scripts/workflow_lint.py)."""
+    skills = tmp_path / "skills"
+    (skills / "tmp").mkdir(parents=True)
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text("No slash-command tokens here.\n")
+    errors = check_skill_references(roots=[docs], skills_dir=skills, allowlist=frozenset())
+    assert len(errors) == 1, f"expected exactly one collision error, got: {errors}"
+    assert "SKILL_REF_FS_ROOTS" in errors[0]
+    assert "tmp" in errors[0]
 
 
 def test_check_skill_refs_repo_tree_is_clean():


### PR DESCRIPTION
Closes task #1445. Adds SKILL_REF_FS_ROOTS (20 filesystem roots) as a fourth resolution branch in the skill-reference check so bare backticked paths like `/tmp` no longer read as dead skill references; migrates 'workspace' out of SKILL_REF_ALLOWLIST; adds 5 regression tests incl. a live-skill disjointness guard + in-function collision guard.