### PR TITLE
task #1561: hub-verify lint — exempt Store/Del-ctx monkeypatch targets

### DIFF
--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -7337,17 +7337,29 @@ def _hub_verify_bare_hits(tree: ast.Module) -> list[tuple[int, str]]:
 
     Two legs:
 
-    * any ``ast.Attribute`` whose ``attr`` is in
+    * any **Load-ctx** ``ast.Attribute`` whose ``attr`` is in
       :data:`HUB_VERIFY_BARE_TARGETS` — covers ``api.list_repo_files(...)``,
       ``HfApi().list_repo_tree(...)``, ``hh.file_exists(...)`` under a module
       alias, AND the bare-reference form passed to a retry wrapper /
-      ``asyncio.to_thread`` (mirrors :func:`_is_batches_create_attr`);
-    * any ``ast.Name`` whose id is a name BOUND by a
+      ``asyncio.to_thread`` (mirrors :func:`_is_batches_create_attr`, plus
+      the ctx gate below);
+    * any **Load-ctx** ``ast.Name`` whose id is a name BOUND by a
       ``from huggingface_hub import <target> [as alias]`` — the ImportFrom
       pre-pass builds an asname-aware bound-name map, so both the plain and
       the aliased import forms are caught, while a script-local
       ``def file_exists(...)`` helper (no huggingface_hub import of that
       symbol) is never flagged.
