### PR TITLE
issue-1729: fix c38 pytest arm false positive on backticked node ids

### DIFF
--- a/scripts/verify_plan.py
+++ b/scripts/verify_plan.py
@@ -6705,7 +6705,11 @@ def _c38_repo_wide_cmd(line: str) -> str | None:
     workflow_lint arg tail; a ``.py`` path / ``::`` node id / ``-k``
     filter in the pytest tail; any non-``.`` path token in the ruff tail.
     Arm B (the "no-flags default run" phrase) is suppressed when the line
-    already carries a SCOPED workflow_lint invocation (commentary shape)."""
+    already carries a SCOPED workflow_lint invocation (commentary shape).
+    Pytest arm: the scoped test additionally re-scans the rest of the line
+    past the arg-tail terminator, so a scoping ``::`` node id / ``tests?/…py``
+    path / ``-k`` filter written inside backticks after the word "pytest"
+    does NOT read as unscoped."""
     saw_scoped_lint = False
     for m in _C38_LINT_OCC_RE.finditer(line):
         tail = _C38_TAIL_SPLIT_RE.split(line[m.end() :], 1)[0]
@@ -6716,8 +6720,13 @@ def _c38_repo_wide_cmd(line: str) -> str | None:
     if not saw_scoped_lint and _C38_NOFLAGS_RUN_RE.search(line):
         return "the workflow_lint no-flags default run"
     for m in _C38_PYTEST_OCC_RE.finditer(line):
-        tail = _C38_TAIL_SPLIT_RE.split(line[m.end() :], 1)[0]
-        if not _C38_PYTEST_SCOPED_RE.search(tail):
+        rest = line[m.end() :]
+        tail = _C38_TAIL_SPLIT_RE.split(rest, 1)[0]
+        # A scoping token (`::` node id, `tests?/…py` path, or `-k` filter)
+        # may live PAST a backtick that terminates the arg tail — the
+        # ordinary prose shape "Concrete pytest node id: `tests/x.py::y`".
+        # Widen to the rest-of-line so the tail split does not hide it.
+        if not _C38_PYTEST_SCOPED_RE.search(tail) and not _C38_PYTEST_SCOPED_RE.search(rest):
             return "pytest (no path scope)"
     for m in _C38_RUFF_OCC_RE.finditer(line):
         tail = _C38_TAIL_SPLIT_RE.split(line[m.end() :], 1)[0]
@@ -6747,8 +6756,11 @@ def check_exit0_repo_wide_baseline(plan: str, kind: str) -> CheckResult:
     assertion vocabulary (endemic; partially c37's subject); an
     assertion sentence separated from its fenced command by ≥1 line;
     "full suite" with no literal pytest token. Disclosed over-trigger
-    residual: a prose pytest mention with a non-scoping tail on an
-    assertion-bearing line. Deliberate reading (disclosed,
+    residual (narrowed 2026-07-27 for #1729): a bare unscoped `pytest`
+    assertion whose only nearby scoping token is on an unrelated line.
+    (The backticked-node-id class — a scoping ``::`` / ``tests?/…py`` /
+    ``-k`` token past the arg-tail terminator on the SAME line — is now
+    handled by the pytest arm's rest-of-line rescan.) Deliberate reading (disclosed,
     fact-checker-confirmed correct): an EMPTY arg tail — bare
     `ruff check` / bare `pytest` plus an assertion word — classifies
     REPO-WIDE and WARNs (both default to cwd/repo-wide; `all([]) is

--- a/tests/test_verify_plan.py
+++ b/tests/test_verify_plan.py
@@ -8137,6 +8137,47 @@ def test_c38_scoped_pytest_does_not_trigger():
     assert _status(_c38_plan(line), "c38_exit0_repo_wide_baseline", kind="infra") == "SKIP"
 
 
+def test_c38_pytest_node_id_in_backticks_does_not_trigger():
+    # #1729: the ordinary prose shape "Concrete pytest node id:
+    # `tests/x.py::test_y`" MUST NOT read as unscoped — the arg-tail
+    # split truncates at the opening backtick, hiding the scope from
+    # tail-only inspection. The rest-of-line rescan is what catches it.
+    line = (
+        "- Acceptance: mapper exits 0. "
+        "Concrete pytest node id: `tests/test_select_step9c_tests.py::test_map_files`."
+    )
+    assert _status(_c38_plan(line), "c38_exit0_repo_wide_baseline", kind="infra") == "SKIP"
+
+
+def test_c38_pytest_bare_unscoped_still_warns():
+    # #1729 trade-off (i): a bare `pytest` assertion with NO scoping
+    # token anywhere on the line MUST still WARN — the deliberate,
+    # fact-checker-confirmed reading that an empty arg tail classifies
+    # repo-wide (docstring: "an EMPTY arg tail — bare `ruff check` /
+    # bare `pytest` plus an assertion word — classifies REPO-WIDE").
+    line = "- Acceptance: the full pytest suite must exit 0 after the edit."
+    _, by_id = _run(_c38_plan(line), kind="infra")
+    r = by_id["c38_exit0_repo_wide_baseline"]
+    assert r.status == "WARN"
+    assert "pytest (no path scope)" in r.detail
+
+
+def test_c38_pytest_repro_helper_returns_none():
+    # #1729 direct pin on the private helper: exactly the
+    # verified-at-filing reproduction. Guards against a future refactor
+    # that keeps the WARN-level pin green but silently regresses the
+    # helper (e.g. if `check_exit0_repo_wide_baseline` grew a
+    # compensating filter that hid a re-broken `_c38_repo_wide_cmd`).
+    line = (
+        "- Acceptance: mapper exits 0. "
+        "Concrete pytest node id: `tests/test_select_step9c_tests.py::test_map_files`."
+    )
+    assert verify_plan._c38_repo_wide_cmd(line) is None
+
+    bare = "- Acceptance: the full pytest suite must exit 0 after the edit."
+    assert verify_plan._c38_repo_wide_cmd(bare) == "pytest (no path scope)"
+
+
 def test_c38_repo_wide_ruff_warns():
     _, by_id = _run(_c38_plan("uv run ruff check .  # exit 0"), kind="infra")
     r = by_id["c38_exit0_repo_wide_baseline"]


### PR DESCRIPTION
Closes task #1729.

Fixes `scripts/verify_plan.py::_c38_repo_wide_cmd`'s pytest arm: the arg-tail split at the first backtick was hiding scoping tokens sitting inside backticks after "pytest" (the ordinary prose shape "Concrete pytest node id: \`tests/x.py::test_y\`"), producing a false `c38_exit0_repo_wide_baseline` WARN. The fix re-scans the rest-of-line past the arg-tail terminator for the same scope tokens, returning the "no path scope" label only when NEITHER the tail NOR the rest carries a scope.

Preserves the empty-arg-tail bare-`pytest` classifies-repo-wide semantics; the newly-quiet trade-off (bare unscoped `pytest` + unrelated `tests/…py` on the same line) is explicitly named in the plan §11 and NOT pin-tested as an invariant.

3 new c38 pin tests (16 existing + 3 new = 19 pass); ruff clean on touched files; workflow_lint gate PASS (single pre-existing failure on `.claude/agents/planner.md` is unchanged pre-existing red on origin/main, verified by compare classification).

Plan v2 at https://eps.superkaiba.com/tasks/1729/plan.