### PR TITLE
issue-1499: alias legacy step id 9b -> 9b-same in post_step_completed.py

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -7697,6 +7697,16 @@ inline, this loop handles the GPU-backed case (the cheap `< 20` GPU-h
 band auto-runs in both modes; the expensive band auto-runs only in
 autonomous mode or on an explicit user pick).
 
+**Canonical §5 step id for this loop is `9b-same`.** workflow.yaml
+§ steps has no `9b` id — the prose name "Step 9b" is NOT a step id — so
+any `scripts/post_step_completed.py` post made from within this loop
+passes `--step 9b-same` (the helper aliases legacy `9b` → `9b-same` as
+a backstop, #1499). A helper refusal (exit 2, unknown step id) means
+the resume record was NOT posted: re-run with a canonical id from the
+stderr `Known:` list / `Did you mean` hint before continuing — never
+continue past the refusal (#1335: the dropped record degraded crash
+recovery for the `followups_running` hold).
+
 **Loop liveness backstop (arm BEFORE dispatching loop work — BOTH session modes).**
 ANY session driving this loop — interactive (typically entry point (b),
 a chat session) OR autonomous (the Step 9b C3 cheap-band / step-6
@@ -11244,6 +11254,12 @@ uv run python scripts/post_step_completed.py \
 The helper looks up `next_expected_step` from `.claude/workflow.yaml`
 and appends the event row; refuses to post if the step ID is unknown to
 the YAML or if `exit_kind` is not in the choices list (typo guard).
+
+Legacy prose id `9b` is aliased to canonical `9b-same` before
+validation (the marker records the canonical id), and an unknown-id
+refusal prints near-miss suggestions (#1499). A nonzero exit from this
+helper means NO resume record was posted — correct the step id and
+re-post; ignoring the refusal silently drops the §5 record.
 
 **Re-entry router.**
 `src/explore_persona_space/orchestrate/resume.py:decide_entry_step`

--- a/scripts/post_step_completed.py
+++ b/scripts/post_step_completed.py
@@ -21,6 +21,9 @@ The helper looks up ``next_expected_step`` from ``workflow.yaml`` and
 fills the marker body. Refuses to post if the step ID is not in
 workflow.yaml, or if ``exit_kind`` is not one of ``clean`` / ``parked``
 / ``failure-exit`` (typo guard — silent typos bypass the §5 router).
+Legacy prose step names are aliased to canonical yaml ids before
+validation (``9b`` -> ``9b-same``, #1499); the marker always records
+the CANONICAL id, and an unknown-id refusal suggests near-miss ids.
 
 Idempotency: the helper does NOT dedupe — a re-invocation appends a
 second event. The router consumes the LATEST marker, so duplicates
@@ -31,6 +34,7 @@ per EXIT site.
 from __future__ import annotations
 
 import argparse
+import difflib
 import subprocess
 import sys
 from datetime import UTC, datetime
@@ -45,6 +49,18 @@ import task_state as sagan_state
 WORKFLOW_YAML = Path(".claude/workflow.yaml")
 
 VALID_EXIT_KINDS = ("clean", "parked", "failure-exit")
+
+# Legacy prose step names -> canonical workflow.yaml § steps ids. The
+# /issue SKILL.md prose calls the same-issue follow-up loop "Step 9b"
+# but the canonical yaml id is "9b-same"; a #1335 follow-up session
+# improvised `--step 9b`, the helper refused (exit 2), and the resume
+# record was dropped (#1499). Applied BEFORE validation; the marker
+# records the CANONICAL id, and the alias TARGET is re-validated
+# against workflow.yaml so a future yaml rename fails loud instead of
+# silently mapping to a dead id. Add entries ONLY for incident-backed
+# prose names with an unambiguous canonical target — speculative
+# aliases weaken the typo guard.
+_STEP_ALIASES = {"9b": "9b-same"}
 
 
 def _git_head_short() -> str:
@@ -128,7 +144,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--step",
         required=True,
-        help="Step ID (must exist in workflow.yaml § steps), e.g. '5b' or '6c'.",
+        help=(
+            "Step ID (must exist in workflow.yaml § steps), e.g. '5b' or '6c'. "
+            "Legacy prose id '9b' is aliased to '9b-same'."
+        ),
     )
     parser.add_argument(
         "--exit-kind",
@@ -151,11 +170,21 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    canonical = _STEP_ALIASES.get(args.step)
+    if canonical is not None:
+        print(
+            f"NOTE: legacy step id {args.step!r} aliased to canonical {canonical!r}",
+            file=sys.stderr,
+        )
+        args.step = canonical
+
     by_id = _load_workflow_steps()
     if args.step not in by_id:
+        close = difflib.get_close_matches(args.step, sorted(by_id), n=3, cutoff=0.6)
+        suggestion = f" Did you mean: {', '.join(close)}?" if close else ""
         print(
             f"ERROR: step {args.step!r} is not in workflow.yaml § steps. "
-            f"Known: {', '.join(sorted(by_id))}",
+            f"Known: {', '.join(sorted(by_id))}.{suggestion}",
             file=sys.stderr,
         )
         return 2

--- a/tests/test_step_completed_resume.py
+++ b/tests/test_step_completed_resume.py
@@ -443,3 +443,67 @@ def test_helper_dry_run_prints_body_for_known_step(helper_module, capsys):
     # next_expected_step is looked up from workflow.yaml. For step 5
     # (code_review) the §1 mapping says "6a" (pod_provision).
     assert "next_expected_step: 6a" in captured.out
+
+
+def test_helper_aliases_legacy_9b_to_9b_same(helper_module, capsys):
+    """#1499: legacy prose id '9b' aliases to canonical '9b-same'.
+
+    The marker body records the CANONICAL id (the §5 router and the
+    watcher's step-field readers key on workflow.yaml ids),
+    next_expected_step resolves from the canonical row ('2' — the loop
+    re-enters the pipeline), and the alias is announced on stderr.
+    """
+    rc = helper_module.main(
+        ["--issue", "1499", "--step", "9b", "--exit-kind", "clean", "--dry-run"]
+    )
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "step: 9b-same" in captured.out
+    assert "step: 9b\n" not in captured.out  # canonical only, never the legacy id
+    assert "next_expected_step: 2" in captured.out
+    assert "aliased to canonical" in captured.err
+
+
+def test_helper_canonical_9b_same_still_accepted_directly(helper_module, capsys):
+    """The canonical id passes through the alias map unchanged (no NOTE)."""
+    rc = helper_module.main(
+        ["--issue", "1499", "--step", "9b-same", "--exit-kind", "parked", "--dry-run"]
+    )
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "step: 9b-same" in captured.out
+    assert "next_expected_step: 2" in captured.out
+    assert "aliased" not in captured.err
+
+
+def test_unknown_step_error_suggests_near_miss(helper_module, capsys):
+    """The exit-2 typo guard survives the alias AND names near-miss ids."""
+    rc = helper_module.main(
+        ["--issue", "1499", "--step", "9b-sam", "--exit-kind", "clean", "--dry-run"]
+    )
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "is not in workflow.yaml" in captured.err
+    assert "Did you mean: 9b-same" in captured.err
+
+
+def test_alias_keys_never_shadow_real_step_ids(helper_module):
+    """#1499: an alias key must never collide with a REAL workflow.yaml id.
+
+    If a future workflow.yaml genuinely adds a `9b` step id, the alias
+    would silently rewrite every `--step 9b` post to `9b-same`; this
+    test makes that collision fail the suite instead.
+    """
+    assert set(helper_module._STEP_ALIASES) & set(helper_module._load_workflow_steps()) == set()
+
+
+def test_skill_md_followup_loop_names_canonical_9b_same_id():
+    """Durability pin (#1499): the same-issue follow-up loop section names
+    the canonical `9b-same` step id + the exit-2 refusal duty, so a later
+    SKILL.md editor cannot silently drop the guidance."""
+    text = SKILL_MD_PATH.read_text()
+    section_start = text.find("**Same-issue follow-up loop (`question_relation: same`).**")
+    assert section_start > 0
+    window = text[section_start : section_start + 4000]
+    assert "9b-same" in window
+    assert "post_step_completed.py" in window


### PR DESCRIPTION
Closes task #1499. Workflow-fix: helper alias {9b -> 9b-same} + difflib near-miss hint on exit-2 refusal + SKILL.md canonical-id prose + 5 tests.