### PR TITLE
task #1560: sync lint/guard family at Step 5a + Step 10d pre-gate re-sync

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -2192,7 +2192,16 @@ already runs on `main`):
 # — NOT the #506 path-doubling bug; do NOT change to --git-common-dir here. The
 # self-no-op case (session already on main) is why show-toplevel is correct.
 WT=$(git rev-parse --show-toplevel)
-SPECS=".claude/agents .claude/skills .claude/rules .claude/workflow.yaml CLAUDE.md"
+# Lint/guard family rides the sync (#1560): the specs synced below are budget-
+# checked by workflow_lint.py constants, enforced by .claude/hooks/, and pinned
+# by the test_workflow_lint*/test_guard_lessons_edit pin tests — syncing
+# specs without their enforcing family creates the #1489/#1482/#1417 vintage
+# skew. `:(glob)` is a git pathspec (never shell-expands: no path starts with
+# ":(glob)"), so `git checkout main --` matches main-NEW pin tests too. The
+# per-file branch-side-edit guard's skip grain is PER-ITEM: a branch editing
+# ONE pin test skips the whole `:(glob)` family entry (fail-safe — status-quo
+# staleness for those files, never a clobber).
+SPECS=".claude/agents .claude/skills .claude/rules .claude/workflow.yaml CLAUDE.md scripts/workflow_lint.py .claude/hooks tests/test_guard_lessons_edit.py :(glob)tests/test_workflow_lint*.py"
 MB=$(git -C "$WT" merge-base HEAD main)
 SAFE_SPECS=""
 for f in $SPECS; do
@@ -2200,7 +2209,8 @@ for f in $SPECS; do
   # EXCLUDING prior spec-freshness sync commits (which legitimately
   # touch spec paths — without the exclusion, the first sync's own
   # commit would poison every later freshness check on the branch).
-  bs_commits=$(git -C "$WT" log --oneline "$MB"..HEAD --grep='spec-freshness' --invert-grep -- "$f")
+  bs_commits=$(git -C "$WT" log --format='%H %s' "$MB"..HEAD -- "$f" \
+    | awk 'index($0, "spec-freshness") == 0')
   if [ -z "$bs_commits" ]; then
     SAFE_SPECS="$SAFE_SPECS $f"
   else
@@ -2247,21 +2257,38 @@ content has already landed on main (in which case the orchestrator can
 safely override the skip for those specific files with a manual
 `git -C "$WT" checkout main -- <paths>`).
 
-**The sync scope is deliberately specs-only — do NOT extend it to
-`scripts/` or `tests/`.** The sync exists because the Agent/Skill tools
-load specs from the session's cwd; workflow-helper SCRIPTS are already
-resolved from the MAIN checkout (Step 0 § worktree spec-freshness:
-`"$REPO_ROOT"/scripts/...`), so syncing worktree copies buys no runtime
-correctness. Blind-syncing `tests/` is actively unsafe: main's newer
-workflow tests pin behavior implemented in main's newer `scripts/` +
-`src/` (e.g. `task_workflow.py`, `backends/`) that the branch predates,
-so a partial code sync makes the worktree suite REDDER or breaks the
+**The sync scope is specs + the spec-coupled lint/guard family — do NOT
+extend it further into `scripts/`, `tests/`, or `src/`.** The family
+exception (#1560: `scripts/workflow_lint.py`, `.claude/hooks`,
+`tests/test_guard_lessons_edit.py`, `:(glob)tests/test_workflow_lint*.py`)
+exists because those files execute FROM the worktree tree on four
+surfaces — the Step 10d TG legs, worktree pytest / Step 9c, the hooks'
+own-tree `workflow_lint` import, and the inline gate invoked in a
+worktree — and their constants/budgets pair with the specs this sync
+already refreshes: half-syncing manufactured the #1489/#1482/#1417 gate
+blocks. The family is deliberately closed up to ONE seam: its only src
+imports are from the low-churn `explore_persona_space.workflow` module
+(the linter's 2-symbol import at `workflow_lint.py:672-681`, plus
+`tests/test_workflow_lint.py:96`'s 3-symbol
+`MarkerEntry, WorkflowYaml, load_workflow_yaml`) — the accepted
+residual: a synced family file ImportError-ing on that module means
+branch-era `src/explore_persona_space/workflow.py` skew (rebase onto
+origin/main, or cross-check at the repo root; module stable since
+2026-06-13). Everything ELSE keeps the original rationale: workflow-
+helper SCRIPTS are already resolved from the MAIN checkout (Step 0
+§ worktree spec-freshness: `"$REPO_ROOT"/scripts/...`), and blind-
+syncing broader `tests/` is actively unsafe — main's newer workflow
+tests pin behavior implemented in main's newer `scripts/` + `src/`
+(e.g. `task_workflow.py`, `backends/`) that the branch predates, so a
+partial code sync makes the worktree suite REDDER or breaks the
 branch's own imports — and the per-path branch-side-edit guard would
