### PR TITLE
issue-1638: extend pre_reg audit head nouns (layers?/rungs?/windows?) for the #1586 escape

### DIFF
--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -433,6 +433,12 @@ deliberate GCP fence sized off the p90 per-cell wall, never the mean
 + per-out-root disk rows that NAME the target filesystem/mount the path
 resolves to on the routed lane (never a bare GB number; preamble assert per
 `.claude/rules/plan-compute-sizing.md` § Out-root mount binding).
+A multi-arm dispatch coupling arms of DIFFERENT minimum GPU widths
+behind one provision additionally states each arm's MINIMUM runnable width
+and pre-registers the stall-time down-width split (≥ ~1 h sustained
+capacity stall ⇒ split out + probe the narrowest-runnable arms; the #1121
+walk's down-going sibling — `.claude/rules/plan-compute-sizing.md`
+§ Multi-arm min-width + stall-time down-width split; incident #1112).
 Compute-sizing recipes: `.claude/rules/plan-compute-sizing.md`
 (on-demand); phase placement + GPU-width right-sizing are always-on in
 CLAUDE.md § Pods.

--- a/.claude/rules/LESSONS.md
+++ b/.claude/rules/LESSONS.md
@@ -34,7 +34,7 @@ Row grammar: `- <rule>.md — <fires-when trigger>`
 - ood-generalization-folds.md — a held-out predictive DV (R²/ρ) over grouped samples (GROUP-level fold — LOFO/transfer, not pointwise LOO).
 - persona-distance-metrics.md — you write base-model persona-distance predictor code (canonical KL/JS/cosine defs).
 - persona-vectors-recipe.md — a plan elects persona vectors / a mean-difference contrastive direction (arXiv 2507.21509 EXCEPT logit scoring).
-- plan-compute-sizing.md — a plan sizes §9 compute (HBM, disk/ckpt retention, fan-out accumulation, out-root mount binding, sentinel lanes, store/IO, RAM/RSS routing, wall-time floors incl. the MEASURED 1-cell pilot basis (fit loops AND draw batteries), p90 fences).
+- plan-compute-sizing.md — a plan sizes §9 compute (HBM, disk/ckpt retention, fan-out accumulation, out-root mounts, sentinel lanes, store/IO, RAM/RSS routing, wall-time floors incl. MEASURED 1-cell pilot basis (fits AND draw batteries), p90 fences, stall down-width split).
 - planner-section-reference.md — the planner writes a plan section (pointer-loaded from planner.md).
 - pm-audit-reference.md — the PM scopes fleet burn, triages unmapped/non-EPS team pods, or renders a Mode-2 audit.
 - pod-config.md — pod SSH/MCP keeps failing, you touch the pod scripts/pods.conf (live-API vs pods.conf authority split), or you stop/park a pod for >~1h (STOPPED volume is NON-durable — persist resume state to HF first).

--- a/.claude/rules/compute-backend-failover.md
+++ b/.claude/rules/compute-backend-failover.md
@@ -945,6 +945,22 @@ sanctioned actor ever starts deleting LIVE PENDING instances, the trigger
 needs an operations-log delete-op check (a genuine vanish leaves NO delete
 operation; an actor's delete leaves one) — a re-plan, not a tweak.
 
+### Coupled multi-arm dispatch stall → down-width split (#1633)
+
+Every trigger in this Part re-shapes or fails over ONE dispatch's machine
+(queue-timeout, queue-vanish, boot-loop, the #1379 wide-intent 8→4→2
+degrade). None of them can DECOMPOSE a dispatch that bundles arms of
+DIFFERENT minimum GPU widths behind one provision — the #1112 failure
+mode: 1×-runnable arms held ~14 h behind a coupled 4×/8× provision during
+an A100 drought while the 1× shape had stock. On a SUSTAINED capacity
+stall (≥ ~1 h queued / stocked-out across rungs) of a coupled multi-arm
+dispatch, the owning orchestrator splits out and probes the
+narrowest-runnable arms as their own dispatch(es) instead of continuing
+to hold them; the wide arm keeps its ladder walk. The plan-side duty
+(per-arm MINIMUM runnable width + the pre-registered split) lives in
+`.claude/rules/plan-compute-sizing.md` § Multi-arm min-width + stall-time
+down-width split; this section is the dispatch-time cross-reference.
+
 ### Pre-workload boot-loop → RunPod (#1029)
 
 A boot-looping rung — the #763 shape: `flexstart_l4` re-selected by every

--- a/.claude/rules/plan-compute-sizing.md
+++ b/.claude/rules/plan-compute-sizing.md
@@ -1,5 +1,5 @@
 ---
-description: Planner §9 compute-sizing recipes — activation-capture HBM sizing, merge-disk budget, sentinel-signaling lane pins, the floor cross-check for long / many-call phases (planned_wall_h > 4 OR >~500 serial calls), the measured 1-cell fit-pilot basis for per-cell fit / factorization / GD phases (#1060), the store-heavy / IO-heavy phase recipe (measured per-item serialization+upload wall-time; compression-default-OFF for fp16→Xet), the CPU-phase RAM/RSS routing gate (projected peak RSS per VM-placed phase; ≥~16 GB single-or-summed routes off the shared VM), the dose-ladder checkpoint-retention default (keep dose-selected + latest, clean ruled-out rungs between rungs; size disk to the RETAINED set, #1133), the fan-out end-of-run accumulated footprint rule (#1541, from incident #1481: an N-cell fan-out retaining per-cell outputs sizes the boot disk to the end-of-run SUM of every cell's retained outputs + the transient high-water mark, or declares a driver-side between-phase reap of consumed cell outputs), and costing wall-time against the machine the router will ACTUALLY provision + p90-based fence sizing, and the external-stream >~1h presumption for network-bound streaming/harvest phases (#1092), and the out-root mount-binding contract (#1414, from incident #1333: each disk out-root names its target filesystem/mount; the workload preamble asserts headroom at that mount), and the phase-ordering checkpoint high-water requirement (#1612, from incident #1586 r5: the stated ckpt high-water is computed against the IMPLEMENTED phase ordering — every phase accumulating checkpoints without an intervening reap is itself reap-bounded; a downstream-unit reap cannot bound an upstream train-all accumulation) (loads at plan time via plan-file paths; relocated verbatim from planner.md §9, #829)
+description: Planner §9 compute-sizing recipes — activation-capture HBM sizing, merge-disk budget, sentinel-signaling lane pins, the floor cross-check for long / many-call phases (planned_wall_h > 4 OR >~500 serial calls), the measured 1-cell fit-pilot basis for per-cell fit / factorization / GD phases (#1060), the store-heavy / IO-heavy phase recipe (measured per-item serialization+upload wall-time; compression-default-OFF for fp16→Xet), the CPU-phase RAM/RSS routing gate (projected peak RSS per VM-placed phase; ≥~16 GB single-or-summed routes off the shared VM), the dose-ladder checkpoint-retention default (keep dose-selected + latest, clean ruled-out rungs between rungs; size disk to the RETAINED set, #1133), the fan-out end-of-run accumulated footprint rule (#1541, from incident #1481: an N-cell fan-out retaining per-cell outputs sizes the boot disk to the end-of-run SUM of every cell's retained outputs + the transient high-water mark, or declares a driver-side between-phase reap of consumed cell outputs), and costing wall-time against the machine the router will ACTUALLY provision + p90-based fence sizing, and the external-stream >~1h presumption for network-bound streaming/harvest phases (#1092), and the out-root mount-binding contract (#1414, from incident #1333: each disk out-root names its target filesystem/mount; the workload preamble asserts headroom at that mount), and the phase-ordering checkpoint high-water requirement (#1612, from incident #1586 r5: the stated ckpt high-water is computed against the IMPLEMENTED phase ordering — every phase accumulating checkpoints without an intervening reap is itself reap-bounded; a downstream-unit reap cannot bound an upstream train-all accumulation), and the multi-arm min-width + stall-time down-width split (#1633, from incident #1112: 1×-runnable arms held ~14 h behind a coupled 4×/8× provision during an A100 drought; a mixed-width multi-arm plan names each arm's MINIMUM runnable width and pre-registers splitting out the narrowest-runnable arms on a ≥ ~1 h sustained capacity stall) (loads at plan time via plan-file paths; relocated verbatim from planner.md §9, #829)
 paths:
   - ".claude/plans/**"
   - "tasks/**/plans/**"
@@ -7,7 +7,7 @@ paths:
 
 # Plan compute sizing (planner §9 relocated recipes)
 
-These thirteen recipes are the planner-specific §9 sizing blocks — five relocated
+These fourteen recipes are the planner-specific §9 sizing blocks — five relocated
 verbatim from `.claude/agents/planner.md` (#829), plus the
 store-heavy / IO-heavy phase recipe (#910, from incident #813), the
 CPU-phase RAM/RSS routing gate (#1031, from incidents #778/#833), the
@@ -17,7 +17,8 @@ here), the dose-ladder checkpoint-retention default (#1133, from incident
 #1112), the out-root mount-binding contract (#1414, from incident
 #1333), the fan-out end-of-run accumulation rule (#1541, from incident
 #1481), and the phase-ordering checkpoint high-water requirement (#1612,
-from incident #1586 r5). The planner
+from incident #1586 r5), and the multi-arm min-width + stall-time
+down-width split (#1633, from incident #1112). The planner
 applies each when its trigger matches; the compute-projection table spec +
 stratification spec stay inline in planner.md §9.
 
@@ -539,3 +540,39 @@ long-run residual gap named (`/issue` SKILL.md Step 6b residual gap (d)).
 A plan that silently lets a conditional phase ride past the fence loses
 the phase mid-run (#599: the pre-registered §7.3 extension probe was
 hard-deleted at step 149/2400 by the 24h fence).
+
+
+**Multi-arm min-width + stall-time down-width split — the down-going
+sibling of the #1121 wide-first rung walk.** A plan whose §9 couples two
+or more arms with DIFFERENT minimum GPU requirements behind ONE provision
+(e.g. a 1×-runnable LoRA-ladder arm and a 4×-needing ZeRO-3 full-FT arm
+dispatched together on a 4×/8× pod) MUST name, per arm, that arm's
+MINIMUM runnable width — the smallest GPU count × class the arm can
+actually execute on (a min-width column or per-arm line in the §9
+compute-projection table) — and MUST pre-register the down-width split:
+if the coupled provision sits in a SUSTAINED capacity stall — ≥ ~1 h
+queued / stocked-out across rungs (prose guidance, not a coded gate;
+calibrated as several full ladder walks — the router's per-rung queue
+timeout is 600 s, `EPS_GCP_QUEUE_WAIT_SECONDS`, and the free-lane park is
+600 s, `router.FREE_WAIT_SECONDS`) — the owning orchestrator SPLITS OUT
+the narrowest-runnable arms as their own narrow dispatch(es) and probes
+that shape immediately, rather than holding every arm behind the widest
+arm's provision; the wide arm keeps its own ladder walk unchanged.
+Composition invariant (all three untouched): the #1121 wide-FIRST walk
+still leads for any single shardable phase (wide `a2-ultragpu` rungs
+tried first when work shards); the #1379 explicit-wide 8→4→2 degrade
+still narrows ONE dispatch's machine on a capacity miss — it CANNOT
+decompose arms of different minimum widths bundled behind one provision,
+which is exactly the #1112 failure mode; and the saturate-or-downsize
+idle-width protections are unchanged (a split-out narrow arm must still
+saturate its own pod). Incident #1112 (2026-07-22): a coupled dispatch
+held 1×-runnable arms ~14 h through a GCP A100 drought (dozens of
+create attempts, both zones) while the 1× shape had stock — the Arm-A-only 1×
+dispatch provisioned immediately and finished in ~55 min. A plan that
+couples mixed-width arms without per-arm minimum widths and the
+pre-registered split leaves the mid-run orchestrator no licensed
+decomposition — that omission is the gap this recipe closes. (Up-front
+DECOUPLING of mixed-min-width arms into separate provisions was
+considered and rejected: wide coupling wins when capacity exists — one
+provision, shared setup — so the split is a stall-time remedy, not the
+default dispatch shape.)

--- a/scripts/audit_clean_results_body_discipline.py
+++ b/scripts/audit_clean_results_body_discipline.py
@@ -152,6 +152,41 @@ PATTERNS: dict[str, tuple[str, str]] = {
         # AND no incident string), and 'estimate' is a far more common
         # object of verb-register 'registered' than 'estimator', so both
         # stay out until an incident or attested hit mandates them.
+        # #1638 (2026-07-23) adds `layers?`/`rungs?`/`windows?` for the
+        # #1586 round-1 escape: 'the registered layer' (x5) and 'reported
+        # at the registered layer' in #1586's clean-result draft could not
+        # match — 'layer' was absent from the alternation — and were
+        # caught only by the LM critic's Lens 7 read. #1586's CURRENT body
+        # carries 0 hits (the analyzer revised them out post-critique), so
+        # `layers?` rides the incident mandate per the #1475
+        # cut/lever/smoke rule PLUS 4 attested corpus hits; `rungs?` and
+        # `windows?` are critic-sketched siblings included on attested
+        # genuine hits. The critic's other sketched siblings
+        # (lattice/band/read/margin/verdict) were already listed by #1419
+        # — nothing to add. Measured 2026-07-23 over all 1,571
+        # tasks/*/*/body.md (full-pattern old-vs-new match-start diff,
+        # re.IGNORECASE): 13 new hits — layer(s) 10 (4 genuine: #1112
+        # 'registered layer 14', #1333 'the registered layer 25', #542
+        # 'the registered layer', #509 'previously-registered single
+        # layer-20'; + 6 in #1638's own body quoting the incident, the
+        # #1553 self-quote class), rung(s) 1 (#1005 'the parent's
+        # registered retry rung'), window(s) 2 (#1332 'the plan's
+        # registered window', 'the registered apply-gate window') — every
+        # one manually classified genuine pre-registration jargon (the
+        # deciding question: does 'registered' here mean PRE-REGISTERED?),
+        # 0 benign verb-use false positives. OLD-minus-NEW match starts: 0
+        # — measured empirically this round (an implementation-time
+        # re-check, not an inference from the leftmost 'pre-?registered'
+        # alternative ordering). Accepted residuals (each 0/1,571
+        # attested; the same trade #1419 accepted): determiner-first verb
+        # objects on the new nouns ('the run registered a window of
+        # instability') would flag; and the mid-window-preposition /
+        # hook-register form ('registered a hook at layer 20' — the
+        # determiner + noun tokens consume window positions 1-3, so
+        # 'layer' heads the match and the FIRST-token preposition
+        # lookahead does not guard positions 2-3) would flag — a
+        # pre-existing property of the #1419 intervening-token window,
+        # not new to these nouns.
         r"pre-?registered|pre-?registration|(?<![a-z])pre-reg(?![a-z])|registered hypothesis"
         r"|registered alpha|\bas registered\b|fail at the gate|passed the gate"
         r"|gate-pre-?registered"
@@ -159,7 +194,8 @@ PATTERNS: dict[str, tuple[str, str]] = {
         r"(?:[\w%/<>=≤≥−+-]+(?:[.\-−]\d+)*[ \t]+){0,3}?"  # noqa: RUF001
         r"(?:verdicts?|lattices?|margins?|reads?|criteri(?:on|a)|thresholds?|bands?"
         r"|gates?|rules?|endpoints?|contrasts?|floors?|companions?|hypothes[ei]s|alpha"
-        r"|cuts?|paths?|clauses?|controls?|levers?|bars?|smokes?|estimators?)\b",
+        r"|cuts?|paths?|clauses?|controls?|levers?|bars?|smokes?|estimators?"
+        r"|layers?|rungs?|windows?)\b",
         "Pre-registration jargon ('pre-registered', 'as registered', "
         "'fail at the gate', bare 'registered <verdict/margin/read/...>', etc.)",
     ),

--- a/tests/test_audit_clean_results_body_discipline.py
+++ b/tests/test_audit_clean_results_body_discipline.py
@@ -1222,6 +1222,55 @@ def test_pre_reg_registered_estimator_in_v4_results_prose_is_flagged():
     assert any("estimator" in s.lower() for s in findings["pre_reg"]), findings["pre_reg"]
 
 
+def test_pre_reg_bare_registered_noun_1586_escape_strings_are_flagged():
+    """The #1586 round-1 escape class trips `pre_reg` in v4 Results prose
+    now that #1638 added `layers?`/`rungs?`/`windows?` to the head-noun
+    alternation: the two #1586 incident forms, the #1333 corpus form
+    (numeral AFTER the head noun), the #1005 rung form (two intervening
+    modifier tokens), and the two #1332 window forms."""
+    phrases = [
+        "reported at the registered layer",
+        "the registered layer",
+        "shift DVs at the registered layer 25",
+        "the parent's registered retry rung",
+        "the plan's registered window",
+        "the registered apply-gate window",
+    ]
+    for phrase in phrases:
+        body = V4_BODY_CLEAN.replace(
+            "The lift holds at every seed in the held-out evaluation.",
+            f"{phrase}.",
+        )
+        assert body != V4_BODY_CLEAN
+        findings = audit.audit_body(body)
+        assert "pre_reg" in findings, (phrase, findings)
+        assert any("registered" in s.lower() for s in findings["pre_reg"]), (phrase, findings)
+
+
+def test_pre_reg_1638_new_nouns_benign_verb_usages_not_flagged():
+    """Benign verb-register shapes for the #1638 nouns stay clean: the
+    first-token preposition guard covers 'registered at layer 20' /
+    'registered on layer hooks' / 'registered in the dashboard config' /
+    'registered under the sweep', including noun-BEFORE-verb subjects
+    ('three windows registered in ...', 'the ladder rungs registered
+    under ...'). NOTE (measured 2026-07-23, #1638): the mid-window-
+    preposition / hook-register form 'registered a hook at layer 20'
+    WOULD flag (the determiner + noun tokens consume window positions
+    1-3, so 'layer' heads the match; the lookahead guards only the FIRST
+    token) — a documented accepted residual with 0/1,571-body corpus
+    attestation, a pre-existing #1419-window property, deliberately NOT
+    pinned here as a passing negative."""
+    body = V4_BODY_CLEAN.replace(
+        "The lift holds at every seed in the held-out evaluation.",
+        "the forward hook registered at layer 20 fired; activations "
+        "registered on layer hooks; three windows registered in the "
+        "dashboard config; the ladder rungs registered under the sweep.",
+    )
+    assert body != V4_BODY_CLEAN
+    findings = audit.audit_body(body)
+    assert "pre_reg" not in findings, findings
+
+
 # ─── v4 ## Methodology sample-data <details> exemption (#1171) ───────────
 #
 # The v4 spec moved the verbatim sample rows to `## Methodology` →


### PR DESCRIPTION
Closes task #1638.

Extends the `pre_reg` bare-registered head-noun alternation in `scripts/audit_clean_results_body_discipline.py` (+`layers?|rungs?|windows?`) for the #1586 'registered layer' escape class, with the file's standard corpus measurement (1,571 bodies: +13 marginal hits, 0 benign FPs, OLD-minus-NEW=0) recorded in the provenance comment, and positive/negative test pins.

Pipeline: plan v1 (verify_plan PASS; 3× critic APPROVE; consistency PASS) → code-review PASS r1 → step9c test-verdict PASS (compare exit 0; 2 pre-existing-main reds stripped by the pristine oracle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)