### PR TITLE
issue-1459: concern-summary cap UX — CLI word-boundary truncation + message/help/doc sync

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -250,10 +250,12 @@ Inherit each open concern (severity=`BLOCKER` or `CONCERN`, latest event
 - A new substantive concern this round that you want the orchestrator to
   bind MUST be persisted via `task.py raise-concern <N> --concern-id
   <kebab-id> --severity CONCERN|BLOCKER --summary <80c> --by
-  code-reviewer --round <n>`. The `--summary` is HARD-CAPPED at 200
-  chars (`raise-concern` raises `ValueError: summary too long` past it —
-  two tracebacks on 2026-06-09); compose the one-liner within the cap
-  and put detail in the evidence field / verdict body. Verdict-body
+  code-reviewer --round <n>`. The `--summary` is capped at 200 chars —
+  compose the one-liner within the cap and put detail in the evidence
+  field / verdict body; an over-cap `--summary` via the CLI is
+  auto-truncated at a word boundary with a loud warning (full text
+  shifted into `--evidence` when evidence is empty; programmatic callers
+  still get `ValueError: summary too long`). Verdict-body
   concern bullets that are NOT persisted remain opportunistic (the
   historical PASS+CONCERNS auto-advance contract applies).
 - **A deferred feature the plan's PRODUCTION path requires is ALWAYS a

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -2793,8 +2793,9 @@ This step does NOT override 5c-bis — mechanical-contract-only FAILs
 still strip and cosmetic gripes about present evidence still don't
 bounce the implementer. The check operates on a different signal
 (concerns.jsonl persisted via `task.py raise-concern` — NOTE the
-`--summary` arg is hard-capped at 200 chars, ValueError above it; put
-detail in `--evidence`) and gates
+`--summary` arg is capped at 200 chars — the CLI truncates longer text
+at a word boundary with a loud warning (programmatic `task_workflow`
+callers still get ValueError); put detail in `--evidence`) and gates
 auto-advance ON TOP of the existing flow. The same subroutine fires at
 Step 9a (interp ensemble) and Step 9a-bis (clean-result ensemble) with
 the same logic.

--- a/.claude/workflow.yaml
+++ b/.claude/workflow.yaml
@@ -1422,11 +1422,15 @@ concerns_protocol:
     advisory verdict-body text.
   concern_id_format: "^[a-z0-9][a-z0-9-]{1,79}$"  # stable kebab-case
   summary_cap: |
-    `--summary` is HARD-CAPPED at 200 chars — task.py raises ValueError
-    above it (5 reviewer crashes on 2026-06-10 alone: 238-410-char
-    summaries). Compose the summary as one tight sentence and move all
-    detail to `--evidence`. The same cap applies to `address-concern`
-    carried summaries.
+    Stored concern summaries are HARD-CAPPED at 200 chars (the library
+    layer raises ValueError above it; 5 reviewer crashes on 2026-06-10
+    alone: 238-410-char summaries). The task.py CLI (raise-concern /
+    address-concern) auto-truncates a longer `--summary` at a word
+    boundary with a loud stderr warning instead of crashing — on
+    raise-concern the full original is shifted into `--evidence` when
+    evidence is empty. Compose the summary as one tight sentence and
+    move all detail to `--evidence`. The same cap applies to
+    `address-concern` carried summaries.
   concern_id_examples:
     - probe-position-undefined
     - missing-mlm-control

--- a/scripts/task.py
+++ b/scripts/task.py
@@ -1083,19 +1083,70 @@ def cmd_reap_husks(args: argparse.Namespace) -> None:
 
 # ─── Binding-concerns handlers ────────────────────────────────────────────
 
+CONCERN_SUMMARY_CAP = 200
+
+
+def _truncate_summary(summary: str, cap: int = CONCERN_SUMMARY_CAP) -> tuple[str, str | None]:
+    """Truncate an over-cap concern summary at a word boundary.
+
+    Returns ``(kept, dropped_tail)``. ``dropped_tail`` is ``None`` when
+    ``summary`` already fits (after stripping trailing whitespace). When
+    truncated, ``kept`` is <= ``cap`` chars, ends with ``"..."``, and cuts
+    at the last space at or before the budget (hard-cut when the text has
+    no usable space in that span).
+    """
+    summary = summary.rstrip()
+    if len(summary) <= cap:
+        return summary, None
+    budget = cap - 3  # room for the "..." marker (ASCII, not U+2026)
+    cut = summary.rfind(" ", 0, budget + 1)
+    if cut <= 0:
+        cut = budget
+    kept = summary[:cut].rstrip() + "..."
+    if kept == "...":
+        # Degenerate whitespace-heavy input: the kept prefix stripped to
+        # nothing — hard-cut the raw text so the stored summary is never
+        # content-free.
+        cut = budget
+        kept = summary[:cut].rstrip() + "..."
+    return kept, summary[cut:].strip()
+
 
 def cmd_raise_concern(args: argparse.Namespace) -> None:
     """Append a `raised` (or `verified-open` on re-raise) event to
     concerns.jsonl. Re-raising the SAME concern_id at the SAME round with
-    the SAME severity is a no-op (returns the existing event)."""
+    the SAME severity is a no-op (returns the existing event). An over-cap
+    ``--summary`` is truncated at a word boundary with a loud stderr
+    warning (full original shifted into evidence when --evidence is
+    empty); the library layer keeps the hard 200-char cap."""
+    summary, dropped = _truncate_summary(args.summary)
+    evidence = args.evidence
+    if dropped is not None:
+        if evidence is None:
+            evidence = args.summary  # preserve the full original text
+            print(
+                f"[task.py] WARNING: --summary was {len(args.summary)} chars "
+                f"(cap {CONCERN_SUMMARY_CAP}); truncated at a word boundary to "
+                f"{len(summary)} chars. Full original preserved in the "
+                "concern's evidence field.",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"[task.py] WARNING: --summary was {len(args.summary)} chars "
+                f"(cap {CONCERN_SUMMARY_CAP}); truncated at a word boundary to "
+                f"{len(summary)} chars; --evidence kept as given. "
+                f"Dropped tail: {dropped!r}",
+                file=sys.stderr,
+            )
     payload = raise_concern(
         args.number,
         args.concern_id,
         severity=args.severity,
-        summary=args.summary,
+        summary=summary,
         raised_by=args.by,
         raised_at_round=args.round,
-        evidence=args.evidence,
+        evidence=evidence,
     )
     _safe_echo(
         json.dumps(payload, indent=2, ensure_ascii=False),
@@ -1107,13 +1158,26 @@ def cmd_address_concern(args: argparse.Namespace) -> None:
     """Append an `addressed` event recording that the implementer (or
     analyzer / planner) believes the concern has been fixed. The next
     reviewer round verifies; a re-raise after `addressed` becomes a
-    `verified-open` event rather than a fresh `raised`."""
+    `verified-open` event rather than a fresh `raised`. An over-cap
+    explicit ``--summary`` is truncated at a word boundary with a loud
+    stderr warning (the ``None`` carried-forward path is untouched)."""
+    summary = args.summary
+    if summary is not None:
+        summary, dropped = _truncate_summary(summary)
+        if dropped is not None:
+            print(
+                f"[task.py] WARNING: --summary was {len(args.summary)} chars "
+                f"(cap {CONCERN_SUMMARY_CAP}); truncated at a word boundary to "
+                f"{len(summary)} chars. Dropped tail: {dropped!r} "
+                "(detail belongs in the round report / the raise's evidence).",
+                file=sys.stderr,
+            )
     payload = address_concern(
         args.number,
         args.concern_id,
         addressed_by=args.by,
         addressed_at_round=args.round,
-        summary=args.summary,
+        summary=summary,
     )
     _safe_echo(
         json.dumps(payload, indent=2, ensure_ascii=False),
@@ -1709,7 +1773,13 @@ def main() -> None:
         choices=sorted(CONCERN_SEVERITIES),
         help="BLOCKER (no deferral), CONCERN (binding), NIT (optional)",
     )
-    p.add_argument("--summary", required=True, help="one-line ≤200-char description")
+    p.add_argument(
+        "--summary",
+        required=True,
+        help="one-line description (<=200 chars; longer text is truncated at a word "
+        "boundary with a warning, the full original shifted into --evidence when "
+        "--evidence is empty)",
+    )
     p.add_argument("--by", required=True, help="reviewer name (e.g. code-reviewer, critic)")
     p.add_argument(
         "--round",
@@ -1753,7 +1823,8 @@ def main() -> None:
         "--rationale",
         dest="summary",
         default=None,
-        help="optional updated summary; defaults to the original raised summary "
+        help="optional updated summary, <=200 chars (longer text is truncated at a "
+        "word boundary with a warning); defaults to the original raised summary "
         "(--rationale is an accepted alias, matching defer-concern's flag name)",
     )
     p.set_defaults(func=cmd_address_concern)

--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -6531,7 +6531,8 @@ def raise_concern(
         raise ValueError("summary must be a non-empty string")
     if len(summary) > 200:
         raise ValueError(
-            f"summary too long ({len(summary)} chars; max 200). Move detail to evidence."
+            f"summary too long ({len(summary)} chars; max 200). Move detail to "
+            "evidence (the task.py CLI auto-truncates at a word boundary instead)."
         )
     if not isinstance(raised_by, str) or not raised_by.strip():
         raise ValueError("raised_by must be a non-empty string")
@@ -6604,7 +6605,11 @@ def address_concern(
         # consumers don't need to walk history.
         carried_summary = (summary or latest.get("summary") or "").strip()
         if len(carried_summary) > 200:
-            raise ValueError(f"summary too long ({len(carried_summary)} chars; max 200).")
+            raise ValueError(
+                f"summary too long ({len(carried_summary)} chars; max 200). Pass a "
+                "shorter summary — detail belongs in the round report (the task.py "
+                "CLI auto-truncates explicit summaries at a word boundary)."
+            )
         payload: dict[str, Any] = {
             "ts": _utcnow_iso(),
             "event": "addressed",

--- a/tests/test_task_workflow.py
+++ b/tests/test_task_workflow.py
@@ -2893,6 +2893,224 @@ def test_cli_handlers_raise_address_defer_list_roundtrip(concerns_task, capsys):
     assert "user-only" in str(excinfo.value).lower() or "user" in str(excinfo.value).lower()
 
 
+def test_raise_concern_library_rejects_overlong_summary(concerns_task):
+    """The library layer keeps the hard 200-char cap (defense-in-depth for
+    programmatic callers) and its message names the escape + the CLI
+    auto-truncation alternative."""
+    _, tw, tid = concerns_task
+    with pytest.raises(ValueError, match="summary too long") as excinfo:
+        tw.raise_concern(
+            tid,
+            "overlong-summary-lib",
+            severity="CONCERN",
+            summary="x" * 201,
+            raised_by="code-reviewer",
+            raised_at_round=1,
+        )
+    msg = str(excinfo.value)
+    assert "evidence" in msg
+    assert "truncat" in msg
+
+
+def test_address_concern_library_overlong_message_names_escape(concerns_task):
+    """address_concern's >200 ValueError names the cap AND an actionable
+    escape (round report) AND mentions the CLI auto-truncation."""
+    _, tw, tid = concerns_task
+    tw.raise_concern(
+        tid,
+        "overlong-address-lib",
+        severity="CONCERN",
+        summary="A concern with a normal-length summary.",
+        raised_by="code-reviewer",
+        raised_at_round=1,
+    )
+    with pytest.raises(ValueError, match="summary too long") as excinfo:
+        tw.address_concern(
+            tid,
+            "overlong-address-lib",
+            addressed_by="implementer",
+            addressed_at_round=1,
+            summary="y " * 125,  # 250 chars; 249 after the library strip
+        )
+    msg = str(excinfo.value)
+    assert "max 200" in msg
+    assert "round report" in msg
+    assert "truncat" in msg
+
+
+def test_truncate_summary_word_boundary():
+    """Unit tests of the CLI-layer word-boundary truncation helper."""
+    task_cli = _import_task_cli()
+
+    # (a) exactly-at-cap input passes through byte-identical, no tail.
+    at_cap = "x" * 200
+    kept, tail = task_cli._truncate_summary(at_cap)
+    assert kept == at_cap
+    assert tail is None
+
+    # (a') trailing-whitespace-only overage passes clean (rstrip at entry).
+    kept, tail = task_cli._truncate_summary("x" * 200 + " " * 10)
+    assert kept == "x" * 200
+    assert tail is None
+
+    # (b) multi-word 324-char input cuts at a word boundary.
+    original = ("word " * 65).strip()
+    assert len(original) == 324
+    kept, tail = task_cli._truncate_summary(original)
+    assert len(kept) <= 200
+    assert kept.endswith("...")
+    assert original.startswith(kept[:-3])
+    assert not kept[:-3].endswith(" ")  # word-boundary cut + rstrip
+    assert tail
+    assert tail == original[len(kept) - 3 :].strip()
+
+    # (c) spaceless single token hard-cuts at the budget.
+    token = "z" * 300
+    kept, tail = task_cli._truncate_summary(token)
+    assert kept == token[:197] + "..."
+    assert tail == token[197:]
+
+    # (d) degenerate whitespace-heavy input: the word-boundary cut would
+    # strip to a bare "..." — falls back to a hard cut so the stored
+    # summary is never content-free.
+    degenerate = " " * 150 + "a" * 100
+    kept, tail = task_cli._truncate_summary(degenerate)
+    assert kept.endswith("...")
+    assert kept.strip() != "..."
+    assert len(kept) <= 200
+    assert tail == "a" * 53
+
+
+def test_cli_raise_concern_truncates_overlong_summary_and_preserves_in_evidence(
+    concerns_task, capsys
+):
+    """The #1398 replay: a 324-char --summary completes in ONE invocation;
+    the stored row is <=200 chars and the full original is preserved in
+    the evidence field (no --evidence given)."""
+    import argparse
+
+    task_cli = _import_task_cli()
+    _repo, tw, tid = concerns_task
+    original = ("word " * 65).strip()  # 324 chars
+    task_cli.cmd_raise_concern(
+        argparse.Namespace(
+            number=tid,
+            concern_id="overlong-raise-cli",
+            severity="CONCERN",
+            summary=original,
+            by="code-reviewer",
+            round=1,
+            evidence=None,
+        )
+    )
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "truncated at a word boundary" in err
+    assert "evidence field" in err
+    concerns_path = tw.find_task_path(tid) / "concerns.jsonl"
+    rows = [json.loads(line) for line in concerns_path.read_text().splitlines() if line.strip()]
+    row = rows[-1]
+    assert row["concern_id"] == "overlong-raise-cli"
+    assert len(row["summary"]) <= 200
+    assert row["summary"].endswith("...")
+    assert row["evidence"] == original
+
+
+def test_cli_raise_concern_truncation_keeps_given_evidence(concerns_task, capsys):
+    """When --evidence IS given, it is never mutated; the dropped tail is
+    printed in the stderr warning instead."""
+    import argparse
+
+    task_cli = _import_task_cli()
+    _repo, tw, tid = concerns_task
+    original = "alpha " * 50 + "OMEGA-DISTINCTIVE-TOKEN"  # 323 chars
+    task_cli.cmd_raise_concern(
+        argparse.Namespace(
+            number=tid,
+            concern_id="overlong-raise-evidence",
+            severity="CONCERN",
+            summary=original,
+            by="code-reviewer",
+            round=1,
+            evidence="src/foo.py:42",
+        )
+    )
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "Dropped tail" in err
+    assert "OMEGA-DISTINCTIVE-TOKEN" in err
+    concerns_path = tw.find_task_path(tid) / "concerns.jsonl"
+    rows = [json.loads(line) for line in concerns_path.read_text().splitlines() if line.strip()]
+    row = rows[-1]
+    assert len(row["summary"]) <= 200
+    assert row["evidence"] == "src/foo.py:42"
+
+
+def test_cli_address_concern_truncates_overlong_summary(concerns_task, capsys):
+    """The #1090 replay: a 203-char address-concern --summary completes in
+    ONE invocation with a loud warning."""
+    import argparse
+
+    task_cli = _import_task_cli()
+    _repo, tw, tid = concerns_task
+    tw.raise_concern(
+        tid,
+        "overlong-address-cli",
+        severity="CONCERN",
+        summary="A concern with a normal-length summary.",
+        raised_by="code-reviewer",
+        raised_at_round=1,
+    )
+    updated = ("addressed by rekeying the lookup " * 7)[:203]
+    assert len(updated) == 203
+    task_cli.cmd_address_concern(
+        argparse.Namespace(
+            number=tid,
+            concern_id="overlong-address-cli",
+            by="implementer",
+            round=1,
+            summary=updated,
+        )
+    )
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "cap 200" in err
+    concerns_path = tw.find_task_path(tid) / "concerns.jsonl"
+    rows = [json.loads(line) for line in concerns_path.read_text().splitlines() if line.strip()]
+    row = rows[-1]
+    assert row["event"] == "addressed"
+    assert len(row["summary"]) <= 200
+
+
+def test_cli_concern_summary_at_cap_passes_untouched(concerns_task, capsys):
+    """An exactly-200-char summary passes through byte-identical with NO
+    warning (no false-positive truncation). Whitespace-free input because
+    raise_concern stores summary.strip()."""
+    import argparse
+
+    task_cli = _import_task_cli()
+    _repo, tw, tid = concerns_task
+    at_cap = "x" * 200
+    task_cli.cmd_raise_concern(
+        argparse.Namespace(
+            number=tid,
+            concern_id="at-cap-raise-cli",
+            severity="CONCERN",
+            summary=at_cap,
+            by="code-reviewer",
+            round=1,
+            evidence=None,
+        )
+    )
+    err = capsys.readouterr().err
+    assert "WARNING" not in err
+    concerns_path = tw.find_task_path(tid) / "concerns.jsonl"
+    rows = [json.loads(line) for line in concerns_path.read_text().splitlines() if line.strip()]
+    row = rows[-1]
+    assert row["summary"] == at_cap
+    assert "evidence" not in row
+
+
 # ─── paper-stub support (`paper: true` clean-result track) ─────────────────
 
 


### PR DESCRIPTION
Closes task #1459.

CLI-layer word-boundary truncation of >200-char concern summaries (raise-concern + address-concern) with loud stderr warnings; full original shifted into --evidence on raise when evidence is empty; library hard cap + improved error messages; both --summary help strings name the cap; 3 workflow-surface doc syncs; 7 new tests.

Plan v2 critic-APPROVEd (3 lenses) + consistency PASS; code-review PASS; Step 9c test-verdict PASS (1 pre-existing trunk failure stripped via pristine-scratch oracle).