### PR TITLE
issue-1471: extend #1404 EPS-ownership gate to all EXITED pods

### DIFF
--- a/.claude/rules/background-automation.md
+++ b/.claude/rules/background-automation.md
@@ -24,19 +24,22 @@ Auto-terminate pods EXITED >24h — EXEMPT when the owning task carries the
 `keep-running` tag, reported as `kept-exited` instead.
 
 **Team-shared account — the EXITED auto-terminate is positively
-ownership-gated (#1404).** The RunPod account is TEAM-SHARED: non-EPS
-teammates may legitimately run pods whose names carry the managed `pod-`
-prefix, so a managed-looking name is NOT proof of EPS ownership. The
+ownership-gated for EVERY pod name (#1404, extended by #1471).** The
+RunPod account is TEAM-SHARED: non-EPS teammates may legitimately run
+pods whose names carry the managed `pod-` prefix, so NO name — managed
+`pod-` prefix or not — is proof of EPS ownership. The
 EXITED>24h auto-terminate fires only when `_is_eps_owned`
 (`scripts/pod_audit.py`) POSITIVELY confirms EPS ownership via any one of
 three signals — the parsed issue number resolves in `tasks/REGISTRY.json`,
 the pod appears in the `pods_ephemeral.json` sidecar, or
 `_scan_task_references` finds task references — each wrapped
-fail-toward-keep (a raising signal never asserts ownership). An EXITED
-managed-name pod that fails all three surfaces REPORT-ONLY in the
+fail-toward-keep (a raising signal never asserts ownership). ANY EXITED
+pod that fails all three surfaces REPORT-ONLY in the
 `unmanaged-exited` bucket (rendered with a "NEVER auto-terminated"
 advisory), never auto-terminated; termination there is the user's call
-after confirming ownership.
+after confirming ownership. EPS-owned odd-named pods
+(dispatcher-created) still auto-reap via the sidecar / task-reference
+signals.
 
 ## Stale-GCP-VM janitor (09:37 daily, `cron_gcp_audit.sh` → `gcp_audit.py`)
 

--- a/scripts/cron_pod_audit.sh
+++ b/scripts/cron_pod_audit.sh
@@ -8,13 +8,14 @@
 #   - EXITED pods older than 24h are auto-terminated (volume disk charges) —
 #     UNLESS the owning task (from the pod-<N> / epm-issue-<N> name) carries
 #     the keep-running tag; those are reported as kept-exited, never killed.
-#   - The auto-terminate is positively OWNERSHIP-GATED (#1404): the RunPod
-#     account is team-shared, so a non-EPS pod may legitimately carry the
-#     managed pod- prefix. _is_eps_owned (pod_audit.py) must confirm EPS
-#     ownership via any one of: issue in tasks/REGISTRY.json, pod in the
-#     pods_ephemeral.json sidecar, or task references (fail-toward-keep).
-#     EXITED pods NOT positively EPS-owned are surfaced report-only as
-#     unmanaged-exited — NEVER auto-terminated.
+#   - The auto-terminate is positively OWNERSHIP-GATED (#1404, extended to
+#     all names by #1471): the RunPod account is team-shared, so a non-EPS
+#     pod may legitimately carry the managed pod- prefix; the gate applies
+#     to every EXITED pod regardless of name. _is_eps_owned (pod_audit.py)
+#     must confirm EPS ownership via any one of: issue in
+#     tasks/REGISTRY.json, pod in the pods_ephemeral.json sidecar, or task
+#     references (fail-toward-keep). EXITED pods NOT positively EPS-owned
+#     are surfaced report-only as unmanaged-exited — NEVER auto-terminated.
 #   - RUNNING pods with non-canonical names are surfaced in the log but NOT
 #     auto-terminated (could be a real in-flight workload).
 #   - Two REPORT-ONLY flags are surfaced in the log (never auto-acted on,

--- a/scripts/pod_audit.py
+++ b/scripts/pod_audit.py
@@ -12,11 +12,13 @@ existence. A pod is:
 - **active**: ``RUNNING`` AND managed-name (the lifecycle owns it).
 - **orphan-running**: ``RUNNING`` AND non-managed-name. GPU charges accruing
   without lifecycle tracking — surface loudly.
-- **stale**: ``EXITED`` for longer than ``--max-exited-hours`` (default 24h).
-  Volume disk charges accruing for paused state. Candidate for termination.
+- **stale**: ``EXITED`` for longer than ``--max-exited-hours`` (default 24h)
+  AND positively confirmed as EPS-owned (#1404, extended to all names by
+  #1471). Volume disk charges accruing for paused state. Candidate for
+  termination.
 - **unmanaged-exited**: ``EXITED`` past the threshold BUT NOT positively
-  confirmed as EPS-owned (managed-name pods only — the RunPod account is
-  team-shared, so a non-EPS pod may carry the ``pod-`` prefix; #1404).
+  confirmed as EPS-owned — ANY name, managed ``pod-`` prefix or not (the
+  RunPod account is team-shared; #1404/#1471).
   Report-only; NEVER consumed by ``--terminate-stale``.
 - **kept-exited**: ``EXITED`` but the owning task (resolved from the managed
   pod name ``pod-<N>`` / ``epm-issue-<N>``) carries the ``keep-running`` tag —
@@ -51,7 +53,9 @@ Exit codes::
 
 (The report-only flag classes deliberately do NOT affect the exit code —
 ``cron_pod_audit.sh`` treats the log as the audit trail and an idle CPU
-phase is not an audit failure.)
+phase is not an audit failure. ``unmanaged-exited`` likewise never trips
+exit 2: an odd-named, evidence-less ``EXITED``>threshold pod surfaces
+report-only with exit 0 — #1471.)
 
 The ``--terminate-stale`` flag terminates every pod in the ``stale`` bucket
 after a y/N confirmation (suppress with ``--yes``). ``orphan-running`` pods
@@ -218,7 +222,8 @@ def _is_eps_owned(p: PodInfo, pod_id: str) -> bool:
     ``--terminate-stale``. The bias is deliberate: a false keep costs
     nothing (report-only bucket); a false terminate destroys a volume
     irreversibly — the RunPod account is TEAM-SHARED, so a non-EPS pod may
-    carry the managed ``pod-`` prefix.
+    carry ANY name, the managed ``pod-`` prefix included; as of #1471 this
+    gate applies to every EXITED pod past the threshold regardless of name.
     """
     name = p.name or ""
 
@@ -388,16 +393,17 @@ def classify(
                 bucket = "kept-exited"
                 kept_for = issue
             elif age is not None and age >= max_exited_hours:
-                # #1404 ownership gate: only pods POSITIVELY confirmed as
-                # EPS-owned may reach the auto-terminate 'stale' bucket. The
-                # RunPod account is team-shared, so a non-EPS pod can carry
-                # the managed 'pod-' prefix; terminating it would destroy a
-                # teammate's volume irreversibly. Non-managed names keep the
-                # pre-#1404 behavior (no name-collision hazard there).
-                if _is_managed_name(p.name or "") and not _is_eps_owned(p, p.pod_id or ""):
-                    bucket = "unmanaged-exited"
-                else:
-                    bucket = "stale"
+                # #1404 ownership gate, extended to ALL names (#1471): a pod
+                # may reach the auto-terminate 'stale' bucket ONLY when
+                # POSITIVELY confirmed as EPS-owned. The RunPod account is
+                # team-shared — a non-EPS pod may carry ANY name, managed
+                # 'pod-' prefix or not; terminating it would destroy a
+                # teammate's volume irreversibly. EPS-owned odd-named pods
+                # (dispatcher-created) still auto-reap via ownership signals
+                # 2 (pods_ephemeral.json sidecar) and 3 (task references).
+                # Fail-toward-keep: a false keep = small volume-storage cost
+                # + a loud daily report row; a false terminate = irreversible.
+                bucket = "stale" if _is_eps_owned(p, p.pod_id or "") else "unmanaged-exited"
             else:
                 bucket = "fresh-exited"
             # Report-only parked-task flag: the stopped volume keeps billing
@@ -505,9 +511,9 @@ def render_report(rows: list[Classification]) -> str:
     if unmanaged_exited:
         lines.append("")
         lines.append("── unmanaged-exited (report-only; NEVER auto-terminated) ──")
-        lines.append("  EXITED past the threshold but NOT positively confirmed as EPS-owned. The")
-        lines.append("  RunPod account is TEAM-SHARED: non-EPS pods may carry the managed pod-")
-        lines.append("  prefix. Do NOT terminate without confirming ownership with Thomas.")
+        lines.append("  EXITED past the threshold but NOT positively confirmed as EPS-owned —")
+        lines.append("  any name, managed pod- prefix or not (the RunPod account is TEAM-SHARED).")
+        lines.append("  Do NOT terminate without confirming ownership with Thomas.")
         for r in unmanaged_exited:
             age = f"{r.age_hours:.1f}h" if r.age_hours is not None else "?"
             gpu = f"{r.pod.gpu_count}x{r.pod.gpu_type_id}" if r.pod.gpu_count else "?"

--- a/tests/test_pod_audit.py
+++ b/tests/test_pod_audit.py
@@ -2,7 +2,8 @@
 
 The daily stale-pod audit (``cron_pod_audit.sh`` → ``pod.py audit-stale
 --terminate-stale --yes``) auto-terminates every EXITED pod older than
-24h. The ``keep-running`` tag on the owning task is the workflow's
+24h, ownership-gated for every name (#1404/#1471). The ``keep-running``
+tag on the owning task is the workflow's
 documented pod-preservation override (CLAUDE.md, /issue Step 8), so
 ``classify()`` must bucket such pods as ``kept-exited`` — reported, never
 consumed by ``--terminate-stale`` — instead of ``stale``.
@@ -165,6 +166,8 @@ def test_tag_exemption_applies_to_legacy_names(monkeypatch: pytest.MonkeyPatch):
 
 def test_unparseable_name_falls_through_to_stale(monkeypatch: pytest.MonkeyPatch):
     # Tag lookup must never be consulted for a name that doesn't parse.
+    # ownership is fixture-True here; the #1471 any-name gate is exercised
+    # in the gate section below.
     def boom(issue: int) -> bool:
         raise AssertionError("tag lookup called for unparseable name")
 
@@ -457,13 +460,14 @@ def test_flags_do_not_affect_exit_code(monkeypatch: pytest.MonkeyPatch):
     assert rc == 0
 
 
-# ── #1404 EPS-ownership gate (unmanaged-exited bucket) ──────────────────────
+# ── #1404 EPS-ownership gate (unmanaged-exited bucket; all names, #1471) ────
 #
-# The RunPod account is TEAM-SHARED: a non-EPS pod may carry the managed
-# ``pod-`` prefix. An EXITED pod past the threshold reaches the auto-terminate
-# ``stale`` bucket ONLY when positively confirmed as EPS-owned; otherwise it
-# lands in the report-only ``unmanaged-exited`` bucket and is NEVER consumed
-# by ``--terminate-stale``. Every lookup failure fails toward KEEP.
+# The RunPod account is TEAM-SHARED: a non-EPS pod may carry ANY name, the
+# managed ``pod-`` prefix included. An EXITED pod past the threshold reaches
+# the auto-terminate ``stale`` bucket ONLY when positively confirmed as
+# EPS-owned; otherwise it lands in the report-only ``unmanaged-exited``
+# bucket and is NEVER consumed by ``--terminate-stale``. Every lookup
+# failure fails toward KEEP.
 
 
 def _raise_missing(issue: int):
@@ -553,9 +557,53 @@ def test_eps_owned_pod_still_reaches_stale_normally(
     assert row.bucket == "stale"
 
 
-def test_non_managed_name_keeps_stale_without_ownership(monkeypatch: pytest.MonkeyPatch, tmp_path):
-    """A non-managed name has no collision hazard — pre-#1404 stale behavior holds."""
+def test_non_managed_name_without_ownership_never_auto_terminated(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    """#1471: the ownership gate applies to EVERY name — a non-managed EXITED
+    pod without positive EPS evidence routes to unmanaged-exited, never stale,
+    and --terminate-stale never consumes it (fail-toward-keep on the
+    team-shared account)."""
     _no_ownership(monkeypatch, tmp_path)
+    (row,) = classify(
+        [_pod("my-custom-pod", created_at=OLD)],
+        max_exited_hours=24,
+        min_orphan_running_hours=1,
+    )
+    assert row.bucket == "unmanaged-exited"
+
+    # End-to-end: --terminate-stale must never consume it (Durability pin, #1471).
+    monkeypatch.setattr(
+        pod_audit, "list_team_pods", lambda: [_pod("my-custom-pod", created_at=OLD)]
+    )
+    terminated: list[str] = []
+    monkeypatch.setattr(pod_audit, "terminate_pod", terminated.append)
+    rc = pod_audit.main(["--terminate-stale", "--yes"])
+    assert terminated == []
+    assert rc == 0  # not stale, not orphan — no audit-finding exit code
+
+
+@pytest.mark.parametrize("signal", ["ephemeral-pod-id", "ephemeral-name", "task-refs"])
+def test_non_managed_name_with_eps_evidence_still_reaches_stale(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, signal: str
+):
+    """#1471: an EPS-owned odd-named pod (dispatcher-created) still auto-reaps
+    via ownership signals 2 (sidecar) and 3 (task references). Signal 1 cannot
+    fire for an unparseable name by construction."""
+    monkeypatch.setattr(pod_audit, "_is_eps_owned", _REAL_IS_EPS_OWNED)
+    monkeypatch.setattr(pod_audit, "get_task", _raise_missing)  # signal 1 miss
+    sidecar = tmp_path / "absent.json"  # default: signal 2 misses
+    if signal == "ephemeral-pod-id":
+        sidecar = tmp_path / "pods_ephemeral.json"
+        entry = {"name": "some-other-name", "pod_id": "id-my-custom-pod"}
+        sidecar.write_text(json.dumps({"version": 2, "pods": {"x": entry}}))
+    elif signal == "ephemeral-name":
+        sidecar = tmp_path / "pods_ephemeral.json"
+        entry = {"name": "my-custom-pod", "pod_id": "zzz-unrelated"}
+        sidecar.write_text(json.dumps({"version": 2, "pods": {"x": entry}}))
+    elif signal == "task-refs":
+        monkeypatch.setattr(pod_audit, "_scan_task_references", lambda pod_id, name: [1471])
+    monkeypatch.setattr(pod_config, "PODS_EPHEMERAL_JSON", sidecar)
     (row,) = classify(
         [_pod("my-custom-pod", created_at=OLD)],
         max_exited_hours=24,


### PR DESCRIPTION
Closes task #1471. Extends the stale-pod audit's EPS-ownership gate (scripts/pod_audit.py) so every EXITED>24h pod requires positive EPS-ownership evidence to reach the auto-terminate stale bucket; evidence-less pods surface report-only as unmanaged-exited. Plan APPROVE x3 + consistency PASS; code-review PASS; test-verdict PASS (3806 green, compare clean).