### PR TITLE
workflow-fix #1672: stale-worktree reference-lint staleness degrade

### DIFF
--- a/.claude/rules/compute-backend-failover.md
+++ b/.claude/rules/compute-backend-failover.md
@@ -1229,7 +1229,17 @@ every COMPLETE cell's data already present on HF.
 
 **Idempotency = a DURABLE lease + a sentinel, exactly as the GCP analogue
 (#689 blocker-2).** The wedge failover guards its terminate + re-provision with
-TWO records keyed to the wedged pod identity (pod_name/job_id): (1) the
+TWO records keyed to the wedged ATTEMPT identity (pod_name / job_id /
+runpod_attempt_id): on RunPod `pod_name` is the canonical `pod-<N>` and
+`job_id` is `""`, so the per-launch `runpod_attempt_id` is what stops a stale
+record from blinding a fresh adopted attempt — pre-#1668 the 2-key identity
+was degenerate per issue and "exactly once per wedge" silently read as "once
+per issue forever" (#1586). #1668 also adds a PRE-TERMINATE SSH liveness
+cross-probe (`_runpod_wedge_liveness_probe`, fail-open) between the inputs
+gate and the terminate: a matured no-port wedge whose pod still answers SSH is
+a sustained API port-misreport on a HEALTHY pod, so the failover clears the
+wedge clock and returns a non-terminal running JSON instead of terminating;
+probe failure/error proceeds to terminate exactly as before. Records: (1) the
 AUTHORITATIVE durable lease at `~/.eps-routing/` (`Lease.runpod_wedge_failover_of`,
 checked by `_lease_records_runpod_wedge_failover`, stamped by
 `_stamp_runpod_wedge_failover` after the fresh-pod relaunch succeeds) — it
@@ -1500,7 +1510,10 @@ forks. Layers, in the order checked:
    inspection. NO second pivot.
 2. **PER-WEDGE IDEMPOTENCY.** A re-fired tick on the SAME crashed handle after a
    successful pivot short-circuits (durable lease authoritative + `.claude/cache`
-   sentinel fast-path, both keyed to the crashed pod identity).
+   sentinel fast-path, both keyed to the crashed ATTEMPT identity — pod_name /
+   job_id / runpod_attempt_id, #1668 — so a stale stamp never blinds a fresh
+   adopted attempt; no D9 liveness probe on this family — a reachable pod does
+   NOT contradict a CUDA-IMA crash).
 3. **INPUTS-ON-HF GATE** (reused as-is — a PARTIAL cell BLOCKS the irreversible
    terminate; human decides).
 4. **TERMINATE** the crashed pod (best-effort — a CUDA-IMA-wedged pod is usually

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -2342,6 +2342,25 @@ compute phases"; #891. Do not extend this sync to `src/` allowlists — a synced
 `env.py` would still miss torch-before-dotenv importers in-process, which the
 launch prefix caps unconditionally.)
 
