### PR TITLE
issue-1475: extend pre_reg audit — 7 head nouns + range-token widening

### DIFF
--- a/scripts/audit_clean_results_body_discipline.py
+++ b/scripts/audit_clean_results_body_discipline.py
@@ -102,13 +102,43 @@ PATTERNS: dict[str, tuple[str, str]] = {
         # defining the test' is the sanctioned Why-this-test CI-definition
         # register). (RUF001 noqa: the U+2212/U+2264/U+2265 in the token
         # class are the literal chars being matched, not homoglyphs.)
+        # #1475 (2026-07-17) extends the branch for the #1090 round-6
+        # escapes: seven head nouns added (cuts?/paths?/clauses?/
+        # controls?/levers?/bars?/smokes?) and the intervening-token
+        # continuation widened from (?:\.\d+)* to a group that also
+        # accepts '-' and the U+2212 minus sign as repeatable digit-run
+        # separators, so multi-dot / signed numeric range tokens
+        # ('0.60-0.85', and its U+2212 form) are consumable — the old
+        # group could not re-enter a separator after its first dot, so a
+        # range token hid the
+        # head noun after it. Digits-only continuations preserve
+        # the no-sentence-bridge property. Re-measured 2026-07-17 over
+        # all 1,374 completed/awaiting_promotion/archived/on_hold bodies
+        # (full-pattern old-vs-new match-start diff): 16 new hits —
+        # bar/bars 5, clause 4, control(s) 5, path 2, cut/lever/smoke 0
+        # — every one manually classified genuine Lens 7 jargon (the
+        # deciding question: does 'registered' here mean PRE-REGISTERED,
+        # regardless of surface grammar?), 0 benign verb-use false
+        # positives. OLD-minus-NEW starts: 0 (the leftmost
+        # 'pre-?registered' alternative keeps every old match start).
+        # cut/lever/smoke kept at zero corpus attestation: the recorded
+        # #1090 incident strings mandate them and their measured FP cost
+        # is zero. The raw-text scan is a SUPERSET of gate-visible hits,
+        # which cuts both ways: FP-conservative (frontmatter + code
+        # fences + table rows included), but the genuine-hit count
+        # OVERSTATES gate-visible coverage (scope-exempt table-row /
+        # fence hits are counted). The superset argument is contingent
+        # on the [ \t]+-only separators — a future \s widening would
+        # silently break it. 'test' and 'interval' remain deliberately
+        # absent (the sanctioned CI-definition register, see above).
         r"pre-?registered|pre-?registration|(?<![a-z])pre-reg(?![a-z])|registered hypothesis"
         r"|registered alpha|\bas registered\b|fail at the gate|passed the gate"
         r"|gate-pre-?registered"
         r"|\bregistered[ \t]+(?!(?:as|at|by|for|in|into|on|to|under|via|with)\b)"
-        r"(?:[\w%/<>=≤≥−+-]+(?:\.\d+)*[ \t]+){0,3}?"  # noqa: RUF001
+        r"(?:[\w%/<>=≤≥−+-]+(?:[.\-−]\d+)*[ \t]+){0,3}?"  # noqa: RUF001
         r"(?:verdicts?|lattices?|margins?|reads?|criteri(?:on|a)|thresholds?|bands?"
-        r"|gates?|rules?|endpoints?|contrasts?|floors?|companions?|hypothes[ei]s|alpha)\b",
+        r"|gates?|rules?|endpoints?|contrasts?|floors?|companions?|hypothes[ei]s|alpha"
+        r"|cuts?|paths?|clauses?|controls?|levers?|bars?|smokes?)\b",
         "Pre-registration jargon ('pre-registered', 'as registered', "
         "'fail at the gate', bare 'registered <verdict/margin/read/...>', etc.)",
     ),

