### PR TITLE
issue-1218: gate spawn-issue --auto dispatches on the #1027 auth-outage episode (wf-fix #1218)

### DIFF
--- a/.claude/rules/background-automation.md
+++ b/.claude/rules/background-automation.md
@@ -1292,13 +1292,30 @@ probe, BEFORE every spawn arm.
   `EPM_DISABLE_AUTH_OUTAGE_GUARD=1`; `rm ~/.eps-autonomous/auth-outage.json`
   clears a live episode instantly; `--auth-outage-only` runs just this pass
   (pair with `--dry-run` for a live smoke — zero writes, zero pushes).
+- **Dispatch-chokepoint leg (#1218):** `spawn_session.py spawn-issue --auto`
+  (the choke point every non-watcher automated dispatcher funnels through —
+  `file_infra_task.py`, PM dispatch, the #660 program daemon's phase spawns)
+  holds spawns during an ACTIVE in-TTL episode with a rc-0 `AUTH-OUTAGE HELD`
+  line (recognized by `spawn_output_suppressed`, so all callers book
+  nothing); the watcher's canary passes via the pre-spawn `canary_pending`
+  claim; manual spawns + `spawn-campaign` warn-and-proceed; `spawn-pm`
+  untouched. Read-only mirror of the watcher gate (same kill switch, same
+  fail-open TTL); the gate reads the INVOKING process's env (a caller shell
+  carrying a different `EPM_AUTH_OUTAGE_MAX_EPISODE_H` than the watcher cron
+  computes a different TTL — bounded [1,48] h, divergence-toward-allow
+  reproduces the status quo); program-daemon phase spawns defer to the
+  daemon's own 48 h stall surface, not to an automated re-drive; duplicated
+  env parses + constant VALUES + state path pinned by
+  `tests/test_spawn_session_auth_outage_gate.py`.
 - **Accepted residuals (named, deliberate — do NOT "fix"):** (a) hang-style
   outages (sessions never die → no respawn events → no trigger; also no
   churn, so the cost is only the missing alert); (b) new-spawn-only outages
   (`prev_spawned_at=None` arms never count; bounded by the infra/capacity
   per-day caps); (c) the program-orchestrator recovery pass can relaunch the
   #660 program daemon (an indirect spawner) during an episode — v1 residual
-  per the must-ask fence on gating non-spawning passes; (d) two independent
+  per the must-ask fence on gating non-spawning passes — NARROWED by #1218:
+  the relaunched daemon's child `spawn-issue --auto` phase spawns are now
+  held at the dispatch chokepoint; (d) two independent
   issue-specific crash loops can false-trigger — bounded by canary self-heal
   (~50 min) + the 6 h TTL + one push; (e) a wedged-but-registered canary can
   false-resolve — bounded: a still-broken fleet re-accumulates ≥3 new events

--- a/scripts/spawn_session.py
+++ b/scripts/spawn_session.py
@@ -44,6 +44,7 @@ import time
 import urllib.error
 import urllib.request
 import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -118,6 +119,7 @@ DUPLICATE_DISPATCH_NOTE_SENTINEL = "[spawn-session:duplicate-dispatch-suppressed
 DISPATCH_LEASE_HELD_SENTINEL = "DISPATCH-LEASE HELD"
 REGISTRATION_COLLISION_SENTINEL = "REGISTRATION-COLLISION"
 TAKEOVER_HELD_SENTINEL = "TAKEOVER-SENTINEL HELD"
+AUTH_OUTAGE_HELD_SENTINEL = "AUTH-OUTAGE HELD"
 
 # ─── deliberate-takeover sentinel (#866/#903) ────────────────────────────────
 #
@@ -144,8 +146,8 @@ FUTURE_MTIME_SLACK_S = 300.0
 def spawn_output_suppressed(stdout: str | None) -> str | None:
     """Which duplicate-suppression sentinel (if any) a rc-0 ``spawn-issue
     --auto`` subprocess printed: :data:`DISPATCH_LEASE_HELD_SENTINEL` /
-    :data:`REGISTRATION_COLLISION_SENTINEL` / :data:`TAKEOVER_HELD_SENTINEL`,
-    else ``None`` (a real spawn).
+    :data:`REGISTRATION_COLLISION_SENTINEL` / :data:`TAKEOVER_HELD_SENTINEL` /
+    :data:`AUTH_OUTAGE_HELD_SENTINEL`, else ``None`` (a real spawn).
 
     Shared by the watcher's dispatch/respawn callers + the file-time filer so
     a suppressed no-op is never booked as a successful spawn — no dispatch
@@ -156,6 +158,7 @@ def spawn_output_suppressed(stdout: str | None) -> str | None:
         DISPATCH_LEASE_HELD_SENTINEL,
         REGISTRATION_COLLISION_SENTINEL,
         TAKEOVER_HELD_SENTINEL,
+        AUTH_OUTAGE_HELD_SENTINEL,
     ):
         if sentinel in stdout:
             return sentinel
@@ -215,6 +218,113 @@ def takeover_sentinel_fresh(
             if now - mt < ttl and mt > best_mtime:
                 best, best_mtime = p, mt
     return best
+
+
+# ─── auth-outage dispatch hold (#1027 episode gate → #1218 choke-point leg) ──
+#
+# READ-ONLY mirror of the watcher gate's read side
+# (autonomous_session_watch._auth_outage_spawn_gate, #1027): while the
+# watcher-written episode singleton ~/.eps-autonomous/auth-outage.json is
+# ACTIVE and inside its fail-open TTL, every fresh automated session dies on
+# arrival, so automated spawns are held at this choke point too. The watcher's
+# canary probe passes: the watcher persists canary_pending BEFORE shelling out
+# to `spawn-issue --auto`, and this gate allows any spawn matching a fresh
+# canary_pending claim. NEVER writes state; FAIL-OPEN on every uncertain input.
+# Constants are deliberate DUPLICATES of the watcher's (importing the watcher
+# here would be circular — it imports registry constants from THIS module);
+# parity is pinned by tests/test_spawn_session_auth_outage_gate.py.
+
+AUTH_OUTAGE_STATE_FILENAME = "auth-outage.json"
+AUTH_OUTAGE_TTL_H_DEFAULT = 6.0  # watcher: AUTH_OUTAGE_MAX_EPISODE_S (asw:6103)
+AUTH_OUTAGE_TTL_H_BOUNDS = (1.0, 48.0)
+AUTH_OUTAGE_CANARY_MIN_DEFAULT = 30.0  # watcher: AUTH_OUTAGE_CANARY_INTERVAL_S (asw:6094)
+AUTH_OUTAGE_CANARY_MIN_BOUNDS = (10.0, 720.0)
+
+
+def _bounded_env_float(name: str, default: float, lo: float, hi: float) -> float:
+    """Watcher ``_env_float`` parity (asw:4195): missing/garbled OR out-of-[lo,hi]
+    value falls back to the default — a typo'd override must not move the gate."""
+    try:
+        val = float(os.environ.get(name, ""))
+    except ValueError:
+        return default
+    return val if lo <= val <= hi else default
+
+
+def _auth_outage_guard_enabled() -> bool:
+    """Same kill switch as the watcher gate (asw:6127):
+    ``EPM_DISABLE_AUTH_OUTAGE_GUARD`` in {1,true,yes} disables the whole family."""
+    raw = os.environ.get("EPM_DISABLE_AUTH_OUTAGE_GUARD", "").strip().lower()
+    return raw not in {"1", "true", "yes"}
+
+
+def _auth_outage_ttl_s() -> float:
+    """Fail-open episode TTL in seconds (watcher parity: asw:6103)."""
+    return (
+        _bounded_env_float(
+            "EPM_AUTH_OUTAGE_MAX_EPISODE_H", AUTH_OUTAGE_TTL_H_DEFAULT, *AUTH_OUTAGE_TTL_H_BOUNDS
+        )
+        * 3600.0
+    )
+
+
+def _auth_outage_canary_window_s() -> float:
+    """Canary-claim freshness window in seconds (watcher parity: asw:6094)."""
+    return (
+        _bounded_env_float(
+            "EPM_AUTH_OUTAGE_CANARY_INTERVAL_MIN",
+            AUTH_OUTAGE_CANARY_MIN_DEFAULT,
+            *AUTH_OUTAGE_CANARY_MIN_BOUNDS,
+        )
+        * 60.0
+    )
+
+
+def auth_outage_dispatch_hold(
+    issue: int, now: float | None = None, registry_dir: Path | None = None
+) -> str | None:
+    """Human-readable hold reason when an ACTIVE #1027 auth-outage episode
+    should hold an automated dispatch for ``issue``, else None (allow).
+
+    FAIL-OPEN, mirroring the watcher gate exactly: kill switch set, state file
+    missing / garbled / non-dict, ``active`` falsy, ``started_ts`` missing or
+    non-numeric, episode past the fail-open TTL, a fresh watcher canary claim
+    for THIS issue, or ANY internal error -> None. ``now``/``registry_dir``
+    injectable for tests (the :func:`takeover_sentinel_fresh` pattern)."""
+    try:
+        if not _auth_outage_guard_enabled():
+            return None
+        reg = registry_dir if registry_dir is not None else AUTONOMOUS_REGISTRY_DIR
+        path = reg / AUTH_OUTAGE_STATE_FILENAME
+        if not path.is_file():
+            return None
+        try:
+            state = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None  # unreadable state can never suppress (watcher parity)
+        if not isinstance(state, dict) or not state.get("active"):
+            return None
+        now = time.time() if now is None else now
+        started = state.get("started_ts")
+        ttl = _auth_outage_ttl_s()
+        if not isinstance(started, int | float) or now - started >= ttl:
+            return None  # second fail-open layer: suppression ends at the TTL
+        pending = state.get("canary_pending")
+        if (
+            isinstance(pending, dict)
+            and pending.get("issue") == issue
+            and isinstance(pending.get("ts"), int | float)
+            and 0 <= now - pending["ts"] <= _auth_outage_canary_window_s()
+        ):
+            return None  # watcher-authorized canary probe for this issue — MUST spawn
+        started_iso = datetime.fromtimestamp(started, tz=UTC).isoformat(timespec="seconds")
+        return (
+            f"fleet auth-outage episode ACTIVE (started {started_iso}, "
+            f"fail-open TTL {ttl / 3600:.0f}h)"
+        )
+    except Exception as exc:  # FAIL-OPEN: never crash or block a dispatch path
+        print(f"  auth-outage: dispatch-hold check error (fail-open): {exc}", file=sys.stderr)
+        return None
 
 
 def _dispatch_lease_ttl_s() -> float:
@@ -2005,6 +2115,30 @@ def cmd_spawn_issue(args: argparse.Namespace) -> None:
             f"  note: fresh takeover sentinel {sentinel} — a deliberate takeover may be "
             f"in flight; proceeding (manual spawns are not gated)"
         )
