### PR TITLE
task #1550: verify_plan.py c40 — header version label vs persisted filename (WARN-only)

### DIFF
--- a/scripts/verify_plan.py
+++ b/scripts/verify_plan.py
@@ -91,17 +91,24 @@ Check catalog (id — classification — kind scope)
       criterion baseline
   c39 off-pod phase             WARN-only, conditional    experiment only
       declaration
+  c40 header version label vs   WARN-only, conditional    all kinds
+      persisted filename
 
 Kind-exempt checks render as [SKIP] (first-class status, distinguishable
 from genuine passes — the calibration report needs n_skip separate from
 n_pass). Conditional checks (4, 6, 7, 10, 11, 12, 13, 14, 15, 16, 17, 18,
 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
-37, 38, 39) also SKIP when their content trigger does not fire.
+37, 38, 39, 40) also SKIP when their content trigger does not fire.
 Check 23 runs OUTSIDE ``verify_plan_text()`` — it needs task context
 (``body.md`` + ``events.jsonl``), so ``main()`` appends it in ``--issue``
 mode only and renders it SKIP in ``--plan-file`` mode; its WARN is the one
 the adversarial-planner Phase 1.5.0 consumer treats as a mechanical redraft
 bounce (SKILL.md § Goal-currency gate), not a brief-forwarded WARN.
+Check 40 also runs outside ``verify_plan_text()`` — it compares the first
+heading's self-declared ``# Plan v<X>`` label against the persisted
+``v{K}.md`` filename, so ``main()`` appends it in BOTH modes; it SKIPs when
+the filename carries no version (e.g. a ``.claude/plans/issue-<N>.md``
+draft).
 
 Canonical N/A escape phrases (quote verbatim in bounce briefs; each
 satisfies its check ONLY as a standalone declaration line — see
@@ -6410,6 +6417,45 @@ def check_off_pod_phase_declaration(plan: str, kind: str) -> CheckResult:
     )
 
 
+# ─── Check 40 — header version label vs persisted filename (outside CHECKS) ─
+
+_C40_FILENAME_RE = re.compile(r"v(\d+)\.md")  # fullmatch on plan_path.resolve().name
+_C40_HEADER_RE = re.compile(r"(?i)^plan\s+v(\d+)\b")  # on the first heading's TEXT
+
+
+def check_header_version_vs_filename(plan: str, *, plan_path: Path) -> CheckResult:
+    """WARN when the plan's first heading self-declares ``Plan v<X>`` and the
+    persisted filename is ``v{K}.md`` with X != K (#1482: '# Plan v4' rode
+    v5.md + v6.md unnoticed). Version-neutral titles PASS (the sanctioned
+    escape); a non-``v{K}.md`` filename SKIPs (nothing to compare). The
+    filename is read via ``plan_path.resolve()`` so a ``plans/plan.md``
+    symlink invocation compares against the real ``v{K}.md`` target.
+    WARN-only, all kinds."""
+    cid = "c40_header_version_vs_filename"
+    name = "header self-declared version matches persisted filename"
+    m_file = _C40_FILENAME_RE.fullmatch(plan_path.resolve().name)
+    if not m_file:
+        return _skip(cid, name, "filename carries no v{K}.md version (draft / standalone plan)")
+    _, body = split_frontmatter(plan)
+    heads = _headings(body)
+    if not heads:
+        return _skip(cid, name, "no headings in plan")
+    m_head = _C40_HEADER_RE.match(heads[0].text)
+    if not m_head:
+        return _pass(cid, name, "header is version-neutral — no self-declared version")
+    x, k = int(m_head.group(1)), int(m_file.group(1))
+    if x == k:
+        return _pass(cid, name, f"header v{x} matches persisted {plan_path.resolve().name}")
+    return _warn(
+        cid,
+        name,
+        f"header self-declares v{x} but the persisted file is {plan_path.resolve().name} — "
+        f"stale version label (#1482: '# Plan v4' rode v5+v6 unnoticed); retitle the header "
+        f"to v{k} or make it version-neutral ('# Plan (amendment) — …' / "
+        f"'# Plan — Issue #<N>: …')",
+    )
+
+
 # ─── Driver ────────────────────────────────────────────────────────────────
 
 CHECKS = [
@@ -6582,6 +6628,9 @@ def main() -> int:
                 "no task context (--plan-file mode; goal history requires --issue)",
             )
         )
