### PR TITLE
task #1510: check 31 companion-named-not-embedded WARN class

### DIFF
--- a/.claude/rules/clean-result-critic-lens-reference.md
+++ b/.claude/rules/clean-result-critic-lens-reference.md
@@ -1045,9 +1045,13 @@ from it. Concrete checks:
    `## Findings`, `### <finding>`, setup/read prose.) Mechanical
    backstop: `verify_task_body.py` check 31 WARNs when a committed
    `figures/issue_<N>/*per{context,unit,cell}*` PNG at a body-cited
-   figure SHA is unreferenced by any body image URL (task #1011,
-   incident #928) — a pre-gate nudge only; this lens remains the
-   substantive owner.
+   figure SHA is (a) never mentioned in the body, or (b) **named in
+   prose but not embedded without an exemption phrase — detail token
+   `companion-named-not-embedded`, the class to key on** (`not
+   embedded` / `superseded by` in the filename's own paragraph silences
+   it); check 38 owns the markdown-linked-in-Results case
+   (#1011/#1371/#1510; incidents #928/#1315/#1426) — pre-gate nudges
+   only; this lens remains the substantive owner.
 1. **Figures (transformed special case).** Every figure that plots a
    residualized / partialled / binned / log-transformed / normalized
    quantity has its raw counterpart embedded inline inside the same

--- a/.claude/skills/clean-results/SPEC.md
+++ b/.claude/skills/clean-results/SPEC.md
@@ -612,6 +612,12 @@ below). Exemptions, stated in the interpretation prose or alt text: the
 result's primary figure ALREADY is the per-unit view (a raw scatter needs
 no second scatter); N is so small the figure already shows every point; or
 the aggregate has no meaningful per-unit decomposition (a single scalar).
