### PR TITLE
issue-1592: planner.md self-count rule for count-style acceptance criteria

### DIFF
--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -577,3 +577,20 @@ the superseded Goal — one wasted plan round + one wasted implementer round.
   as a new test in an already-registered file: an unregistered new pin file
   never runs on a later SKILL.md diff (#1242/#1268 registered after the fact;
   #1546), and `verify_plan.py` c31 WARNs on it.
+- **Self-count every count-style mechanical acceptance criterion.** Before
+  finalizing any `grep -c` / `wc -l` / "exactly once" / "appears exactly N
+  times" / "pure insertion(s)" acceptance criterion, COUNT the pattern in the
+  plan's OWN fenced verbatim insert text AND (via a draft-time
+  `grep -c '<pattern>' <file>`) in the live text of every file the criterion
+  targets, then set the expected count to the arithmetic total (existing hits
+  + insert hits), stating that arithmetic beside the criterion — or restate
+  the criterion count-robustly (`>= N`, a presence check, or uniqueness
+  scoped to one anchored inserted line). Two traps: `grep -c` counts LINES,
+  not occurrences (a token twice on one line counts once); and a "pure
+  insertion(s)" diff-shape claim is checked against the actual edit list (an
+  Edit that rewrites any existing line is not one). Lineage (#1592; two
+  same-morning union-revise rounds, 2026-07-21): #1581 plan v1's criterion 3
+  (`grep -c ... == 1`) contradicted Edit 3's own two-line insert and its
+  criterion 7 ("pure insertions") contradicted Edit 2's append; #1583 plan
+  v1's "exactly once" was unsatisfiable for a token its verbatim insert
+  carried twice.


### PR DESCRIPTION
Closes task #1592. One pure-append 17-line rule bullet to .claude/agents/planner.md ## Rules (plan v1, 3x APPROVE + consistency PASS).