### PR TITLE
issue-1464: exclude free SLURM lanes from auto chain for CPU-only intents

### DIFF
--- a/src/explore_persona_space/backends/router.py
+++ b/src/explore_persona_space/backends/router.py
@@ -156,7 +156,9 @@ RunPod-on-error, ``route(spec)`` orchestrates the full multi-backend ladder:
    call when the mapped instance cannot hold it, and
    ``RunPodBackend.launch`` threads the disk requirement into the provision
    argv (``--container-disk-gb max(50, boot_disk_gb)``) for mapped CPU
-   intents.
+   intents. Free SLURM lanes are excluded from the auto chain for CPU-only
+   intents (:func:`_is_cpu_only_intent` at ``_auto_route`` candidate
+   assembly) — the lane has no 0-GPU sbatch render (#1464).
 8b. **GCP-only GPU intent translation (#940).** The RunPod launch paths
    (terminal rung + explicit override) translate a GCP-only GPU intent to
    its nearest same-or-narrower RunPod intent via
@@ -459,6 +461,20 @@ def _translated_runpod_intent(spec: RunSpec) -> tuple[str, dict[str, str] | None
             f"Deliberate gaps: {sorted(RUNPOD_INTENT_TRANSLATION_DELIBERATE_GAPS)}."
         )
     return intent, None  # CPU / RunPod-native / custom: verbatim
+
+
+def _is_cpu_only_intent(intent: str) -> bool:
+    """True iff ``intent`` maps to a 0-GPU machine in ``gcp.INTENT_TO_MACHINE``.
+
+    Direct ``INTENT_TO_MACHINE.get(...)`` — never :func:`gcp.machine_for_intent`
+    — so RunPod-/SLURM-native intents with no GCP row (``ft-70b``) and unknown
+    intents read ``False`` instead of raising (the
+    :func:`_translated_runpod_intent` discipline). Single source of truth: a
+    future CPU intent added to ``gcp.INTENT_TO_MACHINE`` with ``gpu_count=0``
+    inherits the CPU routing semantics automatically (#1464).
+    """
+    machine = INTENT_TO_MACHINE.get(intent)
+    return machine is not None and machine.gpu_count == 0
 
 
 #: The router fell back to RunPod because a GCP attempt FAILED THE WORKLOAD
@@ -4001,12 +4017,30 @@ def _auto_route(
     """
     del clock_fn  # reserved for a future "day boundary at posted-time" override
     # Build the candidate list in lane order (skipping unwired lanes +
-    # Mila-when-down + GCP-when-unwired).
+    # Mila-when-down + GCP-when-unwired + free SLURM lanes on CPU-only
+    # intents, #1464).
+    cpu_only = _is_cpu_only_intent(spec.intent)
+    if cpu_only and free_backends:
+        logger.info(
+            "route: CPU-only intent %r — free SLURM lanes (%s) excluded from "
+            "the auto chain. The documented CPU chain is GCP E2 -> RunPod CPU "
+            "for mapped intents (#747) / GCP-only for cpu-bigmem (#677); the "
+            "SLURM lane has no 0-GPU sbatch render (#1464, incident #1336).",
+            spec.intent,
+            ", ".join(sorted(free_backends)),
+        )
     candidates: list[tuple[ComputeBackend, BackendKind]] = []
     for kind in lane_order:
         if kind == "gcp":
             if gcp_backend is not None:
                 candidates.append((gcp_backend, "gcp"))
+            continue
+        if cpu_only:
+            # Excluding the free lanes from ``candidates`` also removes them
+            # from the stage-1 reconnect scan below — deliberately: a CPU-only
+            # intent can never have a live SLURM job to reconnect to (the lane
+            # has no 0-GPU sbatch render, so no prior route() could have
+            # submitted one there). Nothing is lost by not scanning (#1464).
             continue
         backend = free_backends.get(kind)
         if backend is None:

--- a/src/explore_persona_space/backends/slurm.py
+++ b/src/explore_persona_space/backends/slurm.py
@@ -331,6 +331,10 @@ def get_cluster_config(name: str) -> ClusterConfig:
 # via ``gpubase_bygpu_b3`` instead of queuing 4 days out on the 7-day
 # bin per P0(g)). Single floating-point hours; renderer converts to
 # ``HH:MM:SS``.
+# NOTE (#1464): the CPU-only intents (cpu-small / cpu-mid / cpu-bigmem, #747)
+# are DELIBERATELY absent here too — see the fuller note above
+# ``_DEFAULT_GPUS_FOR_INTENT``; do NOT "fix" a CPU-intent ValueError by
+# adding a row.
 _DEFAULT_TIME_BUDGETS_HOURS: dict[str, float] = {
     "lora-7b": 6.0,
     "lora": 6.0,  # alias accepted by stages_for_spec + _DEFAULT_GPUS_FOR_INTENT
@@ -383,6 +387,15 @@ def _format_sbatch_time(hours: float) -> str:
 # intent raises rather than picking 1 silently (consistent with
 # ``stages_for_spec`` + ``time_budget_hours``; a typo should fail the
 # render, not submit a job at the wrong GPU count).
+# NOTE (#1464): the CPU-only intents (cpu-small / cpu-mid / cpu-bigmem, #747)
+# are DELIBERATELY absent from this table (and from
+# _DEFAULT_TIME_BUDGETS_HOURS + stages_for_spec): the SLURM lane serves GPU
+# intents only — render_sbatch scales --cpus-per-task / --mem from the GPU
+# count, so gpus=0 would render an invalid 0-CPU / 0G script. The router
+# excludes the free lanes for CPU-only intents at candidate assembly
+# (router._is_cpu_only_intent); do NOT "fix" a CPU-intent ValueError here by
+# adding a 0 row (a future 0-GPU SLURM feature routes through the router
+# predicate instead).
 _DEFAULT_GPUS_FOR_INTENT: dict[str, int] = {
     "lora-7b": 1,
     "lora": 1,

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -6492,6 +6492,193 @@ def test_async_failover_seam_cpu_infeasible_disk_raises_typed(lease_store, marke
 
 
 # ---------------------------------------------------------------------------
+# #1464 — CPU-only intents exclude the free SLURM lanes from the auto chain
+# (incident #1336: a cpu-mid dispatch probed nibi/fir/mila, logged "treating
+# as unranked" per lane, and burned a doomed prepare/launch attempt per lane;
+# the SLURM lane has no 0-GPU sbatch render — see slurm.py's intent tables).
+# ---------------------------------------------------------------------------
+
+
+def _slurm_estimate_valueerror(spec_intent: str) -> ValueError:
+    """The production-shape estimate failure a CPU intent provokes on SLURM.
+
+    Mirrors slurm.default_gpus_for_intent's ValueError text (the first
+    fail-fast the render path hits for a cpu-* intent), so the caplog
+    no-"treating as unranked" assert genuinely discriminates: pre-fix the
+    recording estimate_fn raises this, _estimate_lanes catches ANY exception
+    and logs the "treating as unranked" warning — red-before, not vacuous.
+    """
+    return ValueError(f"no default GPU count for intent {spec_intent!r}.")
+
+
+def test_auto_route_cpu_intent_never_probes_or_attempts_slurm_lanes(
+    lease_store, marker_poster, captured_markers, caplog
+):
+    """#1464 regression (#1336 E1 shape): a cpu-mid AUTO route with free SLURM
+    lanes wired never probes any free lane's est-start, never records a
+    nibi/fir RouteAttempt, emits no "treating as unranked" warning, and falls
+    GCP -> RunPod CPU exactly per the documented #747 chain."""
+    import logging
+
+    rp = _PassiveRunpod()
+    gcp = _exhausted_gcp_double()
+    estimate_calls: list[BackendKind] = []
+
+    def recording_estimate(backend, kind, lane_spec):
+        estimate_calls.append(kind)
+        raise _slurm_estimate_valueerror(lane_spec.intent)
+
+    spec = RunSpec(issue=1464, intent="cpu-mid", backend="auto", time_budget_hours=1.0)
+    with caplog.at_level(logging.INFO, logger="explore_persona_space.backends.router"):
+        result = route(
+            spec,
+            runpod_backend=rp,
+            free_backends={
+                "nibi": _FreeLaneBackend(
+                    kind="nibi", launch_raises=RuntimeError("must never launch")
+                ),
+                "fir": _FreeLaneBackend(
+                    kind="fir", launch_raises=RuntimeError("must never launch")
+                ),
+            },
+            gcp_backend=gcp,
+            lease_store=lease_store,
+            estimate_fn=recording_estimate,
+            marker_poster=marker_poster,
+            config=RouterConfig(
+                free_wait_seconds=1, poll_interval=0.0, max_gcp_attempts_per_day=99
+            ),
+            now_fn=_clock(),
+            sleep_fn=lambda _s: None,
+        )
+    # The #747 chain is preserved: GCP CPU ladder exhausted -> RunPod CPU.
+    assert result.chosen_kind == "runpod"
+    assert len(rp.launches) == 1
+    # No free-lane est-start probe ever fired (the #1336 degradation source).
+    assert estimate_calls == [], estimate_calls
+    # No nibi/fir RouteAttempt anywhere in the trail.
+    free_attempts = [(a.kind, a.outcome) for a in result.attempts if a.kind in ("nibi", "fir")]
+    assert not free_attempts, free_attempts
+    # No "treating as unranked" degradation warning was logged.
+    assert not any("treating as unranked" in r.message for r in caplog.records), [
+        r.message for r in caplog.records
+    ]
+
+
+def test_auto_route_cpu_bigmem_excludes_slurm_and_keeps_typed_terminal(
+    lease_store, marker_poster, captured_markers, caplog
+):
+    """#1464: same exclusion for cpu-bigmem, with the #677 typed terminal
+    byte-preserved — CpuExhaustedNoRunpodLaneError raised, zero RunPod
+    launches, zero free-lane probes/attempts, terminal marker reason
+    cpu_exhausted_no_runpod_lane."""
+    import logging
+
+    from explore_persona_space.backends.router import (
+        ROUTE_REASON_CPU_EXHAUSTED_NO_RUNPOD,
+        CpuExhaustedNoRunpodLaneError,
+    )
+
+    rp = _PassiveRunpod()
+    gcp = _exhausted_gcp_double()
+    estimate_calls: list[BackendKind] = []
+
+    def recording_estimate(backend, kind, lane_spec):
+        estimate_calls.append(kind)
+        raise _slurm_estimate_valueerror(lane_spec.intent)
+
+    spec = RunSpec(issue=1464, intent="cpu-bigmem", backend="auto", time_budget_hours=1.0)
+    with (
+        caplog.at_level(logging.INFO, logger="explore_persona_space.backends.router"),
+        pytest.raises(CpuExhaustedNoRunpodLaneError),
+    ):
+        route(
+            spec,
+            runpod_backend=rp,
+            free_backends={
+                "nibi": _FreeLaneBackend(
+                    kind="nibi", launch_raises=RuntimeError("must never launch")
+                ),
+                "fir": _FreeLaneBackend(
+                    kind="fir", launch_raises=RuntimeError("must never launch")
+                ),
+            },
+            gcp_backend=gcp,
+            lease_store=lease_store,
+            estimate_fn=recording_estimate,
+            marker_poster=marker_poster,
+            config=RouterConfig(free_wait_seconds=1, poll_interval=0.0),
+            now_fn=_clock(),
+            sleep_fn=lambda _s: None,
+        )
+    # #677 contract byte-preserved: RunPod never attempted, typed reason posted.
+    assert len(rp.launches) == 0
+    cpu_terminals = _by_reason(captured_markers, ROUTE_REASON_CPU_EXHAUSTED_NO_RUNPOD)
+    assert cpu_terminals, captured_markers
+    # The exclusion held on the raise path too: no probes, no free-lane attempts.
+    assert estimate_calls == [], estimate_calls
+    free_attempts = [
+        (a["kind"], a["outcome"])
+        for a in cpu_terminals[-1]["attempts"]
+        if a["kind"] in ("nibi", "fir")
+    ]
+    assert not free_attempts, free_attempts
+    assert not any("treating as unranked" in r.message for r in caplog.records), [
+        r.message for r in caplog.records
+    ]
+
+
+def test_auto_route_gpu_intent_still_probes_slurm_lanes(lease_store, marker_poster):
+    """#1464 control: a GPU intent (lora-7b) with GCP exhausted still PROBES
+    the free lanes' est-starts and launches on nibi — the CPU-only exclusion
+    never fires for GPU intents (byte-identical auto behavior)."""
+    rp = _PassiveRunpod()
+    gcp = _exhausted_gcp_double()
+    nibi = _FreeLaneBackend(kind="nibi")
+    estimate_calls: list[BackendKind] = []
+
+    def recording_estimate(backend, kind, lane_spec):
+        estimate_calls.append(kind)
+        return 0.0
+
+    spec = RunSpec(issue=1464, intent="lora-7b", backend="auto", time_budget_hours=1.0)
+    result = route(
+        spec,
+        runpod_backend=rp,
+        free_backends={"nibi": nibi},
+        gcp_backend=gcp,
+        lease_store=lease_store,
+        estimate_fn=recording_estimate,
+        is_started=lambda _b, _h: True,
+        marker_poster=marker_poster,
+        config=RouterConfig(free_wait_seconds=2, poll_interval=0.0, max_gcp_attempts_per_day=99),
+        now_fn=_clock(),
+        sleep_fn=lambda _s: None,
+    )
+    # The free lane WAS probed and won the route.
+    assert "nibi" in estimate_calls, estimate_calls
+    assert result.chosen_kind == "nibi"
+    assert len(nibi.launches) == 1
+    assert len(rp.launches) == 0
+
+
+def test_is_cpu_only_intent_predicate():
+    """#1464: _is_cpu_only_intent is keyed on gcp.INTENT_TO_MACHINE gpu_count==0
+    via .get() — True for the three CPU intents; False (never a raise) for GPU
+    intents, non-GCP-mapped intents (ft-70b), and unknown strings."""
+    from explore_persona_space.backends.router import _is_cpu_only_intent
+
+    assert _is_cpu_only_intent("cpu-small") is True
+    assert _is_cpu_only_intent("cpu-mid") is True
+    assert _is_cpu_only_intent("cpu-bigmem") is True
+    assert _is_cpu_only_intent("lora-7b") is False
+    assert _is_cpu_only_intent("eval") is False
+    # No INTENT_TO_MACHINE row (RunPod-native / unknown): False, never a raise.
+    assert _is_cpu_only_intent("ft-70b") is False
+    assert _is_cpu_only_intent("totally-bogus") is False
+
+
+# ---------------------------------------------------------------------------
 # #774 round 2 — RouteAttempt.evidence carries the GCP per-zone fan-out to the
 # epm:backend-selected marker. A GcpProvisioningError whose evidence holds
 # per_zone_attempts must round-trip through the catch site -> _attempt_to_dict

--- a/tests/test_slurm_backend_render.py
+++ b/tests/test_slurm_backend_render.py
@@ -232,6 +232,32 @@ def test_default_gpus_unknown_intent_raises_instead_of_silent_default() -> None:
         default_gpus_for_intent(spec)
 
 
+@pytest.mark.parametrize("intent", ["cpu-small", "cpu-mid", "cpu-bigmem"])
+def test_cpu_intents_deliberately_absent_from_slurm_intent_tables(intent: str) -> None:
+    """#1464 (AC4): the CPU-only intents are DELIBERATELY absent from every
+    SLURM intent table — the lane serves GPU intents only (render_sbatch
+    scales --cpus-per-task / --mem from the GPU count, so a 0-GPU row would
+    render an invalid 0-CPU / 0G script). The router excludes the free lanes
+    for CPU-only intents at candidate assembly (router._is_cpu_only_intent);
+    an explicit SLURM pin keeps the loud fail-fast ValueErrors below. This
+    pins the design decision NOT to add 0-rows (the task body's half-fix
+    diff sketch must never be applied silently later)."""
+    from explore_persona_space.backends.slurm import (
+        _DEFAULT_GPUS_FOR_INTENT,
+        _DEFAULT_TIME_BUDGETS_HOURS,
+    )
+
+    assert intent not in _DEFAULT_GPUS_FOR_INTENT
+    assert intent not in _DEFAULT_TIME_BUDGETS_HOURS
+    spec = RunSpec(issue=1, intent=intent, backend="cluster", cluster="nibi")
+    with pytest.raises(ValueError, match="no default GPU count"):
+        default_gpus_for_intent(spec)
+    with pytest.raises(ValueError, match="no default time budget"):
+        time_budget_hours(spec)
+    with pytest.raises(ValueError, match="unsupported intent"):
+        stages_for_spec(spec)
+
+
 # ---------------------------------------------------------------------------
 # job_name + plan-hash
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes task #1464. Fork (c) per approved plan v3: private _is_cpu_only_intent predicate + _auto_route candidate-assembly skip; slurm.py comment-only pins; 5 tests incl. the #1336 regression (red-before verified). Code-review PASS r1; step9c gate 4610 passed / compare clean.