### PR TITLE
issue-1643: fix UP037 quoted annotation at runpod_api.py:488

### DIFF
--- a/scripts/runpod_api.py
+++ b/scripts/runpod_api.py
@@ -485,7 +485,7 @@ class _RawGraphQL(str):
     """A pre-serialized GraphQL fragment (env object lists) — emitted verbatim."""
 
 
-def _public_key_env() -> "_RawGraphQL | None":
+def _public_key_env() -> _RawGraphQL | None:
     """A ``PUBLIC_KEY`` env entry for the pod create input, or None.
 
     The runpod/pytorch image writes ``PUBLIC_KEY`` into authorized_keys at


### PR DESCRIPTION
Closes task #1643. One-line ruff UP037 unquote so tests/test_ruff_policy.py::test_live_workflow_helpers_clean_under_full_ruleset is green on main.