### PR TITLE
workflow-fix #1565: append-side stale-state guard for task_workflow marker appends

### DIFF
--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -4036,6 +4036,37 @@ def _append_jsonl_line(path: Path, payload: dict[str, Any]) -> None:
         os.close(fd)
 
 
+def _iter_jsonl_text(text: str, *, source: str) -> list[dict[str, Any]]:
+    """Tolerantly parse JSONL TEXT (the row loop behind ``_iter_jsonl``).
+
+    ``source`` names the text's origin (a file path, a git index blob ref)
+    in the skip-malformed WARNING. Split out of ``_iter_jsonl`` (#1565) so
+    the append guard can parse a git INDEX BLOB with the same tolerant
+    semantics the on-disk reader has. Behavior is identical to the former
+    inline loop; see ``_iter_jsonl`` for the full recovery rationale.
+
+    Records are split on ``"\\n"`` (NOT ``str.splitlines()``): the paired
+    ``ensure_ascii=False`` writer leaves raw U+2028/U+2029/NEL inside note
+    strings, and ``splitlines()`` treats those as line boundaries — shredding
+    a valid record into skip-malformed fragments = silent marker loss
+    (gotchas.md; #825 → #950).
+    """
+    out: list[dict[str, Any]] = []
+    for lineno, line in enumerate(text.split("\n"), 1):
+        if not line.strip():
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError as e:
+            _log.warning(
+                "skipping malformed line %d in %s: %s",
+                lineno,
+                source,
+                str(e)[:200],
+            )
+    return out
+
+
 def _iter_jsonl(path: Path) -> list[dict[str, Any]]:
     """Parse an append-only JSONL file, tolerating malformed lines.
 
@@ -4059,33 +4090,23 @@ def _iter_jsonl(path: Path) -> list[dict[str, Any]]:
     corrupted line falls through to the existing ``JSONDecodeError`` skip
     path — completing the recovery story.
 
-    Records are split on ``"\\n"`` (NOT ``str.splitlines()``): the paired
-    ``ensure_ascii=False`` writer leaves raw U+2028/U+2029/NEL inside note
-    strings, and ``splitlines()`` treats those as line boundaries — shredding
-    a valid record into skip-malformed fragments = silent marker loss
-    (gotchas.md; #825 → #950).
+    The tolerant row loop itself lives in ``_iter_jsonl_text`` (shared with
+    the append guard's index-blob read, #1565).
     """
     if not path.exists():
         return []
-    out: list[dict[str, Any]] = []
     text = path.read_text(encoding="utf-8", errors="replace")
-    # split("\n"), NOT splitlines(): raw U+2028/U+2029/NEL inside
-    # ensure_ascii=False notes are Unicode line boundaries that would shred
-    # valid records into skip-malformed fragments = silent marker loss
-    # (gotchas.md; #825 → #950).
-    for lineno, line in enumerate(text.split("\n"), 1):
-        if not line.strip():
-            continue
-        try:
-            out.append(json.loads(line))
-        except json.JSONDecodeError as e:
-            _log.warning(
-                "skipping malformed line %d in %s: %s",
-                lineno,
-                path,
-                str(e)[:200],
-            )
-    return out
+    return _iter_jsonl_text(text, source=str(path))
+
+
+def _max_event_ts(rows: list[dict[str, Any]]) -> str:
+    """Max ISO-8601Z ``ts`` across rows (``""`` when none).
+
+    ``_utcnow_iso`` timestamps compare lexicographically == chronologically
+    (fixed-width ``%Y-%m-%dT%H:%M:%SZ``), so plain string ``max`` is the
+    chronological max. Non-string / missing ``ts`` rows are skipped.
+    """
+    return max((r["ts"] for r in rows if isinstance(r.get("ts"), str)), default="")
 
 
 def _next_event_version(events_path: Path, kind: str) -> int:
@@ -4107,6 +4128,158 @@ def _next_event_version(events_path: Path, kind: str) -> int:
         if isinstance(v, int) and v > highest:
             highest = v
     return highest + 1
