### PR TITLE
workflow-fix #1579: step9c selector maps .sh scripts to stem/literal test suites

### DIFF
--- a/scripts/select_step9c_tests.py
+++ b/scripts/select_step9c_tests.py
@@ -761,11 +761,10 @@ def literal_path_targets(touched: list[str]) -> set[str]:
         if f.startswith("tests/"):
             continue
         suffix = Path(f).suffix
-        if suffix == ".py" and (
-            f.startswith("scripts/") or f.startswith("src/explore_persona_space/")
-        ):
-            out.add(f)
-        elif suffix == ".sh" and f.startswith(_SH_ELIGIBLE_PREFIXES):
+        if (
+            suffix == ".py"
+            and (f.startswith("scripts/") or f.startswith("src/explore_persona_space/"))
+        ) or (suffix == ".sh" and f.startswith(_SH_ELIGIBLE_PREFIXES)):
             out.add(f)
     return out
 

--- a/scripts/select_step9c_tests.py
+++ b/scripts/select_step9c_tests.py
@@ -20,11 +20,12 @@ Touched-file -> test mapping (per touched file ``f``):
   * a data/config/doc file (``.json`` / ``.yaml`` / ``.md`` / ... ) -> SKIP
     (not code; no test mapping; not "untested").
   * ``tests/test_<X>.py`` -> include ``f`` itself.
