### PR TITLE
issue-1770: load_dotenv() before heavy imports in two figure scripts (fix main-red thread-caps invariant node)

### DIFF
--- a/scripts/issue1481_coverage_fig.py
+++ b/scripts/issue1481_coverage_fig.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import matplotlib
+from explore_persona_space.orchestrate.env import load_dotenv
+
+# Shared-VM thread caps (#847): env caps must bind BEFORE any heavy import.
+load_dotenv()
+
+import matplotlib  # noqa: E402
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa: E402

--- a/scripts/issue779_scaling_curve_fig.py
+++ b/scripts/issue779_scaling_curve_fig.py
@@ -13,7 +13,12 @@ import statistics as st
 from collections import defaultdict
 from pathlib import Path
 
-import matplotlib
+from explore_persona_space.orchestrate.env import load_dotenv
+
+# Shared-VM thread caps (#847): env caps must bind BEFORE any heavy import.
+load_dotenv()
+
+import matplotlib  # noqa: E402
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa: E402


### PR DESCRIPTION
Closes task #1770. Fixes the main-red workflow-invariant node tests/test_shared_vm_thread_caps.py::test_no_new_torch_before_dotenv_vm_entrypoints by inserting load_dotenv() before the first heavy import in scripts/issue1481_coverage_fig.py and scripts/issue779_scaling_curve_fig.py.