### PR TITLE
workflow-fix #1546: digest crash-tails on orchestrator poll turns

### DIFF
--- a/.claude/rules/LESSONS.md
+++ b/.claude/rules/LESSONS.md
@@ -41,7 +41,7 @@ Row grammar: `- <rule>.md — <fires-when trigger>`
 - replication-fidelity.md — the Goal replicates a published finding (match the paper's data + recipe FIRST; change only the tested variable).
 - research-project-structure.md — you write result artifacts / results index / queue (one source of truth per layer).
 - selection-symmetric-nulls.md — a max/argmax/top-k headline over a free axis vs a null band or bootstrap CI (selection rides per draw / freeze held-out; band vs ceiling), or difference-vector legs sharing one SAMPLED baseline vs noise-free nulls (disjoint halves / shared-B).
-- trigger-dense-review.md — reviewing/reconciling a guard/security artifact or refusal corpus (findings by reference; verdict first; windowed reads), or composing any brief on such targets (first-pass fact-check/critique #1503; revision-round #1413).
+- trigger-dense-review.md — reviewing/reconciling a guard/security artifact or refusal corpus (findings by reference; windowed reads), composing any brief on such targets (#1503/#1413), or an orchestrator poll/forensics turn ingesting run-failure text (digest-only, #1546).
 - upload-policy.md — you write training/Hub/sweep code, or sequence phases around a regeneration-costly store (Hub-API verification, verify + staging-download transport retry, delete-after-eval persist, store-before-long-fit #825, quota-403 recovery, upload-wedge ladder).
 - vectorize-many-cell-fits.md — many-cell GD, dense fits (svd/eigh/lstsq/ridge), or a perm/bootstrap/null-draw battery over a fixed pool (VECTORIZE first; detached+checkpointed VM fits; Supersede contract incl. mid-run ≥2×-deviation + width re-eval).
 - workflow-fix-on-bug.md — any agent hits a bug from a gap in the workflow surface itself (emit a `workflow-fix-candidate`).

--- a/.claude/rules/trigger-dense-review.md
+++ b/.claude/rules/trigger-dense-review.md
@@ -1,5 +1,5 @@
 ---
-description: Reviewing trigger-dense / security-adjacent artifacts (guard hooks, destructive-command test fixtures, refusal/jailbreak corpora) without filter kills — findings by reference, durable verdict first, windowed reads + brief composition for such targets (first-pass #1503, revision-round #1413; findings by reference). Prevention-side sibling of CLAUDE.md § Spurious usage-policy refusals (recovery). Origin incidents #1058, #1152.
+description: Reviewing trigger-dense / security-adjacent artifacts (guard hooks, destructive-command test fixtures, refusal/jailbreak corpora) without filter kills — findings by reference, durable verdict first, windowed reads + brief composition for such targets (first-pass #1503, revision-round #1413; findings by reference); orchestrator poll/forensics turns ingest run-failure text as structural digests (#1546). Prevention-side sibling of CLAUDE.md § Spurious usage-policy refusals (recovery). Origin incidents #1058, #1152.
 paths:
   - ".claude/hooks/*.sh"
   - "scripts/guard_*.sh"
@@ -14,7 +14,10 @@ repeated in generated text — or the ORCHESTRATOR composes a FIRST-PASS
 fact-check / critique / plan-review brief whose TARGET files are such
 artifacts (§ First-pass briefs, #1503), or composes a revision-round /
 bounce / reconcile brief from findings-bearing verdicts on such a round
-(§ Revision-round briefs, #1413). Recognition heuristic
+(§ Revision-round briefs, #1413), or the ORCHESTRATOR ingests
+run-failure / forensics text on its own turn — a poll tick reporting
+stalled/dead, crash-persist artifacts, a guard hook's BLOCKED runtime
+output (§ Orchestrator poll/forensics turns, #1546). Recognition heuristic
 (any one suffices):
 
 - guard / security hook scripts (`.claude/hooks/*.sh`, `scripts/guard_*.sh`)
@@ -124,6 +127,11 @@ the duties attach to the brief itself:
    and 4 bind its output from the first spawn.
 4. Keep the brief's own text in neutral gate vocabulary (CLAUDE.md
    § Spurious usage-policy refusals, rung (e)).
+5. A brief whose target or supporting context includes a guard hook's
+   BLOCKED runtime output passes that text by file reference (the hook
+   script path, or the transcript/log path + line) or marker reference —
+   never inlined into the brief (2026-07-18: 3 content-filter kills from
+   briefs inlining a hook's BLOCKED message).
 
 Rationale: rung (e) neutralizes first-pass brief VOCABULARY, but the
 READ discipline previously attached only to review roles and revision
@@ -153,6 +161,62 @@ truncated mid-sentence). After any refusal on a spawn turn, the
 CLAUDE.md rung-(g) dispatched-prompt completeness check applies to
 revision spawns exactly as to first spawns.
 
+## Orchestrator poll/forensics turns (ingest-side, #1546)
+
+Fires for the ORCHESTRATOR itself — an /issue, /issue-v2, /campaign, or
+tick session — whenever run-failure or forensics text lands on its OWN
+turn: a poll tick reporting stalled/dead (the poll JSON's log-tail
+excerpt field), pod/VM stderr or crash-log tails, crash-persist
+artifacts (`crash_report.json` / `workload.log` under the HF
+`issue<N>_partial/` prefix), lane/queue state dumps, or a guard hook's
+BLOCKED runtime output. The composition-side sections above protect
+SUBAGENT briefs; this section protects the orchestrator's own context —
+the one context whose loss costs a session respawn (CLAUDE.md
+§ Spurious usage-policy refusals rung (f); 2026-07-18: 7 content-filter
+kills on one session's poll turns while it paged raw crash-forensics
+tails; session replaced).
+
+1. **Digest-first, unconditionally.** Ingest failure text as STRUCTURAL
+   DIGESTS: bounded pattern COUNTS
+   (`grep -ciE 'error|traceback|killed|OOM' <log>`), exit codes,
+   phase/lane fields from the poll JSON, and file references (path +
+   byte size + mtime) for the tail itself. The CLAUDE.md § Monitoring
+   matched-line grep and the § 429-pacing `tail -50` bound remain the
+   CEILING for any raw-line read on an ordinary run — never `cat` a
+   multi-KB tail (`guard_log_dump.sh` blocks the local dump shapes
+   mechanically; SSH-remote reads and bounded re-reads are NOT
+   hook-covered, so the discipline there is yours) — and never RE-page
+   the same tail across consecutive poll turns: repetition is what
+   accumulates the refusal surface.
+2. **Routing stays script-side.** `failure_class` routing runs through
+   `scripts/failure_classifier.py --body - --log "$LATEST_LOG_PATH"`
+   (issue SKILL.md Step 7): the SCRIPT reads the log and prints a
+   one-line verdict. Do not re-read the raw log inline to re-derive what
+   the classifier computes; pass log content to it by PATH / stdin,
+   never by pasting text into your own turn.
+3. **Trigger-dense runs escalate to a fresh-context reader.** When the
+   RUN is trigger-dense per the recognition heuristic above — keyed on
+   the WORKLOAD, knowable before any read: it trains/evals on
+   guard/security surfaces, harmful-content or refusal corpora, or
+   jailbreak banks, or its failure text embeds a guard hook's BLOCKED
+   output — even bounded excerpts stay OUT of the orchestrator's
+   context: dispatch a fresh-context subagent to read windowed excerpts
+   (discipline 3) and return a digest per disciplines 1/4 — counts,
+   file:line references, a routing recommendation, no quoted text. A
+   subagent's context is disposable; the orchestrator's is the session.
+4. **Guard-hook BLOCKED output by reference.** A hook's BLOCKED message
+   is attack-shaped by construction (it names what it blocks). Reference
+   it by hook path + a ≤80-char reason slice (the issue-tick
+   GATE-TRANSITION precedent) in turn text and marker notes; on a
+   trigger-dense run the `epm:failure` note carries digest + artifact
+   path, not the raw tail (the note is re-read by later turns and tick
+   digests — raw text there poisons every future read). Brief-side duty:
+   § First-pass briefs item 5.
+5. **Durable record is unchanged.** The raw tail stays WHERE IT IS
+   durable (the pod/VM log file, the crash-persist upload) — this
+   section changes what enters the orchestrator's CONTEXT and generated
+   text, never whether forensic text is persisted.
+
 ## What this rule does NOT change
 
 - The review bar. Every finding still needs a concrete artifact location;
@@ -163,6 +227,11 @@ revision spawns exactly as to first spawns.
   by `.claude/rules/diff-size-budget.md`. This rule adds the
   generated-TEXT + verdict-ordering discipline those read-side rules do
   not cover.
+- The CLAUDE.md § Monitoring recipe on ordinary runs and the mechanical
+  `guard_log_dump.sh` dump blocker. § Orchestrator poll/forensics turns
+  adds the counts-first / no-repeat / trigger-dense-escalation discipline
+  those do not cover — it tightens, never replaces, the existing
+  log-read ceiling.
 
 ## Files of record
 
@@ -174,7 +243,11 @@ orchestrator rung b2), #866 (bank-text paging kills), #1090
 return text wedged the parent orchestrator — discipline 4), #1413 (a
 revision brief inlining a round's findings text — § Revision-round briefs),
 #1436/#1443 (4 first-pass kills on guard-surface targets — § First-pass
-briefs, #1503).
+briefs, #1503), 2026-07-18 (7 poll-turn content-filter kills wedged the
+#1481 session while it paged raw crash-forensics tails, session
+replaced, + 3 brief kills from inlined hook-BLOCKED text —
+§ Orchestrator poll/forensics turns + § First-pass briefs item 5,
+#1546).
 Enforcing pointers:
 `.claude/agents/code-reviewer.md` § Context budget (READ FIRST);
 `.claude/agents/reconciler.md` § Rules (Rule 11);
@@ -182,6 +255,8 @@ Enforcing pointers:
 pre-materialization);
 `.claude/skills/issue/SKILL.md` § File-only Codex verdict posting
 (orchestrator-side posting path, #1275);
+`.claude/skills/issue/SKILL.md` Step 6d.2 (poll-loop forensics-ingest
+pointer, #1546);
 `.claude/skills/adversarial-planner/SKILL.md` Phase 3 +
 `.claude/skills/issue/SKILL.md` Step 5d (revision-brief composition
 pointers, #1413);

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -4089,6 +4089,13 @@ while True:
     #                                  per "GPU-idle escalation handling" below.
 ```
 
+**Forensics-ingest discipline (#1546):** on a stalled/dead tick — and in any
+post-crash forensics this loop or Step 7 performs — ingest failure text per
+`.claude/rules/trigger-dense-review.md` § Orchestrator poll/forensics turns:
+structural digests (counts + file references), classifier-side routing, a
+fresh-context reader for trigger-dense runs, hook-BLOCKED output by
+reference.
+
 (`current_phase` is `"running"` by default; when the poller emits a
 milestone marker like `phase: post_eval`, update the local
 `current_phase` from the milestone before the next tick so the title

--- a/scripts/select_step9c_tests.py
+++ b/scripts/select_step9c_tests.py
@@ -227,6 +227,8 @@ WORKFLOW_INVARIANT: tuple[str, ...] = (
     "tests/test_autonomous_plan_gate.py",
     "tests/test_autonomous_session_watch.py",
     "tests/test_issue_skill_exit_breadcrumb.py",  # NEW (#1242) — SKILL.md exit-breadcrumb pin
+    # NEW (#1546) — SKILL.md forensics-ingest pointer pin
+    "tests/test_issue_skill_forensics_ingest_pointer.py",
     "tests/test_issue_skill_marker_contract.py",
     # NEW (#1268) — SKILL.md Step-10d repin/guard hardening pin
     "tests/test_issue_skill_merge_resnapshot_pin.py",

--- a/tests/test_issue_skill_forensics_ingest_pointer.py
+++ b/tests/test_issue_skill_forensics_ingest_pointer.py
@@ -1,0 +1,28 @@
+"""Prose pin for the #1546 Step 6d.2 forensics-ingest pointer.
+
+The /issue SKILL.md polling loop (Step 6d.2) must point orchestrator-side
+run-failure ingestion at trigger-dense-review.md § Orchestrator
+poll/forensics turns, and the rule file must carry that section heading —
+so a rename of either side breaks this test instead of silently stranding
+the pointer (family: test_issue_skill_exit_breadcrumb.py,
+test_issue_skill_guard_excerpt_brief.py).
+"""
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SKILL_MD = REPO / ".claude" / "skills" / "issue" / "SKILL.md"
+RULE_MD = REPO / ".claude" / "rules" / "trigger-dense-review.md"
+
+
+def test_step6d2_forensics_ingest_pointer_present():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    idx = text.index("Forensics-ingest discipline (#1546)")
+    window = text[idx : idx + 600]
+    assert "Orchestrator poll/forensics turns" in window
+    assert "trigger-dense-review.md" in window
+
+
+def test_rule_carries_orchestrator_ingest_section_heading():
+    text = RULE_MD.read_text(encoding="utf-8")
+    assert "## Orchestrator poll/forensics turns" in text

--- a/tests/test_issue_skill_neutral_gate_vocab_brief.py
+++ b/tests/test_issue_skill_neutral_gate_vocab_brief.py
@@ -99,12 +99,16 @@ def test_trigger_dense_rule_first_pass_brief_section():
     fires = text[text.index("**Fires when:**") : text.index("Recognition heuristic")]
     assert "fact-checker" in fires
     assert "FIRST-PASS" in fires
-    # belt-and-suspenders: the always-on LESSONS index row carries the first-pass arm
+    # belt-and-suspenders: the always-on LESSONS index row carries the
+    # brief-composition arm (compressed by #1546's row rewrite to the
+    # #1503/#1413 id pointers — the "first-pass" label was deliberately
+    # dropped to fit the 280 B row cap; the id IS the pointer)
     lessons = LESSONS_MD.read_text(encoding="utf-8")
     row = next(
         line for line in lessons.splitlines() if line.startswith("- trigger-dense-review.md")
     )
-    assert "first-pass" in row
+    assert "#1503" in row
+    assert "brief" in row
 
 
 def test_adversarial_planner_first_pass_brief_pointers():

--- a/tests/test_select_step9c_tests.py
+++ b/tests/test_select_step9c_tests.py
@@ -147,9 +147,11 @@ def test_pinned_invariant_list_matches_live_tree():
     # #1289 diff-base origin/main pin suite (test_diff_base_origin_main_pin — same tuple
     # rationale: a SKILL.md-only recipe revert must still run the pin) + the #1397
     # fit-loop batching review-lens pin suite (test_fit_loop_batching_review_pin —
-    # agent-`.md` diffs gate ONLY via this tuple).
+    # agent-`.md` diffs gate ONLY via this tuple) + the #1546 SKILL.md forensics-ingest
+    # pointer pin suite (test_issue_skill_forensics_ingest_pointer — same tuple
+    # rationale: a SKILL.md-only edit dropping the pointer must still run the pin).
     assert len(sel.WORKFLOW_INVARIANT) == len(set(sel.WORKFLOW_INVARIANT))
-    assert len(sel.WORKFLOW_INVARIANT) == 38
+    assert len(sel.WORKFLOW_INVARIANT) == 39
 
 
 # --- Case 7: determinism — identical sorted output across two invocations ----


### PR DESCRIPTION
Closes task #1546. Adds the orchestrator poll/forensics ingest-side section + First-pass-briefs item 5 to trigger-dense-review.md, the LESSONS row extension, the Step 6d.2 pointer, a pin test, and its WORKFLOW_INVARIANT registration.