### PR TITLE
issue-1480: stalled-manual escalation rung (#1480)

### DIFF
--- a/.claude/rules/background-automation.md
+++ b/.claude/rules/background-automation.md
@@ -221,8 +221,8 @@ triage-observer pass, and three session reapers — the session-vs-status
 reconcile pass, the zombie-wrapper pass, and the idle-unmapped pass.
 
 **Stall-detection hardening (#845; the five 2026-07-01 incident classes).**
-The stalled detector + the two respawn arms carry six hardening mechanisms
-(five from #845, the sixth from #1137):
+The stalled detector + the two respawn arms carry seven hardening mechanisms
+(five from #845, the sixth from #1137, the seventh from #1480):
 
 - *(a-i) Marker-heartbeat window.* Signal 2 (the newest non-watcher marker)
   has its OWN 2h freshness window (`EPM_STALLED_MARKER_HEARTBEAT_MIN`,
@@ -424,8 +424,33 @@ The stalled detector + the two respawn arms carry six hardening mechanisms
   escalation is by design — changing it would change respawn timing;
   only the marker noise was removed). Respawn/fence/hold semantics
   byte-identical.
+- *(g) Stalled-manual escalation rung (#1480).* A MANUAL registration
+  (`manual-issue-<N>.json`) on an ACTIVE-status task whose one-time (f)
+  alert has gone UNACTIONED — ≥ `EPM_STALLED_MANUAL_ESCALATE_CONFIRMS`
+  (default 3) consecutive stalled-confirmed ticks spanning ≥
+  `EPM_STALLED_MANUAL_ESCALATE_H` (default 24h) from the FIRST
+  confirmation (stall onset — alert time is not persisted, the (f) dedup)
+  with zero non-watcher task progress (consecutiveness × the 2h marker
+  window) — escalates to an UNREGISTER-ONLY action: the manual
+  registration file is deleted (the session itself is NEVER stopped or
+  respawned — #505 stands) plus a loud
+  `[autonomous_session_watch:stalled-manual-escalation]` marker, a sidecar
+  row (`~/.eps-autonomous/stalled-manual-escalation-events.jsonl`), and a
+  Telegram push; the registration-independent orphan sweep then re-drives
+  the task on its next stale tick (~20–30 min; incident #928: a wedged
+  manual session froze a `followups_running` task for ~6 days). Two
+  fire-time vetoes: fresh worktree activity DEFERS (counters kept), and
+  the park-exemption re-probe (user-pause / spend-approval /
+  provision-in-flight / long-phase heartbeat / round-complete re-park /
+  awaiting-child) VETOES + resets the counters. Once per episode by
+  construction (the fire resets the counters; a re-registration starts a
+  fresh accumulation; the counters are advancement-cleared like every
+  #845 field). Autonomous `issue-<N>.json` entries never enter the rung;
+  every unresolvable input fails toward keep (today's alert-only
+  behavior). Kill switch: `EPM_DISABLE_STALLED_MANUAL_ESCALATION=1`.
 
-Per-episode state for all five rides `stalled-<N>.json`
+Per-episode state for all of these — incl. the (g) counters
+`manual_escalate_count` / `manual_escalate_first_ts` — rides `stalled-<N>.json`
 (`stop_pending_sid`/`stop_pending_ts`/`stop_retried`/`stop_failed_alerted`,
 `wt_hold_count`, `daemon_blocked_ticks`/`daemon_blocked_pushed`,
 `wedge_hits`), cleared on self-report advancement; pre-#845 files load with
@@ -781,6 +806,11 @@ adjacent to the two session reapers, consuming their shared daemon
 session-list snapshot in place; daemon-gated (`children is None` ⇒ no-op). Unregistering
 deletes the entry, which is self-deduping; a fresh re-registration restarts
 the clock. Durable trace: `~/.eps-autonomous/stale-registration-events.jsonl`.
+The #1480 stalled-manual escalation rung (§ Stall-detection hardening, (g))
+covers the LIVE-WEDGED manual case this pass's transcript-idle gate cannot:
+a wedged session with ANY transcript activity (user pokes, in-session cron
+ticks) defeats the 12h transcript-idle predicate indefinitely, while the
+rung keys on TASK-level progress (self-report + non-watcher markers).
 
 **Boot-death lane (#1267 arm 1 + #1287 arm 2, `boot_death_pass`).** The
 die-at-or-before-turn-1 complement of the stale-registration pass: a freshly

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -110,7 +110,13 @@ adding a pass means adding a numbered item here AND bumping the digit:
    is posted per staleness episode across both alert producers (decide's
    own alert path and the #759 downgrade lane), and a deliberately-parked
    ``blocked`` task (epm:failure + status-changed halt-contract trail) is
-   never alerted (#1137).
+   never alerted (#1137).  A MANUAL registration on an ACTIVE task whose
+   one-time alert stays unactioned — >= 3 consecutive stalled-confirmed
+   ticks spanning >= 24h from the first confirmation with zero non-watcher
+   task progress — escalates to an UNREGISTER-ONLY action (#1480): the
+   manual registration file is deleted (the session is NEVER stopped) so
+   the registration-independent orphan sweep re-drives the task; kill
+   switch ``EPM_DISABLE_STALLED_MANUAL_ESCALATION``.
 5. **Orphan sweep (registration-INDEPENDENT safety net).** Every other
    session pass starts from the registry files (``issue-<N>.json`` /
    ``manual-issue-<N>.json``), so an ACTIVE-status task with NO registration
@@ -987,6 +993,16 @@ _STALLED_DEAD_SILENCE_STOP_NOTE_SENTINEL = "[autonomous_session_watch:session-de
 # ownership re-check protects a later wake). Same staleness-filter contract.
 _STALE_REGISTRATION_NOTE_SENTINEL = "[autonomous_session_watch:stale-registration-unregister]"
 
+# Substring stamped into the one-time marker posted by the #1480 stalled-MANUAL
+# escalation rung when an unactioned stalled alert on a manual registration
+# (``manual-issue-<N>.json``) holding an ACTIVE task escalates to an
+# UNREGISTER-ONLY action (the session itself is NEVER stopped — #505; the
+# registration-independent orphan sweep then re-drives the task). MUST stay a
+# member of :data:`_WATCHER_NOTE_SENTINELS`: the fire marker would otherwise
+# reset ``_latest_nonwatcher_event_ts`` and push the orphan sweep's staleness
+# clock back ~90 min, delaying the very re-drive the rung exists to enable.
+_STALLED_MANUAL_ESCALATION_NOTE_SENTINEL = "[autonomous_session_watch:stalled-manual-escalation]"
+
 # Substring stamped into the one-time VM-disk-low marker posted by the vm-disk
 # pass (once per low-disk episode, on each ACTIVE registered autonomous issue —
 # the sessions that will die first when / fills up). Same staleness-filter
@@ -1325,6 +1341,7 @@ _WATCHER_NOTE_SENTINELS: frozenset[str] = frozenset(
         _STALLED_EXHAUSTED_NOTE_SENTINEL,
         _STALLED_STOP_FAILED_NOTE_SENTINEL,
         _STALLED_DEAD_SILENCE_STOP_NOTE_SENTINEL,
+        _STALLED_MANUAL_ESCALATION_NOTE_SENTINEL,
         _STALE_REGISTRATION_NOTE_SENTINEL,
         _VM_DISK_NOTE_SENTINEL,
         _ORPHAN_RESPAWN_NOTE_SENTINEL,
@@ -1837,6 +1854,61 @@ STALLED_STATE_MAX_AGE_S = POD_SAFETY_STATE_MAX_AGE_S
 # advance (mirrors the existing alerted-flag clear logic). After exhaustion
 # the pass falls back to a one-time loud marker + leaves it for the user.
 STALLED_MAX_RESPAWNS = 3
+
+# #1480 stalled-manual escalation rung — see _apply_stalled_manual_escalation.
+# Defaults: an unactioned stalled alert on a MANUAL registration escalates to
+# the unregister-only action after >= 3 consecutive stalled-confirmed ticks
+# spanning >= 24h with zero non-watcher task progress. The 24h window doubles
+# the #845 stale-registration precedent (that pass requires 12h TRANSCRIPT
+# idle; this rung deliberately drops the transcript gate, so it earns a
+# longer fuse) and beats the #928 6-day freeze by ~5.7x; K=3 follows the
+# watcher's 3-consecutive convention (#1104/#1127/#1241 lineage).
+STALLED_MANUAL_ESCALATE_WINDOW_S_DEFAULT = 24 * 3600
+STALLED_MANUAL_ESCALATE_CONFIRMS_DEFAULT = 3
+
+
+def _stalled_manual_escalation_enabled() -> bool:
+    """Kill switch: False when ``EPM_DISABLE_STALLED_MANUAL_ESCALATION`` is
+    set truthy ("1"/"true"/"yes", case-insensitive). Default enabled (armed).
+    Mirrors :func:`_boot_death_pass_enabled`."""
+    raw = os.environ.get("EPM_DISABLE_STALLED_MANUAL_ESCALATION", "").strip().lower()
+    return raw not in {"1", "true", "yes"}
+
+
+def _stalled_manual_escalate_window_s() -> float:
+    """Escalation window in seconds (env ``EPM_STALLED_MANUAL_ESCALATE_H``,
+    HOURS; default :data:`STALLED_MANUAL_ESCALATE_WINDOW_S_DEFAULT`).
+    Malformed / non-positive env falls back — a typo'd var must not turn the
+    rung into an instant unregisterer (the :func:`_stale_registration_idle_s`
+    contract)."""
+    raw = os.environ.get("EPM_STALLED_MANUAL_ESCALATE_H")
+    if not raw:
+        return float(STALLED_MANUAL_ESCALATE_WINDOW_S_DEFAULT)
+    try:
+        parsed = float(raw) * 3600.0
+    except ValueError:
+        return float(STALLED_MANUAL_ESCALATE_WINDOW_S_DEFAULT)
+    if parsed <= 0:
+        return float(STALLED_MANUAL_ESCALATE_WINDOW_S_DEFAULT)
+    return parsed
+
+
+def _stalled_manual_escalate_confirms() -> int:
+    """Minimum consecutive stalled confirmations before the rung may fire
+    (env ``EPM_STALLED_MANUAL_ESCALATE_CONFIRMS``; default
+    :data:`STALLED_MANUAL_ESCALATE_CONFIRMS_DEFAULT`). Malformed / < 1 falls
+    back to the default (never a stealth kill switch — the disable var is the
+    only off switch)."""
+    raw = os.environ.get("EPM_STALLED_MANUAL_ESCALATE_CONFIRMS")
+    if not raw:
+        return STALLED_MANUAL_ESCALATE_CONFIRMS_DEFAULT
+    try:
+        parsed = int(raw)
+    except ValueError:
+        return STALLED_MANUAL_ESCALATE_CONFIRMS_DEFAULT
+    if parsed < 1:
+        return STALLED_MANUAL_ESCALATE_CONFIRMS_DEFAULT
+    return parsed
 
 
 def decide_session_stalled(
@@ -2670,6 +2742,71 @@ def decide_stale_registration(
     if self_report_age_s is not None and self_report_age_s < idle_threshold_s:
         return "keep"
     return "unregister"
+
+
+def decide_stalled_manual_escalation(
+    *,
+    in_active: bool,
+    alerted: bool,
+    stale_confirmed: bool,
+    confirm_count: int,
+    first_confirm_ts: float | None,
+    now: float,
+    min_confirms: int,
+    min_window_s: float,
+) -> tuple[str, int, float | None]:
+    """Pure per-tick decision for the #1480 stalled-manual escalation rung.
+
+    Returns ``(verdict, new_count, new_first_ts)``; verdict in
+    ``{"escalate", "count", "reset"}``.
+
+    Window semantics (S1): the escalation window is anchored at STALL ONSET —
+    ``first_confirm_ts`` is the pass-clock timestamp of the FIRST stalled
+    confirmation in the current consecutive run, NOT the alert time (the
+    #1137 dedup makes posted alerts uncountable, and alert time is not
+    persisted). With the alert firing ~2 ticks after onset, the realized
+    wait-after-alert is ~``min_window_s`` minus ~20 min — conservative in
+    the safe direction (never shorter than intended relative to onset).
+
+    - NOT ``stale_confirmed`` (self-report fresh, or any non-watcher marker
+      within the 2h marker window) OR NOT ``in_active`` ->
+      ``("reset", 0, None)``: the consecutive chain broke / the task left
+      the trap shape. A fresh non-watcher marker therefore resets the whole
+      accumulation — the "zero non-watcher task progress" condition is
+      enforced by consecutiveness x the 2h marker window at 10-min tick
+      granularity.
+    - ``stale_confirmed`` AND ``in_active`` -> ``count' = confirm_count + 1``;
+      ``first'`` = ``first_confirm_ts`` iff it is a positive, non-future
+      float, else ``now`` (a malformed / missing / FUTURE-dated anchor —
+      clock skew or a corrupt state file — restarts the window at ``now``:
+      fail toward keep, never an instant fire).
+
+      - ``alerted`` AND ``count' >= min_confirms`` AND
+        ``(now - first') >= min_window_s`` -> ``("escalate", count', first')``.
+      - else -> ``("count", count', first')``. Pre-alert confirmations
+        accumulate but can never fire (``alerted`` is required at fire time:
+        the trigger is an UNACTIONED alert).
+
+    Every input the caller could not resolve is mapped by the CALLER to the
+    conservative value (``in_active=False`` on a ``None`` status read;
+    ``stale_confirmed=False`` when ``self_report_age`` is ``None``), so this
+    function stays total and clock-free (``now`` is injected — the #1127
+    deterministic-anchor posture).
+    """
+    if not stale_confirmed or not in_active:
+        return ("reset", 0, None)
+    new_count = confirm_count + 1
+    if (
+        isinstance(first_confirm_ts, int | float)
+        and float(first_confirm_ts) > 0
+        and float(first_confirm_ts) <= now
+    ):
+        new_first: float = float(first_confirm_ts)
+    else:
+        new_first = now
+    if alerted and new_count >= min_confirms and (now - new_first) >= min_window_s:
+        return ("escalate", new_count, new_first)
+    return ("count", new_count, new_first)
 
 
 def decide_boot_death(
@@ -7349,6 +7486,8 @@ def _save_stalled_state(
     daemon_blocked_ticks: int = 0,
     daemon_blocked_pushed: bool = False,
     wedge_hits: int = 0,
+    manual_escalate_count: int = 0,
+    manual_escalate_first_ts: float | None = None,
     dead_silence_respawn_day: str | None = None,
     dead_silence_respawns_today: int = 0,
     wedge_respawn_day: str | None = None,
@@ -7357,6 +7496,16 @@ def _save_stalled_state(
 ) -> None:
     """Persist the per-session stalled-detector state atomically (temp +
     rename), mirroring :func:`_save_pod_safety_state`.
+
+    #1480 stalled-manual escalation fields: ``manual_escalate_count`` is the
+    number of CONSECUTIVE stalled-confirmed ticks observed for a MANUAL
+    registration this episode; ``manual_escalate_first_ts`` is the pass-clock
+    epoch of the FIRST confirmation in the current consecutive run (the
+    escalation-window anchor — stall onset, not alert time). Both ride the
+    #845 hardening-field contract (advancement-cleared via
+    :func:`_stalled_hardening_fields`: session resumed => trap over => a
+    re-registered manual session starts a fresh accumulation); absent in
+    older on-disk files -> ``(0, None)`` (backward compatible).
 
     #1209 day-cap fields: ``dead_silence_respawn_day`` (UTC ``%Y-%m-%d``
     key) + ``dead_silence_respawns_today`` count the fence episodes the
@@ -7445,6 +7594,8 @@ def _save_stalled_state(
         "daemon_blocked_ticks": daemon_blocked_ticks,
         "daemon_blocked_pushed": daemon_blocked_pushed,
         "wedge_hits": wedge_hits,
+        "manual_escalate_count": manual_escalate_count,
+        "manual_escalate_first_ts": manual_escalate_first_ts,
         "dead_silence_respawn_day": dead_silence_respawn_day,
         "dead_silence_respawns_today": dead_silence_respawns_today,
         "wedge_respawn_day": wedge_respawn_day,
@@ -7466,6 +7617,10 @@ _STALLED_HARDENING_DEFAULTS: dict[str, object] = {
     "daemon_blocked_ticks": 0,
     "daemon_blocked_pushed": False,
     "wedge_hits": 0,
+    # #1480 stalled-manual escalation rung — episode-scoped exactly like the
+    # #845 fields (advancement-clear: session resumed => trap over).
+    "manual_escalate_count": 0,
+    "manual_escalate_first_ts": None,
 }
 
 
@@ -7484,6 +7639,7 @@ def _stalled_hardening_fields(prev_state: dict, advanced: bool) -> dict:
 
     sid = prev_state.get("stop_pending_sid")
     ts = prev_state.get("stop_pending_ts")
+    first_ts = prev_state.get("manual_escalate_first_ts")
     return {
         "stop_pending_sid": sid if isinstance(sid, str) and sid else None,
         "stop_pending_ts": float(ts) if isinstance(ts, int | float) else None,
@@ -7493,6 +7649,10 @@ def _stalled_hardening_fields(prev_state: dict, advanced: bool) -> dict:
         "daemon_blocked_ticks": _int("daemon_blocked_ticks"),
         "daemon_blocked_pushed": bool(prev_state.get("daemon_blocked_pushed", False)),
         "wedge_hits": _int("wedge_hits"),
+        "manual_escalate_count": _int("manual_escalate_count"),
+        "manual_escalate_first_ts": (
+            float(first_ts) if isinstance(first_ts, int | float) else None
+        ),
     }
 
 
@@ -10712,6 +10872,8 @@ class _StalledActionCtx:
         daemon_blocked_ticks: int = 0,
         daemon_blocked_pushed: bool = False,
         wedge_hits: int = 0,
+        manual_escalate_count: int = 0,
+        manual_escalate_first_ts: float | None = None,
         wedge_note: str | None = None,
         daemon_reachable: bool = True,
         downgrade_note: str | None = None,
@@ -10789,6 +10951,13 @@ class _StalledActionCtx:
         self.daemon_blocked_ticks = daemon_blocked_ticks
         self.daemon_blocked_pushed = daemon_blocked_pushed
         self.wedge_hits = wedge_hits
+        # #1480 stalled-manual escalation counters (episode-scoped, threaded
+        # from the hardening fields like the #845 set above; MUTATED by
+        # _apply_stalled_manual_escalation to the values THIS tick must
+        # persist — every persist site forwards them via _persist_stalled_ctx
+        # so keep-path saves never wipe the accumulation).
+        self.manual_escalate_count = manual_escalate_count
+        self.manual_escalate_first_ts = manual_escalate_first_ts
         self.wedge_note = wedge_note
         # #1071 evidence-based alert reasons: ``daemon_reachable`` is the
         # pass-level flag (computed once per tick) and ``downgrade_note`` is
@@ -10847,6 +11016,8 @@ def _persist_stalled_ctx(ctx: _StalledActionCtx, sid: str | None, missed: int, *
         daemon_blocked_ticks=ctx.daemon_blocked_ticks,
         daemon_blocked_pushed=ctx.daemon_blocked_pushed,
         wedge_hits=ctx.wedge_hits,
+        manual_escalate_count=ctx.manual_escalate_count,
+        manual_escalate_first_ts=ctx.manual_escalate_first_ts,
         dead_silence_respawn_day=ctx.dead_silence_respawn_day,
         dead_silence_respawns_today=ctx.dead_silence_respawns_today,
         wedge_respawn_day=ctx.wedge_respawn_day,
@@ -11288,10 +11459,15 @@ def _handle_stalled_alert(ctx: _StalledActionCtx) -> None:
     # that instruction is true). The else-branch self-identifies as a
     # watcher bug instead of inventing a daemon outage.
     if ctx.manual:
-        reason = "manual user-driven session; alert-only by design"
+        reason = "manual user-driven session; alert-first by design (#505)"
         next_step = (
             f"open the session (phone / `spawn_session.py list`) and "
-            f"re-drive `/issue {ctx.issue}` manually if confirmed dead"
+            f"re-drive `/issue {ctx.issue}` manually if confirmed dead; if "
+            f"this alert stays unactioned with zero task progress, the "
+            f"watcher unregisters the manual registration after "
+            f"~EPM_STALLED_MANUAL_ESCALATE_H (default 24h) and the orphan "
+            f"sweep re-drives the task (#1480; the session itself is never "
+            f"stopped)"
         )
     elif not ctx.in_active:
         reason = f"task status not ACTIVE ({ctx.task_status})"
@@ -12003,6 +12179,189 @@ def _apply_wedge_override_with_exemption_probe(
     return action, new_missed, followups_child_alerted, live_consecutive, wedge_hits, wedge_note
 
 
+def _append_stalled_manual_escalation_event(
+    note: str,
+    dry_run: bool,
+    *,
+    issue: int,
+    sid: object,
+    count: int,
+    span_h: float,
+    window_h: float,
+    status: str | None,
+) -> None:
+    """Durable trace for #1480 stalled-manual escalations — one JSON line per
+    fire in ``~/.eps-autonomous/stalled-manual-escalation-events.jsonl``
+    (byte-parallel role to :func:`_append_stale_registration_event`, plus
+    structured fields so a future /daily sweep can parse it without regexing
+    the note). The per-task marker is the primary record; this file survives
+    a task folder move. Fail-soft."""
+    dest = AUTONOMOUS_REGISTRY_DIR / "stalled-manual-escalation-events.jsonl"
+    line = json.dumps(
+        {
+            "ts": datetime.now().astimezone().isoformat(),
+            "kind": "stalled-manual-escalation",
+            "issue": issue,
+            "sid": sid if isinstance(sid, str) else None,
+            "count": count,
+            "span_h": round(span_h, 2),
+            "window_h": round(window_h, 2),
+            "status": status,
+            "note": note,
+        }
+    )
+    if dry_run:
+        print(f"  [dry-run] would append stalled-manual-escalation event to {dest}")
+        return
+    try:
+        AUTONOMOUS_REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
+        with open(dest, "a") as fh:
+            fh.write(line + "\n")
+    except OSError as e:
+        print(
+            f"  WARNING: appending stalled-manual-escalation event failed: {e}",
+            file=sys.stderr,
+        )
+
+
+def _escalate_stalled_manual(ctx: _StalledActionCtx, entry_path: Path, events: list[dict]) -> None:
+    """#1480 fire action: UNREGISTER the manual registration (never stop or
+    spawn the session — #505), post the loud marker + sidecar row + Telegram
+    push, and reset the escalation counters (once-per-episode: the entry is
+    gone next tick, and a re-registered manual session meets reset counters
+    => a fresh full accumulation). Mirrors :func:`_process_stale_registration`'s
+    action block."""
+    first_ts = ctx.manual_escalate_first_ts
+    span_h = ((ctx.now - first_ts) / 3600.0) if isinstance(first_ts, int | float) else 0.0
+    window_h = _stalled_manual_escalate_window_s() / 3600.0
+    count = ctx.manual_escalate_count
+    # Informational note enrichment ONLY — never a gate: a raise here must
+    # not block the fire (plan #1480 §8; narrow guard + logged warning).
+    try:
+        from explore_persona_space.task_workflow import unrun_followup_labels
+
+        groups = unrun_followup_labels(events)
+        labels = ", ".join(str(g.get("followup_label")) for g in groups) or "none on record"
+    except Exception as e:
+        print(
+            f"  WARNING: unrun-followup-labels enrichment failed for #{ctx.issue}: {e}",
+            file=sys.stderr,
+        )
+        labels = "unavailable (enrichment failed)"
+    note = (
+        f"{_STALLED_MANUAL_ESCALATION_NOTE_SENTINEL} ESCALATED stalled MANUAL "
+        f"issue session (#1480; the #928 6-day-freeze class): unregistered "
+        f"manual registration {entry_path.name} — the session itself "
+        f"(sid={ctx.happy_session_id}) was NOT stopped (#505). Trigger: "
+        f"{count} consecutive stalled confirmations spanning {span_h:.1f}h >= "
+        f"{window_h:.1f}h since the FIRST confirmation (stall onset), with "
+        f"zero non-watcher task progress (self-report frozen {ctx.self_gap}, "
+        f"newest non-watcher marker {ctx.marker_gap} old, "
+        f"status={ctx.task_status}); the one-time stalled alert went "
+        f"unactioned. Unrun follow-up scope labels: {labels}. The "
+        f"registration-independent orphan sweep re-drives this ACTIVE task on "
+        f"its next stale tick (~20-30 min). To reclaim ownership: re-drive "
+        f"/issue {ctx.issue} from your session (Step 0 re-registers), or park "
+        f"the task (`task.py set-status {ctx.issue} on_hold`)."
+    )
+    print(f"  issue #{ctx.issue}: stalled-manual escalation — {note}")
+    if not ctx.dry_run:
+        # The ONLY registry mutation: delete exactly the manual entry being
+        # processed (never issue-<N>.json — the dual-registration case is
+        # structurally excluded: stalled_session_pass skips manual entries
+        # when an autonomous entry exists for the same issue).
+        entry_path.unlink(missing_ok=True)
+    _post_progress_marker(ctx.issue, note, ctx.dry_run, label="stalled-manual-escalation")
+    _append_stalled_manual_escalation_event(
+        note,
+        ctx.dry_run,
+        issue=ctx.issue,
+        sid=ctx.happy_session_id,
+        count=count,
+        span_h=span_h,
+        window_h=window_h,
+        status=ctx.task_status,
+    )
+    _telegram_push(
+        f"[EPS watcher] stalled-manual escalation on #{ctx.issue}: manual "
+        f"registration unregistered after {span_h:.1f}h unactioned stall; "
+        f"orphan sweep will re-drive (~30 min). Session NOT stopped.",
+        ctx.dry_run,
+    )
+    ctx.manual_escalate_count, ctx.manual_escalate_first_ts = 0, None
+    _persist_stalled_ctx(ctx, ctx.happy_session_id_str, 0)
+
+
+def _apply_stalled_manual_escalation(
+    ctx: _StalledActionCtx, entry_path: Path, events: list[dict], stale_confirmed: bool
+) -> bool:
+    """#1480: evaluate + (maybe) fire the stalled-manual escalation rung.
+
+    Mutates ``ctx.manual_escalate_count`` / ``ctx.manual_escalate_first_ts``
+    to the values THIS tick must persist (every downstream persist site
+    forwards them via :func:`_persist_stalled_ctx`). Returns True iff this
+    rung fully HANDLED the tick — it FIRED (unregister + marker + sidecar +
+    push + reset-persist), or a fire-time exemption VETOED it with its own
+    reset-persist — so the caller returns early (skipping only the ordinary
+    keep-persist, which the handled paths perform themselves). NEVER stops
+    or spawns a session; the only registry mutation is the manual
+    registration file's unlink. Every unresolvable input fails toward keep
+    (returns False with today's behavior unchanged)."""
+    if not ctx.manual or not _stalled_manual_escalation_enabled():
+        return False
+    verdict, ctx.manual_escalate_count, ctx.manual_escalate_first_ts = (
+        decide_stalled_manual_escalation(
+            in_active=ctx.in_active,  # _task_status read THIS tick by the caller
+            alerted=ctx.alerted,
+            stale_confirmed=stale_confirmed,
+            confirm_count=ctx.manual_escalate_count,
+            first_confirm_ts=ctx.manual_escalate_first_ts,
+            now=ctx.now,
+            min_confirms=_stalled_manual_escalate_confirms(),
+            min_window_s=_stalled_manual_escalate_window_s(),
+        )
+    )
+    if verdict != "escalate":
+        return False
+    # Fire-time veto 1 — fresh worktree activity (someone is mid-edit):
+    # DEFER, keep the counters (re-evaluated next tick; the normal keep-persist
+    # writes them). Same helper the stale-registration pass uses; 2s-bounded
+    # walk, probed only on fire-candidate ticks.
+    if _worktree_recent_activity(ctx.issue, ctx.now, _wt_activity_fresh_s()):
+        print(
+            f"  issue #{ctx.issue}: stalled-manual escalation DEFERRED — "
+            f"fresh worktree activity (counters kept)"
+        )
+        return False
+    # Fire-time veto 2 — exemption re-probe (the wedge lane's #845-r2 design):
+    # the post-alert keep(0) ticks never probed the lazy exemptions, so
+    # re-probe ONCE against the escalation. Any rewrite (user-pause /
+    # spend-approval / provision-in-flight / long-phase heartbeat /
+    # round-complete re-park / awaiting-child) VETOES the fire and RESETS the
+    # counters (the task is legitimately parked; when the park lifts, either
+    # the session resumes -> advancement clear, or a fresh accumulation
+    # begins).
+    probed_action, _probed_missed, ctx.followups_child_alerted, _ex = (
+        _apply_stalled_park_exemptions(
+            issue=ctx.issue,
+            status=ctx.task_status,
+            has_pod=ctx.has_pod,
+            events=events,
+            action="alert",
+            new_missed=ctx.threshold,
+            followups_child_alerted=ctx.followups_child_alerted,
+            now=ctx.now,
+            dry_run=ctx.dry_run,
+        )
+    )
+    if probed_action != "alert":
+        ctx.manual_escalate_count, ctx.manual_escalate_first_ts = 0, None
+        _persist_stalled_ctx(ctx, ctx.happy_session_id_str, 0)
+        return True  # exemption handled/annotated the tick; nothing to dispatch
+    _escalate_stalled_manual(ctx, entry_path, events)
+    return True
+
+
 def _process_stalled_session(
     entry_path: Path,
     pod_active_issues: set[int],
@@ -12305,12 +12664,17 @@ def _process_stalled_session(
     # at 2 ticks (~20 min). `alerted or action == "alert"` counts the very
     # tick the alert fires (the handler persists alerted=True after us).
     stale_now = self_report_age is not None and self_report_age >= STALLED_WINDOW_S
+    # Corroborated staleness: self-report frozen AND no non-watcher marker
+    # within the 2h marker window — the identical expression the
+    # daemon-blocked escalation below consumes; ALSO the per-tick
+    # confirmation signal for the #1480 stalled-manual escalation rung.
+    stale_confirmed = stale_now and (marker_age is None or marker_age >= marker_window_s)
     hard["daemon_blocked_ticks"], hard["daemon_blocked_pushed"] = _apply_daemon_blocked_escalation(
         issue=issue,
         in_active=in_active,
         manual=manual,
         alerted=alerted or action == "alert",
-        stale=stale_now and (marker_age is None or marker_age >= marker_window_s),
+        stale=stale_confirmed,
         daemon_reachable=daemon_reachable,
         blocked_ticks=hard["daemon_blocked_ticks"],
         already_pushed=hard["daemon_blocked_pushed"],
@@ -12361,6 +12725,8 @@ def _process_stalled_session(
         daemon_blocked_ticks=hard["daemon_blocked_ticks"],
         daemon_blocked_pushed=hard["daemon_blocked_pushed"],
         wedge_hits=hard["wedge_hits"],
+        manual_escalate_count=hard["manual_escalate_count"],
+        manual_escalate_first_ts=hard["manual_escalate_first_ts"],
         wedge_note=wedge_note,
         daemon_reachable=daemon_reachable,
         downgrade_note=downgrade_note,
@@ -12369,6 +12735,15 @@ def _process_stalled_session(
         wedge_respawn_day=dead_silence_day_key,
         wedge_respawns_today=wedge_respawns_today,
     )
+
+    # #1480 stalled-manual escalation rung (no-op for autonomous entries,
+    # when disabled, and on every fail-toward-keep input; on the fire tick
+    # action == "keep" by construction — fire requires alerted=True, and an
+    # alerted manual entry's decide verdict is the keep-dedup branch — so the
+    # early return skips only the keep-persist, which the rung performs
+    # itself).
+    if _apply_stalled_manual_escalation(ctx, entry_path, events, stale_confirmed):
+        return
 
     if action == "respawn":
         _handle_stalled_respawn(ctx)
@@ -12407,7 +12782,13 @@ def stalled_session_pass(
     user-driven session at an ACTIVE status raises the one-time alert
     instead of orphaning silently, but is NEVER auto-respawned —
     restarting a session the user drives by hand is the user's call
-    (#505 round-2 orphaning, 2026-06-10). When an issue carries BOTH
+    (#505 round-2 orphaning, 2026-06-10). A manual entry whose alert then
+    goes UNACTIONED for >= EPM_STALLED_MANUAL_ESCALATE_H (default 24h,
+    >= 3 consecutive stalled-confirmed ticks, zero non-watcher progress)
+    on an ACTIVE task escalates to the #1480 UNREGISTER-ONLY rung
+    (:func:`_apply_stalled_manual_escalation`): the registration file is
+    deleted — never the session — so the orphan sweep re-drives the task
+    on its next stale tick. When an issue carries BOTH
     registrations, the autonomous entry wins and the manual one is
     skipped: both would share the same ``stalled-<N>.json`` state file,
     and double-processing in one tick would defeat the 2-miss guard.

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -3505,6 +3505,9 @@ def test_save_stalled_state_carries_first_seen_and_respawn_fields(isolated_regis
     # the SHARED day-keyed cap for the four pre-#1209 wedge triggers, same
     # advancement-clear-EXEMPT / stop-initiation-bump contract, an
     # INDEPENDENT budget; default-absent-safe.
+    # manual_escalate_count / manual_escalate_first_ts are the #1480
+    # stalled-manual escalation counters (episode-scoped, advancement-cleared
+    # via the #845 hardening-field contract); default-absent-safe.
     assert payload == {
         "happy_session_id": "sess-7",
         "missed": 1,
@@ -3522,6 +3525,8 @@ def test_save_stalled_state_carries_first_seen_and_respawn_fields(isolated_regis
         "daemon_blocked_ticks": 0,
         "daemon_blocked_pushed": False,
         "wedge_hits": 0,
+        "manual_escalate_count": 0,
+        "manual_escalate_first_ts": None,
         "dead_silence_respawn_day": None,
         "dead_silence_respawns_today": 0,
         "wedge_respawn_day": None,

--- a/tests/test_stalled_detector_and_gc.py
+++ b/tests/test_stalled_detector_and_gc.py
@@ -2280,6 +2280,9 @@ def test_stalled_hardening_fields_legacy_defaults_and_advancement_clear():
         "daemon_blocked_ticks": 2,
         "daemon_blocked_pushed": True,
         "wedge_hits": 1,
+        # #1480 stalled-manual escalation counters ride the same contract.
+        "manual_escalate_count": 2,
+        "manual_escalate_first_ts": 9.0,
     }
     carried = asw._stalled_hardening_fields(populated, advanced=False)
     assert carried == populated
@@ -2651,3 +2654,563 @@ def test_stalled_pass_daemon_outage_note_threaded(
     assert "Happy daemon unreachable" in note
     assert "next daemon-reachable tick" in note
     assert "watcher bug" not in note
+
+
+# ─── #1480 stalled-manual escalation rung ────────────────────────────────────
+#
+# An unactioned stalled alert on a MANUAL registration (`manual-issue-<N>.json`)
+# holding an ACTIVE task escalates — after >= 3 consecutive stalled-confirmed
+# ticks spanning >= 24h with zero non-watcher task progress — to an
+# UNREGISTER-ONLY action: the registration file is deleted (the session is
+# NEVER stopped — #505) so the registration-independent orphan sweep re-drives
+# the task. Origin incident #928: a wedged manual session froze a
+# followups_running task for ~6 days behind the one-time alert.
+
+
+_ESC_WINDOW_S = 24 * 3600.0
+
+
+@pytest.mark.parametrize(
+    "confirm_count,first_offset_s",
+    [
+        # Exact >= boundary (S3): count' == min_confirms AND span == window.
+        (2, _ESC_WINDOW_S),
+        # Comfortably past both bars.
+        (5, 30 * 3600.0),
+    ],
+)
+def test_decide_stalled_manual_escalation_fires_after_k_confirms_and_window(
+    confirm_count, first_offset_s
+):
+    """AC-1 predicate arm + the AC-10 #928 replay arithmetic: on the #928
+    timeline (alert at ~+2.3h, zero progress after) the first stalled
+    confirmation lands at ~+2.0-2.3h, the count reaches K=3 by ~+2.5h, and
+    the 24h window gate (anchored at the FIRST confirmation — stall onset)
+    fires the escalation at ~+26h; the orphan sweep re-drives ~20-30 min
+    later — recovery <= ~27h vs the incident's ~6.4 days (~5.7x)."""
+    import autonomous_session_watch as asw
+
+    now = 1_000_000.0
+    verdict, count, first = asw.decide_stalled_manual_escalation(
+        in_active=True,
+        alerted=True,
+        stale_confirmed=True,
+        confirm_count=confirm_count,
+        first_confirm_ts=now - first_offset_s,
+        now=now,
+        min_confirms=3,
+        min_window_s=_ESC_WINDOW_S,
+    )
+    assert verdict == "escalate"
+    assert count == confirm_count + 1
+    assert first == now - first_offset_s
+
+
+def test_decide_stalled_manual_escalation_counts_below_k():
+    import autonomous_session_watch as asw
+
+    now = 1_000_000.0
+    anchor = now - 25 * 3600.0
+    assert asw.decide_stalled_manual_escalation(
+        in_active=True,
+        alerted=True,
+        stale_confirmed=True,
+        confirm_count=1,  # 2nd confirmation this tick: still below K=3
+        first_confirm_ts=anchor,
+        now=now,
+        min_confirms=3,
+        min_window_s=_ESC_WINDOW_S,
+    ) == ("count", 2, anchor)
+
+
+def test_decide_stalled_manual_escalation_window_not_met():
+    import autonomous_session_watch as asw
+
+    now = 1_000_000.0
+    anchor = now - 3600.0  # only 1h since first confirmation
+    assert asw.decide_stalled_manual_escalation(
+        in_active=True,
+        alerted=True,
+        stale_confirmed=True,
+        confirm_count=4,  # count'=5 >= 3, but the window gate holds
+        first_confirm_ts=anchor,
+        now=now,
+        min_confirms=3,
+        min_window_s=_ESC_WINDOW_S,
+    ) == ("count", 5, anchor)
+
+
+def test_decide_stalled_manual_escalation_requires_unactioned_alert():
+    # Pre-alert confirmations accumulate but can NEVER fire: the trigger is
+    # an UNACTIONED alert, so alerted=True is required at fire time — even
+    # with both thresholds met (exact boundary AND far past it).
+    import autonomous_session_watch as asw
+
+    now = 1_000_000.0
+    for confirm_count, first_offset_s in ((2, _ESC_WINDOW_S), (99, 40 * 3600.0)):
+        anchor = now - first_offset_s
+        assert asw.decide_stalled_manual_escalation(
+            in_active=True,
+            alerted=False,
+            stale_confirmed=True,
+            confirm_count=confirm_count,
+            first_confirm_ts=anchor,
+            now=now,
+            min_confirms=3,
+            min_window_s=_ESC_WINDOW_S,
+        ) == ("count", confirm_count + 1, anchor)
+
+
+def test_decide_stalled_manual_escalation_resets_on_progress():
+    # A fresh self-report / non-watcher marker (stale_confirmed=False) breaks
+    # the consecutive chain: the WHOLE accumulation resets.
+    import autonomous_session_watch as asw
+
+    now = 1_000_000.0
+    assert asw.decide_stalled_manual_escalation(
+        in_active=True,
+        alerted=True,
+        stale_confirmed=False,
+        confirm_count=99,
+        first_confirm_ts=now - 48 * 3600.0,
+        now=now,
+        min_confirms=3,
+        min_window_s=_ESC_WINDOW_S,
+    ) == ("reset", 0, None)
+
+
+def test_decide_stalled_manual_escalation_resets_on_non_active_status():
+    import autonomous_session_watch as asw
+
+    now = 1_000_000.0
+    assert asw.decide_stalled_manual_escalation(
+        in_active=False,  # None/parked/terminal status read -> conservative False
+        alerted=True,
+        stale_confirmed=True,
+        confirm_count=99,
+        first_confirm_ts=now - 48 * 3600.0,
+        now=now,
+        min_confirms=3,
+        min_window_s=_ESC_WINDOW_S,
+    ) == ("reset", 0, None)
+
+
+@pytest.mark.parametrize(
+    "bad_anchor",
+    [
+        None,  # missing (fresh episode / pre-#1480 on-disk file)
+        0.0,  # zeroed
+        -5.0,  # negative garbage
+        1_000_000.0 + 3600.0,  # FUTURE-dated (S4: clock skew / corrupt state)
+    ],
+)
+def test_decide_stalled_manual_escalation_malformed_anchor_fails_toward_keep(bad_anchor):
+    # A malformed / missing / future-dated anchor RESTARTS the window at
+    # `now` — never an instant fire on a corrupt state file (fail toward
+    # keep), even with an absurd inherited count.
+    import autonomous_session_watch as asw
+
+    now = 1_000_000.0
+    verdict, count, first = asw.decide_stalled_manual_escalation(
+        in_active=True,
+        alerted=True,
+        stale_confirmed=True,
+        confirm_count=99,
+        first_confirm_ts=bad_anchor,
+        now=now,
+        min_confirms=3,
+        min_window_s=_ESC_WINDOW_S,
+    )
+    assert verdict == "count"
+    assert count == 100
+    assert first == now
+
+
+def test_stalled_manual_escalation_env_knob_parsing(monkeypatch):
+    import autonomous_session_watch as asw
+
+    # Window knob: malformed / non-positive -> default (never an instant
+    # unregisterer); valid HOURS parse.
+    for bad in ("abc", "-1", "0"):
+        monkeypatch.setenv("EPM_STALLED_MANUAL_ESCALATE_H", bad)
+        assert asw._stalled_manual_escalate_window_s() == 24 * 3600.0
+    monkeypatch.setenv("EPM_STALLED_MANUAL_ESCALATE_H", "12")
+    assert asw._stalled_manual_escalate_window_s() == 12 * 3600.0
+    monkeypatch.delenv("EPM_STALLED_MANUAL_ESCALATE_H")
+    assert asw._stalled_manual_escalate_window_s() == 24 * 3600.0
+    # Confirms knob: malformed / < 1 -> default (never a stealth kill switch).
+    for bad in ("abc", "0", "-3", "1.5"):
+        monkeypatch.setenv("EPM_STALLED_MANUAL_ESCALATE_CONFIRMS", bad)
+        assert asw._stalled_manual_escalate_confirms() == 3
+    monkeypatch.setenv("EPM_STALLED_MANUAL_ESCALATE_CONFIRMS", "2")
+    assert asw._stalled_manual_escalate_confirms() == 2
+    monkeypatch.delenv("EPM_STALLED_MANUAL_ESCALATE_CONFIRMS")
+    assert asw._stalled_manual_escalate_confirms() == 3
+    # Kill switch: truthy disables the rung entirely; anything else enables.
+    for on in ("1", "true", "YES"):
+        monkeypatch.setenv("EPM_DISABLE_STALLED_MANUAL_ESCALATION", on)
+        assert asw._stalled_manual_escalation_enabled() is False
+    monkeypatch.setenv("EPM_DISABLE_STALLED_MANUAL_ESCALATION", "0")
+    assert asw._stalled_manual_escalation_enabled() is True
+    monkeypatch.delenv("EPM_DISABLE_STALLED_MANUAL_ESCALATION")
+    assert asw._stalled_manual_escalation_enabled() is True
+
+
+def _write_manual_entry(reg_dir, issue, session_id="manual-sess"):
+    """Mimic spawn_session's manual (bare ``spawn-issue``) registration shape."""
+    (reg_dir / f"manual-issue-{issue}.json").write_text(
+        json.dumps(
+            {
+                "issue": issue,
+                "happy_session_id": session_id,
+                "cwd": "/repo",
+                "spawned_at": time.time(),
+                "mode": "manual",
+            }
+        )
+    )
+
+
+def _rig_manual_escalation(
+    monkeypatch,
+    isolated_registry,
+    *,
+    issue=100,
+    now=2_000_000.0,
+    status="running",
+    count=2,
+    first_offset_s=25 * 3600.0,
+    alerted=True,
+):
+    """Fire-ready #1480 rig: a manual registration + a seeded stalled state
+    whose NEXT confirmation crosses both bars (count'=count+1 >= 3, span
+    first_offset_s >= 24h), with every I/O signal stubbed hermetic (frozen
+    self-report matching the seeded ts so the advancement-clear stays off,
+    zero events => marker_age None => stale corroborated, ACTIVE status).
+    Returns (posts, pushes) recorders."""
+    import autonomous_session_watch as asw
+
+    posts: list[tuple[int, str, bool, str]] = []
+    pushes: list[tuple[str, bool]] = []
+    _write_manual_entry(isolated_registry, issue)
+    asw._save_stalled_state(
+        issue,
+        "manual-sess",
+        missed=0,
+        alerted=alerted,
+        last_self_report_ts="2026-06-05T10:00:00Z",
+        manual_escalate_count=count,
+        manual_escalate_first_ts=now - first_offset_s,
+        prev=None,
+    )
+    stale = STALLED_WINDOW_S + 600
+    monkeypatch.setattr(
+        asw,
+        "_self_report_age_seconds",
+        lambda issue, now: (stale, "2026-06-05T10:00:00Z"),
+    )
+    monkeypatch.setattr(asw, "_task_events", lambda issue: [])
+    monkeypatch.setattr(asw, "_running_managed_issue_pods", lambda *_a, **_k: [])
+    monkeypatch.setattr(asw, "_task_status", lambda issue: status)
+    monkeypatch.setattr(asw, "_worktree_recent_activity", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        asw,
+        "_post_progress_marker",
+        lambda issue, note, dry_run, label: posts.append((issue, note, dry_run, label)),
+    )
+    monkeypatch.setattr(
+        asw, "_telegram_push", lambda msg, dry_run: pushes.append((msg, dry_run)) or True
+    )
+    return posts, pushes
+
+
+def test_stalled_manual_escalation_unregisters_and_posts_marker(isolated_registry, monkeypatch):
+    # AC-1: the full fire — registration unlinked, escalation marker posted,
+    # sidecar row appended (with structured fields), push attempted, counters
+    # reset at fire.
+    import autonomous_session_watch as asw
+
+    now = 2_000_000.0
+    posts, pushes = _rig_manual_escalation(monkeypatch, isolated_registry, now=now)
+
+    asw.stalled_session_pass(dry_run=False, threshold=2, now=now, daemon_reachable=True)
+
+    assert not (isolated_registry / "manual-issue-100.json").exists()
+    esc = [p for p in posts if p[3] == "stalled-manual-escalation"]
+    assert len(esc) == 1
+    issue, note, dry_run, _label = esc[0]
+    assert issue == 100
+    assert dry_run is False
+    assert asw._STALLED_MANUAL_ESCALATION_NOTE_SENTINEL in note
+    assert "NOT stopped" in note
+    assert "manual-issue-100.json" in note
+    # Empty events => no unrun follow-up scope on record (informational only).
+    assert "none on record" in note
+    sidecar = isolated_registry / "stalled-manual-escalation-events.jsonl"
+    rows = [json.loads(line) for line in sidecar.read_text().splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "stalled-manual-escalation"
+    assert rows[0]["issue"] == 100
+    assert rows[0]["sid"] == "manual-sess"
+    assert rows[0]["count"] == 3
+    assert rows[0]["span_h"] == 25.0
+    assert rows[0]["window_h"] == 24.0
+    assert rows[0]["status"] == "running"
+    assert len(pushes) == 1
+    assert "NOT stopped" in pushes[0][0]
+    state = json.loads((isolated_registry / f"{STALLED_STATE_PREFIX}100.json").read_text())
+    assert state["manual_escalate_count"] == 0
+    assert state["manual_escalate_first_ts"] is None
+
+
+def test_stalled_manual_escalation_never_stops_or_spawns(isolated_registry, monkeypatch):
+    # AC-2 (#505 preserved): the escalation's ONLY mutation is the
+    # registration-file delete + state/marker/sidecar writes — no session
+    # stop, no spawn, no subprocess of any kind on the fire path.
+    import autonomous_session_watch as asw
+
+    now = 2_000_000.0
+    _posts, _pushes = _rig_manual_escalation(monkeypatch, isolated_registry, now=now)
+    stops: list = []
+    spawns: list = []
+    monkeypatch.setattr(asw, "_stop_session", lambda *a, **k: stops.append(a) or True)
+    monkeypatch.setattr(
+        asw, "_respawn_stalled_session", lambda *a, **k: spawns.append(a) or "spawned"
+    )
+    monkeypatch.setattr(asw, "_respawn", lambda *a, **k: spawns.append(a) or True)
+
+    def _no_subprocess(*a, **k):
+        raise AssertionError(f"subprocess.run called on the escalation path: {a!r}")
+
+    monkeypatch.setattr(asw.subprocess, "run", _no_subprocess)
+
+    asw.stalled_session_pass(dry_run=False, threshold=2, now=now, daemon_reachable=True)
+
+    assert stops == []
+    assert spawns == []
+    # ...and the fire DID happen (the assertions above are not vacuous).
+    assert not (isolated_registry / "manual-issue-100.json").exists()
+
+
+def test_stalled_manual_escalation_once_per_episode(isolated_registry, monkeypatch):
+    # AC-4: registration deletion is self-deduping (the entry no longer
+    # exists next tick) AND the persisted counters reset at fire, so a
+    # RE-REGISTERED manual session starts a fresh full accumulation.
+    import autonomous_session_watch as asw
+
+    now = 2_000_000.0
+    posts, _pushes = _rig_manual_escalation(monkeypatch, isolated_registry, now=now)
+
+    asw.stalled_session_pass(dry_run=False, threshold=2, now=now, daemon_reachable=True)
+    assert not (isolated_registry / "manual-issue-100.json").exists()
+
+    _write_manual_entry(isolated_registry, 100)
+    asw.stalled_session_pass(dry_run=False, threshold=2, now=now + 600, daemon_reachable=True)
+
+    assert (isolated_registry / "manual-issue-100.json").exists()  # no re-fire
+    esc = [p for p in posts if p[3] == "stalled-manual-escalation"]
+    assert len(esc) == 1
+    state = json.loads((isolated_registry / f"{STALLED_STATE_PREFIX}100.json").read_text())
+    assert state["manual_escalate_count"] == 1  # a fresh accumulation began
+
+
+def test_stalled_manual_escalation_never_fires_on_autonomous_entries(
+    isolated_registry, monkeypatch
+):
+    # AC-5: `issue-<N>.json` autonomous registrations never enter the rung
+    # (they keep the existing respawn machinery) — even with an absurd
+    # fire-ready counter seeded in the shared state file.
+    import autonomous_session_watch as asw
+
+    now = 2_000_000.0
+    posts: list = []
+    _write_autonomous_entry(isolated_registry, 200, "sess-200")
+    asw._save_stalled_state(
+        200,
+        "sess-200",
+        missed=0,
+        alerted=True,
+        last_self_report_ts="2026-06-05T10:00:00Z",
+        manual_escalate_count=5,
+        manual_escalate_first_ts=now - 30 * 3600.0,
+        prev=None,
+    )
+    stale = STALLED_WINDOW_S + 600
+    monkeypatch.setattr(
+        asw,
+        "_self_report_age_seconds",
+        lambda issue, now: (stale, "2026-06-05T10:00:00Z"),
+    )
+    monkeypatch.setattr(asw, "_task_events", lambda issue: [])
+    monkeypatch.setattr(asw, "_running_managed_issue_pods", lambda *_a, **_k: [])
+    monkeypatch.setattr(asw, "_task_status", lambda issue: "running")
+    monkeypatch.setattr(asw, "_telegram_push", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        asw,
+        "_post_progress_marker",
+        lambda issue, note, dry_run, label: posts.append((issue, note, dry_run, label)),
+    )
+
+    # daemon UNREACHABLE => the autonomous arm degrades to alert-only, so the
+    # assertion isolates the rung's manual-only gate rather than respawn wiring.
+    asw.stalled_session_pass(dry_run=False, threshold=2, now=now, daemon_reachable=False)
+
+    assert (isolated_registry / "issue-200.json").exists()
+    assert [p for p in posts if p[3] == "stalled-manual-escalation"] == []
+
+
+def test_stalled_manual_escalation_kill_switch(isolated_registry, monkeypatch):
+    # AC-6: EPM_DISABLE_STALLED_MANUAL_ESCALATION=1 disables the rung
+    # entirely (alert-only behavior preserved; counters untouched — the
+    # predicate is never even evaluated).
+    import autonomous_session_watch as asw
+
+    now = 2_000_000.0
+    posts, pushes = _rig_manual_escalation(monkeypatch, isolated_registry, now=now)
+    monkeypatch.setenv("EPM_DISABLE_STALLED_MANUAL_ESCALATION", "1")
+
+    asw.stalled_session_pass(dry_run=False, threshold=2, now=now, daemon_reachable=True)
+
+    assert (isolated_registry / "manual-issue-100.json").exists()
+    assert posts == []  # alerted episode: the ordinary dedup suppresses too
+    assert pushes == []
+    state = json.loads((isolated_registry / f"{STALLED_STATE_PREFIX}100.json").read_text())
+    assert state["manual_escalate_count"] == 2
+    assert state["manual_escalate_first_ts"] == now - 25 * 3600.0
+
+
+@pytest.mark.parametrize(
+    "helper",
+    [
+        "_spend_approval_park_reason",
+        "_user_pause_hold_reason",
+        "_provision_in_flight_reason",
+    ],
+)
+def test_stalled_manual_escalation_exemption_veto(isolated_registry, monkeypatch, helper):
+    # AC-7: a fire-time exemption hit (user-pause prose, over-cap
+    # spend-approval park, in-flight provision, ...) VETOES the fire and
+    # RESETS the counters — the task is legitimately parked, so when the
+    # park lifts either the session resumes (advancement clear) or a fresh
+    # 24h accumulation begins.
+    import autonomous_session_watch as asw
+
+    now = 2_000_000.0
+    posts, pushes = _rig_manual_escalation(monkeypatch, isolated_registry, now=now)
+    monkeypatch.setattr(asw, helper, lambda *_a, **_k: f"stub {helper} exemption")
+
+    asw.stalled_session_pass(dry_run=False, threshold=2, now=now, daemon_reachable=True)
+
+    assert (isolated_registry / "manual-issue-100.json").exists()  # no unregister
+    assert [p for p in posts if p[3] == "stalled-manual-escalation"] == []
+    assert pushes == []
+    state = json.loads((isolated_registry / f"{STALLED_STATE_PREFIX}100.json").read_text())
+    assert state["manual_escalate_count"] == 0
+    assert state["manual_escalate_first_ts"] is None
+
+
+def test_stalled_manual_escalation_worktree_activity_defers(isolated_registry, monkeypatch):
+    # Fire-time veto 1: fresh worktree activity (someone is mid-edit) DEFERS
+    # the fire but KEEPS the accumulated counters (re-evaluated next tick) —
+    # unlike the exemption veto, which resets them.
+    import autonomous_session_watch as asw
+
+    now = 2_000_000.0
+    posts, pushes = _rig_manual_escalation(monkeypatch, isolated_registry, now=now)
+    monkeypatch.setattr(asw, "_worktree_recent_activity", lambda *_a, **_k: True)
+
+    asw.stalled_session_pass(dry_run=False, threshold=2, now=now, daemon_reachable=True)
+
+    assert (isolated_registry / "manual-issue-100.json").exists()
+    assert [p for p in posts if p[3] == "stalled-manual-escalation"] == []
+    assert pushes == []
+    state = json.loads((isolated_registry / f"{STALLED_STATE_PREFIX}100.json").read_text())
+    assert state["manual_escalate_count"] == 3  # this tick's confirmation counted
+    assert state["manual_escalate_first_ts"] == now - 25 * 3600.0
+
+
+def test_stalled_manual_escalation_dry_run(isolated_registry, monkeypatch):
+    # Dry-run fires nothing durable: no unlink, no sidecar file, no state
+    # write; the marker + push helpers are invoked through their dry-run
+    # paths (dry_run=True threaded).
+    import autonomous_session_watch as asw
+
+    now = 2_000_000.0
+    posts, pushes = _rig_manual_escalation(monkeypatch, isolated_registry, now=now)
+    state_before = (isolated_registry / f"{STALLED_STATE_PREFIX}100.json").read_text()
+
+    asw.stalled_session_pass(dry_run=True, threshold=2, now=now, daemon_reachable=True)
+
+    assert (isolated_registry / "manual-issue-100.json").exists()
+    assert (isolated_registry / f"{STALLED_STATE_PREFIX}100.json").read_text() == state_before
+    assert not (isolated_registry / "stalled-manual-escalation-events.jsonl").exists()
+    esc = [p for p in posts if p[3] == "stalled-manual-escalation"]
+    assert len(esc) == 1
+    assert esc[0][2] is True  # dry_run threaded into the marker helper
+    assert len(pushes) == 1
+    assert pushes[0][1] is True  # dry_run threaded into the push helper
+
+
+def test_save_stalled_state_roundtrips_manual_escalate_fields(isolated_registry):
+    import autonomous_session_watch as asw
+
+    asw._save_stalled_state(
+        1480,
+        "sess-1480",
+        missed=0,
+        alerted=True,
+        last_self_report_ts="2026-07-17T10:00:00Z",
+        manual_escalate_count=3,
+        manual_escalate_first_ts=123.0,
+        prev=None,
+    )
+    state = asw._load_stalled_state(1480)
+    assert state["manual_escalate_count"] == 3
+    assert state["manual_escalate_first_ts"] == 123.0
+    # Defaults when not passed -> (0, None) (backward/forward compatible).
+    asw._save_stalled_state(1481, "x", missed=0, alerted=False, last_self_report_ts=None, prev=None)
+    state2 = asw._load_stalled_state(1481)
+    assert state2["manual_escalate_count"] == 0
+    assert state2["manual_escalate_first_ts"] is None
+
+
+def test_stalled_hardening_fields_clear_manual_escalate_on_advancement():
+    # The counters ride the #845 hardening-field contract: episode-scoped —
+    # a self-report ADVANCE (session resumed => trap over) clears them; a
+    # malformed on-disk value loads as the safe default (fail toward keep).
+    import autonomous_session_watch as asw
+
+    prev = {"manual_escalate_count": 3, "manual_escalate_first_ts": 123.0}
+    kept = asw._stalled_hardening_fields(prev, advanced=False)
+    assert kept["manual_escalate_count"] == 3
+    assert kept["manual_escalate_first_ts"] == 123.0
+    cleared = asw._stalled_hardening_fields(prev, advanced=True)
+    assert cleared["manual_escalate_count"] == 0
+    assert cleared["manual_escalate_first_ts"] is None
+    garbled = asw._stalled_hardening_fields(
+        {"manual_escalate_count": "x", "manual_escalate_first_ts": "y"}, advanced=False
+    )
+    assert garbled["manual_escalate_count"] == 0
+    assert garbled["manual_escalate_first_ts"] is None
+
+
+def test_stalled_manual_escalation_sentinel_in_watcher_note_sentinels():
+    """AC-8 Durability pin (anti-liveness): the escalation marker's sentinel
+    MUST be a member of ``_WATCHER_NOTE_SENTINELS`` so the fire marker never
+    resets any staleness clock — otherwise the escalation itself would push
+    the orphan sweep's re-drive back ~90 min and delay the very recovery it
+    exists to enable (#1480)."""
+    import autonomous_session_watch as asw
+
+    assert asw._STALLED_MANUAL_ESCALATION_NOTE_SENTINEL in asw._WATCHER_NOTE_SENTINELS
+    events = [
+        {
+            "kind": "epm:progress",
+            "ts": "2026-07-17T10:00:00Z",
+            "note": (
+                f"{asw._STALLED_MANUAL_ESCALATION_NOTE_SENTINEL} ESCALATED "
+                f"stalled MANUAL issue session (#1480) ..."
+            ),
+        }
+    ]
+    assert asw._latest_nonwatcher_event_ts(events) is None


### PR DESCRIPTION
Closes task #1480. Bounded escalation rung: unactioned stalled-manual alerts on ACTIVE tasks unregister the manual registration (never stopping the session) so the orphan sweep re-drives.