### PR TITLE
task #1581: edit-success gate before new-plan-version persist

### DIFF
--- a/.claude/hooks/guard_trigger_dense_read.sh
+++ b/.claude/hooks/guard_trigger_dense_read.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# PreToolUse(Read) guard: workflow guard scripts are WINDOWED-READ-ONLY
+# (.claude/rules/trigger-dense-review.md § Orchestrator ordinary turns,
+# item 2 — #1563). Mechanizes the single-call READ channel only: a Read of
+# a guard hook script with no `limit` (or `limit` over the cap) is denied;
+# grep-anchored windowed reads (limit <= cap, any offset) pass untouched.
+# The authored-text channel, cross-turn window accumulation, and the
+# Bash/Grep/ssh channels stay rule-side (plan #1577 §4 scope decision).
+#
+# Deny set: (^|/)(scripts|.claude/hooks)/guard_* — the guard scripts
+# THEMSELVES (scripts/guard_*.sh + the .claude/hooks/guard_* family, incl.
+# the .py helper and this file; self-coverage is intentional — this hook
+# parses stdin only and never Reads files, so no recursion). Every member
+# exceeds the 120-line cap (min 210 lines), so none is silently exempt.
+# Motivating incident (2026-07-19): a wholesale Read of
+# scripts/guard_repo_root_branch.sh (128,531 B / 1,983 lines) paged ~41K
+# tokens of trigger-dense text into orchestrator context.
+#
+# Contract: reads the PreToolUse JSON on stdin; exit 0 = allow, exit 2 =
+# blocking deny (stderr fed back to Claude). FAIL-OPEN everywhere: any
+# parse failure / missing jq / non-Read tool / empty path exits 0 — a
+# broken guard must never brick the Read tool fleet-wide.
+# Escape hatch: EPM_ALLOW_GUARD_READ=1 (session env; 1|true|yes).
+# Cap: EPM_GUARD_READ_CAP_LINES (default 120 = the rule's "~120-line
+# windows" bound; non-numeric/absent -> 120).
+set -u
+
+# Session-env escape hatch.
+_allow=$(printf '%s' "${EPM_ALLOW_GUARD_READ:-}" | tr '[:upper:]' '[:lower:]')
+case "$_allow" in 1 | true | yes) exit 0 ;; esac
+
+command -v jq >/dev/null 2>&1 || exit 0 # fail-open: no jq, no verdict
+
+input=$(cat) || exit 0
+tool=$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null) || exit 0
+[ "$tool" = "Read" ] || exit 0 # defensive; the settings.json matcher already scopes to Read
+
+fp=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || exit 0
+[ -n "$fp" ] || exit 0
+
+# Cheap pre-filter: no subprocess spawn on the ordinary-Read hot path.
+# NOTE: the pre-filter runs on the RAW path, so a symlink/alias path not
+# containing 'guard_' skips the realpath arm entirely — accepted for the
+# accidental-read threat model (deliberate evasion has the unguarded Bash
+# channel anyway).
+case "$fp" in *guard_*) ;; *) exit 0 ;; esac
+
+# Deny-set ERE. Dir-anchored but repo-AGNOSTIC: scripts/guard_* /
+# .claude/hooks/guard_* copies in OTHER repos (e.g. the
+# claude-code-workflow mirror) match too — desirable (same trigger-dense
+# family) and stated here so it is not a surprise. Worktree copies match
+# (".../worktrees/issue-N/scripts/guard_x.sh" contains
+# "/scripts/guard_x.sh"); tests/test_guard_*.py and src/**/guard_*.py do
+# NOT (wrong directory).
+DENY_RE='(^|/)(scripts|\.claude/hooks)/guard_[^/]+$'
+
+# realpath-aware like the precedent guard; -m needs no existing file.
+# realpath failure falls back to raw-only matching (fail-open direction).
+resolved=$(realpath -m -- "$fp" 2>/dev/null) || resolved="$fp"
+printf '%s' "$fp" | grep -qE "$DENY_RE" \
+  || printf '%s' "$resolved" | grep -qE "$DENY_RE" \
+  || exit 0
+
+cap="${EPM_GUARD_READ_CAP_LINES:-120}"
+case "$cap" in '' | *[!0-9]*) cap=120 ;; esac # junk/absent -> default
+
+limit=$(printf '%s' "$input" | jq -r '.tool_input.limit // empty' 2>/dev/null) || exit 0
+# Windowed read: a positive integer limit within the cap is the rule's
+# sanctioned pattern — allow, any offset (the bound is the window SIZE,
+# not its position). A present-but-non-numeric limit on an already-matched
+# path is NOT the malformed-input fail-open case (the path match
+# succeeded): deny — the override exists for deliberate full reads.
+case "$limit" in
+  '' | *[!0-9]*) ;; # absent or non-numeric -> fall through to deny
+  *) [ "$limit" -ge 1 ] && [ "$limit" -le "$cap" ] && exit 0 ;;
+esac
+
+echo "BLOCKED: unbounded Read of $fp (${fp##*/} is a trigger-dense guard script; a wholesale read pages it into context — 2026-07-19 incident: ~41K tokens). Read it WINDOWED instead: Grep -n '<anchor>' $fp to locate the span, then Read with offset=<line> and limit<=$cap. Counts/structure only: wc -l, grep -c, git diff --stat. Rule: .claude/rules/trigger-dense-review.md § Orchestrator ordinary turns. Deliberate full read: EPM_ALLOW_GUARD_READ=1 (spawn-time session env — not settable mid-session; mid-session use windowed reads, or Write for a full-file rewrite)." >&2
+exit 2

