### PR TITLE
issue-1570: merge=union for tests/sparse_cones.txt + pin test (#1570)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -43,6 +43,22 @@ tasks/**/comments.jsonl merge=union
 # honor user-defined merge drivers.
 eval_results/INDEX.md merge=union
 
+# tests/sparse_cones.txt (#1570): append-only sparse-cone registry — each new
+# committed-fixture test appends one cone-dir line; concurrent appends
+# conflicted TWICE on 2026-07-19 (#1481 + #1417 merge rounds). union is safe
+# here because BOTH consumers read the registry as a SET: new_worktree.sh
+# _sparse_setup feeds lines to `git sparse-checkout set` (set semantics,
+# dedupes), and step9c_baseline.py _scratch_cones does
+# sorted(set(dirs) | set(registry_lines) | set(wt_cones)) — duplicated /
+# reordered lines are harmless. union is line-oriented: clean for
+# append-append; a rare concurrent EDIT of the same region merges WITHOUT
+# conflict markers and may duplicate/interleave lines — benign here (set
+# consumers), self-healed by the next correcting write. Same SCOPE CAVEAT as
+# above: honored on LOCAL merges/rebases only — server-side `gh pr merge`
+# does not honor user-defined merge drivers (Guard-1 foreign-folder strip +
+# the surgical-additive fast-path remain the server-side defense).
+tests/sparse_cones.txt merge=union
+
 # REGISTRY.json is deliberately NOT unioned — it is a last-writer-wins JSON
 # snapshot (atomic write-temp+rename), never append-only; a union merge would
 # concatenate two JSON objects into invalid JSON.

--- a/tests/test_step10d_guard3.py
+++ b/tests/test_step10d_guard3.py
@@ -103,6 +103,19 @@ def test_gitattributes_union_merge_for_eval_results_index():
     )
 
 
+def test_gitattributes_union_merge_for_sparse_cones():
+    """#1570: tests/sparse_cones.txt is an append-only cone registry (two
+    same-day merge conflicts, 2026-07-19); both consumers read it as a set."""
+    text = _GITATTRIBUTES.read_text(encoding="utf-8")
+    assert "tests/sparse_cones.txt merge=union" in text, (
+        "tests/sparse_cones.txt must use union merge (#1570)"
+    )
+    # Trailing-newline pin: union is line-oriented — a registry whose last
+    # line lacked "\n" could join lines on a future union concatenation.
+    registry = (_REPO_ROOT / "tests" / "sparse_cones.txt").read_text(encoding="utf-8")
+    assert registry.endswith("\n"), "tests/sparse_cones.txt must end with a trailing newline"
+
+
 def test_gitattributes_registry_not_unioned():
     """REGISTRY.json is last-writer-wins; a union merge would break its JSON."""
     text = _GITATTRIBUTES.read_text(encoding="utf-8")


### PR DESCRIPTION
Closes task #1570 (daily-fix: merge=union for tests/sparse_cones.txt).

## Summary
- Add `tests/sparse_cones.txt merge=union` to .gitattributes (append-only cone registry; two same-day local merge conflicts 2026-07-19) with the house-pattern comment block + LOCAL-only scope caveat.
- Pin test `test_gitattributes_union_merge_for_sparse_cones` (+ trailing-newline pin) in tests/test_step10d_guard3.py.

## Test plan
- [x] Scratch-repo append-append union smoke: UNION-SMOKE-OK, no conflict markers
- [x] Step 9c gate: 4018 passed / 6 skipped; compare new=[] (COMPARE_RC=0)
- [x] ruff + no-flags workflow_lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)