### PR TITLE
task #1487: check 40 slashless-subpath arm (workflow-fix)

### DIFF
--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -8748,6 +8748,8 @@ _BACKTICK_DIR_RE = re.compile(r"`(?P<ns>[A-Za-z0-9_\-./]{1,120}/)`")
 # design. Trailing negative lookahead: a paren immediately followed by an
 # HF markdown link is Pattern B's paren-before-link shape — D declines
 # rather than extracting a second, differently-scoped claim.
+# Slashless sibling (check 40 ONLY, #1487): _BACKTICK_SLASHLESS_SUBPATH_COUNT_PAREN_RE
+# (defined in the check-40 block) — Pattern D itself is deliberately untouched.
 _BACKTICK_SUBPATH_COUNT_PAREN_RE = re.compile(
     r"`(?P<sub>(?!\.\.?/)[A-Za-z0-9_\-./]{1,120}/)`"
     r"[ \t]{0,2}"
@@ -9575,6 +9577,25 @@ _UNPINNED_CUE_WINDOW = 250  # chars of same-line look-back for the cue
 # RELATIVE sub-path claim; bound like the Pattern-D binder (same line,
 # bracket-free gap <= _SUBPATH_CLAIM_MAX_GAP).
 _BACKTICK_ISSUE_PARENT_RE = re.compile(r"`(?P<parent>issue\d+_[A-Za-z0-9_\-./]{0,118}/)`")
+# Slashless sibling of _BACKTICK_SUBPATH_COUNT_PAREN_RE (#1487, the #1345
+# `analysis_tensors/turnstore` (10 files) footer shape): same paren/count/
+# noun/lookahead shape VERBATIM, but the token does NOT end in "/". A
+# slashless token has no intrinsic directory signature, so the gatherer
+# admits it ONLY under the strong G4 arms (own issue<N>_ prefix, or a
+# binding backtick parent anchor) — never the weak same-line HF cue — and
+# declines dotted-final-segment tokens (check 32's FILE territory).
+# Consumed ONLY by _gather_hf_unpinned_count_claims; check 30 Pattern D is
+# deliberately untouched (pinned-adjacent slashless claims stay out of
+# BOTH checks' scope — see the gatherer docstring).
+_BACKTICK_SLASHLESS_SUBPATH_COUNT_PAREN_RE = re.compile(
+    r"`(?P<sub>(?!\.\.?/)[A-Za-z0-9_\-./]{0,119}[A-Za-z0-9_\-])`"
+    r"[ \t]{0,2}"
+    r"\((?P<count>\d{1,3}(?:,\d{3})+|\d{1,6})\s+(?P<noun>files?|shards?)\b"
+    r"(?!\s+(?:listed\s+)?per\s+\w+\b)"
+    r"[^()]{0,200}\)"
+    r"(?!\s{0,2}[:\u2013\u2014-]?\s{0,2}\[[^\]]{1,300}\]\(https?://huggingface\.co)",
+    re.IGNORECASE,
+)
 # Per-body cap on unique main-revision count probes (same worst-case
 # per-probe arithmetic as _HF_COUNT_MAX_PROBES: ~22.5 s worst case each;
 # unpinned claims are rare, so 4 suffices — past-cap claims keep their
@@ -9596,20 +9617,33 @@ def _hf_hub_importable() -> bool:
 
 def _gather_hf_unpinned_count_claims(body: str) -> list[tuple[int, str, str, str | None]]:
     """Extract ``(claimed_count, noun, token, resolved_prefix_or_None)``
-    tuples for Pattern-D-shaped backtick ``dir/`` + count-paren claims whose
-    pinned-link binder returned None — the UNPINNED residue of check 30's
-    Pattern D — HF-context-gated (check 40, #1433; the #1345 footer shape).
+    tuples for backtick subpath + count-paren claims whose pinned-link
+    binder returned None — the UNPINNED residue of check 30's Pattern D
+    shape — HF-context-gated (check 40, #1433; the #1345 footer shape;
+    slashless tokens added by #1487).
 
     Gates, ALL required to fire (precision over recall; WARN-only):
 
-    - **G1 shape:** an ``_BACKTICK_SUBPATH_COUNT_PAREN_RE`` match, reused
-      VERBATIM from check 30 Pattern D (trailing-slash dir token,
-      count-opening paren, ``per <word>`` distributive decline,
-      not-Pattern-B trailing lookahead), over the fence-stripped body.
-    - **G2 residue:** ``_nearest_preceding_pinned_tree_link(...)`` is None.
-      Pinned-adjacent matches belong to check 30 Pattern D — the two sets
-      partition the D-shape matches by construction, so no claim is ever
-      double-WARNed.
+    - **G1 shape**, one of TWO regexes: (a) an
+      ``_BACKTICK_SUBPATH_COUNT_PAREN_RE`` match, reused VERBATIM from
+      check 30 Pattern D (trailing-slash dir token, count-opening paren,
+      ``per <word>`` distributive decline, not-Pattern-B trailing
+      lookahead); or (b) a slashless-sibling
+      ``_BACKTICK_SLASHLESS_SUBPATH_COUNT_PAREN_RE`` match (#1487 — same
+      paren/count/noun/lookahead tail, token NOT ending in ``/``). Both run
+      over the fence-stripped body, merged in body order. Slashless-ONLY
+      declines (no directory signature to lean on): a DOTTED final segment
+      (a FILE claim — check 32's territory) and any dot-/empty path
+      segment (``.``/``..``/``//``/leading ``/`` — would join to a
+      nonexistent probe path).
+    - **G2 residue (BOTH shapes):**
+      ``_nearest_preceding_pinned_tree_link(...)`` is None. Pinned-adjacent
+      SLASHED matches belong to check 30 Pattern D — the two sets partition
+      the D-shape matches by construction, so no claim is ever
+      double-WARNed. A pinned-adjacent SLASHLESS claim stays out of BOTH
+      checks' scope (a stated bound, unchanged from pre-#1487: no false
+      missing-pin WARN when the pin is present; its count is simply not
+      verified).
     - **G3 not git/local:** the token's first path segment is nonempty
       (declines absolute ``/workspace/...`` forms) and not in
       ``_GIT_SIDE_ROOTS``.
@@ -9617,29 +9651,52 @@ def _gather_hf_unpinned_count_claims(body: str) -> list[tuple[int, str, str, str
       layout), OR a preceding ``issue<N>_.../`` backtick parent anchor binds
       (same line, no ``[``/``]`` in the gap, gap <=
       ``_SUBPATH_CLAIM_MAX_GAP`` — the Pattern-D binder's constraints), OR
-      ``_HF_CUE_RE`` hits in the same-line
-      <=``_UNPINNED_CUE_WINDOW``-char look-back window.
+      — SLASHED shape ONLY — ``_HF_CUE_RE`` hits in the same-line
+      <=``_UNPINNED_CUE_WINDOW``-char look-back window. Slashless tokens
+      require one of the two STRONG arms (own prefix / parent anchor) and
+      never ride the weak cue (#1487 D2), so a slashless claim always
+      arrives with ``resolved`` non-None.
 
     ``resolved_prefix``: the token itself (slash-stripped) when
     issue-prefixed; ``<parent>/<token>`` when a parent anchor bound; else
-    None (the claim WARNs as missing-pin, unresolvable — ZERO probes).
+    None (the claim WARNs as missing-pin, unresolvable — ZERO probes;
+    reachable for the slashed shape only, per G4).
     Dedup on (count, noun-singular, token).
 
     Known recall sacrifices (each avoids a concrete false-positive class):
-    a dir token WITHOUT the trailing slash (#1345's own sibling claim
-    ``raw_completions/stories`` (16 files)); bare-number parens (``(26)``);
-    count-in-prose without a paren; a legacy underscore-form HF prefix
-    (``issue_568/...``) that neither the cue nor a parent anchor rescues.
+    a slashless token with NEITHER an ``issue<N>_`` prefix NOR a binding
+    parent anchor (cue-only slashless declines by design — no directory
+    signature); a slashless dotted-final-segment token (check 32's FILE
+    territory); bare-number parens (``(26)`` — RETAINED by #1487 D3, a
+    stated deviation from that task Goal's letter: the count-noun is the
+    strongest precision token in the whole check-30/40 family, and a bare
+    ``(N)`` beside a backtick token is routinely a row count / N= /
+    footnote — e.g. #1345's own ``analysis_tensors/preds_cache`` (8), the
+    declared residual miss); count-in-prose without a paren; a legacy
+    underscore-form HF prefix (``issue_568/...``) that neither the cue nor
+    a parent anchor rescues.
     """
     stripped = _strip_fenced_blocks(body)
     link_matches = list(_MD_HF_LINK_RE.finditer(stripped))
     parent_matches = list(_BACKTICK_ISSUE_PARENT_RE.finditer(stripped))
     out: list[tuple[int, str, str, str | None]] = []
     seen: set[tuple[int, str, str]] = set()
-    for dm in _BACKTICK_SUBPATH_COUNT_PAREN_RE.finditer(stripped):
+    d_matches = [(m, False) for m in _BACKTICK_SUBPATH_COUNT_PAREN_RE.finditer(stripped)]
+    sl_matches = [(m, True) for m in _BACKTICK_SLASHLESS_SUBPATH_COUNT_PAREN_RE.finditer(stripped)]
+    for dm, slashless in sorted(d_matches + sl_matches, key=lambda t: t[0].start()):
         if _nearest_preceding_pinned_tree_link(stripped, dm.start(), link_matches) is not None:
-            continue  # G2: pinned-adjacent — check 30 Pattern D's territory
+            # G2 (both shapes): pinned-adjacent. Slashed = check 30 Pattern
+            # D's territory (partition preserved); slashless stays out of
+            # BOTH checks' scope (no false missing-pin WARN — the pin IS
+            # present; a stated bound, see the docstring).
+            continue
         token = dm.group("sub")
+        if slashless:
+            segs = token.split("/")
+            if "." in segs[-1]:
+                continue  # dotted FINAL segment = FILE claim (check 32's territory)
+            if any(s in ("", ".", "..") for s in segs):
+                continue  # dot-/empty segments would join to a nonexistent probe path
         first_seg = token.split("/", 1)[0]
         if not first_seg or first_seg in _GIT_SIDE_ROOTS:
             continue  # G3: git/local path, never an HF data-repo prefix
@@ -9665,6 +9722,8 @@ def _gather_hf_unpinned_count_claims(body: str) -> list[tuple[int, str, str, str
                         p for p in (parent.group("parent").strip("/"), token.strip("/")) if p
                     )
         if resolved is None:
+            if slashless:
+                continue  # STRONG arms only for slashless — no HF-cue fallback (#1487 D2)
             window = stripped[max(0, dm.start() - _UNPINNED_CUE_WINDOW) : dm.start()]
             window = window.rsplit("\n", 1)[-1]  # same-line look-back only
             if _HF_CUE_RE.search(window) is None:
@@ -9688,7 +9747,11 @@ def check_hf_unpinned_count_claims(body: str) -> CheckResult:
     pinned tree link binding on the line (the nearest preceding pinned link
     is declined by the Pattern-D gap guards — intervening brackets + a
     >400-char gap), so checks 30/32 — both pin-adjacent by construction —
-    silently dropped the claim (#1433).
+    silently dropped the claim (#1433). #1487 extends the extraction to
+    SLASHLESS subpath tokens (#1345's ``analysis_tensors/turnstore`` (10
+    files) under an unlinked backtick ``issue<N>_.../`` parent prefix),
+    strong-arm-gated; a pinned-adjacent slashless claim stays out of BOTH
+    checks' scope (see ``_gather_hf_unpinned_count_claims``).
 
     Semantics:
 

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -3718,12 +3718,24 @@ _HF_40_NAME = "backtick HF-path count claims carry an adjacent pinned /tree link
 
 # The verbatim #1345 footer sentence (body.md L189, the incident shape):
 # `rejudge/` (2 files) extracts via the `issue1345_framing/...` parent
-# anchor + the "HF" cue; `raw_completions/stories` (16 files) is the
-# documented no-trailing-slash recall sacrifice.
+# anchor + the "HF" cue; `raw_completions/stories` (16 files) — no trailing
+# slash — was the documented recall sacrifice until #1487's slashless arm
+# and now extracts via the same parent anchor.
 _I1345_UNPINNED_LINE = (
     "Round data on HF under `issue1345_framing/assistant_named_story/` — "
     "`raw_completions/stories` (16 files) and `rejudge/` (2 files), verified live via "
     "scoped `list_repo_tree` (stories at data-repo revision `debcdda045`)."
+)
+
+# The TRUE verbatim pre-patch #1345 story-slot-ablation footer clause —
+# provenance: `git show 003078e125:tasks/followups_running/1345/body.md`
+# (the shape check 40 silently passed pre-#1487): a SLASHLESS subpath
+# token under the unlinked backtick parent prefix, plus a bare-paren `(8)`
+# sibling claim in the same clause (the declared #1487 D3 residual).
+_I1345_SLOT_ABLATION_LINE = (
+    "Round data on HF under `issue1345_framing/story_slot_ablation/` — verified live via "
+    "scoped listing: `analysis_tensors/turnstore` (10 files), `analysis_tensors/preds_cache` "
+    "(8)."
 )
 
 
@@ -3732,13 +3744,22 @@ def test_hf_unpinned_count_claim_warns_missing_pin_1345_shape(monkeypatch):
     #1345 footer sentence produces a check-40 WARN naming the missing pin,
     the `rejudge/` token, and the resolved 2-file count at `main`; overall
     ok STAYS True (WARN never blocks); the probe URL carries the `main`
-    revision (plan assumption 3, mechanically closed)."""
+    revision (plan assumption 3, mechanically closed). Since #1487 the
+    slashless `raw_completions/stories` sibling ALSO extracts — the stub
+    carries its 16 files so BOTH claims read count-consistent (exercising
+    the two-probe path)."""
     monkeypatch.delenv("EPM_VERIFY_BODY_NO_HF", raising=False)
     calls: list = []
     entries = [
         {"path": "issue1345_framing", "type": "directory"},
         {"path": "issue1345_framing/assistant_named_story/rejudge/r0.json", "type": "file"},
         {"path": "issue1345_framing/assistant_named_story/rejudge/r1.json", "type": "file"},
+    ] + [
+        {
+            "path": f"issue1345_framing/assistant_named_story/raw_completions/stories/s{i}.json",
+            "type": "file",
+        }
+        for i in range(16)
     ]
     _stub_tree(monkeypatch, status="ok", entries=entries, calls=calls)
     body = (
@@ -3752,8 +3773,10 @@ def test_hf_unpinned_count_claim_warns_missing_pin_1345_shape(monkeypatch):
     r = by_name[_HF_40_NAME]
     assert r.passed and r.is_warn
     assert "rejudge" in r.detail
+    assert "raw_completions/stories" in r.detail  # the #1487 slashless arm
     assert "no adjacent" in r.detail and "pinned /tree/<sha> link" in r.detail
-    assert "2 file(s)" in r.detail and "count consistent" in r.detail
+    assert "2 file(s)" in r.detail and "16 file(s)" in r.detail
+    assert r.detail.count("count consistent") == 2
     assert ok  # WARN never flips overall ok
     # The count probe resolves against the data repo at the moving ref
     # `main` — `_hf_tree_url` interpolates the branch name opaquely.
@@ -3898,17 +3921,24 @@ def test_hf_unpinned_probe_failure_keeps_missing_pin_warn(monkeypatch):
 def test_hf_unpinned_claim_extractor_shapes():
     """Pure extractor (no monkeypatch, no network): resolution arms +
     declines. An issue-prefixed token resolves to itself; the #1345 line
-    yields exactly ONE claim resolved via the parent-anchor join
-    (`raw_completions/stories` — no trailing slash — is the documented
-    recall sacrifice); a cue-only claim extracts unresolvable (None);
-    declines cover the paren-then-HF-link Pattern-B lookahead, fenced code
-    blocks, the distributive `per <word>` qualifier, and dot-segments."""
+    yields TWO claims resolved via the parent-anchor join — the slashless
+    `raw_completions/stories` (the pre-#1487 recall sacrifice, now covered)
+    in body order before `rejudge/`; a cue-only claim extracts unresolvable
+    (None); declines cover the paren-then-HF-link Pattern-B lookahead,
+    fenced code blocks, the distributive `per <word>` qualifier, and
+    dot-segments."""
     gather = verify_task_body._gather_hf_unpinned_count_claims
     assert gather("Uploaded `issue70_abc/raw/` (3 files).") == [
         (3, "files", "issue70_abc/raw/", "issue70_abc/raw")
     ]
     assert gather(_I1345_UNPINNED_LINE) == [
-        (2, "files", "rejudge/", "issue1345_framing/assistant_named_story/rejudge")
+        (
+            16,
+            "files",
+            "raw_completions/stories",
+            "issue1345_framing/assistant_named_story/raw_completions/stories",
+        ),
+        (2, "files", "rejudge/", "issue1345_framing/assistant_named_story/rejudge"),
     ]
     assert gather("Uploaded to the HF data repo: `mystery/` (3 files).") == [
         (3, "files", "mystery/", None)
@@ -3958,6 +3988,135 @@ def test_hf_unpinned_no_failing_checkresult_in_source():
                     assert not (isinstance(kw.value, ast.Constant) and kw.value.value is False), (
                         f"{fn.__name__} constructs CheckResult(passed=False)"
                     )
+
+
+def test_hf_unpinned_slashless_subpath_1345_turnstore_shape(monkeypatch):
+    """THE #1487 regression fixture + durability pin: the TRUE verbatim
+    pre-patch #1345 story-slot-ablation footer clause
+    (`_I1345_SLOT_ABLATION_LINE`) produces a check-40 WARN naming the
+    slashless `analysis_tensors/turnstore` token, the missing pin, and the
+    resolved 10-file count at `main`; overall ok STAYS True. EXACTLY ONE
+    claim extracts — the bare-paren `analysis_tensors/preds_cache` (8)
+    sibling in the SAME clause does NOT (the #1487 D3 declared residual:
+    bare-`(N)` counts stay excluded, a stated deviation from the task
+    Goal's letter)."""
+    monkeypatch.delenv("EPM_VERIFY_BODY_NO_HF", raising=False)
+    assert verify_task_body._gather_hf_unpinned_count_claims(_I1345_SLOT_ABLATION_LINE) == [
+        (
+            10,
+            "files",
+            "analysis_tensors/turnstore",
+            "issue1345_framing/story_slot_ablation/analysis_tensors/turnstore",
+        )
+    ]
+    entries = [
+        # The directory row satisfies check 23's needle probe for the
+        # `_hf_body` feedface link (the sibling 1345-shape test's shape).
+        {"path": "issue1345_framing", "type": "directory"},
+    ] + [
+        {
+            "path": f"issue1345_framing/story_slot_ablation/analysis_tensors/turnstore/t{i}.pt",
+            "type": "file",
+        }
+        for i in range(10)
+    ]
+    _stub_tree(monkeypatch, status="ok", entries=entries)
+    body = (
+        _hf_body(f"{_I931_REPO}/tree/feedface/issue1345_framing")
+        + "\n"
+        + _I1345_SLOT_ABLATION_LINE
+        + "\n"
+    )
+    ok, results = verify_task_body.verify_text(body)
+    by_name = _results_by_name(results)
+    r = by_name[_HF_40_NAME]
+    assert r.passed and r.is_warn
+    assert "analysis_tensors/turnstore" in r.detail
+    assert "no adjacent" in r.detail and "pinned /tree/<sha> link" in r.detail
+    assert "10 file(s)" in r.detail and "count consistent" in r.detail
+    assert "preds_cache" not in r.detail  # D3: the bare-paren `(8)` claim never extracts
+    assert ok  # WARN never flips overall ok
+
+
+def test_hf_unpinned_slashless_extractor_gating():
+    """Pure extractor (no monkeypatch, no network), the #1487 slashless
+    arm: STRONG-arm-only G4 — an issue-prefixed slashless token resolves to
+    itself; a parent-anchored slashless token (incl. the riskiest
+    single-segment form) resolves via the join; a cue-only slashless token
+    DECLINES (no weak HF-cue arm, unlike the slashed shape); dotted final
+    segments (check 32's FILE territory), git-side first segments (G3),
+    and dot-segment paths decline."""
+    gather = verify_task_body._gather_hf_unpinned_count_claims
+    # (a) own issue<N>_ prefix — resolves to itself (already slash-free).
+    assert gather("Uploaded `issue70_abc/raw` (3 files).") == [
+        (3, "files", "issue70_abc/raw", "issue70_abc/raw")
+    ]
+    # (a') single-segment slashless under a binding parent anchor — the
+    # riskiest-FP form, deliberately pinned as EXTRACTING with the parent
+    # join (#1487 §13 amendment 2; the kill-criterion ≥1-`/` fallback would
+    # flip this to a decline and record the narrowing in the docstring).
+    assert gather("HF under `issue5_x/` — `turnstore` (10 files) verified.") == [
+        (10, "files", "turnstore", "issue5_x/turnstore")
+    ]
+    declines = [
+        # (b) cue-only slashless: the weak HF-cue arm never admits slashless.
+        "Uploaded to the HF data repo: `mystery` (3 files).",
+        # (c) dotted FINAL segment = a FILE claim (check 32's territory),
+        # even under a binding parent anchor.
+        "HF under `issue5_x/` — `analysis/pooled.pt` (3 files) verified.",
+        # (d) git-side first segment under an HF parent anchor on the same
+        # line — G3 applies to the slashless shape too.
+        "HF under `issue9_y/` — `eval_results/issue_9` (34 files) in git.",
+        # (e) dot-segment paths would join to a nonexistent probe path (the
+        # leading form is regex-declined; the mid form is gate-declined).
+        "HF under `issue5_x/` — `../x` (2 files) relative.",
+        "HF under `issue5_x/` — `issue5_x/../y` (2 files) relative.",
+    ]
+    for body in declines:
+        assert gather(body) == [], body
+
+
+def test_hf_unpinned_slashless_pinned_adjacent_declines():
+    """A PINNED-adjacent slashless claim stays out of BOTH checks' scope
+    (the stated #1487 bound): check 40's gatherer declines it (G2 — no
+    false missing-pin WARN when the pin IS present) AND check 30's gatherer
+    still requires the trailing slash (Pattern D byte-unchanged — the cheap
+    check-30-unchanged guard). Pure extractor split: zero probes (autouse
+    guard enforces)."""
+    line = (
+        f"Footer: [issue1112 data]({_I931_REPO}/tree/{_I931_SHA}/issue1112_x) — "
+        "`raw_completions` (7,165 files: shards)"
+    )
+    assert verify_task_body._gather_hf_unpinned_count_claims(line) == []
+    assert verify_task_body._gather_hf_count_claims(line) == []
+    r = verify_task_body.check_hf_unpinned_count_claims(line)
+    assert r.passed and not r.is_warn
+    assert "no unpinned" in r.detail
+
+
+def test_hf_unpinned_slashless_multi_item_list():
+    """#1487 design question 4 (§4.4): ONE parent anchor + a comma list of
+    claims (one slashed, two slashless) — every item binds to the anchor
+    within the 400-char bracket-free gap (earlier items' backticks/parens
+    ride in the gap; they are not decline characters); an intervening
+    markdown link before a later item breaks binding for it (bracket rule —
+    conservative decline; slashless has no cue fallback to fall through
+    to)."""
+    gather = verify_task_body._gather_hf_unpinned_count_claims
+    line = "Data under `issue7_p/` — `a/` (1 file), `b/c` (2 files), `d` (3 files)."
+    assert gather(line) == [
+        (1, "file", "a/", "issue7_p/a"),
+        (2, "files", "b/c", "issue7_p/b/c"),
+        (3, "files", "d", "issue7_p/d"),
+    ]
+    line2 = (
+        "Data under `issue7_p/` — `a/` (1 file), `b/c` (2 files), "
+        "[meta](https://example.com/x) and `d` (3 files)."
+    )
+    assert gather(line2) == [
+        (1, "file", "a/", "issue7_p/a"),
+        (2, "files", "b/c", "issue7_p/b/c"),
+    ]
 
 
 # ─── `_hf_tree_pages`: the shared bounded pagination generator (#1186) ─────


### PR DESCRIPTION
Closes task #1487.

Extends `verify_task_body.py` Check 40 with a slashless-subpath regex arm so `` `analysis_tensors/turnstore` (10 files) ``-style claims under a backticked-but-unlinked `issue<N>_.../` parent prefix extract and WARN (the #1345 footer shape Check 40 silently missed). Strong-arm-only G4 gating for slashless tokens; check 30 byte-unchanged; WARN-only preserved; bare-`(N)` forms remain a declared recall sacrifice (plan §11 D3). Pipeline: plan v3 (ensemble APPROVE round 1), code-review PASS, test-verdict PASS (3799 passed / 6 skipped; compare clean).