### PR TITLE
issue-1646: step9c/10d gate-timeout sizing survives known-slow test files

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -8638,7 +8638,7 @@ suite directly and posts an `epm:test-verdict` event with the result.
       pre-run `rm -f` of all three gate files (a killed run must leave NO
       junit — pytest writes it only at session exit; a stale file from a
       prior round must never be re-read). BACKGROUND IS REQUIRED, NOT
-      OPTIONAL: the selection always contains the 58-file (2026-07-24)
+      OPTIONAL: the selection always contains the 61-file (2026-07-24)
       workflow-invariant set incl. `tests/test_workflow_lint.py` (median
       ~13 min alone, max ~30 min; whole gate median ~18 min, max ~38 min of
       test time plus collection overhead — 330 junit runs measured
@@ -8948,7 +8948,7 @@ suite directly and posts an `epm:test-verdict` event with the result.
       ledger refresh so the next session gets a fresh baseline — do NOT block
       this verdict on it:
       ```bash
-      REFRESH_PID=$(bash -c 'cd "$1" || exit 1; setsid nohup timeout --kill-after=60s 4560s \
+      REFRESH_PID=$(bash -c 'cd "$1" || exit 1; setsid nohup timeout --kill-after=60s 4650s \
         env OMP_NUM_THREADS=8 MKL_NUM_THREADS=8 OPENBLAS_NUM_THREADS=8 NUMEXPR_NUM_THREADS=8 MALLOC_ARENA_MAX=2 \
         uv run python scripts/step9c_baseline.py refresh \
         >> "$1/logs/step9c_baseline_refresh.log" 2>&1 < /dev/null & echo $!' _ "$REPO_ROOT")

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -8623,9 +8623,10 @@ suite directly and posts an `epm:test-verdict` event with the result.
       It prints the exact gate command —
       `timeout --kill-after=60s <T>s uv run pytest <files> -v --tb=short`,
       `<T>` sized deterministically from the selection
-      (`recommended_timeout_s()`: 120s base + 30s/file + a 900s surcharge when
-      `tests/test_workflow_lint.py` is selected, which alone measured up to
-      771s) — plus stderr diagnostics: a one-line work-root + branch
+      (`recommended_timeout_s()`: 120s base + 30s/file + a 2400s surcharge when
+      `tests/test_workflow_lint.py` is selected, which alone measured median
+      789s / max 1819s across 330 gate junits 2026-07-13..24, #1646) — plus
+      stderr diagnostics: a one-line work-root + branch
       provenance breadcrumb on every run, a `recommended-timeout-s=<T>`
       sizing line, any `untested touched file: <path>` WARN lines, and the
       empty-diff NOTE described above. (A code-change task with NO worktree
@@ -8637,10 +8638,11 @@ suite directly and posts an `epm:test-verdict` event with the result.
       pre-run `rm -f` of all three gate files (a killed run must leave NO
       junit — pytest writes it only at session exit; a stale file from a
       prior round must never be re-read). BACKGROUND IS REQUIRED, NOT
-      OPTIONAL: the selection always contains the 37-file workflow-invariant
-      set incl. `tests/test_workflow_lint.py` (median ~6.5 min alone, max
-      ~13 min; whole gate median ~11 min, max ~21 min of test time plus
-      collection overhead — 26 junit runs measured 2026-07-04/05), so the
+      OPTIONAL: the selection always contains the 58-file (2026-07-24)
+      workflow-invariant set incl. `tests/test_workflow_lint.py` (median
+      ~13 min alone, max ~30 min; whole gate median ~18 min, max ~38 min of
+      test time plus collection overhead — 330 junit runs measured
+      2026-07-13..24, #1646), so the
       gate can NEVER fit the 600s foreground Bash tool cap. The
       crash-fix-rounds ~510s foreground `timeout` bound
       (`.claude/rules/crash-fix-rounds.md` § Kill-before-relaunch) applies to
@@ -8812,7 +8814,7 @@ suite directly and posts an `epm:test-verdict` event with the result.
       rc-file/junitxml contract (#1046: the gate is a background invocation;
       `PYTEST_RC` travels via `/tmp/step9c-rc-issue-<N>`, not shell state).
       Step 1d compare — including its pristine single-file oracle runs
-      (600–1950s each, #1129) — runs as its OWN background + rc-file call
+      (600–4950s each, #1129/#1646) — runs as its OWN background + rc-file call
       with the SAME fail-open self-choom preamble (see step 1d); only the
       1d ledger-refresh kick keeps the post-hoc session-sweep form (it
       launches detached BEFORE a choom can be applied). FAIL-OPEN: a
@@ -8840,14 +8842,14 @@ suite directly and posts an `epm:test-verdict` event with the result.
       background + rc-file pattern as 1b. BACKGROUND IS REQUIRED, NOT
       OPTIONAL: `--run-pristine` (always passed here) may run up to
       `--max-pristine-files` (5) single-file pristine oracle runs, each
-      bounded by `derive_pristine_timeout_s` at 600–1950s (#1129:
-      tests/test_workflow_lint.py alone derives 1950s), so a healthy
+      bounded by `derive_pristine_timeout_s` at 600–4950s (#1129/#1646:
+      tests/test_workflow_lint.py alone derives 4950s), so a healthy
       compare can NEVER be guaranteed to fit the 600s foreground Bash tool
       cap — a foreground call converts a classifiable in-process exit 2
       into a tool-layer kill with COMPARE_OUT lost (#1129/#1098). Compare
       stays a SEPARATE background call, NOT folded into the 1b gate call:
       1b's foreground verdict read and the zero-collected guard run
-      between them, and a folded call would burn up to ~77 min of
+      between them, and a folded call would burn up to ~2 h of
       pristine runs on a run those guards fail in seconds.
 
       **Single-flight probe (#1606)** first, per the 1b statement: a
@@ -8876,9 +8878,11 @@ suite directly and posts an `epm:test-verdict` event with the result.
       [ -f /tmp/step9c-rc-issue-<N> ] || { echo "FATAL: 1b rc file missing — apply 1b's FAIL path; compare not run" >&2; exit 1; }
       PYTEST_RC=$(cat /tmp/step9c-rc-issue-<N>)
       # Wedge bound 10800s ≥ the structural ceiling of compare's own in-process
-      # bounds (5 pristine files × 1950s max derived bound + 120s scratch +
-      # ruff/parse overhead) — it only ever fires on a genuine wedge (#1129
-      # generous bias; re-derive if SLOW_TESTS / max-pristine-files change):
+      # bounds: the 5 pristine files are DISTINCT and SLOW_TESTS has one entry,
+      # so ceiling = 4950s (workflow-lint derived) + 4 × 600s floor + 120s
+      # scratch + ruff/parse overhead ≈ 7500s; 10800s keeps ~1.4x margin and
+      # only ever fires on a genuine wedge (#1129 generous bias, figures #1646;
+      # re-derive if SLOW_TESTS gains entries/values or max-pristine-files changes):
       timeout --kill-after=60s 10800s uv run python scripts/step9c_baseline.py compare \
         --junitxml /tmp/step9c-junit-issue-<N>.xml --pytest-rc "$PYTEST_RC" \
         --run-pristine --json \
@@ -8944,7 +8948,7 @@ suite directly and posts an `epm:test-verdict` event with the result.
       ledger refresh so the next session gets a fresh baseline — do NOT block
       this verdict on it:
       ```bash
-      REFRESH_PID=$(bash -c 'cd "$1" || exit 1; setsid nohup timeout --kill-after=60s 2100s \
+      REFRESH_PID=$(bash -c 'cd "$1" || exit 1; setsid nohup timeout --kill-after=60s 4560s \
         env OMP_NUM_THREADS=8 MKL_NUM_THREADS=8 OPENBLAS_NUM_THREADS=8 NUMEXPR_NUM_THREADS=8 MALLOC_ARENA_MAX=2 \
         uv run python scripts/step9c_baseline.py refresh \
         >> "$1/logs/step9c_baseline_refresh.log" 2>&1 < /dev/null & echo $!' _ "$REPO_ROOT")
@@ -10302,9 +10306,9 @@ tests BEFORE anything lands:
       # matched payload paths (attribution grep list) + gated test list:
       cut -f2 /tmp/issue-<N>-tg-map.txt | sort -u > /tmp/issue-<N>-tg-files.txt
       mapfile -t TG_TESTS < <(cut -f1 /tmp/issue-<N>-tg-map.txt | sort -u)
-      # Sized from the selector's map (#1573; floor = the pre-#1573 fixed 300s):
+      # Sized from the selector's map (#1573; floor 600s, #1646):
       TG_T=$(grep -oE 'recommended-timeout-s=[0-9]+' /tmp/issue-<N>-tg-map-err.txt \
-             | tail -1 | cut -d= -f2); [ -z "${TG_T:-}" ] && TG_T=300
+             | tail -1 | cut -d= -f2); [ -z "${TG_T:-}" ] && TG_T=600
       # Route TG fixture temp writes onto the data disk (#1408 recipe; #1363:
       # / at 100% killed a gate). Short --basetemp keeps AF_UNIX socket paths
       # under the 108-byte cap. Falls back silently (no TMPDIR, no --basetemp
@@ -10528,10 +10532,11 @@ tests BEFORE anything lands:
   recovery covers that, and baseline subtraction still removes deterministic
   trunk red. Each pytest leg is bounded at the selector-sized `${TG_T}` —
   grepped from the gated map's machine-greppable `recommended-timeout-s=`
-  stderr sizing line in `/tmp/issue-<N>-tg-map-err.txt`, falling back to the
-  pre-#1573 fixed 300 s when the line is absent (the sizing floor is also
-  300 s, so small maps keep today's bound; the historical 2-test scan map
-  measured ~12.6 s, 2026-07-08). The baseline leg reuses the gated map's
+  stderr sizing line in `/tmp/issue-<N>-tg-map-err.txt`, falling back to a
+  fixed 600 s when the line is absent (the sizing floor is also 600 s —
+  raised from 300 s by #1646: #1634's healthy 5-file baseline leg measured
+  202.9 s and the gated leg was killed at 300 s under residual load; the
+  historical 2-test scan map measured ~12.6 s, 2026-07-08). The baseline leg reuses the gated map's
   `TG_T` (its own map call discards stderr; the gated map is the superset in
   the common case and over-sizing is the safe direction) — a
   k_baseline ≫ k_gated residual fails CLOSED (rc 124 → crash); the known
