### PR TITLE
issue-1743: verdict post via --file + exact-kind read-back (code-reviewer + reconciler)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -37,7 +37,7 @@ uv run python scripts/task.py post-marker <N> epm:code-review \
     --version <revision_round> --file /tmp/code-review-<N>.md
 ```
 
-`--file` is mandatory (never `--note "$(cat ...)"`) — the file is read raw, no shell re-parsing, so a body quoting git verbs / diff text / `$( )` cannot be shell-mangled or trip the repo-root guard's argv-prose scan (CLAUDE.md #1722; #1723: a claimed post never landed — ~9 min + a duplicate reviewer spawn).
+`--file` is mandatory — never pass the body inline via `--note` with a `$(cat ...)` command substitution: the file is read raw, no shell re-parsing, so a body quoting git verbs / diff text / `$( )` cannot be shell-mangled or trip the repo-root guard's argv-prose scan (CLAUDE.md #1722; #1723: a claimed post never landed — ~9 min + a duplicate reviewer spawn).
 
 **Read-back (MANDATORY before returning) — exact-kind + version, NOT `latest-marker --prefix`** (the prefix also matches the twin `epm:code-review-codex`, posted at the SAME per-round version — a prefix read can falsely confirm on the twin's row, or misread it as "my post is absent" and provoke a duplicate re-post):
 

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -34,8 +34,19 @@ You are an adversarial code reviewer. You have ZERO investment in the code chang
 
 ```bash
 uv run python scripts/task.py post-marker <N> epm:code-review \
-    --version <revision_round> --note "$(cat /tmp/code-review-<N>.md)"
+    --version <revision_round> --file /tmp/code-review-<N>.md
 ```
+
+`--file` is mandatory (never `--note "$(cat ...)"`) — the file is read raw, no shell re-parsing, so a body quoting git verbs / diff text / `$( )` cannot be shell-mangled or trip the repo-root guard's argv-prose scan (CLAUDE.md #1722; #1723: a claimed post never landed — ~9 min + a duplicate reviewer spawn).
+
+**Read-back (MANDATORY before returning) — exact-kind + version, NOT `latest-marker --prefix`** (the prefix also matches the twin `epm:code-review-codex`, posted at the SAME per-round version — a prefix read can falsely confirm on the twin's row, or misread it as "my post is absent" and provoke a duplicate re-post):
+
+```bash
+uv run python scripts/task.py view <N> --json | \
+  jq '[.events[] | select(.kind == "epm:code-review")] | last | {kind, version, ts}'
+```
+
+Confirm `"version": <revision_round>` (this round); only then claim posted. Absent → re-post ONCE via `--file`, re-read; still absent → say so in your return text (the orchestrator's Step 5b durable-verdict-first rule handles it) — never claim "posted" unverified. Exit 0 with a stderr commit-deferred ERROR is SUCCESS — the row IS appended; never re-post on it.
 
 Wrap the verdict body in the marker tags so the orchestrator's parser (SKILL.md Step 5c) finds it:
 

--- a/.claude/agents/reconciler.md
+++ b/.claude/agents/reconciler.md
@@ -376,11 +376,27 @@ body's `**Role under adjudication:**` field, NOT in the marker name. The
 key off this one marker kind.
 
 ```bash
-python scripts/task.py post-marker <N> epm:review-reconcile --note "$(cat marker.md)"
+python scripts/task.py post-marker <N> epm:review-reconcile --file marker.md
 ```
 
+The `--file` channel reads the body raw with no shell re-parsing — an
+adjudication body quoting git verbs / diff text / `$( )` can never be
+shell-mangled or trip the repo-root guard's `--note` argv-prose scan
+(CLAUDE.md #1722; the #1723 class: a claimed post that never landed).
+
 If the body is too large, split it using the `part=K/N` convention from
-`markers.md` and re-post each part.
+`markers.md` and post each part via `--file` — each part written to its
+own file; never revert to `--note` for parts.
+
+Read-back duty (before returning): verify the post landed with the
+exact-kind check
+`uv run python scripts/task.py view <N> --json | jq '[.events[] | select(.kind == "epm:review-reconcile")] | last | {kind, version, ts}'`
+and confirm THIS adjudication's version is present; never claim posted
+unverified (the #1723 class). The exact-kind form is used for consistency
+with the code-reviewer recipe — `epm:review-reconcile` currently has no
+sibling prefix kind, but the exact-kind read stays immune if one is ever
+added. A `post-marker` exit 0 with a stderr commit-deferred ERROR is
+SUCCESS — the row IS appended; never re-post on it.
 
 **In-context mode** — print the marker body verbatim to stdout, opening with
 `<!-- epm:plan-critique-reconcile v<round> -->` and closing with

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -2231,7 +2231,7 @@ Brief passed to the implementer:
   (`selector-universe` | `repo-wide` — the REALIZED universe; #1651)
   — never a count-only or glob-family summary (#1494;
   >20 files → fenced block under the Gate-scope line).
-  Belt-and-suspenders on `implementer.md` § After Implementation item 1,
+  Belt-and-suspenders on `implementer.md` § After Implementation items 1 + 1a,
   so round briefs surface the duty without the implementer having to
   recall its agent spec (the #509 precedent).
 - **Marker-version discipline — a brief NEVER instructs a literal marker
@@ -9380,6 +9380,32 @@ suite directly and posts an `epm:test-verdict` event with the result.
         && echo "[step9c] ledger refresh detached pid=$REFRESH_PID log=$REPO_ROOT/logs/step9c_baseline_refresh.log choom=ok" \
         || echo "[step9c] ledger refresh detached pid=$REFRESH_PID log=$REPO_ROOT/logs/step9c_baseline_refresh.log choom=failed"
       ```
