### PR TITLE
task #1669: failover re-provision carries launch env pins

### DIFF
--- a/scripts/backend_poll.py
+++ b/scripts/backend_poll.py
@@ -1902,6 +1902,7 @@ def _runspec_from_runpod_handle(handle, issue):
     for key in ("boot_disk_gb", "min_ram_gb"):
         if extra.get(key):
             rebuilt_extra[key] = extra[key]
+    _forward_env_pins(extra, rebuilt_extra, issue)
     return RunSpec(
         issue=int(issue),
         intent=extra.get("intent", "lora-7b"),
@@ -1912,6 +1913,35 @@ def _runspec_from_runpod_handle(handle, issue):
         hydra_args=hydra_args,
         extra=rebuilt_extra,
     )
+
+
+def _forward_env_pins(extra: dict, rebuilt_extra: dict, issue) -> None:
+    """#1669: forward the launch env pins (WANDB_PROJECT et al.) into a rebuilt spec.
+
+    So the fresh pod's rendered launcher re-exports them — the #1586
+    incident: a wedge failover rebooted with only the generic ``issue<N>``
+    WandB default and the telemetry landed in the wrong project. PER-KEY
+    sanitize-and-warn, never raise: a malformed pin in a hand-edited
+    sidecar must not block the failover (the #1329 warn-only doctrine at
+    this exact site), and one stray key must not lose the valid
+    ``WANDB_PROJECT`` beside it (the strict all-or-nothing validator stays
+    at the CLI + renderer sites). A legacy handle without the key is a
+    no-op (byte-identical reconstruction).
+    """
+    raw_pins = extra.get("env_pins")
+    if not raw_pins:
+        return
+    from explore_persona_space.backends.base import sanitize_env_pins
+
+    kept, dropped = sanitize_env_pins(raw_pins)
+    for reason in dropped:
+        logging.warning(
+            "backend_poll: issue %s: dropping invalid env pin from handle (%s)",
+            issue,
+            reason,
+        )
+    if kept:
+        rebuilt_extra["env_pins"] = kept
 
 
 def _runpod_wedge_already_handled(issue: int, handle, sidecar: Path) -> bool:
@@ -2922,12 +2952,15 @@ def _runspec_from_gcp_handle(handle, issue):
     # pre-#1010 the rebuilt extra carried ONLY repo_branch, so the gate would
     # fail-OPEN there and the #958 shape could recur. Keys forwarded only when
     # present/truthy, so a legacy handle reconstructs byte-identically.
+    # #1669: env_pins forwarded per-key-sanitized (_forward_env_pins) so the
+    # fresh RunPod launcher re-exports the launch's WANDB_PROJECT et al.
     rebuilt_extra: dict = {}
     if extra.get("repo_branch"):
         rebuilt_extra["repo_branch"] = extra["repo_branch"]
     for key in ("boot_disk_gb", "min_ram_gb"):
         if extra.get(key):
             rebuilt_extra[key] = extra[key]
