### PR TITLE
task #1528: guard deny-event sidecar — best-effort JSONL row per deny

### DIFF
--- a/scripts/guard_repo_root_branch.sh
+++ b/scripts/guard_repo_root_branch.sh
@@ -85,6 +85,11 @@
 # the tool call PROCEEDS) — code.claude.com/docs/en/hooks: "If your hook is
 # meant to enforce a policy, use exit 2."
 # Fail-soft: any ambiguity / parse failure exits 0 (never traps the user).
+# Deny-event sidecar (#1528): every deny best-effort-appends ONE JSON row
+# {ts, guard, arm, len, head, clause_head} to EPM_GUARD_DENY_SIDECAR (default
+# $REPO/.claude/cache/guard-deny-events.jsonl); bounded redacted heads only,
+# and every append failure is swallowed — deny/allow, exit codes, and the
+# stderr message are never affected.
 #
 # <!-- known limitation -->
 # Every detector scans the RAW command string — the guard does NOT strip
@@ -534,6 +539,43 @@ set -u
 
 REPO=/home/thomasjiralerspong/explore-persona-space
 REPO_BASE=${REPO##*/}   # basename (explore-persona-space) for the #1098 waiver path globs
+
+# --- deny-event sidecar (#1528) ---------------------------------------------
+# Best-effort forensic record of every deny: one JSON row appended to
+# EPM_GUARD_DENY_SIDECAR (default $REPO/.claude/cache/guard-deny-events.jsonl).
+# NEVER affects the deny/allow decision, exit codes, or the stderr message —
+# every failure (missing dir, unwritable path, disk full) is swallowed by the
+# braced append group below. No full command text is recorded: bounded
+# printable-ASCII redacted heads only (#1501 A-11).
+DENY_SIDECAR="${EPM_GUARD_DENY_SIDECAR:-$REPO/.claude/cache/guard-deny-events.jsonl}"
+
+_deny_head() {  # stdin -> control chars to space, printable ASCII only,
+                # opaque [A-Za-z0-9_-] runs >=20 masked to 4-char prefix + ***,
+                # THEN truncated to 120 chars. Masking runs BEFORE the final
+                # truncate (on a 400-char pre-cut bounding sed cost) so a
+                # secret-shaped token straddling the 120-char boundary cannot
+                # leak a partial fragment (#1528 r1 concern 2).
+  tr '\n\r\t' '   ' | tr -cd ' -~' | cut -c1-400 \
+    | sed -E 's/([A-Za-z0-9_-]{4})[A-Za-z0-9_-]{16,}/\1***/g' | cut -c1-120
+}
+
+log_deny() {  # $1 = arm label ($blocked), $2 = full command, $3 = blocking clause
+  # Defaulted ${N-} expansions: under `set -u` an unbound expansion inside the
+  # braced group ABORTS the script (the `|| true` rescues command failures,
+  # not expansion errors), which would fail the guard OPEN. Defense in depth.
+  local arm_in="${1-}" cmd_in="${2-}" clause_in="${3-}"
+  {
+    mkdir -p "$(dirname "$DENY_SIDECAR")"
+    jq -cn --arg ts "$(date -u +%FT%TZ)" \
+       --arg arm "$(printf '%s' "$arm_in" | _deny_head)" \
+       --argjson len "${#cmd_in}" \
+       --arg head "$(printf '%s' "$cmd_in" | _deny_head)" \
+       --arg clause_head "$(printf '%s' "$clause_in" | _deny_head)" \
+       '{ts:$ts, guard:"repo_root_branch", arm:$arm, len:$len,
+         head:$head, clause_head:$clause_head}' >> "$DENY_SIDECAR"
+  } 2>/dev/null || true
+}
+# --- end deny-event sidecar ---------------------------------------------------
 
 cmd=$(jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
 [ -n "$cmd" ] || exit 0
@@ -1508,4 +1550,5 @@ For composing a doc/report via heredoc whose body carries backticks, command sub
 NOTE: this deny blocked your ENTIRE compound command — earlier clauses did NOT run either; regenerate any files/state those clauses were meant to produce before retrying the safe form (incident class #813/#1056).
 For a POD-side remote git op, a single-statement ssh <host> 'git <verb> ...' remote command is allowed (#1098), and a SINGLE-QUOTED multi-statement remote string is allowed when the quoted payload is the clause's final token and nothing quote- or latch-ambiguous precedes it (#1413); other shapes (double quotes, redirects, trailing tokens, wrapped ssh, quoted/latch-vocabulary prefixes) still need git -C /workspace/<repo> <verb> inside the remote string, a pod-side script, or the SSH MCP.
 For a GCE-side remote git op, the same two shapes are allowed with a gcloud compute ssh <instance> --command='...' head (#1463; an optional literal 'timeout <N>' wrapper is tolerated): keep --command the clause's FINAL token, no in-payload < or > redirects (bound output with | tail INSIDE the single-quoted payload — pipes mask fine), and no trailing local pipe / fd-dup ('2>&1 | tail -N' stays blocked); or put git -C /workspace/<clone> <verb> inside the payload, which is allowed regardless (path-blind -C waiver)." >&2
+log_deny "$blocked" "$cmd" "${clause:-}"
 exit 2

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -8400,7 +8400,11 @@ def _run_root_guard(hook: Path, command: str) -> tuple[int, str]:
     ``(returncode, stderr)``. ``cwd`` is pinned to the hook's own repo root
     (``hook.parent.parent``) so repo-state-consulting detectors give
     deterministic-by-construction verdicts when the lint runs from a
-    worktree (#1176 round-1 Methodology c1)."""
+    worktree (#1176 round-1 Methodology c1). ``EPM_GUARD_DENY_SIDECAR`` is
+    pinned to ``/dev/null`` so lint-driven hook executions (self-test probes
+    + the per-fence scan loop) never append synthetic deny rows to the
+    production deny-event sidecar (#1528); the pin is env-only and cannot
+    change the rc-0/2 verdict this check reads."""
     payload = json.dumps({"tool_input": {"command": command}})
     proc = subprocess.run(
         ["bash", str(hook)],
@@ -8409,6 +8413,7 @@ def _run_root_guard(hook: Path, command: str) -> tuple[int, str]:
         text=True,
         timeout=_ROOT_GUARD_TIMEOUT_S,
         cwd=str(hook.parent.parent),
+        env={**os.environ, "EPM_GUARD_DENY_SIDECAR": "/dev/null"},
     )
     return proc.returncode, proc.stderr
 

--- a/tests/test_guard_repo_root_branch.py
+++ b/tests/test_guard_repo_root_branch.py
@@ -57,6 +57,8 @@ keeps today's blocked disposition (GN-series pins).
 from __future__ import annotations
 
 import json
+import os
+import re
 import subprocess
 import uuid
 from pathlib import Path
@@ -72,16 +74,39 @@ SCRIPT = _REPO_ROOT / "scripts" / "guard_repo_root_branch.sh"
 # canonical checkout, NOT this worktree.
 REPO = Path("/home/thomasjiralerspong/explore-persona-space")
 
+# Deny-event sidecar (#1528): the guard's default sidecar path lives under the
+# CANONICAL checkout's .claude/cache/ (the guard hardcodes REPO). The harness
+# pins EPM_GUARD_DENY_SIDECAR to /dev/null so the suite's hundreds of deny
+# cases never create/append the production sidecar; the snapshot below backs
+# the end-of-module production-protection test.
+_PROD_SIDECAR = REPO / ".claude" / "cache" / "guard-deny-events.jsonl"
+_PROD_SIDECAR_SIZE_AT_IMPORT = _PROD_SIDECAR.stat().st_size if _PROD_SIDECAR.exists() else None
 
-def _run(cmd: str) -> int:
-    """Feed ``cmd`` to the guard via PreToolUse JSON; return its exit code."""
+
+def _run_full(cmd: str, *, sidecar: str | None = None) -> subprocess.CompletedProcess[str]:
+    """Feed ``cmd`` to the guard via PreToolUse JSON; return the full result.
+
+    ``sidecar`` pins ``EPM_GUARD_DENY_SIDECAR`` for the subprocess; the
+    ``/dev/null`` default sinks every deny row so existing tests never touch
+    the production sidecar (#1528). Appending to ``/dev/null`` succeeds
+    silently and ``mkdir -p /dev`` no-ops, so exit-code behavior is unchanged.
+    """
     payload = json.dumps({"tool_input": {"command": cmd}})
-    return subprocess.run([str(SCRIPT)], input=payload, text=True, capture_output=True).returncode
+    env = {**os.environ, "EPM_GUARD_DENY_SIDECAR": sidecar or "/dev/null"}
+    return subprocess.run([str(SCRIPT)], input=payload, text=True, capture_output=True, env=env)
 
 
-def _run_raw(payload: str) -> int:
+def _run(cmd: str, *, sidecar: str | None = None) -> int:
+    """Feed ``cmd`` to the guard via PreToolUse JSON; return its exit code."""
+    return _run_full(cmd, sidecar=sidecar).returncode
+
+
+def _run_raw(payload: str, *, sidecar: str | None = None) -> int:
     """Feed a raw (possibly malformed) stdin payload; return the exit code."""
-    return subprocess.run([str(SCRIPT)], input=payload, text=True, capture_output=True).returncode
+    env = {**os.environ, "EPM_GUARD_DENY_SIDECAR": sidecar or "/dev/null"}
+    return subprocess.run(
+        [str(SCRIPT)], input=payload, text=True, capture_output=True, env=env
+    ).returncode
 
 
 def _git(*args: str) -> subprocess.CompletedProcess[str]:
@@ -2443,3 +2468,139 @@ def test_gcloud_waiver_fail_closed_blocks(cmd):
     today-blocked disposition the additive-only claim quantifies over.
     """
     assert _run(cmd) == 2
+
+
+# ---------------------------------------------------------------------------
+# Deny-event sidecar (#1528) — one best-effort JSON row per deny.
+#
+# Row schema: {ts, guard:"repo_root_branch", arm, len, head, clause_head};
+# heads are printable-ASCII, masked (opaque runs >=20 -> 4-char prefix + ***)
+# BEFORE the 120-char truncate. The append must NEVER change deny/allow, exit
+# codes, or the stderr message. Every test pins EPM_GUARD_DENY_SIDECAR via the
+# harness `sidecar` kwarg; deny-side cases are @on_main (the guard's on-main
+# gate exits 0 off-main, so neither the deny nor the row fires there).
+# Templates reuse the file's existing blocked shapes (branch-switch fence /
+# merge fence M1) — no new gated literals.
+# ---------------------------------------------------------------------------
+
+_SIDECAR_KEYS = {"ts", "guard", "arm", "len", "head", "clause_head"}
+_TS_RE = r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z"
+_SIDECAR_BLOCKED_SWITCH = "git switch fix/foo"  # from test_branch_creation_and_switch_still_block
+_SIDECAR_BLOCKED_MERGE = "git merge issue-123"  # from test_merge_shapes_block (M1)
+
+
+@on_main
+def test_deny_writes_sidecar_row(tmp_path):
+    """T1: a denied command appends exactly one valid JSON row (full schema)."""
+    sidecar = tmp_path / "deny.jsonl"
+    proc = _run_full(_SIDECAR_BLOCKED_SWITCH, sidecar=str(sidecar))
+    assert proc.returncode == 2
+    lines = sidecar.read_text().splitlines()
+    assert len(lines) == 1
+    row = json.loads(lines[0])
+    assert set(row) == _SIDECAR_KEYS
+    assert row["guard"] == "repo_root_branch"
+    assert row["arm"]
+    assert row["len"] == len(_SIDECAR_BLOCKED_SWITCH)
+    assert re.fullmatch(_TS_RE, row["ts"])
+
+
+@on_main
+def test_deny_sidecar_arm_with_parens_valid_json(tmp_path):
+    """T2: an arm label carrying spaces + parentheses still yields valid JSON."""
+    sidecar = tmp_path / "deny.jsonl"
+    proc = _run_full(_SIDECAR_BLOCKED_MERGE, sidecar=str(sidecar))
+    assert proc.returncode == 2
+    row = json.loads(sidecar.read_text().splitlines()[0])
+    assert "(" in row["arm"]
+
+
+def test_allow_writes_no_sidecar_row(tmp_path):
+    """T3: an allowed command writes nothing (sidecar file not created)."""
+    sidecar = tmp_path / "deny.jsonl"
+    assert _run("git status", sidecar=str(sidecar)) == 0
+    assert not sidecar.exists()
+
+
+@on_main
+def test_sidecar_write_failure_preserves_deny_exit(tmp_path):
+    """T4: a failed sidecar append leaves exit 2 + the BLOCKED stderr intact.
+
+    The sidecar's parent is pointed at a regular FILE so both ``mkdir -p`` and
+    the append fail regardless of uid (root ignores a chmod-0500 dir; a
+    file-as-parent fails for root too). A writable re-run in the same test
+    confirms the row WOULD have been written — isolating the failure to the
+    write, not the deny logic.
+    """
+    blocker = tmp_path / "blocker"
+    blocker.write_text("")
+    bad_sidecar = blocker / "deny.jsonl"
+    proc = _run_full(_SIDECAR_BLOCKED_SWITCH, sidecar=str(bad_sidecar))
+    assert proc.returncode == 2
+    assert "BLOCKED:" in proc.stderr
+    assert not bad_sidecar.exists()
+    ok_sidecar = tmp_path / "deny.jsonl"
+    proc2 = _run_full(_SIDECAR_BLOCKED_SWITCH, sidecar=str(ok_sidecar))
+    assert proc2.returncode == 2
+    assert len(ok_sidecar.read_text().splitlines()) == 1
+
+
+@on_main
+def test_sidecar_head_bounded_no_full_command(tmp_path):
+    """T5: no full command text in the row; heads are <=120 chars; len exact."""
+    cmd = _SIDECAR_BLOCKED_SWITCH + " # " + "pad " * 60
+    assert len(cmd) > 240
+    sidecar = tmp_path / "deny.jsonl"
+    proc = _run_full(cmd, sidecar=str(sidecar))
+    assert proc.returncode == 2
+    raw = sidecar.read_text()
+    assert cmd not in raw
+    row = json.loads(raw.splitlines()[0])
+    assert len(row["head"]) <= 120
+    assert len(row["clause_head"]) <= 120
+    assert row["len"] == len(cmd)
+
+
+@on_main
+def test_sidecar_secret_shaped_token_masked(tmp_path):
+    """T6: a secret-shaped token (hf_ + 34 alnum) never survives into the row.
+
+    Variant (a): token inside the first 120 chars (env-assignment prefix
+    before the git verb) — masked to a 4-char prefix + ``***``.
+    Variant (b): token straddling the 120-char truncation boundary — masking
+    runs BEFORE the truncate, so no >=8-char fragment may survive either.
+    """
+    token = "hf_" + "A1b2C3d4" * 4 + "Zz"
+    assert len(token) == 37
+    cmd = f"HF_TOKEN={token} {_SIDECAR_BLOCKED_SWITCH}"
+    sidecar = tmp_path / "deny.jsonl"
+    proc = _run_full(cmd, sidecar=str(sidecar))
+    assert proc.returncode == 2
+    raw = sidecar.read_text()
+    assert token not in raw
+    row = json.loads(raw.splitlines()[0])
+    assert "***" in row["head"]
+
+    prefix = _SIDECAR_BLOCKED_SWITCH + " # " + "pad " * 21
+    cmd2 = prefix + token
+    assert len(prefix) < 120 < len(cmd2)
+    sidecar2 = tmp_path / "deny2.jsonl"
+    proc2 = _run_full(cmd2, sidecar=str(sidecar2))
+    assert proc2.returncode == 2
+    raw2 = sidecar2.read_text()
+    for i in range(len(token) - 7):
+        assert token[i : i + 8] not in raw2
+
+
+def test_zz_production_sidecar_untouched_by_suite():
+    """The suite must never create/append the PRODUCTION deny sidecar (#1528).
+
+    The harness pins EPM_GUARD_DENY_SIDECAR (default ``/dev/null``) on every
+    guard invocation; this end-of-module check compares the production
+    sidecar's size/absence against the module-import snapshot. Runs LAST in
+    file order by position. Known caveat: a concurrent REAL deny in another
+    session appending mid-run would false-fail this — denies are rare
+    exception events, accepted.
+    """
+    current = _PROD_SIDECAR.stat().st_size if _PROD_SIDECAR.exists() else None
+    assert current == _PROD_SIDECAR_SIZE_AT_IMPORT


### PR DESCRIPTION
Closes task #1528 (workflow-fix, kind: infra).

## Summary
- `scripts/guard_repo_root_branch.sh`: on every deny, append one best-effort JSON row {ts, guard, arm, len, head, clause_head} to `.claude/cache/guard-deny-events.jsonl` (env override `EPM_GUARD_DENY_SIDECAR`); jq-produced, mask-before-truncate redaction (≥20-char opaque runs → 4-char prefix + `***`, 120-char bound), placed after the BLOCKED stderr echo inside `{...} 2>/dev/null || true` — deny/allow decisions, exit codes, and stderr byte-identical.
- `scripts/workflow_lint.py`: `_run_root_guard` pins `EPM_GUARD_DENY_SIDECAR=/dev/null` so lint self-test probes write no synthetic production rows.
- `tests/test_guard_repo_root_branch.py`: `/dev/null` sidecar sink in the harness + 7 new tests (row schema/validity, allow-writes-nothing, write-failure preserves exit 2, boundedness, secret masking incl. boundary straddle, production-sidecar protection).

## Test plan
- [x] 495/495 on the touched test file (implementer + independent code-reviewer runs)
- [x] Step 9c gate: 59 files, 2F/4812P — both failures stripped pre-existing-on-main via pristine-scratch oracle (COMPARE_RC=0, no ruff delta)
- [x] Full no-flags workflow_lint exit 0 in worktree; production sidecar confirmed absent afterwards
- [x] Production-default one-shot smoke (row landed, jq-parsed, removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)