### PR TITLE
issue-1629: /issue-tick human-activity screen (no re-drive over a live human thread)

### DIFF
--- a/.claude/skills/issue-tick/SKILL.md
+++ b/.claude/skills/issue-tick/SKILL.md
@@ -93,8 +93,10 @@ class permanently unrecovered.
 STALE-REDRIVE to `HEALTHY` (reason prefix `human-active`) when this
 session's transcript tail shows a human (non-cron) user message within
 `EPM_TICK_HUMAN_ACTIVE_S` (default 2700 s ≈ one tick interval).
-Cron-injected `/issue-tick` / `/issue` prompts, skill-load meta rows, and
-tool results never count as human. Fail toward ticking: any
+Cron-injected `/issue-tick` / `/issue` prompts, harness
+`<task-notification>` rows (Agent-tool spawn briefs / completion
+notifications), skill-load meta rows, and tool results never count as
+human. Fail toward ticking: any
 transcript-resolution or classification failure suppresses nothing.
 Teardown verdicts (TERMINAL / GATE-TRANSITION) are deliberately NOT
 suppressed — the teardown is what stops future interruptions. For the

--- a/.claude/skills/issue-tick/SKILL.md
+++ b/.claude/skills/issue-tick/SKILL.md
@@ -9,7 +9,11 @@ description: >
   computes staleness, screens detached-phase liveness before any
   STALE-REDRIVE — a live identity-verified breadcrumb `pid=`, a fresh
   `log=` mtime, or a fresh `[long-phase-heartbeat]` note reads HEALTHY,
-  #1051 — and maintains the tick snapshot + runaway counter) and
+  #1051 — and screens recent HUMAN activity in this session's transcript
+  (a human (non-cron) user message within ~45 min converts a would-be
+  STALE-REDRIVE to HEALTHY, reason `human-active …`; #1629 — an
+  interactive session is never re-driven over the human's thread) — and
+  maintains the tick snapshot + runaway counter) and
   branches on its one-word verdict: HEALTHY → end the turn immediately;
   TERMINAL → CRON-TEARDOWN, end; GATE-TRANSITION → PushNotification +
   CRON-TEARDOWN, end; STALE-REDRIVE → re-drive the full `/issue` skill
@@ -85,6 +89,26 @@ A broken triage must fail toward coverage (full re-drive), never toward
 silence — a no-op-on-crash tick would leave the alive-stalled-at-PARK
 class permanently unrecovered.
 
