### PR TITLE
issue-1604: wire identity+bias baseline + kNN retrieval mandate into planner/critic lenses

### DIFF
--- a/.claude/agents/critic.md
+++ b/.claude/agents/critic.md
@@ -171,7 +171,8 @@ same-round re-cost of affected §9 rows
 for any power-raising recommendation · 13 OOD generalization folds
 (group-level fold for group-structured held-out DVs) · 14 fail-loud
 acceptance claims backed by committed tests (per claim; grep gates are not
-tests).
+tests) · 15 mapping-baselines pair for fitted representation maps
+(identity+bias baseline + kNN retrieval; both reads or a stated exemption).
 
 Full rubric (every item definition, REVISE bar, N/A escape, and incident
 citation): `.claude/rules/critic-lens-reference.md` § Statistics & Measurement lens — grep the

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -367,8 +367,14 @@ completion-probability SECONDARY) · **Install-strength control** for
 cross-condition leakage comparisons · **Statistical-input existence** for
 registered corrections · **Selection-symmetric nulls** for max-over-axis
 headlines · **OOD generalization folds** for group-structured held-out
-predictive DVs · **Figures to produce** (hero figure + over-produced
-exploratory dump).
+predictive DVs · **Mapping-baselines pair** for every FITTED representation
+map (any v_X→v_Y predictor): report BOTH the identity+learned-bias baseline
+(`analysis/mapping_baselines.identity_bias_predict`; dimension mismatch
+stated as inapplicable) AND the kNN-retrieval read
+(`analysis/mapping_baselines.knn_retrieval`; chance = k/n_pool stated)
+alongside held-out R² — omit only with a stated exemption (CLAUDE.md
+§ Identity+learned-bias baseline bullet) · **Figures to produce** (hero
+figure + over-produced exploratory dump).
 
 Full template + worked examples: `.claude/rules/planner-section-reference.md`
 § 6. Evaluation — read that section (grep the heading, chunked Read) BEFORE writing

--- a/.claude/agents/statistics-critic.md
+++ b/.claude/agents/statistics-critic.md
@@ -176,6 +176,14 @@ all current items). The items I own:
     by construction (`.claude/rules/marker-leakage-measurement.md`).
 14. Fail-loud acceptance claims backed by committed tests (per-claim coverage;
     grep gates are not tests).
+15. Mapping-baselines pair — a plan that FITS a representation map (any v_X→v_Y
+    predictor over activation summaries) reports BOTH (a) the identity+learned-bias
+    baseline (`analysis/mapping_baselines.identity_bias_predict`; dimension mismatch
+    stated as inapplicable, never silently skipped) and (b) the kNN-retrieval read
+    (`analysis/mapping_baselines.knn_retrieval`; chance = k/n_pool stated) alongside
+    held-out R². REVISE when either read is omitted without a stated exemption. Per
+    the CLAUDE.md standing rule (2026-07-22); binding definition in the reference
+    section this lens loads.
 
 Also inherited from the Alternative Explanations lens (I hold its statistics
 piece): the **inherited-positive DV-swap** cross-reference (Alt lens item 4) — a

--- a/.claude/rules/critic-lens-reference.md
+++ b/.claude/rules/critic-lens-reference.md
@@ -926,6 +926,31 @@ composer copies the requested lens's items VERBATIM and IN FULL from this file.
     acceptance claim about committed code has no committed-test backing and no stated reason a test
     cannot exercise it; a doc-file target is the named escape (`N/A — fail-loud claim not
     test-backable` — a .md instruction has no code path a pytest can exercise).
