### PR TITLE
issue #1514: load_dotenv-before-heavy-import fix on issue1092 combined-figure script

### DIFF
--- a/scripts/issue1092_prefixend_monitoring_combined_fig.py
+++ b/scripts/issue1092_prefixend_monitoring_combined_fig.py
@@ -16,10 +16,14 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import matplotlib.pyplot as plt
-import numpy as np
+from explore_persona_space.orchestrate.env import load_dotenv
 
-from explore_persona_space.analysis.paper_plots import (
+load_dotenv()
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+
+from explore_persona_space.analysis.paper_plots import (  # noqa: E402
     paper_palette_role,
     savefig_paper,
     set_paper_style,


### PR DESCRIPTION
Closes task #1514. 2-line import-order fix (62f983e36e shape) so tests/test_shared_vm_thread_caps.py::test_no_new_torch_before_dotenv_vm_entrypoints passes fleet-wide.