### PR TITLE
#1603: honor the exit-75 still-waiting contract at the RunPod terminal rung

### DIFF
--- a/src/explore_persona_space/backends/router.py
+++ b/src/explore_persona_space/backends/router.py
@@ -193,6 +193,7 @@ import hashlib
 import json
 import logging
 import os
+import subprocess
 import time
 from collections.abc import Callable, Iterable, Iterator
 from contextlib import contextmanager
@@ -3233,7 +3234,10 @@ def _runpod_terminal_rung(
             # Lazy import (module convention — matches the existing lazy
             # ``backends.runpod`` import below; runpod.py imports only ``base``
             # at module top, so no cycle either way — lazy is belt-and-braces).
-            from explore_persona_space.backends.runpod import RunPodWorkloadStartError
+            from explore_persona_space.backends.runpod import (
+                EXIT_STILL_WAITING,
+                RunPodWorkloadStartError,
+            )
 
             partial_handle = exc.handle if isinstance(exc, RunPodWorkloadStartError) else None
             if partial_handle is not None:
@@ -3293,6 +3297,51 @@ def _runpod_terminal_rung(
                     reason=ROUTE_REASON_RUNPOD_WORKLOAD_START_FAILED,
                     chosen_kind="runpod",
                     attempts=attempts,
+                )
+                raise
+            # Exit-75 still-waiting (#1603, incident #1586): pod_lifecycle's
+            # bounded wait-for-capacity loop reached its per-process budget —
+            # NOTHING provisioned, NOTHING billing; the contract is "re-run
+            # the same command to continue waiting" (state-free wait,
+            # pod_lifecycle._emit_still_waiting_and_exit). NOT a failure: do
+            # NOT post the terminal failure marker (the orchestrator would
+            # post epm:failure + set-status blocked — the #1586 mis-park) and
+            # do NOT collapse into NoComputeAvailableError. Re-raise verbatim
+            # — returncode + cmd + stderr tail ride the exception (the #1465
+            # relay preserved them for exactly this consumer) — so the sync
+            # producer contract (dispatch_issue._provision_still_waiting →
+            # exit 75, still_waiting: true + rerun: true) covers the terminal
+            # rung exactly as it covers the explicit `backend: runpod`
+            # override. The ASYNC wrapper
+            # (failover_to_runpod_after_async_workload_crash) converts this
+            # to NoComputeAvailableError so the poller's terminal contract is
+            # byte-unchanged.
+            if (
+                isinstance(exc, subprocess.CalledProcessError)
+                and exc.returncode == EXIT_STILL_WAITING
+            ):
+                attempts.append(
+                    RouteAttempt(
+                        kind="runpod",
+                        cluster=None,
+                        est_start_seconds_raw=0.0,
+                        est_start_seconds_clamped=0.0,
+                        outcome="runpod_still_waiting",
+                        detail=(
+                            "runpod terminal rung STILL WAITING for capacity "
+                            f"(pod_lifecycle exit {EXIT_STILL_WAITING}: wait-for-capacity "
+                            "budget reached; nothing provisioned, nothing billing; "
+                            "re-run the same launch command to continue waiting)"
+                        ),
+                        elapsed_seconds=now_fn() - started_at,
+                    )
+                )
+                logger.warning(
+                    "route: runpod terminal rung still WAITING for capacity on "
+                    "issue %d (exit-%d still-waiting contract, #1603; NOT a "
+                    "failure — re-run the same launch command).",
+                    spec.issue,
+                    EXIT_STILL_WAITING,
                 )
                 raise
             # RunPod is the LAST resort — ANY OTHER failure here (prepare /
@@ -3435,6 +3484,13 @@ def failover_to_runpod_after_async_workload_crash(
     propagates here unchanged — the poller maps it to a terminal infra JSON
     with ``reason: no_compute_available`` (re-drivable by the watcher's
     capacity-retry pass once a lane frees).
+
+    Exit-75 still-waiting (#1603): the rung re-raises pod_lifecycle's
+    still-waiting ``CalledProcessError`` VERBATIM for the sync launch path
+    (dispatch_issue's exit-75 re-run contract); on THIS async leg no
+    orchestrator re-runs "the same command", so the wrapper converts rc=75
+    to :class:`NoComputeAvailableError` (terminal marker posted) — every
+    ``backend_poll`` consumer sees the same type as today.
     """
     store = lease_store or LeaseStore()
     now_fn = now_fn or time.monotonic
@@ -3458,24 +3514,56 @@ def failover_to_runpod_after_async_workload_crash(
             "lane has no backend-side executor for hydra runs (named residual, #909)",
             spec.issue,
         )
-    return _runpod_terminal_rung(
-        spec=replace(spec, backend="runpod"),
-        runpod_backend=runpod_backend,
-        store=store,
-        attempts=[],
-        started_at=now_fn(),
-        now_fn=now_fn,
-        marker_poster=marker_poster,
-        on_launched=on_launched,
-        residual_gap=residual_gap,
-        reason=reason,
-        failover_evidence=evidence,
-        # M3b (#669): the GCP-crash identity (pod_name/job_id) this failover is
-        # OF, so the in-flock re-check + stamp can make N concurrent triggerers
-        # launch RunPod exactly once. None on the legacy single-triggerer path
-        # leaves the existing #659 behavior unchanged.
-        gcp_failover_of_identity=gcp_failover_of_identity,
-    )
+    attempts: list[RouteAttempt] = []
+    try:
+        return _runpod_terminal_rung(
+            spec=replace(spec, backend="runpod"),
+            runpod_backend=runpod_backend,
+            store=store,
+            attempts=attempts,
+            started_at=now_fn(),
+            now_fn=now_fn,
+            marker_poster=marker_poster,
+            on_launched=on_launched,
+            residual_gap=residual_gap,
+            reason=reason,
+            failover_evidence=evidence,
+            # M3b (#669): the GCP-crash identity (pod_name/job_id) this failover is
+            # OF, so the in-flock re-check + stamp can make N concurrent triggerers
+            # launch RunPod exactly once. None on the legacy single-triggerer path
+            # leaves the existing #659 behavior unchanged.
+            gcp_failover_of_identity=gcp_failover_of_identity,
+        )
+    except subprocess.CalledProcessError as exc:
+        from explore_persona_space.backends.runpod import EXIT_STILL_WAITING
+
+        if exc.returncode != EXIT_STILL_WAITING:
+            # Defensive: the rung converts every non-75 CalledProcessError to
+            # NoComputeAvailableError before this wrapper sees it (currently
+            # unreachable) — cheap insurance against future rung edits.
+            raise
+        # Exit-75 still-waiting on an ASYNC failover leg (#1603): no
+        # orchestrator re-runs "the same command" here — the poller owns a
+        # bounded tick — so surface the typed capacity terminal the poller
+        # already maps (reason: no_compute_available, re-drivable by the
+        # watcher's capacity-retry pass). The #1596/#1601 queue-loss legs'
+        # clean-residue GCP-STANDARD retry gates on this same type, and an
+        # exit-75 IS a clean-residue capacity outcome by construction
+        # (nothing provisioned, nothing billing).
+        _post_terminal_failure_marker(
+            spec=spec,
+            marker_poster=marker_poster,
+            reason=ROUTE_REASON_NO_COMPUTE,
+            chosen_kind="runpod",
+            attempts=attempts,
+        )
+        raise NoComputeAvailableError(
+            "runpod async-failover leg still WAITING for capacity when the "
+            f"wait-for-capacity budget expired (pod_lifecycle exit "
+            f"{EXIT_STILL_WAITING}: nothing provisioned, nothing billing); "
+            "surfaced as the re-drivable no-compute terminal for the poller",
+            attempts=[_attempt_to_dict(a) for a in attempts],
+        ) from exc
 
 
 def retry_gcp_ondemand_after_queue_vanish(

--- a/src/explore_persona_space/backends/runpod.py
+++ b/src/explore_persona_space/backends/runpod.py
@@ -111,6 +111,17 @@ _POD_LIFECYCLE_TAIL_MAX_LINES = 60
 _POD_LIFECYCLE_TAIL_MAX_LINE_CHARS = 400
 
 
+#: pod_lifecycle.py's structured still-waiting exit (EX_TEMPFAIL, #603): the
+#: bounded wait-for-capacity loop reached its per-process wall-clock budget
+#: with NOTHING provisioned and NOTHING billing — the caller RE-RUNS the same
+#: command to continue waiting (the wait loop is state-free). Mirrored (not
+#: imported) from ``scripts/pod_lifecycle.py::EXIT_STILL_WAITING`` — this
+#: module's imports stay ``base``-only by documented convention (see the
+#: _GPU_VOLUME_FLOOR_GB note above). Parity pinned by
+#: tests/test_dispatch_issue_cli.py::test_exit_still_waiting_matches_pod_lifecycle.
+EXIT_STILL_WAITING = 75
+
+
 class PodLifecycleProcessError(subprocess.CalledProcessError):
     """``CalledProcessError`` whose ``str()`` carries the child's stderr tail.
 

--- a/tests/test_dispatch_issue_cli.py
+++ b/tests/test_dispatch_issue_cli.py
@@ -895,11 +895,38 @@ def test_launch_unrelated_calledprocesserror_keeps_generic_rc4(monkeypatch, tmp_
 def test_exit_still_waiting_matches_pod_lifecycle() -> None:
     """The CLI mirrors ``pod_lifecycle.EXIT_STILL_WAITING`` rather than
     importing it (import-light contract) — pin the two equal so a future
-    renumbering on either side fails loudly here."""
+    renumbering on either side fails loudly here. #1603 adds a THIRD mirror
+    (``backends/runpod.py``, the router terminal rung's consumer) to the
+    same parity pin."""
+    from explore_persona_space.backends.runpod import EXIT_STILL_WAITING as runpod_code
     from scripts.dispatch_issue import EXIT_STILL_WAITING as cli_code
     from scripts.pod_lifecycle import EXIT_STILL_WAITING as pl_code
 
-    assert cli_code == pl_code == 75
+    assert cli_code == pl_code == runpod_code == 75
+
+
+def test_provision_still_waiting_accepts_pod_lifecycle_process_error_subclass() -> None:
+    """#1603 test 6: ``PodLifecycleProcessError`` (the #1465 stderr-tail relay
+    subclass — returncode + cmd ride verbatim) satisfies
+    ``_provision_still_waiting``'s TWO conjuncts end-to-end: returncode 75
+    AND a cmd naming ``pod_lifecycle.py`` + the exact part ``provision`` (the
+    real provision cmd shape). Each conjunct is also pinned individually:
+    the same real-shaped cmd at rc=1 is rejected, and rc=75 with a
+    non-provision cmd shape is rejected (an unrelated rc-75 subprocess from
+    another lane stays out of the still-waiting branch)."""
+    from explore_persona_space.backends.runpod import PodLifecycleProcessError
+    from scripts.dispatch_issue import _provision_still_waiting
+
+    real_cmd = [
+        "/usr/bin/python3",
+        "/repo/scripts/pod_lifecycle.py",
+        "provision",
+        "--issue",
+        "1603",
+    ]
+    assert _provision_still_waiting(PodLifecycleProcessError(75, real_cmd)) is True
+    assert _provision_still_waiting(PodLifecycleProcessError(1, real_cmd)) is False
+    assert _provision_still_waiting(PodLifecycleProcessError(75, ["x"])) is False
 
 
 def test_launch_hydra_args_threaded_into_spec(monkeypatch, tmp_path) -> None:

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -8430,3 +8430,206 @@ def test_runpod_terminal_rung_short_circuits_on_gcp_stamped_lease(lease_store, m
     )
     assert result2.extra.get("failover_already_launched") is None
     assert len(rp2.launches) == 1
+
+
+# ---------------------------------------------------------------------------
+# #1603 — exit-75 still-waiting at the RunPod terminal rung (incident #1586).
+#
+# pod_lifecycle's bounded wait-for-capacity loop exits 75 (EX_TEMPFAIL) with
+# NOTHING provisioned and NOTHING billing — the contract is "re-run the same
+# command to continue waiting". Pre-#1603 the rung's catch-all collapsed that
+# into NoComputeAvailableError + the no_compute_available terminal, mis-parking
+# the task at blocked (#1586, 12:46:02Z). The rung now re-raises the exit-75
+# CalledProcessError VERBATIM (sync path: dispatch_issue's existing exit-75
+# still-waiting arm covers it); the ASYNC wrapper converts it back to
+# NoComputeAvailableError so the poller's terminal contract is byte-unchanged.
+# ---------------------------------------------------------------------------
+
+
+class _StillWaitingRunpod(_BaseBackend):
+    """RunPod double whose ``launch`` raises pod_lifecycle's exit-75
+    still-waiting error through the #1465 stderr-tail relay subclass.
+
+    Fixture-hygiene note (#1603 plan): the SHORT cmd ``["pod_lifecycle",
+    "provision"]`` is rung-only — the rung's predicate is rc-only, but this
+    cmd does NOT satisfy ``dispatch_issue._provision_still_waiting``'s
+    cmd-shape conjunct (``"pod_lifecycle.py"`` is not a substring of
+    ``"pod_lifecycle"``); any assertion crossing into that CLI helper uses
+    the real-shaped cmd (see tests/test_dispatch_issue_cli.py).
+    """
+
+    def __init__(self, *, returncode: int = 75) -> None:
+        self.launches: list[RunSpec] = []
+        self._returncode = returncode
+
+    def launch(self, spec: RunSpec) -> RunHandle:
+        from explore_persona_space.backends.runpod import PodLifecycleProcessError
+
+        self.launches.append(spec)
+        raise PodLifecycleProcessError(
+            self._returncode,
+            ["pod_lifecycle", "provision"],
+            output=None,
+            stderr="[wait-for-capacity] STILL-WAITING: per-process budget reached",
+        )
+
+
+def test_runpod_terminal_rung_still_waiting_exit75_reraises_not_no_compute(
+    lease_store, marker_poster, captured_markers
+):
+    """#1603 AC1 (durability pin): an exit-75 still-waiting provision at the
+    terminal rung re-raises the CalledProcessError VERBATIM — no
+    NoComputeAvailableError collapse, NO terminal failure marker, NO lease
+    write (nothing launched; the wait is state-free) — and records the
+    DISTINCT runpod_still_waiting RouteAttempt."""
+    import subprocess
+
+    from explore_persona_space.backends.router import (
+        ROUTE_REASON_NO_COMPUTE,
+        _runpod_terminal_rung,
+    )
+
+    rp = _StillWaitingRunpod()
+    attempts: list[RouteAttempt] = []
+    clock = _clock()
+    with pytest.raises(subprocess.CalledProcessError) as ei:
+        _runpod_terminal_rung(
+            spec=_spec(backend="auto"),
+            runpod_backend=rp,
+            store=lease_store,
+            attempts=attempts,
+            started_at=clock(),
+            now_fn=clock,
+            marker_poster=marker_poster,
+            on_launched=None,
+            residual_gap="test: every cheaper rung exhausted",
+        )
+    assert ei.value.returncode == 75
+    assert not isinstance(ei.value, NoComputeAvailableError)
+    assert len(rp.launches) == 1
+    # NO terminal failure marker on the still-waiting path (the orchestrator
+    # would otherwise post epm:failure + set-status blocked — the #1586 park).
+    assert not _by_reason(captured_markers, ROUTE_REASON_NO_COMPUTE)
+    # NO lease write — nothing provisioned, nothing billing.
+    assert lease_store.read(137) is None
+    assert attempts[-1].outcome == "runpod_still_waiting"
+    assert "re-run the same launch command" in attempts[-1].detail
+
+
+def test_runpod_terminal_rung_non75_process_error_keeps_no_compute(
+    lease_store, marker_poster, captured_markers
+):
+    """#1603 AC3 (fail-loud backing test): a PodLifecycleProcessError with ANY
+    OTHER returncode keeps the pre-#1603 blanket branch byte-for-byte —
+    NoComputeAvailableError raised AND the no_compute_available terminal
+    marker posted BEFORE the raise."""
+    from explore_persona_space.backends.router import (
+        ROUTE_REASON_NO_COMPUTE,
+        _runpod_terminal_rung,
+    )
+
+    rp = _StillWaitingRunpod(returncode=1)
+    attempts: list[RouteAttempt] = []
+    clock = _clock()
+    with pytest.raises(NoComputeAvailableError):
+        _runpod_terminal_rung(
+            spec=_spec(backend="auto"),
+            runpod_backend=rp,
+            store=lease_store,
+            attempts=attempts,
+            started_at=clock(),
+            now_fn=clock,
+            marker_poster=marker_poster,
+            on_launched=None,
+            residual_gap="test: every cheaper rung exhausted",
+        )
+    finals = _by_reason(captured_markers, ROUTE_REASON_NO_COMPUTE)
+    assert finals
+    assert finals[-1]["reason"] == ROUTE_REASON_NO_COMPUTE
+    assert attempts[-1].outcome == "runpod_fallback_failed"
+
+
+def test_route_auto_chain_exit75_at_terminal_rung_propagates_still_waiting(
+    lease_store, marker_poster, captured_markers
+):
+    """#1603 AC2 (the #1586 sync-park replay): a full route() exhaustion walk
+    (every GCP rung capacity-misses, the free lane never starts) whose RunPod
+    terminal rung exits 75 propagates the CalledProcessError out of route()
+    — no intermediate handler swallows it — so dispatch_issue's existing
+    exit-75 still-waiting arm (exit 75 + still_waiting: true + rerun: true)
+    covers the terminal rung end-to-end."""
+    import subprocess
+
+    rp = _StillWaitingRunpod()
+    nibi = _FreeLaneBackend(kind="nibi", starts_when=10**9)  # never starts
+    gcp = _GcpBackendDouble(
+        launch_raises=GcpProvisioningError(
+            "ZONE_RESOURCE_POOL_EXHAUSTED", evidence={"matched_pattern": "RESOURCE_EXHAUSTED"}
+        )
+    )
+    with pytest.raises(subprocess.CalledProcessError) as ei:
+        route(
+            _short_lora_spec(),
+            runpod_backend=rp,
+            free_backends={"nibi": nibi},
+            gcp_backend=gcp,
+            lease_store=lease_store,
+            is_started=lambda _b, _h: False,
+            is_live_after_cancel=lambda _b, _h: False,
+            marker_poster=marker_poster,
+            config=RouterConfig(
+                free_wait_seconds=1,
+                poll_interval=0.0,
+                cancel_grace_seconds=0,
+                max_gcp_attempts_per_day=99,
+            ),
+            now_fn=_clock(),
+            sleep_fn=lambda _s: None,
+        )
+    assert ei.value.returncode == 75
+    assert not isinstance(ei.value, NoComputeAvailableError)
+    assert len(rp.launches) == 1  # the rung WAS reached (last resort), once
+    # State-free at the RUNPOD rung: no runpod lease was written (nothing
+    # provisioned), so a re-run of the same command re-walks the ladder. (The
+    # nibi PARK attempt writes its own free-lane lease — pre-existing route()
+    # behavior, deliberately not asserted away here.)
+    lease = lease_store.read(137)
+    assert lease is None or lease.backend != "runpod"
+
+
+def test_async_failover_exit75_converts_to_no_compute_available(
+    lease_store, marker_poster, captured_markers
+):
+    """#1603 AC4 (async parity): the async failover wrapper converts an
+    exit-75 still-waiting rung raise to NoComputeAvailableError (terminal
+    marker posted BEFORE the raise, per the test_router L2011-family
+    invariant), preserving the __cause__ chain backend_poll's residue
+    diagnostics read — every backend_poll consumer sees the same type as
+    today."""
+    import subprocess
+
+    from explore_persona_space.backends.router import (
+        ROUTE_REASON_NO_COMPUTE,
+        failover_to_runpod_after_async_workload_crash,
+    )
+
+    rp = _StillWaitingRunpod()
+    with pytest.raises(NoComputeAvailableError) as ei:
+        failover_to_runpod_after_async_workload_crash(
+            spec=_spec(backend="gcp"),
+            runpod_backend=rp,
+            evidence={"source": "async_poller"},
+            marker_poster=marker_poster,
+            lease_store=lease_store,
+            now_fn=_clock(),
+            config=RouterConfig(free_wait_seconds=1, poll_interval=0.0, cancel_grace_seconds=0),
+        )
+    assert "still WAITING" in str(ei.value)
+    cause = ei.value.__cause__
+    assert isinstance(cause, subprocess.CalledProcessError)
+    assert cause.returncode == 75
+    # Terminal marker posted before the raise, carrying the rung's
+    # runpod_still_waiting attempt row.
+    finals = _by_reason(captured_markers, ROUTE_REASON_NO_COMPUTE)
+    assert finals
+    assert finals[-1]["attempts"][-1]["outcome"] == "runpod_still_waiting"


### PR DESCRIPTION
Closes task #1603. Router terminal-rung rc=75 re-raise (sync) + async-wrapper conversion; EXIT_STILL_WAITING mirror; 6 tests.