-skip `scripts/`/`tests/` wholesale anyway (nearly every issue branch
-adds its own `scripts/issue<N>_*.py` + tests). Operational rule
-instead: a workflow test that FAILs inside a long-lived issue worktree
-but PASSes at the repo root on `main` is worktree-staleness, not this
-issue's breakage — cross-check at the repo root before chasing it; the
+skip broad `scripts/`/`tests/` cones wholesale anyway (nearly every
+issue branch adds its own `scripts/issue<N>_*.py` + tests). Operational
+rule instead: a workflow test that FAILs inside a long-lived issue
+worktree but PASSes at the repo root on `main` — **including a
+collection-time ImportError from a `workflow_lint` / rules-pin
+symbol** — is worktree-staleness, not this issue's breakage —
+cross-check at the repo root before chasing it; the
 Step 10d merge resolves it (observed on #542, 2026-06-11). (A shared-infra
 `src/` fix with fleet-wide blast radius — e.g. the #847 thread caps — gets a
 LAUNCH-TIME fallback instead of a sync: the VM-side launch surfaces carry the
@@ -6784,6 +6811,12 @@ explicit eval-data path):
    two inline-landed bare `.list_repo_tree(` scripts broke
    `tests/test_workflow_lint.py` on pristine main fleet-wide; the
    worktree channels are already gated at Step 10d).
+
+   A worktree-cwd inline-gate false block naming a ratchet/grandfather
+   cap or failing to import `workflow_lint` is the stale-family class
+   (#1417): run the Step 5a sync (now family-inclusive) in that
+   worktree and re-run the gate before treating the block as
+   payload-caused.
 4. **Capture the headline before / after.** Read the current `body.md`
    H1 title before the re-spawn and the analyzer-produced H1 after,
    plus the LOW / MODERATE / HIGH confidence tag in each.
@@ -9672,6 +9705,43 @@ tests BEFORE anything lands:
   `ood_eval_results/`, `raw/`, `data/`, `docs/methodology/`). The lint's
   no-flags default run walks `.claude/**`, `CLAUDE.md`, `scripts/`, and
   `src/`, so any code-bearing payload is in scope.
