### PR TITLE
task #1631: committed plan-patch helper for plan-revision anchor edits

### DIFF
--- a/.claude/rules/workflow-fix-on-bug.md
+++ b/.claude/rules/workflow-fix-on-bug.md
@@ -78,7 +78,7 @@ Now it's same-turn (the file + spawn is non-blocking).
   `audit_clean_results_body_discipline.py`,
   `redact_for_gist.py`, `check_no_secret_shaped_strings.py`,
   `codex_task.py`,
-  `poll_pipeline.py`, `dispatch_issue.py`, `backend_poll.py`,
+  `plan_patch.py`, `poll_pipeline.py`, `dispatch_issue.py`, `backend_poll.py`,
   `failure_classifier.py`, `gh_project.py`,
   `pm_queue_report.py`,
   `recent_clean_results.py`, `task_state.py`,

--- a/.claude/skills/adversarial-planner/SKILL.md
+++ b/.claude/skills/adversarial-planner/SKILL.md
@@ -113,7 +113,16 @@ landed. Verify = grep the draft for the revised text
 a non-empty diff vs the prior persisted version
 (`! diff -q <draft> "$(uv run python scripts/task.py find <N>)/plans/plan.md"`
 — the `plan.md` symlink still points at v<K-1> until the persist; identical
-bytes mean the edit silently no-oped); a bare exit 0 is NOT evidence. Never
+bytes mean the edit silently no-oped); a bare exit 0 is NOT evidence. Run the
+EDIT step via the committed helper `uv run python scripts/plan_patch.py
+<draft> --anchor-file <a.txt> --replace-file <r.txt>` (exact-then-normalized
+anchor resolution — whitespace-collapsed, then case-tolerant —
+unique-match-only; fails loud with a nearest-match diff on a missing/ambiguous
+anchor; #1631) instead of improvising a per-turn python/sed anchor script —
+anchor byte-identity drift cost ≥4 re-derive rounds across 3 sessions on
+2026-07-22; prefer anchors carrying ≥1 full line of distinctive context, and
+let the verify step grep the helper's printed `PLAN-PATCH APPLIED` line and/or
+pass `--verify-contains` in addition to the draft grep. Never
 `;`-chain the edit and the persist, and never run the persist inside the same
 script before its asserts have executed. On ANY edit failure, abort LOUDLY
 without persisting — print `EDIT FAILED — not persisting`, Read the CURRENT

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1643,8 +1643,13 @@ only by a PM-chat directive one wasted implementer round later.
 **Edit-success gate:** when the draft was produced or modified by a SCRIPTED
 edit (the Step 2b/3 revise paths included), `&&`-chain edit → verify
 (positive evidence the revised text is present — grep the draft, or a
-non-empty diff vs the prior version) → the `new-plan-version` persist; an
-edit-script failure aborts the persist loudly, never `;`-chained
+non-empty diff vs the prior version) → the `new-plan-version` persist; the
+edit step is the committed helper `uv run python scripts/plan_patch.py`
+(anchor-normalized apply; fail-loud nearest-match diff on a missing/ambiguous
+anchor — #1631; its printed `PLAN-PATCH APPLIED` line and `--verify-contains`
+double as verify evidence; prefer ≥1-line distinctive anchors), never an
+improvised per-turn anchor script; an edit-script failure aborts the persist
+loudly, never `;`-chained
 (`adversarial-planner` SKILL.md § Edit-success gate; incident #1565: a
 chained persist landed v2 as an unmodified copy of v1 after the edit script
 died on an anchor-text `AssertionError`).

--- a/scripts/plan_patch.py
+++ b/scripts/plan_patch.py
@@ -60,6 +60,7 @@ Exit codes
 from __future__ import annotations
 
 import argparse
+import contextlib
 import difflib
 import os
 import sys
@@ -383,10 +384,8 @@ def _atomic_write(path: str, text: str) -> None:
             fh.write(text)
         os.replace(tmp, path)
     except BaseException:
-        try:
+        with contextlib.suppress(OSError):
             os.unlink(tmp)
-        except OSError:
-            pass
         raise
 
 

