### PR TITLE
workflow-fix #1697: --map-files timeout dispersion factor (MAP_TIMEOUT_DISPERSION=2.0)

### DIFF
--- a/scripts/select_step9c_tests.py
+++ b/scripts/select_step9c_tests.py
@@ -628,6 +628,18 @@ MAP_TIMEOUT_FLOOR_S = 600  # Step-10d TG-leg floor (#1646; was 300, basis the
 #                            residual load; 600 ~= 3x the measured healthy
 #                            small-map wall (#1634 run 2 passed, TG legs
 #                            174/174 on both trees).
+MAP_TIMEOUT_DISPERSION = 2.0  # p90 dispersion factor on the map path (#1697;
+#                               was implicit 1.0). Two independent same-day
+#                               sessions #1675/#1682 (2026-07-25) hit the
+#                               undersized-bound trap at 728.19s / 751.7s
+#                               measured walls against the 780s formula-derived
+#                               bound (~1.04-1.07x) and each hand-doubled to
+#                               1560s / 1600s to recover. Matches the p90 x2
+#                               default in .claude/rules/plan-compute-sizing.md
+#                               (#833's realized-vs-planned mean overrun of ~2x).
+#                               Applies ONLY on the --map-files path; the diff
+#                               path already carries the per-file SLOW_TESTS
+#                               surcharge (#1646, 1.40x-dispersion-adjusted).
 
 
 def dependency_map_pairs(files: list[str], work_root: Path) -> list[tuple[str, str]]:
@@ -789,19 +801,31 @@ def resolve_base(base: str, work_root: Path, *, fetch: bool = True) -> str:
     return branch
 
 
-def recommended_timeout_s(tests: list[str], *, floor: int = TIMEOUT_FLOOR_S) -> int:
+def recommended_timeout_s(
+    tests: list[str],
+    *,
+    floor: int = TIMEOUT_FLOOR_S,
+    dispersion: float = 1.0,
+) -> int:
     """Deterministic `timeout(1)` bound for a Step 9c gate selection.
 
-    ``BASE + PER_FILE * len(tests) + sum(slow surcharges)``, floored at
-    *floor* (default ``TIMEOUT_FLOOR_S`` — diff-path callers unchanged;
+    ``BASE + PER_FILE * len(tests)`` scaled by *dispersion*, then plus the
+    slow-file surcharges, floored at *floor*.
+    Default ``dispersion=1.0`` keeps the diff-path callers byte-identical;
+    ``--map-files`` mode passes ``dispersion=MAP_TIMEOUT_DISPERSION`` (2.0;
+    #1697) so a healthy leg's bound is ~2x its measured wall, not ~1x.
+    Slow-file surcharges are NOT re-scaled (they already encode a per-file
+    dispersion-adjusted headroom: #1646 pinned `tests/test_workflow_lint.py`
+    at 2400s = 1.40x its 1819s worst measured wall).
+    Default ``floor`` (``TIMEOUT_FLOOR_S``) keeps diff-path callers unchanged;
     ``--map-files`` mode passes ``floor=MAP_TIMEOUT_FLOOR_S``, the Step-10d
-    TG-leg 600 s floor, #1573/#1646). Invariant-only selection (61 files as
+    TG-leg 600 s floor (#1573/#1646). Invariant-only selection (61 files as
     of 2026-07-24, incl. the workflow-lint surcharge) -> 4350 s (72.5 min),
     matching the invariant-set-scale precedents (``step9c_baseline.py
     refresh`` ``--timeout-s`` default 4350 s; the SKILL.md detached
     refresh's 4650 s).
     """
-    t = TIMEOUT_BASE_S + TIMEOUT_PER_FILE_S * len(tests)
+    t = round(dispersion * (TIMEOUT_BASE_S + TIMEOUT_PER_FILE_S * len(tests)))
     t += sum(SLOW_TESTS.get(x, 0) for x in tests)
     return max(t, floor)
 