+When a committed per-unit companion is deliberately NOT embedded, name the
+file AND state the omission with an explicit exemption phrase — "not
+embedded: <reason>" or "superseded by <the embedded view>" — in the same
+paragraph as the filename; a bare provenance mention ("committed at the
+same pin") does not count, and `verify_task_body.py` check 31 WARNs
+`companion-named-not-embedded`.
 
 **Raw alongside processed** (the transformed-figure special case). When a
 result's figure plots a residualized / partialled / binned /

--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -2706,6 +2706,35 @@ def _linked_unembedded_results_pngs(body: str, issue: int | None) -> dict[str, N
     return linked
 
 
+def _classify_per_unit_png(
+    p: str,
+    body: str,
+    referenced_paths: set[str],
+    embedded_any: set[str],
+    linked_results: set[str],
+) -> str | None:
+    """Disposition of ONE git-tracked path for check 31 (#1510): None
+    (not a per-unit PNG / embedded in any image-URL form / deferred to
+    check 38 / exemption-phrase-exempt), ``"named"`` (class B — stem in
+    body prose, no exemption phrase in its paragraph), or ``"orphan"``
+    (class A — never mentioned)."""
+    base = p.rsplit("/", 1)[-1]
+    if not base.lower().endswith(".png"):
+        return None
+    stem = base[: -len(".png")]
+    if not _PER_UNIT_FIG_RE.search(stem):
+        return None
+    if p in referenced_paths or p.lower() in embedded_any:
+        return None  # embedded (any image-URL form) — discipline satisfied
+    if p.lower() in linked_results:
+        return None  # markdown-linked in v4 Results — check 38 owns the WARN
+    if stem in body:
+        if _stem_exempt_in_paragraph(body, stem):
+            return None  # explicit exemption phrase beside the name
+        return "named"
+    return "orphan"
+
+
 def check_orphaned_per_unit_figures(body: str, *, issue: int | None = None) -> CheckResult:
     """Check 31 (WARN, #1011; tightened #1510): a committed per-unit
     companion PNG at a body-cited figure SHA that the body does not embed.
@@ -2802,22 +2831,13 @@ def check_orphaned_per_unit_figures(body: str, *, issue: int | None = None) -> C
                 n_unreachable += 1  # hard constraint: skip SILENTLY, no WARN
                 continue
             for p in tracked:
-                base = p.rsplit("/", 1)[-1]
-                if not base.lower().endswith(".png"):
-                    continue
-                stem = base[: -len(".png")]
-                if not _PER_UNIT_FIG_RE.search(stem):
-                    continue
-                if p in referenced_paths or p.lower() in embedded_any:
-                    continue  # embedded (any image-URL form) — discipline satisfied
-                if p.lower() in linked_results:
-                    continue  # markdown-linked in v4 Results — check 38 owns the WARN
-                if stem in body:
-                    if _stem_exempt_in_paragraph(body, stem):
-                        continue  # explicit exemption phrase beside the name
+                cls = _classify_per_unit_png(
+                    p, body, referenced_paths, embedded_any, linked_results
+                )
+                if cls == "named":
                     named.setdefault(p, []).append(sha[:8])
-                    continue
-                orphans.setdefault(p, []).append(sha[:8])
+                elif cls == "orphan":
+                    orphans.setdefault(p, []).append(sha[:8])
     if orphans or named:
         parts = []
         if orphans:

--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -606,11 +606,21 @@ Generation-agnostic checks (run on v2 AND v3 — the inline-figure +
   pair; no network) and WARN on any committed PNG whose basename stem
   matches `per[-_]?(context|unit|cell)` (case-insensitive, word-start
   lookbehind; `indiv` deliberately EXCLUDED — it names the per-question
-  REGIME in this project, not a per-unit view) that no body image URL
-  references (repo-relative path equality — SHA-independent, so a
-  re-pinned embed still counts) and whose stem appears nowhere in the
-  body text (the prose disclosure/exemption escape — naming the file
-  silences the WARN). Issue-scoped: with `--issue` / a numeric-parent
+  REGIME in this project, not a per-unit view) that the body does not
+  embed. Two WARN classes in ONE CheckResult (#1510): class A — never
+  mentioned anywhere in the body (the original #928 class); class B —
+  stem named in body prose but embedded nowhere, with NO exemption
+  phrase (`not embedded` / `superseded by`, case-insensitive) in the
+  stem's blank-line-delimited paragraph — tagged
+  `companion-named-not-embedded` in the detail (the token the
+  clean-result-critic keys on; a bare provenance mention like #1426's
+  "committed at the same pin" does not exempt). The embedded set is
+  any-URL-form (raw-GitHub + blob / relative / HTML `<img>`,
+  SHA-independent, case-folded); paths markdown-LINKED in the v4
+  `## Results` prose layer are DEFERRED to check 38 (its WARN set is
+  subtracted — no double-WARN), while links outside 38's gates (a
+  Methodology link, any link in a v3/v2 body) stay class-B-eligible
+  here. Issue-scoped: with `--issue` / a numeric-parent
   `--file` ONLY this task's dir is scanned (a cross-issue embed never
   surfaces another task's orphans); `--body-stdin` falls back to
   per-cited-dir scanning. WARN, never FAIL (prose-stated per-unit
@@ -619,10 +629,12 @@ Generation-agnostic checks (run on v2 AND v3 — the inline-figure +
   unreachable/unknown SHA → that SHA silently skipped (counted in the
   PASS detail, never a WARN); repo unresolved / no cited same-repo
   figure URLs → skip/vacuous PASS. Dispatched OUTSIDE the body-only
-  CHECKS list (needs `issue`; the check-20/#921 precedent). Incident:
+  CHECKS list (needs `issue`; the check-20/#921 precedent). Incidents:
   task #928 — the round-committed per-context companion
   `mlp_indiv_percontext_delta.png` sat unreferenced at a body-cited SHA
-  and reached the LM critic as a Lens 11 blocker. (#1011)
+  and reached the LM critic as a Lens 11 blocker (#1011); task #1426 —
+  two companions named in prose ("committed at the same pin") but never
+  embedded cost a substantive Lens-11 REVISE round (#1510).
 
 - **check 32** (`check_hf_adjacent_file_claims`, WARN): backtick FILENAME
   claims adjacent to hex-pinned HF `/tree/<sha>` markdown links — the
@@ -777,9 +789,12 @@ Generation-agnostic checks (run on v2 AND v3 — the inline-figure +
   Own-issue scoping when `issue` is known (a cross-issue link is a legitimate
   reference); `issue=None` (`--body-stdin`) falls back to every issue dir
   (check 31's documented fallback caveat). PNG-only (a PDF cannot render
-  inline — a PDF link is the correct form). WARN-only, never FAIL. Closes
-  check 31's stem-in-prose blind spot: the link itself puts the stem in the
-  body, silencing 31's only relevant WARN. Named recall sacrifices: the
+  inline — a PDF link is the correct form). WARN-only, never FAIL. Split
+  with check 31 (#1510): 31 defers v4-Results-linked paths to this check
+  (subtracts this WARN set — no double-WARN) and now WARNs
+  `companion-named-not-embedded` on bare prose naming (incl. links outside
+  this check's v4/Results gates) absent an exemption phrase. Named recall
+  sacrifices: the
   embedded set scans the UNSTRIPPED whole body (a fenced example embed can
   silence a real WARN — false-negative direction only); reference-style links
   `[text][ref]` are not matched. Incident: #1315 result 4 linked a committed
@@ -2309,6 +2324,19 @@ _ISSUE_FIGURE_PATH_RE = re.compile(r"^figures/issue_(?P<issue>\d+)/\S")
 # pooled hero `mlp_indiv_hero_4arm.png`), not a per-unit view.
 _PER_UNIT_FIG_RE = re.compile(r"(?<![a-z0-9])per[-_]?(context|unit|cell)", re.IGNORECASE)
 
+# Check 31 (tightened, #1510 / incident #1426): the exemption phrase that
+# silences the companion-named-not-embedded WARN class when it appears in
+# the SAME blank-line-delimited paragraph as the stem mention. Two anchored
+# idioms, precision over recall: "not embedded" (e.g. "deliberately linked,
+# not embedded: <reason>") and "superseded by" (the replaced-view idiom —
+# the #928 footer's real phrasing). A bare provenance clause ("committed at
+# the same pin", the #1426 shape) deliberately does NOT count.
+_PER_UNIT_EXEMPT_PHRASE_RE = re.compile(r"not\s+embedded|superseded\s+by", re.IGNORECASE)
+# Check 31: the greppable WARN-class token for the prose-named-but-unembedded
+# disposition (the class the clean-result-critic keys on; the check-32
+# PAREN|LINKTEXT in-detail-tag precedent).
+_PER_UNIT_NAMED_CLASS = "companion-named-not-embedded"
+
 # Check 38: any markdown link (image embeds are masked out before this
 # scans, so no `!`-lookbehind is needed); link text tolerates `]` not
 # followed by `(` — the same tolerance `_IMAGE_RE` uses — and may be
@@ -2613,20 +2641,107 @@ def _referenced_figure_paths(body: str) -> set[str]:
     return referenced
 
 
+def _paragraphs(body: str) -> list[str]:
+    """Blank-line-delimited paragraph blocks of ``body`` (check 31's
+    exemption-phrase proximity unit, #1510)."""
+    return re.split(r"\n\s*\n", body)
+
+
+def _stem_exempt_in_paragraph(body: str, stem: str) -> bool:
+    """True when some paragraph of ``body`` contains BOTH the stem and an
+    exemption phrase (`_PER_UNIT_EXEMPT_PHRASE_RE`) — check 31's tightened
+    prose-exemption escape (#1510). Paragraph-level co-occurrence: one
+    phrase exempts every stem named in its paragraph (accepted
+    false-negative direction for a WARN-tier backstop)."""
+    return any(
+        stem in para and _PER_UNIT_EXEMPT_PHRASE_RE.search(para) for para in _paragraphs(body)
+    )
+
+
+def _embedded_issue_png_paths(body: str) -> set[str]:
+    """Case-folded repo-relative `figures/issue_<K>/…png` paths embedded as
+    an IMAGE anywhere in the body — markdown `![alt](url)` AND HTML
+    `<img src=…>`, any URL host form (raw-GitHub, blob, relative;
+    SHA-independent). Extracted verbatim from check 38's embedded-set
+    block (#1510); shared by checks 31 + 38."""
+    embedded: set[str] = set()
+    image_urls = [m.group(1) for m in _IMAGE_RE.finditer(body)]
+    image_urls.extend(m.group(1) for m in _HTML_IMG_SRC_RE.finditer(body))
+    for raw_url in image_urls:
+        iu = raw_url.strip().split(None, 1)[0] if raw_url.strip() else ""
+        ipm = _LINKED_ISSUE_PNG_RE.search(iu)
+        if ipm:
+            embedded.add(ipm.group("path").lower())
+    return embedded
+
+
+def _linked_unembedded_results_pngs(body: str, issue: int | None) -> dict[str, None]:
+    """Ordered de-duped `figures/issue_<K>/…png` paths that appear as a
+    non-image markdown LINK in the (footer-truncated, prose-layer) v4
+    `## Results` section and are embedded by no body image — check 38's
+    WARN set, extracted (#1510) so check 31 can subtract it (single
+    ownership per disposition, no double-WARN). Returns {} for non-v4
+    bodies / absent `## Results` (check 38's gates, recomputed here so the
+    helper stays self-contained for check 31)."""
+    if not is_v4(body):
+        return {}
+    results_text = _v4_results_body(body)
+    if results_text is None:
+        return {}
+    prose = _prose_layer(results_text)  # strip fences + <details>
+    masked = _IMAGE_RE.sub("", prose)  # drop image embeds (wrapper residue links stay)
+    embedded = _embedded_issue_png_paths(body)
+    linked: dict[str, None] = {}  # ordered de-dupe: path -> None
+    for m in _MD_LINK_RE.finditer(masked):
+        url = m.group(1).strip().split(None, 1)[0] if m.group(1).strip() else ""
+        pm = _LINKED_ISSUE_PNG_RE.search(url)
+        if not pm:
+            continue
+        if issue is not None and pm.group("issue") != str(issue):
+            continue  # cross-issue links are legitimate references
+        path = pm.group("path")
+        if path.lower() in embedded:
+            continue  # embedded anywhere in the body → discipline satisfied
+        linked.setdefault(path)
+    return linked
+
+
 def check_orphaned_per_unit_figures(body: str, *, issue: int | None = None) -> CheckResult:
-    """Check 31 (WARN, #1011): a committed per-unit companion PNG at a
-    body-cited figure SHA is unreferenced by any body image URL.
+    """Check 31 (WARN, #1011; tightened #1510): a committed per-unit
+    companion PNG at a body-cited figure SHA that the body does not embed.
 
     INVERSE direction of checks 4b/22/29 (which verify what the body
     CITES): enumerate what the body's OWN cited commits contain under
     `figures/issue_<N>/` (one `git ls-tree` per unique (SHA, dir) pair,
-    10 s timeout, no network) and WARN on any committed `.png` whose
-    basename stem matches `_PER_UNIT_FIG_RE` that (a) no body image URL
-    references — repo-relative path equality, SHA-independent, so an
-    orphan committed at SHA A but embedded via a URL pinned at SHA B
-    still counts as referenced — and (b) whose stem appears nowhere in
-    the body text (the prose disclosure/exemption escape: naming the
-    file silences the WARN).
+    10 s timeout, no network) and classify each committed `.png` whose
+    basename stem matches `_PER_UNIT_FIG_RE`:
+
+    - **embedded** — any image-URL form anywhere in the body: the
+      raw-GitHub set (`_referenced_figure_paths`) OR the any-URL-form
+      embedded set (`_embedded_issue_png_paths`: blob / relative / HTML
+      `<img>`; SHA-independent, case-folded) → PASS. The widening
+      (#1510) is principled: pre-#1510 a blob/relative/HTML embed passed
+      only via the stem-in-prose accident.
+    - **markdown-linked in the v4 `## Results` prose layer** (check 38's
+      WARN set, `_linked_unembedded_results_pngs`) → PASS here; check 38
+      owns that WARN (single ownership, no double-WARN). Links OUTSIDE
+      check 38's gates (a `## Methodology` link, any link in a v3/v2
+      body) stay with THIS check via the stem branch below.
+    - **stem named in body text + exemption phrase in the SAME
+      blank-line-delimited paragraph** (`_stem_exempt_in_paragraph`) →
+      PASS: the explicit deliberately-not-embedded disclosure. The
+      phrase set is the two ANCHORED idioms `not embedded` /
+      `superseded by` (case-insensitive) — an idiom must appear
+      verbatim-anchored ("cannot be embedded" does NOT match; a bare
+      provenance clause like #1426's "committed at the same pin" does
+      NOT exempt), while an incidental `superseded by` in a stem-bearing
+      paragraph DOES exempt — the accepted false-negative direction for
+      a WARN-tier backstop (Lens 11 stays the substantive owner).
+    - **stem named, no phrase in its paragraph** → WARN class B, tagged
+      `companion-named-not-embedded` (`_PER_UNIT_NAMED_CLASS`) in the
+      detail — the #1426 round-1 shape (named in prose, never embedded,
+      no stated omission).
+    - **never mentioned** → WARN class A (the original #928 class).
 
     Deliberately NARROW pattern (`per{context,unit,cell}` with `-`/`_`
     variants): `per_source` / `per_seed` / `per_question` / `indiv`
@@ -2636,7 +2751,8 @@ def check_orphaned_per_unit_figures(body: str, *, issue: int | None = None) -> C
     clean-result-critic Lens 11; this check is only its mechanical
     backstop (incident #928: `mlp_indiv_percontext_delta.png` sat
     committed-but-unembedded at a body-cited SHA through three review
-    passes).
+    passes; incident #1426: two prose-named companions "committed at the
+    same pin" cost a substantive Lens-11 REVISE round).
 
     Issue scoping: with `issue` known (`--issue <N>` / a numeric-parent
     `--file`), ONLY `figures/issue_<issue>/` is scanned — a cross-issue
@@ -2669,10 +2785,15 @@ def check_orphaned_per_unit_figures(body: str, *, issue: int | None = None) -> C
     if repo is None:
         return CheckResult(name, True, "skipped — repo root unresolved (running outside the repo)")
     # (3) referenced set: EVERY image URL anywhere in the body (broader than
-    # the result-narrative scan — an embed in ## Methodology still counts).
+    # the result-narrative scan — an embed in ## Methodology still counts),
+    # widened (#1510) with the any-URL-form embedded set + check 38's
+    # linked-in-Results WARN set (deferred there — no double-WARN).
     referenced_paths = _referenced_figure_paths(body)
+    embedded_any = _embedded_issue_png_paths(body)
+    linked_results = {p.lower() for p in _linked_unembedded_results_pngs(body, issue)}
     # (4) enumerate per-unit PNGs at each reachable cited sha; union per dir.
-    orphans: dict[str, list[str]] = {}  # path -> short-shas found at
+    orphans: dict[str, list[str]] = {}  # class A (never mentioned): path -> short-shas
+    named: dict[str, list[str]] = {}  # class B (named, unembedded, no exemption phrase)
     n_unreachable = 0
     for prefix, shas in sorted(cited.items()):
         for sha in sorted(shas):
@@ -2687,24 +2808,44 @@ def check_orphaned_per_unit_figures(body: str, *, issue: int | None = None) -> C
                 stem = base[: -len(".png")]
                 if not _PER_UNIT_FIG_RE.search(stem):
                     continue
-                if p in referenced_paths:  # path match — SHA-independent by construction
-                    continue
-                if stem in body:  # prose disclosure/exemption escape
+                if p in referenced_paths or p.lower() in embedded_any:
+                    continue  # embedded (any image-URL form) — discipline satisfied
+                if p.lower() in linked_results:
+                    continue  # markdown-linked in v4 Results — check 38 owns the WARN
+                if stem in body:
+                    if _stem_exempt_in_paragraph(body, stem):
+                        continue  # explicit exemption phrase beside the name
+                    named.setdefault(p, []).append(sha[:8])
                     continue
                 orphans.setdefault(p, []).append(sha[:8])
-    if orphans:
-        listed = "; ".join(
-            f"`{p}` (committed at {', '.join(sorted(set(shas)))})"
-            for p, shas in sorted(orphans.items())
-        )
+    if orphans or named:
+        parts = []
+        if orphans:
+            parts.append(
+                "; ".join(
+                    f"`{p}` (committed at {', '.join(sorted(set(shas)))}; "
+                    "never mentioned in the body)"
+                    for p, shas in sorted(orphans.items())
+                )
+            )
+        if named:
+            parts.append(
+                "; ".join(
+                    f"`{p}` (committed at {', '.join(sorted(set(shas)))}; "
+                    f"{_PER_UNIT_NAMED_CLASS}: named in body prose but not embedded, "
+                    "with no exemption phrase)"
+                    for p, shas in sorted(named.items())
+                )
+            )
         return CheckResult(
             name,
             True,
-            f"{len(orphans)} committed per-unit figure(s) at body-cited SHA(s) are not "
-            f"embedded by any body image: {listed} — embed the per-unit companion under "
-            "the relevant `### <result>`, or state the exemption in prose (naming the "
-            "file silences this WARN); substantive owner: clean-result-critic Lens 11 "
-            "(incident #928)",
+            f"{len(orphans) + len(named)} committed per-unit figure(s) at body-cited SHA(s) "
+            f"are not embedded by any body image: {'; '.join(parts)} — embed the companion "
+            "under the relevant `### <result>`, or state the deliberate omission beside its "
+            "name ('not embedded: <reason>' / 'superseded by …' in the same paragraph; a "
+            "bare provenance mention does not exempt); substantive owner: "
+            "clean-result-critic Lens 11 (incidents #928, #1426)",
             is_warn=True,
         )
     detail = "no orphaned per-unit figures at body-cited SHAs"
@@ -2721,13 +2862,14 @@ def check_linked_not_embedded_figures(body: str, *, issue: int | None = None) ->
     INVERSE-complement of check 31: 31 asks "what did the body-cited
     commits CONTAIN that the body never shows?" (git-backed); this check
     asks "what does the Results prose LINK TO that the body never
-    embeds?" (pure text — no git / network / subprocess). They compose:
-    31 catches committed-but-never-mentioned per-unit PNGs, but its
-    stem-in-prose escape is satisfied by a markdown LINK's own URL text,
-    so a linked-not-embedded figure silences 31 — this check closes
-    exactly that hole (incident #1315: result 4 referenced a committed
-    per-row PC-scatter grid as `[text](…png)` instead of `![alt](…)`;
-    only clean-result-critic Lens 11 caught it).
+    embeds?" (pure text — no git / network / subprocess). They compose
+    (#1510 split): 31 DEFERS v4-Results-linked paths to this check
+    (subtracting `_linked_unembedded_results_pngs`, so no figure
+    double-WARNs) and itself WARNs `companion-named-not-embedded` on
+    bare prose naming — including links outside this check's v4/Results
+    gates — absent an exemption phrase (incident #1315: result 4
+    referenced a committed per-row PC-scatter grid as `[text](…png)`
+    instead of `![alt](…)`; only clean-result-critic Lens 11 caught it).
 
     Pipeline: `_v4_results_body` (footer-truncated, so footer blob links
     are never scanned) → `_prose_layer` (fences + `<details>` stripped —
@@ -2738,13 +2880,13 @@ def check_linked_not_embedded_figures(body: str, *, issue: int | None = None) ->
     whole-body EMBEDDED set. Blockquote caption lines stay in the prose
     layer, so a caption link to an unembedded PNG deliberately WARNs.
 
-    The EMBEDDED set is symmetric any-URL-form: the repo-relative
+    The EMBEDDED set (`_embedded_issue_png_paths`, shared with check 31
+    as of #1510) is symmetric any-URL-form: the repo-relative
     `figures/issue_<K>/…png` path is extracted from EVERY image-embed
     URL anywhere in the body — markdown `![alt](url)` AND HTML
     `<img src="url">` — raw-GitHub, blob, and relative forms alike
-    (SHA-independent, case-folded path equality). Deliberately NOT
-    `_referenced_figure_paths`, which is raw-GitHub-only: check 4b is
-    Results-scoped and accepts non-raw absolute URLs, so a legitimate
+    (SHA-independent, case-folded path equality). Deliberately NOT the
+    raw-GitHub-only `_referenced_figure_paths`: a legitimate
     Methodology-placed or blob-URL embed would otherwise false-positive
     this WARN. The embedded set scans the UNSTRIPPED whole body, so a
     fenced EXAMPLE embed can silence a real WARN — a false-negative-only
@@ -2778,30 +2920,11 @@ def check_linked_not_embedded_figures(body: str, *, issue: int | None = None) ->
     results_text = _v4_results_body(body)
     if results_text is None:
         return CheckResult(name, True, "no `## Results` section to scan")
-    prose = _prose_layer(results_text)  # strip fences + <details>
-    masked = _IMAGE_RE.sub("", prose)  # drop image embeds (wrapper residue links stay — docstring)
-    # Whole-body EMBEDDED set: markdown image embeds + HTML <img> embeds,
-    # any URL host form, reduced to case-folded repo-relative figure paths.
-    embedded: set[str] = set()
-    image_urls = [m.group(1) for m in _IMAGE_RE.finditer(body)]
-    image_urls.extend(m.group(1) for m in _HTML_IMG_SRC_RE.finditer(body))
-    for raw_url in image_urls:
-        iu = raw_url.strip().split(None, 1)[0] if raw_url.strip() else ""
-        ipm = _LINKED_ISSUE_PNG_RE.search(iu)
-        if ipm:
-            embedded.add(ipm.group("path").lower())
-    linked: dict[str, None] = {}  # ordered de-dupe: path -> None
-    for m in _MD_LINK_RE.finditer(masked):
-        url = m.group(1).strip().split(None, 1)[0] if m.group(1).strip() else ""
-        pm = _LINKED_ISSUE_PNG_RE.search(url)
-        if not pm:
-            continue
-        if issue is not None and pm.group("issue") != str(issue):
-            continue  # cross-issue links are legitimate references
-        path = pm.group("path")
-        if path.lower() in embedded:
-            continue  # embedded anywhere in the body → discipline satisfied
-        linked.setdefault(path)
+    # Full pipeline (prose layer → image mask → link scan → issue scoping →
+    # embedded-set subtraction) extracted to `_linked_unembedded_results_pngs`
+    # (#1510) so check 31 can subtract this WARN set (no double-WARN); the
+    # helper recomputes the two gates above — pure text, negligible cost.
+    linked = _linked_unembedded_results_pngs(body, issue)
     if linked:
         listed = ", ".join(f"`{p}`" for p in linked)
         return CheckResult(

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -1273,6 +1273,10 @@ _PER_UNIT_ORPHAN_CHECK = "per-unit companion figures embedded"
 
 _PER_UNIT_ORPHAN_PATH = "figures/issue_999/hero_percontext.png"
 
+# The class-B WARN token (#1510) — pinned as a LITERAL here (not imported
+# from the module) so a silent token rename breaks the grep contract test.
+_PER_UNIT_NAMED_CLASS = "companion-named-not-embedded"
+
 
 def _make_repo_with_per_unit_orphan(tmp_path):
     """git repo whose HEAD commit tracks `figures/issue_999/hero.png` +
@@ -1326,6 +1330,9 @@ def test_orphan_per_unit_figure_warns(tmp_path, monkeypatch):
     assert _PER_UNIT_ORPHAN_PATH in r.detail
     assert "Lens 11" in r.detail
     assert sha[:8] in r.detail
+    # Class separation (#1510): a never-mentioned orphan reports class A
+    # only — the class-B token must not appear.
+    assert _PER_UNIT_NAMED_CLASS not in r.detail
     assert ok  # the WARN never flips the overall verdict (no-regress guarantee)
     # Scoped subprocess budget on a DIRECT invocation: 1 unique (sha, dir)
     # pair → exactly 1 ls-tree (plan §4.1 budget: 1 per unique pair).
@@ -1375,9 +1382,11 @@ def test_orphan_unreachable_sha_skips_silently(tmp_path, monkeypatch):
 
 
 def test_orphan_prose_mention_suppresses_warn(tmp_path, monkeypatch):
-    """The prose disclosure escape: an unembedded companion whose stem is
-    named in body prose is treated as disclosed → no WARN (mechanizes
-    'exemptions stated in prose are legitimate')."""
+    """The prose disclosure escape, PHRASE-GATED as of #1510: an unembedded
+    companion whose stem is named in body prose is exempt only because the
+    fixture prose carries an exemption idiom ("superseded by") in the
+    stem's own paragraph — the second phrase-set pin (the corpus-real #928
+    footer idiom); a bare naming would now WARN class B."""
     repo, sha = _make_repo_with_per_unit_orphan(tmp_path)
     monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
     body = GOOD_BODY.replace("0123456789abcdef", sha).replace(
@@ -1388,6 +1397,178 @@ def test_orphan_prose_mention_suppresses_warn(tmp_path, monkeypatch):
     r = verify_task_body.check_orphaned_per_unit_figures(body, issue=999)
     assert r.passed is True
     assert r.is_warn is False
+
+
+def test_orphan_named_not_embedded_warns_without_exemption(tmp_path, monkeypatch):
+    """The #1426 regression fixture (#1510 durability pin, incl. for the
+    SPEC/lens prose edits): the companion NAMED in body prose with a bare
+    provenance clause ("committed at the same pin" — the incident's own
+    phrasing) and embedded nowhere → class-B WARN carrying the
+    `companion-named-not-embedded` token; the provenance clause does NOT
+    exempt."""
+    repo, sha = _make_repo_with_per_unit_orphan(tmp_path)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = GOOD_BODY.replace("0123456789abcdef", sha).replace(
+        "The 17-pt lift holds at every seed;",
+        "The per-context views behind these aggregates are `hero_percontext.png`, "
+        "committed at the same pin. The 17-pt lift holds at every seed;",
+    )
+    r = verify_task_body.check_orphaned_per_unit_figures(body, issue=999)
+    assert r.passed is True  # WARN-tier: the overall verdict is never flipped
+    assert r.is_warn is True
+    assert _PER_UNIT_NAMED_CLASS in r.detail
+    assert _PER_UNIT_ORPHAN_PATH in r.detail
+    assert "Lens 11" in r.detail
+    assert sha[:8] in r.detail
+
+
+def test_orphan_named_with_exemption_phrase_no_warn(tmp_path, monkeypatch):
+    """The exemption phrase in the stem's own paragraph silences class B —
+    both anchored idioms, incl. a CAPITALIZED variant (the phrase regex is
+    case-insensitive)."""
+    repo, sha = _make_repo_with_per_unit_orphan(tmp_path)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = GOOD_BODY.replace("0123456789abcdef", sha).replace(
+        "The 17-pt lift holds at every seed;",
+        "Deliberately linked, not embedded: the hero already shows every point — "
+        "see `hero_percontext.png`. The 17-pt lift holds at every seed;",
+    )
+    r = verify_task_body.check_orphaned_per_unit_figures(body, issue=999)
+    assert r.passed is True
+    assert r.is_warn is False
+    body2 = GOOD_BODY.replace("0123456789abcdef", sha).replace(
+        "The 17-pt lift holds at every seed;",
+        "`hero_percontext.png` is a round-1 exploratory view. Superseded by the "
+        "hero's right panel. The 17-pt lift holds at every seed;",
+    )
+    r2 = verify_task_body.check_orphaned_per_unit_figures(body2, issue=999)
+    assert r2.passed is True
+    assert r2.is_warn is False
+
+
+def test_orphan_exemption_phrase_other_paragraph_still_warns(tmp_path, monkeypatch):
+    """Paragraph-proximity scoping: an exemption phrase in a DIFFERENT
+    blank-line-delimited paragraph than the stem does NOT exempt — the
+    stem's own paragraph must carry the phrase."""
+    repo, sha = _make_repo_with_per_unit_orphan(tmp_path)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = GOOD_BODY.replace("0123456789abcdef", sha).replace(
+        "The 17-pt lift holds at every seed;",
+        "The per-context companion is `hero_percontext.png`, committed at the same pin.\n\n"
+        "A different figure was deliberately not embedded for space. "
+        "The 17-pt lift holds at every seed;",
+    )
+    r = verify_task_body.check_orphaned_per_unit_figures(body, issue=999)
+    assert r.passed is True
+    assert r.is_warn is True
+    assert _PER_UNIT_NAMED_CLASS in r.detail
+
+
+def test_orphan_multi_stem_one_paragraph_phrase_exempts_both(tmp_path, monkeypatch):
+    """Accepted false-negative direction (pinned): ONE exemption phrase in
+    a paragraph naming TWO per-unit companion stems exempts BOTH —
+    paragraph-level co-occurrence, not per-stem sentence parsing (WARN-tier
+    backstop; Lens 11 stays the substantive owner)."""
+    repo, _sha_a = _make_repo_with_per_unit_orphan(tmp_path)
+
+    def git(*args):
+        subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+    (repo / "figures" / "issue_999" / "hero_percell.png").write_bytes(b"\x89PNG fake bytes")
+    git("add", "figures")
+    git("commit", "-q", "-m", "add second per-unit companion")
+    sha = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    body = GOOD_BODY.replace("0123456789abcdef", sha).replace(
+        "The 17-pt lift holds at every seed;",
+        "Round-1 exploratory views `hero_percontext.png` and `hero_percell.png` are "
+        "superseded by the embedded hero panels. The 17-pt lift holds at every seed;",
+    )
+    r = verify_task_body.check_orphaned_per_unit_figures(body, issue=999)
+    assert r.passed is True
+    assert r.is_warn is False  # one phrase exempts both co-resident stems
+
+
+def test_orphan_blob_embed_no_warn(tmp_path, monkeypatch):
+    """The widened any-URL-form embedded set (#1510): a GitHub BLOB-URL
+    image embed of the companion is a real embed → clean PASS. Pre-#1510
+    this shape passed only via the stem-in-prose accident (the embed URL
+    text names the stem); under the phrase-gated escape it would now WARN
+    class B were the embed set still raw-GitHub-only."""
+    repo, sha = _make_repo_with_per_unit_orphan(tmp_path)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    embed = (
+        "![Per-context deltas.](https://github.com/superkaiba/explore-persona-space/"
+        f"blob/{sha}/figures/issue_999/hero_percontext.png)"
+    )
+    body = GOOD_BODY.replace("0123456789abcdef", sha).replace(
+        "> **Figure.**", embed + "\n\n> **Figure.**"
+    )
+    r = verify_task_body.check_orphaned_per_unit_figures(body, issue=999)
+    assert r.passed is True
+    assert r.is_warn is False
+    assert "no orphaned per-unit figures" in r.detail
+
+
+def test_orphan_linked_results_path_defers_to_check38(tmp_path, monkeypatch):
+    """Single ownership (no double-WARN): a companion markdown-LINKED in
+    the v4 `## Results` prose layer is check 38's WARN — check 31 carries
+    no class-B token for it. Second arm pins case-fold symmetry of the
+    subtraction: a case-varying link URL still defers (without the
+    case-fold it would surface as class A — the case-varied URL does not
+    put the exact stem in the body)."""
+    repo, sha = _make_repo_with_per_unit_orphan(tmp_path)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    link_url = (
+        "https://raw.githubusercontent.com/superkaiba/explore-persona-space/"
+        f"{sha}/figures/issue_999/hero_percontext.png"
+    )
+    fixture = _c37_body_with_results_link(
+        f"The per-context view behind this aggregate: [companion]({link_url})."
+    ).replace("0123456789abcdef", sha)
+    _fm, body = verify_task_body.split_frontmatter(fixture)
+    r31 = verify_task_body.check_orphaned_per_unit_figures(body, issue=999)
+    assert r31.passed is True
+    assert r31.is_warn is False  # deferred to check 38 — no WARN here
+    assert _PER_UNIT_NAMED_CLASS not in r31.detail
+    r38 = verify_task_body.check_linked_not_embedded_figures(body, issue=999)
+    assert r38.is_warn is True
+    assert _PER_UNIT_ORPHAN_PATH in r38.detail
+    # Case-fold symmetry: the same link with a case-varying basename.
+    upper_url = link_url.replace("hero_percontext.png", "HERO_percontext.png")
+    fixture_u = _c37_body_with_results_link(
+        f"The per-context view behind this aggregate: [companion]({upper_url})."
+    ).replace("0123456789abcdef", sha)
+    _fm, body_u = verify_task_body.split_frontmatter(fixture_u)
+    r31_u = verify_task_body.check_orphaned_per_unit_figures(body_u, issue=999)
+    assert r31_u.passed is True
+    assert r31_u.is_warn is False
+
+
+def test_orphan_nonv4_linked_path_fires_named_class(tmp_path, monkeypatch):
+    """Row-f coverage (deliberate widening, not an accident): a markdown
+    LINK outside check 38's gates — here in a pre-v3 legacy body 38 never
+    scans — is a prose naming of an unembedded companion, so class B fires
+    absent an exemption phrase (the one-phrase remedy applies the same)."""
+    repo, sha = _make_repo_with_per_unit_orphan(tmp_path)
+    monkeypatch.setattr(verify_task_body, "_resolve_repo_root", lambda: repo)
+    link_url = (
+        "https://raw.githubusercontent.com/superkaiba/explore-persona-space/"
+        f"{sha}/figures/issue_999/hero_percontext.png"
+    )
+    body = GOOD_BODY.replace("0123456789abcdef", sha).replace(
+        "The 17-pt lift holds at every seed;",
+        f"Full per-context view: [companion]({link_url}). The 17-pt lift holds at every seed;",
+    )
+    r = verify_task_body.check_orphaned_per_unit_figures(body, issue=999)
+    assert r.passed is True
+    assert r.is_warn is True
+    assert _PER_UNIT_NAMED_CLASS in r.detail
 
 
 def test_orphan_deduped_across_cited_shas(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes task #1510. Tightens verify_task_body.py check 31's prose-naming escape: a prose-named-but-unembedded per-unit companion now WARNs under the distinct class token companion-named-not-embedded unless an exemption phrase (not embedded / superseded by) sits in the stem's paragraph. Incident: #1426 r1.