### PR TITLE
task #1509: verify_task_body check 44 — footer HF artifact paths carry an adjacent pinned link

### DIFF
--- a/.claude/skills/clean-results/SPEC.md
+++ b/.claude/skills/clean-results/SPEC.md
@@ -851,7 +851,12 @@ accepted. No `TBD`, `{{`, `default`, `see config` sentinels. **Write
 MDX-safe markdown** (same three rules as v3): (a) `[label](url)` only,
 never `<https://...>` autolinks; (b) no `<` immediately before a digit
 (`p<0.05`); (c) table-cell tokens with inner pipes (`<|im_start|>`) escape
-the pipes inside a code span.
+the pipes inside a code span. Enforcement note (check 44, WARN — no
+semantic change to this contract): a bare backtick HF-style artifact path
+(`issue<N>_...` prefix, or a `raw_completions`/`analysis_tensors` path) in
+the footer must sit in the same bullet/paragraph as a pinned
+`huggingface.co` `/tree|/resolve|/blob/<rev>` link or carry `@ <rev>`
+immediately after it (`verify_task_body.py` check 44, #1509).
 
 ### Stray `## What I ran` / `## Findings` / `## Data` / `## Reproducibility` / `## Human TL;DR` / `## TL;DR` / `## Details` / `## Figure` is a FAIL (v4)
 

--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -872,6 +872,23 @@ Generation-agnostic checks (run on v2 AND v3 — the inline-figure +
   false claims. Incident: task #1072 r2 footer claimed the gitignored
   `.npz` set inside the pinned `eval_results/issue_1072` git tree (#1507).
 
+- **check 44** (`check_footer_hf_paths_pinned`, WARN, v4-only, #1509):
+  every bare backtick HF-style artifact path in the `**Repro:**`/
+  `**Context:**` footer (`issue<N>_` prefix, or a `raw_completions`/
+  `analysis_tensors` path segment; first segment not a git/local root;
+  brace-expansion/glob charset) sits in a bullet/paragraph unit carrying
+  an HF pin — a pinned `huggingface.co` `/(tree|resolve|blob)/<7-40 hex>`
+  link anywhere in the unit, or `@ [HF ]rev <hex>` immediately after the
+  token (position-anchored: the incident bullet's EARLIER GitHub `@`-pin
+  must not rescue). Tokens check 40's gatherer already claims are excluded
+  (no double-WARN; the check-30/40 partition convention). Fence-aware +
+  blockquote-stripped unit splitter (`_footer_units`). Pure text — zero
+  Hub probes, no env fences; WARN never FAILs. Incident: task #1335's
+  pre-fix footer bullet shipped `issue1335_ablation_ladder/
+  onpolicy_assistant_label/{raw_completions,analysis_tensors}/` bare
+  (GitHub pins + code shas in-bullet, no HF pin) and the verifier read
+  PASS (#1509).
+
 Harmful-content carve-out: checks 18/19 accept the sanitized excerpt
 form (`[truncated — harmful-content row; verify at <path>, row <i>]`)
 exactly as checks 10/11 do today.
@@ -10434,6 +10451,169 @@ def check_figure_sidecar_coverage(body: str) -> CheckResult:
     )
 
 
+# ─── Check 44: footer HF artifact paths carry an adjacent pinned link ────────
+#
+# The #1335 pre-fix footer (git `6d3c847946`) shipped
+# `issue1335_ablation_ladder/onpolicy_assistant_label/
+# {raw_completions,analysis_tensors}/` as a bare backtick path with no HF
+# pin anywhere in its bullet; only URL-bearing or count-paren claims were
+# gated (checks 8/23/30/32/40), so the verifier read PASS and the LM critic
+# had to catch the shape cold (#1509). Pure text check — zero Hub probes
+# (pin ABSENCE is a body-text fact, the check-40 rationale) and no
+# EPM_VERIFY_BODY_NO_HF / EPM_VERIFY_BODY_NO_EVAL_SCAN fences (the
+# check-37 "deliberately NOT fenced" convention).
+
+# Backtick token charset EXTENDED over the plain [A-Za-z0-9_./-] dir-token
+# charset with {},* for brace-expansion / glob forms (the #1335
+# `{raw_completions,analysis_tensors}/` and #841 `issue841_scaling/{...}` /
+# `analysis_tensors/pass_a/*_cx.pt` shapes). Leading ./ ../ declined.
+_FOOTER_HF_PATH_TOKEN_RE = re.compile(r"`(?P<tok>(?!\.\.?/)[A-Za-z0-9_\-./{},*]{1,160})`")
+# HF-identity arm (gate G2b): a raw_completions / analysis_tensors path
+# segment (word-bounded — matches inside braces too).
+_FOOTER_HF_ARTIFACT_SEG_RE = re.compile(r"\b(?:raw_completions|analysis_tensors)\b")
+# Search-form pinned-HF-URL satisfier S1 (the anchored
+# _HF_HUB_TREE_BLOB_URL_RE cannot search inside a unit): huggingface.co +
+# tree|resolve|blob + 7-40 hex, per SPEC.md § "All footer URLs pinned
+# (v4)"; `/tree/main` never matches (not hex).
+_FOOTER_HF_PIN_URL_RE = re.compile(
+    r"huggingface\.co/[^\s()`]*?/(?:tree|resolve|blob)/[0-9a-fA-F]{7,40}\b",
+    re.IGNORECASE,
+)
+# Position-ANCHORED @-rev satisfier S2: must begin within 4 chars of the
+# token's closing backtick (the committed `@ rev `6aab0cce1fac`` /
+# `@ HF rev `deb7a452`` #1112/#1335 footer shapes). Anchoring is
+# load-bearing: the #1335 offending bullet carries `@ `be61a85e`` (a
+# GitHub figures pin) EARLIER in the bullet, so an anywhere-in-unit @-rev
+# (check 37's shape) would false-negative the motivating incident.
+# `@ main` / `@ HEAD` are not hex and never satisfy.
+_FOOTER_AT_REV_ADJ_RE = re.compile(
+    r"[ \t]{0,4}@\s*(?:(?:HF\s+)?rev\s+)?`?[0-9a-fA-F]{7,40}\b", re.IGNORECASE
+)
+
+
+def _footer_units(footer: str) -> list[str]:
+    """Split footer text into pin-adjacency units: each `- `/`* ` bullet
+    (indented AND lazy continuation lines joined) and each non-bullet
+    paragraph run (the `**Repro:**` / `**Context:**` blocks). Fence-aware
+    (illustrative skeletons ignored); `>`-quoted blockquote lines dropped
+    (the #959 verbatim-prompt exemption — quote text is provenance
+    content, not a provenance link); blank lines terminate a unit.
+
+    Generalizes `_footer_reused_bullets` (which keeps only `- Reused`
+    bullets and joins only INDENTED continuations) to ALL footer content.
+    Stated recall/precision trade (#1509 §4.3): lazy (non-indented)
+    continuations also join — a wrapped bullet whose pin lands on an
+    unindented wrap line still satisfies; the cost is a bounded
+    false-negative residual (a pin on an immediately-following unrelated
+    line rescuing a token — blank-line unit termination bounds it).
+    """
+    units: list[str] = []
+    cur: str | None = None
+    in_fence = False
+    for line in footer.splitlines():
+        s = line.strip()
+        if s.startswith("```") or s.startswith("~~~"):
+            in_fence = not in_fence
+            if cur is not None:
+                units.append(cur)
+                cur = None
+            continue
+        if in_fence or s.startswith(">"):
+            continue
+        if not s:
+            if cur is not None:
+                units.append(cur)
+                cur = None
+            continue
+        if re.match(r"^\s*[-*]\s", line):
+            if cur is not None:
+                units.append(cur)
+            cur = s
+        elif cur is not None:
+            cur += " " + s  # indented OR lazy continuation joins its unit
+        else:
+            cur = s
+    if cur is not None:
+        units.append(cur)
+    return units
+
+
+def check_footer_hf_paths_pinned(body: str) -> CheckResult:
+    """Check 44 (WARN, v4-only, #1509): every bare backtick HF-style
+    artifact path in the `**Repro:**`/`**Context:**` footer sits in a
+    unit (bullet / paragraph) carrying an HF pin — a pinned
+    `huggingface.co` `/(tree|resolve|blob)/<7-40 hex>` link anywhere in
+    the unit (S1), or an `@ [HF ]rev <hex>` immediately after the token
+    (S2, position-anchored). Token identity gates: a backtick span with
+    a `/` (G1), first segment not in `_GIT_SIDE_ROOTS` (G3 — git/local
+    paths resolve in git; checks 27/29 territory), and an `issue<N>_`
+    prefix OR a `raw_completions`/`analysis_tensors` segment (G2).
+    Tokens `_gather_hf_unpinned_count_claims` already extracts are
+    excluded (G5 — check 40 keeps its own missing-pin WARN; the
+    check-30/40 partition convention: no claim is ever double-WARNed).
+
+    WARN, never FAIL — there is NO code path returning ``passed=False``
+    (corpus 2026-07-18: 50 committed v4 bodies; 2 parked bodies (#1310,
+    #841) carry 10 genuine unpinned tokens — a FAIL would newly block
+    their promote-time re-verify. FAIL-flip path: a one-line severity
+    change once the parked corpus clears, via a future infra task).
+    Body-text-only: zero Hub probes, no EPM_VERIFY_BODY_NO_HF /
+    EPM_VERIFY_BODY_NO_EVAL_SCAN fence (pin absence is a text fact, cf.
+    check 40; the check-37 unfenced convention). Forward-only via
+    `is_v4` — v3/v2/legacy bodies are never newly flagged.
+
+    Named recall residuals (the LM critic stays the backstop): HF paths
+    OUTSIDE backticks (plain prose / link-text paths are not extracted),
+    and HF paths with NEITHER an `issue<N>_` prefix NOR a
+    raw_completions/analysis_tensors segment (G2 declines — precision
+    first). Incident: task #1335's pre-fix footer bullet (git
+    `6d3c847946`) carried the brace-form path with GitHub pins + bare
+    code shas in-bullet but no HF pin — checks 37/40 both (correctly,
+    per their own scopes) stayed silent.
+    """
+    name = "footer HF artifact paths carry an adjacent pinned link"
+    if not is_v4(body):
+        return CheckResult(name, True, "skipped — not a v4 body (forward-only)")
+    footer = _v4_footer_text(body)
+    if footer is None:
+        return CheckResult(name, True, "skipped — no **Repro:** footer found")
+    # G5 (check-40 interplay): the gatherer is pure regex — ZERO Hub probes
+    # (probes live only in check 40's check function), so it is safe+cheap
+    # to call here for the partition set.
+    c40_tokens = {tok for _c, _n, tok, _r in _gather_hf_unpinned_count_claims(body)}
+    offenders: list[str] = []
+    seen: set[str] = set()
+    for unit in _footer_units(footer):
+        unit_pinned = _FOOTER_HF_PIN_URL_RE.search(unit) is not None
+        for m in _FOOTER_HF_PATH_TOKEN_RE.finditer(unit):
+            tok = m.group("tok")
+            if "/" not in tok:
+                continue  # G1: a path, not a filename / hex token
+            first = tok.split("/", 1)[0]
+            if not first or first in _GIT_SIDE_ROOTS:
+                continue  # G3: git/local path — resolves in git (checks 27/29)
+            if not (_HF_ISSUE_PREFIX_RE.match(tok) or _FOOTER_HF_ARTIFACT_SEG_RE.search(tok)):
+                continue  # G2: not an HF-identity token (precision first)
+            if tok in c40_tokens or tok in seen:
+                continue  # G5: check-40 territory / per-body dedup
+            if unit_pinned:
+                continue  # S1: pinned huggingface.co /(tree|resolve|blob)/<hex> in unit
+            if _FOOTER_AT_REV_ADJ_RE.match(unit, m.end()):
+                continue  # S2: `@ [HF ]rev <hex>` immediately after the token
+            seen.add(tok)
+            offenders.append(tok)
+    if not offenders:
+        return CheckResult(name, True, "all footer HF artifact paths pinned")
+    shown = "; ".join(f"`{t[:120]}`" for t in offenders[:8])
+    detail = (
+        f"{len(offenders)} bare HF artifact path(s) in the footer carry no adjacent "
+        f"pin: {shown} — add a pinned huggingface.co /tree/<rev> (or /resolve|/blob/"
+        "<rev>) link in the same bullet/paragraph, or `@ <rev>` immediately after "
+        "the path (SPEC.md § All footer URLs pinned (v4), check 44)"
+    )
+    return CheckResult(name, True, detail, is_warn=True)
+
+
 def check_concerns_audit(  # noqa: C901 — linear lens: ledger parse → stale-marker scan → ack scan
     body: str, *, concerns_path: Path | None = None
 ) -> CheckResult:
@@ -12613,6 +12793,9 @@ CHECKS = [
     # check 43 (WARN, generation-agnostic) — git-tree twin of check 32: backtick file
     # claims adjacent to same-repo /tree/<sha> links resolve via git ls-tree (#1507):
     check_github_tree_adjacent_file_claims,
+    # check 44 (WARN, v4-only) — bare backtick HF artifact paths in the footer carry
+    # an adjacent pinned huggingface.co link / `@ rev <hex>` (#1509; incident #1335):
+    check_footer_hf_paths_pinned,
     # Check 31 (`check_orphaned_per_unit_figures`, WARN, generation-agnostic)
     # is NOT here either — like check 20 (v4) it needs the issue number (for
     # figures-dir scoping), so it is dispatched separately in `verify_text`

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -159,7 +159,7 @@ def test_good_body_passes_all():
     # is a vacuous PASS here because this fixture carries no
     # availability-denial-near-artifact line. verify_text prepends check 0
     # (body-nonstub) + check 0b (no-duplicate-frontmatter), runs CHECKS[1:]
-    # (42 functions), then appends the Goal soft check, the H1↔frontmatter-
+    # (45 functions), then appends the Goal soft check, the H1↔frontmatter-
     # title sync check (#1110; PASS-skip: not a sentinelled body), the
     # Lens 14
     # concerns-audit, the check-16 lr-matches-plan reconciliation, the
@@ -175,7 +175,7 @@ def test_good_body_passes_all():
     # locally reachable, so the cited SHA is silently skipped), AND the
     # check-38 linked-not-embedded-figures scan (needs `issue` for
     # own-figures-dir scoping, #1371; PASS-skip: not a v4 body) →
-    # 55 results total (2 prepended + CHECKS[1:]=42 + 11 appended; check 36
+    # 58 results total (2 prepended + CHECKS[1:]=45 + 11 appended; check 36
     # `check_v4_result_paragraph_sentences` (#1368), check 37
     # `check_footer_reuse_bullets_pinned` (#1370), check 39
     # `check_v4_sample_disclosure_count` (#1421), check 40
@@ -185,17 +185,20 @@ def test_good_body_passes_all():
     # here, and GOOD_BODY's only same-repo URL lives in the footer so it
     # PASSes vacuously), and check 43
     # `check_github_tree_adjacent_file_claims` (#1507 — vacuous PASS, no
-    # git-tree-adjacent claims) ride CHECKS; 36/37/39
+    # git-tree-adjacent claims), and check 44
+    # `check_footer_hf_paths_pinned` (#1509 — PASS-skip, not a v4 body)
+    # ride CHECKS; 36/37/39/44
     # PASS-skip here — not a v4 body — 40 is the vacuous PASS above, and
     # 41 is the fake-sha NO-OP PASS above). The
     # Lens 14 / check-16 results are PASS-skips when no concerns.jsonl /
     # plans/plan.md sibling is available; check 17 and the v3/v4 checks
     # are PASS-skips on this legacy (pre-v2-sentinel) fixture.
-    assert len(results) == 57
+    assert len(results) == 58
     # By-name membership so the NEXT check addition can key by name instead
     # of re-deriving the arithmetic (#1016 methodology-reconciler Must-Fix).
     assert _HF_32_NAME in {r.name for r in results}
     assert _HF_40_NAME in {r.name for r in results}
+    assert "footer HF artifact paths carry an adjacent pinned link" in {r.name for r in results}
     assert "Sample-slot disclosure count (v4)" in {r.name for r in results}
     assert "cross-issue reuse pins declared (footer Reused bullets)" in {r.name for r in results}
     assert "footer Reused bullets carry a revision/path pin" in {r.name for r in results}
@@ -5581,21 +5584,23 @@ def test_checks_list_size():
     denominator check (needs eval JSONs), and the check-31
     orphaned-per-unit-figures probe (needs `issue` for figures-dir
     scoping, #1011).
-    So `verify_text` returns 57 results (2 prepended + CHECKS[1:]=44 +
+    So `verify_text` returns 58 results (2 prepended + CHECKS[1:]=45 +
     11 appended — see `test_good_body_passes_all`), but `CHECKS` stays
-    at 45 (check 36 `check_v4_result_paragraph_sentences` (#1368),
+    at 46 (check 36 `check_v4_result_paragraph_sentences` (#1368),
     check 37 `check_footer_reuse_bullets_pinned` — the body-only
     footer-side reuse-pin sibling of check 35, #1370 — check 39
     `check_v4_sample_disclosure_count` — the Sample-slot
     `Disclosure: N of M` count reconciliation, #1421 — check 40
     `check_hf_unpinned_count_claims` (#1433) — check 41
-    `check_figure_sidecar_coverage` (#1478) — and checks 42
+    `check_figure_sidecar_coverage` (#1478) — checks 42
     `check_body_artifact_urls_exist` + 43
-    `check_github_tree_adjacent_file_claims` (#1507) ride CHECKS).
+    `check_github_tree_adjacent_file_claims` (#1507) — and check 44
+    `check_footer_hf_paths_pinned` (#1509) ride CHECKS).
     """
-    assert len(verify_task_body.CHECKS) == 45
+    assert len(verify_task_body.CHECKS) == 46
     # By-name membership so the NEXT check addition can key by name instead
     # of re-deriving the arithmetic (#1016 methodology-reconciler Must-Fix).
+    assert verify_task_body.check_footer_hf_paths_pinned in verify_task_body.CHECKS
     assert verify_task_body.check_hf_adjacent_file_claims in verify_task_body.CHECKS
     assert verify_task_body.check_figure_prose_numerics_vs_sidecar in verify_task_body.CHECKS
     assert verify_task_body.check_figure_beat_claims_vs_sidecar_text in verify_task_body.CHECKS
@@ -11102,11 +11107,11 @@ def test_caption_lead_issue1074_verbatim_caption_warns():
 
 def test_check_figure_caption_position_stable():
     """Index-stability pin (#1424): `check_figure_caption` stays at CHECKS
-    position 7 and the CHECKS count matches the current registry (45 as of
-    checks 42/43, #1507; belt-and-suspenders beside the migration-history
+    position 7 and the CHECKS count matches the current registry (46 as of
+    check 44, #1509; belt-and-suspenders beside the migration-history
     `len(CHECKS)` pin)."""
     assert verify_task_body.CHECKS[7] is verify_task_body.check_figure_caption
-    assert len(verify_task_body.CHECKS) == 45
+    assert len(verify_task_body.CHECKS) == 46
 
 
 # ─── Check 26: figure panel/series prose vs figure sidecar (panel drift) ───
@@ -13519,6 +13524,192 @@ def test_footer_reuse_bullet_fenced_skeleton_ignored():
     )
     res = verify_task_body.check_footer_reuse_bullets_pinned(body)
     assert res.passed and not res.is_warn, res.render()
+
+
+# ─── Check 44: footer HF artifact paths carry an adjacent pinned link ───────
+#
+# (#1509, incident #1335): a bare backtick HF-style artifact path in the
+# footer (`issue<N>_` prefix or a raw_completions/analysis_tensors segment,
+# brace/glob charset) whose bullet/paragraph unit carries neither a pinned
+# huggingface.co /(tree|resolve|blob)/<hex> link (S1) nor an
+# immediately-following `@ [HF ]rev <hex>` (S2) -> WARN. Direct-call style
+# on `_V4_GOOD_BODY`-derived fixtures (the check-37 block's convention);
+# `_V4_GOOD_BODY`'s own footer is S1-pinned (the `tree/abc123def` model
+# link) and carries no HF-identity backtick tokens, so appended bullets
+# are the only trigger surface.
+
+# The verbatim PRE-FIX #1335 footer bullet, recovered from
+# `git show 6d3c847946` (the fix commit's `-` side). Load-bearing traps it
+# carries: GitHub /tree/<sha> pins (never HF), bare code shas, an EARLIER
+# `@ `be61a85e`` GitHub figures pin (must NOT rescue under S2 anchoring),
+# non-HF backtick tokens (`cells_/nulls_/...`, `scripts/...`), and the
+# brace-form offending token with NO count-paren (so check 40 never
+# extracts it).
+_I1335_FOOTER_UNPINNED_LINE = (
+    "- Follow-up round `onpolicy-assistant-label` (2026-07-18, ~6 GPU-h, GCE 4×A100-80 "
+    "flex-start, 6-lane parallel dispatch): round artifacts "
+    "[eval_results/issue_1335/onpolicy-assistant-label/](https://github.com/superkaiba/"
+    "explore-persona-space/tree/be61a85e9ae2710f254c6e0b4fd422ac5244dec1/eval_results/"
+    "issue_1335/onpolicy-assistant-label) (`label_comparison.json` + per-cell "
+    "`cells_/nulls_/loso_/swap_/wiring_*.json`); fit/driver `scripts/issue1335_fit.py` + "
+    "`scripts/issue1335_fig_label.py` at code SHA "
+    "`01ebb89738835c656f4b8a942a0d3afe4647be25`. Figures: "
+    "[figures/issue_1335/onpolicy-assistant-label/](https://github.com/superkaiba/"
+    "explore-persona-space/tree/be61a85e9ae2710f254c6e0b4fd422ac5244dec1/figures/"
+    "issue_1335/onpolicy-assistant-label) (`hero_label_delta` + `answer_length_register`, "
+    "with `.meta.json` sidecars, @ `be61a85e`; `placement_panel` + `collapse_slots` @ "
+    "[`185a6bd8ee`](https://github.com/superkaiba/explore-persona-space/tree/"
+    "185a6bd8ee3f9165c346d27f9876efcefe845314/figures/issue_1335/onpolicy-assistant-label)). "
+    "HF rollouts and stores under "
+    "`issue1335_ablation_ladder/onpolicy_assistant_label/{raw_completions,analysis_tensors}/` "
+    "(verified via `list_repo_tree` on the interpretation pass)."
+)
+_I1335_OFFENDING_TOKEN = (
+    "issue1335_ablation_ladder/onpolicy_assistant_label/{raw_completions,analysis_tensors}/"
+)
+_C44_NAME = "footer HF artifact paths carry an adjacent pinned link"
+
+
+def test_footer_hf_path_unpinned_warns_1335_shape():
+    """MAIN / durability-pin test (#1509, incident #1335): the verbatim
+    pre-fix footer bullet -> WARN (`passed=True`, `is_warn=True`) naming
+    the brace-form token. The in-bullet GitHub pins / bare code shas /
+    earlier `@ `be61a85e`` must NOT rescue."""
+    body = _V4_GOOD_BODY + "\n" + _I1335_FOOTER_UNPINNED_LINE + "\n"
+    res = verify_task_body.check_footer_hf_paths_pinned(body)
+    assert res.passed and res.is_warn, res.render()
+    assert _I1335_OFFENDING_TOKEN in res.detail, res.render()
+
+
+def test_footer_hf_path_pinned_same_unit_passes():
+    """S1: the same incident bullet PLUS a pinned huggingface.co
+    /tree/<sha> link in the SAME bullet (the post-fix #1335 shape) ->
+    clean PASS."""
+    line = _I1335_FOOTER_UNPINNED_LINE + (
+        " Full tree: [rollouts](https://huggingface.co/datasets/superkaiba1/"
+        "explore-persona-space-data/tree/53e014c4a530cfba76f1e5f2b29a1ae4841d46b3/"
+        "issue1335_ablation_ladder/onpolicy_assistant_label)."
+    )
+    body = _V4_GOOD_BODY + "\n" + line + "\n"
+    res = verify_task_body.check_footer_hf_paths_pinned(body)
+    assert res.passed and not res.is_warn, res.render()
+    assert "all footer HF artifact paths pinned" in res.detail, res.render()
+
+
+def test_footer_hf_path_adjacent_at_rev_passes():
+    """S2: the committed `@ rev `<hex>`` / `@ HF rev `<hex>`` footer
+    shapes (#1112/#1335) immediately after the token -> clean PASS."""
+    body = _V4_GOOD_BODY + (
+        "\n- Reused mix: `issue1090_pvdatagen/c3-sycophancy-claude/mix/train_mix.jsonl` "
+        "@ rev `6aab0cce1fac` — fit: same recipe.\n"
+        "- Rollouts `issue825_userbase_map/raw_completions/track_s/` @ HF rev `deb7a452` "
+        "verified live.\n"
+    )
+    res = verify_task_body.check_footer_hf_paths_pinned(body)
+    assert res.passed and not res.is_warn, res.render()
+
+
+def test_footer_preceding_at_rev_does_not_rescue():
+    """S2 position-anchoring regression pin (the motivating incident's
+    exact bullet shape): an `@ `<hex>`` EARLIER in the bullet (a GitHub
+    figures pin), bare HF token later, no HF URL -> still WARNs."""
+    body = _V4_GOOD_BODY + (
+        "\n- Figures @ `be61a85e`; stores under `issue999_slug/analysis_tensors/` "
+        "(verified on the interpretation pass).\n"
+    )
+    res = verify_task_body.check_footer_hf_paths_pinned(body)
+    assert res.passed and res.is_warn, res.render()
+    assert "issue999_slug/analysis_tensors/" in res.detail, res.render()
+
+
+def test_footer_hf_path_adjacent_unit_pin_does_not_rescue():
+    """Unit-scoped-adjacency positive control (#1509 §13.2): the
+    offending token in bullet A, a pinned huggingface.co /tree/<hex>
+    link in a SEPARATE blank-line-separated bullet -> still WARNs. A
+    whole-footer pin scope (or a degenerate `_footer_units`) must FAIL
+    this test."""
+    body = _V4_GOOD_BODY + (
+        "\n- Stores under `issue999_slug/raw_completions/` for the record.\n"
+        "\n- Pinned elsewhere: [tree](https://huggingface.co/datasets/superkaiba1/"
+        "explore-persona-space-data/tree/53e014c4a530cfba76f1e5f2b29a1ae4841d46b3/"
+        "issue999_slug).\n"
+    )
+    res = verify_task_body.check_footer_hf_paths_pinned(body)
+    assert res.passed and res.is_warn, res.render()
+    assert "issue999_slug/raw_completions/" in res.detail, res.render()
+
+
+def test_footer_hf_path_v3_body_skipped():
+    """Forward-only: a grandfathered v3 body with the SAME offending line
+    -> vacuous PASS (never newly WARN/FAIL a v3/v2 body)."""
+    body = _V3_GOOD_BODY + "\n" + _I1335_FOOTER_UNPINNED_LINE + "\n"
+    res = verify_task_body.check_footer_hf_paths_pinned(body)
+    assert res.passed and not res.is_warn, res.render()
+    assert "not a v4 body" in res.detail, res.render()
+
+
+def test_footer_local_git_paths_pass():
+    """G3 `_GIT_SIDE_ROOTS`: git/local backtick paths in a pin-less
+    footer bullet (they resolve in git — checks 27/29 territory) ->
+    clean PASS."""
+    body = _V4_GOOD_BODY + (
+        "\n- Round artifacts: `eval_results/issue_1310/onpolicy/*.json`, "
+        "`figures/issue_1335/hero.png`, `scripts/issue1335_fit.py` (committed).\n"
+    )
+    res = verify_task_body.check_footer_hf_paths_pinned(body)
+    assert res.passed and not res.is_warn, res.render()
+
+
+def test_footer_count_claim_token_left_to_check40(monkeypatch):
+    """G5 partition (the check-30/40 convention — exactly ONE WARN per
+    defect): a footer count-paren claim is check 40's territory — the
+    gatherer extracts it, check 44 stays silent, and check 40 names it
+    (offline note-shape assert under the `EPM_VERIFY_BODY_NO_HF=1`
+    fence, per the check-40 test idiom)."""
+    monkeypatch.setenv("EPM_VERIFY_BODY_NO_HF", "1")
+    body = _V4_GOOD_BODY + (
+        "\n- HF rollouts `issue931_story_map/raw_completions/` (6 files) uploaded.\n"
+    )
+    claimed = {t for _c, _n, t, _r in verify_task_body._gather_hf_unpinned_count_claims(body)}
+    assert "issue931_story_map/raw_completions/" in claimed
+    res44 = verify_task_body.check_footer_hf_paths_pinned(body)
+    assert res44.passed and not res44.is_warn, res44.render()
+    res40 = verify_task_body.check_hf_unpinned_count_claims(body)
+    assert res40.passed, res40.render()
+    assert "issue931_story_map/raw_completions/" in res40.detail, res40.render()
+
+
+def test_footer_hf_path_fence_and_blockquote_exempt():
+    """`_footer_units` stripping: the offending line inside a ```-fenced
+    footer block (illustrative skeleton) AND inside a `>` Context quote
+    (#959 verbatim-prompt exemption) -> clean PASS."""
+    body = _V4_GOOD_BODY + (
+        "\n```\n" + _I1335_FOOTER_UNPINNED_LINE + "\n```\n\n> " + _I1335_FOOTER_UNPINNED_LINE + "\n"
+    )
+    res = verify_task_body.check_footer_hf_paths_pinned(body)
+    assert res.passed and not res.is_warn, res.render()
+
+
+def test_footer_hf_path_methodology_out_of_scope():
+    """Footer scoping: the bare token in `## Methodology` prose (above
+    the footer) is out of check 44's scope -> clean PASS (check-40
+    semantics elsewhere in the body are untouched)."""
+    body = _V4_GOOD_BODY.replace(
+        "## Results",
+        "Stores under `issue999_x/analysis_tensors/` (bare mention).\n\n## Results",
+    )
+    res = verify_task_body.check_footer_hf_paths_pinned(body)
+    assert res.passed and not res.is_warn, res.render()
+    assert "all footer HF artifact paths pinned" in res.detail, res.render()
+
+
+def test_footer_hf_path_no_footer_skips():
+    """No-crash on a footer-less v4 body (#1509 §13.3): `_v4_footer_text`
+    -> None path returns cleanly (pass, no exception)."""
+    body = _V4_GOOD_BODY.split("**Repro:**")[0]
+    res = verify_task_body.check_footer_hf_paths_pinned(body)
+    assert res.passed and not res.is_warn, res.render()
+    assert "no **Repro:** footer" in res.detail, res.render()
 
 
 # ─── Check 15 clause-scoping (#893, incident #841) ─────────────────────────


### PR DESCRIPTION
Closes task #1509. Adds check 44 check_footer_hf_paths_pinned (WARN, v4-only): bare backtick HF artifact paths in the v4 Repro/Context footer must carry a same-unit pinned huggingface.co tree/resolve/blob link or an anchored @ rev. 11 tests incl. the verbatim #1335 incident fixture; SPEC.md enforcement note. Plan v3 + critic ensemble + code-review PASS + Step 9c test-verdict PASS on task #1509.