+   e. Urgent-park duty on stripped workflow-invariant red (#1713/#1742) — a
+      mechanical, trigger-keyed duty inside this step; auto-continue (never a
+      gate/pause). When COMPARE_OUT's `urgent_park_required` list is
+      non-empty — or an `URGENT-PARK-REQUIRED:` line appears in the compare
+      stderr `.err` tail — then IN THE SAME TURN as posting
+      `epm:test-verdict`, for EACH listed `<file>::<name>` node id:
+      (i) bounded dedup grep for an already-routable candidate:
+      ```bash
+      grep -rl -- 'failing_test: <node id>' tasks/*/*/events.jsonl \
+        .claude/cache/workflow-fix-events.jsonl 2>/dev/null
+      ```
+      a hit means a routable candidate already exists — record the pointer
+      (the matching events path), do NOT re-emit; (ii) on no hit, emit the
+      `<!-- workflow-fix-candidate v1 -->` block in the session's
+      return/chat text carrying the #1681 urgent grammar — `urgency:
+      main-red` + `failing_test: <the ONE pytest node id>` +
+      `wf_fix: true|false` — routed/parked by the standard workflow-fix
+      protocol (under the recursion guard the PARK is itself the routable
+      record the watcher's urgent-park router consumes); (iii) record the
+      disposition in the `epm:test-verdict` note: `urgent_park: emitted
+      <id>` | `urgent_park: existing <events path>` (omit the line when
+      `urgent_park_required` is empty). This mechanical trigger covers the
+      selector's WORKFLOW_INVARIANT subset ONLY; the Step 10d broad-glob
+      urgent-park duty (#1713 — ANY workflow-surface pre-existing red) is
+      UNCHANGED for non-invariant reds: "no 1e trigger fired" never waives
+      that duty.
 2. Lint: covered by step 1d `compare` — repo-wide `ruff check` /
    `ruff format --check` are diffed against the LIVE main-root baseline
    (only an INCREASE fails; main carries 2000+ pre-existing ruff errors,
@@ -9399,7 +9425,10 @@ any untested-touched-file WARNs (so the orchestrator surfaces wrong-cwd runs
 and coverage gaps — never silently skipped), and the compare classification
 JSON (new vs known-red-stripped failures with any scan-test / diff-linked
 masking WARNs, the ruff delta vs the live main baseline, the ledger main_sha
-+ age + stale flag, and any dirty-code-path flags), and
++ age + stale flag, and any dirty-code-path flags), and the step-1e
+urgent-park disposition line(s) (`urgent_park: emitted <id>` |
+`urgent_park: existing <events path>`; omitted when `urgent_park_required`
+is empty — #1742), and
 the gate + compare earlyoom-protection state — COPY the `[step9c] gate
 earlyoom protection choom=…` and `[step9c] compare earlyoom protection
 choom=…` breadcrumb lines from the gate and compare calls' transcripts (plus

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -11888,11 +11888,14 @@ AGENT_SPEC_SIZE_GRANDFATHER: dict[str, int] = {
     # (#1159) — no longer grandfathered (slim spec is under the FAIL threshold).
     # the rest measured at the #838 tightening (2026-07-02), caps = measured
     # + <=3 KB; each names a future trim direction, none is licensed to grow
-    # measured 131,378 B post-Step-10d-merge (task #1727 Step 0.70
-    # smoke-variable gating gate + task #1716 Step 4 ruff-policy pin +
-    # L99 style-bullet + Step 0.5 pin-invocation marker-shape check —
-    # both landings STACKED at Step 10d merge; cap = measured + ~1.0 KB.
+    # measured 133,188 B post-#1743 (task-bound verdict post switched to
+    # the --file channel + MANDATORY exact-kind read-back duty —
+    # plan-mandated growth; cap = measured + ~1.0 KB.
     # Prior:
+    # 132_500 — measured 131,378 B post-Step-10d-merge (task #1727 Step
+    # 0.70 smoke-variable gating gate + task #1716 Step 4 ruff-policy pin
+    # + L99 style-bullet + Step 0.5 pin-invocation marker-shape check —
+    # both landings STACKED at Step 10d merge),
     # 130_000 — measured 128,507 B post-#1727 unmerged (Step 0.70
     # alone atop pre-#1716 base — trigger + sub-checks (1)/(2)/(3) +
     # waiver form + verdict routing with the smoke-var-ungated /
@@ -11924,7 +11927,7 @@ AGENT_SPEC_SIZE_GRANDFATHER: dict[str, int] = {
     # reads), 99,000 — measured 98,126 B post-#1230 (Step 6 durability-pin
     # shipping duty), 97,000 — measured 96,072 B post-#1119, 95,000 —
     # measured 94,126 B post-#1115)
-    "code-reviewer.md": 132_500,
+    "code-reviewer.md": 134_200,
     # measured 74,082 B post-#1447 (family-enumeration sync: the two
     # byte/bit verdict rows widened to the -exact / bitwise / X-for-X
     # tail — plan-mandated growth; cap = measured + ~1.1 KB. Prior:


### PR DESCRIPTION
Closes task #1743.

Workflow-fix (daily route-2, #1723 incident): switch the Claude code-reviewer's and the reconciler's marker-mode verdict-post recipes from the argv-prose channel (--note with an inline command substitution) to the --file channel, and add a mandatory exact-kind + version read-back duty before either agent may claim 'posted'. Includes a documented AGENT_SPEC_SIZE_GRANDFATHER cap raise for code-reviewer.md (ratchet-collision remedy, accepted in review).

Code-review: r1 FAIL (substantive, fixed) -> r2 PASS. Step 9c: 5128 passed / 6 skipped, compare clean.