+
+    Store/Del-ctx nodes (assignment/deletion targets — the monkeypatch
+    patch/restore shape in self-test code, ``HfApi.list_repo_tree = fake``)
+    are exempt on both legs: a binding target never evaluates to a value,
+    so it can neither be a call nor a callable reference; the assigned
+    VALUE is a separate Load-ctx node scanned independently. On the Name
+    leg the same gate exempts rebinding or deleting the imported name
+    (``list_repo_files = None``, ``del list_repo_files`` — a deletion is
+    not a call). The Load-ctx bare-reference SAVE
+    (``orig = HfApi.list_repo_tree``) REMAINS flagged — a saved alias
+    later called still storms — and takes the waiver (#1482/#1561).
 
     Callers dedupe by line (a call form is a single node either way).
     """
@@ -7360,8 +7372,23 @@ def _hub_verify_bare_hits(tree: ast.Module) -> list[tuple[int, str]]:
     hits: list[tuple[int, str]] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Attribute) and node.attr in HUB_VERIFY_BARE_TARGETS:
+            if isinstance(node.ctx, (ast.Store, ast.Del)):
+                # Assignment/deletion TARGETS — the monkeypatch patch/RESTORE
+                # assignments in self-test code (`HfApi.list_repo_tree = fake`,
+                # `del api.file_exists`) — can never be calls and never
+                # evaluate to a callable reference: the assigned VALUE is a
+                # separate node with its own Load ctx, scanned independently.
+                # The Load-ctx SAVE (`orig = HfApi.list_repo_tree`) stays
+                # flagged deliberately — a bare alias later called still
+                # storms — and takes the waiver (#1482/#1561).
+                continue
             hits.append((node.lineno, f".{node.attr}("))
         elif isinstance(node, ast.Name) and node.id in hf_bound:
+            if isinstance(node.ctx, (ast.Store, ast.Del)):
+                # Rebinding/deleting the imported name is not a call; a
+                # wrap-rebind (`lrf = retry(lrf)`) still hits via its RHS
+                # Load usage on the same line.
+                continue
             hits.append((node.lineno, f"{hf_bound[node.id]}("))
     return hits
 
@@ -7382,14 +7409,19 @@ def check_hub_verify_retry(*, scripts_dir: Path | None = None) -> list[str]:
     ``api.list_repo_files(...)`` reintroduces the class. This check is the
     mechanical gate on new scripts/ call sites (#1202).
 
-    Detection: see :func:`_hub_verify_bare_hits` (Attribute leg + an
-    asname-aware imported-Name leg), deduped by line. Compliant hub-helper
-    usage is structurally invisible (different attr/name strings); comments
-    and docstrings can never match. Within ``scripts/`` ANY spelled bare
-    call is presumed un-retried — even a script-local
-    ``retry_transient(lambda: api.list_repo_files(...))`` is flagged
-    deliberately (the wrapped bare attribute is still a hand-rolled leg);
-    a genuinely-correct raw call takes the waiver comment.
+    Detection: see :func:`_hub_verify_bare_hits` (a Load-ctx Attribute leg
+    + an asname-aware Load-ctx imported-Name leg; Store/Del-ctx binding
+    targets exempt — see :func:`_hub_verify_bare_hits`), deduped by line.
+    Compliant hub-helper usage is structurally invisible (different
+    attr/name strings); comments and docstrings can never match. Within
+    ``scripts/`` ANY spelled bare call is presumed un-retried — even a
+    script-local ``retry_transient(lambda: api.list_repo_files(...))`` is
+    flagged deliberately (the wrapped bare attribute is still a hand-rolled
+    leg); a genuinely-correct raw call takes the waiver comment. A
+    monkeypatch SAVE of the bare attribute (``orig = HfApi.list_repo_tree``)
+    is likewise flagged deliberately and takes the waiver — the saved alias
+    is call-equivalent; the assignment TARGETS of the patch/restore lines
+    need no waiver (Store-ctx exempt, #1482/#1561).
 
     Named residuals NOT covered (deliberate — documented, not detector legs):
     ``repo_info(`` (legitimate metadata uses dominate), ``hf_hub_download``
@@ -7454,7 +7486,11 @@ def check_hub_verify_retry(*, scripts_dir: Path | None = None) -> list[str]:
                 f"raw call (e.g. one you wrap in hub.retry_transient yourself) "
                 f"takes the waiver: '# HUB_VERIFY_RETRY_EXEMPT: <reason>' "
                 f"(reason >= {HUB_VERIFY_WAIVER_MIN_REASON_CHARS} chars) on the "
-                f"call's line or the previous non-blank line (#920/#997/#1202)."
+                f"call's line or the previous non-blank line (#920/#997/#1202). "
+                f"Monkeypatch assignment TARGETS (`HfApi.X = fake`) are exempt "
+                f"by AST ctx and need no waiver; a monkeypatch SAVE of the bare "
+                f"reference (`orig = HfApi.X`) still takes the waiver — a saved "
+                f"alias later called still storms (#1482/#1561)."
             )
     return errors
 

--- a/tests/test_workflow_lint.py
+++ b/tests/test_workflow_lint.py
@@ -4812,6 +4812,126 @@ def test_check_hub_verify_retry_fail_waiver_reason_too_short(tmp_path):
     assert len(errors) == 1, errors
 
 
+def test_check_hub_verify_retry_pass_store_ctx_assignment_target(tmp_path):
+    """A Store-ctx assignment TARGET (the monkeypatch patch shape,
+    ``HfApi.list_repo_tree = _fake``) can never be a call and is exempt
+    without a waiver (#1482/#1561)."""
+    (tmp_path / "issue9999_selftest.py").write_text(
+        "import huggingface_hub\n"
+        "def _fake(*a, **k):\n"
+        "    raise RuntimeError('stub')\n"
+        "def patch():\n"
+        "    huggingface_hub.HfApi.list_repo_tree = _fake\n"
+    )
+    errors = check_hub_verify_retry(scripts_dir=tmp_path)
+    assert errors == [], errors
+
+
+def test_check_hub_verify_retry_pass_del_ctx_attribute(tmp_path):
+    """A Del-ctx attribute (``del api.file_exists`` — the monkeypatch
+    cleanup shape) is a deletion target, not a call; exempt without a
+    waiver."""
+    (tmp_path / "issue9999_unpatch.py").write_text(
+        "from huggingface_hub import HfApi\n"
+        "api = HfApi()\n"
+        "def unpatch():\n"
+        "    del api.file_exists\n"
+    )
+    errors = check_hub_verify_retry(scripts_dir=tmp_path)
+    assert errors == [], errors
+
+
+def test_check_hub_verify_retry_fail_load_ctx_monkeypatch_save(tmp_path):
+    """The Load-ctx monkeypatch SAVE (``orig = HfApi.list_repo_tree``) is
+    STILL flagged — the saved alias is call-equivalent (alias-later-called
+    evasion) — while the Store-ctx restore line yields no second error.
+    The error message names the monkeypatch-save waiver requirement
+    (#1482/#1561)."""
+    (tmp_path / "issue9999_save.py").write_text(
+        "import huggingface_hub\n"
+        "orig = huggingface_hub.HfApi.list_repo_tree\n"
+        "huggingface_hub.HfApi.list_repo_tree = orig\n"
+    )
+    errors = check_hub_verify_retry(scripts_dir=tmp_path)
+    assert len(errors) == 1, errors
+    assert ":2:" in errors[0]
+    assert ".list_repo_tree(" in errors[0]
+    assert "monkeypatch" in errors[0].lower()
+
+
+def test_check_hub_verify_retry_pass_monkeypatch_block_waiver_on_save_only(tmp_path):
+    """The full #1482 monkeypatch block (save / patch / restore, the
+    issue779:618-635 shape) needs exactly ONE waiver — on the Load-ctx
+    save line; the Store-ctx patch/restore lines are exempt by ctx
+    (pre-fix this block required 4 waivers)."""
+    (tmp_path / "issue9999_block.py").write_text(
+        "import huggingface_hub\n"
+        "def _fake(*a, **k):\n"
+        "    raise RuntimeError('stub')\n"
+        "def selftest():\n"
+        "    # HUB_VERIFY_RETRY_EXEMPT: attribute reference only (monkeypatch save), no call\n"
+        "    orig_lrt = huggingface_hub.HfApi.list_repo_tree\n"
+        "    huggingface_hub.HfApi.list_repo_tree = _fake\n"
+        "    try:\n"
+        "        pass\n"
+        "    finally:\n"
+        "        huggingface_hub.HfApi.list_repo_tree = orig_lrt\n"
+    )
+    errors = check_hub_verify_retry(scripts_dir=tmp_path)
+    assert errors == [], errors
+
+
+def test_check_hub_verify_retry_fail_bare_reference_argument_position(tmp_path):
+    """A bare Load-ctx reference passed as a wrapper ARGUMENT
+    (``retry_transient(api.list_repo_files)``) stays flagged — guards
+    against a future over-broad 'only flag ast.Call' change (the exact
+    wrong fix the ctx gate must not become)."""
+    (tmp_path / "issue9999_wrapper_arg.py").write_text(
+        "from huggingface_hub import HfApi\n"
+        "api = HfApi()\n"
+        "def retry_transient(fn):\n"
+        "    return fn\n"
+        "wrapped = retry_transient(api.list_repo_files)\n"
+    )
+    errors = check_hub_verify_retry(scripts_dir=tmp_path)
+    assert len(errors) == 1, errors
+    assert ".list_repo_files(" in errors[0]
+
+
+def test_check_hub_verify_retry_name_leg_store_ctx(tmp_path):
+    """Name-leg ctx gate: a pure rebind of the imported name
+    (``list_repo_files = None``) is no longer flagged (a binding is not a
+    call), while a wrap-rebind (``list_repo_tree = my_retry(list_repo_tree)``)
+    still yields exactly one hit via its RHS Load usage."""
+    (tmp_path / "rebind_only.py").write_text(
+        "from huggingface_hub import list_repo_files\nlist_repo_files = None\n"
+    )
+    (tmp_path / "wrap_rebind.py").write_text(
+        "from huggingface_hub import list_repo_tree\n"
+        "def my_retry(fn):\n"
+        "    return fn\n"
+        "list_repo_tree = my_retry(list_repo_tree)\n"
+    )
+    errors = check_hub_verify_retry(scripts_dir=tmp_path)
+    assert len(errors) == 1, errors
+    assert "wrap_rebind.py" in errors[0]
+
+
+def test_check_hub_verify_retry_pass_augassign_store_target(tmp_path):
+    """An AugAssign target (``api.list_repo_tree += x``) reads ctx=Store —
+    the one Store shape with a runtime getattr; getattr of a method never
+    calls it, so the ctx gate exempts it (optional pin from the #1561 plan
+    review round)."""
+    (tmp_path / "issue9999_augassign.py").write_text(
+        "from huggingface_hub import HfApi\n"
+        "api = HfApi()\n"
+        "def bump(x):\n"
+        "    api.list_repo_tree += x\n"
+    )
+    errors = check_hub_verify_retry(scripts_dir=tmp_path)
+    assert errors == [], errors
+
+
 def test_check_hub_verify_retry_allowlist_is_file_granular(tmp_path):
     """The grandfather allowlist exempts by exact rel path (whole file), and
     a NON-allowlisted offender at the same dir IS flagged — the exemption is


### PR DESCRIPTION
Closes task #1561. Store/Del-ctx exemption in _hub_verify_bare_hits + docs + 7 tests.