### PR TITLE
task #1576: WARN-only inline-interpreter arm for the #1329 workload-cmd lint

### DIFF
--- a/scripts/dispatch_issue.py
+++ b/scripts/dispatch_issue.py
@@ -963,6 +963,60 @@ def _warn_workload_cmd_env_and_flag_marker(
     )
 
 
+def _warn_workload_cmd_inline_interpreter_and_flag_marker(
+    spec: Any, marker_poster: Callable[..., None]
+) -> Callable[..., None]:
+    """WARN-only #1576 arm of the #1329 workload-cmd lint family. Never blocks.
+
+    Flags an inline-interpreter one-liner BODY (``python -c`` / stdin
+    heredoc) per ``lint_workload_cmd_inline_interpreter``; the sanctioned
+    trailing ``write_completion_sentinel`` append is exempt (strip-then-scan).
+    Shares the family kill switch ``EPM_SKIP_WORKLOAD_CMD_ENV_LINT=1`` — a
+    silenced HIT logs one info line for operator symmetry with the family
+    gate. No strict upgrade: ``--strict-workload-cmd-env`` is lane-env-scoped
+    by contract (#1576 plan §11 D1) — this arm has NO refusal path at all.
+    """
+    from explore_persona_space.backends.issue_dispatch import (
+        lint_workload_cmd_inline_interpreter,
+    )
+
+    if not spec.workload_cmd:
+        return marker_poster
+    lint = lint_workload_cmd_inline_interpreter(spec.workload_cmd)
+    if not lint.flagged:
+        return marker_poster
+    log = logging.getLogger("dispatch_issue")
+    if os.environ.get("EPM_SKIP_WORKLOAD_CMD_ENV_LINT") == "1":
+        log.info(
+            "EPM_SKIP_WORKLOAD_CMD_ENV_LINT=1 — workload-cmd inline-interpreter "
+            "lint (#1576) silenced a %s hit.",
+            lint.shape,
+        )
+        return marker_poster
+    log.warning(
+        "--workload-cmd body is an inline interpreter one-liner (%s). Ad-hoc probe "
+        "workloads are committed scripts invoked by path (SKILL.md § Backend dispatch; "
+        "incident #1482: a placeholder-broken inline staging one-liner SyntaxError'd "
+        "post-b0 and spuriously failed over to RunPod) — inline bodies are un-lintable, "
+        "un-smokeable, and quoting-fragile. Rewrite as a committed branch script, push, "
+        "re-dispatch by path with --repo-branch. The trailing "
+        "write_completion_sentinel append is exempt%s. Launch continues; "
+        "epm:backend-selected carries extra.workload_cmd_inline_interpreter. Silence "
+        "with EPM_SKIP_WORKLOAD_CMD_ENV_LINT=1.",
+        lint.shape,
+        " (stripped before this scan)" if lint.sentinel_append_stripped else "",
+    )
+    return _wrap_marker_poster_with_override_flag(
+        marker_poster,
+        {
+            "workload_cmd_inline_interpreter": {
+                "shape": lint.shape,
+                "sentinel_append_stripped": lint.sentinel_append_stripped,
+            }
+        },
+    )
+
+
 def _workload_cmd_env_lint_gate(
     args: argparse.Namespace, spec: Any
 ) -> tuple[Any, dict[str, Any] | None]:
