### PR TITLE
issue-1455: stop releases registration + dispatch lease (wf-fix #1455)

### DIFF
--- a/.claude/rules/background-automation.md
+++ b/.claude/rules/background-automation.md
@@ -877,6 +877,19 @@ unconditional operator cleanup (`--force` requires `--issue` and is refused
 with `--session-id`). Takeover sentinels (`*.paused-takeover-*`) and
 non-registration siblings (`dispatch-lease-*`, `campaign-watch-*`,
 `pm-session.json`) are never touched by any invocation form.
+Since #1455, an OPERATOR `spawn_session.py stop` performs this cleanup
+automatically once the session is confirmed dead (bounded daemon-list poll,
+or `_pid_alive` false on the `--kill` fallback): the sid-matched unregister
+covers all three registration kinds (issue / manual-issue / campaign — an
+operator stop of a campaign session removes `campaign-<N>.json` too), plus an
+ownership-keyed release of the stopped dispatch's OWN lease
+(`acquired_at <= spawned_at`; a successor's newer lease is always kept), so
+the stale-registration collision → HELD-lease compound (the 2026-07-16 #1090
+incident shape) cannot recur on a CLEANED stop — the poll-timeout /
+daemon-unreachable and `--no-cleanup` paths retain the old leave-state shape
+by design. `--no-cleanup` opts out; watcher-sourced stops NEVER clean up —
+the crash-recovery / boot-death / dead-wake respawn arms depend on the
+registration surviving their own stops.
 
 **Program-orchestrator recovery pass (#660 leakage-program bash daemon).** The
 leakage-theory program (#660) is sequenced by a BASH DAEMON

--- a/scripts/spawn_session.py
+++ b/scripts/spawn_session.py
@@ -384,6 +384,195 @@ def release_dispatch_lease(issue: int, token: str) -> None:
         os.close(lock_fd)
 
 
+# ─── operator-stop one-shot cleanup (#1455) ──────────────────────────────────
+#
+# A deliberate operator `stop` used to leave TWO pieces of dispatch state
+# behind — the crash-recovery registration (`issue-<N>.json`) and the
+# per-issue dispatch lease — so the operator's replacement spawn collided
+# (RegistrationCollisionError inside the 900s window), self-stopped, and
+# HELD a second lease (the 2026-07-16 #1090 incident: 1 manual unregister +
+# 2 lease clears + 3 spawn attempts). Once the daemon confirms the stopped
+# session is gone, remove that session's OWN registration + lease so
+# stop -> respawn is one-shot. Watcher-sourced stops NEVER clean up: the
+# boot-death / dead-wake / crash-recovery respawn arms all depend on the
+# registration surviving the watcher's own stops.
+
+STOP_CLEANUP_DEAD_POLL_S = 15.0  # bounded dead-confirm wait after the stop ACK
+STOP_CLEANUP_DEAD_POLL_INTERVAL_S = 0.5
+
+
+def release_dispatch_lease_for_stopped_dispatch(issue: int, reg_spawned_at: float) -> str:
+    """Ownership-keyed unlink of the per-issue dispatch lease on a deliberate
+    operator stop (#1455), serialized under the SAME permanent flock sidecar
+    as acquire/release so it can never race a takeover.
+
+    ``cmd_stop`` does not hold the acquirer's token (it lives only in the
+    lease file + the dispatcher process), so ownership is keyed on dispatch
+    ORDERING instead: the stopped session's own lease was acquired BEFORE its
+    registration was written (acquire -> daemon POST ->
+    ``_register_autonomous_session``, same process), so
+    ``acquired_at <= reg_spawned_at`` identifies it; a successor dispatch's
+    lease (acquired after that registration existed) is always NEWER and is
+    KEPT. NOTE: ``register-current --force`` refreshes the registration's
+    ``spawned_at``, WIDENING the own-lease window — harmless in realistic
+    orderings (see plan #1455 §11 keying rationale).
+
+    Returns an action string for logging/tests: ``released | missing |
+    kept-successor | kept-garbled | kept-contended | kept-oserror``. Fails
+    toward KEEP everywhere (the TTL owns a kept lease)."""
+    try:
+        lock_fd = os.open(_dispatch_lease_lock_path(issue), os.O_CREAT | os.O_WRONLY, 0o644)
+    except OSError:
+        return "kept-oserror"
+    try:
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            return "kept-contended"  # a takeover is in flight; the TTL owns it
+        entry = read_dispatch_lease(issue)
+        if entry is None:
+            return "missing"
+        acquired = entry.get("acquired_at") if isinstance(entry, dict) else None
+        if not isinstance(acquired, int | float) or isinstance(acquired, bool):
+            return "kept-garbled"  # unreadable ownership -> keep; the TTL owns it
+        if acquired > reg_spawned_at:
+            return "kept-successor"  # minted AFTER the stopped session registered
+        dispatch_lease_path(issue).unlink(missing_ok=True)
+        return "released"
+    finally:
+        os.close(lock_fd)
+
+
+def _deliberate_stop_cleanup(sid: str) -> None:
+    """Operator-stop one-shot cleanup (#1455): sid-matched registration
+    removal across all THREE registration kinds (issue / manual-issue /
+    campaign — reuses :func:`unregister_paths`, the #1327 internals) plus
+    ownership-keyed dispatch-lease release for AUTO registrations only
+    (manual/campaign spawns never mint a lease — the single acquire site is
+    the ``--auto`` branch of :func:`cmd_spawn_issue`). Prints one line per
+    REMOVED file / lease action. Callers wrap in the fail-soft
+    :func:`_post_stop_cleanup`; this function itself may raise."""
+    # 1. Capture spawned_at per sid-matched AUTO registration BEFORE removal.
+    #    The `issue-*.json` glob already excludes `manual-issue-*.json` (a
+    #    glob pattern anchors at the name start); the RE re-check is
+    #    belt-and-braces AND parses the issue number.
+    auto_spawned_at: dict[int, float] = {}
+    if AUTONOMOUS_REGISTRY_DIR.is_dir():
+        for path in AUTONOMOUS_REGISTRY_DIR.glob("issue-*.json"):
+            m = _REGISTRATION_NAME_RE.match(path.name)
+            if not m or m.group(1) != "issue":
+                continue
+            try:
+                entry = json.loads(path.read_text())
+            except (OSError, ValueError):
+                continue
+            if isinstance(entry, dict) and entry.get("happy_session_id") == sid:
+                ts = entry.get("spawned_at")
+                if isinstance(ts, int | float) and not isinstance(ts, bool):
+                    auto_spawned_at[int(m.group(2))] = float(ts)
+    # 2. Sid-matched removal across all three kinds (the #1327 guarded path;
+    #    scan mode: issue=None). Guards: mismatched sid kept, garbled kept.
+    #    Print ONLY the removed rows (scan mode appends no kept rows today;
+    #    the filter future-proofs against a chattier unregister_paths — a
+    #    KEPT-SID-MISMATCH line per other live session would be pure noise).
+    rows = unregister_paths(issue=None, session_id=sid)
+    for action, path, detail in rows:
+        if action != "removed":
+            continue
+        print(f"  cleanup: {action.upper():<18} {path}" + (f" ({detail})" if detail else ""))
+    # 3. Lease release ONLY for issues whose AUTO registration was actually
+    #    REMOVED in step 2 (removal proves the stopped session was the
+    #    registered owner) and whose spawned_at was readable in step 1.
+    for action, path, _detail in rows:
+        if action != "removed":
+            continue
+        m = _REGISTRATION_NAME_RE.match(path.name)
+        if not m or m.group(1) != "issue":
+            continue  # manual/campaign registration: no lease to release
+        issue = int(m.group(2))
+        ts = auto_spawned_at.get(issue)
+        if ts is None:
+            print(
+                f"  cleanup: KEPT-LEASE issue #{issue} (registration removed but "
+                f"spawned_at was unreadable at capture; TTL owns the lease)",
+                file=sys.stderr,
+            )
+            continue
+        print(
+            f"  cleanup: dispatch-lease #{issue}: "
+            f"{release_dispatch_lease_for_stopped_dispatch(issue, ts)}"
+        )
+
+
+def _await_session_dead(sid: str, deadline_s: float | None = None) -> str:
+    """Bounded poll of the daemon live list until ``sid`` is absent (#1455).
+
+    Returns ``"dead"`` (confirmed gone from a SUCCESSFUL live-list read),
+    ``"still-live"`` (still listed at the deadline), or
+    ``"daemon-unreachable"`` (the strict probe raised — the daemon could not
+    be listed at all). The caller skips cleanup on anything but ``"dead"``
+    (the #845 'a stop ACK is not a kill' posture). ``deadline_s=None``
+    resolves :data:`STOP_CLEANUP_DEAD_POLL_S` at CALL time — never bind the
+    module constant as a def-time default (it would freeze and defeat
+    monkeypatching).
+
+    R5 hardening (#1455): the probe is ``_live_children(strict=True)``
+    precisely because the lenient :func:`_live_session_ids` returns an EMPTY
+    set on an unreachable daemon, which would falsely read as "session gone"
+    and fire cleanup on a possibly-live session. Do not "simplify" this back
+    to the lenient probe — a daemon-unreachable read must SKIP cleanup
+    (fail toward keep), not treat the empty set as confirmation."""
+    limit = STOP_CLEANUP_DEAD_POLL_S if deadline_s is None else deadline_s
+    deadline = time.time() + limit
+    while True:
+        try:
+            children = _live_children(strict=True)
+        except RuntimeError:
+            return "daemon-unreachable"  # fail toward keep; caller skips cleanup
+        if sid not in {c.get("happySessionId") for c in children}:
+            return "dead"
+        if time.time() >= deadline:
+            return "still-live"
+        time.sleep(STOP_CLEANUP_DEAD_POLL_INTERVAL_S)
+
+
+def _post_stop_cleanup(sid: str, *, dead_confirmed: bool = False) -> None:
+    """Fail-soft wrapper around dead-confirm + cleanup (#1455). NEVER raises
+    and never alters ``cmd_stop``'s exit behavior — the stop already
+    succeeded; cleanup is best-effort hygiene (mirrors the breadcrumb
+    fail-soft posture in :func:`cmd_stop`). This is a deliberate, documented
+    exception to fail-fast: a cleanup crash after a successful stop would
+    strand the operator in a WORSE state than today's, and the WARN + manual
+    command keep the failure loud and diagnosable.
+
+    ``dead_confirmed=True`` (the :func:`_stop_fallback` kill-success branch)
+    skips the daemon dead-poll: the process was already confirmed dead via
+    ``_pid_alive``, which satisfies the confirmed-dead precondition without
+    a daemon read (the sid is daemon-untracked there anyway)."""
+    try:
+        if not dead_confirmed:
+            status = _await_session_dead(sid)
+            if status != "dead":
+                reason = (
+                    f"session {sid} still live per the daemon after {STOP_CLEANUP_DEAD_POLL_S:g}s"
+                    if status == "still-live"
+                    else f"daemon unreachable while confirming session {sid} is dead"
+                )
+                print(
+                    f"WARN: {reason}; skipping registration/lease cleanup — "
+                    f"once it is dead run: spawn_session.py unregister --session-id {sid}",
+                    file=sys.stderr,
+                )
+                return
+        _deliberate_stop_cleanup(sid)
+    except Exception as exc:
+        print(
+            f"WARN: post-stop cleanup failed: {exc!r} — the stop itself succeeded; "
+            f"clean up manually: spawn_session.py unregister --session-id {sid}",
+            file=sys.stderr,
+        )
+
+
 # ─── session-dispatch stagger (#1059) ────────────────────────────────────────
 #
 # Global (cross-issue) pacing of `spawn-issue --auto` session dispatches: each
@@ -2599,6 +2788,21 @@ def cmd_stop(args: argparse.Namespace) -> None:
     with a hard join timeout (:data:`STOP_BREADCRUMB_JOIN_TIMEOUT_S`) so
     a wedged workflow flock can never hang the stop (fail-soft: WARN +
     proceed on any failure or timeout).
+
+    OPERATOR stops additionally run the #1455 one-shot cleanup once the
+    session is CONFIRMED gone (bounded daemon-list poll, or ``_pid_alive``
+    false on the ``--kill`` fallback path): the sid-matched registration
+    file(s) are removed (:func:`unregister_paths`, all three kinds) and the
+    dispatch lease the stopped session's own dispatch minted is released
+    (:func:`release_dispatch_lease_for_stopped_dispatch`), so an immediate
+    respawn hits neither ``REGISTRATION-COLLISION`` nor
+    ``DISPATCH-LEASE HELD``. Gated to ``--stop-source operator`` (the same
+    gate as the breadcrumb): watcher-sourced stops keep their state
+    byte-identical — the watcher's respawn arms depend on the registration
+    surviving its own stops. ``--no-cleanup`` opts out (stop, leave state,
+    let the watcher resurrect). Cleanup is fail-soft
+    (:func:`_post_stop_cleanup`): it never changes this command's exit
+    behavior.
     """
     if args.stop_source == "operator":
         try:  # fail-soft: the WHOLE mapped branch (map load + post)
@@ -2641,13 +2845,23 @@ def cmd_stop(args: argparse.Namespace) -> None:
         except Exception as exc:  # fail-soft side channel: never block the stop
             print(f"WARN: deliberate-stop breadcrumb failed: {exc!r}", file=sys.stderr)
     resp = post("/stop-session", {"sessionId": args.session_id})
+    # getattr defaults (not bare attribute reads) keep eps_sessions.py's
+    # cmd_stop working unchanged — it delegates with a bare
+    # Namespace(session_id, reason, stop_source="operator") carrying no
+    # kill/no_cleanup attrs, and as an operator per-issue stop it SHOULD
+    # inherit the cleanup.
+    do_cleanup = args.stop_source == "operator" and not getattr(args, "no_cleanup", False)
     if resp.get("success"):
         print(f"Stopped session {args.session_id}")
+        if do_cleanup:
+            _post_stop_cleanup(args.session_id)  # #1455: one-shot stop -> respawn
         return
-    _stop_fallback(args.session_id, resp, kill=bool(getattr(args, "kill", False)))
+    _stop_fallback(
+        args.session_id, resp, kill=bool(getattr(args, "kill", False)), cleanup=do_cleanup
+    )
 
 
-def _stop_fallback(sid: str, resp: dict, *, kill: bool) -> None:
+def _stop_fallback(sid: str, resp: dict, *, kill: bool, cleanup: bool = False) -> None:
     """Failure path of :func:`cmd_stop` (#903): resolve a daemon-untracked
     session id to its live happy node wrapper pid via the ``~/.happy/logs``
     reverse map and either report a structured kill-by-pid recipe or — under
@@ -2656,7 +2870,14 @@ def _stop_fallback(sid: str, resp: dict, *, kill: bool) -> None:
     always refuses to the report-only recipe, never a kill — the
     kill-before-relaunch ownership discipline,
     ``.claude/rules/crash-fix-rounds.md``). SIGKILL escalation stays manual
-    by design."""
+    by design.
+
+    ``cleanup=True`` (#1455, operator stops only) runs the registration/lease
+    cleanup on the ONE branch where the process is CONFIRMED dead by
+    construction (``_pid_alive`` false after the SIGTERM). Every ``sys.exit``
+    branch (daemon-tracked-refused, no-pid, report-only recipe,
+    comm/cmdline/daemon-pid refusals, SIGTERM-survivor) is UNCHANGED — no
+    cleanup without a confirmed-dead process."""
     if sid in _live_session_ids():
         sys.exit(
             f"stop failed for DAEMON-TRACKED session {sid}: {resp!r} — the daemon "
@@ -2725,6 +2946,11 @@ def _stop_fallback(sid: str, resp: dict, *, kill: bool) -> None:
             print(
                 f"Stopped daemon-untracked session {sid} via SIGTERM to node pid {pid}.{survivor}"
             )
+            if cleanup:
+                # #1455: the process is confirmed dead via _pid_alive, which
+                # satisfies the confirmed-dead precondition without a daemon
+                # read (the sid is daemon-untracked here anyway).
+                _post_stop_cleanup(sid, dead_confirmed=True)
             return
     sys.exit(
         f"SIGTERM sent to pid {pid} but it survived ~10s; escalate manually after "
@@ -3039,6 +3265,17 @@ def main(argv: list[str] | None = None) -> None:
         help=(
             "if the sid is daemon-untracked but resolvable to a live happy node "
             "pid, SIGTERM that pid (comm re-verified first; no automatic SIGKILL)"
+        ),
+    )
+    p_stop.add_argument(
+        "--no-cleanup",
+        action="store_true",
+        dest="no_cleanup",
+        help=(
+            "skip the operator-stop registration/lease cleanup (#1455; covers "
+            "all three registration kinds: issue / manual-issue / campaign) — "
+            "leave the crash-recovery registration + dispatch lease in place "
+            "so the watcher resurrects the issue instead of you respawning it"
         ),
     )
     p_stop.set_defaults(fn=cmd_stop)

--- a/tests/test_spawn_session_stop_cleanup.py
+++ b/tests/test_spawn_session_stop_cleanup.py
@@ -1,0 +1,355 @@
+"""Tests for the #1455 operator-stop one-shot cleanup in ``scripts/spawn_session.py``.
+
+What this pins (plan #1455 §4; incident 2026-07-16 on #1090: a deliberate
+operator stop left the crash-recovery registration + dispatch lease behind,
+costing 1 manual unregister + 2 lease clears + 3 spawn attempts):
+
+1. A confirmed-dead OPERATOR stop removes the sid-matched registration
+   file(s) and releases the dispatch lease the stopped session's own
+   dispatch minted (``acquired_at <= spawned_at``).
+2. Watcher-sourced stops perform ZERO cleanup — registration + lease are
+   BYTE-IDENTICAL after the stop (the watcher's boot-death / dead-wake /
+   crash-recovery respawn arms REQUIRE the registration to survive its own
+   stops). **Durability pin:** ``test_watcher_source_stop_never_cleans_up``.
+3. Stopping session A never removes B's registration, and never removes a
+   successor dispatch's (newer) lease.
+4. Fail-soft: cleanup failures WARN and never change ``cmd_stop``'s exit
+   behavior; a still-live poll AND a daemon-unreachable strict probe both
+   SKIP cleanup (fail toward keep).
+5. The ``--no-cleanup`` escape hatch restores today's behavior verbatim, and
+   the ``eps_sessions.py`` bare-Namespace delegation shape (no ``kill`` /
+   ``no_cleanup`` attrs) inherits the cleanup without raising.
+6. Forward-drift gate: every ``spawn_session.py stop`` invocation constructed
+   in ``scripts/autonomous_session_watch.py`` threads ``--stop-source
+   watcher`` (an operator-sourced watcher stop would trigger the cleanup and
+   delete the registration its own respawn arms need).
+
+No daemon, no real registry, no real task state: ``AUTONOMOUS_REGISTRY_DIR``,
+``_load_session_issue_map``, ``post``, and ``_live_children`` are all
+monkeypatched (the seam style of ``test_spawn_session_stop_marker.py`` +
+``test_dispatch_lease.py``); ``time.sleep`` is a no-op.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import session_resolver  # noqa: E402
+import spawn_session  # noqa: E402
+
+SID = "sess-1455-owner"
+OTHER_SID = "sess-1455-other"
+ISSUE = 5
+
+
+def _seed_auto_registration(reg: Path, issue: int, sid: str, spawned_at: float) -> Path:
+    """Write an ``issue-<N>.json`` crash-recovery registration recording ``sid``."""
+    path = reg / f"issue-{issue}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "issue": issue,
+                "happy_session_id": sid,
+                "cwd": "/tmp",
+                "auto_approve_gpu_hours": 100.0,
+                "spawned_at": spawned_at,
+                "missed": 0,
+            }
+        )
+    )
+    return path
+
+
+def _seed_lease(reg: Path, issue: int, acquired_at: float) -> Path:
+    """Write a ``dispatch-lease-<N>.json`` in the acquire-site entry shape."""
+    path = reg / f"dispatch-lease-{issue}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "issue": issue,
+                "holder": "spawn-issue --auto pid=1234",
+                "pid": 1234,
+                "token": "tok-1455",
+                "acquired_at": acquired_at,
+            }
+        )
+    )
+    return path
+
+
+@pytest.fixture
+def stop_env(tmp_path, monkeypatch):
+    """Hermetic ``cmd_stop`` seams: isolated registry dir, no real daemon, no
+    real task state, no real sleeping. The daemon live list defaults to empty
+    with the STRICT probe succeeding, so the dead-poll confirms immediately."""
+    monkeypatch.setattr(spawn_session, "AUTONOMOUS_REGISTRY_DIR", tmp_path)
+    monkeypatch.setattr(spawn_session, "_load_session_issue_map", lambda: {})
+    monkeypatch.setattr(spawn_session, "post", lambda path, body: {"success": True})
+    monkeypatch.setattr(spawn_session, "_live_children", lambda *, strict=False: [])
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+    return tmp_path
+
+
+# ── operator-stop cleanup (the one-shot Goal case) ──────────────────────────
+
+
+def test_operator_stop_removes_sid_matched_registration_and_own_lease(stop_env, capsys):
+    t = time.time()
+    reg_path = _seed_auto_registration(stop_env, ISSUE, SID, spawned_at=t)
+    lease_path = _seed_lease(stop_env, ISSUE, acquired_at=t - 3)
+    spawn_session.main(["stop", "--session-id", SID])
+    assert not reg_path.exists()
+    assert not lease_path.exists()
+    out = capsys.readouterr().out
+    assert "REMOVED" in out
+    assert "released" in out
+
+
+def test_operator_stop_keeps_successor_lease(stop_env, capsys):
+    """A lease acquired AFTER the stopped session's registration was written
+    belongs to a successor dispatch mid-flight — never released by the stop."""
+    t = time.time()
+    reg_path = _seed_auto_registration(stop_env, ISSUE, SID, spawned_at=t)
+    lease_path = _seed_lease(stop_env, ISSUE, acquired_at=t + 30)
+    spawn_session.main(["stop", "--session-id", SID])
+    assert not reg_path.exists()
+    assert lease_path.exists()
+    assert "kept-successor" in capsys.readouterr().out
+
+
+def test_stop_of_a_never_deletes_bs_registration_or_lease(stop_env):
+    """Sid-mismatch guard: assert FILE PRESENCE (+ lease presence) — in scan
+    mode ``unregister_paths`` appends NO kept-sid-mismatch/missing rows, so
+    rows/stdout carry no signal for the kept case."""
+    t = time.time()
+    reg_path = _seed_auto_registration(stop_env, ISSUE, OTHER_SID, spawned_at=t)
+    lease_path = _seed_lease(stop_env, ISSUE, acquired_at=t - 3)
+    spawn_session.main(["stop", "--session-id", SID])
+    assert reg_path.exists()
+    assert lease_path.exists()
+
+
+def test_manual_registration_removed_but_no_lease_release(stop_env, capsys):
+    """Manual/campaign spawns never mint a lease — a removed
+    ``manual-issue-<N>.json`` must not trigger any lease action."""
+    t = time.time()
+    manual_path = stop_env / f"manual-issue-{ISSUE}.json"
+    manual_path.write_text(
+        json.dumps(
+            {
+                "issue": ISSUE,
+                "happy_session_id": SID,
+                "cwd": "/tmp",
+                "spawned_at": t,
+                "mode": "manual",
+            }
+        )
+    )
+    lease_path = _seed_lease(stop_env, ISSUE, acquired_at=t - 3)
+    spawn_session.main(["stop", "--session-id", SID])
+    assert not manual_path.exists()
+    assert lease_path.exists()
+    assert "dispatch-lease" not in capsys.readouterr().out
+
+
+# ── gating: watcher source + --no-cleanup ───────────────────────────────────
+
+
+def test_watcher_source_stop_never_cleans_up(stop_env):
+    """DURABILITY PIN (acceptance criterion 2): after a watcher-sourced stop
+    the registration + lease files are BYTE-IDENTICAL — the watcher's
+    boot-death / dead-wake / crash-recovery respawn arms depend on the
+    registration surviving the watcher's own stops."""
+    t = time.time()
+    reg_path = _seed_auto_registration(stop_env, ISSUE, SID, spawned_at=t)
+    lease_path = _seed_lease(stop_env, ISSUE, acquired_at=t - 3)
+    reg_before, lease_before = reg_path.read_bytes(), lease_path.read_bytes()
+    spawn_session.main(["stop", "--session-id", SID, "--stop-source", "watcher"])
+    assert reg_path.read_bytes() == reg_before
+    assert lease_path.read_bytes() == lease_before
+
+
+def test_no_cleanup_flag_skips_cleanup(stop_env):
+    """``--no-cleanup`` = today's operator behavior verbatim (stop, leave
+    state, let the watcher's crash-recovery resurrect)."""
+    t = time.time()
+    reg_path = _seed_auto_registration(stop_env, ISSUE, SID, spawned_at=t)
+    lease_path = _seed_lease(stop_env, ISSUE, acquired_at=t - 3)
+    reg_before, lease_before = reg_path.read_bytes(), lease_path.read_bytes()
+    spawn_session.main(["stop", "--session-id", SID, "--no-cleanup"])
+    assert reg_path.read_bytes() == reg_before
+    assert lease_path.read_bytes() == lease_before
+
+
+# ── dead-confirm precondition + fail-soft ───────────────────────────────────
+
+
+def test_cleanup_skipped_when_sid_still_live_after_poll(stop_env, monkeypatch, capsys):
+    t = time.time()
+    reg_path = _seed_auto_registration(stop_env, ISSUE, SID, spawned_at=t)
+    lease_path = _seed_lease(stop_env, ISSUE, acquired_at=t - 3)
+    monkeypatch.setattr(
+        spawn_session, "_live_children", lambda *, strict=False: [{"happySessionId": SID}]
+    )
+    # Resolved in-body at CALL time (never a def-time default), so this
+    # monkeypatch shrinks the poll deadline to zero.
+    monkeypatch.setattr(spawn_session, "STOP_CLEANUP_DEAD_POLL_S", 0.0)
+    spawn_session.main(["stop", "--session-id", SID])
+    assert reg_path.exists()
+    assert lease_path.exists()
+    err = capsys.readouterr().err
+    assert f"unregister --session-id {SID}" in err
+
+
+def test_cleanup_skipped_when_daemon_unreachable(stop_env, monkeypatch, capsys):
+    """R5 hardening: a daemon that cannot be LISTED at all is not evidence the
+    session is gone — the strict probe's RuntimeError SKIPS cleanup with a
+    WARN, never firing off the lenient empty-set read."""
+    t = time.time()
+    reg_path = _seed_auto_registration(stop_env, ISSUE, SID, spawned_at=t)
+    lease_path = _seed_lease(stop_env, ISSUE, acquired_at=t - 3)
+
+    def raising_children(*, strict=False):
+        raise RuntimeError("daemon /list failed: connection refused")
+
+    monkeypatch.setattr(spawn_session, "_live_children", raising_children)
+    spawn_session.main(["stop", "--session-id", SID])  # must NOT raise
+    assert reg_path.exists()
+    assert lease_path.exists()
+    err = capsys.readouterr().err
+    assert "daemon unreachable" in err
+    assert f"unregister --session-id {SID}" in err
+
+
+def test_cleanup_failure_is_failsoft(stop_env, monkeypatch, capsys):
+    _seed_auto_registration(stop_env, ISSUE, SID, spawned_at=time.time())
+
+    def boom(**_k):
+        raise RuntimeError("registry exploded")
+
+    monkeypatch.setattr(spawn_session, "unregister_paths", boom)
+    spawn_session.main(["stop", "--session-id", SID])  # must NOT raise / SystemExit
+    err = capsys.readouterr().err
+    assert "WARN: post-stop cleanup failed" in err
+
+
+# ── _stop_fallback --kill path + the eps_sessions.py bare Namespace ─────────
+
+
+def test_stop_fallback_kill_success_fires_cleanup(stop_env, monkeypatch):
+    """The ``--kill`` fallback's SIGTERM-confirmed-dead branch (``_pid_alive``
+    false) satisfies the confirmed-dead precondition without a daemon read —
+    cleanup fires there and nowhere else in the fallback."""
+    t = time.time()
+    reg_path = _seed_auto_registration(stop_env, ISSUE, SID, spawned_at=t)
+    lease_path = _seed_lease(stop_env, ISSUE, acquired_at=t - 3)
+    monkeypatch.setattr(spawn_session, "post", lambda path, body: {"success": False})
+    monkeypatch.setattr(spawn_session, "_live_session_ids", lambda: set())
+    monkeypatch.setattr(session_resolver, "find_node_pid_for_session", lambda sid, now=None: 4242)
+    monkeypatch.setattr(session_resolver, "_read_proc_comm", lambda pid: "node")
+    monkeypatch.setattr(
+        session_resolver,
+        "_read_proc_cmdline",
+        lambda pid: "node /home/u/.nvm/node_modules/happy-coder/dist/index.mjs claude --resume",
+    )
+    monkeypatch.setattr(session_resolver, "_happy_daemon_pid", lambda: None)
+    monkeypatch.setattr(session_resolver, "resolve_claude_pid", lambda pid: None)
+    monkeypatch.setattr(session_resolver, "_pid_alive", lambda pid: False)
+    monkeypatch.setattr(os, "kill", lambda pid, sig: None)
+    spawn_session.main(["stop", "--session-id", SID, "--kill"])
+    assert not reg_path.exists()
+    assert not lease_path.exists()
+
+
+def test_eps_sessions_bare_namespace_inherits_cleanup(stop_env):
+    """Pins the getattr defaults: ``eps_sessions.py cmd_stop`` delegates with
+    a bare ``Namespace(session_id, reason, stop_source="operator")`` — NO
+    ``kill``/``no_cleanup`` attrs — and, as an operator per-issue stop,
+    inherits the cleanup without raising."""
+    t = time.time()
+    reg_path = _seed_auto_registration(stop_env, ISSUE, SID, spawned_at=t)
+    ns = argparse.Namespace(session_id=SID, reason="test", stop_source="operator")
+    spawn_session.cmd_stop(ns)  # must not AttributeError on the missing attrs
+    assert not reg_path.exists()
+
+
+# ── release_dispatch_lease_for_stopped_dispatch (pure helper) ───────────────
+
+
+class TestReleaseDispatchLeaseForStoppedDispatch:
+    def test_released_when_lease_predates_registration(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(spawn_session, "AUTONOMOUS_REGISTRY_DIR", tmp_path)
+        t = time.time()
+        lease = _seed_lease(tmp_path, ISSUE, acquired_at=t - 3)
+        assert spawn_session.release_dispatch_lease_for_stopped_dispatch(ISSUE, t) == "released"
+        assert not lease.exists()
+
+    def test_missing_when_no_lease_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(spawn_session, "AUTONOMOUS_REGISTRY_DIR", tmp_path)
+        result = spawn_session.release_dispatch_lease_for_stopped_dispatch(ISSUE, time.time())
+        assert result == "missing"
+
+    def test_kept_successor_when_lease_newer_than_registration(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(spawn_session, "AUTONOMOUS_REGISTRY_DIR", tmp_path)
+        t = time.time()
+        lease = _seed_lease(tmp_path, ISSUE, acquired_at=t + 30)
+        result = spawn_session.release_dispatch_lease_for_stopped_dispatch(ISSUE, t)
+        assert result == "kept-successor"
+        assert lease.exists()
+
+    def test_kept_garbled_on_non_numeric_acquired_at(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(spawn_session, "AUTONOMOUS_REGISTRY_DIR", tmp_path)
+        lease = tmp_path / f"dispatch-lease-{ISSUE}.json"
+        lease.write_text(json.dumps({"issue": ISSUE, "acquired_at": "yesterday"}))
+        result = spawn_session.release_dispatch_lease_for_stopped_dispatch(ISSUE, time.time())
+        assert result == "kept-garbled"
+        assert lease.exists()
+
+    def test_kept_contended_when_flock_held(self, tmp_path, monkeypatch):
+        """A takeover mid-flight (LOCK_EX held on the permanent flock sidecar
+        — flock conflicts across file descriptions, so a second fd in the
+        same process contends) keeps the lease; the TTL owns it."""
+        monkeypatch.setattr(spawn_session, "AUTONOMOUS_REGISTRY_DIR", tmp_path)
+        t = time.time()
+        lease = _seed_lease(tmp_path, ISSUE, acquired_at=t - 3)
+        lock_fd = os.open(
+            spawn_session._dispatch_lease_lock_path(ISSUE), os.O_CREAT | os.O_WRONLY, 0o644
+        )
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            result = spawn_session.release_dispatch_lease_for_stopped_dispatch(ISSUE, t)
+            assert result == "kept-contended"
+            assert lease.exists()
+        finally:
+            os.close(lock_fd)
+
+
+# ── forward-drift gate: watcher stop invocations ────────────────────────────
+
+
+def test_watcher_stop_invocations_carry_stop_source_watcher():
+    """Every ``spawn_session.py stop`` invocation constructed in
+    ``scripts/autonomous_session_watch.py`` must thread ``--stop-source
+    watcher`` — an operator-sourced watcher stop would trigger the #1455
+    cleanup and delete the registration its own respawn arms depend on."""
+    src = (SCRIPTS / "autonomous_session_watch.py").read_text()
+    sites = [m.start() for m in re.finditer(r'spawn_session\.py",\s*"stop"', src)]
+    assert sites, "expected >=1 spawn_session.py stop construction site in the watcher"
+    for pos in sites:
+        window = src[pos : src.index("]", pos)]
+        assert '"--stop-source"' in window and '"watcher"' in window, (
+            f"watcher stop invocation at char {pos} lacks --stop-source watcher:\n{window}"
+        )

--- a/tests/test_spawn_session_stop_marker.py
+++ b/tests/test_spawn_session_stop_marker.py
@@ -58,6 +58,9 @@ def _patch_common(
     from the (mocked) daemon ``post`` — list order IS the observed ordering.
     """
     monkeypatch.setattr(spawn_session, "_load_session_issue_map", lambda: issue_map)
+    # #1455 hermeticity seam: the operator-stop cleanup would otherwise hit
+    # the real ~/.eps-autonomous registry + the daemon live list.
+    monkeypatch.setattr(spawn_session, "_post_stop_cleanup", lambda sid, **_k: None)
 
     def default_post_event(task_id, kind, **kwargs):
         calls.append(("marker", task_id, kind, kwargs))

--- a/tests/test_spawn_session_stop_takeover.py
+++ b/tests/test_spawn_session_stop_takeover.py
@@ -165,6 +165,9 @@ def failing_stop(monkeypatch):
     default (tests override `_live_session_ids` for the tracked case)."""
     monkeypatch.setattr(spawn_session, "post", lambda path, body: {"success": False})
     monkeypatch.setattr(spawn_session, "_live_session_ids", lambda: set())
+    # #1455 hermeticity seam (belt-and-braces: these stops are watcher-sourced
+    # so cleanup is gated off anyway, but a future ns change must not leak).
+    monkeypatch.setattr(spawn_session, "_post_stop_cleanup", lambda sid, **_k: None)
 
 
 def test_cmd_stop_tracked_failure_structured(monkeypatch):


### PR DESCRIPTION
Closes task #1455. Operator stop now removes the sid-matched crash-recovery registration + releases the stopped dispatch's own lease once the session is confirmed dead; watcher stops untouched; --no-cleanup escape; fail-soft.