### PR TITLE
issue-1502: open wf-fix sibling advisory at filing time

### DIFF
--- a/.claude/rules/workflow-fix-on-bug.md
+++ b/.claude/rules/workflow-fix-on-bug.md
@@ -579,6 +579,34 @@ that spots a just-merged duplicate in the list applies the post-hoc remedy:
 archive the just-filed task (`task.py set-status <id> archived`) and stop its
 spawned session (`spawn_session.py stop --session-id <sid>`).
 
+**Open-sibling arm (#1502 — same advisory contract).** The same filing-time
+advisory ALSO lists OPEN (non-terminal — the dedup predicate's own
+`_WF_FIX_NONTERMINAL` set) `kind: infra` siblings overlapping the candidate
+by the same arms (`task_workflow.open_workflow_fix_siblings`; prefixed:
+target-line token / ≥1 shared informative title token; plain infra: ≥2
+shared tokens or full-path body substring; no time window — an open sibling
+is live regardless of filing age; rows sorted most-recently-filed first,
+same 10-row cap). The exact-`(target_file, fingerprint)` OPEN dedup
+predicate is UNCHANGED — a distinct bug on the same file still files by
+design; the open rows exist so the filer can spot a same-bug-different-
+wording LIVE collision (the #678 grain's known blind spot: #1479 was
+filed+spawned while #1476's session was landing the same fix, and #1479's
+~2.3 h pipeline was discarded) and apply the remedy BEFORE the duplicate
+pipeline burns hours: verify the listed sibling actually covers this bug,
+then archive the just-filed task (`task.py set-status <id> archived`) and
+stop its spawned session. Known limitations: (a) a drive-by fix inside an
+unrelated open session — the literal #1476 mechanism, whose filed
+title/target/body shared nothing with the ratchet bug its session also
+fixed — is invisible to any filing-time overlap; the open arm covers the
+visibly-overlapping class only (the open transpose of #1350-vs-#1329).
+(b) Both advisory arms print to the FILER's stderr only: a watcher
+`proposed_infra_sweep` backstop dispatch (~10 min later) never sees them,
+and the /daily route-2 driver (`daily_drive_filings.py`) invokes the filer
+with `capture_output=True` and persists only a ~300-char output tail on a
+successful filing, so the advisory may not reach the /daily session either
+— the same accepted-limitation class as the #1399/#1173/#1283
+filer-stderr-only legs.
+
 ## Recursion guard
 
 A workflow-fix `/issue` session must NOT auto-file MORE workflow-fix

--- a/scripts/file_infra_task.py
+++ b/scripts/file_infra_task.py
@@ -96,6 +96,7 @@ from spawn_session import (  # noqa: E402
 # daily_drive_filings.py; the `uv run` env has the editable install.
 from explore_persona_space.task_workflow import (  # noqa: E402
     WF_FIX_TITLE_PREFIXES,
+    open_workflow_fix_siblings,
     recent_closed_workflow_fix_tasks,
     wf_fix_extract_target,
 )
@@ -332,6 +333,60 @@ def _advise_recent_closed_wf_fix_siblings(args: argparse.Namespace) -> None:
         )
 
 
+def _advise_open_wf_fix_siblings(args: argparse.Namespace) -> None:
+    """#1502 warn-only advisory: before filing a wf-fix-shaped task, list OPEN
+    (non-terminal) infra siblings overlapping the candidate by target path
+    token or informative title tokens. The blocking open-task dedup
+    (task_workflow.is_open_workflow_fix_task) is exact-(target_file,
+    fingerprint) BY DESIGN, so a same-bug-different-wording sibling already
+    mid-pipeline is invisible to it (#1479 was filed+spawned while #1476's
+    session was landing the same fix; #1479's ~2.3h pipeline was discarded).
+    ADVISORY ONLY (the #1399/#1446 contract, verbatim): never blocks, never
+    changes exit codes, never skips the filing — a DISTINCT bug on the same
+    hot file legitimately files its own task (the #678 A1 grain is
+    unchanged); the whole leg is fail-soft (any exception prints a one-line
+    diagnostic and filing proceeds)."""
+    try:
+        body_text = args.body
+        if body_text is None and args.body_file is not None:
+            try:
+                body_text = Path(args.body_file).read_text(encoding="utf-8")
+            except OSError:
+                body_text = None
+        target = wf_fix_extract_target(body_text or "")
+        if "wf-fix" not in (args.tag or []) and target is None:
+            return  # not wf-fix-shaped: zero scan cost (AC6; the #1173/#1283/#1399 gate)
+        hits = open_workflow_fix_siblings(target, args.title)
+        if not hits:
+            return
+        print(
+            f"file_infra_task: ADVISORY — {len(hits)} OPEN sibling task(s) overlap this "
+            "filing (the open-task dedup is exact-(target_file, fingerprint) only; "
+            ".claude/rules/workflow-fix-on-bug.md § Dedup, #1502). If a listed sibling "
+            "is already fixing THIS bug, archive the just-filed task "
+            "(task.py set-status <id> archived) and stop its spawned session "
+            "(spawn_session.py stop --session-id <sid>) instead of running a "
+            "duplicate pipeline; a DISTINCT bug on the same file files by design:",
+            file=sys.stderr,
+        )
+        for h in hits[:_ADVISORY_MAX_ROWS]:
+            print(
+                f"  #{h['id']}  {h['status']}  [{'; '.join(h['matched'])}]  {h['title']}",
+                file=sys.stderr,
+            )
+        if len(hits) > _ADVISORY_MAX_ROWS:
+            print(
+                f"  ... and {len(hits) - _ADVISORY_MAX_ROWS} more open siblings",
+                file=sys.stderr,
+            )
+    except Exception as e:  # deliberate fail-soft: advisory must never break filing (#1502)
+        print(
+            f"file_infra_task: open-sibling advisory leg failed ({e!r}); filing "
+            "proceeds (#1502 fail-soft)",
+            file=sys.stderr,
+        )
+
+
 def cmd_file_infra(args: argparse.Namespace) -> int:
     """File a ripe `kind: infra`/`batch` task, then best-effort dispatch it.
 
@@ -341,10 +396,15 @@ def cmd_file_infra(args: argparse.Namespace) -> int:
     here would make callers think filing failed)."""
     # 0. Warn-only pre-filing backstops (stderr only; exit codes and filing
     # behavior unchanged): #1173 durable-recursion-guard line, #1283 dedup
-    # title-prefix surface, #1399 recently-closed-sibling advisory.
+    # title-prefix surface, #1399 recently-closed-sibling advisory, #1502
+    # open-sibling advisory (closed-then-open ordering keeps the
+    # higher-severity live-collision rows nearest the `filed #N` output).
+    # Both advisory legs run BEFORE the `task.py new` subprocess below, so
+    # the being-filed task cannot self-match (self-exclusion by ordering).
     _warn_missing_wf_fix_provenance(args)
     _warn_missing_wf_fix_title_prefix(args)
     _advise_recent_closed_wf_fix_siblings(args)
+    _advise_open_wf_fix_siblings(args)
 
     # 1. File first (the durable, must-succeed half).
     new_argv = _build_new_argv(args)

--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -1050,6 +1050,9 @@ def is_open_workflow_fix_task(target_file: str, fingerprint: str | None = None) 
     Read-only: no mutation, no commit. The cheap pre-filter (``kind`` / status /
     title) reads the REGISTRY snapshot; the ``tags`` / Provenance check reads the
     task's ``body.md`` (tags are not denormalized into the registry).
+    Advisory complement on the same open population:
+    :func:`open_workflow_fix_siblings` (#1502) SURFACES overlapping open
+    siblings this exact-match predicate deliberately does not block.
     """
     reg = _load_registry()
     for tid_str, entry in reg.get("tasks", {}).items():
@@ -1208,7 +1211,68 @@ def informative_title_tokens(text: str) -> set[str]:
     return _wf_fix_title_tokens(text)
 
 
-def recent_closed_workflow_fix_tasks(  # noqa: C901 — two-population scan; branch shape + gating order pinned by plan #1446 §4.1(c)
+def _wf_fix_sibling_arms(
+    title: str,
+    task_dir: Path,
+    cand_targets: set[str],
+    cand_tokens: set[str],
+) -> tuple[list[str], set[str]]:
+    """Shared per-task arm-matcher for the closed (#1399/#1446) and open
+    (#1502) sibling scans. Returns ``(matched, task_targets)``:
+
+    - PREFIXED titles (``WF_FIX_TITLE_PREFIXES``): ``'target'`` (candidate
+      path tokens intersect the task's anchored ``workflow_fix_target:`` line
+      tokens; ``task_targets`` = the task's OWN target tokens) and
+      ``'title:<tokens>'`` (>=1 shared informative token).
+    - PLAIN titles: ``'infra-title:<tokens>'`` (>=
+      ``_WF_FIX_PLAIN_TITLE_MIN_SHARED`` shared tokens) and ``'infra-target'``
+      (a candidate FULL path token as a body substring; ``task_targets`` =
+      the candidate tokens actually FOUND).
+
+    Body reads happen only when ``cand_targets`` is non-empty; ``(OSError,
+    ValueError)`` on the body read fail-soft to ``body = ""`` (the target
+    arms are then silently unavailable). Window / population gating stays in
+    the CALLERS — the closed scan's #1446 §4.1(c) gating order (prefixed:
+    arms before window; widened: window before body read) is theirs to
+    preserve.
+    """
+    matched: list[str] = []
+    task_targets: set[str] = set()
+    shared = cand_tokens & _wf_fix_title_tokens(title)
+    if title.startswith(WF_FIX_TITLE_PREFIXES):
+        if cand_targets:
+            try:
+                _, body = _read_body(task_dir / "body.md")
+            except (OSError, ValueError):
+                # widened per fact-check 2026-07-17: a non-FNF OSError from
+                # read_text() escaped the old (FileNotFoundError, ValueError)
+                # tuple
+                body = ""  # fail-soft: target arm silently unavailable
+            for m in _WF_FIX_TARGET_LINE_RE.finditer(body):
+                task_targets |= _wf_fix_target_tokens(m.group(1))
+            if cand_targets & task_targets:
+                matched.append("target")
+        if shared:
+            matched.append("title:" + ",".join(sorted(shared)))
+    else:
+        if len(shared) >= _WF_FIX_PLAIN_TITLE_MIN_SHARED:
+            matched.append("infra-title:" + ",".join(sorted(shared)))
+        if cand_targets:
+            try:
+                _, body = _read_body(task_dir / "body.md")
+            except (OSError, ValueError):
+                # same widened catch tuple as the prefixed branch above
+                body = ""  # fail-soft: target arm silently unavailable
+            # Full candidate path token as a body substring (NOT the
+            # basename: bare 'SKILL.md' matches 11/28 in-window bodies,
+            # while full paths measured 0-6; glob tokens stay opaque).
+            task_targets = {t for t in cand_targets if t in body}
+            if task_targets:
+                matched.append("infra-target")
+    return matched, task_targets
+
+
+def recent_closed_workflow_fix_tasks(
     target_file: str | None,
     candidate_title: str | None = None,
     *,
@@ -1299,25 +1363,12 @@ def recent_closed_workflow_fix_tasks(  # noqa: C901 — two-population scan; bra
         except (FileNotFoundError, ValueError):
             # Non-numeric registry key or missing folder: skip this entry.
             continue
-        matched: list[str] = []
-        task_targets: set[str] = set()
+        # Arm semantics live in the shared _wf_fix_sibling_arms helper (#1502);
+        # the WINDOW checks stay HERE, in the #1446 §4.1(c) gating order.
         if prefixed:
-            # ── Prefixed pass: #1399 logic, output-identical except the
-            # declared catch-tuple widening below ──
-            if cand_targets:
-                try:
-                    _, body = _read_body(task_dir / "body.md")
-                except (OSError, ValueError):
-                    # widened per fact-check 2026-07-17: a non-FNF OSError
-                    # from read_text() escaped the old
-                    # (FileNotFoundError, ValueError) tuple
-                    body = ""  # fail-soft: target arm silently unavailable
-                for m in _WF_FIX_TARGET_LINE_RE.finditer(body):
-                    task_targets |= _wf_fix_target_tokens(m.group(1))
-                if cand_targets & task_targets:
-                    matched.append("target")
-            if shared:
-                matched.append("title:" + ",".join(sorted(shared)))
+            # ── Prefixed pass: #1399 logic — arms (incl. any body read)
+            # BEFORE the window check ──
+            matched, task_targets = _wf_fix_sibling_arms(title, task_dir, cand_targets, cand_tokens)
             if not matched:
                 continue
             closed = _wf_fix_closed_at(task_dir)
@@ -1331,20 +1382,7 @@ def recent_closed_workflow_fix_tasks(  # noqa: C901 — two-population scan; bra
             closed = _wf_fix_closed_at(task_dir)
             if closed is None or closed < cutoff or closed > now:
                 continue
-            if len(shared) >= _WF_FIX_PLAIN_TITLE_MIN_SHARED:
-                matched.append("infra-title:" + ",".join(sorted(shared)))
-            if cand_targets:
-                try:
-                    _, body = _read_body(task_dir / "body.md")
-                except (OSError, ValueError):
-                    # same widened catch tuple as the prefixed pass above
-                    body = ""  # fail-soft: target arm silently unavailable
-                # Full candidate path token as a body substring (NOT the
-                # basename: bare 'SKILL.md' matches 11/28 in-window bodies,
-                # while full paths measured 0-6; glob tokens stay opaque).
-                task_targets = {t for t in cand_targets if t in body}
-                if task_targets:
-                    matched.append("infra-target")
+            matched, task_targets = _wf_fix_sibling_arms(title, task_dir, cand_targets, cand_tokens)
             if not matched:
                 continue
         hits.append(
@@ -1358,6 +1396,75 @@ def recent_closed_workflow_fix_tasks(  # noqa: C901 — two-population scan; bra
             }
         )
     hits.sort(key=lambda h: h["closed_at"], reverse=True)
+    return hits
+
+
+def open_workflow_fix_siblings(
+    target_file: str | None,
+    candidate_title: str | None = None,
+    *,
+    include_plain_infra: bool = True,
+) -> list[dict[str, Any]]:
+    """OPEN infra siblings overlapping the candidate (#1502) — the advisory
+    complement of :func:`is_open_workflow_fix_task` on the SAME population:
+    that predicate BLOCKS exact-``(target_file, fingerprint)`` duplicates;
+    this helper only SURFACES overlapping open siblings for the filer to
+    eyeball (a DISTINCT bug on the same hot file still files by design — the
+    #678 A1 grain is unchanged). Population: ``kind == infra`` AND status in
+    ``_WF_FIX_NONTERMINAL`` (the dedup predicate's own open set). No time
+    window: an open sibling is a live collision risk regardless of filing age
+    (a long-parked ``on_hold`` duplicate is exactly what a filer wants to
+    see), and the open population is small (34 open infra tasks vs 1440
+    registry entries, measured 2026-07-18). Arms + per-population bars are
+    the closed enumerator's, via :func:`_wf_fix_sibling_arms`.
+
+    Returns ``[{'id', 'title', 'status', 'target', 'matched'}, ...]`` sorted
+    by id DESC (ids are allocation-ordered, so id DESC = most recently filed
+    first — the open-population analogue of the closed pass's closed_at DESC
+    recency ordering; open rows carry NO ``closed_at``). Read-only: no
+    mutation, no commit, no lock; per-task failures (missing folder,
+    non-numeric registry key) skip that task.
+    """
+    cand_targets = _wf_fix_target_tokens(target_file) if target_file else set()
+    cand_tokens = _wf_fix_title_tokens(candidate_title) if candidate_title else set()
+    if not cand_targets and not cand_tokens:
+        return []
+    hits: list[dict[str, Any]] = []
+    for tid_str, entry in _load_registry().get("tasks", {}).items():
+        if entry.get("kind") != "infra":
+            continue
+        if (entry.get("status") or "") not in _WF_FIX_NONTERMINAL:
+            continue
+        title = str(entry.get("title", ""))
+        prefixed = title.startswith(WF_FIX_TITLE_PREFIXES)
+        if not prefixed and not include_plain_infra:
+            continue
+        shared = cand_tokens & _wf_fix_title_tokens(title)
+        if not prefixed and len(shared) < _WF_FIX_PLAIN_TITLE_MIN_SHARED and not cand_targets:
+            # Registry-only precheck: no plain-infra arm can possibly fire —
+            # skip before any per-task file read (mirror of the closed pass).
+            continue
+        if prefixed and not shared and not cand_targets:
+            continue  # no prefixed arm can fire either
+        try:
+            tid = int(tid_str)
+            task_dir = find_task_path(tid)
+        except (FileNotFoundError, ValueError):
+            # Non-numeric registry key or missing folder: skip this entry.
+            continue
+        matched, task_targets = _wf_fix_sibling_arms(title, task_dir, cand_targets, cand_tokens)
+        if not matched:
+            continue
+        hits.append(
+            {
+                "id": tid,
+                "title": title,
+                "status": entry.get("status"),
+                "target": ", ".join(sorted(task_targets)) or None,
+                "matched": matched,
+            }
+        )
+    hits.sort(key=lambda h: h["id"], reverse=True)
     return hits
 
 

--- a/tests/test_file_infra_task.py
+++ b/tests/test_file_infra_task.py
@@ -69,6 +69,17 @@ def _no_real_recent_closed(monkeypatch):
     monkeypatch.setattr(fit, "recent_closed_workflow_fix_tasks", lambda *a, **k: [])
 
 
+@pytest.fixture(autouse=True)
+def _no_real_open_siblings(monkeypatch):
+    """Hermeticity for the #1502 open-sibling advisory: default the helper to
+    "no open siblings" so pre-existing wf-fix-shaped filings in these tests
+    never scan the LIVE task registry (34 open infra tasks on 2026-07-18 ->
+    nondeterministic stderr rows breaking assertions like the
+    `"workflow_fix_target" not in err` pins). Advisory-specific tests
+    override it — mirror of _no_real_recent_closed above."""
+    monkeypatch.setattr(fit, "open_workflow_fix_siblings", lambda *a, **k: [])
+
+
 def _install_run_recorder(
     monkeypatch,
     *,
@@ -757,3 +768,116 @@ def test_advisory_caps_rows_and_prints_more_line(monkeypatch, capsys, tmp_path):
     row_lines = [ln for ln in err.splitlines() if ln.startswith("  #")]
     assert len(row_lines) == fit._ADVISORY_MAX_ROWS == 10
     assert "... and 2 more within the window" in err
+
+
+# ── #1502: open-sibling advisory (warn-only, fail-soft) ────────────────────────
+
+_CANNED_OPEN_HIT = {
+    "id": 1476,
+    "title": "workflow-fix: selection-inherited bootstrap CI clause",
+    "status": "running",
+    "target": "scripts/workflow_lint.py",
+    "matched": ["target"],
+}
+
+
+def test_wf_fix_filing_prints_open_sibling_advisory(monkeypatch, capsys, tmp_path):
+    # A wf-fix-shaped filing prints the #1502 stderr advisory listing OPEN
+    # siblings with the archive+stop remedy; filing + dispatch behavior and
+    # exit code are unchanged. The recorder ALSO pins the (target, title)
+    # args the filer passes: the body-file's anchored Provenance target + the
+    # verbatim --title (mirrors the #1399 arg-wiring pin above).
+    calls = _install_run_recorder(monkeypatch, new_id="#771")
+    _healthy_dispatch_env(monkeypatch)
+    seen = {}
+
+    def _fake_open(target, title):
+        seen["args"] = (target, title)
+        return [dict(_CANNED_OPEN_HIT)]
+
+    monkeypatch.setattr(fit, "open_workflow_fix_siblings", _fake_open)
+    body = tmp_path / "body.md"
+    body.write_text(_PREFIXED_PROVENANCE_BODY, encoding="utf-8")
+
+    rc = fit.main(["--title", "workflow-fix: x", "--tag", "wf-fix", "--body-file", str(body)])
+
+    assert rc == 0
+    assert len(_new_calls(calls)) == 1  # filing proceeded
+    assert len(_spawn_calls(calls)) == 1  # dispatch behavior unchanged
+    err = capsys.readouterr().err
+    assert "OPEN sibling" in err
+    assert "#1476" in err
+    assert "set-status <id> archived" in err  # the open-sibling remedy text
+    # _PREFIXED_PROVENANCE_BODY carries `- workflow_fix_target: CLAUDE.md`.
+    assert seen["args"] == ("CLAUDE.md", "workflow-fix: x")
+
+
+def test_open_advisory_leg_fail_soft_never_breaks_filing(monkeypatch, capsys, tmp_path):
+    # Any exception inside the open-sibling leg prints a one-line diagnostic
+    # and filing + dispatch proceed with rc unchanged (#1502 fail-soft, the
+    # #1399 contract verbatim).
+    calls = _install_run_recorder(monkeypatch, new_id="#771")
+    _healthy_dispatch_env(monkeypatch)
+
+    def _boom(target, title):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(fit, "open_workflow_fix_siblings", _boom)
+    body = tmp_path / "body.md"
+    body.write_text(_PREFIXED_PROVENANCE_BODY, encoding="utf-8")
+
+    rc = fit.main(["--title", "workflow-fix: x", "--tag", "wf-fix", "--body-file", str(body)])
+
+    assert rc == 0
+    assert len(_new_calls(calls)) == 1  # filing still happened
+    assert len(_spawn_calls(calls)) == 1  # dispatch behavior unchanged
+    assert "open-sibling advisory leg failed" in capsys.readouterr().err
+
+
+def test_non_wf_fix_filing_skips_open_advisory(monkeypatch, capsys, tmp_path):
+    # A plain infra filing (no wf-fix tag, no anchored target line) never
+    # invokes the open enumerator and prints no OPEN advisory (AC6: zero scan
+    # cost on ordinary infra/batch filings).
+    calls = _install_run_recorder(monkeypatch, new_id="#771")
+    _healthy_dispatch_env(monkeypatch)
+    called: list[tuple] = []
+    monkeypatch.setattr(fit, "open_workflow_fix_siblings", lambda *a, **k: called.append(a) or [])
+    body = tmp_path / "body.md"
+    body.write_text("## Goal\n\nordinary infra\n", encoding="utf-8")
+
+    rc = fit.main(["--title", "ordinary infra task", "--body-file", str(body)])
+
+    assert rc == 0
+    assert len(_new_calls(calls)) == 1
+    assert called == []
+    assert "OPEN sibling" not in capsys.readouterr().err
+
+
+def test_open_advisory_caps_rows_and_prints_more_line(monkeypatch, capsys, tmp_path):
+    # >_ADVISORY_MAX_ROWS open hits: exactly 10 rows print plus the "... and
+    # K more open siblings" summary line (the enumerator's id-desc order
+    # keeps the most recently filed siblings inside the cap; the closed leg
+    # is stubbed to [] by _no_real_recent_closed, so every row is open).
+    _install_run_recorder(monkeypatch, new_id="#771")
+    _healthy_dispatch_env(monkeypatch)
+    hits = [
+        {
+            "id": 1500 - i,
+            "title": f"workflow-fix: open sibling {i}",
+            "status": "proposed",
+            "target": "CLAUDE.md",
+            "matched": ["target"],
+        }
+        for i in range(12)
+    ]
+    monkeypatch.setattr(fit, "open_workflow_fix_siblings", lambda *a, **k: list(hits))
+    body = tmp_path / "body.md"
+    body.write_text(_PREFIXED_PROVENANCE_BODY, encoding="utf-8")
+
+    rc = fit.main(["--title", "workflow-fix: x", "--tag", "wf-fix", "--body-file", str(body)])
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    row_lines = [ln for ln in err.splitlines() if ln.startswith("  #")]
+    assert len(row_lines) == fit._ADVISORY_MAX_ROWS == 10
+    assert "... and 2 more open siblings" in err

--- a/tests/test_workflow_fix_dedup.py
+++ b/tests/test_workflow_fix_dedup.py
@@ -705,3 +705,182 @@ def test_recent_closed_hits_sorted_closed_at_desc(fake_repo, monkeypatch):
 
     hits = tw.recent_closed_workflow_fix_tasks(target, now=now)
     assert [h["id"] for h in hits] == list(reversed(tids))
+
+
+# ─── #1502: open-sibling advisory helper ─────────────────────────────────────
+
+
+def test_open_sibling_advisory_lists_overlapping_open_task(fake_repo):
+    """Durability pin + incident-class pin (#1502): a prefixed wf-fix task
+    still OPEN (proposed) with the #1479 shape surfaces for a #1504-shaped
+    candidate via BOTH arms — the target-token arm and the shared informative
+    title tokens {lessons, ratchet} (the same-bug-different-wording class the
+    blocking exact-(target_file, fingerprint) dedup is blind to). Open rows
+    carry no closed_at."""
+    _, tw = fake_repo
+    fp = tw.wf_fix_fingerprint("Trim LESSONS ratchet.", "ratchet over cap")
+    tid = tw.create_task(
+        tw.NewTaskRequest(
+            kind="infra",
+            title="workflow-fix: LESSONS.md over ratchet — trim/bump _LESSONS_RATCHET_BYTES",
+            body=_wf_fix_body(
+                "scripts/workflow_lint.py, .claude/rules/LESSONS.md", fp, "Trim LESSONS ratchet."
+            ),
+            tags=["wf-fix", f"wf-fix-fp:{fp}"],
+        )
+    )
+
+    hits = tw.open_workflow_fix_siblings(
+        "scripts/workflow_lint.py", "daily-fix: LESSONS ratchet constant conflict magnet"
+    )
+    assert [h["id"] for h in hits] == [tid]
+    hit = hits[0]
+    assert "target" in hit["matched"]
+    assert "title:lessons,ratchet" in hit["matched"]
+    assert hit["status"] == "proposed"
+    assert "closed_at" not in hit
+
+
+def test_open_sibling_advisory_terminal_excluded(fake_repo):
+    """The open scan is non-terminal-only: completed/archived siblings never
+    surface (the CLOSED surface stays recent_closed_workflow_fix_tasks's)."""
+    _, tw = fake_repo
+    target = "CLAUDE.md"
+    completed = _file_wf_fix_task(
+        tw, target, tw.wf_fix_fingerprint("Fix A.", "bug A"), proposed_change="Fix A."
+    )
+    tw.set_status(completed, "completed")
+    archived = _file_wf_fix_task(
+        tw, target, tw.wf_fix_fingerprint("Fix B.", "bug B"), proposed_change="Fix B."
+    )
+    tw.set_status(archived, "archived")
+    assert tw.open_workflow_fix_siblings(target) == []
+
+
+def test_open_sibling_advisory_lists_different_fingerprint_sibling(fake_repo):
+    """The advisory sees what the dedup deliberately doesn't: SAME target,
+    DIFFERENT fingerprint is NOT a duplicate (is_open_workflow_fix_task
+    returns None — the #678 A1 grain, unchanged) yet the open sibling still
+    SURFACES for the filer to eyeball."""
+    _, tw = fake_repo
+    target = ".claude/skills/issue/SKILL.md"
+    fp_a = tw.wf_fix_fingerprint("Fix the gate.", "The gate is wrong")
+    fp_b = tw.wf_fix_fingerprint("Re-point the marker docs.", "The marker doc is stale")
+    tid = _file_wf_fix_task(tw, target, fp_a)
+
+    assert tw.is_open_workflow_fix_task(target, fp_b) is None
+    hits = tw.open_workflow_fix_siblings(target, None)
+    assert [h["id"] for h in hits] == [tid]
+    assert hits[0]["matched"] == ["target"]
+
+
+def test_open_sibling_advisory_plain_infra_two_token_bar(fake_repo):
+    """AC4 differential (open transpose of the closed-pass pin): a
+    non-prefixed OPEN infra task sharing 1 informative token -> no widened
+    hit, while the SAME 1-token overlap behind a wf-fix channel prefix still
+    surfaces via the prefixed pass's >=1 bar."""
+    _, tw = fake_repo
+    tw.create_task(
+        tw.NewTaskRequest(
+            kind="infra",
+            title="watcher retry backstop for pod polling",
+            body="## Goal\n\nplain infra sibling\n",
+        )
+    )
+    prefixed = _file_wf_fix_task(
+        tw,
+        "scripts/pod_watch.py",
+        tw.wf_fix_fingerprint("Watcher retry backstop.", "watcher retry gap"),
+        proposed_change="watcher retry backstop for pod polling",
+    )
+
+    hits = tw.open_workflow_fix_siblings(None, "workflow-fix: retry advisory widening")
+    assert [h["id"] for h in hits] == [prefixed]
+    assert hits[0]["matched"] == ["title:retry"]
+
+
+def test_open_sibling_advisory_plain_infra_target_body_match(fake_repo):
+    """Widened arm on the OPEN population: a non-prefixed open infra task
+    whose body contains the candidate FULL path surfaces via infra-target,
+    with `target` echoing the found candidate path (mirror of the closed
+    pass's widened-arm pin)."""
+    _, tw = fake_repo
+    target = "CLAUDE.md"
+    fp = tw.wf_fix_fingerprint("Fix the gate.", "gate wrong")
+    tid = tw.create_task(
+        tw.NewTaskRequest(
+            kind="infra",
+            title="refactor: tidy the gate",
+            body=_wf_fix_body(target, fp, "Fix the gate."),
+            tags=["wf-fix", f"wf-fix-fp:{fp}"],
+        )
+    )
+
+    hits = tw.open_workflow_fix_siblings(target)
+    assert [h["id"] for h in hits] == [tid]
+    assert hits[0]["matched"] == ["infra-target"]
+    assert hits[0]["target"] == "CLAUDE.md"
+
+
+def test_open_sibling_advisory_plain_infra_opt_out(fake_repo):
+    """include_plain_infra=False excludes the non-prefixed open sibling (the
+    kwarg mirrors the closed enumerator's opt-out semantics)."""
+    _, tw = fake_repo
+    target = "CLAUDE.md"
+    fp = tw.wf_fix_fingerprint("Fix the gate.", "gate wrong")
+    tw.create_task(
+        tw.NewTaskRequest(
+            kind="infra",
+            title="refactor: tidy the gate",
+            body=_wf_fix_body(target, fp, "Fix the gate."),
+            tags=["wf-fix", f"wf-fix-fp:{fp}"],
+        )
+    )
+    assert tw.open_workflow_fix_siblings(target, include_plain_infra=False) == []
+
+
+def test_open_sibling_advisory_empty_when_no_candidate_keys(fake_repo, monkeypatch):
+    """(None, None) and ("", "") return [] BEFORE any registry load — the
+    no-candidate short-circuit precedes _load_registry entirely."""
+    _, tw = fake_repo
+
+    def _boom():
+        raise AssertionError("registry scan must not run with no candidate keys")
+
+    monkeypatch.setattr(tw, "_load_registry", _boom)
+    assert tw.open_workflow_fix_siblings(None, None) == []
+    assert tw.open_workflow_fix_siblings("", "") == []
+
+
+def test_open_sibling_advisory_sorted_id_desc(fake_repo):
+    """Overlapping open siblings sort id DESC (ids are allocation-ordered, so
+    most recently filed first — the open-population analogue of the closed
+    pass's closed_at DESC)."""
+    _, tw = fake_repo
+    target = "CLAUDE.md"
+    tids = [
+        _file_wf_fix_task(
+            tw, target, tw.wf_fix_fingerprint(f"Fix {i}.", f"bug {i}"), proposed_change=f"Fix {i}."
+        )
+        for i in range(3)
+    ]
+
+    hits = tw.open_workflow_fix_siblings(target)
+    assert [h["id"] for h in hits] == sorted(tids, reverse=True)
+
+
+def test_open_sibling_advisory_non_infra_kind_excluded(fake_repo):
+    """An open kind:experiment task never surfaces even with a matching
+    prefixed title + anchored target line (the population is kind==infra,
+    same as the dedup predicate's)."""
+    _, tw = fake_repo
+    target = "CLAUDE.md"
+    fp = tw.wf_fix_fingerprint("Fix the gate.", "gate wrong")
+    tw.create_task(
+        tw.NewTaskRequest(
+            kind="experiment",
+            title="workflow-fix: gate advisory fix",
+            body=_wf_fix_body(target, fp, "Fix the gate."),
+        )
+    )
+    assert tw.open_workflow_fix_siblings(target, "workflow-fix: gate advisory fix") == []


### PR DESCRIPTION
Closes task #1502. Adds open_workflow_fix_siblings enumerator + _advise_open_wf_fix_siblings advisory leg (stderr-only, fail-soft, never blocks) + rule-doc open-arm paragraph + 13 tests. Plan: 3x critic APPROVE + consistency PASS; code-review PASS; step-9c test-verdict PASS.