+15. **Mapping-baselines pair (identity+bias baseline + kNN retrieval) for every fitted
+    representation map.** If the plan FITS a map between activation summaries
+    (context→answer, prefix→context, cross-model / cross-framing reparameterization — any
+    v_X→v_Y predictor), verify §6 registers BOTH standing reads alongside held-out R², per
+    the CLAUDE.md standing rule (2026-07-22): (a) the identity-family baseline including the
+    learned-bias form x + b, b = train-fold mean of (y − x) — canonical helper
+    `analysis/mapping_baselines.identity_bias_predict` — whenever input and output spaces
+    share dimension (a dimension mismatch is STATED as inapplicable, never silently
+    skipped); and (b) the kNN-retrieval read P(true target within the k nearest neighbors
+    of the prediction) among the held-out candidate pool — canonical helper
+    `analysis/mapping_baselines.knn_retrieval` (euclidean + cosine, k scaled to the pool,
+    chance = k/n_pool stated; a constant predictor reads exactly chance). Conclusion-
+    changing because the two reads DISSOCIATE in both directions (first measurement
+    2026-07-22): identity+bias scored pooled-OOF R² −6.5 yet retrieval acc@1 0.84 vs the
+    LOFO ridge map's 0.04 on the #722 prefix-level battery map
+    (`eval_results/issue_722/identity_bias_knn/`), while the #779 LMSYS single-context
+    fitted ridge dominated retrieval (acc@1 0.72 vs 0.50 identity+bias, chance 0.001;
+    `eval_results/issue_779/identity_bias_knn/`) — R² alone can both overstate a map
+    (variance a constant shift already explains) and understate one (discriminative but
+    mis-scaled predictions). REVISE when the plan fits a map and omits either read without
+    a stated exemption. Not a REVISE when: the plan fits no map (geometry reads without a
+    fitted predictor, direction extraction without a regression) — "N/A — no representation
+    map fitted" satisfies this item; the omission carries a stated exemption per the
+    standing rule; or the task is `kind: analysis|infra|batch|survey` with no map fit.
+    Full rule: CLAUDE.md § "Identity+learned-bias baseline AND kNN-retrieval metric".
 
 ### Alternative Explanations lens
 

--- a/.claude/rules/experiment-guidelines.md
+++ b/.claude/rules/experiment-guidelines.md
@@ -149,3 +149,22 @@ Full recipe: `docs/api_throughput_guidelines.md`;
 CLAUDE.md § "LLM judge" (Batch API for large sets).
 **Owner:** `efficiency-critic` (plan estimate vs the decision table;
 impl verifies the dispatcher route).
