### PR TITLE
task #1465: relay pod_lifecycle stderr through runpod.py

### DIFF
--- a/src/explore_persona_space/backends/runpod.py
+++ b/src/explore_persona_space/backends/runpod.py
@@ -61,6 +61,7 @@ import re
 import subprocess
 import sys
 import time
+from collections import deque
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
@@ -100,6 +101,85 @@ _CPU_CONTAINER_DISK_FLOOR_GB = 50
 #: default, never shrink it. (Not imported from ``scripts/pod_lifecycle`` —
 #: this module's imports stay ``base``-only by documented convention.)
 _GPU_VOLUME_FLOOR_GB = 200
+
+
+# Bounded stderr tail carried on a failed pod_lifecycle subprocess (#1465).
+# 60 lines covers the 20-50-line traceback class (#775 B2: a 5-line tail
+# truncated vLLM tracebacks; the GCE EXIT trap tails 40); 400 chars/line
+# bounds a pathological single line, worst case ~24 KB << the 50k marker cap.
+_POD_LIFECYCLE_TAIL_MAX_LINES = 60
+_POD_LIFECYCLE_TAIL_MAX_LINE_CHARS = 400
+
+
+class PodLifecycleProcessError(subprocess.CalledProcessError):
+    """``CalledProcessError`` whose ``str()`` carries the child's stderr tail.
+
+    Deliberately a SUBCLASS so every existing contract holds verbatim:
+    ``except subprocess.CalledProcessError`` catches it, and
+    ``dispatch_issue._provision_still_waiting`` reads the SAME
+    ``returncode`` / ``cmd`` fields (the exit-75 still-waiting contract).
+    ``self.stderr`` holds the BOUNDED tail (last
+    ``_POD_LIFECYCLE_TAIL_MAX_LINES`` lines), not the full stream.
+    """
+
+    def __str__(self) -> str:
+        base = super().__str__()
+        if not self.stderr:
+            return base
+        return (
+            f"{base}\n--- pod_lifecycle stderr tail "
+            f"(last {_POD_LIFECYCLE_TAIL_MAX_LINES} lines max) ---\n{self.stderr}"
+        )
+
+
+def _run_pod_lifecycle_relay(
+    cmd: list[str],
+    *,
+    env: dict[str, str] | None = None,
+    relay: Any | None = None,
+) -> None:
+    """Run a ``pod_lifecycle.py`` subprocess, TEEING its stderr live.
+
+    stdout stays INHERITED (untouched — provision progress prints pass
+    through exactly as before). stderr is piped and relayed line-by-line
+    to ``relay`` (default ``sys.stderr``) with an immediate flush, so the
+    ``[wait-for-capacity]`` heartbeat lines the orchestrator scans live
+    (SKILL.md Step 6b) keep streaming in real time across a multi-hour
+    wait, while a bounded deque retains the tail. On non-zero exit raises
+    :class:`PodLifecycleProcessError` with ``returncode`` + ``cmd``
+    verbatim and the tail as ``stderr`` (#1465; incident #1336: an opaque
+    ``exit status 1`` with zero diagnostics).
+    """
+    out = relay if relay is not None else sys.stderr
+    tail: deque[str] = deque(maxlen=_POD_LIFECYCLE_TAIL_MAX_LINES)
+    proc = subprocess.Popen(
+        cmd,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+    )
+    assert proc.stderr is not None  # stderr=PIPE => stream exists
+    with proc:
+        try:
+            # iter(readline, "") — unambiguous no-readahead line streaming.
+            for line in iter(proc.stderr.readline, ""):
+                out.write(line)
+                out.flush()
+                if len(line) > _POD_LIFECYCLE_TAIL_MAX_LINE_CHARS:
+                    line = line[:_POD_LIFECYCLE_TAIL_MAX_LINE_CHARS] + "…[line truncated]\n"
+                tail.append(line)
+            rc = proc.wait()
+        except BaseException:
+            # subprocess.run parity (CPython 3.11 run(): `except: # Including
+            # KeyboardInterrupt ... process.kill(); raise`): kill the child on
+            # ANY interruption rather than hang in __exit__'s wait — preserves
+            # today's Ctrl-C behavior exactly (#1465 plan §12 A10).
+            proc.kill()
+            raise
+    if rc != 0:
+        raise PodLifecycleProcessError(rc, cmd, output=None, stderr="".join(tail))
 
 
 def _shell_quote(s: str) -> str:
@@ -823,12 +903,16 @@ class RunPodBackend(ComputeBackend):
                     "--volume-gb",
                     str(max(_GPU_VOLUME_FLOOR_GB, boot_disk_gb)),
                 ]
-        # subprocess.run raises CalledProcessError on non-zero exit; that
-        # propagates to the selector, which logs + lets the orchestrator
-        # surface the failure as `epm:failure` (slice 1 does NOT add a
-        # provision retry — the existing `--wait-for-capacity` retry inside
-        # `pod_lifecycle.py` already handles SUPPLY_CONSTRAINT).
-        subprocess.run(cmd, check=True)
+        # _run_pod_lifecycle_relay raises PodLifecycleProcessError (a
+        # CalledProcessError subclass carrying the child's stderr tail,
+        # #1465) on non-zero exit; that propagates to the selector, which
+        # logs + lets the orchestrator surface the failure as `epm:failure`
+        # with the diagnostics inline. The exit-75 still-waiting contract
+        # (`dispatch_issue._provision_still_waiting`) is unchanged —
+        # returncode + cmd ride verbatim. (Slice 1 does NOT add a provision
+        # retry — the existing `--wait-for-capacity` retry inside
+        # `pod_lifecycle.py` already handles SUPPLY_CONSTRAINT.)
+        _run_pod_lifecycle_relay(cmd)
         pod_name = _runpod_pod_name(spec.issue)
         # Attempt id + sentinel path minted BEFORE the execution leg (#909 r2,
         # `runpod-execute-missing-completion-sentinel`): the handle's
@@ -1410,8 +1494,9 @@ class RunPodBackend(ComputeBackend):
             str(issue),
             "--yes",
         ]
-        # Inherit current env so RUNPOD_API_KEY etc. propagate. ``check=True``
-        # lets the selector see a non-zero terminate exit (e.g. survivors
-        # detected by the post-terminate live-API re-query inside
-        # ``cmd_terminate``).
-        subprocess.run(cmd, check=True, env=os.environ.copy())
+        # Inherit current env so RUNPOD_API_KEY etc. propagate. The relay
+        # raises PodLifecycleProcessError (a CalledProcessError subclass
+        # carrying the stderr tail, #1465) so the selector sees a non-zero
+        # terminate exit (e.g. survivors detected by the post-terminate
+        # live-API re-query inside ``cmd_terminate``) WITH its diagnostics.
+        _run_pod_lifecycle_relay(cmd, env=os.environ.copy())

