### PR TITLE
issue-1741: sweep park predicate accepts URGENT-PARK / urgency: main-red parks

### DIFF
--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -278,72 +278,24 @@ What exists in the codebase and literature? What approaches have been tried? Wha
 ### 3. Hypothesis
 Specific, falsifiable predictions. State what would confirm and what would falsify. Include quantitative thresholds where possible.
 
-**Registered verdict lattice — declare it in the machine-checkable form.** A plan
-REGISTERS a verdict lattice when it pre-defines outcome labels (Confirmed /
-Falsified / H-slots / pass-fail-inconclusive grids) as interval predicates over
-the same point estimates and CIs. `scripts/verify_plan.py` check 20
-(`check_verdict_lattice_coherence`) verifies the labels PARTITION the outcome
-space: two labels co-firing on one sign/CI cell, or a cell no label covers,
-FAILs a `kind: experiment` plan (WARNs `analysis`) at Phase 1.5.0 and on every
-critic re-verify (incident: #923 v4/v5). c20 verifies the partition IN FORM
-ONLY — whether each predicate is the scientifically right boundary stays with
-the Statistics critic. Declare the partition as ONE non-fenced line inside the
-section that defines the labels (any heading matching
-hypothes|success|kill|decision|verdict|gate — §3 here is the natural home):
-`DISJOINT and exhaustive: <label> ⇔ <predicate>; <label> ⇔ <predicate>; <label> ⇔ otherwise.`
-Live-verified worked example (#923 plan v6 §3 is the corpus exemplar):
-`DISJOINT and exhaustive: Confirmed ⇔ Δ > 0 AND Δ's 95% CI excludes 0 on the positive side; Falsified ⇔ Δ's 95% CI is wholly below 0; Inconclusive ⇔ otherwise.`
-Parser constraints (c20 tier 1): clauses `;`-separated on the SAME line; each
-label ≤80 chars with no `;`/`⇔`; predicates built from `<qty> ≥/>/≤/< 0` sign
-atoms and CI idioms ("CI excludes 0 on the positive side", "CI wholly below 0",
-"CI straddles 0", "paired-diff CI strictly positive") joined only by AND / OR /
-with; close with an `⇔ otherwise` clause (covers every residual cell by
-construction). Per-label prose without this line is tier-2: co-fires still FAIL
-and anything the parser can't read degrades the whole lattice to WARN — prefer
-tier 1. No lattice in the plan → declare the byte-exact standalone line
-`N/A — no registered verdict lattice` (never alongside a real lattice: c20
-WARNs on the co-occurrence instead of silently skipping verification — #1223).
+**Registered verdict lattice (verify_plan.py check 20):** a plan that
+pre-defines outcome labels (Confirmed / Falsified / H-slots / pass-fail
+grids) declares the partition as ONE non-fenced machine-checkable line —
+`DISJOINT and exhaustive: <label> ⇔ <predicate>; …; <label> ⇔ otherwise.`
+— inside the section that defines the labels (§3 is the natural home). No
+lattice in the plan → declare the byte-exact standalone line
+`N/A — no registered verdict lattice`.
 
-**Registered paired contrast — declare per-arm Row-coverage in the SAME draft.**
-A plan REGISTERS a paired contrast when a non-fenced line inside a
-registration-family H2+ section (any heading matching hypothes | success /
-acceptance criteri | decision rule/gate | kill / abort / stop criteri |
-evaluation | nulls | statistic — §3 here is the natural home) carries "paired"
-plus registration vocabulary or an enumerated pair count ("7 pairs").
-`scripts/verify_plan.py` check 18 (`check_paired_contrast_source_coverage`)
-then REQUIRES a per-arm row-coverage declaration — FAIL for `kind: experiment`
-(WARN `analysis`) at Phase 1.5.0 and on every critic re-verify (incidents:
-#810 v13 — 2 of 9 registered rows missing from the named full side; #1112
-amendment drafts v4 AND v7 — one mechanical bounce each, same omission).
-Every `plans/v{K}.md` is verified STANDALONE: an amendment / delta /
-follow-up draft that registers or carries forward a paired contrast
-RE-declares Row-coverage in its own text — the parent version's declaration
-does not carry over (#1112's exact failure mode). Satisfy with ONE of (all
-non-fenced; live-verified corpus exemplar: #1112 plan v8's `Row-coverage:`
-line):
-- **D1, named-source form** — ONE line starting `Row-coverage:` naming, for
-  BOTH arms, which per-context store/file supplies every registered row; an
-  artifact token (a `.pt/.json/.jsonl/.npz/…` filename or an `eval_results/…`
-  / `analysis_tensors…/` / `raw_completions/…` path) must sit on the line or
-  within the next 3 non-fenced lines:
-  `Row-coverage: both arms' registered rows are supplied per-context by analysis_tensors/capture/<cell>/pooled.pt (trained arm) and eval_results/issue_<N>/base_rows.json (base arm).`
-- **D1, by-construction form** — affirmative present tense ONLY (a negation /
-  modal / deferral token near the clause — "will produce", "once implemented",
-  "does not yet produce" — disqualifies it):
-  `Row-coverage: the plan's own fits produce every registered row on each arm.`
-- **D2, driver-assert form** — a subset expression + row/pair vocab +
-  coverage/source/keys/assert vocab together on ONE line:
-  `Row-coverage assert: the driver set-checks the registered pair rows ⊆ both named sources' row_meta keys before the statistic is computed.`
-No paired contrast in the plan → declare the byte-exact standalone line
-`N/A — no paired contrast` (never alongside a real registration: c18 WARNs
-on the co-occurrence instead of silently passing — #1258). Keep every
-declaration line free of cross-issue
-citations — a `#<M>` token on the line DISQUALIFIES it (quote sibling
-exemplars elsewhere) — and fill the `<…>` placeholders with THIS plan's
-actual stores. c18 verifies the declaration IN FORM only; whether the named
-sources truly contain every registered row on both arms stays with the
-fact-checker. Guidance-shape pinned by
-`tests/test_planner_row_coverage_guidance.py`.
+**Registered paired contrast (verify_plan.py check 18):** a plan
+registering a paired contrast declares per-arm Row-coverage in the SAME
+draft — every `plans/v{K}.md` is verified STANDALONE, so an
+amendment/delta draft re-declares its own Row-coverage line. No paired
+contrast → declare the byte-exact standalone line
+`N/A — no paired contrast`.
+
+Full declaration recipes + parser constraints + worked example lines:
+`.claude/rules/planner-section-reference.md` § 3. Hypothesis — read that
+section (grep the heading, chunked Read) BEFORE writing this section.
 
 ### 4. Design
 

--- a/.claude/rules/workflow-fix-on-bug.md
+++ b/.claude/rules/workflow-fix-on-bug.md
@@ -808,6 +808,13 @@ failing_test: <ONE pytest node id, e.g. tests/test_x.py::test_y>
 wf_fix: true|false   # target_file on the workflow surface, or not
 ```
 
+The parking session leads the candidate marker note with `URGENT-PARK`
+(or a `parked (urgent): ...` lead) so pre-#1741 sweep copies in stale
+worktrees also match; the #1741 predicate
+(`scripts/sweep_parked_wf_candidates.py`) accepts either surface — the
+leading token or the in-block `urgency: main-red` field (incident #1718:
+a token-less urgent park was invisible to the sweep for ~16 h).
+
 Labeling is not routing: the parking session still NEVER files or spawns.
 The watcher's urgent-park router pass (`autonomous_session_watch.py`
 `urgent_wf_park_pass`, every 10 min — an independent, non-guarded actor)

--- a/scripts/sweep_parked_wf_candidates.py
+++ b/scripts/sweep_parked_wf_candidates.py
@@ -6,8 +6,14 @@ fallback stream ``.claude/cache/workflow-fix-events.jsonl`` for
 ``epm:workflow-fix-candidate`` rows whose note/``routed`` field marks them
 PARKED — a leading ``parked``, a ``routed:``/``Routing:`` ``parked`` token, a
 bare ``parked: architectural``/``parked: EPM_WORKFLOW_FIX_SESSION``
-routing-decision token, or a mid-note ``parked <punct> ... recursion guard``
-declaration (#1281); casual "parked" mentions do not count — (the
+routing-decision token, a mid-note ``parked <punct> ... recursion guard``
+declaration (#1281), or an URGENT fast-path park (#1741; grammar #1681;
+incident #1718) — a leading ``URGENT-PARK`` token, or an
+``urgency: main-red`` field INSIDE the formal candidate block (the #1681
+grammar never required a "parked" token, so pre-#1741 the emitter and this
+enumerator disagreed on the park surface and the #1718 park was invisible to
+BOTH consumers for ~16 h); casual "parked" mentions — and prose merely
+QUOTING ``urgency: main-red`` outside a formal block — do not count (the
 recursion-guard escape valve,
 ``.claude/rules/workflow-fix-on-bug.md`` § Recursion guard), and prints ONE
 JSON object to stdout listing the candidates no later routed-record has
@@ -178,6 +184,19 @@ _PARKED_MIDNOTE_RE = re.compile(
     r"|\bparked\s*(?:—|--|-\s|:)[^\n]{0,160}\brecursion guard\b",
     re.IGNORECASE,
 )
+# URGENT fast-path park arms (#1741; grammar #1681; incident #1718). The
+# urgent grammar (workflow-fix-on-bug.md § Recursion guard "Urgent fast
+# path") prescribes three in-block fields but never required a "parked"
+# token, so the #1718 park (leads `URGENT-PARK`, zero "parked" tokens) was
+# invisible to every arm above for ~16 h while main stayed red. Arm (a):
+# leading `URGENT-PARK` token (used with .match, mirroring _PARKED_LEAD_RE).
+# Arm (b): `urgency: main-red` field INSIDE the _BLOCK_RE-extracted formal
+# candidate block — searched against the block group ONLY, never the whole
+# note, so prose QUOTING the grammar keeps the casual-mention exclusion. A
+# mis-tagged already-ROUTED urgent block is closed by suppression rules 1/2
+# (demonstrated live by the #1718→#1740 record).
+_URGENT_PARK_LEAD_RE = re.compile(r"\s*urgent-park\b", re.IGNORECASE)
+_URGENT_BLOCK_FIELD_RE = re.compile(r"^urgency:\s*main-red\b", re.IGNORECASE | re.MULTILINE)
 _ARCHITECTURAL_RE = re.compile(r"parked:\s*architectural", re.IGNORECASE)
 _BLOCK_RE = re.compile(
     r"<!--\s*workflow-fix-candidate v1\s*-->(.*?)<!--\s*/workflow-fix-candidate\s*-->",
@@ -286,8 +305,13 @@ def _row_is_parked(row: dict) -> bool:
     Accept paths: a LEADING 'parked' note; 'routed: parked' anywhere; a
     mid-note park DECLARATION (_PARKED_MIDNOTE_RE — 'Routing: parked', the
     bare 'parked: architectural|EPM_WORKFLOW_FIX_SESSION' tokens, or
-    'parked <punct> ... recursion guard'; #1281); or a structured 'routed'
-    field containing 'parked'. Casual mid-note mentions do not count.
+    'parked <punct> ... recursion guard'; #1281); an URGENT fast-path park
+    (#1741; grammar #1681; incident #1718) — a LEADING 'URGENT-PARK' token,
+    or an 'urgency: main-red' field INSIDE the formal candidate block (the
+    block group only, never a whole-note scan); or a structured 'routed'
+    field containing 'parked' (the fallback stays LAST). Casual mid-note
+    mentions — incl. prose quoting 'urgency: main-red' outside a block — do
+    not count.
     """
     note = str(row.get("note") or "")
     if (
@@ -295,6 +319,11 @@ def _row_is_parked(row: dict) -> bool:
         or _PARKED_ROUTED_RE.search(note)
         or _PARKED_MIDNOTE_RE.search(note)
     ):
+        return True
+    if _URGENT_PARK_LEAD_RE.match(note):
+        return True
+    m = _BLOCK_RE.search(note)
+    if m and _URGENT_BLOCK_FIELD_RE.search(m.group(1)):
         return True
     routed = row.get("routed")
     return isinstance(routed, str) and "parked" in routed.lower()

--- a/tests/test_sweep_parked_wf_candidates.py
+++ b/tests/test_sweep_parked_wf_candidates.py
@@ -1573,3 +1573,130 @@ def test_unmatched_advisory_extracts_from_structured_fingerprint_key(tmp_path: P
     )
     result = run_sweep(tmp_path, include_routed=True)
     assert result["unmatched_record_fps"] == [{"source": "task:106", "ref": "#501", "fp": drift_fp}]
+
+
+# ── #1741: URGENT fast-path park accept arms (#1681 grammar; incident #1718) ─
+
+# Byte-verbatim fixture row: _RAW_1718_CAND is the EXACT JSONL line from the
+# live #1718 events.jsonl (the 2026-07-27 urgent fast-path park — leads
+# `URGENT-PARK`, formal block carries urgency: main-red + failing_test +
+# wf_fix, ZERO occurrences of the word "parked"). Pre-#1741 the predicate
+# never enumerated it, so BOTH consumers (the watcher's urgent-park router
+# and the nightly /daily Step C sweep) were blind for ~16 h while main
+# stayed red. Consumed via make_task(raw_event_lines=...), so the sweep
+# parses the same bytes the live tree carries.
+
+_RAW_1718_CAND = r"""{"ts": "2026-07-27T14:38:28Z", "kind": "epm:workflow-fix-candidate", "version": 1, "by": "unknown", "note": "URGENT-PARK workflow-fix candidate raised from #1718 Step 10d merge attempt (autonomous session).\n\n## Context\n\n- Session: task #1718 (workflow-fix session — carries `workflow_fix_target: scripts/workflow_lint.py` Provenance; recursion guard ACTIVE).\n- Blocked action: `/issue 1718` Step 10d local merge (`git merge origin/main` after `gh pr merge --squash` reported CONFLICTING).\n- Blocker: pristine `origin/main` fails the agent-spec-size ratchet. Verified two ways:\n  (a) `git show origin/main:.claude/agents/planner.md | wc -c` = 40900 (over the 40000 FAIL threshold).\n  (b) In a scratch worktree detached at `origin/main` (SHA `0a056258de4de8e209ddd1535269ebf38aa477f2` at diagnosis time; `f36fdb2f84` post-`task #1725: set-body` commit), `uv run python scripts/workflow_lint.py --check-agent-spec-size` prints `workflow_lint: .claude/agents/planner.md: 40900 bytes exceeds the 40000-byte agent-spec FAIL threshold — relocate per-scenario content to .claude/rules/ (see #829). workflow_lint: FAIL (1 error(s))`.\n\n- My branch alone is GREEN — `tests/test_workflow_lint_agent_spec_size.py::test_live_tree_passes` PASSES on `issue-1718` @ `a6d4a4b9a4` (planner.md there = 39371 bytes). The failure entered my worktree only via the merge that pulled origin/main's planner.md at 40900 bytes.\n\n## Why urgent-park (per `.claude/rules/workflow-fix-on-bug.md` § Recursion guard \"Urgent fast path\", #1681)\n\n- My session is a workflow-fix session ⇒ recursion guard PARKS the candidate; the orchestrator does NOT auto-file/spawn.\n- Every intervening Step 10d merge attempt across the fleet must re-classify this red vs the baseline ledger; the #1643-class fleet-wide cost applies.\n- Direct evidence exists: `test_live_tree_passes` FAILs on pristine `origin/main`, and my in-worktree merge attempt fired the same failure through the pre-commit hook (`workflow-lint-agent-spec-size`).\n\n## Post-park action\n\n- Parking #1718 at status `blocked` with `epm:failure v1 failure_class: infra reason: main-red-planner-md-ratchet-blocks-step10d-merge`.\n- The autonomous-session watcher's `urgent_wf_park_pass` (every 10 min) will detect the token, VERIFY the claim (one bounded pytest run of the named node, expecting rc=1), and file+dispatch via `scripts/file_infra_task.py` — `epm:workflow-fix-task-filed` will land on #1718 with the routed record.\n- Once the routed fix lands (planner.md trimmed to <40 KB and merged to main), a fresh `/issue 1718` respawn (via the completed-unmerged watcher pass or manual) can retry Step 10d cleanly.\n\n## Bug details\n\n- **File:** `.claude/agents/planner.md`\n- **Current size (origin/main):** 40900 bytes\n- **FAIL threshold:** 40000 bytes (`AGENT_SPEC_FAIL_BYTES` in `scripts/workflow_lint.py`)\n- **Overage:** 900 bytes\n- **Policy stance (per #829 / #838):** planner.md was DELIBERATELY not grandfathered — it was structurally trimmed to ≤20 KB and per-scenario content moved to `.claude/rules/`. Concurrent growth pushed it past 40 KB without an offsetting relocation.\n- **Correct fix (per the workflow_lint hook message itself):** \"relocate per-scenario content to .claude/rules/ (see #829)\".\n\n<!-- workflow-fix-candidate v1 -->\ntarget_file: .claude/agents/planner.md\nbug_observed: origin/main planner.md is 40900 bytes, exceeds the 40000-byte AGENT_SPEC_FAIL threshold; pristine origin/main fails workflow_lint --check-agent-spec-size and tests/test_workflow_lint_agent_spec_size.py::test_live_tree_passes\nwhy_workflow_gap: planner.md was deliberately NOT grandfathered per #829/#838 (structurally trimmed to <=20 KB, per-scenario content moved to .claude/rules/); concurrent growth pushed it past 40 KB without a relocation, so every Step 10d merge that pulls origin/main hits the pre-commit ratchet hook and cannot land — fleet-wide per-hour cost until fixed\nproposed_change: Relocate per-scenario content in .claude/agents/planner.md to .claude/rules/ subfiles per #829 so planner.md falls below 40000 bytes\ndiff_sketch: |\n  # Scenario-specific content trimming; the spawned session's planner+implementer\n  # will identify the largest relocatable per-scenario sections per the #829\n  # protocol. Verify with:\n  #   uv run pytest tests/test_workflow_lint_agent_spec_size.py::test_live_tree_passes\n  #   uv run python scripts/workflow_lint.py --check-agent-spec-size\nconfidence: high\nrelated_task: #1718\nurgency: main-red\nfailing_test: tests/test_workflow_lint_agent_spec_size.py::test_live_tree_passes\nwf_fix: true\n<!-- /workflow-fix-candidate -->\n\nFingerprint (sha256(normalize(proposed_change) + \"||\" + normalize(bug_observed))[:12]): 06bc0203d759\n"}"""  # noqa: E501
+
+_1718_TS = "2026-07-27T14:38:28Z"
+_1718_FP = "06bc0203d759"
+
+
+def test_issue1741_urgent_park_lead_note_enumerated(tmp_path: Path) -> None:
+    """Arm (a): the verbatim #1718 URGENT-PARK note enumerates with its fp."""
+    # round-trip guard: the embedded fixture line is a single valid JSON row
+    row = json.loads(_RAW_1718_CAND)
+    assert row["ts"] == _1718_TS
+    # the incident's defining property: no "parked" token anywhere
+    assert "parked" not in row["note"].lower()
+    make_task(tmp_path, 1718, "blocked", raw_event_lines=[_RAW_1718_CAND])
+    c = only(run_sweep(tmp_path))
+    assert c["source"] == "task:1718"
+    assert c["formal_block"] is True
+    assert c["fingerprint"] == _1718_FP
+    assert c["target_file"] == ".claude/agents/planner.md"
+    assert c["suppressed"] is False
+
+
+def test_issue1741_urgent_block_token_enumerated_without_lead(tmp_path: Path) -> None:
+    """Arm (b) independently: `urgency: main-red` INSIDE the formal block
+    enumerates with neither an URGENT-PARK lead nor any "parked" token."""
+    bug = "check c99 fails on origin/main after the ratchet landed."
+    change = "raise the size cap for the offending file."
+    note = (
+        "Recursion-guard candidate surfaced for the nightly sweep (no routing "
+        "performed by this session).\n\n"
+        "<!-- workflow-fix-candidate v1 -->\n"
+        "target_file: .claude/agents/planner.md\n"
+        f"bug_observed: {bug}\n"
+        "why_workflow_gap: the ratchet lacks headroom\n"
+        f"proposed_change: {change}\n"
+        "urgency: main-red\n"
+        "failing_test: tests/test_x.py::test_y\n"
+        "wf_fix: true\n"
+        "confidence: high\n"
+        "related_task: #1718\n"
+        "<!-- /workflow-fix-candidate -->\n"
+    )
+    assert "parked" not in note.lower() and not note.lower().startswith("urgent-park")
+    make_task(tmp_path, 42, "completed", events=[cand_row(T0, note)])
+    c = only(run_sweep(tmp_path))
+    assert c["formal_block"] is True
+    assert c["fingerprint"] == wf_fix_fingerprint(change, bug)
+    assert c["target_file"] == ".claude/agents/planner.md"
+
+
+def test_issue1741_urgent_park_suppressed_by_matching_filed_record(tmp_path: Path) -> None:
+    """The #1718→#1740 no-double-route pin: a LATER same-stream filed record
+    carrying the matching fp suppresses the urgent park (suppression rule 1)."""
+    rec = filed_row(
+        "2026-07-28T06:41:05Z",
+        "filed_task: #1740 / target_file: .claude/agents/planner.md / "
+        f"fingerprint: {_1718_FP} / session_spawned: true / "
+        f"source: daily-parked-candidate-sweep / origin_candidate_ts: {_1718_TS}",
+    )
+    make_task(tmp_path, 1718, "blocked", events=[rec], raw_event_lines=[_RAW_1718_CAND])
+    assert run_sweep(tmp_path)["candidates"] == []
+    c = only(run_sweep(tmp_path, include_routed=True))
+    assert c["suppressed"] is True
+    assert c["suppressed_by"] == {"kind": "same-stream-filed", "ref": "#1740"}
+
+
+def test_issue1741_urgency_token_outside_block_not_enumerated(tmp_path: Path) -> None:
+    """Prose QUOTING the grammar (`urgency: main-red` with NO formal block, no
+    park token) stays out — the casual-mention exclusion is not widened."""
+    note = (
+        "Discussion of the #1681 urgent fast path: a parking session adds\n"
+        "urgency: main-red\n"
+        "failing_test: tests/test_x.py::test_y\n"
+        "inside its formal block; the router verifies before filing."
+    )
+    make_task(tmp_path, 43, "completed", events=[cand_row(T0, note)])
+    assert run_sweep(tmp_path)["candidates"] == []
+    assert run_sweep(tmp_path, include_routed=True)["candidates"] == []
+
+
+def test_issue1741_routed_urgent_note_suppressed(tmp_path: Path) -> None:
+    """A mis-tagged ROUTED urgent-block candidate (`routed: filed #999` note
+    lead) is enumerated by arm (b) but closed by its later same-stream filed
+    record — the routed corner the arm-(b) rationale leans on (rule 1)."""
+    bug = "some urgent bug."
+    change = "some urgent change."
+    fp = wf_fix_fingerprint(change, bug)
+    note = (
+        "routed: filed #999\n\n"
+        "<!-- workflow-fix-candidate v1 -->\n"
+        "target_file: a/b.md\n"
+        f"bug_observed: {bug}\n"
+        "why_workflow_gap: gap\n"
+        f"proposed_change: {change}\n"
+        "urgency: main-red\n"
+        "failing_test: tests/test_x.py::test_y\n"
+        "wf_fix: true\n"
+        "confidence: high\n"
+        "related_task: #999\n"
+        "<!-- /workflow-fix-candidate -->\n"
+    )
+    make_task(
+        tmp_path,
+        44,
+        "completed",
+        events=[
+            cand_row(T0, note),
+            filed_row(T1, f"filed_task: #999 / target_file: a/b.md / fingerprint: {fp}"),
+        ],
+    )
+    assert run_sweep(tmp_path)["candidates"] == []
+    c = only(run_sweep(tmp_path, include_routed=True))
+    assert c["suppressed"] is True
+    assert c["suppressed_by"] == {"kind": "same-stream-filed", "ref": "#999"}


### PR DESCRIPTION
Closes task #1741. Adds the fifth urgent-park accept arm to scripts/sweep_parked_wf_candidates.py::_row_is_parked (URGENT-PARK lead + block-scoped urgency: main-red), emitter guidance in workflow-fix-on-bug.md, and 5 regression tests pinning the #1718 incident shape.