+    # #1218 (extends #1027): while a fleet-level auth-outage episode is ACTIVE
+    # every fresh automated session dies on arrival — hold automated spawns at
+    # the same choke point as the takeover sentinel. Placed BEFORE lease
+    # acquisition for the same reason as the takeover gate: acquiring then
+    # suppressing would leave a TTL-held lease that would in turn suppress the
+    # watcher's canary probe for this issue. The watcher's own canary passes:
+    # it persists canary_pending BEFORE shelling out to this command
+    # (asw._auth_outage_spawn_gate). Manual spawns warn-and-proceed (the #843
+    # posture — a human recovering the fleet must never be blocked).
+    hold = auth_outage_dispatch_hold(issue)
+    if hold is not None:
+        if args.auto:
+            print(
+                f"{AUTH_OUTAGE_HELD_SENTINEL} issue #{issue}: {hold}; NOT spawning — "
+                f"a fresh session would die on arrival; the watcher canary probes "
+                f"recovery every ~{_auth_outage_canary_window_s() / 60:.0f} min and the "
+                f"episode fail-opens at the TTL. Manual override: "
+                f"EPM_DISABLE_AUTH_OUTAGE_GUARD=1, or clear the episode: "
+                f"rm {AUTONOMOUS_REGISTRY_DIR / AUTH_OUTAGE_STATE_FILENAME}"
+            )
+            return  # exit 0 — suppressed IS dispatch success (#843 M1b semantics)
+        print(
+            f"  note: {hold} — automated spawns are held; proceeding (manual spawns are not gated)"
+        )
     lease: dict[str, Any] | None = None
     if args.auto:
         # #843 M1: atomic per-issue dispatch lease, acquired BEFORE the daemon
