### PR TITLE
task #1574: extend the trigger-dense structural digest to the GCP/SLURM lane excerpts

### DIFF
--- a/.claude/rules/workflow-fix-on-bug.md
+++ b/.claude/rules/workflow-fix-on-bug.md
@@ -557,13 +557,22 @@ normalize(s) = s.lower(), collapse internal whitespace to single spaces, strip
 - **FALLBACK (documented, WORKING):** the body's `## Provenance`
   `workflow_fix_target: <path>` line (written verbatim by `--body-file`)
   — grepped when the title/tag surfaces are insufficient.
+- **Tag-vs-body-line authority on the /daily route-2 channel (#1580):** the
+  `wf-fix-fp` tag is manifest-computed and AUTHORITATIVE; since #1580 the
+  driver (`daily_drive_filings.ensure_wf_fix_provenance`) reconciles the body's
+  anchored `- fingerprint:` line to the tag value, preserving a differing
+  candidate-block fp as a labeled substring (`(tag-authoritative; supersedes
+  body-carried fingerprint: <old>)`). Pre-#1580 landed bodies (#1554–#1571,
+  #1579) may carry a differing body fp — both values remain individually
+  matchable by the tag-OR-body-line predicates, so neither is dead as a key.
 - **NEVER** route any dedup key through `set_body` — it strips leading
   frontmatter except `paper`/`abstract`.
 
 **Dedup predicate (exact):** a candidate is a duplicate iff there exists a
 task with `kind: infra` AND a `workflow-fix:` or `daily-fix:` title prefix
-(`task_workflow.WF_FIX_TITLE_PREFIXES`) AND a
-`wf-fix-fp:<fp>` tag matching the candidate's fingerprint AND a
+(`task_workflow.WF_FIX_TITLE_PREFIXES`) AND the candidate's fingerprint
+(matched via the `wf-fix-fp:<fp>` tag OR a body `fingerprint: <fp>` line —
+the canonical code's OR, `task_workflow.is_open_workflow_fix_task`) AND a
 `## Provenance` `workflow_fix_target:` line EXACTLY string-matching the
 candidate's `target_file` AND whose status is NOT in the terminal set
 `{completed, archived}`. Same file + DIFFERENT fingerprint is NOT a

--- a/scripts/poll_pipeline.py
+++ b/scripts/poll_pipeline.py
@@ -179,9 +179,11 @@ On a workload declared trigger-dense (task tag ``trigger-dense``,
 #1556), ``log_tail_excerpt`` instead carries a bounded structural
 digest — pattern counts + status/phase/pid liveness + the log path,
 never raw tail lines — and the post-done phase lines are reduced to
-bare ``[phase=<token>]`` tokens (see ``_digest_tail_excerpt`` /
-``_issue_trigger_dense``; ``crash_signature`` stays raw — it is the
-in-process machine surface, never emitted to stdout).
+bare ``[phase=<token>]`` tokens (see the shared
+``explore_persona_space.backends.excerpt_digest`` module (#1574) behind
+the ``_digest_tail_excerpt`` / ``_issue_trigger_dense`` aliases;
+``crash_signature`` stays raw — it is the in-process machine surface,
+never emitted to stdout).
 
 Staleness ALSO folds in per-phase logs + GPU utilization (incident
 #468 multi-phase training-sweep): a launcher that writes
@@ -376,6 +378,7 @@ _SRC = _REPO_ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
+import explore_persona_space.backends.excerpt_digest as _excerpt_digest  # noqa: E402
 from explore_persona_space.task_workflow import (  # noqa: E402
     EVENT_NOTE_MAX,
     find_task_path,
@@ -1146,8 +1149,10 @@ class PollResult:
     # The 5-line excerpt of the freshest log tail — REPLACED by a bounded
     # structural digest (pattern counts + status/phase/pid + log path; NO raw
     # line content) when the issue's workload is declared trigger-dense
-    # (task tag ``trigger-dense``; #1556 — see ``_digest_tail_excerpt``;
-    # ``log_tail_digested`` below records which form this tick carries).
+    # (task tag ``trigger-dense``; #1556 — see the shared
+    # ``backends/excerpt_digest.py`` implementation (#1574) behind the
+    # ``_digest_tail_excerpt`` alias; ``log_tail_digested`` below records
+    # which form this tick carries).
     log_tail_excerpt: str
     gate: str | None = None  # set when a drained sentinel carried a non-empty gate
     sentinels_processed: int = 0
@@ -4792,39 +4797,18 @@ def _log_staleness_secs(
     return last_mtime_ago, phase_log_mtime_ago, shard_log_mtime_ago, output_mtime_ago
 
 
-# The task tag that declares a workload trigger-dense (#1556). Set at dispatch
-# per .claude/rules/trigger-dense-review.md's recognition heuristic via
-# `task.py add-tag <N> trigger-dense`; read fresh every tick (no caching), so a
-# mid-run add-tag takes effect on the next poll.
-_TRIGGER_DENSE_TAG = "trigger-dense"
-
-# Mirror of ``backend_poll.CUDA_IMA_SIGNATURE`` — ``backend_poll`` imports FROM
-# this module, so the reverse import would be circular; the compiled pattern is
-# mirrored here and pinned byte-in-sync by tests/test_poll_pipeline_digest.py::
-# test_digest_cuda_ima_flag_matches_backend_poll_signature (pattern + flags
-# equality). The digest's structural flag fires on the REAL signature family
-# (including the engine-dead alternatives), never a bare substring (#1556).
-_CUDA_IMA_SIGNATURE = re.compile(
-    r"CUDA error:\s*an illegal memory access was encountered"
-    r"|illegal memory access was encountered"
-    r"|EngineDeadError"
-    r"|Engine core proc \S+ died unexpectedly",
-    re.IGNORECASE,
-)
-
-# Case-insensitive per-line substring counts for the trigger-dense digest — the
-# trigger-dense-review.md item-1 pattern set ('error|traceback|killed|OOM')
-# plus the CUDA-IMA class as a human-facing count. The machine contract is the
-# ``_CUDA_IMA_SIGNATURE`` structural flag in ``_digest_tail_excerpt`` — the
-# ``cuda_ima`` COUNT and the flag may legitimately disagree (count=0 with the
-# flag present on an engine-dead-only tail); that is correct, not a bug.
-_DIGEST_PATTERNS: tuple[tuple[str, str], ...] = (
-    ("error", "error"),
-    ("traceback", "traceback"),
-    ("killed", "killed"),
-    ("oom", "oom"),
-    ("cuda_ima", "illegal memory access"),
-)
+# #1574: the trigger-dense structural-digest helpers (tag constant, CUDA-IMA
+# mirror, pattern set, digest builder, tag predicate) moved to the shared src
+# module ``explore_persona_space.backends.excerpt_digest`` — ONE implementation
+# for this RunPod-lane poller AND the GCP/SLURM lane monitors, which build
+# their own ``log_tail_excerpt`` strings. Assignment ALIASES (not
+# ``from X import Y`` — assignments cannot be stripped by an unused-import
+# autofix) keep every internal caller and the #1556 test surface
+# (tests/test_poll_pipeline_digest.py) green unchanged.
+_TRIGGER_DENSE_TAG = _excerpt_digest.TRIGGER_DENSE_TAG
+_CUDA_IMA_SIGNATURE = _excerpt_digest.CUDA_IMA_SIGNATURE_MIRROR
+_DIGEST_PATTERNS = _excerpt_digest.DIGEST_PATTERNS
+_digest_tail_excerpt = _excerpt_digest.digest_tail_excerpt
 
 
 def _issue_trigger_dense(issue: int) -> bool:
@@ -4834,32 +4818,14 @@ def _issue_trigger_dense(issue: int) -> bool:
     gated-content corpora, knowable before any read), or when the task EXISTS
     but its state is unreadable (fail SAFE toward digest, loudly).
 
-    A missing task (``FileNotFoundError`` — ad-hoc/synthetic polls; includes
-    ``StaleTaskPathError``, its subclass) has no declaration surface at all
-    -> False (raw excerpt, today's behavior). Fresh read every tick, no
-    caching: ``task.py add-tag <N> trigger-dense`` mid-run takes effect on the
-    next tick — a live mitigation lever during an unfolding incident. The
-    catch taxonomy mirrors the audited pod_lifecycle pre-terminate set
-    (FileNotFoundError = not in registry/on disk; RuntimeError = branch-guard;
-    ValueError = malformed frontmatter/registry; OSError = unreadable file);
-    anything else propagates (fail-fast).
+    Thin wrapper over the shared ``excerpt_digest.issue_trigger_dense``
+    (#1574 — body + exception taxonomy live there, verbatim #1556 semantics).
     """
-    try:
-        task = get_task(issue)
-    except FileNotFoundError:
-        log.info("trigger-dense check: task #%s not found (ad-hoc poll); raw excerpt", issue)
-        return False
-    except (RuntimeError, ValueError, OSError) as exc:
-        log.warning(
-            "trigger-dense tag read FAILED for issue %s (%s: %s); failing SAFE "
-            "toward digest-on-unknown (raw tail stays readable at the log path)",
-            issue,
-            type(exc).__name__,
-            exc,
-        )
-        return True
-    tags = (task.get("frontmatter") or {}).get("tags") or []
-    return _TRIGGER_DENSE_TAG in tags
+    # ``get_task`` resolves from THIS module's globals at call time, so the
+    # existing ``monkeypatch.setattr(pp, "get_task", ...)`` tests keep
+    # working; ``log`` is poll_pipeline's own "poll_pipeline" logger so the
+    # caplog INFO/WARNING assertions keep capturing.
+    return _excerpt_digest.issue_trigger_dense(issue, get_task_fn=get_task, log=log)
 
 
 def _phase_token_only(line: str) -> str:
@@ -4873,45 +4839,8 @@ def _phase_token_only(line: str) -> str:
     return f"[phase={m.group(1)}]" if m else "[phase=?]"
 
 
-def _digest_tail_excerpt(
-    wide_tail: str,
-    *,
-    status: str,
-    current_phase: str,
-    pid_alive: bool,
-    source: str,
-    log_path: str,
-    mtime_sec_ago: int,
-) -> str:
-    """Bounded structural digest replacing the raw excerpt on trigger-dense runs.
-
-    Pure + deterministic: pattern counts over the wide tail, the poller's own
-    verdict fields (status/phase/pid liveness — the exit-state information
-    this seam actually has; the workload's numeric rc lands in the sentinel
-    channel and in the log the script-side ``failure_classifier.py --log``
-    reads), the winning log source + path, and tail size/staleness. NO raw
-    log line content is inlined — inherently secret-safe (nothing to scrub).
-    The CUDA-IMA structural flag preserves the one content-coupled machine
-    contract (``backend_poll._prior_failure_marker_is_cuda_ima`` regex over
-    ``epm:failure`` notes — the #775 cross-pod fallback) on digested notes.
-    """
-    lines = wide_tail.splitlines()
-    low = [ln.lower() for ln in lines]
-    counts = {name: sum(1 for ln in low if pat in ln) for name, pat in _DIGEST_PATTERNS}
-    counts_s = " ".join(f"{k}={v}" for k, v in counts.items())
-    out = (
-        f"[trigger-dense digest] status={status} phase={current_phase} "
-        f"pid_alive={pid_alive} source={source} log={log_path} "
-        f"tail_lines={len(lines)} tail_bytes={len(wide_tail.encode('utf-8', 'replace'))} "
-        f"log_mtime_sec_ago={mtime_sec_ago} pattern_counts({counts_s}); "
-        f"raw tail NOT inlined (trigger-dense workload; classify via "
-        f"scripts/failure_classifier.py --log <path>)"
-    )
-    if _CUDA_IMA_SIGNATURE.search(wide_tail):
-        # Flag phrase chosen to MATCH signature alternative 2 so the #775
-        # cross-pod marker-note fallback keeps firing on digested notes.
-        out += " cuda_ima_flag: illegal memory access was encountered (structural flag)"
-    return out
+# (#1574) ``_digest_tail_excerpt`` is the assignment alias above — the body
+# lives in ``explore_persona_space.backends.excerpt_digest.digest_tail_excerpt``.
 
 
 def _freshest_wide_tail(

--- a/src/explore_persona_space/backends/excerpt_digest.py
+++ b/src/explore_persona_space/backends/excerpt_digest.py
@@ -1,0 +1,149 @@
+"""Shared #1556 trigger-dense structural-digest helpers (#1574).
+
+ONE implementation consumed by ``scripts/poll_pipeline.py`` (the RunPod-lane
+poller, via assignment aliases + a thin ``_issue_trigger_dense`` wrapper) and
+the GCP / SLURM lane monitors (``backends/gcp.py`` /
+``backends/slurm_monitor.py``), which build their OWN ``log_tail_excerpt``
+strings and were the named residual raw channels pre-#1574.
+
+``src/`` never imports ``scripts/``: the CUDA-IMA regex here is a MIRROR of
+``backend_poll.CUDA_IMA_SIGNATURE`` (``backend_poll`` is scripts-side and
+imports ``poll_pipeline``, so a src import of it would be both barred and
+circular). The mirror is pinned byte-in-sync by
+``tests/test_poll_pipeline_digest.py::test_digest_cuda_ima_flag_matches_backend_poll_signature``
+(through the poll_pipeline alias) and
+``tests/test_backend_excerpt_digest.py::test_cuda_ima_mirror_matches_backend_poll``
+(directly against this module).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# The task tag that declares a workload trigger-dense (#1556). Set at dispatch
+# per .claude/rules/trigger-dense-review.md's recognition heuristic via
+# `task.py add-tag <N> trigger-dense`; read fresh every tick (no caching), so a
+# mid-run add-tag takes effect on the next poll.
+TRIGGER_DENSE_TAG = "trigger-dense"
+
+# Mirror of ``backend_poll.CUDA_IMA_SIGNATURE`` — see the module docstring for
+# why the real one cannot be imported from src/. The digest's structural flag
+# fires on the REAL signature family (including the engine-dead alternatives),
+# never a bare substring (#1556).
+CUDA_IMA_SIGNATURE_MIRROR = re.compile(
+    r"CUDA error:\s*an illegal memory access was encountered"
+    r"|illegal memory access was encountered"
+    r"|EngineDeadError"
+    r"|Engine core proc \S+ died unexpectedly",
+    re.IGNORECASE,
+)
+
+# Case-insensitive per-line substring counts for the trigger-dense digest — the
+# trigger-dense-review.md item-1 pattern set ('error|traceback|killed|OOM')
+# plus the CUDA-IMA class as a human-facing count. The machine contract is the
+# ``CUDA_IMA_SIGNATURE_MIRROR`` structural flag in ``digest_tail_excerpt`` —
+# the ``cuda_ima`` COUNT and the flag may legitimately disagree (count=0 with
+# the flag present on an engine-dead-only tail); that is correct, not a bug.
+DIGEST_PATTERNS: tuple[tuple[str, str], ...] = (
+    ("error", "error"),
+    ("traceback", "traceback"),
+    ("killed", "killed"),
+    ("oom", "oom"),
+    ("cuda_ima", "illegal memory access"),
+)
+
+
+def issue_trigger_dense(
+    issue: int,
+    *,
+    get_task_fn: Callable[[int], dict[str, Any]] | None = None,
+    log: logging.Logger = logger,
+) -> bool:
+    """True when the issue's workload is declared trigger-dense (task tag
+    ``trigger-dense`` — set at dispatch per trigger-dense-review.md's
+    recognition heuristic: the run trains/evals on guard/security surfaces or
+    gated-content corpora, knowable before any read), or when the task EXISTS
+    but its state is unreadable (fail SAFE toward digest, loudly).
+
+    A missing task (``FileNotFoundError`` — ad-hoc/synthetic polls; includes
+    ``StaleTaskPathError``, its subclass) has no declaration surface at all
+    -> False (raw excerpt, today's behavior). Fresh read every tick, no
+    caching: ``task.py add-tag <N> trigger-dense`` mid-run takes effect on the
+    next tick — a live mitigation lever during an unfolding incident. The
+    catch taxonomy mirrors the audited pod_lifecycle pre-terminate set
+    (FileNotFoundError = not in registry/on disk; RuntimeError = branch-guard;
+    ValueError = malformed frontmatter/registry; OSError = unreadable file);
+    anything else propagates (fail-fast).
+
+    Injection seams (#1574): ``get_task_fn`` defaults to a LAZY
+    ``task_workflow.get_task`` import inside the function — keeps this module
+    import-light and cycle-proof, mirroring the lanes' existing lazy
+    task_workflow imports (``slurm_monitor.build_poll_result`` /
+    ``gcp._guest_persist_breadcrumb``); ``log`` lets ``poll_pipeline`` keep
+    emitting on its own "poll_pipeline" logger (its caplog-pinned
+    INFO/WARNING assertions depend on it).
+    """
+    if get_task_fn is None:
+        from explore_persona_space.task_workflow import get_task as get_task_fn
+    try:
+        task = get_task_fn(issue)
+    except FileNotFoundError:
+        log.info("trigger-dense check: task #%s not found (ad-hoc poll); raw excerpt", issue)
+        return False
+    except (RuntimeError, ValueError, OSError) as exc:
+        log.warning(
+            "trigger-dense tag read FAILED for issue %s (%s: %s); failing SAFE "
+            "toward digest-on-unknown (raw tail stays readable at the log path)",
+            issue,
+            type(exc).__name__,
+            exc,
+        )
+        return True
+    tags = (task.get("frontmatter") or {}).get("tags") or []
+    return TRIGGER_DENSE_TAG in tags
+
+
+def digest_tail_excerpt(
+    wide_tail: str,
+    *,
+    status: str,
+    current_phase: str,
+    pid_alive: bool,
+    source: str,
+    log_path: str,
+    mtime_sec_ago: int,
+) -> str:
+    """Bounded structural digest replacing the raw excerpt on trigger-dense runs.
+
+    Pure + deterministic: pattern counts over the wide tail, the poller's own
+    verdict fields (status/phase/pid liveness — the exit-state information
+    this seam actually has; the workload's numeric rc lands in the sentinel
+    channel and in the log the script-side ``failure_classifier.py --log``
+    reads), the winning log source + path, and tail size/staleness. NO raw
+    log line content is inlined — inherently secret-safe (nothing to scrub).
+    The CUDA-IMA structural flag preserves the one content-coupled machine
+    contract (``backend_poll._prior_failure_marker_is_cuda_ima`` regex over
+    ``epm:failure`` notes — the #775 cross-pod fallback) on digested notes.
+    """
+    lines = wide_tail.splitlines()
+    low = [ln.lower() for ln in lines]
+    counts = {name: sum(1 for ln in low if pat in ln) for name, pat in DIGEST_PATTERNS}
+    counts_s = " ".join(f"{k}={v}" for k, v in counts.items())
+    out = (
+        f"[trigger-dense digest] status={status} phase={current_phase} "
+        f"pid_alive={pid_alive} source={source} log={log_path} "
+        f"tail_lines={len(lines)} tail_bytes={len(wide_tail.encode('utf-8', 'replace'))} "
+        f"log_mtime_sec_ago={mtime_sec_ago} pattern_counts({counts_s}); "
+        f"raw tail NOT inlined (trigger-dense workload; classify via "
+        f"scripts/failure_classifier.py --log <path>)"
+    )
+    if CUDA_IMA_SIGNATURE_MIRROR.search(wide_tail):
+        # Flag phrase chosen to MATCH signature alternative 2 so the #775
+        # cross-pod marker-note fallback keeps firing on digested notes.
+        out += " cuda_ima_flag: illegal memory access was encountered (structural flag)"
+    return out

--- a/src/explore_persona_space/backends/gcp.py
+++ b/src/explore_persona_space/backends/gcp.py
@@ -126,6 +126,13 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+# Direct-submodule import (NOT ``from explore_persona_space.backends import
+# ...``): this module is itself imported DURING the package __init__'s
+# execution, so the submodule form is the cycle-safe binding (#1574 — the
+# same shape as the .artifacts / .base imports below). Bound as the MODULE so
+# tests can monkeypatch ``excerpt_digest.issue_trigger_dense`` at the shared
+# module object.
+import explore_persona_space.backends.excerpt_digest as excerpt_digest
 from explore_persona_space.backends.artifacts import (
     DEFAULT_HF_DATA_REPO,
     DEFAULT_HF_MODEL_REPO,
@@ -5434,6 +5441,15 @@ class GcpBackend(ComputeBackend):
                 drain_alarm_class,
             ) = self._drain_sentinels(handle, zone)
 
+            # #1574: per-tick trigger-dense declaration read (#1556 semantics
+            # — fresh read, so a mid-run `task.py add-tag <N> trigger-dense`
+            # takes effect on the next tick). VM-side by construction: this
+            # poll runs gcloud subprocesses from the orchestrator VM, never on
+            # the instance. The ``issue > 0`` guard mirrors _drain_sentinels'
+            # own pre-SSH skip — issue-less ad-hoc handles never read tags.
+            issue = int(handle.extra.get("issue") or 0)
+            trigger_dense = issue > 0 and excerpt_digest.issue_trigger_dense(issue, log=logger)
+
             def _with_drain(base: PollResult) -> PollResult:
                 return _overlay_drain(
                     base,
@@ -5442,6 +5458,8 @@ class GcpBackend(ComputeBackend):
                     alarm=drain_alarm,
                     log_tail=drain_log_tail,
                     log_mtime_ago=drain_log_mtime_ago,
+                    trigger_dense=trigger_dense,
+                    log_path=handle.log_path or "",
                 )
 
             # A RUNNING VM is ambiguous: booting, mid-workload, or DONE
@@ -5490,7 +5508,9 @@ class GcpBackend(ComputeBackend):
                 if relaunch is not None:
                     pid, log_abs = relaunch
                     return _with_drain(
-                        self._probe_relaunched_workload(handle, zone, pid=pid, log_path=log_abs)
+                        self._probe_relaunched_workload(
+                            handle, zone, pid=pid, log_path=log_abs, trigger_dense=trigger_dense
+                        )
                     )
             if phase == "done":
                 return _with_drain(
@@ -6231,7 +6251,13 @@ class GcpBackend(ComputeBackend):
         return int(pid_m.group(1)), log_m.group(1)
 
     def _probe_relaunched_workload(
-        self, handle: RunHandle, zone: str, *, pid: int, log_path: str
+        self,
+        handle: RunHandle,
+        zone: str,
+        *,
+        pid: int,
+        log_path: str,
+        trigger_dense: bool = False,
     ) -> PollResult:
         """Probe the relaunched workload's pid + log over ssh sudo.
 
@@ -6248,6 +6274,12 @@ class GcpBackend(ComputeBackend):
         * probe transport failure → typed ``stalled`` tick (the
           "couldn't ask" ≠ "not running" discipline, #535) — never read
           a probe failure as a terminal verdict.
+
+        ``trigger_dense`` (#1574): when the workload is declared
+        trigger-dense the EMITTED ``log_tail_excerpt`` at all three
+        classification sites is the shared #1556 structural digest of the
+        relaunch tail; the ``latest_phase`` done-corroboration below stays
+        on the RAW ``tail_full`` — detection is never gated.
         """
         quoted_log = shlex.quote(log_path)
         script = (
@@ -6291,6 +6323,23 @@ class GcpBackend(ComputeBackend):
         # and the done-corroboration below scans the UNtruncated text so a
         # long tail can never push the terminal line out of the parse.
         tail = tail_full[-2000:]
+
+        def _emit(status_: str, phase_: str, alive_: bool) -> str:
+            """#1574: the emitted excerpt for one classification site — the
+            shared digest of the FULL relaunch tail when trigger-dense, else
+            the raw last-2000 slice (byte-identical pre-#1574 behavior)."""
+            if not trigger_dense:
+                return tail
+            return excerpt_digest.digest_tail_excerpt(
+                tail_full,
+                status=status_,
+                current_phase=phase_,
+                pid_alive=alive_,
+                source="gcp_relaunch",
+                log_path=log_path,
+                mtime_sec_ago=min(mtime_ago, 10**9),
+            )
+
         if alive:
             return PollResult(
                 status="running",
@@ -6298,7 +6347,7 @@ class GcpBackend(ComputeBackend):
                 new_milestone=False,
                 last_log_mtime_sec_ago=mtime_ago,
                 pid_alive=True,
-                log_tail_excerpt=tail,
+                log_tail_excerpt=_emit("running", "relaunched_workload", True),
             )
         # pid dead: corroborate done from the relaunch log's phase lines,
         # reusing poll_pipeline's parser (same lazy-import pattern as
@@ -6320,7 +6369,7 @@ class GcpBackend(ComputeBackend):
                 new_milestone=True,
                 last_log_mtime_sec_ago=mtime_ago,
                 pid_alive=False,
-                log_tail_excerpt=tail,
+                log_tail_excerpt=_emit("done", "relaunched_workload_done", False),
             )
         return PollResult(
             status="dead",
@@ -6328,7 +6377,7 @@ class GcpBackend(ComputeBackend):
             new_milestone=True,
             last_log_mtime_sec_ago=mtime_ago,
             pid_alive=False,
-            log_tail_excerpt=tail,
+            log_tail_excerpt=_emit("dead", "relaunched_workload_exited", False),
         )
 
     def fetch_logs(self, handle: RunHandle) -> str:
@@ -6798,6 +6847,8 @@ def _overlay_drain(
     alarm: str,
     log_tail: str,
     log_mtime_ago: int | None = None,
+    trigger_dense: bool = False,
+    log_path: str = "",
 ) -> PollResult:
     """Thread sentinel-drain results into a coarse :class:`PollResult`.
 
@@ -6814,7 +6865,30 @@ def _overlay_drain(
     truthful ``last_log_mtime_sec_ago`` (the coarse poll hardwires
     ``10**9``) so phase-stuck zombies become detectable. Terminal results
     (``done`` / ``dead`` / ``stalled``) keep their own values.
+
+    ``trigger_dense`` / ``log_path`` (#1574): on a trigger-dense workload
+    the raw drain ``log_tail`` component is replaced by the shared #1556
+    structural digest BEFORE the merge. ONLY that component is digested —
+    the drain ``alarm`` (#608 fail-loud diagnosis; lane-built text, never
+    raw workload-log lines) and ``base.log_tail_excerpt`` (empty, or
+    already digested at its own construction site) stay intact: a
+    choke-point digest would swallow those structural diagnostics.
+    Additive kw-only defaults keep every pre-#1574 caller byte-identical.
     """
+    if trigger_dense and log_tail:
+        log_tail = excerpt_digest.digest_tail_excerpt(
+            log_tail,
+            status=base.status,
+            current_phase=base.current_phase,
+            pid_alive=base.pid_alive,
+            source="gcp_drain",
+            log_path=log_path,
+            mtime_sec_ago=(
+                log_mtime_ago
+                if log_mtime_ago is not None
+                else min(base.last_log_mtime_sec_ago, 10**9)
+            ),
+        )
 
     merged_gate = base.gate or gate
     merged = replace(

--- a/src/explore_persona_space/backends/slurm_monitor.py
+++ b/src/explore_persona_space/backends/slurm_monitor.py
@@ -104,6 +104,13 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+# Direct-submodule import (NOT ``from explore_persona_space.backends import
+# ...``): this module is itself imported DURING the package __init__'s
+# execution, so the submodule form is the cycle-safe binding (#1574 — the
+# same shape as the .base / .slurm imports below). Bound as the MODULE so
+# tests can monkeypatch ``excerpt_digest.issue_trigger_dense`` at the shared
+# module object.
+import explore_persona_space.backends.excerpt_digest as excerpt_digest
 from explore_persona_space.backends.base import (
     BackendProbeError,
     PollResult,
@@ -232,6 +239,35 @@ _PHASE_LINE_RE = re.compile(r"\[phase=([a-zA-Z0-9_\-]+)\]")
 _TERMINAL_STATUSES: frozenset[str] = frozenset({"done", "dead"})
 
 
+def _emit_tail(
+    log_tail: str,
+    *,
+    trigger_dense: bool,
+    status: str,
+    current_phase: str,
+    pid_alive: bool,
+    log_path: str,
+    log_mtime_sec_ago: int,
+) -> str:
+    """#1574: the emitted tail for one SLURM emission surface.
+
+    The shared #1556 structural digest when the workload is trigger-dense,
+    else the raw (already-scrubbed) tail returned UNTOUCHED — the untagged
+    arm is byte-identical to pre-#1574 output by construction.
+    """
+    if not trigger_dense:
+        return log_tail
+    return excerpt_digest.digest_tail_excerpt(
+        log_tail,
+        status=status,
+        current_phase=current_phase,
+        pid_alive=pid_alive,
+        source="slurm_job_out",
+        log_path=log_path,
+        mtime_sec_ago=min(log_mtime_sec_ago, 10**9),
+    )
+
+
 def build_poll_result(
     *,
     issue: int,
@@ -352,6 +388,17 @@ def build_poll_result(
     # orchestrator may quote (round-6 C1).
     log_tail = _scrub_secret_tokens(log_tail)
 
+    # #1574: per-tick trigger-dense declaration read (#1556 semantics — one
+    # fresh read per tick, so a mid-run `task.py add-tag <N> trigger-dense`
+    # takes effect on the next tick). VM-side by construction: this monitor
+    # composes SSH/rsync from the orchestrator VM — the cluster node has no
+    # git checkout (module docstring § "No sentinel drain on this lane").
+    # Gates ONLY the emitted excerpt surfaces below (the returned PollResult,
+    # the epm:cluster-poll note, the persisted-terminal synthesis); detection
+    # — the C2 freshness gate above, PREFLIGHT_FAIL_MARKER, phase parsing —
+    # always reads the raw ``log_tail``.
+    trigger_dense = excerpt_digest.issue_trigger_dense(issue, log=logger)
+
     slurm_status = state.get("status", "RUNNING")
 
     # ---- Idempotent-reconnect path: SLURM said UNKNOWN ----
@@ -364,7 +411,10 @@ def build_poll_result(
         persisted = _read_persisted_terminal(issue=issue, job_id=job_id, event_reader=event_reader)
         if persisted is not None:
             return _poll_result_from_persisted_terminal(
-                persisted=persisted, log_tail=log_tail, log_mtime_sec_ago=log_mtime_sec_ago
+                persisted=persisted,
+                log_tail=log_tail,
+                log_mtime_sec_ago=log_mtime_sec_ago,
+                trigger_dense=trigger_dense,
             )
         # No marker either — we genuinely don't know. Default to running
         # so the orchestrator doesn't reap a job we haven't proven dead.
@@ -425,6 +475,22 @@ def build_poll_result(
 
     final_phase = current_phase or slurm_status.lower()
 
+    # #1574: on a trigger-dense workload BOTH emitted excerpt surfaces below
+    # (the epm:cluster-poll note and the returned PollResult) carry the
+    # shared #1556 structural digest instead of raw tail lines. The raw arm
+    # passes ``log_tail`` through untouched (``emit_tail is log_tail`` —
+    # byte-identical untagged output); the digest is a short single line, so
+    # the existing ``[-2000:]`` slices below are no-ops on it.
+    emit_tail = _emit_tail(
+        log_tail,
+        trigger_dense=trigger_dense,
+        status=base_status,
+        current_phase=final_phase,
+        pid_alive=base_status == "running",
+        log_path=str(job_out),
+        log_mtime_sec_ago=log_mtime_sec_ago,
+    )
+
     # ---- Post epm:cluster-poll v1 on transition ----
     # Pass the FULL (already-scrubbed) tail; the poster scrubs again and
     # truncates itself so scrub-before-truncate holds for every caller.
@@ -436,7 +502,7 @@ def build_poll_result(
         slurm_state=slurm_status,
         heartbeat_sec_ago=heartbeat_sec_ago,
         gpu_busy=bool(status_data.get("gpu_busy")),
-        log_tail_excerpt=log_tail,
+        log_tail_excerpt=emit_tail,
         marker_poster=marker_poster,
         event_reader=event_reader,
     )
@@ -479,7 +545,7 @@ def build_poll_result(
         new_milestone=new_milestone,
         last_log_mtime_sec_ago=log_mtime_sec_ago,
         pid_alive=base_status == "running",
-        log_tail_excerpt=log_tail[-2000:],
+        log_tail_excerpt=emit_tail[-2000:],
         gate=None,
         # Always 0 by lane contract — SLURM has no sentinel channel
         # (see module docstring § "No sentinel drain on this lane").
@@ -662,7 +728,11 @@ def _read_persisted_terminal(*, issue: int, job_id: str, event_reader) -> dict[s
 
 
 def _poll_result_from_persisted_terminal(
-    *, persisted: dict[str, Any], log_tail: str, log_mtime_sec_ago: int
+    *,
+    persisted: dict[str, Any],
+    log_tail: str,
+    log_mtime_sec_ago: int,
+    trigger_dense: bool = False,
 ) -> PollResult:
     """Synthesize a :class:`PollResult` from a persisted terminal marker.
 
@@ -671,16 +741,30 @@ def _poll_result_from_persisted_terminal(
     The synthesized result carries the persisted status so the
     orchestrator's polling loop reaches its terminal branch instead of
     looping on a stale "running".
+
+    ``trigger_dense`` (#1574): when the workload is declared trigger-dense
+    the synthesized excerpt is the shared #1556 structural digest of the
+    (possibly stale) local tail; the additive default keeps every
+    pre-#1574 caller byte-identical.
     """
     base_status = persisted.get("status", "dead")
     current_phase = persisted.get("slurm_state", "done").lower()
+    emit_tail = _emit_tail(
+        log_tail,
+        trigger_dense=trigger_dense,
+        status=base_status,
+        current_phase=current_phase,
+        pid_alive=False,
+        log_path="",
+        log_mtime_sec_ago=log_mtime_sec_ago,
+    )
     return PollResult(
         status=base_status,
         current_phase=current_phase,
         new_milestone=False,
         last_log_mtime_sec_ago=log_mtime_sec_ago,
         pid_alive=False,
-        log_tail_excerpt=log_tail[-2000:],
+        log_tail_excerpt=emit_tail[-2000:],
         gate=None,
         # Always 0 by lane contract — SLURM has no sentinel channel
         # (see module docstring § "No sentinel drain on this lane").

--- a/tests/test_backend_excerpt_digest.py
+++ b/tests/test_backend_excerpt_digest.py
@@ -1,0 +1,152 @@
+"""#1574 shared trigger-dense digest module — single-implementation pins.
+
+The #1556 structural-digest helpers moved from ``scripts/poll_pipeline.py``
+into ``explore_persona_space.backends.excerpt_digest`` so the GCP / SLURM
+lane monitors (which build their OWN ``log_tail_excerpt`` strings) consume
+the SAME implementation. These tests pin:
+
+1. poll_pipeline's private names are ALIASES of the shared module's objects
+   (``is``-level identity — the "gauge tests the dispatched path"
+   discipline, ``.claude/rules/code-style.md`` § verification gates);
+2. the shared ``issue_trigger_dense`` body across its four read paths via
+   the injectable ``get_task_fn`` / ``log`` seams (autospec'd boundary —
+   no live-registry read), plus the fail-fast propagation of an unexpected
+   exception class;
+3. the LAZY ``get_task_fn=None`` default resolves ``task_workflow.get_task``
+   at CALL time (pinned hermetically by monkeypatching the task_workflow
+   module attribute — the #1574 critic's explicit default-arm ask);
+4. the CUDA-IMA mirror is byte-in-sync with the REAL
+   ``backend_poll.CUDA_IMA_SIGNATURE`` (direct src-side pin — belt to the
+   aliased pin in tests/test_poll_pipeline_digest.py).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import create_autospec
+
+import pytest
+
+from explore_persona_space.backends import excerpt_digest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Synthetic issue id (never a real task — the live-state coupling class the
+# #1556 plan §4 row 11 names); the #1574 family id, distinct from the sibling
+# poll test files' ids (9556 / 9664 / 9813 / 9999 / 9983 / 9704).
+ISSUE = 9574
+
+
+def _load_script_module(filename: str, alias: str):
+    """Load a ``scripts/*.py`` file as a module (mirrors the
+    ``tests/test_poll_pipeline_digest.py`` loader)."""
+    spec = importlib.util.spec_from_file_location(alias, REPO_ROOT / "scripts" / filename)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[alias] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+pp = _load_script_module("poll_pipeline.py", "poll_pipeline_shared_digest_under_test")
+bp = _load_script_module("backend_poll.py", "backend_poll_shared_digest_under_test")
+
+
+# ── 1. identity: the aliases ARE the shared module's objects ─────────────────
+
+
+def test_shared_module_is_the_dispatched_implementation() -> None:
+    """poll_pipeline dispatches the SHARED implementation, not a copy —
+    ``is``-level identity, so a divergent fork can never reappear silently."""
+    assert pp._digest_tail_excerpt is excerpt_digest.digest_tail_excerpt
+    assert pp._CUDA_IMA_SIGNATURE is excerpt_digest.CUDA_IMA_SIGNATURE_MIRROR
+    assert pp._DIGEST_PATTERNS is excerpt_digest.DIGEST_PATTERNS
+    assert pp._TRIGGER_DENSE_TAG == excerpt_digest.TRIGGER_DENSE_TAG
+
+
+# ── 2. the shared predicate body across its four read paths ──────────────────
+
+
+def test_issue_trigger_dense_injectable_four_arms(caplog: pytest.LogCaptureFixture) -> None:
+    """Real shared body, autospec'd ``get_task_fn`` boundary + passed logger.
+
+    Verbatim #1556 semantics: tag present -> True; other tags -> False;
+    missing task (FileNotFoundError) -> False + INFO ("raw excerpt");
+    unreadable state (RuntimeError class) -> True + loud WARNING ("digest");
+    an unexpected exception class propagates (fail-fast).
+    """
+    from explore_persona_space.task_workflow import get_task as real_get_task
+
+    test_log = logging.getLogger("excerpt-digest-test-log")
+
+    fake = create_autospec(
+        real_get_task,
+        return_value={"status": "running", "frontmatter": {"tags": ["trigger-dense"]}},
+    )
+    assert excerpt_digest.issue_trigger_dense(ISSUE, get_task_fn=fake, log=test_log) is True
+    fake.assert_called_once_with(ISSUE)
+
+    other = create_autospec(
+        real_get_task,
+        return_value={"status": "running", "frontmatter": {"tags": ["keep-running"]}},
+    )
+    assert excerpt_digest.issue_trigger_dense(ISSUE, get_task_fn=other, log=test_log) is False
+
+    fnf = create_autospec(real_get_task, side_effect=FileNotFoundError("task #9574 not found"))
+    with caplog.at_level(logging.INFO, logger="excerpt-digest-test-log"):
+        caplog.clear()
+        assert excerpt_digest.issue_trigger_dense(ISSUE, get_task_fn=fnf, log=test_log) is False
+    infos = [r for r in caplog.records if r.levelno == logging.INFO]
+    assert infos, "missing-task arm must log INFO (not silent)"
+    assert "not found" in infos[0].getMessage()
+    assert "raw excerpt" in infos[0].getMessage()
+
+    boom = create_autospec(
+        real_get_task, side_effect=RuntimeError("branch-guard: HEAD is not main")
+    )
+    with caplog.at_level(logging.WARNING, logger="excerpt-digest-test-log"):
+        caplog.clear()
+        assert excerpt_digest.issue_trigger_dense(ISSUE, get_task_fn=boom, log=test_log) is True
+    warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warns, "unreadable-state arm must WARN loudly (not swallow)"
+    msg = warns[0].getMessage()
+    assert "RuntimeError" in msg and "branch-guard: HEAD is not main" in msg
+    assert "digest" in msg
+
+    unexpected = create_autospec(real_get_task, side_effect=KeyError("boom"))
+    with pytest.raises(KeyError):
+        excerpt_digest.issue_trigger_dense(ISSUE, get_task_fn=unexpected, log=test_log)
+
+
+def test_issue_trigger_dense_lazy_default_resolves_task_workflow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ``get_task_fn=None`` default lazily resolves
+    ``task_workflow.get_task`` at CALL time — pinned hermetically by
+    monkeypatching the task_workflow module attribute, so this test never
+    reads the live registry (the #1574 critic's explicit default-arm ask)."""
+    import explore_persona_space.task_workflow as tw
+
+    calls: list[int] = []
+
+    def fake_get_task(issue: int) -> dict:
+        calls.append(issue)
+        return {"status": "running", "frontmatter": {"tags": ["trigger-dense"]}}
+
+    monkeypatch.setattr(tw, "get_task", fake_get_task)
+    assert excerpt_digest.issue_trigger_dense(ISSUE) is True
+    assert calls == [ISSUE]
+
+
+# ── 3. the CUDA-IMA mirror pin (direct src-side belt) ────────────────────────
+
+
+def test_cuda_ima_mirror_matches_backend_poll() -> None:
+    """``CUDA_IMA_SIGNATURE_MIRROR`` stays byte-in-sync with the REAL
+    ``backend_poll.CUDA_IMA_SIGNATURE`` (pattern + flags) — the #775
+    cross-pod marker-note fallback greps digested notes through it."""
+    assert excerpt_digest.CUDA_IMA_SIGNATURE_MIRROR.pattern == bp.CUDA_IMA_SIGNATURE.pattern
+    assert excerpt_digest.CUDA_IMA_SIGNATURE_MIRROR.flags == bp.CUDA_IMA_SIGNATURE.flags

--- a/tests/test_gcp_excerpt_digest.py
+++ b/tests/test_gcp_excerpt_digest.py
@@ -1,0 +1,288 @@
+"""#1574 GCP-lane trigger-dense structural digest for ``log_tail_excerpt``.
+
+The GCP lane builds its OWN excerpts (the sentinel-drain workload-log tail in
+``_overlay_drain`` + the relaunch-probe tail in ``_probe_relaunched_workload``)
+— pre-#1574 they carried raw log lines into orchestrator-facing surfaces even
+on a trigger-dense run. These tests pin, with a payload sentinel standing in
+for gated-content tail text:
+
+1. ``_overlay_drain`` digests the raw drain ``log_tail`` component when
+   tagged (structural drain-ALARM diagnostics stay verbatim — never
+   digested), and the untagged default-kwargs path is byte-identical;
+2. ``_probe_relaunched_workload`` digests all THREE emission branches
+   (alive / dead+done / dead) while the ``latest_phase`` done-corroboration
+   stays on the RAW tail (detection never gated);
+3. ``GcpBackend.poll`` end-to-end on a RUNNING tick: the tag read comes
+   from ``handle.extra["issue"]`` (pinned by the predicate call args), the
+   whole serialized result is content-free when tagged, the raw drain tail
+   survives untagged, and an issue-less handle NEVER reads tags.
+
+Synthetic issue id 9574 + monkeypatched predicate — never a live task read.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import explore_persona_space.backends.gcp as gcp_mod
+from explore_persona_space.backends import excerpt_digest
+from explore_persona_space.backends.base import PollResult, RunHandle
+from explore_persona_space.backends.gcp import (
+    GcloudRunResult,
+    GcpBackend,
+    GcpConfig,
+    _overlay_drain,
+)
+
+# The drain / relaunch probes lazily import ``scripts.poll_pipeline`` — make
+# the repo root importable exactly as the production entrypoints do.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+ISSUE = 9574
+LOG = f"/workspace/logs/issue-{ISSUE}.log"
+
+# Distinctive payload sentinel standing in for gated-content tail text — the
+# thing that must NEVER reach an orchestrator-facing surface on a tagged run.
+SENTINEL = "XYZZYPAYLOAD9574"
+
+RAW_TAIL = f"RuntimeError: boom {SENTINEL}\n2026 ERROR something failed\nworker exited"
+
+
+def _test_config() -> GcpConfig:
+    return GcpConfig(
+        project="eps-test-project",
+        gcloud_config="eps-test-config",
+        primary_zone="us-central1-a",
+        fallback_zones=("us-central1-b", "us-central1-c"),
+        image_family="pytorch-test-family",
+        image_project="deeplearning-platform-release",
+        repo_url="https://github.com/superkaiba/explore-persona-space.git",
+    )
+
+
+def _handle(*, with_issue: bool = True) -> RunHandle:
+    extra: dict = {"zone": "us-central1-a"}
+    if with_issue:
+        extra["issue"] = ISSUE
+    return RunHandle(
+        backend="gcp",
+        cluster=None,
+        job_id="1",
+        pod_name=f"eps-issue-{ISSUE}",
+        scratch_dir=f"/workspace/eps-issue-{ISSUE}",
+        log_path=LOG,
+        extra=extra,
+    )
+
+
+class _ScriptedRunner:
+    """Minimal argv-keyed scripted runner (the test_gcp_backend.py shape)."""
+
+    def __init__(
+        self,
+        *,
+        describe: list[GcloudRunResult] | None = None,
+        guest_attrs: list[GcloudRunResult] | None = None,
+        ssh: list[GcloudRunResult] | None = None,
+    ) -> None:
+        self.calls: list[list[str]] = []
+        self.describe = list(describe or [])
+        self.guest_attrs = list(guest_attrs or [])
+        self.ssh = list(ssh or [])
+
+    def __call__(self, argv):
+        argv = list(argv)
+        self.calls.append(argv)
+        if "describe" in argv and "instances" in argv:
+            return self.describe.pop(0)
+        if "get-guest-attributes" in argv:
+            return self.guest_attrs.pop(0)
+        if "ssh" in argv and "compute" in argv:
+            return self.ssh.pop(0)
+        raise AssertionError(f"unexpected argv: {argv}")
+
+
+def _guest_attr_payload(value: str) -> str:
+    return json.dumps([{"namespace": "eps", "key": "phase", "value": value}])
+
+
+def _drain_stdout(tail: str) -> str:
+    """Drain SSH stdout: no sentinels, a raw workload-log tail + mtime keys."""
+    return (
+        "EPS_LOGTAIL_START\n"
+        + tail
+        + "\nEPS_LOGTAIL_END\n"
+        + "EPS_LOG_MTIME=100\n"
+        + "EPS_LOG_NOW=160\n"
+    )
+
+
+def _running_base() -> PollResult:
+    return PollResult(
+        status="running",
+        current_phase="workload",
+        new_milestone=False,
+        last_log_mtime_sec_ago=10**9,
+        pid_alive=True,
+        log_tail_excerpt="",
+    )
+
+
+# ── 1. _overlay_drain ─────────────────────────────────────────────────────────
+
+
+def test_overlay_drain_digests_raw_drain_tail_when_tagged() -> None:
+    """Tagged: the raw drain ``log_tail`` component becomes the shared
+    digest (sentinel-free); a non-empty structural drain ALARM wins the
+    merge VERBATIM — lane-built diagnostics are never digested."""
+    out = _overlay_drain(
+        _running_base(),
+        processed=0,
+        gate=None,
+        alarm="",
+        log_tail=RAW_TAIL,
+        log_mtime_ago=120,
+        trigger_dense=True,
+        log_path=LOG,
+    )
+    assert out.log_tail_excerpt.startswith("[trigger-dense digest]")
+    assert SENTINEL not in out.log_tail_excerpt
+    assert "source=gcp_drain" in out.log_tail_excerpt
+    assert f"log={LOG}" in out.log_tail_excerpt
+    assert "log_mtime_sec_ago=120" in out.log_tail_excerpt
+
+    alarm = "gcp sentinel drain FAILED (rc=255): ssh: connect to host refused"
+    out_alarm = _overlay_drain(
+        _running_base(),
+        processed=0,
+        gate=None,
+        alarm=alarm,
+        log_tail=RAW_TAIL,
+        log_mtime_ago=None,
+        trigger_dense=True,
+        log_path=LOG,
+    )
+    assert out_alarm.log_tail_excerpt == alarm
+
+
+def test_overlay_drain_untagged_byte_identical() -> None:
+    """Default kwargs (no trigger_dense / log_path): the raw
+    ``alarm or base or log_tail`` merge, string-EQUAL to the raw tail."""
+    out = _overlay_drain(
+        _running_base(),
+        processed=0,
+        gate=None,
+        alarm="",
+        log_tail=RAW_TAIL,
+        log_mtime_ago=120,
+    )
+    assert out.log_tail_excerpt == RAW_TAIL
+    assert out.last_log_mtime_sec_ago == 120
+
+
+# ── 2. _probe_relaunched_workload (three emission branches) ──────────────────
+
+
+def _relaunch_stdout(*, alive: bool, tail: str) -> str:
+    return (
+        f"EPS_RELAUNCH_PID={'alive' if alive else 'dead'}\n"
+        "EPS_RELAUNCH_MTIME=100\n"
+        "EPS_RELAUNCH_NOW=160\n"
+        "EPS_RELAUNCH_TAIL_START\n" + tail + "\nEPS_RELAUNCH_TAIL_END\n"
+    )
+
+
+def _probe(*, alive: bool, tail: str) -> PollResult:
+    runner = _ScriptedRunner(ssh=[GcloudRunResult(0, _relaunch_stdout(alive=alive, tail=tail), "")])
+    backend = GcpBackend(config=_test_config(), runner=runner, marker_poster=lambda **_: None)
+    return backend._probe_relaunched_workload(
+        _handle(), "us-central1-a", pid=4242, log_path=LOG, trigger_dense=True
+    )
+
+
+def test_probe_relaunched_workload_digests_all_three_branches() -> None:
+    """Tagged: every classification branch emits a sentinel-free digest;
+    the dead+done branch still classifies ``done`` off the RAW tail
+    (``latest_phase`` corroboration is never gated)."""
+    # (a) pid alive -> running.
+    pr = _probe(alive=True, tail=f"2026-07-21 [phase=training] {SENTINEL} step 5")
+    assert pr.status == "running"
+    assert pr.current_phase == "relaunched_workload"
+    assert pr.log_tail_excerpt.startswith("[trigger-dense digest]")
+    assert SENTINEL not in pr.log_tail_excerpt
+    assert "source=gcp_relaunch" in pr.log_tail_excerpt
+
+    # (b) pid dead + [phase=done] in the RAW tail -> done (detection ungated).
+    pr = _probe(
+        alive=False,
+        tail=f"2026-07-21 [phase=training] {SENTINEL}\n2026-07-21 [phase=done] run complete",
+    )
+    assert pr.status == "done"
+    assert pr.current_phase == "relaunched_workload_done"
+    assert pr.log_tail_excerpt.startswith("[trigger-dense digest]")
+    assert SENTINEL not in pr.log_tail_excerpt
+
+    # (c) pid dead, no done -> dead.
+    pr = _probe(alive=False, tail=f"RuntimeError: boom {SENTINEL}\nworker exited")
+    assert pr.status == "dead"
+    assert pr.current_phase == "relaunched_workload_exited"
+    assert pr.log_tail_excerpt.startswith("[trigger-dense digest]")
+    assert SENTINEL not in pr.log_tail_excerpt
+
+
+# ── 3. GcpBackend.poll end-to-end (RUNNING tick with a drain tail) ────────────
+
+
+def _poll_once(monkeypatch: pytest.MonkeyPatch, *, tagged: bool, with_issue: bool = True):
+    """Drive one RUNNING poll tick; returns (result, predicate_mock)."""
+    predicate = MagicMock(return_value=tagged)
+    monkeypatch.setattr(excerpt_digest, "issue_trigger_dense", predicate)
+    runner = _ScriptedRunner(
+        describe=[GcloudRunResult(0, json.dumps({"status": "RUNNING"}), "")],
+        guest_attrs=[GcloudRunResult(0, _guest_attr_payload("workload"), "")],
+        ssh=[GcloudRunResult(0, _drain_stdout(RAW_TAIL), "")],
+    )
+    backend = GcpBackend(config=_test_config(), runner=runner, marker_poster=lambda **_: None)
+    return backend.poll(_handle(with_issue=with_issue)), predicate
+
+
+def test_gcp_poll_running_tagged_end_to_end_content_free(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tagged RUNNING tick: the tag read keys on ``handle.extra['issue']``
+    (predicate called exactly once with 9574), and the WHOLE serialized
+    result carries no raw tail text (the field-scope-illusion killer)."""
+    result, predicate = _poll_once(monkeypatch, tagged=True)
+    predicate.assert_called_once_with(ISSUE, log=gcp_mod.logger)
+    assert result.status == "running"
+    assert result.log_tail_excerpt.startswith("[trigger-dense digest]")
+    serialized = json.dumps(dataclasses.asdict(result))
+    assert SENTINEL not in serialized
+
+
+def test_gcp_poll_running_untagged_raw_drain_tail(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Untagged twin: the raw drain tail reaches the excerpt verbatim."""
+    result, predicate = _poll_once(monkeypatch, tagged=False)
+    predicate.assert_called_once_with(ISSUE, log=gcp_mod.logger)
+    assert result.log_tail_excerpt == RAW_TAIL
+    assert SENTINEL in result.log_tail_excerpt
+
+
+def test_gcp_poll_missing_issue_extra_never_reads_tags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An issue-less handle short-circuits the tag read entirely (the
+    ``issue > 0`` guard mirrors _drain_sentinels' own pre-SSH skip) and the
+    raw path — here the structural SKIPPED alarm — is preserved."""
+    result, predicate = _poll_once(monkeypatch, tagged=True, with_issue=False)
+    assert predicate.call_count == 0
+    # The drain skipped pre-SSH; its structural alarm wins the merge.
+    assert "gcp sentinel drain SKIPPED" in result.log_tail_excerpt

--- a/tests/test_slurm_excerpt_digest.py
+++ b/tests/test_slurm_excerpt_digest.py
@@ -1,0 +1,247 @@
+"""#1574 SLURM-lane trigger-dense structural digest for ``log_tail_excerpt``.
+
+The SLURM monitor builds its OWN excerpt (the rsync'd ``job.out`` tail) and
+emits it on THREE orchestrator-facing surfaces: the returned ``PollResult``,
+the git-committed ``epm:cluster-poll`` marker note, and the
+persisted-terminal synthesis. These tests pin, with a payload sentinel
+standing in for gated-content tail text:
+
+1. tagged: BOTH live surfaces (PollResult + the captured cluster-poll note)
+   carry the shared digest, sentinel-free across the WHOLE note string;
+2. untagged: ``log_tail[-2000:]`` verbatim on both surfaces (byte-equality);
+3. detection is never gated: a tagged run whose raw tail carries
+   ``PREFLIGHT_FAIL_MARKER`` still classifies dead / preflight-failed;
+4. the UNKNOWN -> persisted-terminal synthesis digests when tagged (raw on
+   the untagged twin).
+
+Hermetic: the tag predicate is monkeypatched at the SHARED
+``excerpt_digest`` module (the object ``slurm_monitor`` dispatches
+through), so no test reads the live task registry. Synthetic issue id 9574.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from explore_persona_space.backends import excerpt_digest
+from explore_persona_space.backends.slurm import get_cluster_config
+from explore_persona_space.backends.slurm_monitor import build_poll_result
+
+ISSUE = 9574
+SENTINEL = "XYZZYPAYLOAD9574"
+
+
+def _nibi():
+    return get_cluster_config("nibi")
+
+
+@pytest.fixture(autouse=True)
+def _no_real_marker_posts(monkeypatch):
+    """Defense in depth (mirrors tests/test_slurm_monitor.py): never let a
+    monitor test shell out to the real ``task.py post-marker``."""
+    monkeypatch.setattr(
+        "explore_persona_space.backends.slurm.post_marker_via_task_py",
+        lambda **_kw: None,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_local_state_dir(tmp_path, monkeypatch):
+    """Route ``_local_state_dir`` under pytest's ``tmp_path`` (mirrors the
+    round-6 Mn3 fixture in tests/test_slurm_monitor.py)."""
+    monkeypatch.setattr(
+        "explore_persona_space.backends.slurm_monitor._local_state_dir",
+        lambda job_id: tmp_path / f"slurm-{job_id}",
+    )
+
+
+def _pin_predicate(monkeypatch, value: bool) -> list[int]:
+    """Monkeypatch the SHARED tag predicate; returns the recorded issue ids."""
+    calls: list[int] = []
+
+    def fake(issue: int, **_kw) -> bool:
+        calls.append(issue)
+        return value
+
+    monkeypatch.setattr(excerpt_digest, "issue_trigger_dense", fake)
+    return calls
+
+
+def _seed_local_state(
+    tmp_path: Path,
+    job_id: str,
+    *,
+    status_json_body: dict | None,
+    job_out_lines: list[str] | None,
+) -> None:
+    local_dir = tmp_path / f"slurm-{job_id}"
+    local_dir.mkdir(parents=True, exist_ok=True)
+    if status_json_body is not None:
+        (local_dir / "status.json").write_text(json.dumps(status_json_body))
+    if job_out_lines is not None:
+        (local_dir / "job.out").write_text("\n".join(job_out_lines))
+
+
+def _poll_kwargs(job_id: str, now: datetime, markers: list[dict]) -> dict:
+    return dict(
+        issue=ISSUE,
+        job_id=job_id,
+        cluster=_nibi(),
+        scratch_dir=f"/scratch/tjiral/eps/issue-{ISSUE}",
+        log_path=f"/scratch/tjiral/eps/issue-{ISSUE}/job.out",
+        state_querier=lambda *, robot_alias, job_id: {"status": "RUNNING", "exit_code": None},
+        rsyncer=lambda **_: None,
+        now_fn=lambda: now.timestamp(),
+        marker_poster=lambda **kw: markers.append(kw),
+        event_reader=lambda _issue: [],
+    )
+
+
+RAW_LINES = ["[phase=sft]", f"RuntimeError: boom {SENTINEL}", "2026 ERROR something failed"]
+
+
+def test_build_poll_result_digests_pollresult_and_marker_when_tagged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tagged RUNNING tick: the returned PollResult AND the captured
+    ``epm:cluster-poll`` note both carry the digest; the sentinel is absent
+    from the ENTIRE note string (the field-scope-illusion killer)."""
+    job_id = "957401"
+    now = datetime.now(tz=UTC)
+    fresh_ts = now.isoformat().replace("+00:00", "Z")
+    _seed_local_state(
+        tmp_path,
+        job_id,
+        status_json_body={
+            "phase": "sft",
+            "heartbeat_ts": fresh_ts,
+            "gpu_busy": True,
+            "exit_code": "",
+        },
+        job_out_lines=RAW_LINES,
+    )
+    calls = _pin_predicate(monkeypatch, True)
+    markers: list[dict] = []
+
+    poll = build_poll_result(**_poll_kwargs(job_id, now, markers))
+    assert calls == [ISSUE], "exactly ONE fresh tag read per tick"
+    assert poll.status == "running"
+    assert poll.log_tail_excerpt.startswith("[trigger-dense digest]")
+    assert "source=slurm_job_out" in poll.log_tail_excerpt
+    assert SENTINEL not in poll.log_tail_excerpt
+
+    cluster_polls = [m for m in markers if m.get("marker") == "epm:cluster-poll"]
+    assert cluster_polls, "the transition tick must post epm:cluster-poll"
+    note = str(cluster_polls[0]["note"])
+    assert SENTINEL not in note
+    body = json.loads(note)
+    assert body["log_tail_excerpt"].startswith("[trigger-dense digest]")
+
+
+def test_build_poll_result_untagged_byte_identical(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Untagged twin: ``log_tail[-2000:]`` verbatim on BOTH surfaces —
+    string equality against the seeded raw tail, not startswith."""
+    job_id = "957402"
+    now = datetime.now(tz=UTC)
+    fresh_ts = now.isoformat().replace("+00:00", "Z")
+    _seed_local_state(
+        tmp_path,
+        job_id,
+        status_json_body={
+            "phase": "sft",
+            "heartbeat_ts": fresh_ts,
+            "gpu_busy": False,
+            "exit_code": "",
+        },
+        job_out_lines=RAW_LINES,
+    )
+    _pin_predicate(monkeypatch, False)
+    markers: list[dict] = []
+
+    poll = build_poll_result(**_poll_kwargs(job_id, now, markers))
+    raw = "\n".join(RAW_LINES)
+    assert poll.log_tail_excerpt == raw[-2000:]
+    cluster_polls = [m for m in markers if m.get("marker") == "epm:cluster-poll"]
+    assert cluster_polls
+    body = json.loads(str(cluster_polls[0]["note"]))
+    assert body["log_tail_excerpt"] == raw[-2000:]
+
+
+def test_preflight_fail_detection_fires_on_digested_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Detection is never gated: the raw tail's PREFLIGHT_FAIL_MARKER still
+    classifies dead / preflight-failed on a tagged run, while the emitted
+    excerpt is the sentinel-free digest carrying the verdict fields."""
+    job_id = "957403"
+    now = datetime.now(tz=UTC)
+    _seed_local_state(
+        tmp_path,
+        job_id,
+        status_json_body=None,
+        job_out_lines=[f"[phase=preflight-failed] {SENTINEL} preflight died"],
+    )
+    _pin_predicate(monkeypatch, True)
+    markers: list[dict] = []
+
+    poll = build_poll_result(**_poll_kwargs(job_id, now, markers))
+    assert poll.status == "dead"
+    assert poll.current_phase == "preflight-failed"
+    assert poll.log_tail_excerpt.startswith("[trigger-dense digest]")
+    assert "status=dead" in poll.log_tail_excerpt
+    assert "phase=preflight-failed" in poll.log_tail_excerpt
+    assert SENTINEL not in poll.log_tail_excerpt
+
+
+def _persisted_terminal_event(job_id: str) -> dict:
+    body = {
+        "job_id": job_id,
+        "cluster": "nibi",
+        "slurm_state": "FAILED",
+        "exit_code": "1:0",
+        "observed_at": "2026-07-21T00:00:00Z",
+        "next_action": "investigate",
+        "status": "dead",
+    }
+    return {"kind": "epm:cluster-terminal", "note": json.dumps(body)}
+
+
+@pytest.mark.parametrize("tagged", [True, False])
+def test_persisted_terminal_synthesis_digests_when_tagged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, tagged: bool
+) -> None:
+    """UNKNOWN SLURM state + a persisted ``epm:cluster-terminal`` marker:
+    the synthesized PollResult's excerpt digests when tagged; the untagged
+    twin keeps the raw local tail verbatim."""
+    job_id = "957404"
+    now = datetime.now(tz=UTC)
+    _seed_local_state(
+        tmp_path,
+        job_id,
+        status_json_body=None,
+        job_out_lines=[f"RuntimeError: boom {SENTINEL}", "worker exited"],
+    )
+    _pin_predicate(monkeypatch, tagged)
+    markers: list[dict] = []
+    kwargs = _poll_kwargs(job_id, now, markers)
+    kwargs["state_querier"] = lambda *, robot_alias, job_id: {
+        "status": "UNKNOWN",
+        "exit_code": None,
+    }
+    kwargs["event_reader"] = lambda _issue: [_persisted_terminal_event(job_id)]
+
+    poll = build_poll_result(**kwargs)
+    assert poll.status == "dead"
+    assert poll.current_phase == "failed"
+    if tagged:
+        assert poll.log_tail_excerpt.startswith("[trigger-dense digest]")
+        assert SENTINEL not in poll.log_tail_excerpt
+    else:
+        raw = f"RuntimeError: boom {SENTINEL}\nworker exited"
+        assert poll.log_tail_excerpt == raw[-2000:]


### PR DESCRIPTION
Closes task #1574. Shared backends/excerpt_digest.py module (relocated from scripts/poll_pipeline.py) + GCP/SLURM lane digestion of their own log_tail_excerpt constructions; untagged behavior byte-identical; 3 new test files.