### PR TITLE
task #1552: waive the two pre-existing #1481 lint reds

### DIFF
--- a/scripts/issue1481_cjk_audit.py
+++ b/scripts/issue1481_cjk_audit.py
@@ -85,6 +85,7 @@ def _download_pools(cache_dir: Path) -> list[Path]:
     api = HfApi()
     paths: list[str] = []
     for sub in ("panel", "base_arms"):
+        # HUB_VERIFY_RETRY_EXEMPT: frozen #1481 repro script; one-shot scoped listing (#1552)
         for t in api.list_repo_tree(
             DATA_REPO, f"{PREFIX}/raw_completions/{sub}", repo_type="dataset", recursive=True
         ):

--- a/scripts/issue1481_dispatch.sh
+++ b/scripts/issue1481_dispatch.sh
@@ -56,4 +56,8 @@ case "$GROUP" in
     ;;
 esac
 
-echo "[phase=done]"
+# Standalone-lane dispatcher terminal (load-bearing for poll_pipeline.py when this
+# script runs as the MAIN dispatcher — never remove/reword). When invoked as a child
+# by issue1481_phasec.sh (:43/:49, stdout into phasec's main log), phasec emits its
+# own terminal at its line 52; waived per #1552.
+echo "[phase=done]"  # noqa: phase-done-reserved (standalone-lane terminal; see above)


### PR DESCRIPTION
Closes task #1552. Comment-only waivers: HUB_VERIFY_RETRY_EXEMPT above issue1481_cjk_audit.py:88; noqa: phase-done-reserved on issue1481_dispatch.sh:59 (silences both phasec.sh parent edges). code-review PASS r1; test-verdict PASS (4010/0).