+    # Check 40 (header version label vs persisted filename) also runs outside
+    # verify_plan_text() — it needs plan_path, defined in BOTH modes.
+    results.append(check_header_version_vs_filename(raw, plan_path=plan_path))
     overall = all(r.passed for r in results)
 
     if args.json:

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -5873,12 +5873,13 @@ def test_cli_json_schema_and_exit_zero_on_pass(tmp_path):
     assert payload["issue"] is None
     assert payload["kind"] == "experiment"
     assert payload["n_fail"] == 0
-    assert payload["n_skip"] == 32
+    # 33 = the 32 pre-c40 skips + c40 (SKIP: `plan.md` carries no v{K} version).
+    assert payload["n_skip"] == 33
     assert {"id", "name", "status", "detail"} <= set(payload["checks"][0])
     statuses = {c["status"] for c in payload["checks"]}
     assert statuses <= {"PASS", "WARN", "FAIL", "SKIP"}
-    assert len(payload["checks"]) == 40
-    assert len({c["id"] for c in payload["checks"]}) == 40
+    assert len(payload["checks"]) == 41
+    assert len({c["id"] for c in payload["checks"]}) == 41
     # c23 has no task context in --plan-file mode: rendered SKIP (companion
     # assert for test_cli_issue_mode_appends_goal_currency).
     c23 = next(c for c in payload["checks"] if c["id"] == "c23_goal_currency")
@@ -6095,6 +6096,112 @@ def test_cli_issue_mode_appends_goal_currency(tmp_path, monkeypatch, capsys):
     assert len(entries) == 1
     # Synthetic task has no goal frontmatter and no goal-updated markers.
     assert entries[0]["status"] == "SKIP"