--- a/.claude/skills/adversarial-planner/SKILL.md
+++ b/.claude/skills/adversarial-planner/SKILL.md
@@ -101,6 +101,30 @@ verify_plan.py at Phase 1.5.0 (`c23_goal_currency`) is the same bounce
 trigger — the one WARN that bounces instead of riding into the critic
 briefs.
 
+**Edit-success gate (pre-persist; EVERY scripted plan edit feeding a
+`new-plan-version` call).** When the draft being persisted was produced or
+modified by a SCRIPTED edit (a python/sed patch of the plan file — Phase 1.5.0
+mechanical-bounce patches, Phase 3 revision edits, and the /issue Step 2b/3
+revise paths included), sequence edit → verify → persist as SEPARATE
+`&&`-chained commands: the `task.py new-plan-version` persist runs ONLY after
+the edit script exited 0 AND a verify step produced POSITIVE evidence the edit
+landed. Verify = grep the draft for the revised text
+(`grep -qF '<distinctive new text>' <draft>`) and/or — on a revision round —
+a non-empty diff vs the prior persisted version
+(`! diff -q <draft> "$(uv run python scripts/task.py find <N>)/plans/plan.md"`
+— the `plan.md` symlink still points at v<K-1> until the persist; identical
+bytes mean the edit silently no-oped); a bare exit 0 is NOT evidence. Never
+`;`-chain the edit and the persist, and never run the persist inside the same
+script before its asserts have executed. On ANY edit failure, abort LOUDLY
+without persisting — print `EDIT FAILED — not persisting`, Read the CURRENT
+draft and re-derive the anchor text from it (anchor-text mismatch is the
+common failure), re-apply, and only then persist. (#1565, 2026-07-20: an edit
+script died on an anchor-text `AssertionError` yet the same compound command
+still ran the persist — v2 landed as an UNMODIFIED copy of v1 under a log
+reading "Plan v2 written … PASS", silently lacking the critic-mandated
+revision; same shape in #1563. The Goal-currency gate above and this gate are
+the two pre-persist duties — run both before every persist.)
+
 **Strip the harness trailer before persisting.** An `Agent` tool result ends
 with harness-appended metadata — a final `agentId: <id> (use SendMessage ...)`
 line plus a `<usage>...</usage>` block. Remove BOTH before writing the
