### PR TITLE
task #1709: widen Step 5a SPECS family to :(glob)tests/test_guard_*.py

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -2239,14 +2239,14 @@ already runs on `main`):
 WT=$(git rev-parse --show-toplevel)
 # Lint/guard family rides the sync (#1560): the specs synced below are budget-
 # checked by workflow_lint.py constants, enforced by .claude/hooks/, and pinned
-# by the test_workflow_lint*/test_guard_lessons_edit pin tests — syncing
+# by the test_workflow_lint*/test_guard_* pin tests — syncing
 # specs without their enforcing family creates the #1489/#1482/#1417 vintage
 # skew. `:(glob)` is a git pathspec (never shell-expands: no path starts with
 # ":(glob)"), so `git checkout main --` matches main-NEW pin tests too. The
 # per-file branch-side-edit guard's skip grain is PER-ITEM: a branch editing
 # ONE pin test skips the whole `:(glob)` family entry (fail-safe — status-quo
 # staleness for those files, never a clobber).
-SPECS=".claude/agents .claude/skills .claude/rules .claude/workflow.yaml CLAUDE.md scripts/workflow_lint.py .claude/hooks tests/test_guard_lessons_edit.py :(glob)tests/test_workflow_lint*.py"
+SPECS=".claude/agents .claude/skills .claude/rules .claude/workflow.yaml CLAUDE.md scripts/workflow_lint.py .claude/hooks tests/test_guard_lessons_edit.py :(glob)tests/test_workflow_lint*.py :(glob)tests/test_guard_*.py"
 MB=$(git -C "$WT" merge-base HEAD main)
 SAFE_SPECS=""
 for f in $SPECS; do
@@ -2305,7 +2305,7 @@ safely override the skip for those specific files with a manual
 **The sync scope is specs + the spec-coupled lint/guard family — do NOT
 extend it further into `scripts/`, `tests/`, or `src/`.** The family
 exception (#1560: `scripts/workflow_lint.py`, `.claude/hooks`,
-`tests/test_guard_lessons_edit.py`, `:(glob)tests/test_workflow_lint*.py`)
+`:(glob)tests/test_guard_*.py`, `:(glob)tests/test_workflow_lint*.py`)
 exists because those files execute FROM the worktree tree on four
 surfaces — the Step 10d TG legs, worktree pytest / Step 9c, the hooks'
 own-tree `workflow_lint` import, and the inline gate invoked in a

--- a/tests/test_issue_skill_lint_family_sync.py
+++ b/tests/test_issue_skill_lint_family_sync.py
@@ -2,12 +2,12 @@
 
 #1560 (2026-07-20) extended the Step 5a spec-freshness sync to cover the
 lint/guard family (scripts/workflow_lint.py, .claude/hooks, the
-test_guard_lessons_edit / test_workflow_lint* pin tests), subject-scoped the
+test_guard_* / test_workflow_lint* pin tests), subject-scoped the
 sync's per-file branch-side-edit exclusion (the Guard-3 convention), and
 added a mandatory pre-gate freshness re-sync against fetched origin/main to
 the Step 10d pre-push workflow-lint gate — closing the branch-era-linter
 vintage-skew class that red the gate three times on 2026-07-19
-(#1489 / #1482 / #1417).
+(#1489 / #1482 / #1417 / #1675→#1682).
 
 These tests fail the suite if a later SKILL.md editor drops the family
 entries, the boundary-paragraph family exception, the pre-gate re-sync
@@ -64,11 +64,14 @@ def test_step5a_specs_include_lint_family():
     assert (
         'SPECS=".claude/agents .claude/skills .claude/rules .claude/workflow.yaml '
         "CLAUDE.md scripts/workflow_lint.py .claude/hooks "
-        'tests/test_guard_lessons_edit.py :(glob)tests/test_workflow_lint*.py"'
+        "tests/test_guard_lessons_edit.py :(glob)tests/test_workflow_lint*.py "
+        ':(glob)tests/test_guard_*.py"'
     ) in _text(), (
         "Step 5a SPECS must carry the #1560 lint/guard family "
-        "(workflow_lint.py, .claude/hooks, test_guard_lessons_edit.py, "
-        "the :(glob) test_workflow_lint* pin-test family)"
+        "(workflow_lint.py, .claude/hooks, the :(glob) test_workflow_lint* "
+        "and :(glob) test_guard_* pin-test families) — the guard-family "
+        "widening pinned by #1709 covers all tests/test_guard_*.py "
+        "(vintage-skew class #1489/#1482/#1417/#1675→#1682)"
     )
 
 


### PR DESCRIPTION
## Summary

Widens the Step 5a/10d spec-freshness `SPECS` family list in `.claude/skills/issue/SKILL.md:2249` from a single exact `tests/test_guard_lessons_edit.py` entry to also cover the entire `:(glob)tests/test_guard_*.py` family (9 files), plus updates the paired pin test literal.

Closes the vintage-skew class the parked candidate from #1682 named — an in-flight worktree that re-syncs `.claude/hooks/guard_piped_git_push.sh` from `origin/main` now pulls its paired `tests/test_guard_piped_git_push.py` too (or defers via the per-file branch-side-edit guard), instead of stranding new-hook-with-old-test at any spec-freshness sync. This same vintage-skew shape was rediscovered independently on #1679/#1680/#1681/#1682 the same day (2026-07-25, ≈81 min lost across 4 sessions), which is the argument for fixing the family list rather than documenting a workaround.

## Changes

- SKILL.md: 3 lines (`+3/-3`) — the SPECS shell variable (line 2249), the preamble comment enumeration (line 2242), the mirroring family-exception prose (line 2308).
- `tests/test_issue_skill_lint_family_sync.py`: 8 lines (`+8/-5`) — the `test_step5a_specs_include_lint_family` literal + assertion message + module-docstring incidents/family enumeration.

The pre-existing exact `tests/test_guard_lessons_edit.py` entry is KEPT (not dropped) for its finer per-item skip grain — the redundant checkout of the same path is a git no-op.

## Test plan

- [x] `tests/test_issue_skill_lint_family_sync.py` — 8/8 PASS (updated pin test)
- [x] `tests/test_select_step9c_tests.py` — 129/129 PASS (selector semantics unaffected)
- [x] `scripts/workflow_lint.py` no-flags + `--check-references --check-asks --check-tables` PASS
- [x] Step 9c gate: 4496 passed, 6 skipped in 25 min; compare `stripped: []`, `new: []`
- [x] Pre-push workflow-lint gate: PASS (SHA-bound `9ae4377cb4`)
- [x] Code-review (Claude-only; Codex quota outage per #1204 sentinel until 2026-08-06): PASS

## Related

- Parked candidate: task #1682 events.jsonl @ 2026-07-25T17:42:14Z
- Filed by: `/daily` 2026-07-25 route-2 (`daily-auto-filed` tag)
- Vintage-skew class: #1489, #1482, #1417, #1675 (paired hook+test commit), #1679, #1680, #1681, #1682

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>