--- a/src/explore_persona_space/backends/runpod.py
+++ b/src/explore_persona_space/backends/runpod.py
@@ -149,6 +149,11 @@ def _run_pod_lifecycle_relay(
     :class:`PodLifecycleProcessError` with ``returncode`` + ``cmd``
     verbatim and the tail as ``stderr`` (#1465; incident #1336: an opaque
     ``exit status 1`` with zero diagnostics).
+
+    EOF assumption: no pod_lifecycle local child detaches while inheriting
+    stderr (true today — all its grandchildren are foreground
+    ``subprocess.call``); a future backgrounded grandchild holding fd 2
+    open would convert child-exit into a pipe-EOF wait here.
     """
     out = relay if relay is not None else sys.stderr
     tail: deque[str] = deque(maxlen=_POD_LIFECYCLE_TAIL_MAX_LINES)

--- a/tests/test_backend_artifacts_verify.py
+++ b/tests/test_backend_artifacts_verify.py
@@ -859,6 +859,12 @@ def test_runpod_launch_attaches_declaration(monkeypatch) -> None:
     from explore_persona_space.backends.base import RunSpec as _RunSpec
 
     monkeypatch.setattr("subprocess.run", lambda *a, **k: None)
+    # #1465: the provision leg now routes through the Popen-based
+    # pod_lifecycle relay — no-op it too (else a REAL provision runs).
+    monkeypatch.setattr(
+        "explore_persona_space.backends.runpod._run_pod_lifecycle_relay",
+        lambda cmd, **k: None,
+    )
     backend = RunPodBackend()
     handle = backend.launch(_RunSpec(issue=42, intent="lora-7b", backend="runpod"))
     decl = handle.extra[EXPECTED_ARTIFACTS_HANDLE_KEY]
@@ -880,6 +886,12 @@ def test_runpod_stale_sentinel_cannot_satisfy_fresh_declaration(monkeypatch, tmp
     from explore_persona_space.backends.base import RunSpec as _RunSpec
 
     monkeypatch.setattr("subprocess.run", lambda *a, **k: None)
+    # #1465: the provision leg now routes through the Popen-based
+    # pod_lifecycle relay — no-op it too (else a REAL provision runs).
+    monkeypatch.setattr(
+        "explore_persona_space.backends.runpod._run_pod_lifecycle_relay",
+        lambda cmd, **k: None,
+    )
     backend = RunPodBackend()
     handle = backend.launch(_RunSpec(issue=42, intent="lora-7b", backend="runpod"))
     decl = handle.extra[EXPECTED_ARTIFACTS_HANDLE_KEY]

--- a/tests/test_backend_poll.py
+++ b/tests/test_backend_poll.py
@@ -1618,14 +1618,9 @@ def test_production_runpod_handle_repo_branch_roundtrips_reconstructor(monkeypat
     )
     from scripts import backend_poll as bp
 
-    _real_run = RP.subprocess.run
-
-    def _selective_run(cmd, *a, **k):
-        if isinstance(cmd, (list, tuple)) and any("pod_lifecycle.py" in str(c) for c in cmd):
-            return None
-        return _real_run(cmd, *a, **k)
-
-    monkeypatch.setattr(RP.subprocess, "run", _selective_run, raising=False)
+    # #1465: the provision leg routes through the pod_lifecycle-only helper —
+    # patching it is selective by construction (subprocess.run stays real).
+    monkeypatch.setattr(RP, "_run_pod_lifecycle_relay", lambda cmd, **k: None)
     handle = RP.RunPodBackend().launch(
         RunSpec(
             issue=909,
@@ -1701,14 +1696,9 @@ def test_runspec_from_runpod_handle_forwards_boot_disk_gb(monkeypatch):
     )
     from scripts import backend_poll as bp
 
-    _real_run = RP.subprocess.run
-
-    def _selective_run(cmd, *a, **k):
-        if isinstance(cmd, (list, tuple)) and any("pod_lifecycle.py" in str(c) for c in cmd):
-            return None
-        return _real_run(cmd, *a, **k)
-
-    monkeypatch.setattr(RP.subprocess, "run", _selective_run, raising=False)
+    # #1465: the provision leg routes through the pod_lifecycle-only helper —
+    # patching it is selective by construction (subprocess.run stays real).
+    monkeypatch.setattr(RP, "_run_pod_lifecycle_relay", lambda cmd, **k: None)
     handle = RP.RunPodBackend().launch(
         RunSpec(
             issue=1118,

--- a/tests/test_issue_dispatch.py
+++ b/tests/test_issue_dispatch.py
@@ -98,6 +98,13 @@ def test_runpod_launch_stuffs_issue_and_pid_file_onto_handle_extra(monkeypatch) 
     paths don't need to re-derive them.
     """
     monkeypatch.setattr("subprocess.run", lambda *a, **k: None)
+    # #1465: the provision leg now routes through the Popen-based
+    # pod_lifecycle relay — the blanket subprocess.run patch no longer
+    # intercepts it, so no-op the helper too (else a REAL provision runs).
+    monkeypatch.setattr(
+        "explore_persona_space.backends.runpod._run_pod_lifecycle_relay",
+        lambda cmd, **k: None,
+    )
     backend = RunPodBackend()
     spec = RunSpec(issue=99, intent="lora-7b", backend="runpod")
     handle = backend.launch(spec)

--- a/tests/test_runpod_provision_diagnostics.py
+++ b/tests/test_runpod_provision_diagnostics.py
@@ -1,0 +1,230 @@
+"""#1465 — pod_lifecycle stderr relay + tail-bearing provision exceptions.
+
+``RunPodBackend``'s two ``pod_lifecycle.py`` shell-outs (provision at
+``launch``, terminate at ``teardown``) route through
+``_run_pod_lifecycle_relay``, which TEES the child's stderr live (the
+``[wait-for-capacity]`` heartbeats keep streaming during multi-hour waits)
+while keeping a bounded tail, and on non-zero exit raises
+:class:`PodLifecycleProcessError` — a ``subprocess.CalledProcessError``
+SUBCLASS whose ``str()`` carries the stderr tail (the incident-#1336 fix:
+an opaque ``exit status 1`` with zero diagnostics). These tests pin:
+
+* the exception is a ``CalledProcessError`` with ``returncode`` + ``cmd``
+  verbatim and the stderr tail in ``str(exc)``;
+* the exit-75 still-waiting contract is byte-compatible — the REAL
+  ``dispatch_issue._provision_still_waiting`` fires on rc=75 with the
+  provision cmd shape and does NOT fire on rc=1 (both arms exercised);
+* stderr lines are relayed LIVE (streamed as produced, not replayed at
+  child exit — the timed liveness proof);
+* the tail is bounded (last N lines; overlong lines truncated);
+* stdout stays INHERITED (never piped) and the relay fires on success too;
+* both ``launch`` and ``teardown`` route through the helper, and a
+  tail-bearing raise propagates out of ``launch`` unswallowed.
+
+Tests 1-6 execute the helper's REAL body end-to-end (real ``Popen``, real
+pipes, real ``sys.executable -c`` children — the one-production-body-test
+rule, #906); only test 7 stubs it as a seam. All CPU, no pod, no network.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+import pytest
+
+from explore_persona_space.backends import runpod as RP
+from explore_persona_space.backends.base import RunHandle, RunSpec
+
+
+class _RecordingRelayOut:
+    """Injectable ``relay`` sink recording ``(line, monotonic_ts)`` pairs."""
+
+    def __init__(self) -> None:
+        self.lines: list[tuple[str, float]] = []
+        self.flushes = 0
+
+    def write(self, line: str) -> None:
+        self.lines.append((line, time.monotonic()))
+
+    def flush(self) -> None:
+        self.flushes += 1
+
+
+def _child_cmd(py_body: str, *trailing_argv: str) -> list[str]:
+    """A real subprocess command running ``py_body`` under ``sys.executable -c``.
+
+    ``trailing_argv`` tokens land in the child's ``sys.argv`` (ignored by the
+    body) — used to give the cmd LIST the ``pod_lifecycle.py`` + ``provision``
+    shape ``_provision_still_waiting`` matches on.
+    """
+    return [sys.executable, "-c", py_body, *trailing_argv]
+
+
+# ---------------------------------------------------------------------------
+# 1. Failure raises a tail-bearing CalledProcessError (fields verbatim)
+# ---------------------------------------------------------------------------
+
+
+def test_relay_raises_tail_bearing_calledprocesserror_on_failure():
+    cmd = _child_cmd(
+        "import sys; print('DIAG-LINE-1', file=sys.stderr); "
+        "print('DIAG-LINE-2', file=sys.stderr); sys.exit(3)"
+    )
+    with pytest.raises(subprocess.CalledProcessError) as ei:
+        RP._run_pod_lifecycle_relay(cmd, relay=_RecordingRelayOut())
+    exc = ei.value
+    assert isinstance(exc, RP.PodLifecycleProcessError)
+    assert exc.returncode == 3
+    assert exc.cmd is cmd  # verbatim — the still-waiting cmd-shape contract
+    assert "DIAG-LINE-1" in str(exc)
+    assert "DIAG-LINE-2" in str(exc)
+
+
+# ---------------------------------------------------------------------------
+# 2. Exit-75 still-waiting contract — the REAL predicate, both arms
+# ---------------------------------------------------------------------------
+
+
+def test_exit75_still_waiting_contract_byte_compatible():
+    from scripts.dispatch_issue import _provision_still_waiting
+
+    cmd75 = _child_cmd("import sys; sys.exit(75)", "pod_lifecycle.py", "provision")
+    with pytest.raises(subprocess.CalledProcessError) as ei:  # the literal legacy catch
+        RP._run_pod_lifecycle_relay(cmd75, relay=_RecordingRelayOut())
+    assert ei.value.returncode == 75
+    assert _provision_still_waiting(ei.value) is True
+
+    # rc != 75 with the same cmd shape → NOT still-waiting (arm 1 False).
+    cmd1 = _child_cmd("import sys; sys.exit(1)", "pod_lifecycle.py", "provision")
+    with pytest.raises(subprocess.CalledProcessError) as ei1:
+        RP._run_pod_lifecycle_relay(cmd1, relay=_RecordingRelayOut())
+    assert _provision_still_waiting(ei1.value) is False
+
+
+# ---------------------------------------------------------------------------
+# 3. Liveness — lines stream as produced, not capture-then-replay
+# ---------------------------------------------------------------------------
+
+
+def test_relay_streams_lines_live_not_capture_then_replay():
+    recorder = _RecordingRelayOut()
+    cmd = _child_cmd(
+        "import sys, time; "
+        "print('LINE-A', file=sys.stderr, flush=True); "
+        "time.sleep(2.0); "
+        "print('LINE-B', file=sys.stderr, flush=True)"
+    )
+    RP._run_pod_lifecycle_relay(cmd, relay=recorder)
+    by_text = {line.strip(): ts for line, ts in recorder.lines}
+    assert "LINE-A" in by_text and "LINE-B" in by_text
+    # Capture-then-replay would emit both lines ~simultaneously at exit;
+    # live streaming preserves the child's 2.0 s gap (1.0 s = 2x margin
+    # for a loaded shared VM).
+    assert by_text["LINE-B"] - by_text["LINE-A"] >= 1.0
+
+
+# ---------------------------------------------------------------------------
+# 4. Tail bounded to the LAST N lines
+# ---------------------------------------------------------------------------
+
+
+def test_relay_tail_bounded_to_last_lines():
+    n = RP._POD_LIFECYCLE_TAIL_MAX_LINES + 25
+    cmd = _child_cmd(
+        "import sys\n"
+        f"for i in range({n}):\n"
+        "    print(f'TAIL-LINE-{i:04d}', file=sys.stderr)\n"
+        "sys.exit(1)"
+    )
+    with pytest.raises(RP.PodLifecycleProcessError) as ei:
+        RP._run_pod_lifecycle_relay(cmd, relay=_RecordingRelayOut())
+    msg = str(ei.value)
+    assert f"TAIL-LINE-{n - 1:04d}" in msg  # the last line survives
+    assert "TAIL-LINE-0000" not in msg  # the first fell out of the deque
+    # Exactly the bounded window remains on the exception's stderr field.
+    assert len(ei.value.stderr.splitlines()) == RP._POD_LIFECYCLE_TAIL_MAX_LINES
+
+
+# ---------------------------------------------------------------------------
+# 5. Overlong single line truncated in the tail
+# ---------------------------------------------------------------------------
+
+
+def test_relay_truncates_overlong_line():
+    cmd = _child_cmd("import sys; print('X' * 5000, file=sys.stderr); sys.exit(1)")
+    with pytest.raises(RP.PodLifecycleProcessError) as ei:
+        RP._run_pod_lifecycle_relay(cmd, relay=_RecordingRelayOut())
+    msg = str(ei.value)
+    assert "[line truncated]" in msg
+    # Bounded: cap + truncation marker, never the raw 5000-char line.
+    assert len(ei.value.stderr) < RP._POD_LIFECYCLE_TAIL_MAX_LINE_CHARS + 100
+    assert "X" * (RP._POD_LIFECYCLE_TAIL_MAX_LINE_CHARS + 1) not in msg
+
+
+# ---------------------------------------------------------------------------
+# 6. Success returns None, still relays stderr, stdout stays inherited
+# ---------------------------------------------------------------------------
+
+
+def test_relay_success_returns_none_and_still_relays(capfd):
+    recorder = _RecordingRelayOut()
+    cmd = _child_cmd(
+        "import sys; print('HEARTBEAT [wait-for-capacity]', file=sys.stderr, flush=True); "
+        "print('STDOUT-PASSTHROUGH')"
+    )
+    assert RP._run_pod_lifecycle_relay(cmd, relay=recorder) is None
+    # Relay is unconditional (live heartbeats), not failure-only.
+    assert any("HEARTBEAT" in line for line, _ in recorder.lines)
+    assert recorder.flushes >= 1
+    # stdout is INHERITED (never piped) — the child's stdout reaches the
+    # parent's stdout untouched (the plan's hard constraint).
+    out, _err = capfd.readouterr()
+    assert "STDOUT-PASSTHROUGH" in out
+
+
+# ---------------------------------------------------------------------------
+# 7. Call-site routing — launch + teardown go through the relay (seam test)
+# ---------------------------------------------------------------------------
+
+
+def test_launch_and_teardown_route_through_relay(monkeypatch):
+    calls: list[dict] = []
+
+    def _recording_relay(cmd, **kwargs):
+        calls.append({"cmd": [str(c) for c in cmd], **kwargs})
+        return None
+
+    monkeypatch.setattr(RP, "_run_pod_lifecycle_relay", _recording_relay)
+
+    # (a) provision leg: the provision argv reaches the helper.
+    RP.RunPodBackend().launch(RunSpec(issue=1465, intent="lora-7b", backend="runpod"))
+    assert len(calls) == 1
+    assert any("pod_lifecycle.py" in c for c in calls[0]["cmd"])
+    assert "provision" in calls[0]["cmd"]
+
+    # (b) teardown leg: terminate + --yes reach the helper WITH env threaded.
+    handle = RunHandle(
+        backend="runpod",
+        cluster=None,
+        job_id="",
+        pod_name="pod-1465",
+        scratch_dir="/workspace",
+        log_path="/workspace/logs/issue-1465.log",
+        extra={"issue": 1465},
+    )
+    RP.RunPodBackend().teardown(handle)
+    assert len(calls) == 2
+    assert "terminate" in calls[1]["cmd"]
+    assert "--yes" in calls[1]["cmd"]
+    assert calls[1].get("env") is not None  # os.environ.copy() threaded
+
+    # (c) a tail-bearing raise propagates out of launch unswallowed.
+    def _exploding_relay(cmd, **kwargs):
+        raise RP.PodLifecycleProcessError(3, list(cmd), output=None, stderr="BOOM-TAIL")
+
+    monkeypatch.setattr(RP, "_run_pod_lifecycle_relay", _exploding_relay)
+    with pytest.raises(subprocess.CalledProcessError) as ei:
+        RP.RunPodBackend().launch(RunSpec(issue=1465, intent="lora-7b", backend="runpod"))
+    assert "BOOM-TAIL" in str(ei.value)

--- a/tests/test_runpod_wedge_detection.py
+++ b/tests/test_runpod_wedge_detection.py
@@ -816,7 +816,7 @@ def _production_runpod_handle(
 ) -> RunHandle:
     """Build a wedged RunPod handle by invoking the REAL ``RunPodBackend.launch()``.
 