@@ -923,5 +947,6 @@ in as a post-park plan v2.
 - **Never skip the Implementation Critic.** The Implementation Critic catches what the implementer missed. The implementer is biased toward seeing success.
 - **Max 5 revision rounds (planning; the per-reviewer round cap — reconciler invocations don't count), max 2 fix rounds (implementation).** If it's not converging, surface the disagreement to the user.
 - **The user has final say.** Present the plan + critique + revision to the user before executing.
-- **Log the plan.** Register every plan revision via `uv run python scripts/task.py new-plan-version <N> --file <draft>.md`. This writes `tasks/<status>/<N>/plans/v<K>.md` and updates the `plans/plan.md` symlink. Downstream subagents read through the symlink.
+- **Log the plan.** Register every plan revision via `uv run python scripts/task.py new-plan-version <N> --file <draft>.md`. This writes `tasks/<status>/<N>/plans/v<K>.md` and updates the `plans/plan.md` symlink. Downstream subagents read through the symlink. A scripted edit gates its persist on verified edit success — `&&`-chain edit
+→ verify → persist, abort loudly on failure (§ Edit-success gate).
 - **Read a Bash-materialized plan copy before Editing it.** When a revision round creates the draft via Bash (`cp plans/plan.md /tmp/...`, a heredoc, or a python writer), the harness requires an in-session `Read` of that file before any `Edit` — firing Edits straight at a just-copied file bounces every one with "File has not been read yet" (7 consecutive bounces in one 2026-07-04 session). Read once, then edit.

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1625,6 +1625,15 @@ planner against the amended Goal; NOT a critic round). Incident #922
 earlier by `epm:goal-updated`, was auto-approved 3 s later, and was caught
 only by a PM-chat directive one wasted implementer round later.
 
+**Edit-success gate:** when the draft was produced or modified by a SCRIPTED
+edit (the Step 2b/3 revise paths included), `&&`-chain edit → verify
+(positive evidence the revised text is present — grep the draft, or a
+non-empty diff vs the prior version) → the `new-plan-version` persist; an
+edit-script failure aborts the persist loudly, never `;`-chained
+(`adversarial-planner` SKILL.md § Edit-success gate; incident #1565: a
+chained persist landed v2 as an unmodified copy of v1 after the edit script
+died on an anchor-text `AssertionError`).
+
 Post the plan body via `new-plan-version` (writes
 `tasks/<status>/<N>/plans/v<K>.md` and rotates the `plan.md` symlink),
 then announce it with an `epm:plan` event. The handoff file carries a

--- a/tests/test_plan_handoff_path_convention.py
+++ b/tests/test_plan_handoff_path_convention.py
@@ -1,4 +1,5 @@
-"""Regression tests for the plan-handoff convention (issue #282 [4/4]).
+"""Regression tests for the plan-handoff convention (issue #282 [4/4]); #1581 pins the
+edit-success pre-persist gate.
 
 CLAUDE.md documents that subagent dispatch must hand over the PATH to the
 cached plan (`.claude/plans/issue-<N>.md`), not the plan body. These tests
@@ -36,4 +37,30 @@ def test_claude_md_contains_plan_handoff_rule() -> None:
     body = (REPO_ROOT / "CLAUDE.md").read_text()
     assert "Plan handoff convention" in body, (
         "CLAUDE.md must include the 'Plan handoff convention' rule"
+    )
+
+
+AP_SKILL = REPO_ROOT / ".claude" / "skills" / "adversarial-planner" / "SKILL.md"
+ISSUE_SKILL = REPO_ROOT / ".claude" / "skills" / "issue" / "SKILL.md"
+
+
+def test_adversarial_planner_edit_success_gate_pinned() -> None:
+    """#1581: a scripted plan edit gates its `new-plan-version` persist on
+    verified edit success (edit -> verify -> persist, &&-chained; an edit
+    failure aborts the persist loudly). Dropping this prose re-opens the
+    #1565/#1563 gap where an AssertionError'd edit script still persisted the
+    plan as an unmodified copy of the prior version."""
+    ap = AP_SKILL.read_text()
+    for token in (
+        "Edit-success gate",
+        "EDIT FAILED — not persisting",
+        "edit → verify → persist",
+        "never run the persist inside the same\nscript",
+    ):
+        assert token.replace("\n", " ") in ap.replace("\n", " "), (
+            f"adversarial-planner SKILL.md lost edit-success-gate token {token!r}"
+        )
+    issue = ISSUE_SKILL.read_text()
+    assert "Edit-success gate" in issue, (
+        "issue SKILL.md lost the edit-success-gate pointer next to its Goal-currency gate"
     )


### PR DESCRIPTION
Closes task #1581. Adds the Edit-success gate paragraph to the adversarial-planner plan-revision recipe (+ issue/SKILL.md pointer + pin test).