### PR TITLE
issue-1696: guard-surface reviewer posts verdict first

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -940,6 +940,145 @@ verify crawl wedged a live A100 run in 429 storms). Record
 `Hub-call-scoping sub-check: N/A — no data-repo Hub calls in diff` when
 absent. Full listings of the SMALL model repo are fine — data repo only.
 
+### Step 0.69: Phase-idempotency + inter-phase-contract gate (any diff type; multi-phase dispatchers only)
+
+A phased dispatcher that lacks skip-if-output-exists is the recurring paid-API
+spend leak: a downstream vLLM crash restarts the pipeline from the top, re-running
+a paid-Anthropic / paid-OpenAI phase whose artifacts already sit on HF. And a
+consumer phase that asserts its input JSONL contract AFTER model initialization
+turns a schema mismatch into a wasted GPU cycle (the #1689 shape: 79,800 rows
+rendered, vLLM initialized, then `ValueError: The decoder prompt cannot be
+empty` — 33% of rows resolved to `messages: [...]` with no `prompt_text` — after
+the pod was billing). Both are code-review-time catchable from the dispatcher
+diff alone. This gate is the review-side sibling of `.claude/rules/code-style.md`
+line 53 (checkpoint-per-phase, ADVISORY-prose): the rule exists, and this gate
+enforces it on dispatcher diffs.
+
+**Trigger — does the diff add/modify a multi-phase dispatcher?** Grep the diff
+for a phase-dispatch shape:
+
+```bash
+# Bash entrypoint dispatchers (issue<N>_dispatch.sh, one line per phase):
+grep -nE '^phase_[a-z0-9_]+\s*\(\)|^case .* in$|_run_phase [a-z0-9_]+' <each dispatcher .sh in diff>
+# Python phase-loop dispatchers (`for phase in PHASES`, `if args.phase == 'a'`):
+grep -nE 'def phase_[a-z0-9_]+|PHASES *= *\[|args\.phase|--phase' <each dispatcher .py in diff>
+```
+
+Multi-phase = >1 phase name. Not a trigger — a single-entrypoint script or a
+one-phase run: record `Step 0.69: N/A — diff carries no multi-phase dispatcher`
+and proceed.
+
+**Sub-check (1) — phase-level skip-if-output-exists.** For each phase, verify
+ONE of the two patterns holds by reading the phase entry body:
+
+- **(a) Sentinel/output-artifact skip.** The phase body checks a declared
+  completion-sentinel or primary-output path at entry
+  (`[ -e "$OUT/phaseA_done" ] && { echo "[phaseA] skip — sentinel exists"; return; }`,
+  or a Python `if OUT.exists() and not args.force: return`). Bare file existence
+  is ACCEPTABLE only when the phase writes its output atomically-then-renames
+  (`os.replace` or `mv` of a tmp file) — otherwise the sentinel discipline of
+  CLAUDE.md § Monitoring re-run discipline applies (never key "done" on a
+  half-written file). Prefer a completion sentinel over a bare glob.
+- **(b) First-class `--force` (or equivalently-named) flag.** The dispatcher
+  accepts `--force` / `--rerun` / `--no-skip` / `--overwrite` (or the same as
+  an env var like `FORCE_PHASE=1`) whose DEFAULT is OFF and whose value is
+  threaded through the phase entry — so a deliberate rerun stays first-class.
+  A phase that ALWAYS re-runs (no sentinel check AND no force flag) FAILs
+  this sub-check.
+
+Waiver form (mirrors `# CVD_PIN_EXEMPT: <reason>` from
+`.claude/rules/gotchas.md`): a phase legitimately non-idempotent by nature (a
+stochastic sampling phase whose output is per-run, an eval whose "done" state
+is a WandB run id, etc.) carries `# PHASE_IDEMPOTENCY_EXEMPT: <reason ≥ 20 chars>`
+on the phase entry's signature line. A waiver ≥ 20 chars is credited PASS.
+
+**Verdict routing — sub-check (1):**
+
+- Phase ships with (a) or (b) or a valid waiver → PASS this sub-check.
+- **Phase makes paid API calls** (Anthropic/OpenAI/HF inference — grep the
+  phase transitively for `anthropic.Anthropic`, `openai.OpenAI`,
+  `api_dispatch.dispatch_judge_items` / `batch_judge` / `judge_completions_batch`,
+  `openai.chat.completions.create`, or the plan §9 marks the phase `paid`) OR
+  **holds a GPU** (grep for `vllm`, `AutoModel.from_pretrained`, `train_lora`,
+  `LLM(`, `torch.cuda`, `accelerate launch`) AND ships without (a)/(b)/waiver →
+  return verdict FAIL with a single `Critical` issue tagged `phase-not-idempotent`
+  (SUBSTANTIVE — never stripped by Step 5c-bis), AND still read the diff and
+  report substantive findings in the same pass (do not short-circuit — see
+  Step 0.7):
+
+  > `epm:experiment-implementation v<n>`'s dispatcher `scripts/<file>` phase
+  > `<name>` makes paid API calls (or holds a GPU) but has no skip-if-output-exists
+  > guard and accepts no `--force`/`--rerun` flag. A downstream crash re-runs it
+  > from scratch, re-spending its API budget (or re-holding its GPU) each cycle
+  > — the #1689 shape (4× re-runs of the same 3-condition × 3800-row Sonnet
+  > phase across crash-fix relaunches). Re-post `v<n+1>` adding EITHER a
+  > completion-sentinel check at phase entry (`[ -e "$SENTINEL" ] && return`)
+  > OR a first-class `--force`-family flag (defaulting OFF), threaded through
+  > the phase entry. Prefer a completion sentinel over bare file existence
+  > (CLAUDE.md § Monitoring re-run discipline). A legitimately
+  > non-idempotent phase carries `# PHASE_IDEMPOTENCY_EXEMPT: <reason ≥ 20c>`
+  > on its entry.
+
+- Phase is cheap CPU-only (no paid API, no GPU) AND ships without (a)/(b)/waiver
+  → CONCERN bullet under "Issues Found"; NOT a standalone FAIL. Persist via
+  `task.py raise-concern` per Step 0.8 / Rule 11 so the concern actually binds.
+
+**Sub-check (2) — consumer inter-phase contract assertion.** For each phase
+whose INPUT is another phase's persistent output (a JSONL / parquet / npz file
+the earlier phase wrote), READ the consumer phase's entry:
+
+- The consumer asserts every required input field non-empty (`assert
+  row['prompt_text']` — never a silent `row.get('prompt_text', '')` chained to a
+  filter), reports drop counts (`n_dropped > 0 → fail loud with the drop
+  fraction`, per `.claude/rules/llm-judging.md` rule 9's drop-never-coerce
+  discipline and CLAUDE.md § Critical Rules "Fail fast"), and does the check
+  BEFORE any heavy initialization: `AutoModel.from_pretrained`, `LLM(`,
+  `accelerate launch`, `torch.distributed.init_process_group`, first GPU-tensor
+  allocation.
+- **Verdict routing — sub-check (2):**
+  - Contract assertion present + fail-loud + BEFORE model init → PASS.
+  - Assertion present but AFTER model init → verdict FAIL with a single
+    `Critical` issue tagged `consumer-contract-post-init` (SUBSTANTIVE, never
+    stripped):
+
+    > `epm:experiment-implementation v<n>`'s consumer phase `<name>` reads
+    > `<producer_output.jsonl>` and initializes vLLM / AutoModel before checking
+    > the input contract. A schema mismatch (missing field, empty row) then
+    > wastes a pod cycle rather than seconds of CPU (the #1689 shape: 79,800
+    > render rows, vLLM initialized, then died on 33% empty `prompt_text` — one
+    > `.get()` with no assert). Re-post `v<n+1>` moving the assertion above the
+    > model init call: `assert all(r['prompt_text'] for r in rows), f'{sum(1
+    > for r in rows if not r.get(\"prompt_text\")):d} rows empty'` (fail loud;
+    > no silent drop, no default fill).
+
+  - Assertion silently drops / defaults / substring-matches → CONCERN bullet,
+    persisted via `task.py raise-concern` (contract enforcement present but
+    permissive enough that a schema mismatch could mask itself).
+  - No assertion + consumer initializes heavy state → same FAIL as above.
+
+**Fingerprint-of-degradation.** A gate that cannot NAME the expected phase
+output artifact degrades to a judgement call (task-body constraint). This gate
+credits an artifact name from THREE sources, in order: (i) the plan §9
+`phase_outputs:` map (planner.md §9 requirement, see the sibling planner-side
+edit), (ii) a `--out-root` / `--sentinel` flag the dispatcher exposes, (iii)
+a plan-body `**Design:**` / `**Methodology:**` section explicitly naming the
+output. If NONE of the three exist, record `Step 0.69: unable to verify —
+plan/diff names no phase output artifact` (a CONCERNS bullet, NOT a FAIL — the
+gate is designed to degrade gracefully; the sibling planner.md §9 edit is what
+raises the artifact-name floor over time, without ratcheting this gate to a
+false FAIL). This matches Step 0.65's "necessary-but-not-sufficient grep"
+caution and Step 0.67's "plausible-but-unconfirmed" pattern (CONCERNS not FAIL).
+
+Record the verdict as one line: `Step 0.69: PASS — <N> phases idempotent, <M>
+consumers assert contract early`, `Step 0.69: FAIL — <phase> not idempotent /
+<phase> contract post-init`, `Step 0.69: CONCERNS — <one-liner>`, or `Step
+0.69: N/A — no multi-phase dispatcher in diff`.
+
+Sibling: this gate reads dispatcher SHAPE for idempotency; Step 3.6 reads
+long-loop RESTARTABILITY (>~1h serial loops must persist + resume) — the two
+compose (a Step 0.69-idempotent phase's inner loop still owes Step 3.6's
+intra-phase checkpointing).
+
 ### Step 0.7: Pre-diff gates never short-circuit the diff
 
 Steps 0.5, 0.55, 0.6, 0.65, and 0.67 are pre-diff *contract* checks, not a

