### PR TITLE
workflow-fix #1505: bind parenthetical HF file-count claims after pinned /tree links (Pattern F)

### DIFF
--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -560,7 +560,13 @@ Generation-agnostic checks (run on v2 AND v3 — the inline-figure +
   (`[summary store](…/tree/<sha>/…) (52 files)`, the #1005 footer shape —
   ANY distributive `per <word>` qualifier declines, and a paren
   immediately followed by an HF markdown link is Pattern B's
-  paren-before-link shape: E declines, B wins, #1422))
+  paren-before-link shape: E declines, B wins, #1422); or, at ANY position
+  inside that same paren-after-link, a count immediately followed (one
+  optional `,` / `:` / dash separator) by the phrase
+  `listing (re-)?verified` (`…; logs — 44 files, listing verified live at
+  write time`, the #1072 footer shape — files-only, `;` never crossed,
+  same B-adjacency decline as E, #1505; the paren-body bound is 600 chars,
+  widened from 300 for #1072's corrected 309-char paren))
   must match a files-only scoped Hub tree count at the pinned revision —
   the same bounded raw tree-endpoint probe checks 23/25 use (#733; never
   the SDK `list_repo_tree` / `list_repo_files`), counted EXHAUSTIVELY with
@@ -583,7 +589,11 @@ Generation-agnostic checks (run on v2 AND v3 — the inline-figure +
   row where the scoped tree holds 7,165 files + 207 folders (#1143);
   task #1005's footer claimed 51/15 in bare trailing parens right after
   its pinned links where the pinned trees hold 52/17 — no pattern reached
-  the count-opening paren-after-link position (#1422).
+  the count-opening paren-after-link position (#1422); task #1072 shipped
+  "44 files, listing verified live at write time" mid-paren after an
+  em-dash where the pinned tree holds 40 files + 4 folders (the
+  folder-inflation signature), and its corrected 309-char paren exceeded
+  the old 300-char paren-body bound (#1505).
 
 - **check 31** (`check_orphaned_per_unit_figures`, WARN): the INVERSE
   direction of checks 4b/22/29 (which verify what the body CITES) —
@@ -8629,7 +8639,18 @@ def check_audit_availability_claims_match_hf(body: str) -> CheckResult:
 # trailing parens — `[summary store + manifest](…/tree/<sha>/…) (51
 # files)` — where the pinned trees hold 52/17: a count-OPENING paren
 # right after the link that matches no anchored phrase; Pattern E closes
-# that gap (#1422).
+# that gap (#1422). #1072's footer then carried `(analysis_tensors: …;
+# logs — 44 files, listing verified live at write time)` right after its
+# pinned link — "44 files" mid-paren after an em-dash, where the pinned
+# tree holds 40 files + 4 directory entries (44 = 40+4, the
+# folder-inflation signature again): C's phrase anchors miss ("listing
+# verified live at write time" ≠ "at the pinned revision") and E's
+# .match() fails (the paren opens "analysis_tensors:"). Its CORRECTED
+# footer ("40 files, listing re-verified live at write time …") runs a
+# 309-char paren body, over the old 300-char _HF_LINKTEXT_THEN_PAREN_RE
+# bound, so even that count-OPENING claim went unextracted. Pattern F
+# (the listing-verified phrase anchor) + the 600-char paren-body bound
+# close both gaps (#1505).
 
 # A markdown link whose target is an HF Hub URL. Two-stage extraction: match
 # the link structure first, then scan the TEXT for a count-noun and parse the
@@ -8676,7 +8697,13 @@ _COUNT_PAREN_LINK_RE = re.compile(
 # sacrifice.
 _HF_LINKTEXT_THEN_PAREN_RE = re.compile(
     r"\[(?P<text>[^\]]{1,300})\]\((?P<url>https?://huggingface\.co/[^)\s]+)\)"
-    r"[ \t]{0,2}\((?P<paren>[^()]{1,300})\)"
+    # Paren-body bound 600 (#1505, widened from 300): #1072's corrected
+    # footer paren measures 309 chars, so its count-OPENING claim missed
+    # the old bound entirely; ~2x margin mirrors Pattern D's
+    # qualifier-bound sizing (#1143: 200 vs live 85). Still bounded — a
+    # cap keeps pathological single-line scans cheap (the
+    # _SUBPATH_CLAIM_MAX_GAP rationale).
+    r"[ \t]{0,2}\((?P<paren>[^()]{1,600})\)"
 )
 # Phrase-anchored count claims INSIDE the paren (any position — the phrase,
 # not the position, is the precision anchor; #833's count sits after an `=`).
@@ -8695,11 +8722,27 @@ _FILES_AT_PINNED_REV_RE = re.compile(
     r"at\s+the\s+pinned\s+revision\b",
     re.IGNORECASE,
 )
+# Pattern F (#1505, the #1072 footer shape): a count-noun ANYWHERE inside the
+# paren immediately AFTER the pinned link whose count is immediately followed
+# (one optional , : en-/em-dash / hyphen separator) by the listing-verification
+# phrase — `…; logs — 44 files, listing verified live at write time` /
+# `(40 files, listing re-verified live at write time via `list_repo_tree` …)`.
+# The PHRASE, not the position, is the precision anchor (Pattern C philosophy):
+# a sub-scoped clause count ("analysis_tensors: 16 files; …") carries no such
+# phrase. files-only (C parity); `;` deliberately NOT in the separator class
+# (a claim never binds across a clause boundary); per-`<word>` distributive
+# counts are excluded by adjacency (the phrase must directly follow `files`).
+_FILES_LISTING_VERIFIED_RE = re.compile(
+    r"\b(?P<count>\d{1,3}(?:,\d{3})+|\d{1,6})\s+files?"
+    r"\s{0,2}[,:–—-]?\s{0,2}"
+    r"listing\s+(?:re-?)?verified\b",
+    re.IGNORECASE,
+)
 # Pattern E (#1005, the trailing-parenthetical footer shape): the paren
 # immediately AFTER the pinned link OPENS with the count-noun —
 # `[summary store + manifest](…/tree/<sha>/…) (52 files)`. Applied via
 # .match() on the paren body captured by _HF_LINKTEXT_THEN_PAREN_RE, so the
-# same-line separator ([ \t]{0,2}) and [^()]{1,300} paren-body bounds are
+# same-line separator ([ \t]{0,2}) and [^()]{1,600} paren-body bounds are
 # inherited from that iterator. Wide distributive decline like Pattern D:
 # ANY "per <word>" qualifier declines — "per namespace" belongs to the #833
 # per-namespace leg; "per adapter"/"per seed" (#460 class) have per-unit
@@ -8826,7 +8869,7 @@ def _gather_hf_count_claims(body: str) -> list[tuple[int, str, str, str, str, st
     shared URL regex only matches 7-40-char hex revisions, mirroring
     check 23).
 
-    Five conservative positions (precision over recall — a missed claim
+    Six conservative positions (precision over recall — a missed claim
     costs nothing, the check is a net-new WARN):
 
     - **Pattern A** — the count-noun sits INSIDE the markdown link TEXT
@@ -8871,6 +8914,23 @@ def _gather_hf_count_claims(body: str) -> list[tuple[int, str, str, str, str, st
       see the E-specific sacrifices below). An at-pinned-revision paren
       fires BOTH C and E with identical args — the shared ``seen`` key
       collapses them to one tuple.
+    - **Pattern F (listing-verified phrase, #1505)** — a count-noun at ANY
+      position inside the paren immediately AFTER the link whose count is
+      immediately followed (one optional ``,`` / ``:`` / en-/em-dash /
+      hyphen separator) by the phrase ``listing (re-)?verified``
+      (``…; logs — 44 files, listing verified live at write time``, the
+      #1072 footer shape). The PHRASE, not the position, is the precision
+      anchor (Pattern C's design philosophy, #1088): a verification-of-
+      listing phrase is pragmatically a whole-prefix claim, while a
+      sub-scoped clause count ("analysis_tensors: 16 files; …") carries
+      no such phrase and stays invisible. files-only (C parity — the noun
+      is hard-coded ``"files"``); per-``<word>`` distributive counts are
+      excluded by ADJACENCY (the phrase must directly follow ``files``,
+      so "files per namespace, listing verified" cannot match — C's
+      mutual-exclusion-by-adjacency argument); same B-adjacency decline
+      as Pattern E (#1422 parity). A count-OPENING listing-verified paren
+      (the corrected #1072 footer) fires E AND F with identical args —
+      the shared ``seen`` key collapses them to one tuple.
 
     Known recall sacrifices (each avoids a concrete false-positive class):
     prose counts near BARE (non-markdown) HF URLs; prose counts AFTER the
@@ -8896,7 +8956,27 @@ def _gather_hf_count_claims(body: str) -> list[tuple[int, str, str, str, str, st
     (``_HF_LINK_FOLLOWS_PAREN_RE`` — B wins; its whitespace separators
     span newlines, so a paren at end-of-line followed by a NEXT-LINE HF
     markdown link also declines — a conservative recall residue, a
-    declined claim, never a wrong one). Lookahead ASYMMETRY (deliberate):
+    declined claim, never a wrong one). Pattern-F-specific sacrifices: a
+    shards-with-phrase claim ("16 shards, listing verified" — files-only,
+    C parity; unseen in the wild); a "verified" phrase without "listing"
+    ("44 files, verified at write time" — too weak an anchor); a
+    clause-crossing claim (``;`` is deliberately NOT in the separator
+    class, so "16 files; listing verified" never binds across the clause
+    boundary); a phrase-anchored count in a paren immediately followed by
+    an HF markdown link (F declines, #1422 parity — a deliberate
+    divergence from C, which predates #1422 and is grandfathered without
+    the decline); a phrase-anchored count after a sub-scoped ``word:``
+    clause marker in the SAME clause is a RESIDUAL accepted precision
+    risk (the phrase pragmatically refers to the linked listing —
+    identical in kind to C's accepted residual); SENTENCE-position counts
+    outside the paren (the "/sentence" half of the #1505 Goal — live
+    example: #560's "— 98 files, listing verified via the Hub API" in
+    sentence position) and hyphenated count-adjective forms ("59-file
+    listing") stay unextracted — the prose-count false-positive surface
+    is too large (the "180 of 197 valid quotes" class named in Pattern
+    A's doc); #555's paren-before-link shape that does NOT open with the
+    count-noun (so Pattern B cannot fire) is likewise a NAMED documented
+    miss. Lookahead ASYMMETRY (deliberate):
     Patterns D and E decline ANY distributive ``per <word>`` qualifier
     while A/B keep the narrow #833 per-namespace-only lookahead — a "per
     adapter"-style count in A/B position is a PRE-EXISTING hole outside
@@ -8946,17 +9026,31 @@ def _gather_hf_count_claims(body: str) -> list[tuple[int, str, str, str, str, st
             _add(cm.group("count"), cm.group("noun"), lm.group("url"))
     for pm in _COUNT_PAREN_LINK_RE.finditer(stripped):  # Pattern B: paren before link
         _add(pm.group("count"), pm.group("noun"), pm.group("url"))
-    for lm in _HF_LINKTEXT_THEN_PAREN_RE.finditer(stripped):  # Patterns C + E: paren after link
+    # Patterns C + E + F: paren after link
+    for lm in _HF_LINKTEXT_THEN_PAREN_RE.finditer(stripped):
         for cm in _FILES_AT_PINNED_REV_RE.finditer(lm.group("paren")):  # C (pinned-revision)
             _add(cm.group("count"), "files", lm.group("url"))
-        # Pattern E (#1005): the paren OPENS with the count-noun — .match()
-        # gives B/D-parity anchor semantics ("( 52 files)" with a leading
-        # space deliberately does not match, a documented recall sacrifice).
-        # An at-pinned-revision paren fires BOTH C and E with identical
-        # _add args — the shared `seen` key collapses them to one tuple.
-        em = _COUNT_OPEN_PAREN_AFTER_LINK_RE.match(lm.group("paren"))
-        if em is not None and _HF_LINK_FOLLOWS_PAREN_RE.match(stripped, lm.end()) is None:
-            _add(em.group("count"), em.group("noun"), lm.group("url"))
+        # B-adjacency decline shared by E and F (#1422): a paren immediately
+        # followed by an HF markdown link is Pattern B's paren-before-link
+        # shape — B may extract the paren-OPENING count with the FOLLOWING
+        # link's scope, so E and F both decline. C predates #1422 and keeps
+        # its grandfathered no-decline position (deliberate divergence).
+        followed = _HF_LINK_FOLLOWS_PAREN_RE.match(stripped, lm.end()) is not None
+        if not followed:
+            # Pattern F (#1505): phrase-anchored listing-verified count at
+            # ANY position inside the paren — noun hard-coded "files" like C.
+            for cm in _FILES_LISTING_VERIFIED_RE.finditer(lm.group("paren")):
+                _add(cm.group("count"), "files", lm.group("url"))
+            # Pattern E (#1005): the paren OPENS with the count-noun — .match()
+            # gives B/D-parity anchor semantics ("( 52 files)" with a leading
+            # space deliberately does not match, a documented recall sacrifice).
+            # An at-pinned-revision paren fires BOTH C and E with identical
+            # _add args — the shared `seen` key collapses them to one tuple;
+            # a count-OPENING listing-verified paren (the corrected #1072
+            # footer) fires E AND F and collapses the same way.
+            em = _COUNT_OPEN_PAREN_AFTER_LINK_RE.match(lm.group("paren"))
+            if em is not None:
+                _add(em.group("count"), em.group("noun"), lm.group("url"))
     for dm in _BACKTICK_SUBPATH_COUNT_PAREN_RE.finditer(stripped):  # Pattern D (#1143)
         lm = _nearest_preceding_pinned_tree_link(stripped, dm.start(), link_matches)
         if lm is None:
@@ -9185,7 +9279,10 @@ def check_hf_file_count_claims(body: str) -> CheckResult:
     ``dir/`` sub-path + count-opening paren bound to the nearest preceding
     pinned link and scoped to ``<link-prefix>/<sub-path>`` (#1143, the
     #1112 footer shape) / Pattern E a paren immediately AFTER the link
-    that OPENS with the count-noun (#1422, the #1005 footer shape); see
+    that OPENS with the count-noun (#1422, the #1005 footer shape) /
+    Pattern F a count at ANY position in the paren AFTER the link whose
+    count is immediately followed by the phrase ``listing (re-)?verified``
+    (#1505, the #1072 footer shape); see
     its docstring for
     the precision/recall trade-offs) against an EXHAUSTIVE files-only count
     of the pinned prefix (``_hf_file_count_for_prefix`` → the #733 bounded

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -2163,8 +2163,10 @@ def test_hf_check25_not_found_is_skip_not_fail(monkeypatch):
 # positions: Pattern A count-in-link-text, Pattern B paren-before-link,
 # Pattern C anchored paren-after-link + the per-namespace form (#1088),
 # Pattern D backtick `dir/` sub-path + count-opening paren bound to
-# the nearest preceding pinned link (#1143, the #1112 footer shape), and
-# Pattern E trailing count-opening paren (#1422, the #1005 footer shape).
+# the nearest preceding pinned link (#1143, the #1112 footer shape),
+# Pattern E trailing count-opening paren (#1422, the #1005 footer shape),
+# and Pattern F listing-verified phrase-anchored count at ANY position in
+# the paren after the link (#1505, the #1072 footer shape).
 # All tests are offline: extractor tests need no stub; probe tests stub
 # `verify_task_body._hf_tree_get` (`_stub_tree` / inline stateful
 # closures) after removing the conftest EPM_VERIFY_BODY_NO_HF fence.
@@ -3316,6 +3318,230 @@ def test_hf_count_trailing_paren_match_passes(monkeypatch):
     assert r.passed and not r.is_warn, r.detail
     assert "unverified" not in r.detail
     assert "1 claim(s) checked" in r.detail
+
+
+# ─── Check 30 Pattern F: listing-verified phrase (#1505) ───────────────────
+# #1072's footer carried, right after its pinned /tree link, the paren
+# `(analysis_tensors: 16 decomposed accumulator shards + …; eval_results
+# mirror; logs — 44 files, listing verified live at write time)` — "44
+# files" mid-paren after an em-dash, where the pinned tree holds 40 files +
+# 4 directory entries (44 = 40+4, the #931 folder-inflation signature): C's
+# phrase anchors miss ("listing verified live at write time" ≠ "at the
+# pinned revision") and E's .match() fails (the paren opens
+# "analysis_tensors:"), so check 30 reported "no file-count claims
+# adjacent". The CORRECTED live footer's 309-char paren body then exceeded
+# the old 300-char `_HF_LINKTEXT_THEN_PAREN_RE` bound (widened to 600).
+# Extractor tests are pure; probe tests stub `_hf_tree_get` after removing
+# the conftest fence.
+
+_I1072_SHA = "9c4258b242ad89dfa66cad18ce09d74fb5c357ad"
+_I1072_REPO_ID = "superkaiba1/explore-persona-space-data"
+_I1072_PREFIX = "issue1072_component_decomposition"
+
+
+def _i1072_footer_incident() -> str:
+    """The verbatim filing-time #1072 footer construct (FROZEN incident
+    history — recover via `git log -p -- 'tasks/*/1072/body.md'` in the
+    main checkout; the live body no longer carries it; never re-read at
+    test time — the `_i1005_footer_excerpt` precedent). Paren body 161
+    chars."""
+    return (
+        "HF data repo [`issue1072_component_decomposition/`](https://huggingface.co/datasets/su"
+        "perkaiba1/explore-persona-space-data/tree/9c4258b242ad89dfa66cad18ce09d74fb5c357ad/iss"
+        "ue1072_component_decomposition) (analysis_tensors: 16 decomposed accumulator shards + "
+        "next-token id and position arrays; eval_results mirror; logs — 44 files, listing "
+        "verified live at write time)."
+    )
+
+
+def _i1072_footer_corrected() -> str:
+    """The verbatim CORRECTED live #1072 footer construct (re-probed from
+    `task.py view 1072` at implementation time, 2026-07-18). Paren body
+    309 chars — over the OLD 300-char bound, so even this count-OPENING
+    (Pattern-E-shaped) claim went unextracted pre-#1505."""
+    return (
+        "HF data repo [`issue1072_component_decomposition/`](https://huggingface.co/datasets/su"
+        "perkaiba1/explore-persona-space-data/tree/9c4258b242ad89dfa66cad18ce09d74fb5c357ad/iss"
+        "ue1072_component_decomposition) (40 files, listing re-verified live at write time via "
+        "`list_repo_tree` at the pinned revision: analysis_tensors — 25, incl. the 16 "
+        "decomposed accumulator shards + next-token id and position arrays; eval_results "
+        "mirror — 14, excluding the 2 VM-computed stats JSONs, which live in git only; logs — "
+        "1 workload log)"
+    )
+
+
+def test_hf_count_extractor_listing_verified_1072_incident_shape():
+    """Pure extractor (Pattern F, #1505) — THE DURABILITY PIN: the verbatim
+    filing-time #1072 footer construct yields EXACTLY one claim tuple,
+    bound to the LINK's whole prefix. Exact equality also pins that the
+    sub-scoped clause count ("analysis_tensors: 16 decomposed accumulator
+    shards …") yields nothing."""
+    claims = verify_task_body._gather_hf_count_claims(_i1072_footer_incident())
+    assert claims == [
+        (44, "files", _I1072_REPO_ID, "dataset", _I1072_SHA, _I1072_PREFIX),
+    ]
+
+
+def test_hf_count_extractor_listing_verified_1072_corrected_shape():
+    """Pure extractor: the verbatim CORRECTED live #1072 footer (309-char
+    paren body — pins the widened 600 bound in the live shape) yields
+    EXACTLY one tuple: E and F both fire on the count-OPENING
+    listing-verified paren and the shared `seen` key collapses them."""
+    claims = verify_task_body._gather_hf_count_claims(_i1072_footer_corrected())
+    assert claims == [
+        (40, "files", _I1072_REPO_ID, "dataset", _I1072_SHA, _I1072_PREFIX),
+    ]
+
+
+def test_hf_count_extractor_listing_verified_shapes():
+    """Pure extractor: minimal Pattern-F positives on a synthetic pinned
+    URL — mid-paren after an em-dash, no separator, comma / colon / dash
+    separators, comma-grouped thousands, the `re-verified` form, and an
+    IGNORECASE variant."""
+    u = f"{_I931_REPO}/tree/abc1234def/p"
+    shapes = [
+        (f"[x]({u}) (…; logs — 44 files, listing verified)", 44),
+        (f"[x]({u}) (prose — 44 files listing verified)", 44),
+        (f"[x]({u}) (mid — 44 files — listing verified live)", 44),
+        (f"[x]({u}) (44 files: listing verified)", 44),
+        (f"[x]({u}) (1,234 files, listing verified)", 1234),
+        (f"[x]({u}) (40 files, listing re-verified live at write time)", 40),
+        (f"[x]({u}) (bulk — 44 FILES, LISTING VERIFIED)", 44),
+    ]
+    for body, count in shapes:
+        claims = verify_task_body._gather_hf_count_claims(body)
+        assert [(c[0], c[1], c[5]) for c in claims] == [(count, "files", "p")], body
+
+
+def test_hf_count_extractor_listing_verified_negative_cases():
+    """Shapes that must NOT extract (precision-first; each guards a named
+    false-positive class from the Pattern-F recall-sacrifice list)."""
+    u = f"{_I931_REPO}/tree/abc1234def/p"
+    negatives = [
+        # Sub-scoped clause counts with no phrase (the incident paren's own
+        # "analysis_tensors: 16 …" clause never binds).
+        f"[x]({u}) (analysis_tensors: 16 files; eval_results mirror)",
+        # "verified" without "listing" — too weak an anchor.
+        f"[x]({u}) (logs — 44 files, verified at write time)",
+        # Per-<word> distributive — excluded by adjacency (the phrase must
+        # directly follow `files`; the per-namespace leg keeps its own
+        # semantics for the bare per-namespace form).
+        f"[x]({u}) (44 files per namespace, listing verified)",
+        # Shards never bind via F (files-only, C parity).
+        f"[x]({u}) (bulk — 16 shards, listing verified)",
+        # Clause-crossing: `;` is deliberately NOT in the separator class.
+        f"[x]({u}) (analysis_tensors: 16 files; listing verified live)",
+        # Moving ref / /blob/ / fenced block / newline gap — iterator guards.
+        f"[x]({_I931_REPO}/tree/main/p) (logs — 44 files, listing verified)",
+        f"[x]({_I931_REPO}/blob/abc1234def/p/f.json) (logs — 44 files, listing verified)",
+        f"```\n[x]({u}) (logs — 44 files, listing verified)\n```",
+        f"[x]({u})\n(logs — 44 files, listing verified)",
+        # A NON-count-opening listing-verified paren immediately followed by
+        # an HF markdown link: F declines (B-adjacency) and B cannot fire
+        # (the count does not OPEN the paren) → nothing extracts.
+        (
+            f"[x @abc1234]({_I931_REPO}/tree/abc1234def/p) "
+            f"(logs — 44 files, listing verified): "
+            f"[y @abc1234]({_I931_REPO}/tree/abc1234def/other)"
+        ),
+    ]
+    for body in negatives:
+        assert verify_task_body._gather_hf_count_claims(body) == [], body
+
+
+def test_hf_count_listing_verified_b_adjacency_declines():
+    """`[x](url1) (44 files, listing verified): [y](url2)` → E and F both
+    decline (the paren is immediately followed by an HF markdown link —
+    Pattern B's paren-before-link shape) and B ALONE extracts, scoped to
+    url2's OWN prefix: exactly one tuple, never a second
+    differently-scoped claim from the same paren (mirrors
+    test_hf_count_trailing_paren_b_adjacency_declines)."""
+    body = (
+        f"[x @abc1234]({_I931_REPO}/tree/abc1234def/p) (44 files, listing verified): "
+        f"[y @abc1234]({_I931_REPO}/tree/abc1234def/other)"
+    )
+    claims = verify_task_body._gather_hf_count_claims(body)
+    assert [(c[0], c[1], c[5]) for c in claims] == [(44, "files", "other")]
+
+
+def test_hf_count_extractor_paren_bound_600():
+    """The `_HF_LINKTEXT_THEN_PAREN_RE` paren-body bound is pinned EXACTLY
+    two-sided at 600 (#1505, widened from 300 for #1072's corrected
+    309-char paren): a count-opening paren whose body is exactly 600 chars
+    extracts via E (previously missed above 300), and a 601-char body
+    declines."""
+    u = f"{_I931_REPO}/tree/abc1234def/p"
+    body_600 = "9 files, " + "x" * 591
+    assert len(body_600) == 600
+    claims = verify_task_body._gather_hf_count_claims(f"[x]({u}) ({body_600})")
+    assert [(c[0], c[1], c[5]) for c in claims] == [(9, "files", "p")]
+    body_601 = "9 files, " + "x" * 592
+    assert len(body_601) == 601
+    assert verify_task_body._gather_hf_count_claims(f"[x]({u}) ({body_601})") == []
+
+
+def test_hf_count_listing_verified_mismatch_warns_1072_shape(monkeypatch):
+    """The #1072 incident reconstruction: the filing-time footer's claim of
+    44 files against a stubbed pinned tree of 40 files + 4 directory
+    entries → WARN naming both numbers AND the files+folders consistency
+    diagnostic (44 = 40+4, the #931 folder-inflation signature); `passed`
+    stays True (WARN-only invariant — no `passed=False` path added)."""
+    monkeypatch.delenv("EPM_VERIFY_BODY_NO_HF", raising=False)
+    # Explicit cache hygiene (the Pattern-E test precedent): this test and
+    # its match-passes sibling share the same (repo, sha, prefix) key and
+    # `_HF_TREE_FILE_COUNT_CACHE` is module-global.
+    verify_task_body._HF_TREE_FILE_COUNT_CACHE.clear()
+    entries = [
+        {"path": f"{_I1072_PREFIX}/{d}", "type": "directory"}
+        for d in ("analysis_tensors", "eval_results", "logs", "raw")
+    ]
+    entries += [
+        {"path": f"{_I1072_PREFIX}/analysis_tensors/f{i}.npz", "type": "file"} for i in range(40)
+    ]
+    _stub_tree(monkeypatch, status="ok", entries=entries)
+    r = verify_task_body.check_hf_file_count_claims(_i1072_footer_incident())
+    assert r.passed and r.is_warn, r.detail
+    assert "44" in r.detail and "40 file(s)" in r.detail
+    assert "consistent with files+folders" in r.detail
+
+
+def test_hf_count_listing_verified_match_passes(monkeypatch):
+    """The CORRECTED live #1072 footer (40 files) against the same stubbed
+    40-file + 4-folder tree → clean PASS: no WARN, no `unverified` note,
+    `1 claim(s) checked` (the E+F co-fire collapsed to ONE claim by the
+    shared `seen` key — a double count would read "2 claim(s) checked")."""
+    monkeypatch.delenv("EPM_VERIFY_BODY_NO_HF", raising=False)
+    # Same explicit cache hygiene as the mismatch sibling above.
+    verify_task_body._HF_TREE_FILE_COUNT_CACHE.clear()
+    entries = [
+        {"path": f"{_I1072_PREFIX}/{d}", "type": "directory"}
+        for d in ("analysis_tensors", "eval_results", "logs", "raw")
+    ]
+    entries += [
+        {"path": f"{_I1072_PREFIX}/analysis_tensors/f{i}.npz", "type": "file"} for i in range(40)
+    ]
+    _stub_tree(monkeypatch, status="ok", entries=entries)
+    r = verify_task_body.check_hf_file_count_claims(_i1072_footer_corrected())
+    assert r.passed and not r.is_warn, r.detail
+    assert "unverified" not in r.detail
+    assert "1 claim(s) checked" in r.detail
+
+
+def test_check40_gatherer_ignores_listing_verified_parens():
+    """Check-40 non-interaction (#1505 acceptance criterion 5): the
+    unpinned-count gatherer extracts NOTHING from either #1072 construct
+    (their counts are link-adjacent, not backtick-token-adjacent — between
+    `](url)` and `(` there is no room for a backtick token) nor from the
+    minimal Pattern-F positive shapes."""
+    u = f"{_I931_REPO}/tree/abc1234def/p"
+    bodies = [
+        _i1072_footer_incident(),
+        _i1072_footer_corrected(),
+        f"[x]({u}) (…; logs — 44 files, listing verified)",
+        f"[x]({u}) (44 files: listing verified)",
+    ]
+    for body in bodies:
+        assert verify_task_body._gather_hf_unpinned_count_claims(body) == [], body
 
 
 # ─── Check 32: HF-adjacent backtick file claims vs the pinned tree (WARN) ──


### PR DESCRIPTION
Closes task #1505. Pattern F (phrase-anchored 'listing (re-)verified' count in the paren after a pinned HF /tree link) + paren-body bound 300→600 in check 30 of scripts/verify_task_body.py, with 9 new tests. Incident: #1072 footer '44 files' unbound while the pinned tree holds 40.