### PR TITLE
task #1571: hub per-commit file-count advisory WARN + keyword-only call-shape docs

### DIFF
--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -122,6 +122,25 @@ section wins on invocation form.
 - **No silent failures.** No `except: pass`. No `--force`. No hardcoding secrets.
 - **Never skip steps.** If a test fails, investigate — don't disable it.
 - **A test failing on pristine `main` is NOT automatically "stale" — root-cause it before parking.** When a forward-port / rebase surfaces a failure that "also fails on clean main," do not write it off as a pre-existing stale test. If the test pins a documented invariant or gotcha (grep `.claude/rules/gotchas.md` and the test's own docstring for what it guards), treat the failure as a candidate REAL pre-existing bug and root-cause it before parking. (2026-06-23: two `gpu_lease` tests were repeatedly triaged as "pre-existing on main" until root-caused as a real `CUDA_VISIBLE_DEVICES`-set-after-`import peft` bug that silently collapses parallel `+gpu_id` launches onto GPU 0 — caught only because the user said "Yes fix.")
+- **New ENUMERATED check id → probe `origin/main` for the CURRENT max id at
+  implement time, immediately before the round's final commit — never trust the
+  plan's number (#1569).** Plans assign check ids from a stale view of main;
+  with concurrent workflow-fix sessions the same-day collision recurs
+  (2026-07-19: #1550 and #1551 both implemented verify_plan.py `c40` — PR #1321
+  needed a c40→c41 renumber + conflict round; 2026-07-18: #1520 and #1521 both
+  titled verify_task_body.py `check 46`). Probe (the two known registries;
+  apply the same pattern to any other numbered check registry you touch):
+  `git fetch origin main`, then
+  `git show origin/main:scripts/verify_plan.py | grep -oE '\bc[0-9]+\b' | sort -uV | tail -1`
+  or `git show origin/main:scripts/verify_task_body.py | grep -oE 'check [0-9]+' | sort -uV | tail -1`.
+  If your id ≤ that max, take max+1 and renumber EVERY id surface in your
+  diff — docstring catalog row, conditional-checks enumeration, `(check N)`
+  escape-phrase labels, `cid` strings + `_cNN_*` helper names, test names +
+  count pins, any adversarial-planner SKILL.md escape-list row (full fan-out:
+  agent-memory `reference_verify_plan_check_fanout.md`). The plan named a
+  SLOT, not a contract: the renumber is pre-authorized — record it in your
+  results marker (`plan said c40; origin/main max was c40 → landed c41`), no
+  plan amendment needed. Re-run the probe after any rebase / conflict round.
 - **Commit messages: follow repo convention.** Check `git log --oneline -10` for style.
 - **ALL code edits on local VM.** Never edit code directly on pods. If pods need the change, commit + push, then experimenter `git pull`s. Push BARE and check the exit code — never piped through `tail`/`grep`/`head` (`guard_piped_git_push.sh` blocks it; a pipe masks a rejected push).
 

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -492,8 +492,8 @@ Behaviours:
   no ``# NO_RETRY: <reason>`` waiver on the line or the line above.
   hf_hub 0.36.2 natively retries only 500/502/503/504 on the download/LFS
   paths and the commit API not at all, so a bare live site is a 429
-  single-point-of-failure (#1426/#1335, the 2026-07-18 storm). The 297
-  per-issue historical files present at #1547 implement time are
+  single-point-of-failure (#1426/#1335, the 2026-07-18 storm). The
+  per-issue historical files frozen at #1547 landing time are
   snapshot-exempt (:data:`HF_ROUTING_FROZEN_SNAPSHOT` — the routing
   requirement attaches at REUSE time via artifact-reuse check (i)); NEWLY
   written files, including new ``scripts/issue<N>_*.py`` drivers, ARE
@@ -501,7 +501,9 @@ Behaviours:
   (pattern strings) and ``backends/gcp.py`` (generated pod-side heredocs
   with their own bounded retry) are constant-excluded. Bare
   ``snapshot_download`` / ``list_repo_files`` sites are OUT of the predicate
-  by design (#1547).
+  by design (#1547). Regenerate the snapshot with
+  ``--regen-hf-routing-snapshot`` (maintenance flag) — see the constant's
+  comment for the staleness-race recipe (#1568).
 * ``--check-no-literal-round-marker-versions`` (also bundled into the no-flags
   default run): FAIL on a literal ``v1`` posting instruction for a
   round-versioned marker kind (``epm:experiment-implementation`` /
@@ -7778,6 +7780,28 @@ HF_ROUTING_GENERATED_CODE_FILES: frozenset[str] = frozenset(
 # `scripts/issue<N>_*.py` drivers — are NOT in this snapshot and ARE scanned
 # (the `JUDGE_PIN_LEGACY_ALLOWLIST` snapshot idiom: exempt today's tree
 # once, gate everything that lands after).
+#
+# STALENESS RACE (#1568, incident #1547 -> 74bf37250b): this constant is a
+# source-frozen artifact, so it can go stale between its generation and the
+# round's Step 10d merge gate whenever main churn lands a new offender for
+# the CURRENT predicate. Steady state is safe (the check exists on main:
+# both gate legs carry it and new bare-call files block at their own
+# gates); the race re-opens when a round TIGHTENS this check (predicate /
+# window / scope) or introduces a sibling snapshot-based check. Recipe:
+# regenerate via `workflow_lint.py --regen-hf-routing-snapshot` on a
+# main-synced tree as the LAST pre-gate step, and again on any gate re-run
+# after main churn; review the stderr `+` lines — a file YOUR round created
+# must be routed, never grandfathered. NOTE: a whole-literal regen paste
+# can 3-way-CONFLICT with a concurrent main-side one-line append at the
+# gate's #1456 merge of a payload-touched workflow_lint.py — resolve by
+# re-running regen on the freshly synced tree, never by hand-merging the
+# hunks. Do NOT add dead-entry hygiene (a deleted member's entry is inert;
+# enforcing removal would CREATE gate friction on unrelated deletions).
+# Keep the FAIL-message text stable while main is red anywhere: the merge
+# gate's baseline-vs-gated subtraction compares normalized message LINES,
+# so a message rewrite that lands while an offender exists on main would
+# false-block as NEW (companion note at the message construction in
+# _hf_routing_file_errors).
 HF_ROUTING_FROZEN_SNAPSHOT: frozenset[str] = frozenset(
     {
         "scripts/_issue543_common.py",
@@ -8106,6 +8130,60 @@ def _hf_routing_call_is_wrapped(lines: list[str], i: int, match_start: int) -> b
     return False
 
 
+def _hf_routing_scan_files(root: Path):
+    """Yield ``(path, rel)`` for every scanned candidate under
+    :data:`HF_ROUTING_SCOPE_ROOTS`, excluding the pattern-string +
+    generated-code constants (NOT the frozen snapshot — callers apply that:
+    the check exempts it, the regen flag deliberately re-derives it, #1568).
+    """
+    for scope in HF_ROUTING_SCOPE_ROOTS:
+        base = root / scope
+        if not base.exists():
+            continue
+        for py in sorted(base.rglob("*.py")):
+            if not py.is_file() or "__pycache__" in py.parts:
+                continue
+            rel = py.relative_to(root).as_posix()
+            if rel in HF_ROUTING_PATTERN_STRING_FILES or rel in HF_ROUTING_GENERATED_CODE_FILES:
+                continue
+            yield py, rel
+
+
+def _hf_routing_file_errors(py: Path, rel: str) -> list[str]:
+    """Per-file scan body shared by :func:`check_live_hf_retry_routing`
+    (verdict) and :func:`regen_hf_routing_snapshot` (offender enumeration).
+    Snapshot-BLIND — the caller decides whether the frozen snapshot exempts
+    ``rel`` (#1568). Returns one error line per bare (unwrapped, unwaived)
+    HF Hub call.
+    """
+    errors: list[str] = []
+    lines = py.read_text(encoding="utf-8").splitlines()
+    for i, line in enumerate(lines):
+        stripped = line.lstrip()
+        if stripped.startswith("#") or stripped.startswith("what="):
+            continue
+        m = HF_ROUTING_CALL_RE.search(line)
+        if m is None:
+            continue
+        if "# NO_RETRY:" in line or (i > 0 and "# NO_RETRY:" in lines[i - 1]):
+            continue
+        if _hf_routing_call_is_wrapped(lines, i, m.start()):
+            continue
+        # Message-edit hazard: the Step 10d merge gate compares normalized
+        # message LINES (baseline vs gated legs), so rewording this error
+        # while ANY offender exists on main would false-register as NEW and
+        # block an unrelated merge — see the STALENESS RACE comment on
+        # HF_ROUTING_FROZEN_SNAPSHOT before editing this string (#1568).
+        errors.append(
+            f"[live-hf-retry-routing] {rel}:{i + 1}: bare HF Hub "
+            f"call in LIVE code — route through hub.retry_transient, waive with "
+            f"`# NO_RETRY: <reason>`, or (pre-existing file this round never "
+            f"touched — snapshot staleness, #1568) regen on a main-synced tree: "
+            f"`workflow_lint.py --regen-hf-routing-snapshot`: {stripped[:100]}"
+        )
+    return errors
+
+
 def check_live_hf_retry_routing(*, repo_root: Path | None = None) -> list[str]:
     """Walk ``scripts/**/*.py`` + ``src/explore_persona_space/**/*.py`` and
     FAIL on a bare (un-retried) HuggingFace Hub mutation/download call in
@@ -8122,7 +8200,7 @@ def check_live_hf_retry_routing(*, repo_root: Path | None = None) -> list[str]:
     * a ``# NO_RETRY: <reason>`` waiver sits on the line or the line above; or
     * the line is the wrap idiom's own ``what=`` descriptor kwarg
       (``what=f"hf_hub_download({repo}/{path})"``); or
-    * the file is in :data:`HF_ROUTING_FROZEN_SNAPSHOT` (the 298 per-issue
+    * the file is in :data:`HF_ROUTING_FROZEN_SNAPSHOT` (the per-issue
       historical files frozen at #1547 landing time — the routing
       requirement attaches at REUSE time via artifact-reuse check (i)),
       :data:`HF_ROUTING_PATTERN_STRING_FILES` (this file + verify_plan.py:
@@ -8134,42 +8212,52 @@ def check_live_hf_retry_routing(*, repo_root: Path | None = None) -> list[str]:
     ``list_repo_files`` sites are OUT of the predicate — a 429 there is not
     a gap in THIS check (see `.claude/rules/upload-policy.md` § Fleet-shared
     commit budget). ``repo_root`` is a unit-test override hook; production
-    callers pass None. Bundled into the no-flags default run.
+    callers pass None. Bundled into the no-flags default run. Snapshot
+    staleness (the check fires on a pre-existing file the round never
+    touched): regenerate on a main-synced tree via
+    ``--regen-hf-routing-snapshot`` (#1568).
     """
     root = repo_root if repo_root is not None else _REPO_ROOT
     errors: list[str] = []
-    for scope in HF_ROUTING_SCOPE_ROOTS:
-        base = root / scope
-        if not base.exists():
+    for py, rel in _hf_routing_scan_files(root):
+        if rel in HF_ROUTING_FROZEN_SNAPSHOT:
             continue
-        for py in sorted(base.rglob("*.py")):
-            if not py.is_file() or "__pycache__" in py.parts:
-                continue
-            rel = py.relative_to(root).as_posix()
-            if (
-                rel in HF_ROUTING_FROZEN_SNAPSHOT
-                or rel in HF_ROUTING_PATTERN_STRING_FILES
-                or rel in HF_ROUTING_GENERATED_CODE_FILES
-            ):
-                continue
-            lines = py.read_text(encoding="utf-8").splitlines()
-            for i, line in enumerate(lines):
-                stripped = line.lstrip()
-                if stripped.startswith("#") or stripped.startswith("what="):
-                    continue
-                m = HF_ROUTING_CALL_RE.search(line)
-                if m is None:
-                    continue
-                if "# NO_RETRY:" in line or (i > 0 and "# NO_RETRY:" in lines[i - 1]):
-                    continue
-                if _hf_routing_call_is_wrapped(lines, i, m.start()):
-                    continue
-                errors.append(
-                    f"[live-hf-retry-routing] {rel}:{i + 1}: bare HF Hub "
-                    f"call in LIVE code — route through hub.retry_transient (or waive "
-                    f"with `# NO_RETRY: <reason>`): {stripped[:100]}"
-                )
+        errors.extend(_hf_routing_file_errors(py, rel))
     return errors
+
+
+def regen_hf_routing_snapshot(*, repo_root: Path | None = None) -> int:
+    """Maintenance (#1568): print the ready-to-paste
+    ``HF_ROUTING_FROZEN_SNAPSHOT`` literal for the CURRENT tree — every
+    scanned file carrying >=1 bare (unwrapped, unwaived) HF Hub call,
+    re-derived snapshot-blind — plus a +/- diff summary vs the compiled-in
+    constant on stderr. Run on a MAIN-SYNCED tree (repo root on current
+    main, or the worktree after a rebase onto origin/main). REVIEW the
+    stderr ``+`` lines before pasting: a file YOUR round created must be
+    ROUTED through hub.retry_transient (or NO_RETRY-waived), never
+    grandfathered — the stderr summary exists so the round's code review
+    sees the delta. Not part of the no-flags bundle; early-dispatched in
+    ``main()``. Returns 0 (the paste-ready literal is the product, not a
+    verdict).
+    """
+    root = repo_root if repo_root is not None else _REPO_ROOT
+    offenders = sorted(
+        rel for py, rel in _hf_routing_scan_files(root) if _hf_routing_file_errors(py, rel)
+    )
+    sys.stdout.write("HF_ROUTING_FROZEN_SNAPSHOT: frozenset[str] = frozenset(\n    {\n")
+    for rel in offenders:
+        sys.stdout.write(f'        "{rel}",\n')
+    sys.stdout.write("    }\n)\n")
+    added = sorted(set(offenders) - HF_ROUTING_FROZEN_SNAPSHOT)
+    removed = sorted(HF_ROUTING_FROZEN_SNAPSHOT - set(offenders))
+    sys.stderr.write(
+        f"# regen vs compiled-in constant: +{len(added)} added, -{len(removed)} removed\n"
+    )
+    for rel in added:
+        sys.stderr.write(f"# + {rel}  (NEW offender — route it if this round created it)\n")
+    for rel in removed:
+        sys.stderr.write(f"# - {rel}  (no longer flags: deleted, routed, or waived)\n")
+    return 0
 
 
 # --- `--check-phase-done-reserved` (#930): reserved `[phase=done]` token ----
@@ -12246,10 +12334,24 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         "the call and no '# NO_RETRY: <reason>' waiver. hf_hub 0.36.2 natively "
         "retries only 500/502/503/504 on download/LFS paths and the commit API "
         "not at all, so a bare live site is a 429 single-point-of-failure "
-        "(#1426/#1335, the 2026-07-18 storm). The ~297 per-issue historical "
+        "(#1426/#1335, the 2026-07-18 storm). The per-issue historical "
         "files frozen at #1547 implement time are snapshot-exempt "
-        "(HF_ROUTING_FROZEN_SNAPSHOT); NEW files are scanned. Bundled into the "
-        "no-flags default run (#1547).",
+        "(HF_ROUTING_FROZEN_SNAPSHOT; stale snapshot? see "
+        "--regen-hf-routing-snapshot); NEW files are scanned. Bundled into "
+        "the no-flags default run (#1547).",
+    )
+    parser.add_argument(
+        "--regen-hf-routing-snapshot",
+        action="store_true",
+        help="MAINTENANCE (#1568, not a check; runs alone and early-returns — "
+        "combining it with check flags is unsupported, regen wins): print the "
+        "ready-to-paste HF_ROUTING_FROZEN_SNAPSHOT literal for the current "
+        "tree (stdout) + a +/- diff summary vs the compiled-in constant "
+        "(stderr). Run on a main-synced tree when the live-hf-retry-routing "
+        "check fires on a file your round never touched (implementer-time "
+        "snapshot went stale before the merge gate — the #1547 race). Review "
+        "added entries before pasting; never bundled into the no-flags "
+        "default run.",
     )
     parser.add_argument(
         "--check-no-literal-round-marker-versions",
@@ -12419,6 +12521,13 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         "instead. Bundled into the no-flags default run.",
     )
     args = parser.parse_args(argv)
+
+    if args.regen_hf_routing_snapshot:
+        # Maintenance flag (#1568): print-and-exit; never runs checks, never
+        # loads workflow.yaml, never enters the no-flags bundle (combining
+        # with check flags is unsupported — regen wins). Early dispatch
+        # keeps stdout EXACTLY the paste-ready literal.
+        return regen_hf_routing_snapshot()
 
     path = Path(args.file) if args.file else None
     try:

--- a/src/explore_persona_space/orchestrate/hub.py
+++ b/src/explore_persona_space/orchestrate/hub.py
@@ -707,6 +707,22 @@ def _filecount_fallback_enabled() -> bool:
 HUB_DIR_FILE_LIMIT = 10_000
 # Advisory watermark = the gotchas.md shard recipe (shard_NNNN/ of <=5000).
 HUB_DIR_FILECOUNT_WARN = 5_000
+# Advisory per-COMMIT total-staged-files THROUGHPUT watermark (#1571): one
+# upload_folder commit of many small files crawls in Hub-side per-operation
+# pre-processing regardless of byte size (#1481 incident, session 98ff0f37:
+# 31,000 files / 135 MB in one commit — killed exit 144 after >20 min,
+# repacked into <stem>.shardNN.jsonl line-shards). huggingface_hub 0.36.2's
+# upload_folder prep path already logs its own WARNING above 200 filtered
+# files recommending `upload_large_folder` (hf_api.py:9610-9617); this
+# project tier deliberately differs: a tunable, testable knob at 2,000 whose
+# remedy is the pack/shard recipe (.claude/rules/upload-policy.md) — the
+# project deliberately does not use `upload_large_folder`. HF's hub docs
+# recommend ~50-100 files per commit and merging small files into fewer
+# larger ones (repositories-recommendations); 2,000 = 20x that
+# recommendation — quiet on normal-scale uploads, loud well below the
+# incident scale. DISTINCT from the two SERVER caps above (10k/dir #658,
+# 100k/repo #1108): this tier NEVER raises. warn_total <= 0 disables.
+HUB_COMMIT_FILECOUNT_WARN = 2_000
 
 
 class HubDirFileCountError(ValueError):
@@ -768,10 +784,21 @@ def assert_hub_dir_filecounts(
     ignore_patterns: list[str] | None = None,
     limit: int = HUB_DIR_FILE_LIMIT,
     warn_at: int = HUB_DIR_FILECOUNT_WARN,
+    warn_total: int = HUB_COMMIT_FILECOUNT_WARN,
 ) -> dict[str, int]:
     """Fail loud BEFORE staging when any target repo dir would receive
     more than ``limit`` files in one commit (strict ``>``; the server accepts
     exactly 10,000). Returns the per-dir counts (for logging / tests).
+
+    Third tier (#1571) — ADVISORY-only per-COMMIT total: when the commit's
+    TOTAL staged file count across all target dirs exceeds ``warn_total``
+    (strict ``>``; default :data:`HUB_COMMIT_FILECOUNT_WARN`), log ONE
+    WARNING pointing at the pack/shard recipe. This is a THROUGHPUT nudge
+    (many-small-file commits crawl in Hub-side per-operation pre-processing,
+    #1481) — not a server 400 like the per-DIR ``limit`` tier — so it NEVER
+    raises. ``warn_total <= 0`` disables it; the kill switch
+    ``EPM_SKIP_HF_DIR_FILECOUNT_GUARD`` does NOT gate it (an advisory log
+    line blocks nothing, so there is nothing to unwedge).
 
     Public — direct ``HfApi.upload_folder`` callers in ``scripts/`` call this
     one-liner before their upload (the ``--check-hub-dir-filecount`` lint
@@ -799,6 +826,27 @@ def assert_hub_dir_filecounts(
         allow_patterns=allow_patterns,
         ignore_patterns=ignore_patterns,
     )
+    total = sum(counts.values())
+    if warn_total > 0 and total > warn_total:
+        # Advisory THROUGHPUT tier (#1571) — never raises, independent of the
+        # SERVER-cap tiers below. NOTE: any #1108 model-repo overflow-fallback
+        # re-entry of _upload with >2k staged files re-runs the guard and logs
+        # this twice (idempotent + harmless — same note as the kill-switch
+        # WARN below). Comma-format the numbers (the "500"-substring trap, msg
+        # note below); this is a log line (never an exception), so the trap
+        # cannot bite, but the discipline stays uniform across the guard's
+        # messages.
+        logger.warning(
+            "upload stages %s files in ONE commit (advisory throughput "
+            "threshold %s) — many-small-file commits crawl in Hub-side "
+            "pre-processing regardless of byte size (#1481: a 31,000-file / "
+            "135 MB commit was killed and repacked). Prefer PACKING small "
+            "text/JSON files into <= 9 MB <stem>.shardNN.jsonl line-shards + "
+            "a manifest (.claude/rules/upload-policy.md), or fewer larger "
+            "files; proceeding — advisory only.",
+            f"{total:,}",
+            f"{warn_total:,}",
+        )
     offenders = {d: n for d, n in counts.items() if n > limit}
     if offenders:
         worst_dir, worst_n = max(offenders.items(), key=lambda kv: kv[1])
@@ -990,6 +1038,16 @@ def _retry_upload(fn, *, what: str, max_attempts: int = 6, budget_s: float | Non
     backoff ``min(180, 10*2^k)`` with 0-25% jitter (de-synchronizes fleet
     retries). Storage-quota-403 / non-transient re-raise IMMEDIATELY; on
     exhaustion the final exception propagates (fail-loud, no swallow).
+
+    Args:
+        fn: ZERO-ARG thunk — wrap the real call in a ``lambda``.
+        what: REQUIRED KEYWORD-ONLY log label naming the wrapped operation.
+            A positional call raises ``TypeError: _retry_upload() missing 1
+            required keyword-only argument: 'what'`` (#1571 incident) — pass
+            it explicitly:
+            ``retry_transient(lambda: api.upload_folder(...), what="upload_folder")``.
+        max_attempts / budget_s: keyword-only tuning knobs; see the bound
+            convention above.
     """
     budget = _retry_budget_s() if budget_s is None else budget_s
     start = time.monotonic()
@@ -1052,6 +1110,8 @@ def _retry_upload(fn, *, what: str, max_attempts: int = 6, budget_s: float | Non
 
 # Public, greppable name for per-issue dispatch scripts (#606: scripts assumed a
 # hub `_retry_transient` that never existed; the i528 family hand-rolled four copies).
+# Call shape: retry_transient(lambda: <hub call>, what="<label>") — 'what' is
+# keyword-only REQUIRED (#1571).
 retry_transient = _retry_upload
 
 
@@ -1085,6 +1145,18 @@ def verify_repo_paths_uploaded(
     falls back to ONE retried ``HfApi.file_exists`` HEAD probe instead of
     falsely reporting a successfully-uploaded file as missing. Transport/auth
     errors propagate after the retry budget.
+
+    Call shape (``path_in_repo`` is REQUIRED KEYWORD-ONLY — omitting it, or
+    trying to pass it as a positional 4th arg, raises ``TypeError``; the
+    #1571 incident's stumble was ``TypeError: ... missing 1 required
+    keyword-only argument: 'path_in_repo'``)::
+
+        missing = verify_repo_paths_uploaded(
+            HfApi(),
+            "superkaiba1/explore-persona-space-data",
+            expected_repo_paths,
+            path_in_repo="issue<N>_<slug>/raw_completions",
+        )
     """
     from huggingface_hub.utils import EntryNotFoundError
 

--- a/tests/sparse_cones.txt
+++ b/tests/sparse_cones.txt
@@ -48,6 +48,10 @@
 #   eval_results/issue_1482 — test_issue1482_pdshrink.py::test_g1_committed_split_sha_constants_pin_committed_file
 #                             reads split_1482.json (pins PDSHRINK_COMMITTED_SPLIT_SHAS
 #                             to the committed G1 leg-(i) anchor shas)
+#   eval_results/issue_779  — test_issue1482_driver.py::_fake_gate_a_inputs reads
+#                             fitter-fair-comparison-n1m/n1m_fits.json (the Gate-A
+#                             ridge-anchor fixture; missing line surfaced as a
+#                             sparse-worktree FileNotFoundError on #1571's gate run)
 eval_results/issue_545
 eval_results/issue_521
 eval_results/issue_257
@@ -62,3 +66,4 @@ eval_results/issue_825
 eval_results/issue_1417
 eval_results/issue_1434
 eval_results/issue_1482
+eval_results/issue_779

--- a/tests/test_hub_dir_filecount_guard.py
+++ b/tests/test_hub_dir_filecount_guard.py
@@ -328,3 +328,100 @@ class TestWiring:
         assert ("upload_folder", "user/repo", "dest") in fake_api.calls
         warned = "\n".join(r.getMessage() for r in caplog.records)
         assert "EPM_SKIP_HF_DIR_FILECOUNT_GUARD=1 set" in warned, warned
+
+
+# ---------------------------------------------------------------------------
+# Advisory per-COMMIT total-staged-files THROUGHPUT tier (#1571)
+# ---------------------------------------------------------------------------
+
+
+class TestCommitTotalWarn:
+    def test_default_constant_value(self):
+        assert hub.HUB_COMMIT_FILECOUNT_WARN == 2_000
+
+    def test_total_above_threshold_warns_and_never_raises(self, tmp_path, caplog):
+        """THE INCIDENT SHAPE (#1481): files spread across dirs, EVERY dir
+        under the per-dir tiers — only the TOTAL crosses. (durability pin)"""
+        _make_tree(tmp_path, "a", 5)
+        _make_tree(tmp_path, "b", 4)
+        _make_tree(tmp_path, "c", 3)
+        with caplog.at_level(logging.WARNING, logger=HUB_LOGGER):
+            counts = hub.assert_hub_dir_filecounts(
+                tmp_path, "p", limit=100, warn_at=100, warn_total=10
+            )
+        assert counts == {"p/a": 5, "p/b": 4, "p/c": 3}, counts  # returned, no raise
+        warned = "\n".join(r.getMessage() for r in caplog.records)
+        assert "ONE commit" in warned and "12" in warned, warned  # fired, names total
+        assert "shardNN.jsonl" in warned and "upload-policy.md" in warned, warned
+        # Per-dir tiers are silent by construction here (max dir 5 <= 100),
+        # so the advisory is the ONLY record — pins exactly-one-WARNING.
+        assert len(caplog.records) == 1, [r.getMessage() for r in caplog.records]
+
+    def test_total_at_threshold_stays_silent(self, tmp_path, caplog):
+        """Strict > : exactly-warn_total is silent."""
+        _make_tree(tmp_path, "a", 10)
+        with caplog.at_level(logging.WARNING, logger=HUB_LOGGER):
+            hub.assert_hub_dir_filecounts(tmp_path, "p", limit=100, warn_at=100, warn_total=10)
+        assert caplog.records == [], [r.getMessage() for r in caplog.records]
+
+    def test_warn_total_nonpositive_disables(self, tmp_path, caplog):
+        _make_tree(tmp_path, "a", 50)
+        with caplog.at_level(logging.WARNING, logger=HUB_LOGGER):
+            hub.assert_hub_dir_filecounts(tmp_path, "p", limit=100, warn_at=100, warn_total=0)
+        assert caplog.records == [], [r.getMessage() for r in caplog.records]
+
+    def test_default_threshold_fires_on_spread_tree_no_raise(self, tmp_path, caplog):
+        """DEFAULTS end-to-end: 2,001 files across 3 dirs (each far under the
+        5,000/dir watermark) fire the advisory, comma-formatted, no raise."""
+        for d, n in (("a", 667), ("b", 667), ("c", 667)):
+            _make_tree(tmp_path, d, n)
+        with caplog.at_level(logging.WARNING, logger=HUB_LOGGER):
+            counts = hub.assert_hub_dir_filecounts(tmp_path, "p")
+        assert sum(counts.values()) == 2_001, counts
+        warned = "\n".join(r.getMessage() for r in caplog.records)
+        assert "ONE commit" in warned, warned
+        assert "2,001" in warned, warned  # pins the comma-format discipline
+
+    def test_advisory_also_logs_on_raise_path(self, big_tree, caplog):
+        """big_tree = 10,001 files in one dir: the raise still happens, and
+        the advisory logs FIRST (remediation context for the over-cap tree —
+        packing is the right remedy there too)."""
+        with (
+            caplog.at_level(logging.WARNING, logger=HUB_LOGGER),
+            pytest.raises(hub.HubDirFileCountError),
+        ):
+            hub.assert_hub_dir_filecounts(big_tree, "dest")
+        assert any("ONE commit" in r.getMessage() for r in caplog.records), [
+            r.getMessage() for r in caplog.records
+        ]
+
+    def test_message_disjoint_from_transient_error_scan(self, tmp_path, caplog):
+        """No 500-family substring once the RENDERED comma-formatted dynamic
+        values (the exact f"{total:,}" / f"{warn_total:,}" strings) are
+        scrubbed — mirrors TestRaiseMessage's scrub pattern."""
+        total, warn_total = 12, 10
+        _make_tree(tmp_path, "a", total)
+        with caplog.at_level(logging.WARNING, logger=HUB_LOGGER):
+            hub.assert_hub_dir_filecounts(
+                tmp_path, "p", limit=100, warn_at=100, warn_total=warn_total
+            )
+        warned = "\n".join(r.getMessage() for r in caplog.records)
+        scrubbed = warned.replace(f"{total:,}", "").replace(f"{warn_total:,}", "")
+        for code in ("500", "502", "503", "504"):
+            assert code not in scrubbed, f"bare {code!r} in advisory message: {warned}"
+
+
+# ---------------------------------------------------------------------------
+# Keyword-only call-shape docs (#1571 deliverable b)
+# ---------------------------------------------------------------------------
+
+
+class TestKeywordOnlyDocs:
+    def test_retry_upload_doc_names_keyword_only_what(self):
+        doc = hub._retry_upload.__doc__
+        assert "keyword-only" in doc.lower() and 'what="' in doc, doc
+        assert hub.retry_transient is hub._retry_upload  # alias shares the doc
+
+    def test_verify_repo_paths_doc_names_keyword_only_path_in_repo(self):
+        doc = hub.verify_repo_paths_uploaded.__doc__
+        assert "keyword-only" in doc.lower() and 'path_in_repo="' in doc, doc

--- a/tests/test_workflow_lint.py
+++ b/tests/test_workflow_lint.py
@@ -8149,3 +8149,177 @@ def test_check_live_hf_retry_routing_registered_in_no_flags_default_run():
     assert "or args.check_live_hf_retry_routing" in src, (
         "--check-live-hf-retry-routing is missing from the no_flags detection tuple"
     )
+
+
+# ---------------------------------------------------------------------------
+# --regen-hf-routing-snapshot (#1568): paste-ready snapshot regeneration
+# ---------------------------------------------------------------------------
+
+
+def test_regen_hf_routing_snapshot_lists_bare_skips_wrapped_and_waived(tmp_path, capsys):
+    """The regen walker applies the same bare/wrapped/waived predicate as the
+    check. The tmp root is NON-GIT by construction — pinned explicitly below,
+    naming the gate-tree constraint (the Step 10d `git archive | tar -x`
+    landing tree has no .git; #1568 hard constraint 1)."""
+    from workflow_lint import regen_hf_routing_snapshot
+
+    root = _hf_routing_root(tmp_path)
+    assert not (root / ".git").exists()
+    (root / "scripts" / "bare.py").write_text(
+        "from huggingface_hub import hf_hub_download\n"
+        "def fetch():\n"
+        "    return hf_hub_download('org/repo', 'a.bin')\n",
+        encoding="utf-8",
+    )
+    (root / "scripts" / "wrapped.py").write_text(
+        "from explore_persona_space.orchestrate.hub import retry_transient\n"
+        "from huggingface_hub import hf_hub_download\n"
+        "def fetch():\n"
+        "    return retry_transient(\n"
+        "        lambda: hf_hub_download('org/repo', 'a.bin'),\n"
+        "        what='hf_hub_download(org/repo/a.bin)',\n"
+        "    )\n",
+        encoding="utf-8",
+    )
+    (root / "scripts" / "waived.py").write_text(
+        "from huggingface_hub import hf_hub_download\n"
+        "def probe():\n"
+        "    # NO_RETRY: deliberate existence probe\n"
+        "    return hf_hub_download('org/repo', 'a.bin')\n",
+        encoding="utf-8",
+    )
+    assert regen_hf_routing_snapshot(repo_root=root) == 0
+    out = capsys.readouterr().out
+    entries = re.findall(r'^        "([^"]+)",$', out, flags=re.MULTILINE)
+    assert entries == ["scripts/bare.py"], entries
+
+
+def test_regen_hf_routing_snapshot_is_snapshot_blind(tmp_path, capsys):
+    """A bare call AT a frozen-snapshot member path is exempt for the CHECK
+    but enumerated by regen — the snapshot is re-derived, never inherited."""
+    from workflow_lint import (
+        HF_ROUTING_FROZEN_SNAPSHOT,
+        check_live_hf_retry_routing,
+        regen_hf_routing_snapshot,
+    )
+
+    frozen_member = "scripts/eval_issue562_panel.py"
+    assert frozen_member in HF_ROUTING_FROZEN_SNAPSHOT
+    root = _hf_routing_root(tmp_path)
+    (root / frozen_member).write_text(
+        "from huggingface_hub import hf_hub_download\n"
+        "def fetch():\n"
+        "    return hf_hub_download('org/repo', 'a.bin')\n",
+        encoding="utf-8",
+    )
+    assert check_live_hf_retry_routing(repo_root=root) == []
+    assert regen_hf_routing_snapshot(repo_root=root) == 0
+    out = capsys.readouterr().out
+    assert f'        "{frozen_member}",\n' in out
+
+
+def test_regen_hf_routing_snapshot_output_paste_round_trip(tmp_path, capsys):
+    """stdout is byte-compatible with the source shape: the exact header
+    line, sorted quoted entries, `    }` + `)` closers — and the set body
+    `ast.literal_eval`s back to the offender set (paste-replace safe)."""
+    import ast
+
+    from workflow_lint import regen_hf_routing_snapshot
+
+    root = _hf_routing_root(tmp_path)
+    for name in ("b_tool.py", "a_tool.py"):
+        (root / "scripts" / name).write_text(
+            "from huggingface_hub import hf_hub_download\n"
+            "x = hf_hub_download('org/repo', 'a.bin')\n",
+            encoding="utf-8",
+        )
+    assert regen_hf_routing_snapshot(repo_root=root) == 0
+    out = capsys.readouterr().out
+    lines = out.splitlines()
+    assert lines[0] == "HF_ROUTING_FROZEN_SNAPSHOT: frozenset[str] = frozenset("
+    assert lines[1] == "    {"
+    assert lines[-2] == "    }"
+    assert lines[-1] == ")"
+    parsed = ast.literal_eval("\n".join(lines[1:-1]))
+    assert parsed == {"scripts/a_tool.py", "scripts/b_tool.py"}
+    entries = re.findall(r'^        "([^"]+)",$', out, flags=re.MULTILINE)
+    assert entries == sorted(entries)
+
+
+def test_regen_hf_routing_snapshot_diff_summary_on_stderr(tmp_path, capsys):
+    """stderr carries the +/- summary vs the compiled-in constant: the tmp
+    offender is a `+` line, and (on a tmp root) every compiled-in member
+    reads as a `-` line — the delta the round's code review must see."""
+    from workflow_lint import HF_ROUTING_FROZEN_SNAPSHOT, regen_hf_routing_snapshot
+
+    root = _hf_routing_root(tmp_path)
+    (root / "scripts" / "new_offender.py").write_text(
+        "from huggingface_hub import hf_hub_download\nx = hf_hub_download('org/repo', 'a.bin')\n",
+        encoding="utf-8",
+    )
+    assert regen_hf_routing_snapshot(repo_root=root) == 0
+    err = capsys.readouterr().err
+    assert f"+1 added, -{len(HF_ROUTING_FROZEN_SNAPSHOT)} removed" in err
+    assert "# + scripts/new_offender.py" in err
+    assert err.count("# - ") == len(HF_ROUTING_FROZEN_SNAPSHOT)
+
+
+def test_regen_hf_routing_snapshot_live_tree_subset_of_current():
+    """Walker-parity pin: on the LIVE tree the regen offender set is a
+    subset of the compiled-in snapshot (the check is green, so no offender
+    outside the snapshot exists). Divergence diagnosis is in the assert
+    message."""
+    from workflow_lint import (
+        _REPO_ROOT,
+        HF_ROUTING_FROZEN_SNAPSHOT,
+        _hf_routing_file_errors,
+        _hf_routing_scan_files,
+    )
+
+    offenders = {
+        rel for py, rel in _hf_routing_scan_files(_REPO_ROOT) if _hf_routing_file_errors(py, rel)
+    }
+    unexpected = sorted(offenders - HF_ROUTING_FROZEN_SNAPSHOT)
+    assert not unexpected, (
+        f"regen enumerates offenders outside HF_ROUTING_FROZEN_SNAPSHOT: {unexpected}. "
+        "If any of these is workflow_lint.py / verify_plan.py / backends/gcp.py, the "
+        "regen walker DIVERGED from the check walker (dropped a constant exclusion — "
+        "code bug). Otherwise a genuinely-new bare-call offender landed on main after "
+        "this branch forked — NOT a walker bug: rebase onto origin/main and re-run "
+        "(that red IS the staleness signal working; #1568 plan §6 kill criterion 3)."
+    )
+
+
+def test_workflow_lint_regen_hf_routing_snapshot_cli():
+    """rc=0 and stdout is EXACTLY the paste-ready literal: the early dispatch
+    means no `workflow_lint:` check-output line ever contaminates stdout
+    (the bundle never ran)."""
+    result = _run("--regen-hf-routing-snapshot")
+    assert result.returncode == 0, (
+        f"workflow_lint --regen-hf-routing-snapshot failed:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert result.stdout.startswith("HF_ROUTING_FROZEN_SNAPSHOT: frozenset[str] = frozenset(")
+    assert "workflow_lint:" not in result.stdout
+
+
+def test_regen_flag_early_dispatch_and_not_in_no_flags_tuple():
+    """Source pins (#1568): (a) the regen dispatch early-returns BEFORE the
+    no_flags computation; (b) the flag is NOT in the no_flags detection
+    tuple (the early return makes membership dead code — pin it OUT, the
+    inverse of the check's registration test); (c) the check's FAIL message
+    names the recovery flag (the message-hint durability pin)."""
+    src = _LINT.read_text(encoding="utf-8")
+    dispatch_at = src.index("if args.regen_hf_routing_snapshot:")
+    no_flags_at = src.index("no_flags = not (")
+    assert dispatch_at < no_flags_at, "regen dispatch must precede the no_flags computation"
+    tuple_match = re.search(r"no_flags = not \(.*?\n    \)", src, flags=re.DOTALL)
+    assert tuple_match is not None, "no_flags detection tuple not found in workflow_lint.py"
+    assert "regen_hf_routing_snapshot" not in tuple_match.group(0), (
+        "--regen-hf-routing-snapshot must NOT be in the no-flags detection tuple"
+    )
+    fn_start = src.index("def _hf_routing_file_errors(")
+    fn_end = src.index("def check_live_hf_retry_routing(", fn_start)
+    assert "--regen-hf-routing-snapshot" in src[fn_start:fn_end], (
+        "the live-hf-retry-routing FAIL message must name --regen-hf-routing-snapshot"
+    )


### PR DESCRIPTION
Closes task #1571.

- Advisory per-commit total-staged-files WARN tier (`HUB_COMMIT_FILECOUNT_WARN = 2_000`, keyword-only `warn_total`) in `assert_hub_dir_filecounts` — throughput nudge for the #1481 31k-small-file crawl class; never raises.
- Keyword-only call-shape docstrings for `_retry_upload`/`retry_transient` + `verify_repo_paths_uploaded`.
- `tests/sparse_cones.txt`: `eval_results/issue_779` cone (pre-existing #671-class gap).

Plan: tasks/reviewing/1571/plans/plan.md · critics 3×APPROVE + consistency PASS · code-review PASS · test-verdict PASS (4900 passed).