+    _forward_env_pins(extra, rebuilt_extra, issue)
     return RunSpec(
         issue=int(issue),
         intent=extra.get("intent", "lora-7b"),

--- a/scripts/dispatch_issue.py
+++ b/scripts/dispatch_issue.py
@@ -1292,6 +1292,28 @@ def _issue_worktree_git_root(issue: int) -> str | None:
     return str(wt) if wt.exists() else None
 
 
+def _parse_env_pins(pairs: list[str] | None) -> dict[str, str]:
+    """Parse repeated ``--env-pin KEY=VALUE`` pairs into a validated dict (#1669).
+
+    Splits each pair on the FIRST ``=`` (a ``WANDB_TAGS=a=b`` value is
+    legal); a pair with no ``=`` raises ``ValueError``. Validation is the
+    strict :func:`backends.base.validate_env_pins` (allowlisted key,
+    non-empty single-line non-secret-shaped value) — ``main()``'s
+    parse-time guard converts the raise to ``parser.error`` (exit 2).
+    """
+    from explore_persona_space.backends.base import validate_env_pins
+
+    if not pairs:
+        return {}
+    pins: dict[str, str] = {}
+    for pair in pairs:
+        key, sep, value = pair.partition("=")
+        if not sep:
+            raise ValueError(f"--env-pin {pair!r} is not KEY=VALUE (no '=')")
+        pins[key] = value
+    return validate_env_pins(pins)
+
+
 def _launch_extra_from_args(args: argparse.Namespace) -> dict[str, Any]:  # noqa: C901 — flat per-knob if-chain: one independent branch per launch CLI flag (#1468 added --min-gpu-mem-gb); extracting sub-helpers would obscure the knob-to-extra mapping (annotated-noqa precedent: gcp.py GcpBackend.launch).
     """Build ``spec.extra`` from the launch CLI's lane-specific knobs.
 
@@ -1338,6 +1360,20 @@ def _launch_extra_from_args(args: argparse.Namespace) -> dict[str, Any]:  # noqa
         # an undersized pod. GCP machine selection is unchanged (by intent);
         # inert on SLURM lanes.
         extra["min_ram_gb"] = int(args.min_ram_gb)
+    if getattr(args, "env_pin", None):
+        # #1669: launch env pins (WANDB_PROJECT et al.) — persisted into the
+        # handle sidecar so the failover reconstructors
+        # (backend_poll._runspec_from_*_handle) forward them into a fresh
+        # provision, and rendered as shell-escaped exports BEFORE each lane's
+        # WANDB_PROJECT:-issue<N> default (incident #1586). Set ONLY when
+        # non-empty (omit-when-absent — the #934 lane_suffix discipline: a
+        # None/empty-valued key would flip canonicalize_spec output and every
+        # live lease spec-hash). main()'s parse-time guard already rejected
+        # malformed / non-allowlisted pins and pins without --workload-cmd,
+        # so this re-parse cannot raise on the CLI path.
+        pins = _parse_env_pins(args.env_pin)
+        if pins:
+            extra["env_pins"] = pins
     if getattr(args, "min_gpu_mem_gb", None):
         # GCP A100-40 rung gate (#1468): read by gcp.a100_40_fallback_for_intent
         # — a declared per-GPU requirement strictly above gcp.A100_40_USABLE_GIB
@@ -2480,6 +2516,33 @@ def _build_argparser() -> argparse.ArgumentParser:
         ),
     )
     launch.add_argument(
+        "--env-pin",
+        action="append",
+        default=None,
+        metavar="KEY=VALUE",
+        help=(
+            "Launch env pin (repeatable, #1669): an environment export the "
+            "workload must see on EVERY provision, incl. watcher/poller "
+            "failover re-provisions (incident #1586: a wedge-failover pod "
+            "rebooted with only the generic issue<N> WandB default and its "
+            "runs landed in the wrong project). KEY is restricted to "
+            "backends.base.ENV_PIN_ALLOWED_KEYS (WANDB_PROJECT / "
+            "WANDB_RUN_GROUP / WANDB_TAGS / EPM_PERSIST_ADAPTER_* / "
+            "EPM_UPLOAD_MERGED) — secret keys are unrepresentable by "
+            "construction. Splits on the FIRST '=' (WANDB_TAGS=a=b is "
+            "legal). Threads to spec.extra['env_pins'] -> the handle "
+            "sidecar; every lane's workload-cmd launcher exports the pins "
+            "(shell-escaped) BEFORE its WANDB_PROJECT:-issue<N> default, so "
+            "the pin wins over the generic default. Requires a non-empty "
+            "--workload-cmd (all renderer insertion points are workload-cmd "
+            "branches; a hydra launch has no pin consumer). ADOPTION (the "
+            "--boot-disk-gb pattern): launch composers SHOULD pass "
+            "--env-pin WANDB_PROJECT=<declared project> whenever the plan's "
+            "Reproducibility Card declares a non-default WandB project; a "
+            "flag-less launch keeps today's behavior."
+        ),
+    )
+    launch.add_argument(
         "--min-gpu-mem-gb",
         type=int,
         default=None,
@@ -2710,6 +2773,24 @@ def main(
                 "--execute-workload requires a non-empty --workload-cmd "
                 "(it cannot execute a --hydra run)"
             )
+        # #1669: --env-pin is workload-cmd-only — every renderer insertion
+        # point (runpod launcher / gcp startup workload branch / slurm
+        # custom stage) is a workload-cmd branch, so a pin on a hydra
+        # launch would silently no-op; gating here is also what keeps the
+        # GCP hydra-branch render byte-identical by construction. Malformed
+        # / non-allowlisted / secret-shaped pins reject at parse time too
+        # (exit 2), BEFORE any backend is built (mirrors the
+        # --execute-workload guard above).
+        if getattr(args, "env_pin", None):
+            if not has_workload_cmd:
+                parser.error(
+                    "--env-pin requires a non-empty --workload-cmd "
+                    "(the lane launchers' pin exports are workload-cmd-only, #1669)"
+                )
+            try:
+                _parse_env_pins(args.env_pin)
+            except ValueError as exc:
+                parser.error(str(exc))
     logging.basicConfig(
         stream=sys.stderr,
         level=logging.DEBUG if args.debug else logging.INFO,

--- a/src/explore_persona_space/backends/base.py
+++ b/src/explore_persona_space/backends/base.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import re
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Literal
@@ -79,6 +80,113 @@ def validate_lane_suffix(suffix: str) -> str:
             f"len('att-YYYYmmdd-HHMMSS-') + suffix <= 63), got {len(suffix)}"
         )
     return suffix
+
+
+# ---------------------------------------------------------------------------
+# Launch env pins (#1669)
+# ---------------------------------------------------------------------------
+
+#: #1669: env-pin key ALLOWLIST — the only keys a launch may persist into the
+#: handle sidecar (``.claude/cache/issue-<N>-handle.json``) / render into lane
+#: launchers. Deliberately an allowlist, never a denylist: the sidecar is
+#: plain JSON in ``.claude/cache/``, handle fields ride ``epm:backend-selected``
+#: marker ``extra``, and GCP bakes the rendered startup script into instance
+#: metadata (readable via ``describe``), so a secret pin must be
+#: UNREPRESENTABLE, not merely discouraged. Extend by editing this frozenset
+#: (code review is the gate). Incident #1586: a wedge-failover pod rebooted
+#: with only the generic ``issue<N>`` WandB default and its runs landed in the
+#: wrong project — these keys are the launch-declared destinations a failover
+#: re-provision must inherit.
+ENV_PIN_ALLOWED_KEYS: frozenset[str] = frozenset(
+    {
+        "WANDB_PROJECT",
+        "WANDB_RUN_GROUP",
+        "WANDB_TAGS",
+        "EPM_PERSIST_ADAPTER_HF_REPO",
+        "EPM_PERSIST_ADAPTER_SUBFOLDER",
+        "EPM_UPLOAD_MERGED",
+    }
+)
+
+#: Belt-and-suspenders screen against ``--env-pin WANDB_PROJECT=$HF_TOKEN``
+#: shell-expansion accidents: the ALLOWLIST is the primary secret defense
+#: (secret KEY names are unrepresentable); this regex additionally refuses a
+#: secret-shaped VALUE smuggled under an allowlisted key. Patterns mirror
+#: ``scripts/check_no_secret_shaped_strings.py``'s token families.
+_ENV_PIN_SECRET_VALUE_RE = re.compile(
+    r"(hf_[A-Za-z0-9]{16,}|ghp_[A-Za-z0-9]{16,}|github_pat_|sk-[A-Za-z0-9-]{16,}|AKIA[0-9A-Z]{16})"
+)
+
+#: Max env-pin value length — generous for WandB project/group/tag strings,
+#: tight enough that a pasted blob/credential dump cannot ride a pin.
+ENV_PIN_VALUE_MAX_LEN = 512
+
+
+def _env_pin_violation(key: object, value: object) -> str | None:
+    """Return a one-line violation reason for one (key, value) pin, or None.
+
+    Shared by the strict all-or-nothing :func:`validate_env_pins` (CLI +
+    renderer sites) and the per-key :func:`sanitize_env_pins` (failover
+    reconstructor sites, #1329 warn-only doctrine).
+    """
+    if not isinstance(key, str) or key not in ENV_PIN_ALLOWED_KEYS:
+        return f"key {key!r} not in ENV_PIN_ALLOWED_KEYS {sorted(ENV_PIN_ALLOWED_KEYS)}"
+    if not isinstance(value, str):
+        return f"{key}: value must be str, got {type(value).__name__}"
+    if not value:
+        return f"{key}: value must be non-empty"
+    if "\n" in value or "\r" in value or "\x00" in value:
+        return f"{key}: value must be single-line with no NUL"
+    if len(value) > ENV_PIN_VALUE_MAX_LEN:
+        return f"{key}: value exceeds {ENV_PIN_VALUE_MAX_LEN} chars ({len(value)})"
+    if _ENV_PIN_SECRET_VALUE_RE.search(value):
+        return f"{key}: value matches a secret-shaped token pattern"
+    return None
+
+
+def validate_env_pins(pins: Mapping[str, object] | None) -> dict[str, str]:
+    """Validate + normalize an env-pin mapping; raise ``ValueError`` on ANY violation.
+
+    Rules: key in :data:`ENV_PIN_ALLOWED_KEYS`; value a non-empty single-line
+    ``str`` (no NUL, len <= :data:`ENV_PIN_VALUE_MAX_LEN`) not matching the
+    secret-shaped-value regex. Returns ``{}`` for ``None``/empty. This is the
+    STRICT form for the CLI capture + renderer defense-in-depth sites; the
+    failover reconstructors use :func:`sanitize_env_pins` (per-key drop) so a
+    malformed pin in a hand-edited sidecar can never block a failover (#1669).
+    """
+    if pins is None:
+        return {}
+    if not isinstance(pins, Mapping):
+        raise ValueError(f"env_pins must be a mapping, got {type(pins).__name__}")
+    violations = [v for k, val in pins.items() if (v := _env_pin_violation(k, val))]
+    if violations:
+        raise ValueError("invalid env pin(s): " + "; ".join(violations))
+    return {str(k): str(v) for k, v in pins.items()}
+
+
+def sanitize_env_pins(pins: object) -> tuple[dict[str, str], list[str]]:
+    """Per-key drop-and-report variant of :func:`validate_env_pins` (#1669).
+
+    Returns ``(kept, dropped_reasons)``: every valid pin is KEPT, every
+    invalid entry is dropped with a one-line reason — so a hand-edited
+    sidecar with one stray key does not lose the valid ``WANDB_PROJECT``
+    too, and a failover is never blocked (the #1329 warn-only doctrine at
+    the ``backend_poll`` reconstructor sites). A non-mapping input drops
+    wholesale with one reason.
+    """
+    if not pins:
+        return {}, []
+    if not isinstance(pins, Mapping):
+        return {}, [f"env_pins is not a mapping: {type(pins).__name__}"]
+    kept: dict[str, str] = {}
+    dropped: list[str] = []
+    for key, value in pins.items():
+        reason = _env_pin_violation(key, value)
+        if reason is None:
+            kept[str(key)] = str(value)
+        else:
+            dropped.append(reason)
+    return kept, dropped
 
 
 # ---------------------------------------------------------------------------

--- a/src/explore_persona_space/backends/gcp.py
+++ b/src/explore_persona_space/backends/gcp.py
@@ -147,6 +147,7 @@ from explore_persona_space.backends.base import (
     RunHandle,
     RunSpec,
     recommend_lane_next_interval,
+    validate_env_pins,
     validate_lane_suffix,
 )
 
@@ -1437,6 +1438,23 @@ def render_startup_script(
     # single line). The hydra branch is the byte-identical pre-#588
     # lines, gated only by ``if spec.workload_cmd``.
     if spec.workload_cmd:
+        # #1669: launch env pins (WANDB_PROJECT et al., incident #1586) —
+        # WORKLOAD-CMD BRANCH ONLY (the hydra branch is pin-free by
+        # construction: dispatch_issue.py's --env-pin guard requires a
+        # non-empty --workload-cmd, which keeps the hydra-only
+        # byte-identity snapshot untouched). Re-validated here as defense
+        # in depth (the rendered startup script lands in instance metadata
+        # and the handle sidecar is a hand-editable JSON), shlex-quoted,
+        # and spliced immediately BEFORE the WANDB_PROJECT:-issue<N>
+        # default below so the `:-` default preserves the pin and a
+        # pin-less render is byte-identical. An inline `WANDB_PROJECT=...
+        # cmd` prefix in workload_cmd still supersedes the export for that
+        # command (bash per-command env semantics — the documented
+        # zero-code override).
+        env_pin_lines = [
+            f"export {k}={shlex.quote(str(v))}"
+            for k, v in sorted(validate_env_pins((spec.extra or {}).get("env_pins")).items())
+        ]
         workload_block = [
             "# === REPO_ROOT export (#641; trap #599) ===",
             "# The GCE startup script clones the repo to $WORKLOAD_ROOT",
@@ -1465,6 +1483,7 @@ def render_startup_script(
             "# Masks the trap for managed launches only; hand launches still",
             "# need the gotchas.md _ensure_repo_root_on_syspath() guidance.",
             'export PYTHONPATH="$WORKLOAD_ROOT${PYTHONPATH:+:$PYTHONPATH}"',
+            *env_pin_lines,
             "# === WandB project default (#601 follow-up r1) ===",
             "# HF-Trainer workloads that never set WANDB_PROJECT land in WandB's",
             "# global default project 'huggingface', violating the Upload Policy",
@@ -4344,6 +4363,10 @@ def reconnect_or_none(
                     for k, v in {
                         "boot_disk_gb": (spec.extra or {}).get("boot_disk_gb"),
                         "min_ram_gb": (spec.extra or {}).get("min_ram_gb"),
+                        # #1669: launch env pins — carried on the reconnect
+                        # handle so an exit-75 rerun's sidecar overwrite
+                        # stays failover-capable WITH the pins (#1586).
+                        "env_pins": (spec.extra or {}).get("env_pins"),
                     }.items()
                     if v
                 }
@@ -5605,6 +5628,12 @@ class GcpBackend(ComputeBackend):
                     for k, v in {
                         "boot_disk_gb": spec.extra.get("boot_disk_gb"),
                         "min_ram_gb": spec.extra.get("min_ram_gb"),
+                        # #1669: launch env pins — persisted so the async
+                        # GCP→RunPod failover reconstruction
+                        # (backend_poll._runspec_from_gcp_handle) forwards
+                        # them and the fresh RunPod launcher re-exports
+                        # them (#1586). Key OMITTED when absent/falsy.
+                        "env_pins": spec.extra.get("env_pins"),
                     }.items()
                     if v
                 },

--- a/src/explore_persona_space/backends/issue_dispatch.py
+++ b/src/explore_persona_space/backends/issue_dispatch.py
@@ -712,6 +712,16 @@ RECONNECT_CARRY_FORWARD_EXTRA_KEYS: tuple[str, ...] = (
     "gpu_count",
     "boot_disk_gb",
     "min_ram_gb",
+    # #1669: launch env pins (WANDB_PROJECT et al.) — carried VERBATIM,
+    # with no sanitize step here BY CHOICE: the pins were strict-validated
+    # at the original launch (dispatch_issue._parse_env_pins), every
+    # renderer re-validates fail-loud at consumption (covers a hand-edited
+    # sidecar on this live-operator reconnect path), and the failover
+    # reconstructors keep their own per-key sanitize-and-warn
+    # (backends.base.sanitize_env_pins). The `v not in (None, "", [])`
+    # filter keeps a non-empty dict and skips an absent key (legacy
+    # sidecars carry no env_pins).
+    "env_pins",
 )
 
 

--- a/src/explore_persona_space/backends/runpod.py
+++ b/src/explore_persona_space/backends/runpod.py
@@ -58,11 +58,12 @@ import json
 import logging
 import os
 import re
+import shlex
 import subprocess
 import sys
 import time
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -73,6 +74,7 @@ from explore_persona_space.backends.base import (
     PollResult,
     RunHandle,
     RunSpec,
+    validate_env_pins,
 )
 
 if TYPE_CHECKING:
@@ -483,6 +485,7 @@ def _render_launch_script(
     pid_file: str,
     sentinel_path: str,
     attempt_id: str,
+    env_pins: Mapping[str, str] | None = None,
 ) -> str:
     """Remote script (b): write the launcher + detach it (setsid + nohup + pidfile).
 
@@ -574,6 +577,20 @@ def _render_launch_script(
     # itself (no second copy of the /workspace/eval_results/issue_<N> root).
     issue_dir = sentinel_dir.rsplit("/", 1)[0]
     sentinel_name = sentinel_path.rsplit("/", 1)[1]
+    # #1669: launch env pins (WANDB_PROJECT et al., incident #1586) —
+    # re-validated here as defense in depth (the rendered launcher executes
+    # as root, and the handle sidecar the failover reconstructors read is a
+    # hand-editable JSON), then rendered as shlex-quoted `export K=V` lines
+    # spliced immediately BEFORE the `WANDB_PROJECT:-issue<N>` default below,
+    # so the `:-` default preserves the pin and a pin-less render is
+    # byte-identical. Values are validated single-line, so the quoted EPSEOF
+    # heredoc delimiter cannot be terminated by a pin. An inline
+    # `WANDB_PROJECT=... cmd` prefix in workload_cmd still supersedes the
+    # export for that command (bash per-command env semantics — the
+    # documented zero-code override; see the REPO_ROOT comment doctrine).
+    pin_lines = [
+        f"export {k}={shlex.quote(str(v))}" for k, v in sorted(validate_env_pins(env_pins).items())
+    ]
     sentinel_json = json.dumps({"phase": "done", "issue": int(issue), "attempt_id": attempt_id})
     if "'" in sentinel_json:
         # The JSON is embedded single-quoted inside the launcher; both
@@ -602,6 +619,7 @@ def _render_launch_script(
             "cd /workspace/explore-persona-space",
             "set -a; [ -f .env ] && source .env; set +a",
             'export REPO_ROOT="${REPO_ROOT:-/workspace/explore-persona-space}"',
+            *pin_lines,
             f'export WANDB_PROJECT="${{WANDB_PROJECT:-issue{issue}}}"',
             f"echo $$ > {pid_file}",
             "WORKLOAD_START_EPOCH=$(date +%s)",
@@ -744,6 +762,11 @@ def _execute_workload_on_pod(
                 pid_file=pid_file,
                 sentinel_path=sentinel_path,
                 attempt_id=attempt_id,
+                # #1669: thread the launch env pins into the rendered
+                # launcher — this call-site kwarg is what makes a failover
+                # re-execution (reconstructed spec.extra carries env_pins)
+                # actually re-export them on the fresh pod.
+                env_pins=(spec.extra or {}).get("env_pins"),
             ),
             timeout=120,
             context=f"workload detach on {pod_name}",
@@ -1035,6 +1058,10 @@ class RunPodBackend(ComputeBackend):
                     for k, v in {
                         "boot_disk_gb": (spec.extra or {}).get("boot_disk_gb"),
                         "min_ram_gb": (spec.extra or {}).get("min_ram_gb"),
+                        # #1669: launch env pins — persisted so the wedge /
+                        # CUDA-IMA fresh-pod re-provision forwards them and
+                        # the fresh launcher re-exports them (#1586).
+                        "env_pins": (spec.extra or {}).get("env_pins"),
                     }.items()
                     if v
                 },

--- a/src/explore_persona_space/backends/slurm.py
+++ b/src/explore_persona_space/backends/slurm.py
@@ -87,6 +87,7 @@ from explore_persona_space.backends.base import (
     PollResult,
     RunHandle,
     RunSpec,
+    validate_env_pins,
 )
 
 logger = logging.getLogger(__name__)
@@ -1406,6 +1407,27 @@ def _group_cleanup_lines(cluster: ClusterConfig) -> list[str]:
     ]
 
 
+def _env_pin_export_lines(spec: RunSpec) -> list[str]:
+    """#1669: shlex-quoted ``export K=V`` lines for the launch env pins.
+
+    Rendered into the CUSTOM (workload-cmd) stage BEFORE its
+    ``WANDB_PROJECT:-issue<N>`` default so the ``:-`` default preserves
+    the pin; a pin-less spec returns ``[]`` (byte-identical render).
+    Included on SLURM because fellows is the FIRST auto lane — a flag
+    silently no-op'ing on the default lane would be a foot-gun. SLURM
+    handles are never failover-reconstructed (no SLURM failover path
+    exists), so this fresh-launch render leg is the whole SLURM surface
+    (no handle persistence needed). Re-validates (defense in depth —
+    incident #1586); DISTINCT from the deliberately-rejected ambient
+    WANDB_PROJECT passthrough — pins are explicit per-launch
+    declarations, never the dispatch process's ambient env.
+    """
+    return [
+        f"export {k}={shlex.quote(str(v))}"
+        for k, v in sorted(validate_env_pins((spec.extra or {}).get("env_pins")).items())
+    ]
+
+
 def render_sbatch(
     *,
     spec: RunSpec,
@@ -1761,6 +1783,12 @@ def render_sbatch(
             # submission unique analogue.
             stage_blocks.append(f"export EPS_ISSUE={spec.issue}")
             stage_blocks.append('export EPS_ATTEMPT_ID="slurm-${SLURM_JOB_ID}"')
+            # #1669: launch env pins (WANDB_PROJECT et al., incident
+            # #1586) — exported BEFORE the WANDB_PROJECT:-issue<N> default
+            # below so the `:-` default preserves the pin (a pin-less
+            # render appends nothing, byte-identical). See
+            # _env_pin_export_lines for the SLURM-surface rationale.
+            stage_blocks.extend(_env_pin_export_lines(spec))
             # WandB project default (#601 follow-up r1) — parity with the
             # GCP workload_cmd lane: HF-Trainer workloads that never set
             # WANDB_PROJECT land in WandB's global default project

--- a/tests/test_backend_poll.py
+++ b/tests/test_backend_poll.py
@@ -4449,3 +4449,120 @@ def test_gcp_queue_timeout_ondemand_retry_skipped_on_leaked_residue(tmp_path, mo
     assert out["reason"] == "runpod_provision_leaked_pod"
     assert gcp.launch_calls == 0  # the retry never fired
     assert terminations == []
+
+
+# ---------------------------------------------------------------------------
+# #1669 — launch env pins (WANDB_PROJECT et al.) forwarded by BOTH failover
+# reconstructors, per-key sanitize-and-warn, legacy handles byte-identical.
+# ---------------------------------------------------------------------------
+
+
+def test_runspec_from_runpod_handle_forwards_env_pins(monkeypatch):
+    """#1669 incident-path pin (#1586): a pinned launch's PRODUCTION handle
+    (real launch, provision no-op'd) carries ``env_pins``, and
+    ``_runspec_from_runpod_handle`` forwards them into the rebuilt spec
+    extra after the sidecar serialize/deserialize roundtrip."""
+    from explore_persona_space.backends import runpod as RP
+    from explore_persona_space.backends.base import RunSpec
+    from explore_persona_space.backends.issue_dispatch import (
+        deserialize_handle,
+        serialize_handle,
+    )
+    from scripts import backend_poll as bp
+
+    pins = {"WANDB_PROJECT": "issue1586_methodgen", "WANDB_RUN_GROUP": "fu-lora"}
+    monkeypatch.setattr(RP, "_run_pod_lifecycle_relay", lambda cmd, **k: None)
+    handle = RP.RunPodBackend().launch(
+        RunSpec(
+            issue=1586,
+            intent="lora-7b",
+            backend="runpod",
+            workload_cmd="bash scripts/issue1586_dispatch.sh",
+            extra={"env_pins": pins},
+        )
+    )
+    assert handle.extra["env_pins"] == pins
+    roundtripped = deserialize_handle(serialize_handle(handle))
+    spec = bp._runspec_from_runpod_handle(roundtripped, 1586)
+    assert spec.extra.get("env_pins") == pins
+
+
+def test_runspec_from_runpod_handle_legacy_handle_without_env_pins_byte_identical():
+    """#1669 back-compat twin: a legacy handle without ``env_pins``
+    reconstructs a rebuilt extra byte-identical to pre-#1669 (empty here)."""
+    from explore_persona_space.backends.base import RunHandle
+    from scripts import backend_poll as bp
+
+    legacy = RunHandle(
+        backend="runpod",
+        cluster=None,
+        job_id="",
+        pod_name="pod-689",
+        scratch_dir="/workspace",
+        log_path="/workspace/logs/issue-689.log",
+        extra={
+            "issue": 689,
+            "intent": "lora-7b",
+            "workload_cmd": "bash scripts/x.sh",
+            "hydra_args": [],
+            "gpus": None,
+            "time_budget_hours": None,
+        },
+    )
+    spec = bp._runspec_from_runpod_handle(legacy, 689)
+    assert spec.extra == {}
+
+
+def test_runspec_from_runpod_handle_drops_invalid_env_pins_warn_only(caplog):
+    """#1669 note-1 semantics: PER-KEY drop-and-warn at the reconstructor —
+    a hand-edited sidecar with one stray key keeps the valid
+    ``WANDB_PROJECT``, the warning names the issue id, and an all-invalid
+    dict forwards NO ``env_pins`` key. Never raises (the #1329 warn-only
+    doctrine: a malformed pin must not block a failover)."""
+    import logging as _logging
+
+    from explore_persona_space.backends.base import RunHandle
+    from scripts import backend_poll as bp
+
+    def _handle(pins):
+        return RunHandle(
+            backend="runpod",
+            cluster=None,
+            job_id="",
+            pod_name="pod-1669",
+            scratch_dir="/workspace",
+            log_path="/workspace/logs/issue-1669.log",
+            extra={
+                "issue": 1669,
+                "intent": "lora-7b",
+                "workload_cmd": "bash scripts/x.sh",
+                "hydra_args": [],
+                "env_pins": pins,
+            },
+        )
+
+    with caplog.at_level(_logging.WARNING):
+        spec = bp._runspec_from_runpod_handle(
+            _handle({"WANDB_PROJECT": "ok-project", "WANDB_API_KEY": "stray"}), 1669
+        )
+    assert spec.extra["env_pins"] == {"WANDB_PROJECT": "ok-project"}
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= _logging.WARNING]
+    assert any("1669" in m and "env pin" in m for m in warnings), warnings
+
+    # All-invalid → no env_pins key at all (still no raise).
+    spec2 = bp._runspec_from_runpod_handle(_handle({"HF_HOME": "/x"}), 1669)
+    assert "env_pins" not in spec2.extra
+
+
+def test_runspec_from_gcp_handle_forwards_env_pins():
+    """#1669: the GCP→RunPod async-failover reconstructor forwards
+    ``env_pins`` so the fresh RunPod launcher re-exports them."""
+    from scripts import backend_poll as bp
+
+    pins = {"WANDB_PROJECT": "issue1586_methodgen"}
+    handle = _gcp_handle({**_GCP_EXTRA_659, "env_pins": pins})
+    spec = bp._runspec_from_gcp_handle(handle, 659)
+    assert spec.extra.get("env_pins") == pins
+    # Legacy GCP handle (no key) stays byte-identical: no env_pins forwarded.
+    legacy_spec = bp._runspec_from_gcp_handle(_gcp_handle(), 659)
+    assert "env_pins" not in legacy_spec.extra

--- a/tests/test_dispatch_issue_cli.py
+++ b/tests/test_dispatch_issue_cli.py
@@ -4607,3 +4607,122 @@ def test_reconnect_fellows_threads_job_name_suffix(monkeypatch) -> None:
     assert out is None, "patched query_by_name returns None (no live job)"
     assert captured["job_name"] == "eps-issue-1609-superkaiba"
     assert captured["robot_alias"] == "charmander"
+
+
+# ---------------------------------------------------------------------------
+# #1669 — --env-pin: threading + the parse-time guards (exit 2)
+# ---------------------------------------------------------------------------
+
+
+def _explode_factory():
+    raise AssertionError("backends must not be built when the --env-pin guard refuses")
+
+
+def test_env_pin_flag_threads_extra(monkeypatch, tmp_path) -> None:
+    """#1669: repeated ``--env-pin KEY=VALUE`` threads to
+    ``spec.extra['env_pins']`` — splitting on the FIRST '=' (implementer
+    note 4: a ``WANDB_TAGS=a=b`` value is legal)."""
+    _cd_to_tmp(monkeypatch, tmp_path)
+    nibi = _MockBackend(kind="nibi")
+    factory = _build_mock_factory(nibi=nibi)
+
+    from scripts.dispatch_issue import main
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = main(
+            [
+                "launch",
+                "--issue",
+                "1586",
+                "--intent",
+                "lora-7b",
+                "--workload-cmd",
+                "bash scripts/issue1586_dispatch.sh",
+                "--env-pin",
+                "WANDB_PROJECT=issue1586_methodgen",
+                "--env-pin",
+                "WANDB_TAGS=a=b",
+            ],
+            backends_factory=factory,
+        )
+    assert rc == 0
+    assert nibi.launches[0].extra["env_pins"] == {
+        "WANDB_PROJECT": "issue1586_methodgen",
+        "WANDB_TAGS": "a=b",
+    }
+
+
+def test_env_pin_requires_workload_cmd_exit_2(monkeypatch, tmp_path) -> None:
+    """#1669: ``--env-pin`` on a hydra launch exits 2 at parse time (all
+    renderer insertion points are workload-cmd branches — a hydra pin
+    would silently no-op; the guard is also what keeps the GCP hydra
+    snapshot untouched by construction), BEFORE any backend is built."""
+    _cd_to_tmp(monkeypatch, tmp_path)
+    from scripts.dispatch_issue import main
+
+    with pytest.raises(SystemExit) as ei:
+        main(
+            [
+                "launch",
+                "--issue",
+                "304",
+                "--intent",
+                "lora-7b",
+                "--hydra",
+                "seed=42",
+                "--env-pin",
+                "WANDB_PROJECT=px",
+            ],
+            backends_factory=_explode_factory,
+        )
+    assert ei.value.code == 2
+
+
+def test_env_pin_rejects_non_allowlisted_key_exit_2(monkeypatch, tmp_path) -> None:
+    """#1669: a non-allowlisted key (e.g. WANDB_API_KEY — a secret key) and
+    a malformed no-'=' pair both exit 2 at parse time."""
+    _cd_to_tmp(monkeypatch, tmp_path)
+    from scripts.dispatch_issue import main
+
+    base = [
+        "launch",
+        "--issue",
+        "304",
+        "--intent",
+        "lora-7b",
+        "--workload-cmd",
+        "bash scripts/x.sh",
+    ]
+    with pytest.raises(SystemExit) as ei:
+        main([*base, "--env-pin", "WANDB_API_KEY=x"], backends_factory=_explode_factory)
+    assert ei.value.code == 2
+    with pytest.raises(SystemExit) as ei2:
+        main([*base, "--env-pin", "WANDB_PROJECT"], backends_factory=_explode_factory)
+    assert ei2.value.code == 2
+
+
+def test_env_pin_rejects_secret_shaped_value_exit_2(monkeypatch, tmp_path) -> None:
+    """#1669 belt-and-suspenders: a secret-shaped VALUE under an allowlisted
+    key (the ``--env-pin WANDB_PROJECT=$HF_TOKEN`` shell-expansion
+    accident) exits 2 at parse time."""
+    _cd_to_tmp(monkeypatch, tmp_path)
+    from scripts.dispatch_issue import main
+
+    secret_shaped = "hf_" + "A" * 20  # constructed at runtime — never a committed literal
+    with pytest.raises(SystemExit) as ei:
+        main(
+            [
+                "launch",
+                "--issue",
+                "304",
+                "--intent",
+                "lora-7b",
+                "--workload-cmd",
+                "bash scripts/x.sh",
+                "--env-pin",
+                f"WANDB_PROJECT={secret_shaped}",
+            ],
+            backends_factory=_explode_factory,
+        )
+    assert ei.value.code == 2

--- a/tests/test_gcp_backend.py
+++ b/tests/test_gcp_backend.py
@@ -10886,3 +10886,120 @@ def test_push_verify_leg_executes_in_tmp_repo_case_c_noop(tmp_path: Path) -> Non
     assert proc.returncode == 0, (proc.stdout, proc.stderr)
     assert "[push-verify] OK: no unpushed commits" in proc.stdout
     assert not (workload / "data" / "issue_137").exists()
+
+
+# ---------------------------------------------------------------------------
+# #1669 — launch env pins: GCP handle persist + reconnect carry + render
+# ---------------------------------------------------------------------------
+
+_PINS_1669 = {"WANDB_PROJECT": "issue1586_methodgen"}
+
+
+def test_gcp_launch_handle_extra_carries_env_pins(no_marker_posts) -> None:
+    """#1669 (consistency-checker gap): the GCP LAUNCH path persists
+    ``env_pins`` into handle extra — without it the GCP→RunPod
+    second-failover inheritance leg rests on an untested persist. A
+    pin-less launch OMITS the key (legacy-shape parity)."""
+    created_payload = json.dumps([{"name": "eps-issue-137", "id": "112233"}])
+
+    def _launch(extra: dict | None):
+        runner = _Runner(
+            list_results=[GcloudRunResult(0, "[]", "")],
+            create_results=[GcloudRunResult(0, created_payload, "")],
+        )
+        backend = GcpBackend(config=_test_config(), runner=runner, marker_poster=lambda **kw: None)
+        return backend.launch(
+            _workload_spec("bash scripts/issue1669_dispatch.sh")
+            if extra is None
+            else _spec(
+                hydra_args=(),
+                workload_cmd="bash scripts/issue1669_dispatch.sh",
+                extra=extra,
+            )
+        )
+
+    handle = _launch({"env_pins": dict(_PINS_1669)})
+    assert handle.extra["env_pins"] == _PINS_1669
+    handle2 = _launch(None)
+    assert "env_pins" not in handle2.extra
+
+
+def test_render_startup_script_workload_cmd_exports_env_pins() -> None:
+    """#1669: the WORKLOAD-CMD branch renders shlex-quoted pin exports
+    immediately BEFORE the WandB project default; the HYDRA branch renders
+    NO pin line even when extra carries pins (workload-branch-only by
+    design — no hydra consumer, keeps the hydra snapshot untouched)."""
+    tricky_value = "fu lora's group"
+    spec = _spec(
+        hydra_args=(),
+        workload_cmd="bash scripts/issue1669_dispatch.sh",
+        extra={"env_pins": {"WANDB_PROJECT": "px", "WANDB_RUN_GROUP": tricky_value}},
+    )
+    script = render_startup_script(spec=spec, config=_test_config(), attempt_id="att-fixed-001")
+    lines = script.splitlines()
+    group_line = f"export WANDB_RUN_GROUP={shlex.quote(tricky_value)}"
+    proj_idx = lines.index("export WANDB_PROJECT=px")
+    group_idx = lines.index(group_line)
+    default_idx = next(i for i, ln in enumerate(lines) if 'WANDB_PROJECT="${WANDB_PROJECT:-' in ln)
+    assert proj_idx < group_idx < default_idx  # sorted, both before the :-default
+
+    # Hydra branch: pins structurally unreachable (CLI-gated), and even a
+    # hand-built hydra spec carrying pins renders none.
+    hydra_script = render_startup_script(
+        spec=_spec(extra={"env_pins": dict(_PINS_1669)}),
+        config=_test_config(),
+        attempt_id="att-fixed-001",
+    )
+    assert "export WANDB_PROJECT=issue1586_methodgen" not in hydra_script
+
+
+def test_render_startup_script_no_pins_byte_identical_workload_branch() -> None:
+    """#1669 (implementer note 2 — no circular fixture): a pin-less
+    workload-cmd render carries NO pin export for any allowlisted key —
+    the only WANDB_PROJECT export is the ``:-`` default — and an
+    absent-key spec renders identically to an explicit empty-dict pin
+    spec."""
+    from explore_persona_space.backends.base import ENV_PIN_ALLOWED_KEYS
+
+    script = render_startup_script(
+        spec=_workload_spec("bash scripts/issue1669_dispatch.sh"),
+        config=_test_config(),
+        attempt_id="att-fixed-001",
+    )
+    script_empty = render_startup_script(
+        spec=_spec(
+            hydra_args=(),
+            workload_cmd="bash scripts/issue1669_dispatch.sh",
+            extra={"env_pins": {}},
+        ),
+        config=_test_config(),
+        attempt_id="att-fixed-001",
+    )
+    assert script == script_empty
+    lines = script.splitlines()
+    wandb_project_exports = [ln for ln in lines if ln.startswith("export WANDB_PROJECT")]
+    assert wandb_project_exports == ['export WANDB_PROJECT="${WANDB_PROJECT:-issue137}"']
+    for key in sorted(ENV_PIN_ALLOWED_KEYS - {"WANDB_PROJECT"}):
+        assert not any(ln.startswith(f"export {key}=") for ln in lines), key
+
+
+def test_reconnect_handle_carries_env_pins() -> None:
+    """#1669 (mirror of test_reconnect_handle_carries_workload_extras): a
+    pinned workload spec's reconnect handle carries ``env_pins`` so an
+    exit-75 rerun's sidecar overwrite stays failover-capable WITH the
+    pins; a pin-less spec omits the key."""
+    spec = _spec(
+        workload_cmd="bash scripts/issue1669_dispatch.sh",
+        hydra_args=(),
+        extra={"env_pins": dict(_PINS_1669)},
+    )
+    runner = _Runner(list_results=[GcloudRunResult(0, _running_instance_payload(), "")])
+    handle = reconnect_or_none(spec=spec, config=_test_config(), runner=runner)
+    assert handle is not None
+    assert handle.extra["env_pins"] == _PINS_1669
+
+    spec2 = _spec(workload_cmd="bash scripts/issue1669_dispatch.sh", hydra_args=())
+    runner2 = _Runner(list_results=[GcloudRunResult(0, _running_instance_payload(), "")])
+    handle2 = reconnect_or_none(spec=spec2, config=_test_config(), runner=runner2)
+    assert handle2 is not None
+    assert "env_pins" not in handle2.extra

--- a/tests/test_issue_dispatch.py
+++ b/tests/test_issue_dispatch.py
@@ -1822,3 +1822,108 @@ def test_on_launched_early_write_carries_reconnect_merge(
     assert recovered.extra["repo_branch"] == "issue-1122"
     for key in ("gpus", "time_budget_hours", "gpu_count", "boot_disk_gb"):
         assert recovered.extra[key] == _PRIOR_EXTRA_1122[key], key
+
+
+# ---------------------------------------------------------------------------
+# #1669 — launch env pins: reconnect carry-forward + validator rules
+# ---------------------------------------------------------------------------
+
+
+def test_reconnect_carry_forward_includes_env_pins(tmp_path) -> None:
+    """#1669: ``env_pins`` is a RECONNECT_CARRY_FORWARD_EXTRA_KEYS member
+    and the sidecar snapshot keeps a non-empty pins dict (the
+    ``v not in (None, "", [])`` filter keeps a dict — plan assumption 8 —
+    and skips an absent key on a legacy sidecar)."""
+    from explore_persona_space.backends.issue_dispatch import (
+        RECONNECT_CARRY_FORWARD_EXTRA_KEYS,
+        _prior_sidecar_failover_extras,
+        write_handle_sidecar,
+    )
+
+    assert "env_pins" in RECONNECT_CARRY_FORWARD_EXTRA_KEYS
+
+    pins = {"WANDB_PROJECT": "issue1586_methodgen"}
+    sidecar = tmp_path / "issue-1669-handle.json"
+    write_handle_sidecar(
+        RunHandle(
+            backend="gcp",
+            cluster=None,
+            job_id="gce-1",
+            pod_name="eps-issue-1669",
+            scratch_dir="/s",
+            log_path="/l",
+            extra={"workload_cmd": "bash scripts/x.sh", "hydra_args": [], "env_pins": pins},
+        ),
+        sidecar,
+    )
+    prior = _prior_sidecar_failover_extras(sidecar)
+    assert prior is not None
+    assert prior["extra"]["env_pins"] == pins
+
+    # Legacy sidecar (no env_pins key): the snapshot omits it.
+    sidecar2 = tmp_path / "issue-1669-legacy-handle.json"
+    write_handle_sidecar(
+        RunHandle(
+            backend="gcp",
+            cluster=None,
+            job_id="gce-2",
+            pod_name="eps-issue-1669",
+            scratch_dir="/s",
+            log_path="/l",
+            extra={"workload_cmd": "bash scripts/x.sh", "hydra_args": []},
+        ),
+        sidecar2,
+    )
+    prior2 = _prior_sidecar_failover_extras(sidecar2)
+    assert prior2 is not None
+    assert "env_pins" not in prior2["extra"]
+
+
+@pytest.mark.parametrize(
+    ("pins", "ok"),
+    [
+        ({"WANDB_PROJECT": "issue1586_methodgen"}, True),
+        ({"WANDB_TAGS": "a=b", "WANDB_RUN_GROUP": "g 1"}, True),
+        (None, True),  # None → {}
+        ({}, True),  # empty → {}
+        ({"WANDB_API_KEY": "x"}, False),  # non-allowlisted (secret) key
+        ({"wandb_project": "x"}, False),  # case-sensitive allowlist
+        ({"WANDB_PROJECT": ""}, False),  # empty value
+        ({"WANDB_PROJECT": "a\nb"}, False),  # multi-line value
+        ({"WANDB_PROJECT": 42}, False),  # non-str value
+        ({"WANDB_PROJECT": "x" * 513}, False),  # over ENV_PIN_VALUE_MAX_LEN
+        ("WANDB_PROJECT=x", False),  # non-mapping input
+    ],
+)
+def test_validate_env_pins_allowlist_and_value_rules(pins, ok) -> None:
+    """#1669: the strict validator's allowlist + value rules (the CLI +
+    renderer defense); the secret-shaped-value case is covered separately
+    below (runtime-constructed token, never a committed literal)."""
+    from explore_persona_space.backends.base import validate_env_pins
+
+    if ok:
+        out = validate_env_pins(pins)
+        assert out == (dict(pins) if pins else {})
+    else:
+        with pytest.raises(ValueError):
+            validate_env_pins(pins)
+
+
+def test_validate_env_pins_rejects_secret_shaped_value_and_sanitize_splits() -> None:
+    """#1669: a secret-shaped VALUE is rejected by the strict validator,
+    and ``sanitize_env_pins`` (the reconstructor-side per-key variant)
+    keeps valid entries while reporting each dropped one."""
+    from explore_persona_space.backends.base import sanitize_env_pins, validate_env_pins
+
+    secret_shaped = "sk-" + "A" * 20  # constructed at runtime
+    with pytest.raises(ValueError, match="secret-shaped"):
+        validate_env_pins({"WANDB_PROJECT": secret_shaped})
+
+    kept, dropped = sanitize_env_pins(
+        {"WANDB_PROJECT": "ok", "WANDB_RUN_GROUP": secret_shaped, "HF_TOKEN": "x"}
+    )
+    assert kept == {"WANDB_PROJECT": "ok"}
+    assert len(dropped) == 2
+    # Non-mapping input drops wholesale with one reason, never raises.
+    kept2, dropped2 = sanitize_env_pins(["WANDB_PROJECT=x"])
+    assert kept2 == {} and len(dropped2) == 1

--- a/tests/test_runpod_workload_exec.py
+++ b/tests/test_runpod_workload_exec.py
@@ -892,6 +892,140 @@ def test_launch_fractional_boot_disk_gb_raises_named_valueerror(monkeypatch):
     assert argvs == []
 
 
+# ---------------------------------------------------------------------------
+# #1669 — launch env pins: handle persist + launcher render + end-to-end
+# ---------------------------------------------------------------------------
+
+_PINS_1669 = {"WANDB_PROJECT": "issue1586_methodgen"}
+
+
+def test_launch_handle_extra_carries_env_pins(monkeypatch):
+    """#1669 (mirror of test_launch_handle_extra_carries_boot_disk_gb): a
+    pinned spec's handle extra carries ``env_pins`` verbatim; a pin-less
+    spec OMITS the key (the omit-when-absent contract the
+    ``_PRE_954_SUCCESS_EXTRA_KEYS`` exact-set tests pin)."""
+    _wire_exec_leg(monkeypatch, [])
+    handle = RP.RunPodBackend().launch(_spec(extra={"env_pins": dict(_PINS_1669)}))
+    assert handle.extra["env_pins"] == _PINS_1669
+
+    _wire_exec_leg(monkeypatch, [])
+    handle2 = RP.RunPodBackend().launch(_spec())
+    assert "env_pins" not in handle2.extra
+
+
+def test_launch_with_env_pins_renders_pin_export_before_default(monkeypatch):
+    """#1669 END-TO-END incident-path test (#1586): pinned launch → handle →
+    sidecar roundtrip → ``_runspec_from_runpod_handle`` → the router's
+    ``execute_workload`` opt-in (the ``router.py`` failover ``replace``
+    shape) → a REAL ``launch()`` through ``_wire_exec_leg`` (only
+    ``_ssh_pod_run`` faked, so ``_execute_workload_on_pod`` runs for real)
+    — and the RECORDED launcher body carries the pin export at an index
+    BEFORE the ``${WANDB_PROJECT:-issue<N>}`` default line. This is the
+    ONLY test spanning the renderer call-site kwarg thread: without it, an
+    implementer who adds the renderer kwarg but forgets the call-site
+    thread goes green while the failover pod boots with the generic
+    default."""
+    from dataclasses import replace
+
+    from explore_persona_space.backends.issue_dispatch import (
+        deserialize_handle,
+        serialize_handle,
+    )
+    from scripts import backend_poll as bp
+
+    # (1) The pinned launch persists env_pins into the handle sidecar.
+    _wire_exec_leg(monkeypatch, [])
+    handle = RP.RunPodBackend().launch(_spec(extra={"env_pins": dict(_PINS_1669)}))
+    roundtripped = deserialize_handle(serialize_handle(handle))
+    # (2) The failover reconstructor forwards them.
+    spec2 = bp._runspec_from_runpod_handle(roundtripped, 909)
+    assert spec2.extra["env_pins"] == _PINS_1669
+    # (3) The failover opts into the execution leg (router.py's
+    #     `replace(spec, extra={**dict(spec.extra or {}), "execute_workload": True})`).
+    spec3 = replace(spec2, extra={**dict(spec2.extra or {}), "execute_workload": True})
+    ssh = _wire_exec_leg(
+        monkeypatch,
+        ["SYNC-OK abc123\n", "WRAPPER-STARTED 4242\n", "LAUNCH-OK pid=777\n"],
+    )
+    handle2 = RP.RunPodBackend().launch(spec3)
+    assert handle2.extra["workload_executed"] is True
+    body = ssh.calls[1]  # sync -> DETACH (the launcher heredoc) -> verify
+    pin_idx = body.index("export WANDB_PROJECT=issue1586_methodgen")
+    default_idx = body.index('WANDB_PROJECT="${WANDB_PROJECT:-')
+    assert pin_idx < default_idx, "pin export must precede the :-default line"
+
+
+def test_render_launch_script_exports_shell_escaped_env_pins():
+    """#1669: a pin value with a space + single-quote renders shlex-quoted,
+    sorted, and positioned BEFORE the WANDB_PROJECT:-default line."""
+    import shlex as _shlex
+
+    tricky_value = "fu lora's group"  # space + single-quote → must shlex-quote
+    body = RP._render_launch_script(
+        issue=909,
+        workload_cmd=WORKLOAD,
+        log_path="/workspace/logs/issue-909.log",
+        pid_file="/workspace/logs/issue-909.pid",
+        sentinel_path="/workspace/eval_results/issue_909/att/s.json",
+        attempt_id=ATTEMPT,
+        env_pins={"WANDB_RUN_GROUP": tricky_value, "WANDB_PROJECT": "px"},
+    )
+    lines = body.splitlines()
+    group_line = f"export WANDB_RUN_GROUP={_shlex.quote(tricky_value)}"
+    assert group_line in lines
+    proj_idx = lines.index("export WANDB_PROJECT=px")
+    group_idx = lines.index(group_line)
+    default_idx = next(i for i, ln in enumerate(lines) if 'WANDB_PROJECT="${WANDB_PROJECT:-' in ln)
+    # Sorted (WANDB_PROJECT < WANDB_RUN_GROUP) and both before the default.
+    assert proj_idx < group_idx < default_idx
+
+
+def test_render_launch_script_no_pins_byte_identical():
+    """#1669 (implementer note 2 — NO circular post-change fixture): a
+    pin-less render carries NO pin export for any allowlisted key — the
+    only ``export WANDB_PROJECT`` line is the ``:-`` default — and
+    ``env_pins=None`` renders identically to ``env_pins={}`` (both take
+    the no-pin path). Structural launcher content intact."""
+    from explore_persona_space.backends.base import ENV_PIN_ALLOWED_KEYS
+
+    kwargs = dict(
+        issue=909,
+        workload_cmd=WORKLOAD,
+        log_path="/workspace/logs/issue-909.log",
+        pid_file="/workspace/logs/issue-909.pid",
+        sentinel_path="/workspace/eval_results/issue_909/att/s.json",
+        attempt_id=ATTEMPT,
+    )
+    body_default = RP._render_launch_script(**kwargs)
+    body_none = RP._render_launch_script(**kwargs, env_pins=None)
+    body_empty = RP._render_launch_script(**kwargs, env_pins={})
+    assert body_default == body_none == body_empty
+    lines = body_default.splitlines()
+    wandb_project_lines = [ln for ln in lines if ln.startswith("export WANDB_PROJECT")]
+    assert wandb_project_lines == ['export WANDB_PROJECT="${WANDB_PROJECT:-issue909}"']
+    for key in sorted(ENV_PIN_ALLOWED_KEYS - {"WANDB_PROJECT"}):
+        assert not any(ln.startswith(f"export {key}=") for ln in lines), key
+    # Structural content intact (heredoc + detach + pidfile echo).
+    assert "EPSEOF" in body_default
+    assert "setsid" in body_default
+    assert "echo $$ > /workspace/logs/issue-909.pid" in body_default
+
+
+def test_render_launch_script_rejects_non_allowlisted_pin_key():
+    """#1669 defense in depth: the renderer re-validates independently of
+    the CLI — a non-allowlisted key in a (hand-edited) sidecar raises."""
+    with pytest.raises(ValueError, match="ENV_PIN_ALLOWED_KEYS"):
+        RP._render_launch_script(
+            issue=909,
+            workload_cmd=WORKLOAD,
+            log_path="/workspace/logs/issue-909.log",
+            pid_file="/workspace/logs/issue-909.pid",
+            sentinel_path="/workspace/eval_results/issue_909/att/s.json",
+            attempt_id=ATTEMPT,
+            env_pins={"WANDB_API_KEY": "x"},
+        )
+
+
 def test_launch_handle_extra_carries_boot_disk_gb(monkeypatch):
     """#1118: the launch handle's extra persists the footprint fields
     (boot_disk_gb / min_ram_gb) so _runspec_from_runpod_handle can forward

--- a/tests/test_slurm_backend_render.py
+++ b/tests/test_slurm_backend_render.py
@@ -2840,3 +2840,75 @@ def test_assert_repo_branch_synced_accepts_detached_materialized_tree(tmp_path) 
     # Detached at the WRONG commit → still refuses.
     with pytest.raises(ValueError, match="cannot honor repo_branch='issue-X'"):
         backend._assert_repo_branch_synced(spec, src_root=wrong)
+
+
+# ---------------------------------------------------------------------------
+# #1669 — launch env pins on the SLURM custom (workload-cmd) stage
+# ---------------------------------------------------------------------------
+
+
+def _custom_spec_with_pins(pins: dict[str, str]) -> RunSpec:
+    """``_custom_spec`` twin carrying #1669 launch env pins in extra."""
+    return RunSpec(
+        issue=137,
+        intent="lora-7b",
+        backend="cluster",
+        cluster="nibi",
+        workload_cmd="bash scripts/issue1669_dispatch.sh",
+        extra={"env_pins": dict(pins)},
+    )
+
+
+def test_custom_stage_exports_env_pins() -> None:
+    """#1669: the custom stage exports shlex-quoted pins BEFORE the
+    WANDB_PROJECT:-issue<N> default (fellows is the FIRST auto lane — a
+    pin silently no-op'ing there would be a foot-gun)."""
+    tricky_value = "fu lora's group"
+    spec = _custom_spec_with_pins({"WANDB_PROJECT": "px", "WANDB_RUN_GROUP": tricky_value})
+    script = render_sbatch(
+        spec=spec,
+        cluster=_nibi(),
+        plan=stages_for_spec(spec),
+        scratch_dir="/scratch/tjiral/eps/issue-137",
+    )
+    lines = script.splitlines()
+    group_line = f"export WANDB_RUN_GROUP={shlex.quote(tricky_value)}"
+    proj_idx = lines.index("export WANDB_PROJECT=px")
+    group_idx = lines.index(group_line)
+    default_idx = next(i for i, ln in enumerate(lines) if 'WANDB_PROJECT="${WANDB_PROJECT:-' in ln)
+    assert proj_idx < group_idx < default_idx  # sorted, both before the :-default
+
+
+def test_custom_stage_no_pins_byte_identical() -> None:
+    """#1669 (implementer note 2 — no circular fixture): a pin-less custom
+    stage renders NO pin export for any allowlisted key — the only
+    WANDB_PROJECT export is the ``:-`` default — and an absent-key spec
+    renders identically to an explicit empty-dict pin spec."""
+    from explore_persona_space.backends.base import ENV_PIN_ALLOWED_KEYS
+
+    spec = _custom_spec()
+    script = render_sbatch(
+        spec=spec,
+        cluster=_nibi(),
+        plan=stages_for_spec(spec),
+        scratch_dir="/scratch/tjiral/eps/issue-137",
+    )
+    spec_empty = _custom_spec_with_pins({})
+    script_empty = render_sbatch(
+        spec=spec_empty,
+        cluster=_nibi(),
+        plan=stages_for_spec(spec_empty),
+        scratch_dir="/scratch/tjiral/eps/issue-137",
+    )
+    lines = script.splitlines()
+    wandb_project_exports = [ln for ln in lines if ln.startswith("export WANDB_PROJECT")]
+    assert wandb_project_exports == ['export WANDB_PROJECT="${WANDB_PROJECT:-issue137}"']
+    for key in sorted(ENV_PIN_ALLOWED_KEYS - {"WANDB_PROJECT"}):
+        assert not any(ln.startswith(f"export {key}=") for ln in lines), key
+    # The empty-dict pin spec renders the same pin-free custom stage (the
+    # two scripts differ only in the workload command they embed).
+    empty_lines = script_empty.splitlines()
+    for key in sorted(ENV_PIN_ALLOWED_KEYS):
+        assert not any(
+            ln.startswith(f"export {key}=") and ":-issue" not in ln for ln in empty_lines
+        ), key


### PR DESCRIPTION
Closes task #1669. Env-pin channel: --env-pin flag -> allowlist validator -> handle sidecar -> failover reconstructors -> lane launcher renders.