### PR TITLE
issue-1740: relocate planner.md §3 recipes below agent-spec-size ratchet

### DIFF
--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -278,72 +278,24 @@ What exists in the codebase and literature? What approaches have been tried? Wha
 ### 3. Hypothesis
 Specific, falsifiable predictions. State what would confirm and what would falsify. Include quantitative thresholds where possible.
 
-**Registered verdict lattice — declare it in the machine-checkable form.** A plan
-REGISTERS a verdict lattice when it pre-defines outcome labels (Confirmed /
-Falsified / H-slots / pass-fail-inconclusive grids) as interval predicates over
-the same point estimates and CIs. `scripts/verify_plan.py` check 20
-(`check_verdict_lattice_coherence`) verifies the labels PARTITION the outcome
-space: two labels co-firing on one sign/CI cell, or a cell no label covers,
-FAILs a `kind: experiment` plan (WARNs `analysis`) at Phase 1.5.0 and on every
-critic re-verify (incident: #923 v4/v5). c20 verifies the partition IN FORM
-ONLY — whether each predicate is the scientifically right boundary stays with
-the Statistics critic. Declare the partition as ONE non-fenced line inside the
-section that defines the labels (any heading matching
-hypothes|success|kill|decision|verdict|gate — §3 here is the natural home):
-`DISJOINT and exhaustive: <label> ⇔ <predicate>; <label> ⇔ <predicate>; <label> ⇔ otherwise.`
-Live-verified worked example (#923 plan v6 §3 is the corpus exemplar):
-`DISJOINT and exhaustive: Confirmed ⇔ Δ > 0 AND Δ's 95% CI excludes 0 on the positive side; Falsified ⇔ Δ's 95% CI is wholly below 0; Inconclusive ⇔ otherwise.`
-Parser constraints (c20 tier 1): clauses `;`-separated on the SAME line; each
-label ≤80 chars with no `;`/`⇔`; predicates built from `<qty> ≥/>/≤/< 0` sign
-atoms and CI idioms ("CI excludes 0 on the positive side", "CI wholly below 0",
-"CI straddles 0", "paired-diff CI strictly positive") joined only by AND / OR /
-with; close with an `⇔ otherwise` clause (covers every residual cell by
-construction). Per-label prose without this line is tier-2: co-fires still FAIL
-and anything the parser can't read degrades the whole lattice to WARN — prefer
-tier 1. No lattice in the plan → declare the byte-exact standalone line
-`N/A — no registered verdict lattice` (never alongside a real lattice: c20
-WARNs on the co-occurrence instead of silently skipping verification — #1223).
+**Registered verdict lattice (verify_plan.py check 20):** a plan that
+pre-defines outcome labels (Confirmed / Falsified / H-slots / pass-fail
+grids) declares the partition as ONE non-fenced machine-checkable line —
+`DISJOINT and exhaustive: <label> ⇔ <predicate>; …; <label> ⇔ otherwise.`
+— inside the section that defines the labels (§3 is the natural home). No
+lattice in the plan → declare the byte-exact standalone line
+`N/A — no registered verdict lattice`.
 
-**Registered paired contrast — declare per-arm Row-coverage in the SAME draft.**
-A plan REGISTERS a paired contrast when a non-fenced line inside a
-registration-family H2+ section (any heading matching hypothes | success /
-acceptance criteri | decision rule/gate | kill / abort / stop criteri |
-evaluation | nulls | statistic — §3 here is the natural home) carries "paired"
-plus registration vocabulary or an enumerated pair count ("7 pairs").
-`scripts/verify_plan.py` check 18 (`check_paired_contrast_source_coverage`)
-then REQUIRES a per-arm row-coverage declaration — FAIL for `kind: experiment`
-(WARN `analysis`) at Phase 1.5.0 and on every critic re-verify (incidents:
-#810 v13 — 2 of 9 registered rows missing from the named full side; #1112
-amendment drafts v4 AND v7 — one mechanical bounce each, same omission).
-Every `plans/v{K}.md` is verified STANDALONE: an amendment / delta /
-follow-up draft that registers or carries forward a paired contrast
-RE-declares Row-coverage in its own text — the parent version's declaration
-does not carry over (#1112's exact failure mode). Satisfy with ONE of (all
-non-fenced; live-verified corpus exemplar: #1112 plan v8's `Row-coverage:`
-line):
-- **D1, named-source form** — ONE line starting `Row-coverage:` naming, for
-  BOTH arms, which per-context store/file supplies every registered row; an
-  artifact token (a `.pt/.json/.jsonl/.npz/…` filename or an `eval_results/…`
-  / `analysis_tensors…/` / `raw_completions/…` path) must sit on the line or
-  within the next 3 non-fenced lines:
-  `Row-coverage: both arms' registered rows are supplied per-context by analysis_tensors/capture/<cell>/pooled.pt (trained arm) and eval_results/issue_<N>/base_rows.json (base arm).`
-- **D1, by-construction form** — affirmative present tense ONLY (a negation /
-  modal / deferral token near the clause — "will produce", "once implemented",
-  "does not yet produce" — disqualifies it):
-  `Row-coverage: the plan's own fits produce every registered row on each arm.`
-- **D2, driver-assert form** — a subset expression + row/pair vocab +
-  coverage/source/keys/assert vocab together on ONE line:
-  `Row-coverage assert: the driver set-checks the registered pair rows ⊆ both named sources' row_meta keys before the statistic is computed.`
-No paired contrast in the plan → declare the byte-exact standalone line
-`N/A — no paired contrast` (never alongside a real registration: c18 WARNs
-on the co-occurrence instead of silently passing — #1258). Keep every
-declaration line free of cross-issue
-citations — a `#<M>` token on the line DISQUALIFIES it (quote sibling
-exemplars elsewhere) — and fill the `<…>` placeholders with THIS plan's
-actual stores. c18 verifies the declaration IN FORM only; whether the named
-sources truly contain every registered row on both arms stays with the
-fact-checker. Guidance-shape pinned by
-`tests/test_planner_row_coverage_guidance.py`.
+**Registered paired contrast (verify_plan.py check 18):** a plan
+registering a paired contrast declares per-arm Row-coverage in the SAME
+draft — every `plans/v{K}.md` is verified STANDALONE, so an
+amendment/delta draft re-declares its own Row-coverage line. No paired
+contrast → declare the byte-exact standalone line
+`N/A — no paired contrast`.
+
+Full declaration recipes + parser constraints + worked example lines:
+`.claude/rules/planner-section-reference.md` § 3. Hypothesis — read that
+section (grep the heading, chunked Read) BEFORE writing this section.
 
 ### 4. Design
 

--- a/.claude/rules/planner-section-reference.md
+++ b/.claude/rules/planner-section-reference.md
@@ -3,7 +3,7 @@ paths:
   - ".claude/rules/planner-section-reference.md"
 description: >
   Full templates + worked examples for the planner.md plan sections
-  (§0.0 / §0 / §4 / §6 / §6.5 / §7 / §9 / §10 / §11), relocated verbatim from
+  (§0.0 / §0 / §3 / §4 / §6 / §6.5 / §7 / §9 / §10 / §11 / §12), relocated verbatim from
   .claude/agents/planner.md (#838). Loaded ONLY via the explicit pointer lines
   in planner.md — the self-matching `paths:` glob keeps this file out of every
   other agent context (a missing `paths:` key would auto-inject it always-on
@@ -114,6 +114,77 @@ code-enforced gate in `task.py --auto-approve-if-autonomous` already
 decided, and the PreToolUse hook
 <!-- gate: gates.plan_approval --> hard-blocks any `AskUserQuestion` if
 reached.
+
+## 3. Hypothesis
+
+(Relocated verbatim from planner.md §3, #1740.)
+
+**Registered verdict lattice — declare it in the machine-checkable form.** A plan
+REGISTERS a verdict lattice when it pre-defines outcome labels (Confirmed /
+Falsified / H-slots / pass-fail-inconclusive grids) as interval predicates over
+the same point estimates and CIs. `scripts/verify_plan.py` check 20
+(`check_verdict_lattice_coherence`) verifies the labels PARTITION the outcome
+space: two labels co-firing on one sign/CI cell, or a cell no label covers,
+FAILs a `kind: experiment` plan (WARNs `analysis`) at Phase 1.5.0 and on every
+critic re-verify (incident: #923 v4/v5). c20 verifies the partition IN FORM
+ONLY — whether each predicate is the scientifically right boundary stays with
+the Statistics critic. Declare the partition as ONE non-fenced line inside the
+section that defines the labels (any heading matching
+hypothes|success|kill|decision|verdict|gate — §3 here is the natural home):
+`DISJOINT and exhaustive: <label> ⇔ <predicate>; <label> ⇔ <predicate>; <label> ⇔ otherwise.`
+Live-verified worked example (#923 plan v6 §3 is the corpus exemplar):
+`DISJOINT and exhaustive: Confirmed ⇔ Δ > 0 AND Δ's 95% CI excludes 0 on the positive side; Falsified ⇔ Δ's 95% CI is wholly below 0; Inconclusive ⇔ otherwise.`
+Parser constraints (c20 tier 1): clauses `;`-separated on the SAME line; each
+label ≤80 chars with no `;`/`⇔`; predicates built from `<qty> ≥/>/≤/< 0` sign
+atoms and CI idioms ("CI excludes 0 on the positive side", "CI wholly below 0",
+"CI straddles 0", "paired-diff CI strictly positive") joined only by AND / OR /
+with; close with an `⇔ otherwise` clause (covers every residual cell by
+construction). Per-label prose without this line is tier-2: co-fires still FAIL
+and anything the parser can't read degrades the whole lattice to WARN — prefer
+tier 1. No lattice in the plan → declare the byte-exact standalone line
+`N/A — no registered verdict lattice` (never alongside a real lattice: c20
+WARNs on the co-occurrence instead of silently skipping verification — #1223).
+
+**Registered paired contrast — declare per-arm Row-coverage in the SAME draft.**
+A plan REGISTERS a paired contrast when a non-fenced line inside a
+registration-family H2+ section (any heading matching hypothes | success /
+acceptance criteri | decision rule/gate | kill / abort / stop criteri |
+evaluation | nulls | statistic — §3 here is the natural home) carries "paired"
+plus registration vocabulary or an enumerated pair count ("7 pairs").
+`scripts/verify_plan.py` check 18 (`check_paired_contrast_source_coverage`)
+then REQUIRES a per-arm row-coverage declaration — FAIL for `kind: experiment`
+(WARN `analysis`) at Phase 1.5.0 and on every critic re-verify (incidents:
+#810 v13 — 2 of 9 registered rows missing from the named full side; #1112
+amendment drafts v4 AND v7 — one mechanical bounce each, same omission).
+Every `plans/v{K}.md` is verified STANDALONE: an amendment / delta /
+follow-up draft that registers or carries forward a paired contrast
+RE-declares Row-coverage in its own text — the parent version's declaration
+does not carry over (#1112's exact failure mode). Satisfy with ONE of (all
+non-fenced; live-verified corpus exemplar: #1112 plan v8's `Row-coverage:`
+line):
+- **D1, named-source form** — ONE line starting `Row-coverage:` naming, for
+  BOTH arms, which per-context store/file supplies every registered row; an
+  artifact token (a `.pt/.json/.jsonl/.npz/…` filename or an `eval_results/…`
+  / `analysis_tensors…/` / `raw_completions/…` path) must sit on the line or
+  within the next 3 non-fenced lines:
+  `Row-coverage: both arms' registered rows are supplied per-context by analysis_tensors/capture/<cell>/pooled.pt (trained arm) and eval_results/issue_<N>/base_rows.json (base arm).`
+- **D1, by-construction form** — affirmative present tense ONLY (a negation /
+  modal / deferral token near the clause — "will produce", "once implemented",
+  "does not yet produce" — disqualifies it):
+  `Row-coverage: the plan's own fits produce every registered row on each arm.`
+- **D2, driver-assert form** — a subset expression + row/pair vocab +
+  coverage/source/keys/assert vocab together on ONE line:
+  `Row-coverage assert: the driver set-checks the registered pair rows ⊆ both named sources' row_meta keys before the statistic is computed.`
+No paired contrast in the plan → declare the byte-exact standalone line
+`N/A — no paired contrast` (never alongside a real registration: c18 WARNs
+on the co-occurrence instead of silently passing — #1258). Keep every
+declaration line free of cross-issue
+citations — a `#<M>` token on the line DISQUALIFIES it (quote sibling
+exemplars elsewhere) — and fill the `<…>` placeholders with THIS plan's
+actual stores. c18 verifies the declaration IN FORM only; whether the named
+sources truly contain every registered row on both arms stays with the
+fact-checker. Guidance-shape pinned by
+`tests/test_planner_row_coverage_guidance.py`.
 
 ## 4. Design
 

--- a/tests/test_planner_row_coverage_guidance.py
+++ b/tests/test_planner_row_coverage_guidance.py
@@ -1,9 +1,17 @@
-"""Pins the planner.md SS3 Row-coverage authoring guidance (#1208) and asserts
-its worked-example declaration lines satisfy the LIVE verify_plan c18 check --
-guidance that teaches a non-satisfying shape is worse than none.
+"""Pins the SS3 Row-coverage authoring guidance (#1208) — relocated by #1740
+from planner.md SS3 to .claude/rules/planner-section-reference.md
+"## 3. Hypothesis" — and asserts its worked-example declaration lines satisfy
+the LIVE verify_plan c18 check -- guidance that teaches a non-satisfying shape
+is worse than none.
+
+Widened pin surface after the #1740 repoint: the count-3 regex in
+``_example_lines`` scans the ENTIRE ~89 KB reference file, so ANY future
+standalone backticked ``Row-coverage`` line added anywhere in
+planner-section-reference.md (not just its SS3 section) trips the count pin —
+a by-design tripwire, not an accident.
 """
 
-# The literal strings below quote the planner.md guidance verbatim, em-dashes
+# The literal strings below quote the relocated guidance verbatim, em-dashes
 # included -- the byte-exactness IS what the pin verifies (same convention as
 # tests/test_verify_plan.py).
 
@@ -15,7 +23,7 @@ import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
-PLANNER = REPO / ".claude" / "agents" / "planner.md"
+GUIDANCE = REPO / ".claude" / "rules" / "planner-section-reference.md"
 
 # Byte-exact c18 escape (em-dash) — test_trigger_with_na_escape_passes_c18
 # executes it against the live check, so a drifted copy fails loud here.
@@ -50,16 +58,19 @@ def _verify_plan_mod():
 
 def _example_lines() -> list[str]:
     """Extract the guidance's worked-example declaration lines: standalone
-    backticked lines starting `Row-coverage` (bullet-indented). The
-    line-anchored regex is why each example must stay on ONE physical line
-    in planner.md; the `N/A — no paired contrast` escape line is deliberately
+    backticked lines starting `Row-coverage` (bullet-indented), from
+    planner-section-reference.md (SS3 Hypothesis, relocated there by #1740).
+    The line-anchored regex is why each example must stay on ONE physical
+    line — and it scans the WHOLE reference file, so any future standalone
+    backticked `Row-coverage` line anywhere in that file trips the count-3
+    pin by design; the `N/A — no paired contrast` escape line is deliberately
     NOT extracted (it does not start with `Row-coverage`)."""
-    text = PLANNER.read_text(encoding="utf-8")
+    text = GUIDANCE.read_text(encoding="utf-8")
     return re.findall(r"(?m)^\s*`(Row-coverage[^`]+)`\s*$", text)
 
 
-def test_planner_md_has_row_coverage_authoring_guidance():
-    text = PLANNER.read_text(encoding="utf-8")
+def test_reference_has_row_coverage_authoring_guidance():
+    text = GUIDANCE.read_text(encoding="utf-8")
     assert "Registered paired contrast — declare per-arm Row-coverage" in text
     assert NA_ESCAPE in text
     # amendment-standalone sentence present (the #1112 v4/v7 failure mode)
@@ -70,7 +81,8 @@ def test_guidance_examples_satisfy_c18():
     vp = _verify_plan_mod()
     examples = _example_lines()
     # Pins the example count: ANY future standalone backticked `Row-coverage`
-    # line added to (or dropped from) planner.md breaks this test by design.
+    # line added to (or dropped from) planner-section-reference.md breaks
+    # this test by design.
     assert len(examples) == 3, examples
     for line in examples:
         plan = TRIGGER_PLAN + line + "\n"
@@ -87,7 +99,7 @@ def test_trigger_without_declaration_fails_c18():
 def test_trigger_with_na_escape_warns_c18():
     # #1258 (the #1223 c20 port): the escape co-occurring with a detected
     # registration is the masking shape — c18 now WARNs (non-blocking)
-    # instead of silently PASSing, matching the refreshed planner.md
+    # instead of silently PASSing, matching the refreshed guidance
     # parenthetical ("c18 WARNs on the co-occurrence instead of silently
     # passing — #1258"). The escape stays honored (SKIP) on trigger-free
     # plans, pinned by tests/test_verify_plan.py::


### PR DESCRIPTION
Closes task #1740. Shrinks .claude/agents/planner.md 40,900 → 36,960 B (under the 40,000 B agent-spec-size FAIL ratchet; main red on test_live_tree_passes since #1721) by relocating the §3 Hypothesis c20/c18 recipe blocks verbatim to .claude/rules/planner-section-reference.md (#838 mechanism) and repointing tests/test_planner_row_coverage_guidance.py.