@@ -11494,9 +11499,9 @@ Decision tree:
   if [ "$TG_CRASH" = no ] && [ -s /tmp/issue-<N>-tg-map.txt ]; then
     cut -f2 /tmp/issue-<N>-tg-map.txt | sort -u > /tmp/issue-<N>-tg-files.txt
     mapfile -t TG_TESTS < <(cut -f1 /tmp/issue-<N>-tg-map.txt | sort -u)
-    # Sized from the selector's map (#1573; floor = the pre-#1573 fixed 300s):
+    # Sized from the selector's map (#1573; floor 600s, #1646):
     TG_T=$(grep -oE 'recommended-timeout-s=[0-9]+' /tmp/issue-<N>-tg-map-err.txt \
-           | tail -1 | cut -d= -f2); [ -z "${TG_T:-}" ] && TG_T=300
+           | tail -1 | cut -d= -f2); [ -z "${TG_T:-}" ] && TG_T=600
     # Route TG fixture temp writes onto the data disk (#1408 recipe; #1363:
     # / at 100% killed a gate). Short --basetemp keeps AF_UNIX socket paths
     # under the 108-byte cap. Falls back silently (no TMPDIR, no --basetemp

--- a/scripts/inline_lint_gate.py
+++ b/scripts/inline_lint_gate.py
@@ -75,7 +75,7 @@ FETCH_TIMEOUT_S = 60
 # — a false-INCONCLUSIVE generator on slow machines, never a false pass).
 PYTEST_BASE_S = 120
 PYTEST_PER_FILE_S = 30
