### PR TITLE
issue-1494: isfinite product clamp for tier-(e) byte-knob env parsers

### DIFF
--- a/scripts/vm_disk_guard.py
+++ b/scripts/vm_disk_guard.py
@@ -1057,7 +1057,9 @@ def home_hf_revision_max_age_days() -> float:
 def home_hf_repo_escalate_bytes() -> int:
     """Single-repo footprint (bytes) above which tier (e) always escalates
     with a per-revision breakdown. Env ``EPS_VM_HOME_HF_CACHE_REPO_ESCALATE_GB``
-    (float GB); invalid/negative -> default."""
+    (float GB); invalid/negative/non-finite -- or a finite value whose byte
+    product overflows float (int(inf) would raise OverflowError, #1494) ->
+    default."""
     raw = os.environ.get("EPS_VM_HOME_HF_CACHE_REPO_ESCALATE_GB", "").strip()
     gb = DEFAULT_HOME_HF_REPO_ESCALATE_GB
     if raw:
@@ -1065,7 +1067,7 @@ def home_hf_repo_escalate_bytes() -> int:
             val = float(raw)
         except ValueError:
             val = -1.0
-        if val >= 0.0:
+        if val >= 0.0 and math.isfinite(val * 1e9):
             gb = val
     return int(gb * 1e9)
 
@@ -1073,8 +1075,10 @@ def home_hf_repo_escalate_bytes() -> int:
 def home_hf_cache_cap_bytes() -> int:
     """Total hub-cache footprint (bytes) above which tier (e)'s size-cap arm
     (arm 3, #1450) reaps ELIGIBLE revisions oldest-first down to the cap.
-    Env ``EPS_VM_HOME_HF_CACHE_CAP_GB`` (float GB); blank/invalid/negative ->
-    default 50 GB. Effectively disable with a very large value."""
+    Env ``EPS_VM_HOME_HF_CACHE_CAP_GB`` (float GB); blank/invalid/negative/
+    non-finite -- or a finite value whose byte product overflows float
+    (int(inf) would raise OverflowError, #1494) -> default 50 GB. Effectively
+    disable with a very large (product-finite) value."""
     raw = os.environ.get("EPS_VM_HOME_HF_CACHE_CAP_GB", "").strip()
     gb = DEFAULT_HOME_HF_CACHE_CAP_GB
     if raw:
@@ -1082,7 +1086,7 @@ def home_hf_cache_cap_bytes() -> int:
             val = float(raw)
         except ValueError:
             val = -1.0
-        if val >= 0.0:
+        if val >= 0.0 and math.isfinite(val * 1e9):
             gb = val
     return int(gb * 1e9)
 

--- a/tests/test_vm_disk_guard_home_hf_cache.py
+++ b/tests/test_vm_disk_guard_home_hf_cache.py
@@ -987,3 +987,31 @@ def test_home_tier_size_cap_degenerate_multi_revision_repo_kept(env, monkeypatch
     assert all("ddd" not in h for req in executed for h in req)
     assert any("degenerate-repo-kept: 1 repo(s)" in d for d in res.detail)
     assert any("size-cap (arm 3)" in d for d in res.detail)
+
+
+def test_repo_escalate_bytes_nonfinite_env_never_raises(monkeypatch):
+    """inf/-inf/nan/product-overflowing-huge env -> default, never OverflowError
+    (#1494; the tier-(e) sibling of the #1457 devfs fix)."""
+    default_bytes = int(vdg.DEFAULT_HOME_HF_REPO_ESCALATE_GB * 1e9)
+    for raw in ("inf", "-inf", "nan", "1e300", "not-a-number"):
+        monkeypatch.setenv("EPS_VM_HOME_HF_CACHE_REPO_ESCALATE_GB", raw)
+        assert vdg.home_hf_repo_escalate_bytes() == default_bytes
+    monkeypatch.setenv("EPS_VM_HOME_HF_CACHE_REPO_ESCALATE_GB", "10")
+    assert vdg.home_hf_repo_escalate_bytes() == int(10 * 1e9)
+    # huge-but-product-finite is ACCEPTED: the clamp is int()-safety, not a magnitude cap
+    monkeypatch.setenv("EPS_VM_HOME_HF_CACHE_REPO_ESCALATE_GB", "1e290")
+    assert vdg.home_hf_repo_escalate_bytes() == int(1e290 * 1e9)
+
+
+def test_cache_cap_bytes_nonfinite_env_never_raises(monkeypatch):
+    """Same clamp for the size-cap knob (#1494): inf/-inf/nan/1e300/invalid ->
+    default; valid and huge-but-product-finite values accepted."""
+    default_bytes = int(vdg.DEFAULT_HOME_HF_CACHE_CAP_GB * 1e9)
+    for raw in ("inf", "-inf", "nan", "1e300", "not-a-number"):
+        monkeypatch.setenv("EPS_VM_HOME_HF_CACHE_CAP_GB", raw)
+        assert vdg.home_hf_cache_cap_bytes() == default_bytes
+    monkeypatch.setenv("EPS_VM_HOME_HF_CACHE_CAP_GB", "10")
+    assert vdg.home_hf_cache_cap_bytes() == int(10 * 1e9)
+    # huge-but-product-finite is ACCEPTED: the clamp is int()-safety, not a magnitude cap
+    monkeypatch.setenv("EPS_VM_HOME_HF_CACHE_CAP_GB", "1e290")
+    assert vdg.home_hf_cache_cap_bytes() == int(1e290 * 1e9)


### PR DESCRIPTION
Closes task #1494. Product-finiteness clamps in home_hf_repo_escalate_bytes() + home_hf_cache_cap_bytes() (scripts/vm_disk_guard.py) + two pinning tests. Plan v2 approved (3x APPROVE + consistency PASS); code-review v1 PASS.