+
+
+# Fail-soft observability sidecar for append-guard violations (#1565) — one
+# JSONL row per quarantined stale dir, repo-relative (lives IN the repo, next
+# to the other .claude/cache sidecar streams; the quarantine itself lives
+# outside the repo under LOCK_DIR).
+_APPEND_GUARD_SIDECAR_REL = ".claude/cache/append-guard-events.jsonl"
+
+
+def _guarded_task_dir_for_append(task_id: int) -> tuple[Path, bool]:
+    """``find_task_path`` + a stale-restored-state cross-check against the git
+    index (#1565; incident #1524). Returns ``(task_dir, rerouted)``.
+
+    Caller MUST hold ``_locked()`` (the violation arm quarantines a dir and
+    re-writes REGISTRY). Fail-OPEN on any git probe error (marker posting is
+    the fleet's highest-frequency mutation — a git hiccup degrades to today's
+    unguarded behavior); ``StaleTaskPathError`` only on ambiguous /
+    doubly-corrupt states. All-validate-then-mutate: no destructive action
+    before the re-route target is proven usable.
+
+    The predicate: ALLOW iff nothing is tracked in the index for this id
+    (fresh create with a deferred commit, #1030), OR the resolved dir is the
+    tracked one (normal), OR the resolved dir is untracked while exactly one
+    OTHER status dir is tracked AND the resolved on-disk ``events.jsonl``'s
+    max ``ts`` is at-least-as-new as the tracked index blob's (a durably
+    applied but uncommitted status move — disk ahead of git). VIOLATION
+    (quarantine + re-route) iff the resolved dir is untracked, exactly one
+    other status dir is tracked, and the resolved file is STRICTLY OLDER —
+    possible only when the resolved file is MISSING rows the index has, i.e.
+    a stale restored snapshot (events.jsonl is append-only and ``set_status``
+    moves the whole file, so any legit current file is a row-superset of any
+    index blob of this task). RAISE on multiple tracked status dirs
+    (committed husk — never guess, mirroring ``find_task_path``'s multi-hit
+    rule) or a violation whose tracked target is unusable on disk (a blind
+    ``O_CREAT`` there would commit a history-losing one-row file).
+
+    Freshness is read from ``events.jsonl`` even when the append target is
+    ``comments.jsonl`` / ``concerns.jsonl``: a stale restore restores the
+    WHOLE task dir (the #1524 shape), so the co-located events.jsonl — the
+    highest-frequency append-only log — dates the dir; on a tie the guard
+    allows, which equals today's unguarded behavior (status-quo-equivalent).
+    """
+    resolved = find_task_path(task_id)
+    repo = repo_root()
+    try:
+        tracked = _tracked_status_dirs(task_id, repo)
+    except (subprocess.CalledProcessError, OSError) as e:
+        _log.warning(
+            "append-guard: git probe failed for task #%d (%s); appending unguarded",
+            task_id,
+            e,
+        )
+        return resolved, False  # fail-open
+    # relative_to cannot raise here: find_task_path only ever returns
+    # tasks_dir()-rooted paths, which live under repo_root() by construction
+    # (a ValueError from it would be a resolver bug — let it propagate loud).
+    rel_resolved = str(resolved.relative_to(repo))
+    if not tracked or rel_resolved in tracked:
+        return resolved, False  # fresh create (commit deferred, #1030) / normal
+    if len(tracked) > 1:
+        raise StaleTaskPathError(  # committed husk + resolved at a THIRD location: never guess
+            f"task #{task_id}: resolved at {rel_resolved!r} (untracked) while the git "
+            f"index tracks it at MULTIPLE status dirs {sorted(tracked)}; refusing to "
+            f"append — run `task.py audit --repair --apply` / `task.py reap-husks`."
+        )
+    (target_rel,) = tracked
+    try:
+        blob = _run_git(["show", f":{target_rel}/events.jsonl"]).stdout
+    except (subprocess.CalledProcessError, OSError) as e:
+        _log.warning(
+            "append-guard: index blob read failed for %s (%s); appending unguarded",
+            target_rel,
+            e,
+        )
+        return resolved, False  # fail-open
+    blob_max = _max_event_ts(_iter_jsonl_text(blob, source=f":{target_rel}/events.jsonl"))
+    disk_max = _max_event_ts(_iter_jsonl(resolved / "events.jsonl"))  # '' if file missing
+    if disk_max >= blob_max:
+        _log.warning(
+            "append-guard: task #%d resolved at %s (untracked) while index tracks "
+            "%s, but resolved state is at-least-as-new (%r >= %r) — deferred-commit "
+            "shape, allowing",
+            task_id,
+            rel_resolved,
+            target_rel,
+            disk_max,
+            blob_max,
+        )
+        return resolved, False
+    # ── VIOLATION: the #1524 stale-restore shape. Validate target FIRST. ──
+    target = repo / target_rel
+    if not (target / "events.jsonl").exists():
+        raise StaleTaskPathError(
+            f"task #{task_id}: index tracks {target_rel!r} but its events.jsonl is missing "
+            f"on disk, and the resolved dir {rel_resolved!r} is a stale snapshot "
+            f"(max ts {disk_max!r} < index {blob_max!r}); refusing to append to either — "
+            f"restore first: `git checkout -- {target_rel}` then retry, "
+            f"or `task.py audit --repair --apply`."
+        )
+    try:
+        fm, _ = _read_body(target / "body.md")  # validates target body BEFORE any mutation
+    except StaleTaskPathError as e:
+        raise StaleTaskPathError(
+            f"task #{task_id}: index tracks {target_rel!r} but its body.md is missing on "
+            f"disk ({e}), and the resolved dir {rel_resolved!r} is a stale snapshot "
+            f"(max ts {disk_max!r} < index {blob_max!r}); refusing to append to either — "
+            f"restore first: `git checkout -- {target_rel}` then retry, "
+            f"or `task.py audit --repair --apply`."
+        ) from e
+    stale_status = _status_from_path(resolved)
+    quarantine = (
+        LOCK_DIR
+        / "stale-task-dirs"
+        / f"{_utcnow_iso().replace(':', '')}-task{task_id}-{stale_status}-{os.getpid()}"
+    )
+    quarantine.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(resolved), str(quarantine))
+    reg = _load_registry()  # mutation path, _locked() held: safe re-sync
+    entry = reg["tasks"].get(str(task_id))
+    if entry and entry.get("path") == rel_resolved:
+        _registry_set(reg, task_id, target, fm)
+        _save_registry(reg)
+    _log.warning(
+        "append-guard: task #%d: STALE restored dir %s (max ts %r) shadowed the "
+        "index-tracked %s (max ts %r) — quarantined to %s, registry re-synced, "
+        "append re-routed (#1565; the #1524 husk shape). The quarantined rows are "
+        "forensic evidence — inspect/re-integrate unique rows manually from %s; "
+        "never delete.",
+        task_id,
+        rel_resolved,
+        disk_max,
+        target_rel,
+        blob_max,
+        quarantine,
+        quarantine,
+    )
+    try:  # fail-soft observability sidecar
+        _append_jsonl_line(
+            repo / _APPEND_GUARD_SIDECAR_REL,
+            {
+                "ts": _utcnow_iso(),
+                "task_id": task_id,
+                "stale_path": rel_resolved,
+                "target_path": target_rel,
+                "quarantine": str(quarantine),
+                "disk_max_ts": disk_max,
+                "blob_max_ts": blob_max,
+            },
+        )
+    except OSError:
+        _log.warning("append-guard: sidecar write failed (fail-soft)")
+    return target, True
 
 
 def post_event(
@@ -4138,7 +4311,10 @@ def post_event(
             f"caller must post epm:failure v1 with reason=note_oversize"
         )
     with _locked():
-        path = find_task_path(task_id) / "events.jsonl"
+        # Guard runs BEFORE _next_event_version: the version derivation must
+        # read the CORRECT (index-tracked) file, not a stale restore (#1565).
+        folder, rerouted = _guarded_task_dir_for_append(task_id)
+        path = folder / "events.jsonl"
         if version is None:
             version = _next_event_version(path, kind)
         payload: dict[str, Any] = {
@@ -4157,7 +4333,7 @@ def post_event(
         # primary checkout is deferred (loud ERROR + forensic sidecar row),
         # not raised, so a caller retry cannot duplicate the marker (#1030).
         _commit_after_durable_append(
-            [path],
+            [path, registry_path()] if rerouted else [path],
             f"task #{task_id}: {kind}" + (f" — {note[:60]}" if note else ""),
             task_id=task_id,
             op="post_event",
@@ -4206,27 +4382,35 @@ def _rollback_move(src: Path, dst: Path) -> None:
         raise
 
 
+def _tracked_status_dirs(task_id: int, repo: Path) -> set[str]:
+    """Repo-relative ``tasks/<status>/<id>`` dirs with >=1 file in the git
+    INDEX. Extracted from ``_task_status_dir_pathspecs`` (#1565); one
+    ``git ls-files`` call over exact per-STATUSES pathspecs (no fnmatch
+    wildcards — exact-id matching only, so id 89 never sweeps id 898;
+    ``ls-files`` silently ignores pathspecs that match nothing)."""
+    rel_tasks = tasks_dir().relative_to(repo)
+    candidates = [str(rel_tasks / status / str(task_id)) for status in STATUSES]
+    tracked = _run_git(["ls-files", "--", *candidates]).stdout.splitlines()
+    n_parts = len(rel_tasks.parts) + 2  # <tasks>/<status>/<id>
+    return {"/".join(p.split("/")[:n_parts]) for p in tracked if p.strip()}
+
+
 def _task_status_dir_pathspecs(task_id: int, repo: Path) -> list[str]:
     """All ``tasks/<status>/<id>`` dirs for this task that git TRACKS or that
     exist on disk — the staging pathspec set that reconciles any residue a
     previously-crashed transition left behind (ghost old-status dirs whose
     deletions were never staged; #825 / the #644 stale-task-folder class).
 
-    One ``git ls-files`` call over deterministic per-STATUSES pathspecs (no
-    fnmatch wildcards — exact-id matching only, so id 89 never sweeps id
-    898). ``ls-files`` silently ignores pathspecs that match nothing, so the
-    candidate list is safe to pass wholesale. The returned set is restricted
-    to tracked-or-on-disk dirs BECAUSE ``git add`` (without
-    ``--ignore-unmatch``) and ``git commit --only`` both FAIL LOUD on a
-    pathspec that matches neither the index/HEAD nor the working tree — a
-    dir that is neither tracked nor on disk has nothing to stage and must be
-    excluded, not passed along.
+    The tracked side is ``_tracked_status_dirs`` (one ``git ls-files`` call;
+    see its docstring). The returned set is restricted to tracked-or-on-disk
+    dirs BECAUSE ``git add`` (without ``--ignore-unmatch``) and ``git commit
+    --only`` both FAIL LOUD on a pathspec that matches neither the
+    index/HEAD nor the working tree — a dir that is neither tracked nor on
+    disk has nothing to stage and must be excluded, not passed along.
     """
     rel_tasks = tasks_dir().relative_to(repo)
     candidates = [str(rel_tasks / status / str(task_id)) for status in STATUSES]
-    tracked = _run_git(["ls-files", "--", *candidates]).stdout.splitlines()
-    n_parts = len(rel_tasks.parts) + 2  # <tasks>/<status>/<id>
-    dirs = {"/".join(p.split("/")[:n_parts]) for p in tracked if p.strip()}
+    dirs = _tracked_status_dirs(task_id, repo)
     dirs |= {c for c in candidates if (repo / c).is_dir()}
     return sorted(dirs)
 
@@ -5979,7 +6163,8 @@ def append_comment(
     if kind not in COMMENT_KINDS:
         raise ValueError(f"unknown comment kind: {kind!r}; expected one of {sorted(COMMENT_KINDS)}")
     with _locked():
-        path = find_task_path(task_id) / "comments.jsonl"
+        folder, rerouted = _guarded_task_dir_for_append(task_id)
+        path = folder / "comments.jsonl"
         path.parent.mkdir(parents=True, exist_ok=True)
         # Allocate a sequential id (c001, c002, ...) by counting lines.
         n_existing = sum(1 for _ in path.open()) if path.exists() else 0
@@ -5999,7 +6184,7 @@ def append_comment(
         # Comment row is durable; a retry would append a duplicate row with
         # a fresh cNNN id — defer a commit failure instead (#1030).
         _commit_after_durable_append(
-            [path],
+            [path, registry_path()] if rerouted else [path],
             f"task #{task_id}: comment {cid} ({kind})",
             task_id=task_id,
             op="append_comment",
@@ -6713,9 +6898,10 @@ def _append_concern_event(task_id: int, payload: dict[str, Any]) -> None:
     the payload (including ``ts``). The mirror event posted to
     events.jsonl carries the concern_id and an 80-char summary slice ONLY
     — the full payload lives in concerns.jsonl. The git commit covers
-    BOTH files in a single commit.
+    BOTH files in a single commit (plus REGISTRY when the append guard
+    re-routed a stale restore, #1565).
     """
-    folder = find_task_path(task_id)
+    folder, rerouted = _guarded_task_dir_for_append(task_id)
     concerns_file = folder / "concerns.jsonl"
     _append_jsonl_line(concerns_file, payload)
 
@@ -6744,7 +6930,7 @@ def _append_concern_event(task_id: int, payload: dict[str, Any]) -> None:
     # Concern row + events.jsonl mirror are durable; a retry would append
     # duplicates of both — defer a commit failure instead (#1030).
     _commit_after_durable_append(
-        [concerns_file, events_file],
+        [concerns_file, events_file, registry_path()] if rerouted else [concerns_file, events_file],
         f"task #{task_id}: concern-{payload['event']} {payload['concern_id']}",
         task_id=task_id,
         op="append_concern_event",

--- a/tests/test_task_workflow.py
+++ b/tests/test_task_workflow.py
@@ -5219,3 +5219,295 @@ def test_keep_running_tag_constant_value():
     ``_KEEP_RUNNING_TAG`` (parity pinned in tests/test_pod_lifecycle.py)."""
     tw = _tw()
     assert tw.KEEP_RUNNING_TAG == "keep-running"
+
+
+# ─── Append guard (#1565) ───────────────────────────────────────────────────
+#
+# _guarded_task_dir_for_append: the stale-restored-state cross-check against
+# the git index that post_event / append_comment / _append_concern_event run
+# before appending (incident #1524: a restored pre-move snapshot + stale
+# REGISTRY silently recreated a dead status folder on main).
+
+
+def _rewrite_registry_entry(repo: Path, tid: int, rel_path: str, status: str) -> None:
+    """Point the REGISTRY entry for ``tid`` at ``rel_path`` (hand-edit, no git)."""
+    reg_path = repo / "tasks" / "REGISTRY.json"
+    reg = json.loads(reg_path.read_text())
+    reg["tasks"][str(tid)]["path"] = rel_path
+    reg["tasks"][str(tid)]["status"] = status
+    reg_path.write_text(json.dumps(reg, indent=2, sort_keys=True) + "\n")
+
+
+def _setup_stale_restore(repo: Path, tw) -> int:
+    """Reproduce the #1524 stale-restore shape (simplified two-hop timeline;
+    shape-identical to the real three-hop proposed→planning→…→running one:
+    resolved dir untracked, exactly one newer-status dir tracked, restored
+    events.jsonl strictly older than the index blob).
+
+    Task created + committed at proposed, one marker posted (committed),
+    moved to planning (committed) — then a stale pre-move snapshot of
+    tasks/proposed/<id>/ is restored on disk and REGISTRY is poisoned to
+    point at it (disk and registry stale but mutually consistent — exactly
+    the shape find_task_path's #825 envelope cannot see). The stale row's
+    ts is hand-written OLD (2020) so second-granularity _utcnow_iso can
+    never produce an accidental tie.
+    """
+    tid = tw.create_task(tw.NewTaskRequest(kind="infra", title="append-guard fixture"))
+    tw.post_event(tid, "epm:progress", by="test", note="pre-move marker")
+    tw.set_status(tid, "planning")
+    cur = repo / "tasks" / "planning" / str(tid)
+    stale = repo / "tasks" / "proposed" / str(tid)
+    stale.mkdir(parents=True)
+    shutil.copy2(cur / "body.md", stale / "body.md")
+    (stale / "events.jsonl").write_text(
+        json.dumps({"ts": "2020-01-01T00:00:00Z", "kind": "epm:created", "version": 1, "by": "t"})
+        + "\n"
+    )
+    _rewrite_registry_entry(repo, tid, f"tasks/proposed/{tid}", "proposed")
+    return tid
+
+
+def _git_ls_files(repo: Path, spec: str) -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files", "--", spec], cwd=repo, capture_output=True, text=True, check=True
+    )
+    return [ln for ln in out.stdout.splitlines() if ln.strip()]
+
+
+def test_1524_stale_restore_reroutes_append_to_tracked_dir(fake_repo, caplog):
+    repo, tw = fake_repo
+    tid = _setup_stale_restore(repo, tw)
+    with caplog.at_level(logging.WARNING, logger="explore_persona_space.task_workflow"):
+        tw.post_event(tid, "epm:progress", by="test", note="guarded append")
+    # Row landed in the index-tracked (current) folder, not the stale restore.
+    cur = repo / "tasks" / "planning" / str(tid)
+    rows = tw._iter_jsonl(cur / "events.jsonl")
+    assert any(r.get("note") == "guarded append" for r in rows)
+    # Stale dir quarantined OUT of the repo, forensic rows preserved.
+    assert not (repo / "tasks" / "proposed" / str(tid)).exists()
+    qdirs = list((repo / ".task-workflow" / "stale-task-dirs").iterdir())
+    assert len(qdirs) == 1
+    q_rows = tw._iter_jsonl(qdirs[0] / "events.jsonl")
+    assert q_rows and q_rows[0]["ts"] == "2020-01-01T00:00:00Z"
+    # REGISTRY re-synced to the tracked dir.
+    reg = json.loads((repo / "tasks" / "REGISTRY.json").read_text())
+    assert reg["tasks"][str(tid)]["path"] == f"tasks/planning/{tid}"
+    assert any("append-guard" in r.getMessage() for r in caplog.records)
+    # Fail-soft observability sidecar row.
+    sidecar = tw._iter_jsonl(repo / ".claude" / "cache" / "append-guard-events.jsonl")
+    assert sidecar and sidecar[0]["task_id"] == tid
+    assert sidecar[0]["stale_path"] == f"tasks/proposed/{tid}"
+    # End-to-end no-husk: a subsequent transition's ghost sweep (git add
+    # --all over the pathspecs) commits NO resurrected proposed dir.
+    tw.set_status(tid, "plan_pending")
+    assert _git_ls_files(repo, f"tasks/proposed/{tid}") == []
+
+
+def test_append_guard_fresh_create_uncommitted_allows(fake_repo):
+    repo, tw = fake_repo
+    # Hand-build the deferred-create shape (#1030): dir + body + created-row
+    # events + REGISTRY entry, ZERO git ops — nothing tracked at HEAD/index.
+    tid = 7001
+    d = repo / "tasks" / "proposed" / str(tid)
+    d.mkdir(parents=True)
+    (d / "body.md").write_text(
+        "---\ntitle: fresh\nkind: infra\nhas_clean_result: false\n---\n## Goal\n\nx\n"
+    )
+    (d / "events.jsonl").write_text(
+        json.dumps({"ts": "2020-01-01T00:00:00Z", "kind": "epm:created", "version": 1, "by": "t"})
+        + "\n"
+    )
+    reg_path = repo / "tasks" / "REGISTRY.json"
+    reg = json.loads(reg_path.read_text()) if reg_path.exists() else {"highest_id": 0, "tasks": {}}
+    reg["tasks"][str(tid)] = {
+        "path": f"tasks/proposed/{tid}",
+        "title": "fresh",
+        "kind": "infra",
+        "status": "proposed",
+        "has_clean_result": False,
+    }
+    reg["highest_id"] = max(reg.get("highest_id", 0), tid)
+    reg_path.parent.mkdir(parents=True, exist_ok=True)
+    reg_path.write_text(json.dumps(reg, indent=2, sort_keys=True) + "\n")
+
+    tw.post_event(tid, "epm:progress", by="test", note="fresh append")
+    rows = tw._iter_jsonl(d / "events.jsonl")
+    assert any(r.get("note") == "fresh append" for r in rows)
+    assert d.is_dir()  # no reroute, no quarantine, no raise
+    assert not (repo / ".task-workflow" / "stale-task-dirs").exists()
+
+
+def test_append_guard_deferred_status_move_disk_newer_allows(fake_repo, caplog):
+    repo, tw = fake_repo
+    tid = tw.create_task(tw.NewTaskRequest(kind="infra", title="deferred move"))
+    # Hand-simulate the durably-applied-but-uncommitted status move (#825
+    # crash envelope): whole-dir move + REGISTRY update + a NEWER
+    # hand-appended status-changed row; NO git ops (index still at proposed).
+    old = repo / "tasks" / "proposed" / str(tid)
+    new = repo / "tasks" / "planning" / str(tid)
+    new.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(old), str(new))
+    moved_row = {"ts": "2099-01-01T00:00:00Z", "kind": "epm:status-changed", "version": 1}
+    with (new / "events.jsonl").open("a") as fh:
+        fh.write(json.dumps(moved_row) + "\n")
+    _rewrite_registry_entry(repo, tid, f"tasks/planning/{tid}", "planning")
+
+    with caplog.at_level(logging.WARNING, logger="explore_persona_space.task_workflow"):
+        tw.post_event(tid, "epm:progress", by="test", note="post-move append")
+    rows = tw._iter_jsonl(new / "events.jsonl")
+    assert any(r.get("note") == "post-move append" for r in rows)
+    assert not (repo / ".task-workflow" / "stale-task-dirs").exists()
+    assert any("deferred-commit shape, allowing" in r.getMessage() for r in caplog.records)
+
+
+def test_append_guard_identical_restore_ts_tie_allows(fake_repo):
+    repo, tw = fake_repo
+    tid = _setup_stale_restore(repo, tw)
+    # Overwrite the restored events.jsonl with content byte-equal to the
+    # index blob of the TRACKED dir → max-ts TIE → `>=` allows: no
+    # destructive act without STRICT staleness evidence (behavior equals
+    # today's unguarded append on ties).
+    blob = subprocess.run(
+        ["git", "show", f":tasks/planning/{tid}/events.jsonl"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    stale = repo / "tasks" / "proposed" / str(tid)
+    (stale / "events.jsonl").write_text(blob)
+    tw.post_event(tid, "epm:progress", by="test", note="tie append")
+    rows = tw._iter_jsonl(stale / "events.jsonl")
+    assert any(r.get("note") == "tie append" for r in rows)
+    assert stale.is_dir()
+    assert not (repo / ".task-workflow" / "stale-task-dirs").exists()
+
+
+def test_append_guard_multi_tracked_husk_raises(fake_repo):
+    repo, tw = fake_repo
+    tid = tw.create_task(tw.NewTaskRequest(kind="infra", title="husk"))
+    # Fabricate a COMMITTED husk at a second status dir.
+    husk = repo / "tasks" / "planning" / str(tid)
+    husk.mkdir(parents=True)
+    (husk / "events.jsonl").write_text(
+        json.dumps({"ts": "2020-01-01T00:00:00Z", "kind": "epm:created", "version": 1, "by": "t"})
+        + "\n"
+    )
+    subprocess.run(["git", "add", "--", f"tasks/planning/{tid}"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "fabricate husk"], cwd=repo, check=True)
+    # Hand-move the resolved state to a THIRD location.
+    old = repo / "tasks" / "proposed" / str(tid)
+    new = repo / "tasks" / "running" / str(tid)
+    new.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(old), str(new))
+    _rewrite_registry_entry(repo, tid, f"tasks/running/{tid}", "running")
+
+    before = tw._iter_jsonl(new / "events.jsonl")
+    with pytest.raises(tw.StaleTaskPathError, match="MULTIPLE status dirs"):
+        tw.post_event(tid, "epm:progress", by="test", note="must not land")
+    # No row appended ANYWHERE; nothing quarantined (never-guess).
+    assert tw._iter_jsonl(new / "events.jsonl") == before
+    for events_path in (repo / "tasks").rglob("events.jsonl"):
+        assert not any(r.get("note") == "must not land" for r in tw._iter_jsonl(events_path))
+    assert not (repo / ".task-workflow" / "stale-task-dirs").exists()
+
+
+def test_append_guard_target_missing_on_disk_raises(fake_repo):
+    repo, tw = fake_repo
+    tid = _setup_stale_restore(repo, tw)
+    # Index still tracks planning, but its dir is gone from disk: a blind
+    # re-route would O_CREAT a history-losing one-row file there.
+    shutil.rmtree(repo / "tasks" / "planning" / str(tid))
+    stale = repo / "tasks" / "proposed" / str(tid)
+    with pytest.raises(tw.StaleTaskPathError, match=r"events\.jsonl is missing"):
+        tw.post_event(tid, "epm:progress", by="test", note="must not land")
+    # Raise PRECEDES quarantine: the stale dir is untouched (fail-loud
+    # acceptance backing — no evidence destruction on the raise path).
+    assert stale.is_dir()
+    assert not (repo / ".task-workflow" / "stale-task-dirs").exists()
+
+
+def test_append_guard_git_probe_failure_fails_open(fake_repo, caplog):
+    repo, tw = fake_repo
+    tid = tw.create_task(tw.NewTaskRequest(kind="infra", title="probe fail"))
+
+    def _boom(args, **kwargs):
+        raise subprocess.CalledProcessError(128, ["git", *args], stderr="fatal: boom")
+
+    with (
+        caplog.at_level(logging.WARNING, logger="explore_persona_space.task_workflow"),
+        pytest.MonkeyPatch.context() as mp,
+    ):
+        mp.setattr(tw, "_run_git", _boom)
+        payload = tw.post_event(tid, "epm:progress", by="test", note="unguarded append")
+    assert payload["note"] == "unguarded append"
+    rows = tw._iter_jsonl(repo / "tasks" / "proposed" / str(tid) / "events.jsonl")
+    assert any(r.get("note") == "unguarded append" for r in rows)
+    assert any("append-guard: git probe failed" in r.getMessage() for r in caplog.records)
+
+
+def test_append_comment_rerouted_on_stale_restore(fake_repo):
+    repo, tw = fake_repo
+    tid = _setup_stale_restore(repo, tw)
+    tw.append_comment(tid, author="tester", kind="note", body="rerouted comment")
+    cur = repo / "tasks" / "planning" / str(tid)
+    rows = tw._iter_jsonl(cur / "comments.jsonl")
+    assert any(r.get("body") == "rerouted comment" for r in rows)
+    assert not (repo / "tasks" / "proposed" / str(tid)).exists()  # quarantined
+
+
+def test_append_guard_concern_rerouted_on_stale_restore(fake_repo):
+    repo, tw = fake_repo
+    tid = _setup_stale_restore(repo, tw)
+    tw.raise_concern(
+        tid,
+        "guard-test-concern",
+        severity="CONCERN",
+        summary="rerouted concern",
+        raised_by="test",
+        raised_at_round=1,
+    )
+    cur = repo / "tasks" / "planning" / str(tid)
+    c_rows = tw._iter_jsonl(cur / "concerns.jsonl")
+    assert any(r.get("summary") == "rerouted concern" for r in c_rows)
+    e_rows = tw._iter_jsonl(cur / "events.jsonl")
+    assert any(r.get("kind") == "epm:concern-raised" for r in e_rows)
+    assert not (repo / "tasks" / "proposed" / str(tid)).exists()  # quarantined
+    reg = json.loads((repo / "tasks" / "REGISTRY.json").read_text())
+    assert reg["tasks"][str(tid)]["path"] == f"tasks/planning/{tid}"
+
+
+def test_append_guard_deferred_move_truncated_tail_allows(fake_repo):
+    repo, tw = fake_repo
+    tid = tw.create_task(tw.NewTaskRequest(kind="infra", title="truncated tail"))
+    old = repo / "tasks" / "proposed" / str(tid)
+    new = repo / "tasks" / "planning" / str(tid)
+    new.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(old), str(new))
+    # Crash-truncated hand-appended row (cut mid-object, no newline — the
+    # #1367 shape): the tolerant reader SKIPS it, the remaining parseable
+    # rows TIE the index blob (same rows) → `>=` allows; truncation of the
+    # newest row can never push the guard into a false quarantine.
+    with (new / "events.jsonl").open("ab") as fh:
+        fh.write(b'{"ts": "2099-01-01T00')
+    _rewrite_registry_entry(repo, tid, f"tasks/planning/{tid}", "planning")
+    tw.post_event(tid, "epm:progress", by="test", note="truncated-tail append")
+    rows = tw._iter_jsonl(new / "events.jsonl")
+    assert any(r.get("note") == "truncated-tail append" for r in rows)
+    assert new.is_dir()
+    assert not (repo / ".task-workflow" / "stale-task-dirs").exists()
+
+
+def test_task_status_dir_pathspecs_unchanged_after_refactor(fake_repo):
+    repo, tw = fake_repo
+    tid = tw.create_task(tw.NewTaskRequest(kind="infra", title="pathspecs"))
+    # Mixed fixture: proposed is tracked+on-disk; planning is on-disk ONLY
+    # (untracked ghost). The recomposed helper must return BOTH, sorted —
+    # byte-identical to the pre-#1565 single-function output.
+    ghost = repo / "tasks" / "planning" / str(tid)
+    ghost.mkdir(parents=True)
+    (ghost / "events.jsonl").write_text("")
+    specs = tw._task_status_dir_pathspecs(tid, repo)
+    assert specs == sorted([f"tasks/proposed/{tid}", f"tasks/planning/{tid}"])
+    # The extracted tracked-side probe returns ONLY the index-tracked dir.
+    assert tw._tracked_status_dirs(tid, repo) == {f"tasks/proposed/{tid}"}


### PR DESCRIPTION
Closes task #1565. Adds _guarded_task_dir_for_append (git-index cross-check + quarantine + registry re-sync) at the 3 append-family sites; 11 new tests. Plan v2 ensemble-APPROVEd; code-review PASS; Step-9c gate 5274/0.