+
+## 11. Identity+learned-bias baseline AND kNN retrieval for every representation mapping
+
+Any experiment that FITS a map between activation summaries (context→answer,
+prefix→context, cross-model / cross-framing reparameterization — any v_X→v_Y
+predictor) reports, alongside held-out R²: (a) the identity-family baseline
+including the learned-bias form x + b, b = train-fold mean of (y − x)
+(canonical helper `analysis/mapping_baselines.identity_bias_predict`) whenever
+input and output spaces share dimension — a mismatch is stated as inapplicable,
+never silently skipped; and (b) the kNN-retrieval read P(true target within the
+k nearest neighbors of the prediction) among the held-out pool
+(`analysis/mapping_baselines.knn_retrieval`; euclidean + cosine, chance =
+k/n_pool stated). The two reads dissociate in both directions — R² alone both
+overstates and understates maps (#722 / #779 first measurements, 2026-07-22).
+Omitting either read without a stated exemption is a REVISE; no map fit → the
+plan states "N/A — no representation map fitted".
+Full rule: CLAUDE.md § "Identity+learned-bias baseline AND kNN-retrieval metric".
+**Owner:** `statistics-critic` (+ Codex twin); v1: `critic` Statistics &
+Measurement lens item 15.

--- a/.claude/rules/lens-coverage-map.md
+++ b/.claude/rules/lens-coverage-map.md
@@ -79,6 +79,7 @@ Rows are honest: a check with no v2 owner is a `GAP:` row, never papered over.
 | 12 Re-cost on power-raising recommendations (same round) | critic.md Statistics 12 | v2-owner: statistics-critic |
 | 13 OOD generalization folds (eval set fully disjoint from training) | critic.md Statistics 13 | v2-owner: statistics-critic |
 | 14 Fail-loud acceptance claims backed by committed tests | critic.md Statistics 14 | v2-owner: statistics-critic |
+| 15 Mapping-baselines pair (identity+bias baseline + kNN retrieval) | critic.md Statistics 15 | v2-owner: statistics-critic |
 
 ## C. Monolithic `critic` — Alternative Explanations lens items
 

--- a/.claude/rules/planner-section-reference.md
+++ b/.claude/rules/planner-section-reference.md
@@ -269,6 +269,33 @@ predictive DV write "N/A — no held-out predictive DV" and move on; a
 plan claiming a genuinely iid sample writes the iid argument here
 instead of the N/A.
 
+**Required: mapping-baselines pair (fitted representation maps).** If the
+plan FITS a map between activation summaries (context→answer,
+prefix→context, cross-model / cross-framing reparameterization — any
+v_X→v_Y predictor), §6 MUST register BOTH standing reads alongside
+held-out R², per the CLAUDE.md standing rule (2026-07-22): (a) the
+identity-family baseline including the learned-bias form x + b with
+b = train-fold mean of (y − x) — canonical helper
+`analysis/mapping_baselines.identity_bias_predict` — whenever input and
+output spaces share dimension (a dimension mismatch is STATED as
+inapplicable, never silently skipped); and (b) the kNN-retrieval read
+P(true target within the k nearest neighbors of the prediction) among the
+held-out candidate pool — canonical helper
+`analysis/mapping_baselines.knn_retrieval` (euclidean + cosine, k scaled
+to the pool, chance = k/n_pool stated; a constant predictor reads exactly
+chance). The two reads DISSOCIATE in both directions (first measurement
+2026-07-22): identity+bias scored pooled-OOF R² −6.5 yet retrieval acc@1
+0.84 vs the LOFO ridge map's 0.04 on the #722 prefix-level 50-context
+battery map (`eval_results/issue_722/identity_bias_knn/`), while the #779
+LMSYS single-context fitted ridge dominated retrieval (acc@1 0.72 vs 0.50
+identity+bias, chance 0.001; `eval_results/issue_779/identity_bias_knn/`)
+— R² alone can both overstate a map (variance a constant shift already
+explains) and understate one (discriminative but mis-scaled predictions).
+Omitting either read is a stated deviation, never a silent default. Plans
+that fit no map write "N/A — no representation map fitted" and move on.
+Full rule: CLAUDE.md § "Identity+learned-bias baseline AND kNN-retrieval
+metric".
+
 **Figures to produce (over-produce; ask only when the hero is ambiguous).** The plan names the specific hero figure(s) the headline needs AND a short exploratory dump the analyzer over-produces at the end (per-cell bars, per-seed scatter, per-step trajectory lines, raw-alongside-residualized). Default to over-producing exploratory views; the analyzer picks the hero from them rather than producing one figure and hoping it lands. When the view that best supports the headline is genuinely non-obvious, surface ONE plan-time question to the user about which view to feature.
 
 ## 6.5 Primary deliverable (the upstream completeness-vs-plan gate)

--- a/scripts/select_step9c_tests.py
+++ b/scripts/select_step9c_tests.py
@@ -283,6 +283,9 @@ WORKFLOW_INVARIANT: tuple[str, ...] = (
     "tests/test_issue_skill_stopped_volume_persist_pin.py",
     # NEW (#1587) — SKILL.md trigger-dense tag-adoption pin
     "tests/test_issue_skill_trigger_dense_tag_adoption.py",
+    # NEW (#1604) — mapping-baselines wiring pin (CLAUDE.md standing rule →
+    # planner/critic/statistics-critic/experiment-guidelines + helper)
+    "tests/test_mapping_baselines_wiring_pins.py",
     "tests/test_step10d_guard3.py",  # NEW (#1242) — SKILL.md Step 10d guard/merge pin
     "tests/test_step_completed_resume.py",  # NEW (#1242) — resume/step-completed contract pin
     # NEW (#1598) — CLAUDE.md teammate-coordination bullet pins (a)-(d)

--- a/tests/step9c_workflow_invariant_manifest.txt
+++ b/tests/step9c_workflow_invariant_manifest.txt
@@ -22,6 +22,7 @@ tests/test_issue_skill_orchestrator_turn_discipline_pointer.py
 tests/test_issue_skill_staged_index_verification.py
 tests/test_issue_skill_stopped_volume_persist_pin.py
 tests/test_issue_skill_trigger_dense_tag_adoption.py
+tests/test_mapping_baselines_wiring_pins.py
 tests/test_no_auto_runpod_path_under_any_failure.py
 tests/test_no_direct_task_path_construction.py
 tests/test_no_dollar_budget_caps.py

--- a/tests/test_mapping_baselines_wiring_pins.py
+++ b/tests/test_mapping_baselines_wiring_pins.py
@@ -1,0 +1,50 @@
+"""Pins the mapping-baselines wiring (#1604): the CLAUDE.md standing rule
+(identity+learned-bias baseline AND kNN retrieval for every fitted
+representation map) stays named in the enforcing workflow files —
+.claude/agents/planner.md, .claude/agents/critic.md,
+.claude/agents/statistics-critic.md, .claude/rules/critic-lens-reference.md,
+.claude/rules/planner-section-reference.md,
+.claude/rules/experiment-guidelines.md, .claude/rules/lens-coverage-map.md —
+and the canonical helper keeps exposing both reads."""
+
+import importlib.util
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+BOTH_TOKENS = ("mapping_baselines.identity_bias_predict", "mapping_baselines.knn_retrieval")
+FULL_TOKEN_FILES = (
+    ".claude/agents/planner.md",
+    ".claude/agents/statistics-critic.md",
+    ".claude/rules/critic-lens-reference.md",
+    ".claude/rules/planner-section-reference.md",
+    ".claude/rules/experiment-guidelines.md",
+)
+
+
+def test_wired_files_name_mapping_baselines_reads():
+    """Every full-token wired file names BOTH canonical helper reads (#1604)."""
+    for rel in FULL_TOKEN_FILES:
+        text = (REPO / rel).read_text(encoding="utf-8")
+        for tok in BOTH_TOKENS:
+            assert tok in text, f"{rel} lost the {tok} wiring (#1604)"
+
+
+def test_critic_capsule_names_item_15():
+    """critic.md's Statistics & Measurement capsule roster carries item 15."""
+    text = (REPO / ".claude/agents/critic.md").read_text(encoding="utf-8")
+    assert "15 mapping-baselines pair" in text
+
+
+def test_lens_coverage_map_carries_row_15():
+    """lens-coverage-map.md §B carries the item-15 ledger row with its v2 owner."""
+    text = (REPO / ".claude/rules/lens-coverage-map.md").read_text(encoding="utf-8")
+    assert "critic.md Statistics 15" in text and "v2-owner: statistics-critic" in text
+
+
+def test_helper_exposes_both_reads():
+    """The canonical helper module exposes both callable reads the wiring names."""
+    p = REPO / "src/explore_persona_space/analysis/mapping_baselines.py"
+    spec = importlib.util.spec_from_file_location("mapping_baselines_1604", p)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    assert callable(mod.identity_bias_predict) and callable(mod.knn_retrieval)


### PR DESCRIPTION
Closes task #1604. Wires the CLAUDE.md mapping-baselines standing rule (2026-07-22) into planner.md §6, critic-lens-reference.md Statistics item 15, critic.md capsule, statistics-critic.md, experiment-guidelines.md guideline 11, lens-coverage-map.md row 15 + durability pin test.