### PR TITLE
issue-1632: exclude /tmp,/var/tmp,/dev/shm from PostToolUse ruff hook

### DIFF
--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -433,6 +433,12 @@ deliberate GCP fence sized off the p90 per-cell wall, never the mean
 + per-out-root disk rows that NAME the target filesystem/mount the path
 resolves to on the routed lane (never a bare GB number; preamble assert per
 `.claude/rules/plan-compute-sizing.md` § Out-root mount binding).
+A multi-arm dispatch coupling arms of DIFFERENT minimum GPU widths
+behind one provision additionally states each arm's MINIMUM runnable width
+and pre-registers the stall-time down-width split (≥ ~1 h sustained
+capacity stall ⇒ split out + probe the narrowest-runnable arms; the #1121
+walk's down-going sibling — `.claude/rules/plan-compute-sizing.md`
+§ Multi-arm min-width + stall-time down-width split; incident #1112).
 Compute-sizing recipes: `.claude/rules/plan-compute-sizing.md`
 (on-demand); phase placement + GPU-width right-sizing are always-on in
 CLAUDE.md § Pods.

--- a/.claude/rules/LESSONS.md
+++ b/.claude/rules/LESSONS.md
@@ -34,7 +34,7 @@ Row grammar: `- <rule>.md — <fires-when trigger>`
 - ood-generalization-folds.md — a held-out predictive DV (R²/ρ) over grouped samples (GROUP-level fold — LOFO/transfer, not pointwise LOO).
 - persona-distance-metrics.md — you write base-model persona-distance predictor code (canonical KL/JS/cosine defs).
 - persona-vectors-recipe.md — a plan elects persona vectors / a mean-difference contrastive direction (arXiv 2507.21509 EXCEPT logit scoring).
-- plan-compute-sizing.md — a plan sizes §9 compute (HBM, disk/ckpt retention, fan-out accumulation, out-root mount binding, sentinel lanes, store/IO, RAM/RSS routing, wall-time floors incl. the MEASURED 1-cell pilot basis (fit loops AND draw batteries), p90 fences).
+- plan-compute-sizing.md — a plan sizes §9 compute (HBM, disk/ckpt retention, fan-out accumulation, out-root mounts, sentinel lanes, store/IO, RAM/RSS routing, wall-time floors incl. MEASURED 1-cell pilot basis (fits AND draw batteries), p90 fences, stall down-width split).
 - planner-section-reference.md — the planner writes a plan section (pointer-loaded from planner.md).
 - pm-audit-reference.md — the PM scopes fleet burn, triages unmapped/non-EPS team pods, or renders a Mode-2 audit.
 - pod-config.md — pod SSH/MCP keeps failing, you touch the pod scripts/pods.conf (live-API vs pods.conf authority split), or you stop/park a pod for >~1h (STOPPED volume is NON-durable — persist resume state to HF first).

--- a/.claude/rules/compute-backend-failover.md
+++ b/.claude/rules/compute-backend-failover.md
@@ -945,6 +945,22 @@ sanctioned actor ever starts deleting LIVE PENDING instances, the trigger
 needs an operations-log delete-op check (a genuine vanish leaves NO delete
 operation; an actor's delete leaves one) — a re-plan, not a tweak.
 
+### Coupled multi-arm dispatch stall → down-width split (#1633)
+
+Every trigger in this Part re-shapes or fails over ONE dispatch's machine
+(queue-timeout, queue-vanish, boot-loop, the #1379 wide-intent 8→4→2
+degrade). None of them can DECOMPOSE a dispatch that bundles arms of
+DIFFERENT minimum GPU widths behind one provision — the #1112 failure
+mode: 1×-runnable arms held ~14 h behind a coupled 4×/8× provision during
+an A100 drought while the 1× shape had stock. On a SUSTAINED capacity
+stall (≥ ~1 h queued / stocked-out across rungs) of a coupled multi-arm
+dispatch, the owning orchestrator splits out and probes the
+narrowest-runnable arms as their own dispatch(es) instead of continuing
+to hold them; the wide arm keeps its ladder walk. The plan-side duty
+(per-arm MINIMUM runnable width + the pre-registered split) lives in
+`.claude/rules/plan-compute-sizing.md` § Multi-arm min-width + stall-time
+down-width split; this section is the dispatch-time cross-reference.
+
 ### Pre-workload boot-loop → RunPod (#1029)
 
 A boot-looping rung — the #763 shape: `flexstart_l4` re-selected by every

--- a/.claude/rules/plan-compute-sizing.md
+++ b/.claude/rules/plan-compute-sizing.md
@@ -1,5 +1,5 @@
 ---
-description: Planner §9 compute-sizing recipes — activation-capture HBM sizing, merge-disk budget, sentinel-signaling lane pins, the floor cross-check for long / many-call phases (planned_wall_h > 4 OR >~500 serial calls), the measured 1-cell fit-pilot basis for per-cell fit / factorization / GD phases (#1060), the store-heavy / IO-heavy phase recipe (measured per-item serialization+upload wall-time; compression-default-OFF for fp16→Xet), the CPU-phase RAM/RSS routing gate (projected peak RSS per VM-placed phase; ≥~16 GB single-or-summed routes off the shared VM), the dose-ladder checkpoint-retention default (keep dose-selected + latest, clean ruled-out rungs between rungs; size disk to the RETAINED set, #1133), the fan-out end-of-run accumulated footprint rule (#1541, from incident #1481: an N-cell fan-out retaining per-cell outputs sizes the boot disk to the end-of-run SUM of every cell's retained outputs + the transient high-water mark, or declares a driver-side between-phase reap of consumed cell outputs), and costing wall-time against the machine the router will ACTUALLY provision + p90-based fence sizing, and the external-stream >~1h presumption for network-bound streaming/harvest phases (#1092), and the out-root mount-binding contract (#1414, from incident #1333: each disk out-root names its target filesystem/mount; the workload preamble asserts headroom at that mount), and the phase-ordering checkpoint high-water requirement (#1612, from incident #1586 r5: the stated ckpt high-water is computed against the IMPLEMENTED phase ordering — every phase accumulating checkpoints without an intervening reap is itself reap-bounded; a downstream-unit reap cannot bound an upstream train-all accumulation) (loads at plan time via plan-file paths; relocated verbatim from planner.md §9, #829)
+description: Planner §9 compute-sizing recipes — activation-capture HBM sizing, merge-disk budget, sentinel-signaling lane pins, the floor cross-check for long / many-call phases (planned_wall_h > 4 OR >~500 serial calls), the measured 1-cell fit-pilot basis for per-cell fit / factorization / GD phases (#1060), the store-heavy / IO-heavy phase recipe (measured per-item serialization+upload wall-time; compression-default-OFF for fp16→Xet), the CPU-phase RAM/RSS routing gate (projected peak RSS per VM-placed phase; ≥~16 GB single-or-summed routes off the shared VM), the dose-ladder checkpoint-retention default (keep dose-selected + latest, clean ruled-out rungs between rungs; size disk to the RETAINED set, #1133), the fan-out end-of-run accumulated footprint rule (#1541, from incident #1481: an N-cell fan-out retaining per-cell outputs sizes the boot disk to the end-of-run SUM of every cell's retained outputs + the transient high-water mark, or declares a driver-side between-phase reap of consumed cell outputs), and costing wall-time against the machine the router will ACTUALLY provision + p90-based fence sizing, and the external-stream >~1h presumption for network-bound streaming/harvest phases (#1092), and the out-root mount-binding contract (#1414, from incident #1333: each disk out-root names its target filesystem/mount; the workload preamble asserts headroom at that mount), and the phase-ordering checkpoint high-water requirement (#1612, from incident #1586 r5: the stated ckpt high-water is computed against the IMPLEMENTED phase ordering — every phase accumulating checkpoints without an intervening reap is itself reap-bounded; a downstream-unit reap cannot bound an upstream train-all accumulation), and the multi-arm min-width + stall-time down-width split (#1633, from incident #1112: 1×-runnable arms held ~14 h behind a coupled 4×/8× provision during an A100 drought; a mixed-width multi-arm plan names each arm's MINIMUM runnable width and pre-registers splitting out the narrowest-runnable arms on a ≥ ~1 h sustained capacity stall) (loads at plan time via plan-file paths; relocated verbatim from planner.md §9, #829)
 paths:
   - ".claude/plans/**"
   - "tasks/**/plans/**"
@@ -7,7 +7,7 @@ paths:
 
 # Plan compute sizing (planner §9 relocated recipes)
 
-These thirteen recipes are the planner-specific §9 sizing blocks — five relocated
+These fourteen recipes are the planner-specific §9 sizing blocks — five relocated
 verbatim from `.claude/agents/planner.md` (#829), plus the
 store-heavy / IO-heavy phase recipe (#910, from incident #813), the
 CPU-phase RAM/RSS routing gate (#1031, from incidents #778/#833), the
@@ -17,7 +17,8 @@ here), the dose-ladder checkpoint-retention default (#1133, from incident
 #1112), the out-root mount-binding contract (#1414, from incident
 #1333), the fan-out end-of-run accumulation rule (#1541, from incident
 #1481), and the phase-ordering checkpoint high-water requirement (#1612,
-from incident #1586 r5). The planner
+from incident #1586 r5), and the multi-arm min-width + stall-time
+down-width split (#1633, from incident #1112). The planner
 applies each when its trigger matches; the compute-projection table spec +
 stratification spec stay inline in planner.md §9.
 
@@ -539,3 +540,39 @@ long-run residual gap named (`/issue` SKILL.md Step 6b residual gap (d)).
 A plan that silently lets a conditional phase ride past the fence loses
 the phase mid-run (#599: the pre-registered §7.3 extension probe was
 hard-deleted at step 149/2400 by the 24h fence).
+
+
+**Multi-arm min-width + stall-time down-width split — the down-going
+sibling of the #1121 wide-first rung walk.** A plan whose §9 couples two
+or more arms with DIFFERENT minimum GPU requirements behind ONE provision
+(e.g. a 1×-runnable LoRA-ladder arm and a 4×-needing ZeRO-3 full-FT arm
+dispatched together on a 4×/8× pod) MUST name, per arm, that arm's
+MINIMUM runnable width — the smallest GPU count × class the arm can
+actually execute on (a min-width column or per-arm line in the §9
+compute-projection table) — and MUST pre-register the down-width split:
+if the coupled provision sits in a SUSTAINED capacity stall — ≥ ~1 h
+queued / stocked-out across rungs (prose guidance, not a coded gate;
+calibrated as several full ladder walks — the router's per-rung queue
+timeout is 600 s, `EPS_GCP_QUEUE_WAIT_SECONDS`, and the free-lane park is
+600 s, `router.FREE_WAIT_SECONDS`) — the owning orchestrator SPLITS OUT
+the narrowest-runnable arms as their own narrow dispatch(es) and probes
+that shape immediately, rather than holding every arm behind the widest
+arm's provision; the wide arm keeps its own ladder walk unchanged.
+Composition invariant (all three untouched): the #1121 wide-FIRST walk
+still leads for any single shardable phase (wide `a2-ultragpu` rungs
+tried first when work shards); the #1379 explicit-wide 8→4→2 degrade
+still narrows ONE dispatch's machine on a capacity miss — it CANNOT
+decompose arms of different minimum widths bundled behind one provision,
+which is exactly the #1112 failure mode; and the saturate-or-downsize
+idle-width protections are unchanged (a split-out narrow arm must still
+saturate its own pod). Incident #1112 (2026-07-22): a coupled dispatch
+held 1×-runnable arms ~14 h through a GCP A100 drought (dozens of
+create attempts, both zones) while the 1× shape had stock — the Arm-A-only 1×
+dispatch provisioned immediately and finished in ~55 min. A plan that
+couples mixed-width arms without per-arm minimum widths and the
+pre-registered split leaves the mid-run orchestrator no licensed
+decomposition — that omission is the gap this recipe closes. (Up-front
+DECOUPLING of mixed-min-width arms into separate provisions was
+considered and rejected: wide coupling wins when capacity exists — one
+provision, shared setup — so the split is a stall-time remedy, not the
+default dispatch shape.)

--- a/.claude/rules/workflow-fix-on-bug.md
+++ b/.claude/rules/workflow-fix-on-bug.md
@@ -78,7 +78,7 @@ Now it's same-turn (the file + spawn is non-blocking).
   `audit_clean_results_body_discipline.py`,
   `redact_for_gist.py`, `check_no_secret_shaped_strings.py`,
   `codex_task.py`,
-  `poll_pipeline.py`, `dispatch_issue.py`, `backend_poll.py`,
+  `plan_patch.py`, `poll_pipeline.py`, `dispatch_issue.py`, `backend_poll.py`,
   `failure_classifier.py`, `gh_project.py`,
   `pm_queue_report.py`,
   `recent_clean_results.py`, `task_state.py`,

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -159,7 +159,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "file_path=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty'); if [ -n \"$file_path\" ] && echo \"$file_path\" | grep -qE '\\.py$'; then cd /home/thomasjiralerspong/explore-persona-space && uv run ruff check --fix --quiet \"$file_path\" 2>/dev/null; uv run ruff format --quiet \"$file_path\" 2>/dev/null; fi"
+            "command": "file_path=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty'); if [ -n \"$file_path\" ] && echo \"$file_path\" | grep -qE '\\.py$' && ! echo \"$file_path\" | grep -qE '^/(tmp|var/tmp|dev/shm)/'; then cd /home/thomasjiralerspong/explore-persona-space && uv run ruff check --fix --quiet \"$file_path\" 2>/dev/null; uv run ruff format --quiet \"$file_path\" 2>/dev/null; fi"
           }
         ]
       }

--- a/.claude/skills/adversarial-planner/SKILL.md
+++ b/.claude/skills/adversarial-planner/SKILL.md
@@ -113,7 +113,16 @@ landed. Verify = grep the draft for the revised text
 a non-empty diff vs the prior persisted version
 (`! diff -q <draft> "$(uv run python scripts/task.py find <N>)/plans/plan.md"`
 — the `plan.md` symlink still points at v<K-1> until the persist; identical
-bytes mean the edit silently no-oped); a bare exit 0 is NOT evidence. Never
+bytes mean the edit silently no-oped); a bare exit 0 is NOT evidence. Run the
+EDIT step via the committed helper `uv run python scripts/plan_patch.py
+<draft> --anchor-file <a.txt> --replace-file <r.txt>` (exact-then-normalized
+anchor resolution — whitespace-collapsed, then case-tolerant —
+unique-match-only; fails loud with a nearest-match diff on a missing/ambiguous
+anchor; #1631) instead of improvising a per-turn python/sed anchor script —
+anchor byte-identity drift cost ≥4 re-derive rounds across 3 sessions on
+2026-07-22; prefer anchors carrying ≥1 full line of distinctive context, and
+let the verify step grep the helper's printed `PLAN-PATCH APPLIED` line and/or
+pass `--verify-contains` in addition to the draft grep. Never
 `;`-chain the edit and the persist, and never run the persist inside the same
 script before its asserts have executed. On ANY edit failure, abort LOUDLY
 without persisting — print `EDIT FAILED — not persisting`, Read the CURRENT

--- a/.claude/skills/issue-tick/SKILL.md
+++ b/.claude/skills/issue-tick/SKILL.md
@@ -9,7 +9,11 @@ description: >
   computes staleness, screens detached-phase liveness before any
   STALE-REDRIVE — a live identity-verified breadcrumb `pid=`, a fresh
   `log=` mtime, or a fresh `[long-phase-heartbeat]` note reads HEALTHY,
-  #1051 — and maintains the tick snapshot + runaway counter) and
+  #1051 — and screens recent HUMAN activity in this session's transcript
+  (a human (non-cron) user message within ~45 min converts a would-be
+  STALE-REDRIVE to HEALTHY, reason `human-active …`; #1629 — an
+  interactive session is never re-driven over the human's thread) — and
+  maintains the tick snapshot + runaway counter) and
   branches on its one-word verdict: HEALTHY → end the turn immediately;
   TERMINAL → CRON-TEARDOWN, end; GATE-TRANSITION → PushNotification +
   CRON-TEARDOWN, end; STALE-REDRIVE → re-drive the full `/issue` skill
@@ -85,6 +89,28 @@ A broken triage must fail toward coverage (full re-drive), never toward
 silence — a no-op-on-crash tick would leave the alive-stalled-at-PARK
 class permanently unrecovered.
 
+**Human-activity screen (#1629).** `tick_triage.py` converts a would-be
+STALE-REDRIVE to `HEALTHY` (reason prefix `human-active`) when this
+session's transcript tail shows a human (non-cron) user message within
+`EPM_TICK_HUMAN_ACTIVE_S` (default 2700 s ≈ one tick interval).
+Cron-injected `/issue-tick` / `/issue` prompts, harness
+`<task-notification>` rows (Agent-tool spawn briefs / completion
+notifications), skill-load meta rows, and tool results never count as
+human. Fail toward ticking: any
+transcript-resolution or classification failure suppresses nothing.
+Teardown verdicts (TERMINAL / GATE-TRANSITION) are deliberately NOT
+suppressed — the teardown is what stops future interruptions. For the
+alive-stalled-at-PARK class the re-drive resumes within ~window + one
+tick interval (≈90 min) of the human's last message — the human in the
+thread is the interim supervisor (the watcher deliberately does not
+respawn PARK sessions). Kill switch: `EPM_TICK_HUMAN_ACTIVE_PROBE=0`;
+debug telemetry: `EPM_TICK_HUMAN_PROBE_DEBUG=1` (stderr `[human-probe]`
+line, paths/counts only). Deliberate non-goal: the tick never tears down
+its cron on human activity alone (coverage loss would strand a stalled
+task; use `task.py set-status <N> on_hold` / user-pause for a deliberate
+park), and the screen does NOT prevent the cron prompt's arrival
+(harness-side) — it bounds the tick turn to one Bash call.
+
 ## Digest-only task-state reads (every tick turn, every task)
 
 Any task-state read a tick turn makes BEYOND the one `tick_triage.py`
@@ -157,7 +183,9 @@ cosmetic and accepted.
 (>~25 min) at a non-gate, non-terminal status AND its detached-phase
 liveness screen found no evidence (no live identity-verified breadcrumb
 `pid=`, no fresh breadcrumb `log=` mtime, no fresh
-`[long-phase-heartbeat]` note — #1051). Two sub-cases, split by
+`[long-phase-heartbeat]` note — #1051) AND its human-activity screen
+found no recent human (non-cron) user message in this session's
+transcript (#1629). Two sub-cases, split by
 the status named in the verdict reason:
 
 **ACTIVE statuses** (`approved` / `running` / `verifying` /
@@ -368,6 +396,9 @@ means the job being gone is the goal.
   bodies, interpretation bodies, or raw completions into context — every
   task-state read beyond the triage call is a jq-filtered digest
   (§ Digest-only task-state reads; refusal-thinned re-drive rule).
+- It does NOT re-drive over a live human thread — `tick_triage.py`'s
+  human-activity screen (#1629) converts that STALE-REDRIVE to HEALTHY;
+  teardown verdicts still fire (a teardown STOPS future interruptions).
 
 ## Why this skill exists (background)
 

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1643,8 +1643,13 @@ only by a PM-chat directive one wasted implementer round later.
 **Edit-success gate:** when the draft was produced or modified by a SCRIPTED
 edit (the Step 2b/3 revise paths included), `&&`-chain edit → verify
 (positive evidence the revised text is present — grep the draft, or a
-non-empty diff vs the prior version) → the `new-plan-version` persist; an
-edit-script failure aborts the persist loudly, never `;`-chained
+non-empty diff vs the prior version) → the `new-plan-version` persist; the
+edit step is the committed helper `uv run python scripts/plan_patch.py`
+(anchor-normalized apply; fail-loud nearest-match diff on a missing/ambiguous
+anchor — #1631; its printed `PLAN-PATCH APPLIED` line and `--verify-contains`
+double as verify evidence; prefer ≥1-line distinctive anchors), never an
+improvised per-turn anchor script; an edit-script failure aborts the persist
+loudly, never `;`-chained
 (`adversarial-planner` SKILL.md § Edit-success gate; incident #1565: a
 chained persist landed v2 as an unmodified copy of v1 after the edit script
 died on an anchor-text `AssertionError`).

--- a/scripts/plan_patch.py
+++ b/scripts/plan_patch.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python
+"""Anchor-normalized plan-patch helper (#1631).
+
+Applies ONE anchor-based edit to a UTF-8 text file (typically a plan draft at
+``/tmp/issue-<N>-plan-v<K>-<ts>.md``) as the EDIT step of the plan-revision
+Edit-success gate (``.claude/skills/adversarial-planner/SKILL.md``
+"Edit-success gate"; ``.claude/skills/issue/SKILL.md`` Step 2 mirror). It
+never calls ``task.py new-plan-version`` and never touches ``tasks/**`` — the
+gate's separate verify + persist steps stay ``&&``-chained after it.
+
+Matching semantics
+------------------
+The anchor resolves through THREE stages, walked in order; the FIRST stage
+with >=1 candidate decides (per-stage candidate sets, NEVER unioned — an
+exact match wins even when a drifted near-duplicate exists elsewhere):
+
+1. ``exact`` — byte-exact non-overlapping scan (only a lone trailing newline
+   on the anchor is tolerated, via an ``rstrip("\\n")`` comparison fallback —
+   anchor files usually end in a newline).
+2. ``ws-normalized`` — every maximal whitespace run (space, tab, ``\\n``,
+   ``\\r``, ...) collapsed to ONE space on both sides; the anchor is
+   additionally stripped. Absorbs line-wrap / indentation drift.
+3. ``ws+case-normalized`` — stage 2 plus per-char ``lower()``. A char whose
+   ``lower()`` is not length-1 (e.g. ``İ``) is kept as-is so the index map
+   stays 1:1 — such anchors fail toward a MISS, never a wrong span.
+
+At the deciding stage: exactly one candidate -> apply; two or more ->
+fail-loud ambiguity (exit 2) listing every candidate location — NEVER a
+fall-through to a looser stage (looser stages are supersets; falling through
+could only add candidates). All three stages empty -> exit 2 with a
+nearest-match report (best line window by ``SequenceMatcher`` ratio + a
+unified diff of anchor vs window over the ORIGINAL texts). The report is a
+REPORT only — this tool never fuzzy-applies (no ``patch(1)``-style fuzz).
+
+Edit modes
+----------
+``--replace`` splices the payload byte-exactly over the matched span
+(``--replace ''`` deletes it). ``--insert-after`` / ``--insert-before`` are
+LINE-based: the payload lands as full lines adjacent to the line containing
+the span's end / start — a mid-line anchor inserts after/before the
+containing LINE, not byte-adjacent to the match. Payloads are read VERBATIM
+(no normalization is ever applied to a payload). Insert modes are idempotent
+on the EXACT payload block only: a re-run that finds the identical block
+already at the insertion point exits 3 (ALREADY-APPLIED, file untouched).
+Replace mode is deliberately asymmetric: after a successful replace consumed
+the anchor, a crash re-run reads exit 2 (anchor missing), not 3 — a replace
+re-run cannot prove the prior apply used THIS payload.
+
+Exit codes
+----------
+- ``0`` — applied (or a clean ``--dry-run``); stdout carries
+  ``PLAN-PATCH APPLIED (<stage> match at lines <A>-<B> of <file>)`` plus the
+  unified diff — grep-able positive evidence for the gate's verify step.
+- ``2`` — failed, file untouched: missing anchor (nearest-match report),
+  ambiguous anchor, ``EDIT NO-OP``, ``--verify-contains`` miss, usage /
+  encoding / size errors. Stderr prefix: ``PLAN-PATCH FAILED:``.
+- ``3`` — already-applied (insert modes only); file untouched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import difflib
+import os
+import sys
+import tempfile
+from collections import Counter
+
+# Plans are 50-300 KB; refuse pathological inputs (keeps the O(lines * anchor)
+# nearest-match scan trivially fast). Module-level so tests can monkeypatch.
+MAX_FILE_BYTES = 10 * 1024 * 1024
+
+STAGE_EXACT = "exact"
+STAGE_WS = "ws-normalized"
+STAGE_WS_CASE = "ws+case-normalized"
+
+_EXIT_EPILOG = """\
+exit codes:
+  0  applied (or clean --dry-run); stdout: "PLAN-PATCH APPLIED (<stage> match
+     at lines <A>-<B> of <file>)" + the unified diff
+  2  failed, file untouched (missing/ambiguous anchor, EDIT NO-OP,
+     --verify-contains miss, usage/encoding/size errors)
+  3  already-applied (insert modes only: the exact payload block already sits
+     at the insertion point); file untouched
+
+Insert-mode idempotency is exact-payload-block-only; --insert-after with a
+mid-line anchor inserts after the containing LINE (not byte-adjacent). Stage
+order is exact -> ws-normalized -> ws+case-normalized with per-stage candidate
+sets (never unioned): an exact match wins even when a drifted near-duplicate
+exists elsewhere. A replace-mode crash re-run reads exit 2 (anchor consumed),
+asymmetric with insert-mode exit 3 — deliberate.
+"""
+
+
+class PatchError(Exception):
+    """Any failure that leaves the file untouched -> exit 2."""
+
+
+class AlreadyApplied(Exception):
+    """Insert-mode idempotent re-run -> exit 3, file untouched."""
+
+
+class MissingAnchor(Exception):
+    """Anchor resolved to zero candidates at every stage."""
+
+
+class AmbiguousAnchor(Exception):
+    """Anchor resolved to >=2 candidates at its deciding stage."""
+
+    def __init__(self, stage: str, spans: list[tuple[int, int]]):
+        super().__init__(f"{len(spans)} matches at the {stage} stage")
+        self.stage = stage
+        self.spans = spans
+
+
+def normalize_with_map(text: str, *, lower: bool) -> tuple[str, list[int]]:
+    """Collapse every maximal whitespace run (incl. \\n, \\r, \\t) to ONE space.
+
+    Optionally per-char ``lower()``; a char whose ``lower()`` is not length-1
+    is kept as-is, so the index map stays 1:1 (fails toward a stage MISS,
+    never a wrong span). Returns ``(normalized, idx_map)`` where
+    ``idx_map[i]`` is the index in the ORIGINAL text of normalized char
+    ``i`` (a whitespace run maps to its first original char).
+    """
+    chars: list[str] = []
+    idx_map: list[int] = []
+    i, n = 0, len(text)
+    while i < n:
+        ch = text[i]
+        if ch.isspace():
+            j = i + 1
+            while j < n and text[j].isspace():
+                j += 1
+            chars.append(" ")
+            idx_map.append(i)
+            i = j
+        else:
+            if lower:
+                low = ch.lower()
+                ch = low if len(low) == 1 else ch
+            chars.append(ch)
+            idx_map.append(i)
+            i += 1
+    return "".join(chars), idx_map
+
+
+def _scan(haystack: str, needle: str) -> list[tuple[int, int]]:
+    """Non-overlapping left-to-right spans of ``needle``; needle non-empty."""
+    if not needle:  # defensive: empty needles are rejected before any scan
+        raise PatchError("internal: empty scan needle")
+    spans: list[tuple[int, int]] = []
+    pos = 0
+    while True:
+        hit = haystack.find(needle, pos)
+        if hit < 0:
+            return spans
+        spans.append((hit, hit + len(needle)))
+        pos = hit + len(needle)
+
+
+def _normalized_candidates(file_text: str, anchor: str, *, lower: bool) -> list[tuple[int, int]]:
+    """Original-text spans matching the whitespace-collapsed anchor."""
+    norm_file, idx_map = normalize_with_map(file_text, lower=lower)
+    norm_anchor, _ = normalize_with_map(anchor, lower=lower)
+    norm_anchor = norm_anchor.strip()
+    if not norm_anchor:
+        return []
+    # First/last anchor chars are non-space post-strip, so the mapped span is
+    # tight: idx_map[s] and idx_map[e-1] both point at non-space originals.
+    return [(idx_map[s], idx_map[e - 1] + 1) for s, e in _scan(norm_file, norm_anchor)]
+
+
+def find_candidates(file_text: str, anchor: str) -> tuple[str, tuple[int, int]]:
+    """Resolve the anchor to exactly one original-text span.
+
+    Walks the stages in order; at the FIRST stage with >=1 candidate: exactly
+    one -> return ``(stage, span)``; >=2 -> raise :class:`AmbiguousAnchor`
+    (never fall through — looser stages are supersets and can only add
+    candidates). All stages empty -> raise :class:`MissingAnchor`.
+    """
+    exact = _scan(file_text, anchor)
+    if not exact:
+        stripped = anchor.rstrip("\n")
+        if stripped and stripped != anchor:
+            exact = _scan(file_text, stripped)
+    stages: list[tuple[str, list[tuple[int, int]]]] = [(STAGE_EXACT, exact)]
+    if not exact:
+        ws = _normalized_candidates(file_text, anchor, lower=False)
+        stages.append((STAGE_WS, ws))
+        if not ws:
+            stages.append((STAGE_WS_CASE, _normalized_candidates(file_text, anchor, lower=True)))
+    for stage, spans in stages:
+        if len(spans) == 1:
+            return stage, spans[0]
+        if len(spans) >= 2:
+            raise AmbiguousAnchor(stage, spans)
+    raise MissingAnchor()
+
+
+def _best_local_ratio(norm_window: str, norm_anchor: str, floor: float) -> float:
+    """Max SequenceMatcher ratio of the anchor vs the window OR any
+    anchor-length slice of it (a partial-ratio scan: a short drifted anchor
+    inside a LONG markdown line still scores high — the full-window
+    ``ratio()`` structurally penalizes long lines). Report-scoring only;
+    ``floor`` lets the slice scan prefilter against the best score so far.
+    """
+    matcher = difflib.SequenceMatcher(autojunk=False)
+    matcher.set_seq2(norm_anchor)
+    matcher.set_seq1(norm_window)
+    best = matcher.ratio()
+    n_a = len(norm_anchor)
+    if n_a and len(norm_window) > n_a:
+        stride = max(1, n_a // 4)
+        starts = list(range(0, len(norm_window) - n_a + 1, stride))
+        if starts[-1] != len(norm_window) - n_a:
+            starts.append(len(norm_window) - n_a)
+        for start in starts:
+            matcher.set_seq1(norm_window[start : start + n_a])
+            bar = max(best, floor)
+            if matcher.real_quick_ratio() <= bar or matcher.quick_ratio() <= bar:
+                continue
+            ratio = matcher.ratio()
+            if ratio > best:
+                best = ratio
+    return best
+
+
+def nearest_match_report(file_text: str, anchor: str) -> str:
+    """Best-window similarity report for a missing anchor. REPORT only.
+
+    Line-window scan (window height = the anchor's line count, stride 1) over
+    ws+case-normalized texts; each window is scored by the MAX of the
+    full-window ``SequenceMatcher.ratio()`` and a partial-ratio slice scan
+    (:func:`_best_local_ratio`), behind a cheap character-multiset upper
+    bound. Always reports the best candidate (no cutoff — as a report there
+    is no wrong answer). Degenerate inputs (empty file, file shorter than the
+    anchor) get a designed message, never a traceback.
+    """
+    file_lines = file_text.splitlines()
+    if not file_lines:
+        return "nearest-match report: file is empty — no candidate window to compare."
+    anchor_lines = anchor.splitlines() or [""]
+    height = len(anchor_lines)
+    prefix = ""
+    if len(file_lines) < height:
+        prefix = (
+            f"nearest-match report: file has {len(file_lines)} line(s), shorter than "
+            f"the {height}-line anchor — comparing against the whole file.\n"
+        )
+        height = len(file_lines)
+    norm_anchor, _ = normalize_with_map(anchor, lower=True)
+    norm_anchor = norm_anchor.strip()
+    n_a = len(norm_anchor)
+    anchor_counts = Counter(norm_anchor)
+    best: tuple[int, int] = (1, height)
+    best_ratio = -1.0
+    for i in range(len(file_lines) - height + 1):
+        window = "\n".join(file_lines[i : i + height])
+        norm_window, _ = normalize_with_map(window, lower=True)
+        norm_window = norm_window.strip()
+        window_counts = Counter(norm_window)
+        common = sum(min(cnt, window_counts.get(ch, 0)) for ch, cnt in anchor_counts.items())
+        denom_full = len(norm_window) + n_a
+        upper_bound = max(
+            (2 * common / denom_full) if denom_full else 0.0,
+            (common / n_a) if n_a else 0.0,  # ceiling for any anchor-length slice
+        )
+        if upper_bound <= best_ratio:
+            continue
+        ratio = _best_local_ratio(norm_window, norm_anchor, best_ratio)
+        if ratio > best_ratio:
+            best_ratio = ratio
+            best = (i + 1, i + height)
+    a, b = best
+    diff = difflib.unified_diff(
+        anchor_lines,
+        file_lines[a - 1 : b],
+        fromfile="anchor (as given)",
+        tofile=f"closest match in file (lines {a}-{b})",
+        lineterm="",
+    )
+    return (
+        prefix
+        + f"nearest match: lines {a}-{b} (similarity {max(best_ratio, 0.0):.3f})\n"
+        + "\n".join(diff)
+    )
+
+
+def _line_bounds(text: str, index: int) -> tuple[int, int]:
+    """(start, end) of the line containing ``text[index]``.
+
+    ``end`` is the index just past the line's newline (``len(text)`` for an
+    unterminated last line).
+    """
+    start = text.rfind("\n", 0, index) + 1
+    newline = text.find("\n", index)
+    end = len(text) if newline < 0 else newline + 1
+    return start, end
+
+
+def apply_edit(file_text: str, mode: str, span: tuple[int, int], payload: str) -> str:
+    """Return the patched text; raise AlreadyApplied / PatchError (no-op)."""
+    start, end = span
+    if mode == "replace":
+        new_text = file_text[:start] + payload + file_text[end:]
+    else:
+        block = payload if payload.endswith("\n") else payload + "\n"
+        if mode == "insert-after":
+            _, insert_pos = _line_bounds(file_text, end - 1)
+            lead = ""
+            if insert_pos == len(file_text) and file_text and not file_text.endswith("\n"):
+                lead = "\n"  # keep the payload on its own full lines
+            if not lead and file_text[insert_pos : insert_pos + len(block)] == block:
+                raise AlreadyApplied()
+            new_text = file_text[:insert_pos] + lead + block + file_text[insert_pos:]
+        else:  # insert-before
+            insert_pos, _ = _line_bounds(file_text, start)
+            if (
+                insert_pos >= len(block)
+                and file_text[insert_pos - len(block) : insert_pos] == block
+            ):
+                raise AlreadyApplied()
+            new_text = file_text[:insert_pos] + block + file_text[insert_pos:]
+    if new_text == file_text:
+        raise PatchError(
+            "EDIT NO-OP — replacement equals existing text; nothing would change "
+            "(the #1565 silent-no-op shape)"
+        )
+    return new_text
+
+
+def _span_lines(text: str, span: tuple[int, int]) -> tuple[int, int]:
+    """1-based (first, last) line numbers covered by an original-text span."""
+    start, end = span
+    first = text.count("\n", 0, start) + 1
+    last = text.count("\n", 0, max(start, end - 1)) + 1
+    return first, last
+
+
+def _unified_diff(old: str, new: str, path: str) -> str:
+    diff = difflib.unified_diff(
+        old.splitlines(),
+        new.splitlines(),
+        fromfile=f"{path} (before)",
+        tofile=f"{path} (after)",
+        lineterm="",
+    )
+    return "\n".join(diff)
+
+
+def _ambiguous_message(file_text: str, exc: AmbiguousAnchor) -> str:
+    lines = [
+        f"ambiguous anchor — {len(exc.spans)} matches at the {exc.stage} stage "
+        "(unique match required; not falling through to a looser stage):"
+    ]
+    for span in exc.spans:
+        first, last = _span_lines(file_text, span)
+        matched = file_text[span[0] : span[1]]
+        excerpt = (matched.splitlines() or [""])[0][:80]
+        lines.append(f"  lines {first}-{last}: {excerpt!r}")
+    lines.append(
+        "file untouched — make the anchor more distinctive (>=1 full line of unique context)."
+    )
+    return "\n".join(lines)
+
+
+def _read_text_file(path: str, role: str) -> str:
+    try:
+        with open(path, encoding="utf-8", newline="") as fh:
+            return fh.read()
+    except FileNotFoundError as exc:
+        raise PatchError(f"{role} not found: {path!r}") from exc
+    except UnicodeDecodeError as exc:
+        raise PatchError(f"{role} {path!r} is not UTF-8 text: {exc}") from exc
+
+
+def _atomic_write(path: str, text: str) -> None:
+    """tempfile-in-same-dir + os.replace, preserving bytes via newline=''."""
+    directory = os.path.dirname(os.path.abspath(path)) or "."
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=".plan-patch-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
+            fh.write(text)
+        os.replace(tmp, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="plan_patch.py",
+        description=(
+            "Apply one anchor-based edit to a plan draft: exact-then-normalized "
+            "anchor resolution (whitespace-collapsed, then case-tolerant), "
+            "unique-match-only, fail-loud with a nearest-match diff. The EDIT "
+            "step of the plan-revision Edit-success gate (#1631); the gate's "
+            "verify + persist steps stay separate."
+        ),
+        epilog=_EXIT_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("file", help="the draft file to patch (UTF-8 text, <=10 MB)")
+    anchor = parser.add_mutually_exclusive_group(required=True)
+    anchor.add_argument("--anchor", help="anchor text, inline (short single-line anchors)")
+    anchor.add_argument(
+        "--anchor-file",
+        help="anchor text read verbatim from a file (RECOMMENDED for multi-line anchors)",
+    )
+    payload = parser.add_mutually_exclusive_group(required=True)
+    payload.add_argument(
+        "--replace", help="replacement text spliced over the matched span ('' deletes it)"
+    )
+    payload.add_argument("--replace-file", help="replacement text read verbatim from a file")
+    payload.add_argument(
+        "--insert-after",
+        help="payload inserted as full lines AFTER the line containing the anchor's end",
+    )
+    payload.add_argument("--insert-after-file", help="file variant of --insert-after")
+    payload.add_argument(
+        "--insert-before",
+        help="payload inserted as full lines BEFORE the line containing the anchor's start",
+    )
+    payload.add_argument("--insert-before-file", help="file variant of --insert-before")
+    parser.add_argument(
+        "--verify-contains",
+        action="append",
+        default=[],
+        metavar="TEXT",
+        help=(
+            "assert TEXT is present in the patched text BEFORE any write "
+            "(repeatable); failure exits 2 with the would-be diff printed"
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="resolve + print the would-be diff, write nothing (exit 0 on a unique match)",
+    )
+    return parser
+
+
+def _resolve_payload(args: argparse.Namespace) -> tuple[str, str]:
+    for mode, inline, from_file in (
+        ("replace", args.replace, args.replace_file),
+        ("insert-after", args.insert_after, args.insert_after_file),
+        ("insert-before", args.insert_before, args.insert_before_file),
+    ):
+        if inline is not None:
+            return mode, inline
+        if from_file is not None:
+            return mode, _read_text_file(from_file, "payload file")
+    raise AssertionError("argparse required group guarantees one payload mode")
+
+
+def _run(args: argparse.Namespace) -> int:
+    path = args.file
+    try:
+        size = os.path.getsize(path)
+    except OSError as exc:
+        raise PatchError(f"cannot stat target file {path!r}: {exc}") from exc
+    if size > MAX_FILE_BYTES:
+        raise PatchError(
+            f"target file {path!r} is {size} bytes — refusing files larger than "
+            f"{MAX_FILE_BYTES} bytes (plan drafts are KB-scale)"
+        )
+    file_text = _read_text_file(path, "target file")
+    if args.anchor is not None:
+        anchor = args.anchor
+    else:
+        anchor = _read_text_file(args.anchor_file, "anchor file")
+    if not anchor.strip():
+        # A zero-length needle in a non-overlapping find() scan is an
+        # infinite-loop hazard; an all-whitespace anchor normalizes to "".
+        raise PatchError("anchor must contain non-whitespace text")
+    mode, payload = _resolve_payload(args)
+    if mode != "replace" and payload == "":
+        raise PatchError(
+            "insert payload must be non-empty (use --replace '' to delete the anchor span)"
+        )
+    try:
+        stage, span = find_candidates(file_text, anchor)
+    except MissingAnchor:
+        raise PatchError(
+            "anchor not found at any stage (exact, ws-normalized, ws+case-normalized)\n"
+            + nearest_match_report(file_text, anchor)
+        ) from None
+    except AmbiguousAnchor as exc:
+        raise PatchError(_ambiguous_message(file_text, exc)) from None
+    new_text = apply_edit(file_text, mode, span, payload)
+    diff = _unified_diff(file_text, new_text, path)
+    for needle in args.verify_contains:
+        if needle not in new_text:
+            raise PatchError(
+                f"--verify-contains failed — {needle!r} not present in the patched "
+                "text; file untouched. The would-be diff (for diagnosis):\n" + diff
+            )
+    first, last = _span_lines(file_text, span)
+    if args.dry_run:
+        print(
+            f"PLAN-PATCH DRY-RUN OK ({stage} match at lines {first}-{last} of {path})"
+            " — would apply; no write performed"
+        )
+        print(diff)
+        return 0
+    _atomic_write(path, new_text)
+    print(f"PLAN-PATCH APPLIED ({stage} match at lines {first}-{last} of {path})")
+    print(diff)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return _run(args)
+    except AlreadyApplied:
+        print("PLAN-PATCH ALREADY-APPLIED — no change made", file=sys.stderr)
+        return 3
+    except PatchError as exc:
+        print(f"PLAN-PATCH FAILED: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/select_step9c_tests.py
+++ b/scripts/select_step9c_tests.py
@@ -322,6 +322,10 @@ WORKFLOW_INVARIANT: tuple[str, ...] = (
     # stem/literal/dependency arms are .py-only, so a later .sh-hook /
     # settings.json diff re-runs this pin ONLY via this tuple.
     "tests/test_guard_trigger_dense_read.py",
+    # NEW (#1632) — PostToolUse ruff-hook ephemeral-root (/tmp) exclusion pin:
+    # the selector's arms are .py-only, so a settings.json diff re-runs this
+    # pin ONLY via this tuple.
+    "tests/test_ruff_format_hook_tmp_exclusion.py",
 )
 
 # --- Touched files that short-circuit (no per-file test map). ----------------

--- a/tests/step9c_workflow_invariant_manifest.txt
+++ b/tests/step9c_workflow_invariant_manifest.txt
@@ -35,6 +35,7 @@ tests/test_no_per_file_raw_completions_loop.py
 tests/test_no_pod_side_task_py_shellout.py
 tests/test_plan_handoff_path_convention.py
 tests/test_precommit_gitleaks_merge_scope.py
+tests/test_ruff_format_hook_tmp_exclusion.py
 tests/test_sparse_worktree.py
 tests/test_step10d_guard3.py
 tests/test_step_completed_resume.py

--- a/tests/test_ruff_format_hook_tmp_exclusion.py
+++ b/tests/test_ruff_format_hook_tmp_exclusion.py
@@ -1,0 +1,125 @@
+"""Pin tests for the PostToolUse ruff-format hook's ephemeral-root exclusion (#1632).
+
+The PostToolUse ``Edit|Write`` hook in ``.claude/settings.json`` runs
+``ruff check --fix`` + ``ruff format`` on every edited ``.py`` path. Scratch
+scripts under ``/tmp/``, ``/var/tmp/``, and ``/dev/shm/`` are
+written-to-be-executed-once; formatting them buys nothing and invalidates the
+writer's in-context file state (incident #1602: an Edit right after a Write
+failed with "String to replace not found" because the hook reformatted the
+file in between). The hook therefore excludes paths matching
+``^/(tmp|var/tmp|dev/shm)/`` while keeping repo-tree formatting unchanged.
+
+These tests pin that behavior (pattern precedent:
+``tests/test_guard_trigger_dense_read.py`` — parse settings.json, then drive
+the CONFIGURED command end-to-end with synthetic stdin JSON). Registered in
+``WORKFLOW_INVARIANT`` (``scripts/select_step9c_tests.py``) because the
+selector's stem/literal/dependency arms are .py-only — a settings.json diff
+maps to no test otherwise.
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Resolve against THIS checkout (worktree or main), so the test exercises the
+# settings.json of whichever tree it runs in.
+CHECKOUT_ROOT = Path(__file__).resolve().parent.parent
+SETTINGS_PATH = CHECKOUT_ROOT / ".claude" / "settings.json"
+
+EXCLUSION_LITERAL = "^/(tmp|var/tmp|dev/shm)/"
+EPHEMERAL_ROOTS = ["/tmp", "/var/tmp", "/dev/shm"]
+# Both jq extraction arms of the hook command: Edit/Write tool_input carries
+# file_path; the tool_response fallback carries filePath.
+PAYLOAD_FORMS = ["tool_input", "tool_response"]
+
+
+def _load_settings() -> dict:
+    return json.loads(SETTINGS_PATH.read_text(encoding="utf-8"))
+
+
+def _hook_command() -> str:
+    """Locate the Edit|Write PostToolUse hook command that runs ruff format."""
+    for entry in _load_settings()["hooks"]["PostToolUse"]:
+        if entry.get("matcher") != "Edit|Write":
+            continue
+        for hook in entry.get("hooks", []):
+            command = hook.get("command", "")
+            if "ruff format" in command:
+                return command
+    raise AssertionError(
+        "No PostToolUse hook with matcher 'Edit|Write' and a 'ruff format' command "
+        f"found in {SETTINGS_PATH}"
+    )
+
+
+def _payload(form: str, file_path: str) -> str:
+    if form == "tool_input":
+        return json.dumps({"tool_input": {"file_path": file_path}})
+    if form == "tool_response":
+        return json.dumps({"tool_response": {"filePath": file_path}})
+    raise ValueError(f"unknown payload form: {form}")
+
+
+def _run_hook(command: str, payload: str) -> None:
+    subprocess.run(
+        ["bash", "-c", command],
+        input=payload,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=180,
+    )
+
+
+def test_settings_json_parses():
+    """Fleet-wide blast-radius guard: settings.json must stay valid JSON."""
+    settings = _load_settings()
+    assert isinstance(settings, dict)
+    assert settings, "settings.json parsed to an empty object"
+
+
+def test_ruff_hook_carries_tmp_exclusion():
+    """Durability pin: the hook keeps the ephemeral-root exclusion AND the
+    original .py filter + ruff invocations (repo-path behavior retained)."""
+    command = _hook_command()
+    assert EXCLUSION_LITERAL in command
+    assert "\\.py$" in command
+    assert "ruff check --fix" in command
+    assert "ruff format" in command
+
+
+@pytest.mark.parametrize("payload_form", PAYLOAD_FORMS)
+@pytest.mark.parametrize("root", EPHEMERAL_ROOTS)
+def test_hook_skips_ephemeral_paths(root: str, payload_form: str):
+    """Behavioral: a deliberately-unformatted .py under an ephemeral root is
+    left byte-unchanged (pre-fix, the hook reformatted it — the #1602 bug)."""
+    root_path = Path(root)
+    if not root_path.is_dir() or not os.access(root, os.W_OK):
+        pytest.skip(f"{root} absent or unwritable on this host")
+    target = root_path / f"eps1632_pin_{os.getpid()}_{payload_form}.py"
+    try:
+        target.write_text("x=1\n", encoding="utf-8")
+        _run_hook(_hook_command(), _payload(payload_form, str(target)))
+        assert target.read_text(encoding="utf-8") == "x=1\n"
+    finally:
+        target.unlink(missing_ok=True)
+
+
+@pytest.mark.parametrize("payload_form", PAYLOAD_FORMS)
+def test_hook_formats_repo_path(payload_form: str):
+    """Behavioral control: a repo-tree .py path still gets formatted.
+
+    The leading underscore keeps pytest from ever collecting the scratch file.
+    If ruff's normalization of ``x=1`` ever changes, relax the equality below
+    to "bytes changed" (content != "x=1\\n").
+    """
+    target = CHECKOUT_ROOT / "tests" / f"_eps1632_pin_{os.getpid()}_{payload_form}.py"
+    try:
+        target.write_text("x=1\n", encoding="utf-8")
+        _run_hook(_hook_command(), _payload(payload_form, str(target)))
+        assert target.read_text(encoding="utf-8") == "x = 1\n"
+    finally:
+        target.unlink(missing_ok=True)

--- a/tests/test_select_step9c_tests.py
+++ b/tests/test_select_step9c_tests.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import math
 import os
 import subprocess
 from pathlib import Path
@@ -1162,14 +1163,27 @@ def test_import_map_relative_import_skipped(tmp_path: Path):
 
 # --- Case 48: aggregate parse-failure WARN (systemic-breakage signal) -----------
 def test_import_map_aggregate_parse_failure_warn(tmp_path: Path, capsys):
-    """>5% of scanned test files failing to parse emits ONE extra summary WARN."""
-    files = {f"test_broken_{i}.py": "import widgetlib\ndef broken(:\n" for i in range(3)}
-    files["test_ok.py"] = "import widgetlib\n"
-    repo = _make_import_tree(tmp_path, files)  # 3 broken / ~43 scanned ≈ 7% > 5%
+    """>5% of scanned test files failing to parse emits ONE extra summary WARN.
+
+    The broken-stub count is sized PROPORTIONALLY to the seeded fixture tree:
+    ``_make_tree`` seeds one stub per live ``WORKFLOW_INVARIANT`` /
+    ``GLOB_SCAN_TESTS`` member, so a hardcoded count is a registry-growth
+    knife-edge — at 60 members a fixed 3 broken files read 3/60 = 5.00%,
+    which the strict ``> 5%`` gate does NOT fire (#1632: both aggregate-WARN
+    tests went red on trunk when the registry grew).
+    """
+    repo = _make_import_tree(tmp_path, {"test_ok.py": "import widgetlib\n"})
+    # Count exactly what the scanner enumerates (recursive test_*.py), then add
+    # enough broken files to clear the strict >5% threshold at ANY registry size.
+    n_pre = len(list((repo / "tests").rglob("test_*.py")))
+    n_broken = math.ceil(0.05 * n_pre) + 1
+    assert n_broken / (n_pre + n_broken) > 0.05  # self-check: aggregate WARN must fire
+    for i in range(n_broken):
+        (repo / "tests" / f"test_broken_{i}.py").write_text("import widgetlib\ndef broken(:\n")
     tests, _, _ = sel.select_tests_with_reasons(["scripts/widgetlib.py"], repo)
     assert "tests/test_ok.py" in tests
     err = capsys.readouterr().err
-    assert err.count("import-map cannot parse") == 3  # one per-file WARN each
+    assert err.count("import-map cannot parse") == n_broken  # one per-file WARN each
     assert err.count("systemic tests/ breakage") == 1  # exactly one aggregate WARN
 
 
@@ -1344,15 +1358,23 @@ def test_rules_pin_unreadable_test_file_warns_not_crash(tmp_path: Path, capsys):
 # --- Case 59: aggregate read-failure WARN (systemic-breakage signal) ---------------
 def test_rules_pin_aggregate_read_failure_warn(tmp_path: Path, capsys):
     """>5% of scanned test files unreadable emits ONE extra summary WARN
-    (mirrors the import-map arm's #1299 aggregate signal, case 48)."""
+    (mirrors the import-map arm's #1299 aggregate signal, case 48).
+
+    Broken-stub count sized proportionally to the seeded tree — the same
+    #1632 registry-growth knife-edge as case 48 (a fixed 3 broken files read
+    3/60 = 5.00% at 60 seeded members, failing the strict ``> 5%`` gate).
+    """
     repo = _make_tree(tmp_path, [])
-    for i in range(3):
-        (repo / "tests" / f"test_bad_{i}.py").write_bytes(b"\xff\xfe bad")
     (repo / "tests" / "test_ok_pin.py").write_text('R = ".claude/rules/some-rule.md"\n')
+    n_pre = len(list((repo / "tests").rglob("test_*.py")))
+    n_broken = math.ceil(0.05 * n_pre) + 1
+    assert n_broken / (n_pre + n_broken) > 0.05  # self-check: aggregate WARN must fire
+    for i in range(n_broken):
+        (repo / "tests" / f"test_bad_{i}.py").write_bytes(b"\xff\xfe bad")
     tests, _, _ = sel.select_tests_with_reasons([".claude/rules/some-rule.md"], repo)
     assert "tests/test_ok_pin.py" in tests
     err = capsys.readouterr().err
-    assert err.count("rules-pin scan cannot read") == 3  # one per-file WARN each
+    assert err.count("rules-pin scan cannot read") == n_broken  # one per-file WARN each
     assert err.count("systemic tests/ breakage") == 1  # exactly one aggregate WARN
 
 


### PR DESCRIPTION
Closes task #1632. One-string hook edit + pin test + two-place WORKFLOW_INVARIANT registration. Plan: tasks/*/1632/plans/v3.md