### PR TITLE
task #1695: refusal/transport-aware session recovery (daily-fix)

### DIFF
--- a/.claude/skills/issue-tick/SKILL.md
+++ b/.claude/skills/issue-tick/SKILL.md
@@ -89,6 +89,28 @@ A broken triage must fail toward coverage (full re-drive), never toward
 silence — a no-op-on-crash tick would leave the alive-stalled-at-PARK
 class permanently unrecovered.
 
+**Api-error-after-marker screen (#1695).** `tick_triage.py` converts a
+would-be `HEALTHY` to `STALE-REDRIVE` (reason suffix
+`api-error-after-marker`) when this session's transcript tail carries an
+assistant row with `isApiErrorMessage: true` whose ts is NEWER than the
+latest `events.jsonl` marker — a refusal or 529 that killed the driving
+turn is otherwise masked by marker-age freshness (marker-age is measured
+from the LAST event log post, which precedes the dying turn by
+construction; incidents #1687 refusal-killed turn read HEALTHY at ~1 min
+marker age, #1689 first-turn 529 waited ~3h for the refusal-lane
+re-dispatch). The predicate reads the SAME transcript file the
+human-activity screen reads (256 KB tail via
+`_transcript_tail_rows_1629`), only on the HEALTHY-verdict branch — so
+the HEALTHY tick stays ONE Bash call by construction. Fail toward
+today's verdict: any transcript-resolution or classification failure
+suppresses nothing (a spurious STALE-REDRIVE is cheaper than a missed
+one on this predicate; the marker-age STALE-REDRIVE remains the
+backstop). Teardown verdicts (TERMINAL / GATE-TRANSITION) are UNAFFECTED
+— the same posture as the #1629 screen (a refusal after gate-park is
+still a teardown; honoring it here would create an infinite alternation
+between TERMINAL and STALE-REDRIVE). Kill switch:
+`EPM_TICK_API_ERROR_PROBE=0`.
+
 **Human-activity screen (#1629).** `tick_triage.py` converts a would-be
 STALE-REDRIVE to `HEALTHY` (reason prefix `human-active`) when this
 session's transcript tail shows a human (non-cron) user message within

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -25097,6 +25097,43 @@ def _boot_death_api_error_excerpt(rows: list[dict], cap: int = 200) -> str | Non
     return None
 
 
+def _boot_death_arm2_shape_and_window(
+    all_turns_failed: bool | None,
+    tail_rows: list[dict] | None,
+    refusal_window_s: float,
+    transport_window_s: float,
+) -> tuple[str, float]:
+    """Pre-classify the arm-2 subclass (#1695) and pick its age window.
+
+    Finds the LAST ``api-error`` row in ``tail_rows`` and routes to
+    ``"boot-transport"`` (freely-retryable 5-min threshold) vs
+    ``"boot-refusal"`` (usage-policy 30-min threshold) via
+    :func:`classify_boot_death_row`. When arm 2 does not apply
+    (``all_turns_failed`` is not ``True`` OR ``tail_rows`` is empty/None)
+    or no api-error row is present, defaults to ``"boot-refusal"``
+    (matching arm 1's 30-min threshold; refusal wins on tie, so unknown
+    text stays refusal by design). Returns ``(shape_pre, window_s)`` where
+    ``shape_pre`` is one of ``"boot-refusal"`` / ``"boot-transport"``.
+
+    Pure helper factored out of :func:`_process_boot_death` for C901 —
+    the classification loop + shape/window ternaries added ~5 to that
+    function's cyclomatic complexity.
+    """
+    last_api_error_row: dict | None = None
+    if all_turns_failed is True and tail_rows:
+        for r in reversed(tail_rows):
+            if _classify_wedge_row(r) == "api-error":
+                last_api_error_row = r
+                break
+    shape_pre = (
+        classify_boot_death_row(last_api_error_row)
+        if last_api_error_row is not None
+        else "boot-refusal"
+    )
+    window_s = transport_window_s if shape_pre == "boot-transport" else refusal_window_s
+    return shape_pre, window_s
+
+
 def _process_boot_death(path: Path, pids_by_sid: dict[str, int], now: float, dry_run: bool) -> None:
     """Evaluate ONE auto registration against the boot-death predicate and
     STOP its session when it verdicts ``"stop"`` (cap permitting). Every
@@ -25158,25 +25195,12 @@ def _process_boot_death(path: Path, pids_by_sid: dict[str, int], now: float, dry
         None if turns is None else bool(turns) and all(o == "failed" for o, _ts in turns)
     )
     idle_s, _why = _transcript_idle_age_s(pid, now)
-    # Pre-classify the arm-2 subclass (#1695): find the LAST api-error row
-    # in the tail and route to boot-transport (freely-retryable 5-min
-    # threshold) vs boot-refusal (usage-policy 30-min threshold). Arm 1
-    # (zero-response) has no api-error row to classify — it defaults to
-    # boot-refusal, and its 30-min threshold is unchanged. Refusal wins on
-    # tie: unknown text stays boot-refusal by design, preserving today's
-    # behavior on any unlabeled row.
-    last_api_error_row: dict | None = None
-    if all_turns_failed is True and tail_rows:
-        for r in reversed(tail_rows):
-            if _classify_wedge_row(r) == "api-error":
-                last_api_error_row = r
-                break
-    shape_pre = (
-        classify_boot_death_row(last_api_error_row)
-        if last_api_error_row is not None
-        else "boot-refusal"
+    # Pre-classify the arm-2 subclass (#1695) — see
+    # :func:`_boot_death_arm2_shape_and_window` for the docstring covering
+    # the refusal-wins-on-tie tie-break and the arm-1 default.
+    shape_pre, window_s = _boot_death_arm2_shape_and_window(
+        all_turns_failed, tail_rows, refusal_window_s, transport_window_s
     )
-    window_s = transport_window_s if shape_pre == "boot-transport" else refusal_window_s
     state = _load_boot_death_state(issue)
     day_key = time.strftime("%Y-%m-%d", time.gmtime(now))  # the #1209/#1241 day-cap derivation
     stops_today = _day_scoped_count(state, "stop_day", "stops_today", day_key)
@@ -25229,10 +25253,7 @@ def _process_boot_death(path: Path, pids_by_sid: dict[str, int], now: float, dry
     # turns), so arm 1 owning the tag when it fired is unambiguous. The
     # arm-2 shape is the pre-classified boot-refusal | boot-transport
     # (#1695).
-    if response_row_seen is False:
-        shape = "zero-response"
-    else:
-        shape = shape_pre  # boot-refusal | boot-transport
+    shape = "zero-response" if response_row_seen is False else shape_pre
     if shape == "zero-response":
         evidence = (
             f"transcript rows={len(rows)} size={size}B with ZERO response rows "

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -1619,6 +1619,59 @@ BOOT_DEATH_QUIET_S = 10 * 60
 BOOT_DEATH_TAIL_BYTES = 256 * 1024
 BOOT_DEATH_STOPS_PER_DAY = 3
 
+# Boot-death arm-2 subclass split (#1695). The 30-min refusal window
+# (BOOT_DEATH_WINDOW_S) is correct for a usage-policy refusal — the API
+# will refuse the same content on retry, so waiting shields a session that
+# is only genuinely dead once the tick cron backstop times out. It is
+# WRONG for a transport failure (529/429/timeout/connection): those are
+# freely retryable (`.claude/rules/llm-judging.md` rule 24), the SDK's
+# transient tuple resolves inside its 5-retry AIMD budget in ~seconds to
+# a few minutes, and waiting 30 min forfeits ~25 min of latency per
+# incident at zero benefit (#1689: first-turn 529 waited ~2h 24m
+# post-stop grace on top of the 30-min refusal window).
+#
+# The 5-min transport threshold sits past the SDK's transient retry
+# budget's typical wall-time envelope; 10 min was rejected as slack (a
+# healthy 529 is resolved well inside that window), 1 min was rejected
+# as too tight (leaves no room for a first-turn retry that would
+# complete in-session). The stop cap is UNCHANGED and SHARED across all
+# three shapes (zero-response / boot-refusal / boot-transport) — no new
+# bucket, no new day-cap key: a degenerate transport re-dispatch loop is
+# bounded at BOOT_DEATH_STOPS_PER_DAY (default 3) per issue per UTC day.
+BOOT_TRANSPORT_MIN_AGE_S = 5 * 60
+
+# Transport substrings (case-insensitive, whole-content match). Verbatim
+# from the #1689 incident content ("Repeated 529 Overloaded errors. The
+# API is at capacity") + the SDK-standard transient-error class
+# (`.claude/rules/llm-judging.md` rule 24 —
+# `anthropic._exceptions.OverloadedError` / `RateLimitError` /
+# `APITimeoutError` / `APIConnectionError` / `APIStatusError` with
+# `status_code == 529`). Claude Code renders these into the
+# ``isApiErrorMessage`` row's content with those exact substrings.
+BOOT_TRANSPORT_SUBSTRINGS: tuple[str, ...] = (
+    "529",
+    "overloaded",
+    "429",
+    "rate limit",
+    "ratelimit",
+    "timeout",
+    "connection error",
+    "api connection",
+)
+
+# Usage-policy substrings (also case-insensitive). REFUSAL WINS ON TIE:
+# a row containing BOTH a transport substring AND a usage-policy
+# substring stays boot-refusal — we deliberately do NOT weaken the
+# pre-existing 30-min refusal grace. The exact refusal wording Claude
+# Code emits on a usage-policy refusal (CLAUDE.md § "Spurious
+# usage-policy refusals" — "violates our Usage Policy" verbatim);
+# "cyber content" is the guard-surface subclass from #1098.
+BOOT_REFUSAL_SUBSTRINGS: tuple[str, ...] = (
+    "usage policy",
+    "violates our",
+    "cyber content",
+)
+
 # OPT-IN heartbeat sentinel for legitimately-slow phases (off-pod analyzer
 # verifier rounds, in-flight Anthropic Batch polling). UNLIKE every other
 # sentinel in this file, this one is stamped by the LONG-RUNNING PHASE
@@ -24840,6 +24893,69 @@ def _boot_death_window_s() -> float:
     return parsed
 
 
+def _boot_transport_min_age_s() -> float:
+    """Boot-transport registration-age threshold in seconds (env
+    ``EPM_BOOT_TRANSPORT_MIN_AGE_MIN``, MINUTES — the collapsed lane for
+    freely-retryable transport failures, #1695; default
+    :data:`BOOT_TRANSPORT_MIN_AGE_S`). Malformed / non-positive env falls
+    back to the default; never a kill switch (the lane's kill switch is
+    ``EPM_DISABLE_BOOT_DEATH_PASS=1``, unchanged). Byte-parallel to
+    :func:`_boot_death_window_s`."""
+    raw = os.environ.get("EPM_BOOT_TRANSPORT_MIN_AGE_MIN")
+    if not raw:
+        return float(BOOT_TRANSPORT_MIN_AGE_S)
+    try:
+        parsed = float(raw) * 60.0
+    except ValueError:
+        return float(BOOT_TRANSPORT_MIN_AGE_S)
+    if parsed <= 0:
+        return float(BOOT_TRANSPORT_MIN_AGE_S)
+    return parsed
+
+
+def _boot_death_row_texts(row: dict) -> list[str]:
+    """Every text field the row's ``message.content`` exposes. Pure helper
+    factored from :func:`_boot_death_api_error_excerpt` (whose iteration
+    shape it mirrors byte-for-byte) so the classifier and the excerpt
+    helper share ONE content walker (#1695). Never raises on the dict
+    shapes ``row`` can hold — a text block whose ``"text"`` value is
+    non-str is skipped."""
+    msg = row.get("message")
+    content = msg.get("content") if isinstance(msg, dict) else None
+    texts: list[str] = []
+    if isinstance(content, str):
+        texts.append(content)
+    elif isinstance(content, list):
+        texts.extend(
+            b["text"]
+            for b in content
+            if isinstance(b, dict) and b.get("type") == "text" and isinstance(b.get("text"), str)
+        )
+    return texts
+
+
+def classify_boot_death_row(row: dict) -> str:
+    """Classify the failing api-error row that killed the boot turn (#1695).
+
+    Returns ``"boot-transport"`` when the row's text contains ANY
+    :data:`BOOT_TRANSPORT_SUBSTRINGS` (case-insensitive) AND NO
+    :data:`BOOT_REFUSAL_SUBSTRINGS`. Returns ``"boot-refusal"`` otherwise —
+    the default: unclassifiable content, empty text, and content that
+    matches BOTH sets all keep today's 30-min refusal grace (refusal wins
+    on tie, since a row whose text names a transport substring in passing
+    but IS a usage-policy refusal must not be routed to the collapsed
+    5-min transport threshold). Pure string scanning; never raises."""
+    texts = _boot_death_row_texts(row)
+    joined = " ".join(texts).lower()
+    if not joined:
+        return "boot-refusal"  # no text to classify -> today's default
+    if any(sub in joined for sub in BOOT_REFUSAL_SUBSTRINGS):
+        return "boot-refusal"  # refusal wins on tie
+    if any(sub in joined for sub in BOOT_TRANSPORT_SUBSTRINGS):
+        return "boot-transport"
+    return "boot-refusal"  # unknown text -> today's default
+
+
 def _boot_death_stops_per_day() -> int:
     """Daily per-issue cap on boot-death stops (env
     ``EPM_BOOT_DEATH_STOPS_PER_DAY``; default
@@ -24974,20 +25090,7 @@ def _boot_death_api_error_excerpt(rows: list[dict], cap: int = 200) -> str | Non
     for row in reversed(rows):
         if _classify_wedge_row(row) != "api-error":
             continue
-        msg = row.get("message")
-        content = msg.get("content") if isinstance(msg, dict) else None
-        texts: list[str] = []
-        if isinstance(content, str):
-            texts.append(content)
-        elif isinstance(content, list):
-            texts.extend(
-                b["text"]
-                for b in content
-                if isinstance(b, dict)
-                and b.get("type") == "text"
-                and isinstance(b.get("text"), str)
-            )
-        for text in texts:
+        for text in _boot_death_row_texts(row):
             excerpt = " ".join(text.split())
             if excerpt:
                 return excerpt[:cap]
@@ -25021,7 +25124,16 @@ def _process_boot_death(path: Path, pids_by_sid: dict[str, int], now: float, dry
         entry_age_s = now - float(spawned_at)
     # Cheap early exits BEFORE any transcript IO: a dead sid is the
     # crash-recovery pass's property; a young/unaged entry can't fire.
-    if pid is None or entry_age_s is None or entry_age_s < _boot_death_window_s():
+    # NOTE (#1695): the min-window floor is the SHORTER of the two shape
+    # thresholds — a boot-transport session age >= 5 min but < 30 min must
+    # not be filtered out here (its shape-specific 5-min threshold is
+    # applied later, after row classification). Arm 1 (zero-response) and
+    # boot-refusal keep the 30-min window via the `window_s=` selection
+    # below.
+    refusal_window_s = _boot_death_window_s()
+    transport_window_s = _boot_transport_min_age_s()
+    min_window_s = min(refusal_window_s, transport_window_s)
+    if pid is None or entry_age_s is None or entry_age_s < min_window_s:
         return
     # Activity guards (both fail toward keep): something owns this issue.
     if _provision_in_flight_reason(issue, now) is not None:
@@ -25046,6 +25158,25 @@ def _process_boot_death(path: Path, pids_by_sid: dict[str, int], now: float, dry
         None if turns is None else bool(turns) and all(o == "failed" for o, _ts in turns)
     )
     idle_s, _why = _transcript_idle_age_s(pid, now)
+    # Pre-classify the arm-2 subclass (#1695): find the LAST api-error row
+    # in the tail and route to boot-transport (freely-retryable 5-min
+    # threshold) vs boot-refusal (usage-policy 30-min threshold). Arm 1
+    # (zero-response) has no api-error row to classify — it defaults to
+    # boot-refusal, and its 30-min threshold is unchanged. Refusal wins on
+    # tie: unknown text stays boot-refusal by design, preserving today's
+    # behavior on any unlabeled row.
+    last_api_error_row: dict | None = None
+    if all_turns_failed is True and tail_rows:
+        for r in reversed(tail_rows):
+            if _classify_wedge_row(r) == "api-error":
+                last_api_error_row = r
+                break
+    shape_pre = (
+        classify_boot_death_row(last_api_error_row)
+        if last_api_error_row is not None
+        else "boot-refusal"
+    )
+    window_s = transport_window_s if shape_pre == "boot-transport" else refusal_window_s
     state = _load_boot_death_state(issue)
     day_key = time.strftime("%Y-%m-%d", time.gmtime(now))  # the #1209/#1241 day-cap derivation
     stops_today = _day_scoped_count(state, "stop_day", "stops_today", day_key)
@@ -25056,7 +25187,7 @@ def _process_boot_death(path: Path, pids_by_sid: dict[str, int], now: float, dry
         response_row_seen=response_row_seen,
         all_turns_failed=all_turns_failed,
         transcript_idle_s=idle_s,
-        window_s=_boot_death_window_s(),
+        window_s=window_s,
         quiet_s=BOOT_DEATH_QUIET_S,
         stops_today=stops_today,
         stops_per_day=cap,
@@ -25095,8 +25226,13 @@ def _process_boot_death(path: Path, pids_by_sid: dict[str, int], now: float, dry
     _save_boot_death_state(issue, state, dry_run)
     stop_ok = _stop_session(sid, dry_run)
     # Arms are mutually exclusive (zero response rows => zero completed
-    # turns), so arm 1 owning the tag when it fired is unambiguous.
-    shape = "zero-response" if response_row_seen is False else "boot-refusal"
+    # turns), so arm 1 owning the tag when it fired is unambiguous. The
+    # arm-2 shape is the pre-classified boot-refusal | boot-transport
+    # (#1695).
+    if response_row_seen is False:
+        shape = "zero-response"
+    else:
+        shape = shape_pre  # boot-refusal | boot-transport
     if shape == "zero-response":
         evidence = (
             f"transcript rows={len(rows)} size={size}B with ZERO response rows "
@@ -25106,14 +25242,20 @@ def _process_boot_death(path: Path, pids_by_sid: dict[str, int], now: float, dry
         n_tail = len(tail_rows) if tail_rows is not None else 0
         n_turns = len(turns) if turns else 0
         api_error_rows = sum(1 for r in (tail_rows or []) if _classify_wedge_row(r) == "api-error")
+        if shape == "boot-transport":
+            descriptor = (
+                "transport-class api-error (529 / 429 / timeout / connection) — "
+                "freely-retryable, collapsed 5-min threshold, #1695"
+            )
+        else:
+            descriptor = "refusal-killed boot turn, #1287"
         evidence = (
             f"256KB-tail rows={n_tail} (file size={size}B): {n_turns} completed "
-            f"turn(s), ALL failed ({api_error_rows} api-error row(s) — "
-            f"refusal-killed boot turn, #1287)"
+            f"turn(s), ALL failed ({api_error_rows} api-error row(s) — {descriptor})"
         )
     note = (
         f"{_BOOT_DEATH_STOP_NOTE_SENTINEL} stopped boot-dead session sid={sid}: "
-        f"registration age {entry_age_s / 60:.0f}m >= {_boot_death_window_s() / 60:.0f}m, "
+        f"registration age {entry_age_s / 60:.0f}m >= {window_s / 60:.0f}m, "
         f"shape={shape}, {evidence}, idle {(idle_s or 0) / 60:.0f}m; stop_ok={stop_ok}; "
         f"task status={status}; stop {stops_today + 1}/{cap} today; registration kept: "
         f"crash-recovery re-drives an ACTIVE task (~20 min); the proposed-infra sweep's "

--- a/scripts/tick_triage.py
+++ b/scripts/tick_triage.py
@@ -796,6 +796,70 @@ def is_human_transcript_row(row: object) -> bool:
     return False
 
 
+def api_error_after_marker_reason(now: float, marker_ts: float | None) -> str | None:
+    """Return a content-invariant reason suffix when THIS session's transcript
+    tail carries an assistant row with ``isApiErrorMessage: true`` whose ts is
+    NEWER than the latest events.jsonl marker ts (#1687), else ``None``.
+
+    Fully exception-guarded (fail toward today's verdict — a spurious
+    STALE-REDRIVE is more expensive than a missed one on this predicate; the
+    marker-age STALE-REDRIVE remains the backstop). Content invariant #1000:
+    the returned reason names ages/counts ONLY, NEVER the row's message text
+    (refusal bodies are trigger-dense — the #866/#1073/#1098 containment).
+
+    Reuses the same transcript reader ``human_activity_reason`` uses
+    (:func:`_transcript_tail_rows_1629` at 256 KB tail bound); on a HEALTHY
+    tick this predicate is the ONLY reader of that file, so the healthy tick
+    stays ONE Bash call by construction (the `human_activity_reason` call
+    lives inside the ``verdict == STALE-REDRIVE`` branch, which is not entered
+    on the HEALTHY path).
+
+    Kill switch: ``EPM_TICK_API_ERROR_PROBE=0`` (or ``false``/``off``) reverts
+    to pre-#1695 HEALTHY behavior. Default enabled — parallel to
+    :func:`human_active_probe_enabled`.
+    """
+    try:
+        raw = os.environ.get("EPM_TICK_API_ERROR_PROBE", "").strip().lower()
+        if raw in ("0", "false", "off"):
+            return None
+        path = _own_session_transcript_path()
+        if path is None:
+            return None
+        newest_api_error_ts: float | None = None
+        for row in _transcript_tail_rows_1629(path):
+            if not isinstance(row, dict) or row.get("type") != "assistant":
+                continue
+            if row.get("isApiErrorMessage") is not True:
+                continue
+            ts = parse_event_ts(row.get("timestamp"))
+            if ts is None:
+                continue
+            if newest_api_error_ts is None or ts > newest_api_error_ts:
+                newest_api_error_ts = ts
+        if newest_api_error_ts is None:
+            return None
+        # STRICT `>`: a marker posted at the same ts as the api-error row
+        # (or newer) wins (fail toward today's verdict; row ts precision is
+        # ~1s so a tie is ambiguous — the marker-post likely followed).
+        if marker_ts is not None and newest_api_error_ts <= marker_ts:
+            return None
+        age = now - newest_api_error_ts
+        # Future-dated row (clock skew, age < 0): skip, don't latch (mirrors
+        # `human_activity_reason`'s future-row skip).
+        if age < 0:
+            return None
+        return f"api-error-after-marker (api-error {age / 60:.0f}m ago, newer than marker)"
+    except Exception as exc:
+        # Debug-only error rung (parallel to `human_activity_reason`): TYPE
+        # only (content invariant #1000), itself guarded so the helper can
+        # never raise into triage().
+        try:
+            _human_probe_debug(f"api-error-probe error={type(exc).__name__}")
+        except Exception:
+            return None
+        return None
+
+
 def human_activity_reason(now: float) -> str | None:
     """Return a content-invariant reason suffix when a HUMAN (non-cron)
     user message appears in THIS session's transcript within the recency
@@ -1060,6 +1124,28 @@ def triage(issue: int, kind: str, now: float | None = None) -> tuple[str, str]:
                 )
                 verdict = "HEALTHY"
                 reason = f"status={status}, {age_desc} — {live}"
+        elif verdict == "HEALTHY":
+            # #1687 api-error-after-marker predicate: an assistant row with
+            # `isApiErrorMessage: true` newer than the latest marker means a
+            # refusal / 529 killed the driving turn AFTER the last real
+            # event log post — marker-age freshness masks the death.
+            # HEALTHY -> STALE-REDRIVE, so the tick loads the full /issue
+            # skill and re-drives. Placement on the HEALTHY branch keeps
+            # the STALE-REDRIVE cascade (liveness / human-active) untouched;
+            # since the new predicate reads the SAME transcript file as
+            # `human_activity_reason` and the HEALTHY path never enters the
+            # STALE branch, a HEALTHY tick still costs ONE Bash call.
+            # Teardown verdicts (TERMINAL / GATE-TRANSITION) are UNAFFECTED
+            # — a refusal after gate-park is still a teardown (the same
+            # posture as the #1629 screen). Kill switch:
+            # ``EPM_TICK_API_ERROR_PROBE=0``.
+            api_err = api_error_after_marker_reason(now, marker_ts)
+            if api_err is not None:
+                verdict = "STALE-REDRIVE"
+                age_desc = (
+                    "no markers" if marker_age is None else f"marker age {marker_age / 60:.0f}m"
+                )
+                reason = f"status={status}, {age_desc} — {api_err}"
 
     # Runaway streak counts every TEARDOWN verdict, not just the terminal
     # STATUS sets — a teardown that whiffs forever at over-cap plan_pending

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -18996,6 +18996,277 @@ def test_boot_death_sentinels_in_watcher_note_sentinels():
     assert asw._BOOT_DEATH_CAP_NOTE_SENTINEL in asw._WATCHER_NOTE_SENTINELS
 
 
+# ── boot-transport subclass split (#1695) ───────────────────────────────────
+
+
+def _api_error_row_with_text(text: str) -> dict:
+    """An `isApiErrorMessage: true` assistant row carrying ``text``.
+    Mirrors the shape :func:`_boot_refusal_rows_fixture` builds."""
+    return {
+        "type": "assistant",
+        "isApiErrorMessage": True,
+        "message": {"content": [{"type": "text", "text": text}]},
+    }
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "API Error: Repeated 529 Overloaded errors. The API is at capacity",
+        "529",
+        "overloaded",
+        "429",
+        "rate limit",
+        "ratelimit",  # no-space variant — plan calibration Statistics critic pin
+        "timeout",
+        "connection error",
+        "api connection",  # api-connection error variant
+        "TIMEOUT",  # case-insensitive
+        "Rate Limit exceeded",  # mixed case
+    ],
+)
+def test_boot_death_classifier_transport_substrings(phrase):
+    """Every listed transport substring routes the row to boot-transport
+    (case-insensitive) — covers the two substrings the plan enumerated but
+    that were not pinned in the plan's own §6.2 test enumeration:
+    `"ratelimit"` (no-space) and `"api connection"`."""
+    import autonomous_session_watch as asw
+
+    row = _api_error_row_with_text(phrase)
+    assert asw.classify_boot_death_row(row) == "boot-transport"
+
+
+def test_boot_death_classifier_classifies_issue_1689_incident_string_as_transport():
+    """The strongest "the fix actually addresses the incident that motivated
+    it" invariant — the verbatim #1689 incident content string classifies
+    as boot-transport, so the 5-min collapsed threshold engages (not the
+    30-min refusal grace that caused #1689's ~2h 24m wait)."""
+    import autonomous_session_watch as asw
+
+    text = "API Error: Repeated 529 Overloaded errors. The API is at capacity"
+    row = _api_error_row_with_text(text)
+    assert asw.classify_boot_death_row(row) == "boot-transport"
+
+
+def test_boot_death_classifier_returns_refusal_for_usage_policy():
+    """A usage-policy refusal is classified as boot-refusal (preserves
+    today's 30-min grace — the API will refuse the same content on retry)."""
+    import autonomous_session_watch as asw
+
+    row = _api_error_row_with_text("I can't help with cyber content, it violates our usage policy.")
+    assert asw.classify_boot_death_row(row) == "boot-refusal"
+
+
+def test_boot_death_classifier_refusal_wins_on_tie():
+    """DURABILITY PIN (#1695): a row containing BOTH a refusal substring and
+    a transport substring stays boot-refusal — refusal wins on tie, so we
+    never weaken the pre-existing 30-min refusal grace on a row that also
+    mentions a transport keyword in passing."""
+    import autonomous_session_watch as asw
+
+    # Contains both "529" AND "usage policy" — refusal must win.
+    row = _api_error_row_with_text("429 rate limit hit while text violates our usage policy check")
+    assert asw.classify_boot_death_row(row) == "boot-refusal"
+
+
+def test_boot_death_classifier_defaults_to_refusal_on_unknown_text():
+    """Content matching neither substring set defaults to boot-refusal —
+    unknown text keeps today's 30-min grace, never the collapsed 5-min
+    threshold."""
+    import autonomous_session_watch as asw
+
+    row = _api_error_row_with_text("boot script exited with an unusual error")
+    assert asw.classify_boot_death_row(row) == "boot-refusal"
+
+
+def test_boot_death_classifier_empty_text_defaults_to_refusal():
+    """Fail-toward-refusal on empty / missing text — a row we cannot
+    classify keeps the 30-min grace."""
+    import autonomous_session_watch as asw
+
+    # Empty content
+    assert (
+        asw.classify_boot_death_row({"type": "assistant", "message": {"content": ""}})
+        == "boot-refusal"
+    )
+    # No message at all
+    assert asw.classify_boot_death_row({"type": "assistant"}) == "boot-refusal"
+
+
+def test_boot_transport_env_default_is_5_min(monkeypatch):
+    """Default 5 min (300s) when the env is unset; parity with
+    :func:`_boot_death_window_s` env-parse test."""
+    import autonomous_session_watch as asw
+
+    monkeypatch.delenv("EPM_BOOT_TRANSPORT_MIN_AGE_MIN", raising=False)
+    assert asw._boot_transport_min_age_s() == 300.0
+
+
+def test_boot_transport_env_honors_valid_minutes(monkeypatch):
+    """A valid minutes value is honored (minutes x 60 = seconds)."""
+    import autonomous_session_watch as asw
+
+    monkeypatch.setenv("EPM_BOOT_TRANSPORT_MIN_AGE_MIN", "7")
+    assert asw._boot_transport_min_age_s() == 420.0
+
+
+@pytest.mark.parametrize("bad", ["0", "-5", "junk", "-0.1"])
+def test_boot_transport_env_reject_negative_and_malformed(monkeypatch, bad):
+    """Malformed / non-positive env falls back to the default. Never a kill
+    switch — the lane's kill switch is EPM_DISABLE_BOOT_DEATH_PASS=1."""
+    import autonomous_session_watch as asw
+
+    monkeypatch.setenv("EPM_BOOT_TRANSPORT_MIN_AGE_MIN", bad)
+    assert asw._boot_transport_min_age_s() == 300.0
+
+
+def test_process_boot_death_uses_transport_threshold_when_row_is_529(
+    isolated_registry, monkeypatch
+):
+    """End-to-end pin: a boot-transport-classified refusal at registration
+    age 7 min (past the 5-min transport threshold but < 30-min refusal
+    threshold) STOPS the session — the collapsed lane engages. Companion
+    assertion: the marker note carries the new shape token and the
+    transport-descriptor language."""
+    import autonomous_session_watch as asw
+
+    # #1287 arm 2 shape (all completed turns failed) with a 529 api-error row.
+    rows = _boot_refusal_rows_fixture()
+    # Replace the trailing api-error text with a transport-classifiable
+    # phrase — the classifier must route to boot-transport.
+    for row in reversed(rows):
+        if row.get("isApiErrorMessage"):
+            row["message"] = {"content": [{"type": "text", "text": "API Error: 529 Overloaded"}]}
+            break
+
+    stops: list = []
+    monkeypatch.setattr(
+        asw, "_stop_session", lambda sid, dry_run: bool(stops.append((sid, dry_run))) or True
+    )
+    markers: list = []
+    monkeypatch.setattr(
+        asw,
+        "_post_progress_marker",
+        lambda issue, note, dry_run, label: markers.append((issue, label, note, dry_run)),
+    )
+    _boot_death_env(monkeypatch, asw, rows=rows)
+    # Registration age = 7 min: BELOW the 30-min refusal threshold, ABOVE
+    # the 5-min transport threshold — the collapsed lane must fire here
+    # and would NOT fire without the split.
+    _write_boot_death_entry(isolated_registry, 991, "sess-991", _BOOT_DEATH_NOW - 7 * 60)
+    asw.boot_death_pass(
+        dry_run=False,
+        children=[{"happySessionId": "sess-991", "pid": 5252}],
+        now=_BOOT_DEATH_NOW,
+    )
+
+    assert stops == [("sess-991", False)], f"Expected transport-classified stop, got: {stops}"
+    assert len(markers) == 1
+    note = markers[0][2]
+    assert "shape=boot-transport" in note
+    assert "transport-class" in note
+
+
+def test_process_boot_death_boot_refusal_keeps_before_30_min(isolated_registry, monkeypatch):
+    """Companion to the previous test: at the SAME age (7 min) with a
+    boot-refusal-classified row, the session is NOT stopped — the 30-min
+    threshold still binds for refusals. This pins the "refusal wins on tie"
+    fail-safe: only the transport case gets the collapsed threshold."""
+    import autonomous_session_watch as asw
+
+    # Use the default fixture (its trailing api-error text is _BOOT_REFUSAL_TEXT
+    # `"API Error: 400 request was blocked by our usage policy"` — a refusal).
+    rows = _boot_refusal_rows_fixture()
+
+    stops: list = []
+    monkeypatch.setattr(
+        asw, "_stop_session", lambda sid, dry_run: bool(stops.append((sid, dry_run))) or True
+    )
+    _boot_death_env(monkeypatch, asw, rows=rows)
+    _write_boot_death_entry(isolated_registry, 992, "sess-992", _BOOT_DEATH_NOW - 7 * 60)
+    asw.boot_death_pass(
+        dry_run=False,
+        children=[{"happySessionId": "sess-992", "pid": 5253}],
+        now=_BOOT_DEATH_NOW,
+    )
+
+    assert stops == [], (
+        "Refusal at 7 min must NOT stop — the 30-min threshold is unchanged for refusals"
+    )
+
+
+def test_process_boot_death_transport_stop_counts_against_shared_day_cap(
+    isolated_registry, monkeypatch
+):
+    """SHARED DAY CAP PIN (#1695 A3): boot-transport stops count against the
+    same `stops_today` counter as boot-refusal / zero-response, so a
+    degenerate transport re-dispatch loop is bounded by
+    EPM_BOOT_DEATH_STOPS_PER_DAY (default 3) — no new bucket, no new key."""
+    import json
+    import time as _t
+
+    import autonomous_session_watch as asw
+
+    # Boot-transport shape at 7 min age.
+    rows = _boot_refusal_rows_fixture()
+    for row in reversed(rows):
+        if row.get("isApiErrorMessage"):
+            row["message"] = {"content": [{"type": "text", "text": "API Error: 529"}]}
+            break
+
+    monkeypatch.setattr(asw, "_stop_session", lambda sid, dry_run: True)
+    markers: list = []
+    monkeypatch.setattr(
+        asw,
+        "_post_progress_marker",
+        lambda issue, note, dry_run, label: markers.append((issue, label, note, dry_run)),
+    )
+    _boot_death_env(monkeypatch, asw, rows=rows)
+
+    # Pre-seed the day-cap counter at 3 (cap reached).
+    day_key = _t.strftime("%Y-%m-%d", _t.gmtime(_BOOT_DEATH_NOW))
+    state_path = isolated_registry / "boot-death-993.json"
+    state_path.write_text(json.dumps({"stop_day": day_key, "stops_today": 3}))
+
+    _write_boot_death_entry(isolated_registry, 993, "sess-993", _BOOT_DEATH_NOW - 7 * 60)
+    asw.boot_death_pass(
+        dry_run=False,
+        children=[{"happySessionId": "sess-993", "pid": 5254}],
+        now=_BOOT_DEATH_NOW,
+    )
+
+    # Cap reached => cap-alert marker fires (not a stop), and the transport
+    # shape shares the counter.
+    labels = [la for _i, la, _n, _d in markers]
+    assert labels == ["boot-death-cap-exhausted"], (
+        f"Expected cap-alert (transport shares the shared day cap), got: {labels}"
+    )
+
+
+def test_process_boot_death_zero_response_keeps_30_min_threshold(isolated_registry, monkeypatch):
+    """ARM 1 PIN: zero-response (no api-error row to classify) uses the
+    30-min refusal threshold — a boot-transport miscategorization must not
+    escape via arm 1. At age 7 min zero-response keeps."""
+    import autonomous_session_watch as asw
+
+    # Zero-response fixture (no api-error, no assistant rows).
+    rows = _boot_death_rows_fixture()
+
+    stops: list = []
+    monkeypatch.setattr(
+        asw, "_stop_session", lambda sid, dry_run: bool(stops.append((sid, dry_run))) or True
+    )
+    _boot_death_env(monkeypatch, asw, rows=rows)
+    _write_boot_death_entry(isolated_registry, 994, "sess-994", _BOOT_DEATH_NOW - 7 * 60)
+    asw.boot_death_pass(
+        dry_run=False,
+        children=[{"happySessionId": "sess-994", "pid": 5255}],
+        now=_BOOT_DEATH_NOW,
+    )
+
+    assert stops == [], "Zero-response at 7 min must NOT stop — arm 1 keeps the 30-min threshold"
+
+
 def test_main_order_boot_death_before_stale_registration(isolated_registry, monkeypatch):
     # #1267 wiring: boot_death_pass runs AFTER gate_push_pass (the gate-push-
     # before-reaper ordering invariant) and BEFORE stale_registration_pass,

--- a/tests/test_issue_skill_marker_contract.py
+++ b/tests/test_issue_skill_marker_contract.py
@@ -42,6 +42,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 ISSUE_SKILL = ROOT / ".claude" / "skills" / "issue" / "SKILL.md"
+ISSUE_TICK_SKILL = ROOT / ".claude" / "skills" / "issue-tick" / "SKILL.md"
 EXPERIMENT_IMPLEMENTER = ROOT / ".claude" / "agents" / "experiment-implementer.md"
 CODE_REVIEWER = ROOT / ".claude" / "agents" / "code-reviewer.md"
 IMPLEMENTER = ROOT / ".claude" / "agents" / "implementer.md"
@@ -296,3 +297,19 @@ def test_sha_verbatim_report_rule_pinned():
                 "rev-parse-corrected before the relaunch brief — downstream "
                 "briefs/markers re-cite report SHAs verbatim)."
             )
+
+
+def test_skill_md_documents_api_error_after_marker():
+    """#1695 durability pin: the issue-tick SKILL.md documents the new
+    ``api-error-after-marker`` STALE-REDRIVE reason (the token that
+    `tick_triage.api_error_after_marker_reason` embeds in the verdict
+    string). A future editor silently dropping the docs row would leave
+    the runtime behavior unexplained; this test greps the literal token
+    so the SKILL.md stays in sync with the runtime."""
+    body = ISSUE_TICK_SKILL.read_text(encoding="utf-8")
+    assert "api-error-after-marker" in body, (
+        "issue-tick SKILL.md must document the api-error-after-marker "
+        "STALE-REDRIVE reason (#1695). The token is what "
+        "tick_triage.api_error_after_marker_reason embeds in the verdict "
+        "string — the docs and the runtime must not drift."
+    )

--- a/tests/test_tick_triage.py
+++ b/tests/test_tick_triage.py
@@ -1266,3 +1266,84 @@ def test_debug_telemetry_line(monkeypatch, tmp_path, capsys):
     assert "[human-probe]" in err
     assert path in err and "human=1" in err and "verdict=suppress" in err
     assert secret not in err
+
+
+# ── api-error-after-marker screen (#1695) ───────────────────────────────────
+
+
+def _api_error_row(age_s: float, text: str = "API Error: 500") -> dict:
+    """An `isApiErrorMessage: true` assistant row in the shape Claude Code
+    writes to the session transcript (verified live on #1687/#1689)."""
+    return {
+        "type": "assistant",
+        "isApiErrorMessage": True,
+        "timestamp": _iso_ms(NOW - age_s),
+        "message": {"role": "assistant", "content": [{"type": "text", "text": text}]},
+    }
+
+
+def test_api_error_after_marker_returns_stale_redrive(state_dir, monkeypatch, tmp_path):
+    """#1695 durability pin: a fresh assistant api-error row NEWER than the
+    latest marker converts a would-be HEALTHY to STALE-REDRIVE with the
+    exact `api-error-after-marker` reason substring."""
+    # marker at 300s ago; api-error at 60s ago (newer) — HEALTHY would fire
+    # by default (marker fresh), the api-error screen must flip it.
+    path = _write_transcript(tmp_path, [_api_error_row(60)])
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: path)
+    _patch_issue_state(monkeypatch, "running", [_event("epm:progress v1", 300)])
+    verdict, reason = tick_triage.triage(1695, "issue")
+    assert verdict == "STALE-REDRIVE", (verdict, reason)
+    assert "api-error-after-marker" in reason
+
+
+def test_api_error_after_marker_falls_open_on_missing_transcript(state_dir, monkeypatch):
+    """Fail-toward-today: when `_own_session_transcript_path` returns None
+    the predicate returns None and the initial verdict is preserved
+    (HEALTHY on a fresh marker)."""
+    # The autouse fixture already patches _own_session_transcript_path to
+    # return None, but be explicit for the pin.
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: None)
+    _patch_issue_state(monkeypatch, "running", [_event("epm:progress v1", 300)])
+    verdict, _ = tick_triage.triage(1695, "issue")
+    assert verdict == "HEALTHY"
+
+
+def test_api_error_older_than_marker_returns_healthy(state_dir, monkeypatch, tmp_path):
+    """Strict `>`: an api-error row OLDER than the latest marker (a
+    resolved incident whose next successful turn posted a fresh event) is
+    NOT a wedge — HEALTHY stays HEALTHY. Also covers the equal-ts tie
+    (which stays HEALTHY by design; the marker likely followed the row)."""
+    # api-error at 600s ago (older than the 60s-ago marker): the incident
+    # was resolved before the last marker post.
+    path = _write_transcript(tmp_path, [_api_error_row(600)])
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: path)
+    _patch_issue_state(monkeypatch, "running", [_event("epm:progress v1", 60)])
+    verdict, _ = tick_triage.triage(1695, "issue")
+    assert verdict == "HEALTHY"
+
+
+def test_api_error_probe_kill_switch(state_dir, monkeypatch, tmp_path):
+    """`EPM_TICK_API_ERROR_PROBE=0` disables the predicate — a HEALTHY tick
+    with a fresh api-error row and stale marker stays HEALTHY (pre-#1695
+    behavior). Confirms the kill switch is honored."""
+    monkeypatch.setenv("EPM_TICK_API_ERROR_PROBE", "0")
+    path = _write_transcript(tmp_path, [_api_error_row(60)])
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: path)
+    _patch_issue_state(monkeypatch, "running", [_event("epm:progress v1", 300)])
+    verdict, _ = tick_triage.triage(1695, "issue")
+    assert verdict == "HEALTHY"
+
+
+def test_api_error_probe_incident_1689_content_string(state_dir, monkeypatch, tmp_path):
+    """The verbatim #1689 incident content string (`"API Error: Repeated
+    529 Overloaded errors. The API is at capacity"`) trips the predicate.
+    The strongest "the fix actually addresses the incident that motivated
+    it" invariant — a regression that changes the field or shape the
+    predicate reads would break here."""
+    text = "API Error: Repeated 529 Overloaded errors. The API is at capacity"
+    path = _write_transcript(tmp_path, [_api_error_row(60, text=text)])
+    monkeypatch.setattr(tick_triage, "_own_session_transcript_path", lambda: path)
+    _patch_issue_state(monkeypatch, "running", [_event("epm:progress v1", 300)])
+    verdict, reason = tick_triage.triage(1689, "issue")
+    assert verdict == "STALE-REDRIVE", (verdict, reason)
+    assert "api-error-after-marker" in reason


### PR DESCRIPTION
Closes task #1695. Auto-filed by /daily route 2 (workflow-fix).

## What changed

1. `scripts/tick_triage.py`: new `api_error_after_marker_reason()` predicate — converts HEALTHY → STALE-REDRIVE when the session transcript tail has an `isApiErrorMessage: true` row NEWER than the latest events.jsonl marker. Reuses the existing `_transcript_tail_rows_1629` reader (no new I/O path). Kill switch `EPM_TICK_API_ERROR_PROBE`. Fail-open on transcript-resolve failure.
2. `scripts/autonomous_session_watch.py`: boot-death lane ARM 2 split into `boot-refusal` (30-min threshold, unchanged) vs `boot-transport` (5-min threshold via `EPM_BOOT_TRANSPORT_MIN_AGE_MIN`) — refusal-wins-on-tie fail-safe; shared day cap invariant preserved.
3. `.claude/skills/issue-tick/SKILL.md`: verdict-vocabulary documentation for `api-error-after-marker`.

## Incidents addressed

- **#1687** — refusal-killed orchestrator turn read as HEALTHY by `tick_triage`, one second before the tick fire (07:54:25Z refusal → 07:54:31Z HEALTHY misread).
- **#1689** — 529 transport-class error mis-classified as `boot-refusal` (~3h1m task-creation-to-real-work; 2h24m of that was the 30-min pre-stop + post-stop grace).

## Testing

- 20 new pin tests (5 tick_triage + 13 watcher + 1 SKILL contract + 1 refactor helper). Full-ruleset ruff clean; `_process_boot_death` complexity ≤15 after round-2 refactor extracting `_boot_death_arm2_shape_and_window()`.
- Step 9c gate: 5962 passed, 6 skipped, 0 failed. COMPARE_RC=0 (no NEW failures, no lint regression).