+- **Pre-gate freshness re-sync (#1560; forms (i)/(ii) — form (iii) operates
+  on the root tree and is exempt).** Step 5a syncs fire at fan-out time, so
+  a branch merged hours later can carry stale spec + lint/guard-family
+  copies that would land regressive content on trunk (a rebase replays the
+  morning copies over evening main) and red the gate (#1489 blockers 1 AND
+  2; #1482; #1417). BEFORE launching the background gate call, run the
+  Step 5a spec-freshness block (§ Step 5a) ONCE with source `origin/main` —
+  **against the ALREADY-BOUND `$WT`**: the merge flow bound
+  `WT="$REPO_ROOT/.claude/worktrees/issue-<N>"` in the guards block, so
+  DROP the Step 5a block's own `WT=$(git rev-parse --show-toplevel)` line —
+  do NOT re-derive `$WT` at Step 10d (a repo-root cwd would rebind it to
+  the SHARED ROOT and either silently no-op the re-sync or check out +
+  commit older origin/main content over newer root-main state). Then: first
+  `timeout --kill-after=30s 120s git -C "$WT" fetch origin main --quiet || true`,
+  then the rest of the block with every `main` ref replaced by
+  `origin/main`. Same per-file branch-side-edit guard, subject-scoped per
+  the Step 5a block (a branch whose deliverable edits a family file keeps
+  its copies — the gate's #1456 3-way merge covers its lint legs, and its
+  TG legs then run the branch's kept copies plus any main-new synced pin
+  tests: a fail-closed hybrid that mirrors the post-merge trunk state, not
+  a fully coherent pair); same `spec-freshness` commit-subject convention.
+  Commit-message filtering follows the Guard-3 subject-scoped convention —
+  never write a full-message grep-exclusion invocation into this Step 10d
+  gate section (enforcement = the gate-region negative assert in
+  `tests/test_issue_skill_lint_family_sync.py`, whose region spans this
+  pre-push gate section through the auto-merge heading — the Guard-3 pin
+  test's own region ban stops at the fast-path heading and does not reach
+  here). End the re-sync with one echo —
+  `[step10d] pre-gate re-sync: synced <n> files (<sha>) | no drift` — so
+  ran-vs-never-ran is observable in the gate transcript (copy the line
+  into the epm:merged / epm:merge-failed note). Run the re-sync to
+  completion BEFORE the gate's stale-verdict `rm` below, so the verdict
+  sha-binds the synced tip; a no-change re-sync commits nothing and the
+  flow is idempotent. Synced files enter the own-diff (they differ from
+  the merge-base) — harmless by construction: the overlay writes
+  origin/main-identical bytes, and any TG hits they trigger are identical
+  on both legs and subtract to empty.
 - **Run a LANDING-TREE lint copy, both legs — no-flags bundle PLUS the parity leg.**
   The gate builds ONE ephemeral landing tree in /tmp (`git archive
   origin/main` over the lint-scanned cones), runs the BASELINE legs from
@@ -10107,9 +10177,15 @@ tests BEFORE anything lands:
   runs the branch-tip copy of the scan test, so a check added on `main` after
   the branch forked is not enforced there (fail-safe direction; the LINT legs
   no longer share this residual — the #1212 gate tree runs the landing tree's
-  lint on every path-(i) run; the TEST legs keep it because syncing
-  individual test files without their import closure — conftest, tests/
-  helpers — risks hybrid trees); (b) the baseline leg runs on the
+  lint on every path-(i) run; the TEST legs keep branch-tip copies because
+  syncing arbitrary individual test files without their import closure —
+  conftest, tests/ helpers — risks hybrid trees, but the lint/guard pin-test
+  FAMILY is now Step-5a-synced AND pre-gate re-synced from origin/main
+  (#1560), narrowing the drift window to (α) non-family rules-pin tests —
+  prose-pin skew; symptom: a gated-only red in a rules-mentioning test the
+  family does not cover — and (β) the `explore_persona_space.workflow` seam,
+  same remedy for both: rebase onto origin/main / cross-check at the repo
+  root); (b) the baseline leg runs on the
   always-dirty shared root — dirt biases toward PASS, never a false block: an
   untracked concurrent-session file (including an untracked same-path draft
   of the payload file at the root, which the directory scan picks up
@@ -10264,7 +10340,13 @@ tests BEFORE anything lands:
   and extending the set is the fix (the #1154 `docs/` pins are the
   precedent); (c) the mapped invariant-TEST legs keep the branch-tip test
   copies and the dirty-root baseline (path-(i) test-VERSION drift,
-  fail-safe direction) — the trunk pytest remains their backstop; (d) a
+  fail-safe direction) — the lint/guard family is now Step-5a-synced AND
+  pre-gate re-synced from origin/main (#1560), so the remaining drift
+  window is (α) non-family rules-pin tests (prose-pin skew; symptom: a
+  gated-only red in a rules-mentioning test the family does not cover)
+  and (β) the `explore_persona_space.workflow` seam, both with the same
+  remedy (rebase onto origin/main / cross-check at the repo root); the
+  trunk pytest remains their backstop; (d) a
   lint-scanned file BOTH main and the branch modified post-fork lints as
   the BRANCH's copy (the overlay takes branch-HEAD wholesale; EXCEPT
   `scripts/workflow_lint.py` itself, which is 3-way-merged per #1456 —

--- a/tests/test_issue_skill_lint_family_sync.py
+++ b/tests/test_issue_skill_lint_family_sync.py
@@ -1,0 +1,196 @@
+"""Pin the #1560 lint/guard-family freshness sync in .claude/skills/issue/SKILL.md.
+
+#1560 (2026-07-20) extended the Step 5a spec-freshness sync to cover the
+lint/guard family (scripts/workflow_lint.py, .claude/hooks, the
+test_guard_lessons_edit / test_workflow_lint* pin tests), subject-scoped the
+sync's per-file branch-side-edit exclusion (the Guard-3 convention), and
+added a mandatory pre-gate freshness re-sync against fetched origin/main to
+the Step 10d pre-push workflow-lint gate — closing the branch-era-linter
+vintage-skew class that red the gate three times on 2026-07-19
+(#1489 / #1482 / #1417).
+
+These tests fail the suite if a later SKILL.md editor drops the family
+entries, the boundary-paragraph family exception, the pre-gate re-sync
+bullet (or reorders it after the gate's stale-verdict rm), the 9a-ter
+staleness note, or reintroduces the full-message commit filter the Step 5a
+sync and the gate section deliberately avoid.
+
+NOTE for future SKILL.md editors: these assertions pin literal snippet text.
+A legitimate rewording of the pinned lines in SKILL.md must update the
+matching assertions here IN THE SAME COMMIT, or the suite goes red.
+"""
+
+from pathlib import Path
+
+SKILL = Path(__file__).resolve().parents[1] / ".claude" / "skills" / "issue" / "SKILL.md"
+
+# The banned full-message commit-filter literal, built by CONCATENATION so
+# this test file itself never carries the token its negative asserts scan for.
+_FULL_MESSAGE_FILTER = "--grep=" + "'spec-freshness'"
+_FULL_MESSAGE_INVERT = _FULL_MESSAGE_FILTER + " --invert-grep"
+
+
+def _text() -> str:
+    return SKILL.read_text(encoding="utf-8")
+
+
+def _step5a_span(text: str) -> str:
+    """The Step 5a spec-freshness block + its boundary paragraph.
+
+    From the block's leading comment (unique) to the 429-pacing blockquote
+    that follows the boundary paragraph (unique).
+    """
+    start = text.index("# Step 5a WANTS the WORKTREE root")
+    end = text.index("429 pacing at every ensemble fan-out", start)
+    return text[start:end]
+
+
+def _gate_region(text: str) -> str:
+    """The pre-push workflow-lint gate section: gate H4 through the auto-merge H4.
+
+    Region-scoped deliberately: the stale-verdict rm line occurs 5x file-wide
+    (Step 9c and auto-merge consumers), so whole-file index() would be vacuous
+    for the ordering assert; within this region it occurs exactly once.
+    """
+    start = text.index("#### Pre-push workflow-lint gate")
+    end = text.index("#### The auto-merge procedure", start)
+    return text[start:end]
+
+
+# --- (1) Step 5a SPECS family entries -------------------------------------
+
+
+def test_step5a_specs_include_lint_family():
+    assert (
+        'SPECS=".claude/agents .claude/skills .claude/rules .claude/workflow.yaml '
+        "CLAUDE.md scripts/workflow_lint.py .claude/hooks "
+        'tests/test_guard_lessons_edit.py :(glob)tests/test_workflow_lint*.py"'
+    ) in _text(), (
+        "Step 5a SPECS must carry the #1560 lint/guard family "
+        "(workflow_lint.py, .claude/hooks, test_guard_lessons_edit.py, "
+        "the :(glob) test_workflow_lint* pin-test family)"
+    )
+
+
+# --- (2) boundary paragraph names the family + retains the exclusion ------
+
+
+def test_sync_scope_paragraph_names_family_boundary():
+    span = _step5a_span(_text())
+    assert "spec-coupled lint/guard family" in span, (
+        "the sync-scope boundary paragraph must name the family exception"
+    )
+    assert "do NOT\nextend it further into `scripts/`, `tests/`, or `src/`" in span, (
+        "the boundary paragraph must retain the exclusion for everything else"
+    )
+    assert "main's newer workflow\ntests pin behavior implemented in main's newer" in span, (
+        "the boundary paragraph must retain rationale (ii): main's newer tests "
+        "pin main's newer scripts/+src/"
+    )
+    assert "explore_persona_space.workflow" in span, (
+        "the boundary paragraph must name the accepted single src seam"
+    )
+    assert "collection-time ImportError" in span, (
+        "the cross-check-at-root operational rule must carry the "
+        "collection-time-ImportError staleness symptom"
+    )
+
+
+# --- (3) pre-gate re-sync bullet present + ordered before the verdict rm --
+
+
+def test_step10d_pregate_resync_present_and_ordered():
+    region = _gate_region(_text())
+    bullet_idx = region.index("**Pre-gate freshness re-sync (#1560")
+    assert "origin/main" in region[bullet_idx:], "re-sync must anchor to origin/main"
+    assert 'timeout --kill-after=30s 120s git -C "$WT" fetch origin main --quiet' in region, (
+        "re-sync must start with the bounded fetch"
+    )
+    assert "[step10d] pre-gate re-sync: synced <n> files (<sha>) | no drift" in region, (
+        "the re-sync must end with the ran-vs-never-ran echo breadcrumb"
+    )
+    rm_idx = region.index("rm -f /tmp/issue-<N>-lint-verdict.txt")
+    assert bullet_idx < rm_idx, (
+        "the pre-gate re-sync must complete BEFORE the gate's stale-verdict rm "
+        "so the verdict sha-binds the synced tip"
+    )
+
+
+# --- (4) 9a-ter inline-gate staleness note ---------------------------------
+
+
+def test_9ater_staleness_note_present():
+    text = _text()
+    assert "is the stale-family class" in text, (
+        "the 9a-ter inline-gate bullet must carry the #1417 staleness-class diagnostic"
+    )
+    assert "run the Step 5a sync (now family-inclusive)" in text, (
+        "the 9a-ter staleness note must name the Step 5a sync remedy"
+    )
+
+
+# --- (5) no full-message grep-exclusion literal in the gate region ---------
+
+
+def test_no_grep_specfreshness_in_gate_region():
+    """The gate section must never carry the full-message commit-filter form
+    (a commit BODY mentioning the token would launder a genuine deliverable
+    at the pre-gate re-sync). The existing test_step10d_guard3.py ban covers
+    only the Guard-3 span, which stops at the fast-path heading and does NOT
+    reach the gate section — hence this region's own negative assert."""
+    region = _gate_region(_text())
+    assert _FULL_MESSAGE_FILTER not in region, (
+        "the pre-push gate section must not carry a full-message "
+        "grep-exclusion invocation (subject-scoped filtering only)"
+    )
+
+
+# --- (6) the :(glob)/never-shell-expands comment at the SPECS line ---------
+
+
+def test_glob_pathspec_comment_present():
+    span = _step5a_span(_text())
+    assert "`:(glob)` is a git pathspec (never shell-expands" in span, (
+        "the SPECS comment must document that :(glob) is a git pathspec that never shell-expands"
+    )
+    assert "skip grain is PER-ITEM" in span, (
+        "the SPECS comment must document the per-item skip grain of the "
+        "branch-side-edit guard over the :(glob) family entry"
+    )
+
+
+# --- (7) Step 5a exclusion is subject-scoped (the MF-B pin) -----------------
+
+
+def test_step5a_exclusion_is_subject_scoped():
+    span = _step5a_span(_text())
+    assert "--format='%H %s'" in span, (
+        "the Step 5a branch-side-edit exclusion must emit '<sha> <subject>' "
+        "(subject-scoped, the Guard-3 convention)"
+    )
+    assert "awk 'index($0, \"spec-freshness\") == 0'" in span, (
+        "the Step 5a exclusion must filter via the subject-scoped awk index() form"
+    )
+    assert _FULL_MESSAGE_INVERT not in span, (
+        "the Step 5a exclusion must NOT use the full-message form (it would "
+        "wrongly exclude a deliverable whose commit BODY mentions the token)"
+    )
+
+
+# --- (8) the re-sync never re-derives $WT (the MF-A pin) --------------------
+
+
+def test_pregate_resync_does_not_rederive_wt():
+    region = _gate_region(_text())
+    bullet_idx = region.index("**Pre-gate freshness re-sync (#1560")
+    bullet = region[bullet_idx : region.index("[step10d] pre-gate re-sync:", bullet_idx)]
+    assert "ALREADY-BOUND `$WT`" in bullet, (
+        "the re-sync bullet must state $WT is already bound by the merge flow"
+    )
+    assert "WT=$(git rev-parse --show-toplevel)` line" in bullet, (
+        "the re-sync bullet must name the Step 5a WT-derivation line to DROP"
+    )
+    assert "do NOT re-derive `$WT` at Step 10d" in bullet, (
+        "the re-sync bullet must ban re-deriving $WT at Step 10d (a repo-root "
+        "cwd would rebind it to the shared root)"
+    )

--- a/tests/test_step10d_guard3.py
+++ b/tests/test_step10d_guard3.py
@@ -338,10 +338,25 @@ def test_guard3_region_does_not_use_grep_spec_freshness():
 
 
 def test_step5a_grep_filter_untouched():
-    """Defensive: the unrelated Step-5a spec-freshness sync keeps its filter."""
+    """The Step-5a spec-freshness sync's branch-side-edit exclusion is
+    SUBJECT-scoped (deliberately changed by #1560 from the old full-message
+    --grep/--invert-grep form — which Guard 3's own note bans: a commit BODY
+    mentioning the token would launder a genuine branch deliverable, and at
+    the #1560 pre-gate re-sync position that mis-exclusion would check out
+    origin/main over a reviewed deliverable). Supersedes the pre-#1560
+    defensive pin that the full-message filter remained (that pin was out of
+    #787 scope; #1560 deliberately subject-scoped the Step 5a filter)."""
     text = _skill_text()
-    assert "--grep='spec-freshness' --invert-grep" in text, (
-        "the Step-5a sync's --grep filter must remain (it is out of #787 scope)"
+    start = text.index('SPECS=".claude/agents')
+    span = text[start : text.index("429 pacing at every ensemble fan-out", start)]
+    assert "--format='%H %s'" in span, (
+        "the Step-5a exclusion must emit '<sha> <subject>' (subject-scoped)"
+    )
+    assert "awk 'index($0, \"spec-freshness\") == 0'" in span, (
+        "the Step-5a exclusion must filter via the subject-scoped awk index() form"
+    )
+    assert "--grep='spec-freshness' --invert-grep" not in span, (
+        "the Step-5a sync must not use the full-message --grep filter (#1560)"
     )
 
 


### PR DESCRIPTION
Closes task #1560. Stops branch-era workflow_lint.py + guard-test copies from redding the Step 10d gates (#1489/#1482/#1417 vintage-skew class).