### PR TITLE
issue-1553: extend pre_reg audit head nouns — estimators? (#1482 escape)

### DIFF
--- a/scripts/audit_clean_results_body_discipline.py
+++ b/scripts/audit_clean_results_body_discipline.py
@@ -131,6 +131,27 @@ PATTERNS: dict[str, tuple[str, str]] = {
         # on the [ \t]+-only separators — a future \s widening would
         # silently break it. 'test' and 'interval' remain deliberately
         # absent (the sanctioned CI-definition register, see above).
+        # #1553 (2026-07-19) adds `estimators?` for the #1482 round-4
+        # escape: 'the plotted floor is the registered fresh-4 estimator'
+        # (Results, k-resample H3 what-is-plotted line) could not match
+        # this pattern — 'estimator' was absent from the alternation — and
+        # was caught only by the LM critic's Lens 7 read. NOTE the
+        # originally-filed diagnosis (extend _PRE_REG_PROSE_SECTIONS to
+        # the v4 section names) was reproduced as a NO-OP: that tuple is
+        # consumed only by the v3 branch of
+        # _restrict_pre_reg_to_prose_sections; the v4 branch already scans
+        # whole-body-minus-tables. Measured 2026-07-19 over all 1,485
+        # tasks/*/*/body.md (full-pattern old-vs-new match-start diff):
+        # 7 new hits — 4 in #536, 1 in #589 (genuine 'registered
+        # [uncertainty] estimator' jargon that had escaped), 2 in #1553's
+        # own body quoting the incident — every one genuine, 0 benign
+        # verb-use false positives. OLD-minus-NEW starts: 0. The sibling
+        # nouns `estimates?` and `estimand` were measured and EXCLUDED:
+        # zero additional corpus hits each, no incident mandate (inverse
+        # of the #1475 cut/lever/smoke inclusion logic — no attestation
+        # AND no incident string), and 'estimate' is a far more common
+        # object of verb-register 'registered' than 'estimator', so both
+        # stay out until an incident or attested hit mandates them.
         r"pre-?registered|pre-?registration|(?<![a-z])pre-reg(?![a-z])|registered hypothesis"
         r"|registered alpha|\bas registered\b|fail at the gate|passed the gate"
         r"|gate-pre-?registered"
@@ -138,7 +159,7 @@ PATTERNS: dict[str, tuple[str, str]] = {
         r"(?:[\w%/<>=≤≥−+-]+(?:[.\-−]\d+)*[ \t]+){0,3}?"  # noqa: RUF001
         r"(?:verdicts?|lattices?|margins?|reads?|criteri(?:on|a)|thresholds?|bands?"
         r"|gates?|rules?|endpoints?|contrasts?|floors?|companions?|hypothes[ei]s|alpha"
-        r"|cuts?|paths?|clauses?|controls?|levers?|bars?|smokes?)\b",
+        r"|cuts?|paths?|clauses?|controls?|levers?|bars?|smokes?|estimators?)\b",
         "Pre-registration jargon ('pre-registered', 'as registered', "
         "'fail at the gate', bare 'registered <verdict/margin/read/...>', etc.)",
     ),

--- a/tests/test_audit_clean_results_body_discipline.py
+++ b/tests/test_audit_clean_results_body_discipline.py
@@ -796,10 +796,13 @@ def test_pre_reg_innocuous_registered_usage_not_flagged():
     """Plain 'registered' verb usages in a SCANNED prose section ('registered
     the adapter on HF', 'was registered in WandB', 'alias registered') must
     NOT trip `pre_reg` — the new alternation is anchored to the literal
-    'as registered' bigram, and the leading `\\b` fails inside 'was'/'alias'."""
+    'as registered' bigram, and the leading `\\b` fails inside 'was'/'alias'.
+    #1553 adds a noun-before-verb guard for the new `estimators?` head noun
+    ('the estimator was registered in WandB' — preposition-lookahead form)."""
     body = V3_BODY_WITH_DATA_CODES.replace(
         "- Headline finding: the implant installs cleanly across three seeds.",
-        "- Registered the adapter on HF; the run was registered in WandB; alias registered too.",
+        "- Registered the adapter on HF; the run was registered in WandB; alias registered "
+        "too; the estimator was registered in WandB.",
     )
     assert body != V3_BODY_WITH_DATA_CODES
     findings = audit.audit_body(body)
@@ -1192,7 +1195,9 @@ def test_pre_reg_registered_interval_defining_the_test_not_flagged():
     """'the registered interval defining the test' is the sanctioned
     Why-this-test CI-definition register — 'interval' and 'test' are
     deliberately absent from the head-noun list, so `pre_reg` stays
-    silent (the LM critic owns any residual judgment call here)."""
+    silent (the LM critic owns any residual judgment call here). This
+    also pins the sanctioned register against future head-noun
+    extensions (#1553 `estimators?` included)."""
     body = V4_BODY_CLEAN.replace(
         "The lift holds at every seed in the held-out evaluation.",
         "**Why this test:** the bootstrap CI is the registered interval defining the test.",
@@ -1200,6 +1205,21 @@ def test_pre_reg_registered_interval_defining_the_test_not_flagged():
     assert body != V4_BODY_CLEAN
     findings = audit.audit_body(body)
     assert "pre_reg" not in findings, findings
+
+
+def test_pre_reg_registered_estimator_in_v4_results_prose_is_flagged():
+    """The verbatim #1482 round-4 escape — 'The plotted floor is the
+    registered fresh-4 estimator.' in a v4 body's ## Results H3 prose —
+    trips `pre_reg` now that #1553 added `estimators?` to the head-noun
+    alternation ('fresh-4' is one intervening modifier token)."""
+    body = V4_BODY_CLEAN.replace(
+        "The lift holds at every seed in the held-out evaluation.",
+        "The plotted floor is the registered fresh-4 estimator.",
+    )
+    assert body != V4_BODY_CLEAN
+    findings = audit.audit_body(body)
+    assert "pre_reg" in findings, findings
+    assert any("estimator" in s.lower() for s in findings["pre_reg"]), findings["pre_reg"]
 
 
 # ─── v4 ## Methodology sample-data <details> exemption (#1171) ───────────


### PR DESCRIPTION
Closes task #1553 (workflow-fix). One-line head-noun extension of the pre_reg audit regex + comment-block measurement record + tests. Deflects the filed no-op tuple sketch (mechanism reproduced as v3-branch-only).