+**Human-activity screen (#1629).** `tick_triage.py` converts a would-be
+STALE-REDRIVE to `HEALTHY` (reason prefix `human-active`) when this
+session's transcript tail shows a human (non-cron) user message within
+`EPM_TICK_HUMAN_ACTIVE_S` (default 2700 s ≈ one tick interval).
+Cron-injected `/issue-tick` / `/issue` prompts, skill-load meta rows, and
+tool results never count as human. Fail toward ticking: any
+transcript-resolution or classification failure suppresses nothing.
+Teardown verdicts (TERMINAL / GATE-TRANSITION) are deliberately NOT
+suppressed — the teardown is what stops future interruptions. For the
+alive-stalled-at-PARK class the re-drive resumes within ~window + one
+tick interval (≈90 min) of the human's last message — the human in the
+thread is the interim supervisor (the watcher deliberately does not
+respawn PARK sessions). Kill switch: `EPM_TICK_HUMAN_ACTIVE_PROBE=0`;
+debug telemetry: `EPM_TICK_HUMAN_PROBE_DEBUG=1` (stderr `[human-probe]`
+line, paths/counts only). Deliberate non-goal: the tick never tears down
+its cron on human activity alone (coverage loss would strand a stalled
+task; use `task.py set-status <N> on_hold` / user-pause for a deliberate
+park), and the screen does NOT prevent the cron prompt's arrival
+(harness-side) — it bounds the tick turn to one Bash call.
+
 ## Digest-only task-state reads (every tick turn, every task)
 
 Any task-state read a tick turn makes BEYOND the one `tick_triage.py`
@@ -157,7 +181,9 @@ cosmetic and accepted.
 (>~25 min) at a non-gate, non-terminal status AND its detached-phase
 liveness screen found no evidence (no live identity-verified breadcrumb
 `pid=`, no fresh breadcrumb `log=` mtime, no fresh
-`[long-phase-heartbeat]` note — #1051). Two sub-cases, split by
+`[long-phase-heartbeat]` note — #1051) AND its human-activity screen
+found no recent human (non-cron) user message in this session's
+transcript (#1629). Two sub-cases, split by
 the status named in the verdict reason:
 
 **ACTIVE statuses** (`approved` / `running` / `verifying` /
@@ -368,6 +394,9 @@ means the job being gone is the goal.
   bodies, interpretation bodies, or raw completions into context — every
   task-state read beyond the triage call is a jq-filtered digest
   (§ Digest-only task-state reads; refusal-thinned re-drive rule).
+- It does NOT re-drive over a live human thread — `tick_triage.py`'s
+  human-activity screen (#1629) converts that STALE-REDRIVE to HEALTHY;
+  teardown verdicts still fire (a teardown STOPS future interruptions).
 
 ## Why this skill exists (background)
 

--- a/scripts/select_step9c_tests.py
+++ b/scripts/select_step9c_tests.py
@@ -299,6 +299,7 @@ WORKFLOW_INVARIANT: tuple[str, ...] = (
     "tests/test_issue_skill_trigger_dense_tag_adoption.py",
     # NEW (#1616) — SKILL.md width-re-evaluation pin (test landed #1346; gap surfaced #1594)
     "tests/test_issue_skill_width_reeval_pointer.py",
+    "tests/test_issue_tick_skill.py",  # NEW (#1629) — issue-tick SKILL prose pins
     # NEW (#1604) — mapping-baselines wiring pin (CLAUDE.md standing rule →
     # planner/critic/statistics-critic/experiment-guidelines + helper)
     "tests/test_mapping_baselines_wiring_pins.py",

--- a/scripts/tick_triage.py
+++ b/scripts/tick_triage.py
@@ -30,6 +30,24 @@ pid dies fires STALE-REDRIVE exactly when the re-driven session can harvest
 (the intended sequencing; a 48h breadcrumb cap bounds a wedged-leader
 latch). Kill switch: ``EPM_TICK_LIVENESS_PROBE=0``.
 
+A second screen (issue #1629, ``human_activity_reason``) runs when the
+liveness screen finds nothing: a HUMAN (non-cron) user message in THIS
+session's transcript within ``EPM_TICK_HUMAN_ACTIVE_S`` (default 2700 s)
+converts the would-be STALE-REDRIVE to HEALTHY (reason prefix
+``human-active``) — an interactive session is not a stalled autonomous
+session, and re-driving the 44K-token /issue skill would hijack the
+human's thread. The transcript is resolved happy-log-only via a /proc
+ancestry walk (bash -> claude -> happy node wrapper -> the wrapper's
+log names the transcript); cron-injected ``<command-message>``-wrapped
+prompts, skill-load meta rows, and tool results never count as human.
+Fail toward ticking: ANY resolution, parse, or classification failure
+suppresses nothing (today's exact behavior). Teardown verdicts
+(TERMINAL / GATE-TRANSITION) are never suppressed — the teardown is
+what stops future interruptions. Kill switch:
+``EPM_TICK_HUMAN_ACTIVE_PROBE=0``; debug telemetry:
+``EPM_TICK_HUMAN_PROBE_DEBUG=1`` (stderr ``[human-probe]`` line —
+paths/counts/ages only, never transcript text).
+
 Side effects (both under ``~/.eps-autonomous``, overridable for tests via
 ``EPM_TICK_STATE_DIR``):
 
@@ -92,6 +110,20 @@ CAMPAIGN_CHILD_DONEISH = CAMPAIGN_CHILD_LANDED | {"archived"}
 
 STALE_S_DEFAULT = 25 * 60  # the tick skills' long-standing ~25-min staleness window
 RUNAWAY_STREAK_DEFAULT = 3
+
+# ── human-activity screen constants (issue #1629) ───────────────────────────
+# Recency window default: one tick interval — "any human message since the
+# last tick fired" is the natural semantics (env: EPM_TICK_HUMAN_ACTIVE_S).
+HUMAN_ACTIVE_S_DEFAULT = 45 * 60
+# Transcript tail-read bound: watcher parity (the #1104 wedge-probe widening).
+TRANSCRIPT_TAIL_BYTES = 262_144
+# /proc ancestry walk bound (measured chain depth to `claude` is 4 hops from a
+# `uv run python` child; 15 covers deeper shell nesting with margin).
+_ANCESTRY_MAX_DEPTH = 15
+# Happy-log whole-read stat guard (~2x the largest measured live wrapper log,
+# 66.6 MB on 2026-07-23; env: EPM_TICK_HUMAN_LOG_MAX_BYTES). Crossing it
+# fails SAFE: skip -> no suppression -> today's behavior.
+HUMAN_LOG_MAX_BYTES_DEFAULT = 128 * 2**20
 
 # VM root-disk band labels mirrored from autonomous_session_watch (task #679):
 # the tick snapshot carries the same coarse band so a cron-driven tick surfaces
@@ -583,6 +615,227 @@ def issue_liveness_reason(events: list[dict], now: float, stale_after_s: float) 
         return None
 
 
+# ── human-activity screen (issue #1629) ─────────────────────────────────────
+
+
+def _human_probe_debug(msg: str) -> None:
+    """Emit one ``[human-probe] <msg>`` stderr line iff
+    ``EPM_TICK_HUMAN_PROBE_DEBUG=1`` (default off — ZERO output in
+    production ticks). Callers pass paths/counts/ages ONLY, never
+    transcript message text (content invariant #1000)."""
+    if os.environ.get("EPM_TICK_HUMAN_PROBE_DEBUG", "").strip() == "1":
+        print(f"[human-probe] {msg}", file=sys.stderr)
+
+
+def human_active_probe_enabled() -> bool:
+    """``EPM_TICK_HUMAN_ACTIVE_PROBE`` kill switch (default on; ``0``/
+    ``false`` disables — restores pre-#1629 STALE-REDRIVE behavior
+    fleet-wide; clone of ``liveness_probe_enabled``)."""
+    raw = os.environ.get("EPM_TICK_HUMAN_ACTIVE_PROBE", "").strip().lower()
+    return raw not in ("0", "false")
+
+
+def human_active_s() -> float:
+    """``EPM_TICK_HUMAN_ACTIVE_S`` (seconds) -> recency window; malformed or
+    non-positive -> ``HUMAN_ACTIVE_S_DEFAULT`` (the ``stale_s()`` parse
+    shape)."""
+    raw = os.environ.get("EPM_TICK_HUMAN_ACTIVE_S", "")
+    try:
+        val = float(raw)
+    except ValueError:
+        return float(HUMAN_ACTIVE_S_DEFAULT)
+    return val if val > 0 else float(HUMAN_ACTIVE_S_DEFAULT)
+
+
+def human_log_max_bytes() -> float:
+    """``EPM_TICK_HUMAN_LOG_MAX_BYTES`` (bytes) -> happy-log read ceiling;
+    malformed or non-positive -> ``HUMAN_LOG_MAX_BYTES_DEFAULT`` (the
+    ``stale_s()`` parse shape)."""
+    raw = os.environ.get("EPM_TICK_HUMAN_LOG_MAX_BYTES", "")
+    try:
+        val = float(raw)
+    except ValueError:
+        return float(HUMAN_LOG_MAX_BYTES_DEFAULT)
+    return val if val > 0 else float(HUMAN_LOG_MAX_BYTES_DEFAULT)
+
+
+def _proc_ppid(pid: int) -> int | None:
+    """Parent pid from ``_PROC_ROOT/<pid>/stat`` (parsed after the LAST
+    ``)`` so a comm containing ``') '`` cannot shift fields — the
+    ``proc_start_epoch`` parse shape; ppid = index 1 after comm).
+    ``None`` on any read/parse failure."""
+    try:
+        stat = (_PROC_ROOT / str(pid) / "stat").read_text()
+        after_comm = stat.rsplit(")", 1)[1].split()
+        # after_comm[0] is field 3 (state); field 4 (ppid) is index 1.
+        return int(after_comm[1])
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def _own_node_wrapper_pid() -> int | None:
+    """Walk UP the /proc ancestry from this process to the first ancestor
+    whose comm is ``claude``; return its PARENT pid (the happy node
+    wrapper). ``None`` when no claude ancestor within
+    ``_ANCESTRY_MAX_DEPTH`` (bare-claude / non-happy runtimes -> the
+    caller suppresses nothing). Uses ``session_resolver._read_proc_comm``
+    (it strips the trailing newline — an inline unstripped
+    ``/proc/<pid>/comm`` read comparing ``== "claude"`` would never
+    match)."""
+    import session_resolver  # lazy: sys.path[0]=scripts/ per the SKILL contract
+
+    pid = os.getpid()
+    for _ in range(_ANCESTRY_MAX_DEPTH):
+        ppid = _proc_ppid(pid)
+        if ppid is None or ppid <= 1:
+            return None
+        if session_resolver._read_proc_comm(pid) == "claude":
+            return ppid
+        pid = ppid
+    return None
+
+
+def _own_session_transcript_path() -> str | None:
+    """Resolve THIS session's Claude transcript path via the happy wrapper
+    log — happy-log-only resolution (the #845 wedge-probe policy: a
+    filesystem fallback could bind the WRONG session's transcript, and a
+    wrong-session match is worse than a miss). ``None`` at every miss
+    (fail toward ticking); the ``st_size`` guard runs BEFORE the
+    whole-file log read so a pathological log never stalls the tick."""
+    import session_resolver  # lazy: an import failure is a caller-guarded miss
+
+    node = _own_node_wrapper_pid()
+    if node is None:
+        _human_probe_debug("miss=no-claude-ancestor")
+        return None
+    log = session_resolver._find_happy_log_for_node(node)
+    if log is None:
+        _human_probe_debug("miss=no-happy-log")
+        return None
+    if log.stat().st_size > human_log_max_bytes():
+        _human_probe_debug("miss=log-too-big")
+        return None
+    path = session_resolver.extract_transcript_from_happy_log(log.read_text(errors="replace"))
+    if not path:
+        _human_probe_debug("miss=no-transcript-path")
+        return None
+    if not os.path.isfile(path):
+        _human_probe_debug("miss=transcript-missing")
+        return None
+    return path
+
+
+def _transcript_tail_rows_1629(path: str, max_bytes: int = TRANSCRIPT_TAIL_BYTES) -> list[dict]:
+    """Parsed dict rows from the LAST ``max_bytes`` of a transcript JSONL.
+
+    SEEK-FROM-END is load-bearing (#1287: a head-capped read defeated its
+    own motivating incident — recent rows live at EOF). After a mid-file
+    seek the partial first line is dropped; each line's ``json.loads`` is
+    guarded (a concurrent append can truncate the last line — one skipped
+    row, re-read next tick)."""
+    size = os.stat(path).st_size
+    with open(path, "rb") as fh:
+        if size > max_bytes:
+            fh.seek(size - max_bytes)
+        data = fh.read()
+    lines = data.split(b"\n")
+    if size > max_bytes:
+        lines = lines[1:]  # drop the partial first line after the seek
+    rows: list[dict] = []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+            continue
+        if isinstance(row, dict):
+            rows.append(row)
+    return rows
+
+
+def is_human_transcript_row(row: object) -> bool:
+    """True iff a transcript JSONL row is direct HUMAN input (#1629).
+
+    Conservative toward ticking: any ambiguous / automation-shaped row
+    reads False. A human-typed slash command reads False too (wrapped
+    identically to a cron-injected one) — acceptable: mistaking a human
+    for automation only costs one tick turn, never a stranded task.
+    """
+    if not isinstance(row, dict) or row.get("type") != "user" or row.get("isMeta"):
+        return False
+    msg = row.get("message")
+    if not isinstance(msg, dict) or msg.get("role") != "user":
+        return False
+    content = msg.get("content")
+    if isinstance(content, str):
+        s = content.lstrip()
+        if not s:
+            return False
+        if "<command-name>" in content or s.startswith(("<command-message>", "<local-command")):
+            return False
+        return True
+    if isinstance(content, list):  # the ONE list-shape human signal: the interrupt row
+        for block in content:
+            if (
+                isinstance(block, dict)
+                and block.get("type") == "text"
+                and isinstance(block.get("text"), str)
+                and block["text"].lstrip().startswith("[Request interrupted by user")
+            ):
+                return True
+    return False
+
+
+def human_activity_reason(now: float) -> str | None:
+    """Return a content-invariant reason suffix when a HUMAN (non-cron)
+    user message appears in THIS session's transcript within the recency
+    window (issue #1629), else ``None``. Entirely exception-guarded: ANY
+    failure -> ``None`` (fail toward ticking — the #1629 hard
+    constraint; the helper can never raise into ``triage()``).
+
+    Aggregation is any-row-in-window (per-row ``0 <= age < window``,
+    smallest in-window age reported): a single future-dated row (clock
+    skew, ``age < 0``) can never mask a valid fresh row — future rows
+    are skipped, never latched as "the newest"."""
+    try:
+        if not human_active_probe_enabled():
+            _human_probe_debug("miss=disabled")
+            return None
+        path = _own_session_transcript_path()
+        if path is None:
+            return None
+        window = human_active_s()
+        n_rows = 0
+        n_human = 0
+        best_age: float | None = None  # smallest IN-WINDOW age among human rows
+        for row in _transcript_tail_rows_1629(path):
+            n_rows += 1
+            if not is_human_transcript_row(row):
+                continue
+            n_human += 1
+            ts = parse_event_ts(row.get("timestamp"))
+            if ts is None:
+                continue
+            age = now - ts
+            if 0 <= age < window and (best_age is None or age < best_age):
+                best_age = age
+        if n_human == 0:
+            _human_probe_debug("miss=no-human-rows")
+            return None
+        age_str = "none" if best_age is None else f"{best_age:.1f}"
+        verdict_str = "suppress" if best_age is not None else "no-suppress"
+        _human_probe_debug(
+            f"transcript={path} rows={n_rows} human={n_human} "
+            f"newest_age_s={age_str} verdict={verdict_str}"
+        )
+        if best_age is None:
+            return None
+        return f"human-active (last human msg {best_age / 60:.0f}m ago < {window / 60:.0f}m)"
+    except Exception:
+        return None
+
+
 # ── pure verdict logic ──────────────────────────────────────────────────────
 
 
@@ -778,8 +1031,13 @@ def triage(issue: int, kind: str, now: float | None = None) -> tuple[str, str]:
             # ACTIVE (#931's incident status `followups_running` is in
             # ISSUE_PARK). Streak semantics unchanged (STALE-REDRIVE and
             # HEALTHY are both non-teardown verdicts); snapshot shape
-            # untouched; campaign branch untouched.
+            # untouched; campaign branch untouched. The human-activity
+            # screen (issue #1629) runs SECOND, only when the liveness
+            # screen found nothing — same PARK+ACTIVE scope, same
+            # fail-toward-ticking posture.
             live = issue_liveness_reason(events, now, stale_s())
+            if live is None:
+                live = human_activity_reason(now)
             if live is not None:
                 age_desc = (
                     "no markers" if marker_age is None else f"marker age {marker_age / 60:.0f}m"

--- a/scripts/tick_triage.py
+++ b/scripts/tick_triage.py
@@ -39,7 +39,9 @@ session, and re-driving the 44K-token /issue skill would hijack the
 human's thread. The transcript is resolved happy-log-only via a /proc
 ancestry walk (bash -> claude -> happy node wrapper -> the wrapper's
 log names the transcript); cron-injected ``<command-message>``-wrapped
-prompts, skill-load meta rows, and tool results never count as human.
+prompts, harness ``<task-notification>`` rows (Agent-tool spawn briefs /
+completion notifications), skill-load meta rows, and tool results never
+count as human.
 Fail toward ticking: ANY resolution, parse, or classification failure
 suppresses nothing (today's exact behavior). Teardown verdicts
 (TERMINAL / GATE-TRANSITION) are never suppressed — the teardown is
@@ -761,6 +763,11 @@ def is_human_transcript_row(row: object) -> bool:
     reads False. A human-typed slash command reads False too (wrapped
     identically to a cron-injected one) — acceptable: mistaking a human
     for automation only costs one tick turn, never a stranded task.
+    Harness-injected ``<task-notification>`` rows (Agent-tool spawn briefs
+    / completion notifications — plain-string user rows, the dominant
+    string-row class in autonomous transcripts: 149/149 measured across
+    two transcripts, r2 Must-Fix) classify automation via the prefix
+    exclusion below.
     """
     if not isinstance(row, dict) or row.get("type") != "user" or row.get("isMeta"):
         return False
@@ -772,7 +779,9 @@ def is_human_transcript_row(row: object) -> bool:
         s = content.lstrip()
         if not s:
             return False
-        if "<command-name>" in content or s.startswith(("<command-message>", "<local-command")):
+        if "<command-name>" in content or s.startswith(
+            ("<command-message>", "<local-command", "<task-notification")
+        ):
             return False
         return True
     if isinstance(content, list):  # the ONE list-shape human signal: the interrupt row
@@ -832,7 +841,14 @@ def human_activity_reason(now: float) -> str | None:
         if best_age is None:
             return None
         return f"human-active (last human msg {best_age / 60:.0f}m ago < {window / 60:.0f}m)"
-    except Exception:
+    except Exception as exc:
+        # Debug-only error rung (r2 Minor): exception TYPE only (content
+        # invariant #1000), itself guarded so the helper still can never
+        # raise into triage() (the #1629 hard constraint).
+        try:
+            _human_probe_debug(f"error={type(exc).__name__}")
+        except Exception:
+            return None
         return None
 
 

--- a/tests/step9c_workflow_invariant_manifest.txt
+++ b/tests/step9c_workflow_invariant_manifest.txt
@@ -25,6 +25,7 @@ tests/test_issue_skill_staged_index_verification.py
 tests/test_issue_skill_stopped_volume_persist_pin.py
 tests/test_issue_skill_trigger_dense_tag_adoption.py
 tests/test_issue_skill_width_reeval_pointer.py
+tests/test_issue_tick_skill.py
 tests/test_mapping_baselines_wiring_pins.py
 tests/test_no_auto_runpod_path_under_any_failure.py
 tests/test_no_direct_task_path_construction.py

--- a/tests/test_issue_tick_skill.py
+++ b/tests/test_issue_tick_skill.py
@@ -85,6 +85,19 @@ def test_issue_tick_skill_branches_on_verdict():
         assert verdict in body, f"skill must document the {verdict} verdict branch"
 
 
+def test_issue_tick_skill_documents_human_active_noop():
+    """#1629: the human-activity screen (a human (non-cron) user message in
+    this session's transcript converts a would-be STALE-REDRIVE to HEALTHY)
+    is documented in the skill AND implemented + kill-switched in
+    tick_triage.py. Presence checks only — never counts."""
+    body = ISSUE_TICK_SKILL.read_text()
+    assert "human-active" in body, "skill must document the human-activity screen (#1629)"
+    assert "EPM_TICK_HUMAN_ACTIVE_PROBE" in body, "skill must name the kill switch"
+    triage = (ROOT / "scripts" / "tick_triage.py").read_text()
+    assert "EPM_TICK_HUMAN_ACTIVE_PROBE" in triage, "tick_triage must carry the kill switch"
+    assert "EPM_TICK_HUMAN_PROBE_DEBUG" in triage, "tick_triage must carry the debug telemetry env"
+
+
 def test_issue_tick_skill_title_refresh_moved_to_watcher():
     body = ISSUE_TICK_SKILL.read_text()
     # The per-tick title refresh moved to the watcher's gate-push pass

--- a/tests/test_tick_triage.py
+++ b/tests/test_tick_triage.py
@@ -53,6 +53,23 @@ def state_dir(tmp_path, monkeypatch):
     return tmp_path
 
 
+# Saved BEFORE the autouse fixture below patches the module attribute, so the
+# #1629 resolution-chain tests can opt back in to the REAL resolver.
+_REAL_TRANSCRIPT_RESOLVER = tick_triage._own_session_transcript_path
+
+
+@pytest.fixture(autouse=True)
+def _neutralize_human_probe(monkeypatch):
+    """AUTOUSE (#1629, consistency WARN 2): the human-activity probe reads
+    AMBIENT state (/proc ancestry from ``os.getpid()``), so a pytest run
+    inside an interactive Claude session would resolve the LIVE session
+    transcript and could flip every pre-existing STALE-REDRIVE expectation
+    to HEALTHY. Neutralize by default; the #1629 suppression tests opt back
+    in by re-patching to their fixture path (or to
+    ``_REAL_TRANSCRIPT_RESOLVER`` for the resolution-chain tests)."""
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: None)
+
+
 # ── compute_issue_verdict ───────────────────────────────────────────────────
 
 
@@ -835,3 +852,367 @@ def test_breadcrumb_parse_on_real_931_note():
         "/home/thomasjiralerspong/explore-persona-space/.claude/worktrees/issue-931/logs/"
         "issue931_author_blocked_folds_production.log"
     )
+
+
+# ── human-activity screen (#1629) ───────────────────────────────────────────
+# Transcript fixtures use the millisecond ISO timestamp form real transcripts
+# carry (`2026-07-23T06:27:15.951Z`; parse_event_ts handles it via
+# fromisoformat after the Z replace).
+
+
+def _iso_ms(epoch: float) -> str:
+    from datetime import UTC, datetime
+
+    return datetime.fromtimestamp(epoch, tz=UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+def _transcript_row(kind: str, age_s: float, text: str = "hello") -> dict:
+    """A transcript JSONL row in one of the measured §4.2 shapes:
+    ``human`` / ``cron`` / ``meta`` / ``tool_result`` / ``interrupt``."""
+    base: dict = {
+        "type": "user",
+        "isMeta": None,
+        "userType": "external",  # measured NON-discriminator: external on human AND cron
+        "timestamp": _iso_ms(NOW - age_s),
+    }
+    if kind == "human":
+        base["message"] = {"role": "user", "content": text}
+    elif kind == "cron":
+        base["message"] = {
+            "role": "user",
+            "content": (
+                "<command-message>issue-tick is running…</command-message>\n"
+                "<command-name>/issue-tick</command-name>\n<command-args>1629</command-args>"
+            ),
+        }
+    elif kind == "meta":
+        base["isMeta"] = True
+        base["message"] = {
+            "role": "user",
+            "content": [{"type": "text", "text": f"Base directory for this skill: {text}"}],
+        }
+    elif kind == "tool_result":
+        base["message"] = {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "toolu_x", "content": text}],
+        }
+    elif kind == "interrupt":
+        base["message"] = {
+            "role": "user",
+            "content": [{"type": "text", "text": "[Request interrupted by user]"}],
+        }
+    else:
+        raise ValueError(kind)
+    return base
+
+
+def _write_transcript(tmp_path: Path, rows: list, name: str = "transcript.jsonl") -> str:
+    path = tmp_path / name
+    path.write_text("".join(json.dumps(r) + "\n" for r in rows))
+    return str(path)
+
+
+def test_human_activity_suppresses_stale_redrive(state_dir, monkeypatch, tmp_path):
+    """Durability pin (#1629): ACTIVE status + stale marker + a fresh human
+    transcript row => HEALTHY with the `human-active` reason prefix."""
+    path = _write_transcript(tmp_path, [_transcript_row("human", 900)])
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: path)
+    _patch_issue_state(monkeypatch, "running", [_event("epm:progress v1", 3600)])
+    verdict, reason = tick_triage.triage(1629, "issue")
+    assert verdict == "HEALTHY", reason
+    assert "human-active" in reason
+
+
+@pytest.mark.parametrize("status", ["planning", "followups_running"])
+def test_human_activity_suppresses_at_park_status(state_dir, monkeypatch, tmp_path, status):
+    path = _write_transcript(tmp_path, [_transcript_row("human", 900)])
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: path)
+    _patch_issue_state(monkeypatch, status, [_event("epm:progress v1", 3600)])
+    verdict, reason = tick_triage.triage(1629, "issue")
+    assert verdict == "HEALTHY", reason
+    assert "human-active" in reason
+
+
+def test_cron_prompt_only_transcript_does_not_suppress(state_dir, monkeypatch, tmp_path):
+    """Fresh cron-injected slash-command, skill-load meta, and tool_result
+    rows are ALL automation — a transcript with only those keeps the
+    STALE-REDRIVE (the incident's cron row must never read as human)."""
+    rows = [
+        _transcript_row("cron", 900),
+        _transcript_row("meta", 890),
+        _transcript_row("tool_result", 880),
+    ]
+    path = _write_transcript(tmp_path, rows)
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: path)
+    _patch_issue_state(monkeypatch, "running", [_event("epm:progress v1", 3600)])
+    verdict, _ = tick_triage.triage(1629, "issue")
+    assert verdict == "STALE-REDRIVE"
+
+
+def test_resolution_failure_fails_toward_ticking(state_dir, monkeypatch, capsys):
+    """Resolution returning None AND raising both fall through to
+    STALE-REDRIVE; the exit-code contract is intact (main() returns 0)."""
+    _patch_issue_state(monkeypatch, "running", [_event("epm:progress v1", 3600)])
+    # (a) resolution miss (the autouse default: _own_session_transcript_path -> None)
+    verdict, _ = tick_triage.triage(201, "issue")
+    assert verdict == "STALE-REDRIVE"
+
+    # (b) resolution RAISES -> the blanket guard eats it -> still STALE-REDRIVE
+    def boom():
+        raise RuntimeError("resolution blew up")
+
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", boom)
+    rc = tick_triage.main(["201"])
+    out = capsys.readouterr().out.strip()
+    assert rc == 0
+    assert out.startswith("STALE-REDRIVE")
+
+
+def test_kill_switch_disables_human_probe(state_dir, monkeypatch, tmp_path):
+    monkeypatch.setenv("EPM_TICK_HUMAN_ACTIVE_PROBE", "0")
+    path = _write_transcript(tmp_path, [_transcript_row("human", 60)])
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: path)
+    _patch_issue_state(monkeypatch, "running", [_event("epm:progress v1", 3600)])
+    verdict, _ = tick_triage.triage(1629, "issue")
+    assert verdict == "STALE-REDRIVE"
+
+
+def test_window_boundary(monkeypatch, tmp_path):
+    """Per-row window test: age just over the window never suppresses, just
+    under does, and a future-dated (clock-skewed) row never suppresses."""
+    window = tick_triage.human_active_s()
+    over = _write_transcript(tmp_path, [_transcript_row("human", window + 60)], name="over.jsonl")
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: over)
+    assert tick_triage.human_activity_reason(NOW) is None
+    under = _write_transcript(tmp_path, [_transcript_row("human", window - 60)], name="under.jsonl")
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: under)
+    reason = tick_triage.human_activity_reason(NOW)
+    assert reason is not None and "human-active" in reason
+    future = _write_transcript(tmp_path, [_transcript_row("human", -120)], name="future.jsonl")
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: future)
+    assert tick_triage.human_activity_reason(NOW) is None
+
+
+def test_mixed_clock_skew_rows(monkeypatch, tmp_path):
+    """Any-row-in-window semantics pin: a future-dated human row (last in the
+    file — the position newest-row-wins would latch) can never mask a valid
+    fresh row earlier in the tail."""
+    rows = [_transcript_row("human", 300), _transcript_row("human", -600)]
+    path = _write_transcript(tmp_path, rows)
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: path)
+    reason = tick_triage.human_activity_reason(NOW)
+    assert reason is not None and "human-active" in reason
+
+
+def test_interrupt_row_counts_as_human(state_dir, monkeypatch, tmp_path):
+    """The `[Request interrupted by user]` list-text row is a direct human
+    action (the incident's 06:27:17 interrupt row) => suppression."""
+    path = _write_transcript(tmp_path, [_transcript_row("interrupt", 300)])
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: path)
+    _patch_issue_state(monkeypatch, "running", [_event("epm:progress v1", 3600)])
+    verdict, reason = tick_triage.triage(1629, "issue")
+    assert verdict == "HEALTHY", reason
+    assert "human-active" in reason
+
+
+def test_terminal_and_gate_verdicts_unchanged_when_human_active(state_dir, monkeypatch, tmp_path):
+    """Teardown verdicts are deliberately NOT suppressed — the teardown is
+    what stops future interruptions (pro-human)."""
+    path = _write_transcript(tmp_path, [_transcript_row("human", 60)])
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: path)
+    _patch_issue_state(monkeypatch, "awaiting_promotion", [_event("epm:progress v1", 60)])
+    verdict, _ = tick_triage.triage(301, "issue")
+    assert verdict == "GATE-TRANSITION", "first gate crossing fires the push branch"
+    verdict, _ = tick_triage.triage(301, "issue")
+    assert verdict == "TERMINAL"
+
+
+@pytest.mark.parametrize(
+    ("row", "expected"),
+    [
+        (_transcript_row("human", 60), True),
+        (_transcript_row("human", 60, text="what does this even mean"), True),
+        (_transcript_row("interrupt", 60), True),
+        (_transcript_row("cron", 60), False),
+        (_transcript_row("meta", 60), False),
+        (_transcript_row("tool_result", 60), False),
+        ("not a dict", False),
+        (42, False),
+        (None, False),
+        ({"type": "assistant", "message": {"role": "assistant", "content": "hi"}}, False),
+        ({"type": "user"}, False),  # missing message
+        ({"type": "user", "message": "not a dict"}, False),
+        ({"type": "user", "message": {"role": "assistant", "content": "hi"}}, False),
+        ({"type": "user", "message": {"role": "user", "content": ""}}, False),
+        ({"type": "user", "message": {"role": "user", "content": "   "}}, False),
+        ({"type": "user", "message": {"role": "user", "content": None}}, False),
+        (
+            {
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": (
+                        "<command-message>x</command-message>\n<command-name>/x</command-name>"
+                    ),
+                },
+            },
+            False,
+        ),
+        (
+            {"type": "user", "message": {"role": "user", "content": "<local-command-stdout>x"}},
+            False,
+        ),
+        (
+            {"type": "user", "isMeta": True, "message": {"role": "user", "content": "hello"}},
+            False,
+        ),
+        (  # a plain list text block is NOT the interrupt row => automation
+            {
+                "type": "user",
+                "message": {"role": "user", "content": [{"type": "text", "text": "plain text"}]},
+            },
+            False,
+        ),
+    ],
+)
+def test_is_human_transcript_row_classifier(row, expected):
+    assert tick_triage.is_human_transcript_row(row) is expected
+
+
+def test_human_reason_free_of_transcript_text(state_dir, monkeypatch, tmp_path):
+    """Content invariant #1000: the verdict reason carries ages only — never
+    the human message text (the reason line prints into an LLM tick turn)."""
+    secret = "SECRET-HUMAN-MESSAGE-TEXT-xyzzy"
+    path = _write_transcript(tmp_path, [_transcript_row("human", 300, text=secret)])
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: path)
+    _patch_issue_state(monkeypatch, "running", [_event("epm:progress v1", 3600)])
+    verdict, reason = tick_triage.triage(401, "issue")
+    assert verdict == "HEALTHY" and "human-active" in reason
+    assert secret not in reason
+
+
+def test_tail_read_bounded_finds_recent_rows(monkeypatch, tmp_path):
+    """Documents the 256 KB bound + the seek-from-END shape (#1287): a human
+    row at EOF of an over-bound transcript IS seen; a human row only BEFORE
+    the tail boundary (with an automation tail after it) is NOT."""
+    filler = [_transcript_row("tool_result", 400, text="x" * 2048) for _ in range(140)]
+    at_eof = _write_transcript(tmp_path, [*filler, _transcript_row("human", 300)], name="a.jsonl")
+    assert os.stat(at_eof).st_size > tick_triage.TRANSCRIPT_TAIL_BYTES
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: at_eof)
+    reason = tick_triage.human_activity_reason(NOW)
+    assert reason is not None and "human-active" in reason
+    before = _write_transcript(tmp_path, [_transcript_row("human", 300), *filler], name="b.jsonl")
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: before)
+    assert tick_triage.human_activity_reason(NOW) is None
+
+
+def test_liveness_screen_takes_precedence(state_dir, monkeypatch, tmp_path):
+    """Ordering pin: the #1051 liveness screen runs FIRST — when both screens
+    have fresh evidence the reason is the liveness one (byte-preserving the
+    existing behavior; the human screen fires only on a liveness miss)."""
+    monkeypatch.setattr(tick_triage, "pid_alive_with_identity", lambda *_a: True)
+    path = _write_transcript(tmp_path, [_transcript_row("human", 300)])
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: path)
+    _patch_issue_state(monkeypatch, "running", [_crumb(7200, pid=4242)])
+    verdict, reason = tick_triage.triage(501, "issue")
+    assert verdict == "HEALTHY"
+    assert "detached phase alive" in reason
+    assert "human-active" not in reason
+
+
+def test_campaign_kind_skips_human_probe(state_dir, monkeypatch, tmp_path):
+    """Scope pin: the campaign branch never consults the human-activity
+    screen (mirrors the #1051 campaign exclusion)."""
+    path = _write_transcript(tmp_path, [_transcript_row("human", 300)])
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: path)
+    monkeypatch.setattr(tick_triage, "load_campaign_state", lambda _n: {})
+    monkeypatch.setattr(tick_triage, "load_children", lambda _n: [])
+    _patch_issue_state(monkeypatch, "running", [_event("epm:campaign-decision v1", 7200)])
+    verdict, _ = tick_triage.triage(601, "campaign")
+    assert verdict == "STALE-REDRIVE"
+
+
+def test_size_guard_boundary(monkeypatch, tmp_path):
+    """REAL _own_session_transcript_path with only the OS boundary faked:
+    a log at the byte cap resolves; one byte over the cap returns None
+    (both sides of EPM_TICK_HUMAN_LOG_MAX_BYTES; fail SAFE = skip)."""
+    import session_resolver
+
+    transcript = _write_transcript(tmp_path, [_transcript_row("human", 300)])
+    log = tmp_path / "2026-07-23-00-00-00-pid-12345.log"
+    log.write_text(json.dumps({"transcript_path": transcript}) + "\n")
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", _REAL_TRANSCRIPT_RESOLVER)
+    monkeypatch.setattr(tick_triage, "_own_node_wrapper_pid", lambda: 12345)
+    monkeypatch.setattr(session_resolver, "_find_happy_log_for_node", lambda pid, now=None: log)
+    size = log.stat().st_size
+    monkeypatch.setenv("EPM_TICK_HUMAN_LOG_MAX_BYTES", str(size))  # log <= cap => resolves
+    assert tick_triage._own_session_transcript_path() == transcript
+    monkeypatch.setenv("EPM_TICK_HUMAN_LOG_MAX_BYTES", str(size - 1))  # log > cap => None
+    assert tick_triage._own_session_transcript_path() is None
+
+
+def test_transcript_extract_then_isfile_leg(monkeypatch, tmp_path):
+    """REAL _own_session_transcript_path: the extracted transcript_path is
+    returned iff it exists on disk; a missing file is a resolution miss."""
+    import session_resolver
+
+    transcript = _write_transcript(tmp_path, [_transcript_row("human", 300)])
+    log = tmp_path / "2026-07-23-00-00-00-pid-777.log"
+    log.write_text(json.dumps({"transcript_path": transcript}) + "\n")
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", _REAL_TRANSCRIPT_RESOLVER)
+    monkeypatch.setattr(tick_triage, "_own_node_wrapper_pid", lambda: 777)
+    monkeypatch.setattr(session_resolver, "_find_happy_log_for_node", lambda pid, now=None: log)
+    assert tick_triage._own_session_transcript_path() == transcript
+    log.write_text(json.dumps({"transcript_path": str(tmp_path / "gone.jsonl")}) + "\n")
+    assert tick_triage._own_session_transcript_path() is None
+
+
+def test_ancestry_walk_with_faked_proc(monkeypatch):
+    """REAL _own_node_wrapper_pid over a synthetic /proc chain
+    (python -> uv -> bash -> claude -> node): returns the node wrapper pid;
+    a chain with no claude ancestor and a chain deeper than the cap both
+    return None."""
+    import session_resolver
+
+    me = os.getpid()
+    ppids = {me: 100, 100: 200, 200: 300, 300: 400, 400: 1}
+    comms = {me: "python3", 100: "uv", 200: "bash", 300: "claude", 400: "node"}
+    monkeypatch.setattr(tick_triage, "_proc_ppid", lambda pid: ppids.get(pid))
+    monkeypatch.setattr(session_resolver, "_read_proc_comm", lambda pid: comms.get(pid))
+    assert tick_triage._own_node_wrapper_pid() == 400
+
+    no_claude = {me: "python3", 100: "uv", 200: "bash", 300: "sshd", 400: "systemd"}
+    monkeypatch.setattr(session_resolver, "_read_proc_comm", lambda pid: no_claude.get(pid))
+    assert tick_triage._own_node_wrapper_pid() is None
+
+    deep_ppids: dict[int, int] = {}
+    deep_comms: dict[int, str] = {}
+    pid = me
+    for i in range(tick_triage._ANCESTRY_MAX_DEPTH + 3):
+        nxt = 10_000 + i
+        deep_ppids[pid] = nxt
+        deep_comms[pid] = "bash"
+        pid = nxt
+    deep_comms[pid] = "claude"  # claude sits DEEPER than the walk cap
+    deep_ppids[pid] = 99_999
+    monkeypatch.setattr(tick_triage, "_proc_ppid", lambda p: deep_ppids.get(p))
+    monkeypatch.setattr(session_resolver, "_read_proc_comm", lambda p: deep_comms.get(p))
+    assert tick_triage._own_node_wrapper_pid() is None
+
+
+def test_debug_telemetry_line(monkeypatch, tmp_path, capsys):
+    """EPM_TICK_HUMAN_PROBE_DEBUG=1 emits one stderr [human-probe] line with
+    path/counts/ages and NEVER transcript message text; default OFF emits
+    nothing (zero production output)."""
+    secret = "DEBUG-SECRET-MESSAGE-TEXT"
+    path = _write_transcript(tmp_path, [_transcript_row("human", 300, text=secret)])
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: path)
+    monkeypatch.delenv("EPM_TICK_HUMAN_PROBE_DEBUG", raising=False)
+    assert tick_triage.human_activity_reason(NOW) is not None
+    assert capsys.readouterr().err == ""
+    monkeypatch.setenv("EPM_TICK_HUMAN_PROBE_DEBUG", "1")
+    assert tick_triage.human_activity_reason(NOW) is not None
+    err = capsys.readouterr().err
+    assert "[human-probe]" in err
+    assert path in err and "human=1" in err and "verdict=suppress" in err
+    assert secret not in err

