### PR TITLE
issue-1507: checks 42/43 — body-wide git-URL existence + git-tree backtick-claims twin

### DIFF
--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -124,6 +124,8 @@ checks (3/3b) run on the v2 sentinel; v3-only checks (v3 structure +
     external-repo links stay shape-checked only (check 8): their
     existence is not decidable from the local object DB, and an
     unauthenticated 404 on an external private repo would false-FAIL.
+    Body-wide coverage of the same URL shapes outside the
+    Reproducibility region is check 42's job.
 9. Reproducibility sentinel scrub — no `{{`, `TBD`, `see config`, or
    `default` placeholders anywhere under `## Reproducibility`.
    `default` is flagged ONLY in placeholder positions — a bare table-cell
@@ -828,6 +830,45 @@ Generation-agnostic checks (run on v2 AND v3 — the inline-figure +
   promote-time re-verify). Incident #1434: 3 of 12 embedded figures had
   no sidecar; slug tick labels passed the mechanical gate until
   clean-result-critique round 3 (#1478).
+
+- **check 42** (`check_body_artifact_urls_exist`, FAIL on v4 / WARN on
+  grandfathered v3/v2/legacy — forward-only): same-repo
+  `github.com/<this-repo>/(blob|tree)/<sha>/<path>` HTML URLs ANYWHERE in
+  the body must point at objects that exist — the body-wide extension of
+  check 8b's footer-only protection. Footer URLs stay check 8b's
+  (set-difference on 8b's gathered URLs, both sides normalized with the
+  same trailing-punctuation/quote strip — no double-report). Fenced code
+  blocks + blockquote lines stripped (#959); `<details>` blocks
+  deliberately NOT exempt (the motivating #1072 404 blob links lived
+  inside `<details>` Sample blocks). Offline-first via
+  `git cat-file -e <sha>:<path>` per unique URL; locally-unknown shas
+  fall back to at most `_BODYWIDE_HEAD_CAP` (8) HTTP HEADs per body;
+  past-cap / indeterminate probes are `unverified` PASS-notes, never a
+  FAIL. Raw-host URLs out of scope (check 4b / 8b territory). Incident:
+  task #1072 r2 — two 404 GitHub blob links in the Methodology Sample
+  `<details>` blocks PASSed the footer-scoped 8b (#1507).
+
+- **check 43** (`check_github_tree_adjacent_file_claims`, WARN,
+  generation-agnostic): backtick FILENAME claims adjacent to SAME-REPO
+  hex-pinned GitHub `/tree/<sha>` markdown links — the git twin of
+  check 32 — must appear by exact BASENAME, any depth, in ONE memoized
+  `git ls-tree -r -t` listing per unique (sha, prefix), entries strictly
+  UNDER the prefix (ancestor tree entries excluded). Same two anchored
+  shapes as check 32 (PAREN paren-after-link, bound 600 per the #1505
+  widening; LINKTEXT dotted token in link text), plus bounded numeric
+  `{N..M}` brace expansion (≤32, digits-only single group) so the
+  incident's `per_context_stats_1072_fold{0..4}.npz` claim fires, plus a
+  disclaimer-negation suppressor: an adjacency instance whose
+  paren/linktext carries explicit not-in-git vocabulary outside backtick
+  spans ("gitignored", "not committed", "mirror only", …) is a
+  disclaimer, not a claim — the CORRECTED #1072 footer stays silent.
+  Zero network (no bounded remote git-tree listing exists); unknown sha /
+  git error → `unverified` note on a PASS line; WARN never FAILs (no
+  `passed=False` path). Named recall sacrifices: backtick-before-link,
+  /blob/-adjacent (8b/42 probe the URL itself), other-repo links,
+  comma-alternation / nested / over-wide brace globs, disclaimer-sharing
+  false claims. Incident: task #1072 r2 footer claimed the gitignored
+  `.npz` set inside the pinned `eval_results/issue_1072` git tree (#1507).
 
 Harmful-content carve-out: checks 18/19 accept the sanitized excerpt
 form (`[truncated — harmful-content row; verify at <path>, row <i>]`)
@@ -6176,6 +6217,107 @@ def check_repro_artifact_urls_exist(body: str) -> CheckResult:
     return CheckResult(name, True, detail)
 
 
+# ─── Check 42: body-wide same-repo artifact-URL existence (#1507) ──────────
+# Per-body cap on HTTP HEAD fallbacks for locally-unknown shas (check 42).
+# Same bounded-probe philosophy as _HF_MEMBER_MAX_PROBES (check 32): past-cap
+# URLs surface as `unverified` notes, never a FAIL. Offline git probes are
+# uncapped (~10-20 ms each, deduped per unique URL).
+_BODYWIDE_HEAD_CAP = 8
+
+
+def _gather_body_artifact_urls(body: str) -> list[str]:
+    """Same-repo `github.com/<this-repo>/(blob|tree)/<sha>/<path>` HTML URLs
+    anywhere in the body (check 42). Fenced code blocks stripped (a ``` URL is
+    illustrative); blockquote lines stripped (#959 — the **Context:** verbatim
+    originating-prompt quote cannot be edited). `<details>` blocks are
+    deliberately NOT stripped: the motivating #1072 404 blob links lived
+    inside `<details>` Sample blocks (git show 12663c2e47), and the
+    25300695e4 details exemption covers WORDING discipline only — a dead link
+    in a sample dropdown is still a false artifact claim. Raw-host
+    (`raw.githubusercontent.com`) URLs are out of scope here: figure embeds
+    are check 4b's territory and footer raw links are check 8b's. Trailing
+    sentence punctuation AND quote chars are stripped (legacy bodies carry
+    `href="..."` fragments whose closing quote would false-miss the probe).
+    Order-preserving, deduplicated."""
+    urls: list[str] = []
+    scan = _strip_blockquote_lines(_strip_fenced_blocks(body))
+    for token in _REPRO_URL_TOKEN_RE.findall(scan):
+        url = token.rstrip(".,;:!?\"'")
+        m = _GITHUB_BLOB_TREE_URL_RE.match(url)
+        if m and (m.group("owner").lower(), m.group("repo").lower()) == _THIS_REPO_SLUG:
+            if url not in urls:
+                urls.append(url)
+    return urls
+
+
+def check_body_artifact_urls_exist(body: str) -> CheckResult:
+    """Check 42: same-repo blob/tree URLs ANYWHERE in the body must point at
+    objects that exist. Body-wide extension of check 8b's footer protection
+    (incident #1072 r2: two 404 GitHub blob links in the Methodology Sample
+    `<details>` blocks PASSed — 8b probes only the Reproducibility region).
+    Footer URLs stay 8b's (set-difference — no double-report; both sides of
+    the difference are normalized with the same trailing-punctuation strip).
+    Offline-first: `git cat-file -e <sha>:<path>` per unique URL; unknown
+    shas fall back to at most _BODYWIDE_HEAD_CAP HTTP HEADs per body.
+    Severity: FAIL on v4; WARN on grandfathered v3/v2/legacy (forward-only —
+    the check_h1_matches_frontmatter_title precedent). Indeterminate probes
+    are `unverified` PASS-notes, never FAIL/WARN."""
+    name = "Body-wide same-repo artifact URLs exist"
+    repro = _repro_section_text(body)
+    footer_urls = (
+        {u.rstrip(".,;:!?\"'") for u in _gather_repro_artifact_urls(repro)}
+        if repro is not None
+        else set()
+    )
+    urls = [u for u in _gather_body_artifact_urls(body) if u not in footer_urls]
+    if not urls:
+        return CheckResult(name, True, "no non-footer same-repo artifact URLs to check")
+    repo = _resolve_repo_root()
+    bad: list[str] = []
+    unverified: list[str] = []
+    head_budget = _BODYWIDE_HEAD_CAP
+    for url in urls:
+        m = _GITHUB_BLOB_TREE_URL_RE.match(url)  # gatherer guarantees a match
+        path = m.group("path").rstrip("/")
+        verdict = "skip"
+        if repo is not None:
+            verdict, _detail = _git_object_exists(repo, m.group("sha"), path)
+        if verdict == "pass":
+            continue
+        if verdict == "fail":
+            bad.append(f"body URL 404s — `{path}` does not exist at `{m.group('sha')[:8]}`")
+            continue
+        # sha unknown locally -> bounded HTTP fallback (same as 8b, capped).
+        if head_budget <= 0:
+            unverified.append(f"`{url}` (per-body HEAD cap)")
+            continue
+        head_budget -= 1
+        code = _http_head_status(url)
+        if code == 404:
+            bad.append(f"body URL 404s — `{url}`")
+        elif code is not None and code < 400:
+            continue
+        else:
+            unverified.append(
+                f"`{url}` (HTTP probe unavailable)" if code is None else f"`{url}` (HTTP {code})"
+            )
+    detail_tail = ""
+    if unverified:
+        detail_tail = f"; {len(unverified)} unverified (existence not confirmed): " + "; ".join(
+            unverified
+        )
+    if bad:
+        if is_v4(body):
+            return CheckResult(name, False, "; ".join(bad) + detail_tail)
+        return CheckResult(  # forward-only: v3/v2/legacy grandfathered to WARN
+            name,
+            True,
+            "grandfathered v3/v2/legacy body — WARN only: " + "; ".join(bad) + detail_tail,
+            is_warn=True,
+        )
+    return CheckResult(name, True, f"{len(urls)} URL(s)" + detail_tail)
+
+
 # An HF Hub `/tree/<sha>/<path>` or `/blob/<sha>/<path>` URL pinned to a hex
 # revision. Both dataset repos (`huggingface.co/datasets/<owner>/<repo>/...`)
 # and model/space repos (`huggingface.co/<owner>/<repo>/...`) are matched.
@@ -9618,6 +9760,223 @@ def check_hf_adjacent_file_claims(body: str) -> CheckResult:
     return CheckResult(name, True, detail + unverified_detail)
 
 
+# ─── Check 43: GitHub-tree-adjacent backtick file claims (git twin of 32) ──
+# (#1507; incident #1072 r2 footer: `Artifacts: [`eval_results/issue_1072/`]
+# (…github…/tree/1f19deacf…/eval_results/issue_1072) (`stats_component.json`,
+# …, `per_context_stats_1072_fold{0..4}.npz`, …)` — the .npz are gitignored,
+# absent from the tree; check 32 covers only HF /tree links.)
+_GH_LINK_THEN_PAREN_RE = re.compile(  # PAREN shape (check 32's, github host;
+    r"\]\((?P<url>https?://github\.com/[^)\s]+)\)\s{0,2}\((?P<paren>[^()]{1,600})\)"
+)  # paren bound 600 per the #1505 widening)
+_MD_GH_LINK_RE = re.compile(  # LINKTEXT shape (sibling of _MD_HF_LINK_RE)
+    r"\[(?P<text>[^\]]{1,300})\]\((?P<url>https?://github\.com/[^)\s]+)\)"
+)
+# Bounded numeric brace-range expansion: `fold{0..4}.npz` -> fold0..fold4.
+# Single group, digits only, width <= _GH_BRACE_MAX_EXPANSIONS; comma
+# alternation `{a,b}` and nested braces are named recall sacrifices.
+_BRACE_RANGE_TOKEN_RE = re.compile(
+    r"^(?P<pre>[A-Za-z0-9._\-]*)\{(?P<a>\d{1,4})\.\.(?P<b>\d{1,4})\}(?P<post>[A-Za-z0-9._\-]*)$"
+)
+_GH_BRACE_MAX_EXPANSIONS = 32
+
+# Disclaimer-negation suppressor (check 43): an adjacency instance whose
+# paren body / link text EXPLICITLY states the named files are NOT in the
+# git tree is a disclaimer, not a claim — suppress the whole instance.
+# Grounded on the corrected #1072 footer (line 173: "… are gitignored and
+# live on the HF eval_results mirror only"), which must NOT WARN.
+# Precision/recall trade (P1, #1507 critique round): the disclaimer scan
+# runs on text with backtick code spans MASKED OUT (a filename token like
+# `HF_mirror_config.json` or `not_in_git.txt` can never carry disclaimer
+# vocabulary), and the anchors are ABSENCE-SPECIFIC — the draft's broad
+# `not\s+tracked` (hits "not tracked in WandB") and `HF[\w\s-]{0,40}mirror`
+# (hits HF-mirror filenames) alternatives were dropped. Named recall
+# sacrifices: a genuinely-false claim sharing a paren/linktext with
+# disclaimer vocabulary is missed (instance-level suppression,
+# precision-first WARN-tier house style), and a disclaimer phrased outside
+# these anchors ("lives elsewhere") still WARNs.
+_GH_TREE_DISCLAIMER_RE = re.compile(
+    r"git-?ignored"
+    r"|not\s+(?:committed|in\s+(?:the\s+)?git(?:\s+tree)?)"
+    r"|absent\s+from\s+(?:the\s+)?(?:git\s+)?tree"
+    r"|mirror\s+only"
+    r"|only\s+on\s+(?:the\s+)?HF",
+    re.IGNORECASE,
+)
+
+
+def _gh_tree_disclaimer_present(text: str) -> bool:
+    """True when `text` (one PAREN body / LINKTEXT) carries explicit
+    not-in-git disclaimer vocabulary OUTSIDE backtick code spans (check 43).
+    Backtick spans are masked with a bridging-safe placeholder (` _ `) so a
+    filename token can neither carry disclaimer vocabulary nor glue two
+    prose fragments into a spurious anchor match."""
+    return _GH_TREE_DISCLAIMER_RE.search(_BACKTICK_TOKEN_RE.sub(" _ ", text)) is not None
+
+
+def _expand_claim_token(token: str) -> list[str]:
+    """[token] for a plain token; the expanded list for a bounded {N..M}
+    numeric brace range; [] for a malformed / over-wide range (no probe,
+    no WARN — recall sacrifice)."""
+    m = _BRACE_RANGE_TOKEN_RE.match(token)
+    if m is None:
+        return [token]
+    a, b = int(m.group("a")), int(m.group("b"))
+    if b < a or (b - a + 1) > _GH_BRACE_MAX_EXPANSIONS:
+        return []
+    return [f"{m.group('pre')}{i}{m.group('post')}" for i in range(a, b + 1)]
+
+
+def _gather_gh_tree_adjacent_file_claims(body: str) -> list[tuple[str, str, str, str]]:
+    """(sha, path_prefix, filename, shape) tuples for backtick FILENAME
+    claims adjacent to SAME-REPO hex-pinned GitHub /tree markdown links
+    (check 43). Mirrors _gather_hf_adjacent_file_claims: fence-stripped;
+    PAREN + LINKTEXT shapes only; _HF_ADJ_FILENAME_RE whitelist per (brace-
+    expanded) token; token == URL terminal component skipped (8b/42 probe the
+    URL's own path); dedup on (sha, prefix, fname).
+    Precision/recall trade-offs (named recall sacrifices, check-32 style):
+    backtick filenames BEFORE the link (misattribution risk); /blob/-adjacent
+    claims (the blob URL itself is probed by 8b/42); other-repo github links;
+    moving refs (/tree/main fails the hex regex); non-markdown bare URLs;
+    comma-alternation + nested + over-wide brace globs; relative-path /
+    wildcard tokens (whitelist rejects); whole adjacency instances whose
+    paren/linktext carries disclaimer-negation vocabulary outside backtick
+    spans (_gh_tree_disclaimer_present — a false claim sharing a paren with
+    a disclaimer is missed, AC10 precision trade). Any-depth basename
+    membership incl. directory entries (ls-tree -r -t) — an any-depth
+    collision can mask a wrong-PATH claim, accepted at WARN tier (same
+    residual as check 32)."""
+    stripped = _strip_fenced_blocks(body)
+    out: list[tuple[str, str, str, str]] = []
+    seen: set[tuple[str, str, str]] = set()
+
+    def _add(url: str, token: str, shape: str) -> None:
+        m = _GITHUB_BLOB_TREE_URL_RE.match(url.rstrip(".,;:!?"))
+        if m is None or f"/tree/{m.group('sha')}" not in url:
+            return  # non-github / other shape / blob
+        if (m.group("owner").lower(), m.group("repo").lower()) != _THIS_REPO_SLUG:
+            return  # other-repo: undecidable locally
+        prefix = m.group("path").rstrip("/")
+        for fname in _expand_claim_token(token.strip()):
+            if not _HF_ADJ_FILENAME_RE.match(fname):
+                continue
+            if posixpath.basename(prefix) == fname:
+                continue  # the URL's own terminal component — 8b/42 cover it
+            key = (m.group("sha"), prefix, fname)
+            if key not in seen:
+                seen.add(key)
+                out.append((m.group("sha"), prefix, fname, shape))
+
+    for pm in _GH_LINK_THEN_PAREN_RE.finditer(stripped):  # shape PAREN
+        if _gh_tree_disclaimer_present(pm.group("paren")):
+            continue  # disclaimer, not a claim (AC10)
+        for token in _BACKTICK_TOKEN_RE.findall(pm.group("paren")):
+            _add(pm.group("url"), token, "PAREN")
+    for lm in _MD_GH_LINK_RE.finditer(stripped):  # shape LINKTEXT
+        if _gh_tree_disclaimer_present(lm.group("text")):
+            continue  # disclaimer, not a claim (AC10)
+        for token in _BACKTICK_TOKEN_RE.findall(lm.group("text")):
+            _add(lm.group("url"), token, "LINKTEXT")
+    return out
+
+
+def _git_tree_basenames(repo: Path, sha: str, prefix: str) -> tuple[str, frozenset[str], str]:
+    """('ok'|'skip', basenames, note): basenames of ALL entries (blobs AND
+    trees — `ls-tree -r -t`) strictly UNDER sha:prefix; the prefix itself and
+    its ANCESTOR tree entries are excluded (ls-tree with a pathspec also
+    emits the prefix's ancestors — e.g. `eval_results` for prefix
+    `eval_results/issue_1072` — and a bare `p != prefix` would keep them as
+    spurious WARN-suppressing members). 'skip' when the sha does not resolve
+    (shallow/unknown — a PARTIAL/absent listing must never ground a WARN) or
+    on any git error. Own helper — check 29's _git_tracked_under is
+    files-only (`-r` without `-t`) and shared; do not modify it."""
+    try:
+        rev = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", f"{sha}^{{commit}}"],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        return "skip", frozenset(), f"git rev-parse failed: {e}"
+    if rev.returncode != 0:
+        return "skip", frozenset(), f"sha `{sha}` did not resolve in this repo (unknown / shallow)"
+    try:
+        r = subprocess.run(
+            [
+                "git",
+                "-c",
+                "core.quotePath=off",
+                "ls-tree",
+                "-r",
+                "-t",
+                "--name-only",
+                sha,
+                "--",
+                prefix,
+            ],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        return "skip", frozenset(), f"git ls-tree failed: {e}"
+    if r.returncode != 0:
+        return "skip", frozenset(), "git ls-tree failed"
+    basenames = {
+        posixpath.basename(p.strip())
+        for p in r.stdout.splitlines()
+        if p.strip().startswith(prefix + "/")  # UNDER-prefix filter (fact-check A8)
+    }
+    return "ok", frozenset(basenames), ""
+
+
+def check_github_tree_adjacent_file_claims(body: str) -> CheckResult:
+    """Check 43 (WARN): a backtick-named file claimed adjacent to a same-repo
+    hex-pinned GitHub /tree markdown link must appear (by basename, any
+    depth) in the git tree at sha:prefix. Git twin of check 32. WARN never
+    FAILs (no passed=False path). Offline-only: unknown sha / git error ->
+    `unverified` note on a PASS line; NO network fallback (there is no
+    bounded remote git-tree listing analogous to the #733 HF probe)."""
+    name = "GitHub-tree-adjacent backtick file claims exist in the pinned tree"
+    claims = _gather_gh_tree_adjacent_file_claims(body)
+    if not claims:
+        return CheckResult(
+            name, True, "no backtick file claims adjacent to same-repo git tree links"
+        )
+    repo = _resolve_repo_root()
+    if repo is None:
+        return CheckResult(name, True, f"{len(claims)} claim(s) unverified — repo root unavailable")
+    missing: list[str] = []
+    unverified: list[str] = []
+    memo: dict[tuple[str, str], tuple[str, frozenset[str], str]] = {}
+    for sha, prefix, fname, shape in claims:
+        key = (sha, prefix)
+        if key not in memo:
+            memo[key] = _git_tree_basenames(repo, sha, prefix)
+        status, basenames, note = memo[key]
+        if status != "ok":
+            skip_note = f"`{fname}` at `{prefix}@{sha[:8]}` ({note})"
+            if skip_note not in unverified:
+                unverified.append(skip_note)
+            continue
+        if fname not in basenames:
+            missing.append(
+                f"body claims `{fname}` adjacent to the pinned git tree `{prefix}` "
+                f"at `{sha[:8]}`, but no entry with that basename exists (shape: {shape})"
+            )
+    unverified_detail = ""
+    if unverified:
+        unverified_detail = (
+            f"; {len(unverified)} unverified (existence not confirmed): " + "; ".join(unverified)
+        )
+    if missing:
+        return CheckResult(name, True, "; ".join(missing) + unverified_detail, is_warn=True)
+    detail = f"{len(claims)} adjacent file claim(s) against {len(memo)} pinned git tree(s)"
+    return CheckResult(name, True, detail + unverified_detail)
+
+
 # ─── Check 40: unpinned backtick HF-path count claims (WARN) — #1433/#1345 ──
 # `rejudge/` (2 files) in a footer sentence with NO adjacent pinned
 # /tree/<sha> link escaped checks 30/32 entirely (both fire only for
@@ -12208,6 +12567,12 @@ CHECKS = [
     # check 41 (WARN, generation-agnostic) — sidecar-less embedded figures:
     # names the figures checks 24/28/33/34 silently skipped (#1478; incident #1434):
     check_figure_sidecar_coverage,
+    # check 42 (FAIL on v4, WARN grandfathered — forward-only) — body-wide same-repo
+    # blob/tree URL existence; footer stays check 8b's (#1507; incident #1072 r2):
+    check_body_artifact_urls_exist,
+    # check 43 (WARN, generation-agnostic) — git-tree twin of check 32: backtick file
+    # claims adjacent to same-repo /tree/<sha> links resolve via git ls-tree (#1507):
+    check_github_tree_adjacent_file_claims,
     # Check 31 (`check_orphaned_per_unit_figures`, WARN, generation-agnostic)
     # is NOT here either — like check 20 (v4) it needs the issue number (for
     # figures-dir scoping), so it is dispatched separately in `verify_text`

--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -6244,9 +6244,10 @@ def _gather_body_artifact_urls(body: str) -> list[str]:
     for token in _REPRO_URL_TOKEN_RE.findall(scan):
         url = token.rstrip(".,;:!?\"'")
         m = _GITHUB_BLOB_TREE_URL_RE.match(url)
-        if m and (m.group("owner").lower(), m.group("repo").lower()) == _THIS_REPO_SLUG:
-            if url not in urls:
-                urls.append(url)
+        if m is None or (m.group("owner").lower(), m.group("repo").lower()) != _THIS_REPO_SLUG:
+            continue
+        if url not in urls:
+            urls.append(url)
     return urls
 
 

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -180,13 +180,18 @@ def test_good_body_passes_all():
     # `check_footer_reuse_bullets_pinned` (#1370), check 39
     # `check_v4_sample_disclosure_count` (#1421), check 40
     # `check_hf_unpinned_count_claims` (#1433), and check 41
-    # `check_figure_sidecar_coverage` (#1478) ride CHECKS; 36/37/39
+    # `check_figure_sidecar_coverage` (#1478), check 42
+    # `check_body_artifact_urls_exist` (#1507 — grandfathered-WARN tier
+    # here, and GOOD_BODY's only same-repo URL lives in the footer so it
+    # PASSes vacuously), and check 43
+    # `check_github_tree_adjacent_file_claims` (#1507 — vacuous PASS, no
+    # git-tree-adjacent claims) ride CHECKS; 36/37/39
     # PASS-skip here — not a v4 body — 40 is the vacuous PASS above, and
     # 41 is the fake-sha NO-OP PASS above). The
     # Lens 14 / check-16 results are PASS-skips when no concerns.jsonl /
     # plans/plan.md sibling is available; check 17 and the v3/v4 checks
     # are PASS-skips on this legacy (pre-v2-sentinel) fixture.
-    assert len(results) == 55
+    assert len(results) == 57
     # By-name membership so the NEXT check addition can key by name instead
     # of re-deriving the arithmetic (#1016 methodology-reconciler Must-Fix).
     assert _HF_32_NAME in {r.name for r in results}
@@ -5575,17 +5580,19 @@ def test_checks_list_size():
     denominator check (needs eval JSONs), and the check-31
     orphaned-per-unit-figures probe (needs `issue` for figures-dir
     scoping, #1011).
-    So `verify_text` returns 55 results (2 prepended + CHECKS[1:]=42 +
+    So `verify_text` returns 57 results (2 prepended + CHECKS[1:]=44 +
     11 appended — see `test_good_body_passes_all`), but `CHECKS` stays
-    at 43 (check 36 `check_v4_result_paragraph_sentences` (#1368),
+    at 45 (check 36 `check_v4_result_paragraph_sentences` (#1368),
     check 37 `check_footer_reuse_bullets_pinned` — the body-only
     footer-side reuse-pin sibling of check 35, #1370 — check 39
     `check_v4_sample_disclosure_count` — the Sample-slot
     `Disclosure: N of M` count reconciliation, #1421 — check 40
-    `check_hf_unpinned_count_claims` (#1433) — and check 41
-    `check_figure_sidecar_coverage` (#1478) ride CHECKS).
+    `check_hf_unpinned_count_claims` (#1433) — check 41
+    `check_figure_sidecar_coverage` (#1478) — and checks 42
+    `check_body_artifact_urls_exist` + 43
+    `check_github_tree_adjacent_file_claims` (#1507) ride CHECKS).
     """
-    assert len(verify_task_body.CHECKS) == 43
+    assert len(verify_task_body.CHECKS) == 45
     # By-name membership so the NEXT check addition can key by name instead
     # of re-deriving the arithmetic (#1016 methodology-reconciler Must-Fix).
     assert verify_task_body.check_hf_adjacent_file_claims in verify_task_body.CHECKS
@@ -11094,11 +11101,11 @@ def test_caption_lead_issue1074_verbatim_caption_warns():
 
 def test_check_figure_caption_position_stable():
     """Index-stability pin (#1424): `check_figure_caption` stays at CHECKS
-    position 7 and the CHECKS count matches the current registry (43 as of
-    check 41, #1478; belt-and-suspenders beside the migration-history
+    position 7 and the CHECKS count matches the current registry (45 as of
+    checks 42/43, #1507; belt-and-suspenders beside the migration-history
     `len(CHECKS)` pin)."""
     assert verify_task_body.CHECKS[7] is verify_task_body.check_figure_caption
-    assert len(verify_task_body.CHECKS) == 43
+    assert len(verify_task_body.CHECKS) == 45
 
 
 # ─── Check 26: figure panel/series prose vs figure sidecar (panel drift) ───
@@ -13792,3 +13799,420 @@ def test_h1_title_sync_sentinel_only_in_fence_skips():
     res = _results_by_name(results)[_H1_SYNC_NAME]
     assert res.passed and res.is_warn is False, res.render()
     assert "not a sentinelled" in res.detail
+
+
+# ─── Checks 42 + 43: body-wide git-URL existence + git-tree backtick claims ─
+#
+# Incident task #1072 r2 (#1507): two GitHub blob links in the `## Methodology`
+# Sample `<details>` blocks 404'd (gitignored `.npz`, never committed), and the
+# footer `Artifacts:` parenthetical claimed `per_context_stats_1072_fold{0..4}.npz`
+# inside the pinned `eval_results/issue_1072` git tree, which lacks them —
+# check 8b (footer-only) and check 32 (HF /tree-only) both PASSed the body.
+# Check 42 probes same-repo blob/tree URLs body-wide (FAIL on v4, WARN on
+# grandfathered); check 43 is the WARN-only git twin of check 32.
+
+_GH_REPO = "https://github.com/superkaiba/explore-persona-space"
+
+_BODYWIDE_NAME = "Body-wide same-repo artifact URLs exist"
+_GH_TREE_NAME = "GitHub-tree-adjacent backtick file claims exist in the pinned tree"
+
+
+def _gh_blob_url(sha, path):
+    """Same-repo /blob/<sha>/<path> HTML URL (check 42/43 fixtures)."""
+    return f"{_GH_REPO}/blob/{sha}/{path}"
+
+
+def _gh_tree_url(sha, path):
+    """Same-repo /tree/<sha>/<path> HTML URL (check 42/43 fixtures)."""
+    return f"{_GH_REPO}/tree/{sha}/{path}"
+
+
+def _make_repo_with_issue1072_tree(tmp_path):
+    """Throwaway git repo whose HEAD commit carries the #1072 incident tree
+    shape — `eval_results/issue_1072/` with the committed JSONs
+    (`stats_component.json`, `supplementary_reads.json`,
+    `battery_1072_fold0..4.json`, `capture_gates.json`,
+    `stage_manifest.json`) but NO `.npz` (gitignored in the incident, never
+    committed); returns (repo_path, head_sha)."""
+    repo = tmp_path / "i1072repo"
+    repo.mkdir()
+
+    def git(*args):
+        subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+    git("init", "-q")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "Test")
+    d = repo / "eval_results" / "issue_1072"
+    d.mkdir(parents=True)
+    fnames = ["stats_component.json", "supplementary_reads.json"]
+    fnames += [f"battery_1072_fold{i}.json" for i in range(5)]
+    fnames += ["capture_gates.json", "stage_manifest.json"]
+    for fname in fnames:
+        (d / fname).write_text("{}\n")
+    git("add", "eval_results")
+    git("commit", "-q", "-m", "add issue_1072 eval JSONs (no .npz)")
+    sha = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return repo, sha
+
+
+# The VERBATIM #1072 r2 PRE-FIX footer Artifacts fragment (recover via
+# `git show 12663c2e47:tasks/interpreting/1072/body.md`, footer, grep
+# `per_context_stats`; the incident sha 1f19deacf… is swapped for the fixture
+# repo's sha at use time — the _I952_R1_LINE convention): the paren after the
+# pinned eval_results tree link claims the five gitignored `.npz` via a
+# brace range — the must-WARN check-43 fixture.
+_I1072_PREFIX_ARTIFACTS_LINE = (
+    "Artifacts: [`eval_results/issue_1072/`]({tree_url}) "
+    "(`stats_component.json`, `supplementary_reads.json`, "
+    "`battery_1072_fold{{0..4}}.json`, `per_context_stats_1072_fold{{0..4}}.npz`, "
+    "`capture_gates.json`, `stage_manifest.json`, pilot gates)"
+)
+
+# The VERBATIM CURRENT #1072 footer Artifacts fragment (recover from
+# `tasks/followups_running/1072/body.md`, footer Artifacts clause, ~line 173;
+# sha swapped to the fixture sha): same `{0..4}.npz` backtick tokens inside
+# the qualifying paren, but as an explicit "gitignored … HF eval_results
+# mirror only" DISCLAIMER — the must-NOT-warn check-43 fixture (AC10).
+_I1072_CURRENT_ARTIFACTS_LINE = (
+    "Artifacts: [`eval_results/issue_1072/`]({tree_url}) "
+    "(11 JSONs: `stats_component.json`, `supplementary_reads.json`, "
+    "`battery_1072_fold{{0..4}}.json`, `capture_gates.json`, "
+    "`stage_manifest.json`, pilot gates; the 5 "
+    "`per_context_stats_1072_fold{{0..4}}.npz` are gitignored and live on the "
+    "HF eval_results mirror only)"
+)
+
+# The VERBATIM #1072 r2 Methodology Sample `<details>` shape (recover via
+# `git show 12663c2e47:tasks/interpreting/1072/body.md`, Sample-slot
+# `<details>` blocks at body offsets ~81/~97; blob-link sha swapped to the
+# fixture sha): the 404 blob link lives INSIDE the dropdown — the check-42
+# details-are-probed fixture (AC1/AC4; the durability pin).
+_I1072_DETAILS_BLOCK = """<details>
+<summary>Worked example — matched context 408, layer 26, mean remainder cell, fold 4</summary>
+
+1 of 3,188 rows — a random sample (numpy seed 42); full arrays:
+[`per_context_stats_1072_fold4.npz`]({blob_url}) plus folds 0-3 in the same
+directory, mirrored on the HF data repo (footer).
+
+</details>"""
+
+
+_V4_RESULTS_PROSE_ANCHOR = (
+    "The 17-pt lift holds at every seed; "
+    "the smallest within-condition gap between seeds is 1.2 pts."
+)
+
+
+def test_bodywide_url_missing_path_fails_v4(tmp_path, monkeypatch):
+    """AC1 — a v4 body citing a same-repo blob URL whose sha resolves locally
+    but whose path is absent from that tree FAILs check 42 (detail names the
+    path + sha[:8]) and flips verify_text ok=False."""
+    repo, sha = _make_repo_with_issue1072_tree(tmp_path)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    dead = _gh_blob_url(sha, "eval_results/issue_1072/per_context_stats_1072_fold4.npz")
+    body = _V4_GOOD_BODY.replace(
+        _V4_RESULTS_PROSE_ANCHOR,
+        f"Full arrays: [`per_context_stats_1072_fold4.npz`]({dead}).",
+    )
+    assert body != _V4_GOOD_BODY  # anchor still present in the fixture
+    ok, results = verify_task_body.verify_text(body)
+    assert not ok
+    r = _results_by_name(results)[_BODYWIDE_NAME]
+    assert not r.passed
+    assert "per_context_stats_1072_fold4.npz" in r.detail
+    assert sha[:8] in r.detail
+
+
+def test_bodywide_details_urls_are_probed(tmp_path, monkeypatch):
+    """AC1/AC4 (durability pin) — the VERBATIM #1072 Sample-slot shape: the
+    dead blob link sits INSIDE a `<details>` block and is still probed (the
+    25300695e4 details exemption covers wording discipline only) → check-42
+    FAIL on a v4 body."""
+    repo, sha = _make_repo_with_issue1072_tree(tmp_path)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    dead = _gh_blob_url(sha, "eval_results/issue_1072/per_context_stats_1072_fold4.npz")
+    details = _I1072_DETAILS_BLOCK.format(blob_url=dead)
+    body = _V4_GOOD_BODY.replace(_V4_RESULTS_PROSE_ANCHOR, details)
+    assert body != _V4_GOOD_BODY
+    r = verify_task_body.check_body_artifact_urls_exist(body)
+    assert not r.passed
+    assert "per_context_stats_1072_fold4.npz" in r.detail and sha[:8] in r.detail
+    ok, _results = verify_task_body.verify_text(body)
+    assert not ok
+
+
+def test_bodywide_url_present_passes(tmp_path, monkeypatch):
+    """AC3 — a resolving non-footer same-repo URL PASSes with the counted
+    `1 URL(s)` detail (pins the non-vacuous probe path — NOT the no-URLs
+    vacuous PASS) and no `unverified` note."""
+    repo, sha = _make_repo_with_issue1072_tree(tmp_path)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    live = _gh_blob_url(sha, "eval_results/issue_1072/stats_component.json")
+    body = f"Stats live at [`stats_component.json`]({live}).\n"
+    r = verify_task_body.check_body_artifact_urls_exist(body)
+    assert r.passed and not r.is_warn, r.detail
+    assert "1 URL(s)" in r.detail
+    assert "unverified" not in r.detail
+
+
+def test_bodywide_fenced_and_blockquoted_urls_not_probed(tmp_path, monkeypatch):
+    """AC4 (#959) — a dead same-repo URL inside a ``` fence AND on a `>`
+    blockquote line is never gathered → vacuous PASS, no FAIL."""
+    repo, sha = _make_repo_with_issue1072_tree(tmp_path)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    dead = _gh_blob_url(sha, "eval_results/issue_1072/missing.npz")
+    body = f"```\ncurl {dead}\n```\n\n> Originating prompt cites {dead} verbatim.\n"
+    assert verify_task_body._gather_body_artifact_urls(body) == []
+    r = verify_task_body.check_body_artifact_urls_exist(body)
+    assert r.passed and not r.is_warn
+    assert "no non-footer" in r.detail
+
+
+def test_bodywide_grandfathered_v3_warns_not_fails(tmp_path, monkeypatch):
+    """AC5 (forward-only) — the same dead URL under a v3 sentinel (and a v2
+    variant) yields passed=True + is_warn=True with a grandfathered detail;
+    a fully-passing v3 integration body keeps verify_text ok=True."""
+    repo, sha = _make_repo_with_issue1072_tree(tmp_path)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    dead = _gh_blob_url(sha, "eval_results/issue_1072/missing_fold9.npz")
+    para = f"Full arrays: [`missing_fold9.npz`]({dead})."
+    for sentinel in ("<!-- clean-result-v3 -->", "<!-- clean-result-v2 -->"):
+        r = verify_task_body.check_body_artifact_urls_exist(f"{sentinel}\n\n{para}\n")
+        assert r.passed and r.is_warn, r.render()
+        assert "grandfathered" in r.detail and "missing_fold9.npz" in r.detail
+    # Integration: the v3 good body + the dead URL stays overall ok=True.
+    body = _V3_GOOD_BODY.replace(
+        "The 17-pt lift holds at every seed; "
+        "the smallest within-condition gap between seeds is 1.2 pts.",
+        para,
+    )
+    assert body != _V3_GOOD_BODY
+    ok, results = verify_task_body.verify_text(body)
+    rr = _results_by_name(results)[_BODYWIDE_NAME]
+    assert rr.passed and rr.is_warn
+    assert ok, [r.render() for r in results if not r.passed]
+
+
+def test_bodywide_skips_footer_urls_owned_by_8b(tmp_path, monkeypatch):
+    """AC6 — a dead URL that appears ONLY in the v4 footer is reported by
+    check 8b and set-difference-skipped by check 42 (no double-report)."""
+    repo, sha = _make_repo_with_issue1072_tree(tmp_path)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = _V4_GOOD_BODY.replace(
+        f"{_GH_REPO}/blob/0123456789abcdef/scripts/run.py",
+        _gh_blob_url(sha, "eval_results/issue_1072/missing.npz"),
+    )
+    assert body != _V4_GOOD_BODY
+    ok, results = verify_task_body.verify_text(body)
+    assert not ok
+    by_name = _results_by_name(results)
+    assert not by_name["Reproducibility artifact URLs exist"].passed  # 8b owns it
+    r42 = by_name[_BODYWIDE_NAME]
+    assert r42.passed and "no non-footer" in r42.detail  # 42 skips it
+
+
+def test_bodywide_unknown_sha_head_fallback(monkeypatch):
+    """AC7/AC8 — sha unknown to the local object DB: an HTTP-HEAD 404 FAILs
+    (v4); a None probe (offline) is an `unverified` PASS-note, never a
+    FAIL. Never relies on live HTTP — `_http_head_status` is stubbed (the
+    conftest EPM_VERIFY_BODY_NO_HTTP=1 fence covers un-stubbed paths)."""
+    dead = _gh_blob_url("0123456789abcdef", "eval_results/issue_1072/missing.npz")
+    body = f"<!-- clean-result-v4 -->\n\nFull arrays: [`missing.npz`]({dead}).\n"
+    monkeypatch.setattr(verify_task_body, "_http_head_status", lambda url, timeout=5.0: 404)
+    r = verify_task_body.check_body_artifact_urls_exist(body)
+    assert not r.passed
+    assert "404" in r.detail
+    monkeypatch.setattr(verify_task_body, "_http_head_status", lambda url, timeout=5.0: None)
+    r2 = verify_task_body.check_body_artifact_urls_exist(body)
+    assert r2.passed and not r2.is_warn
+    assert "unverified" in r2.detail
+
+
+def test_bodywide_head_cap_bounds_probes(monkeypatch):
+    """AC7 — 10 unknown-sha URLs against a counting `_http_head_status` stub:
+    at most _BODYWIDE_HEAD_CAP (8) HEADs issue; past-cap URLs surface as
+    `per-body HEAD cap` unverified notes on a PASS line."""
+    calls: list[str] = []
+
+    def counting_head(url, timeout=5.0):
+        calls.append(url)
+        return None
+
+    monkeypatch.setattr(verify_task_body, "_http_head_status", counting_head)
+    lines = [
+        f"See [`f{i}.json`]({_gh_blob_url('0123456789abcdef', f'eval_results/issue_1072/f{i}.json')})."
+        for i in range(10)
+    ]
+    body = "<!-- clean-result-v4 -->\n\n" + "\n".join(lines) + "\n"
+    r = verify_task_body.check_body_artifact_urls_exist(body)
+    assert len(calls) == verify_task_body._BODYWIDE_HEAD_CAP == 8
+    assert r.passed
+    assert "per-body HEAD cap" in r.detail
+
+
+def test_bodywide_other_repo_and_trailing_quote():
+    """Gatherer scope — other-repo github URLs are never gathered (existence
+    undecidable locally); a legacy `href="…"` fragment's trailing quote is
+    stripped so the probe sees the clean URL (D8)."""
+    other = "https://github.com/otherowner/otherrepo/blob/0123456789abcdef/x.json"
+    ours = f"{_GH_REPO}/blob/0123456789abcdef/scripts/run.py"
+    body = f'See {other} and <a href="{ours}">entry script</a>.\n'
+    assert verify_task_body._gather_body_artifact_urls(body) == [ours]
+
+
+def test_gh_tree_adjacent_claim_missing_warns_1072_shape(tmp_path, monkeypatch):
+    """AC2 — the VERBATIM #1072 pre-fix Artifacts line (sha swapped to the
+    fixture sha) against a tree carrying the JSONs but not the `.npz` →
+    check-43 WARN naming the expanded missing basenames + prefix + sha[:8] +
+    the PAREN shape tag; the present JSONs are never reported."""
+    repo, sha = _make_repo_with_issue1072_tree(tmp_path)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    line = _I1072_PREFIX_ARTIFACTS_LINE.format(
+        tree_url=_gh_tree_url(sha, "eval_results/issue_1072")
+    )
+    r = verify_task_body.check_github_tree_adjacent_file_claims(line)
+    assert r.passed and r.is_warn
+    assert r.render().startswith("  [WARN]")
+    for i in range(5):
+        assert f"per_context_stats_1072_fold{i}.npz" in r.detail
+    assert "eval_results/issue_1072" in r.detail and sha[:8] in r.detail
+    assert "shape: PAREN" in r.detail
+    # Present files are never reported missing.
+    assert "claims `stats_component.json`" not in r.detail
+    assert "claims `battery_1072_fold0.json`" not in r.detail
+
+
+def test_gh_tree_adjacent_claim_present_passes(tmp_path, monkeypatch):
+    """AC3 — every claimed basename (incl. the brace expansions) is a tree
+    member → clean PASS, no WARN, no `unverified` note."""
+    repo, sha = _make_repo_with_issue1072_tree(tmp_path)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    line = (
+        f"Artifacts: [`eval_results/issue_1072/`]({_gh_tree_url(sha, 'eval_results/issue_1072')}) "
+        "(`stats_component.json`, `battery_1072_fold{0..4}.json`)"
+    )
+    r = verify_task_body.check_github_tree_adjacent_file_claims(line)
+    assert r.passed and not r.is_warn, r.detail
+    assert "unverified" not in r.detail
+    assert "6 adjacent file claim(s) against 1 pinned git tree(s)" in r.detail
+
+
+def test_gh_tree_blob_and_hf_links_out_of_scope():
+    """Partition — claims adjacent to same-repo `/blob/` links (8b/42 probe
+    the URL itself), HF `/tree/` links (check 32's territory), and
+    other-repo github links extract ZERO check-43 claims."""
+    blob_path = "eval_results/issue_1072/per_context_stats_1072_fold4.npz"
+    bodies = [
+        f"Full arrays: [`per_context_stats_1072_fold4.npz`]({_gh_blob_url('0123456789abcdef', blob_path)})",
+        "Mirror: [`stats_component.json`](https://huggingface.co/datasets/o/r/tree/abc1234def/dir/)",
+        "Other: [`x.json`](https://github.com/otherowner/otherrepo/tree/0123456789abcdef/dir) (`y.json`)",
+    ]
+    for body in bodies:
+        assert verify_task_body._gather_gh_tree_adjacent_file_claims(body) == [], body
+
+
+def test_gh_tree_unknown_sha_unverified(tmp_path, monkeypatch):
+    """AC8 — an unresolvable sha (unknown / shallow) is an `unverified`
+    PASS-note, never a WARN (a partial/absent listing must never ground a
+    WARN); zero network involved."""
+    repo, _sha = _make_repo_with_issue1072_tree(tmp_path)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    line = (
+        f"Artifacts: [`eval_results/issue_1072/`]"
+        f"({_gh_tree_url('beefcafe1234', 'eval_results/issue_1072')}) "
+        "(`stats_component.json`)"
+    )
+    r = verify_task_body.check_github_tree_adjacent_file_claims(line)
+    assert r.passed and not r.is_warn, r.detail
+    assert "unverified" in r.detail
+    assert "did not resolve" in r.detail
+
+
+def test_gh_tree_warn_never_fails(tmp_path, monkeypatch):
+    """AC5 — check 43 has NO passed=False code path: the missing-claim case
+    keeps passed=True (is_warn=True), and a grandfathered v2 integration
+    body carrying BOTH new shapes (dead non-footer URL + missing tree claim)
+    keeps verify_text ok=True (42 WARNs on v2; 43 WARNs by design)."""
+    repo, sha = _make_repo_with_issue1072_tree(tmp_path)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    missing_line = _I1072_PREFIX_ARTIFACTS_LINE.format(
+        tree_url=_gh_tree_url(sha, "eval_results/issue_1072")
+    )
+    r = verify_task_body.check_github_tree_adjacent_file_claims(missing_line)
+    assert r.passed is True and r.is_warn is True
+    dead = _gh_blob_url(sha, "eval_results/issue_1072/missing.npz")
+    body = _V2_GOOD_BODY.replace(
+        "0.81 — no regression at 25% mixing.",
+        f"0.81 — no regression at 25% mixing.\n\n{missing_line} "
+        f"Dead sample link: [`missing.npz`]({dead}).",
+    )
+    assert body != _V2_GOOD_BODY
+    ok, results = verify_task_body.verify_text(body)
+    by_name = _results_by_name(results)
+    assert by_name[_BODYWIDE_NAME].passed and by_name[_BODYWIDE_NAME].is_warn
+    assert by_name[_GH_TREE_NAME].passed and by_name[_GH_TREE_NAME].is_warn
+    assert ok, [r.render() for r in results if not r.passed]
+
+
+def test_expand_claim_token_bounds():
+    """D5 — bounded numeric brace expansion: `{0..4}` → 5 names; an
+    over-wide or inverted range expands to [] (no probe, no WARN); comma
+    alternation and nested braces stay plain tokens the filename whitelist
+    then rejects."""
+    assert verify_task_body._expand_claim_token("battery_1072_fold{0..4}.json") == [
+        f"battery_1072_fold{i}.json" for i in range(5)
+    ]
+    assert verify_task_body._expand_claim_token("x{0..4000}.npz") == []
+    assert verify_task_body._expand_claim_token("x{4..0}.npz") == []
+    for token in ("x{a,b}.npz", "x{0..{1..2}}.npz"):
+        assert verify_task_body._expand_claim_token(token) == [token]
+        assert not verify_task_body._HF_ADJ_FILENAME_RE.match(token)
+    assert verify_task_body._expand_claim_token("stats_component.json") == ["stats_component.json"]
+
+
+def test_gh_tree_disclaimer_suppresses_warn(tmp_path, monkeypatch):
+    """AC10 (D10) — the VERBATIM CURRENT #1072 footer line: the `{0..4}.npz`
+    tokens sit inside the qualifying paren as an explicit "gitignored … HF
+    eval_results mirror only" DISCLAIMER → zero claims gathered, clean PASS
+    against a tree lacking the `.npz`. P2: deleting the disclaimer substring
+    from the SAME line re-yields gathered claims + a WARN (pins D10 as live
+    code, not dead code)."""
+    repo, sha = _make_repo_with_issue1072_tree(tmp_path)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    line = _I1072_CURRENT_ARTIFACTS_LINE.format(
+        tree_url=_gh_tree_url(sha, "eval_results/issue_1072")
+    )
+    assert verify_task_body._gather_gh_tree_adjacent_file_claims(line) == []
+    r = verify_task_body.check_github_tree_adjacent_file_claims(line)
+    assert r.passed and not r.is_warn, r.detail
+    undisclaimed = line.replace(" are gitignored and live on the HF eval_results mirror only", "")
+    assert undisclaimed != line
+    claims = verify_task_body._gather_gh_tree_adjacent_file_claims(undisclaimed)
+    assert any(c[2] == "per_context_stats_1072_fold0.npz" for c in claims)
+    r2 = verify_task_body.check_github_tree_adjacent_file_claims(undisclaimed)
+    assert r2.passed and r2.is_warn
+    assert "per_context_stats_1072_fold0.npz" in r2.detail
+
+
+def test_gh_tree_ancestor_entries_not_members(tmp_path):
+    """Fact-check A8 (P8) — `git ls-tree -r -t -- <prefix>` also emits the
+    prefix's ANCESTOR tree entries (`eval_results`) and the prefix itself
+    (`issue_1072`); the UNDER-prefix filter (`p.startswith(prefix + "/")`)
+    excludes both, so an ancestor/prefix dir basename never counts as a
+    member (a bare `p != prefix` would keep the ancestors as spurious
+    WARN-suppressing members)."""
+    repo, sha = _make_repo_with_issue1072_tree(tmp_path)
+    status, basenames, note = verify_task_body._git_tree_basenames(
+        repo, sha, "eval_results/issue_1072"
+    )
+    assert status == "ok", note
+    assert "eval_results" not in basenames
+    assert "issue_1072" not in basenames
+    assert "stats_component.json" in basenames
+    assert "battery_1072_fold4.json" in basenames


### PR DESCRIPTION
Closes task #1507. Adds verify_task_body.py check 42 (body-wide same-repo blob/tree URL existence; FAIL v4 / WARN grandfathered) + check 43 (git-tree twin of check 32, WARN-only, disclaimer suppressor). Plan v2: 3x critic APPROVE + consistency PASS; code-review PASS r1; test-verdict PASS.