-PYTEST_WORKFLOW_LINT_SURCHARGE_S = 900
+PYTEST_WORKFLOW_LINT_SURCHARGE_S = 2400  # select_step9c_tests.SLOW_TESTS parity (#1646)
 PYTEST_TIMEOUT_FLOOR_S = 900  # select_step9c_tests.TIMEOUT_FLOOR_S parity (pinned by test)
 
 # Healthy lint terminal line; `workflow_lint: schema FAIL` does NOT match.

--- a/scripts/select_step9c_tests.py
+++ b/scripts/select_step9c_tests.py
@@ -179,7 +179,7 @@ src/scripts code file with ZERO pairs across all arms draws one tab-free
 ``no mapped tests for code file`` stderr WARN (#1573's fail-loud floor —
 rc stays 0). A non-empty map additionally prints a tab-free machine-greppable
 ``recommended-timeout-s=<T>`` stderr sizing line
-(``recommended_timeout_s(tests, floor=MAP_TIMEOUT_FLOOR_S)``, floor 300 s —
+(``recommended_timeout_s(tests, floor=MAP_TIMEOUT_FLOOR_S)``, floor 600 s —
 the Step-10d TG legs size their pytest bound from it). Empty stdout on
 no match is a SUCCESS (exit 0 — the gate's skip signal); exit 1 only when FILE
 is unreadable (the gate fails CLOSED on an unclassifiable payload). A FILE
@@ -194,9 +194,9 @@ payload is a legitimate zero-resolution list).
 Default output: the exact gate invocation
 ``timeout --kill-after=60s <T>s uv run pytest <files...> -v --tb=short`` on
 stdout — ``<T>`` sized deterministically by :func:`recommended_timeout_s`
-(#1046: 120s base + 30s/file + a 900s surcharge when
-``tests/test_workflow_lint.py`` is selected; measured from 27 real gate junits
-2026-07-04/05, workflow-lint present in 26 of them) — then any
+(#1046: 120s base + 30s/file + a 2400s surcharge when
+``tests/test_workflow_lint.py`` is selected; re-measured from 330 real gate
+junits 2026-07-13..24, #1646) — then any
 ``untested touched file: <path>`` WARN lines on stderr. Every run also prints
 a one-line provenance breadcrumb to stderr (the resolved work root + current
 branch) so the Step 9c marker records which checkout the subset was selected
@@ -519,7 +519,7 @@ def rules_pin_pairs(files: list[str], work_root: Path) -> list[tuple[str, str]]:
     """Sorted ``(pin_test, rule_file)`` pairs for ``--map-files`` (#1496).
 
     WORKFLOW_INVARIANT members are EXCLUDED here (they already gate every
-    Step 9c run; this also keeps the 900 s tests/test_workflow_lint.py out of
+    Step 9c run; this also keeps the 2400 s tests/test_workflow_lint.py out of
     the Step 10d / inline-payload lint gate). The Step 9c selection arm keeps
     them (harmless extra reason; the union dedupes) — the deliberate asymmetry
     is pinned by test_cli_map_files_rules_pin_excludes_invariant.
@@ -534,8 +534,12 @@ def rules_pin_pairs(files: list[str], work_root: Path) -> list[tuple[str, str]]:
 
 
 # --- src/scripts dependency arms for --map-files (#1573). ---------------------
-MAP_TIMEOUT_FLOOR_S = 300  # Step-10d TG-leg parity floor (SKILL.md measured basis
-#                            ~12.6 s for the historical 2-test scan map, 2026-07-08)
+MAP_TIMEOUT_FLOOR_S = 600  # Step-10d TG-leg floor (#1646; was 300, basis the
+#                            ~12.6 s 2-test scan map of 2026-07-08). #1634's
+#                            healthy 5-file baseline leg measured 202.9 s and
+#                            the identical gated leg was killed at 300 s under
+#                            residual load; 600 ~= 3x the measured healthy
+#                            small-map wall.
 
 
 def dependency_map_pairs(files: list[str], work_root: Path) -> list[tuple[str, str]]:
@@ -544,7 +548,7 @@ def dependency_map_pairs(files: list[str], work_root: Path) -> list[tuple[str, s
     (#1498) via the ONE shared :func:`_scan_test_files` read pass, plus
     stem-map path arithmetic. WORKFLOW_INVARIANT members are EXCLUDED
     (the :func:`rules_pin_pairs` asymmetry: they already gate every Step 9c
-    run, and exclusion keeps the 900 s tests/test_workflow_lint.py out of the
+    run, and exclusion keeps the 2400 s tests/test_workflow_lint.py out of the
     Step 10d / inline-payload gates — sft.py literal-hits it via
     workflow_lint's LIVE_WORKFLOW_HELPERS list). The stem arm is restricted
     to the :func:`literal_path_targets` eligibility set (``.py`` under
@@ -591,17 +595,18 @@ def transitive_consumer_pairs(files: list[str], work_root: Path) -> list[tuple[s
     )
 
 
-# --- Gate-timeout sizing (#1046). --------------------------------------------
-# Measured from 27 Step 9c gate junits on the shared VM (2026-07-04..05,
-# /tmp/step9c-junit-issue-*.xml, per-testcase `time` summed per file;
-# test_workflow_lint.py present in 26 of them):
-# tests/test_workflow_lint.py alone min 319 s / median 390 s / max 771 s;
-# whole-gate totals median ~662 s / max 1285 s on 32-46-file selections. The
-# foreground Bash tool cap is 600 s, so the printed command carries this bound
-# and Step 9c runs the gate as a BACKGROUND invocation (SKILL.md 9c step 1b).
+# --- Gate-timeout sizing (#1046; figures re-measured by #1646). ---------------
+# Measured from 330 Step 9c gate junits on the shared VM (2026-07-13..24,
+# /tmp/step9c-junit-issue-*.xml, per-testcase `time` summed per file):
+# tests/test_workflow_lint.py alone min 472 s / median 789 s / p90 1111 s /
+# max 1819 s (58/330 runs exceeded the previous 1050 s one-file bound);
+# whole-gate testcase-time totals median ~1094 s / p90 ~1568 s / max ~2289 s.
+# The foreground Bash tool cap is 600 s, so the printed command carries this
+# bound and Step 9c runs the gate as a BACKGROUND invocation (SKILL.md 9c 1b).
 # Constants are deliberately generous (~1.4-2x over worst measured): an
 # oversized bound only ever fires on a genuine wedge; an undersized one kills
-# healthy gates (#991/#996/#906, exit 143 at 480-540 s foreground bounds).
+# healthy gates (#991/#996/#906, exit 143 at 480-540 s foreground bounds;
+# #1642: a 900 s surcharge vs a 1188.62 s measured wall).
 TIMEOUT_BASE_S = 120  # pytest startup + collection (~2500 tests) + imports
 TIMEOUT_PER_FILE_S = 30  # ~2x the p90 per-file runtime of non-slow files
 TIMEOUT_FLOOR_S = 900
@@ -609,8 +614,11 @@ TIMEOUT_FLOOR_S = 900
 # by an order of magnitude. Pinned literal (same curation rule as
 # WORKFLOW_INVARIANT); live-tree drift pin in tests/test_select_step9c_tests.py.
 SLOW_TESTS: dict[str, int] = {
-    # 3845 lines; runs whole-tree lints repeatedly. Max 771 s measured (n=26).
-    "tests/test_workflow_lint.py": 900,
+    # Runs whole-tree lints repeatedly; wall GREW 771 -> 1819 s max between the
+    # n=26 (2026-07-04..05) and n=330 (2026-07-13..24) junit samples (#1642
+    # measured 1188.62 s standalone). 2400 puts the one-file bound at
+    # 120 + 30 + 2400 = 2550 s = 1.40x the 1819 s worst measured (#1646).
+    "tests/test_workflow_lint.py": 2400,
 }
 
 # --- Diff-base resolution (#1289). -------------------------------------------
@@ -691,11 +699,11 @@ def recommended_timeout_s(tests: list[str], *, floor: int = TIMEOUT_FLOOR_S) -> 
     ``BASE + PER_FILE * len(tests) + sum(slow surcharges)``, floored at
     *floor* (default ``TIMEOUT_FLOOR_S`` — diff-path callers unchanged;
     ``--map-files`` mode passes ``floor=MAP_TIMEOUT_FLOOR_S``, the Step-10d
-    TG-leg 300 s parity floor, #1573). Invariant-only selection (38 files
-    incl. the workflow-lint surcharge) -> 2160 s (36 min), consistent with
-    the existing invariant-set-scale precedents (``step9c_baseline.py
-    refresh`` ``--timeout-s`` default 1800 s; the SKILL.md detached
-    refresh's 2100 s).
+    TG-leg 600 s floor, #1573/#1646). Invariant-only selection (58 files as
+    of 2026-07-24, incl. the workflow-lint surcharge) -> 4260 s (71 min),
+    matching the invariant-set-scale precedents (``step9c_baseline.py
+    refresh`` ``--timeout-s`` default 4260 s; the SKILL.md detached
+    refresh's 4560 s).
     """
     t = TIMEOUT_BASE_S + TIMEOUT_PER_FILE_S * len(tests)
     t += sum(SLOW_TESTS.get(x, 0) for x in tests)

--- a/scripts/select_step9c_tests.py
+++ b/scripts/select_step9c_tests.py
@@ -600,7 +600,8 @@ def transitive_consumer_pairs(files: list[str], work_root: Path) -> list[tuple[s
 # Measured from 330 Step 9c gate junits on the shared VM (2026-07-13..24,
 # /tmp/step9c-junit-issue-*.xml, per-testcase `time` summed per file):
 # tests/test_workflow_lint.py alone min 472 s / median 789 s / p90 1111 s /
-# max 1819 s (58/330 runs exceeded the previous 1050 s one-file bound);
+# max 1819 s (58/330 runs exceeded the previous 1050 s one-file bound;
+# fresh standalone re-measure 1271 s, 2026-07-24, #1646);
 # whole-gate testcase-time totals median ~1094 s / p90 ~1568 s / max ~2289 s.
 # The foreground Bash tool cap is 600 s, so the printed command carries this
 # bound and Step 9c runs the gate as a BACKGROUND invocation (SKILL.md 9c 1b).

--- a/scripts/select_step9c_tests.py
+++ b/scripts/select_step9c_tests.py
@@ -701,11 +701,11 @@ def recommended_timeout_s(tests: list[str], *, floor: int = TIMEOUT_FLOOR_S) -> 
     ``BASE + PER_FILE * len(tests) + sum(slow surcharges)``, floored at
     *floor* (default ``TIMEOUT_FLOOR_S`` — diff-path callers unchanged;
     ``--map-files`` mode passes ``floor=MAP_TIMEOUT_FLOOR_S``, the Step-10d
-    TG-leg 600 s floor, #1573/#1646). Invariant-only selection (58 files as
-    of 2026-07-24, incl. the workflow-lint surcharge) -> 4260 s (71 min),
+    TG-leg 600 s floor, #1573/#1646). Invariant-only selection (61 files as
+    of 2026-07-24, incl. the workflow-lint surcharge) -> 4350 s (72.5 min),
     matching the invariant-set-scale precedents (``step9c_baseline.py
-    refresh`` ``--timeout-s`` default 4260 s; the SKILL.md detached
-    refresh's 4560 s).
+    refresh`` ``--timeout-s`` default 4350 s; the SKILL.md detached
+    refresh's 4650 s).
     """
     t = TIMEOUT_BASE_S + TIMEOUT_PER_FILE_S * len(tests)
     t += sum(SLOW_TESTS.get(x, 0) for x in tests)

--- a/scripts/select_step9c_tests.py
+++ b/scripts/select_step9c_tests.py
@@ -539,7 +539,8 @@ MAP_TIMEOUT_FLOOR_S = 600  # Step-10d TG-leg floor (#1646; was 300, basis the
 #                            healthy 5-file baseline leg measured 202.9 s and
 #                            the identical gated leg was killed at 300 s under
 #                            residual load; 600 ~= 3x the measured healthy
-#                            small-map wall.
+#                            small-map wall (#1634 run 2 passed, TG legs
+#                            174/174 on both trees).
 
 
 def dependency_map_pairs(files: list[str], work_root: Path) -> list[tuple[str, str]]:

--- a/scripts/step9c_baseline.py
+++ b/scripts/step9c_baseline.py
@@ -12,7 +12,7 @@ vouch for.
 
 Subcommands::
 
-    uv run python scripts/step9c_baseline.py refresh [--repo-root PATH] [--timeout-s 4260] [--json]
+    uv run python scripts/step9c_baseline.py refresh [--repo-root PATH] [--timeout-s 4350] [--json]
     uv run python scripts/step9c_baseline.py status  [--repo-root PATH] [--max-age-hours 24]
                                                      [--max-code-commits 150] [--json]
     uv run python scripts/step9c_baseline.py compare --junitxml PATH --pytest-rc INT [--base REF]
@@ -62,7 +62,7 @@ Exit codes (pinned by ``tests/test_step9c_baseline.py``):
 ===========  ==========================================================================
 
 Safety invariants (plan #1022 v3 R1-R7): the refresh NEVER runs ``pytest tests/``
-wholesale (only the predictable Step 9c workflow-invariant universe — 58 files
+wholesale (only the predictable Step 9c workflow-invariant universe — 61 files
 as of 2026-07-24 — timeout-bounded,
 thread-capped, process-group-killed on expiry); blind-strip requires a fresh,
 clean-rooted (``dirty_code_paths: false``) ledger AND a non-diff-linked node
@@ -1894,8 +1894,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_refresh = sub.add_parser("refresh", help="run the Step 9c universe on main; write ledger")
     p_refresh.add_argument("--repo-root", default=None, help="main-root override (tests)")
     # #1646: == recommended_timeout_s(WORKFLOW_INVARIANT) at current constants
-    # (120 + 30*58 + 2400); re-derive when SLOW_TESTS / the invariant set change.
-    p_refresh.add_argument("--timeout-s", type=float, default=4260.0)
+    # (120 + 30*61 + 2400); re-derive when SLOW_TESTS / the invariant set change.
+    p_refresh.add_argument("--timeout-s", type=float, default=4350.0)
     p_refresh.add_argument("--json", action="store_true")
     p_refresh.set_defaults(func=cmd_refresh)
 

--- a/scripts/step9c_baseline.py
+++ b/scripts/step9c_baseline.py
@@ -1071,7 +1071,7 @@ def present_on_disk(files: Iterable[str], root: Path) -> list[str]:
 
 
 def cmd_refresh(args: argparse.Namespace) -> int:
-    """Run the predictable Step 9c workflow-invariant universe on main; write the ledger atomically."""
+    """Run the Step 9c workflow-invariant universe on main; write the ledger atomically."""
     root = Path(args.repo_root).resolve() if args.repo_root else main_repo_root()
     lock = acquire_refresh_lock(root / ".claude" / "cache" / "step9c-baseline.lock")
     if lock is None:

--- a/scripts/step9c_baseline.py
+++ b/scripts/step9c_baseline.py
@@ -12,7 +12,7 @@ vouch for.
 
 Subcommands::
 
-    uv run python scripts/step9c_baseline.py refresh [--repo-root PATH] [--timeout-s 1800] [--json]
+    uv run python scripts/step9c_baseline.py refresh [--repo-root PATH] [--timeout-s 4260] [--json]
     uv run python scripts/step9c_baseline.py status  [--repo-root PATH] [--max-age-hours 24]
                                                      [--max-code-commits 150] [--json]
     uv run python scripts/step9c_baseline.py compare --junitxml PATH --pytest-rc INT [--base REF]
@@ -62,7 +62,8 @@ Exit codes (pinned by ``tests/test_step9c_baseline.py``):
 ===========  ==========================================================================
 
 Safety invariants (plan #1022 v3 R1-R7): the refresh NEVER runs ``pytest tests/``
-wholesale (only the predictable 37-file Step 9c universe, timeout-bounded,
+wholesale (only the predictable Step 9c workflow-invariant universe — 58 files
+as of 2026-07-24 — timeout-bounded,
 thread-capped, process-group-killed on expiry); blind-strip requires a fresh,
 clean-rooted (``dirty_code_paths: false``) ledger AND a non-diff-linked node
 whose test file is unchanged on main since the ledger SHA — everything else is
@@ -1070,7 +1071,7 @@ def present_on_disk(files: Iterable[str], root: Path) -> list[str]:
 
 
 def cmd_refresh(args: argparse.Namespace) -> int:
-    """Run the 37-file predictable Step 9c universe on main; write the ledger atomically."""
+    """Run the predictable Step 9c workflow-invariant universe on main; write the ledger atomically."""
     root = Path(args.repo_root).resolve() if args.repo_root else main_repo_root()
     lock = acquire_refresh_lock(root / ".claude" / "cache" / "step9c-baseline.lock")
     if lock is None:
@@ -1269,8 +1270,10 @@ def derive_pristine_timeout_s(sel: object, test_file: str) -> float:
     Reads the #1046 constants off the LOADED selector module (``ctx.sel``) via
     ``getattr`` so a pre-#1046 worktree selector copy (deliberate version skew,
     #1022 §3.3) degrades to the legacy 600 s floor instead of crashing.
-    tests/test_workflow_lint.py -> 120 + 30 + 2*900 = 1950 s (~2.5x its ~780 s
-    measured pristine runtime, #1098); files without surcharge knowledge -> 600 s.
+    tests/test_workflow_lint.py -> 120 + 30 + 2*2400 = 4950 s (#1646: in-gate
+    walls median 789 s / max 1819 s over 330 junits 2026-07-13..24, ~2.7x the
+    worst measured; #1098 had measured ~780 s pristine at the old 900 surcharge);
+    files without surcharge knowledge -> 600 s.
     """
     base = float(getattr(sel, "TIMEOUT_BASE_S", 0))
     per_file = float(getattr(sel, "TIMEOUT_PER_FILE_S", 0))
@@ -1890,7 +1893,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_refresh = sub.add_parser("refresh", help="run the Step 9c universe on main; write ledger")
     p_refresh.add_argument("--repo-root", default=None, help="main-root override (tests)")
-    p_refresh.add_argument("--timeout-s", type=float, default=1800.0)
+    # #1646: == recommended_timeout_s(WORKFLOW_INVARIANT) at current constants
+    # (120 + 30*58 + 2400); re-derive when SLOW_TESTS / the invariant set change.
+    p_refresh.add_argument("--timeout-s", type=float, default=4260.0)
     p_refresh.add_argument("--json", action="store_true")
     p_refresh.set_defaults(func=cmd_refresh)
 

--- a/tests/test_inline_lint_gate.py
+++ b/tests/test_inline_lint_gate.py
@@ -493,10 +493,18 @@ def test_mapped_pytest_timeout_floor_matches_selector(tmp_path: Path) -> None:
     sel = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(sel)
     assert ilg.PYTEST_TIMEOUT_FLOOR_S == sel.TIMEOUT_FLOOR_S  # parity pin
+    # Surcharge parity (#1646): the deliberately-duplicated ilg constant must
+    # track the selector's SLOW_TESTS entry — drift here is a silent re-split
+    # of the two gates' sizing.
+    assert sel.SLOW_TESTS["tests/test_workflow_lint.py"] == ilg.PYTEST_WORKFLOW_LINT_SURCHARGE_S
     # 1 non-slow file: formula 120+30=150 < floor -> floored.
     assert ilg.mapped_pytest_timeout(["tests/test_x.py"]) == sel.TIMEOUT_FLOOR_S
-    # Slow-surcharge case stays above the floor (120 + 30 + 900).
-    assert ilg.mapped_pytest_timeout(["tests/test_workflow_lint.py"]) == 1050
+    # Slow-surcharge case stays above the floor (120 + 30 + 2400) and matches
+    # the selector's own sizing for the identical selection.
+    assert ilg.mapped_pytest_timeout(["tests/test_workflow_lint.py"]) == 2550
+    assert ilg.mapped_pytest_timeout(["tests/test_workflow_lint.py"]) == sel.recommended_timeout_s(
+        ["tests/test_workflow_lint.py"]
+    )
 
 
 def test_added_line_ranges_parses_u0_hunks(tmp_path: Path) -> None:

--- a/tests/test_issue_skill_step9c_compare_background.py
+++ b/tests/test_issue_skill_step9c_compare_background.py
@@ -1,7 +1,7 @@
 """Pin: Step 9c step-1d compare is a background + rc-file invocation (#1197).
 
 A foreground compare is the 600s-tool-cap kill class (#1129/#1098): one
-SLOW_TESTS pristine oracle run legitimately derives 640-1950s.
+SLOW_TESTS pristine oracle run legitimately derives 600-4950s.
 """
 
 from pathlib import Path

--- a/tests/test_select_step9c_tests.py
+++ b/tests/test_select_step9c_tests.py
@@ -1646,8 +1646,8 @@ def test_cli_map_files_import_edge_sft_regression(tmp_path: Path, capsys):
     ZERO pairs pre-#1573 — the founding incident (the ``use_rslora`` change,
     commit d7908a3837, broke test_rslora_engine_pin with no gate firing).
     Also pins the WORKFLOW_INVARIANT exclusion on the live tree: sft.py
-    literal-hits the 900 s tests/test_workflow_lint.py (LIVE_WORKFLOW_HELPERS)
-    which must NOT reach the 300 s-class TG legs (A1 + A4 live half)."""
+    literal-hits the 2400 s tests/test_workflow_lint.py (LIVE_WORKFLOW_HELPERS)
+    which must NOT reach the 600 s-class TG legs (A1 + A4 live half)."""
     repo_root = Path(sel.__file__).resolve().parents[1]
     listing = tmp_path / "payload.txt"
     listing.write_text("src/explore_persona_space/train/sft.py\n")
@@ -1734,22 +1734,22 @@ def test_map_files_sizing_line(tmp_path: Path, capsys):
     rc = sel.main(["--map-files", str(listing), "--repo-root", str(repo)])
     assert rc == 0
     captured = capsys.readouterr()
-    # 2 tests: 120 + 2*30 = 180 -> floored at MAP_TIMEOUT_FLOOR_S = 300.
-    assert "recommended-timeout-s=300" in captured.err
+    # 2 tests: 120 + 2*30 = 180 -> floored at MAP_TIMEOUT_FLOOR_S = 600.
+    assert "recommended-timeout-s=600" in captured.err
     assert not any("\t" in line for line in captured.err.splitlines())
     assert len(captured.out.splitlines()) == 2
-    # 7 tests clear the floor: 120 + 7*30 = 330.
-    repo7 = _make_import_tree(
-        tmp_path / "seven",
+    # 17 tests clear the floor: 120 + 17*30 = 630.
+    repo17 = _make_import_tree(
+        tmp_path / "seventeen",
         {
             f"test_consumer_{i}.py": "from explore_persona_space.widgetlib import f\n"
-            for i in range(7)
+            for i in range(17)
         },
     )
-    rc = sel.main(["--map-files", str(listing), "--repo-root", str(repo7)])
+    rc = sel.main(["--map-files", str(listing), "--repo-root", str(repo17)])
     assert rc == 0
     captured = capsys.readouterr()
-    assert "recommended-timeout-s=330" in captured.err
+    assert "recommended-timeout-s=630" in captured.err
     assert not any("\t" in line for line in captured.err.splitlines())
 
 
@@ -1757,10 +1757,10 @@ def test_map_files_sizing_line(tmp_path: Path, capsys):
 def test_recommended_timeout_s_floor_kwarg():
     """Default floor unchanged (TIMEOUT_FLOOR_S = 900, diff-path callers
     byte-identical); an explicit floor= is honored; the formula wins above it."""
-    assert sel.MAP_TIMEOUT_FLOOR_S == 300
+    assert sel.MAP_TIMEOUT_FLOOR_S == 600
     two = ["tests/test_a.py", "tests/test_b.py"]
     assert sel.recommended_timeout_s(two) == sel.TIMEOUT_FLOOR_S  # default floor binds
-    assert sel.recommended_timeout_s(two, floor=sel.MAP_TIMEOUT_FLOOR_S) == 300
+    assert sel.recommended_timeout_s(two, floor=sel.MAP_TIMEOUT_FLOOR_S) == 600
     forty = [f"tests/test_x{i}.py" for i in range(40)]
     expected = sel.TIMEOUT_BASE_S + 40 * sel.TIMEOUT_PER_FILE_S  # 1320 > both floors
     assert sel.recommended_timeout_s(forty, floor=sel.MAP_TIMEOUT_FLOOR_S) == expected
@@ -2028,7 +2028,7 @@ def test_cli_map_files_transitive_pairs_live_tree(tmp_path: Path, capsys):
         f"tests/test_shared_vm_thread_caps.py\t{_SELECTOR_KEY}",
         f"tests/test_step9c_baseline.py\t{_SELECTOR_KEY}",
     ]
-    assert "map-files — 6 pairs, 6 tests; recommended-timeout-s=300" in captured.err
+    assert "map-files — 6 pairs, 6 tests; recommended-timeout-s=600" in captured.err
 
 
 # --- Case 87: map-leg asymmetry — an invariant registration is excluded -----------

--- a/tests/test_step10d_guard3.py
+++ b/tests/test_step10d_guard3.py
@@ -1303,8 +1303,8 @@ def _tg_blocks(text: str) -> list[str]:
 def test_tg_leg_selector_sized_timeout():
     """#1573: both TG blocks size their pytest bound from the selector's
     machine-greppable `recommended-timeout-s=` stderr line (gated map,
-    /tmp/issue-<N>-tg-map-err.txt) with the pre-#1573 fixed 300s as the
-    fallback floor; NO fixed `--kill-after=30s 300s` remains as a TG pytest
+    /tmp/issue-<N>-tg-map-err.txt) with the fixed 600s (#1646; pre-#1573:
+    300s) as the fallback floor; NO fixed `--kill-after=30s 300s` remains as a TG pytest
     bound. The surgical pass-arm `git push origin main` 300s bound is a
     DIFFERENT command — exempted by its `git push` CONTENT, never by line
     number (it may move)."""
@@ -1314,15 +1314,16 @@ def test_tg_leg_selector_sized_timeout():
             "TG block must grep the selector's sizing line"
         )
         assert "/tmp/issue-<N>-tg-map-err.txt" in block
-        assert "TG_T=300" in block, "the 300s floor fallback must be present"
+        assert "TG_T=600" in block, "the 600s floor fallback must be present (#1646)"
         assert block.count("timeout --kill-after=30s ${TG_T}s") == 2, (
             "BOTH pytest legs (baseline + gated) must carry the sized bound"
         )
         for line in block.splitlines():
-            if "--kill-after=30s 300s" in line:
-                assert "git push" in line, (
-                    f"a fixed 300s bound must not remain on a TG pytest leg: {line!r}"
-                )
+            for fixed in ("--kill-after=30s 300s", "--kill-after=30s 600s"):
+                if fixed in line:
+                    assert "git push" in line, (
+                        f"a fixed bound must not remain on a TG pytest leg: {line!r}"
+                    )
 
 
 def test_tg_leg_node_grain_subtraction():


### PR DESCRIPTION
Closes task #1646. SLOW_TESTS[test_workflow_lint.py] 900→2400 (n=330 junit basis, max 1819s; fresh W=1271s); MAP_TIMEOUT_FLOOR_S 300→600 (#1634); refresh default 4350 + detached 4650 @ N=61; TG_T fallbacks 600; 10800s wedge KEPT (ceiling 7470s). Pipeline: plan v4 (3-lens critique + consistency), code-review r1 CONCERNS → r2 PASS, Step 9c 4639p/6s + compare exit 0.