### PR TITLE
issue-1786: WARN when dispatch handle points at dead attempt

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -10390,7 +10390,7 @@ rebase-merged. Five guards:
    MB=$(git -C "$WT" merge-base HEAD origin/main)
    # is the merge-base reachable on origin/main's first-parent mainline?
    ON_MAINLINE=$(git -C "$WT" rev-list --first-parent origin/main \
-     | grep -Fxq "$MB" && echo yes || echo no)
+     | grep -Fxq -- "$MB" && echo yes || echo no)
    ```
 
    The branch is **unsafe to blind-rebase** if EITHER `ON_MAINLINE=no`
@@ -10499,7 +10499,7 @@ rebase-merged. Five guards:
    `origin/main` ADDED since the merge-base (post-merge-base additions
    only — never `main`'s own pre-fork content), then check whether each
    such line is present in the branch's current version of that file
-   (`grep -Fxq` — full-line, fixed-string, so quoting or partial
+   (`grep -Fxq --` — full-line, fixed-string, so quoting or partial
    substring matches cannot mask a drop). A missing line is by
    definition a main-side addition the branch's snapshot silently
    REVERTED — a legitimate branch DELETION of a pre-existing function
@@ -10525,7 +10525,7 @@ rebase-merged. Five guards:
              while IFS= read -r ADD_LINE; do
                [ -z "$ADD_LINE" ] && continue
                if ! git -C "$WT" show HEAD:"$P" 2>/dev/null \
-                    | grep -Fxq "$ADD_LINE"; then
+                    | grep -Fxq -- "$ADD_LINE"; then
                  MISSING_ON_BRANCH=$((MISSING_ON_BRANCH + 1))
                fi
              done < /tmp/1713-main-adds.txt
@@ -13033,7 +13033,7 @@ elif ! git -C "$REPO_ROOT" ls-tree -d -r --name-only origin/main \
 # this arm never opens a delete of the canonical folder. Only a
 # still-absent CANON takes the branch — terminal echo + false, nothing
 # deleted.
-elif ! grep -qxF "$CANON" /tmp/issue-<N>-postmerge-lstree.txt \
+elif ! grep -qxF -- "$CANON" /tmp/issue-<N>-postmerge-lstree.txt \
     && { for _ in 1 2; do
            uv run python "$REPO_ROOT/scripts/sync_repo_root.py"
            NEW_CANON=$(realpath --relative-to="$REPO_ROOT" \
@@ -13042,10 +13042,10 @@ elif ! grep -qxF "$CANON" /tmp/issue-<N>-postmerge-lstree.txt \
            git -C "$REPO_ROOT" fetch origin main --quiet \
              && git -C "$REPO_ROOT" ls-tree -d -r --name-only origin/main \
                 > /tmp/issue-<N>-postmerge-lstree.txt \
-             && grep -qxF "$CANON" /tmp/issue-<N>-postmerge-lstree.txt \
+             && grep -qxF -- "$CANON" /tmp/issue-<N>-postmerge-lstree.txt \
              && break
          done
-         ! grep -qxF "$CANON" /tmp/issue-<N>-postmerge-lstree.txt; }; then
+         ! grep -qxF -- "$CANON" /tmp/issue-<N>-postmerge-lstree.txt; }; then
   echo "post-merge stale-task-folder guard: canonical folder $CANON still ABSENT from origin/main after 2 root syncs — cannot classify duplicates (removing origin's only copy would leave ZERO folders for task <N>)"
   false
 # Work arm: every committed task-<N> folder on origin/main (matches

--- a/scripts/backend_poll.py
+++ b/scripts/backend_poll.py
@@ -679,9 +679,8 @@ def _maybe_warn_stale_handle(
         # ``scripts.poll_pipeline`` resolvable).
         from datetime import UTC, datetime
 
-        from scripts.poll_pipeline import MARKER_PID_RE
-
         from explore_persona_space.task_workflow import list_events
+        from scripts.poll_pipeline import MARKER_PID_RE
 
         rows = [e for e in list_events(int(issue)) if e.get("kind") == "epm:run-launched"]
         if not rows:

--- a/scripts/backend_poll.py
+++ b/scripts/backend_poll.py
@@ -592,6 +592,155 @@ def _missing_sidecar_json(issue: int, sidecar_path: Path, reason: str) -> dict:
     }
 
 
+#: Slack (seconds) before the handle sidecar's mtime is called stale against
+#: a relaunch marker (#1786). Grounded on the #1156 precedent's slack default
+#: (``EPM_POLL_PID_MARKER_SLACK_SEC`` = 600 in ``scripts/poll_pipeline.py`` —
+#: pod-side-reporting.md § Residual honesty).
+HANDLE_MARKER_SLACK_SEC = 600
+
+
+def _handle_stale_flags(
+    *,
+    handle_workload_pid,
+    sidecar_mtime_epoch: float,
+    run_launched_ts_epochs: list[float],
+    marker_pid: int | None,
+    slack_sec: int = HANDLE_MARKER_SLACK_SEC,
+) -> tuple[bool, bool]:
+    """Pure discriminator (#1786): ``(handle_stale_vs_live, handle_older_than_relaunch)``.
+
+    ``handle_stale_vs_live``: the newest ``epm:run-launched`` marker's ``pid=``
+    and the handle's ``extra.workload_pid`` are BOTH present + parseable ints
+    AND differ. Inert (False) when either side is missing/unparseable — lanes
+    that never populate ``extra.workload_pid`` (GCP/SLURM) are inert by
+    construction.
+
+    ``handle_older_than_relaunch``: >=2 run-launched markers exist AND
+    ``sidecar_mtime_epoch + slack_sec < run_launched_ts_epochs[-2]`` — the
+    SECOND-newest marker, deliberately. A COMPLIANT relaunch rewrites the
+    sidecar at (re)dispatch time, which necessarily POSTDATES the PREVIOUS
+    launch's marker, while a never-rewritten handle's mtime is the original
+    dispatch write, which PREDATES it. Comparing against the NEWEST marker
+    would fire persistently on the compliant re-dispatch path itself (the
+    sidecar is rewritten at dispatch; the fresh marker posts up to ~50 min
+    later on the RunPod lane) — the same dispatch->marker latency that makes
+    the first-launch case undiscriminable. The second-newest comparison is
+    latency-insensitive.
+
+    Pure — no IO; unit-testable with no SSH (mirror of
+    ``poll_pipeline._pid_file_predates_marker``, #1156).
+    """
+    try:
+        handle_pid = int(str(handle_workload_pid))
+    except (TypeError, ValueError):
+        handle_pid = None
+    stale_vs_live = handle_pid is not None and marker_pid is not None and handle_pid != marker_pid
+    older_than_relaunch = (
+        sidecar_mtime_epoch > 0
+        and len(run_launched_ts_epochs) >= 2
+        and sidecar_mtime_epoch + slack_sec < run_launched_ts_epochs[-2]
+    )
+    return stale_vs_live, older_than_relaunch
+
+
+def _maybe_warn_stale_handle(
+    *, issue: int, sidecar: Path, handle, lane_suffix
+) -> tuple[bool, bool]:
+    """#1786 WARN-only handle-staleness detector; returns the two tick-JSON flags.
+
+    Mechanical backstop for the #1750 prose duty (pod-side-reporting.md
+    item 1e: rewrite the handle sidecar on relaunch); incident #1689 r15b:
+    the handle kept pointing at the OLD attempt's completion sentinel, so
+    completion was never observed and nothing warned. WARN-only by contract —
+    neither flag ever contributes to status / stall_reason / verdict /
+    next_interval.
+
+    Returns ``(False, False)`` IMMEDIATELY when ``lane_suffix`` is set: the
+    sidecar is per-LANE (#934) but ``epm:run-launched`` markers are per-ISSUE,
+    so under multi-lane polling lane A's tick would read lane B's newer marker
+    and both checks would false-fire every tick on healthy handles.
+
+    Benign transient window for ``handle_stale_vs_live``: on a COMPLIANT
+    relaunch the fresh marker and the handle rewrite land seconds-to-minutes
+    apart, so the flag may fire for a few ticks in between — acceptable for a
+    WARN that feeds no verdict.
+
+    Fail-soft: any exception is swallowed to DEBUG and returns
+    ``(False, False)`` — the same deliberate, narrow exception to fail-fast as
+    ``poll_pipeline._maybe_warn_stale_pid_file`` (#1156): the flags are
+    observability feeding no verdict, and this hot shared poll script runs on
+    every live poll loop fleet-wide (#1786).
+    """
+    try:
+        if lane_suffix:
+            return (False, False)
+        # Lazy imports — the GCP idle block's precedent (keeps the --help path
+        # fast; the repo-root sys.path bootstrap above makes
+        # ``scripts.poll_pipeline`` resolvable).
+        from datetime import UTC, datetime
+
+        from scripts.poll_pipeline import MARKER_PID_RE
+
+        from explore_persona_space.task_workflow import list_events
+
+        rows = [e for e in list_events(int(issue)) if e.get("kind") == "epm:run-launched"]
+        if not rows:
+            return (False, False)
+        # events.jsonl is append-only, so file order IS ascending-ts order.
+        ts_epochs: list[float] = []
+        for ev in rows:
+            try:
+                parsed = datetime.fromisoformat(str(ev.get("ts")))
+            except (TypeError, ValueError):
+                continue
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=UTC)
+            ts_epochs.append(parsed.timestamp())
+        m = MARKER_PID_RE.search(str(rows[-1].get("note", "") or ""))
+        marker_pid = int(m.group(1)) if m else None
+        extra = getattr(handle, "extra", None) or {}
+        stale_vs_live, older_than_relaunch = _handle_stale_flags(
+            handle_workload_pid=extra.get("workload_pid"),
+            sidecar_mtime_epoch=float(Path(sidecar).stat().st_mtime),
+            run_launched_ts_epochs=ts_epochs,
+            marker_pid=marker_pid,
+        )
+        if stale_vs_live:
+            logging.warning(
+                "handle sidecar %s for #%d carries extra.workload_pid=%s but the newest "
+                "epm:run-launched marker says pid=%s — the handle points at a PRIOR "
+                "attempt's run-scoped fields (#1689 r15b shape). WARN-only; verdict "
+                "unchanged. Recovery: rewrite the handle sidecar per "
+                ".claude/rules/pod-side-reporting.md item 1e, or re-dispatch through "
+                "dispatch_issue.py so the router rewrites it.",
+                sidecar,
+                issue,
+                extra.get("workload_pid"),
+                marker_pid,
+            )
+        if older_than_relaunch:
+            logging.warning(
+                "handle sidecar %s for #%d was last written before the SECOND-newest "
+                "epm:run-launched marker (mtime + %ds slack < ts(marker[-2])) — a "
+                "relaunch happened without the item-1e handle rewrite (#1786). "
+                "WARN-only; verdict unchanged. Recovery: rewrite the handle sidecar per "
+                ".claude/rules/pod-side-reporting.md item 1e, or re-dispatch through "
+                "dispatch_issue.py so the router rewrites it.",
+                sidecar,
+                issue,
+                HANDLE_MARKER_SLACK_SEC,
+            )
+        return (stale_vs_live, older_than_relaunch)
+    except Exception as exc:
+        logging.debug(
+            "handle-staleness detector failed for #%s (ignored — WARN-only "
+            "observability, #1786/#1156): %s",
+            issue,
+            exc,
+        )
+        return (False, False)
+
+
 def _is_gcp_async_workload_failure(handle, result) -> bool:
     """True ONLY for a GCP handle whose poll surfaced a failover-eligible death (#659, #669).
 
@@ -4782,10 +4931,25 @@ def main(argv: list[str] | None = None) -> int:
             },
         )
 
+    # ── #1786 WARN-only handle-staleness flags (normal tick-JSON tail only) ──
+    # Fail-soft observability alongside the GCP idle flags above: the early-
+    # return terminal JSON paths are EXEMPT (they emit their own payload
+    # shapes and terminate the loop anyway). Runs on every normal-tail tick
+    # unconditionally — WARN-only, so a terminal-phase tick firing the flag is
+    # harmless and still informative.
+    handle_stale_vs_live, handle_older_than_relaunch = _maybe_warn_stale_handle(
+        issue=args.issue,
+        sidecar=Path(sidecar),
+        handle=handle,
+        lane_suffix=args.lane_suffix,
+    )
+
     out = _serialize_poll_result(result)
     out["gcp_gpu_idle_advisory_posted"] = gcp_gpu_idle_advisory_posted
     out["gcp_gpu_idle_escalation_posted"] = gcp_gpu_idle_escalation_posted
     out["gcp_gpu_width_advisory_posted"] = gcp_gpu_width_advisory_posted
+    out["handle_stale_vs_live"] = handle_stale_vs_live
+    out["handle_older_than_relaunch"] = handle_older_than_relaunch
     print(json.dumps(out))
     return 0
 

--- a/tests/test_backend_poll.py
+++ b/tests/test_backend_poll.py
@@ -4577,3 +4577,234 @@ def test_runspec_from_gcp_handle_forwards_env_pins():
     # Legacy GCP handle (no key) stays byte-identical: no env_pins forwarded.
     legacy_spec = bp._runspec_from_gcp_handle(_gcp_handle(), 659)
     assert "env_pins" not in legacy_spec.extra
+
+
+# ---------------------------------------------------------------------------
+# #1786 — WARN-only handle-staleness flags (handle_stale_vs_live /
+# handle_older_than_relaunch). Pure decision table for _handle_stale_flags,
+# wrapper tests for _maybe_warn_stale_handle (lane-suffix inertness + the
+# fail-soft swallow-to-DEBUG pin), and the normal-tail tick-JSON integration.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_task_events(monkeypatch):
+    """Default ``task_workflow.list_events`` to an EMPTY event list.
+
+    #1786: ``main()``'s normal tick-JSON tail now calls
+    ``_maybe_warn_stale_handle`` on EVERY tick, which lazily imports
+    ``task_workflow.list_events`` (the same VM-side read
+    ``_prior_failure_marker_is_cuda_ima`` does). Without this default, every
+    pre-existing tail-path test would read the REAL ``tasks/`` tree for its
+    fake issue number (fail-soft, but nondeterministic + repo-state-coupled —
+    the same hermeticity concern ``_hermetic_runpod_team_list`` closes for
+    the #1490 live-pod snapshot). An empty list leaves the detector inert
+    (no run-launched markers -> ``(False, False)``); the #1786 positive
+    tests override with their own event fakes.
+    """
+    import explore_persona_space.task_workflow as tw
+
+    monkeypatch.setattr(tw, "list_events", lambda task_id: [])
+
+
+def _iso_z(epoch: float) -> str:
+    """events.jsonl ``ts`` shape (``task_workflow._utcnow_iso``: %Y-%m-%dT%H:%M:%SZ)."""
+    from datetime import UTC, datetime
+
+    return datetime.fromtimestamp(epoch, tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _run_launched_event(*, ts_epoch: float, note: str) -> dict:
+    return {"kind": "epm:run-launched", "ts": _iso_z(ts_epoch), "note": note}
+
+
+@pytest.mark.parametrize(
+    ("workload_pid", "marker_pid", "expected_stale_vs_live"),
+    [
+        (1234, 1234, False),  # pid match — no fire
+        (1234, 5678, True),  # pid mismatch — the #1689 r15b shape, FIRE
+        (None, 5678, False),  # missing workload_pid (GCP/SLURM lanes) — inert
+        ("n/a", 5678, False),  # unparseable workload_pid — inert
+        (1234, None, False),  # marker carries no pid= — inert
+    ],
+)
+def test_handle_stale_flags_pid_identity_decision_table(
+    workload_pid, marker_pid, expected_stale_vs_live
+):
+    """#1786 pure decision table, pid-identity axis (acceptance criterion 2)."""
+    from scripts.backend_poll import _handle_stale_flags
+
+    stale_vs_live, older = _handle_stale_flags(
+        handle_workload_pid=workload_pid,
+        sidecar_mtime_epoch=20_500.0,  # newer than the newest marker: axis-2 inert
+        run_launched_ts_epochs=[10_000.0, 20_000.0],
+        marker_pid=marker_pid,
+    )
+    assert stale_vs_live is expected_stale_vs_live
+    assert older is False
+
+
+@pytest.mark.parametrize(
+    ("sidecar_mtime", "ts_epochs", "expected_older"),
+    [
+        # Single-marker first launch: no relaunch to compare against — no fire.
+        (5_000.0, [10_000.0], False),
+        # Two-marker never-rewritten handle: mtime predates ts(marker[-2]) by
+        # more than the 600s slack — FIRE.
+        (9_000.0, [10_000.0, 20_000.0], True),
+        # Two-marker compliant rewrite: mtime between ts(marker[-2]) and
+        # ts(marker[-1]) (the dispatch-time rewrite postdates the PREVIOUS
+        # launch's marker) — no fire.
+        (15_000.0, [10_000.0, 20_000.0], False),
+        # mtime newer than the newest marker — no fire.
+        (25_000.0, [10_000.0, 20_000.0], False),
+        # Boundary: mtime + slack == ts(marker[-2]) exactly — strict < — no fire.
+        (9_400.0, [10_000.0, 20_000.0], False),
+        # Three markers: [-2] is the SECOND-newest (20_000), not the first.
+        (19_000.0, [10_000.0, 20_000.0, 30_000.0], True),
+    ],
+)
+def test_handle_stale_flags_mtime_vs_relaunch_decision_table(
+    sidecar_mtime, ts_epochs, expected_older
+):
+    """#1786 pure decision table, mtime-vs-second-newest-marker axis
+    (acceptance criterion 3 — the second-newest comparison is what keeps the
+    compliant re-dispatch path from false-firing on dispatch->marker latency)."""
+    from scripts.backend_poll import _handle_stale_flags
+
+    stale_vs_live, older = _handle_stale_flags(
+        handle_workload_pid=1234,
+        sidecar_mtime_epoch=sidecar_mtime,
+        run_launched_ts_epochs=ts_epochs,
+        marker_pid=1234,  # pids match: axis-1 inert
+    )
+    assert stale_vs_live is False
+    assert older is expected_older
+
+
+def test_handle_stale_flags_positive_control_raises_nothing_on_well_formed_inputs():
+    """#1786 fail-loud pin sibling (acceptance criterion 8): the PURE helper
+    raises nothing across well-formed input combinations — the wrapper's
+    swallow-to-DEBUG is for the IO edges, never a mask over helper bugs."""
+    from scripts.backend_poll import _handle_stale_flags
+
+    for pid in (None, 1234, "1234", "n/a", 12.0):
+        for ts_epochs in ([], [10_000.0], [10_000.0, 20_000.0]):
+            for mtime in (0.0, 9_000.0, 25_000.0):
+                out = _handle_stale_flags(
+                    handle_workload_pid=pid,
+                    sidecar_mtime_epoch=mtime,
+                    run_launched_ts_epochs=ts_epochs,
+                    marker_pid=1234,
+                )
+                assert isinstance(out, tuple) and len(out) == 2
+
+
+def test_handle_stale_wrapper_lane_suffix_forces_inert(tmp_path, monkeypatch):
+    """#1786 acceptance criterion 4: a lane-suffixed poll returns
+    ``(False, False)`` IMMEDIATELY — per-lane sidecar (#934) but per-ISSUE
+    markers means lane A's tick would read lane B's newer marker and
+    false-fire every tick on a healthy handle. The event read must never
+    even run on this path."""
+    import explore_persona_space.task_workflow as tw
+    from scripts import backend_poll as bp
+
+    calls: list[int] = []
+    monkeypatch.setattr(tw, "list_events", lambda task_id: calls.append(task_id) or [])
+    sidecar = tmp_path / "issue-1786-cpu-handle.json"  # deliberately absent
+    handle = _gcp_handle({**_GCP_EXTRA_659, "workload_pid": 1111})
+    assert bp._maybe_warn_stale_handle(
+        issue=1786, sidecar=sidecar, handle=handle, lane_suffix="cpu"
+    ) == (False, False)
+    assert calls == []
+
+
+def test_handle_stale_wrapper_swallows_exceptions_to_debug(tmp_path, monkeypatch, caplog):
+    """#1786 acceptance criteria 6 + 8 (the Fail-loud pin): any exception
+    inside the detector is swallowed to DEBUG and returns ``(False, False)``
+    — the #1156 narrow fail-soft carve-out (WARN-only observability feeding
+    no verdict on the hot shared poll script), never a silent verdict
+    change and never a raised tick."""
+    import logging as _logging
+
+    import explore_persona_space.task_workflow as tw
+    from scripts import backend_poll as bp
+
+    def _boom(task_id):
+        raise RuntimeError("synthetic events-read failure (#1786 fail-soft pin)")
+
+    monkeypatch.setattr(tw, "list_events", _boom)
+    sidecar = tmp_path / "issue-1786-handle.json"
+    write_handle_sidecar(_gcp_handle(), sidecar)
+    with caplog.at_level(_logging.DEBUG):
+        flags = bp._maybe_warn_stale_handle(
+            issue=1786, sidecar=sidecar, handle=_gcp_handle(), lane_suffix=None
+        )
+    assert flags == (False, False)
+    debug_msgs = [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno == _logging.DEBUG and "handle-staleness detector failed" in r.getMessage()
+    ]
+    assert debug_msgs, "the swallowed exception must be logged at DEBUG"
+    assert not [
+        r
+        for r in caplog.records
+        if r.levelno >= _logging.WARNING and "handle sidecar" in r.getMessage()
+    ], "the exception path must not emit the staleness WARNs"
+
+
+def test_handle_stale_wrapper_fires_both_flags_and_warns(tmp_path, monkeypatch, caplog):
+    """#1786 wrapper positive (executes the REAL body end-to-end, fakes only
+    at the events-read filesystem boundary): a handle whose
+    ``extra.workload_pid`` names the dead prior attempt while the newest
+    marker carries the live relaunch pid, AND whose sidecar mtime predates
+    the second-newest marker by > slack, fires BOTH flags with one WARN
+    each naming the item-1e recovery."""
+    import logging as _logging
+    import os
+
+    import explore_persona_space.task_workflow as tw
+    from scripts import backend_poll as bp
+
+    now = _time.time()
+    events = [
+        {"kind": "epm:progress", "ts": _iso_z(now - 9_000), "note": "unrelated row"},
+        _run_launched_event(ts_epoch=now - 7_200, note="launched pid=1111 pid_file=/x.pid"),
+        _run_launched_event(ts_epoch=now - 60, note="relaunched pid=2222 pid_file=/x.pid"),
+    ]
+    monkeypatch.setattr(tw, "list_events", lambda task_id: list(events))
+    handle = _gcp_handle({**_GCP_EXTRA_659, "workload_pid": 1111})
+    sidecar = tmp_path / "issue-1786-handle.json"
+    write_handle_sidecar(handle, sidecar)
+    old = now - 10_000  # predates ts(marker[-2]) = now-7200 by > 600s slack
+    os.utime(sidecar, (old, old))
+    with caplog.at_level(_logging.WARNING):
+        flags = bp._maybe_warn_stale_handle(
+            issue=1786, sidecar=sidecar, handle=handle, lane_suffix=None
+        )
+    assert flags == (True, True)
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= _logging.WARNING]
+    assert any("workload_pid" in m and "pod-side-reporting.md item 1e" in m for m in warnings)
+    assert any("SECOND-newest" in m and "pod-side-reporting.md item 1e" in m for m in warnings)
+
+
+def test_poll_tick_json_carries_handle_staleness_flags_default_false(tmp_path, monkeypatch, capsys):
+    """#1786 acceptance criterion 1 (integration): the NORMAL tick-JSON tail
+    carries both flags, default false, alongside the GCP idle keys. The
+    early-return terminal paths are exempt (own payload shapes). Event read
+    is the autouse hermetic empty default -> detector inert."""
+    sidecar = tmp_path / "issue-659-handle.json"
+    write_handle_sidecar(_gcp_handle_with_clock(phase="workload", ts=_time.time() - 30), sidecar)
+    monkeypatch.setattr(
+        "scripts.backend_poll._resolve_backend",
+        lambda name: _PollDouble(_running_poll("workload", reachability_alarm=False)),
+    )
+    rc = backend_poll_main(["--issue", "659", "--handle-file", str(sidecar)])
+    assert rc == 0
+    out = _last_json_line(capsys)
+    assert out["status"] == "running"
+    assert out["handle_stale_vs_live"] is False
+    assert out["handle_older_than_relaunch"] is False
+    # The flags never contribute to the verdict keys (acceptance criterion 5).
+    assert out["current_phase"] == "workload"

--- a/tests/test_issue_dispatch.py
+++ b/tests/test_issue_dispatch.py
@@ -1290,6 +1290,11 @@ def test_backend_poll_script_produces_legacy_poll_pipeline_json_shape(
         # (Pin update landed with #909's green-gate pass: #873 added the
         # emitter without updating this shape test — pre-existing on main.)
         "gcp_gpu_width_advisory_posted",
+        # #1786 WARN-only handle-staleness flags — always emitted by
+        # backend_poll.main on the NORMAL tick-JSON tail, default False;
+        # never verdict-bearing (WARN-only observability).
+        "handle_stale_vs_live",
+        "handle_older_than_relaunch",
     }
     # Values were correctly threaded through.
     assert decoded["status"] == "done"


### PR DESCRIPTION
Closes task #1786. WARN-only handle-sidecar staleness detector in scripts/backend_poll.py (tick-JSON flags handle_stale_vs_live + handle_older_than_relaunch, #1156-mirror fail-soft), 16 new unit tests. Plan v3 critic-APPROVED; code-review PASS; test-verdict PASS.