### PR TITLE
task #1713: restore check_inline_round_duty_mirror + Step 10d lost-update guard

### DIFF
--- a/.claude/rules/workflow-fix-on-bug.md
+++ b/.claude/rules/workflow-fix-on-bug.md
@@ -756,10 +756,16 @@ executable-tested (`tests/test_workflow_fix_dedup.py`
 is a CURRENTLY-FAILING test on origin/main has fleet-wide per-hour cost
 (every intervening session's Step 9c gate must re-classify the red;
 incident #1643: an 07:08Z park's red lived ~11.5h to #1666's merge). When
-the parking session has direct evidence of a live red (e.g. its own Step
-9c gate classified the node pre-existing-red against the baseline ledger),
-it SHOULD park in the MECHANICALLY ROUTABLE form: the formal candidate
-block PLUS three fields inside it —
+the parking session has direct evidence of a live red — its own Step 9c
+gate has classified the node pre-existing-red against the baseline
+ledger — it MUST park in the MECHANICALLY ROUTABLE form (the three
+fields below); a prose "noted for /daily follow-up" terminal
+disposition is banned in this evidence-strong case (SKILL.md Step 9c
+"Verdict" block, #1713). Sessions WITHOUT direct Step 9c evidence
+retain the SHOULD form (their claim cannot be verified within a tick
+without a bounded pytest run; the router still verifies before
+filing). The routable form is the formal candidate block PLUS three
+fields inside it —
 
 ```
 urgency: main-red

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -10113,6 +10113,77 @@ rebase-merged. Three guards:
    its `origin/main...HEAD` diff carries the whole `#472` parent
    payload, failing the content check.)
 
+4. **Lost-update refusal (shared workflow-surface files).** A branch
+   whose copy of a SHARED workflow-surface file predates a sibling's
+   already-merged additions can carry a whole-file snapshot that
+   silently DROPS lines that landed on `origin/main` after the branch's
+   merge-base — no conflict, no warning, hard to spot in the diff,
+   catastrophic when it drops a bundled `workflow_lint.py` check or an
+   operational SKILL.md guardrail (incident #1701 → #1698, 2026-07-26:
+   153 lines of `check_inline_round_duty_mirror` deleted 45 min after
+   they landed, breaking full-suite collection fleet-wide for ~15.5 h;
+   #1713 encodes this guard as the mechanical backstop). Refuse the
+   merge with a loud message when the shape is detected.
+
+   Scope: `scripts/workflow_lint.py`, `.claude/skills/**/SKILL.md`,
+   `.claude/rules/*.md`, `.claude/workflow.yaml`, `CLAUDE.md`. Predicate:
+   for every branch-touched path in that scope, enumerate the lines
+   `origin/main` ADDED since the merge-base (post-merge-base additions
+   only — never `main`'s own pre-fork content), then check whether each
+   such line is present in the branch's current version of that file
+   (`grep -Fxq` — full-line, fixed-string, so quoting or partial
+   substring matches cannot mask a drop). A missing line is by
+   definition a main-side addition the branch's snapshot silently
+   REVERTED — a legitimate branch DELETION of a pre-existing function
+   is NOT this class, because those lines were never main-side
+   additions past the merge-base. Kill switch:
+   `EPM_SKIP_LOST_UPDATE_GUARD=1` (document the reason on the
+   `epm:merged` note when used — e.g. the branch DELIBERATELY reverts
+   a merged sibling per a user directive).
+
+   ```bash
+   if [ -z "${EPM_SKIP_LOST_UPDATE_GUARD:-}" ]; then
+     MB=$(git -C "$WT" merge-base HEAD origin/main)
+     LOST_UPDATE_PATHS=""
+     while IFS= read -r P; do
+       case "$P" in
+         scripts/workflow_lint.py|.claude/skills/*|.claude/rules/*|.claude/workflow.yaml|CLAUDE.md)
+           MAIN_ADDS=$(git -C "$WT" diff --numstat "$MB" origin/main -- "$P" \
+             | awk '{print $1+0}')
+           if [ "${MAIN_ADDS:-0}" -gt 0 ]; then
+             git -C "$WT" diff "$MB" origin/main -- "$P" \
+               | grep -E '^\+[^+]' | sed 's/^\+//' > /tmp/1713-main-adds.txt
+             MISSING_ON_BRANCH=0
+             while IFS= read -r ADD_LINE; do
+               [ -z "$ADD_LINE" ] && continue
+               if ! git -C "$WT" show HEAD:"$P" 2>/dev/null \
+                    | grep -Fxq "$ADD_LINE"; then
+                 MISSING_ON_BRANCH=$((MISSING_ON_BRANCH + 1))
+               fi
+             done < /tmp/1713-main-adds.txt
+             if [ "$MISSING_ON_BRANCH" -gt 0 ]; then
+               LOST_UPDATE_PATHS="$LOST_UPDATE_PATHS $P(${MISSING_ON_BRANCH})"
+             fi
+           fi
+           ;;
+       esac
+     done < <(git -C "$WT" diff --name-only "$MB"...HEAD)
+     if [ -n "$LOST_UPDATE_PATHS" ]; then
+       echo "LOST-UPDATE REFUSAL (Guard 4, #1713): branch carries a" \
+            "whole-file snapshot dropping main-side additions on:" \
+            "$LOST_UPDATE_PATHS" >&2
+       echo "Recovery: rebase onto origin/main and re-apply the intended" \
+            "edits by explicit path; post epm:merge-failed v1" \
+            "(reason: lost-update, paths=$LOST_UPDATE_PATHS)."
+       false
+     fi
+   fi
+   ```
+
+   Non-workflow-surface files stay covered by Guards 1-3 alone; Guard 4
+   focuses the scan on the files whose silent-revert blast radius is
+   fleet-wide.
+
 #### Fast-path routing pre-check (workflow-fix / small-ADDED-diff far-behind branches)
 
 Run this AFTER guards 1-3 and BEFORE the safe-case `gh pr merge $MERGE_FORM`
@@ -10866,6 +10937,30 @@ tests BEFORE anything lands:
      an unconditional block-path verdict: fix the crash cause in the
      worktree, re-run the gate ONCE; still crashing → the SAME
      `epm:merge-failed v1` handling as case 1. Never merge/push on `crash`.
+- **Mandatory urgent-park emission on workflow-surface pre-existing red
+  (#1713).** Whenever the gate's `pass` verdict rests on a pre-existing
+  red hit whose file matches the workflow surface (`scripts/`,
+  `.claude/`, `CLAUDE.md`, `docs/`, `tests/`), the session MUST emit —
+  in the same turn as the `epm:merged` (or `epm:progress` completion)
+  note — a `<!-- workflow-fix-candidate v1 -->` block carrying the
+  #1681 urgent grammar: three fields inside the block —
+  `urgency: main-red`, `failing_test: <ONE pytest node id, e.g.
+  tests/test_x.py::test_y>`, and `wf_fix: true|false` (`true` when the
+  offending file itself lives on the workflow surface, `false`
+  otherwise; the parked candidate is still mechanically routable
+  regardless via the watcher's urgent-park router pass). Prose
+  alternatives ("noted for /daily follow-up", "will be picked up
+  later", "leaving for the sweep") are NOT acceptable terminal
+  dispositions — the nightly /daily Step C sweep is the FALLBACK, not
+  the primary route: without the urgent grammar every intervening
+  session's Step 9c gate must re-classify the same pre-existing red
+  (incident #1701 → #1698: the red lived ~15.5 h fleet-wide before
+  #1713 landed the fix). See
+  `.claude/rules/workflow-fix-on-bug.md` § Recursion guard "Urgent
+  fast path" for the router semantics; the parking session STILL
+  never files or spawns the fix itself. Non-workflow-surface
+  pre-existing red keeps the report-and-continue disposition
+  unchanged.
 - **Baseline semantics per binding form (the baseline is ALWAYS a
   payload-free tree).** The mapped invariant-TEST legs (#1147) keep the
   ORIGINAL per-form placement (gated = the `$WT` copy on the branch-tip /

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -11639,6 +11639,131 @@ def check_lessons_index(  # noqa: C901 -- flat failure-mode ladder (index parity
     return errors
 
 
+# `--check-inline-round-duty-mirror` (#1701): the three "Inline
+# estimator-validity + record-integrity duties" sentences mirror byte-for-byte
+# between CLAUDE.md § "User-chat inline free analysis" and
+# .claude/skills/issue/SKILL.md Step 9a-ter. A future editor who updates one
+# location and forgets the other silently drifts the mirror; a count-only
+# check would slip past a mid-sentence text edit that keeps the anchor
+# prefix. Two-part invariant: (a) each of three anchor prefixes appears
+# exactly once in EACH file, (b) the full sentence starting at each anchor
+# prefix is BYTE-IDENTICAL across the two files.
+
+_INLINE_ROUND_DUTY_ANCHORS: tuple[str, ...] = (
+    "(1) BEFORE any ridge",
+    "(2) BEFORE launching any re-implemented",
+    "(3) When a round REFUTES",
+)
+
+
+def _extract_inline_round_duty_sentence(text: str, anchor: str) -> str | None:
+    """Extract the full sentence starting at ``anchor`` through the next
+    terminator: the first ``. `` (period + whitespace) OR ``.\\n`` OR a bare
+    newline. Returns None if the anchor is not present.
+
+    In-line ``.`` inside a backtick-quoted span does not terminate — e.g.
+    ``scripts/issue1345_operator_comparison`` has no closing period. The
+    canonical anchor sentences end with ``.`` followed by whitespace or a
+    newline; the terminator scan walks past backtick spans.
+    """
+    idx = text.find(anchor)
+    if idx == -1:
+        return None
+    n = len(text)
+    i = idx
+    in_backtick = False
+    while i < n:
+        ch = text[i]
+        if ch == "`":
+            in_backtick = not in_backtick
+        elif ch == "\n" and not in_backtick:
+            return text[idx:i]
+        elif ch == "." and not in_backtick and i + 1 < n:
+            nxt = text[i + 1]
+            if nxt.isspace():
+                return text[idx : i + 1]
+        i += 1
+    return text[idx:n]
+
+
+def check_inline_round_duty_mirror(*, repo_root: Path | None = None) -> list[str]:
+    """FAIL if the three "Inline estimator-validity + record-integrity
+    duties" anchor sentences drift between CLAUDE.md and
+    .claude/skills/issue/SKILL.md.
+
+    Two-part invariant per anchor prefix:
+      (a) COUNT: the anchor prefix appears exactly once in EACH file
+          (locates the sentence unambiguously — zero hits means the block
+          was deleted; more than one means an editor duplicated it).
+      (b) BYTE-EQUALITY: the full sentence (anchor prefix through next
+          terminator — see ``_extract_inline_round_duty_sentence``) is
+          byte-identical across the two files.
+
+    ``repo_root`` is a unit-test override hook; production callers pass
+    None. Bundled into the no-flags default run.
+    """
+    import os as _os
+
+    if repo_root is not None:
+        root = repo_root
+    else:
+        # Env-override so BEHAVIORAL subprocess tests can point the check
+        # at a tmp corpus without also having to relocate every other
+        # bundled check. Absent: the production _REPO_ROOT.
+        env_root = _os.environ.get("EPS_WORKFLOW_LINT_REPO_ROOT")
+        root = Path(env_root) if env_root else _REPO_ROOT
+    claude_path = root / "CLAUDE.md"
+    skill_path = root / ".claude" / "skills" / "issue" / "SKILL.md"
+    errors: list[str] = []
+    try:
+        claude_text = claude_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        errors.append(f"check-inline-round-duty-mirror: {claude_path} not found")
+        return errors
+    try:
+        skill_text = skill_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        errors.append(f"check-inline-round-duty-mirror: {skill_path} not found")
+        return errors
+
+    claude_rel = claude_path.relative_to(root) if claude_path.is_relative_to(root) else claude_path
+    skill_rel = skill_path.relative_to(root) if skill_path.is_relative_to(root) else skill_path
+
+    for anchor in _INLINE_ROUND_DUTY_ANCHORS:
+        claude_count = claude_text.count(anchor)
+        skill_count = skill_text.count(anchor)
+        if claude_count != 1:
+            errors.append(
+                f"check-inline-round-duty-mirror: {claude_rel} has {claude_count} "
+                f"occurrence(s) of anchor {anchor!r}, expected exactly 1 "
+                "(part (a) count invariant)"
+            )
+        if skill_count != 1:
+            errors.append(
+                f"check-inline-round-duty-mirror: {skill_rel} has {skill_count} "
+                f"occurrence(s) of anchor {anchor!r}, expected exactly 1 "
+                "(part (a) count invariant)"
+            )
+        if claude_count != 1 or skill_count != 1:
+            continue  # cannot compare byte-equality without unambiguous anchors
+        claude_sent = _extract_inline_round_duty_sentence(claude_text, anchor)
+        skill_sent = _extract_inline_round_duty_sentence(skill_text, anchor)
+        if claude_sent is None or skill_sent is None:
+            errors.append(
+                f"check-inline-round-duty-mirror: could not extract anchor sentence "
+                f"for {anchor!r} (part (b) byte-equality invariant)"
+            )
+            continue
+        if claude_sent != skill_sent:
+            errors.append(
+                f"check-inline-round-duty-mirror: anchor sentence for {anchor!r} "
+                f"drifted between {claude_rel} and {skill_rel} "
+                "(part (b) byte-equality invariant); the three duty sentences "
+                "must stay byte-identical across the two files"
+            )
+    return errors
+
+
 # `--check-rule-frontmatter-parses` (#1385, from #1348): a `.claude/rules/*.md`
 # rule on-demand-loads ONLY through its frontmatter `paths:` globs. A YAML
 # parse failure (e.g. an unquoted `description:` containing ': ') silently
@@ -12866,6 +12991,17 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         "Bundled into the no-flags default run.",
     )
     parser.add_argument(
+        "--check-inline-round-duty-mirror",
+        action="store_true",
+        help="Verify the three 'Inline estimator-validity + record-integrity "
+        "duties' anchor sentences are mirrored byte-identically between "
+        "CLAUDE.md § 'User-chat inline free analysis' and "
+        ".claude/skills/issue/SKILL.md Step 9a-ter (#1701). Two-part "
+        "invariant: (a) each anchor prefix appears exactly once in each "
+        "file; (b) the full anchor sentence is byte-identical across the "
+        "two files. Bundled into the no-flags default run.",
+    )
+    parser.add_argument(
         "--check-rule-frontmatter-parses",
         action="store_true",
         help="YAML-parse every .claude/rules/*.md frontmatter block and "
@@ -13329,6 +13465,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         or args.check_no_repo_root_worktree_revert
         or args.check_gate_ids_unique
         or args.check_lessons_index
+        or args.check_inline_round_duty_mirror
         or args.check_rule_frontmatter_parses
         or args.check_compute_shape_review_lens
         or args.check_long_loop_restartability_review_lens
@@ -13452,6 +13589,8 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 -- flat flag-dispa
         errors.extend(check_gate_ids_unique(workflow))
     if args.check_lessons_index or no_flags:
         errors.extend(check_lessons_index())
+    if args.check_inline_round_duty_mirror or no_flags:
+        errors.extend(check_inline_round_duty_mirror())
     if args.check_rule_frontmatter_parses or no_flags:
         errors.extend(check_rule_frontmatter_parses())
     if args.check_agent_spec_size or no_flags:

--- a/tests/test_workflow_lint.py
+++ b/tests/test_workflow_lint.py
@@ -9086,3 +9086,33 @@ def test_hub_verify_bare_hits_default_targets_unchanged():
     assert default_patterns == [".list_repo_files(", ".list_repo_tree(", "file_exists("]
     narrowed = _hub_verify_bare_hits(tree, targets=frozenset({"list_repo_files"}))
     assert narrowed == [(5, ".list_repo_files(")]
+
+
+def test_check_inline_round_duty_mirror_symbol_and_argparse_pin() -> None:
+    """#1713 lost-update regression pin. Fails if a future whole-file
+    snapshot of scripts/workflow_lint.py silently drops the
+    check_inline_round_duty_mirror function OR unregisters the flag.
+
+    Complements tests/test_workflow_lint_inline_round_duty_mirror.py by
+    firing at import + argparse layer, so a delete of THAT test file
+    still leaves this pin.
+    """
+    import contextlib
+    import io
+
+    from workflow_lint import check_inline_round_duty_mirror, main
+
+    assert callable(check_inline_round_duty_mirror)
+
+    buf = io.StringIO()
+    rc = None
+    with contextlib.redirect_stdout(buf):
+        try:
+            main(["--help"])
+        except SystemExit as e:
+            rc = e.code
+    help_text = buf.getvalue()
+    assert "--check-inline-round-duty-mirror" in help_text, (
+        "flag missing from argparse; #1701 restoration incomplete"
+    )
+    assert rc == 0


### PR DESCRIPTION
Closes task #1713.

## Summary

`main` has been RED since 15:03Z on 2026-07-26 (~18 h at merge time) because `#1698`'s stale-branch merge (`a5c9a09427`) dropped 153 lines that `#1701` (`10eda16ed3`) added 45 min earlier, including `check_inline_round_duty_mirror` from `scripts/workflow_lint.py`. The surviving test `tests/test_workflow_lint_inline_round_duty_mirror.py` imports the missing symbol → full-suite `pytest --collect-only` aborts fleet-wide with rc=2.

Four sub-tasks landed as four explicit-path commits (a/c/b+d.i/d.ii):

- **(a)** `scripts/workflow_lint.py` (+139/-0): `check_inline_round_duty_mirror` + `_INLINE_ROUND_DUTY_ANCHORS` + `_extract_inline_round_duty_sentence` restored byte-faithful vs `10eda16ed3`; argparse `--check-inline-round-duty-mirror` + bundle registration at both sites; `AGENT_SPEC_SIZE_GRANDFATHER` UNTOUCHED (#1698 + #1702 caps preserved: `experimenter.md: 75_400`, `codex-code-reviewer.md: 60_800`).
- **(c)** `tests/test_workflow_lint.py` (+30/-0): `test_check_inline_round_duty_mirror_symbol_and_argparse_pin` (symbol + argparse presence pin, fires even if the surviving behavioral test file is later deleted).
- **(b + d.i)** `.claude/skills/issue/SKILL.md` (+95/-0): Step 10d Guard 4 — lost-update refusal (Bash `git merge-base` + per-line `grep -Fxq` on shared workflow-surface files; kill switch `EPM_SKIP_LOST_UPDATE_GUARD=1`; incident #1701→#1698 cited). Step 9c Verdict — mandatory `<!-- workflow-fix-candidate v1 -->` with #1681 urgent grammar (`urgency:` + `failing_test:` + `wf_fix:`) on workflow-surface pre-existing red; prose "noted for /daily follow-up" banned as terminal disposition.
- **(d.ii)** `.claude/rules/workflow-fix-on-bug.md` (+10/-4): Urgent fast path — SHOULD → MUST when the parking session has direct Step 9c evidence.

## Verification

- `pytest --collect-only -q` → rc=0, 16509 collected (main red fixed).
- `pytest tests/test_workflow_lint_inline_round_duty_mirror.py` → 6/6 PASS.
- `pytest tests/test_workflow_lint.py::test_check_inline_round_duty_mirror_symbol_and_argparse_pin` → PASS.
- `python scripts/workflow_lint.py` (no-flags) → rc=0.
- `ruff check scripts/workflow_lint.py tests/test_workflow_lint.py` → PASS.
- Preservation invariants: `experimenter.md: 75_400` ×1, `codex-code-reviewer.md: 60_800` ×1.
- Step 9c gate (touched-scope, 99 files, 5215 passed / 6 skipped in 39min41s): COMPARE_RC=0, no NEW failures, no lint regression.

## Test plan

- [x] Full-suite `pytest --collect-only -q` returns rc=0 post-merge
- [x] `#1701` behavioral pin + `#1713` symbol pin both PASS
- [x] `#1698`'s + `#1702`'s legitimate grandfather-cap raises preserved
- [x] Step 10d Guard 4 refuses a lost-update on shared workflow-surface files (opt-out `EPM_SKIP_LOST_UPDATE_GUARD=1`)

Generated with [Claude Code](https://claude.ai/claude-code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>