--- a/.claude/agents/codex-code-reviewer.md
+++ b/.claude/agents/codex-code-reviewer.md
@@ -419,6 +419,14 @@ both reviewers are graded against the same standard. Read
   data-repo Hub calls). Copy in full so Codex never
   re-derives a narrower check (incident #823: round-1 plan-adherence blessed
   the slow import while the body named the fast twin).
+- **Step 0.69 — Phase-idempotency + inter-phase-contract gate** — for every
+  multi-phase dispatcher in the diff, verify each phase (a) checks a
+  completion-sentinel / output-artifact at entry (or accepts `--force`) and
+  (b) any consumer phase asserts its input JSONL contract BEFORE model init.
+  BLOCKER (`phase-not-idempotent`) for paid-API / GPU-holding phases without
+  a skip/force; BLOCKER (`consumer-contract-post-init`) for post-init
+  contract asserts. CONCERN for the cheap-CPU or permissive variants.
+  Full rubric: inlined from `.claude/agents/code-reviewer.md` Step 0.69.
 - "Step 0.7: Mechanical-contract gates never short-circuit the diff" — the two
   hard rules (a FAIL must carry a genuine-absence blocker OR a substantive
   finding; always read the diff even when raising a 0.5 / 0.6 / 0.65

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -443,6 +443,16 @@ Compute-sizing recipes: `.claude/rules/plan-compute-sizing.md`
 (on-demand); phase placement + GPU-width right-sizing are always-on in
 CLAUDE.md § Pods.
 
+Phase-output declaration (idempotency gate at code review): a plan whose §9
+per-component compute-projection table lists MORE THAN ONE phase MUST carry a
+fenced `phase_outputs:` map in this section — per phase: `sentinel` (the
+completion-sentinel path the phase writes atomically at end) OR `outputs`
+(the primary output artifact(s) the phase produces). This gives the
+code-reviewer's Step 0.69 (Phase-idempotency + inter-phase-contract gate) a
+concrete artifact to grep the dispatcher against; a single-phase run omits the
+block entirely. Template + worked example:
+`.claude/rules/planner-section-reference.md` § 9 (phase_outputs).
+
 Phase-ORDER expensive-intermediate persistence: the §9 phase sequence names
 the upload point of every regeneration-costly intermediate (extraction /
 activation store, capture, rollout set) BEFORE — or detached-concurrent

--- a/.claude/rules/trigger-dense-review.md
+++ b/.claude/rules/trigger-dense-review.md
@@ -63,6 +63,28 @@ reviewers never attempt model pins themselves (pins live on the Agent call).
    Step 5b). In-context modes (adversarial-planner Phase 2 lenses;
    reconciler `mode: in-context`) have no marker: put the role-tagged
    verdict block FIRST in the returned text, any extra prose after it.
