### PR TITLE
issue-1504: retire the LESSONS.md total-size growth ratchet (per-channel budgets)

### DIFF
--- a/.claude/hooks/guard_lessons_edit.sh
+++ b/.claude/hooks/guard_lessons_edit.sh
@@ -3,7 +3,7 @@
 # LESSONS.md byte budgets / index parity (task #1279).
 #
 # `.claude/rules/LESSONS.md` is the always-on index every session loads; #1269
-# added blocking byte-budget/ratchet/per-row/parity gates in
+# added blocking byte-budget/per-row/non-row/parity gates in
 # `scripts/workflow_lint.py::check_lessons_index`, but those fire only where
 # the lint runs (pre-commit in worktrees / PR path). A direct repo-root Edit +
 # explicit-path commit never runs the lint, so the budget could be silently
@@ -63,13 +63,12 @@ run_self_test() {
   # Fixture sizes come from the RESOLVED lint constants at runtime (never
   # hardcoded) so a future constant retune cannot silently break this suite.
   # This first `uv run` also warms the project env before any timed dispatch.
-  local consts ratchet headroom rowcap maxbytes
+  local consts nonrow rowcap maxbytes
   consts=$(cd "$REPO_ROOT" && uv run python "$HELPER" --print-constants 2>/dev/null)
-  ratchet=$(printf '%s' "$consts" | jq -r '._LESSONS_RATCHET_BYTES // empty' 2>/dev/null)
-  headroom=$(printf '%s' "$consts" | jq -r '._LESSONS_RATCHET_MAX_HEADROOM_BYTES // empty' 2>/dev/null)
+  nonrow=$(printf '%s' "$consts" | jq -r '._LESSONS_NONROW_MAX_BYTES // empty' 2>/dev/null)
   rowcap=$(printf '%s' "$consts" | jq -r '._LESSONS_ROW_MAX_BYTES // empty' 2>/dev/null)
   maxbytes=$(printf '%s' "$consts" | jq -r '._LESSONS_MAX_BYTES // empty' 2>/dev/null)
-  if [ -z "$ratchet" ] || [ -z "$headroom" ] || [ -z "$rowcap" ] || [ -z "$maxbytes" ]; then
+  if [ -z "$nonrow" ] || [ -z "$rowcap" ] || [ -z "$maxbytes" ]; then
     echo "self-test: FAIL (could not resolve lint constants via --print-constants)" >&2
     return 1
   fi
@@ -86,7 +85,10 @@ run_self_test() {
   local LESSONS="$TMP/.claude/rules/LESSONS.md"
   local WT_LESSONS="$TMP/.claude/worktrees/issue-9/.claude/rules/LESSONS.md"
 
-  local valid_total=$(( ratchet - headroom / 2 ))
+  # No minimum size — the retired ratchet's banked-slack floor is gone (#1504);
+  # mk_content padding is NON-ROW bytes, so the valid fixture must stay under
+  # the non-row budget (half of it leaves comfortable margin for the rows).
+  local valid_total=$(( nonrow / 2 ))
   local longtrig
   longtrig=$(head -c "$rowcap" /dev/zero | tr '\0' 'y')   # > rowcap once row prefix is added
 
@@ -118,7 +120,9 @@ run_self_test() {
   mk_content "$valid_total" "$ROW_A" "$ROW_B" '- ghost.md — trigger g' > "$TMP/stalerow.md"
   mk_content "$valid_total" "$ROW_A"                                   > "$TMP/missingrow.md"
   mk_content $(( maxbytes + 200 )) "$ROW_A" "$ROW_B"                   > "$TMP/overcap.md"
-  mk_content $(( ratchet + 100 )) "$ROW_A" "$ROW_B"                    > "$TMP/overratchet.md"
+  # non-row bytes ~= nonrow + 354 (> budget) while total ~= 1,300 stays far
+  # under the warn band/cap -> isolates the non-row scaffolding FAIL (#1504).
+  mk_content $(( nonrow + 400 )) "$ROW_A" "$ROW_B"                     > "$TMP/overnonrow.md"
   mk_content $(( maxbytes + 200 )) '- alpha.md — trigger a'            > "$TMP/wt_overcap.md"
   cp "$TMP/valid.md" "$LESSONS"   # on-disk current content for the Edit cases
 
@@ -168,12 +172,12 @@ run_self_test() {
 
   # §4e case table (the behavior-matrix source of truth)
   run_case "1: Write to unrelated path allowed"                0 "$(wp "$TMP/notes.md" "$TMP/valid.md")"
-  run_case "2: valid Write within ratchet band allowed"        0 "$(wp "$LESSONS" "$TMP/valid.md")"
+  run_case "2: valid Write allowed"                            0 "$(wp "$LESSONS" "$TMP/valid.md")"
   run_case "3: Write with row over per-row cap blocks"         2 "$(wp "$LESSONS" "$TMP/longrow.md")" '' 'per-row cap'
   run_case "4: Write with row naming nonexistent rule blocks"  2 "$(wp "$LESSONS" "$TMP/stalerow.md")" '' 'no matching'
   run_case "5: Write missing a row for a stub rule blocks"     2 "$(wp "$LESSONS" "$TMP/missingrow.md")" '' 'no index row'
   run_case "6: Write over the leanness cap blocks"             2 "$(wp "$LESSONS" "$TMP/overcap.md")" '' 'leanness cap'
-  run_case "7: Write past the growth ratchet blocks"           2 "$(wp "$LESSONS" "$TMP/overratchet.md")" '' 'grew past'
+  run_case "7: Write past the non-row scaffolding budget blocks" 2 "$(wp "$LESSONS" "$TMP/overnonrow.md")" '' 'non-row'
   run_case "8: Edit growing a row over the row cap blocks"     2 "$(ep "$LESSONS" 'trigger a' "$longtrig")" '' 'per-row cap'
   run_case "9: Edit with absent old_string allowed"            0 "$(ep "$LESSONS" 'ZZZ_NOT_PRESENT' 'zzz')"
   run_case "10: Edit with ambiguous old_string allowed"        0 "$(ep "$LESSONS" 'trigger' "$longtrig")"

--- a/.claude/hooks/guard_lessons_edit_check.py
+++ b/.claude/hooks/guard_lessons_edit_check.py
@@ -17,9 +17,9 @@ EDITED tree's rules dir. If a future lint version reads outside
 ``<root>/.claude/rules/``, this materialization must grow with it.
 
 Constant resolution: the lint module is imported from the EDITED tree's
-``scripts/workflow_lint.py`` FIRST (so a same-diff ratchet/constant bump in
-that tree is honored at edit time, per the #1269 constant-first ordering),
-falling back to this hook's own repo copy.
+``scripts/workflow_lint.py`` FIRST (so a same-diff constant bump — grandfather
+caps, non-row budget — in that tree is honored at edit time, per the #1269
+constant-first ordering), falling back to this hook's own repo copy.
 
 ``--print-constants`` dumps the resolved (own-repo) lint constants as JSON —
 used by the wrapper's ``--self-test`` and the pytest suite to size fixtures at
@@ -40,8 +40,7 @@ from types import ModuleType
 _CONST_KEYS = (
     "_LESSONS_MAX_BYTES",
     "_LESSONS_WARN_BYTES",
-    "_LESSONS_RATCHET_BYTES",
-    "_LESSONS_RATCHET_MAX_HEADROOM_BYTES",
+    "_LESSONS_NONROW_MAX_BYTES",
     "_LESSONS_ROW_MAX_BYTES",
     "_LESSONS_ROW_GRANDFATHER_MAX_BYTES",
     "_LESSONS_ROW_GRANDFATHER_MAX_HEADROOM_BYTES",
@@ -132,9 +131,12 @@ def _block_message(errors: list[str]) -> str:
     lines += [f"  - {e}" for e in errors]
     lines += [
         "Recovery:",
-        "  - Growing the index deliberately? Raise _LESSONS_RATCHET_BYTES in",
-        "    scripts/workflow_lint.py of THIS tree FIRST (same-diff constant bump),",
-        "    then retry this edit. Trimming? Ratchet the same constant DOWN after.",
+        "  - Row over its cap? Trim the row's trigger (_LESSONS_ROW_MAX_BYTES); a",
+        "    grandfathered row's deliberate growth raises",
+        "    _LESSONS_ROW_GRANDFATHER_MAX_BYTES in THIS tree's scripts/workflow_lint.py",
+        "    FIRST (same-diff), then retry this edit.",
+        "  - Non-row scaffolding over budget? Trim header prose, or (a deliberate",
+        "    header-restructure decision) raise _LESSONS_NONROW_MAX_BYTES the same way.",
         "  - Adding a row for a new rule? Create .claude/rules/<name>.md BEFORE",
         "    adding its index row.",
         "  - Verify after fixing: uv run python scripts/workflow_lint.py --check-lessons-index",
@@ -153,7 +155,9 @@ def main() -> int:
         if wl is None:
             print("{}")
             return 1
-        print(json.dumps({k: getattr(wl, k) for k in _CONST_KEYS}))
+        # hasattr-tolerant: a cross-vintage lint copy (pre-/post-#1504) may
+        # lack a key; dump only what resolves so the self-test never crashes.
+        print(json.dumps({k: getattr(wl, k) for k in _CONST_KEYS if hasattr(wl, k)}))
         return 0
 
     payload = json.load(sys.stdin)

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -9607,8 +9607,9 @@ tests BEFORE anything lands:
     done < /tmp/issue-<N>-overlay-files.txt
     # LINT-VINTAGE 3-WAY MERGE (#1456; incidents #1366/#1411): when the own
     # diff touches scripts/workflow_lint.py, the loop above overlaid the
-    # BRANCH's lint copy, whose ratchet constants (_LESSONS_RATCHET_BYTES,
-    # agent-spec caps, gotchas row caps — bumped on main every few days) may
+    # BRANCH's lint copy, whose ratchet constants
+    # (_LESSONS_ROW_GRANDFATHER_MAX_BYTES, AGENT_SPEC_SIZE_GRANDFATHER —
+    # bumped on main every few days) may
     # predate main's raises and flag main-advanced files on the gated legs
     # only (NEW non-empty -> spurious block). Approximate the post-rebase
     # trunk lint instead: 3-way-merge branch copy (ours) + merge-base copy +

--- a/scripts/verify_plan.py
+++ b/scripts/verify_plan.py
@@ -5686,14 +5686,15 @@ def _c34_headroom(rel: str, wl) -> tuple[int, int, str] | None:
         return None
     size = p.stat().st_size
     if p.name == "LESSONS.md":
-        # #1269: the binding runtime constraint is min(cap, growth ratchet) —
-        # a plan passing the 8000-byte cap headroom could still FAIL
-        # workflow_lint's ratchet at implement time (the plan-time miss c34
-        # exists to close).
-        ratchet = wl._LESSONS_RATCHET_BYTES
-        cap = min(wl._LESSONS_MAX_BYTES, ratchet)
-        src = "_LESSONS_RATCHET_BYTES" if ratchet < wl._LESSONS_MAX_BYTES else "_LESSONS_MAX_BYTES"
-        return cap - size, cap, src
+        # #1504: the TOTAL growth ratchet is retired — the binding total
+        # constraint is the leanness cap. Per-row / non-row budgets also
+        # bind at implement time; c34's summed-block-bytes heuristic keeps
+        # the total cap as its denominator (a single-row insert over
+        # _LESSONS_ROW_MAX_BYTES is a disclosed FN here, caught by the
+        # lint). No trigger-regex change (_C34_PATH_RE / _C34_VERB_RE /
+        # _C34_BUDGET_RE untouched) — the re-audit clause does not fire;
+        # the looser denominator only monotonically reduces WARNs.
+        return wl._LESSONS_MAX_BYTES - size, wl._LESSONS_MAX_BYTES, "_LESSONS_MAX_BYTES"
     cap = wl.AGENT_SPEC_SIZE_GRANDFATHER.get(p.name)
     if cap is not None:
         return cap - size, cap, "AGENT_SPEC_SIZE_GRANDFATHER"

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -9562,39 +9562,35 @@ _LESSONS_ROW_GRANDFATHER_MAX_BYTES: dict[str, int] = {
 }
 _LESSONS_ROW_GRANDFATHER_MAX_HEADROOM_BYTES = 40
 
-# Growth ratchet (#1269, the #986 agent-spec grandfather pattern applied to
-# LESSONS.md's TOTAL size): the constant must HUG the measured size. Growing
-# the index requires raising this constant IN THE SAME DIFF (visible,
-# reviewed, and merge-conflicting for concurrent growers — the 07-10
-# silent-sum failure shape); it may never exceed _LESSONS_MAX_BYTES. Trimming
-# the index requires ratcheting it DOWN (banked slack defeats the mechanism).
-# Measured 5,780 B at the #1269 row-grammar migration; ratchet = measured
-# + ~220 (<= _LESSONS_RATCHET_MAX_HEADROOM_BYTES). #1366 grew the
-# artifact-reuse row (parent-lineage trigger, (a)-(k)): measured 6,046 B;
-# ratchet = measured + ~34. #1396 grew the upload-policy row
-# (phase-sequencing trigger, store-before-long-fit #825): measured 6,147 B;
-# ratchet = measured + ~253 (<= _LESSONS_RATCHET_MAX_HEADROOM_BYTES). #1395
-# grew the plan-compute-sizing row (pilot basis covers fit loops AND draw
-# batteries): merged measured 6,178 B; ratchet 6400 retained (headroom ~222,
-# covers both concurrent growers).
-# #1435 grew the gotchas row (subprocess-registry / full-panel-fresh-child-smoke
-# trigger; merged with #1431's raise): re-measured total 6,456 B; ratchet 6650
-# (headroom ~194, <= _LESSONS_RATCHET_MAX_HEADROOM_BYTES).
-# #1476 reworded the selection-symmetric-nulls row (bootstrap-CI
-# selection-inheritance trigger; row 278 B -> 278 B, net 0) and absorbed
-# the pre-existing committed overage (6,675 B vs ratchet 6,650 — the
-# #1462-era growth at 26d450bce8 landed without a raise): re-measured
-# total 6,675 B; ratchet 6800 (headroom ~125,
-# <= _LESSONS_RATCHET_MAX_HEADROOM_BYTES).
-_LESSONS_RATCHET_BYTES = 6800
-_LESSONS_RATCHET_MAX_HEADROOM_BYTES = 400
+# Non-row scaffolding budget (#1504). Growth control for the always-on index
+# is PER-CHANNEL, not a hand-bumped total:
+#   - rows: _LESSONS_ROW_MAX_BYTES / _LESSONS_ROW_GRANDFATHER_MAX_BYTES catch
+#     a bloated row at edit time in the grower's own tree (#1269), and index
+#     parity means a NEW row requires a reviewed .claude/rules/*.md;
+#   - non-row scaffolding (header prose, headings, blank lines, row newlines,
+#     anything the row grammar does not match): bounded by this FIXED budget;
+#   - aggregate: the _LESSONS_WARN_BYTES advisory band + _LESSONS_MAX_BYTES.
+# The former TOTAL growth ratchet (_LESSONS_RATCHET_BYTES, #1269) is RETIRED
+# (#1504): its same-diff constant bump made every concurrent LESSONS.md
+# growth a merge-conflict / trunk-red hazard — 2 Step-10d conflicts (#1335
+# PR #1227, #1435 PR #1188), 1 fleet-wide trunk red (#1462), 1 duplicate fix
+# pipeline (#1476/#1479) in ~48h — while per-row caps + parity already make
+# row growth deliberate. Residual: two individually-green concurrent growths
+# can sum past the 8000 cap post-merge, but every such residual-red scenario
+# has BOTH growers already inside the 7200 WARN band before pushing (for two
+# cap-sized 280-B rows the window opens at base >= ~7,440 > 7,200). Measured
+# non-row bytes at retirement: 546 (2026-07-18). 900 leaves headroom for a
+# deliberate header note. Raise ONLY for a deliberate header restructure —
+# NEVER for row growth (rows never count against this budget; pinned by
+# test_check_lessons_index_nonrow_ignores_row_bytes).
+_LESSONS_NONROW_MAX_BYTES = 900
 
 
-def check_lessons_index(  # noqa: C901 -- flat failure-mode ladder (index parity, total cap/warn, growth ratchet, per-row caps + grandfather hygiene, #1269); extracting a branch would just relocate it
+def check_lessons_index(  # noqa: C901 -- flat failure-mode ladder (index parity, total cap/warn, non-row budget, per-row caps + grandfather hygiene, #1269/#1504); extracting a branch would just relocate it
     *,
     repo_root: Path | None = None,
     warn_sink: list[str] | None = None,
-    ratchet_bytes: int | None = _LESSONS_RATCHET_BYTES,
+    nonrow_max_bytes: int | None = _LESSONS_NONROW_MAX_BYTES,
     row_max_bytes: int | None = _LESSONS_ROW_MAX_BYTES,
 ) -> list[str]:
     """FAIL if `.claude/rules/LESSONS.md` and the `.claude/rules/*.md` set
@@ -9612,18 +9608,18 @@ def check_lessons_index(  # noqa: C901 -- flat failure-mode ladder (index parity
     advisory WARN band (#992): an index over `_LESSONS_WARN_BYTES` but at or
     under the cap emits an early-warning WARN — stderr-only / advisory, never
     a FAIL — so a near-cap landing is visible a few rows before the next
-    addition FAILs. #1269 adds the durable growth mechanisms: (e) the growth
-    RATCHET — total size over `_LESSONS_RATCHET_BYTES` FAILs (grow only via a
-    same-diff constant raise), a ratchet sitting more than
-    `_LESSONS_RATCHET_MAX_HEADROOM_BYTES` above the live size FAILs (banked
-    slack / stale ratchet — ratchet DOWN after a trim), and a ratchet above
-    `_LESSONS_MAX_BYTES` FAILs (config error — the ratchet can never
-    authorize crossing the cap); (f) PER-ROW caps — a row over
-    `_LESSONS_ROW_MAX_BYTES` FAILs (naming the offending row), with the
+    addition FAILs; the cap FAIL and WARN both name the largest rows as
+    actionable trim targets (#1504); (e) the NON-ROW scaffolding budget
+    (#1504) — bytes the row grammar does not claim (header prose, headings,
+    blank lines, row newlines, malformed rows) over
+    `_LESSONS_NONROW_MAX_BYTES` FAIL; row growth NEVER counts against this
+    budget (the per-growth TOTAL ratchet is retired — see the
+    `_LESSONS_NONROW_MAX_BYTES` comment); (f) PER-ROW caps (#1269) — a row
+    over `_LESSONS_ROW_MAX_BYTES` FAILs (naming the offending row), with the
     `_LESSONS_ROW_GRANDFATHER_MAX_BYTES` legacy exceptions under the same
     over-cap / excess-hug / obsolete-entry hygiene as the #986 agent-spec
     grandfather. `repo_root` is a unit-test override hook; production
-    callers pass None (canonical repo root). `ratchet_bytes` /
+    callers pass None (canonical repo root). `nonrow_max_bytes` /
     `row_max_bytes` are TEST-ONLY opt-outs (`None` disables that mode so a
     small synthetic fixture can isolate another failure mode); production
     callers never pass them. `warn_sink` mirrors
@@ -9649,6 +9645,17 @@ def check_lessons_index(  # noqa: C901 -- flat failure-mode ladder (index parity
         )
         return errors
     raw = lessons.read_bytes()
+    text = raw.decode("utf-8")
+    row_matches = list(_LESSONS_ROW_RE.finditer(text))
+    row_sizes = sorted(
+        ((len(m.group(0).encode("utf-8")), m.group("name")) for m in row_matches),
+        reverse=True,
+    )
+    largest_suffix = (
+        " Largest rows: " + ", ".join(f"{name} ({b} B)" for b, name in row_sizes[:3]) + "."
+        if row_sizes
+        else ""
+    )
     if len(raw) > _LESSONS_MAX_BYTES:
         errors.append(
             f".claude/rules/LESSONS.md: {len(raw)} bytes exceeds the "
@@ -9656,44 +9663,31 @@ def check_lessons_index(  # noqa: C901 -- flat failure-mode ladder (index parity
             f"always-on; trim 'fires when:' triggers until it fits. "
             f"(em-dashes are multibyte; counting in BYTES not chars is "
             f"deliberate.)"
+            f"{largest_suffix}"
         )
     elif len(raw) > _LESSONS_WARN_BYTES:
         _warn(
             f".claude/rules/LESSONS.md at {len(raw)}/{_LESSONS_MAX_BYTES} bytes — inside "
             f"the warn band (>{_LESSONS_WARN_BYTES}); slim rows or plan a deliberate cap "
-            f"decision before the next addition FAILs."
+            f"decision before the next addition FAILs.{largest_suffix}"
         )
-    # Growth ratchet (#1269) — three failure modes, all strictly-greater and
-    # DISTINCT from the 8000-byte leanness-cap FAIL above: a ratchet RED means
-    # "one-line constant bump in the SAME diff", not a real budget breach.
-    if ratchet_bytes is not None:
-        if ratchet_bytes > _LESSONS_MAX_BYTES:
+    # Non-row scaffolding budget (#1504): bytes the row grammar does not
+    # claim. Row growth NEVER counts here — growing/adding rows must not
+    # require touching this file (the retired ratchet's per-growth bump was
+    # the 4-incidents/48h conflict magnet; see _LESSONS_NONROW_MAX_BYTES).
+    if nonrow_max_bytes is not None:
+        row_total = sum(b for b, _ in row_sizes)
+        nonrow = len(raw) - row_total
+        if nonrow > nonrow_max_bytes:
             errors.append(
-                f"_LESSONS_RATCHET_BYTES ({ratchet_bytes}) exceeds "
-                f"_LESSONS_MAX_BYTES ({_LESSONS_MAX_BYTES}) — config error: "
-                f"the growth ratchet can never authorize crossing the "
-                f"leanness cap; lower the ratchet (a cap raise is a "
-                f"deliberate #869/#872-class token-budget decision)."
-            )
-        if len(raw) > ratchet_bytes:
-            errors.append(
-                f".claude/rules/LESSONS.md: {len(raw)} bytes grew past the "
-                f"_LESSONS_RATCHET_BYTES growth ratchet "
-                f"({len(raw)}/{ratchet_bytes}) — this is the one-line-bump "
-                f"gate, NOT the {_LESSONS_MAX_BYTES}-byte budget breach: "
-                f"trim the index, or raise _LESSONS_RATCHET_BYTES in the "
-                f"SAME diff (a deliberate, reviewed budget consumption — "
-                f"never above the _LESSONS_MAX_BYTES cap)."
-            )
-        elif ratchet_bytes - len(raw) > _LESSONS_RATCHET_MAX_HEADROOM_BYTES:
-            errors.append(
-                f"_LESSONS_RATCHET_BYTES ({ratchet_bytes}) sits "
-                f"{ratchet_bytes - len(raw)} bytes above the live "
-                f".claude/rules/LESSONS.md ({len(raw)} bytes) — banked slack "
-                f"/ stale ratchet defeats the growth mechanism (max headroom "
-                f"{_LESSONS_RATCHET_MAX_HEADROOM_BYTES}); ratchet DOWN to <= "
-                f"{len(raw) + _LESSONS_RATCHET_MAX_HEADROOM_BYTES} after a "
-                f"trim."
+                f".claude/rules/LESSONS.md: {nonrow} non-row scaffolding bytes "
+                f"(total {len(raw)} minus {row_total} row bytes) exceed the "
+                f"{nonrow_max_bytes}-byte non-row budget "
+                f"(_LESSONS_NONROW_MAX_BYTES). Trim header/scaffolding prose "
+                f"(a malformed index row also lands here — check the row "
+                f"grammar), or — a deliberate header-restructure decision — "
+                f"raise _LESSONS_NONROW_MAX_BYTES in the SAME diff. Row "
+                f"growth never needs this constant."
             )
     # Count occurrences (not a set) so a name appearing on >1 row is caught —
     # a set comprehension would collapse duplicates and let both the missing
@@ -9701,7 +9695,7 @@ def check_lessons_index(  # noqa: C901 -- flat failure-mode ladder (index parity
     # The same pass runs the per-row byte budgets (#1269): the full-line row
     # regex makes `m.group(0)` the whole row.
     index_counts: Counter[str] = Counter()
-    for m in _LESSONS_ROW_RE.finditer(raw.decode("utf-8")):
+    for m in row_matches:
         name = m.group("name")
         index_counts[name] += 1
         if row_max_bytes is None:

--- a/tests/test_guard_lessons_edit.py
+++ b/tests/test_guard_lessons_edit.py
@@ -19,11 +19,12 @@ verbatim rewrite of the live LESSONS.md is allowed), and (6) assert the
 settings.json wiring (#965 ``TestSettingsWiring`` convention — closing the
 "hook ships green but inert" channel).
 
-Fixture rules (plan §12-9): every fixture size is computed at runtime from
-the imported ``workflow_lint`` constants (the banked-slack check FAILs a
-too-small allow fixture, so allow totals sit inside ``[ratchet - headroom,
-ratchet]``); no synthetic stub is ever named ``gotchas.md`` (the grandfather
-hygiene would FAIL a short gotchas row). Deny/allow determinism: every run
+Fixture rules (plan §12-9, updated #1504): every fixture size is computed at
+runtime from the imported ``workflow_lint`` constants; ``_sized`` padding is
+NON-ROW bytes, so allow fixtures stay under ``_LESSONS_NONROW_MAX_BYTES``
+(no minimum size — the retired total ratchet's banked-slack floor is gone);
+no synthetic stub is ever named ``gotchas.md`` (the grandfather hygiene
+would FAIL a short gotchas row). Deny/allow determinism: every run
 scrubs ``EPM_ALLOW_LESSONS_EDIT`` and points the sentinel escape hatch at a
 nonexistent path via ``EPM_LESSONS_EDIT_SENTINEL``.
 """
@@ -52,12 +53,13 @@ if str(_SCRIPTS) not in sys.path:
 
 from workflow_lint import (  # noqa: E402
     _LESSONS_MAX_BYTES,
-    _LESSONS_RATCHET_BYTES,
-    _LESSONS_RATCHET_MAX_HEADROOM_BYTES,
+    _LESSONS_NONROW_MAX_BYTES,
     _LESSONS_ROW_MAX_BYTES,
 )
 
-VALID_TOTAL = _LESSONS_RATCHET_BYTES - _LESSONS_RATCHET_MAX_HEADROOM_BYTES // 2
+# `_sized` padding is NON-ROW bytes, so allow fixtures must sit under the
+# non-row budget; no minimum size (the banked-slack floor is retired, #1504).
+VALID_TOTAL = _LESSONS_NONROW_MAX_BYTES // 2
 ROW_A = "- alpha.md — trigger a"
 ROW_B = "- beta.md — trigger b"
 LONG_TRIGGER = "y" * (_LESSONS_ROW_MAX_BYTES + 20)
@@ -155,7 +157,7 @@ def test_valid_write_allowed(tmp_path: Path) -> None:
     ("rows", "total", "want"),
     [
         pytest.param([ROW_A, ROW_B], _LESSONS_MAX_BYTES + 200, "leanness cap", id="total-cap"),
-        pytest.param([ROW_A, ROW_B], _LESSONS_RATCHET_BYTES + 100, "grew past", id="ratchet"),
+        pytest.param([ROW_A, ROW_B], _LESSONS_NONROW_MAX_BYTES + 400, "non-row", id="nonrow"),
         pytest.param(
             [f"- alpha.md — {LONG_TRIGGER}", ROW_B], VALID_TOTAL, "per-row cap", id="per-row"
         ),
@@ -165,12 +167,6 @@ def test_valid_write_allowed(tmp_path: Path) -> None:
             VALID_TOTAL,
             "no matching",
             id="parity-stale-row",
-        ),
-        pytest.param(
-            [ROW_A, ROW_B],
-            _LESSONS_RATCHET_BYTES - _LESSONS_RATCHET_MAX_HEADROOM_BYTES - 500,
-            "banked slack",
-            id="banked-slack",
         ),
     ],
 )
@@ -186,7 +182,7 @@ def test_block_message_names_recovery_paths(tmp_path: Path) -> None:
     lessons = _mk_tree(tmp_path)
     r = _run(_write_payload(lessons, _sized([ROW_A, ROW_B], _LESSONS_MAX_BYTES + 200)))
     assert r.returncode == 2, (r.returncode, r.stderr)
-    assert "_LESSONS_RATCHET_BYTES" in r.stderr, r.stderr
+    assert "_LESSONS_NONROW_MAX_BYTES" in r.stderr, r.stderr
     assert "EPM_ALLOW_LESSONS_EDIT" in r.stderr, r.stderr
     # The sentinel hatch is named by its RESOLVED ABSOLUTE path (a worktree-cwd
     # session following a relative touch recipe would touch the wrong file).
@@ -309,27 +305,26 @@ from pathlib import Path
 
 _LESSONS_MAX_BYTES = 200000
 _LESSONS_WARN_BYTES = 190000
-_LESSONS_RATCHET_BYTES = 50000
-_LESSONS_RATCHET_MAX_HEADROOM_BYTES = 200000
+_LESSONS_NONROW_MAX_BYTES = 50000
 _LESSONS_ROW_MAX_BYTES = 100000
 _LESSONS_ROW_GRANDFATHER_MAX_BYTES = {}
 _LESSONS_ROW_GRANDFATHER_MAX_HEADROOM_BYTES = 40
 
 
 def check_lessons_index(*, repo_root=None, warn_sink=None,
-                        ratchet_bytes=_LESSONS_RATCHET_BYTES,
+                        nonrow_max_bytes=_LESSONS_NONROW_MAX_BYTES,
                         row_max_bytes=_LESSONS_ROW_MAX_BYTES):
-    """Toy stand-in honoring only the total-byte ratchet (test double)."""
+    """Toy stand-in honoring only a total-byte budget (test double)."""
     lessons = Path(repo_root) / ".claude" / "rules" / "LESSONS.md"
     raw = lessons.read_bytes()
-    if len(raw) > ratchet_bytes:
-        return [f"stub-ratchet: {len(raw)} grew past {ratchet_bytes}"]
+    if len(raw) > nonrow_max_bytes:
+        return [f"stub-budget: {len(raw)} bytes over the stub budget {nonrow_max_bytes}"]
     return []
 '''
 
 
 def _mk_stub_lint_tree(tmp_path: Path) -> Path:
-    """Synthetic tree carrying its OWN scripts/workflow_lint.py with a 50k ratchet."""
+    """Synthetic tree carrying its OWN scripts/workflow_lint.py with a 50k budget."""
     lessons = _mk_tree(tmp_path)
     scripts = tmp_path / "scripts"
     scripts.mkdir()
@@ -338,20 +333,21 @@ def _mk_stub_lint_tree(tmp_path: Path) -> Path:
 
 
 def test_edited_tree_constants_bind_allow_side(tmp_path: Path) -> None:
-    """Content over the REAL ratchet but under the edited tree's stub ratchet -> allow.
+    """Content over MAIN's non-row budget but under the stub's budget -> allow.
 
     Pins the #1269 constant-first ordering at edit time: a same-tree constant
-    bump (here a stub lint with ratchet 50000) is honored, so 7000-byte
-    content that the hook-repo lint would block passes.
+    bump (here a stub lint whose budget is 50000) is honored, so content the
+    hook-repo lint would block (non-row bytes over _LESSONS_NONROW_MAX_BYTES)
+    passes under the edited tree's own constants.
     """
     lessons = _mk_stub_lint_tree(tmp_path)
-    content = _sized([ROW_A, ROW_B], _LESSONS_RATCHET_BYTES + 1000)
+    content = _sized([ROW_A, ROW_B], _LESSONS_NONROW_MAX_BYTES + 1000)
     r = _run(_write_payload(lessons, content))
     assert r.returncode == 0, (r.returncode, r.stderr)
 
 
 def test_edited_tree_constants_bind_block_side(tmp_path: Path) -> None:
-    """Content over the stub's OWN ratchet -> the stub blocks (not fail-open).
+    """Content over the stub's OWN budget -> the stub blocks (not fail-open).
 
     Companion to the allow-side case: proves the stub actually loaded and
     produced the block (its error string appears), so the allow-side pass
@@ -361,7 +357,7 @@ def test_edited_tree_constants_bind_block_side(tmp_path: Path) -> None:
     content = _sized([ROW_A, ROW_B], 60000)
     r = _run(_write_payload(lessons, content))
     assert r.returncode == 2, (r.returncode, r.stderr)
-    assert "stub-ratchet" in r.stderr, r.stderr
+    assert "stub-budget" in r.stderr, r.stderr
 
 
 def test_live_lessons_rewrite_allowed() -> None:

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -6853,12 +6853,12 @@ def test_skillmd_canonical_escapes_documents_standalone_line():
 # Fixture strategy (plan #1260 §6): monkeypatch verify_plan._C34_REPO_ROOT to
 # tmp_path and create ratcheted files at controlled sizes — testagent.md at
 # 39,900 B (non-grandfathered → headroom 100 B vs AGENT_SPEC_FAIL_BYTES
-# 40,000) and LESSONS.md 50 B under its BINDING constraint (#1269:
-# min(_LESSONS_MAX_BYTES, _LESSONS_RATCHET_BYTES) — the growth ratchet in
-# practice; derived from the live constants so routine ratchet bumps don't
-# shift the pinned headroom arithmetic). The trigger fragments mirror the
-# real #1230 plan v1 §4.1 shape: a heading naming the path, a "Verbatim text
-# to insert" line, then the fenced block.
+# 40,000) and LESSONS.md 50 B under its BINDING constraint (#1504: the total
+# growth ratchet is retired, so the binding TOTAL constraint is the
+# _LESSONS_MAX_BYTES leanness cap; derived from the live constant so a
+# coordinated cap raise doesn't shift the pinned headroom arithmetic). The
+# trigger fragments mirror the real #1230 plan v1 §4.1 shape: a heading
+# naming the path, a "Verbatim text to insert" line, then the fenced block.
 
 
 def _c34_fixture_root(tmp_path):
@@ -6866,7 +6866,7 @@ def _c34_fixture_root(tmp_path):
     (tmp_path / ".claude" / "agents").mkdir(parents=True)
     (tmp_path / ".claude" / "rules").mkdir(parents=True)
     (tmp_path / ".claude" / "agents" / "testagent.md").write_bytes(b"x" * 39_900)
-    lessons_size = min(wl._LESSONS_MAX_BYTES, wl._LESSONS_RATCHET_BYTES) - 50
+    lessons_size = wl._LESSONS_MAX_BYTES - 50
     (tmp_path / ".claude" / "rules" / "LESSONS.md").write_bytes(b"x" * lessons_size)
     return tmp_path
 
@@ -7009,14 +7009,14 @@ def test_c34_fenced_path_mention_does_not_trigger():
 
 
 def test_c34_lessons_md_headroom_warns(tmp_path, monkeypatch):
-    # #1269: the binding LESSONS.md constraint is min(cap, growth ratchet) —
-    # the ratchet in practice (it must sit under the cap), so the WARN
-    # detail names _LESSONS_RATCHET_BYTES as the cap source.
+    # #1504: the total growth ratchet is retired, so the binding LESSONS.md
+    # TOTAL constraint is the leanness cap — the WARN detail names
+    # _LESSONS_MAX_BYTES as the cap source.
     monkeypatch.setattr(verify_plan, "_C34_REPO_ROOT", _c34_fixture_root(tmp_path))
     _, by_id = _run(GOOD_PLAN + _c34_lessons_fragment(200), kind="infra")
     r = by_id["c34_ratchet_headroom"]
     assert r.status == "WARN"
-    assert "_LESSONS_RATCHET_BYTES" in r.detail
+    assert "_LESSONS_MAX_BYTES" in r.detail
     assert "headroom 50 B" in r.detail
 
 

--- a/tests/test_workflow_lint.py
+++ b/tests/test_workflow_lint.py
@@ -4525,10 +4525,10 @@ def _write_lessons_row(rules_dir, name, row_bytes):
 
 def test_check_lessons_index_fails_on_missing_row(tmp_path):
     rules = tmp_path / ".claude" / "rules"
-    # rule 'gamma' exists but is NOT indexed -> FAIL (ratchet mode disabled:
-    # the tiny synthetic fixture isolates the index-parity failure mode).
+    # rule 'gamma' exists but is NOT indexed -> FAIL (armed defaults: the
+    # tiny unpadded fixture passes every size mode, isolating parity).
     _write_lessons_fixture(rules, ["alpha", "beta", "gamma"], ["alpha", "beta"])
-    errs = check_lessons_index(repo_root=tmp_path, ratchet_bytes=None)
+    errs = check_lessons_index(repo_root=tmp_path)
     assert errs, "expected a FAIL for the un-indexed rule 'gamma'"
     assert any("gamma" in e for e in errs)
 
@@ -4537,14 +4537,14 @@ def test_check_lessons_index_fails_on_stale_row(tmp_path):
     rules = tmp_path / ".claude" / "rules"
     # 'delta' is indexed but has no rule file -> FAIL
     _write_lessons_fixture(rules, ["alpha", "beta"], ["alpha", "beta", "delta"])
-    errs = check_lessons_index(repo_root=tmp_path, ratchet_bytes=None)
+    errs = check_lessons_index(repo_root=tmp_path)
     assert errs and any("delta" in e for e in errs)
 
 
 def test_check_lessons_index_passes_on_match(tmp_path):
     rules = tmp_path / ".claude" / "rules"
     _write_lessons_fixture(rules, ["alpha", "beta"], ["alpha", "beta"])
-    assert check_lessons_index(repo_root=tmp_path, ratchet_bytes=None) == []
+    assert check_lessons_index(repo_root=tmp_path) == []
 
 
 def test_check_lessons_index_passes_on_live_repo():
@@ -4554,8 +4554,9 @@ def test_check_lessons_index_passes_on_live_repo():
 
 def test_check_lessons_index_fails_when_index_exceeds_cap(tmp_path):
     # Leanness cap is mechanical — an index over _LESSONS_MAX_BYTES must FAIL.
-    # ratchet mode disabled so the fixture isolates the CAP failure mode
-    # (the ratchet's own modes have their own tests below).
+    # non-row mode disabled: the prose padding is NON-ROW bytes by
+    # construction, so the fixture must isolate the CAP failure mode
+    # (the non-row budget has its own boundary test below).
     from workflow_lint import _LESSONS_MAX_BYTES
 
     rules = tmp_path / ".claude" / "rules"
@@ -4568,8 +4569,10 @@ def test_check_lessons_index_fails_when_index_exceeds_cap(tmp_path):
         f"# LESSONS\n\n## Rules\n\n{rows}\n\n{padding}\n",
         encoding="utf-8",
     )
-    errs = check_lessons_index(repo_root=tmp_path, ratchet_bytes=None)
+    errs = check_lessons_index(repo_root=tmp_path, nonrow_max_bytes=None)
     assert errs and any("leanness cap" in e for e in errs)
+    # #1504: the cap FAIL names the largest rows as actionable trim targets.
+    assert any("Largest rows:" in e and "alpha" in e for e in errs)
 
 
 def test_check_lessons_index_fails_on_duplicate_row(tmp_path):
@@ -4579,7 +4582,7 @@ def test_check_lessons_index_fails_on_duplicate_row(tmp_path):
     # FAIL because the contract is exactly one matching row per rule (#739 r2).
     rules = tmp_path / ".claude" / "rules"
     _write_lessons_fixture(rules, ["alpha"], ["alpha", "alpha"])
-    errs = check_lessons_index(repo_root=tmp_path, ratchet_bytes=None)
+    errs = check_lessons_index(repo_root=tmp_path)
     assert errs, "expected a FAIL for the duplicate 'alpha' index row"
     assert any(("duplicate" in e or "exactly one" in e) and "alpha" in e for e in errs)
 
@@ -4588,8 +4591,8 @@ def test_check_lessons_index_warns_in_warn_band(tmp_path):
     # The #992 early-warning band: an index strictly between _LESSONS_WARN_BYTES
     # and _LESSONS_MAX_BYTES emits one advisory WARN (warn_sink / stderr),
     # never a FAIL; the over-cap FAIL branch takes precedence over the WARN.
-    # ratchet mode disabled throughout: the band fixtures sit far above the
-    # ratchet by design and must isolate the WARN-band mode.
+    # non-row mode disabled throughout: the band fixtures pad with NON-ROW
+    # prose by design and must isolate the WARN-band mode.
     from workflow_lint import _LESSONS_MAX_BYTES, _LESSONS_WARN_BYTES
 
     # Pin the band constant itself (#992 plan latitude: 7000-7400, below cap).
@@ -4600,86 +4603,104 @@ def test_check_lessons_index_warns_in_warn_band(tmp_path):
     # (1) Sub-warn-band fixture -> no FAIL, empty sink.
     sink: list[str] = []
     _write_lessons_fixture(rules, ["alpha"], ["alpha"])
-    assert check_lessons_index(repo_root=tmp_path, warn_sink=sink, ratchet_bytes=None) == []
+    assert check_lessons_index(repo_root=tmp_path, warn_sink=sink, nonrow_max_bytes=None) == []
     assert sink == []
 
     # (2) EXACTLY at the threshold -> still no warn (the band is strictly-greater).
     sink = []
     _write_lessons_at_exact_bytes(rules, _LESSONS_WARN_BYTES)
-    assert check_lessons_index(repo_root=tmp_path, warn_sink=sink, ratchet_bytes=None) == []
+    assert check_lessons_index(repo_root=tmp_path, warn_sink=sink, nonrow_max_bytes=None) == []
     assert sink == []
 
-    # (3) One byte over the threshold -> no FAIL, exactly one warn-band message.
+    # (3) One byte over the threshold -> no FAIL, exactly one warn-band message
+    # naming the largest rows as trim targets (#1504).
     sink = []
     _write_lessons_at_exact_bytes(rules, _LESSONS_WARN_BYTES + 1)
-    assert check_lessons_index(repo_root=tmp_path, warn_sink=sink, ratchet_bytes=None) == []
+    assert check_lessons_index(repo_root=tmp_path, warn_sink=sink, nonrow_max_bytes=None) == []
     assert len(sink) == 1 and "warn band" in sink[0]
+    assert "Largest rows:" in sink[0] and "alpha" in sink[0]
 
     # (4) Over the cap -> the FAIL branch fires; no warn message rides along.
     sink = []
     _write_lessons_at_exact_bytes(rules, _LESSONS_MAX_BYTES + 100)
-    errs = check_lessons_index(repo_root=tmp_path, warn_sink=sink, ratchet_bytes=None)
+    errs = check_lessons_index(repo_root=tmp_path, warn_sink=sink, nonrow_max_bytes=None)
     assert errs and any("leanness cap" in e for e in errs)
     assert sink == []
 
 
-def test_check_lessons_index_fails_on_over_ratchet(tmp_path):
-    # Durability pin (#1269): growing the index past _LESSONS_RATCHET_BYTES
-    # FAILs under the PRODUCTION defaults (no explicit kwarg — a default
-    # flipped to None would turn this test RED via the constants-sane pin,
-    # and stripping the ratchet code turns it RED here).
-    from workflow_lint import _LESSONS_RATCHET_BYTES
+def _write_lessons_nonrow(rules_dir, nonrow_target):
+    """One valid alpha row + non-row padding sized so non-row bytes == target."""
+    rules_dir.mkdir(parents=True, exist_ok=True)
+    (rules_dir / "alpha.md").write_text("x", encoding="utf-8")
+    row = "- alpha.md — x."
+    base = f"# LESSONS\n\n## Rules\n\n{row}\n"
+    row_bytes = len(row.encode("utf-8"))
+    pad = nonrow_target - (len(base.encode("utf-8")) - row_bytes)
+    assert pad >= 0, (nonrow_target, pad)
+    (rules_dir / "LESSONS.md").write_bytes(base.encode("utf-8") + b"x" * pad)
+
+
+def test_check_lessons_index_fails_on_nonrow_over_budget(tmp_path):
+    # Strictly-greater boundary pair for the #1504 non-row scaffolding budget.
+    from workflow_lint import _LESSONS_NONROW_MAX_BYTES
 
     rules = tmp_path / ".claude" / "rules"
-    _write_lessons_at_exact_bytes(rules, _LESSONS_RATCHET_BYTES + 1)
+    rules.mkdir(parents=True)
+    _write_lessons_nonrow(rules, _LESSONS_NONROW_MAX_BYTES + 1)
     errs = check_lessons_index(repo_root=tmp_path)
-    assert errs and any("_LESSONS_RATCHET_BYTES" in e and "grew past" in e for e in errs)
-    # The ratchet FAIL is textually DISTINCT from the 8000-cap budget breach:
-    # a session seeing RED can tell one-line-bump from a real budget decision.
-    assert not any("leanness cap" in e for e in errs)
-
-
-def test_check_lessons_index_passes_at_exact_ratchet(tmp_path):
-    # Strictly-greater boundary: a file at EXACTLY the ratchet passes.
-    from workflow_lint import _LESSONS_RATCHET_BYTES
-
-    rules = tmp_path / ".claude" / "rules"
-    _write_lessons_at_exact_bytes(rules, _LESSONS_RATCHET_BYTES)
+    assert errs and any("_LESSONS_NONROW_MAX_BYTES" in e and "non-row" in e for e in errs)
+    _write_lessons_nonrow(rules, _LESSONS_NONROW_MAX_BYTES)
     assert check_lessons_index(repo_root=tmp_path) == []
 
 
-def test_check_lessons_index_fails_on_excess_ratchet_headroom(tmp_path):
-    # Banked slack: a ratchet sitting more than the headroom bound above the
-    # live size FAILs (stale ratchet after a trim defeats the mechanism);
-    # a file at EXACTLY ratchet - headroom passes (strictly-greater).
-    from workflow_lint import _LESSONS_RATCHET_BYTES, _LESSONS_RATCHET_MAX_HEADROOM_BYTES
+def test_check_lessons_index_nonrow_ignores_row_bytes(tmp_path):
+    # THE retirement pin (#1504): rows at the per-row cap, ARMED defaults,
+    # zero workflow_lint.py edits — row growth never needs a constant bump.
+    from workflow_lint import _LESSONS_ROW_MAX_BYTES
 
     rules = tmp_path / ".claude" / "rules"
-    _write_lessons_at_exact_bytes(
-        rules, _LESSONS_RATCHET_BYTES - _LESSONS_RATCHET_MAX_HEADROOM_BYTES - 1
-    )
-    errs = check_lessons_index(repo_root=tmp_path)
-    assert errs and any("banked slack" in e and "ratchet DOWN" in e for e in errs)
-
-    _write_lessons_at_exact_bytes(
-        rules, _LESSONS_RATCHET_BYTES - _LESSONS_RATCHET_MAX_HEADROOM_BYTES
-    )
+    rules.mkdir(parents=True)
+    rows = []
+    for name in ("alpha", "beta", "gamma"):
+        (rules / f"{name}.md").write_text("x", encoding="utf-8")
+        prefix = f"- {name}.md — "
+        rows.append(prefix + "y" * (_LESSONS_ROW_MAX_BYTES - len(prefix.encode("utf-8"))))
+    content = "# LESSONS\n\n## Rules\n\n" + "\n".join(rows) + "\n"
+    (rules / "LESSONS.md").write_text(content, encoding="utf-8")
     assert check_lessons_index(repo_root=tmp_path) == []
 
 
-def test_check_lessons_index_fails_on_ratchet_above_cap(tmp_path):
-    # Config error: the ratchet can never authorize crossing the leanness
-    # cap. Fixture sized inside the (over-cap ratchet)'s hug window so ONLY
-    # the config-error FAIL fires; the warn-band WARN is swallowed by sink.
-    from workflow_lint import _LESSONS_MAX_BYTES
+def test_lessons_total_ratchet_retired():
+    # Anti-resurrection pin (#1504): re-introducing the per-growth TOTAL
+    # ratchet (the 4-incidents/48h conflict magnet) must consciously delete
+    # this test.
+    import inspect
 
-    rules = tmp_path / ".claude" / "rules"
-    sink: list[str] = []
-    _write_lessons_at_exact_bytes(rules, _LESSONS_MAX_BYTES - 300)
-    errs = check_lessons_index(
-        repo_root=tmp_path, warn_sink=sink, ratchet_bytes=_LESSONS_MAX_BYTES + 1
+    import workflow_lint as wl
+
+    assert not hasattr(wl, "_LESSONS_RATCHET_BYTES")
+    assert not hasattr(wl, "_LESSONS_RATCHET_MAX_HEADROOM_BYTES")
+    params = inspect.signature(wl.check_lessons_index).parameters
+    assert "ratchet_bytes" not in params
+    assert "nonrow_max_bytes" in params
+
+
+def test_lessons_index_bundled_in_no_flags_source_pin():
+    """NON-VACUOUS no-flags bundling pin (#1504; the #1385 source-pin
+    pattern): `check_lessons_index` must be dispatched by the BARE
+    ``workflow_lint.py`` run. The ratchet retirement's deliberateness
+    replacement (per-row caps + non-row budget + index parity) rests on
+    this bundling firing on every gating path (guard hook + Step 10d
+    pre-push lint), so its silent un-bundling must turn a test RED."""
+    src = _LINT.read_text(encoding="utf-8")
+    assert re.search(
+        r"if args\.check_lessons_index or no_flags:\s*\n"
+        r"\s*errors\.extend\(check_lessons_index\(\)\)",
+        src,
+    ), "check_lessons_index is not dispatched on the no-flags branch"
+    assert "or args.check_lessons_index" in src, (
+        "--check-lessons-index is missing from the no_flags detection tuple"
     )
-    assert errs == [e for e in errs if "config error" in e] and errs, errs
 
 
 def test_check_lessons_index_fails_on_row_over_cap(tmp_path):
@@ -4688,12 +4709,12 @@ def test_check_lessons_index_fails_on_row_over_cap(tmp_path):
 
     rules = tmp_path / ".claude" / "rules"
     _write_lessons_row(rules, "alpha", _LESSONS_ROW_MAX_BYTES + 1)
-    errs = check_lessons_index(repo_root=tmp_path, ratchet_bytes=None)
+    errs = check_lessons_index(repo_root=tmp_path)
     assert errs and any("'alpha'" in e and "per-row cap" in e for e in errs)
 
     # Strictly-greater boundary: a row at EXACTLY the cap passes.
     _write_lessons_row(rules, "alpha", _LESSONS_ROW_MAX_BYTES)
-    assert check_lessons_index(repo_root=tmp_path, ratchet_bytes=None) == []
+    assert check_lessons_index(repo_root=tmp_path) == []
 
 
 def test_check_lessons_index_grandfather_row_over_its_cap_fails(tmp_path, monkeypatch):
@@ -4705,7 +4726,7 @@ def test_check_lessons_index_grandfather_row_over_its_cap_fails(tmp_path, monkey
     monkeypatch.setattr(workflow_lint, "_LESSONS_ROW_GRANDFATHER_MAX_BYTES", {"alpha": 460})
     rules = tmp_path / ".claude" / "rules"
     _write_lessons_row(rules, "alpha", 461)
-    errs = check_lessons_index(repo_root=tmp_path, ratchet_bytes=None)
+    errs = check_lessons_index(repo_root=tmp_path)
     assert errs and any(
         "grandfather cap" in e
         and "trim the row" in e
@@ -4716,13 +4737,13 @@ def test_check_lessons_index_grandfather_row_over_its_cap_fails(tmp_path, monkey
     # Strictly-greater + exact-hug boundary: a row at EXACTLY the cap passes
     # (cap - actual == 0 <= headroom bound).
     _write_lessons_row(rules, "alpha", 460)
-    assert check_lessons_index(repo_root=tmp_path, ratchet_bytes=None) == []
+    assert check_lessons_index(repo_root=tmp_path) == []
 
     # Exact hug bound passes: cap - actual == the headroom bound exactly.
     from workflow_lint import _LESSONS_ROW_GRANDFATHER_MAX_HEADROOM_BYTES
 
     _write_lessons_row(rules, "alpha", 460 - _LESSONS_ROW_GRANDFATHER_MAX_HEADROOM_BYTES)
-    assert check_lessons_index(repo_root=tmp_path, ratchet_bytes=None) == []
+    assert check_lessons_index(repo_root=tmp_path) == []
 
 
 def test_check_lessons_index_grandfather_hug_and_obsolete_entry_fail(tmp_path, monkeypatch):
@@ -4741,33 +4762,39 @@ def test_check_lessons_index_grandfather_hug_and_obsolete_entry_fail(tmp_path, m
     # Hug FAIL: one byte past the exact-hug bound (row still over the
     # general cap, so the obsolete branch does not fire).
     _write_lessons_row(rules, "alpha", 460 - _LESSONS_ROW_GRANDFATHER_MAX_HEADROOM_BYTES - 1)
-    errs = check_lessons_index(repo_root=tmp_path, ratchet_bytes=None)
+    errs = check_lessons_index(repo_root=tmp_path)
     assert errs and any("max headroom" in e and "lower the cap" in e for e in errs)
 
     # Obsolete FAIL: the row now fits the general cap — remove the entry.
     _write_lessons_row(rules, "alpha", _LESSONS_ROW_MAX_BYTES)
-    errs = check_lessons_index(repo_root=tmp_path, ratchet_bytes=None)
+    errs = check_lessons_index(repo_root=tmp_path)
     assert errs and any("no longer needs grandfathering" in e for e in errs)
 
 
-def test_lessons_ratchet_constants_sane():
-    # Live-tree config coherence (#1269): the constants must describe the
-    # real LESSONS.md, and the production defaults must be ARMED.
+def test_lessons_budget_constants_sane():
+    # Live-tree config coherence (#1269/#1504): the constants must describe
+    # the real LESSONS.md, and the production defaults must be ARMED.
     import inspect
 
     import workflow_lint as wl
 
-    assert wl._LESSONS_RATCHET_BYTES <= wl._LESSONS_MAX_BYTES
     assert wl._LESSONS_WARN_BYTES < wl._LESSONS_MAX_BYTES
-    # Defaults armed: a default flipped to None would disarm the ratchet /
+    assert 0 < wl._LESSONS_NONROW_MAX_BYTES < wl._LESSONS_MAX_BYTES
+    # Defaults armed: a default flipped to None would disarm the non-row /
     # row caps fleet-wide while every explicit-kwarg test stayed green.
     params = inspect.signature(wl.check_lessons_index).parameters
-    assert params["ratchet_bytes"].default == wl._LESSONS_RATCHET_BYTES
+    assert params["nonrow_max_bytes"].default == wl._LESSONS_NONROW_MAX_BYTES
     assert params["row_max_bytes"].default == wl._LESSONS_ROW_MAX_BYTES
-    # Live-tree hug: the ratchet must track the real file (banked slack
-    # defeats the mechanism).
+    # Live-tree fit: the real index must satisfy the cap AND the non-row
+    # budget, computed exactly as the check computes it (row bytes = the
+    # _LESSONS_ROW_RE full-line matches; everything else is scaffolding).
     live = (wl._REPO_ROOT / ".claude" / "rules" / "LESSONS.md").read_bytes()
-    assert 0 <= wl._LESSONS_RATCHET_BYTES - len(live) <= wl._LESSONS_RATCHET_MAX_HEADROOM_BYTES
+    assert len(live) <= wl._LESSONS_MAX_BYTES
+    live_row_total = sum(
+        len(m.group(0).encode("utf-8")) for m in wl._LESSONS_ROW_RE.finditer(live.decode("utf-8"))
+    )
+    live_nonrow = len(live) - live_row_total
+    assert 0 <= live_nonrow <= wl._LESSONS_NONROW_MAX_BYTES, (live_nonrow, len(live))
     # Grandfather entries: each cap sits above the general row cap and hugs
     # its LIVE row (the synthetic-fixture tests cover the failure modes).
     rows = {m.group("name"): m.group(0) for m in wl._LESSONS_ROW_RE.finditer(live.decode("utf-8"))}


### PR DESCRIPTION
Closes task #1504. Retires the hand-bumped _LESSONS_RATCHET_BYTES total ratchet (4 incidents/48h conflict magnet); adds fixed _LESSONS_NONROW_MAX_BYTES=900; keeps 8000 cap / 7200 WARN / per-row caps / parity.