### PR TITLE
issue-1534: merge=union for eval_results/INDEX.md (#1534)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -29,6 +29,20 @@ tasks/**/comments.jsonl merge=union
 # server-side `gh pr merge` does not honor user-defined merge drivers.
 .claude/agent-memory/**/*.md merge=union
 
+# eval_results/INDEX.md (#1534): append-dominant markdown results index —
+# /issue Step 10 appends one row per completed experiment; many concurrent
+# sessions append, and concurrent repo-root pulls (sync_repo_root.py
+# `git pull --rebase=merges --autostash`) repeatedly conflicted on exactly
+# these appends (#1525's stranded-commit incident). union is line-oriented:
+# clean for append-append; a rare mid-file EDIT of an old row racing a
+# concurrent edit of the SAME region merges WITHOUT conflict markers and may
+# duplicate/interleave lines — accepted trade-off (benign duplication in a
+# human-legible table, self-healed by the next correcting write) vs a hard
+# conflict blocking a fleet-wide root sync. Same SCOPE CAVEAT as above:
+# honored on LOCAL merges/rebases only — server-side `gh pr merge` does not
+# honor user-defined merge drivers.
+eval_results/INDEX.md merge=union
+
 # REGISTRY.json is deliberately NOT unioned — it is a last-writer-wins JSON
 # snapshot (atomic write-temp+rename), never append-only; a union merge would
 # concatenate two JSON objects into invalid JSON.

--- a/tests/test_step10d_guard3.py
+++ b/tests/test_step10d_guard3.py
@@ -94,6 +94,15 @@ def test_gitattributes_union_merge_for_agent_memory():
     )
 
 
+def test_gitattributes_union_merge_for_eval_results_index():
+    """#1534: eval_results/INDEX.md is append-dominant (one row per completed
+    experiment, many concurrent sessions) and must union-merge locally."""
+    text = _GITATTRIBUTES.read_text(encoding="utf-8")
+    assert "eval_results/INDEX.md merge=union" in text, (
+        "eval_results/INDEX.md must use union merge (#1534)"
+    )
+
+
 def test_gitattributes_registry_not_unioned():
     """REGISTRY.json is last-writer-wins; a union merge would break its JSON."""
     text = _GITATTRIBUTES.read_text(encoding="utf-8")


### PR DESCRIPTION
Closes task #1534. One new .gitattributes union block for eval_results/INDEX.md + pin test in tests/test_step10d_guard3.py.