### PR TITLE
issue-1498: literal-path pinning-test arm for the Step 9c selector

### DIFF
--- a/scripts/select_step9c_tests.py
+++ b/scripts/select_step9c_tests.py
@@ -37,6 +37,16 @@ Touched-file -> test mapping (per touched file ``f``):
     mark the touched file tested (suppresses its ``untested_touched`` WARN):
     the test executes the touched module's code, strictly stronger evidence
     than the filename-substring stem glob that also sets ``matched``.
+  * any ``tests/**/test_*.py`` whose RAW TEXT contains a touched ``scripts/``
+    or ``src/explore_persona_space/`` ``.py`` file's repo-relative path as a
+    literal substring is ADDITIONALLY selected with reason
+    ``literal-path:<touched file>`` (#1498 — the pinning-test shape: e.g.
+    ``tests/test_ruff_policy.py`` hardcodes ``scripts/...`` paths in
+    ``LIVE_WORKFLOW_HELPERS`` and lints them at test time, reachable from no
+    stem / scan glob / import). Like a glob-scan hit, a literal-path hit does
+    NOT mark the touched file tested (a pinning test asserts an invariant
+    ABOUT the file, not the file's own logic), so ``untested_touched`` WARNs
+    still fire.
 
 ``safe-by-direction``: the broad ``*{stem}*`` glob arm deliberately OVER-matches
 on short stems (e.g. stem ``gcp`` selects ``test_gcp_backend.py``) — running a
@@ -68,6 +78,22 @@ reads on a workflow-surface-only diff; a short / colliding stem parses extra
 files, bounded by the measured ~4-8 s whole-tree worst case), and import-map
 selections flow into :func:`recommended_timeout_s` automatically (it sizes on
 ``len(tests)``).
