### PR TITLE
issue-1619: call load_dotenv() before heavy imports in 3 issue1092 figure scripts

### DIFF
--- a/scripts/issue1092_result3_merged_fig.py
+++ b/scripts/issue1092_result3_merged_fig.py
@@ -18,8 +18,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import numpy as np
-from scipy.stats import spearmanr
+from explore_persona_space.orchestrate.env import load_dotenv
+
+load_dotenv()
+
+import numpy as np  # noqa: E402
+from scipy.stats import spearmanr  # noqa: E402
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 C658 = PROJECT_ROOT / "eval_results/issue_658/inline_a3_5a_coherence/per_condition_layer.npz"

--- a/scripts/issue1092_result4_spread_fig.py
+++ b/scripts/issue1092_result4_spread_fig.py
@@ -15,8 +15,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import numpy as np
-from scipy.stats import spearmanr
+from explore_persona_space.orchestrate.env import load_dotenv
+
+load_dotenv()
+
+import numpy as np  # noqa: E402
+from scipy.stats import spearmanr  # noqa: E402
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 STRATA = PROJECT_ROOT / "eval_results/issue_1092/inline_spread_whitened_strata"

--- a/scripts/issue1092_shrinkage_fig.py
+++ b/scripts/issue1092_shrinkage_fig.py
@@ -25,8 +25,6 @@ import sys
 import time
 from pathlib import Path
 
-import numpy as np
-
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
@@ -34,6 +32,7 @@ from explore_persona_space.orchestrate.env import load_dotenv  # noqa: E402
 
 load_dotenv()
 
+import numpy as np  # noqa: E402
 import issue1092_fair_deepdive as dd  # noqa: E402  (loaders + _prep_cell + _shrinkage)
 from issue1092_fit_grid import _fit_cv, _folds_from_manifest, _r2  # noqa: E402
 from issue1092_fit_grid import _basis_targets_with_info  # noqa: E402


### PR DESCRIPTION
Closes task #1619. Greens tests/test_shared_vm_thread_caps.py::test_no_new_torch_before_dotenv_vm_entrypoints (import-order-only change, 3 files).