### PR TITLE
issue-1656: detached long-compute phases declare a harvest contract at launch (#1656)

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -75,7 +75,8 @@ CLAUDE.md as always-on rules; the rest live here and load when you touch code.)
   (session-wide; children inherit; −600 not −1000 so a runaway fit still dies first; pipefail
   makes an empty/failed pgrep FAIL the sweep — `choom=ok` only when the sweep pipeline exited
   zero; on any failure proceed unprotected and record `choom=failed`).
-  Record `pid=$PHASE_PID` + the log path + `choom=ok|failed` in the stage-dispatch breadcrumb
+  Record `pid=$PHASE_PID` + the log path + `choom=ok|failed` + `harvest=<abs output path>` (the
+  § Harvest contract's declared results location; #1656) in the stage-dispatch breadcrumb
   (SKILL.md § Detached VM-side long compute phases — incl. the collateral-kill signature and the
   relaunch-once-then-pod-pivot rule; #811).
 - **Env sync after dep changes:** `uv lock && git push`, then `pod.py sync env`.

--- a/.claude/rules/vectorize-many-cell-fits.md
+++ b/.claude/rules/vectorize-many-cell-fits.md
@@ -127,7 +127,8 @@ solve one shared reduction + cheap per-λ updates.
 7. **Launch it protected + checkpointed — the launch form is part of the fix.**
    Any VM-side fit / battery / aggregation phase with projected wall-time >~15 min
    MUST use the canonical detached launch: `setsid` pid-capture wrapper +
-   `sudo -n choom -n -600` session sweep + the `pid= log= choom=ok|failed`
+   `sudo -n choom -n -600` session sweep + the
+   `pid= log= choom=ok|failed harvest=<abs output path>`
    breadcrumb — recipe owned by `.claude/skills/issue/SKILL.md`
    § "Detached VM-side long compute phases" (short form:
    `.claude/rules/code-style.md` § "Always run with `nohup`"); do not copy the

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -6126,13 +6126,48 @@ healthy ~3-6h Phase-D fit died mid-flight this way (2026-07-02, ~2h lost, pure
 signal kill). `setsid` gives the phase its own session + process group (group
 kills miss it; it reparents to PID 1 when the launching shell exits);
 `< /dev/null >> log` drops every fd tether to the dying session. The phase's
-stage-dispatch breadcrumb MUST carry three additional fields:
-`... pid=<PHASE_PID> log=<abs log path> choom=ok|failed` (additive whitespace-split
+stage-dispatch breadcrumb MUST carry four additional fields:
+`... pid=<PHASE_PID> log=<abs log path> choom=ok|failed harvest=<abs output path>`
+(additive whitespace-split
 `key=value` tokens — `_breadcrumb_fields` parses them order-free; keep the
 log path space-free; #833's own breadcrumbs already carried a RELATIVE `log=`
-— this convention upgrades it to a REQUIRED absolute path, and `pid=` is the
-genuinely new field), and the `external-markers triaged:` line
+— this convention upgrades it to a REQUIRED absolute path, `pid=` is the
+genuinely new #833 field, and `harvest=` is the § Harvest contract's declared
+results location, new with #1656), and the `external-markers triaged:` line
 (§ Pre-dispatch external-marker triage above).
+
+**Harvest contract (declared AT LAUNCH — a closed session never strands finished
+results; #1310, #1656).** Detachment protects the RUN; this clause protects the
+RESULTS. Every detached launch declares its harvest path at launch time:
+
+1. **Durable out-root (REQUIRED).** `<cmd>` writes its results to a durable,
+   session-independent location — `eval_results/issue_<N>/...`, the task's
+   `artifacts/` dir, an HF-upload staging dir under `data/issue_<N>/`, or (for a
+   log-only probe) the breadcrumb's own `log=` file — never session-scoped scratch
+   only the launching conversation knows about.
+2. **`harvest=` token (REQUIRED).** The stage-dispatch breadcrumb's
+   `harvest=<abs, space-free output path or glob>` (comma-separate multiple paths;
+   values are whitespace-split tokens, so no spaces) names where completion outputs
+   land. The § Successor / re-entry rule probes THIS path for "completion output
+   present" and collects from it — no guessing. Breadcrumbs predating this contract
+   lack the token: consumers fall back to log-tail + known output dirs (the same
+   graceful-optional convention as `label=`).
+3. **Self-harvest chaining (PREFERRED).** When collection is one idempotent command,
+   make it part of the detached unit itself — as a SINGLE command unit substituted
+   for `<cmd>`: a driver script whose final act is the collection/upload (an HF
+   upload of raw completions/tensors, a copy into `eval_results/issue_<N>/`), or an
+   inner `bash -c '<workload> && <harvest-cmd>'`. NEVER splice a bare
+   `<workload> && <harvest-cmd>` into the template: the `&&` splits the launch line,
+   binding setsid/nohup/env to the first command and the redirections + trailing `&`
+   to the second — detachment silently breaks. This is the detached-phase instance
+   of the batch-judge deadline-bounded self-harvest. The identity verify is
+   unchanged (the distinctive workload substring still appears in
+   `ps -p $PHASE_PID -o args=` for either wrapped form). Only the steps that MUST
+   stay session-side — the explicit-path git commit under the concurrent-committer
+   discipline, folding numbers into the body — are left to the successor; the DATA
+   is durable before any session touches it.
+
+The contract costs one token + a path choice at launch — never a new gate.
 
 **Earlyoom protection is REQUIRED on the verified phase (#957; incident #811).**
 The shared VM runs `earlyoom` with `--prefer '(^|/)(pytest|python3?)$'` (+300
@@ -6209,8 +6244,15 @@ FLIGHT regardless of breadcrumb age (a detached multi-hour phase posts no
 markers while computing): RE-ATTACH — poll the pid, `tail` the breadcrumb's
 `log=` for real progress (alive ≠ progressing; the log is the progress
 signal), post a liveness `epm:progress` note — never relaunch. Dead — or an
-args MISMATCH (recycled pid: treat as dead) — with its completion sentinel /
-output present → stage done; proceed. Dead with no completion output →
+args MISMATCH (recycled pid: treat as dead) — with completion output present
+at the breadcrumb's `harvest=` path (§ Harvest contract; pre-contract
+breadcrumbs lack the token — fall back to log-tail + known output dirs) →
+stage done; RUN THE HARVEST — collect the declared outputs, commit/upload
+them per the Upload Policy, fold them forward — then proceed. An EMPTY
+`harvest=` path beside a log tail showing clean completion is a
+declared-path mismatch (typo / divergence), not a failed run — cross-check
+the log's real output locations before treating the phase as failed.
+Dead with no completion output →
 genuinely failed: run the kill-before-relaunch probe
 (`.claude/rules/crash-fix-rounds.md` § Kill-before-relaunch), then relaunch.
 `stage_dispatch_should_skip` knows nothing about pids, so the polling
@@ -6756,7 +6798,8 @@ statement is posted before that launch. A round with no fit/battery stage AND no
 A statement covering a VM-side phase >~15 min ALSO names the detached launch
 shape + log path + the thread-cap `env` prefix (OMP/MKL/OPENBLAS/NUMEXPR=8 — #891;
 or the wider explicit value + one-line reason) + the earlyoom protection state
-(`choom=ok|failed`) per the Step 9 entry-guard
+(`choom=ok|failed`) **+ the harvest contract (the durable
+out-root + the `harvest=` token)** per the Step 9 entry-guard
 § "Detached VM-side long compute phases" convention.
 Routing, auto-continue behavior, and the marker schema are unchanged.
 

--- a/scripts/select_step9c_tests.py
+++ b/scripts/select_step9c_tests.py
@@ -287,6 +287,10 @@ WORKFLOW_INVARIANT: tuple[str, ...] = (
     # NEW (#1659) — SKILL.md 9a-ter + CLAUDE.md measured 1-cell pilot +
     # >=2x pilot-extrapolated fence-sizing pin
     "tests/test_issue_skill_compute_pilot_fence_pin.py",
+    # NEW (#1656) — SKILL.md detached-phase harvest contract pin (#1310):
+    # four-field breadcrumb (harvest= token), successor consumption, 9a-ter
+    # mention + the two mirror duty-lists
+    "tests/test_issue_skill_detached_harvest_pin.py",
     # Registration rider (#1659) — the pre-existing 9a-ter element-(5) content
     # pin (#1393) was never registered (the #1546 unregistered-pin class)
     "tests/test_issue_skill_disk_routing_pin.py",

--- a/tests/step9c_workflow_invariant_manifest.txt
+++ b/tests/step9c_workflow_invariant_manifest.txt
@@ -18,6 +18,7 @@ tests/test_failure_classifier.py
 tests/test_fit_loop_batching_review_pin.py
 tests/test_guard_trigger_dense_read.py
 tests/test_issue_skill_compute_pilot_fence_pin.py
+tests/test_issue_skill_detached_harvest_pin.py
 tests/test_issue_skill_disk_routing_pin.py
 tests/test_issue_skill_exit_breadcrumb.py
 tests/test_issue_skill_followup_cap_park_note_pin.py

--- a/tests/test_issue_skill_detached_harvest_pin.py
+++ b/tests/test_issue_skill_detached_harvest_pin.py
@@ -1,0 +1,114 @@
+"""Pin the #1656 detached-phase harvest contract in `/issue` SKILL.md + mirrors.
+
+Incident #1310 (2026-07-16): a detached VM-side long-compute phase survived its
+session (the #833 setsid convention protected the RUN) but its finished results
+were collectable only by the launching conversation — the harvest step was
+session-bound, and an autoharvest was bolted on only after the user asked
+"if I close this terminal will it continue running?". #1656 adds the launch-time
+harvest contract: a durable out-root (REQUIRED), a fourth stage-dispatch
+breadcrumb token `harvest=<abs output path>` (REQUIRED, additive/order-free per
+`task_workflow._breadcrumb_fields`; graceful pre-contract fallback like
+`label=`), and self-harvest chaining as a SINGLE command unit (PREFERRED —
+never a bare `&&` splice into the setsid template, which mis-binds
+setsid/nohup/env and silently breaks detachment).
+
+These tests pin, against `.claude/skills/issue/SKILL.md` (+ the two
+paths-triggered mirror duty-lists):
+
+1. the "Harvest contract" block exists INSIDE the detached-phases block with
+   its load-bearing pieces — the token grammar, the four-field sentence, the
+   pre-contract fallback, the durable out-root, and the bare-`&&`-splice
+   detachment warning;
+2. the Successor / re-entry rule CONSUMES the declared `harvest=` path (and
+   runs the harvest) instead of guessing;
+3. the Step 9a-ter compute-character detached-launch sentence names the
+   harvest contract among the launch duties;
+4. both mirror duty-lists (`.claude/rules/code-style.md` +
+   `.claude/rules/vectorize-many-cell-fits.md`) carry the `harvest=` token,
+   so a future edit cannot silently regress a mirror back to three fields
+   (the #957 criterion-1b shape).
+
+Prose assertions run on whitespace-NORMALIZED text (the file wraps prose
+mid-phrase, so a required phrase can span lines).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILL_MD = REPO_ROOT / ".claude" / "skills" / "issue" / "SKILL.md"
+CODE_STYLE_MD = REPO_ROOT / ".claude" / "rules" / "code-style.md"
+VECTORIZE_MD = REPO_ROOT / ".claude" / "rules" / "vectorize-many-cell-fits.md"
+
+DETACHED_HEADING = "**Detached VM-side long compute phases"
+SUCCESSOR_HEADING = "**Successor / re-entry rule"
+GUARD_HEADING = "**Checkable guard rule"
+
+
+def _norm(text: str) -> str:
+    """Collapse all whitespace runs to single spaces (wrap-tolerant match)."""
+    return re.sub(r"\s+", " ", text)
+
+
+def _skill_text() -> str:
+    assert SKILL_MD.exists(), f"missing {SKILL_MD}"
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+def _region(text: str, start_anchor: str, end_anchor: str) -> str:
+    start = text.find(start_anchor)
+    assert start != -1, f"anchor {start_anchor!r} not found in SKILL.md"
+    end = text.find(end_anchor, start)
+    assert end != -1, f"anchor {end_anchor!r} not found after {start_anchor!r}"
+    return text[start:end]
+
+
+def test_harvest_contract_block_present() -> None:
+    """The Harvest contract lives inside the detached-phases block, complete."""
+    block = _norm(_region(_skill_text(), DETACHED_HEADING, SUCCESSOR_HEADING))
+    assert "Harvest contract" in block, "detached block lacks the '**Harvest contract' clause"
+    # Token grammar (Edit 1's field list + Edit 2 clause 2 both carry it).
+    assert "harvest=<abs" in block, "detached block lacks the harvest=<abs ...> token grammar"
+    # The upgraded required-fields sentence (three -> four, unbolded 'four').
+    assert "four additional fields" in block, "breadcrumb sentence not upgraded to four fields"
+    # Pre-contract fallback (the label=-style graceful-optional convention).
+    assert "predating this contract" in block or "fall back" in block, (
+        "harvest contract lacks the pre-contract breadcrumb fallback clause"
+    )
+    # Clause 1: the durable out-root requirement.
+    assert "durable" in block, "harvest contract lacks the durable out-root requirement"
+    # Clause 3: the bare-&&-splice detachment-break warning (single command unit).
+    assert "NEVER splice a bare" in block, (
+        "harvest contract lacks the bare-&&-splice detachment warning"
+    )
+
+
+def test_successor_rule_consumes_harvest() -> None:
+    """The Successor / re-entry rule reads harvest= and runs the harvest."""
+    para = _norm(_region(_skill_text(), SUCCESSOR_HEADING, GUARD_HEADING))
+    assert "harvest=" in para, "Successor rule does not consume the harvest= breadcrumb path"
+    assert "RUN THE HARVEST" in para, "Successor rule lacks the RUN THE HARVEST instruction"
+
+
+def test_compute_character_statement_names_harvest() -> None:
+    """The 9a-ter compute-character detached-launch sentence names the contract."""
+    region = _norm(
+        _region(
+            _skill_text(),
+            "A statement covering a VM-side phase",
+            "Routing, auto-continue behavior, and the marker schema are unchanged",
+        )
+    )
+    assert "harvest contract" in region, (
+        "9a-ter compute-character detached sentence does not name the harvest contract"
+    )
+
+
+def test_mirror_duty_lists_carry_harvest() -> None:
+    """Both paths-triggered mirror duty-lists carry the harvest= token (#957 shape)."""
+    for path in (CODE_STYLE_MD, VECTORIZE_MD):
+        assert path.exists(), f"missing {path}"
+        text = _norm(path.read_text(encoding="utf-8"))
+        assert "harvest=" in text, f"{path.name} mirror duty-list lacks the harvest= token"


### PR DESCRIPTION
Closes task #1656 (daily-fix wf-fix). Adds the Harvest contract to /issue SKILL.md § Detached VM-side long compute phases (four-field breadcrumb incl. harvest=, 3-clause contract, successor-rule consumption, 9a-ter statement), syncs the two mirror duty-lists (code-style.md, vectorize-many-cell-fits.md), adds the registered pin test tests/test_issue_skill_detached_harvest_pin.py. Plan v3 critic-approved; code-review PASS; test-verdict PASS (0 new failures).