+
+Literal-path scope + cost (#1498): the arm shares the import arm's single
+read pass (:func:`_scan_test_files`) — zero ADDITIONAL file reads on any diff
+that already triggered the import scan, and a workflow-surface-only diff
+still reads nothing (both arms' target sets empty -> early return). A diff
+whose only eligible ``.py`` maps to no module name (``scripts/__init__.py``)
+now triggers the read pass, with ZERO ast parses (empty token pre-filter).
+Raw substring on file text is deliberate: comment / docstring mentions
+over-select in the safe direction (safe-by-direction, above). Extendable
+miss classes, out of scope for now — an uncovered eligible ``.py`` still
+lands in the ``untested_touched`` WARN, while a non-``.py`` pin target sits
+outside the code-file mapping entirely: constructed paths
+(``Path("scripts") / "x.py"``, f-strings with variable parts, multi-line
+string concatenation); ``conftest.py``-resident pin lists (the scan is
+``rglob("test_*.py")``, matching the import arm's scope); and non-``.py``
+pins (e.g. a test hardcoding ``scripts/bootstrap_pod.sh``).
 
 Root resolution: with no ``--repo-root``, everything (the ``git diff`` cwd,
 touched-test existence checks, stem-glob mapping, invariant presence) resolves
@@ -129,7 +155,8 @@ BACKGROUND invocation — SKILL.md 9c step 1b). ``--json`` emits
 "n_tests": <int>, "recommended_timeout_s": <int>,
 "slow_tests_selected": [...]}`` (a
 reason is ``invariant`` / ``touched-test`` / ``stem-map:<touched file>`` /
-``glob-scan:<touched file>`` / ``import-map:<touched file>`` — #1022, #1299).
+``glob-scan:<touched file>`` / ``import-map:<touched file>`` /
+``literal-path:<touched file>`` — #1022, #1299, #1498).
 Exit 0 on success (even with WARN lines);
 exit 1 if an underlying ``git`` call fails irrecoverably (work-root resolution
 or the diff) or if the selection comes back EMPTY (the zero-test-gate
@@ -520,40 +547,74 @@ def _import_names(tree: ast.AST) -> set[str]:
     return names
 
 
-def import_map_hits(touched: list[str], work_root: Path) -> tuple[dict[str, set[str]], set[str]]:
-    """Scan ``tests/**/test_*.py`` for imports of touched modules (#1299).
+def literal_path_targets(touched: list[str]) -> set[str]:
+    """Touched files eligible for the literal-path arm (#1498).
 
-    Returns ``({test_relpath: {touched files it imports}}, {touched files with
-    >= 1 importing test})``. Subdir tests (``tests/experiments/``) are in scope
-    (sorted ``rglob`` — pytest collects them and the touched-test arm already
-    admits their paths), so the import arm matches that scope.
-
-    Cost bound: an empty module map (workflow-surface-only diff) returns
-    immediately with ZERO file reads. Otherwise each test file's raw text is
-    read and a SUBSTRING PRE-FILTER applies: the file is ``ast``-parsed only
-    when its text contains the last dotted component of at least one candidate
-    module name — any absolute import of module M must literally spell M's last
-    component, so the filter is over-inclusive (never a false negative).
-    Typical touched sets parse a handful of files; worst case the whole tree
-    (~500 files, measured ~4-8 s under shared-VM load — module docstring).
-
-    Fail-soft (#1299 rationale R5): a file that cannot be read / decoded /
-    parsed (``OSError``, ``SyntaxError``, ``ValueError`` incl.
-    ``UnicodeDecodeError``) emits ONE stderr WARN and is SKIPPED for the import
-    arm — never crashes the selector. The selection stays well-defined for
-    every other file, and if the broken file is itself part of the diff the
-    touched-test arm still selects it (pytest collection then fails loud at the
-    right surface). When parse failures exceed 5% of the scanned files, ONE
-    additional aggregate WARN flags the systemic tests/ breakage.
+    Eligible: ``.py`` code files under ``scripts/`` or
+    ``src/explore_persona_space/`` — never ``tests/`` (the touched-test arm
+    owns those; the ``.md`` / workflow-surface pin mapping is deliberately out
+    of scope here — #1496's surface). Each returned repo-relative path is
+    matched as a raw substring of every scanned test file's text.
     """
-    hits: dict[str, set[str]] = {}
+    return {
+        f
+        for f in touched
+        if Path(f).suffix == ".py"
+        and not f.startswith("tests/")
+        and (f.startswith("scripts/") or f.startswith("src/explore_persona_space/"))
+    }
+
+
+def _scan_test_files(
+    touched: list[str], work_root: Path
+) -> tuple[dict[str, set[str]], set[str], dict[str, set[str]]]:
+    """ONE shared read pass over ``tests/**/test_*.py`` for both text-scan arms.
+
+    Returns ``(import_hits, import_tested, literal_hits)``:
+      * ``import_hits`` — ``{test_relpath: {touched files it imports}}``
+        (#1299, the import-map arm);
+      * ``import_tested`` — touched files with >= 1 importing test (these
+        suppress the ``untested_touched`` WARN);
+      * ``literal_hits`` — ``{test_relpath: {touched files whose repo-relative
+        path appears as a raw substring of the test's text}}`` (#1498, the
+        literal-path arm; never suppresses the WARN).
+
+    Subdir tests (``tests/experiments/``) are in scope (sorted ``rglob`` —
+    pytest collects them and the touched-test arm already admits their paths).
+
+    Cost bound: when BOTH target sets are empty (workflow-surface-only diff)
+    the pass returns immediately with ZERO file reads. Otherwise each test
+    file's raw text is read ONCE and (a) checked against each literal target
+    as a plain substring, then (b) ``ast``-parsed ONLY when its text contains
+    the last dotted component of at least one candidate module name — any
+    absolute import of module M must literally spell M's last component, so
+    the filter is over-inclusive (never a false negative). A literal-only
+    trigger (e.g. ``scripts/__init__.py``, which maps to no module name)
+    reads the tree with ZERO parses (empty token pre-filter). Typical touched
+    sets parse a handful of files; worst case the whole tree (~500 files,
+    measured ~4-8 s under shared-VM load — module docstring).
+
+    Fail-soft (#1299 rationale R5): a file whose RAW READ fails (``OSError``,
+    ``ValueError`` incl. ``UnicodeDecodeError``) emits ONE stderr WARN and is
+    skipped for BOTH arms; a file that reads but fails to PARSE
+    (``SyntaxError``, ``ValueError``) is skipped for the import arm ONLY —
+    its literal hits are kept (raw text already read; an additive
+    improvement, #1498). Never crashes the selector; if the broken file is
+    itself part of the diff the touched-test arm still selects it (pytest
+    collection then fails loud at the right surface). When read + parse
+    failures exceed 5% of the scanned files, ONE additional aggregate WARN
+    flags the systemic tests/ breakage.
+    """
+    import_hits: dict[str, set[str]] = {}
     tested: set[str] = set()
+    literal_hits: dict[str, set[str]] = {}
     module_map = touched_module_names(touched)
-    if not module_map:
-        return hits, tested
+    literal_targets = literal_path_targets(touched)
+    if not module_map and not literal_targets:
+        return import_hits, tested, literal_hits
     tests_dir = work_root / "tests"
     if not tests_dir.is_dir():
-        return hits, tested
+        return import_hits, tested, literal_hits
     tokens = {name.rsplit(".", 1)[-1] for name in module_map}
     n_scanned = 0
     n_failed = 0
@@ -562,28 +623,54 @@ def import_map_hits(touched: list[str], work_root: Path) -> tuple[dict[str, set[
         rel = test_path.relative_to(work_root).as_posix()
         try:
             text = test_path.read_text(encoding="utf-8")
-            if not any(tok in text for tok in tokens):
-                continue
-            imported = _import_names(ast.parse(text))
-        except (OSError, SyntaxError, ValueError) as exc:
+        except (OSError, ValueError) as exc:
             n_failed += 1
             print(
                 f"select_step9c_tests: WARN — import-map cannot parse {rel}: {exc}; "
-                "file skipped for the import arm",
+                "file skipped for the import and literal-path arms",
+                file=sys.stderr,
+            )
+            continue
+        for f in literal_targets:
+            if f in text:
+                literal_hits.setdefault(rel, set()).add(f)
+        if not any(tok in text for tok in tokens):
+            continue
+        try:
+            imported = _import_names(ast.parse(text))
+        except (SyntaxError, ValueError) as exc:
+            n_failed += 1
+            print(
+                f"select_step9c_tests: WARN — import-map cannot parse {rel}: {exc}; "
+                "file skipped for the import arm (literal-path hits on its raw text, "
+                "if any, are kept)",
                 file=sys.stderr,
             )
             continue
         for name, files in module_map.items():
             if name in imported:
-                hits.setdefault(rel, set()).update(files)
+                import_hits.setdefault(rel, set()).update(files)
                 tested.update(files)
     if n_scanned and n_failed / n_scanned > 0.05:
         print(
-            f"select_step9c_tests: WARN — import-map parse failures on "
+            f"select_step9c_tests: WARN — test-scan read/parse failures on "
             f"{n_failed}/{n_scanned} scanned test files (>5%): systemic tests/ breakage; "
-            "the import arm may under-select",
+            "the import and literal-path arms may under-select",
             file=sys.stderr,
         )
+    return import_hits, tested, literal_hits
+
+
+def import_map_hits(touched: list[str], work_root: Path) -> tuple[dict[str, set[str]], set[str]]:
+    """Back-compat wrapper over :func:`_scan_test_files` (the #1299 public shape).
+
+    Returns ``(import_hits, import_tested)``, dropping the literal-path
+    element. NOTE (#1498): the underlying shared pass also triggers on
+    literal-eligible touched files, so a ``scripts/__init__.py``-only call
+    now scans (with zero parses) where the pre-refactor arm returned early
+    with zero reads; the returned import elements are unchanged.
+    """
+    hits, tested, _ = _scan_test_files(touched, work_root)
     return hits, tested
 
 
@@ -592,27 +679,46 @@ def _seed_import_reasons(import_hits: dict[str, set[str]]) -> dict[str, set[str]
     return {t: {f"import-map:{f}" for f in files} for t, files in import_hits.items()}
 
 
+def _seed_scan_reasons(
+    import_hits: dict[str, set[str]], literal_hits: dict[str, set[str]]
+) -> dict[str, set[str]]:
+    """Initial ``{test: reasons}`` mapping seeded from BOTH text-scan arms.
+
+    Import-map hits (#1299) plus literal-path hits (#1498) — a test hit by
+    both carries both reason kinds. Purely additive: only ever adds
+    tests/reasons to the seed.
+    """
+    selected = _seed_import_reasons(import_hits)
+    for lit_test, lit_files in literal_hits.items():
+        for lit_f in lit_files:
+            selected.setdefault(lit_test, set()).add(f"literal-path:{lit_f}")
+    return selected
+
+
 def select_tests_with_reasons(
     touched: list[str], work_root: Path
 ) -> tuple[list[str], list[str], dict[str, list[str]]]:
     """Superset of :func:`select_tests`: also returns ``{test: sorted reasons}``.
 
     A reason is ``'invariant' | 'touched-test' | 'stem-map:<touched file>' |
-    'glob-scan:<touched file>' | 'import-map:<touched file>'``; a test may
+    'glob-scan:<touched file>' | 'import-map:<touched file>' |
+    'literal-path:<touched file>'``; a test may
     carry several (e.g. an invariant that is also stem-mapped from a touched
     file). Selection behavior is IDENTICAL to :func:`select_tests` — same
     tests, same ``untested_touched`` WARN list, same sorted ordering (#1022:
     the reasons feed ``step9c_baseline.py compare``'s diff-linked-ness read,
     which must come from the SAME mapping logic that selected the run's tests).
     """
-    # Import-map arm (#1299): seeds the selection — additive by construction
-    # (it only ever adds tests/reasons here and, via the ``matched`` seed
-    # below, removes entries from the untested WARN list; no code path drops a
+    # Text-scan arms (ONE shared read pass, _scan_test_files): the import-map
+    # arm (#1299) seeds the selection and the literal-path arm (#1498) adds
+    # pinning-test hits — both additive by construction (they only ever add
+    # tests/reasons here and, via the ``matched`` seed below, the IMPORT arm
+    # alone removes entries from the untested WARN list; no code path drops a
     # stem-map / glob-scan / invariant / touched-test selection, so selection
     # only GROWS). Ordering is irrelevant: the terminal sorted() reads below
     # keep the output deterministic.
-    import_hits, import_tested = import_map_hits(touched, work_root)
-    selected: dict[str, set[str]] = _seed_import_reasons(import_hits)
+    import_hits, import_tested, literal_hits = _scan_test_files(touched, work_root)
+    selected: dict[str, set[str]] = _seed_scan_reasons(import_hits, literal_hits)
     untested: list[str] = []
 
     def _add(test: str, reason: str) -> None:
@@ -849,8 +955,8 @@ def main(argv: list[str] | None = None) -> int:
     missing = missing_invariants(work_root)
 
     # Fail loud on an EMPTY selection (defense-in-depth beside the Step 9c shell
-    # guard against a silent test-gate pass). WORKFLOW_INVARIANT has 37 always-on
-    # entries, so an empty list can only mean the work root resolved wrong (e.g.
+    # guard against a silent test-gate pass). WORKFLOW_INVARIANT is a non-empty
+    # always-on pinned set, so an empty list can only mean the work root resolved wrong (e.g.
     # invoked from a directory outside the repo, or a bad --repo-root override)
     # or the invariant files all vanished — either way the gate would run zero
     # tests. Never let that surface as an exit-0 "no tests ran".

--- a/tests/test_select_step9c_tests.py
+++ b/tests/test_select_step9c_tests.py
@@ -1095,3 +1095,188 @@ def test_import_map_live_tree_issue1286_shape():
     assert "import-map:scripts/issue810_fit_readout.py" in reasons[target]
     assert "scripts/issue810_common.py" not in untested
     assert "scripts/issue810_fit_readout.py" not in untested
+
+
+# --- Cases 52+ (#1498): the literal-path pinning arm -----------------------------
+# Fixtures write test files whose RAW TEXT hardcodes a touched file's
+# repo-relative path (the tests/test_ruff_policy.py LIVE_WORKFLOW_HELPERS
+# shape). The shared _make_tree stubs contain no repo paths, so the arm
+# no-ops on every pre-existing fixture by construction.
+
+
+# --- Case 52: a pinning test is selected with the literal-path reason ------------
+def test_literal_path_pin_selected(tmp_path: Path):
+    repo = _make_import_tree(tmp_path, {"test_pin_x.py": 'LIVE = ["scripts/foo_helper.py"]\n'})
+    tests, _, reasons = sel.select_tests_with_reasons(["scripts/foo_helper.py"], repo)
+    assert "tests/test_pin_x.py" in tests
+    assert reasons["tests/test_pin_x.py"] == ["literal-path:scripts/foo_helper.py"]
+
+
+# --- Case 53: THE durability pin — the #1498 founding case on the LIVE tree ------
+def test_literal_path_founding_case_live_tree():
+    """No fixtures: the real tree's tests/test_ruff_policy.py hardcodes
+    ``scripts/daily_drive_filings.py`` in LIVE_WORKFLOW_HELPERS and lints it at
+    test time, yet shares no stem, matches no scan glob, and imports nothing —
+    reachable ONLY through the literal-path arm (#1498 founding incident).
+
+    If a future cleanup removes scripts/daily_drive_filings.py or drops it from
+    LIVE_WORKFLOW_HELPERS, this pin fails loud — repoint it at another
+    committed pin relationship (test_ruff_policy.py has dozens).
+    """
+    repo_root = Path(sel.__file__).resolve().parents[1]
+    tests, _, reasons = sel.select_tests_with_reasons(["scripts/daily_drive_filings.py"], repo_root)
+    assert "tests/test_ruff_policy.py" in tests
+    assert "literal-path:scripts/daily_drive_filings.py" in reasons["tests/test_ruff_policy.py"]
+
+
+# --- Case 54: precision — a pin of a DIFFERENT path is not selected --------------
+def test_literal_path_negative_not_selected(tmp_path: Path):
+    repo = _make_import_tree(
+        tmp_path, {"test_bystander_pin.py": 'LIVE = ["scripts/other_helper.py"]\n'}
+    )
+    tests, _, _ = sel.select_tests_with_reasons(["scripts/foo_helper.py"], repo)
+    assert "tests/test_bystander_pin.py" not in tests
+
+
+# --- Case 55: a literal hit does NOT suppress the untested_touched WARN ----------
+def test_literal_path_does_not_suppress_untested_warn(tmp_path: Path):
+    """A pinning test asserts an invariant ABOUT the file (e.g. ruff
+    cleanliness), not the file's own logic — unlike an import hit, it never
+    sets ``matched`` (plan R3; glob-scan precedent)."""
+    repo = _make_import_tree(tmp_path, {"test_pin_x.py": 'LIVE = ["scripts/foo_helper.py"]\n'})
+    tests, untested, _ = sel.select_tests_with_reasons(["scripts/foo_helper.py"], repo)
+    assert "tests/test_pin_x.py" in tests
+    assert untested == ["scripts/foo_helper.py"]
+
+
+# --- Case 56: monotonicity — the arm only ever GROWS the selection ---------------
+def test_literal_path_only_grows_selection(tmp_path: Path):
+    """Same touched set, tree WITH vs WITHOUT the pin-bearing test file:
+    WITH-selection is a superset and every WITHOUT reason list is preserved
+    verbatim (mirror of case 41 for the literal arm)."""
+    touched = ["scripts/widgetlib.py", "scripts/orphan.py"]
+    repo_without = _make_tree(tmp_path / "without", ["test_widgetlib.py"])
+    t_without, u_without, r_without = sel.select_tests_with_reasons(touched, repo_without)
+    repo_with = _make_tree(tmp_path / "with", ["test_widgetlib.py"])
+    (repo_with / "tests" / "test_pins.py").write_text('LIVE = ["scripts/widgetlib.py"]\n')
+    t_with, u_with, r_with = sel.select_tests_with_reasons(touched, repo_with)
+    assert set(t_with) >= set(t_without)
+    for test, rs in r_without.items():
+        assert r_with[test] == rs  # pre-existing reason lists preserved verbatim
+    assert r_with["tests/test_pins.py"] == ["literal-path:scripts/widgetlib.py"]
+    # orphan.py has no test in either tree; widgetlib.py is stem-mapped in both.
+    assert u_without == ["scripts/orphan.py"]
+    assert u_with == ["scripts/orphan.py"]
+
+
+# --- Case 57: unreadable file WARNs + is skipped for BOTH arms; never crashes ----
+def test_literal_path_unreadable_file_warns_not_crash(tmp_path: Path, capsys):
+    repo = _make_import_tree(tmp_path, {"test_good_pin.py": 'LIVE = ["scripts/foo_helper.py"]\n'})
+    (repo / "tests" / "test_undecodable.py").write_bytes(
+        b'LIVE = ["scripts/foo_helper.py"]\n\xff\xfe bad'
+    )
+    tests, _, reasons = sel.select_tests_with_reasons(["scripts/foo_helper.py"], repo)
+    assert "tests/test_good_pin.py" in tests  # the valid hit still selected
+    assert reasons["tests/test_good_pin.py"] == ["literal-path:scripts/foo_helper.py"]
+    assert "tests/test_undecodable.py" not in tests  # read failed -> both arms skip
+    err = capsys.readouterr().err
+    assert "import-map cannot parse" in err
+    assert "test_undecodable.py" in err
+
+
+# --- Case 58: a syntax-error file's literal hit still lands (read/parse split) ---
+def test_literal_path_syntax_error_file_still_matched(tmp_path: Path, capsys):
+    """The raw read succeeded, so the literal hit is recorded even though the
+    ast parse (triggered by the 'foo_helper' pre-filter token) fails — the
+    import-arm WARN fires and the literal selection lands."""
+    repo = _make_import_tree(
+        tmp_path, {"test_broken_pin.py": 'LIVE = ["scripts/foo_helper.py"]\ndef broken(:\n'}
+    )
+    tests, untested, reasons = sel.select_tests_with_reasons(["scripts/foo_helper.py"], repo)
+    assert "tests/test_broken_pin.py" in tests
+    assert reasons["tests/test_broken_pin.py"] == ["literal-path:scripts/foo_helper.py"]
+    assert untested == ["scripts/foo_helper.py"]  # literal hit never sets matched
+    err = capsys.readouterr().err
+    assert err.count("import-map cannot parse") == 1
+    assert "test_broken_pin.py" in err
+
+
+# --- Case 59: workflow-surface-only diff -> still ZERO file reads ----------------
+def test_literal_path_md_only_diff_zero_scan(tmp_path: Path, capsys):
+    """Mirror of case 44 under the shared pass: no touched file is eligible for
+    EITHER arm, so the scan never reads tests/ (the planted undecodable file
+    would WARN on any read — case 57 is the positive control)."""
+    repo = _make_import_tree(tmp_path, {})
+    (repo / "tests" / "test_undecodable.py").write_bytes(b"bad \xff\xfe")
+    assert sel.literal_path_targets([".claude/rules/foo.md", "notes.md"]) == set()
+    tests, untested, _ = sel.select_tests_with_reasons([".claude/rules/foo.md", "notes.md"], repo)
+    err = capsys.readouterr().err
+    assert "import-map cannot parse" not in err  # zero reads: never touched the bad file
+    assert set(tests) == set(sel.WORKFLOW_INVARIANT)
+    assert untested == []
+
+
+# --- Case 60: scripts/__init__.py is a NEW scan trigger, with zero parses --------
+def test_literal_path_init_py_triggers_scan_zero_parses(tmp_path: Path, capsys):
+    """``scripts/__init__.py`` maps to no module name (empty module map) but IS
+    a literal target -> the shared pass runs. The empty token pre-filter means
+    ZERO ast parses: the planted syntax-error file would WARN if parsed."""
+    repo = _make_import_tree(
+        tmp_path,
+        {
+            "test_pkg_pin.py": 'PINNED = "scripts/__init__.py"\n',
+            "test_broken.py": "def broken(:\n",
+        },
+    )
+    tests, _, reasons = sel.select_tests_with_reasons(["scripts/__init__.py"], repo)
+    assert "tests/test_pkg_pin.py" in tests
+    assert reasons["tests/test_pkg_pin.py"] == ["literal-path:scripts/__init__.py"]
+    assert "import-map cannot parse" not in capsys.readouterr().err  # zero parses
+
+
+# --- Case 61: literal_path_targets eligibility rules ------------------------------
+def test_literal_path_touched_test_not_a_target():
+    assert sel.literal_path_targets(["tests/test_a.py"]) == set()
+    assert sel.literal_path_targets(
+        [
+            "tests/test_a.py",  # tests/ — the touched-test arm owns it
+            "other/module.py",  # outside the two eligible roots
+            "scripts/notes.md",  # not .py
+            ".claude/skills/issue/SKILL.md",  # workflow surface — #1496's mapping
+            "scripts/x.py",
+            "src/explore_persona_space/y.py",
+            "scripts/__init__.py",  # eligible: a literal target even with no module name
+        ]
+    ) == {"scripts/x.py", "src/explore_persona_space/y.py", "scripts/__init__.py"}
+
+
+# --- Case 62: end-to-end through main() --json — the reason token is carried -----
+def test_cli_json_carries_literal_path_reason(tmp_path: Path, monkeypatch, capsys):
+    repo = _make_import_tree(tmp_path, {"test_pin.py": 'LIVE = ["scripts/widgetlib.py"]\n'})
+    monkeypatch.setattr(sel, "_resolve_work_root", lambda _arg: repo)
+    monkeypatch.setattr(sel, "compute_touched", lambda *_a, **_k: ["scripts/widgetlib.py"])
+    rc = sel.main(["--json", "--no-fetch", "--repo-root", str(repo)])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "tests/test_pin.py" in payload["tests"]
+    assert payload["selection_reasons"]["tests/test_pin.py"] == [
+        "literal-path:scripts/widgetlib.py"
+    ]
+    # The WARN still reaches the JSON consumer: literal hits never suppress it.
+    assert payload["untested_touched"] == ["scripts/widgetlib.py"]
+
+
+# --- Case 63: --map-files mode ignores literal-path pins (GLOB_SCAN_TESTS-only) --
+def test_map_files_ignores_literal_path_hits(tmp_path: Path, capsys):
+    """The Step 10d mapping mode (#1147) stays pure GLOB_SCAN_TESTS path
+    arithmetic (zero file reads): a payload naming a literal-PINNED but
+    not-scan-globbed file yields EMPTY stdout + rc 0 (pins the deliberate
+    #1498 scoping decision, plan R4)."""
+    repo = _make_import_tree(
+        tmp_path, {"test_pin.py": 'LIVE = ["src/explore_persona_space/widgetlib.py"]\n'}
+    )
+    listing = tmp_path / "payload.txt"
+    listing.write_text("src/explore_persona_space/widgetlib.py\n")
+    rc = sel.main(["--map-files", str(listing), "--repo-root", str(repo)])
+    assert rc == 0
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
Closes task #1498. Adds a literal-path scan arm to scripts/select_step9c_tests.py (design (a)): touched code files select tests that pin them by literal path (founding case: tests/test_ruff_policy.py for scripts/daily_drive_filings.py). Shared single read pass with the import-map arm; additive-only; --map-files untouched.