@@ -2242,6 +2376,14 @@ def cmd_spawn_campaign(args: argparse.Namespace) -> None:
             f"then runs `task.py set-status {issue} approved` — workflow.yaml § "
             f"gates.campaign_brief_approval) or 'running' (respawn re-entry)."
         )
+
+    # #1218: campaign CLI spawns are human/PM-driven off a fresh user approval
+    # (status gate above) — warn-only, never suppress (manual-spawn posture).
+    # The watcher's campaign recovery arm is already unit-gated watcher-side
+    # (#1027 MF-3), so during an episode the watcher never reaches this path.
+    hold = auth_outage_dispatch_hold(issue)
+    if hold is not None:
+        print(f"  note: {hold} — the spawned campaign session may die on arrival; proceeding")
 
     # A campaign session ALWAYS injects HAPPY_INITIAL_PROMPT + claudeArgs (same
     # #685 severity as the --auto issue path). Verify the daemon patch is

--- a/tests/test_spawn_session_auth_outage_gate.py
+++ b/tests/test_spawn_session_auth_outage_gate.py
@@ -1,0 +1,414 @@
+"""Tests for the #1218 auth-outage dispatch hold in ``scripts/spawn_session.py``.
+
+The gate (`auth_outage_dispatch_hold`) is a READ-ONLY mirror of the watcher's
+#1027 `_auth_outage_spawn_gate` read side: while the watcher-written episode
+singleton ``~/.eps-autonomous/auth-outage.json`` is ACTIVE and inside its
+fail-open TTL, `spawn-issue --auto` suppresses with a rc-0 ``AUTH-OUTAGE
+HELD`` line (recognized by :func:`spawn_session.spawn_output_suppressed`, so
+every automated caller books nothing), manual spawns + `spawn-campaign`
+warn-and-proceed, and the watcher's own canary probe passes via the
+pre-spawn-persisted ``canary_pending`` claim.
+
+What this pins (plan #1218 §6, items 1-18):
+
+- Pure-gate fail-open cases (1-10): active hold, missing/garbled/non-dict
+  state, falsy ``active``, missing/non-numeric ``started_ts``, TTL expiry,
+  env-override + out-of-range fallback, the canary-claim bypass (fresh /
+  other-issue / stale / malformed), the kill switch, and read-only-ness.
+- Watcher-parity pin family (11a-11e): VALUE pins on the duplicated
+  defaults, source-regex BOUNDS pins on the watcher's `_env_float` call
+  sites, parse-SEMANTICS parity, kill-switch parity, and the FULL state-file
+  path pin — a watcher-side retune or state-file relocation must fail a
+  test, never silently de-sync the two gates.
+- Sentinel + cmd-level (12-18): recognizer membership, the `--auto`
+  suppression (exit 0, no daemon POST, no lease left behind, print↔recognizer
+  loop closed on CAPTURED stdout), manual warn-and-proceed, the canary
+  end-to-end replay, the exception-arm fail-open, the campaign
+  warn-and-proceed, and the future-dated ``started_ts`` disposition.
+"""
+
+from __future__ import annotations
+
+import argparse
+import inspect
+import json
+import re
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import autonomous_session_watch as asw  # noqa: E402
+import spawn_session as ss  # noqa: E402
+
+# An issue number with no live worktree so `cmd_spawn_issue` resolves
+# cwd=PROJECT_ROOT (which passes `_assert_spawn_cwd`) — the
+# test_spawn_session_stop_takeover.py convention.
+_FAKE_ISSUE = 9918
+
+NOW = 1_800_000_000.0
+
+_ENV_KNOBS = (
+    "EPM_DISABLE_AUTH_OUTAGE_GUARD",
+    "EPM_AUTH_OUTAGE_MAX_EPISODE_H",
+    "EPM_AUTH_OUTAGE_CANARY_INTERVAL_MIN",
+)
+
+
+def _write_state(reg: Path, **fields) -> Path:
+    """Write the auth-outage state singleton into ``reg`` and return its path."""
+    path = reg / ss.AUTH_OUTAGE_STATE_FILENAME
+    path.write_text(json.dumps(fields))
+    return path
+
+
+def _active_state(reg: Path, now: float = NOW, age_s: float = 60.0, **extra) -> Path:
+    return _write_state(reg, active=True, started_ts=now - age_s, **extra)
+
+
+@pytest.fixture
+def reg(tmp_path, monkeypatch):
+    """Isolated registry dir; env knobs cleared so the DEFAULTS bind."""
+    for knob in _ENV_KNOBS:
+        monkeypatch.delenv(knob, raising=False)
+    reg_dir = tmp_path / "reg"
+    reg_dir.mkdir()
+    return reg_dir
+
+
+@pytest.fixture
+def cmd_registry(reg, monkeypatch):
+    """The cmd-level harness: module-global registry dir pinned at the tmp
+    ``reg`` (covers the takeover-sentinel glob, the dispatch-lease paths, AND
+    the auth-outage state read — the test_spawn_session_stop_takeover.py
+    pattern), takeover TTL env cleared."""
+    monkeypatch.delenv("EPS_TAKEOVER_TTL_H", raising=False)
+    monkeypatch.setattr(ss, "AUTONOMOUS_REGISTRY_DIR", reg)
+    return reg
+
+
+def _spawn_ns(*, auto: bool) -> argparse.Namespace:
+    """A minimal `spawn-issue` Namespace covering every attribute
+    `cmd_spawn_issue` reads before (and at) the auth-outage gate."""
+    return argparse.Namespace(
+        issue=_FAKE_ISSUE,
+        auto=auto,
+        initial_prompt=None,
+        betas=None,
+        model=None,
+        effort=None,
+    )
+
+
+# ── pure-gate cases (plan §6 items 1-10) ────────────────────────────────────
+
+
+def test_hold_when_episode_active(reg):
+    _active_state(reg, age_s=60.0)
+    reason = ss.auth_outage_dispatch_hold(_FAKE_ISSUE, now=NOW, registry_dir=reg)
+    assert reason is not None
+    assert "auth-outage episode ACTIVE" in reason
+    from datetime import UTC, datetime
+
+    started_iso = datetime.fromtimestamp(NOW - 60.0, tz=UTC).isoformat(timespec="seconds")
+    assert started_iso in reason  # names the start time
+    assert "fail-open TTL 6h" in reason  # names the TTL
+
+
+def test_allow_when_no_state_file(reg):
+    assert ss.auth_outage_dispatch_hold(_FAKE_ISSUE, now=NOW, registry_dir=reg) is None
+
+
+def test_allow_when_inactive(reg):
+    _write_state(reg, active=False, started_ts=NOW - 60.0)
+    assert ss.auth_outage_dispatch_hold(_FAKE_ISSUE, now=NOW, registry_dir=reg) is None
+
+
+def test_allow_when_garbled_json(reg):
+    (reg / ss.AUTH_OUTAGE_STATE_FILENAME).write_text("{not json !!")
+    assert ss.auth_outage_dispatch_hold(_FAKE_ISSUE, now=NOW, registry_dir=reg) is None
+
+
+def test_allow_when_non_dict_json(reg):
+    (reg / ss.AUTH_OUTAGE_STATE_FILENAME).write_text('["active", true]')
+    assert ss.auth_outage_dispatch_hold(_FAKE_ISSUE, now=NOW, registry_dir=reg) is None
+
+
+def test_allow_when_started_ts_missing_or_non_numeric(reg):
+    _write_state(reg, active=True)  # missing started_ts
+    assert ss.auth_outage_dispatch_hold(_FAKE_ISSUE, now=NOW, registry_dir=reg) is None
+    _write_state(reg, active=True, started_ts="yesterday")  # non-numeric
+    assert ss.auth_outage_dispatch_hold(_FAKE_ISSUE, now=NOW, registry_dir=reg) is None
+
+
+def test_allow_past_ttl(reg):
+    # Second fail-open layer: even a wedged watcher pass cannot suppress past
+    # the 6h default TTL.
+    _active_state(reg, age_s=6.05 * 3600)
+    assert ss.auth_outage_dispatch_hold(_FAKE_ISSUE, now=NOW, registry_dir=reg) is None
+
+
+def test_ttl_env_override_and_out_of_range_fallback(reg, monkeypatch):
+    _active_state(reg, age_s=2 * 3600)  # a 2h-old episode
+    # In-bounds override: TTL=1h -> the 2h-old episode is expired -> allow.
+    monkeypatch.setenv("EPM_AUTH_OUTAGE_MAX_EPISODE_H", "1")
+    assert ss.auth_outage_dispatch_hold(_FAKE_ISSUE, now=NOW, registry_dir=reg) is None
+    # Out-of-range override (below lo=1.0): the DEFAULT 6h binds -> hold.
+    monkeypatch.setenv("EPM_AUTH_OUTAGE_MAX_EPISODE_H", "0.2")
+    assert ss.auth_outage_dispatch_hold(_FAKE_ISSUE, now=NOW, registry_dir=reg) is not None
+
+
+def test_canary_pending_matching_issue_allows(reg):
+    _active_state(reg, canary_pending={"issue": _FAKE_ISSUE, "arm": "crash", "ts": NOW - 60.0})
+    assert ss.auth_outage_dispatch_hold(_FAKE_ISSUE, now=NOW, registry_dir=reg) is None
+
+
+def test_canary_pending_other_issue_holds(reg):
+    _active_state(reg, canary_pending={"issue": _FAKE_ISSUE + 1, "arm": "crash", "ts": NOW - 60.0})
+    assert ss.auth_outage_dispatch_hold(_FAKE_ISSUE, now=NOW, registry_dir=reg) is not None
+
+
+def test_canary_pending_stale_holds(reg):
+    # A claim older than the 30-min default window has expired — hold.
+    _active_state(reg, canary_pending={"issue": _FAKE_ISSUE, "arm": "crash", "ts": NOW - 31 * 60.0})
+    assert ss.auth_outage_dispatch_hold(_FAKE_ISSUE, now=NOW, registry_dir=reg) is not None
+
+
+def test_canary_pending_malformed_holds(reg):
+    _active_state(reg, canary_pending={"issue": _FAKE_ISSUE, "arm": "crash"})  # missing ts
+    assert ss.auth_outage_dispatch_hold(_FAKE_ISSUE, now=NOW, registry_dir=reg) is not None
+    _active_state(reg, canary_pending={"issue": _FAKE_ISSUE, "arm": "crash", "ts": "soon"})
+    assert ss.auth_outage_dispatch_hold(_FAKE_ISSUE, now=NOW, registry_dir=reg) is not None
+
+
+def test_kill_switch_allows(reg, monkeypatch):
+    _active_state(reg)
+    monkeypatch.setenv("EPM_DISABLE_AUTH_OUTAGE_GUARD", "1")
+    assert ss.auth_outage_dispatch_hold(_FAKE_ISSUE, now=NOW, registry_dir=reg) is None
+
+
+def test_gate_never_writes_state(reg, monkeypatch):
+    """READ-ONLY invariant: the state file's bytes are identical after every
+    gate outcome exercised above (hold, canary allow, kill-switch allow)."""
+    path = _active_state(
+        reg, canary_pending={"issue": _FAKE_ISSUE + 1, "arm": "crash", "ts": NOW - 60.0}
+    )
+    before = path.read_bytes()
+    assert ss.auth_outage_dispatch_hold(_FAKE_ISSUE, now=NOW, registry_dir=reg) is not None
+    assert ss.auth_outage_dispatch_hold(_FAKE_ISSUE + 1, now=NOW, registry_dir=reg) is None
+    monkeypatch.setenv("EPM_DISABLE_AUTH_OUTAGE_GUARD", "1")
+    assert ss.auth_outage_dispatch_hold(_FAKE_ISSUE, now=NOW, registry_dir=reg) is None
+    monkeypatch.delenv("EPM_DISABLE_AUTH_OUTAGE_GUARD")
+    assert path.read_bytes() == before
+
+
+# ── watcher-parity pin family (plan §6 item 11, Statistics-critic MF r1) ────
+
+
+def _skip_if_env_tainted(*names: str) -> None:
+    """The watcher module constants froze at import; a live env override makes
+    the VALUE pins meaningless (delenv cannot undo an import-time read)."""
+    import os
+
+    for name in names:
+        if name in os.environ:
+            pytest.skip(f"env-tainted session: {name} is set")
+
+
+def test_watcher_parity_ttl_value():
+    # 11a: catches a watcher-side default retune (6.0 -> 4.0 h).
+    _skip_if_env_tainted("EPM_AUTH_OUTAGE_MAX_EPISODE_H")
+    assert ss.AUTH_OUTAGE_TTL_H_DEFAULT * 3600.0 == asw.AUTH_OUTAGE_MAX_EPISODE_S
+
+
+def test_watcher_parity_canary_window_value():
+    # 11a: the canary-window direction is the one that would wedge episodes
+    # (the choke gate suppressing a watcher-authorized canary).
+    _skip_if_env_tainted("EPM_AUTH_OUTAGE_CANARY_INTERVAL_MIN")
+    assert ss.AUTH_OUTAGE_CANARY_MIN_DEFAULT * 60.0 == asw.AUTH_OUTAGE_CANARY_INTERVAL_S
+
+
+def test_watcher_parity_bounds():
+    # 11b: the watcher's bounds live only in its `_env_float` call-site kwargs
+    # (no module constant) — pin them by source regex.
+    src = inspect.getsource(asw)
+
+    def call_site(env_name: str) -> tuple[float, float, float]:
+        m = re.search(
+            r'_env_float\(\s*"' + env_name + r'",\s*([\d.]+),\s*lo=([\d.]+),\s*hi=([\d.]+)\s*\)',
+            src,
+        )
+        assert m is not None, f"watcher _env_float call site for {env_name} not found"
+        return float(m.group(1)), float(m.group(2)), float(m.group(3))
+
+    default, lo, hi = call_site("EPM_AUTH_OUTAGE_MAX_EPISODE_H")
+    assert default == ss.AUTH_OUTAGE_TTL_H_DEFAULT
+    assert (lo, hi) == ss.AUTH_OUTAGE_TTL_H_BOUNDS
+    default, lo, hi = call_site("EPM_AUTH_OUTAGE_CANARY_INTERVAL_MIN")
+    assert default == ss.AUTH_OUTAGE_CANARY_MIN_DEFAULT
+    assert (lo, hi) == ss.AUTH_OUTAGE_CANARY_MIN_BOUNDS
+
+
+@pytest.mark.parametrize("raw", [None, "12", "junk", "0.2", "99"])
+def test_watcher_parity_env_parse(raw, monkeypatch):
+    # 11c: parse-SEMANTICS parity — call the watcher's parse FUNCTION fresh
+    # against the same env value (unset / in-bounds / garbled / out-of-range
+    # low / out-of-range high).
+    if raw is None:
+        monkeypatch.delenv("EPM_AUTH_OUTAGE_MAX_EPISODE_H", raising=False)
+        monkeypatch.delenv("EPM_AUTH_OUTAGE_CANARY_INTERVAL_MIN", raising=False)
+    else:
+        monkeypatch.setenv("EPM_AUTH_OUTAGE_MAX_EPISODE_H", raw)
+        monkeypatch.setenv("EPM_AUTH_OUTAGE_CANARY_INTERVAL_MIN", raw)
+    assert ss._auth_outage_ttl_s() == (
+        asw._env_float("EPM_AUTH_OUTAGE_MAX_EPISODE_H", 6.0, lo=1.0, hi=48.0) * 3600
+    )
+    assert ss._auth_outage_canary_window_s() == (
+        asw._env_float("EPM_AUTH_OUTAGE_CANARY_INTERVAL_MIN", 30.0, lo=10.0, hi=720.0) * 60
+    )
+
+
+@pytest.mark.parametrize("raw", [None, "1", "true", "yes", "TRUE", " yes ", "0", "junk"])
+def test_watcher_parity_kill_switch(raw, monkeypatch):
+    # 11d: the truthy set is a third duplicated surface — pin it against the
+    # watcher's own pure env-reading function.
+    if raw is None:
+        monkeypatch.delenv("EPM_DISABLE_AUTH_OUTAGE_GUARD", raising=False)
+    else:
+        monkeypatch.setenv("EPM_DISABLE_AUTH_OUTAGE_GUARD", raw)
+    assert ss._auth_outage_guard_enabled() == asw._auth_outage_enabled()
+
+
+def test_watcher_parity_state_path():
+    # 11e: FULL-path pin — a `.name`-only pin would stay green across a
+    # watcher-side relocation of the singleton's parent dir while the choke
+    # gate reads a nonexistent path (tests-green/gate-inert vacuity).
+    assert (
+        asw._auth_outage_state_path()
+    ) == ss.AUTONOMOUS_REGISTRY_DIR / ss.AUTH_OUTAGE_STATE_FILENAME
+
+
+# ── sentinel + cmd-level (plan §6 items 12-18) ──────────────────────────────
+
+
+def test_sentinel_recognized_by_spawn_output_suppressed():
+    out = f"{ss.AUTH_OUTAGE_HELD_SENTINEL} issue #{_FAKE_ISSUE}: episode ACTIVE; NOT spawning"
+    assert ss.spawn_output_suppressed(out) == ss.AUTH_OUTAGE_HELD_SENTINEL
+    assert ss.spawn_output_suppressed(f"Spawned session abc for issue #{_FAKE_ISSUE}") is None
+
+
+def test_cmd_spawn_issue_auto_suppressed_exit0(cmd_registry, monkeypatch, capsys):
+    # The gate must fire BEFORE the daemon POST and BEFORE lease acquisition
+    # (pre-lease placement pin: a gate after the lease would leave a TTL-held
+    # lease suppressing the watcher's canary for this issue).
+    _active_state(cmd_registry, now=time.time())
+    monkeypatch.setattr(ss, "post", lambda *a, **k: pytest.fail("daemon POST must not happen"))
+    monkeypatch.setattr(
+        ss,
+        "acquire_dispatch_lease",
+        lambda *a, **k: pytest.fail("dispatch lease must not be acquired"),
+    )
+    monkeypatch.setattr(
+        ss, "_spawn_issue_session", lambda *a, **k: pytest.fail("spawn tail must not be reached")
+    )
+    ss.cmd_spawn_issue(_spawn_ns(auto=True))  # returns (exit 0), no SystemExit
+    out = capsys.readouterr().out
+    # Producer -> recognizer loop closed on the CAPTURED stdout (a hand-built
+    # fixture string could drift from the actual print; #607 class) — this is
+    # what pins f-string/recognizer format agreement end-to-end.
+    assert ss.spawn_output_suppressed(out) == ss.AUTH_OUTAGE_HELD_SENTINEL
+    # test_gate_before_lease, folded: no lease file was left behind.
+    assert not ss.dispatch_lease_path(_FAKE_ISSUE).exists()
+
+
+def test_cmd_spawn_issue_manual_warns_and_proceeds(cmd_registry, monkeypatch, capsys):
+    _active_state(cmd_registry, now=time.time())
+    reached: list[int] = []
+    monkeypatch.setattr(
+        ss, "_spawn_issue_session", lambda args, issue, *rest, **k: reached.append(issue)
+    )
+    ss.cmd_spawn_issue(_spawn_ns(auto=False))
+    out = capsys.readouterr().out
+    assert reached == [_FAKE_ISSUE]  # manual spawns are not gated
+    assert "auth-outage episode ACTIVE" in out
+    assert ss.spawn_output_suppressed(out) is None  # warn line is NOT a suppression
+
+
+def test_cmd_spawn_issue_auto_canary_passes_end_to_end(cmd_registry, monkeypatch, capsys):
+    # The watcher-canary replay at the choke point: the watcher persisted
+    # canary_pending BEFORE shelling out to `spawn-issue --auto`, so the spawn
+    # tail (daemon POST + registration) must be reached.
+    now = time.time()
+    _active_state(
+        cmd_registry,
+        now=now,
+        canary_pending={"issue": _FAKE_ISSUE, "arm": "crash", "ts": now - 5.0},
+    )
+    reached: list[int] = []
+    monkeypatch.setattr(
+        ss, "_spawn_issue_session", lambda args, issue, *rest, **k: reached.append(issue)
+    )
+    ss.cmd_spawn_issue(_spawn_ns(auto=True))
+    out = capsys.readouterr().out
+    assert reached == [_FAKE_ISSUE]
+    assert ss.spawn_output_suppressed(out) is None
+
+
+def test_exception_arm_fails_open(reg, monkeypatch, capsys):
+    # §5 "Fail-open everywhere": an internal error can never hold a dispatch.
+    _active_state(reg)
+    monkeypatch.setattr(
+        ss, "_auth_outage_ttl_s", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    assert ss.auth_outage_dispatch_hold(_FAKE_ISSUE, now=NOW, registry_dir=reg) is None
+    err = capsys.readouterr().err
+    assert "dispatch-hold check error (fail-open)" in err
+
+
+def test_cmd_spawn_campaign_warns_and_proceeds(cmd_registry, monkeypatch, capsys):
+    # §4.4: campaign CLI spawns are human/PM-driven off a fresh user approval
+    # — warn-only, never suppress; the daemon POST is still reached.
+    _active_state(cmd_registry, now=time.time())
+    monkeypatch.setattr(
+        "explore_persona_space.task_workflow.get_task",
+        lambda issue: {"frontmatter": {"kind": "campaign"}, "status": "approved"},
+    )
+    verified: list[str] = []
+    monkeypatch.setattr(ss, "_verify_happy_patch_or_die", lambda context: verified.append(context))
+    posts: list[str] = []
+
+    def fake_post(endpoint, body):
+        posts.append(endpoint)
+        return {"success": True, "sessionId": "sid-campaign-test"}
+
+    monkeypatch.setattr(ss, "post", fake_post)
+    monkeypatch.setattr(ss, "_register_campaign_session", lambda *a, **k: None)
+    ns = argparse.Namespace(
+        issue=_FAKE_ISSUE,
+        budget_gpu_hours=None,
+        max_concurrent=None,
+        per_child_cap=None,
+        betas=None,
+        model=None,
+        effort=None,
+    )
+    ss.cmd_spawn_campaign(ns)
+    out = capsys.readouterr().out
+    assert "auth-outage episode ACTIVE" in out
+    assert "may die on arrival; proceeding" in out
+    assert posts == ["/spawn-session"]  # the POST was reached — never suppressed
+    assert verified == ["spawn-campaign"]
+    assert ss.spawn_output_suppressed(out) is None
+
+
+def test_future_dated_started_ts_holds(reg):
+    # §7 row 4: a future-dated started_ts HOLDS — deliberate watcher parity
+    # (asw:6307 has identical arithmetic); diverging here would create two
+    # gates disagreeing on one state file.
+    _write_state(reg, active=True, started_ts=NOW + 3600.0)
+    assert ss.auth_outage_dispatch_hold(_FAKE_ISSUE, now=NOW, registry_dir=reg) is not None


### PR DESCRIPTION
Closes task #1218. Adds a read-only, fail-open auth-outage dispatch hold to spawn_session.py (--auto-only suppression mirroring the takeover-sentinel posture; watcher canary passes via the pre-spawn canary_pending claim; zero watcher changes). Plan v3, code-review PASS r1, test-verdict PASS (4214P/1F pre-existing).