+   **Guard/hook-surface rounds — file-first ordering (post-marker before
+   composing the report; #1673/#1675/#1676/#1687).** On a trigger-dense
+   round targeting `.claude/hooks/*.sh` or `scripts/guard_*.sh`, the
+   verdict body is composed DIRECTLY into its file via the `Write` tool —
+   never as inline assistant text or reasoning first — then posted with
+   `uv run python scripts/task.py post-marker <N> epm:code-review
+   --version <K> --file <path>` (or the reconciler analogue
+   `epm:review-reconcile`; `--file`, never `--note`, because the marker
+   body itself is trigger-dense and must ride the file path). The
+   reviewer's ordered tool-call sequence on such rounds is `Write` (verdict
+   file) → `Bash` (post-marker `--file`) → return text; composing the
+   verdict body as inline assistant text on a turn that then gets killed
+   by the filter destroys the verdict before it ever reaches the file
+   (four refusal kills on the #1667–#1689 wave: #1673, #1675 15 tool calls
+   in, #1676 24 tool calls in, #1687 on the orchestrator turn itself).
+   The in-context RETURN TEXT (marker mode) or the role-tagged verdict
+   block (in-context mode) is composed AFTER the marker lands and stays
+   under the discipline 4 shape (verdict + pointer + counts, no findings
+   recap). Pairs with SKILL.md Step 5b's durable-verdict-first probe: with
+   the marker landed first, a final-turn refusal costs the summary
+   (recoverable via a discipline-4-clean re-post or the orchestrator's
+   own summary composition) rather than the verdict (a full respawn).
 3. **Windowed reads; excerpts over originals.** Prefer orchestrator-provided
    pre-materialized excerpt files with stated read budgets when the brief
    names them. Reading the artifact directly: Grep for the finding's anchor

--- a/.claude/skills/issue/clarifier.md
+++ b/.claude/skills/issue/clarifier.md
@@ -100,6 +100,19 @@ for the gaps that remain:
    discoverable. `Grep` for the symbol/module the issue mentions before asking
    "which files are in scope".
 
+6. **Guard/hook file reads — WINDOWED, never wholesale.** When the issue body
+   names a target under `.claude/hooks/` or `scripts/guard_*.sh`, do NOT
+   wholesale-`Read` the file. `Grep` for the anchor (function name, error
+   string, blocked pattern) first, then `Read` with `offset=<line>`
+   `limit=~120`. The `guard_trigger_dense_read.sh` PreToolUse hook
+   mechanically blocks unbounded reads of those targets at runtime; a
+   wholesale attempt wastes a tool call (incident #1676 clarifier turn: a
+   whole-file `Read` of `guard_root_code_commit.sh` was BLOCKED by the
+   hook). Counts/structure only (`wc -l`, `grep -c`, `git diff --stat`)
+   never trip. Full rule: `.claude/rules/trigger-dense-review.md`
+   § Orchestrator ordinary turns (windowed-read discipline 3, generalized
+   here to context-gathering).
+
 After this pass, write a short internal note (NOT posted to the issue unless
 the user asks for it) of the form:
 

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -11763,19 +11763,22 @@ AGENT_SPEC_SIZE_GRANDFATHER: dict[str, int] = {
     # (#1159) — no longer grandfathered (slim spec is under the FAIL threshold).
     # the rest measured at the #838 tightening (2026-07-02), caps = measured
     # + <=3 KB; each names a future trim direction, none is licensed to grow
-    # measured 112,177 B post-#1692 (Step 0.55 SHAPE-check binding: per-arm
-    # attestation-row consistency + import-resolution three-shape gate for
-    # the smoke-architecture-check marker — plan-mandated growth; cap =
-    # measured + ~0.3 KB. Prior: 110,300 — measured 109,583 B post-#1449
-    # (Step 0.65 plan-glob vs uploader-eligibility parity sub-check),
-    # 108,000 — measured 106,853 B post-#1397 (Step 2 fit-loop
-    # batched-helper naming paragraph), 105,000 — measured 104,235 B
-    # post-#1317 (Step 4.6 Gate-scope line verification), 101,500 —
+    # measured 120,709 B post-#1693 (Step 0.69 phase-idempotency +
+    # inter-phase-contract gate — plan-mandated growth atop #1692's
+    # Step 0.55 SHAPE-check binding; cap = measured + ~0.6 KB. Prior:
+    # 112,500 — measured 112,177 B post-#1692 (Step 0.55 SHAPE-check
+    # binding: per-arm attestation-row consistency + import-resolution
+    # three-shape gate for the smoke-architecture-check marker),
+    # 110,300 — measured 109,583 B post-#1449 (Step 0.65 plan-glob vs
+    # uploader-eligibility parity sub-check), 108,000 — measured
+    # 106,853 B post-#1397 (Step 2 fit-loop batched-helper naming
+    # paragraph), 105,000 — measured 104,235 B post-#1317 (Step 4.6
+    # Gate-scope line verification), 101,500 —
     # measured 100,555 B post-#1254 (Step 3.9 degenerate-statistic check,
-    # observed-vs-null reads), 99,000 — measured 98,126 B post-#1230
-    # (Step 6 durability-pin shipping duty), 97,000 — measured 96,072 B
-    # post-#1119, 95,000 — measured 94,126 B post-#1115)
-    "code-reviewer.md": 112_500,
+    # observed-vs-null reads), 99,000 — measured 98,126 B post-#1230 (Step 6
+    # durability-pin shipping duty), 97,000 — measured 96,072 B post-#1119,
+    # 95,000 — measured 94,126 B post-#1115)
+    "code-reviewer.md": 121_300,
     # measured 74,082 B post-#1447 (family-enumeration sync: the two
     # byte/bit verdict rows widened to the -exact / bitwise / X-for-X
     # tail — plan-mandated growth; cap = measured + ~1.1 KB. Prior:
@@ -11785,14 +11788,16 @@ AGENT_SPEC_SIZE_GRANDFATHER: dict[str, int] = {
     # 72,229 B post-#1056, 72,000 post-#1050 r2, 71,000 post-#1050 r1,
     # 60,554 B pre-#1050)
     "codex-clean-result-critic.md": 75_200,
+    # measured 59,576 B post-#1693 (Step 0.69 mirror paragraph pointing at
+    # code-reviewer.md's phase-idempotency + inter-phase-contract gate —
+    # plan-mandated growth; cap = measured + ~1.2 KB. Prior: 59,200 —
     # measured 58,271 B post-#1438 (Step 0.9 copy-list bullet + inlined-
-    # rubric 0.9 slot + Blocker-tags data-access-blocked entry —
-    # plan-mandated growth; cap = measured + <=~1 KB. Prior: 56,800 —
-    # measured 55,870 B post-#1380 (Step 4.6 copy-list bullet +
+    # rubric 0.9 slot + Blocker-tags data-access-blocked entry),
+    # 56,800 — measured 55,870 B post-#1380 (Step 4.6 copy-list bullet +
     # inlined-rubric 4.6 slot + Blocker-tags 4.6-presence), 53,300 —
     # measured 52,361 B post-#1254, 51,600 — measured 50,642 B post-#948,
     # 47,930 B post-#881)
-    "codex-code-reviewer.md": 59_200,
+    "codex-code-reviewer.md": 60_800,
     # measured 76,274 B post-#1692 (item 5 Axis 1 import-resolution leg,
     # Axis 2 per-arm resolution attestation, PASS_PARTIAL verdict +
     # post-marker template extension — plan-mandated growth; cap =


### PR DESCRIPTION
Closes task #1696.

**What:** on a guard/hook-surface round the reviewer composes its verdict body directly into a file via the `Write` tool, then posts the marker via `task.py post-marker --file` BEFORE composing any return text. Clarifier reads `.claude/hooks/` / `scripts/guard_*.sh` targets windowed.

**Why:** the 2026-07-25 wave (#1673/#1675/#1676/#1687) surfaced four spurious usage-policy refusals at reviewers' final turns after 15-24 tool calls. Discipline 2 already ordered "post marker BEFORE closing chat text" but did NOT bar composing the verdict body INLINE in assistant text before the file write; the added clause names the composition-mode failure mode.

**Diff:** +35 / -0 lines across 2 files.

## Test plan
- [x] `verify_plan.py --issue 1696` PASS (Phase 1.5.0)
- [x] 3 adversarial-planner lens critics APPROVE
- [x] `code-reviewer` Claude PASS (Codex twin skipped — quota LIVE)
- [x] Step 9c test-verdict: 4475 passed / 6 skipped in 23:25; compare_rc=0 (no new failures, no lint regression)
- [x] Step 10d pre-push workflow-lint gate PASS

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>