### PR TITLE
issue-1600: scope RunPod burn cap to managed pods (workflow-fix #1600)

### DIFF
--- a/scripts/pod_lifecycle.py
+++ b/scripts/pod_lifecycle.py
@@ -374,9 +374,18 @@ def _write_metadata_file(
 _MANAGED_PREFIXES: tuple[str, ...] = ("pod-", "epm-issue-")
 
 
+def _is_managed_pod_name(name: str) -> bool:
+    """True if a pod NAME (as reported by the RunPod API) belongs to this
+    project — ``pod-*`` (canonical, incl. ``pod-<N>-<slug>`` follow-up pods,
+    #1334) or ``epm-issue-*`` (legacy). String-level twin of
+    :func:`_is_managed_pod` for callers holding only a name (the $/hr-cap
+    guard's burn-breakdown rows, #1600)."""
+    return any(name.startswith(p) for p in _MANAGED_PREFIXES)
+
+
 def _is_managed_pod(pod: PodInfo) -> bool:
     """True if this pod is one our project manages."""
-    return any(pod.name.startswith(p) for p in _MANAGED_PREFIXES)
+    return _is_managed_pod_name(pod.name)
 
 
 # Back-compat alias: external callers historically imported this name.
@@ -1597,6 +1606,13 @@ def _live_ssh_endpoint(issue: int) -> tuple[str | None, int | None]:
 # pre-flight with the projected total instead of mid-run (incidents #503,
 # #505 on 2026-06-05). Default 80.0 USD/hr; override via env to match
 # whatever the console cap is set to.
+#
+# The original single-tenant premise drifted (#1600): the team account is now
+# shared with the Anthropic-fellows cluster fleet, whose unmanaged pods alone
+# exceed any sane local cap, so the guard's burn sum is scoped to MANAGED
+# pods by default (see ``_burn_scope`` below). The guard's purpose is bounding
+# OUR spend (#503/#505/#506), not gating on pods we neither created nor can
+# stop.
 _DEFAULT_ACCOUNT_HOURLY_CAP_USD = 80.0
 
 
@@ -1617,6 +1633,41 @@ def _account_hourly_cap_usd() -> float:
             file=sys.stderr,
         )
         return _DEFAULT_ACCOUNT_HOURLY_CAP_USD
+
+
+# Scope of the pre-flight $/hr guard (#1600). The RunPod team account is
+# shared with the Anthropic-fellows cluster fleet (July 2026): ~80+ unmanaged
+# pods (~$2.7k/hr) that we neither created nor can stop, so an account-wide
+# burn sum permanently exceeds any sane local cap — 13/13 wait-for-capacity
+# refusals on #779 (2026-07-22). The guard exists to bound OUR spend
+# (#503/#505/#506); default scope is therefore 'managed'. Set
+# EPM_RUNPOD_BURN_SCOPE=all to restore the account-wide sum (correct for a
+# single-tenant account).
+_BURN_SCOPE_VALUES = ("managed", "all")
+
+
+def _burn_scope() -> str:
+    """Read EPM_RUNPOD_BURN_SCOPE (default ``managed``). Bad values fall
+    back to the default with a stderr WARN rather than crash the lifecycle
+    (mirrors :func:`_account_hourly_cap_usd`)."""
+    raw = os.environ.get("EPM_RUNPOD_BURN_SCOPE", "").strip().lower()
+    if not raw:
+        return "managed"
+    if raw in _BURN_SCOPE_VALUES:
+        return raw
+    print(
+        f"[pod_lifecycle] WARN: EPM_RUNPOD_BURN_SCOPE={raw!r} is not one of "
+        f"{_BURN_SCOPE_VALUES}; using 'managed'.",
+        file=sys.stderr,
+    )
+    return "managed"
+
+
+# Once-per-process latch for the unmanaged-burn WARN in
+# ``_assert_under_account_hourly_cap``: the wait loop re-runs the guard every
+# backoff tick (13 ticks on #779), and 13 identical WARNs is noise. Tests
+# reset via monkeypatch.
+_unmanaged_burn_warned = False
 
 
 def _assert_under_account_hourly_cap(
@@ -1661,19 +1712,55 @@ def _assert_under_account_hourly_cap(
         the API-side fix from #506 could even fire). Default OFF preserves
         the byte-identical SystemExit behavior for every pre-existing caller.
 
+    Scope (#1600): the burn sum this guard gates on is controlled by
+    ``EPM_RUNPOD_BURN_SCOPE`` (default ``managed`` — only the ``pod-*`` /
+    ``epm-issue-*`` pods our project manages; ``all`` restores the
+    account-wide sum). The team account is shared with the fellows cluster
+    fleet, whose burn must not gate our provisions. Under managed scope a
+    once-per-process stderr WARN fires when the excluded unmanaged burn
+    alone exceeds the cap, and every over-cap SystemExit message carries an
+    excluded-unmanaged summary line (count, $/hr, account-wide total) so
+    the full account picture stays visible.
+
     Per the "Fail fast — never hide failures" rule: if
     :func:`current_account_hourly_burn` raises (API unreachable), the
     exception propagates. We CANNOT make the decision without the live state,
     so we refuse the operation rather than silently letting RunPod surface it
     mid-run.
     """
+    global _unmanaged_burn_warned
     cap = _account_hourly_cap_usd()
     intended_rate = estimate_pod_hourly_rate(intended_gpu_type, intended_gpu_count)
-    current_total, breakdown = current_account_hourly_burn()
+    account_total, account_breakdown = current_account_hourly_burn()
+    # Read the scope AFTER the API call: list_team_pods() lazily loads .env
+    # (runpod_api._load_dotenv, non-overriding), so an .env-only
+    # EPM_RUNPOD_BURN_SCOPE is visible here even in a fresh process.
+    scope = _burn_scope()
+    if scope == "managed":
+        breakdown = [(n, r) for n, r in account_breakdown if _is_managed_pod_name(n)]
+        unmanaged = [(n, r) for n, r in account_breakdown if not _is_managed_pod_name(n)]
+        unmanaged_total = sum(r for _, r in unmanaged)
+        current_total = sum(r for _, r in breakdown)
+        if unmanaged_total > cap and not _unmanaged_burn_warned:
+            _unmanaged_burn_warned = True
+            print(
+                f"[pod_lifecycle] WARN: ${unmanaged_total:.2f}/hr of RUNNING burn on the "
+                f"shared team account is {len(unmanaged)} UNMANAGED pod(s) (not ours; "
+                f"excluded from the $/hr-cap guard — EPM_RUNPOD_BURN_SCOPE=all to "
+                f"include). Managed burn: ${current_total:.2f}/hr.",
+                file=sys.stderr,
+            )
+    else:
+        breakdown = account_breakdown
+        unmanaged = []
+        unmanaged_total = 0.0
+        current_total = account_total
     if skip_for_same_pod:
         # Subtract any RUNNING pod sharing the resumed pod's name (defensive
         # vs duplicate-provision races; in the normal resume path the stopped
-        # pod isn't in `breakdown` at all because it's EXITED).
+        # pod isn't in `breakdown` at all because it's EXITED). Resumed pods
+        # are managed-named by construction, so they survive the managed-
+        # scope filter above and the subtraction works under both scopes.
         for name, rate in breakdown:
             if name == skip_for_same_pod:
                 current_total -= rate
@@ -1689,20 +1776,26 @@ def _assert_under_account_hourly_cap(
         # terminal, and the loop heartbeat already prints attempt/elapsed.
         raise RunPodInsufficientBalanceError(
             f"local pre-flight: projected ${projected:.2f}/hr (current "
-            f"${current_total:.2f} + this pod ${intended_rate:.2f}) "
-            f"exceeds cap ${cap:.2f}/hr"
+            f"${current_total:.2f} [{scope} scope] + this pod "
+            f"${intended_rate:.2f}) exceeds cap ${cap:.2f}/hr"
         )
     breakdown_lines = (
         "\n".join(f"    {name:<30} ${rate:6.2f}/hr" for name, rate in breakdown[:10])
-        or "    (no other RUNNING pods)"
+        or "    (no other RUNNING pods in scope)"
     )
     omitted = max(0, len(breakdown) - 10)
     if omitted:
         breakdown_lines += f"\n    ... and {omitted} more"
+    if unmanaged:
+        breakdown_lines += (
+            f"\n    (excluded: {len(unmanaged)} unmanaged team pod(s), "
+            f"${unmanaged_total:.2f}/hr — account-wide total ${account_total:.2f}/hr; "
+            f"EPM_RUNPOD_BURN_SCOPE=all to include)"
+        )
     raise SystemExit(
         f"\nRefusing to {verb} {pod_label}: would exceed the RunPod account "
         f"hourly spending cap.\n"
-        f"  Current burn   : ${current_total:6.2f}/hr (sum of RUNNING pods)\n"
+        f"  Current burn   : ${current_total:6.2f}/hr (RUNNING pods, {scope} scope)\n"
         f"  This pod adds  : ${intended_rate:6.2f}/hr "
         f"({intended_gpu_count}x {_short_gpu_label(intended_gpu_type)})\n"
         f"  Projected total: ${projected:6.2f}/hr\n"

--- a/scripts/runpod_api.py
+++ b/scripts/runpod_api.py
@@ -24,7 +24,8 @@ Public surface
 - list_team_pods()
 - wait_for_ssh(pod_id, timeout=600)  # poll until 22/tcp is publicly mapped
 - estimate_pod_hourly_rate(gpu_type_id, gpu_count)  # USD/hr best-effort
-- current_account_hourly_burn()  # sum estimated $/hr across RUNNING managed pods
+- current_account_hourly_burn()  # sum estimated $/hr across ALL RUNNING team pods
+                                 # (the pre-flight guard scopes to managed — see pod_lifecycle)
 
 CLI usage is via scripts/pod_lifecycle.py — this module is the library.
 """
@@ -994,9 +995,12 @@ def current_account_hourly_burn() -> tuple[float, list[tuple[str, float]]]:
 
     Returns ``(total_usd_per_hr, breakdown)`` where ``breakdown`` is a list of
     ``(pod_name, pod_hourly_usd)`` for each RUNNING pod (sorted by cost
-    descending). Includes both managed (`pod-N` / `epm-issue-N`) and unmanaged
-    pods on the account — the RunPod spending cap applies to ALL of them, so
-    the guard must too.
+    descending). Includes managed (`pod-N` / `epm-issue-N`) AND unmanaged pods
+    — this is the account-wide view the fleet-burn one-liners display. The
+    pre-flight $/hr guard (``pod_lifecycle._assert_under_account_hourly_cap``)
+    scopes this sum to managed pods by default (``EPM_RUNPOD_BURN_SCOPE``,
+    #1600): the team account is shared with the fellows cluster, whose burn
+    our cap must not gate on.
 
     Stopped (EXITED) pods are excluded because they don't accrue hourly GPU
     charges — only volume storage, which is not subject to the $/hr cap.

--- a/tests/test_pod_lifecycle_account_spend_guard.py
+++ b/tests/test_pod_lifecycle_account_spend_guard.py
@@ -278,3 +278,243 @@ def test_guard_api_failure_propagates(monkeypatch):
             intended_gpu_type="H100",
             intended_gpu_count=1,
         )
+
+
+# ---------------------------------------------------------------------------
+# EPM_RUNPOD_BURN_SCOPE — managed-scope guard on the shared team account (#1600)
+# ---------------------------------------------------------------------------
+#
+# The RunPod team account is shared with the Anthropic-fellows cluster fleet:
+# ~80+ unmanaged pods whose burn permanently exceeds any sane local cap
+# (13/13 wait-for-capacity refusals on #779, 2026-07-22). The guard therefore
+# scopes its burn sum to MANAGED pods (`pod-*` / `epm-issue-*`) by default;
+# `EPM_RUNPOD_BURN_SCOPE=all` restores the account-wide sum. Unmanaged
+# fixture names below are verbatim from the #779 marker transcript.
+
+
+def _fellows_fleet() -> list[PodInfo]:
+    """Three unmanaged fellows-cluster pods, 8x H200 each ($44/hr) → $132/hr
+    total, exceeding the $120 cap of the #779 shape on their own."""
+    return [
+        _info("Anthropic 2-pod-5-m9a", gpu_count=8, gpu_type_id="NVIDIA H200"),
+        _info("cluster-EUR-IS-pod-5", gpu_count=8, gpu_type_id="NVIDIA H200"),
+        _info("styfeng_temp_48hr_C", gpu_count=8, gpu_type_id="NVIDIA H200"),
+    ]
+
+
+def _delenv_rates_and_scope(monkeypatch):
+    """Deterministic env for the scope tests: no rate overrides, default scope."""
+    monkeypatch.delenv("RUNPOD_RATE_H100_USD", raising=False)
+    monkeypatch.delenv("RUNPOD_RATE_H200_USD", raising=False)
+    monkeypatch.delenv("EPM_RUNPOD_BURN_SCOPE", raising=False)
+
+
+def test_is_managed_pod_name_matches_prefixes():
+    """The string-level twin recognizes canonical + suffixed + legacy managed
+    names and rejects the fellows-fleet names (verbatim from #779)."""
+    assert pod_lifecycle._is_managed_pod_name("pod-779")
+    assert pod_lifecycle._is_managed_pod_name("pod-825-followup")
+    assert pod_lifecycle._is_managed_pod_name("epm-issue-12")
+    assert not pod_lifecycle._is_managed_pod_name("Anthropic 2-pod-5-m9a")
+    assert not pod_lifecycle._is_managed_pod_name("cluster-EUR-IS-pod-5")
+    assert not pod_lifecycle._is_managed_pod_name("styfeng_temp_48hr_C")
+    assert not pod_lifecycle._is_managed_pod_name("")
+
+
+def test_guard_default_scope_excludes_unmanaged_pods(monkeypatch):
+    """The #779 regression: unmanaged pods summing over the cap + one managed
+    $4/hr intent → the guard PASSES under the default (managed) scope."""
+    _delenv_rates_and_scope(monkeypatch)
+    monkeypatch.setenv("RUNPOD_ACCOUNT_HOURLY_CAP", "120")
+    monkeypatch.setattr(pod_lifecycle, "_unmanaged_burn_warned", False)
+    monkeypatch.setattr(runpod_api, "list_team_pods", _fellows_fleet)
+    # Managed burn $0 + this pod $4 = $4 ≤ $120 → None, despite $132 unmanaged.
+    assert (
+        pod_lifecycle._assert_under_account_hourly_cap(
+            verb="provision",
+            pod_label="pod-779",
+            intended_gpu_type="H100",
+            intended_gpu_count=1,
+        )
+        is None
+    )
+
+
+def test_guard_transient_default_scope_excludes_unmanaged(monkeypatch):
+    """The exact wait-loop path that refused 13/13 on #779: same fixture with
+    ``transient_on_exceed=True`` → returns None (no transient raise)."""
+    _delenv_rates_and_scope(monkeypatch)
+    monkeypatch.setenv("RUNPOD_ACCOUNT_HOURLY_CAP", "120")
+    monkeypatch.setattr(pod_lifecycle, "_unmanaged_burn_warned", False)
+    monkeypatch.setattr(runpod_api, "list_team_pods", _fellows_fleet)
+    assert (
+        pod_lifecycle._assert_under_account_hourly_cap(
+            verb="provision",
+            pod_label="pod-779",
+            intended_gpu_type="H100",
+            intended_gpu_count=1,
+            transient_on_exceed=True,
+        )
+        is None
+    )
+
+
+def test_guard_scope_all_restores_account_wide_behavior(monkeypatch):
+    """``EPM_RUNPOD_BURN_SCOPE=all`` restores the old account-wide gate: the
+    same fixture now refuses, naming the unmanaged pod + the account total."""
+    _delenv_rates_and_scope(monkeypatch)
+    monkeypatch.setenv("RUNPOD_ACCOUNT_HOURLY_CAP", "120")
+    monkeypatch.setenv("EPM_RUNPOD_BURN_SCOPE", "all")
+    monkeypatch.setattr(runpod_api, "list_team_pods", _fellows_fleet)
+    with pytest.raises(SystemExit) as exc:
+        pod_lifecycle._assert_under_account_hourly_cap(
+            verb="provision",
+            pod_label="pod-779",
+            intended_gpu_type="H100",
+            intended_gpu_count=1,
+        )
+    msg = str(exc.value)
+    assert "Anthropic 2-pod-5-m9a" in msg  # unmanaged row IS in scope under `all`
+    assert "132.00" in msg  # account-wide current burn
+    assert "all scope" in msg
+    assert "120.00" in msg  # cap
+
+
+def test_guard_scope_all_transient_raises_insufficient_balance(monkeypatch):
+    """Acceptance criterion 2, transient half: under ``all`` scope the
+    wait-loop path raises ``RunPodInsufficientBalanceError`` (not SystemExit),
+    preserving the transient-vs-SystemExit contract."""
+    from runpod_api import RunPodInsufficientBalanceError
+
+    _delenv_rates_and_scope(monkeypatch)
+    monkeypatch.setenv("RUNPOD_ACCOUNT_HOURLY_CAP", "120")
+    monkeypatch.setenv("EPM_RUNPOD_BURN_SCOPE", "all")
+    monkeypatch.setattr(runpod_api, "list_team_pods", _fellows_fleet)
+    with pytest.raises(RunPodInsufficientBalanceError) as exc:
+        pod_lifecycle._assert_under_account_hourly_cap(
+            verb="provision",
+            pod_label="pod-779",
+            intended_gpu_type="H100",
+            intended_gpu_count=1,
+            transient_on_exceed=True,
+        )
+    msg = str(exc.value)
+    assert not isinstance(exc.value, SystemExit)
+    assert "exceeds cap" in msg
+    assert "[all scope]" in msg
+    assert "120.00" in msg
+
+
+def test_guard_bad_scope_value_falls_back_to_managed(monkeypatch, capsys):
+    """A garbage ``EPM_RUNPOD_BURN_SCOPE`` falls back to ``managed`` with a
+    stderr WARN (mirrors ``_account_hourly_cap_usd``), never crashes."""
+    _delenv_rates_and_scope(monkeypatch)
+    monkeypatch.setenv("RUNPOD_ACCOUNT_HOURLY_CAP", "120")
+    monkeypatch.setenv("EPM_RUNPOD_BURN_SCOPE", "frobnicate")
+    monkeypatch.setattr(pod_lifecycle, "_unmanaged_burn_warned", False)
+    monkeypatch.setattr(runpod_api, "list_team_pods", _fellows_fleet)
+    assert (
+        pod_lifecycle._assert_under_account_hourly_cap(
+            verb="provision",
+            pod_label="pod-779",
+            intended_gpu_type="H100",
+            intended_gpu_count=1,
+        )
+        is None
+    )
+    err = capsys.readouterr().err
+    assert "EPM_RUNPOD_BURN_SCOPE" in err
+    assert "frobnicate" in err
+    assert "using 'managed'" in err
+
+
+def test_guard_unmanaged_warn_emitted_once_per_process(monkeypatch, capsys):
+    """When unmanaged burn alone exceeds the cap under managed scope, a stderr
+    WARN names the exclusion — once per process (latch), because the wait loop
+    re-runs the guard every backoff tick."""
+    _delenv_rates_and_scope(monkeypatch)
+    monkeypatch.setenv("RUNPOD_ACCOUNT_HOURLY_CAP", "120")
+    monkeypatch.setattr(pod_lifecycle, "_unmanaged_burn_warned", False)
+    monkeypatch.setattr(runpod_api, "list_team_pods", _fellows_fleet)
+
+    def call():
+        return pod_lifecycle._assert_under_account_hourly_cap(
+            verb="provision",
+            pod_label="pod-779",
+            intended_gpu_type="H100",
+            intended_gpu_count=1,
+        )
+
+    assert call() is None
+    first = capsys.readouterr().err
+    assert "UNMANAGED" in first
+    assert "132.00" in first  # unmanaged total
+    assert "EPM_RUNPOD_BURN_SCOPE=all" in first
+    assert call() is None
+    second = capsys.readouterr().err
+    assert "UNMANAGED" not in second  # latched
+
+
+def test_guard_skip_for_same_pod_still_works_under_managed_scope(monkeypatch):
+    """``skip_for_same_pod`` still subtracts a managed sibling under the
+    default scope; unmanaged noise rows are ignored by the filter."""
+    _delenv_rates_and_scope(monkeypatch)
+    monkeypatch.delenv("RUNPOD_ACCOUNT_HOURLY_CAP", raising=False)
+    monkeypatch.setattr(pod_lifecycle, "_unmanaged_burn_warned", False)
+    monkeypatch.setattr(
+        runpod_api,
+        "list_team_pods",
+        lambda: [
+            _info("pod-7", gpu_count=8, gpu_type_id="NVIDIA H200"),  # $44 — to skip
+            _info("pod-8", gpu_count=4),  # $16
+            *_fellows_fleet(),  # $132 unmanaged noise, excluded from the sum
+        ],
+    )
+    # Managed burn $60 minus skipped $44 = $16; adding a 4xH100 = $16 → $32
+    # projected, under the $80 default cap (unmanaged $132 ignored).
+    assert (
+        pod_lifecycle._assert_under_account_hourly_cap(
+            verb="resume",
+            pod_label="pod-7",
+            intended_gpu_type="H100",
+            intended_gpu_count=4,
+            skip_for_same_pod="pod-7",
+        )
+        is None
+    )
+
+
+def test_guard_systemexit_message_shows_unmanaged_exclusion_line(monkeypatch):
+    """A managed-scope refusal (OUR pods over cap) still shows the full account
+    picture: scoped rows, the excluded-unmanaged summary (count + $/hr), the
+    account-wide total, and the scope knob name."""
+    _delenv_rates_and_scope(monkeypatch)
+    monkeypatch.delenv("RUNPOD_ACCOUNT_HOURLY_CAP", raising=False)
+    monkeypatch.setattr(pod_lifecycle, "_unmanaged_burn_warned", False)
+    # 18 managed H100s = $72; adding 4xH100 = $16 → $88 > $80 default cap.
+    monkeypatch.setattr(
+        runpod_api,
+        "list_team_pods",
+        lambda: [_info(f"pod-{i}", gpu_count=1) for i in range(18)] + _fellows_fleet(),
+    )
+    with pytest.raises(SystemExit) as exc:
+        pod_lifecycle._assert_under_account_hourly_cap(
+            verb="provision",
+            pod_label="pod-new",
+            intended_gpu_type="H100",
+            intended_gpu_count=4,
+        )
+    msg = str(exc.value)
+    # The pre-#1600 pinned literals survive (managed-only sums).
+    assert "72.00" in msg  # current burn (managed scope)
+    assert "88.00" in msg  # projected total
+    assert "80.00" in msg  # cap
+    assert "managed scope" in msg
+    # Scoped breakdown rows: managed names only.
+    assert "pod-0" in msg
+    assert "Anthropic 2-pod-5-m9a" not in msg
+    # The exclusion summary keeps the shared account visible.
+    assert "excluded: 3 unmanaged team pod(s)" in msg
+    assert "132.00" in msg  # unmanaged $/hr
+    assert "204.00" in msg  # account-wide total (72 + 132)
+    assert "EPM_RUNPOD_BURN_SCOPE" in msg


### PR DESCRIPTION
Closes task #1600. Scope the RunPod pre-flight $/hr guard to managed pods (EPM_RUNPOD_BURN_SCOPE, default managed) so the shared fellows-team fleet no longer permanently refuses the RunPod lane.