### PR TITLE
issue-1788: daily-fix: Guard-4 grep -Fxq needs -- (false LOST-UPDATE)

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -10390,7 +10390,7 @@ rebase-merged. Five guards:
    MB=$(git -C "$WT" merge-base HEAD origin/main)
    # is the merge-base reachable on origin/main's first-parent mainline?
    ON_MAINLINE=$(git -C "$WT" rev-list --first-parent origin/main \
-     | grep -Fxq "$MB" && echo yes || echo no)
+     | grep -Fxq -- "$MB" && echo yes || echo no)
    ```
 
    The branch is **unsafe to blind-rebase** if EITHER `ON_MAINLINE=no`
@@ -10499,7 +10499,7 @@ rebase-merged. Five guards:
    `origin/main` ADDED since the merge-base (post-merge-base additions
    only — never `main`'s own pre-fork content), then check whether each
    such line is present in the branch's current version of that file
-   (`grep -Fxq` — full-line, fixed-string, so quoting or partial
+   (`grep -Fxq --` — full-line, fixed-string, so quoting or partial
    substring matches cannot mask a drop). A missing line is by
    definition a main-side addition the branch's snapshot silently
    REVERTED — a legitimate branch DELETION of a pre-existing function
@@ -10525,7 +10525,7 @@ rebase-merged. Five guards:
              while IFS= read -r ADD_LINE; do
                [ -z "$ADD_LINE" ] && continue
                if ! git -C "$WT" show HEAD:"$P" 2>/dev/null \
-                    | grep -Fxq "$ADD_LINE"; then
+                    | grep -Fxq -- "$ADD_LINE"; then
                  MISSING_ON_BRANCH=$((MISSING_ON_BRANCH + 1))
                fi
              done < /tmp/1713-main-adds.txt
@@ -13033,7 +13033,7 @@ elif ! git -C "$REPO_ROOT" ls-tree -d -r --name-only origin/main \
 # this arm never opens a delete of the canonical folder. Only a
 # still-absent CANON takes the branch — terminal echo + false, nothing
 # deleted.
-elif ! grep -qxF "$CANON" /tmp/issue-<N>-postmerge-lstree.txt \
+elif ! grep -qxF -- "$CANON" /tmp/issue-<N>-postmerge-lstree.txt \
     && { for _ in 1 2; do
            uv run python "$REPO_ROOT/scripts/sync_repo_root.py"
            NEW_CANON=$(realpath --relative-to="$REPO_ROOT" \
@@ -13042,10 +13042,10 @@ elif ! grep -qxF "$CANON" /tmp/issue-<N>-postmerge-lstree.txt \
            git -C "$REPO_ROOT" fetch origin main --quiet \
              && git -C "$REPO_ROOT" ls-tree -d -r --name-only origin/main \
                 > /tmp/issue-<N>-postmerge-lstree.txt \
-             && grep -qxF "$CANON" /tmp/issue-<N>-postmerge-lstree.txt \
+             && grep -qxF -- "$CANON" /tmp/issue-<N>-postmerge-lstree.txt \
              && break
          done
-         ! grep -qxF "$CANON" /tmp/issue-<N>-postmerge-lstree.txt; }; then
+         ! grep -qxF -- "$CANON" /tmp/issue-<N>-postmerge-lstree.txt; }; then
   echo "post-merge stale-task-folder guard: canonical folder $CANON still ABSENT from origin/main after 2 root syncs — cannot classify duplicates (removing origin's only copy would leave ZERO folders for task <N>)"
   false
 # Work arm: every committed task-<N> folder on origin/main (matches

--- a/tests/test_step10d_guard3.py
+++ b/tests/test_step10d_guard3.py
@@ -1255,7 +1255,7 @@ def test_post_merge_guard_unpushed_mv_precheck_syncs_before_classify():
     assert len(fences) == 1, "guard region must still carry exactly one fenced bash block"
     fence = fences[0]
 
-    precheck = fence.find('elif ! grep -qxF "$CANON" /tmp/issue-<N>-postmerge-lstree.txt')
+    precheck = fence.find('elif ! grep -qxF -- "$CANON" /tmp/issue-<N>-postmerge-lstree.txt')
     lstree_arm = fence.find('elif ! git -C "$REPO_ROOT" ls-tree -d -r --name-only origin/main')
     dupes_arm = fence.find("elif mapfile -t DUPES < <(grep -E")
     assert precheck != -1, "the unpushed-mv pre-check arm must exist (#1300)"
@@ -1284,7 +1284,7 @@ def test_post_merge_guard_unpushed_mv_precheck_syncs_before_classify():
     # (iv) fall-through: the condition list's FINAL command is the
     # still-absent re-test (recovery success -> condition false -> the
     # DUPES arm runs against the regenerated file).
-    assert '! grep -qxF "$CANON" /tmp/issue-<N>-postmerge-lstree.txt; }; then' in arm, (
+    assert '! grep -qxF -- "$CANON" /tmp/issue-<N>-postmerge-lstree.txt; }; then' in arm, (
         "the recovery must live in the arm's CONDITION with the still-absent "
         "re-test as its final command (successful recovery falls through)"
     )
@@ -1450,3 +1450,30 @@ def test_mergefile_block_untouched_order():
     done_idx = gate.index("done < /tmp/issue-<N>-overlay-files.txt")
     lint_vintage_idx = gate.index("LINT-VINTAGE 3-WAY MERGE")
     assert done_idx < lint_vintage_idx
+
+
+def test_guard_greps_carry_end_of_options_separator():
+    """#1788 (incidents #1742/#1758): every VARIABLE-pattern full-line grep in
+    the Step 10d guards carries the `--` end-of-options separator. Without it
+    a main-added line starting with `-` (a markdown bullet — ubiquitous on the
+    workflow surface Guard 4 scans) is parsed as grep OPTIONS ("invalid
+    option", rc=2), which the loop miscounts as MISSING_ON_BRANCH and Guard 4
+    false-fires a LOST-UPDATE refusal on a byte-identical branch."""
+    text = _skill_text()
+    # (a) The separator-bearing forms are present.
+    assert 'grep -Fxq -- "$ADD_LINE"' in text, "Guard-4 membership grep lost its -- separator"
+    assert 'grep -Fxq -- "$MB"' in text, "Guard-3 ON_MAINLINE grep lost its -- separator"
+    # (b) No separator-less VARIABLE-pattern form remains, in EITHER flag
+    # ordering. Literal-pattern greps (e.g. -qxF 'scripts/workflow_lint.py')
+    # are exempt by construction: the regex requires the pattern argument to
+    # start with `"$` (a shell-variable pattern), which only a variable-
+    # pattern site has; the fixed forms carry `-- ` and do not match.
+    offenders = [
+        f"line {i}: {line.strip()}"
+        for i, line in enumerate(text.splitlines(), start=1)
+        if re.search(r'grep -(?:Fxq|qxF) "\$', line)
+    ]
+    assert not offenders, (
+        "separator-less variable-pattern grep -Fxq/-qxF site(s) in SKILL.md "
+        "(add `--` before the pattern): " + "; ".join(offenders)
+    )


### PR DESCRIPTION
Closes task #1788. Adds the -- end-of-options separator to the Step 10d Guard-4 membership grep (+ 5 lockstep variable-pattern sites) and a durability pin test.