-    Mocks ONLY ``subprocess.run`` (no pod is actually provisioned), so the
+    Mocks ONLY the provision subprocess (no pod is actually provisioned), so the
     returned handle's ``extra`` dict is byte-for-byte what production persists —
     this is the production-shaped handle the round-3 blocker requires, NOT the
     hand-built ``_runpod_handle_with_workload``. The reconstruction path
@@ -826,18 +826,11 @@ def _production_runpod_handle(
     from explore_persona_space.backends import runpod as RP
     from explore_persona_space.backends.base import RunSpec
 
-    # ``subprocess.run`` is the GLOBAL module singleton (env.py's git probe + the
-    # artifact-declaration helpers use it too), so a blanket lambda would break
-    # them. No-op ONLY the ``pod_lifecycle.py provision`` call; delegate every
-    # other subprocess to the real implementation.
-    _real_run = RP.subprocess.run
-
-    def _selective_run(cmd, *a, **k):
-        if isinstance(cmd, (list, tuple)) and any("pod_lifecycle.py" in str(c) for c in cmd):
-            return None  # the provision call — no real pod
-        return _real_run(cmd, *a, **k)
-
-    monkeypatch.setattr(RP.subprocess, "run", _selective_run, raising=False)
+    # Since #1465 the provision leg routes through the pod_lifecycle-only
+    # helper ``RP._run_pod_lifecycle_relay`` (never bare ``subprocess.run``),
+    # so patching the helper no-ops ONLY the provision call — env.py's git
+    # probe + the artifact-declaration helpers keep the real subprocess.run.
+    monkeypatch.setattr(RP, "_run_pod_lifecycle_relay", lambda cmd, **k: None)
     spec = RunSpec(
         issue=issue,
         intent=intent,

--- a/tests/test_runpod_workload_exec.py
+++ b/tests/test_runpod_workload_exec.py
@@ -49,20 +49,14 @@ ATTEMPT = "rp-20260703T000000Z-ab12"
 
 
 def _noop_provision(monkeypatch) -> None:
-    """No-op ONLY the ``pod_lifecycle.py provision`` subprocess call.
+    """No-op the ``pod_lifecycle.py provision`` subprocess call.
 
-    ``subprocess.run`` is the module-global singleton (the artifact
-    declaration helpers use it too), so a blanket lambda would break them —
-    the selective pattern from ``tests/test_runpod_wedge_detection.py``.
+    Since #1465 the provision leg routes through the pod_lifecycle-only
+    helper ``RP._run_pod_lifecycle_relay`` (never bare ``subprocess.run``),
+    so patching the helper is selective BY CONSTRUCTION — env.py's git probe
+    and the artifact-declaration helpers keep the real ``subprocess.run``.
     """
-    _real_run = RP.subprocess.run
-
-    def _selective_run(cmd, *a, **k):
-        if isinstance(cmd, (list, tuple)) and any("pod_lifecycle.py" in str(c) for c in cmd):
-            return None
-        return _real_run(cmd, *a, **k)
-
-    monkeypatch.setattr(RP.subprocess, "run", _selective_run, raising=False)
+    monkeypatch.setattr(RP, "_run_pod_lifecycle_relay", lambda cmd, **k: None)
 
 
 class _RecordingSsh:
@@ -289,7 +283,7 @@ def test_programmatic_flag_with_empty_workload_cmd_raises(monkeypatch):
     def _explode(*a, **k):
         raise AssertionError("provision must NOT run on the flag+empty-cmd cell")
 
-    monkeypatch.setattr(RP.subprocess, "run", _explode, raising=False)
+    monkeypatch.setattr(RP, "_run_pod_lifecycle_relay", _explode)
     with pytest.raises(RP.RunPodWorkloadStartError, match="empty workload_cmd"):
         RP.RunPodBackend().launch(
             _spec(workload_cmd="", hydra_args=("seed=1",), extra={"execute_workload": True})
@@ -761,7 +755,7 @@ def test_pre_provision_guard_keeps_handle_none(monkeypatch):
     def _explode(*a, **k):
         raise AssertionError("provision must NOT run on the flag+empty-cmd cell")
 
-    monkeypatch.setattr(RP.subprocess, "run", _explode, raising=False)
+    monkeypatch.setattr(RP, "_run_pod_lifecycle_relay", _explode)
     with pytest.raises(RP.RunPodWorkloadStartError) as ei:
         RP.RunPodBackend().launch(
             _spec(workload_cmd="", hydra_args=("seed=1",), extra={"execute_workload": True})
@@ -775,19 +769,17 @@ def test_pre_provision_guard_keeps_handle_none(monkeypatch):
 
 
 def _recording_provision(monkeypatch) -> list[list[str]]:
-    """Selectively no-op the ``pod_lifecycle.py provision`` subprocess AND
-    record its argv (the recording variant of ``_noop_provision`` — that
-    fixture records nothing)."""
-    _real_run = RP.subprocess.run
+    """No-op the ``pod_lifecycle.py provision`` call AND record its argv
+    (the recording variant of ``_noop_provision`` — that fixture records
+    nothing). Patches the #1465 pod_lifecycle-only helper
+    ``RP._run_pod_lifecycle_relay`` — selective by construction."""
     argvs: list[list[str]] = []
 
-    def _selective_run(cmd, *a, **k):
-        if isinstance(cmd, (list, tuple)) and any("pod_lifecycle.py" in str(c) for c in cmd):
-            argvs.append([str(c) for c in cmd])
-            return None
-        return _real_run(cmd, *a, **k)
+    def _recording_relay(cmd, **k):
+        argvs.append([str(c) for c in cmd])
+        return None
 
-    monkeypatch.setattr(RP.subprocess, "run", _selective_run, raising=False)
+    monkeypatch.setattr(RP, "_run_pod_lifecycle_relay", _recording_relay)
     return argvs
 
 


### PR DESCRIPTION
Closes task #1465. PodLifecycleProcessError (CalledProcessError subclass) + stderr live-tee helper; provision + terminate legs relay the child's stderr tail in the raised exception. Exit-75 still-waiting contract + heartbeat streaming preserved.