### PR TITLE
issue-1503: extend trigger-dense brief discipline to first-pass briefs (#1503)

### DIFF
--- a/.claude/rules/LESSONS.md
+++ b/.claude/rules/LESSONS.md
@@ -41,7 +41,7 @@ Row grammar: `- <rule>.md — <fires-when trigger>`
 - replication-fidelity.md — the Goal replicates a published finding (match the paper's data + recipe FIRST; change only the tested variable).
 - research-project-structure.md — you write result artifacts / results index / queue (one source of truth per layer).
 - selection-symmetric-nulls.md — a max/argmax/top-k headline over a free axis vs a null band or bootstrap CI (selection rides per draw / freeze held-out; band vs ceiling), or difference-vector legs sharing one SAMPLED baseline vs noise-free nulls (disjoint halves / shared-B).
-- trigger-dense-review.md — reviewing/reconciling a guard/security artifact or refusal corpus (findings by reference; verdict first; windowed reads), or composing a revision-round/bounce brief from such verdicts (#1413).
+- trigger-dense-review.md — reviewing/reconciling a guard/security artifact or refusal corpus (findings by reference; verdict first; windowed reads), or composing any brief on such targets (first-pass fact-check/critique #1503; revision-round #1413).
 - upload-policy.md — you write training/Hub/sweep code, or sequence phases around a regeneration-costly store (Hub-API verification, verify + staging-download transport retry, delete-after-eval persist, store-before-long-fit #825, quota-403 recovery, upload-wedge ladder).
 - vectorize-many-cell-fits.md — many-cell GD, dense fits (svd/eigh/lstsq/ridge), or a perm/bootstrap/null-draw battery over a fixed pool (VECTORIZE first; detached+checkpointed VM fits; Supersede contract incl. mid-run ≥2×-deviation + width re-eval).
 - workflow-fix-on-bug.md — any agent hits a bug from a gap in the workflow surface itself (emit a `workflow-fix-candidate`).

--- a/.claude/rules/trigger-dense-review.md
+++ b/.claude/rules/trigger-dense-review.md
@@ -1,5 +1,5 @@
 ---
-description: Reviewing trigger-dense / security-adjacent artifacts (guard hooks, destructive-command test fixtures, refusal/jailbreak corpora) without filter kills — findings by reference, durable verdict first, windowed reads + revision-round brief composition (findings by reference, #1413). Prevention-side sibling of CLAUDE.md § Spurious usage-policy refusals (recovery). Origin incidents #1058, #1152.
+description: Reviewing trigger-dense / security-adjacent artifacts (guard hooks, destructive-command test fixtures, refusal/jailbreak corpora) without filter kills — findings by reference, durable verdict first, windowed reads + brief composition for such targets (first-pass #1503, revision-round #1413; findings by reference). Prevention-side sibling of CLAUDE.md § Spurious usage-policy refusals (recovery). Origin incidents #1058, #1152.
 paths:
   - ".claude/hooks/*.sh"
   - "scripts/guard_*.sh"
@@ -7,11 +7,14 @@ paths:
 
 # Trigger-dense artifact review — reference, don't quote; verdict before summary
 
-**Fires when:** a code-reviewer, reconciler, or any review-role subagent's
-artifact under review is TRIGGER-DENSE — its own vocabulary can trip the
-content filter when repeated in generated text — or the ORCHESTRATOR
-composes a revision-round / bounce / reconcile brief from findings-bearing
-verdicts on such a round (§ Revision-round briefs). Recognition heuristic
+**Fires when:** a code-reviewer, reconciler, fact-checker, or any
+review-/verification-role subagent's artifact under review is
+TRIGGER-DENSE — its own vocabulary can trip the content filter when
+repeated in generated text — or the ORCHESTRATOR composes a FIRST-PASS
+fact-check / critique / plan-review brief whose TARGET files are such
+artifacts (§ First-pass briefs, #1503), or composes a revision-round /
+bounce / reconcile brief from findings-bearing verdicts on such a round
+(§ Revision-round briefs, #1413). Recognition heuristic
 (any one suffices):
 
 - guard / security hook scripts (`.claude/hooks/*.sh`, `scripts/guard_*.sh`)
@@ -101,6 +104,34 @@ characterize a disputed quote, paraphrase it abstractly. Marker mode: post
 `epm:review-reconcile` before any closing chat text (discipline 2); the
 closing text itself is discipline-4-minimal.
 
+## First-pass briefs (composition-side, #1503)
+
+Fires for the ORCHESTRATOR composing any FIRST-PASS subagent brief whose
+TARGET files include a trigger-dense artifact per the recognition
+heuristic above — the Phase-1.5 fact-checker brief, the Phase-2 critic
+and consistency-checker briefs, a plan-review or first code-review
+brief. No verdict exists yet, so § Revision-round briefs cannot fire;
+the duties attach to the brief itself:
+
+1. Name the guard-surface target files by PATH (plus the specific claims
+   or assumptions to check against them) — never inline their content
+   into the brief (discipline 1 governs the form).
+2. Instruct windowed reads: grep for the anchor first, then Read
+   ≤~120-line windows (discipline 3); where the orchestrator can,
+   pre-materialize excerpt files and name them + a read budget (the
+   issue-SKILL Step 5a pattern).
+3. Instruct the subagent to return findings by reference — disciplines 1
+   and 4 bind its output from the first spawn.
+4. Keep the brief's own text in neutral gate vocabulary (CLAUDE.md
+   § Spurious usage-policy refusals, rung (e)).
+
+Rationale: rung (e) neutralizes first-pass brief VOCABULARY, but the
+READ discipline previously attached only to review roles and revision
+briefs — first-pass fact-checkers/critics paged whole guard files and
+were filter-killed before any recovery rung fired (2026-07-17: 4 kills
+across #1436/#1443 — fact-checker ×2, Alternatives critic ×2 — ~35+ min
+recovered via rung (b2)).
+
 ## Revision-round briefs (composition-side, #1413)
 
 Fires for the ORCHESTRATOR composing any follow-on brief from
@@ -141,7 +172,9 @@ kills + ~2.7h orchestrator wedge), #1092 (implementer refusal kills;
 orchestrator rung b2), #866 (bank-text paging kills), #1090
 (refusal-truncated Agent spawns), #1152 (a findings recap in a reviewer's
 return text wedged the parent orchestrator — discipline 4), #1413 (a
-revision brief inlining a round's findings text — § Revision-round briefs).
+revision brief inlining a round's findings text — § Revision-round briefs),
+#1436/#1443 (4 first-pass kills on guard-surface targets — § First-pass
+briefs, #1503).
 Enforcing pointers:
 `.claude/agents/code-reviewer.md` § Context budget (READ FIRST);
 `.claude/agents/reconciler.md` § Rules (Rule 11);
@@ -151,4 +184,6 @@ pre-materialization);
 (orchestrator-side posting path, #1275);
 `.claude/skills/adversarial-planner/SKILL.md` Phase 3 +
 `.claude/skills/issue/SKILL.md` Step 5d (revision-brief composition
-pointers, #1413).
+pointers, #1413);
+`.claude/skills/adversarial-planner/SKILL.md` Phase 1.5 + Phase 2
+(first-pass brief-composition pointers, #1503).

--- a/.claude/skills/adversarial-planner/SKILL.md
+++ b/.claude/skills/adversarial-planner/SKILL.md
@@ -330,6 +330,14 @@ Run the structural verifier against the plan version just persisted:
 
 The Planner's assumptions are the #1 source of experiment-invalidating errors. Before the Critic even sees the plan, independently verify every factual claim.
 
+**Trigger-dense targets — first-pass fact-checker brief (#1503).** When
+the plan's assumptions or reuse rows point the fact-checker at
+guard/security artifacts per `.claude/rules/trigger-dense-review.md`
+(guard hooks, gated-command fixtures, refusal corpora), compose its
+brief per that rule's § First-pass briefs: targets named by path,
+grep-anchored windowed reads instructed (never wholesale), findings by
+reference, neutral gate vocabulary in the brief text (CLAUDE.md rung (e)).
+
 Spawn a SEPARATE Agent (fresh context, no access to planner's reasoning) with this role:
 
 ```
@@ -439,6 +447,13 @@ rubric (per-item REVISE bars, N/A escapes, incident citations) silently
 never loaded. (The `codex-critic` composer is unaffected: it resolves
 `lens=<id>` to the canonical subheading from its own spec —
 `.claude/agents/codex-critic.md` Step 2.)
+
+**Trigger-dense targets — first-pass critic briefs (#1503).** Same duty
+at this site: when the plan's target files include guard/security
+artifacts, every critic brief (and the consistency-checker brief)
+carries `.claude/rules/trigger-dense-review.md` § First-pass briefs —
+targets by path, windowed grep-anchored reads, findings by reference in
+the returned lens block, neutral gate vocabulary in the brief itself.
 
 **Shared preamble — prepend to each critic's brief before its lens-specific questions:**
 

--- a/tests/test_issue_skill_neutral_gate_vocab_brief.py
+++ b/tests/test_issue_skill_neutral_gate_vocab_brief.py
@@ -10,7 +10,11 @@ revision-round side: trigger-dense-review.md § Revision-round briefs
 (findings passed by marker/file reference, never inlined), the
 adversarial-planner Phase 3 critique-by-file pointer, the Step 5d / 9a
 by-reference parentheticals, and the rung-(e) steering-vocabulary +
-revision-round clauses (#1413, #1415).
+revision-round clauses (#1413, #1415). The #1503 extension pins the
+FIRST-PASS side: trigger-dense-review.md § First-pass briefs + the
+widened fires-when (fact-checker named), the LESSONS.md index row's
+first-pass arm, and the adversarial-planner Phase 1.5 / Phase 2
+brief-composition pointers.
 """
 
 from pathlib import Path
@@ -20,6 +24,7 @@ SKILL_MD = _REPO / ".claude" / "skills" / "issue" / "SKILL.md"
 CLAUDE_MD = _REPO / "CLAUDE.md"
 RULE_MD = _REPO / ".claude" / "rules" / "trigger-dense-review.md"
 AP_SKILL_MD = _REPO / ".claude" / "skills" / "adversarial-planner" / "SKILL.md"
+LESSONS_MD = _REPO / ".claude" / "rules" / "LESSONS.md"
 
 
 def _step5a_section() -> str:
@@ -81,6 +86,37 @@ def test_step9a_analyzer_respawn_by_reference():
     start = text.index("If `final_verdict == REVISE`")
     s9a = text[start : text.index("Max 5 rounds per reviewer", start)]
     assert "critique events by reference" in s9a
+
+
+# --- #1503 first-pass extension pins ---
+
+
+def test_trigger_dense_rule_first_pass_brief_section():
+    text = RULE_MD.read_text(encoding="utf-8")
+    assert "## First-pass briefs" in text
+    assert "#1503" in text
+    # first-pass fires-when widening (fact-checker named; target-file trigger)
+    fires = text[text.index("**Fires when:**") : text.index("Recognition heuristic")]
+    assert "fact-checker" in fires
+    assert "FIRST-PASS" in fires
+    # belt-and-suspenders: the always-on LESSONS index row carries the first-pass arm
+    lessons = LESSONS_MD.read_text(encoding="utf-8")
+    row = next(
+        line for line in lessons.splitlines() if line.startswith("- trigger-dense-review.md")
+    )
+    assert "first-pass" in row
+
+
+def test_adversarial_planner_first_pass_brief_pointers():
+    text = AP_SKILL_MD.read_text(encoding="utf-8")
+    start = text.index("### Phase 1.5: Verify Assumptions")
+    mid = text.index("### Phase 2: Parallel Critique")
+    end = text.index("### Phase 3: Revise")
+    ph15 = text[start:mid]
+    ph2 = text[mid:end]
+    for span in (ph15, ph2):
+        assert "First-pass briefs" in span
+        assert "trigger-dense-review.md" in span
 
 
 def test_claude_md_rung_e_steering_vocab():


### PR DESCRIPTION
Closes task #1503. Extends .claude/rules/trigger-dense-review.md (+ LESSONS index row + adversarial-planner SKILL.md pointers + 2 pin tests) so first-pass fact-check/critique briefs on guard-surface targets carry the windowed-read + findings-by-reference discipline.