-  * a code file (``scripts/<X>.py`` / ``src/.../<X>.py`` / any other ``*.py``):
-    map ``stem = Path(f).stem`` to ``tests/test_{stem}.py`` (exact) PLUS the
-    broad ``tests/test_*{stem}*.py`` glob. If NEITHER matches an existing test
-    -> the file lands in ``untested_touched`` (a loud WARN the Step 9c marker
-    surfaces; never a silent coverage hole).
+  * a code file (``scripts/<X>.py`` / ``src/.../<X>.py`` / any other ``*.py``
+    — and, #1579, any ``*.sh``): map ``stem = Path(f).stem`` to
+    ``tests/test_{stem}.py`` (exact) PLUS the broad ``tests/test_*{stem}*.py``
+    glob. If NEITHER matches an existing test -> the file lands in
+    ``untested_touched`` (a loud WARN the Step 9c marker surfaces; never a
+    silent coverage hole).
   * ANY touched path matching a ``GLOB_SCAN_TESTS`` scan glob ADDITIONALLY
     selects that scanning test (tests that cover files via a directory scan
     at test time are reachable from no stem — #895). A map hit never
@@ -94,14 +95,24 @@ still reads nothing (both arms' target sets empty -> early return). A diff
 whose only eligible ``.py`` maps to no module name (``scripts/__init__.py``)
 now triggers the read pass, with ZERO ast parses (empty token pre-filter).
 Raw substring on file text is deliberate: comment / docstring mentions
-over-select in the safe direction (safe-by-direction, above). Extendable
-miss classes, out of scope for now — an uncovered eligible ``.py`` still
-lands in the ``untested_touched`` WARN, while a non-``.py`` pin target sits
-outside the code-file mapping entirely: constructed paths
+over-select in the safe direction (safe-by-direction, above). ``.sh`` under
+``scripts/`` | ``src/explore_persona_space/`` | ``.claude/hooks/`` is IN
+scope as of #1579 (:func:`literal_path_targets`'s ``.sh`` branch — the
+guard-hook pin shape, e.g. a test hardcoding
+``scripts/guard_repo_root_branch.sh``). Extendable miss classes, out of
+scope for now — an uncovered eligible ``.py``/``.sh`` still lands in the
+``untested_touched`` WARN, while a non-code-suffix pin target sits outside
+the code-file mapping entirely: constructed paths
 (``Path("scripts") / "x.py"``, f-strings with variable parts, multi-line
 string concatenation); ``conftest.py``-resident pin lists (the scan is
-``rglob("test_*.py")``, matching the import arm's scope); and non-``.py``
-pins (e.g. a test hardcoding ``scripts/bootstrap_pod.sh``).
+``rglob("test_*.py")``, matching the import arm's scope); non-code-suffix
+pin targets (a hardcoded data/config path); and OUT-OF-PREFIX ``.sh`` in
+MAPPING mode — an ``external/foo.sh`` / root-level ``launch_*.sh`` payload
+still yields an empty ``--map-files`` output with NO #1573 WARN (the floor
+iterates :func:`literal_path_targets`-eligible files only), while diff mode
+stem-maps/WARNs it; byte-symmetric with ``.py``'s ``external/x.py`` today,
+named so a future filing does not rediscover it as "the #1579 fix didn't
+work".
 
 Root resolution: with no ``--repo-root``, everything (the ``git diff`` cwd,
 touched-test existence checks, stem-glob mapping, invariant presence) resolves
@@ -145,9 +156,9 @@ read newline-delimited repo-relative paths from FILE and print one
 rules-pin discovery hit on a ``.claude/rules/*.md`` payload file
 (:func:`rules_pin_pairs`, #1496 — WORKFLOW_INVARIANT members excluded) PLUS
 the src/scripts dependency arms (:func:`dependency_map_pairs`, #1573 —
-import-map (#1299) + literal-path (#1498) + stem-map pairs for ``.py``
-payloads under ``scripts/`` | ``src/explore_persona_space/``,
-WORKFLOW_INVARIANT members excluded), skipping the diff-based selection
+import-map (#1299) + literal-path (#1498) + stem-map pairs for ``.py``/``.sh``
+payloads (``.sh`` #1579) under the :func:`literal_path_targets` eligibility
+prefixes, WORKFLOW_INVARIANT members excluded), skipping the diff-based selection
 entirely (mapping mode never runs git — no fetch). A scan
 test absent from the work root is dropped with a stderr WARN; an eligible
 src/scripts code file with ZERO pairs across all arms draws one tab-free
@@ -439,9 +450,11 @@ def dependency_map_pairs(files: list[str], work_root: Path) -> list[tuple[str, s
     Step 10d / inline-payload gates — sft.py literal-hits it via
     workflow_lint's LIVE_WORKFLOW_HELPERS list). The stem arm is restricted
     to the :func:`literal_path_targets` eligibility set (``.py`` under
-    ``scripts/`` | ``src/explore_persona_space/``) — it is the closing
+    ``scripts/`` | ``src/explore_persona_space/``; plus, #1579, ``.sh``
+    under those prefixes or ``.claude/hooks/``) — it is the closing
     mechanism for the dynamic-import (``pytest.importorskip`` / ``importlib``)
-    getsource subclass, where the test file is stem-named after the module.
+    getsource subclass, where the test file is stem-named after the module,
+    and (#1579) for ``.sh`` scripts, which are never importable at all.
     """
     inv = set(WORKFLOW_INVARIANT)
     import_hits, _tested, literal_hits = _scan_test_files(files, work_root)
@@ -716,22 +729,45 @@ def _import_names(tree: ast.AST) -> set[str]:
     return names
 
 
+# .sh eligibility prefixes for the literal/stem map arms (#1579): workflow shell
+# scripts live under scripts/ and .claude/hooks/ (6 of the 8 guard suites map to
+# hook scripts there); src/ included for symmetry with the .py branch (no tracked
+# .sh today — zero current cost, no future gap).
+_SH_ELIGIBLE_PREFIXES: tuple[str, ...] = (
+    "scripts/",
+    "src/explore_persona_space/",
+    ".claude/hooks/",
+)
+
+
 def literal_path_targets(touched: list[str]) -> set[str]:
-    """Touched files eligible for the literal-path arm (#1498).
+    """Touched files eligible for the literal-path arm (#1498; ``.sh`` joined #1579).
 
     Eligible: ``.py`` code files under ``scripts/`` or
-    ``src/explore_persona_space/`` — never ``tests/`` (the touched-test arm
-    owns those; the ``.md`` / workflow-surface pin mapping is deliberately out
-    of scope here — #1496's surface). Each returned repo-relative path is
-    matched as a raw substring of every scanned test file's text.
+    ``src/explore_persona_space/`` (UNCHANGED — byte-identical to the #1498
+    predicate), plus ``.sh`` scripts under ``scripts/``,
+    ``src/explore_persona_space/``, or ``.claude/hooks/`` (#1579 — guard
+    hooks / workflow shell scripts whose pinned suites hardcode the script
+    path or stem-name themselves after it). Never ``tests/`` (the
+    touched-test arm owns those; the ``.md`` / workflow-surface pin mapping
+    is deliberately out of scope here — #1496's surface). Each returned
+    repo-relative path is matched as a raw substring of every scanned test
+    file's text; this set is ALSO the stem-arm eligibility for
+    ``--map-files`` (:func:`dependency_map_pairs`) and the #1573 zero-mapped
+    WARN floor.
     """
-    return {
-        f
-        for f in touched
-        if Path(f).suffix == ".py"
-        and not f.startswith("tests/")
-        and (f.startswith("scripts/") or f.startswith("src/explore_persona_space/"))
-    }
+    out: set[str] = set()
+    for f in touched:
+        if f.startswith("tests/"):
+            continue
+        suffix = Path(f).suffix
+        if suffix == ".py" and (
+            f.startswith("scripts/") or f.startswith("src/explore_persona_space/")
+        ):
+            out.add(f)
+        elif suffix == ".sh" and f.startswith(_SH_ELIGIBLE_PREFIXES):
+            out.add(f)
+    return out
 
 
 def _scan_test_files(
@@ -759,7 +795,10 @@ def _scan_test_files(
     absolute import of module M must literally spell M's last component, so
     the filter is over-inclusive (never a false negative). A literal-only
     trigger (e.g. ``scripts/__init__.py``, which maps to no module name)
-    reads the tree with ZERO parses (empty token pre-filter). Typical touched
+    reads the tree with ZERO parses (empty token pre-filter); a ``.sh``-only
+    diff is the same cost class (#1579 — ``touched_module_names`` stays
+    ``.py``-only, so ``.sh`` paths join ``literal_targets`` with an empty
+    token set: one raw-text pass, zero AST parses). Typical touched
     sets parse a handful of files; worst case the whole tree (~500 files,
     measured ~4-8 s under shared-VM load — module docstring).
 
@@ -920,8 +959,12 @@ def select_tests_with_reasons(
         # Data / config / doc files: not code, no test mapping.
         if p.suffix in _DATA_DOC_SUFFIXES:
             continue
-        # Code files (.py anywhere): map stem -> test_<stem>.py + test_*<stem>*.py.
-        if p.suffix == ".py":
+        # Code files (.py / .sh anywhere): map stem -> test_<stem>.py +
+        # test_*<stem>*.py. (#1579: .sh joins — guard hooks + workflow shell
+        # scripts have stem-named pinned suites, e.g.
+        # scripts/guard_repo_root_branch.sh -> tests/test_guard_repo_root_branch.py;
+        # previously silently ignored, not even untested_touched-WARNed.)
+        if p.suffix in (".py", ".sh"):
             stem = p.stem
             # An import-map hit marks the touched file tested (#1299): the
             # importing test executes the touched module's code — strictly
@@ -938,8 +981,9 @@ def select_tests_with_reasons(
                 matched = True
             if not matched:
                 untested.append(f)
-        # Any other extension (no recognized mapping): ignore silently — it is
-        # neither code with a test nor a workflow-invariant surface.
+        # Any other extension (no recognized mapping — .py/.sh are the code
+        # suffixes): ignore silently — it is neither code with a test nor a
+        # workflow-invariant surface.
 
     for t in WORKFLOW_INVARIANT:
         if (work_root / t).exists():

--- a/tests/test_select_step9c_tests.py
+++ b/tests/test_select_step9c_tests.py
@@ -1633,3 +1633,145 @@ def test_dependency_map_pairs_import_and_literal_union(tmp_path: Path):
         ("tests/test_imports_w.py", "scripts/widgetlib.py"),
         ("tests/test_widgetlib.py", "scripts/widgetlib.py"),
     ]
+
+
+# --- Cases 71+ (#1579): the .sh stem/literal arms ---------------------------------
+# A .sh-only diff previously selected ZERO stem-matched tests, returned zero
+# --map-files pairs, and skipped the untested_touched WARN entirely (all three
+# code-file arms were .py-gated). These cases pin the .sh extension of the stem
+# arm + the literal_path_targets eligibility; the .py branch stays byte-identical
+# (cases 1-70 unmodified are the pin).
+
+
+# --- Case 71: scripts/X.sh -> test_X.py + test_*X*.py (mirror of case 1) ----------
+def test_sh_stem_map_exact_and_glob(tmp_path: Path):
+    """A touched .sh maps via the exact stem test AND the broad *stem* glob."""
+    repo = _make_tree(tmp_path, ["test_widget.py", "test_widget_cli.py", "test_other.py"])
+    tests, untested, reasons = sel.select_tests_with_reasons(["scripts/widget.sh"], repo)
+    assert "tests/test_widget.py" in tests  # exact
+    assert "tests/test_widget_cli.py" in tests  # broad *widget* glob
+    assert "tests/test_other.py" not in tests
+    assert untested == []
+    assert "stem-map:scripts/widget.sh" in reasons["tests/test_widget.py"]
+
+
+# --- Case 72: founding live-tree case — guard_repo_root_branch.sh (#1579) ---------
+def test_sh_stem_map_live_tree_founding_case():
+    """#1579 founding incident: a .sh-only diff selected zero stem-matched tests."""
+    repo_root = _HELPER_PATH.parents[1]
+    tests, untested, reasons = sel.select_tests_with_reasons(
+        ["scripts/guard_repo_root_branch.sh"], repo_root
+    )
+    assert "tests/test_guard_repo_root_branch.py" in tests
+    assert (
+        "stem-map:scripts/guard_repo_root_branch.sh"
+        in reasons["tests/test_guard_repo_root_branch.py"]
+    )
+    assert untested == []
+
+
+# --- Case 73: .claude/hooks/*.sh reaches the stem arm (live tree) -----------------
+def test_sh_hooks_stem_map_live_tree():
+    """Hook scripts match no WORKFLOW_SURFACE glob, so the stem arm maps them."""
+    repo_root = _HELPER_PATH.parents[1]
+    tests, untested, _reasons = sel.select_tests_with_reasons(
+        [".claude/hooks/guard_lessons_edit.sh"], repo_root
+    )
+    assert "tests/test_guard_lessons_edit.py" in tests
+    assert untested == []
+
+
+# --- Case 74: an unmatched .sh lands in untested_touched (no longer silent) -------
+def test_sh_untested_code_file_warns(tmp_path: Path):
+    """A .sh with no stem-matched test WARNs, symmetric with .py (#1579 gap 3)."""
+    repo = _make_tree(tmp_path, ["test_other.py"])
+    _tests, untested, _ = sel.select_tests_with_reasons(["scripts/lonely_helper.sh"], repo)
+    assert untested == ["scripts/lonely_helper.sh"]
+
+
+# --- Case 75: literal_path_targets .sh eligibility (unit) -------------------------
+def test_sh_literal_path_targets_eligibility():
+    """The .sh branch admits scripts/ + hooks/ + src/; the .py branch is unchanged."""
+    got = sel.literal_path_targets(
+        [
+            "scripts/a.sh",
+            ".claude/hooks/b.sh",
+            "src/explore_persona_space/c.sh",
+            "tests/d.sh",
+            "external/e.sh",
+            "docs/g.sh",
+            ".claude/agents/h.sh",
+            "scripts/f.py",  # the .py branch: byte-identical eligibility
+        ]
+    )
+    assert got == {
+        "scripts/a.sh",
+        ".claude/hooks/b.sh",
+        "src/explore_persona_space/c.sh",
+        "scripts/f.py",
+    }
+
+
+# --- Case 76: a pinning test hardcoding a .sh path selects via literal-path -------
+def test_sh_literal_path_pin_selected(tmp_path: Path):
+    """A raw-substring .sh path pin is discovered; the WARN is NOT suppressed."""
+    repo = _make_import_tree(tmp_path, {"test_pin_sh.py": 'P = "scripts/guardfoo.sh"\n'})
+    _tests, untested, reasons = sel.select_tests_with_reasons(["scripts/guardfoo.sh"], repo)
+    assert "literal-path:scripts/guardfoo.sh" in reasons["tests/test_pin_sh.py"]
+    assert untested == ["scripts/guardfoo.sh"]  # a literal hit never suppresses the WARN
+
+
+# --- Case 77: dependency_map_pairs carries the .sh stem pair (live tree) ----------
+def test_dependency_map_pairs_sh_live_tree():
+    """--map-files' dependency arms emit .sh stem pairs (exact AND broad glob)."""
+    repo_root = _HELPER_PATH.parents[1]
+    pairs = sel.dependency_map_pairs(["scripts/guard_repo_root_branch.sh"], repo_root)
+    assert (
+        "tests/test_guard_repo_root_branch.py",
+        "scripts/guard_repo_root_branch.sh",
+    ) in pairs
+    # Broad-glob map pair for .sh (the bootstrap_pod class — no exact
+    # tests/test_bootstrap_pod.py exists; reachable by NO other arm):
+    bp = sel.dependency_map_pairs(["scripts/bootstrap_pod.sh"], repo_root)
+    assert ("tests/test_bootstrap_pod_path.py", "scripts/bootstrap_pod.sh") in bp
+
+
+# --- Case 78: CLI --map-files on a .sh payload prints the stem pair ---------------
+def test_cli_map_files_sh_stem_pair(tmp_path: Path, capsys):
+    """A .sh payload with a stem-matched test prints a real pytest pair (was empty)."""
+    repo = _make_tree(tmp_path, ["test_guardfoo.py"])
+    payload = tmp_path / "payload.txt"
+    payload.write_text("scripts/guardfoo.sh\n")
+    rc = sel.main(["--map-files", str(payload), "--repo-root", str(repo)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "tests/test_guardfoo.py\tscripts/guardfoo.sh" in out
+
+
+# --- Case 79: .py behavior byte-identical — the .sh arm only grows ----------------
+def test_sh_arm_only_grows_selection(tmp_path: Path):
+    """Adding a .sh to a diff never drops a .py-derived test or reason."""
+    repo = _make_tree(tmp_path, ["test_widget.py", "test_widget_cli.py"])
+    t_before, u_before, r_before = sel.select_tests_with_reasons(["scripts/widget.py"], repo)
+    t_after, u_after, r_after = sel.select_tests_with_reasons(
+        ["scripts/widget.py", "scripts/unrelated.sh"], repo
+    )
+    assert set(t_before) <= set(t_after)
+    assert u_before == []
+    for t, rs in r_before.items():
+        assert set(rs) <= set(r_after[t])  # every .py-derived reason preserved verbatim
+    assert u_after == ["scripts/unrelated.sh"]
+
+
+# --- Case 80: unmapped eligible .sh payload draws the #1573 WARN floor (CLI) ------
+def test_cli_map_files_sh_unmapped_warns(tmp_path: Path, capsys):
+    """An eligible .sh payload with zero pairs draws the fail-loud stderr WARN."""
+    repo = _make_tree(tmp_path, ["test_other.py"])
+    payload = tmp_path / "payload.txt"
+    payload.write_text("scripts/lonely_helper.sh\n")
+    rc = sel.main(["--map-files", str(payload), "--repo-root", str(repo)])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out.strip() == ""  # no pairs
+    assert "no mapped tests for code file" in captured.err  # the fail-loud floor
+    assert "scripts/lonely_helper.sh" in captured.err


### PR DESCRIPTION
Closes task #1579. Extends the Step-9c selector's stem arm + literal_path_targets eligibility from .py-only to .py+.sh (guard hooks / workflow shell scripts), with 10 drift pins. .py selection byte-identical.