@@ -1674,7 +1698,11 @@ def main(argv: list[str] | None = None) -> int:
             # TG legs can size their pytest bound from the map (#1573; floor =
             # the pre-#1573 fixed 300 s TG-leg bound).
             k_tests = sorted({t for t, _f in all_pairs})
-            map_timeout = recommended_timeout_s(k_tests, floor=MAP_TIMEOUT_FLOOR_S)
+            map_timeout = recommended_timeout_s(
+                k_tests,
+                floor=MAP_TIMEOUT_FLOOR_S,
+                dispersion=MAP_TIMEOUT_DISPERSION,
+            )
             print(
                 f"select_step9c_tests: map-files — {len(all_pairs)} pairs, "
                 f"{len(k_tests)} tests; recommended-timeout-s={map_timeout}",

--- a/tests/test_select_step9c_tests.py
+++ b/tests/test_select_step9c_tests.py
@@ -1764,7 +1764,7 @@ def test_map_files_sizing_line(tmp_path: Path, capsys):
     assert "recommended-timeout-s=600" in captured.err
     assert not any("\t" in line for line in captured.err.splitlines())
     assert len(captured.out.splitlines()) == 2
-    # 17 tests clear the floor: 120 + 17*30 = 630.
+    # 17 tests clear the floor: (120 + 17*30) * 2.0 dispersion = 1260 (#1697).
     repo17 = _make_import_tree(
         tmp_path / "seventeen",
         {
@@ -1775,7 +1775,7 @@ def test_map_files_sizing_line(tmp_path: Path, capsys):
     rc = sel.main(["--map-files", str(listing), "--repo-root", str(repo17)])
     assert rc == 0
     captured = capsys.readouterr()
-    assert "recommended-timeout-s=630" in captured.err
+    assert "recommended-timeout-s=1260" in captured.err
     assert not any("\t" in line for line in captured.err.splitlines())
 
 
@@ -1791,6 +1791,52 @@ def test_recommended_timeout_s_floor_kwarg():
     expected = sel.TIMEOUT_BASE_S + 40 * sel.TIMEOUT_PER_FILE_S  # 1320 > both floors
     assert sel.recommended_timeout_s(forty, floor=sel.MAP_TIMEOUT_FLOOR_S) == expected
     assert sel.recommended_timeout_s(forty) == expected
+
+
+# --- Case 69-bis (#1697): --map-files dispersion factor ---------------------------
+def test_recommended_timeout_s_map_dispersion():
+    """The --map-files path applies MAP_TIMEOUT_DISPERSION=2.0 to base+per_file,
+    but NOT to the SLOW_TESTS surcharge; diff-path (default dispersion=1.0)
+    stays byte-identical. Ties to #1697 (the #1675/#1682 undersized-bound trap
+    at 780 s vs 728-752 s measured walls, ~1.04-1.07x)."""
+    assert sel.MAP_TIMEOUT_DISPERSION == 2.0
+
+    # The exact #1682/#1675 shape: 26 tests, no SLOW_TESTS members in the map.
+    # NOTE: tests/test_workflow_lint_x{i}.py filenames are NOT in SLOW_TESTS —
+    # only the exact `tests/test_workflow_lint.py` key matches (single-file
+    # per-key surcharge, not a glob-family), so these 26 synthetic tests
+    # contribute 0 surcharge and exercise the base+per_file*dispersion path
+    # cleanly.
+    twenty_six = [f"tests/test_workflow_lint_x{i}.py" for i in range(26)]
+    # Base+per_file only: 120 + 30*26 = 900. Times 2.0 dispersion = 1800.
+    assert (
+        sel.recommended_timeout_s(
+            twenty_six, floor=sel.MAP_TIMEOUT_FLOOR_S, dispersion=sel.MAP_TIMEOUT_DISPERSION
+        )
+        == 1800
+    )
+    # Diff-path default: dispersion=1.0, byte-identical to today's arithmetic.
+    assert sel.recommended_timeout_s(twenty_six) == 900
+
+    # SLOW_TESTS surcharge is NOT re-scaled by dispersion (already headroom'd).
+    with_wl = [*twenty_six, "tests/test_workflow_lint.py"]
+    # Dispersed base: (120 + 30*27) * 2 = 1860. Plus 2400 surcharge = 4260.
+    expected_map = (
+        round(sel.MAP_TIMEOUT_DISPERSION * (sel.TIMEOUT_BASE_S + 27 * sel.TIMEOUT_PER_FILE_S))
+        + sel.SLOW_TESTS["tests/test_workflow_lint.py"]
+    )
+    assert (
+        sel.recommended_timeout_s(
+            with_wl, floor=sel.MAP_TIMEOUT_FLOOR_S, dispersion=sel.MAP_TIMEOUT_DISPERSION
+        )
+        == expected_map
+    )
+    assert expected_map == 4260  # explicit sanity — 1860 + 2400
+
+    # Diff-path with SLOW_TESTS unchanged: 120 + 30*27 + 2400 = 4130.
+    assert sel.recommended_timeout_s(with_wl) == (
+        sel.TIMEOUT_BASE_S + 27 * sel.TIMEOUT_PER_FILE_S + 2400
+    )
 
 
 # --- Case 70: dependency_map_pairs unit — import + literal + stem union, sorted ----


### PR DESCRIPTION
## Summary

Adds a p90 dispersion margin (×2) to the `--map-files` `recommended_timeout_s` sizing on the Step-10d TG leg, so a healthy gate leg's bound is ~2× its measured wall (matching the project's own `.claude/rules/plan-compute-sizing.md` § p90 dispersion default) rather than the current ~1×.

**Delivered:**
- New constant `MAP_TIMEOUT_DISPERSION = 2.0` in `scripts/select_step9c_tests.py`.
- `recommended_timeout_s` gets a new keyword-only `dispersion: float = 1.0` arg; body applies `round(dispersion * (base + per_file * N))` before the unchanged `SLOW_TESTS` surcharge sum.
- The `--map-files` call site passes `dispersion=MAP_TIMEOUT_DISPERSION`; the diff-path call at L1725 keeps the default and stays byte-identical.
- Pin test `tests/test_select_step9c_tests.py::test_recommended_timeout_s_map_dispersion` (Case 69-bis) locks the new behaviour with three orthogonal assertions.
- Mechanical Case 68 update: expected `recommended-timeout-s=630` → `1260` (same-commit landing).

**Grounding:** two independent same-day sessions (#1675, #1682) hit the undersized-bound trap at 728.19s / 751.7s measured walls against the same 780s formula-derived bound (~1.04–1.07×) and each hand-doubled to 1560s / 1600s to recover; the ×2 factor codifies that convergent expert calibration together with the standing p90-dispersion rule.

**Field-verified acceptance:**

    $ uv run python scripts/select_step9c_tests.py --map-files /tmp/issue-1682-touched.txt
    select_step9c_tests: map-files — 26 pairs, 26 tests; recommended-timeout-s=1800

(up from 900s, 2.39× the measured #1682 wall of 751.7s).

## Test plan

- [x] `uv run pytest tests/test_select_step9c_tests.py -q` → 129 passed
- [x] Step 9c test-verdict gate: 4743 passed, 6 skipped, 0 new failures, 0 lint regressions (Compare `new: []`, `stripped: []`, `lint.ok: true`)
- [x] Ruff check + format clean on both touched files
- [x] Pin test discriminates: 26-test map returns 1800 (dispersion), 900 (default), 4260 (with SLOW_TESTS + dispersion), 4130 (with SLOW_TESTS default)
- [x] `origin/issue-865` (sibling on same file, disjoint function) — verified no collision

Closes task #1697.