+
+
+# ─── Check 40 — header version label vs persisted filename (outside CHECKS) ─
+
+
+def test_c40_header_version_mismatch_warns():
+    plan = "# Plan v4 (amendment) — issue #1482, marker follow-up\n\nSome body prose.\n"
+    r = verify_plan.check_header_version_vs_filename(plan, plan_path=Path("v6.md"))
+    assert r.status == "WARN"
+    assert "v4" in r.detail
+    assert "v6.md" in r.detail
+    assert "retitle" in r.detail
+
+
+def test_c40_header_version_match_passes():
+    plan = "# Plan v6 — issue #1482, marker follow-up\n\nSome body prose.\n"
+    r = verify_plan.check_header_version_vs_filename(plan, plan_path=Path("v6.md"))
+    assert r.status == "PASS"
+
+
+def test_c40_version_neutral_header_passes():
+    # Version-neutral titles are the sanctioned escape: explicit PASS,
+    # never SKIP, never WARN (both incident shapes: v7-style + v1-style).
+    for title in ("# Plan (amendment) — issue #1482", "# Plan — Issue #1482: marker follow-up"):
+        r = verify_plan.check_header_version_vs_filename(
+            f"{title}\n\nSome body prose.\n", plan_path=Path("v6.md")
+        )
+        assert r.status == "PASS", title
+        assert "version-neutral" in r.detail
+
+
+def test_c40_unversioned_filename_skips():
+    plan = "# Plan v4 (amendment) — issue #1482\n\nSome body prose.\n"
+    r = verify_plan.check_header_version_vs_filename(plan, plan_path=Path("issue-1550.md"))
+    assert r.status == "SKIP"
+
+
+def test_c40_no_headings_skips():
+    r = verify_plan.check_header_version_vs_filename(
+        "just prose, no headings anywhere\n", plan_path=Path("v3.md")
+    )
+    assert r.status == "SKIP"
+    assert "no headings" in r.detail
+
+
+def test_c40_fenced_or_prose_plan_v_mentions_do_not_trigger():
+    # Fence-awareness + first-heading-only scope: a fenced `# Plan v3` line
+    # and later prose/headings quoting sibling versions must not trip c40.
+    plan = (
+        "```\n"
+        "# Plan v3 — fenced example, must be masked\n"
+        "```\n\n"
+        "# Plan (amendment) — issue #1482 fixture\n\n"
+        "Prose later mentions plan v4 divergences from parent plan v3.\n\n"
+        "## Divergences from parent plan v9\n"
+    )
+    r = verify_plan.check_header_version_vs_filename(plan, plan_path=Path("v6.md"))
+    assert r.status == "PASS"
+
+
+def test_cli_issue_mode_appends_header_version_check(tmp_path, monkeypatch, capsys):
+    # Mirror of test_cli_issue_mode_appends_goal_currency, at plans/v2.md with
+    # a stale `# Plan v1` first heading: exactly one c40 entry, WARN, rc 0
+    # (WARN keeps overall PASS).
+    (tmp_path / "plans").mkdir()
+    (tmp_path / "plans" / "v2.md").write_text("# Plan v1 — x\n\n" + GOOD_PLAN)
+    (tmp_path / "body.md").write_text("---\ntitle: x\nkind: experiment\n---\n# x\n")
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    import explore_persona_space.task_workflow as tw
+
+    monkeypatch.setattr(tw, "find_task_path", lambda n: tmp_path)
+    monkeypatch.setattr(sys, "argv", ["verify_plan.py", "--issue", "999", "--json"])
+    rc = verify_plan.main()
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    entries = [c for c in payload["checks"] if c["id"] == "c40_header_version_vs_filename"]
+    assert len(entries) == 1
+    assert entries[0]["status"] == "WARN"
+
+
+def test_cli_plan_file_mode_parses_versioned_filename(tmp_path):
+    # --plan-file mode PARSES a v{K}.md-shaped filename (D2: unlike c23, c40
+    # runs in both modes); a non-versioned filename SKIPs; a plan.md SYMLINK
+    # resolves to its v{K}.md target (concern 1: plan_path.resolve()).
+    text = "# Plan v2 — issue #999 fixture\n\n" + GOOD_PLAN.split("\n", 1)[1]
+    p3 = tmp_path / "v3.md"
+    p3.write_text(text)
+    proc = _run_cli("--plan-file", str(p3), "--json")
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    c40 = next(c for c in payload["checks"] if c["id"] == "c40_header_version_vs_filename")
+    assert c40["status"] == "WARN"
+
+    draft = tmp_path / "issue-999.md"
+    draft.write_text(text)
+    proc = _run_cli("--plan-file", str(draft), "--json")
+    payload = json.loads(proc.stdout)
+    c40 = next(c for c in payload["checks"] if c["id"] == "c40_header_version_vs_filename")
+    assert c40["status"] == "SKIP"
+
+    link = tmp_path / "plan.md"
+    link.symlink_to(p3)
+    proc = _run_cli("--plan-file", str(link), "--json")
+    payload = json.loads(proc.stdout)
+    c40 = next(c for c in payload["checks"] if c["id"] == "c40_header_version_vs_filename")
+    assert c40["status"] == "WARN"
 
 
 # ─── Cross-file anchor pins (planner.md / CLAUDE.md drift detector) ────────


### PR DESCRIPTION
Closes task #1550. Adds WARN-only check c40_header_version_vs_filename to scripts/verify_plan.py (+8 tests, 1 budgeted expectation update). Incident: #1482 stale '# Plan v4' header rode v5-v7 persists.