--- a/tests/test_audit_clean_results_body_discipline.py
+++ b/tests/test_audit_clean_results_body_discipline.py
@@ -1083,6 +1083,34 @@ def test_pre_reg_bare_registered_noun_incident_strings_are_flagged():
         assert any("registered" in s.lower() for s in findings["pre_reg"]), (phrase, findings)
 
 
+def test_pre_reg_bare_registered_noun_1090_escape_strings_are_flagged():
+    """All eight #1090 round-6 escape strings trip `pre_reg` in v4 Results
+    prose (#1475). The two 'band' strings isolate the token-class widening
+    (`band` is a #1419 noun; only the widened token group lets the range
+    token '0.60-0.85' — ASCII hyphen, or its U+2212 minus-sign variant —
+    be consumed as an intervening token); the other six isolate the seven
+    nouns added by #1475 (cut/path/clause/control/lever/bar[/smoke])."""
+    phrases = [
+        "the registered 0.60-0.85 band",
+        "the registered 0.60−0.85 band",  # noqa: RUF001
+        "registered kill path",
+        "registered per-arm abort clause",
+        "registered 0.30 cut",
+        "registered install-strength control",
+        "registered unrun lever",
+        "registered 10% kill bar",
+    ]
+    for phrase in phrases:
+        body = V4_BODY_CLEAN.replace(
+            "The lift holds at every seed in the held-out evaluation.",
+            f"{phrase}.",
+        )
+        assert body != V4_BODY_CLEAN
+        findings = audit.audit_body(body)
+        assert "pre_reg" in findings, (phrase, findings)
+        assert any("registered" in s.lower() for s in findings["pre_reg"]), (phrase, findings)
+
+
 def test_pre_reg_bare_registered_noun_in_v4_takeaways_is_flagged():
     """Incident 1's actual placement (#1345 Takeaways bullet 2) trips
     `pre_reg` under the v4 whole-body scope."""
@@ -1131,11 +1159,29 @@ def test_pre_reg_bare_registered_noun_does_not_bridge_sentences():
     """The intervening-token window never bridges a sentence or bullet
     boundary — both bridge shapes observed in the plan-time corpus dry-run
     ('registered conditions.\\n\\nThe honest read', 'registered unrun
-    lever.\\n- Verdicts') stay clean."""
+    dial.\\n- Verdicts') stay clean. NOTE (#1475): the second fixture
+    originally used 'lever', chosen when `lever` was unlisted; #1475 moved
+    `levers?` into the head-noun list (making it a genuine WITHIN-sentence
+    hit), so the fixture now exercises the same boundary property with the
+    non-listed noun 'dial'."""
     body = V4_BODY_CLEAN.replace(
         "The lift holds at every seed in the held-out evaluation.",
         "All cells were registered conditions.\n\nThe honest read is a null.\n\n"
-        "It used a registered unrun lever.\n- Verdicts fired on every cell.",
+        "It used a registered unrun dial.\n- Verdicts fired on every cell.",
+    )
+    assert body != V4_BODY_CLEAN
+    findings = audit.audit_body(body)
+    assert "pre_reg" not in findings, findings
+
+
+def test_pre_reg_new_nouns_benign_verb_usages_not_flagged():
+    """Benign verb-register shapes for the highest-FP-risk #1475 noun
+    (`paths?`) stay clean: noun-BEFORE-verb ('the adapter paths registered
+    on HF') and the first-token preposition-guard shape ('registered on HF
+    under paths/')."""
+    body = V4_BODY_CLEAN.replace(
+        "The lift holds at every seed in the held-out evaluation.",
+        "the adapter paths registered on HF; artifacts registered on HF under paths/.",
     )
     assert body != V4_BODY_CLEAN
     findings = audit.audit_body(body)


### PR DESCRIPTION
Closes task #1475 (workflow-fix: pre_reg audit — verdict-lattice head nouns + range tokens escape). Plan: tasks/*/1475/plans/v3.md. Corpus re-measure: 1,374 bodies / 16 new hits / 0 benign FPs.