+**Reference-lint staleness is handled LINT-side, never by widening this sync
+(#1622 → #1672).** The synced specs may reference `scripts/` helpers that
+landed on main after the branch point (e.g. `scripts/plan_patch.py`, #1631)
+and are absent from the stale worktree tree; the sync commit's own pre-commit
+hooks then run the (freshly-synced) `workflow_lint.py --check-references`
+against the WORKTREE tree. Rather than syncing those helpers in — banned
+above; nothing may execute `scripts/` copies from the worktree —
+`check_script_references` / `check_skill_references` degrade exactly that
+case to a `WARN:` on a non-main checkout (referenced target missing locally
+but present at `main`/`origin/main`), so the sync commit passes on files the
+round never touched. A hard reference FAIL inside a worktree therefore means
+the target is missing on main too — a genuine dead reference introduced by
+this round, fix it. Strictness is unchanged on the main checkout and in the
+Step 10d landing-tree gate (a non-git tree probes nothing and keeps the hard
+FAIL). (Named residual: a detached scratch-worktree merge commit — CLAUDE.md
+§ Concurrent repo-root committers — also commits in the WARN regime; a
+branch that deletes a still-referenced script is caught post-merge on main
+by the strict main-tree lint.)
+
 > **429 pacing at every ensemble fan-out (applies here, to the Step 9
 > critic ensembles, and to /adversarial-planner Phase 2):** when MORE than
 > two agent prompts go out at once (e.g. 3 critic lenses x 2 models), pause

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -28,7 +28,11 @@ Behaviours:
   any ``scripts/<name>.py`` reference whose target does not exist under
   ``scripts/``. Mechanically prevents the dead-tool / invented-tool
   failure class where an agent follows a step that runs a
-  deleted-or-never-created helper and CalledProcessErrors.
+  deleted-or-never-created helper and CalledProcessErrors. On a
+  non-``main`` checkout (a stale issue worktree) a reference missing
+  locally but tracked at ``main``/``origin/main`` degrades to a
+  non-blocking ``WARN:`` (#1622/#1672); a non-git tree or a failed git
+  probe stays strict (hard FAIL).
 * ``--check-skill-refs`` (also bundled into ``--check-references`` and the
   no-flags default run): walk every ``.md`` under ``.claude/agents/``,
   every ``SKILL.md`` under ``.claude/skills/``, every ``.md`` under
@@ -44,7 +48,11 @@ Behaviours:
   ``/weekly``) leaves stray load-bearing references that no mechanical
   check catches. Backtick-anchor + trailing-``/``-rejecting lookahead +
   fenced-code exclusion are the false-positive controls; lines carrying
-  :data:`HISTORICAL_REF_OPT_OUT` are a one-off narrative escape.
+  :data:`HISTORICAL_REF_OPT_OUT` are a one-off narrative escape. On a
+  non-``main`` checkout a plain single-segment ref unresolved locally but
+  whose ``SKILL.md`` is tracked at ``main``/``origin/main`` degrades to a
+  non-blocking ``WARN:`` (#1622/#1672); non-git trees / failed probes /
+  ``:``-namespaced refs stay strict.
 * ``--check-wandb-required``: walk every ``*.py`` under
   ``src/explore_persona_space/experiments/`` whose source mentions a
   trainer-config builder (``TrainLoraConfig``, ``SFTConfig``,
@@ -708,6 +716,7 @@ from __future__ import annotations
 import argparse
 import ast
 import dataclasses
+import functools
 import json
 import os
 import re
@@ -715,7 +724,7 @@ import subprocess
 import sys
 import tempfile
 from collections import Counter
-from collections.abc import Collection, Iterator
+from collections.abc import Callable, Collection, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -2925,8 +2934,49 @@ def _check_status_label_coverage(workflow: WorkflowYaml) -> list[str]:
     return errors
 
 
+def _head_is_main(repo_root: Path) -> bool:
+    """True iff the checkout containing ``repo_root`` has branch ``main``
+    checked out — the STRICT reference-lint regime. Fail-safe: any git
+    failure (non-git tree, e.g. the Step 10d /tmp landing-tree gate copy)
+    returns True, keeping hard-FAIL semantics (#1672)."""
+    try:
+        r = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:
+        return True
+    return r.returncode != 0 or r.stdout.strip() == "main"
+
+
+@functools.lru_cache(maxsize=None)
+def _tracked_on_main_ref(relpath: str, repo_root_s: str) -> bool:
+    """True iff ``relpath`` exists as a tracked path at local ``main`` or
+    ``origin/main`` in the repo containing ``repo_root_s`` (worktrees share
+    refs with the common dir). Fail-safe: any git failure returns False —
+    the caller keeps the hard FAIL (#1622/#1672)."""
+    for ref in ("main", "origin/main"):
+        try:
+            r = subprocess.run(
+                ["git", "-C", repo_root_s, "cat-file", "-e", f"{ref}:{relpath}"],
+                capture_output=True,
+                timeout=10,
+            )
+        except Exception:
+            return False
+        if r.returncode == 0:
+            return True
+    return False
+
+
 def check_script_references(
-    *, roots: list[Path] | None = None, scripts_dir: Path | None = None
+    *,
+    roots: list[Path] | None = None,
+    scripts_dir: Path | None = None,
+    main_probe: Callable[[str], bool] | None = None,
+    warn_sink: list[str] | None = None,
 ) -> list[str]:
     """Walk ``.claude/agents/**.md`` + ``.claude/skills/**/SKILL.md`` and
     FAIL on any ``scripts/<name>.py`` reference whose target does not exist
@@ -2950,9 +3000,35 @@ def check_script_references(
     which excludes OTHER worktrees but scans the current one — see
     :func:`_other_worktree_prefix`) and resolves references against
     ``<repo_root>/scripts``. Tests scope both to a fixture directory.
+
+    Staleness degrade (#1622/#1672): in production scope only (``scripts_dir``
+    is None) on a NON-``main`` checkout, a reference whose target is missing
+    locally but tracked at ``main``/``origin/main`` (lazy ``git cat-file -e``
+    probe, only on a miss) is downgraded to a non-blocking ``WARN:`` — the
+    Step 5a spec-freshness sync never syncs ``scripts/`` helpers, so a freshly
+    synced spec may reference a main-new helper a stale worktree lacks.
+    Fail-safe in every direction: a non-git tree (the Step 10d landing-tree
+    gate), a failed git probe, or ``HEAD == main`` keeps the hard FAIL.
+    ``main_probe`` / ``warn_sink`` are unit-test override hooks.
     """
     errors: list[str] = []
+
+    def _warn(msg: str) -> None:
+        if warn_sink is not None:
+            warn_sink.append(msg)
+        else:
+            sys.stderr.write(f"WARN: {msg}\n")
+
     scripts_root = scripts_dir if scripts_dir is not None else _REPO_ROOT / "scripts"
+    # Staleness-aware degrade (#1622/#1672): PRODUCTION scope only (fixture-
+    # scoped test calls stay strict unless a probe is injected), and only on
+    # a non-main checkout — main-checkout semantics are byte-identical.
+    if main_probe is None and scripts_dir is None and not _head_is_main(_REPO_ROOT):
+
+        def _default_script_probe(name: str) -> bool:
+            return _tracked_on_main_ref(f"scripts/{name}", str(_REPO_ROOT))
+
+        main_probe = _default_script_probe
     for path in _resolve_ask_target_files(roots):
         for lineno, line in enumerate(path.read_text().splitlines(), start=1):
             if HISTORICAL_REF_OPT_OUT in line:
@@ -2960,6 +3036,16 @@ def check_script_references(
             for match in SCRIPT_REF_RE.finditer(line):
                 script_name = match.group(1)
                 if not (scripts_root / script_name).exists():
+                    if main_probe is not None and main_probe(script_name):
+                        _warn(
+                            f"{path}:{lineno}: references 'scripts/{script_name}' — "
+                            f"missing under {scripts_root}/ but present at "
+                            f"main/origin/main: stale worktree tree, not this "
+                            f"commit's breakage (#1622/#1672). Not blocking; the "
+                            f"main-tree lint and the Step 10d landing-tree gate "
+                            f"re-check strictly."
+                        )
+                        continue
                     errors.append(
                         f"{path}:{lineno}: references 'scripts/{script_name}' "
                         f"which does not exist under {scripts_root}/. Repoint "
@@ -3060,6 +3146,8 @@ def check_skill_references(
     skills_dir: Path | None = None,
     allowlist: frozenset[str] | None = None,
     fs_roots: frozenset[str] | None = None,
+    main_probe: Callable[[str], bool] | None = None,
+    warn_sink: list[str] | None = None,
 ) -> list[str]:
     """Walk the workflow-doc surface (agents + skills + rules + CLAUDE.md +
     workflow.yaml) and FAIL on any backtick-delimited ``/<skill-name>`` token
@@ -3086,9 +3174,34 @@ def check_skill_references(
 
     ``roots`` / ``skills_dir`` / ``allowlist`` / ``fs_roots`` are unit-test
     override hooks; production callers pass None.
+
+    Staleness degrade (#1622/#1672), same pattern as
+    :func:`check_script_references`: in production scope only (``skills_dir``
+    is None) on a NON-``main`` checkout, a plain single-segment ``/skill``
+    token unresolved locally but whose ``.claude/skills/<ref>/SKILL.md`` is
+    tracked at ``main``/``origin/main`` is downgraded to a non-blocking
+    ``WARN:`` (a ``:``-namespaced ref resolves via the allowlist, which rides
+    the synced lint copy — the probe never fires for it). Fail-safe: non-git
+    tree, failed probe, or ``HEAD == main`` keeps the hard FAIL;
+    ``main_probe`` / ``warn_sink`` are unit-test override hooks.
     """
     errors: list[str] = []
+
+    def _warn(msg: str) -> None:
+        if warn_sink is not None:
+            warn_sink.append(msg)
+        else:
+            sys.stderr.write(f"WARN: {msg}\n")
+
     sk_dir = skills_dir if skills_dir is not None else _REPO_ROOT / ".claude" / "skills"
+    # Staleness-aware degrade (#1622/#1672): PRODUCTION scope only, non-main
+    # checkout only — mirrors check_script_references.
+    if main_probe is None and skills_dir is None and not _head_is_main(_REPO_ROOT):
+
+        def _default_skill_probe(ref_name: str) -> bool:
+            return _tracked_on_main_ref(f".claude/skills/{ref_name}/SKILL.md", str(_REPO_ROOT))
+
+        main_probe = _default_skill_probe
     live = _live_skill_names(sk_dir)
     allow = allowlist if allowlist is not None else SKILL_REF_ALLOWLIST
     fsr = fs_roots if fs_roots is not None else SKILL_REF_FS_ROOTS
@@ -3111,6 +3224,16 @@ def check_skill_references(
             for match in SKILL_REF_RE.finditer(line):
                 ref = match.group(1)
                 if _skill_ref_resolves(ref, live, allow, fsr):
+                    continue
+                if main_probe is not None and ":" not in ref and main_probe(ref):
+                    _warn(
+                        f"{path}:{lineno}: unresolved skill reference '/{ref}' — "
+                        f"not resolvable in this tree but present at "
+                        f"main/origin/main: stale worktree tree, not this "
+                        f"commit's breakage (#1622/#1672). Not blocking; the "
+                        f"main-tree lint and the Step 10d landing-tree gate "
+                        f"re-check strictly."
+                    )
                     continue
                 errors.append(
                     f"{path}:{lineno}: unresolved skill reference '/{ref}' — not a "

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -2951,7 +2951,7 @@ def _head_is_main(repo_root: Path) -> bool:
     return r.returncode != 0 or r.stdout.strip() == "main"
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def _tracked_on_main_ref(relpath: str, repo_root_s: str) -> bool:
     """True iff ``relpath`` exists as a tracked path at local ``main`` or
     ``origin/main`` in the repo containing ``repo_root_s`` (worktrees share

--- a/tests/test_workflow_lint.py
+++ b/tests/test_workflow_lint.py
@@ -46,10 +46,12 @@ from workflow_lint import (  # noqa: E402
     SKILL_REF_FS_ROOTS,
     UPLOAD_FILE_IN_LOOP_LEGACY_ALLOWLIST,
     UPLOAD_PREFIX_CLOBBER_ALLOWLIST,
+    _head_is_main,
     _iter_ask_target_files,
     _live_skill_names,
     _other_worktree_prefix,
     _run_root_guard,
+    _tracked_on_main_ref,
     _values_equal,
     check_agent_model_pins,
     check_asks,
@@ -550,6 +552,191 @@ def test_check_script_refs_repo_tree_is_clean():
         "committed .claude/ agents/skills reference scripts that do not "
         "exist under scripts/:\n" + "\n".join(errors)
     )
+
+
+# ---------------------------------------------------------------------------
+# Staleness-aware degrade for check_script_references / check_skill_references
+# (#1622/#1672): inside a stale non-``main`` worktree, a reference whose
+# target is missing locally but tracked at main/origin/main WARNs instead of
+# FAILing (the Step 5a sync deliberately never syncs scripts/ helpers).
+# Test notes: the two production-mode tests
+# ``test_check_script_refs_repo_tree_is_clean`` (above) and
+# ``test_check_skill_refs_repo_tree_is_clean`` (below) call the checks with
+# NO fixture args, so post-#1672 they become degrade-ACTIVE when Step 9c runs
+# them inside a worktree (a target missing locally but present on main WARNs
+# instead of FAILing) and stay fully strict on the main checkout — intended
+# behavior (#1672 plan §7 risk 1): merge-time strictness lives in the
+# Step 10d landing-tree gate (non-git tree ⇒ strict) plus the main-checkout
+# run of these same tests.
+# ---------------------------------------------------------------------------
+
+
+def test_check_script_refs_stale_tree_present_on_main_warns(tmp_path):
+    """A dangling ref whose target IS on main degrades to one WARN, no error
+    (#1622/#1672 stale-worktree tolerance); the WARN names the script, the
+    main ref, and the incident."""
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "SKILL.md").write_text("Run `uv run python scripts/plan_patch.py <draft>`.\n")
+    sink: list[str] = []
+    errors = check_script_references(
+        roots=[docs], scripts_dir=scripts_dir, main_probe=lambda n: True, warn_sink=sink
+    )
+    assert errors == [], f"expected WARN degrade, got errors: {errors}"
+    assert len(sink) == 1, f"expected exactly one WARN, got: {sink}"
+    assert "scripts/plan_patch.py" in sink[0]
+    assert "main" in sink[0]
+    assert "#1622" in sink[0]
+
+
+def test_check_script_refs_stale_tree_absent_on_main_fails(tmp_path):
+    """A dangling ref whose target is ALSO absent on main still FAILs with
+    the unchanged strict message — the degrade is not a bypass."""
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "SKILL.md").write_text("Run `scripts/zz_invented_helper.py --go`.\n")
+    sink: list[str] = []
+    errors = check_script_references(
+        roots=[docs], scripts_dir=scripts_dir, main_probe=lambda n: False, warn_sink=sink
+    )
+    assert len(errors) == 1, f"expected exactly one error, got: {errors}"
+    assert "scripts/zz_invented_helper.py" in errors[0]
+    assert "does not exist" in errors[0]
+    assert sink == [], f"expected no WARN, got: {sink}"
+
+
+def test_check_script_refs_fixture_mode_never_probes_ambiently(tmp_path):
+    """Fixture-scoped calls (scripts_dir set, no probe injected) stay strict
+    even when the referenced script exists on main and pytest runs inside a
+    non-main worktree: the ambient degrade is gated on production scope
+    (``scripts_dir is None``), keeping existing unit tests hermetic."""
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    # scripts/task.py exists on main — if the ambient probe fired in fixture
+    # mode this would WARN instead of erroring.
+    (docs / "SKILL.md").write_text("Run `uv run python scripts/task.py view 1`.\n")
+    errors = check_script_references(roots=[docs], scripts_dir=scripts_dir)
+    assert len(errors) == 1, f"expected one strict error (fixture mode), got: {errors}"
+    assert "scripts/task.py" in errors[0]
+
+
+def test_head_is_main_fail_safe_nongit(tmp_path):
+    """A non-git tree (the Step 10d /tmp landing-tree gate copy) reads as
+    'main' — i.e. the STRICT regime — by fail-safe."""
+    assert _head_is_main(tmp_path) is True
+
+
+def test_head_is_main_git_fixture(tmp_path):
+    """On a real git fixture: True on branch main, False on a feature branch."""
+
+    def git(*args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "-c", "user.email=t@e.st", "-c", "user.name=t", *args],
+            check=True,
+            capture_output=True,
+        )
+
+    git("init", "-b", "main")
+    git("commit", "--allow-empty", "-m", "root")
+    assert _head_is_main(tmp_path) is True
+    git("checkout", "-b", "feature")
+    assert _head_is_main(tmp_path) is False
+
+
+def test_tracked_on_main_ref_git_fixture(tmp_path):
+    """A committed path on a fixture repo's main resolves True; a missing
+    path resolves False. Fresh tmp repo per test so the lru_cache key
+    (relpath, repo_root) never collides across tests."""
+    root = tmp_path / "repo"
+    root.mkdir()
+
+    def git(*args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(root), "-c", "user.email=t@e.st", "-c", "user.name=t", *args],
+            check=True,
+            capture_output=True,
+        )
+
+    git("init", "-b", "main")
+    (root / "scripts").mkdir()
+    (root / "scripts" / "x.py").write_text("# helper\n")
+    git("add", "scripts/x.py")
+    git("commit", "-m", "add x")
+    assert _tracked_on_main_ref("scripts/x.py", str(root)) is True
+    assert _tracked_on_main_ref("scripts/y.py", str(root)) is False
+
+
+def test_check_skill_refs_stale_tree_present_on_main_warns(tmp_path):
+    """A /skill token unresolved locally but present on main degrades to one
+    WARN, no error — the skill-refs sibling of the script-refs degrade."""
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text("Run `/ghost-skill` here.\n")
+    sink: list[str] = []
+    errors = check_skill_references(
+        roots=[docs],
+        skills_dir=skills,
+        allowlist=frozenset(),
+        main_probe=lambda r: True,
+        warn_sink=sink,
+    )
+    assert errors == [], f"expected WARN degrade, got errors: {errors}"
+    assert len(sink) == 1, f"expected exactly one WARN, got: {sink}"
+    assert "/ghost-skill" in sink[0]
+    assert "main" in sink[0]
+    assert "#1622" in sink[0]
+
+
+def test_check_skill_refs_stale_tree_absent_on_main_fails(tmp_path):
+    """A /skill token absent locally AND on main still FAILs with the
+    unchanged strict message."""
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "a.md").write_text("Run `/ghost-skill` here.\n")
+    sink: list[str] = []
+    errors = check_skill_references(
+        roots=[docs],
+        skills_dir=skills,
+        allowlist=frozenset(),
+        main_probe=lambda r: False,
+        warn_sink=sink,
+    )
+    assert len(errors) == 1, f"expected exactly one error, got: {errors}"
+    assert "/ghost-skill" in errors[0]
+    assert "SKILL_REF_ALLOWLIST" in errors[0]
+    assert sink == [], f"expected no WARN, got: {sink}"
+
+
+def test_check_script_refs_ambient_wiring_degrade_active(tmp_path, monkeypatch, capsys):
+    """Pins the AMBIENT production wiring line (``main_probe is None and
+    scripts_dir is None and not _head_is_main(...)``): with a non-main HEAD
+    and a main-tracked target (both monkeypatched), a dangling ref in an
+    ambient call (scripts_dir=None) WARNs to stderr and returns no error —
+    so a later refactor cannot silently retire the degrade while every
+    injected-probe test stays green."""
+    import workflow_lint as wl
+
+    monkeypatch.setattr(wl, "_head_is_main", lambda _root: False)
+    monkeypatch.setattr(wl, "_tracked_on_main_ref", lambda _rel, _root: True)
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    # The fixture name must not exist under the real scripts/ dir.
+    (docs / "SKILL.md").write_text("Run `scripts/zz_nonexistent_1672.py` now.\n")
+    errors = check_script_references(roots=[docs])
+    assert errors == [], f"expected ambient WARN degrade, got errors: {errors}"
+    err = capsys.readouterr().err
+    assert "WARN:" in err
+    assert "scripts/zz_nonexistent_1672.py" in err
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes task #1672. Lint-side fix: check_script_references + check_skill_references degrade a missing-locally-but-present-on-main reference to WARN on non-main checkouts (#1622 incident class); fail-safe strict on non-git trees / probe failures / main. 8 new tests + SKILL.md Step 5a scope-note addendum.