### PR TITLE
task #1668: adopted failover un-blinds the runpod-wedge guard (attempt-keyed identity + liveness probe)

### DIFF
--- a/.claude/rules/compute-backend-failover.md
+++ b/.claude/rules/compute-backend-failover.md
@@ -1229,7 +1229,17 @@ every COMPLETE cell's data already present on HF.
 
 **Idempotency = a DURABLE lease + a sentinel, exactly as the GCP analogue
 (#689 blocker-2).** The wedge failover guards its terminate + re-provision with
-TWO records keyed to the wedged pod identity (pod_name/job_id): (1) the
+TWO records keyed to the wedged ATTEMPT identity (pod_name / job_id /
+runpod_attempt_id): on RunPod `pod_name` is the canonical `pod-<N>` and
+`job_id` is `""`, so the per-launch `runpod_attempt_id` is what stops a stale
+record from blinding a fresh adopted attempt — pre-#1668 the 2-key identity
+was degenerate per issue and "exactly once per wedge" silently read as "once
+per issue forever" (#1586). #1668 also adds a PRE-TERMINATE SSH liveness
+cross-probe (`_runpod_wedge_liveness_probe`, fail-open) between the inputs
+gate and the terminate: a matured no-port wedge whose pod still answers SSH is
+a sustained API port-misreport on a HEALTHY pod, so the failover clears the
+wedge clock and returns a non-terminal running JSON instead of terminating;
+probe failure/error proceeds to terminate exactly as before. Records: (1) the
 AUTHORITATIVE durable lease at `~/.eps-routing/` (`Lease.runpod_wedge_failover_of`,
 checked by `_lease_records_runpod_wedge_failover`, stamped by
 `_stamp_runpod_wedge_failover` after the fresh-pod relaunch succeeds) — it
@@ -1500,7 +1510,10 @@ forks. Layers, in the order checked:
    inspection. NO second pivot.
 2. **PER-WEDGE IDEMPOTENCY.** A re-fired tick on the SAME crashed handle after a
    successful pivot short-circuits (durable lease authoritative + `.claude/cache`
-   sentinel fast-path, both keyed to the crashed pod identity).
+   sentinel fast-path, both keyed to the crashed ATTEMPT identity — pod_name /
+   job_id / runpod_attempt_id, #1668 — so a stale stamp never blinds a fresh
+   adopted attempt; no D9 liveness probe on this family — a reachable pod does
+   NOT contradict a CUDA-IMA crash).
 3. **INPUTS-ON-HF GATE** (reused as-is — a PARTIAL cell BLOCKS the irreversible
    terminate; human decides).
 4. **TERMINATE** the crashed pod (best-effort — a CUDA-IMA-wedged pod is usually

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -9428,8 +9428,14 @@ def _wedge_failover(
 
     Outcomes:
 
-    * ``"failover"`` — terminated + re-provisioned a FRESH pod (or a
-      running-shaped success);
+    * ``"failover"`` — terminated + re-provisioned a FRESH pod (the
+      relaunch-success running return, ``current_phase`` = FRESH_POD_PHASE);
+    * ``"probe-alive"`` — the D9 pre-terminate liveness probe contradicted the
+      no-port read (#1668): the pod answers SSH, so NOTHING was terminated and
+      no fresh pod was provisioned; the wedge clock was cleared by the shared
+      recovery, and the caller posts a TRUTHFUL note (structurally keyed on
+      ``current_phase == backend_poll.RUNPOD_WORKLOAD_OBSERVED_PHASE`` — the
+      only other running-status return of ``_failover_wedged_runpod``);
     * ``"already-handled"`` — the poller or a prior watcher tick already failed
       this wedge over (bounded-once short-circuit on the idempotency lease /
       sentinel), OR the sidecar was re-pointed at a DIFFERENT pod between the
@@ -9511,7 +9517,7 @@ def _wedge_failover(
         print(f"  [dry-run] would terminate+failover wedged pod for issue #{issue}")
         return ("failover", None)
     try:
-        from backend_poll import _failover_wedged_runpod
+        from backend_poll import RUNPOD_WORKLOAD_OBSERVED_PHASE, _failover_wedged_runpod
 
         from explore_persona_space.backends.issue_dispatch import (
             read_handle_sidecar,
@@ -9652,6 +9658,15 @@ def _wedge_failover(
     status = out.get("status")
     reason = out.get("reason")
     if status == "running":
+        # #1668 D10: the D9 probe-success return (the pre-terminate liveness probe
+        # contradicted the no-port read; NOTHING terminated, no fresh pod
+        # provisioned) is STRUCTURALLY keyed on current_phase ==
+        # RUNPOD_WORKLOAD_OBSERVED_PHASE — the relaunch success carries
+        # FRESH_POD_PHASE ("runpod_noport_wedge_failover_fresh_pod"), the only
+        # other running-status return of _failover_wedged_runpod. Structural key
+        # only; note/log-text matching is FORBIDDEN (plan v3 §3-D10).
+        if out.get("current_phase") == RUNPOD_WORKLOAD_OBSERVED_PHASE:
+            return ("probe-alive", out)
         return ("failover", out)  # fresh pod re-provisioned (running-shaped success)
     if reason == "runpod_wedge_already_handled":
         return ("already-handled", out)  # bounded-once short-circuit (cross-actor idempotency)
@@ -10326,8 +10341,10 @@ def _handle_wedge_failover_outcome(
       AND ``set-status <N> blocked`` (CRITICAL #1) — then clear the wedge clock.
       The re-drivable ``no_compute_available`` block is re-driven by the
       capacity-retry pass; a non-capacity reason stays parked for a human.
-    * ``"failover"`` / ``"already-handled"`` → a success / no-op: a generic
-      ``epm:progress`` note (NOT a failure), then clear the wedge clock.
+    * ``"failover"`` / ``"already-handled"`` / ``"probe-alive"`` → a success /
+      no-op: a generic ``epm:progress`` note (NOT a failure), then clear the
+      wedge clock. The ``"probe-alive"`` note is TRUTHFUL to the #1668 D9
+      probe-success return: nothing terminated, no fresh pod provisioned.
 
     Returns ``"handled"`` when the outcome was fully processed here (the caller
     returns), or ``"alert"`` to defer to the alert block. ``state_save`` carries
@@ -10418,10 +10435,12 @@ def _handle_wedge_failover_outcome(
             )
             return "handled"
     else:
-        # outcome in ("failover", "already-handled") — a success / no-op, NOT a
-        # failure: a generic progress note (NOT epm:failure, NOT a status change).
-        # "already-handled" also covers the fresh-pod race the sidecar-binding
-        # defense catches.
+        # outcome in ("failover", "already-handled", "probe-alive") — a success /
+        # no-op, NOT a failure: a generic progress note (NOT epm:failure, NOT a
+        # status change). "already-handled" also covers the fresh-pod race the
+        # sidecar-binding defense catches; "probe-alive" is the #1668 D9
+        # probe-success return (nothing terminated, no fresh pod provisioned —
+        # the note must stay truthful to that).
         note = {
             "failover": (
                 f"{_WEDGE_FAILOVER_NOTE_SENTINEL} TERMINATED + re-provisioned a FRESH pod "
@@ -10442,6 +10461,13 @@ def _handle_wedge_failover_outcome(
                 f"the sidecar was re-pointed at a FRESH pod between the inputs-safe read and "
                 f"the failover re-read (the fresh-pod race; the watcher refuses to terminate "
                 f"the fresh pod). No second terminate. Clearing the wedge clock."
+            ),
+            "probe-alive": (
+                f"{_WEDGE_FAILOVER_NOTE_SENTINEL} liveness probe contradicted the no-port "
+                f"read for issue #{issue} pod {pod_id}: direct SSH answered, so the pod is "
+                f"NOT host-wedged (#1668 D9) — pod NOT terminated, no fresh pod "
+                f"provisioned; wedge clock cleared (a genuine wedge must re-mature). "
+                f"Sustained no-port API misreport suspected (the #1586 shape)."
             ),
         }[outcome]
         _post_progress_marker(issue, note, dry_run, label="wedge-failover")

--- a/scripts/backend_poll.py
+++ b/scripts/backend_poll.py
@@ -1812,17 +1812,28 @@ def _wedged_run_inputs_on_hf(issue: int, handle) -> _WedgeInputsGate:
 
 
 def _runpod_handle_identity(handle) -> dict:
-    """The (pod_name, job_id) identity of a RunPod handle, for sentinel matching.
+    """The identity of a RunPod handle, for wedge / CUDA-IMA record matching (#1668).
 
-    Mirrors :func:`_gcp_handle_identity`: the sentinel records the identity of the
-    wedged RunPod run that ALREADY launched a fresh-pod failover, so a later,
-    genuinely-NEW run (a fresh-pod re-provision writes a NEW pod_name to the
-    sidecar) is NOT suppressed by a stale sentinel.
+    On RunPod, ``pod_name`` is the canonical issue-derived ``pod-<N>`` and
+    ``job_id`` is ``""`` (launch does not capture the pod_id), so
+    ``(pod_name, job_id)`` is DEGENERATE PER ISSUE — a fresh re-provision keeps
+    the SAME name, and a record keyed on it turns "exactly once per wedge" into
+    "once per issue forever" (#1586). ``extra["runpod_attempt_id"]`` (minted per
+    launch, #598) is the per-attempt discriminator: included whenever present.
+    A LEGACY handle without it keeps the 2-key identity (pre-#598 sidecars —
+    which also cannot relaunch: ``runpod_wedge_relaunch_spec_missing``).
+    Unlike :func:`_gcp_handle_identity`, where job_id is the per-create
+    instance id and already discriminates attempts.
     """
-    return {
+    identity = {
         "pod_name": getattr(handle, "pod_name", None),
         "job_id": getattr(handle, "job_id", None),
     }
+    extra = getattr(handle, "extra", None)
+    attempt = extra.get("runpod_attempt_id") if isinstance(extra, dict) else None
+    if attempt:
+        identity["runpod_attempt_id"] = attempt
+    return identity
 
 
 def _runpod_wedge_sentinel_path(sidecar: Path) -> Path:
@@ -1841,10 +1852,11 @@ def _runpod_wedge_sentinel_path(sidecar: Path) -> Path:
 def _write_runpod_wedge_sentinel(sentinel: Path, *, issue: int, handle) -> None:
     """Persist the RunPod-wedge idempotency sentinel atomically, best-effort.
 
-    Records the wedged RunPod run identity (pod_name/job_id) so a subsequent poll
-    on the SAME wedged handle short-circuits (no second terminate/re-provision). A
-    write failure is LOGGED, not raised — the worst case is one extra
-    terminate-and-reprovision on the next tick, never a silent suppression.
+    Records the wedged RunPod run identity (pod_name / job_id /
+    runpod_attempt_id, #1668) so a subsequent poll on the SAME wedged handle
+    short-circuits (no second terminate/re-provision). A write failure is
+    LOGGED, not raised — the worst case is one extra terminate-and-reprovision
+    on the next tick, never a silent suppression.
     """
     try:
         sentinel.parent.mkdir(parents=True, exist_ok=True)
@@ -1932,9 +1944,11 @@ def _runpod_wedge_already_handled(issue: int, handle, sidecar: Path) -> bool:
          as ABSENT (``_read_failover_sentinel`` returns ``None``) — worst case one
          extra terminate-and-reprovision, never a silent suppression.
 
-    Both are keyed to the wedged pod's pod_name/job_id, so a genuinely-new run (a
-    fresh-pod re-provision writes a NEW pod_name to the sidecar) does NOT match a
-    stale record and still gets its own one failover.
+    Both are keyed to the wedged ATTEMPT's identity (pod_name / job_id /
+    runpod_attempt_id, #1668): a fresh re-provision keeps the SAME canonical
+    ``pod-<N>`` name; the NEW ``runpod_attempt_id`` is what makes it a
+    different identity, so a stale record does NOT match a genuinely-new
+    attempt and that attempt still gets its own one failover.
     """
     # 1. DURABLE LEASE (authoritative; survives a .claude/cache-wide disk failure).
     if _lease_records_runpod_wedge_failover(issue, handle):
@@ -2176,6 +2190,57 @@ def _relaunch_fresh_runpod(
     }
 
 
+def _runpod_wedge_liveness_probe(handle, *, timeout_sec: int = 10) -> bool:
+    """True iff the pod answers a cheap SSH liveness probe (#1668, fail-open).
+
+    A live SSH round-trip contradicts the #664 RUNNING-but-no-port host wedge's
+    DEFINING property (unreachability): a pod that answers SSH is not
+    host-wedged regardless of what the RunPod API's ``runtime.ports`` reads (a
+    sustained API port-misreport, the #1586 shape). FAIL-OPEN: ANY failure —
+    no pods.conf row (``_resolve_pod_endpoint`` raises
+    ``RunPodWorkloadStartError``), resolve error, SSH timeout, non-zero exit,
+    unexpected exception — is LOGGED and returns ``False``, so the established
+    terminate path proceeds — a true wedge (unreachable pod) is never
+    suppressed by a probe defect. Note a true wedge with a stale-but-ANSWERING
+    pods.conf row is not possible: the port answers only if the mapping is
+    live.
+    """
+    pod_name = getattr(handle, "pod_name", None)
+    try:
+        from explore_persona_space.backends.runpod import (
+            _resolve_pod_endpoint,  # pods.conf path (runpod.py)
+        )
+
+        host, port = _resolve_pod_endpoint(pod_name)
+        rc = subprocess.run(
+            [
+                "ssh",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                f"ConnectTimeout={timeout_sec}",
+                "-o",
+                "StrictHostKeyChecking=accept-new",
+                "-p",
+                str(port),
+                f"root@{host}",
+                "true",
+            ],
+            timeout=timeout_sec + 5,
+            capture_output=True,
+        ).returncode
+        return rc == 0
+    except Exception as exc:  # deliberate, logged fail-open (probe = advisory cross-check)
+        logging.warning(
+            "backend_poll: wedge liveness probe failed for %s (%s: %s); "
+            "proceeding on the established terminate path",
+            pod_name,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+
+
 def _failover_wedged_runpod(*, issue: int, handle, result, sidecar: Path) -> dict:
     """Terminate a wedged RunPod pod + re-provision fresh, idempotently (#664).
 
@@ -2184,7 +2249,15 @@ def _failover_wedged_runpod(*, issue: int, handle, result, sidecar: Path) -> dic
     terminate — return a terminal infra JSON
     (``reason="runpod_wedge_inputs_unverified"``) so a human decides (CLAUDE.md
     halt-criterion #2). Idempotency is a durable lease + sidecar sentinel keyed
-    to the wedged pod_id (``_runpod_wedge_already_handled``).
+    to the wedged attempt identity (``_runpod_wedge_already_handled``, #1668).
+
+    Step order (#1668): guard -> inputs gate -> LIVENESS PROBE -> terminate ->
+    sentinel -> relaunch -> stamp. The pre-terminate liveness cross-probe
+    (step 2.5) intercepts a matured wedge on a pod that still answers SSH — a
+    sustained API port-misreport on a HEALTHY pod (the #1586 shape) — clearing
+    the wedge clock and returning a non-terminal running JSON instead of
+    terminating; probe failure/error proceeds to terminate exactly as before
+    (fail-open).
     """
     # 1. IDEMPOTENCY SHORT-CIRCUIT (sentinel keyed to the wedged pod identity). A
     #    second tick on the OLD handle after a successful failover short-circuits —
@@ -2217,6 +2290,36 @@ def _failover_wedged_runpod(*, issue: int, handle, result, sidecar: Path) -> dic
                 f"needed; complete={len(gate.complete)} absent={len(gate.absent)}"
             ),
         )
+
+    # 2.5 PRE-TERMINATE LIVENESS CROSS-PROBE (#1668, fail-open). The #664 wedge's
+    #     defining property is UNREACHABILITY (RUNNING + no public port). A live
+    #     SSH round-trip contradicts the API's no-port read — a sustained API
+    #     port-misreport (the #1586 06:31->08:43Z shape), not a host wedge. Do
+    #     NOT terminate: clear the wedge clock (a genuine wedge must re-mature
+    #     from scratch) and return a NON-terminal running JSON. Probe failure /
+    #     error (timeout, stale or missing pods.conf row) proceeds to terminate
+    #     exactly as today — fail-open, so a true wedge (unreachable pod) is
+    #     never suppressed.
+    if _runpod_wedge_liveness_probe(handle):
+        _clear_runpod_noport_clock(sidecar)
+        return {
+            "status": "running",
+            "current_phase": RUNPOD_WORKLOAD_OBSERVED_PHASE,
+            "new_milestone": True,
+            "last_log_mtime_sec_ago": 0,
+            "pid_alive": True,
+            "log_tail_excerpt": (
+                f"RunPod {handle.pod_name}: no-port API read contradicted by live SSH; "
+                f"wedge clock cleared (#1668 liveness probe) — not terminating"
+            ),
+            "gate": None,
+            "sentinels_processed": 0,
+            "phase_log_mtime_sec_ago": 10**9,
+            "shard_log_mtime_sec_ago": 10**9,
+            "gpu_util": "unknown",
+            "next_interval": _DEFAULT_NEXT_INTERVAL_SEC,
+            "issue": int(issue),
+        }
 
     # 3. TERMINATE the billing leak (fail-loud; terminate_pod raises on API error).
     _ensure_scripts_dir_on_sys_path()
@@ -2261,10 +2364,11 @@ def _write_runpod_cuda_ima_sentinel(sentinel: Path, *, issue: int, handle) -> No
     """Persist the RunPod CUDA-IMA failover idempotency sentinel atomically (#775).
 
     Byte-mirror of :func:`_write_runpod_wedge_sentinel`. Records the crashed
-    RunPod run identity (pod_name/job_id) so a subsequent poll on the SAME crashed
-    handle short-circuits. A write failure is LOGGED, not raised — worst case one
-    extra terminate-and-reprovision on the next tick (the durable lease still
-    bounds it), never a silent suppression.
+    RunPod run identity (pod_name / job_id / runpod_attempt_id, #1668) so a
+    subsequent poll on the SAME crashed handle short-circuits. A write failure
+    is LOGGED, not raised — worst case one extra terminate-and-reprovision on
+    the next tick (the durable lease still bounds it), never a silent
+    suppression.
     """
     try:
         sentinel.parent.mkdir(parents=True, exist_ok=True)
@@ -2297,8 +2401,11 @@ def _runpod_cuda_ima_already_handled(issue: int, handle, sidecar: Path) -> bool:
          corrupted/unreadable sentinel reads as ABSENT (one extra reprovision at
          worst, never a silent suppression).
 
-    Both keyed to the crashed pod's pod_name/job_id, so a genuinely-new run (the
-    fresh-host re-provision writes a NEW pod_name) does NOT match a stale record.
+    Both keyed to the crashed ATTEMPT's identity (pod_name / job_id /
+    runpod_attempt_id, #1668): a fresh re-provision keeps the SAME canonical
+    ``pod-<N>`` name; the NEW ``runpod_attempt_id`` is what makes it a
+    different identity, so a stale record does NOT match a genuinely-new
+    attempt.
     """
     # 1. DURABLE LEASE (authoritative; survives a .claude/cache-wide disk failure).
     if _lease_records_runpod_cuda_ima_failover(issue, handle):
@@ -2640,11 +2747,12 @@ def _lease_records_runpod_wedge_failover(issue: int, handle, *, lease_store=None
     ``LeaseStore`` default), so a failing ``.claude/cache`` mount does not also
     fail the lease.
 
-    Keyed to the wedged pod's stable identity (``pod_name``/``job_id``), so it
-    fires "exactly once PER WEDGE", NOT "exactly once per issue": a genuinely-new
-    run on the same issue (the fresh-pod re-provision writes a NEW pod_name) does
-    NOT match a prior wedge stamp, so a later, distinct wedge still gets its own
-    single failover.
+    Keyed to the wedged ATTEMPT's identity (``pod_name`` / ``job_id`` /
+    ``runpod_attempt_id``, #1668), so it fires "exactly once PER WEDGE", NOT
+    "exactly once per issue": a fresh re-provision keeps the SAME canonical
+    ``pod-<N>`` name, and the NEW ``runpod_attempt_id`` is what makes it a
+    different identity — a prior wedge stamp does NOT match a genuinely-new
+    attempt, so a later, distinct wedge still gets its own single failover.
 
     A LeaseStore failure (no ``$HOME``, dir uncreatable) is treated as "no record"
     (return ``False``) — the worst case is one extra terminate + re-provision (the
@@ -2722,9 +2830,11 @@ def _lease_records_runpod_cuda_ima_failover(issue: int, handle, *, lease_store=N
     AUTHORITATIVE for the once-more bound: ``_failover_cuda_ima_runpod`` reads it
     to decide whether THIS run already spent its one bounded CUDA-IMA pivot — if
     so, a second same-signature crash on the fresh host routes to terminal
-    ``failure_class: code`` (NOT a second pivot). Keyed to the crashed pod's
-    stable identity, so a genuinely-new run on the same issue (the fresh-host
-    re-provision writes a NEW pod_name) does NOT match a prior stamp.
+    ``failure_class: code`` (NOT a second pivot). Keyed to the crashed
+    ATTEMPT's identity (pod_name / job_id / runpod_attempt_id, #1668): a fresh
+    re-provision keeps the SAME canonical ``pod-<N>`` name, and the NEW
+    ``runpod_attempt_id`` is what makes it a different identity, so a prior
+    stamp does NOT match a genuinely-new attempt.
 
     Lives at ``~/.eps-routing/`` (a DIFFERENT directory from ``.claude/cache``),
     so it survives the EDQUOT / read-only-fs mode that fails BOTH the sidecar and
@@ -2765,15 +2875,19 @@ def _lease_has_any_runpod_cuda_ima_failover(issue: int, *, lease_store=None) -> 
         CURRENT handle's identity.
       - **Layer-2** (this function — the once-more bound in
         :func:`_failover_cuda_ima_runpod`) must fire "this RUN already spent its
-        one CUDA-IMA pivot" REGARDLESS of which pod crashed. A successful pivot
-        stamps the OLD (crashed) pod's identity, then re-points the sidecar at
-        the FRESH pod; the SECOND CUDA-IMA crash arrives on the FRESH handle, so
-        an identity-equality check (layer-1) against the OLD stamp would always
-        be ``False`` and the run would pivot again indefinitely (the unbounded-
-        spend bug this task exists to prevent). An ANY-non-null check survives
-        the fresh-pod identity change. Plan §5 specifies exactly this: the bound
+        one CUDA-IMA pivot" REGARDLESS of which attempt crashed. A successful
+        pivot stamps the OLD (crashed) attempt's identity, then re-points the
+        sidecar at the FRESH attempt — which keeps the SAME canonical
+        ``pod-<N>`` name but carries a NEW ``runpod_attempt_id`` (#1668) — so
+        the SECOND CUDA-IMA crash arrives on the FRESH handle, an
+        identity-equality check (layer-1) against the OLD stamp reads ``False``,
+        and the run would pivot again indefinitely (the unbounded-spend bug this
+        bound exists to prevent). An ANY-non-null check survives the
+        fresh-attempt identity change. Plan §5 specifies exactly this: the bound
         "checks whether ``runpod_cuda_ima_failover_of`` is set to ANY non-null
-        value on the issue's lease".
+        value on the issue's lease". Deliberately UNCHANGED by #1668 (a
+        per-issue bound is the conservative direction — a spent pivot parks a
+        later repeat at ``failure_class: code`` rather than pivoting again).
 
     A LeaseStore failure (no ``$HOME``, dir uncreatable) reads as "no record"
     (return ``False``) — worst case is one extra pivot, NEVER a silent

--- a/src/explore_persona_space/backends/router.py
+++ b/src/explore_persona_space/backends/router.py
@@ -1152,8 +1152,10 @@ class Lease:
     #: DURABLE idempotency record for the RunPod RUNNING-but-no-port host-wedge
     #: failover (#664/#689). The exact sibling of ``gcp_failover_of``: when this
     #: lease's fresh-pod re-provision was a failover OF a specific WEDGED RunPod
-    #: pod, this holds that wedged pod's stable identity
-    #: (``{"pod_name": ..., "job_id": ...}``). The poller
+    #: pod, this holds that wedged ATTEMPT's stable identity
+    #: (``{"pod_name": ..., "job_id": ..., "runpod_attempt_id": ...}`` — the
+    #: attempt key present whenever the handle carries one, #1668; a legacy
+    #: pre-#598 record holds the 2-key form). The poller
     #: (``scripts/backend_poll.py``) stamps it AFTER the fresh-pod relaunch
     #: succeeds, so even when EDQUOT / a read-only-fs / out-of-inodes fails BOTH
     #: the ``.claude/cache`` sidecar write AND the same-dir wedge sentinel write,
@@ -1165,7 +1167,9 @@ class Lease:
     #: failover (#775). The exact sibling of ``runpod_wedge_failover_of``: when
     #: this lease's fresh-host re-provision was a failover OF a specific RunPod
     #: pod that crashed twice with the SAME CUDA-IMA crash signature, this holds
-    #: that crashed pod's stable identity (``{"pod_name": ..., "job_id": ...}``).
+    #: that crashed ATTEMPT's stable identity (``{"pod_name": ..., "job_id":
+    #: ..., "runpod_attempt_id": ...}`` — attempt key per #1668, as its
+    #: sibling).
     #: A SEPARATE field from ``runpod_wedge_failover_of`` so a no-port wedge
     #: failover and a CUDA-IMA repeat failover on the SAME issue do not
     #: cross-suppress (each gets its own one bounded pivot). The poller

--- a/tests/test_autonomous_session_watch_wedge.py
+++ b/tests/test_autonomous_session_watch_wedge.py
@@ -2292,3 +2292,88 @@ def test_wedge_owner_defer_dry_run_no_writes(isolated_registry, monkeypatch):
     assert failovers == []
     assert posts == []  # the stub was restored; nothing recorded there either
     assert asw._load_pod_safety_state(692) == seeded  # no state write under dry_run
+
+
+# ===========================================================================
+# 13. #1668 D10 (T13): the watcher's durable wedge-failover note is TRUTHFUL
+#     on the D9 probe-success return — the REAL _wedge_failover mapping
+#     (structural current_phase key) + the REAL _handle_wedge_failover_outcome
+#     note composer run end-to-end; only backend_poll._failover_wedged_runpod
+#     (the shared recovery, via _stub_failover_fn) and the I/O seams are
+#     stubbed. Constants come from backend_poll (never literals).
+# ===========================================================================
+
+
+def test_wedge_probe_alive_outcome_posts_truthful_note_and_failover_note_unchanged(
+    isolated_registry, monkeypatch, tmp_path
+):
+    """T13: leg (a) — the D9 probe-success running return (current_phase ==
+    RUNPOD_WORKLOAD_OBSERVED_PHASE) posts a note that claims NEITHER a
+    terminate NOR a re-provision (nothing happened to the pod), names the
+    probe, and clears the wedge-episode state exactly as the success branch
+    does today. Leg (b) — the relaunch-success running return
+    (current_phase == FRESH_POD_PHASE) still posts the established
+    "TERMINATED + re-provisioned" note (no regression on true-failover
+    narration)."""
+    now = 1_000_000.0
+    posts: list[tuple[int, str, str]] = []
+    monkeypatch.setattr(asw, "_task_status", lambda issue: "running")
+    monkeypatch.setattr(asw, "_wedge_keep_running", lambda issue: False)
+    monkeypatch.setattr(asw, "_wedge_inputs_safe", lambda issue: True)
+    monkeypatch.setattr(asw, "_wedge_owner_live", lambda issue, now: False)  # #1667: no owner
+    monkeypatch.setattr(asw, "_task_events", lambda issue: [])
+    monkeypatch.setattr(
+        asw,
+        "_stop_pod",
+        lambda issue, dry_run: (_ for _ in ()).throw(
+            AssertionError("watcher must never _stop_pod")
+        ),
+    )
+    monkeypatch.setattr(
+        asw,
+        "_post_progress_marker",
+        lambda issue, note, dry_run, label: posts.append((issue, note, label)),
+    )
+    _stub_handle_sidecar(monkeypatch, tmp_path)
+
+    # ── leg (a): D9 probe-success shape → the "probe-alive" truthful note ──
+    _matured_confirming_state(now)
+    _stub_failover_fn(
+        monkeypatch,
+        returns={
+            "status": "running",
+            "current_phase": bp.RUNPOD_WORKLOAD_OBSERVED_PHASE,
+            "log_tail_excerpt": "no-port API read contradicted by live SSH",
+        },
+    )
+    asw._process_pod(692, "p692", _wedged_info(), now, dry_run=False, threshold=2)
+    wedge_posts = [(i, n) for i, n, label in posts if label == "wedge-failover"]
+    assert len(wedge_posts) == 1
+    note = wedge_posts[0][1]
+    assert "TERMINATED" not in note  # nothing was terminated — no false durable record
+    assert "re-provisioned" not in note  # nothing was re-provisioned
+    assert "probe" in note  # names the liveness probe as the reason
+    # The wedge-episode state clears exactly as the success branch does today.
+    loaded = asw._load_pod_safety_state(692)
+    assert loaded["wedge_first_seen"] is None
+    assert loaded["wedge_missed"] == 0
+    assert loaded["wedge_alerted"] is False
+
+    # ── leg (b): relaunch-success shape → the terminate note still posts ──
+    posts.clear()
+    _matured_confirming_state(now)
+    _stub_failover_fn(
+        monkeypatch,
+        returns={
+            "status": "running",
+            "current_phase": bp.RUNPOD_NOPORT_WEDGE_FAILOVER_FRESH_POD_PHASE,
+            "log_tail_excerpt": "terminated + re-provisioned fresh pod",
+        },
+    )
+    asw._process_pod(692, "p692", _wedged_info(), now, dry_run=False, threshold=2)
+    wedge_posts = [(i, n) for i, n, label in posts if label == "wedge-failover"]
+    assert len(wedge_posts) == 1
+    note_b = wedge_posts[0][1]
+    assert "TERMINATED + re-provisioned" in note_b  # the true-failover narration is unchanged
+    loaded = asw._load_pod_safety_state(692)
+    assert loaded["wedge_first_seen"] is None  # state clears on the failover outcome too

--- a/tests/test_runpod_wedge_detection.py
+++ b/tests/test_runpod_wedge_detection.py
@@ -1578,3 +1578,278 @@ def test_prior_failure_marker_cuda_ima_real_parser_realistic_body(monkeypatch):
     ]
     monkeypatch.setattr(TW, "list_events", lambda issue: benign, raising=False)
     assert bp._prior_failure_marker_is_cuda_ima(689) is False
+
+
+# ---------------------------------------------------------------------------
+# 15. #1668 attempt-keyed identity (T1-T10) + pre-terminate liveness probe
+#     (T11/T12). Hermeticity: EVERY lease-touching pin routes through
+#     ``_real_lease_store_in`` AND seeds a base lease — the stamp silently
+#     no-ops leaseless, so an unseeded mismatch test would pass VACUOUSLY;
+#     T3/T4/T5/T8/T9 carry explicit positive-control legs. Handle fixtures
+#     share the production-faithful RunPod shape (same canonical pod-<N> name,
+#     same job_id="") and differ ONLY in ``extra["runpod_attempt_id"]``.
+#     T11/T12 monkeypatch ONLY the named probe seam
+#     (``bp._runpod_wedge_liveness_probe``), never the functions under test.
+# ---------------------------------------------------------------------------
+
+_ATTEMPT_A = "rp-20260724T010000Z-aaaa"
+_ATTEMPT_B = "rp-20260724T054033Z-03ce"  # the live #1586 watcher-failover attempt id
+
+
+def _attempt_handle(attempt_id, *, pod_name: str = "pod-689", issue: int = 689) -> RunHandle:
+    """A production-faithful RunPod handle: canonical ``pod-<N>`` name,
+    ``job_id=""`` (launch does not capture the pod_id — runpod.py's
+    truthful-empty contract), attempt id in ``extra`` when given (None = a
+    legacy pre-#598 handle)."""
+    extra: dict = {"issue": issue}
+    if attempt_id is not None:
+        extra["runpod_attempt_id"] = attempt_id
+    return RunHandle(
+        backend="runpod",
+        cluster=None,
+        job_id="",
+        pod_name=pod_name,
+        scratch_dir="/workspace",
+        log_path=f"/workspace/logs/issue-{issue}.log",
+        extra=extra,
+    )
+
+
+def test_runpod_handle_identity_includes_attempt_id_when_present():
+    """T1: the identity dict carries the ``runpod_attempt_id`` key iff ``extra``
+    has a truthy value (acceptance criterion 4 — presence check, not a count)."""
+    ident = bp._runpod_handle_identity(_attempt_handle(_ATTEMPT_A))
+    assert ident == {"pod_name": "pod-689", "job_id": "", "runpod_attempt_id": _ATTEMPT_A}
+    assert "runpod_attempt_id" in ident
+
+
+def test_runpod_handle_identity_legacy_handle_omits_attempt_key():
+    """T2: no / empty attempt id (or a non-dict ``extra``) -> exactly the 2-key
+    legacy dict — the back-compat identity for pre-#598 sidecars."""
+    two_key = {"pod_name": "pod-689", "job_id": ""}
+    assert bp._runpod_handle_identity(_attempt_handle(None)) == two_key
+    assert bp._runpod_handle_identity(_attempt_handle("")) == two_key
+
+    class _NonDictExtraHandle:
+        pod_name = "pod-689"
+        job_id = ""
+        extra = None
+
+    assert bp._runpod_handle_identity(_NonDictExtraHandle()) == two_key
+
+
+def test_wedge_guard_fresh_attempt_does_not_match_stale_lease_stamp(tmp_path, monkeypatch):
+    """T3 (fails pre-fix): a stale LEASE stamp from attempt A must not blind a
+    fresh attempt B on the same canonical pod name (the sentinel is absent, so
+    the lease arm decides)."""
+    store = _real_lease_store_in(tmp_path, monkeypatch)
+    handle_a = _attempt_handle(_ATTEMPT_A)
+    handle_b = _attempt_handle(_ATTEMPT_B)
+    bp._stamp_runpod_wedge_failover(689, handle_a)
+    # POSITIVE CONTROL (non-vacuity): the stamp actually landed on the lease.
+    lease = store.read(689)
+    assert lease is not None
+    assert lease.runpod_wedge_failover_of == bp._runpod_handle_identity(handle_a)
+    sidecar = _empty_sidecar(tmp_path)
+    # Fresh attempt: the stale stamp must NOT match -> live poll.
+    assert bp._runpod_wedge_already_handled(689, handle_b, sidecar) is False
+
+
+def test_wedge_guard_fresh_attempt_does_not_match_stale_sentinel(tmp_path, monkeypatch):
+    """T4 (fails pre-fix): a stale SENTINEL from attempt A must not blind a
+    fresh attempt B (empty lease — no stamp — so the sentinel arm decides)."""
+    _real_lease_store_in(tmp_path, monkeypatch)  # pin the store; base lease carries NO stamp
+    handle_a = _attempt_handle(_ATTEMPT_A)
+    handle_b = _attempt_handle(_ATTEMPT_B)
+    sidecar = _empty_sidecar(tmp_path)
+    bp._write_runpod_wedge_sentinel(
+        bp._runpod_wedge_sentinel_path(sidecar), issue=689, handle=handle_a
+    )
+    # POSITIVE CONTROL: the sentinel arm matches the SAME attempt.
+    assert bp._runpod_wedge_already_handled(689, handle_a, sidecar) is True
+    # Fresh attempt: no match -> live poll.
+    assert bp._runpod_wedge_already_handled(689, handle_b, sidecar) is False
+
+
+def test_wedge_guard_same_attempt_refire_short_circuits_both_arms(tmp_path, monkeypatch):
+    """T5 (req c, #689 both-records contract): a re-fired tick on the SAME
+    wedged attempt short-circuits via the LEASE arm (seeded + stamped — the
+    mandatory positive control against vacuous passes), and, with the lease
+    record cleared, via the SENTINEL arm."""
+    from explore_persona_space.backends import router as R
+
+    store = _real_lease_store_in(tmp_path, monkeypatch)
+    handle_a = _attempt_handle(_ATTEMPT_A)
+    sidecar = _empty_sidecar(tmp_path)
+    # LEASE arm.
+    bp._stamp_runpod_wedge_failover(689, handle_a)
+    assert bp._runpod_wedge_already_handled(689, handle_a, sidecar) is True
+    # Clear the lease record; with the sentinel still absent the guard reads False
+    # (proves the next True comes from the SENTINEL arm, not lease residue).
+    store.write(
+        R.Lease(issue=689, spec_hash="h", attempt_id="a", backend="runpod", job_id="pod-fresh-1")
+    )
+    assert bp._runpod_wedge_already_handled(689, handle_a, sidecar) is False
+    # SENTINEL arm.
+    bp._write_runpod_wedge_sentinel(
+        bp._runpod_wedge_sentinel_path(sidecar), issue=689, handle=handle_a
+    )
+    assert bp._runpod_wedge_already_handled(689, handle_a, sidecar) is True
+
+
+def _seed_1586_legacy_artifacts(tmp_path, monkeypatch):
+    """Hand-seed the EXACT #1586 incident artifacts: the 2-key legacy lease
+    field + the 2-key legacy sentinel payload (both measured 2026-07-25)."""
+    from explore_persona_space.backends import router as R
+
+    store = _real_lease_store_in(tmp_path, monkeypatch)
+    store.write(
+        R.Lease(
+            issue=1586,
+            spec_hash="h",
+            attempt_id="a",
+            backend="runpod",
+            job_id="",
+            runpod_wedge_failover_of={"job_id": "", "pod_name": "pod-1586"},
+        )
+    )
+    sidecar = tmp_path / "issue-1586-handle.json"
+    sidecar.write_text(json.dumps({"backend": "runpod", "pod_name": "pod-1586", "extra": {}}))
+    bp._runpod_wedge_sentinel_path(sidecar).write_text(
+        json.dumps(
+            {
+                "issue": 1586,
+                "reason": "runpod_noport_wedge_failover",
+                "runpod_wedge": {"job_id": "", "pod_name": "pod-1586"},
+            }
+        )
+    )
+    return sidecar
+
+
+def test_wedge_guard_legacy_record_does_not_blind_modern_handle(tmp_path, monkeypatch):
+    """T6 (the #1586 incident regression pin; fails pre-fix): the EXACT legacy
+    2-key lease + sentinel records must NOT match a modern (attempt-bearing)
+    handle — fail-toward-live-poll, the chosen back-compat direction."""
+    sidecar = _seed_1586_legacy_artifacts(tmp_path, monkeypatch)
+    modern = _attempt_handle(_ATTEMPT_B, pod_name="pod-1586", issue=1586)
+    assert bp._runpod_wedge_already_handled(1586, modern, sidecar) is False
+
+
+def test_wedge_guard_legacy_handle_vs_legacy_record_still_short_circuits(tmp_path, monkeypatch):
+    """T7 (back-compat preservation): a LEGACY handle (no attempt id) against a
+    legacy 2-key record still short-circuits — today's behavior preserved."""
+    sidecar = _seed_1586_legacy_artifacts(tmp_path, monkeypatch)
+    legacy = _attempt_handle(None, pod_name="pod-1586", issue=1586)
+    assert bp._runpod_wedge_already_handled(1586, legacy, sidecar) is True
+
+
+def test_cuda_ima_guard_fresh_attempt_does_not_match_stale_stamp(tmp_path, monkeypatch):
+    """T8 (fails pre-fix): the CUDA-IMA layer-1 mirror of T3 — a stale
+    ``runpod_cuda_ima_failover_of`` stamp from attempt A must not blind a
+    fresh attempt B (lease arm; sentinel absent)."""
+    store = _real_lease_store_in(tmp_path, monkeypatch)
+    handle_a = _attempt_handle(_ATTEMPT_A)
+    handle_b = _attempt_handle(_ATTEMPT_B)
+    bp._stamp_runpod_cuda_ima_failover(689, handle_a)
+    # POSITIVE CONTROL (non-vacuity): the stamp actually landed.
+    lease = store.read(689)
+    assert lease is not None
+    assert lease.runpod_cuda_ima_failover_of == bp._runpod_handle_identity(handle_a)
+    sidecar = _empty_sidecar(tmp_path)
+    assert bp._runpod_cuda_ima_already_handled(689, handle_b, sidecar) is False
+
+
+def test_cuda_ima_guard_same_attempt_refire_short_circuits(tmp_path, monkeypatch):
+    """T9: the CUDA-IMA mirror of T5 — a re-fired tick on the SAME crashed
+    attempt short-circuits via the lease arm, then via the sentinel arm."""
+    from explore_persona_space.backends import router as R
+
+    store = _real_lease_store_in(tmp_path, monkeypatch)
+    handle_a = _attempt_handle(_ATTEMPT_A)
+    sidecar = _empty_sidecar(tmp_path)
+    bp._stamp_runpod_cuda_ima_failover(689, handle_a)
+    assert bp._runpod_cuda_ima_already_handled(689, handle_a, sidecar) is True
+    store.write(
+        R.Lease(issue=689, spec_hash="h", attempt_id="a", backend="runpod", job_id="pod-fresh-1")
+    )
+    assert bp._runpod_cuda_ima_already_handled(689, handle_a, sidecar) is False
+    bp._write_runpod_cuda_ima_sentinel(
+        bp._runpod_cuda_ima_sentinel_path(sidecar), issue=689, handle=handle_a
+    )
+    assert bp._runpod_cuda_ima_already_handled(689, handle_a, sidecar) is True
+
+
+def test_cuda_ima_once_more_bound_any_stamp_unchanged(tmp_path, monkeypatch):
+    """T10: the layer-2 once-more bound is DELIBERATELY identity-independent
+    (#775, unchanged by #1668): ANY non-null stamp bounds the run, even while
+    the identity-keyed layer-1 correctly reads False for a fresh attempt."""
+    _real_lease_store_in(tmp_path, monkeypatch)
+    handle_a = _attempt_handle(_ATTEMPT_A)
+    handle_b = _attempt_handle(_ATTEMPT_B)
+    assert bp._lease_has_any_runpod_cuda_ima_failover(689) is False
+    bp._stamp_runpod_cuda_ima_failover(689, handle_a)
+    assert bp._lease_has_any_runpod_cuda_ima_failover(689) is True
+    assert bp._lease_records_runpod_cuda_ima_failover(689, handle_b) is False
+
+
+def test_wedge_failover_liveness_probe_success_skips_terminate_and_clears_clock(
+    tmp_path, monkeypatch
+):
+    """T11 (D9): a matured wedge whose pod ANSWERS the liveness probe is a
+    sustained API port-misreport on a HEALTHY pod — no terminate, no relaunch,
+    a NON-terminal running JSON, and the sidecar's no-port clock is REMOVED
+    (a genuine wedge must re-mature from scratch)."""
+    terminated = _failover_with_mocked_gate(monkeypatch)
+    relaunched: list = []
+    monkeypatch.setattr(
+        bp,
+        "_relaunch_fresh_runpod",
+        lambda **kw: relaunched.append(kw) or {"status": "running"},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        bp, "_runpod_wedge_liveness_probe", lambda handle, **kw: True, raising=False
+    )
+    sidecar = tmp_path / "issue-689-handle.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "backend": "runpod",
+                "pod_name": "pod-689",
+                "extra": {"runpod_noport_first_seen_ts": 1784874699.56},
+            }
+        )
+    )
+    out = bp._failover_wedged_runpod(
+        issue=689, handle=_attempt_handle(_ATTEMPT_B), result=_dead_poll(), sidecar=sidecar
+    )
+    assert out["status"] == "running"  # NON-terminal
+    assert out["current_phase"] == bp.RUNPOD_WORKLOAD_OBSERVED_PHASE
+    assert terminated == []  # terminate_pod NOT called
+    assert relaunched == []  # the router relaunch NOT called
+    extra = json.loads(sidecar.read_text())["extra"]
+    assert "runpod_noport_first_seen_ts" not in extra  # clock cleared
+
+
+def test_wedge_failover_liveness_probe_failure_proceeds_to_terminate(tmp_path, monkeypatch):
+    """T12 (D9 fail-open): probe False -> the established terminate + relaunch
+    path proceeds exactly as today (a true wedge is never suppressed)."""
+    terminated = _failover_with_mocked_gate(monkeypatch)
+    relaunched: list = []
+    monkeypatch.setattr(
+        bp,
+        "_relaunch_fresh_runpod",
+        lambda **kw: relaunched.append(kw) or {"status": "running"},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        bp, "_runpod_wedge_liveness_probe", lambda handle, **kw: False, raising=False
+    )
+    sidecar = _empty_sidecar(tmp_path)
+    out = bp._failover_wedged_runpod(
+        issue=689, handle=_attempt_handle(_ATTEMPT_B), result=_dead_poll(), sidecar=sidecar
+    )
+    assert terminated == ["pod-id-55"]  # terminate fired exactly once
+    assert len(relaunched) == 1  # the fresh relaunch fires
+    assert out["status"] == "running"

--- a/tests/test_runpod_wedge_detection.py
+++ b/tests/test_runpod_wedge_detection.py
@@ -1853,3 +1853,63 @@ def test_wedge_failover_liveness_probe_failure_proceeds_to_terminate(tmp_path, m
     assert terminated == ["pod-id-55"]  # terminate fired exactly once
     assert len(relaunched) == 1  # the fresh relaunch fires
     assert out["status"] == "running"
+
+
+def test_liveness_probe_real_body_ssh_outcomes(monkeypatch):
+    """Production-body coverage for the T11/T12 seam (code-style § One
+    production-body test per seam-stubbed function): execute the REAL
+    ``_runpod_wedge_liveness_probe`` body, faking ONLY the external
+    filesystem/network boundary — ``_resolve_pod_endpoint`` (pods.conf read;
+    a ``def``-mirroring fake) and ``subprocess.run`` (SSH; autospec'd,
+    returning a real ``CompletedProcess``). Reaches the endpoint-resolution
+    call, the ssh argv construction, and the ``.returncode`` dereference."""
+    import subprocess as sp
+    from unittest import mock
+
+    import explore_persona_space.backends.runpod as RP
+
+    def fake_resolve(pod_name: str) -> tuple[str, int]:
+        assert pod_name == "pod-689"
+        return ("1.2.3.4", 41234)
+
+    monkeypatch.setattr(RP, "_resolve_pod_endpoint", fake_resolve, raising=True)
+    fake_run = mock.create_autospec(
+        sp.run, return_value=sp.CompletedProcess(args=["ssh"], returncode=0)
+    )
+    monkeypatch.setattr(bp.subprocess, "run", fake_run, raising=True)
+
+    # rc == 0 -> reachable -> True.
+    assert bp._runpod_wedge_liveness_probe(_attempt_handle(_ATTEMPT_A)) is True
+    argv = fake_run.call_args.args[0]
+    assert argv[0] == "ssh" and "BatchMode=yes" in argv and "root@1.2.3.4" in argv
+    assert "41234" in argv  # the resolved port is threaded into -p
+    assert fake_run.call_args.kwargs.get("timeout") == 15  # timeout_sec + 5
+
+    # rc != 0 -> unreachable -> False (the established terminate path proceeds).
+    fake_run.return_value = sp.CompletedProcess(args=["ssh"], returncode=255)
+    assert bp._runpod_wedge_liveness_probe(_attempt_handle(_ATTEMPT_A)) is False
+
+
+def test_liveness_probe_real_body_fail_open_on_errors(monkeypatch):
+    """The REAL probe body's fail-open legs: a missing pods.conf row
+    (``_resolve_pod_endpoint`` raises ``RunPodWorkloadStartError``) and an SSH
+    timeout (``subprocess.TimeoutExpired``) each return False — LOGGED, never
+    raised — so a true wedge is never suppressed by a probe defect."""
+    import subprocess as sp
+    from unittest import mock
+
+    import explore_persona_space.backends.runpod as RP
+
+    def raise_resolve(pod_name: str) -> tuple[str, int]:
+        raise RP.RunPodWorkloadStartError(f"pod {pod_name!r} has no pods.conf row")
+
+    monkeypatch.setattr(RP, "_resolve_pod_endpoint", raise_resolve, raising=True)
+    assert bp._runpod_wedge_liveness_probe(_attempt_handle(_ATTEMPT_A)) is False
+
+    def ok_resolve(pod_name: str) -> tuple[str, int]:
+        return ("1.2.3.4", 41234)
+
+    monkeypatch.setattr(RP, "_resolve_pod_endpoint", ok_resolve, raising=True)
+    fake_run = mock.create_autospec(sp.run, side_effect=sp.TimeoutExpired(cmd=["ssh"], timeout=15))
+    monkeypatch.setattr(bp.subprocess, "run", fake_run, raising=True)
+    assert bp._runpod_wedge_liveness_probe(_attempt_handle(_ATTEMPT_A)) is False


### PR DESCRIPTION
Closes task #1668. D1 attempt-keyed identity + D2 docstring truth fixes + D9 pre-terminate fail-open liveness probe + T1-T12 pins.