### PR TITLE
issue-1520: verify_task_body check 46 — brace-expanded HF paths vs adjacent /tree pins

### DIFF
--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -925,6 +925,44 @@ Generation-agnostic checks (run on v2 AND v3 — the inline-figure +
   "all 50 contexts lie below zero" beside a sidecar carrying a +0.004
   point; caught only at Lens 3 (#1511).
 
+- **check 46** (`check_hf_brace_expanded_path_claims`, WARN,
+  generation-agnostic, #1520): backtick brace-expansion path tokens
+  (`sampled_rollout/seed{42,137}/` — single-group comma alternation of
+  2–32 alternatives, or a numeric `{N..M}` range ≤32 wide; multi-group /
+  nested / glob / range-in-alternation / ellipsis-segment tokens extract
+  nothing) adjacent to a hex-pinned HF
+  `/tree/<sha>` markdown link must resolve at that pin's revision: each
+  expansion is overlap-joined onto the pin's path prefix (root pin /
+  repeated-prefix / single-segment basename overlap / plain descend; an
+  ambiguous multi-segment overlap declines to `unverified`) and tested
+  for exact direct-child membership against ONE bounded non-recursive
+  listing per unique joined parent (`_hf_tree_pages(recursive=False)`,
+  the #733 stack — never the SDK `list_repo_tree` / `list_repo_files`).
+  A pin-alive precheck disambiguates the tree endpoint's conflated 404:
+  an `ok`/`partial` pin listing proves the pin ALIVE, and only then is a
+  child-parent `not_found` a definitive missing-artifact signal (the
+  incident arm: prefix 200, `…/sampled_rollout` 404); a dead pin defers
+  to check 23's FAIL. Two anchored shapes: LINKTEXT (token inside the
+  pinned link's text — the fixed #1426 shape) and NEARBIND (bare token
+  bound via check 30's Pattern-D binder: same line, bracket-free,
+  ≤400-char gap — the pre-fix #1426 shape). Suppressors: git-side-root
+  first segment / leading `/` (NEARBIND), a token-adjacent
+  `@ [HF ]rev <hex>` own-pin, HF-absence disclaimer vocabulary
+  ("not yet uploaded", "upload pending", "git-only", "local-only",
+  "not on HF/hub") in the link text / forward window. Fail-soft: the
+  offline fence, a missing hub lib, network errors, page/time caps, and
+  the per-body `_HF_BRACE_MAX_PROBES` cap → `unverified` notes on a PASS
+  line; present-in-partial passes, missing is never grounded on a
+  partial listing. WARN never FAILs (no `passed=False` path). Named
+  recall sacrifices: multi-segment prefix–token overlap, `@ rev`-pinned
+  tokens (declined, not re-probed at that rev), pin-less brace tokens
+  (check 44's footer territory), false claims sharing a window with
+  disclaimer vocabulary, `/blob/` links, other hosts, moving refs.
+  Incident: task #1426's pre-fix footer cited
+  `sampled_rollout/seed{42,137}/` under the `c244377f` prefix pin while
+  the round's upload postdated the pin — both seed dirs 404 at the
+  pinned revision; caught only by the adversarial critic (#1520).
+
 Harmful-content carve-out: checks 18/19 accept the sanitized excerpt
 form (`[truncated — harmful-content row; verify at <path>, row <i>]`)
 exactly as checks 10/11 do today.
@@ -11216,6 +11254,426 @@ def check_figure_caption_count_claims_vs_sidecar(body: str) -> CheckResult:
     )
 
 
+# ─── Check 46: brace-expanded backtick HF paths vs the adjacent /tree pin ──
+# (#1520; incident #1426: the pre-fix footer cited `sampled_rollout/seed{42,137}/`
+# under a prefix link pinned at `c244377f…` — the robustness round's upload
+# postdated the pin, so both seed dirs 404 at the pinned revision; only the
+# adversarial critic caught it by re-resolving the path by hand. Check 32
+# rejects brace tokens by construction; check 43 owns git-host links; check 44
+# fires only on UNpinned footer units — the pinned brace-path class was
+# mechanically uncovered.)
+
+# Brace-path token recognizer: exactly ONE brace group by construction
+# (full-match + brace-free pre/post charsets — multi-group and nested braces
+# never match, the check-43 named-sacrifice pattern in the opposite
+# direction). `*` excluded everywhere (globs unprobeable). Alternatives
+# exclude `/` so all expansions of one group are path siblings. Leading
+# ./ ../ declined (the Pattern-D precedent).
+_HF_BRACE_PATH_TOKEN_RE = re.compile(
+    r"^(?!\.\.?/)"
+    r"(?P<pre>[A-Za-z0-9._\-/]*)"
+    r"\{(?P<grp>"
+    r"\d{1,4}\.\.\d{1,4}"  # numeric range {N..M} (check-43 parity)
+    r"|[A-Za-z0-9._\-]{1,64}(?:,[A-Za-z0-9._\-]{1,64}){1,31}"  # comma alternation, 2..32 alts
+    r")\}"
+    r"(?P<post>[A-Za-z0-9._\-/]*)$"
+)
+# Per-body cap on UNIQUE (repo, type, sha, parent) direct-children listings
+# (pin-alive prechecks included) — same value + worst-case wall arithmetic as
+# check 30's `_HF_COUNT_MAX_PROBES` (see that comment: ~22.5 s worst case per
+# probe, ~3 min per body under a pathologically slow Hub; typical is one
+# sub-second page per parent). Claims past the cap surface as unverified
+# notes, never a WARN.
+_HF_BRACE_MAX_PROBES = 8
+# Successful EXHAUSTIVE listings only: (repo_id, repo_type, sha, parent) →
+# frozenset of direct-child FULL paths. A skip / partial / not_found is NEVER
+# cached — same convention as _HF_EXISTENCE_CACHE (#733) — so a transient
+# throttle is re-probed on the next invocation.
+_HF_DIRECT_CHILDREN_CACHE: dict[tuple[str, str, str, str], frozenset[str]] = {}
+# HF-absence disclaimer suppressor — the HF-side sibling of check 43's
+# `_GH_TREE_DISCLAIMER_RE`, absence-specific anchors only. Scanned with
+# backtick code spans masked out (a filename token can never carry disclaimer
+# vocabulary). Instance-level suppression: a genuinely-false claim sharing
+# its window with disclaimer vocabulary is missed (the check-43 P1 precision
+# trade, named).
+_HF_UPLOAD_DISCLAIMER_RE = re.compile(
+    r"not\s+(?:yet\s+)?uploaded"
+    r"|upload\s+pending"
+    r"|pending\s+upload"
+    r"|git[- ]only"
+    r"|local[- ]only"
+    r"|not\s+on\s+(?:the\s+)?(?:HF|hub)\b",
+    re.IGNORECASE,
+)
+
+
+def _hf_upload_disclaimer_present(text: str) -> bool:
+    """True when `text` (one LINKTEXT / NEARBIND forward window) carries
+    explicit not-on-HF disclaimer vocabulary OUTSIDE backtick code spans
+    (check 46; mirrors `_gh_tree_disclaimer_present` — bridging-safe ` _ `
+    mask)."""
+    return _HF_UPLOAD_DISCLAIMER_RE.search(_BACKTICK_TOKEN_RE.sub(" _ ", text)) is not None
+
+
+def _expand_hf_brace_token(token: str) -> list[str]:
+    """The expanded sibling list for a single-group brace path token
+    (check 46) — `[]` for a non-brace / malformed / multi-group / glob /
+    over-wide token, a mixed range-in-alternation form (`..` inside a
+    comma alternative), or an ellipsis pure-dot path segment (no probe,
+    no WARN — recall sacrifices, each named inline). Unlike check 43's
+    `_expand_claim_token`, plain tokens do NOT pass through: this check
+    is brace-REQUIRED (plain `dir/` tokens stay check 30/40/44
+    territory). Comma form → split alternatives (2–32 by regex
+    construction); range form → `range(a, b+1)` gated by `b >= a` and
+    width ≤ `_GH_BRACE_MAX_EXPANSIONS` (=32, the shared check-43 bound)."""
+    m = _HF_BRACE_PATH_TOKEN_RE.match(token)
+    if m is None:
+        return []
+    pre, grp, post = m.group("pre"), m.group("grp"), m.group("post")
+    if re.fullmatch(r"\d{1,4}\.\.\d{1,4}", grp):
+        a, b = (int(x) for x in grp.split(".."))
+        if b < a or (b - a + 1) > _GH_BRACE_MAX_EXPANSIONS:
+            return []
+        alts = [str(i) for i in range(a, b + 1)]
+    else:
+        alts = grp.split(",")
+        if len(alts) > _GH_BRACE_MAX_EXPANSIONS:
+            return []
+        if any(".." in a for a in alts):
+            # Mixed range-in-alternation shorthand (`{A1..A5,B1..B5,C1}`,
+            # the #560 corpus shape): bash treats `A1..A5` as a LITERAL
+            # alternative, but the author's evident intent is a range —
+            # probing the literal manufactures a guaranteed false WARN
+            # while the intended artifacts resolve. Decline the whole
+            # token (AC10 precision; named recall sacrifice).
+            return []
+    out = [f"{pre}{alt}{post}" for alt in alts]
+    if any(seg and set(seg) == {"."} for e in out for seg in e.split("/")):
+        # A pure-dot path segment (`picked_categories/{coding,travel}/...`,
+        # the #617 corpus shape) is ellipsis PROSE, not a path — probing
+        # it asks the Hub about a nonsense literal. Decline (same class
+        # as globs: unprobeable; named recall sacrifice).
+        return []
+    return out
+
+
+def _join_brace_expansion(pin_prefix: str, expansion: str) -> str | None:
+    """Overlap-aware join of ONE brace expansion onto the pin URL's path
+    prefix (check 46). Four accepting branches, one decline:
+
+    - bare `/tree/<sha>` root pin → the token IS the repo-root path;
+    - the token repeats the prefix (repo-root-absolute citation) → as-is;
+    - single-segment basename overlap — the FIXED #1426 LINKTEXT shape:
+      prefix `…/sampled_rollout` + token `sampled_rollout/seed42` →
+      `…/sampled_rollout/seed42`;
+    - plain descend — the pre-fix NEARBIND shape: prefix + `/` + token.
+
+    Decline (returns ``None`` → the caller marks the claim `unverified`,
+    never probes a doubled path): the token's FIRST segment equals a
+    NON-basename prefix segment — a multi-segment-overlap citation
+    (e.g. prefix `a/b`, token `a/c`) that plain descend would join to the
+    doubled `a/b/a/c`, a guaranteed-404 false-WARN class. Deeper
+    multi-segment overlaps stay a named recall sacrifice (a deterministic
+    single rule beats a fuzzy longest-overlap scan)."""
+    t, p = expansion.rstrip("/"), pin_prefix.strip("/")
+    if not p:
+        return t
+    if t == p or t.startswith(p + "/"):
+        return t
+    base = posixpath.basename(p)
+    if base and t.startswith(base + "/"):
+        return p + t[len(base) :]
+    first_seg = t.split("/", 1)[0]
+    if first_seg and first_seg in p.split("/")[:-1]:
+        return None  # ambiguous multi-segment overlap — decline, never probe
+    return p + "/" + t
+
+
+def _gather_hf_brace_path_claims(
+    body: str,
+) -> list[tuple[str, str, str, str, str, list[str], str]]:
+    """Extract ``(repo_id, repo_type, sha, pin_prefix, token, expansions,
+    shape)`` tuples for backtick BRACE-PATH claims adjacent to hex-pinned
+    HF ``/tree`` markdown links (check 46). Scans
+    ``_strip_blockquote_lines(_strip_fenced_blocks(body))`` (the check-42
+    combination — a blockquoted verbatim prompt is quoted provenance, not
+    the body's claim, #959). Dedup on ``(repo_id, sha, pin_prefix,
+    token)``. Two anchored shapes (precision over recall — a missed claim
+    costs nothing on a WARN-only check):
+
+    - **LINKTEXT** — a backtick brace token inside the TEXT of a
+      hex-pinned HF ``/tree/<sha>`` markdown link (the fixed #1426 shape);
+      the whole instance is declined when the link text carries HF-absence
+      disclaimer vocabulary.
+    - **NEARBIND** — a bare backtick brace token bound to the nearest
+      preceding hex-pinned HF ``/tree/<sha>`` markdown link on the same
+      line via the reused check-30 Pattern-D binder
+      (``_nearest_preceding_pinned_tree_link``: no newline, no ``[``/``]``,
+      ≤400-char gap — the bracket guard also auto-declines tokens sitting
+      inside another link's text, so LINKTEXT/NEARBIND partition per
+      instance; a post-link paren token binds here naturally). The pre-fix
+      #1426 shape. Declined when: the token starts with ``/`` or its first
+      path segment is a git/local root (``_GIT_SIDE_ROOTS`` — the same
+      line's ``eval_results/…seed{42,137}/`` token); a position-anchored
+      ``@ [HF ]rev <hex>`` follows the token
+      (``_FOOTER_AT_REV_ADJ_RE.match`` at the token's closing backtick —
+      the token's OWN pin governs; re-probing at that rev is a named
+      recall sacrifice); or HF-absence disclaimer vocabulary sits in the
+      forward window (token end → +120 chars, same line, backtick-masked).
+
+    Tokens without a valid single brace group extract nothing (plain
+    ``dir/`` tokens stay check 30/40/44 territory; brace FILE claims on
+    git links stay check 43's). No HF-identity gate (check 44's G2) — pin
+    ADJACENCY is the identity signal (the check-30/32 posture). ``/blob/``
+    links and moving refs (``/tree/main``) are out of scope.
+    """
+    kind_to_type = {"datasets": "dataset", "spaces": "space", None: "model"}
+    stripped = _strip_blockquote_lines(_strip_fenced_blocks(body))
+    out: list[tuple[str, str, str, str, str, list[str], str]] = []
+    seen: set[tuple[str, str, str, str]] = set()
+
+    def _add(url: str, token: str, shape: str) -> None:
+        tok = token.strip()
+        expansions = _expand_hf_brace_token(tok)
+        if not expansions:
+            return
+        m = _HF_HUB_TREE_BLOB_URL_RE.match(url.rstrip(".,;:!?"))
+        if m is None or f"/tree/{m.group('sha')}" not in url:
+            return  # non-HF / /blob/ / moving ref → out of scope
+        prefix = (m.group("path") or "").rstrip("/")
+        repo_id = f"{m.group('owner')}/{m.group('repo')}"
+        key = (repo_id, m.group("sha"), prefix, tok)
+        if key in seen:
+            return
+        seen.add(key)
+        out.append(
+            (
+                repo_id,
+                kind_to_type[m.group("kind")],
+                m.group("sha"),
+                prefix,
+                tok,
+                expansions,
+                shape,
+            )
+        )
+
+    link_matches = list(_MD_HF_LINK_RE.finditer(stripped))
+    for lm in link_matches:  # shape LINKTEXT
+        if _hf_upload_disclaimer_present(lm.group("text")):
+            continue
+        for token in _BACKTICK_TOKEN_RE.findall(lm.group("text")):
+            _add(lm.group("url"), token, "LINKTEXT")
+    for tm in _BACKTICK_TOKEN_RE.finditer(stripped):  # shape NEARBIND
+        tok = tm.group(1).strip()
+        if "{" not in tok or not _expand_hf_brace_token(tok):
+            continue
+        if tok.startswith("/") or tok.split("/", 1)[0] in _GIT_SIDE_ROOTS:
+            continue  # G3: git/local claim, never an HF prefix
+        if _FOOTER_AT_REV_ADJ_RE.match(stripped, tm.end()) is not None:
+            continue  # token-adjacent own-pin governs (named recall sacrifice)
+        line_end = stripped.find("\n", tm.end())
+        window_end = line_end if line_end != -1 else len(stripped)
+        if _hf_upload_disclaimer_present(stripped[tm.end() : min(window_end, tm.end() + 120)]):
+            continue
+        lm = _nearest_preceding_pinned_tree_link(stripped, tm.start(), link_matches)
+        if lm is None:
+            continue
+        _add(lm.group("url"), tm.group(1), "NEARBIND")
+    return out
+
+
+def _hf_direct_children(
+    repo_id: str, repo_type: str, sha: str, parent: str
+) -> tuple[str, frozenset[str], str]:
+    """Bounded NON-recursive direct-children listing → ``(status,
+    child_full_paths, note)`` (check 46).
+
+    Consumes ``_hf_tree_pages(…, recursive=False)`` (#733 — the 4th
+    consumer its docstring invites; never the SDK ``list_repo_tree`` /
+    ``list_repo_files``). ``status``:
+
+    - ``"ok"`` ONLY on an EXHAUSTIVE listing (``exhausted`` event) —
+      cached in ``_HF_DIRECT_CHILDREN_CACHE``;
+    - ``"partial"`` on a page/time-cap hit, with the child paths seen so
+      far (positive membership usable; a missing verdict is NEVER
+      grounded on a partial — the check-32 rule); never cached;
+    - ``"not_found"`` returned DISTINCTLY, not collapsed to skip (this
+      call site's independent mapping, licensed by the
+      ``_TreeProbeResult`` docstring — the pin-alive precheck in
+      ``check_hf_brace_expanded_path_claims`` is what makes a
+      child-parent ``not_found`` definitive);
+    - ``"skip"`` under the ``EPM_VERIFY_BODY_NO_HF=1`` fence, a missing
+      ``huggingface_hub``, or a transient/network error.
+    """
+    if os.environ.get("EPM_VERIFY_BODY_NO_HF") == "1":
+        return "skip", frozenset(), "HF probe fenced"
+    try:
+        import huggingface_hub  # noqa: F401 — local import: optional-dependency guard
+    except ImportError:
+        return "skip", frozenset(), "huggingface_hub unavailable"
+    needle = parent.strip("/")
+    key = (repo_id, repo_type, sha, needle)
+    cached = _HF_DIRECT_CHILDREN_CACHE.get(key)
+    if cached is not None:
+        return "ok", cached, ""
+    children: set[str] = set()
+    for ev in _hf_tree_pages(repo_id, repo_type, sha, needle, recursive=False):
+        if ev.kind == "not_found":
+            return "not_found", frozenset(), "no such revision/path"
+        if ev.kind == "indeterminate":
+            return "skip", frozenset(), ev.note
+        if ev.kind == "cap":
+            return "partial", frozenset(children), "HF tree listing exceeded page/time cap"
+        if ev.kind == "exhausted":
+            result = frozenset(children)
+            _HF_DIRECT_CHILDREN_CACHE[key] = result
+            return "ok", result, ""
+        for e in ev.entries:
+            path = e.get("path", "")
+            if path and path != needle:
+                children.add(path)
+    raise AssertionError("unreachable: _hf_tree_pages ended without a terminal event")
+
+
+def check_hf_brace_expanded_path_claims(body: str) -> CheckResult:  # noqa: C901 — linear verdict walk
+    """Check 46 (WARN): a backtick brace-expansion path claimed adjacent
+    to a hex-pinned HF ``/tree`` markdown link must resolve — every
+    expansion, as a direct child of its joined parent — at the pinned
+    revision.
+
+    Incident: task #1426's pre-fix footer cited
+    ``sampled_rollout/seed{42,137}/`` under the ``c244377f…`` prefix pin;
+    the robustness round's upload postdated the pin, so both seed dirs
+    404 at the pinned revision and the cited artifacts were effectively
+    unpinned (#1520).
+
+    Semantics:
+
+    - **WARN, never FAIL.** There is NO code path returning
+      ``passed=False`` — two inference steps (pin binding + path join)
+      make a false FAIL too costly (the check-30/32/40/43/44 tier
+      convention; check 41's grandfathered-body argument). Each WARN line
+      carries its claim's shape tag (``shape: LINKTEXT`` /
+      ``shape: NEARBIND``).
+    - **Pin-alive precheck.** The Hub tree endpoint conflates "no such
+      revision" and "no such path" in one 404, so the pin prefix itself
+      is listed FIRST (memoized; counts toward the cap): ``not_found``
+      there → `unverified` ("check 23 owns the dead-pin FAIL"); ``skip``
+      → `unverified`; ``ok`` OR ``partial`` both prove the pin ALIVE and
+      proceed to the child probes — only then is a child-parent
+      ``not_found`` a DEFINITIVE missing-artifact signal (the incident
+      arm: prefix 200, ``…/sampled_rollout`` 404).
+    - **Exact direct-child membership.** Expansions are overlap-joined
+      onto the pin prefix (``_join_brace_expansion``; an ambiguous
+      multi-segment overlap declines to `unverified`) and grouped by
+      parent — one non-recursive listing verifies all sibling expansions
+      (alternatives exclude ``/`` by construction, so the common case is
+      ONE GET, shared with the pin precheck).
+    - **Partial listings.** Present-in-partial passes; a missing verdict
+      is NEVER grounded on a partial (the check-32 rule) — the unfound
+      expansion degrades to `unverified`.
+    - **Fail-soft everywhere.** The offline fence
+      (``EPM_VERIFY_BODY_NO_HF=1``), a missing ``huggingface_hub``, a
+      429 / network error, and the per-body ``_HF_BRACE_MAX_PROBES`` cap
+      all surface as `unverified` notes on a PASS line. When missing and
+      unverified claims coexist, the unverified list is appended to the
+      WARN detail (never dropped).
+    - **Probe accounting.** Unique ``(repo, type, sha, parent)`` keys are
+      probed AT MOST once per invocation via an intra-invocation memo;
+      skipped keys count toward the cap. The cross-process
+      ``_HF_DIRECT_CHILDREN_CACHE`` stores only successful exhaustive
+      listings.
+
+    Vacuous PASS — with ZERO Hub probes issued — when no brace-path claim
+    sits adjacent to a pinned HF tree link.
+    """
+    name = "HF brace-expanded path claims resolve at the adjacent pin"
+    claims = _gather_hf_brace_path_claims(body)
+    if not claims:
+        return CheckResult(
+            name, True, "no brace-expanded path claims adjacent to pinned HF tree links"
+        )
+    missing: list[str] = []
+    unverified: list[str] = []
+    probe_memo: dict[tuple[str, str, str, str], tuple[str, frozenset[str], str]] = {}
+
+    def _children(
+        repo_id: str, repo_type: str, sha: str, parent: str
+    ) -> tuple[str, frozenset[str], str] | None:
+        key = (repo_id, repo_type, sha, parent.strip("/"))
+        if key not in probe_memo:
+            if len(probe_memo) >= _HF_BRACE_MAX_PROBES:
+                return None  # per-body probe cap — caller appends the cap note
+            probe_memo[key] = _hf_direct_children(repo_id, repo_type, sha, parent)
+        return probe_memo[key]
+
+    def _note(entry: str) -> None:
+        if entry not in unverified:
+            unverified.append(entry)
+
+    for repo_id, repo_type, sha, prefix, tok, expansions, shape in claims:
+        where = f"`{prefix or repo_id}@{sha[:8]}`"
+        joined = [_join_brace_expansion(prefix, e) for e in expansions]
+        if any(j is None for j in joined):
+            _note(f"`{tok}` at {where} (ambiguous prefix overlap — join declined)")
+            continue
+        pin_res = _children(repo_id, repo_type, sha, prefix)
+        if pin_res is None:
+            _note(f"`{tok}` at {where} (per-body probe cap)")
+            continue
+        st_pin, _kids_pin, note_pin = pin_res
+        if st_pin == "not_found":
+            _note(f"`{tok}` at {where} (pin itself unresolvable — check 23 owns the dead-pin FAIL)")
+            continue
+        if st_pin == "skip":
+            _note(f"`{tok}` at {where} ({note_pin})")
+            continue
+        # st_pin in {"ok", "partial"} → the pin is ALIVE; probe the joined parents.
+        by_parent: dict[str, list[str]] = {}
+        for j in joined:
+            by_parent.setdefault(posixpath.dirname(j), []).append(j)
+        tok_missing: list[str] = []
+        for parent in sorted(by_parent):
+            group = by_parent[parent]
+            if parent.strip("/") == prefix.strip("/"):
+                st, kids, note = pin_res  # one GET for the common case
+            else:
+                res = _children(repo_id, repo_type, sha, parent)
+                if res is None:
+                    _note(f"`{tok}` at {where} (per-body probe cap)")
+                    continue
+                st, kids, note = res
+            if st == "not_found":
+                # DEFINITIVE: pin alive, parent absent — the incident arm.
+                tok_missing.extend(f"`{j}`" for j in group)
+            elif st == "ok":
+                tok_missing.extend(f"`{j}`" for j in group if j not in kids)
+            elif st == "partial":
+                for j in group:
+                    if j not in kids:  # present-in-partial passes
+                        _note(f"`{j}` at {where} (partial listing — missing never grounded)")
+            else:  # skip
+                _note(f"`{tok}` at {where} ({note})")
+        if tok_missing:
+            missing.append(
+                f"body claims `{tok}` under the pinned HF prefix `{prefix or '/'}` at "
+                f"`{repo_id}@{sha[:8]}`, but {', '.join(tok_missing)} "
+                f"do{'es' if len(tok_missing) == 1 else ''} not resolve at that revision "
+                f"({len(tok_missing)}/{len(joined)} expansions missing; shape: {shape}) — "
+                "artifact likely uploaded after the pin; re-pin to its upload revision"
+            )
+    unverified_detail = ""
+    if unverified:
+        unverified_detail = (
+            f"; {len(unverified)} unverified (existence not confirmed): " + "; ".join(unverified)
+        )
+    if missing:
+        return CheckResult(name, True, "; ".join(missing) + unverified_detail, is_warn=True)
+    detail = f"{len(claims)} brace-path claim(s) against {len(probe_memo)} pinned parent(s)"
+    return CheckResult(name, True, detail + unverified_detail)
+
+
 def check_concerns_audit(  # noqa: C901 — linear lens: ledger parse → stale-marker scan → ack scan
     body: str, *, concerns_path: Path | None = None
 ) -> CheckResult:
@@ -13404,6 +13862,10 @@ CHECKS = [
     # point-value pools; contradiction-only, any-size-matching-pool-satisfies
     # (#1511; incident #1426):
     check_figure_caption_count_claims_vs_sidecar,
+    # check 46 (WARN, generation-agnostic) — brace-expanded backtick HF paths
+    # adjacent to a pinned /tree/<sha> link resolve at that revision
+    # (#1520; incident #1426):
+    check_hf_brace_expanded_path_claims,
     # Check 31 (`check_orphaned_per_unit_figures`, WARN, generation-agnostic)
     # is NOT here either — like check 20 (v4) it needs the issue number (for
     # figures-dir scoping), so it is dispatched separately in `verify_text`

--- a/scripts/verify_task_body.py
+++ b/scripts/verify_task_body.py
@@ -928,7 +928,7 @@ Generation-agnostic checks (run on v2 AND v3 — the inline-figure +
 - **check 46** (`check_hf_brace_expanded_path_claims`, WARN,
   generation-agnostic, #1520): backtick brace-expansion path tokens
   (`sampled_rollout/seed{42,137}/` — single-group comma alternation of
-  2–32 alternatives, or a numeric `{N..M}` range ≤32 wide; multi-group /
+  2-32 alternatives, or a numeric `{N..M}` range ≤32 wide; multi-group /
   nested / glob / range-in-alternation / ellipsis-segment tokens extract
   nothing) adjacent to a hex-pinned HF
   `/tree/<sha>` markdown link must resolve at that pin's revision: each
@@ -954,7 +954,7 @@ Generation-agnostic checks (run on v2 AND v3 — the inline-figure +
   the per-body `_HF_BRACE_MAX_PROBES` cap → `unverified` notes on a PASS
   line; present-in-partial passes, missing is never grounded on a
   partial listing. WARN never FAILs (no `passed=False` path). Named
-  recall sacrifices: multi-segment prefix–token overlap, `@ rev`-pinned
+  recall sacrifices: multi-segment prefix-token overlap, `@ rev`-pinned
   tokens (declined, not re-probed at that rev), pin-less brace tokens
   (check 44's footer territory), false claims sharing a window with
   disclaimer vocabulary, `/blob/` links, other hosts, moving refs.
@@ -11323,7 +11323,7 @@ def _expand_hf_brace_token(token: str) -> list[str]:
     no WARN — recall sacrifices, each named inline). Unlike check 43's
     `_expand_claim_token`, plain tokens do NOT pass through: this check
     is brace-REQUIRED (plain `dir/` tokens stay check 30/40/44
-    territory). Comma form → split alternatives (2–32 by regex
+    territory). Comma form → split alternatives (2-32 by regex
     construction); range form → `range(a, b+1)` gated by `b >= a` and
     width ≤ `_GH_BRACE_MAX_EXPANSIONS` (=32, the shared check-43 bound)."""
     m = _HF_BRACE_PATH_TOKEN_RE.match(token)

--- a/tests/test_verify_task_body.py
+++ b/tests/test_verify_task_body.py
@@ -175,7 +175,7 @@ def test_good_body_passes_all():
     # locally reachable, so the cited SHA is silently skipped), AND the
     # check-38 linked-not-embedded-figures scan (needs `issue` for
     # own-figures-dir scoping, #1371; PASS-skip: not a v4 body) →
-    # 59 results total (2 prepended + CHECKS[1:]=46 + 11 appended; check 36
+    # 60 results total (2 prepended + CHECKS[1:]=47 + 11 appended; check 36
     # `check_v4_result_paragraph_sentences` (#1368), check 37
     # `check_footer_reuse_bullets_pinned` (#1370), check 39
     # `check_v4_sample_disclosure_count` (#1421), check 40
@@ -189,13 +189,16 @@ def test_good_body_passes_all():
     # `check_footer_hf_paths_pinned` (#1509 — PASS-skip, not a v4 body),
     # and check 45
     # `check_figure_caption_count_claims_vs_sidecar` (#1511 — vacuous
-    # PASS, no registered count claim) ride CHECKS; 36/37/39/44
+    # PASS, no registered count claim), and check 46
+    # `check_hf_brace_expanded_path_claims` (#1520 — vacuous PASS, no
+    # brace-path claims adjacent to pinned HF tree links) ride CHECKS;
+    # 36/37/39/44
     # PASS-skip here — not a v4 body — 40 is the vacuous PASS above, and
     # 41 is the fake-sha NO-OP PASS above). The
     # Lens 14 / check-16 results are PASS-skips when no concerns.jsonl /
     # plans/plan.md sibling is available; check 17 and the v3/v4 checks
     # are PASS-skips on this legacy (pre-v2-sentinel) fixture.
-    assert len(results) == 59
+    assert len(results) == 60
     # By-name membership so the NEXT check addition can key by name instead
     # of re-deriving the arithmetic (#1016 methodology-reconciler Must-Fix).
     assert _HF_32_NAME in {r.name for r in results}
@@ -1894,16 +1897,20 @@ def _clear_hf_existence_cache():
     memoizes successful exhaustive `(n_files, n_dirs)` listings in
     `_HF_TREE_FILE_COUNT_CACHE` (#1008), and the check-32 membership probe
     memoizes successful exhaustive basename listings in
-    `_HF_TREE_BASENAMES_CACHE` (#1016). Clear all three before AND after
+    `_HF_TREE_BASENAMES_CACHE` (#1016), and the check-46 brace-path probe
+    memoizes successful exhaustive direct-children listings in
+    `_HF_DIRECT_CHILDREN_CACHE` (#1520). Clear all four before AND after
     each test so a cached verdict keyed on a (repo, sha, path) reused across
     fixtures never leaks one test's stubbed outcome into another."""
     verify_task_body._HF_EXISTENCE_CACHE.clear()
     verify_task_body._HF_TREE_FILE_COUNT_CACHE.clear()
     verify_task_body._HF_TREE_BASENAMES_CACHE.clear()
+    verify_task_body._HF_DIRECT_CHILDREN_CACHE.clear()
     yield
     verify_task_body._HF_EXISTENCE_CACHE.clear()
     verify_task_body._HF_TREE_FILE_COUNT_CACHE.clear()
     verify_task_body._HF_TREE_BASENAMES_CACHE.clear()
+    verify_task_body._HF_DIRECT_CHILDREN_CACHE.clear()
 
 
 # The real probe primitive, captured at module import time — BEFORE any
@@ -5767,9 +5774,9 @@ def test_checks_list_size():
     denominator check (needs eval JSONs), and the check-31
     orphaned-per-unit-figures probe (needs `issue` for figures-dir
     scoping, #1011).
-    So `verify_text` returns 59 results (2 prepended + CHECKS[1:]=46 +
+    So `verify_text` returns 60 results (2 prepended + CHECKS[1:]=47 +
     11 appended — see `test_good_body_passes_all`), but `CHECKS` stays
-    at 47 (check 36 `check_v4_result_paragraph_sentences` (#1368),
+    at 48 (check 36 `check_v4_result_paragraph_sentences` (#1368),
     check 37 `check_footer_reuse_bullets_pinned` — the body-only
     footer-side reuse-pin sibling of check 35, #1370 — check 39
     `check_v4_sample_disclosure_count` — the Sample-slot
@@ -5778,10 +5785,11 @@ def test_checks_list_size():
     `check_figure_sidecar_coverage` (#1478) — checks 42
     `check_body_artifact_urls_exist` + 43
     `check_github_tree_adjacent_file_claims` (#1507) — check 44
-    `check_footer_hf_paths_pinned` (#1509) — and check 45
-    `check_figure_caption_count_claims_vs_sidecar` (#1511) ride CHECKS).
+    `check_footer_hf_paths_pinned` (#1509) — check 45
+    `check_figure_caption_count_claims_vs_sidecar` (#1511) — and check 46
+    `check_hf_brace_expanded_path_claims` (#1520) ride CHECKS).
     """
-    assert len(verify_task_body.CHECKS) == 47
+    assert len(verify_task_body.CHECKS) == 48
     # By-name membership so the NEXT check addition can key by name instead
     # of re-deriving the arithmetic (#1016 methodology-reconciler Must-Fix).
     assert verify_task_body.check_footer_hf_paths_pinned in verify_task_body.CHECKS
@@ -11291,11 +11299,11 @@ def test_caption_lead_issue1074_verbatim_caption_warns():
 
 def test_check_figure_caption_position_stable():
     """Index-stability pin (#1424): `check_figure_caption` stays at CHECKS
-    position 7 and the CHECKS count matches the current registry (47 as of
-    checks 44/45, #1509/#1511; belt-and-suspenders beside the migration-history
+    position 7 and the CHECKS count matches the current registry (48 as of
+    check 46, #1520; belt-and-suspenders beside the migration-history
     `len(CHECKS)` pin)."""
     assert verify_task_body.CHECKS[7] is verify_task_body.check_figure_caption
-    assert len(verify_task_body.CHECKS) == 47
+    assert len(verify_task_body.CHECKS) == 48
 
 
 # ─── Check 26: figure panel/series prose vs figure sidecar (panel drift) ───
@@ -15117,3 +15125,396 @@ def test_check45_subset_claim_larger_pool_rescue():
     claims3 = verify_task_body._caption_count_claims("all 3 contexts lie below zero")
     warns3, n3, _s3 = verify_task_body._count_claim_failures(claims3, pools_incident, "f.png")
     assert n3 == 1 and len(warns3) == 1 and "pos_ctx" in warns3[0]
+
+
+# ─── Check 46: brace-expanded backtick HF paths vs the adjacent /tree pin ───
+#
+# (#1520; incident #1426.) Conventions: `_stub_tree` / inline `_hf_tree_get`
+# stubs re-patch over the autouse `_no_unexpected_probes` raise-guard (an
+# unstubbed probe is a hard error, which doubles as the zero-probe assert in
+# the gather-only / fenced tests); the conftest-level EPM_VERIFY_BODY_NO_HF
+# fence is delenv'd only in tests that exercise the online verdict path.
+
+# Verbatim **Repro:** line 204 of the PRE-FIX #1426 body (commit b2b5eb0b74) — the
+# NEARBIND incident shape: `sampled_rollout/seed{42,137}/` 272 bracket-free chars
+# after the c244377f-pinned prefix link.
+_I1426_PREFIX_REPRO_LINE = (
+    "**Repro:** primary — GCP 1× A100-80 (`eps-issue-1426`, us-central1), one provision; "
+    "3 launches of attempt `att-20260717-234120` — launches 1–2 died on transient HF 429 "
+    "rate limits during artifact staging (infra only; resume digest-validated per unit), "
+    "launch 3 completed after commit `98d7218ee1` added transient-retry to the upload hel"
+    "per. Gate: terminal pass (usable 0.986 on the non-collapse slice, offender rate 0.83"
+    "%, p95 generation length 1,746 tokens vs the 8,192 cap). Driver at `4e53cedec8`; run"
+    " artifacts committed at `3f67cf6e83`; the covariate phase (a 0-GPU VM-side re-reduct"
+    "ion the pod driver does not run) was executed during upload verification and committ"
+    "ed at `3fdf8222e5`; analyzer figures at `891e7851ff`, revised (reader-facing MLP-her"
+    "o labels, tercile denominator legend) + the 45 driver-generated F1 figures mirrored "
+    "from HF at `4a65c36ab0`; pooled tri-lineage gradient analysis artifact + figure at `"
+    "4b3adbe612`, load_dotenv hot-fix at `62f983e36e` (branch `issue-1426`). Robustness r"
+    "ound — GCP 2× A100-80 (`eps-issue-1426-sampled`, us-central1), ~55 min (~1.8 GPU-h);"
+    " commits `e6dab7d18d` + `fb4e92445c` + `ce341a98ac` (driver + analysis) + `148a95a6c"
+    "a` (figures) on branch `issue-1426-sampled`. Eval JSONs: `eval_results/issue_1426/` "
+    "(primary + `cap16k/` + `indiv-mlp-nonlinearity-control/`) and `eval_results/issue_14"
+    "26/sampled-rollout-robustness/seed{42,137}/`. HF data repo `superkaiba1/explore-pers"
+    "ona-space-data`, prefix [`issue1426_cot_decomposition_r1llama/`](https://huggingface"
+    ".co/datasets/superkaiba1/explore-persona-space-data/tree/c244377f2b5bc9e1ed8dd093b05"
+    "035aa0c4940e9/issue1426_cot_decomposition_r1llama): `raw_completions/thinking_rollou"
+    "ts/` + `thinking_rollouts_16k/`, `analysis_tensors/` (store manifest + summaries + d"
+    "ecomp tensors + MLP control), `fit_results/` + `fit_results_16k/`, `figures/` (listi"
+    "ngs verified via `list_repo_tree` at write time); sampled rollouts at `sampled_rollo"
+    "ut/seed{42,137}/`. Reused inputs: the 50-context battery + 48-probe pool (sha-pinned"
+    ", from [#928](https://github.com/superkaiba/explore-persona-space/issues/928)/[#1005"
+    "](https://github.com/superkaiba/explore-persona-space/issues/1005)); both prior line"
+    "ages' committed per-context delta artifacts and figure sidecars (`eval_results/issue"
+    "_928/percontext_deltas.json`, `eval_results/issue_1005/percontext_deltas.json`, `fig"
+    "ures/issue_928/percontext_scatter_avg_q.meta.json`, `figures/issue_928/percontext_sc"
+    "atter_indiv.meta.json`, `figures/issue_1005/fam_contrast_length_matched.meta.json`) "
+    "for the like-for-like baselines — fit: same contrast code, parity-gated against comm"
+    "itted values."
+)
+
+# Verbatim **Repro:** line 204 of the FIXED #1426 body (commit 0ee2cb1744) — the
+# LINKTEXT shape: the brace token inside the text of the 31d4fb5c-pinned
+# `…/sampled_rollout` link.
+_I1426_FIXED_REPRO_LINE = (
+    "**Repro:** primary — GCP 1× A100-80 (`eps-issue-1426`, us-central1), one provision; "
+    "3 launches of attempt `att-20260717-234120` — launches 1–2 died on transient HF 429 "
+    "rate limits during artifact staging (infra only; resume digest-validated per unit), "
+    "launch 3 completed after commit `98d7218ee1` added transient-retry to the upload hel"
+    "per. Gate: terminal pass (usable 0.986 on the non-collapse slice, offender rate 0.83"
+    "%, p95 generation length 1,746 tokens vs the 8,192 cap). Driver at `4e53cedec8`; run"
+    " artifacts committed at `3f67cf6e83`; the covariate phase (a 0-GPU VM-side re-reduct"
+    "ion the pod driver does not run) was executed during upload verification and committ"
+    "ed at `3fdf8222e5`; analyzer figures at `891e7851ff`, revised (reader-facing MLP-her"
+    "o labels, tercile denominator legend) + the 45 driver-generated F1 figures mirrored "
+    "from HF at `4a65c36ab0`; pooled tri-lineage gradient analysis artifact + figure at `"
+    "4b3adbe612`, load_dotenv hot-fix at `62f983e36e` (branch `issue-1426`). Robustness r"
+    "ound — GCP 2× A100-80 (`eps-issue-1426-sampled`, us-central1), ~55 min (~1.8 GPU-h);"
+    " commits `e6dab7d18d` + `fb4e92445c` + `ce341a98ac` (driver + analysis) + `148a95a6c"
+    "a` (figures) on branch `issue-1426-sampled`. Eval JSONs: `eval_results/issue_1426/` "
+    "(primary + `cap16k/` + `indiv-mlp-nonlinearity-control/`) and `eval_results/issue_14"
+    "26/sampled-rollout-robustness/seed{42,137}/`. HF data repo `superkaiba1/explore-pers"
+    "ona-space-data`, prefix [`issue1426_cot_decomposition_r1llama/`](https://huggingface"
+    ".co/datasets/superkaiba1/explore-persona-space-data/tree/c244377f2b5bc9e1ed8dd093b05"
+    "035aa0c4940e9/issue1426_cot_decomposition_r1llama): `raw_completions/thinking_rollou"
+    "ts/` + `thinking_rollouts_16k/`, `analysis_tensors/` (store manifest + summaries + d"
+    "ecomp tensors + MLP control), `fit_results/` + `fit_results_16k/`, `figures/` (listi"
+    "ngs verified via `list_repo_tree` at write time); sampled rollouts at [`sampled_roll"
+    "out/seed{42,137}/` (pinned)](https://huggingface.co/datasets/superkaiba1/explore-per"
+    "sona-space-data/tree/31d4fb5cc07ef3fe34bcc252e0defa5b5e44a408/issue1426_cot_decompos"
+    "ition_r1llama/sampled_rollout) — uploaded after the primary pin, hence the separate "
+    "revision. Reused inputs: the 50-context battery + 48-probe pool (sha-pinned, from [#"
+    "928](https://github.com/superkaiba/explore-persona-space/issues/928)/[#1005](https:/"
+    "/github.com/superkaiba/explore-persona-space/issues/1005)); both prior lineages' com"
+    "mitted per-context delta artifacts and figure sidecars (`eval_results/issue_928/perc"
+    "ontext_deltas.json`, `eval_results/issue_1005/percontext_deltas.json`, `figures/issu"
+    "e_928/percontext_scatter_avg_q.meta.json`, `figures/issue_928/percontext_scatter_ind"
+    "iv.meta.json`, `figures/issue_1005/fam_contrast_length_matched.meta.json`) for the l"
+    "ike-for-like baselines — fit: same contrast code, parity-gated against committed val"
+    "ues."
+)
+
+_I1426_SHA_PRE = "c244377f2b5bc9e1ed8dd093b05035aa0c4940e9"
+_I1426_SHA_FIX = "31d4fb5cc07ef3fe34bcc252e0defa5b5e44a408"
+_I1426_HF_PREFIX = "issue1426_cot_decomposition_r1llama"
+# A throwaway hex pin for the synthetic check-46 bodies.
+_C46_SHA = "aaaa1111bbbb2222cccc3333dddd4444eeee5555"
+
+
+def _c46_link(path, text="`x`", sha=_C46_SHA):
+    """One hex-pinned HF dataset /tree markdown link for check-46 bodies."""
+    return f"[{text}](https://huggingface.co/datasets/o/r/tree/{sha}/{path})"
+
+
+def _stub_tree_by_url(monkeypatch, responses, calls=None):
+    """`_hf_tree_get` stub dispatching on URL substring (first match wins) →
+    (status, entries, next_page); raises on an unmatched URL (missed-mock
+    detection, the `_no_unexpected_probes` convention). Child-parent URLs
+    are `quote(path, safe="")`-encoded, so nested-path needles use `%2F`."""
+
+    def _fake(url, params, headers, *, timeout_s):
+        if calls is not None:
+            calls.append((url, params))
+        for needle, (status, entries, next_page) in responses:
+            if needle in url:
+                return verify_task_body._TreeProbeResult(status, list(entries), next_page, "")
+        raise AssertionError(f"unexpected probe URL: {url}")
+
+    monkeypatch.setattr(verify_task_body, "_hf_tree_get", _fake)
+
+
+def test_hf_brace_claim_missing_warns_1426_prefix_shape(monkeypatch):
+    """AC1: the VERBATIM pre-fix #1426 Repro line WARNs — pin prefix alive
+    (200, 5 entries, no sampled_rollout), the expansions' parent 404s →
+    definitive missing, both joined expansions named, NEARBIND shape;
+    the alive no-brace tokens are never reported. (AC8: passed stays True.)"""
+    monkeypatch.delenv("EPM_VERIFY_BODY_NO_HF", raising=False)
+    calls = []
+    entries = [
+        {"path": f"{_I1426_HF_PREFIX}/{n}", "type": "directory"}
+        for n in (
+            "raw_completions",
+            "analysis_tensors",
+            "fit_results",
+            "fit_results_16k",
+            "figures",
+        )
+    ]
+    _stub_tree_by_url(
+        monkeypatch,
+        [
+            ("%2Fsampled_rollout", ("not_found", [], None)),
+            (f"/tree/{_I1426_SHA_PRE}/{_I1426_HF_PREFIX}", ("ok", entries, None)),
+        ],
+        calls=calls,
+    )
+    res = verify_task_body.check_hf_brace_expanded_path_claims(_I1426_PREFIX_REPRO_LINE)
+    assert res.passed is True and res.is_warn is True, res.render()
+    assert res.render().startswith("  [WARN]")
+    assert "sampled_rollout/seed{42,137}/" in res.detail
+    assert f"`{_I1426_HF_PREFIX}/sampled_rollout/seed42`" in res.detail
+    assert f"`{_I1426_HF_PREFIX}/sampled_rollout/seed137`" in res.detail
+    assert "c244377f" in res.detail
+    assert "shape: NEARBIND" in res.detail
+    assert "2/2 expansions missing" in res.detail
+    assert "thinking_rollouts" not in res.detail  # alive no-brace tokens never reported
+    assert len(calls) == 2  # pin-alive precheck + one child-parent listing
+
+
+def test_hf_brace_claim_present_passes_fixed_1426_linktext_shape(monkeypatch):
+    """AC2: the VERBATIM fixed #1426 line PASSes clean — the LINKTEXT token
+    overlap-joins onto the `…/sampled_rollout` prefix (single-segment
+    basename overlap) and both seed dirs resolve; ONE probed parent (the
+    pin precheck IS the parent listing), no WARN, no unverified."""
+    monkeypatch.delenv("EPM_VERIFY_BODY_NO_HF", raising=False)
+    calls = []
+    entries = [
+        {"path": f"{_I1426_HF_PREFIX}/sampled_rollout/seed42", "type": "directory"},
+        {"path": f"{_I1426_HF_PREFIX}/sampled_rollout/seed137", "type": "directory"},
+    ]
+    _stub_tree_by_url(monkeypatch, [("%2Fsampled_rollout", ("ok", entries, None))], calls=calls)
+    res = verify_task_body.check_hf_brace_expanded_path_claims(_I1426_FIXED_REPRO_LINE)
+    assert res.passed is True and res.is_warn is False, res.render()
+    assert "unverified" not in res.detail
+    assert len(calls) == 1
+
+
+def test_hf_brace_partial_missing_warns_only_absent_expansion(monkeypatch):
+    """AC3: an exhaustive listing carrying seed42 only → WARN names ONLY the
+    absent seed137 expansion (singular 'does not resolve')."""
+    monkeypatch.delenv("EPM_VERIFY_BODY_NO_HF", raising=False)
+    _stub_tree_by_url(
+        monkeypatch,
+        [(f"/tree/{_C46_SHA}/dir", ("ok", [{"path": "dir/seed42", "type": "directory"}], None))],
+    )
+    body = _c46_link("dir", text="`seed{42,137}/`")
+    res = verify_task_body.check_hf_brace_expanded_path_claims(body)
+    assert res.passed is True and res.is_warn is True, res.render()
+    assert "`dir/seed137`" in res.detail
+    assert "dir/seed42" not in res.detail
+    assert "1/2 expansions missing" in res.detail
+    assert "does not resolve" in res.detail
+    assert "shape: LINKTEXT" in res.detail
+
+
+def test_expand_hf_brace_token_bounds_and_charset():
+    """AC4: comma alternation (2-32, no `/`) and numeric {N..M} (<=32 wide)
+    expand; malformed / over-wide / multi-group / glob / plain tokens
+    extract ZERO expansions."""
+    expand = verify_task_body._expand_hf_brace_token
+    assert expand("seed{42,137}") == ["seed42", "seed137"]
+    assert expand("{raw_completions,analysis_tensors}/") == [
+        "raw_completions/",
+        "analysis_tensors/",
+    ]
+    assert expand("fold{0..4}") == ["fold0", "fold1", "fold2", "fold3", "fold4"]
+    assert expand("x{0..4000}") == []  # over-wide range
+    assert expand("x{4..0}") == []  # reversed range
+    assert expand("{a}") == []  # single alternative — not a brace group
+    assert expand("{a,b/c}") == []  # `/` inside an alternative
+    assert expand("a{1,2}b{3,4}") == []  # multi-group
+    assert expand("x*{a,b}") == []  # glob
+    assert expand("plain/dir/") == []  # no brace — brace-REQUIRED check
+    assert expand("../up{1,2}") == []  # leading ../ declined
+    # mixed range-in-alternation shorthand (the #560 corpus shape) declined —
+    # bash-literal alternatives would probe nonsense while the intended
+    # per-range artifacts resolve (AC10 precision):
+    assert expand("i474_loc_{A1..A5,B1..B5,C1}_ep1") == []
+    # ellipsis pure-dot segment (the #617 corpus shape) declined — `...` is
+    # prose, not a path:
+    assert expand("picked_categories/{coding,travel}/...") == []
+
+
+def test_join_brace_expansion_branches():
+    """All four accepting `_join_brace_expansion` branches + the ambiguous
+    multi-segment-overlap decline (returns None)."""
+    join = verify_task_body._join_brace_expansion
+    assert join("", "x1") == "x1"  # bare root pin
+    assert join("a/b", "a/b/c") == "a/b/c"  # token repeats the prefix
+    assert join("a/b", "a/b") == "a/b"  # token IS the prefix
+    # single-segment basename overlap — the FIXED #1426 shape:
+    assert join("p/sampled_rollout", "sampled_rollout/seed42/") == "p/sampled_rollout/seed42"
+    assert join("p", "seed42/") == "p/seed42"  # plain descend
+    assert join("a/b", "a/c1") is None  # doubled-path false-WARN class → decline
+
+
+def test_hf_brace_git_side_root_excluded():
+    """AC5 (G3): a git-side-root token (`eval_results/…`) in the binder gap
+    extracts ZERO claims (and zero probes — no stub installed, the autouse
+    raise-guard would fail any GET)."""
+    body = (
+        _c46_link("x", text="`x/`")
+        + ": `eval_results/x/sampled-rollout-robustness/seed{42,137}/` committed in git."
+    )
+    assert verify_task_body._gather_hf_brace_path_claims(body) == []
+    res = verify_task_body.check_hf_brace_expanded_path_claims(body)
+    assert res.passed is True and res.is_warn is False
+    assert "no brace-expanded path claims" in res.detail
+
+
+def test_hf_brace_nearbind_gap_guards():
+    """NEARBIND precision: gap >400 chars / newline in gap / intervening
+    markdown link each decline; the small-gap control binds."""
+    link = _c46_link("p", text="`p/`")
+    tok = "`sub/seed{1,2}/`"
+    gather = verify_task_body._gather_hf_brace_path_claims
+    assert gather(link + " " + "x" * 401 + " " + tok) == []
+    assert gather(link + "\n" + tok) == []
+    assert gather(link + " [other](https://example.com/y) " + tok) == []
+    claims = gather(link + " sampled at " + tok)
+    assert len(claims) == 1 and claims[0][6] == "NEARBIND"
+
+
+def test_hf_brace_token_own_at_rev_pin_declines():
+    """AC5: a token-adjacent `@ rev <hex>` own-pin governs — the NEARBIND
+    binding to the earlier link is declined (zero claims)."""
+    body = _c46_link("p", text="`p/`") + " rollouts `sub/seed{1,2}/` @ rev `deadbeef12` later."
+    assert verify_task_body._gather_hf_brace_path_claims(body) == []
+
+
+def test_hf_brace_disclaimer_suppresses():
+    """AC5: HF-absence disclaimer vocabulary in the forward window (NEARBIND)
+    or the link text (LINKTEXT) suppresses the instance; the same line
+    without the disclaimer fires."""
+    link = _c46_link("p", text="`p/`")
+    gather = verify_task_body._gather_hf_brace_path_claims
+    assert gather(link + " plus `sub/seed{1,2}/` (not yet uploaded).") == []
+    assert (
+        gather(
+            f"[`sub/seed{{1,2}}/` (upload pending)](https://huggingface.co/datasets/o/r/tree/{_C46_SHA}/p)"
+        )
+        == []
+    )
+    claims = gather(link + " plus `sub/seed{1,2}/` (uploaded 2026-07-18).")
+    assert len(claims) == 1
+
+
+def test_hf_brace_offline_fence_unverified_zero_probes():
+    """AC6: with the conftest EPM_VERIFY_BODY_NO_HF fence left in place, a
+    real claim degrades to an `unverified` fence note on a PASS line with
+    ZERO GETs (the autouse raise-guard stays active — any probe raises)."""
+    body = _c46_link("dir", text="`seed{1,2}/`")
+    res = verify_task_body.check_hf_brace_expanded_path_claims(body)
+    assert res.passed is True and res.is_warn is False, res.render()
+    assert "unverified" in res.detail and "HF probe fenced" in res.detail
+
+
+def test_hf_brace_pin_dead_defers_to_check23(monkeypatch):
+    """AC7: pin-prefix listing → not_found → `unverified` note deferring to
+    check 23 (dead-pin FAIL is check 23's), never a WARN from this check."""
+    monkeypatch.delenv("EPM_VERIFY_BODY_NO_HF", raising=False)
+    _stub_tree(monkeypatch, status="not_found")
+    body = _c46_link("dir", text="`seed{1,2}/`")
+    res = verify_task_body.check_hf_brace_expanded_path_claims(body)
+    assert res.passed is True and res.is_warn is False, res.render()
+    assert "check 23" in res.detail
+
+
+def test_hf_brace_probe_cap_unverified(monkeypatch):
+    """AC6: 9 unique pinned parents → at most `_HF_BRACE_MAX_PROBES`=8 unique
+    listings; past-cap claims surface as `per-body probe cap` notes."""
+    monkeypatch.delenv("EPM_VERIFY_BODY_NO_HF", raising=False)
+    calls = []
+    _stub_tree(monkeypatch, status="ok", entries=(), next_page=None, calls=calls)
+    body = " ".join(_c46_link(f"d{i}", text="`seed{1,2}/`") for i in range(9))
+    res = verify_task_body.check_hf_brace_expanded_path_claims(body)
+    assert res.passed is True
+    assert "per-body probe cap" in res.detail
+    assert len(calls) == verify_task_body._HF_BRACE_MAX_PROBES == 8
+
+
+def test_hf_brace_vacuous_pass_zero_probes():
+    """AC6: pinned links but no brace tokens → vacuous PASS, `_hf_tree_get`
+    never called (autouse raise-guard active, no stub)."""
+    body = _c46_link("dir", text="`file.json`") + " and `plain/dir/` here."
+    res = verify_task_body.check_hf_brace_expanded_path_claims(body)
+    assert res.passed is True and res.is_warn is False
+    assert "no brace-expanded path claims" in res.detail
+
+
+def test_hf_brace_partial_listing_never_grounds_warn(monkeypatch):
+    """AC6/AC8: a page-capped (partial) listing — present-in-partial passes,
+    the unfound expansion degrades to `unverified` (never a WARN), and the
+    partial result is never cached."""
+    monkeypatch.delenv("EPM_VERIFY_BODY_NO_HF", raising=False)
+
+    def _fake(url, params, headers, *, timeout_s):
+        return verify_task_body._TreeProbeResult(
+            "ok", [{"path": "dir/seed1", "type": "directory"}], "https://next-page", ""
+        )
+
+    monkeypatch.setattr(verify_task_body, "_hf_tree_get", _fake)
+    body = _c46_link("dir", text="`seed{1,2}/`")
+    res = verify_task_body.check_hf_brace_expanded_path_claims(body)
+    assert res.passed is True and res.is_warn is False, res.render()
+    assert "partial listing — missing never grounded" in res.detail
+    assert "`dir/seed2`" in res.detail and "dir/seed1" not in res.detail
+    assert verify_task_body._HF_DIRECT_CHILDREN_CACHE == {}
+
+
+def test_hf_brace_partial_pin_precheck_still_probes_children(monkeypatch):
+    """A partial (page-capped) pin precheck still proves the pin ALIVE and
+    proceeds to the child probes — only not_found/skip defer; with the
+    child listing exhaustive and complete the claim PASSes clean."""
+    monkeypatch.delenv("EPM_VERIFY_BODY_NO_HF", raising=False)
+
+    def _fake(url, params, headers, *, timeout_s):
+        if "%2Fsub" in url:
+            entries = [
+                {"path": "p/sub/seed1", "type": "directory"},
+                {"path": "p/sub/seed2", "type": "directory"},
+            ]
+            return verify_task_body._TreeProbeResult("ok", entries, None, "")
+        return verify_task_body._TreeProbeResult(
+            "ok", [{"path": "p/other", "type": "directory"}], "https://next-page", ""
+        )
+
+    monkeypatch.setattr(verify_task_body, "_hf_tree_get", _fake)
+    body = _c46_link("p") + " rollouts `sub/seed{1,2}/` here."
+    res = verify_task_body.check_hf_brace_expanded_path_claims(body)
+    assert res.passed is True and res.is_warn is False, res.render()
+    assert "unverified" not in res.detail
+
+
+def test_hf_brace_ambiguous_overlap_declines_to_unverified():
+    """Critic concern 3: a token whose first segment equals a NON-basename
+    prefix segment (prefix `a/b`, token `a/c{1,2}/`) declines the join →
+    `unverified`, ZERO probes (decline precedes the pin precheck)."""
+    body = _c46_link("a/b", text="`a/c{1,2}/`")
+    res = verify_task_body.check_hf_brace_expanded_path_claims(body)
+    assert res.passed is True and res.is_warn is False, res.render()
+    assert "ambiguous prefix overlap" in res.detail
+
+
+def test_hf_brace_dedup_same_token_same_pin():
+    """Critic concern 5: the same token bound twice to the same pin dedups
+    to ONE claim on (repo_id, sha, pin_prefix, token)."""
+    link = _c46_link("p", text="`p/`")
+    body = link + " `sub/seed{1,2}/` and again `sub/seed{1,2}/`."
+    assert len(verify_task_body._gather_hf_brace_path_claims(body)) == 1
+
+
+def test_check46_registered():
+    """Critic concern 1: the check rides `CHECKS` (generation-agnostic
+    block) — a forgotten CHECKS append must not ship green."""
+    assert verify_task_body.check_hf_brace_expanded_path_claims in verify_task_body.CHECKS


### PR DESCRIPTION
Closes task #1520 (workflow-fix). New WARN-tier check 46: brace-expanded backtick HF paths adjacent to hex-pinned /tree/<sha> links must resolve at the pin's revision (incident #1426). +875/−12 across scripts/verify_task_body.py + tests/test_verify_task_body.py; code-review PASS r1; test-verdict PASS (compare rc=0, 1 stripped pre-existing red); pre-push lint gate pass @ 7bdfb9ab8e.