--- a/tests/test_tick_triage.py
+++ b/tests/test_tick_triage.py
@@ -901,6 +901,17 @@ def _transcript_row(kind: str, age_s: float, text: str = "hello") -> dict:
             "role": "user",
             "content": [{"type": "text", "text": "[Request interrupted by user]"}],
         }
+    elif kind == "notification":
+        # Agent-tool completion notification / spawn brief (r2 Must-Fix):
+        # a plain-STRING user row starting with the literal
+        # <task-notification> — the dominant string-row class in autonomous
+        # transcripts (149/149 measured across two transcripts).
+        base["message"] = {
+            "role": "user",
+            "content": (
+                f"<task-notification>Background task bash_1 completed</task-notification>\n{text}"
+            ),
+        }
     else:
         raise ValueError(kind)
     return base
@@ -947,6 +958,34 @@ def test_cron_prompt_only_transcript_does_not_suppress(state_dir, monkeypatch, t
     _patch_issue_state(monkeypatch, "running", [_event("epm:progress v1", 3600)])
     verdict, _ = tick_triage.triage(1629, "issue")
     assert verdict == "STALE-REDRIVE"
+
+
+def test_agent_notification_row_does_not_suppress(state_dir, monkeypatch, tmp_path):
+    """r2 Must-Fix pin (fresh-ts fixture): a FRESH Agent-tool
+    `<task-notification>` plain-string user row — the near-continuous
+    row class during agent-heavy autonomous work — classifies automation
+    and never suppresses the STALE-REDRIVE."""
+    path = _write_transcript(tmp_path, [_transcript_row("notification", 60)])
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: path)
+    _patch_issue_state(monkeypatch, "running", [_event("epm:progress v1", 3600)])
+    verdict, _ = tick_triage.triage(1629, "issue")
+    assert verdict == "STALE-REDRIVE"
+
+
+def test_debug_error_rung_on_raising_probe(state_dir, monkeypatch, capsys):
+    """r2 Minor: with debug ON, a raising probe emits an `error=<ExcType>`
+    rung (type name only — content invariant #1000) and still returns
+    None (fail toward ticking)."""
+    monkeypatch.setenv("EPM_TICK_HUMAN_PROBE_DEBUG", "1")
+
+    def boom():
+        raise RuntimeError("resolution blew up")
+
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", boom)
+    assert tick_triage.human_activity_reason(NOW) is None
+    err = capsys.readouterr().err
+    assert "[human-probe] error=RuntimeError" in err
+    assert "resolution blew up" not in err  # exception TYPE only, never the message
 
 
 def test_resolution_failure_fails_toward_ticking(state_dir, monkeypatch, capsys):
@@ -1060,6 +1099,17 @@ def test_terminal_and_gate_verdicts_unchanged_when_human_active(state_dir, monke
         ),
         (
             {"type": "user", "message": {"role": "user", "content": "<local-command-stdout>x"}},
+            False,
+        ),
+        (  # r2 Must-Fix pin: Agent-tool <task-notification> string rows are automation
+            _transcript_row("notification", 60),
+            False,
+        ),
+        (
+            {
+                "type": "user",
+                "message": {"role": "user", "content": "<task-notification>Agent brief…"},
+            },
             False,
         ),
         (


### PR DESCRIPTION
Closes task #1629. tick_triage.py converts a would-be STALE-REDRIVE to HEALTHY when the session transcript shows a recent human (non-cron, non-notification) user message; fail-toward-ticking on every resolution path; EPM_TICK_HUMAN_ACTIVE_PROBE kill switch + EPM_TICK_HUMAN_PROBE_DEBUG telemetry. Plan v3; code-review r2 PASS; step9c compare exit 0 (2 pre-existing trunk reds stripped).