--- a/scripts/plan_patch.py
+++ b/scripts/plan_patch.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python
+"""Anchor-normalized plan-patch helper (#1631).
+
+Applies ONE anchor-based edit to a UTF-8 text file (typically a plan draft at
+``/tmp/issue-<N>-plan-v<K>-<ts>.md``) as the EDIT step of the plan-revision
+Edit-success gate (``.claude/skills/adversarial-planner/SKILL.md``
+"Edit-success gate"; ``.claude/skills/issue/SKILL.md`` Step 2 mirror). It
+never calls ``task.py new-plan-version`` and never touches ``tasks/**`` — the
+gate's separate verify + persist steps stay ``&&``-chained after it.
+
+Matching semantics
+------------------
+The anchor resolves through THREE stages, walked in order; the FIRST stage
+with >=1 candidate decides (per-stage candidate sets, NEVER unioned — an
+exact match wins even when a drifted near-duplicate exists elsewhere):
+
+1. ``exact`` — byte-exact non-overlapping scan (only a lone trailing newline
+   on the anchor is tolerated, via an ``rstrip("\\n")`` comparison fallback —
+   anchor files usually end in a newline).
+2. ``ws-normalized`` — every maximal whitespace run (space, tab, ``\\n``,
+   ``\\r``, ...) collapsed to ONE space on both sides; the anchor is
+   additionally stripped. Absorbs line-wrap / indentation drift.
+3. ``ws+case-normalized`` — stage 2 plus per-char ``lower()``. A char whose
+   ``lower()`` is not length-1 (e.g. ``İ``) is kept as-is so the index map
+   stays 1:1 — such anchors fail toward a MISS, never a wrong span.
+
+At the deciding stage: exactly one candidate -> apply; two or more ->
+fail-loud ambiguity (exit 2) listing every candidate location — NEVER a
+fall-through to a looser stage (looser stages are supersets; falling through
+could only add candidates). All three stages empty -> exit 2 with a
+nearest-match report (best line window by ``SequenceMatcher`` ratio + a
+unified diff of anchor vs window over the ORIGINAL texts). The report is a
+REPORT only — this tool never fuzzy-applies (no ``patch(1)``-style fuzz).
+
+Edit modes
+----------
+``--replace`` splices the payload byte-exactly over the matched span
+(``--replace ''`` deletes it). ``--insert-after`` / ``--insert-before`` are
+LINE-based: the payload lands as full lines adjacent to the line containing
+the span's end / start — a mid-line anchor inserts after/before the
+containing LINE, not byte-adjacent to the match. Payloads are read VERBATIM
+(no normalization is ever applied to a payload). Insert modes are idempotent
+on the EXACT payload block only: a re-run that finds the identical block
+already at the insertion point exits 3 (ALREADY-APPLIED, file untouched).
+Replace mode is deliberately asymmetric: after a successful replace consumed
+the anchor, a crash re-run reads exit 2 (anchor missing), not 3 — a replace
+re-run cannot prove the prior apply used THIS payload.
+
+Exit codes
+----------
+- ``0`` — applied (or a clean ``--dry-run``); stdout carries
+  ``PLAN-PATCH APPLIED (<stage> match at lines <A>-<B> of <file>)`` plus the
+  unified diff — grep-able positive evidence for the gate's verify step.
+- ``2`` — failed, file untouched: missing anchor (nearest-match report),
+  ambiguous anchor, ``EDIT NO-OP``, ``--verify-contains`` miss, usage /
+  encoding / size errors. Stderr prefix: ``PLAN-PATCH FAILED:``.
+- ``3`` — already-applied (insert modes only); file untouched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import os
+import sys
+import tempfile
+from collections import Counter
+
+# Plans are 50-300 KB; refuse pathological inputs (keeps the O(lines * anchor)
+# nearest-match scan trivially fast). Module-level so tests can monkeypatch.
+MAX_FILE_BYTES = 10 * 1024 * 1024
+
+STAGE_EXACT = "exact"
+STAGE_WS = "ws-normalized"
+STAGE_WS_CASE = "ws+case-normalized"
+
+_EXIT_EPILOG = """\
+exit codes:
+  0  applied (or clean --dry-run); stdout: "PLAN-PATCH APPLIED (<stage> match
+     at lines <A>-<B> of <file>)" + the unified diff
+  2  failed, file untouched (missing/ambiguous anchor, EDIT NO-OP,
+     --verify-contains miss, usage/encoding/size errors)
+  3  already-applied (insert modes only: the exact payload block already sits
+     at the insertion point); file untouched
+
+Insert-mode idempotency is exact-payload-block-only; --insert-after with a
+mid-line anchor inserts after the containing LINE (not byte-adjacent). Stage
+order is exact -> ws-normalized -> ws+case-normalized with per-stage candidate
+sets (never unioned): an exact match wins even when a drifted near-duplicate
+exists elsewhere. A replace-mode crash re-run reads exit 2 (anchor consumed),
+asymmetric with insert-mode exit 3 — deliberate.
+"""
+
+
+class PatchError(Exception):
+    """Any failure that leaves the file untouched -> exit 2."""
+
+
+class AlreadyApplied(Exception):
+    """Insert-mode idempotent re-run -> exit 3, file untouched."""
+
+
+class MissingAnchor(Exception):
+    """Anchor resolved to zero candidates at every stage."""
+
+
+class AmbiguousAnchor(Exception):
+    """Anchor resolved to >=2 candidates at its deciding stage."""
+
+    def __init__(self, stage: str, spans: list[tuple[int, int]]):
+        super().__init__(f"{len(spans)} matches at the {stage} stage")
+        self.stage = stage
+        self.spans = spans
+
+
+def normalize_with_map(text: str, *, lower: bool) -> tuple[str, list[int]]:
+    """Collapse every maximal whitespace run (incl. \\n, \\r, \\t) to ONE space.
+
+    Optionally per-char ``lower()``; a char whose ``lower()`` is not length-1
+    is kept as-is, so the index map stays 1:1 (fails toward a stage MISS,
+    never a wrong span). Returns ``(normalized, idx_map)`` where
+    ``idx_map[i]`` is the index in the ORIGINAL text of normalized char
+    ``i`` (a whitespace run maps to its first original char).
+    """
+    chars: list[str] = []
+    idx_map: list[int] = []
+    i, n = 0, len(text)
+    while i < n:
+        ch = text[i]
+        if ch.isspace():
+            j = i + 1
+            while j < n and text[j].isspace():
+                j += 1
+            chars.append(" ")
+            idx_map.append(i)
+            i = j
+        else:
+            if lower:
+                low = ch.lower()
+                ch = low if len(low) == 1 else ch
+            chars.append(ch)
+            idx_map.append(i)
+            i += 1
+    return "".join(chars), idx_map
+
+
+def _scan(haystack: str, needle: str) -> list[tuple[int, int]]:
+    """Non-overlapping left-to-right spans of ``needle``; needle non-empty."""
+    if not needle:  # defensive: empty needles are rejected before any scan
+        raise PatchError("internal: empty scan needle")
+    spans: list[tuple[int, int]] = []
+    pos = 0
+    while True:
+        hit = haystack.find(needle, pos)
+        if hit < 0:
+            return spans
+        spans.append((hit, hit + len(needle)))
+        pos = hit + len(needle)
+
+
+def _normalized_candidates(file_text: str, anchor: str, *, lower: bool) -> list[tuple[int, int]]:
+    """Original-text spans matching the whitespace-collapsed anchor."""
+    norm_file, idx_map = normalize_with_map(file_text, lower=lower)
+    norm_anchor, _ = normalize_with_map(anchor, lower=lower)
+    norm_anchor = norm_anchor.strip()
+    if not norm_anchor:
+        return []
+    # First/last anchor chars are non-space post-strip, so the mapped span is
+    # tight: idx_map[s] and idx_map[e-1] both point at non-space originals.
+    return [(idx_map[s], idx_map[e - 1] + 1) for s, e in _scan(norm_file, norm_anchor)]
+
+
+def find_candidates(file_text: str, anchor: str) -> tuple[str, tuple[int, int]]:
+    """Resolve the anchor to exactly one original-text span.
+
+    Walks the stages in order; at the FIRST stage with >=1 candidate: exactly
+    one -> return ``(stage, span)``; >=2 -> raise :class:`AmbiguousAnchor`
+    (never fall through — looser stages are supersets and can only add
+    candidates). All stages empty -> raise :class:`MissingAnchor`.
+    """
+    exact = _scan(file_text, anchor)
+    if not exact:
+        stripped = anchor.rstrip("\n")
+        if stripped and stripped != anchor:
+            exact = _scan(file_text, stripped)
+    stages: list[tuple[str, list[tuple[int, int]]]] = [(STAGE_EXACT, exact)]
+    if not exact:
+        ws = _normalized_candidates(file_text, anchor, lower=False)
+        stages.append((STAGE_WS, ws))
+        if not ws:
+            stages.append((STAGE_WS_CASE, _normalized_candidates(file_text, anchor, lower=True)))
+    for stage, spans in stages:
+        if len(spans) == 1:
+            return stage, spans[0]
+        if len(spans) >= 2:
+            raise AmbiguousAnchor(stage, spans)
+    raise MissingAnchor()
+
+
+def _best_local_ratio(norm_window: str, norm_anchor: str, floor: float) -> float:
+    """Max SequenceMatcher ratio of the anchor vs the window OR any
+    anchor-length slice of it (a partial-ratio scan: a short drifted anchor
+    inside a LONG markdown line still scores high — the full-window
+    ``ratio()`` structurally penalizes long lines). Report-scoring only;
+    ``floor`` lets the slice scan prefilter against the best score so far.
+    """
+    matcher = difflib.SequenceMatcher(autojunk=False)
+    matcher.set_seq2(norm_anchor)
+    matcher.set_seq1(norm_window)
+    best = matcher.ratio()
+    n_a = len(norm_anchor)
+    if n_a and len(norm_window) > n_a:
+        stride = max(1, n_a // 4)
+        starts = list(range(0, len(norm_window) - n_a + 1, stride))
+        if starts[-1] != len(norm_window) - n_a:
+            starts.append(len(norm_window) - n_a)
+        for start in starts:
+            matcher.set_seq1(norm_window[start : start + n_a])
+            bar = max(best, floor)
+            if matcher.real_quick_ratio() <= bar or matcher.quick_ratio() <= bar:
+                continue
+            ratio = matcher.ratio()
+            if ratio > best:
+                best = ratio
+    return best
+
+
+def nearest_match_report(file_text: str, anchor: str) -> str:
+    """Best-window similarity report for a missing anchor. REPORT only.
+
+    Line-window scan (window height = the anchor's line count, stride 1) over
+    ws+case-normalized texts; each window is scored by the MAX of the
+    full-window ``SequenceMatcher.ratio()`` and a partial-ratio slice scan
+    (:func:`_best_local_ratio`), behind a cheap character-multiset upper
+    bound. Always reports the best candidate (no cutoff — as a report there
+    is no wrong answer). Degenerate inputs (empty file, file shorter than the
+    anchor) get a designed message, never a traceback.
+    """
+    file_lines = file_text.splitlines()
+    if not file_lines:
+        return "nearest-match report: file is empty — no candidate window to compare."
+    anchor_lines = anchor.splitlines() or [""]
+    height = len(anchor_lines)
+    prefix = ""
+    if len(file_lines) < height:
+        prefix = (
+            f"nearest-match report: file has {len(file_lines)} line(s), shorter than "
+            f"the {height}-line anchor — comparing against the whole file.\n"
+        )
+        height = len(file_lines)
+    norm_anchor, _ = normalize_with_map(anchor, lower=True)
+    norm_anchor = norm_anchor.strip()
+    n_a = len(norm_anchor)
+    anchor_counts = Counter(norm_anchor)
+    best: tuple[int, int] = (1, height)
+    best_ratio = -1.0
+    for i in range(len(file_lines) - height + 1):
+        window = "\n".join(file_lines[i : i + height])
+        norm_window, _ = normalize_with_map(window, lower=True)
+        norm_window = norm_window.strip()
+        window_counts = Counter(norm_window)
+        common = sum(min(cnt, window_counts.get(ch, 0)) for ch, cnt in anchor_counts.items())
+        denom_full = len(norm_window) + n_a
+        upper_bound = max(
+            (2 * common / denom_full) if denom_full else 0.0,
+            (common / n_a) if n_a else 0.0,  # ceiling for any anchor-length slice
+        )
+        if upper_bound <= best_ratio:
+            continue
+        ratio = _best_local_ratio(norm_window, norm_anchor, best_ratio)
+        if ratio > best_ratio:
+            best_ratio = ratio
+            best = (i + 1, i + height)
+    a, b = best
+    diff = difflib.unified_diff(
+        anchor_lines,
+        file_lines[a - 1 : b],
+        fromfile="anchor (as given)",
+        tofile=f"closest match in file (lines {a}-{b})",
+        lineterm="",
+    )
+    return (
+        prefix
+        + f"nearest match: lines {a}-{b} (similarity {max(best_ratio, 0.0):.3f})\n"
+        + "\n".join(diff)
+    )
+
+
+def _line_bounds(text: str, index: int) -> tuple[int, int]:
+    """(start, end) of the line containing ``text[index]``.
+
+    ``end`` is the index just past the line's newline (``len(text)`` for an
+    unterminated last line).
+    """
+    start = text.rfind("\n", 0, index) + 1
+    newline = text.find("\n", index)
+    end = len(text) if newline < 0 else newline + 1
+    return start, end
+
+
+def apply_edit(file_text: str, mode: str, span: tuple[int, int], payload: str) -> str:
+    """Return the patched text; raise AlreadyApplied / PatchError (no-op)."""
+    start, end = span
+    if mode == "replace":
+        new_text = file_text[:start] + payload + file_text[end:]
+    else:
+        block = payload if payload.endswith("\n") else payload + "\n"
+        if mode == "insert-after":
+            _, insert_pos = _line_bounds(file_text, end - 1)
+            lead = ""
+            if insert_pos == len(file_text) and file_text and not file_text.endswith("\n"):
+                lead = "\n"  # keep the payload on its own full lines
+            if not lead and file_text[insert_pos : insert_pos + len(block)] == block:
+                raise AlreadyApplied()
+            new_text = file_text[:insert_pos] + lead + block + file_text[insert_pos:]
+        else:  # insert-before
+            insert_pos, _ = _line_bounds(file_text, start)
+            if (
+                insert_pos >= len(block)
+                and file_text[insert_pos - len(block) : insert_pos] == block
+            ):
+                raise AlreadyApplied()
+            new_text = file_text[:insert_pos] + block + file_text[insert_pos:]
+    if new_text == file_text:
+        raise PatchError(
+            "EDIT NO-OP — replacement equals existing text; nothing would change "
+            "(the #1565 silent-no-op shape)"
+        )
+    return new_text
+
+
+def _span_lines(text: str, span: tuple[int, int]) -> tuple[int, int]:
+    """1-based (first, last) line numbers covered by an original-text span."""
+    start, end = span
+    first = text.count("\n", 0, start) + 1
+    last = text.count("\n", 0, max(start, end - 1)) + 1
+    return first, last
+
+
+def _unified_diff(old: str, new: str, path: str) -> str:
+    diff = difflib.unified_diff(
+        old.splitlines(),
+        new.splitlines(),
+        fromfile=f"{path} (before)",
+        tofile=f"{path} (after)",
+        lineterm="",
+    )
+    return "\n".join(diff)
+
+
+def _ambiguous_message(file_text: str, exc: AmbiguousAnchor) -> str:
+    lines = [
+        f"ambiguous anchor — {len(exc.spans)} matches at the {exc.stage} stage "
+        "(unique match required; not falling through to a looser stage):"
+    ]
+    for span in exc.spans:
+        first, last = _span_lines(file_text, span)
+        matched = file_text[span[0] : span[1]]
+        excerpt = (matched.splitlines() or [""])[0][:80]
+        lines.append(f"  lines {first}-{last}: {excerpt!r}")
+    lines.append(
+        "file untouched — make the anchor more distinctive (>=1 full line of unique context)."
+    )
+    return "\n".join(lines)
+
+
+def _read_text_file(path: str, role: str) -> str:
+    try:
+        with open(path, encoding="utf-8", newline="") as fh:
+            return fh.read()
+    except FileNotFoundError as exc:
+        raise PatchError(f"{role} not found: {path!r}") from exc
+    except UnicodeDecodeError as exc:
+        raise PatchError(f"{role} {path!r} is not UTF-8 text: {exc}") from exc
+
+
+def _atomic_write(path: str, text: str) -> None:
+    """tempfile-in-same-dir + os.replace, preserving bytes via newline=''."""
+    directory = os.path.dirname(os.path.abspath(path)) or "."
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=".plan-patch-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
+            fh.write(text)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="plan_patch.py",
+        description=(
+            "Apply one anchor-based edit to a plan draft: exact-then-normalized "
+            "anchor resolution (whitespace-collapsed, then case-tolerant), "
+            "unique-match-only, fail-loud with a nearest-match diff. The EDIT "
+            "step of the plan-revision Edit-success gate (#1631); the gate's "
+            "verify + persist steps stay separate."
+        ),
+        epilog=_EXIT_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("file", help="the draft file to patch (UTF-8 text, <=10 MB)")
+    anchor = parser.add_mutually_exclusive_group(required=True)
+    anchor.add_argument("--anchor", help="anchor text, inline (short single-line anchors)")
+    anchor.add_argument(
+        "--anchor-file",
+        help="anchor text read verbatim from a file (RECOMMENDED for multi-line anchors)",
+    )
+    payload = parser.add_mutually_exclusive_group(required=True)
+    payload.add_argument(
+        "--replace", help="replacement text spliced over the matched span ('' deletes it)"
+    )
+    payload.add_argument("--replace-file", help="replacement text read verbatim from a file")
+    payload.add_argument(
+        "--insert-after",
+        help="payload inserted as full lines AFTER the line containing the anchor's end",
+    )
+    payload.add_argument("--insert-after-file", help="file variant of --insert-after")
+    payload.add_argument(
+        "--insert-before",
+        help="payload inserted as full lines BEFORE the line containing the anchor's start",
+    )
+    payload.add_argument("--insert-before-file", help="file variant of --insert-before")
+    parser.add_argument(
+        "--verify-contains",
+        action="append",
+        default=[],
+        metavar="TEXT",
+        help=(
+            "assert TEXT is present in the patched text BEFORE any write "
+            "(repeatable); failure exits 2 with the would-be diff printed"
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="resolve + print the would-be diff, write nothing (exit 0 on a unique match)",
+    )
+    return parser
+
+
+def _resolve_payload(args: argparse.Namespace) -> tuple[str, str]:
+    for mode, inline, from_file in (
+        ("replace", args.replace, args.replace_file),
+        ("insert-after", args.insert_after, args.insert_after_file),
+        ("insert-before", args.insert_before, args.insert_before_file),
+    ):
+        if inline is not None:
+            return mode, inline
+        if from_file is not None:
+            return mode, _read_text_file(from_file, "payload file")
+    raise AssertionError("argparse required group guarantees one payload mode")
+
+
+def _run(args: argparse.Namespace) -> int:
+    path = args.file
+    try:
+        size = os.path.getsize(path)
+    except OSError as exc:
+        raise PatchError(f"cannot stat target file {path!r}: {exc}") from exc
+    if size > MAX_FILE_BYTES:
+        raise PatchError(
+            f"target file {path!r} is {size} bytes — refusing files larger than "
+            f"{MAX_FILE_BYTES} bytes (plan drafts are KB-scale)"
+        )
+    file_text = _read_text_file(path, "target file")
+    if args.anchor is not None:
+        anchor = args.anchor
+    else:
+        anchor = _read_text_file(args.anchor_file, "anchor file")
+    if not anchor.strip():
+        # A zero-length needle in a non-overlapping find() scan is an
+        # infinite-loop hazard; an all-whitespace anchor normalizes to "".
+        raise PatchError("anchor must contain non-whitespace text")
+    mode, payload = _resolve_payload(args)
+    if mode != "replace" and payload == "":
+        raise PatchError(
+            "insert payload must be non-empty (use --replace '' to delete the anchor span)"
+        )
+    try:
+        stage, span = find_candidates(file_text, anchor)
+    except MissingAnchor:
+        raise PatchError(
+            "anchor not found at any stage (exact, ws-normalized, ws+case-normalized)\n"
+            + nearest_match_report(file_text, anchor)
+        ) from None
+    except AmbiguousAnchor as exc:
+        raise PatchError(_ambiguous_message(file_text, exc)) from None
+    new_text = apply_edit(file_text, mode, span, payload)
+    diff = _unified_diff(file_text, new_text, path)
+    for needle in args.verify_contains:
+        if needle not in new_text:
+            raise PatchError(
+                f"--verify-contains failed — {needle!r} not present in the patched "
+                "text; file untouched. The would-be diff (for diagnosis):\n" + diff
+            )
+    first, last = _span_lines(file_text, span)
+    if args.dry_run:
+        print(
+            f"PLAN-PATCH DRY-RUN OK ({stage} match at lines {first}-{last} of {path})"
+            " — would apply; no write performed"
+        )
+        print(diff)
+        return 0
+    _atomic_write(path, new_text)
+    print(f"PLAN-PATCH APPLIED ({stage} match at lines {first}-{last} of {path})")
+    print(diff)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return _run(args)
+    except AlreadyApplied:
+        print("PLAN-PATCH ALREADY-APPLIED — no change made", file=sys.stderr)
+        return 3
+    except PatchError as exc:
+        print(f"PLAN-PATCH FAILED: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/select_step9c_tests.py
+++ b/scripts/select_step9c_tests.py
@@ -302,6 +302,8 @@ WORKFLOW_INVARIANT: tuple[str, ...] = (
     # NEW (#1604) — mapping-baselines wiring pin (CLAUDE.md standing rule →
     # planner/critic/statistics-critic/experiment-guidelines + helper)
     "tests/test_mapping_baselines_wiring_pins.py",
+    # NEW (#1631) — plan-patch helper + SKILL.md pointer pin
+    "tests/test_plan_patch.py",
     "tests/test_step10d_guard3.py",  # NEW (#1242) — SKILL.md Step 10d guard/merge pin
     "tests/test_step_completed_resume.py",  # NEW (#1242) — resume/step-completed contract pin
     # NEW (#1598) — CLAUDE.md teammate-coordination bullet pins (a)-(d)

--- a/tests/step9c_workflow_invariant_manifest.txt
+++ b/tests/step9c_workflow_invariant_manifest.txt
@@ -32,6 +32,7 @@ tests/test_no_dollar_budget_caps.py
 tests/test_no_per_file_raw_completions_loop.py
 tests/test_no_pod_side_task_py_shellout.py
 tests/test_plan_handoff_path_convention.py
+tests/test_plan_patch.py
 tests/test_precommit_gitleaks_merge_scope.py
 tests/test_sparse_worktree.py
 tests/test_step10d_guard3.py

--- a/tests/test_plan_patch.py
+++ b/tests/test_plan_patch.py
@@ -1,0 +1,364 @@
+"""Tests for ``scripts/plan_patch.py`` (#1631) + the SKILL.md pointer pin.
+
+Pins the anchor-normalized plan-patch helper: 3-stage matching
+(exact -> ws-normalized -> ws+case-normalized, unique-match-only, no
+fall-through on ambiguity), exit codes 0/2/3, the nearest-match report,
+line-based insert modes / byte-exact replace, ``--verify-contains``,
+``--dry-run``, atomic byte-preserving writes, and the guards added from the
+critic-ensemble round (empty/whitespace anchor, degenerate nearest-match
+windows, non-UTF-8 input, the 10 MB size guard).
+
+The final test is the durability pin: ``scripts/plan_patch.py`` must stay
+named inside the Edit-success gate prose of BOTH plan-revision recipes
+(``.claude/skills/adversarial-planner/SKILL.md`` and
+``.claude/skills/issue/SKILL.md``). Presence asserts only — deliberately not
+count-exact, so unrelated future mentions don't false-fail.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_HELPER_PATH = REPO_ROOT / "scripts" / "plan_patch.py"
+_spec = importlib.util.spec_from_file_location("plan_patch", _HELPER_PATH)
+assert _spec is not None and _spec.loader is not None
+pp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(pp)
+
+
+def _run(*argv) -> int:
+    return pp.main([str(a) for a in argv])
+
+
+# --- stage resolution + apply -------------------------------------------------
+
+
+def test_exact_match_replace_applies(tmp_path, capsys):
+    f = tmp_path / "d.md"
+    f.write_text("intro\nthe target sentence.\ntail\n", encoding="utf-8")
+    rc = _run(f, "--anchor", "the target sentence.", "--replace", "the REVISED sentence.")
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "PLAN-PATCH APPLIED (exact match at lines 2-2" in out
+    assert "-the target sentence." in out and "+the REVISED sentence." in out
+    assert f.read_text(encoding="utf-8") == "intro\nthe REVISED sentence.\ntail\n"
+
+
+def test_ws_normalized_match_resolves_wrapped_anchor(tmp_path, capsys):
+    # The #1604/#1609 shape: anchor drafted from intended wording, file wraps
+    # the same words across lines with extra indentation.
+    f = tmp_path / "d.md"
+    f.write_text("start\nalpha beta\n  gamma delta\nend\n", encoding="utf-8")
+    rc = _run(f, "--anchor", "alpha beta gamma delta", "--replace", "REPLACED")
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "ws-normalized match at lines 2-3" in out
+    assert f.read_text(encoding="utf-8") == "start\nREPLACED\nend\n"
+
+
+def test_case_stage_resolves_case_drift(tmp_path, capsys):
+    # The #1415 shape: case-drifted anchor; resolves at stage 3 only.
+    f = tmp_path / "d.md"
+    f.write_text("start\nThe Quick Fox Jumps\nend\n", encoding="utf-8")
+    rc = _run(f, "--anchor", "the quick fox jumps", "--replace", "REPLACED")
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "ws+case-normalized match at lines 2-2" in out
+    assert "REPLACED" in f.read_text(encoding="utf-8")
+
+
+def test_missing_anchor_fails_with_nearest_match_diff(tmp_path, capsys):
+    f = tmp_path / "d.md"
+    before = "one\nthe quick brown fox jumps over\nthree\n"
+    f.write_text(before, encoding="utf-8")
+    rc = _run(f, "--anchor", "the quick brown dog leaps over", "--replace", "X")
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "PLAN-PATCH FAILED" in err
+    assert "nearest match: lines 2-2" in err
+    assert "--- anchor (as given)" in err
+    assert "+++ closest match in file (lines 2-2)" in err
+    assert f.read_text(encoding="utf-8") == before  # untouched
+
+
+def test_ambiguous_exact_anchor_fails_loud(tmp_path, capsys):
+    f = tmp_path / "d.md"
+    before = "dup line\nmiddle\ndup line\n"
+    f.write_text(before, encoding="utf-8")
+    rc = _run(f, "--anchor", "dup line", "--replace", "X")
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "ambiguous anchor — 2 matches at the exact stage" in err
+    assert "lines 1-1" in err and "lines 3-3" in err
+    assert f.read_text(encoding="utf-8") == before
+
+
+def test_ambiguous_at_normalized_stage_fails_no_fallthrough(tmp_path, capsys):
+    # exact: 0 hits; ws-normalized: 2 hits -> ambiguity is reported AT the
+    # ws-normalized stage (never a fall-through to the case stage).
+    f = tmp_path / "d.md"
+    before = "foo  bar\nqux\nfoo\tbar\n"
+    f.write_text(before, encoding="utf-8")
+    rc = _run(f, "--anchor", "foo bar", "--replace", "X")
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "2 matches at the ws-normalized stage" in err
+    assert f.read_text(encoding="utf-8") == before
+
+
+def test_noop_replacement_fails(tmp_path, capsys):
+    # The #1565 guard: an edit that changes nothing must fail loud, not
+    # "succeed" into an unchanged persist.
+    f = tmp_path / "d.md"
+    f.write_text("keep this line\n", encoding="utf-8")
+    rc = _run(f, "--anchor", "keep this line", "--replace", "keep this line")
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "EDIT NO-OP" in err
+    assert f.read_text(encoding="utf-8") == "keep this line\n"
+
+
+# --- insert modes ---------------------------------------------------------------
+
+
+def test_insert_after_is_line_based_with_trailing_newline(tmp_path):
+    # Mid-line anchor: payload (no trailing newline) still lands as a full
+    # line AFTER the anchor's containing line, not byte-adjacent to the match.
+    f = tmp_path / "d.md"
+    f.write_text("aaa bbb ccc\nnext line\n", encoding="utf-8")
+    rc = _run(f, "--anchor", "bbb", "--insert-after", "INSERTED")
+    assert rc == 0
+    assert f.read_text(encoding="utf-8") == "aaa bbb ccc\nINSERTED\nnext line\n"
+
+
+def test_insert_before(tmp_path):
+    f = tmp_path / "d.md"
+    f.write_text("aaa bbb ccc\nnext line\n", encoding="utf-8")
+    rc = _run(f, "--anchor", "next line", "--insert-before", "INSERTED")
+    assert rc == 0
+    assert f.read_text(encoding="utf-8") == "aaa bbb ccc\nINSERTED\nnext line\n"
+
+
+def test_insert_rerun_exits_3_without_double_insert(tmp_path, capsys):
+    f = tmp_path / "d.md"
+    f.write_text("anchor line\ntail\n", encoding="utf-8")
+    assert _run(f, "--anchor", "anchor line", "--insert-after", "NEW LINE") == 0
+    once = f.read_text(encoding="utf-8")
+    rc = _run(f, "--anchor", "anchor line", "--insert-after", "NEW LINE")
+    err = capsys.readouterr().err
+    assert rc == 3
+    assert "PLAN-PATCH ALREADY-APPLIED" in err
+    assert f.read_text(encoding="utf-8") == once  # no double insert
+
+
+# --- byte / encoding handling ---------------------------------------------------
+
+
+def test_crlf_anchor_matches_lf_file(tmp_path):
+    # \r is whitespace at stage 2; LF bytes outside the span are preserved.
+    f = tmp_path / "d.md"
+    f.write_text("intro\nalpha beta\ngamma delta\ntail\n", encoding="utf-8", newline="")
+    rc = _run(f, "--anchor", "alpha beta\r\ngamma delta", "--replace", "REPLACED")
+    assert rc == 0
+    text = f.read_bytes().decode("utf-8")
+    assert text == "intro\nREPLACED\ntail\n"
+    assert "\r" not in text
+
+
+def test_multiline_anchor_exact_and_normalized(tmp_path, capsys):
+    f1 = tmp_path / "exact.md"
+    f1.write_text("head\nline one\nline two\nfoot\n", encoding="utf-8")
+    assert _run(f1, "--anchor", "line one\nline two", "--replace", "MERGED") == 0
+    assert "exact match at lines 2-3" in capsys.readouterr().out
+    assert f1.read_text(encoding="utf-8") == "head\nMERGED\nfoot\n"
+
+    f2 = tmp_path / "wrapped.md"
+    f2.write_text("head\nline one\nline two\nfoot\n", encoding="utf-8")
+    assert _run(f2, "--anchor", "line one line two", "--replace", "MERGED") == 0
+    assert "ws-normalized match at lines 2-3" in capsys.readouterr().out
+    assert f2.read_text(encoding="utf-8") == "head\nMERGED\nfoot\n"
+
+
+def test_non_utf8_target_exits_2(tmp_path, capsys):
+    f = tmp_path / "d.md"
+    f.write_bytes(b"\xff\xfe\x80 not utf8")
+    rc = _run(f, "--anchor", "anything", "--replace", "X")
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "not UTF-8" in err
+
+
+def test_file_size_guard_refuses_over_limit(tmp_path, capsys, monkeypatch):
+    monkeypatch.setattr(pp, "MAX_FILE_BYTES", 64)
+    f = tmp_path / "d.md"
+    f.write_text("x" * 100, encoding="utf-8")
+    rc = _run(f, "--anchor", "xxx", "--replace", "y")
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "refusing files larger than 64 bytes" in err
+
+
+# --- verify-contains / dry-run / file variants ----------------------------------
+
+
+def test_verify_contains_failure_blocks_write(tmp_path, capsys):
+    f = tmp_path / "d.md"
+    before = "one\ntwo\nthree\n"
+    f.write_text(before, encoding="utf-8")
+    rc = _run(f, "--anchor", "two", "--replace", "TWO", "--verify-contains", "NOT_THERE")
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "--verify-contains failed" in err
+    # Concern 1: the would-be diff is printed so a mis-drafted verify string
+    # is one-shot diagnosable.
+    assert "+TWO" in err and "(after)" in err
+    assert f.read_text(encoding="utf-8") == before
+
+
+def test_dry_run_prints_diff_and_writes_nothing(tmp_path, capsys):
+    f = tmp_path / "d.md"
+    before = "one\ntwo\nthree\n"
+    f.write_text(before, encoding="utf-8")
+    rc = _run(f, "--anchor", "two", "--replace", "TWO", "--dry-run")
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "PLAN-PATCH DRY-RUN OK (exact match at lines 2-2" in out
+    assert "+TWO" in out
+    assert f.read_text(encoding="utf-8") == before
+
+
+def test_anchor_and_payload_file_variants(tmp_path):
+    f = tmp_path / "d.md"
+    f.write_text("head\nthe anchor text here\nfoot\n", encoding="utf-8")
+    anchor_file = tmp_path / "a.txt"
+    anchor_file.write_text("the anchor text here\n", encoding="utf-8")
+    payload_file = tmp_path / "r.txt"
+    payload = "verbatim  payload — é kept as-is,  double  spaces too"
+    payload_file.write_text(payload + "\n", encoding="utf-8")
+    rc = _run(f, "--anchor-file", anchor_file, "--replace-file", payload_file)
+    assert rc == 0
+    assert f.read_text(encoding="utf-8") == f"head\n{payload}\nfoot\n"
+
+    # Lone-trailing-newline tolerance (the rstrip fallback): the anchor file
+    # ends in \n but the file's match sits at EOF without one.
+    f2 = tmp_path / "eof.md"
+    f2.write_text("head\nthe anchor text here", encoding="utf-8")
+    rc = _run(f2, "--anchor-file", anchor_file, "--replace", "REPLACED")
+    assert rc == 0
+    assert f2.read_text(encoding="utf-8") == "head\nREPLACED"
+
+
+def test_write_is_atomic_and_preserves_unrelated_bytes(tmp_path):
+    f = tmp_path / "d.md"
+    before = "héad — non-ascii\nreplace me\ntail  with  spacing\n"
+    f.write_text(before, encoding="utf-8", newline="")
+    rc = _run(f, "--anchor", "replace me", "--replace", "replaced")
+    assert rc == 0
+    after = f.read_bytes().decode("utf-8")
+    assert after == "héad — non-ascii\nreplaced\ntail  with  spacing\n"
+    # No temp-file residue from the atomic-write path.
+    assert not list(tmp_path.glob(".plan-patch-*"))
+
+
+# --- guards from the critic-ensemble round --------------------------------------
+
+
+def test_empty_or_whitespace_anchor_rejected(tmp_path, capsys):
+    f = tmp_path / "d.md"
+    before = "content\n"
+    f.write_text(before, encoding="utf-8")
+    for bad_anchor in ("", "  \n\t "):
+        rc = _run(f, "--anchor", bad_anchor, "--replace", "X")
+        err = capsys.readouterr().err
+        assert rc == 2
+        assert "anchor must contain non-whitespace text" in err
+    assert f.read_text(encoding="utf-8") == before
+
+
+def test_nearest_match_degenerate_windows(tmp_path, capsys):
+    # File shorter than the anchor: designed report, never a traceback.
+    short = tmp_path / "short.md"
+    short.write_text("only line\n", encoding="utf-8")
+    rc = _run(short, "--anchor", "aaa\nbbb\nccc", "--replace", "X")
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "shorter than the 3-line anchor" in err
+
+    # Empty file: designed report, never a max()-on-empty traceback.
+    empty = tmp_path / "empty.md"
+    empty.write_text("", encoding="utf-8")
+    rc = _run(empty, "--anchor", "anything", "--replace", "X")
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "file is empty" in err
+
+
+def test_nearest_match_finds_true_region_inside_long_line(tmp_path, capsys):
+    # The report scorer must not let a short decoy line outrank the TRUE
+    # region when the true region is a LONG markdown line (full-window
+    # ratio() penalizes long lines; the partial-ratio slice scan fixes it).
+    decoy = "the quick brown fox leaps"
+    long_line = (
+        "unrelated prefix words repeated here " * 5
+        + "the quick brown fox jumps over the lazy dog"
+        + " and unrelated suffix words repeated here" * 5
+    )
+    f = tmp_path / "d.md"
+    f.write_text(f"{decoy}\nmiddle line\n{long_line}\n", encoding="utf-8")
+    rc = _run(f, "--anchor", "the brown quick fox jumps over the lazy dog", "--replace", "X")
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "nearest match: lines 3-3" in err  # the long TRUE line, not the decoy
+
+
+def test_replace_empty_payload_deletes_span(tmp_path):
+    f = tmp_path / "d.md"
+    f.write_text("keep DELETE-ME keep\n", encoding="utf-8")
+    rc = _run(f, "--anchor", " DELETE-ME", "--replace", "")
+    assert rc == 0
+    assert f.read_text(encoding="utf-8") == "keep keep\n"
+
+
+def test_insert_empty_payload_rejected(tmp_path, capsys):
+    f = tmp_path / "d.md"
+    f.write_text("anchor line\n", encoding="utf-8")
+    rc = _run(f, "--anchor", "anchor line", "--insert-after", "")
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "insert payload must be non-empty" in err
+
+
+# --- CLI smoke + durability pin --------------------------------------------------
+
+
+def test_cli_subprocess_smoke(tmp_path):
+    f = tmp_path / "d.md"
+    f.write_text("one\ntwo\nthree\n", encoding="utf-8")
+    proc = subprocess.run(
+        [sys.executable, str(_HELPER_PATH), str(f), "--anchor", "two", "--replace", "TWO"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    assert "PLAN-PATCH APPLIED" in proc.stdout
+    assert f.read_text(encoding="utf-8") == "one\nTWO\nthree\n"
+
+
+def test_skillmd_pointer_present_in_both_recipes():
+    # THE durability pin (#1631): the helper must stay named inside both
+    # plan-revision recipes, and the adversarial-planner mention must sit in
+    # the same file as the Edit-success gate prose. Presence asserts only.
+    ap_text = (REPO_ROOT / ".claude" / "skills" / "adversarial-planner" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    issue_text = (REPO_ROOT / ".claude" / "skills" / "issue" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    assert "scripts/plan_patch.py" in ap_text
+    assert "scripts/plan_patch.py" in issue_text
+    assert "Edit-success gate" in ap_text

--- a/tests/test_ruff_policy.py
+++ b/tests/test_ruff_policy.py
@@ -51,6 +51,7 @@ LIVE_WORKFLOW_HELPERS = [
     "scripts/dispatch_issue.py",
     "scripts/failure_classifier.py",
     "scripts/gpu_heuristics.py",
+    "scripts/plan_patch.py",
     "scripts/pm_queue_report.py",
     "scripts/pod.py",
     "scripts/pod_audit.py",


### PR DESCRIPTION
Closes task #1631 (kind: infra, wf-fix). New stdlib scripts/plan_patch.py (anchor-normalized apply, fail-loud nearest-match diff) + Edit-success-gate pointers in both plan-revision recipes + WORKFLOW_INVARIANT registration + 25 tests. Code-review r1 PASS; Step 9c test-verdict PASS (2 pre-existing main reds stripped by baseline compare).