### PR TITLE
issue-1490: transactional GCP→RunPod failover cleanup (#1490)

### DIFF
--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -9461,7 +9461,14 @@ def _maybe_flag_orphan_gcp_handle_pod(
         )
     # Mirror into the caller's in-memory snapshot so the status-class arm's
     # later save (which passes prev=prev_state) carries the flag forward.
+    # The pod_id mirrors TOO (r2 Minor fix): _save_pod_safety_state's None-carry
+    # is pod_id-keyed (same_pod), so on a NEW pod incarnation a stale OLD
+    # pod_id in prev_state would make the status-class save recompute
+    # same_pod=False and clobber the just-persisted flag back to False — one
+    # duplicate alert on the next tick. The arm just persisted this pod_id to
+    # disk (above), so the in-memory mirror only restores consistency.
     prev_state["orphan_gcp_noted"] = True
+    prev_state["pod_id"] = info.pod_id
     return True
 
 

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -992,6 +992,24 @@ _WEDGE_STOP_NOTE_SENTINEL = "[autonomous_session_watch:runpod-noport-wedge-stop]
 # from "real progress" like the other wedge markers.
 _WEDGE_FAILOVER_NOTE_SENTINEL = "[autonomous_session_watch:runpod-noport-wedge-failover]"
 
+# Substring stamped into the #1490 orphan-gcp-handle alert marker: a RUNNING
+# bare `pod-<N>` whose run-handle sidecar still points at backend=gcp past the
+# grace window — the residue class the poller-side D1 reclaim can miss (poller
+# crash between provision and reclaim, or a failed terminate). ALERT-ONLY:
+# this arm never stops/terminates anything. Deduped once per pod incarnation
+# via the `orphan_gcp_noted` pod-safety state field.
+_ORPHAN_GCP_HANDLE_NOTE_SENTINEL = "[autonomous_session_watch:orphan-gcp-handle-alert]"
+
+#: Grace (seconds) before the #1490 orphan-gcp-handle arm flags a RUNNING bare
+#: ``pod-<N>`` with a stale ``backend=gcp`` sidecar. Sized ~2x the healthy
+#: failover create→bootstrap→execute→sidecar-re-point window (bootstrap
+#: ~5-15 min; wait-for-capacity runs pre-create so it never counts against pod
+#: age) — the ``RUNPOD_WEDGE_K_SEC = 900`` sizing convention doubled, because
+#: bootstrap is longer than port bring-up. Env-overridable at CALL time via
+#: ``EPM_ORPHAN_GCP_HANDLE_GRACE_SEC`` (:func:`_orphan_gcp_handle_grace_sec`,
+#: mirroring ``backend_poll._gcp_queue_wait_seconds``).
+ORPHAN_GCP_HANDLE_GRACE_SEC = 1800
+
 # Substring stamped into every session-stalled-alert marker note. Same role as
 # _ALERT_NOTE_SENTINEL for the pod-safety pass: a session-stalled alert is
 # posted as epm:progress and MUST be filtered out of the "real progress" set,
@@ -1385,6 +1403,7 @@ _WATCHER_NOTE_SENTINELS: frozenset[str] = frozenset(
         _WEDGE_ALERT_NOTE_SENTINEL,
         _WEDGE_STOP_NOTE_SENTINEL,
         _WEDGE_FAILOVER_NOTE_SENTINEL,
+        _ORPHAN_GCP_HANDLE_NOTE_SENTINEL,
         _STALLED_ALERT_NOTE_SENTINEL,
         _STALLED_RESPAWN_NOTE_SENTINEL,
         _STALLED_EXHAUSTED_NOTE_SENTINEL,
@@ -7378,6 +7397,7 @@ def _save_pod_safety_state(
     keep_running_noted: bool | None = None,
     followup_noted: bool | None = None,
     stop_failed_noted: bool | None = None,
+    orphan_gcp_noted: bool | None = None,
     wedge_first_seen: float | None = _CARRY,
     wedge_missed: int | None = _CARRY,
     wedge_alerted: bool | None = _CARRY,
@@ -7399,7 +7419,11 @@ def _save_pod_safety_state(
     None carries forward identically. ``stop_failed_noted`` is the same
     dedup/carry-forward flag owned by the stop arm's FAILED branch (one
     durable ``stop-failed`` marker per state-file lifetime, #1155); None
-    carries forward identically.  ``prev`` is the existing on-disk
+    carries forward identically. ``orphan_gcp_noted`` is the same
+    dedup/carry-forward flag owned by the #1490 orphan-gcp-handle alert arm
+    (once per pod incarnation; the arm itself treats a stored flag under a
+    DIFFERENT ``pod_id`` as not-noted — the wedge-clock reset convention);
+    None carries forward identically.  ``prev`` is the existing on-disk
     payload (if any), passed so callers that already loaded it don't re-read;
     ``first_seen`` carries forward when present so the age backstop measures
     the original episode start, not the latest save.
@@ -7433,6 +7457,19 @@ def _save_pod_safety_state(
         followup_noted = bool((prev or {}).get("followup_noted", False))
     if stop_failed_noted is None:
         stop_failed_noted = bool((prev or {}).get("stop_failed_noted", False))
+    if orphan_gcp_noted is None:
+        # #1490 orphan-gcp-handle alert dedup (once per pod incarnation) —
+        # None carries the prior on-disk value forward like
+        # ``keep_running_noted`` / ``followup_noted``, EXCEPT that the carry
+        # is pod_id-keyed: a save under a NEW pod_id resets the flag to False
+        # (the wedge-clock reset convention), so a fresh pod incarnation
+        # re-alerts. This reset must live HERE (not only in the arm's own
+        # predicate) because the #692 wedge arm's ``_clear_wedge_state`` save
+        # rewrites ``pod_id`` earlier in the same tick, which would otherwise
+        # launder the stale flag onto the new incarnation before the orphan
+        # arm ever observes the change.
+        same_pod = (prev or {}).get("pod_id") == pod_id
+        orphan_gcp_noted = bool((prev or {}).get("orphan_gcp_noted", False)) and same_pod
     if wedge_first_seen is _CARRY:
         prev_wedge_first_seen = (prev or {}).get("wedge_first_seen")
         wedge_first_seen = (
@@ -7451,6 +7488,7 @@ def _save_pod_safety_state(
         "keep_running_noted": bool(keep_running_noted),
         "followup_noted": bool(followup_noted),
         "stop_failed_noted": bool(stop_failed_noted),
+        "orphan_gcp_noted": bool(orphan_gcp_noted),
         "first_seen": prev_first_seen,
         "wedge_first_seen": wedge_first_seen,
         "wedge_missed": int(wedge_missed),
@@ -9273,6 +9311,160 @@ def _process_wedged_pod(
         )
 
 
+def _orphan_gcp_handle_grace_sec() -> int:
+    """Read the #1490 orphan-gcp-handle grace, defaulting to 1800s.
+
+    Read at CALL time (not import time) from ``EPM_ORPHAN_GCP_HANDLE_GRACE_SEC``
+    so ops can retune without restarting the watcher cron — mirroring
+    ``backend_poll._gcp_queue_wait_seconds`` (#783). A missing / non-integer /
+    non-positive value falls back to :data:`ORPHAN_GCP_HANDLE_GRACE_SEC`.
+    """
+    raw = os.environ.get("EPM_ORPHAN_GCP_HANDLE_GRACE_SEC")
+    if raw is None:
+        return ORPHAN_GCP_HANDLE_GRACE_SEC
+    try:
+        val = int(raw)
+    except (TypeError, ValueError):
+        return ORPHAN_GCP_HANDLE_GRACE_SEC
+    return val if val > 0 else ORPHAN_GCP_HANDLE_GRACE_SEC
+
+
+def _orphan_gcp_sidecar_is_gcp(issue: int) -> bool:
+    """True iff issue ``issue``'s run-handle sidecar resolves AND reads backend=gcp.
+
+    The #1490 orphan-arm predicate leg: a RUNNING bare ``pod-<N>`` coexisting
+    with a gcp-pointing handle is anomalous (the failover either re-points the
+    sidecar at runpod or tears the pod down). Uses the SAME sidecar resolver
+    the wedge arm uses (``resolve_handle_sidecar_path``). ANY read / parse /
+    import failure returns False — bias QUIET (alert-only arm, a miss is
+    cheap) — with ONE stderr diagnostic line so the quiet miss is diagnosable
+    (plan v2 fold-in).
+    """
+    try:
+        from explore_persona_space.backends.issue_dispatch import (
+            read_handle_sidecar,
+            resolve_handle_sidecar_path,
+        )
+
+        path, _probed = resolve_handle_sidecar_path(issue)
+        if not path.exists():
+            return False
+        return read_handle_sidecar(path).backend == "gcp"
+    except Exception as exc:
+        print(
+            f"  orphan-gcp-handle: sidecar unreadable for #{issue} "
+            f"({type(exc).__name__}: {exc}); no alert (bias quiet)",
+            file=sys.stderr,
+        )
+        return False
+
+
+def _maybe_flag_orphan_gcp_handle_pod(
+    issue: int,
+    info: PodInfo,
+    now: float,
+    keep_running: bool,
+    followup_active: bool,
+    prev_state: dict,
+    dry_run: bool,
+) -> bool:
+    """ALERT-ONLY #1490 orphan arm: flag a RUNNING bare ``pod-<N>`` whose run
+    handle still points at ``backend=gcp`` past the grace window.
+
+    The residue class the poller-side D1 reclaim
+    (``backend_poll._reclaim_failed_runpod_provision``) can miss — a poller
+    crash between provision and reclaim, or a failed/unattributable terminate.
+    PURELY ADDITIVE: never stops, never terminates, never returns-early on
+    behalf of the caller — ``_process_pod`` falls through to the status-class
+    decision unconditionally. Returns whether it alerted (for tests).
+
+    Predicate, ALL must hold (cheap legs first; the ``task.py``-subprocess
+    shield re-checks run LAST so they are paid at most once per pod
+    incarnation): (1) bare canonical name ``pod-<issue>`` (suffixed follow-up
+    pods excluded — the failover only ever provisions the bare name); (2) not
+    already noted for THIS pod incarnation (``orphan_gcp_noted`` under the
+    same ``pod_id``; a pod_id change resets, the wedge-clock convention);
+    (3) pod age ``now - first_seen`` >= the grace (the existing
+    per-pod-incarnation clock in the pod-safety state — a fresh state file has
+    no clock yet, so the arm stays quiet until the age accumulates);
+    (4) the handle sidecar resolves and reads ``backend == "gcp"``;
+    (5) no keep-running / live-follow-up shield (the passed flags — computed
+    lazily by the caller only on the auto-stop-done branch — OR'd with a
+    direct lazy re-check, so a deliberate parallel pod on a RUNNING-status
+    task is shielded too).
+
+    On a hit: one alert marker via the pass's existing mechanics
+    (:func:`_post_progress_marker`, sentinel
+    :data:`_ORPHAN_GCP_HANDLE_NOTE_SENTINEL` — anti-liveness, in
+    ``_WATCHER_NOTE_SENTINELS``) + a stderr line, then ``orphan_gcp_noted``
+    is persisted (and mirrored into the caller's in-memory ``prev_state`` so
+    the status-class arm's later save carries it forward instead of
+    clobbering it with the stale pre-alert snapshot).
+    """
+    if info.name != f"pod-{issue}":
+        return False
+    prev_noted = bool(prev_state.get("orphan_gcp_noted", False)) and prev_state.get(
+        "pod_id"
+    ) == getattr(info, "pod_id", None)
+    if prev_noted:
+        return False
+    first_seen = prev_state.get("first_seen")
+    if not isinstance(first_seen, int | float):
+        return False  # no incarnation clock yet — age accumulates from the first save
+    age = now - float(first_seen)
+    if age < _orphan_gcp_handle_grace_sec():
+        return False
+    if not _orphan_gcp_sidecar_is_gcp(issue):
+        return False
+    if keep_running or followup_active:
+        return False
+    # Lazy shield re-check: the caller computes the passed flags only on the
+    # auto-stop-done branch, so for an ACTIVE-status task they are False even
+    # when the tag/signal is present. Paid at most once per pod incarnation
+    # (the noted flag below short-circuits every later tick).
+    if _task_keep_running(issue) or _task_followup_active(issue):
+        return False
+    age_h = age / 3600.0
+    _post_progress_marker(
+        issue,
+        f"{_ORPHAN_GCP_HANDLE_NOTE_SENTINEL} ORPHAN GCP-handle pod (#1490): RUNNING pod "
+        f"{info.name} (pod_id={info.pod_id}) has been up {age_h:.1f}h while the run-handle "
+        f"sidecar still points at backend=gcp — the GCP→RunPod failover either re-points "
+        f"the sidecar at runpod or tears the pod down, so this pod is likely provision "
+        f"residue from a failed failover launch (poller crash mid-window, or a failed "
+        f"terminate; the #1417 shape). NOT auto-stopped (alert-only arm). Recovery: "
+        f"inspect, then `uv run python scripts/pod.py terminate --issue {issue} --yes` "
+        f"(add --skip-upload-verify for a never-ran pod). Posted once per pod "
+        f"incarnation; `task.py add-tag {issue} keep-running` shields a deliberate keep.",
+        dry_run,
+        label="orphan-gcp-handle",
+    )
+    print(
+        f"  ORPHAN-GCP-HANDLE issue #{issue}: RUNNING {info.name} with a stale "
+        f"backend=gcp sidecar for {age_h:.1f}h (grace {_orphan_gcp_handle_grace_sec()}s); "
+        f"alert-only, NOT stopping.",
+        file=sys.stderr,
+    )
+    if not dry_run:
+        _save_pod_safety_state(
+            issue,
+            info.pod_id,
+            missed=prev_state.get("missed", 0) if isinstance(prev_state.get("missed"), int) else 0,
+            alerted=bool(prev_state.get("alerted", False)),
+            last_progress_ts=(
+                prev_state.get("last_progress_ts")
+                if isinstance(prev_state.get("last_progress_ts"), int | float)
+                else None
+            ),
+            orphan_gcp_noted=True,
+            prev=prev_state,
+        )
+    # Mirror into the caller's in-memory snapshot so the status-class arm's
+    # later save (which passes prev=prev_state) carries the flag forward.
+    prev_state["orphan_gcp_noted"] = True
+    return True
+
+
 def _escaped_pod_exemptions(issue: int, status_class: str, events: list) -> tuple[bool, bool]:
     """Lazy escaped-pod auto-stop exemptions for :func:`_process_pod`.
 
@@ -9354,6 +9546,16 @@ def _process_pod(
     prev_progress = prev_state.get("last_progress_ts")
     if not isinstance(prev_progress, int | float):
         prev_progress = None
+
+    # ── #1490 orphan-gcp-handle arm (ALERT-ONLY, purely additive) ────────────
+    # A RUNNING bare pod-<N> whose run-handle sidecar still reads backend=gcp
+    # past the grace is likely provision residue from a failed GCP→RunPod
+    # failover launch the poller-side reclaim missed (poller crash mid-window,
+    # failed terminate — the #1417 shape). Falls through UNCONDITIONALLY to
+    # the status-class decision below; never stops/terminates/returns-early.
+    _maybe_flag_orphan_gcp_handle_pod(
+        issue, info, now, keep_running, followup_active, prev_state, dry_run
+    )
 
     # Clear the alerted flag so a new staleness episode can re-alert when
     # EITHER (a) real progress advanced since last tick, OR (b) the task is

--- a/scripts/backend_poll.py
+++ b/scripts/backend_poll.py
@@ -2950,20 +2950,35 @@ RUNPOD_PROVISION_LEAKED_REASON = "runpod_provision_leaked_pod"
 #: - ``[wait-for-capacity] STILL-WAITING`` + ``EXIT_STILL_WAITING == 75``
 #:   (pod_lifecycle.py ``_emit_still_waiting_and_exit``, stderr+stdout — the
 #:   wait loop exhausted its budget BEFORE any create ran);
-#: - the ``cmd_provision`` idempotency refusal ``Pod <name> already exists ...
-#:   Use `pod.py resume`` (pod_lifecycle.py ~L1903-1907 — refused BEFORE
-#:   creating). NOTE: that text prints to STDOUT, which the relay leaves
-#:   INHERITED (only the stderr tail rides ``PodLifecycleProcessError``), so
-#:   in production this shape usually classifies ``unknown`` → ``leaked``
-#:   (still never a terminate; the matcher fires when the text does reach the
-#:   evidence, e.g. via a future relay change or a caller-composed message);
 #: - a no-capacity shape (``RunPodNoCapacityError`` / ``SUPPLY_CONSTRAINT``,
 #:   runpod_api.py — the create was refused, nothing exists).
+#: NOTE (r2, mixed-evidence): these markers can co-occur with a LATER create —
+#: the per-attempt wait-for-capacity heartbeat (pod_lifecycle.py ~L1154-1157)
+#: embeds the capacity exception text (``SUPPLY_CONSTRAINT``) on stderr, and
+#: the relay's 60-line tail keeps those lines when bootstrap fails early — so
+#: :func:`_classify_provision_failure` gives :data:`_CREATED_THEN_FAILED_MARKERS`
+#: PRECEDENCE (positive our-create evidence always wins).
 _CREATED_NOTHING_MARKERS: tuple[str, ...] = (
     "STILL-WAITING",
-    "already exists",
     "RunPodNoCapacityError",
     "SUPPLY_CONSTRAINT",
+)
+
+#: The ``cmd_provision`` idempotency-refusal pair (pod_lifecycle.py
+#: ~L1903-1907): ``Pod <name> already exists (status=..., id=...).\nUse
+#: `pod.py resume --issue <N>...``` — refused BEFORE creating, so it is a
+#: ``created-nothing`` shape, matched CONJUNCTIVELY (BOTH fragments required;
+#: r2 sibling-B fix: a bare ``already exists`` substring also occurs in
+#: bootstrap stderr — e.g. git's ``destination path ... already exists and is
+#: not an empty directory`` — which must NOT read as created-nothing).
+#: NOTE: the refusal text prints to STDOUT, which the relay leaves INHERITED
+#: (only the stderr tail rides ``PodLifecycleProcessError``), so in production
+#: this shape usually classifies ``unknown`` → ``leaked`` (still never a
+#: terminate; the matcher fires when the text does reach the evidence, e.g.
+#: via a future relay change or a caller-composed message).
+_PROVISION_REFUSAL_MARKERS: tuple[str, ...] = (
+    "already exists",
+    "Use `pod.py resume",
 )
 
 #: ``created-then-failed`` = our provision CREATED a pod, then failed — the
@@ -3015,17 +3030,28 @@ def _classify_provision_failure(evidence_text: str, returncode: int | None) -> s
     Returns ``"created-nothing"`` (our provision provably created NO pod),
     ``"created-then-failed"`` (our provision created a pod, then failed —
     the POSITIVE our-create evidence the terminate requires), or
-    ``"unknown"``. The ``created-nothing`` markers are checked FIRST so mixed
-    evidence biases toward never-terminate (the fail-safe direction);
-    ``returncode == 75`` is ``EXIT_STILL_WAITING`` (pod_lifecycle.py — the
-    exit-75 still-waiting contract ``dispatch_issue._provision_still_waiting``
-    also reads).
+    ``"unknown"``. The ``created-then-failed`` markers take PRECEDENCE over
+    mixed evidence (r2 fix, concern
+    ``mixed-evidence-misroutes-residue-foreign-created``): a provision that
+    WAITED for capacity, then CREATED the pod, then failed bootstrap carries
+    BOTH families in the bounded stderr tail (the wait heartbeat embeds
+    ``SUPPLY_CONSTRAINT`` text), and the bootstrap/SSH markers only ever
+    appear when OUR create ran — so they always win, keeping the terminate
+    reachable for the genuine #1417 residue. ``returncode == 75`` is
+    ``EXIT_STILL_WAITING`` (pod_lifecycle.py — the exit-75 still-waiting
+    contract ``dispatch_issue._provision_still_waiting`` also reads; the
+    exit-75 path structurally precedes any create, so it cannot co-occur
+    with a real created-then-failed marker). The idempotency-refusal pair
+    is matched conjunctively (BOTH fragments) so a generic ``already
+    exists`` inside bootstrap stderr never reads as created-nothing.
     """
     text = evidence_text or ""
-    if returncode == 75 or any(marker in text for marker in _CREATED_NOTHING_MARKERS):
-        return "created-nothing"
     if any(marker in text for marker in _CREATED_THEN_FAILED_MARKERS):
         return "created-then-failed"
+    if returncode == 75 or any(marker in text for marker in _CREATED_NOTHING_MARKERS):
+        return "created-nothing"
+    if all(marker in text for marker in _PROVISION_REFUSAL_MARKERS):
+        return "created-nothing"
     return "unknown"
 
 
@@ -3034,13 +3060,23 @@ def _terminate_error_is_pod_not_found(exc: Exception) -> bool:
 
     The RunPod GraphQL layer surfaces a terminate of a nonexistent pod id as a
     ``RunPodError`` whose message carries the API's ``POD_NOT_FOUND`` error
-    code / a ``not found`` phrase (see runpod_api.py — a GraphQL ``errors``
-    payload raises with its message text; the project's canonical shape is the
+    code / a ``not found`` phrase INSIDE a GraphQL-errors payload (see
+    runpod_api.py — ``graphql()`` raises ``RunPodError(f"GraphQL errors:
+    {err_text}")`` with the errors JSON; the project's canonical shape is the
     ``POD_NOT_FOUND`` extension code). A pod that is already gone is a
     SUCCESSFUL reclaim (#1490 test 15 — no needless human park), not a leak.
+
+    r2 sibling-C fix: the phrase form REQUIRES the ``GraphQL errors`` context
+    — a bare lowercase ``not found`` also matches transport-shaped errors
+    (``RunPodError(f"HTTP 404 from RunPod: <html>Not Found...")``,
+    runpod_api.py ~L346 — a transient proxy blip), which must classify
+    ``leaked`` (fail direction: an unrecognized terminate error never reads
+    torn-down while the pod may still bill).
     """
     text = str(exc)
-    return "POD_NOT_FOUND" in text or "not found" in text.lower()
+    if "POD_NOT_FOUND" in text:
+        return True
+    return "GraphQL errors" in text and "not found" in text.lower()
 
 
 def _reclaim_failed_runpod_provision(

--- a/scripts/backend_poll.py
+++ b/scripts/backend_poll.py
@@ -2932,6 +2932,257 @@ def _runspec_from_gcp_handle(handle, issue):
     )
 
 
+# ─── #1490 provision-residue reclaim (the failover NoComputeAvailableError branch) ───
+
+#: Terminal reason for a failover whose failed RunPod provision left a live
+#: ``pod-<N>`` behind that could NOT be reclaimed or attributed (#1490).
+#: Deliberately NOT in the watcher's ``TRANSIENT_CAPACITY_REASONS``
+#: (autonomous_session_watch.py) — a re-drivable label on a run whose pod
+#: bills unattended invites the capacity-retry churn (the #931 mislabel #954
+#: fixed for the workload-start case with ``runpod_workload_start_failed``),
+#: so this reason PARKS the task at ``blocked`` for a human.
+RUNPOD_PROVISION_LEAKED_REASON = "runpod_provision_leaked_pod"
+
+#: Provision-failure evidence markers for the #1490 TWO-SIGNAL terminate gate,
+#: grepped from the producers at implementation time. ``created-nothing`` =
+#: our provision provably created NO pod (a singleton new id under these
+#: shapes is a FOREIGN actor's pod — never terminate):
+#: - ``[wait-for-capacity] STILL-WAITING`` + ``EXIT_STILL_WAITING == 75``
+#:   (pod_lifecycle.py ``_emit_still_waiting_and_exit``, stderr+stdout — the
+#:   wait loop exhausted its budget BEFORE any create ran);
+#: - the ``cmd_provision`` idempotency refusal ``Pod <name> already exists ...
+#:   Use `pod.py resume`` (pod_lifecycle.py ~L1903-1907 — refused BEFORE
+#:   creating). NOTE: that text prints to STDOUT, which the relay leaves
+#:   INHERITED (only the stderr tail rides ``PodLifecycleProcessError``), so
+#:   in production this shape usually classifies ``unknown`` → ``leaked``
+#:   (still never a terminate; the matcher fires when the text does reach the
+#:   evidence, e.g. via a future relay change or a caller-composed message);
+#: - a no-capacity shape (``RunPodNoCapacityError`` / ``SUPPLY_CONSTRAINT``,
+#:   runpod_api.py — the create was refused, nothing exists).
+_CREATED_NOTHING_MARKERS: tuple[str, ...] = (
+    "STILL-WAITING",
+    "already exists",
+    "RunPodNoCapacityError",
+    "SUPPLY_CONSTRAINT",
+)
+
+#: ``created-then-failed`` = our provision CREATED a pod, then failed — the
+#: positive our-create evidence the terminate requires:
+#: - ``Bootstrap exited with code`` / ``Pod is up but not experiment-ready``
+#:   (pod_lifecycle.py ``cmd_provision`` bootstrap-failure exit, stderr — the
+#:   #1417 shape);
+#: - ``exposed no public SSH mapping`` (pod_lifecycle.py
+#:   ``_provision_wait_register_bootstrap`` — the pod exists and bills but
+#:   SSH never came up within the window, stderr).
+_CREATED_THEN_FAILED_MARKERS: tuple[str, ...] = (
+    "Bootstrap exited with code",
+    "Pod is up but not experiment-ready",
+    "exposed no public SSH mapping",
+)
+
+
+def _live_runpod_ids_for_issue(issue: int) -> set[str] | None:
+    """Live pod_ids whose name is EXACTLY ``pod-<issue>`` (suffixed pods excluded).
+
+    The attribution probe for the #1490 provision-residue reclaim: called once
+    BEFORE the failover launch (the ``pre`` snapshot) and once in the
+    ``NoComputeAvailableError`` branch (the ``post`` snapshot). Returns
+    ``None`` on ANY API failure (probe-unknown; callers bias SAFE — an unknown
+    snapshot never licenses a terminate). One GraphQL list call per snapshot;
+    GCP→RunPod failovers are rare events. Post-probe listing lag (a
+    just-created pod missing from the team list) reads as no-residue — the
+    #1490 D2 watcher orphan arm catches that leak on a later tick.
+    """
+    try:
+        _ensure_scripts_dir_on_sys_path()
+        from runpod_api import list_team_pods  # lazy import (#770/#775 pattern)
+
+        name = f"pod-{int(issue)}"
+        return {p.pod_id for p in list_team_pods() if p.name == name}
+    except Exception as exc:
+        logging.warning(
+            "backend_poll: provision-residue live-pod probe failed (%s: %s); "
+            "treating the snapshot as unknown (bias safe — no terminate)",
+            type(exc).__name__,
+            exc,
+        )
+        return None
+
+
+def _classify_provision_failure(evidence_text: str, returncode: int | None) -> str:
+    """Classify failover-provision-failure evidence (#1490 two-signal gate).
+
+    Returns ``"created-nothing"`` (our provision provably created NO pod),
+    ``"created-then-failed"`` (our provision created a pod, then failed —
+    the POSITIVE our-create evidence the terminate requires), or
+    ``"unknown"``. The ``created-nothing`` markers are checked FIRST so mixed
+    evidence biases toward never-terminate (the fail-safe direction);
+    ``returncode == 75`` is ``EXIT_STILL_WAITING`` (pod_lifecycle.py — the
+    exit-75 still-waiting contract ``dispatch_issue._provision_still_waiting``
+    also reads).
+    """
+    text = evidence_text or ""
+    if returncode == 75 or any(marker in text for marker in _CREATED_NOTHING_MARKERS):
+        return "created-nothing"
+    if any(marker in text for marker in _CREATED_THEN_FAILED_MARKERS):
+        return "created-then-failed"
+    return "unknown"
+
+
+def _terminate_error_is_pod_not_found(exc: Exception) -> bool:
+    """True when a failed ``terminate_pod`` means the pod is ALREADY GONE.
+
+    The RunPod GraphQL layer surfaces a terminate of a nonexistent pod id as a
+    ``RunPodError`` whose message carries the API's ``POD_NOT_FOUND`` error
+    code / a ``not found`` phrase (see runpod_api.py — a GraphQL ``errors``
+    payload raises with its message text; the project's canonical shape is the
+    ``POD_NOT_FOUND`` extension code). A pod that is already gone is a
+    SUCCESSFUL reclaim (#1490 test 15 — no needless human park), not a leak.
+    """
+    text = str(exc)
+    return "POD_NOT_FOUND" in text or "not found" in text.lower()
+
+
+def _reclaim_failed_runpod_provision(
+    *,
+    issue: int,
+    pre_ids: set[str] | None,
+    evidence: tuple[str, int | None],
+    cause_label: str,
+    failover_tag: str,
+) -> dict:
+    """Best-effort reclaim of a pod the JUST-FAILED failover provision created (#1490).
+
+    Implements the plan-§3 v2 decision table over ``post − pre`` live-pod
+    set-difference AND the provision-failure evidence shape. The surgical
+    ``terminate_pod(pod_id)`` (the #770/#775 in-file precedent — pod-id
+    scoped, bypassing ``cmd_terminate``'s upload-verify + keep-running guards,
+    which would refuse for a just-provisioned never-ran pod) fires ONLY on the
+    TWO-SIGNAL gate: a SINGLETON new id AND positive ``created-then-failed``
+    evidence. Every ambiguous / created-nothing / unknown cell never
+    terminates. NEVER raises — an unexpected error degrades to
+    ``no-residue`` (today's exact re-drivable behavior).
+
+    Returns ``{"outcome": "no-residue" | "torn-down" | "pre-existing" |
+    "foreign-created" | "leaked", "pod_ids": [...], "detail": str}``.
+    ``leaked`` routes to the non-re-drivable
+    :data:`RUNPOD_PROVISION_LEAKED_REASON` terminal; every other outcome keeps
+    today's re-drivable ``no_compute_available``.
+    """
+    del cause_label, failover_tag  # display strings live on the terminal JSON
+    try:
+        post_ids = _live_runpod_ids_for_issue(issue)
+        if post_ids is None:
+            return {
+                "outcome": "no-residue",
+                "pod_ids": [],
+                "detail": (
+                    "post-provision live-pod probe failed — residue unknown; "
+                    "the watcher orphan-gcp-handle arm is the backstop"
+                ),
+            }
+        if not post_ids:
+            return {"outcome": "no-residue", "pod_ids": [], "detail": ""}
+        if pre_ids is None:
+            return {
+                "outcome": "leaked",
+                "pod_ids": sorted(post_ids),
+                "detail": (
+                    f"pre-provision probe failed; live pod(s) {sorted(post_ids)} cannot be "
+                    f"attributed to this failover — never terminate what we can't attribute"
+                ),
+            }
+        new_ids = post_ids - pre_ids
+        if not new_ids:
+            return {
+                "outcome": "pre-existing",
+                "pod_ids": sorted(post_ids),
+                "detail": f"live pod(s) {sorted(post_ids)} pre-existed this failover",
+            }
+        if len(new_ids) > 1:
+            return {
+                "outcome": "leaked",
+                "pod_ids": sorted(new_ids),
+                "detail": (
+                    f"{len(new_ids)} new pods {sorted(new_ids)} appeared during the failover "
+                    f"window — concurrent-creator ambiguity; never terminate"
+                ),
+            }
+        evidence_text, returncode = evidence
+        shape = _classify_provision_failure(evidence_text, returncode)
+        (pod_id,) = new_ids
+        if shape == "created-nothing":
+            return {
+                "outcome": "foreign-created",
+                "pod_ids": [pod_id],
+                "detail": (
+                    f"the provision failure shape proves OUR provision created no pod; "
+                    f"new pod {pod_id} belongs to another actor — never terminate (a "
+                    f"re-drive's provision idempotency-refuses on it safely)"
+                ),
+            }
+        if shape != "created-then-failed":
+            return {
+                "outcome": "leaked",
+                "pod_ids": [pod_id],
+                "detail": (
+                    f"provision-failure evidence is '{shape}' — cannot positively attribute "
+                    f"new pod {pod_id} to this failover's provision; never terminate on "
+                    f"ambiguity"
+                ),
+            }
+        # TWO-SIGNAL gate satisfied: singleton new id AND positive
+        # created-then-failed evidence. Surgical pod-id terminate.
+        try:
+            _ensure_scripts_dir_on_sys_path()
+            from runpod_api import terminate_pod  # lazy import (#770/#775 pattern)
+
+            terminate_pod(pod_id)
+        except Exception as exc:
+            if _terminate_error_is_pod_not_found(exc):
+                return {
+                    "outcome": "torn-down",
+                    "pod_ids": [pod_id],
+                    "detail": (
+                        f"provision-residue pod-{int(issue)} ({pod_id}) already gone at "
+                        f"terminate ({type(exc).__name__}) — nothing bills"
+                    ),
+                }
+            return {
+                "outcome": "leaked",
+                "pod_ids": [pod_id],
+                "detail": (
+                    f"terminate of provision-residue pod {pod_id} FAILED "
+                    f"({type(exc).__name__}: {exc})"
+                ),
+            }
+        logging.warning(
+            "backend_poll: terminated provision-residue RunPod pod-%d (%s) left by the "
+            "failed failover provision — billing stopped (#1490)",
+            int(issue),
+            pod_id,
+        )
+        return {
+            "outcome": "torn-down",
+            "pod_ids": [pod_id],
+            "detail": (
+                f"terminated provision-residue pod-{int(issue)} ({pod_id}; created-then-failed)"
+            ),
+        }
+    except Exception as exc:  # NEVER raises — degrade to today's exact behavior
+        logging.warning(
+            "backend_poll: provision-residue reclaim errored (%s: %s); degrading to the "
+            "re-drivable no_compute_available terminal",
+            type(exc).__name__,
+            exc,
+        )
+        return {
+            "outcome": "no-residue",
+            "pod_ids": [],
+            "detail": f"reclaim error ({type(exc).__name__}: {exc})",
+        }
+
+
 def _terminal_infra_json(*, issue: int, sidecar: Path, reason: str, log_tail: str) -> dict:
     """A ``status='dead'`` / ``failure_class='infra'`` poll JSON keyed by ``reason``.
 
@@ -3280,6 +3531,12 @@ def _failover_gcp_to_runpod(
             )
 
     spec = _runspec_from_gcp_handle(handle, issue)
+    # #1490 pre-launch attribution snapshot: the live pod_ids named EXACTLY
+    # pod-<N> BEFORE the RunPod launch is attempted, so the
+    # NoComputeAvailableError branch below can tell a pod THIS failover's
+    # provision created (post − pre singleton) from a pre-existing one. None
+    # on probe failure (bias safe — an unknown baseline never terminates).
+    pre_provision_ids = _live_runpod_ids_for_issue(issue)
     workload_start_error: str | None = None
     try:
         route_result = failover_to_runpod_after_async_workload_crash(
@@ -3339,17 +3596,69 @@ def _failover_gcp_to_runpod(
         launched_handle = partial
         workload_start_error = str(exc)[:500]
         already_launched = False
-    except NoComputeAvailableError:
-        # RunPod truly unavailable: terminal infra JSON with
-        # reason=no_compute_available so the watcher's capacity-retry pass CAN
-        # re-drive once a lane frees. Sidecar left pointing at the GCP handle.
-        # No lease stamp here — nothing launched, so a later poll SHOULD retry.
+    except NoComputeAvailableError as exc:
+        # RunPod truly unavailable — but "unavailable" can be a LIE about the
+        # residue (#1490 / incident #1417): a provision that CREATED pod-<N>,
+        # then failed bootstrap/SSH, still surfaces here (the rung's generic
+        # branch re-raises NoComputeAvailableError), leaving an idle billing
+        # pod + a stale gcp sidecar behind a re-drivable terminal. Reclaim the
+        # residue transactionally: post-launch snapshot + the two-signal
+        # decision table (singleton new id AND positive created-then-failed
+        # evidence → surgical terminate; every other cell never terminates).
+        # The evidence is str(exc) — the rung embeds
+        # ``({type(exc).__name__}: {exc})`` — plus the __cause__ chain's
+        # returncode/stderr/output tails (PodLifecycleProcessError, the #1465
+        # stderr-tail carrier; the rung raises ``from exc``).
+        evidence_text = str(exc)
+        returncode: int | None = None
+        cause = exc.__cause__
+        if cause is not None:
+            rc = getattr(cause, "returncode", None)
+            returncode = rc if isinstance(rc, int) else None
+            for attr in ("stderr", "output"):
+                val = getattr(cause, attr, None)
+                if isinstance(val, str) and val:
+                    evidence_text += "\n" + val
+        reclaim = _reclaim_failed_runpod_provision(
+            issue=issue,
+            pre_ids=pre_provision_ids,
+            evidence=(evidence_text, returncode),
+            cause_label=cause_label,
+            failover_tag=failover_tag,
+        )
+        if reclaim["outcome"] == "leaked":
+            # A pod exists and bills but could not be reclaimed/attributed. Do
+            # NOT return the re-drivable no_compute_available (the #931/#954
+            # mislabel: the watcher's capacity-retry pass would re-drive while
+            # the pod bills). No lease stamp — the task parks at blocked on
+            # this non-re-drivable reason, so retry ticks are moot.
+            return _terminal_infra_json(
+                issue=issue,
+                sidecar=sidecar,
+                reason=RUNPOD_PROVISION_LEAKED_REASON,
+                log_tail=(
+                    f"{cause_label} on {handle.pod_name}; RunPod fallback launch FAILED and a "
+                    f"live pod-{issue} remains ({reclaim['detail']}); NOT watcher-re-drivable. "
+                    f"Recovery: inspect + `uv run python scripts/pod.py terminate --issue "
+                    f"{issue} --yes` (add --skip-upload-verify for a never-ran pod), then "
+                    f"re-dispatch ({failover_tag})"
+                ),
+            )
+        # no-residue / torn-down / pre-existing / foreign-created: today's
+        # re-drivable terminal, now safe (no unattended pod created by THIS
+        # failover is left billing; a foreign-created singleton belongs to
+        # another actor and a watcher re-drive's provision idempotency-refuses
+        # on it). No lease stamp here — nothing launched (or the residue is
+        # torn down), so a later poll SHOULD retry against a clean slate.
         return _terminal_infra_json(
             issue=issue,
             sidecar=sidecar,
             reason="no_compute_available",
             log_tail=(
-                f"{cause_label} on {handle.pod_name}; RunPod also unavailable ({failover_tag})"
+                f"{cause_label} on {handle.pod_name}; RunPod also unavailable "
+                f"({failover_tag}; provision-residue: {reclaim['outcome']}"
+                + (f" — {reclaim['detail']}" if reclaim["detail"] else "")
+                + ")"
             ),
         )
 

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -1866,6 +1866,10 @@ def test_save_pod_safety_state_carries_first_seen_forward(isolated_registry):
         # #1155: the stop arm's failed-branch dedup flag is part of the schema
         # now; a save with no prior episode defaults it False.
         "stop_failed_noted": False,
+        # #1490: the orphan-gcp-handle alert arm's once-per-pod-incarnation
+        # dedup flag is part of the schema now; a save with no prior episode
+        # defaults it False (and the carry is pod_id-keyed).
+        "orphan_gcp_noted": False,
         "first_seen": 1234.0,
         # #692 MF3: the wedge fields are part of the schema now; a status-class
         # save with no wedge state defaults them (no prior wedge to carry).

--- a/tests/test_autonomous_session_watch_orphan_pod.py
+++ b/tests/test_autonomous_session_watch_orphan_pod.py
@@ -184,6 +184,63 @@ def test_orphan_arm_realerts_on_new_pod_incarnation(
     assert len(_orphan_posts(marker_recorder)) == 1
     assert stop_recorder == []
 
+    # End-to-end once-per-incarnation pin (r2): after the alert tick, the
+    # persisted state carries the NEW pod_id + the noted flag, and a second
+    # tick on the same incarnation stays quiet. On THIS (healthy-pod) path the
+    # wedge arm's _clear_wedge_state laundering save re-keys the state to the
+    # new pod_id BEFORE the status-class load, so the flag survives even
+    # pre-r2; the direct pre-fix-failing pin of the r2 pod_id mirror is
+    # test_orphan_arm_mirror_survives_status_class_save_on_new_incarnation.
+    state = json.loads((isolated_registry / "pod-safety-1417.json").read_text())
+    assert state["pod_id"] == "p_NEW"
+    assert state["orphan_gcp_noted"] is True
+
+    asw._process_pod(
+        1417, "p_NEW", _healthy_info(pod_id="p_NEW"), now + 600, dry_run=False, threshold=2
+    )
+    assert len(_orphan_posts(marker_recorder)) == 1
+    assert stop_recorder == []
+
+
+def test_orphan_arm_mirror_survives_status_class_save_on_new_incarnation(
+    isolated_registry, gcp_sidecar, marker_recorder, monkeypatch
+):
+    """r2 Minor fix (pod_id-change-tick carry clobber): when NO earlier save
+    re-keyed the state to the new incarnation (the wedged-DONE-status MF6
+    fall-through skips the wedge arm's _clear_wedge_state laundering save),
+    the caller's in-memory prev_state still holds the OLD pod_id when the arm
+    alerts. The arm mirrors the NEW pod_id alongside the flag, so a later
+    status-class-arm save in the SAME tick (orphan_gcp_noted at the
+    pod_id-keyed None carry, prev=the in-memory snapshot) carries the
+    just-persisted flag forward — pre-fix it recomputed same_pod=False off
+    the stale OLD pod_id and clobbered the flag back to False, costing one
+    duplicate alert on the next tick."""
+    monkeypatch.setattr(asw, "_task_keep_running", lambda issue: False)
+    monkeypatch.setattr(asw, "_task_followup_active", lambda issue, events=None: False)
+    now = time.time()
+    prev_state = {
+        "pod_id": "p_OLD",
+        "missed": 0,
+        "alerted": False,
+        "last_progress_ts": None,
+        "first_seen": now - GRACE - 600,
+        "orphan_gcp_noted": True,
+    }
+    alerted = asw._maybe_flag_orphan_gcp_handle_pod(
+        1417, _healthy_info(pod_id="p_NEW"), now, False, False, prev_state, False
+    )
+    assert alerted is True
+    assert prev_state["pod_id"] == "p_NEW"  # the r2 mirror
+
+    # The status-class arm's later same-tick save (keep-shaped: the flag left
+    # at its None carry, prev=the in-memory snapshot the arm just mirrored).
+    asw._save_pod_safety_state(
+        1417, "p_NEW", missed=0, alerted=False, last_progress_ts=None, prev=prev_state
+    )
+    state = json.loads((isolated_registry / "pod-safety-1417.json").read_text())
+    assert state["orphan_gcp_noted"] is True  # pre-fix: clobbered to False
+    assert state["pod_id"] == "p_NEW"
+
 
 # ---------------------------------------------------------------------------
 # 10. Negative controls (parametrized where the predicate leg allows)

--- a/tests/test_autonomous_session_watch_orphan_pod.py
+++ b/tests/test_autonomous_session_watch_orphan_pod.py
@@ -1,0 +1,375 @@
+"""Unit tests for the #1490 ALERT-ONLY orphan-gcp-handle pod-safety arm.
+
+The watcher-side D2 companion of the poller-side D1 provision-residue reclaim
+(``backend_poll._reclaim_failed_runpod_provision``, pinned in
+``tests/test_backend_poll.py``): a RUNNING bare ``pod-<N>`` whose run-handle
+sidecar still points at ``backend=gcp`` past a grace window is likely
+provision residue from a failed GCP->RunPod failover launch the poller-side
+reclaim missed (poller crash between provision and reclaim, or a failed /
+unattributable terminate — the #1417 shape: pod-1417 idled 45 min on 4xH100
+until a human noticed). Covers:
+
+* the end-to-end arm in ``_process_pod`` — exactly ONE alert per pod
+  incarnation (``orphan_gcp_noted`` dedup), never a stop/terminate;
+* the predicate's negative controls (runpod sidecar / absent sidecar /
+  unreadable sidecar / suffixed pod name / within grace / keep-running /
+  follow-up shields — passed-flag AND lazy-re-check legs);
+* the additive-only contract: the firing arm never blocks the pre-existing
+  status-class decision (the DONE-task auto-stop still happens).
+
+Follows ``tests/test_autonomous_session_watch_wedge.py`` conventions: PodInfo
+fixtures, the patched state dir, ``task.py`` reads monkeypatched, no network.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import autonomous_session_watch as asw  # noqa: E402
+from runpod_api import PodInfo  # noqa: E402
+
+from explore_persona_space.backends.base import RunHandle  # noqa: E402
+from explore_persona_space.backends.issue_dispatch import write_handle_sidecar  # noqa: E402
+
+GRACE = asw.ORPHAN_GCP_HANDLE_GRACE_SEC  # 1800s (env-overridable at call time)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / doubles
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_registry(tmp_path, monkeypatch):
+    """Point the per-pod state dir at a tmp dir (mirrors the wedge suite)."""
+    monkeypatch.setattr(asw, "AUTONOMOUS_REGISTRY_DIR", tmp_path)
+    return tmp_path
+
+
+def _healthy_info(pod_id: str = "p1417", name: str = "pod-1417") -> PodInfo:
+    """A RUNNING pod with a public port (so the #692 wedge arm never handles it)."""
+    return PodInfo(
+        pod_id=pod_id, name=name, desired_status="RUNNING", ssh_host="1.2.3.4", ssh_port=22001
+    )
+
+
+def _gcp_handle(issue: int = 1417) -> RunHandle:
+    return RunHandle(
+        backend="gcp",
+        cluster=None,
+        job_id="instance-fake-1",
+        pod_name=f"eps-issue-{issue}",
+        scratch_dir=f"/workspace/eps-issue-{issue}",
+        log_path=f"/workspace/logs/issue-{issue}.log",
+        extra={"issue": issue},
+    )
+
+
+def _seed_state(tmp_path, issue: int, *, pod_id: str, first_seen: float, missed: int = 0) -> None:
+    """Write a pod-safety state file with an aged incarnation clock."""
+    payload = {
+        "pod_id": pod_id,
+        "missed": missed,
+        "alerted": False,
+        "last_progress_ts": None,
+        "first_seen": first_seen,
+    }
+    (tmp_path / f"pod-safety-{issue}.json").write_text(json.dumps(payload))
+
+
+@pytest.fixture
+def gcp_sidecar(tmp_path, monkeypatch):
+    """A REAL backend=gcp handle sidecar, resolved by the arm's real read leg."""
+    sidecar = tmp_path / "issue-1417-handle.json"
+    write_handle_sidecar(_gcp_handle(), sidecar)
+    monkeypatch.setattr(
+        "explore_persona_space.backends.issue_dispatch.resolve_handle_sidecar_path",
+        lambda issue: (sidecar, False),
+    )
+    return sidecar
+
+
+@pytest.fixture
+def marker_recorder(monkeypatch):
+    posts: list[tuple[int, str, str]] = []
+    monkeypatch.setattr(
+        asw,
+        "_post_progress_marker",
+        lambda issue, note, dry_run, label=None: posts.append((issue, note, label)),
+    )
+    return posts
+
+
+@pytest.fixture
+def stop_recorder(monkeypatch):
+    stops: list[int] = []
+    monkeypatch.setattr(asw, "_stop_pod", lambda issue, dry_run: stops.append(issue) or True)
+    return stops
+
+
+@pytest.fixture
+def active_task(monkeypatch):
+    """A RUNNING-status task with fresh progress (status-class action=keep)."""
+    monkeypatch.setattr(asw, "_task_status", lambda issue: "running")
+    monkeypatch.setattr(asw, "_task_events", lambda issue: [])
+    monkeypatch.setattr(asw, "_latest_progress_ts", lambda events: time.time() - 600)
+    monkeypatch.setattr(asw, "_task_keep_running", lambda issue: False)
+    monkeypatch.setattr(asw, "_task_followup_active", lambda issue, events=None: False)
+
+
+def _orphan_posts(posts):
+    return [p for p in posts if asw._ORPHAN_GCP_HANDLE_NOTE_SENTINEL in p[1]]
+
+
+# ---------------------------------------------------------------------------
+# 9. The end-to-end alert (once per pod incarnation) — AC 6
+# ---------------------------------------------------------------------------
+
+
+def test_orphan_gcp_handle_pod_alerts_once(
+    isolated_registry, gcp_sidecar, marker_recorder, stop_recorder, active_task
+):
+    """AC 6: RUNNING bare pod-1417 + backend=gcp sidecar + age past grace and
+    no exemptions -> exactly ONE alert on tick 1, none on tick 2
+    (orphan_gcp_noted persisted); NO stop/terminate ever."""
+    now = time.time()
+    _seed_state(isolated_registry, 1417, pod_id="p1417", first_seen=now - GRACE - 600)
+
+    asw._process_pod(1417, "p1417", _healthy_info(), now, dry_run=False, threshold=2)
+    orphan = _orphan_posts(marker_recorder)
+    assert len(orphan) == 1
+    issue, note, label = orphan[0]
+    assert issue == 1417
+    assert label == "orphan-gcp-handle"
+    assert "pod-1417" in note
+    assert "backend=gcp" in note
+    assert "pod.py terminate --issue 1417" in note
+    assert stop_recorder == []
+    state = json.loads((isolated_registry / "pod-safety-1417.json").read_text())
+    assert state["orphan_gcp_noted"] is True
+
+    # Tick 2: the persisted dedup flag short-circuits — no second alert.
+    asw._process_pod(1417, "p1417", _healthy_info(), now + 600, dry_run=False, threshold=2)
+    assert len(_orphan_posts(marker_recorder)) == 1
+    assert stop_recorder == []
+
+
+def test_orphan_arm_realerts_on_new_pod_incarnation(
+    isolated_registry, gcp_sidecar, marker_recorder, stop_recorder, active_task
+):
+    """The dedup flag is per pod INCARNATION (the wedge-clock reset
+    convention): a stored orphan_gcp_noted under a DIFFERENT pod_id does not
+    suppress the fresh incarnation's alert."""
+    now = time.time()
+    payload = {
+        "pod_id": "p_OLD",
+        "missed": 0,
+        "alerted": False,
+        "last_progress_ts": None,
+        "first_seen": now - GRACE - 600,
+        "orphan_gcp_noted": True,
+    }
+    (isolated_registry / "pod-safety-1417.json").write_text(json.dumps(payload))
+
+    asw._process_pod(1417, "p_NEW", _healthy_info(pod_id="p_NEW"), now, dry_run=False, threshold=2)
+    assert len(_orphan_posts(marker_recorder)) == 1
+    assert stop_recorder == []
+
+
+# ---------------------------------------------------------------------------
+# 10. Negative controls (parametrized where the predicate leg allows)
+# ---------------------------------------------------------------------------
+
+
+def _run_helper(
+    isolated_registry,
+    *,
+    info: PodInfo,
+    now: float,
+    first_seen: float,
+    keep_running: bool = False,
+    followup_active: bool = False,
+) -> bool:
+    prev_state = {
+        "pod_id": info.pod_id,
+        "missed": 0,
+        "alerted": False,
+        "last_progress_ts": None,
+        "first_seen": first_seen,
+    }
+    return asw._maybe_flag_orphan_gcp_handle_pod(
+        1417, info, now, keep_running, followup_active, prev_state, False
+    )
+
+
+def test_orphan_arm_negative_control_runpod_sidecar(
+    isolated_registry, tmp_path, monkeypatch, marker_recorder, active_task
+):
+    """A sidecar already re-pointed at backend=runpod never alerts (the
+    failover completed; the pod is the legitimate fallback run)."""
+    sidecar = tmp_path / "issue-1417-handle.json"
+    write_handle_sidecar(
+        RunHandle(
+            backend="runpod",
+            cluster=None,
+            job_id="pod-fake",
+            pod_name="pod-1417",
+            scratch_dir="/workspace",
+            log_path="/workspace/logs/issue-1417.log",
+            extra={"issue": 1417},
+        ),
+        sidecar,
+    )
+    monkeypatch.setattr(
+        "explore_persona_space.backends.issue_dispatch.resolve_handle_sidecar_path",
+        lambda issue: (sidecar, False),
+    )
+    now = time.time()
+    assert not _run_helper(
+        isolated_registry, info=_healthy_info(), now=now, first_seen=now - GRACE - 600
+    )
+    assert _orphan_posts(marker_recorder) == []
+
+
+def test_orphan_arm_negative_control_sidecar_absent(
+    isolated_registry, tmp_path, monkeypatch, marker_recorder, active_task
+):
+    """No resolvable sidecar -> quiet (bias quiet; nothing to attribute)."""
+    monkeypatch.setattr(
+        "explore_persona_space.backends.issue_dispatch.resolve_handle_sidecar_path",
+        lambda issue: (tmp_path / "no-such-handle.json", False),
+    )
+    now = time.time()
+    assert not _run_helper(
+        isolated_registry, info=_healthy_info(), now=now, first_seen=now - GRACE - 600
+    )
+    assert _orphan_posts(marker_recorder) == []
+
+
+def test_orphan_arm_negative_control_sidecar_unreadable(
+    isolated_registry, tmp_path, monkeypatch, marker_recorder, active_task, capsys
+):
+    """An unreadable/garbled sidecar -> quiet, with ONE stderr diagnostic line
+    (plan v2 fold-in: the quiet miss is diagnosable)."""
+    sidecar = tmp_path / "issue-1417-handle.json"
+    sidecar.write_text("{not json")
+    monkeypatch.setattr(
+        "explore_persona_space.backends.issue_dispatch.resolve_handle_sidecar_path",
+        lambda issue: (sidecar, False),
+    )
+    now = time.time()
+    assert not _run_helper(
+        isolated_registry, info=_healthy_info(), now=now, first_seen=now - GRACE - 600
+    )
+    assert _orphan_posts(marker_recorder) == []
+    assert "sidecar unreadable" in capsys.readouterr().err
+
+
+def test_orphan_arm_negative_control_suffixed_pod_name(
+    isolated_registry, gcp_sidecar, marker_recorder, active_task
+):
+    """A suffixed follow-up pod (pod-1417-b) is NOT the failover's bare
+    canonical name -> never alerts."""
+    now = time.time()
+    assert not _run_helper(
+        isolated_registry,
+        info=_healthy_info(name="pod-1417-b"),
+        now=now,
+        first_seen=now - GRACE - 600,
+    )
+    assert _orphan_posts(marker_recorder) == []
+
+
+def test_orphan_arm_negative_control_within_grace(
+    isolated_registry, gcp_sidecar, marker_recorder, active_task
+):
+    """A pod younger than the grace window stays quiet (a healthy failover
+    bootstrap can hold a gcp sidecar briefly)."""
+    now = time.time()
+    assert not _run_helper(
+        isolated_registry, info=_healthy_info(), now=now, first_seen=now - GRACE + 60
+    )
+    assert _orphan_posts(marker_recorder) == []
+
+
+@pytest.mark.parametrize("flag", ["keep_running", "followup_active"])
+def test_orphan_arm_negative_control_passed_shield_flags(
+    isolated_registry, gcp_sidecar, marker_recorder, active_task, flag
+):
+    """The caller-passed keep-running / follow-up shields suppress the alert
+    (the documented shields for deliberate parallel pods)."""
+    now = time.time()
+    assert not _run_helper(
+        isolated_registry,
+        info=_healthy_info(),
+        now=now,
+        first_seen=now - GRACE - 600,
+        **{flag: True},
+    )
+    assert _orphan_posts(marker_recorder) == []
+
+
+@pytest.mark.parametrize("helper", ["_task_keep_running", "_task_followup_active"])
+def test_orphan_arm_negative_control_lazy_shield_recheck(
+    isolated_registry, gcp_sidecar, marker_recorder, active_task, monkeypatch, helper
+):
+    """The lazy shield re-check: on an ACTIVE-status task the caller passes
+    False flags (the lazy exemptions never ran), so the arm re-checks the tag /
+    follow-up signal directly and stays quiet when either is live."""
+    now = time.time()
+    if helper == "_task_keep_running":
+        monkeypatch.setattr(asw, "_task_keep_running", lambda issue: True)
+    else:
+        monkeypatch.setattr(asw, "_task_followup_active", lambda issue, events=None: True)
+    assert not _run_helper(
+        isolated_registry, info=_healthy_info(), now=now, first_seen=now - GRACE - 600
+    )
+    assert _orphan_posts(marker_recorder) == []
+
+
+def test_orphan_arm_dry_run_alerts_but_persists_nothing(
+    isolated_registry, gcp_sidecar, marker_recorder, stop_recorder, active_task
+):
+    """Dry-run: the alert marker goes through _post_progress_marker (which
+    no-ops real posts under dry_run in production) but NO state file write."""
+    now = time.time()
+    _seed_state(isolated_registry, 1417, pod_id="p1417", first_seen=now - GRACE - 600)
+    asw._process_pod(1417, "p1417", _healthy_info(), now, dry_run=True, threshold=2)
+    assert len(_orphan_posts(marker_recorder)) == 1
+    state = json.loads((isolated_registry / "pod-safety-1417.json").read_text())
+    assert "orphan_gcp_noted" not in state  # the seeded file was never rewritten
+    assert stop_recorder == []
+
+
+# ---------------------------------------------------------------------------
+# 11. Additive-only: the arm never blocks the existing status-class decision
+# ---------------------------------------------------------------------------
+
+
+def test_orphan_arm_never_blocks_existing_decisions(
+    isolated_registry, gcp_sidecar, marker_recorder, stop_recorder, monkeypatch
+):
+    """With the orphan arm FIRING, the pod still reaches the pre-existing
+    status-class branch unchanged: a DONE-status escaped pod past the miss
+    threshold is STILL auto-stopped on the same tick (additive-only)."""
+    now = time.time()
+    monkeypatch.setattr(asw, "_task_status", lambda issue: "completed")
+    monkeypatch.setattr(asw, "_task_events", lambda issue: [])
+    monkeypatch.setattr(asw, "_latest_progress_ts", lambda events: None)
+    monkeypatch.setattr(asw, "_task_keep_running", lambda issue: False)
+    monkeypatch.setattr(asw, "_task_followup_active", lambda issue, events=None: False)
+    # missed=1 -> new_missed=2 == threshold -> the auto-stop fires this tick.
+    _seed_state(isolated_registry, 1417, pod_id="p1417", first_seen=now - GRACE - 600, missed=1)
+
+    asw._process_pod(1417, "p1417", _healthy_info(), now, dry_run=False, threshold=2)
+    assert len(_orphan_posts(marker_recorder)) == 1  # the arm fired...
+    assert stop_recorder == [1417]  # ...and the canonical auto-stop still ran

--- a/tests/test_backend_poll.py
+++ b/tests/test_backend_poll.py
@@ -3828,3 +3828,135 @@ def test_failover_terminate_not_found_treated_torn_down(tmp_path, monkeypatch, c
     assert "torn-down" in out["log_tail_excerpt"]
     assert "already gone" in out["log_tail_excerpt"]
     assert terminations == []
+
+
+@pytest.mark.parametrize(
+    "heartbeat",
+    [
+        "[wait-for-capacity] attempt 3 for pod-1116: no capacity "
+        '(RunPodSupplyConstraintError: GraphQL errors: [{"message": "SUPPLY_CONSTRAINT"}]); '
+        "waited 2m 0s, next retry in 30.0s",
+        "[wait-for-capacity] STILL-WAITING: provision pod-1116 has been waiting 10m 0s "
+        "across 3 attempt(s) (a later attempt then created the pod).",
+    ],
+    ids=["supply-constraint-heartbeat", "still-waiting-line"],
+)
+def test_failover_provision_mixed_evidence_created_then_failed_wins(
+    tmp_path, monkeypatch, capsys, heartbeat
+):
+    """#1490 r2 Major fix (concern mixed-evidence-misroutes-residue-foreign-created):
+    a provision that WAITED for capacity, then CREATED the pod, then failed
+    bootstrap carries BOTH marker families in the bounded stderr tail — the
+    per-attempt wait heartbeat (pod_lifecycle.py ~L1154-1157) embeds the
+    SUPPLY_CONSTRAINT exception text and the 60-line relay tail retains it.
+    The created-then-failed markers are POSITIVE our-create evidence and take
+    precedence, so the genuine #1417 residue is terminated (torn-down) —
+    never misrouted to the re-drivable foreign-created cell while the pod
+    bills."""
+    from explore_persona_space.backends.runpod import PodLifecycleProcessError
+
+    exc = PodLifecycleProcessError(
+        1,
+        ["uv", "run", "python", "scripts/pod_lifecycle.py", "provision", "--issue", "1116"],
+        output=None,
+        stderr=heartbeat + "\nBootstrap exited with code 1. Pod is up but not experiment-ready.",
+    )
+    team_list = _ScriptedTeamList([[], [_residue_pod("podX")]])
+    sidecar, _rp, terminations = _reclaim_setup(
+        tmp_path, monkeypatch, team_list=team_list, backend=_ProvisionFailedRunpodBackend(exc=exc)
+    )
+
+    rc = backend_poll_main(["--issue", "1116", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["reason"] == "no_compute_available"
+    assert "torn-down" in out["log_tail_excerpt"]
+    assert "foreign-created" not in out["log_tail_excerpt"]
+    assert terminations == ["podX"]
+
+
+def test_failover_provision_generic_already_exists_not_created_nothing(
+    tmp_path, monkeypatch, capsys
+):
+    """#1490 r2 sibling-B fix: a bare ``already exists`` substring in the
+    stderr tail (git's ``destination path ... already exists and is not an
+    empty directory`` during a failed bootstrap) is NOT the pod_lifecycle
+    idempotency-refusal — without the distinctive ``Use `pod.py resume``
+    fragment the pair does not match, the evidence stays unknown, and the
+    singleton routes to the non-re-drivable leaked park (never terminate,
+    never the confidently-false foreign-created detail)."""
+    from explore_persona_space.backends.runpod import PodLifecycleProcessError
+
+    exc = PodLifecycleProcessError(
+        1,
+        ["uv", "run", "python", "scripts/pod_lifecycle.py", "provision", "--issue", "1116"],
+        output=None,
+        stderr=(
+            "fatal: destination path 'explore-persona-space' already exists and is "
+            "not an empty directory."
+        ),
+    )
+    team_list = _ScriptedTeamList([[], [_residue_pod("podX")]])
+    sidecar, _rp, terminations = _reclaim_setup(
+        tmp_path, monkeypatch, team_list=team_list, backend=_ProvisionFailedRunpodBackend(exc=exc)
+    )
+
+    rc = backend_poll_main(["--issue", "1116", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["reason"] == "runpod_provision_leaked_pod"
+    assert "foreign-created" not in out["log_tail_excerpt"]
+    assert terminations == []
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        (
+            'GraphQL errors: [{"message": "pod not found", '
+            '"extensions": {"code": "POD_NOT_FOUND"}}]',
+            True,
+        ),
+        ('GraphQL errors: [{"message": "Pod not found"}]', True),
+        ("HTTP 404 from RunPod: <html><head><title>404 Not Found</title></head></html>", False),
+        ("Network error contacting RunPod: [Errno 110] Connection timed out", False),
+        ("boom", False),
+    ],
+    ids=[
+        "graphql-pod-not-found-code",
+        "graphql-not-found-phrase",
+        "http-404-transient",
+        "network-error",
+        "unrelated",
+    ],
+)
+def test_terminate_error_is_pod_not_found_shapes(text, expected):
+    """#1490 r2 sibling-C fix: the ALREADY-GONE classifier requires the
+    ``POD_NOT_FOUND`` code or a ``not found`` phrase INSIDE a GraphQL-errors
+    payload — an HTTP-404-shaped transient (a proxy blip whose body carries
+    ``Not Found``) must NOT read torn-down while the pod may still bill."""
+    from scripts.backend_poll import _terminate_error_is_pod_not_found
+
+    assert _terminate_error_is_pod_not_found(RuntimeError(text)) is expected
+
+
+def test_failover_terminate_http_404_transient_leaked_not_torn_down(tmp_path, monkeypatch, capsys):
+    """#1490 r2 sibling-C end-to-end: terminate_pod raising an HTTP-404-shaped
+    transport error routes to the non-re-drivable leaked park (the pod may
+    still bill), NEVER the torn-down/re-drivable read the old bare
+    ``not found`` catch-all produced."""
+    runpod_api = _import_runpod_api()
+    team_list = _ScriptedTeamList([[], [_residue_pod("podX")]])
+    sidecar, _rp, terminations = _reclaim_setup(tmp_path, monkeypatch, team_list=team_list)
+
+    def _raise_404(pod_id):
+        raise RuntimeError("HTTP 404 from RunPod: <html><title>404 Not Found</title></html>")
+
+    monkeypatch.setattr(runpod_api, "terminate_pod", _raise_404, raising=False)
+
+    rc = backend_poll_main(["--issue", "1116", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["reason"] == "runpod_provision_leaked_pod"
+    assert "torn-down" not in out["log_tail_excerpt"]
+    assert terminations == []

--- a/tests/test_backend_poll.py
+++ b/tests/test_backend_poll.py
@@ -150,6 +150,42 @@ def _isolate_lease_store(monkeypatch, tmp_path):
     monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
 
 
+def _import_runpod_api():
+    """Deterministic scripts-dir bootstrap + ``import runpod_api``.
+
+    backend_poll's lazy ``from runpod_api import ...`` relies on scripts/
+    being on sys.path; mirror it here (the same bootstrap the #954 tests do
+    inline) so patching runpod_api attributes is test-ordering-independent.
+    """
+    import sys
+
+    import scripts.backend_poll as bp
+
+    scripts_dir = str(Path(bp.__file__).resolve().parent)
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    import runpod_api
+
+    return runpod_api
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_runpod_team_list(monkeypatch):
+    """Default ``runpod_api.list_team_pods`` to an EMPTY live-pod list.
+
+    #1490: ``_failover_gcp_to_runpod`` now takes a pre-launch live-pod
+    snapshot (``_live_runpod_ids_for_issue`` -> ``list_team_pods``) on EVERY
+    failover invocation, so without this default every pre-existing failover
+    test would attempt a real GraphQL call (the helper fail-softs to ``None``,
+    but the retry backoff is slow and network-dependent). An empty list makes
+    pre == post == set() -> outcome ``no-residue`` -> byte-preserved terminal
+    semantics for every pre-#1490 test. The #1490 reclaim tests override with
+    their own stateful fakes.
+    """
+    runpod_api = _import_runpod_api()
+    monkeypatch.setattr(runpod_api, "list_team_pods", lambda: [], raising=False)
+
+
 # ---------------------------------------------------------------------------
 # The poller-level acceptance test (the end-to-end seam)
 # ---------------------------------------------------------------------------
@@ -3413,3 +3449,382 @@ def test_module_level_scripts_bootstrap_recognizer_semantics():
         "ROOT = Path('/repo')\n"
         'sys.path.insert(0, str(ROOT / "src"))\n'
     )
+
+
+# ---------------------------------------------------------------------------
+# #1490 — transactional provision-residue reclaim in the shared failover
+# core's NoComputeAvailableError branch. The #1417 shape: the RunPod fallback
+# provision CREATED pod-<N> (bootstrap then failed), the rung re-raised
+# NoComputeAvailableError, and the poller returned the re-drivable
+# no_compute_available terminal while the pod idled and billed. The reclaim
+# is TWO-SIGNAL gated: terminate ONLY on a singleton new pod id (post - pre
+# live-API snapshot) AND positive created-then-failed evidence; every
+# ambiguous / created-nothing / unknown cell never terminates. All tests
+# drive the queue-vanish caller end-to-end (the #954 shared-core pattern), so
+# the REAL router rung produces the NoComputeAvailableError chain.
+# ---------------------------------------------------------------------------
+
+
+def _residue_pod(pod_id: str, name: str = "pod-1116"):
+    """A live PodInfo named exactly ``pod-1116`` (the reclaim's name filter)."""
+    runpod_api = _import_runpod_api()
+    return runpod_api.PodInfo(
+        pod_id=pod_id, name=name, desired_status="RUNNING", ssh_host="1.2.3.4", ssh_port=22001
+    )
+
+
+class _ScriptedTeamList:
+    """Stateful ``list_team_pods`` fake: pops ONE scripted snapshot per call
+    (a list of PodInfo, or an Exception instance to RAISE for that call);
+    returns ``[]`` once exhausted. Records the call count."""
+
+    def __init__(self, snapshots: list) -> None:
+        self.snapshots = list(snapshots)
+        self.calls = 0
+
+    def __call__(self):
+        self.calls += 1
+        if not self.snapshots:
+            return []
+        item = self.snapshots.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+class _ProvisionFailedRunpodBackend:
+    """RunPodBackend stand-in whose ``launch`` raises the #1417 shape.
+
+    Default: ``PodLifecycleProcessError`` carrying the created-then-failed
+    bootstrap-failure stderr tail — what ``_run_pod_lifecycle_relay`` raises
+    when ``pod_lifecycle.py provision`` created the pod and bootstrap then
+    exited non-zero. The REAL router rung catches it in its generic branch
+    and re-raises ``NoComputeAvailableError`` ``from`` it, so the poller's
+    evidence classifier sees the true production chain (class name + stderr
+    tail embedded in str, ``__cause__`` carrying returncode/stderr). Pass
+    ``exc`` to script a different failure shape.
+    """
+
+    def __init__(self, exc: Exception | None = None) -> None:
+        self.launches: list = []
+        self._exc = exc
+
+    def launch(self, spec):
+        from explore_persona_space.backends.runpod import PodLifecycleProcessError
+
+        self.launches.append(spec)
+        if self._exc is not None:
+            raise self._exc
+        raise PodLifecycleProcessError(
+            1,
+            ["uv", "run", "python", "scripts/pod_lifecycle.py", "provision", "--issue", "1116"],
+            output=None,
+            stderr="Bootstrap exited with code 1. Pod is up but not experiment-ready.",
+        )
+
+
+def _reclaim_setup(tmp_path, monkeypatch, *, team_list, backend=None):
+    """Queue-vanish caller setup driving the shared failover core end-to-end.
+
+    Returns ``(sidecar, rp, terminations)`` — the vanish-shaped sidecar, the
+    (by default provision-failing) RunPod backend fake, and the recorded
+    ``terminate_pod`` calls.
+    """
+    runpod_api = _import_runpod_api()
+    sidecar = tmp_path / "issue-1116-handle.json"
+    write_handle_sidecar(_vanish_handle(), sidecar)
+    monkeypatch.setattr(
+        "scripts.backend_poll._resolve_backend", lambda name: _PollDouble(_not_found_poll())
+    )
+    rp = backend if backend is not None else _ProvisionFailedRunpodBackend()
+    monkeypatch.setattr("explore_persona_space.backends.runpod.RunPodBackend", lambda: rp)
+    monkeypatch.setattr(runpod_api, "list_team_pods", team_list, raising=False)
+    terminations: list[str] = []
+    monkeypatch.setattr(
+        runpod_api,
+        "terminate_pod",
+        lambda pod_id: terminations.append(pod_id) or True,
+        raising=False,
+    )
+    return sidecar, rp, terminations
+
+
+def test_gcp_queue_vanish_failover_repoints_sidecar_to_runpod(tmp_path, monkeypatch, capsys):
+    """#1490 AC 1 (Goal items 1-2 verified-existing, D3): a queue-vanish
+    failover whose RunPod launch SUCCEEDS re-points the handle sidecar to
+    backend=runpod (readback-proven) and emits the running-shaped JSON —
+    the launch-verify + re-point legs the #909/#954/#659 line already built."""
+    sidecar = tmp_path / "issue-1116-handle.json"
+    write_handle_sidecar(_vanish_handle(), sidecar)
+    monkeypatch.setattr(
+        "scripts.backend_poll._resolve_backend", lambda name: _PollDouble(_not_found_poll())
+    )
+    rp = _PassiveRunpodBackend()
+    monkeypatch.setattr("explore_persona_space.backends.runpod.RunPodBackend", lambda: rp)
+
+    rc = backend_poll_main(["--issue", "1116", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["status"] == "running"
+    assert out["current_phase"] == "gcp_queue_vanish_failover_runpod"
+    recovered = read_handle_sidecar(sidecar)
+    assert recovered.backend == "runpod"
+
+
+def test_failover_provision_failure_after_pod_created_tears_down_pod(tmp_path, monkeypatch, capsys):
+    """#1490 AC 2 (the #1417 shape): pre snapshot [], post snapshot [podX],
+    created-then-failed evidence -> terminate_pod called exactly once with
+    podX; today's re-drivable no_compute_available terminal with a log_tail
+    naming the reclaim; sidecar still gcp; NO failover sentinel/lease stamp
+    (tick 2 re-attempts the launch against the clean slate)."""
+    team_list = _ScriptedTeamList([[], [_residue_pod("podX")]])
+    sidecar, rp, terminations = _reclaim_setup(tmp_path, monkeypatch, team_list=team_list)
+
+    rc = backend_poll_main(["--issue", "1116", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["status"] == "dead"
+    assert out["failure_class"] == "infra"
+    assert out["reason"] == "no_compute_available"
+    assert "torn-down" in out["log_tail_excerpt"]
+    assert "pod-1116" in out["log_tail_excerpt"]
+    assert terminations == ["podX"]
+    assert read_handle_sidecar(sidecar).backend == "gcp"
+    assert len(rp.launches) == 1
+
+    # Tick 2 (no-stamp contract): the scripted fake is exhausted, so both
+    # snapshots read the post-teardown state [] -> a SECOND launch attempt
+    # occurs (a later poll SHOULD retry after a clean reclaim).
+    rc2 = backend_poll_main(["--issue", "1116", "--handle-file", str(sidecar)])
+    assert rc2 == 0
+    out2 = _last_json_line(capsys)
+    assert out2["reason"] == "no_compute_available"
+    assert len(rp.launches) == 2
+    assert terminations == ["podX"]  # nothing further to reclaim
+
+
+def test_failover_provision_failure_no_pod_created_unchanged(tmp_path, monkeypatch, capsys):
+    """#1490 AC 3 (negative control): pre [] post [] -> NO terminate; the
+    re-drivable no_compute_available terminal (byte-behavior-preserving up to
+    the provision-residue note)."""
+    team_list = _ScriptedTeamList([[], []])
+    sidecar, _rp, terminations = _reclaim_setup(tmp_path, monkeypatch, team_list=team_list)
+
+    rc = backend_poll_main(["--issue", "1116", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["reason"] == "no_compute_available"
+    assert "no-residue" in out["log_tail_excerpt"]
+    assert terminations == []
+
+
+def test_failover_provision_failure_preexisting_pod_not_torn_down(tmp_path, monkeypatch, capsys):
+    """#1490 AC 4: a pod-1116 alive BEFORE the failover launch (pre == post ==
+    [podX]) is NEVER terminated by the cleanup — new_ids is empty, outcome
+    pre-existing, re-drivable terminal."""
+    team_list = _ScriptedTeamList([[_residue_pod("podX")], [_residue_pod("podX")]])
+    sidecar, _rp, terminations = _reclaim_setup(tmp_path, monkeypatch, team_list=team_list)
+
+    rc = backend_poll_main(["--issue", "1116", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["reason"] == "no_compute_available"
+    assert "pre-existing" in out["log_tail_excerpt"]
+    assert terminations == []
+
+
+def test_failover_provision_failure_terminate_fails_leaked_reason(tmp_path, monkeypatch, capsys):
+    """#1490 AC 5 (first half): the two-signal gate fires but terminate_pod
+    RAISES -> the NON-re-drivable runpod_provision_leaked_pod terminal naming
+    the pod + the recovery command (the #954 runpod_workload_start_failed
+    precedent: never a re-drivable label while a pod bills)."""
+    runpod_api = _import_runpod_api()
+    team_list = _ScriptedTeamList([[], [_residue_pod("podX")]])
+    sidecar, _rp, terminations = _reclaim_setup(tmp_path, monkeypatch, team_list=team_list)
+
+    def _raise_terminate(pod_id):
+        raise RuntimeError("runpod api down")
+
+    monkeypatch.setattr(runpod_api, "terminate_pod", _raise_terminate, raising=False)
+
+    rc = backend_poll_main(["--issue", "1116", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["status"] == "dead"
+    assert out["failure_class"] == "infra"
+    assert out["reason"] == "runpod_provision_leaked_pod"
+    assert "pod-1116" in out["log_tail_excerpt"]
+    assert "pod.py terminate --issue 1116" in out["log_tail_excerpt"]
+    assert terminations == []
+
+
+def test_failover_provision_leak_not_transient_capacity_block(tmp_path, monkeypatch, capsys):
+    """#1490 AC 5 (second half): the leaked terminal's fields, composed into
+    the epm:failure note shape, parse via the watcher's REAL
+    ``_is_transient_capacity_block`` to NOT-retriable — the capacity-retry
+    pass never re-drives a run whose pod exists and bills (mirror of the #954
+    AC5 test; drift guard, not fix-engaged evidence)."""
+    import scripts.autonomous_session_watch as asw
+
+    runpod_api = _import_runpod_api()
+    team_list = _ScriptedTeamList([[], [_residue_pod("podX")]])
+    sidecar, _rp, _terminations = _reclaim_setup(tmp_path, monkeypatch, team_list=team_list)
+
+    def _raise_terminate(pod_id):
+        raise RuntimeError("runpod api down")
+
+    monkeypatch.setattr(runpod_api, "terminate_pod", _raise_terminate, raising=False)
+
+    rc = backend_poll_main(["--issue", "1116", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    note = (
+        f"failure_class: {out['failure_class']} reason: {out['reason']} — {out['log_tail_excerpt']}"
+    )
+    synthetic_marker = {"kind": "epm:failure v1", "note": note, "ts": None}
+    retriable, parsed_reason, _block_ts = asw._is_transient_capacity_block([synthetic_marker])
+    assert retriable is False
+    assert parsed_reason == "runpod_provision_leaked_pod"
+    assert "runpod_provision_leaked_pod" not in asw.TRANSIENT_CAPACITY_REASONS
+
+
+def test_failover_provision_probe_failure_bias_safe(tmp_path, monkeypatch, capsys):
+    """#1490 decision-table bias-safe cell: list_team_pods raises on EVERY
+    call (pre AND post unknown) -> no terminate, today's re-drivable terminal
+    with the probe-failure detail."""
+    team_list = _ScriptedTeamList(
+        [RuntimeError("graphql flake"), RuntimeError("graphql flake"), RuntimeError("x")]
+    )
+    sidecar, _rp, terminations = _reclaim_setup(tmp_path, monkeypatch, team_list=team_list)
+
+    rc = backend_poll_main(["--issue", "1116", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["reason"] == "no_compute_available"
+    assert "probe failed" in out["log_tail_excerpt"]
+    assert terminations == []
+
+
+def test_failover_provision_ambiguous_new_pods_leaked_no_terminate(tmp_path, monkeypatch, capsys):
+    """#1490 ambiguity cell: TWO new pods named pod-1116 appeared in the
+    window (concurrent-creator ambiguity) -> never terminate; the
+    non-re-drivable leaked terminal (a pod bills unattributably)."""
+    team_list = _ScriptedTeamList([[], [_residue_pod("podX"), _residue_pod("podY")]])
+    sidecar, _rp, terminations = _reclaim_setup(tmp_path, monkeypatch, team_list=team_list)
+
+    rc = backend_poll_main(["--issue", "1116", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["reason"] == "runpod_provision_leaked_pod"
+    assert terminations == []
+
+
+def test_failover_provision_pre_probe_failure_singleton_no_terminate(tmp_path, monkeypatch, capsys):
+    """#1490 v2 Statistics Must-Fix 1 (decision-table row 3): the PRE probe
+    failed (pre_ids=None) and the post snapshot is non-empty -> the singleton
+    is UNATTRIBUTABLE, so NO terminate + the non-re-drivable leaked terminal.
+    This is the cell where a ``pre_ids = pre_ids or set()`` coercion bug would
+    wrongly terminate while every other test stayed green."""
+    team_list = _ScriptedTeamList([RuntimeError("graphql flake"), [_residue_pod("podX")]])
+    sidecar, _rp, terminations = _reclaim_setup(tmp_path, monkeypatch, team_list=team_list)
+
+    rc = backend_poll_main(["--issue", "1116", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["reason"] == "runpod_provision_leaked_pod"
+    assert "cannot be attributed" in out["log_tail_excerpt"]
+    assert terminations == []
+
+
+@pytest.mark.parametrize(
+    ("returncode", "stderr"),
+    [
+        (
+            1,
+            "Pod pod-1116 already exists (status=RUNNING, id=podFOREIGN).\n"
+            "Use `pod.py resume --issue 1116` to bring it back, or `pod.py terminate "
+            "--issue 1116` first if you want a fresh one.",
+        ),
+        (
+            75,
+            "[wait-for-capacity] STILL-WAITING: provision pod-1116 has been waiting 30m 0s "
+            "across 6 attempt(s) and reached this process's wall-clock budget. No pod was "
+            "provisioned; nothing is billing.",
+        ),
+    ],
+    ids=["idempotency-refusal", "exit75-still-waiting"],
+)
+def test_failover_provision_created_nothing_singleton_no_terminate(
+    tmp_path, monkeypatch, capsys, returncode, stderr
+):
+    """#1490 v2 Alternatives Must-Fix 1 (the two-signal gate): a singleton new
+    pod appearing under a CREATED-NOTHING provision-failure shape (idempotency
+    refusal / exit-75 STILL-WAITING) is a FOREIGN actor's pod — NEVER
+    terminated; the re-drivable terminal (a re-drive's provision
+    idempotency-refuses on it safely) with foreign-created in the log_tail."""
+    from explore_persona_space.backends.runpod import PodLifecycleProcessError
+
+    exc = PodLifecycleProcessError(
+        returncode,
+        ["uv", "run", "python", "scripts/pod_lifecycle.py", "provision", "--issue", "1116"],
+        output=None,
+        stderr=stderr,
+    )
+    team_list = _ScriptedTeamList([[], [_residue_pod("podFOREIGN")]])
+    sidecar, _rp, terminations = _reclaim_setup(
+        tmp_path, monkeypatch, team_list=team_list, backend=_ProvisionFailedRunpodBackend(exc=exc)
+    )
+
+    rc = backend_poll_main(["--issue", "1116", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["reason"] == "no_compute_available"
+    assert "foreign-created" in out["log_tail_excerpt"]
+    assert terminations == []
+
+
+def test_failover_provision_unknown_evidence_singleton_leaked_no_terminate(
+    tmp_path, monkeypatch, capsys
+):
+    """#1490 v2 positive-evidence gate: an UNKNOWN-shape failure (a bare
+    RuntimeError relayed by the rung — neither created-nothing nor
+    created-then-failed markers) + a singleton new pod -> cannot positively
+    attribute, NEVER terminate; the non-re-drivable leaked terminal."""
+    team_list = _ScriptedTeamList([[], [_residue_pod("podX")]])
+    sidecar, _rp, terminations = _reclaim_setup(
+        tmp_path,
+        monkeypatch,
+        team_list=team_list,
+        backend=_ProvisionFailedRunpodBackend(exc=RuntimeError("boom")),
+    )
+
+    rc = backend_poll_main(["--issue", "1116", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["reason"] == "runpod_provision_leaked_pod"
+    assert terminations == []
+
+
+def test_failover_terminate_not_found_treated_torn_down(tmp_path, monkeypatch, capsys):
+    """#1490 v2 (POD_NOT_FOUND-class terminate result): a terminate that fails
+    because the pod is ALREADY GONE counts as torn-down (nothing bills), so
+    the re-drivable terminal — never a needless human park."""
+    runpod_api = _import_runpod_api()
+    team_list = _ScriptedTeamList([[], [_residue_pod("podX")]])
+    sidecar, _rp, terminations = _reclaim_setup(tmp_path, monkeypatch, team_list=team_list)
+
+    def _raise_not_found(pod_id):
+        raise RuntimeError(
+            'RunPod GraphQL errors: [{"message": "pod not found", '
+            '"extensions": {"code": "POD_NOT_FOUND"}}]'
+        )
+
+    monkeypatch.setattr(runpod_api, "terminate_pod", _raise_not_found, raising=False)
+
+    rc = backend_poll_main(["--issue", "1116", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["reason"] == "no_compute_available"
+    assert "torn-down" in out["log_tail_excerpt"]
+    assert "already gone" in out["log_tail_excerpt"]
+    assert terminations == []


### PR DESCRIPTION
Closes task #1490. Two-signal-gated provision-residue reclaim in backend_poll + alert-only watcher orphan arm + 37 tests. Plan v2; code-review r2 PASS; Step 9c gate 5505 green.