@@ -1554,6 +1608,11 @@ def _cmd_launch(args: argparse.Namespace, *, backends_factory: Callable[[], dict
     # epm:backend-selected marker); exit-2 pre-route refusal only when the
     # crash is provably certain on the pinned lane (lint.certain) or under
     # --strict-workload-cmd-env. Kill switch: EPM_SKIP_WORKLOAD_CMD_ENV_LINT=1.
+    # A SECOND, WARN-only family arm (#1576, incident #1482) flags an
+    # inline-interpreter one-liner body (python -c / stdin heredoc; the
+    # sanctioned write_completion_sentinel append is exempt) via the
+    # marker-poster decoration below — never a refusal, and
+    # --strict-workload-cmd-env does NOT upgrade it.
     env_lint, env_refusal = _workload_cmd_env_lint_gate(args, spec)
     if env_refusal is not None:
         print(json.dumps(env_refusal, sort_keys=True))
@@ -1561,6 +1620,7 @@ def _cmd_launch(args: argparse.Namespace, *, backends_factory: Callable[[], dict
 
     deps = backends_factory()
     marker_poster = _warn_workload_cmd_env_and_flag_marker(env_lint, deps["marker_poster"])
+    marker_poster = _warn_workload_cmd_inline_interpreter_and_flag_marker(spec, marker_poster)
     marker_poster = _check_runpod_override_frontmatter(int(args.issue), args.backend, marker_poster)
     marker_poster = _warn_default_boot_disk_ft_intent(spec, int(args.issue), marker_poster)
     try:
@@ -2474,7 +2534,10 @@ def _build_argparser() -> argparse.ArgumentParser:
             "done (#601). SLURM lanes (nibi/fir/mila): the command MUST BLOCK until the "
             "workload finishes — the sbatch terminal block + job COMPLETED fire on command "
             "return and the job-exit cgroup teardown kills detached children (no /workspace "
-            "pid contract exists there; #601 follow-up). Mutually "
+            "pid contract exists there; #601 follow-up). An inline-interpreter one-liner "
+            "BODY (python -c / stdin heredoc) draws a WARN-only lint (#1576, incident "
+            "#1482; the trailing write_completion_sentinel append is exempt) — prefer a "
+            "committed branch script invoked by path. Mutually "
             "exclusive with --hydra; exactly one of the two is required (#588)."
         ),
     )

--- a/src/explore_persona_space/backends/issue_dispatch.py
+++ b/src/explore_persona_space/backends/issue_dispatch.py
@@ -500,6 +500,93 @@ def lint_workload_cmd_lane_env(
     return WorkloadCmdEnvLint(flagged=flagged, certain=certain, reachable_lanes=reachable)
 
 
+#: Sanctioned trailing sentinel append (experimenter.md § item 11):
+#: ``<workload-cmd> && [uv run ]python -c "...write_completion_sentinel..."``.
+#: Leftmost ``&& [uv run ]python -c`` whose remainder mentions
+#: ``write_completion_sentinel``; anchored to end-of-string via DOTALL ``.+$``
+#: so only a TRAILING append (plus anything after the first such join) is
+#: stripped before the inline-interpreter scan.
+_SENTINEL_APPEND_RE = re.compile(r"&&\s*(?:uv\s+run\s+)?python3?\s+-c\s+(?P<rest>.+)$", re.DOTALL)
+#: Inline interpreter as the PRIMARY command: optional ``VAR=val`` env
+#: prefixes, then ``[uv run ]python[3] -c``.
+_INLINE_C_BODY_RE = re.compile(
+    r"^\s*(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*(?:uv\s+run\s+)?python3?\s+-c(?=\s)"
+)
+#: Stdin-heredoc python anywhere: ``python - <<EOF``, ``python - <<'EOF'``,
+#: ``python <<EOF``, with/without ``uv run``, optional ``<<-``.
+_STDIN_HEREDOC_RE = re.compile(r"(?:uv\s+run\s+)?python3?\s+-?\s*<<-?\s*['\"]?\w+")
+
+
+@dataclass(frozen=True)
+class WorkloadCmdInlineLint:
+    """Result of :func:`lint_workload_cmd_inline_interpreter` (#1576).
+
+    ``shape`` names the detected anti-pattern (``"inline_c"`` |
+    ``"stdin_heredoc"``) or ``None`` when unflagged.
+    ``sentinel_append_stripped`` records whether the sanctioned trailing
+    ``write_completion_sentinel`` append was removed before the scan.
+    """
+
+    flagged: bool
+    shape: str | None
+    sentinel_append_stripped: bool
+
+
+def strip_sentinel_append(workload_cmd: str) -> tuple[str, bool]:
+    """Strip the experimenter.md-sanctioned trailing sentinel append.
+
+    Returns ``(body, stripped)``: the command with the leftmost
+    ``&& [uv run ]python -c`` join removed when its remainder mentions
+    ``write_completion_sentinel`` (the ONE sanctioned inline ``-c`` suffix),
+    else the command unchanged.
+    """
+    m = _SENTINEL_APPEND_RE.search(workload_cmd)
+    if m is not None and "write_completion_sentinel" in m.group("rest"):
+        return workload_cmd[: m.start()], True
+    return workload_cmd, False
+
+
+def lint_workload_cmd_inline_interpreter(workload_cmd: str) -> WorkloadCmdInlineLint:
+    """WARN-class #1576 detection: inline interpreter one-liner as the workload BODY.
+
+    Mechanizes the SKILL.md § Backend dispatch prose rule "Ad-hoc probe
+    workloads are committed scripts invoked by path" (incident #1482: a
+    placeholder-broken inline staging one-liner would have SyntaxError'd
+    post-b0 and spuriously failed over to RunPod). Scans the RAW command —
+    never the ``_SINGLE_QUOTED_SEGMENT_RE``-stripped text the lane-env lint
+    uses — because an inline ``-c`` body is usually single-quoted, so the
+    quote strip would erase exactly the evidence this arm needs. The
+    sanctioned trailing ``write_completion_sentinel`` append is removed via
+    :func:`strip_sentinel_append` BEFORE the scan (strip-then-scan: an inline
+    body that ALSO ends with the sentinel append still flags).
+
+    Scope: router-lane dispatches only — this lint runs inside
+    ``dispatch_issue.py launch``; direct-SSH pod launches bypass it.
+
+    Deliberate v1 FALSE NEGATIVES (named, mirroring the
+    ``_bare_reference_re`` docstring discipline — widen if one bites):
+
+    * a mid-chain non-sentinel ``&& python -c`` segment after a
+      committed-script body;
+    * ``bash -c '...'`` / ``sh -c '...'`` wrapping;
+    * ``python -m module`` bodies and non-python interpreters;
+    * the no-space ``python -c'x'`` shape (the ``-c`` lookahead requires
+      whitespace);
+    * sentinel-token smuggling: ``true && uv run python -c "<staging>;
+      ...write_completion_sentinel(...)"`` post-strips to ``true`` and does
+      not flag (the strip keys on the token alone).
+    """
+    body = (workload_cmd or "").strip()
+    if not body:
+        return WorkloadCmdInlineLint(flagged=False, shape=None, sentinel_append_stripped=False)
+    body, stripped = strip_sentinel_append(body)
+    if _INLINE_C_BODY_RE.search(body):
+        return WorkloadCmdInlineLint(True, "inline_c", stripped)
+    if _STDIN_HEREDOC_RE.search(body):
+        return WorkloadCmdInlineLint(True, "stdin_heredoc", stripped)
+    return WorkloadCmdInlineLint(False, None, stripped)
+
+
 def build_run_spec(
     *,
     issue: int,
@@ -1125,15 +1212,18 @@ __all__ = [
     "DispatchOutcome",
     "TerminalTranslation",
     "WorkloadCmdEnvLint",
+    "WorkloadCmdInlineLint",
     "build_run_spec",
     "classify_terminal_exception",
     "default_handle_sidecar_path",
     "deserialize_handle",
     "dispatch_for_issue",
+    "lint_workload_cmd_inline_interpreter",
     "lint_workload_cmd_lane_env",
     "normalize_backend_value",
     "read_handle_sidecar",
     "resolve_handle_sidecar_path",
     "serialize_handle",
+    "strip_sentinel_append",
     "write_handle_sidecar",
 ]

--- a/tests/test_workload_cmd_env_lint.py
+++ b/tests/test_workload_cmd_env_lint.py
@@ -30,7 +30,10 @@ import pytest
 from explore_persona_space.backends.base import RunHandle
 from explore_persona_space.backends.issue_dispatch import (
     LANE_WORKLOAD_ENV_EXPORTS,
+    WorkloadCmdInlineLint,
+    lint_workload_cmd_inline_interpreter,
     lint_workload_cmd_lane_env,
+    strip_sentinel_append,
 )
 from tests.test_dispatch_issue_cli import (
     _backend_selected_extras,
@@ -403,7 +406,8 @@ def test_launch_strict_with_clean_cmd_proceeds(monkeypatch, tmp_path, caplog) ->
 
 
 def test_launch_hydra_lint_noop(monkeypatch, tmp_path, caplog) -> None:
-    """Plan test 15: a --hydra launch has no workload_cmd → lint no-op."""
+    """Plan test 15: a --hydra launch has no workload_cmd → lint no-op
+    (BOTH family arms: lane-env #1329 and inline-interpreter #1576)."""
     _cd_to_tmp(monkeypatch, tmp_path)
     nibi = _MockBackend(kind="nibi")
     factory = _build_mock_factory(runpod=_MockBackend(kind="runpod"), nibi=nibi)
@@ -418,6 +422,7 @@ def test_launch_hydra_lint_noop(monkeypatch, tmp_path, caplog) -> None:
         )
     assert rc == 0
     assert not _lane_env_warnings(caplog)
+    assert not _inline_warnings(caplog)
 
 
 def test_kill_switch_env_skips_lint_launch_proceeds(monkeypatch, tmp_path, caplog) -> None:
@@ -585,3 +590,285 @@ def test_skill_step6b_lane_portable_repo_root_pin() -> None:
         "SKILL.md re-prescribes the bare $WORKLOAD_ROOT composition (#825/#1329)"
     )
     assert "${WORKLOAD_ROOT:-" in skill
+
+
+# ---------------------------------------------------------------------------
+# Inline-interpreter WARN arm (#1576, incident #1482) — pure detection
+# ---------------------------------------------------------------------------
+
+#: The experimenter.md § item-11 sanctioned trailing sentinel append.
+SENTINEL_APPEND = (
+    ' && uv run python -c "from explore_persona_space.backends.artifacts import '
+    "write_completion_sentinel; write_completion_sentinel("
+    "'/workspace/logs/issue-1576-results.json')\""
+)
+#: A representative inline-interpreter workload body (the #1482 class).
+INLINE_C_CMD = "uv run python -c 'import json; print(json.dumps({}))'"
+HEREDOC_CMD = "uv run python - <<'EOF'\nprint(1)\nEOF"
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "python -c 'x'",
+        'python3 -c "x"',
+        'uv run python -c "x"',
+        'PYTHONUNBUFFERED=1 uv run python -c "x"',
+    ],
+)
+def test_inline_c_body_flags(cmd: str) -> None:
+    """#1576 plan §4.3: a leading [VAR=val ]*[uv run ]python[3] -c body flags."""
+    r = lint_workload_cmd_inline_interpreter(cmd)
+    assert r.flagged and r.shape == "inline_c"
+    assert r.sentinel_append_stripped is False
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        HEREDOC_CMD,
+        "python - <<EOF\nimport sys\nEOF",
+        "python <<-EOF\nprint(1)\nEOF",
+    ],
+)
+def test_heredoc_body_flags(cmd: str) -> None:
+    """#1576 plan §4.3: a python stdin-heredoc anywhere flags as stdin_heredoc."""
+    r = lint_workload_cmd_inline_interpreter(cmd)
+    assert r.flagged and r.shape == "stdin_heredoc"
+
+
+def test_committed_script_with_sentinel_append_does_not_flag() -> None:
+    """Acceptance 2: the experimenter.md item-11 shape — committed script by
+    path + the trailing write_completion_sentinel append — never flags."""
+    r = lint_workload_cmd_inline_interpreter(
+        "bash scripts/issue1576_run.sh --full" + SENTINEL_APPEND
+    )
+    assert not r.flagged and r.shape is None
+    assert r.sentinel_append_stripped is True
+
+
+def test_inline_body_with_sentinel_append_still_flags() -> None:
+    """Acceptance 3 (strip-then-scan): an inline body that ALSO ends with the
+    sanctioned sentinel append STILL flags."""
+    r = lint_workload_cmd_inline_interpreter('python -c "work()"' + SENTINEL_APPEND)
+    assert r.flagged and r.shape == "inline_c"
+    assert r.sentinel_append_stripped is True
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        'REPO_ROOT="${WORKLOAD_ROOT:-$PWD}" bash scripts/driver.sh',
+        "uv run python scripts/driver.py --full",
+    ],
+)
+def test_committed_script_by_path_not_flagged(cmd: str) -> None:
+    """#1576 plan §4.3: committed-script-by-path bodies never flag."""
+    r = lint_workload_cmd_inline_interpreter(cmd)
+    assert not r.flagged and r.shape is None and r.sentinel_append_stripped is False
+
+
+@pytest.mark.parametrize("cmd", ["", "   "])
+def test_inline_lint_empty_cmd_noop(cmd: str) -> None:
+    """Acceptance 4: empty/whitespace cmd (a --hydra launch) is a no-op."""
+    r = lint_workload_cmd_inline_interpreter(cmd)
+    assert r == WorkloadCmdInlineLint(flagged=False, shape=None, sentinel_append_stripped=False)
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        # Mid-chain non-sentinel `&& python -c` after a committed-script body.
+        'bash scripts/a.sh && python -c "probe"',
+        'bash scripts/a.sh &&  python -c "probe"',
+        # bash -c / sh -c wrapping (critic fold-in rows).
+        "bash -c 'python -c \"x\"'",
+        "sh -c 'python -c \"x\"'",
+        # python -m module bodies.
+        "uv run python -m explore_persona_space.orchestrate.preflight",
+        # The no-space -c'x' shape (the lookahead requires whitespace).
+        "python -c'x'",
+    ],
+)
+def test_inline_deliberate_v1_false_negatives(cmd: str) -> None:
+    """Pins the docstring's NAMED deliberate v1 false negatives: these shapes
+    do NOT flag today — a future widening is a conscious change."""
+    r = lint_workload_cmd_inline_interpreter(cmd)
+    assert not r.flagged and r.shape is None
+
+
+def test_sentinel_token_smuggle_is_deliberate_v1_false_negative() -> None:
+    """Critic fold-in: an inline body smuggling the sentinel token —
+    ``true && uv run python -c "<staging>; ...write_completion_sentinel(...)"``
+    — post-strips to ``true`` and does NOT flag. Pinned as a NAMED deliberate
+    v1 false negative (the strip keys on the token alone)."""
+    r = lint_workload_cmd_inline_interpreter(
+        'true && uv run python -c "stage_inputs(); '
+        "from explore_persona_space.backends.artifacts import write_completion_sentinel; "
+        "write_completion_sentinel('/workspace/logs/issue-1576-results.json')\""
+    )
+    assert not r.flagged and r.shape is None
+    assert r.sentinel_append_stripped is True
+
+
+def test_strip_sentinel_append_direct() -> None:
+    """strip_sentinel_append: strips ONLY a tail whose remainder mentions the
+    sentinel token; a non-sentinel `&& python -c` tail is left untouched."""
+    body, stripped = strip_sentinel_append("bash scripts/x.sh" + SENTINEL_APPEND)
+    # The strip removes from the leftmost `&&` join; the pre-join trailing
+    # whitespace stays (harmless — the scan regexes are start-anchored).
+    assert stripped is True and body.rstrip() == "bash scripts/x.sh"
+    cmd = 'bash scripts/x.sh && python -c "probe"'
+    body, stripped = strip_sentinel_append(cmd)
+    assert stripped is False and body == cmd
+
+
+# ---------------------------------------------------------------------------
+# Inline-interpreter WARN arm (#1576) — CLI wiring
+# ---------------------------------------------------------------------------
+
+
+def _inline_warnings(caplog) -> list[str]:
+    return [
+        rec.getMessage()
+        for rec in caplog.records
+        if rec.levelno >= logging.WARNING and "inline interpreter one-liner" in rec.getMessage()
+    ]
+
+
+def test_launch_inline_c_body_warns_flags_marker_and_proceeds(
+    monkeypatch, tmp_path, caplog
+) -> None:
+    """Acceptance 1: an inline -c body on auto → exit 0, backend launched, one
+    loud warning naming the anti-pattern + #1482 + the fix, and
+    ``extra.workload_cmd_inline_interpreter`` on the posted marker."""
+    _cd_to_tmp(monkeypatch, tmp_path)
+    nibi = _MockBackend(kind="nibi")
+    marker_posts: list[dict] = []
+    factory = _build_mock_factory(
+        runpod=_MockBackend(kind="runpod"), nibi=nibi, marker_posts=marker_posts
+    )
+
+    from scripts.dispatch_issue import main
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = main(
+            ["launch", "--issue", "825", "--intent", "lora-7b", "--workload-cmd", INLINE_C_CMD],
+            backends_factory=factory,
+        )
+    assert rc == 0
+    assert len(nibi.launches) == 1
+    warnings = _inline_warnings(caplog)
+    assert len(warnings) == 1, "expected exactly one inline-interpreter warning"
+    assert "inline_c" in warnings[0]
+    assert "#1482" in warnings[0]
+    assert "committed" in warnings[0]
+    extras = _backend_selected_extras(marker_posts)
+    assert extras, "expected an epm:backend-selected post"
+    assert all(
+        e.get("workload_cmd_inline_interpreter")
+        == {"shape": "inline_c", "sentinel_append_stripped": False}
+        for e in extras
+    )
+
+
+def test_launch_sentinel_append_committed_script_no_inline_warning(
+    monkeypatch, tmp_path, caplog
+) -> None:
+    """Acceptance 2 at launch level: committed script + sanctioned sentinel
+    append → no inline warning, no inline extra key, exit 0."""
+    _cd_to_tmp(monkeypatch, tmp_path)
+    nibi = _MockBackend(kind="nibi")
+    marker_posts: list[dict] = []
+    factory = _build_mock_factory(
+        runpod=_MockBackend(kind="runpod"), nibi=nibi, marker_posts=marker_posts
+    )
+
+    from scripts.dispatch_issue import main
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = main(
+            [
+                "launch",
+                "--issue",
+                "825",
+                "--intent",
+                "lora-7b",
+                "--workload-cmd",
+                "bash scripts/issue1576_run.sh --full" + SENTINEL_APPEND,
+            ],
+            backends_factory=factory,
+        )
+    assert rc == 0
+    assert len(nibi.launches) == 1
+    assert not _inline_warnings(caplog)
+    for extra in _backend_selected_extras(marker_posts):
+        assert "workload_cmd_inline_interpreter" not in extra
+
+
+def test_launch_strict_flag_does_not_upgrade_inline_arm(monkeypatch, tmp_path, caplog) -> None:
+    """Critic fold-in (non-upgrade contract, §11 D1): --strict-workload-cmd-env
+    + an inline -c body (no lane-env refs) → exit 0, launch proceeds, and the
+    WARN-only inline warning still fires — the strict flag stays
+    lane-env-scoped and never upgrades this arm to a refusal."""
+    _cd_to_tmp(monkeypatch, tmp_path)
+    nibi = _MockBackend(kind="nibi")
+    factory = _build_mock_factory(runpod=_MockBackend(kind="runpod"), nibi=nibi)
+
+    from scripts.dispatch_issue import main
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = main(
+            [
+                "launch",
+                "--issue",
+                "825",
+                "--intent",
+                "lora-7b",
+                "--strict-workload-cmd-env",
+                "--workload-cmd",
+                INLINE_C_CMD,
+            ],
+            backends_factory=factory,
+        )
+    assert rc == 0
+    assert len(nibi.launches) == 1
+    assert _inline_warnings(caplog), "the WARN-only inline warning must still fire under strict"
+
+
+def test_kill_switch_env_skips_inline_lint(monkeypatch, tmp_path, caplog) -> None:
+    """Acceptance 4: EPM_SKIP_WORKLOAD_CMD_ENV_LINT=1 + an inline -c body →
+    exit 0, no warning, no inline extra key, and one info line naming the
+    silenced hit (operator symmetry with the family gate)."""
+    _cd_to_tmp(monkeypatch, tmp_path)
+    monkeypatch.setenv("EPM_SKIP_WORKLOAD_CMD_ENV_LINT", "1")
+    caplog.set_level(logging.INFO, logger="dispatch_issue")
+    nibi = _MockBackend(kind="nibi")
+    marker_posts: list[dict] = []
+    factory = _build_mock_factory(
+        runpod=_MockBackend(kind="runpod"), nibi=nibi, marker_posts=marker_posts
+    )
+
+    from scripts.dispatch_issue import main
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = main(
+            ["launch", "--issue", "825", "--intent", "lora-7b", "--workload-cmd", INLINE_C_CMD],
+            backends_factory=factory,
+        )
+    assert rc == 0
+    assert len(nibi.launches) == 1
+    assert not _inline_warnings(caplog)
+    infos = [
+        rec.getMessage()
+        for rec in caplog.records
+        if rec.levelno == logging.INFO and "inline-interpreter" in rec.getMessage()
+    ]
+    assert len(infos) == 1
+    assert "inline_c" in infos[0]
+    for extra in _backend_selected_extras(marker_posts):
+        assert "workload_cmd_inline_interpreter" not in extra


### PR DESCRIPTION
Closes task #1576.

## Summary
- Adds a WARN-only inline-interpreter detection arm to the #1329 workload-cmd dispatch lint (incident #1482 class): flags a `python -c` / `python3 -c` / `uv run python -c` leading body and `python - <<EOF` stdin heredocs, scanning the RAW cmd.
- Exempts the experimenter.md item-11 sanctioned `&& uv run python -c "...write_completion_sentinel..."` append via strip-then-scan (inline body + append still flags).
- Never blocks a launch; `--strict-workload-cmd-env` does NOT upgrade it (test-pinned); shared `EPM_SKIP_WORKLOAD_CMD_ENV_LINT=1` kill switch; marker `extra.workload_cmd_inline_interpreter`.

## Test plan
- [x] 25 new tests in tests/test_workload_cmd_env_lint.py (59 in file, all green)
- [x] Step 9c gate: 5529 passed / 6 skipped; baseline compare new=[] / ruff_delta=null
- [x] ruff check + format clean on the 3 touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)