### PR TITLE
workflow-fix #1524: merged card — prose pointer must not shadow a structural declaration

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -4918,7 +4918,13 @@ sources contribute to `running`-phase progress:
     (16 adapters)` + a free-text `wandb:` line) resolves to nothing and
     trips false `hf_model` / `wandb_run` MISSING rows on a
     fully-uploaded sweep that the upload-verifier must then supersede
-    row-by-row — incident #612.)
+    row-by-row — incident #612. A results RE-post (resume pass,
+    crash-fix relaunch, final re-post) must re-declare the structured
+    fields in full or OMIT them entirely (the verifier's merge falls
+    back per field to the older declaration) — never substitute a prose
+    pointer like `"unchanged from the v1 results marker"`; the merge
+    bypasses a non-structural value in favor of an older structural
+    declaration (#1489).)
   - `wandb_url` (string)
   - `hf_hub_url` (string)
   - `worktree_path` (string, absolute path on local VM)
@@ -7075,7 +7081,9 @@ steps 4 + 6-9 are the LATE JOIN executed here):
    carry an empty card (#601: `adapter_paths: {}` after every cell
    `resumed_skip`) that would hand the methodology-writer nothing:
    resolve each field newest-wins from the newest card that declares
-   it non-empty (empty dict/list/string/None is not a declaration) —
+   it non-empty (empty dict/list/string/None is not a declaration; nor —
+   for `adapter_paths` / `wandb_run_names` — a non-dict/non-list prose
+   pointer, #1489) —
    the same semantics as `verify_uploads.py` `merged_results_card`.
    The body-slice form below is the
    fallback (serial) path, where the body IS final: slice just the

--- a/scripts/verify_uploads.py
+++ b/scripts/verify_uploads.py
@@ -577,6 +577,48 @@ def _is_structural(key: str, value) -> bool:
     return key not in _STRUCTURED_CARD_FIELDS or isinstance(value, (dict, list))
 
 
+def _fold_cards(cards: list[tuple[dict, str]]) -> tuple[dict, dict[str, str], list[str]]:
+    """Newest-wins per-field fold over ``cards`` (newest first).
+
+    Returns ``(merged, fallback_fields, bypassed_prose)``: the merged card,
+    the ``field -> ts`` map of fields that fell back past the newest card,
+    and the ``"field @ ts"`` list of non-structural declarations bypassed in
+    favor of a structural value from another marker (#1489).
+    """
+    merged: dict = {}
+    fallback_fields: dict[str, str] = {}
+    # Newest non-structural value per structured field, kept as a LAST
+    # resort (#1489): used only when no marker declares a dict/list, so a
+    # prose-only history still reaches the #612 _prose_declaration_row
+    # diagnostic downstream instead of degrading to a generic MISSING.
+    deferred_nonstructural: dict[str, tuple[object, str, int]] = {}
+    for pos, (card, ts) in enumerate(cards):
+        for key, value in card.items():
+            if key in merged or not _is_declared(value):
+                continue
+            if key.startswith("_") and pos > 0:
+                # Provenance notes (e.g. a synthesized card's
+                # ``_card_provenance`` — #599) travel only with the newest
+                # card; an older card's note would misattribute the merged
+                # fields.
+                continue
+            if not _is_structural(key, value):
+                deferred_nonstructural.setdefault(key, (value, ts, pos))
+                continue
+            merged[key] = value
+            if pos > 0:
+                fallback_fields[key] = ts
+    bypassed_prose: list[str] = []
+    for key, (value, ts, pos) in deferred_nonstructural.items():
+        if key in merged:
+            bypassed_prose.append(f"{key} @ {ts}")
+            continue
+        merged[key] = value
+        if pos > 0:
+            fallback_fields[key] = ts
+    return merged, fallback_fields, bypassed_prose
+
+
 def merged_results_card(events: list[dict]) -> dict | None:
     """Merge reproducibility cards across ALL ``epm:results`` events.
 
@@ -609,37 +651,7 @@ def merged_results_card(events: list[dict]) -> dict | None:
             cards.append((card, str(ev.get("ts", "")) or "unknown-ts"))
     if not cards:
         return None
-    merged: dict = {}
-    fallback_fields: dict[str, str] = {}
-    # Newest non-structural value per structured field, kept as a LAST
-    # resort (#1489): used only when no marker declares a dict/list, so a
-    # prose-only history still reaches the #612 _prose_declaration_row
-    # diagnostic downstream instead of degrading to a generic MISSING.
-    deferred_nonstructural: dict[str, tuple[object, str, int]] = {}
-    for pos, (card, ts) in enumerate(cards):
-        for key, value in card.items():
-            if key in merged or not _is_declared(value):
-                continue
-            if key.startswith("_") and pos > 0:
-                # Provenance notes (e.g. a synthesized card's
-                # ``_card_provenance`` — #599) travel only with the newest
-                # card; an older card's note would misattribute the merged
-                # fields.
-                continue
-            if not _is_structural(key, value):
-                deferred_nonstructural.setdefault(key, (value, ts, pos))
-                continue
-            merged[key] = value
-            if pos > 0:
-                fallback_fields[key] = ts
-    bypassed_prose: list[str] = []
-    for key, (value, ts, pos) in deferred_nonstructural.items():
-        if key in merged:
-            bypassed_prose.append(f"{key} @ {ts}")
-            continue
-        merged[key] = value
-        if pos > 0:
-            fallback_fields[key] = ts
+    merged, fallback_fields, bypassed_prose = _fold_cards(cards)
     notes: list[str] = []
     if fallback_fields:
         notes.append(

--- a/scripts/verify_uploads.py
+++ b/scripts/verify_uploads.py
@@ -45,7 +45,11 @@ sentinel whose cells all ``resumed_skip`` carries an empty card
 (``adapter_paths: {}``) that must not shadow the first marker's full
 declaration, so the card is MERGED across all epm:results markers —
 newest-wins per field, where an empty dict/list/string does not count as
-a declaration (see ``merged_results_card``).
+a declaration (see ``merged_results_card``). Nor — for the structured-
+contract fields ``adapter_paths`` / ``wandb_run_names`` — does a
+non-dict/non-list prose pointer when a structural declaration exists in
+any marker; the prose value is kept only as a last resort so the #612
+prose diagnostic still fires (#1489).
 
 GCP-lane driver sentinels (#599) carry no reproducibility card at all —
 per-seed provenance lives under ``production_provenance`` (e.g.
@@ -560,6 +564,19 @@ def _is_declared(value) -> bool:
     return value is not None and value != "" and value != {} and value != []
 
 
+# Card fields the epm:results sentinel contract requires as per-cell
+# dicts/lists (SKILL.md Step 7; the #612 ``_prose_declaration_row`` pair).
+# A prose-pointer string here ("unchanged from epm:results v1 ...") is
+# truthy, so it would win the newest-wins fold and shadow an older
+# marker's real declaration (#1489).
+_STRUCTURED_CARD_FIELDS = ("adapter_paths", "wandb_run_names")
+
+
+def _is_structural(key: str, value) -> bool:
+    """False when a structured-contract field carries a non-dict/non-list."""
+    return key not in _STRUCTURED_CARD_FIELDS or isinstance(value, (dict, list))
+
+
 def merged_results_card(events: list[dict]) -> dict | None:
     """Merge reproducibility cards across ALL ``epm:results`` events.
 
@@ -569,8 +586,13 @@ def merged_results_card(events: list[dict]) -> dict | None:
     (#601: a resume pass with every cell ``resumed_skip`` posted
     ``adapter_paths: {}``, masking 16 verified adapter paths). Each FIELD
     therefore resolves newest-wins: the value comes from the newest card
-    that declares it non-empty (``_is_declared``). When any field falls
-    back past the newest card, the merged card carries a
+    that declares it non-empty (``_is_declared``). For the structured-
+    contract fields (``_STRUCTURED_CARD_FIELDS``) a non-dict/non-list
+    declaration additionally does not count as a declaration when a
+    structural one exists in ANY card — it is kept only as a last resort
+    so the #612 prose diagnostic still fires downstream (#1489: a re-post
+    prose pointer shadowed an older marker's real 64-path list). When any
+    field falls back past the newest card, the merged card carries a
     ``_card_provenance`` note that the row checks append to their detail.
     Returns ``None`` when no event declares a card (or every card is
     entirely empty) — the caller falls through to the strict MISSING row.
@@ -589,6 +611,11 @@ def merged_results_card(events: list[dict]) -> dict | None:
         return None
     merged: dict = {}
     fallback_fields: dict[str, str] = {}
+    # Newest non-structural value per structured field, kept as a LAST
+    # resort (#1489): used only when no marker declares a dict/list, so a
+    # prose-only history still reaches the #612 _prose_declaration_row
+    # diagnostic downstream instead of degrading to a generic MISSING.
+    deferred_nonstructural: dict[str, tuple[object, str, int]] = {}
     for pos, (card, ts) in enumerate(cards):
         for key, value in card.items():
             if key in merged or not _is_declared(value):
@@ -599,13 +626,33 @@ def merged_results_card(events: list[dict]) -> dict | None:
                 # card; an older card's note would misattribute the merged
                 # fields.
                 continue
+            if not _is_structural(key, value):
+                deferred_nonstructural.setdefault(key, (value, ts, pos))
+                continue
             merged[key] = value
             if pos > 0:
                 fallback_fields[key] = ts
+    bypassed_prose: list[str] = []
+    for key, (value, ts, pos) in deferred_nonstructural.items():
+        if key in merged:
+            bypassed_prose.append(f"{key} @ {ts}")
+            continue
+        merged[key] = value
+        if pos > 0:
+            fallback_fields[key] = ts
+    notes: list[str] = []
     if fallback_fields:
-        note = "field(s) declared by an earlier epm:results marker, not the latest: " + ", ".join(
-            f"{k} @ {ts}" for k, ts in sorted(fallback_fields.items())
+        notes.append(
+            "field(s) declared by an earlier epm:results marker, not the latest: "
+            + ", ".join(f"{k} @ {ts}" for k, ts in sorted(fallback_fields.items()))
         )
+    if bypassed_prose:
+        notes.append(
+            "non-structural (prose) declaration(s) bypassed in favor of a "
+            "structural value from another marker (#1489): " + ", ".join(sorted(bypassed_prose))
+        )
+    if notes:
+        note = "; ".join(notes)
         existing = merged.get("_card_provenance")
         merged["_card_provenance"] = f"{existing}; {note}" if existing else note
     return merged or None

--- a/tests/test_verify_uploads_card_fallback.py
+++ b/tests/test_verify_uploads_card_fallback.py
@@ -193,6 +193,161 @@ class TestMergedResultsCard:
         card = verify_uploads.merged_results_card([{"kind": "epm:results", "note": _NOTE_608}])
         assert "_card_provenance" not in card
 
+    def test_prose_pointer_does_not_shadow_older_structural_adapter_paths(self):
+        """The #1489 repro: an epm:results v2 re-post whose adapter_paths is
+        a prose POINTER ("unchanged from epm:results v1 ...") is truthy and
+        used to win the newest-wins fold, shadowing v1's real 64-path LIST
+        and producing a false hf_model MISSING. The merge must bypass the
+        non-structural value in favor of the older structural declaration."""
+        events = [
+            {
+                "kind": "epm:results",
+                "ts": "2026-07-18T18:43:00Z",
+                "note": (
+                    '{"reproducibility_card": '
+                    '{"hf_model_repo": "superkaiba1/explore-persona-space", '
+                    '"adapter_paths": ["adapters/issue_1489/a/ckpt1", '
+                    '"adapters/issue_1489/a/ckpt2", "adapters/issue_1489/b/ckpt1"]}}'
+                ),
+            },
+            {
+                "kind": "epm:results",
+                "ts": "2026-07-18T22:56:00Z",
+                "note": (
+                    '{"reproducibility_card": {"adapter_paths": '
+                    '"unchanged from epm:results v1 (64 paths under adapters/issue_1489/)"}}'
+                ),
+            },
+        ]
+        card = verify_uploads.merged_results_card(events)
+        assert card["adapter_paths"] == [
+            "adapters/issue_1489/a/ckpt1",
+            "adapters/issue_1489/a/ckpt2",
+            "adapters/issue_1489/b/ckpt1",
+        ]
+        assert "adapter_paths @ 2026-07-18T18:43:00Z" in card["_card_provenance"]
+        assert "bypassed" in card["_card_provenance"]
+
+    def test_prose_only_adapter_paths_still_reaches_prose_diagnostic(self):
+        """Last-resort semantics (design question 2): on a prose-ONLY history
+        (no marker ever declared a dict/list) the prose value must survive
+        the merge so the end-to-end path still produces the #612
+        producer-contract-violation row — a naive drop-the-prose merge would
+        degrade it to a generic MISSING."""
+        events = [
+            {
+                "kind": "epm:results",
+                "ts": "t0",
+                "note": (
+                    '{"reproducibility_card": '
+                    '{"adapter_paths": "adapters/issue_612/all (16 adapters)"}}'
+                ),
+            },
+        ]
+        card = verify_uploads.merged_results_card(events)
+        assert card["adapter_paths"] == "adapters/issue_612/all (16 adapters)"
+        with patch.object(
+            verify_uploads,
+            "check_hf_hub_path",
+            side_effect=AssertionError("nothing checkable must be probed"),
+        ):
+            res = verify_uploads.check_hf_model_from_card(card)
+        assert res is not None
+        assert res["status"] == "MISSING"
+        assert "producer-contract violation" in res["detail"]
+
+    def test_prose_pointer_wandb_run_names_falls_back_to_structural(self):
+        """The #1489 shadow mechanism is byte-identical for the contract
+        pair's other field: a newer prose wandb_run_names string defers to
+        an older per-cell dict."""
+        events = [
+            {
+                "kind": "epm:results",
+                "ts": "t0",
+                "note": (
+                    '{"reproducibility_card": '
+                    '{"wandb_run_names": {"seed42": "run42", "seed137": "run137"}}}'
+                ),
+            },
+            {
+                "kind": "epm:results",
+                "ts": "t1",
+                "note": '{"reproducibility_card": {"wandb_run_names": "unchanged from v1"}}',
+            },
+        ]
+        card = verify_uploads.merged_results_card(events)
+        assert card["wandb_run_names"] == {"seed42": "run42", "seed137": "run137"}
+        assert "wandb_run_names @ t0" in card["_card_provenance"]
+        assert "bypassed" in card["_card_provenance"]
+
+    def test_string_valued_fields_still_win_newest(self):
+        """The structural guard is FIELD-scoped: legitimately-string card
+        fields (hf_model_path, wandb_project, ...) keep plain newest-wins."""
+        events = [
+            {
+                "kind": "epm:results",
+                "ts": "t0",
+                "note": (
+                    '{"reproducibility_card": '
+                    '{"hf_model_path": "old/path", "wandb_project": "old-project"}}'
+                ),
+            },
+            {
+                "kind": "epm:results",
+                "ts": "t1",
+                "note": (
+                    '{"reproducibility_card": '
+                    '{"hf_model_path": "new/path", "wandb_project": "new-project"}}'
+                ),
+            },
+        ]
+        card = verify_uploads.merged_results_card(events)
+        assert card["hf_model_path"] == "new/path"
+        assert card["wandb_project"] == "new-project"
+        assert "_card_provenance" not in card
+
+    def test_synthesized_hint_prose_wandb_run_names_defers_to_structural(self):
+        """A synthesized GCP-sentinel card CAN carry a non-structural
+        wandb_run_names: _PROVENANCE_HINT_KEYS includes it, so the top-level
+        hint carryover copies a payload-level prose string when per-cell
+        provenance yielded no run names. The merge defers that string to an
+        older card's structural per-cell dict."""
+        events = [
+            {
+                "kind": "epm:results",
+                "ts": "t0",
+                "note": '{"reproducibility_card": {"wandb_run_names": {"seed42": "run42"}}}',
+            },
+            {
+                "kind": "epm:results",
+                "ts": "t1",
+                "note": (
+                    '{"issue": 1524, "production_provenance": '
+                    '{"seed42": {"hf_adapter_subfolder": "issue_1524/a"}}, '
+                    '"wandb_run_names": "52 runs under project issue1524"}'
+                ),
+            },
+        ]
+        card = verify_uploads.merged_results_card(events)
+        assert card["adapter_paths"] == {"seed42": "issue_1524/a"}
+        assert card["wandb_run_names"] == {"seed42": "run42"}
+        assert "wandb_run_names @ t0" in card["_card_provenance"]
+
+    def test_nonstructural_scalar_kept_as_last_resort(self):
+        """An int-valued structured field with no structural sibling anywhere
+        survives the merge unchanged (last resort, same as today's fold);
+        downstream ignores non-dict/list/str values → generic MISSING."""
+        events = [
+            {
+                "kind": "epm:results",
+                "ts": "t0",
+                "note": '{"reproducibility_card": {"adapter_paths": 7}}',
+            },
+        ]
+        card = verify_uploads.merged_results_card(events)
+        assert card["adapter_paths"] == 7
+        assert "_card_provenance" not in card
+
 
 # ── _card_from_provenance (GCP-lane driver sentinels, #599) ───────────────────
 


### PR DESCRIPTION
Closes task #1524.

Field-scoped structural-type guard in verify_uploads.py merged_results_card: a non-dict/non-list adapter_paths / wandb_run_names declaration is deferred (last-resort only) so a prose pointer never shadows an older structural declaration (#1489 incident; extends the #601 empty-card guard). + 2 SKILL.md producer-guidance sentences + 6 pin tests.