### PR TITLE
issue-1599: sweep subsumption by fix merge/close time, not creation

### DIFF
--- a/.claude/agents/experimenter.md
+++ b/.claude/agents/experimenter.md
@@ -336,7 +336,11 @@ authoritative recipe is agent memory
    non-zero exit = fix absent — do NOT launch) and execute the brief's
    stale-checkpoint disposition before launch, confirming the resume
    glob resolves as the disposition requires (empty / the fresh path /
-   exactly the RETAINED expected paths). Recipe:
+   exactly the RETAINED expected paths). On a MooseFS-backed pod
+   (`/workspace` lane), ALSO run the MooseFS content read of every
+   fix-touched path — `git hash-object -- <f>` vs
+   `git rev-parse HEAD:<f>` — ancestry/HEAD do not prove the served
+   bytes are fresh (#1112). Recipe:
    `.claude/rules/crash-fix-rounds.md` § Crash-fix relaunch.
 3. **Run preflight on the pod.**
    ```bash

--- a/.claude/rules/workflow-fix-on-bug.md
+++ b/.claude/rules/workflow-fix-on-bug.md
@@ -582,7 +582,9 @@ is the canonical, tested implementation (`tests/test_workflow_fix_dedup.py`).
 A closed (`completed`/`archived`) workflow-fix task does NOT block a
 re-raise of the same bug. (The /daily Step C parked-candidate sweep applies
 this temporally: a swept PARKED candidate that PREdates a closed matching fix
-task's creation is treated as subsumed by it — suppressed, pure churn to
+task's merge/close time — the latest of its `epm:merged` / terminal
+`epm:status-changed` / `epm:done` markers, creation-time fallback (#1599) —
+is treated as subsumed by it — suppressed, pure churn to
 re-route — while a candidate parked AFTER the fix closed is a genuine
 re-raise and stays enumerated; see
 `scripts/sweep_parked_wf_candidates.py`.)

--- a/scripts/sweep_parked_wf_candidates.py
+++ b/scripts/sweep_parked_wf_candidates.py
@@ -44,10 +44,17 @@ Suppression rules (a candidate is SUPPRESSED == already routed):
 2. **fp-tag scan** (fingerprint computable only) — a ``kind: infra`` task
    whose ``body.md`` carries ``wf-fix-fp:<fp>`` (tag) or ``fingerprint: <fp>``
    (Provenance line). A NON-terminal hit suppresses unconditionally; a
-   TERMINAL (completed/archived) hit suppresses only when the task's creation
-   ts (first parseable events.jsonl row) POSTdates the candidate ts — a
-   candidate that predates the closed fix was subsumed by it; one raised
-   after it closed is a genuine re-raise and stays enumerated.
+   TERMINAL (completed/archived) hit suppresses only when the task's
+   merge/close ts POSTdates the candidate ts — the max ts over ``epm:merged``
+   / ``epm:done`` / ``epm:promoted`` rows and the ``epm:status-changed`` row
+   whose ``to`` is terminal, with the creation ts (first parseable row) as
+   the first check and the fallback when no close-signal row parses — a
+   candidate parked before the fix CLOSED was subsumed by it; one parked
+   after it closed is a genuine re-raise and stays enumerated. The
+   creation-only key missed the created-before-park/merged-after-park window
+   (#1599: #1577's park at 10:59:07Z sat 79 s before #1579's merge). The
+   emitted ``suppressed_by`` carries ``basis: creation|close``; the ``kind``
+   string stays ``fp-tag-closed``.
 3. **Row dedup** — identical (source, ts, content-hash) rows collapse to one;
    the dedup set is shared across all status folders of one task id, so
    byte-identical fork copies collapse too (observed verbatim duplication in
@@ -104,6 +111,13 @@ from explore_persona_space.task_workflow import (
 CANDIDATE_KIND_PREFIX = "epm:workflow-fix-candidate"
 FILED_KIND_PREFIX = "epm:workflow-fix-task-filed"
 TERMINAL_STATUSES = ("completed", "archived")
+
+# Close-signal event kinds for _task_closed_ts (#1599). epm:merged is
+# load-bearing: on the motivating incident the terminal status flip PREdated
+# the park while the Step 10d merge POSTdated it (#1577 park 10:59:07Z between
+# #1579's flip 10:46:50Z and merge 11:00:26Z). epm:promoted mirrors
+# task_workflow._WF_FIX_CLOSURE_EVENT_KINDS (never fires on kind: infra).
+_CLOSE_EVENT_KINDS = frozenset({"epm:merged", "epm:done", "epm:promoted"})
 
 _PARKED_LEAD_RE = re.compile(r"\s*parked\b", re.IGNORECASE)
 _PARKED_ROUTED_RE = re.compile(r"routed:\s*parked\b", re.IGNORECASE)
@@ -403,15 +417,70 @@ def _task_creation_ts(task_dir: Path) -> datetime | None:
     return None
 
 
+def _task_closed_ts(task_dir: Path) -> datetime | None:
+    """Latest merge/close-signal ts in events.jsonl; None when no such row parses.
+
+    Max ts over rows whose kind is in _CLOSE_EVENT_KINDS plus
+    epm:status-changed rows whose structured ``to`` is terminal
+    (completed/archived). Max, never "the last row": marker order varies
+    (#1577 posted epm:done AFTER epm:merged; #1579 the reverse). Unreadable
+    file / no close-signal row / unparseable ts -> None; the caller falls
+    back to the creation-ts rule (fail-open toward ENUMERATION, never a
+    silent drop).
+    """
+    events = task_dir / "events.jsonl"
+    try:
+        # split("\n"), NEVER splitlines(): splitlines() splits on U+2028/U+2029
+        # etc. and shreds valid JSONL rows whose note strings carry them
+        # (.claude/rules/gotchas.md "splitlines shreds JSONL", #950).
+        lines = events.read_text(encoding="utf-8").split("\n")
+    except OSError:
+        return None
+    closed: datetime | None = None
+    for line in lines:
+        if not line.strip():
+            continue
+        # Cheap substring prefilter before json.loads (the task_workflow
+        # _wf_fix_closed_at pattern; live events files run to hundreds of rows).
+        if (
+            '"epm:merged"' not in line
+            and '"epm:done"' not in line
+            and '"epm:promoted"' not in line
+            and '"epm:status-changed"' not in line
+        ):
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(row, dict):
+            continue
+        kind = str(row.get("kind") or "")
+        if kind not in _CLOSE_EVENT_KINDS and not (
+            kind == "epm:status-changed" and row.get("to") in TERMINAL_STATUSES
+        ):
+            continue
+        dt = parse_ts(row.get("ts"))
+        if dt is not None and (closed is None or dt > closed):
+            closed = dt
+    return closed
+
+
 def _fp_tag_scan(
     bodies: list[tuple[int, str, Path, str, dict]], fp: str, cand_ts: datetime
 ) -> dict | None:
     """Suppression rule 2: an infra task carrying this fp (tag or Provenance line).
 
-    Non-terminal hit -> suppress unconditionally; terminal hit -> suppress only
-    when the task's creation ts POSTdates the candidate (the candidate was
-    subsumed by the fix). An unreadable creation ts fails toward ENUMERATION
-    (treated as a re-raise), never toward a silent drop.
+    Non-terminal hit -> suppress unconditionally; terminal hit -> suppress when
+    the candidate ts PREdates the task's merge/close time — the creation ts
+    (first parseable row; the pre-#1599 rule, checked first) or the close ts
+    (_task_closed_ts: max over epm:merged / epm:done / epm:promoted / the
+    terminal epm:status-changed). The creation-only key missed the
+    created-before-park/merged-after-park window (#1599: #1577's park at
+    10:59:07Z sat between #1579's creation and its 11:00:26Z merge). An
+    unreadable creation AND close ts fails toward ENUMERATION (treated as a
+    re-raise), never toward a silent drop. suppressed_by carries
+    basis: "creation" | "close" for auditability; kind stays "fp-tag-closed".
     """
     for tid, status, body_path, text, fm in bodies:
         if fm.get("kind") != "infra":
@@ -422,7 +491,10 @@ def _fp_tag_scan(
             return {"kind": "fp-tag-open", "ref": f"#{tid}"}
         created = _task_creation_ts(body_path.parent)
         if created is not None and created > cand_ts:
-            return {"kind": "fp-tag-closed", "ref": f"#{tid}"}
+            return {"kind": "fp-tag-closed", "ref": f"#{tid}", "basis": "creation"}
+        closed = _task_closed_ts(body_path.parent)
+        if closed is not None and closed > cand_ts:
+            return {"kind": "fp-tag-closed", "ref": f"#{tid}", "basis": "close"}
     return None
 
 

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -10123,6 +10123,8 @@ _CRASH_FIX_CONTRACT_SURFACES: tuple[tuple[tuple[str, ...], str, str, str, tuple[
             "execute the brief's stale-checkpoint disposition before launch",
             "confirming the resume glob resolves as the disposition requires",
             "empty / the fresh path / exactly the RETAINED expected paths",
+            # MooseFS served-bytes content-read duty on same-pod relaunches (#1112/#1594)
+            "MooseFS content read",
         ),
     ),
     (

--- a/tests/test_sweep_parked_wf_candidates.py
+++ b/tests/test_sweep_parked_wf_candidates.py
@@ -225,7 +225,7 @@ def test_terminal_fp_task_created_after_candidate_suppresses(tmp_path: Path) -> 
         events=[{"ts": T2, "kind": "epm:created", "note": "created after the park"}],
     )
     c = only(run_sweep(tmp_path, include_routed=True))
-    assert c["suppressed_by"] == {"kind": "fp-tag-closed", "ref": "#61"}
+    assert c["suppressed_by"] == {"kind": "fp-tag-closed", "ref": "#61", "basis": "creation"}
 
 
 def test_terminal_fp_task_created_before_candidate_is_re_raise(tmp_path: Path) -> None:
@@ -875,3 +875,226 @@ def test_casual_parked_negation_near_recursion_guard_not_enumerated(tmp_path: Pa
         ],
     )
     assert run_sweep(tmp_path, include_routed=True)["candidates"] == []
+
+
+# ── 20. #1599: merge/close-time subsumption for terminal fp-tag hits ────────
+#
+# Byte-verbatim fixture rows: each _RAW_1599_* constant is the EXACT JSONL line
+# from the live tasks/completed/1579/events.jsonl (lines 1 / 25 / 27; ts values
+# verified 2026-07-22). The incident temporal shape: #1577's fp-computable-class
+# park at 2026-07-21T10:59:07Z sat BETWEEN #1579's terminal status flip
+# (10:46:50Z) and its Step 10d merge (11:00:26Z) — 79 s before the merge — so
+# the pre-#1599 creation-only key read it as a genuine re-raise. The close rule
+# is max over {epm:merged, epm:done, epm:promoted, terminal epm:status-changed}
+# because marker order varies (#1577 posted epm:done AFTER epm:merged).
+
+_RAW_1599_CREATED = r"""{"ts": "2026-07-21T06:38:56Z", "kind": "epm:created", "version": 1, "by": "task.py", "kind_": "infra"}"""  # noqa: E501
+_RAW_1599_FLIP = r"""{"ts": "2026-07-21T10:46:50Z", "kind": "epm:status-changed", "version": 1, "by": "task.py", "from": "reviewing", "to": "completed", "note": "Step 10 auto-complete: kind=infra, code-review PASS r1, test-verdict PASS (4236 passed, compare clean), completion audit PASS. No children."}"""  # noqa: E501
+_RAW_1599_MERGED = r"""{"ts": "2026-07-21T11:00:26Z", "kind": "epm:merged", "version": 1, "by": "unknown", "note": "Step 10d auto-merge: PR #1356 squash-merged to main (merge_form: squash; merge_attempts: 1; merge sha f0770307ce5c08bea3ed44f90d01d0ec762f425e; branch tip 3351767f5a certified by the pre-push lint gate: verdict pass, BASE_RC=0 GATED_RC=0 TG legs 0/0, pre-gate re-sync no-drift, choom=ok). Worktree kept."}"""  # noqa: E501
+
+# The real #1577 park ts (tasks/completed/1577/events.jsonl, verified 2026-07-22).
+_1599_PARK_TS = "2026-07-21T10:59:07Z"
+
+
+def _make_1599_fix_task(root: Path, fp: str) -> None:
+    """The byte-verbatim #1579 fixture: a completed infra fix task carrying fp."""
+    # round-trip guard: the embedded fixture lines are single valid JSON rows
+    assert json.loads(_RAW_1599_CREATED)["ts"] == "2026-07-21T06:38:56Z"
+    flip = json.loads(_RAW_1599_FLIP)
+    assert (flip["ts"], flip["to"]) == ("2026-07-21T10:46:50Z", "completed")
+    assert json.loads(_RAW_1599_MERGED)["ts"] == "2026-07-21T11:00:26Z"
+    make_task(
+        root,
+        1579,
+        "completed",
+        body_extra=f"- fingerprint: {fp}\n",
+        raw_event_lines=[_RAW_1599_CREATED, _RAW_1599_FLIP, _RAW_1599_MERGED],
+    )
+
+
+def test_issue1599_terminal_fp_task_merged_after_park_suppresses(tmp_path: Path) -> None:
+    """#1599 red-green + durability pin (acceptance criterion 1): a candidate
+    parked BETWEEN the fix task's terminal status flip and its Step 10d merge
+    is subsumed — the epm:merged arm, not the status flip, decides (the park ts
+    postdates the flip, so a status-changed-only key would NOT suppress)."""
+    bug, change = "bug 1599-a.", "change 1599-a."
+    fp = wf_fix_fingerprint(change, bug)
+    make_task(
+        tmp_path,
+        1577,
+        "completed",
+        events=[cand_row(_1599_PARK_TS, block_note("a/b.md", bug, change))],
+    )
+    _make_1599_fix_task(tmp_path, fp)
+    c = only(run_sweep(tmp_path, include_routed=True))
+    assert c["suppressed"] is True
+    assert c["suppressed_by"] == {"kind": "fp-tag-closed", "ref": "#1579", "basis": "close"}
+    # and the DEFAULT (unsuppressed) listing drops it
+    assert run_sweep(tmp_path)["candidates"] == []
+
+
+def test_issue1599_candidate_parked_after_merge_is_re_raise(tmp_path: Path) -> None:
+    """Criterion 2: a candidate parked AFTER the fix task's merge/close is a
+    genuine re-raise and stays enumerated."""
+    bug, change = "bug 1599-b.", "change 1599-b."
+    fp = wf_fix_fingerprint(change, bug)
+    make_task(
+        tmp_path,
+        30,
+        "completed",
+        events=[cand_row("2026-07-21T12:00:00Z", block_note("a/b.md", bug, change))],
+    )
+    _make_1599_fix_task(tmp_path, fp)
+    c = only(run_sweep(tmp_path))
+    assert c["suppressed"] is False
+
+
+def test_issue1599_unparseable_events_fail_open_to_enumeration(tmp_path: Path) -> None:
+    """Criterion 3: unreadable / garbage / ts-less events.jsonl → neither the
+    creation nor the close ts parses → enumerated (fail-open preserved)."""
+    bug, change = "bug 1599-c.", "change 1599-c."
+    fp = wf_fix_fingerprint(change, bug)
+    make_task(tmp_path, 31, "archived", events=[cand_row(T1, block_note("a/b.md", bug, change))])
+    make_task(
+        tmp_path,
+        65,
+        "completed",
+        body_extra=f"- fingerprint: {fp}\n",
+        raw_event_lines=[
+            "{this is not json",
+            json.dumps({"kind": "epm:status-changed", "to": "completed", "note": "no ts"}),
+        ],
+    )
+    c = only(run_sweep(tmp_path))
+    assert c["suppressed"] is False
+
+
+def test_issue1599_creation_after_park_takes_creation_basis(tmp_path: Path) -> None:
+    """Ordering pin: creation-after-park decides FIRST (the pre-#1599 rule),
+    even when a later epm:merged row would also decide."""
+    bug, change = "bug 1599-d.", "change 1599-d."
+    fp = wf_fix_fingerprint(change, bug)
+    make_task(tmp_path, 32, "archived", events=[cand_row(T0, block_note("a/b.md", bug, change))])
+    make_task(
+        tmp_path,
+        66,
+        "completed",
+        body_extra=f"- fingerprint: {fp}\n",
+        events=[
+            {"ts": T2, "kind": "epm:created", "note": "created after the park"},
+            {"ts": "2026-07-07T10:00:00Z", "kind": "epm:merged", "note": "merged later still"},
+        ],
+    )
+    c = only(run_sweep(tmp_path, include_routed=True))
+    assert c["suppressed_by"] == {"kind": "fp-tag-closed", "ref": "#66", "basis": "creation"}
+
+
+def test_issue1599_non_terminal_to_status_change_is_not_a_close_signal(tmp_path: Path) -> None:
+    """Criterion 5: an epm:status-changed row with a NON-terminal ``to`` is
+    never a close signal (the structured-``to`` discrimination)."""
+    bug, change = "bug 1599-e.", "change 1599-e."
+    fp = wf_fix_fingerprint(change, bug)
+    make_task(tmp_path, 33, "archived", events=[cand_row(T1, block_note("a/b.md", bug, change))])
+    make_task(
+        tmp_path,
+        67,
+        "completed",
+        body_extra=f"- fingerprint: {fp}\n",
+        events=[
+            {"ts": T0, "kind": "epm:created", "note": "created before the park"},
+            {"ts": T2, "kind": "epm:status-changed", "from": "approved", "to": "reviewing"},
+        ],
+    )
+    c = only(run_sweep(tmp_path))
+    assert c["suppressed"] is False
+
+
+def test_issue1599_archived_close_via_terminal_status_change(tmp_path: Path) -> None:
+    """Criterion 6 (the archived shape, grounded on tasks/archived/1101): an
+    archived task closes via its ``to: archived`` status-changed row alone —
+    archived tasks carry no epm:merged / epm:done rows."""
+    bug, change = "bug 1599-f.", "change 1599-f."
+    fp = wf_fix_fingerprint(change, bug)
+    make_task(tmp_path, 34, "archived", events=[cand_row(T1, block_note("a/b.md", bug, change))])
+    make_task(
+        tmp_path,
+        68,
+        "archived",
+        body_extra=f"- fingerprint: {fp}\n",
+        events=[
+            {"ts": T0, "kind": "epm:created", "note": "created before the park"},
+            {"ts": T2, "kind": "epm:status-changed", "from": "proposed", "to": "archived"},
+        ],
+    )
+    c = only(run_sweep(tmp_path, include_routed=True))
+    assert c["suppressed_by"] == {"kind": "fp-tag-closed", "ref": "#68", "basis": "close"}
+
+
+def test_issue1599_close_equal_to_park_ts_is_not_subsumption(tmp_path: Path) -> None:
+    """Tie boundary (advisory): closed == cand_ts does NOT suppress — the rule
+    is strict ``closed > cand_ts``, mirroring the creation check."""
+    bug, change = "bug 1599-g.", "change 1599-g."
+    fp = wf_fix_fingerprint(change, bug)
+    make_task(tmp_path, 35, "archived", events=[cand_row(T1, block_note("a/b.md", bug, change))])
+    make_task(
+        tmp_path,
+        69,
+        "completed",
+        body_extra=f"- fingerprint: {fp}\n",
+        events=[
+            {"ts": T0, "kind": "epm:created", "note": "created before the park"},
+            {"ts": T1, "kind": "epm:merged", "note": "merged at exactly the park ts"},
+        ],
+    )
+    c = only(run_sweep(tmp_path))
+    assert c["suppressed"] is False
+
+
+def test_issue1599_done_only_close_arm_suppresses(tmp_path: Path) -> None:
+    """epm:done-only close arm (advisory): a completed task with neither an
+    epm:merged row nor a terminal status-changed row still closes via epm:done."""
+    bug, change = "bug 1599-h.", "change 1599-h."
+    fp = wf_fix_fingerprint(change, bug)
+    make_task(tmp_path, 36, "archived", events=[cand_row(T1, block_note("a/b.md", bug, change))])
+    make_task(
+        tmp_path,
+        70,
+        "completed",
+        body_extra=f"- fingerprint: {fp}\n",
+        events=[
+            {"ts": T0, "kind": "epm:created", "note": "created before the park"},
+            {"ts": T2, "kind": "epm:done", "note": "outcome recorded"},
+        ],
+    )
+    c = only(run_sweep(tmp_path, include_routed=True))
+    assert c["suppressed_by"] == {"kind": "fp-tag-closed", "ref": "#70", "basis": "close"}
+
+
+def test_issue1599_scan_continues_past_non_suppressing_terminal_hit(tmp_path: Path) -> None:
+    """Multi-hit continue-scanning (advisory): a terminal fp hit that fails
+    BOTH temporal checks does not end the scan — a later fp-bearing body may
+    still decide."""
+    bug, change = "bug 1599-i.", "change 1599-i."
+    fp = wf_fix_fingerprint(change, bug)
+    make_task(tmp_path, 37, "archived", events=[cand_row(T1, block_note("a/b.md", bug, change))])
+    # sorts first (completed/71 < completed/72): created before the park, no close rows
+    make_task(
+        tmp_path,
+        71,
+        "completed",
+        body_extra=f"- fingerprint: {fp}\n",
+        events=[{"ts": T0, "kind": "epm:created", "note": "created before the park"}],
+    )
+    # sorts second: closes after the park → decides
+    make_task(
+        tmp_path,
+        72,
+        "completed",
+        body_extra=f"- fingerprint: {fp}\n",
+        events=[
+            {"ts": T0, "kind": "epm:created", "note": "created before the park"},
+            {"ts": T2, "kind": "epm:merged", "note": "merged after the park"},
+        ],
+    )
+    c = only(run_sweep(tmp_path, include_routed=True))
+    assert c["suppressed_by"] == {"kind": "fp-tag-closed", "ref": "#72", "basis": "close"}

--- a/tests/test_workflow_lint.py
+++ b/tests/test_workflow_lint.py
@@ -6889,6 +6889,9 @@ _CRASH_FIX_CONFORMING: dict[str, str] = {
         "   brief's stale-checkpoint disposition before launch, confirming\n"
         "   the resume glob resolves as the disposition requires (empty /\n"
         "   the fresh path / exactly the RETAINED expected paths).\n"
+        "   On a MooseFS-backed pod (`/workspace` lane), ALSO run the MooseFS\n"
+        "   content read of every fix-touched path — `git hash-object -- <f>`\n"
+        "   vs `git rev-parse HEAD:<f>` (#1112).\n"
         "3. **Run preflight.**\n"
         "\n"
         "Decoy AFTER the span: the glob resolves EMPTY unconditionally.\n"
@@ -6923,11 +6926,13 @@ _CRASH_FIX_CONFORMING: dict[str, str] = {
     ),
 }
 
-# The three load-bearing pins (#1181 plan § deviations): the disposition trio,
-# the disposition-conditional confirm, and the fix_sha= note-token duty.
+# The four load-bearing pins (#1181 plan § deviations; MooseFS added by #1594):
+# the disposition trio, the disposition-conditional confirm, the fix_sha=
+# note-token duty, and the MooseFS content-read duty (#1112).
 _CRASH_FIX_TRIO_TOKEN = "empty / the fresh path / exactly the RETAINED expected paths"
 _CRASH_FIX_CONFIRM_TOKEN = "confirming the resume glob resolves as the disposition requires"
 _CRASH_FIX_SHA_TOKEN = "records `fix_sha=<sha>` and the executed disposition"
+_CRASH_FIX_MOOSEFS_TOKEN = "MooseFS content read"
 
 
 def _write_crash_fix_tree(tmp_path, bodies: dict[str, str] | None = None) -> None:
@@ -7025,12 +7030,19 @@ def test_crash_fix_relaunch_contract_fails_on_duplicate_anchor(tmp_path) -> None
             _CRASH_FIX_SHA_TOKEN,
             id="fix-sha-note-token",
         ),
+        pytest.param(
+            ".claude/agents/experimenter.md",
+            "ALSO run the MooseFS\n   content read of every fix-touched path",
+            "ALSO run a served-bytes\n   check of every fix-touched path",
+            _CRASH_FIX_MOOSEFS_TOKEN,
+            id="moosefs-content-read",
+        ),
     ],
 )
 def test_crash_fix_relaunch_contract_fails_on_missing_load_bearing_token(
     tmp_path, surface, old, new, token
 ) -> None:
-    """Deleting any of the THREE load-bearing pins from its fixture FAILs with
+    """Deleting any of the FOUR load-bearing pins from its fixture FAILs with
     a missing-token error naming that token — mutation-visibility for the
     surfaces table: an edit that drops one of these tokens from
     ``_CRASH_FIX_CONTRACT_SURFACES`` makes the corresponding case pass on the


### PR DESCRIPTION
Closes task #1599. Extends sweep_parked_wf_candidates.py suppression rule 2: TERMINAL fp-tag hits now suppress when the candidate park ts predates the fix task's merge/close time (max over epm:merged/epm:done/epm:promoted/terminal status-changed), creation-time first-check + fallback. Additive suppressed_by.basis field; 9 new tests + 1 updated assert; docstring + workflow-fix-on-bug.md § Dedup prose aligned.