### PR TITLE
issue-1800: daily-fix: WARN when GCP workload chain has no persist phase

### DIFF
--- a/.claude/agents/experimenter.md
+++ b/.claude/agents/experimenter.md
@@ -624,6 +624,39 @@ authoritative recipe is agent memory
    and posted `epm:results` at silently-degraded coverage. The plan's
    Reproducibility Card listed 18 cells; one `ls | wc -l` against the
    data directory before launch would have caught the shortfall.
+4b. **Verify a persist step exists for every plan-declared output (the
+   OUTPUT-side sibling of the item-4 input gate; #1800, incident
+   #1739).** Before launch, read the plan's execution design (the
+   dispatcher/driver phase chain + any plan-named off-pod/VM-side
+   steps) and confirm every plan-declared HF/git-destined output class
+   — raw completions, eval JSONs, checkpoints, analysis tensors — has a
+   persist step SOMEWHERE in that design: an upload call in the
+   dispatch chain, or a plan-NAMED off-pod harvest+upload step (that
+   COUNTS as the persist step — the launch chain itself need not carry
+   it). Grounding: Upload Policy "Raw completions MUST upload before
+   pod termination" + the #779 persist-by-default rule. Disposition
+   split:
+   - Declared outputs with NO persist step ANYWHERE in the plan's
+     execution design AND the run's primary outputs are raw
+     completions / generations → REFUSE to launch: post
+     `<!-- epm:failure v1 -->` with `failure_class: infra`,
+     `reason: no-persist-phase-for-declared-artifacts` (naming the
+     orphaned output classes) and EXIT — `/issue` Step 7 routes
+     `infra` to a fresh respawn once the chain gains its persist
+     step.
+   - Any OTHER missing-persist case → WARN loudly and launch: the
+     `epm:run-launched` note carries the named line
+     `persist-phase: MISSING for <outputs> — launching anyway because
+     <one-line reason>`.
+   - Persist step present for every declared output → silent (no note
+     line).
+   Rationale: incident #1739 (2026-07-28) — a GCP `--workload-cmd` run
+   completed its phases and approached grace-poweroff with ZERO
+   artifacts on HF (all 7 expected prefixes MISS); ~2h of improvised
+   recovery uploads raced the poweroff clock. #1779 fixed the
+   PLAN-time layer; this gate is the dispatch-time backstop (the
+   `dispatch_issue.py` #1800 persist-evidence lint is the mechanical
+   sibling on router-lane launches).
 5. **List assumptions** — for factual claims about hardware, GPU memory,
    library versions on this specific pod. Mark confidence (high/medium/low).
    Verify anything below high before launching.

--- a/.claude/rules/compute-backend-failover.md
+++ b/.claude/rules/compute-backend-failover.md
@@ -154,7 +154,9 @@ HF data repo under `issue<N>_partial/<attempt_id>/`:
    verify gate passes: the transcript existence probe read True, or ≥1
    `upload_folder` returned success), `failed_uploads` (rc 3 — the
    persist ran to completion but ZERO uploads verifiably succeeded,
-   #1343/#1315), `timeout` (rc 124), `failed_rc<N>` (any other rc). A
+   #1343/#1315), `timeout` (rc 124), `failed_stream_flush` (rc 120 —
+   dead stdout/fd-3 pipe at interpreter exit, #1799),
+   `failed_rc<N>` (any other rc). A
    MISSING rc file deliberately writes NOTHING: the standing `attempted`
    IS the killed-mid-persist signal. A boot-time DELETE clears the key so
    a salvage-relaunch second boot never inherits a prior crash's value.
@@ -179,6 +181,7 @@ HF data repo under `issue<N>_partial/<attempt_id>/`:
    | `failed_uploads` | absent | the #1315 shape: TOTAL upload failure (dead HF channel / 429 storm / rejected token) previously masked as `ok`; nothing recoverable on HF — recover via serial console / boot-disk surgery |
    | `failed_uploads` | present | late-landing commit(s) — the #1339 gateway-timeout shape: the client logged FAILED, the commit landed server-side after the probe; trust a scoped prefix listing over the breadcrumb |
    | `timeout` | absent/partial | 300s budget exhausted (stalled uploads — the 504 shape). Since #1343, `timeout` can also follow a completed-uploads persist whose verify probe ate the budget tail — a PRESENT HF prefix alongside `timeout` is consistent with a healthy persist SIGTERMed mid-probe |
+   | `failed_stream_flush` | absent | pre-#1799 shape: the persist python died on a dead stdout/fd-3 pipe (runner killed — kernel-OOM unit teardown, #491 scanner overflow) before the first upload (rc 120, the CPython Py_FinalizeEx std-stream flush failure; incident #1739). Post-#1799 the `_say` guard + streamer PIPE re-arm + `os._exit` make this value unreachable — its reappearance means the #1799 guards regressed |
    | `failed_rc<N>` | absent | bootstrap/compound failure (127 = uv missing; 1 = cd short-circuit OR python top-level failure; else python rc) |
 
 **Sweep scope (explicit):** the partial sweep covers exactly the three

--- a/scripts/dispatch_issue.py
+++ b/scripts/dispatch_issue.py
@@ -1020,6 +1020,116 @@ def _warn_workload_cmd_inline_interpreter_and_flag_marker(
     )
 
 
+#: First committed driver-script token in a ``--workload-cmd`` string
+#: (``bash scripts/<driver>.sh`` / ``uv run python scripts/<x>.py``) —
+#: the resolution anchor for the #1800 persist-evidence lint.
+_WORKLOAD_CMD_SCRIPT_TOKEN_RE = re.compile(r"scripts/[A-Za-z0-9_.\-/]+\.(?:sh|py)\b")
+
+
+def _resolve_workload_driver_script(
+    workload_cmd: str, repo_branch: str | None
+) -> tuple[str | None, str | None]:
+    """Fail-soft driver-script text resolution for the #1800 persist lint.
+
+    Extracts the FIRST ``scripts/<x>.sh|.py`` token from the workload
+    command and resolves its text in ladder order: ``git show
+    origin/<repo_branch>:<path>`` (the ref the gcp/runpod lanes actually
+    clone), the local ``<repo_branch>`` ref, then the invoking working
+    tree. Returns ``(path, text)``; ``(path, None)`` when the token
+    resolved NOWHERE (caller skips the lint with ONE note); ``(None,
+    None)`` when the command names no script token at all. Never raises —
+    an unresolvable script must never block a launch.
+    """
+    m = _WORKLOAD_CMD_SCRIPT_TOKEN_RE.search(workload_cmd or "")
+    if m is None:
+        return None, None
+    path = m.group(0)
+    refs = [f"origin/{repo_branch}", repo_branch] if repo_branch else []
+    for ref in refs:
+        try:
+            proc = subprocess.run(
+                ["git", "show", f"{ref}:{path}"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if proc.returncode == 0 and proc.stdout:
+            return path, proc.stdout
+    try:
+        p = Path(path)
+        if p.is_file():
+            return path, p.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        pass
+    return path, None
+
+
+def _warn_workload_cmd_persist_and_flag_marker(
+    spec: Any, marker_poster: Callable[..., None]
+) -> Callable[..., None]:
+    """WARN-only #1800 arm of the workload-cmd lint family. Never blocks.
+
+    Flags a workload chain with ZERO persist-evidence tokens (per
+    ``lint_workload_cmd_persist_evidence``) across the command + the
+    resolved driver-script text — the #1739 class: a run completes every
+    phase with no upload step wired anywhere and leaves zero artifacts on
+    HF. Fail-soft: an unresolvable driver script skips the lint with ONE
+    stderr note, never a refusal. Own kill switch
+    ``EPM_SKIP_WORKLOAD_CMD_PERSIST_LINT=1``. No strict upgrade:
+    ``--strict-workload-cmd-env`` is lane-env-scoped by contract (the
+    #1576 precedent) — this arm has NO refusal path at all. Hydra
+    launches (no ``--workload-cmd``) are exempt: ``train.py`` carries
+    built-in upload paths.
+    """
+    from explore_persona_space.backends.issue_dispatch import (
+        PERSIST_EVIDENCE_TOKENS,
+        lint_workload_cmd_persist_evidence,
+    )
+
+    if not spec.workload_cmd:
+        return marker_poster
+    log = logging.getLogger("dispatch_issue")
+    if os.environ.get("EPM_SKIP_WORKLOAD_CMD_PERSIST_LINT") == "1":
+        log.info(
+            "EPM_SKIP_WORKLOAD_CMD_PERSIST_LINT=1 — workload-cmd persist-evidence "
+            "lint (#1800) skipped."
+        )
+        return marker_poster
+    script_path, script_text = _resolve_workload_driver_script(
+        spec.workload_cmd, (spec.extra or {}).get("repo_branch")
+    )
+    lint = lint_workload_cmd_persist_evidence(spec.workload_cmd, script_text)
+    if lint.skipped:
+        log.info(
+            "workload-cmd persist-evidence lint (#1800) skipped — driver script %s "
+            "unresolvable (git show origin/<branch> / local branch / working tree). "
+            "Step 8 upload-verification remains the hard persist gate.",
+            script_path or "<none named in --workload-cmd>",
+        )
+        return marker_poster
+    if not lint.flagged:
+        return marker_poster
+    log.warning(
+        "--workload-cmd chain carries NO persist-evidence token (%s) in the command "
+        "or the resolved driver script %s — the #1739 class: the run can complete "
+        "every phase and leave ZERO artifacts on HF, forcing improvised recovery "
+        "uploads against the poweroff clock. Wire an upload/persist step (Upload "
+        "Policy: raw completions MUST upload before teardown; #779 "
+        "persist-by-default), or a plan-NAMED off-pod harvest+upload step. Launch "
+        "continues; epm:backend-selected carries "
+        "extra.workload_cmd_no_persist_evidence. Silence with "
+        "EPM_SKIP_WORKLOAD_CMD_PERSIST_LINT=1.",
+        ", ".join(PERSIST_EVIDENCE_TOKENS),
+        script_path,
+    )
+    return _wrap_marker_poster_with_override_flag(
+        marker_poster, {"workload_cmd_no_persist_evidence": True}
+    )
+
+
 def _workload_cmd_env_lint_gate(
     args: argparse.Namespace, spec: Any
 ) -> tuple[Any, dict[str, Any] | None]:
@@ -1651,7 +1761,11 @@ def _cmd_launch(args: argparse.Namespace, *, backends_factory: Callable[[], dict
     # inline-interpreter one-liner body (python -c / stdin heredoc; the
     # sanctioned write_completion_sentinel append is exempt) via the
     # marker-poster decoration below — never a refusal, and
-    # --strict-workload-cmd-env does NOT upgrade it.
+    # --strict-workload-cmd-env does NOT upgrade it. A THIRD, WARN-only
+    # arm (#1800, incident #1739) flags a chain with NO persist-evidence
+    # token in the command + the resolved driver script (kill switch:
+    # EPM_SKIP_WORKLOAD_CMD_PERSIST_LINT=1; unresolvable script → lint
+    # skipped with one note; never a refusal, no strict upgrade).
     env_lint, env_refusal = _workload_cmd_env_lint_gate(args, spec)
     if env_refusal is not None:
         print(json.dumps(env_refusal, sort_keys=True))
@@ -1660,6 +1774,7 @@ def _cmd_launch(args: argparse.Namespace, *, backends_factory: Callable[[], dict
     deps = backends_factory()
     marker_poster = _warn_workload_cmd_env_and_flag_marker(env_lint, deps["marker_poster"])
     marker_poster = _warn_workload_cmd_inline_interpreter_and_flag_marker(spec, marker_poster)
+    marker_poster = _warn_workload_cmd_persist_and_flag_marker(spec, marker_poster)
     marker_poster = _check_runpod_override_frontmatter(int(args.issue), args.backend, marker_poster)
     marker_poster = _warn_default_boot_disk_ft_intent(spec, int(args.issue), marker_poster)
     try:

--- a/scripts/dispatch_issue.py
+++ b/scripts/dispatch_issue.py
@@ -1053,6 +1053,7 @@ def _resolve_workload_driver_script(
                 text=True,
                 timeout=15,
                 check=False,
+                env={**os.environ},
             )
         except (OSError, subprocess.SubprocessError):
             continue

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -11989,7 +11989,11 @@ AGENT_SPEC_SIZE_GRANDFATHER: dict[str, int] = {
     # measured 65,540 B post-#1081 r2 (D3 crash-fix-relaunch addendum:
     # disposition-conditional resume-glob confirm), 65,500 — measured
     # 62,672 B)
-    "experimenter.md": 75_400,
+    # measured 76,828 B post-#1800 (Before Running item 4b output-persist
+    # pre-launch gate — the #1739 dispatch-time backstop, output-side
+    # sibling of the item-4 input gate; plan-mandated growth; cap =
+    # measured + ~0.87 KB — LANDING bytes, per #1753.)
+    "experimenter.md": 77_700,
     # measured 49,740 B post-#1115 (read-hygiene context-budget section —
     # plan-mandated growth; cap = measured + <=~1 KB. Prior: 49,000 —
     # measured 48,197 B post-#1102)

--- a/src/explore_persona_space/backends/issue_dispatch.py
+++ b/src/explore_persona_space/backends/issue_dispatch.py
@@ -590,6 +590,85 @@ def lint_workload_cmd_inline_interpreter(workload_cmd: str) -> WorkloadCmdInline
     return WorkloadCmdInlineLint(False, None, stripped)
 
 
+#: Case-insensitive persist-evidence substrings (#1800). A workload chain
+#: (command + resolved driver-script text) carrying NONE of these has no
+#: visible upload/persist WIRING for its outputs — the #1739 class. The
+#: composition is a v1 heuristic pinned by tests
+#: (``tests/test_workload_cmd_persist_lint.py``); incident-replay
+#: calibration (plan #1800 §2): the pre-fix #1739 dispatcher
+#: (``origin/issue-1739`` @ ``3bcc140bbd``) reads 0 hits → flags, the
+#: post-fix tip reads 17 hits → clean.
+PERSIST_EVIDENCE_TOKENS: tuple[str, ...] = (
+    "upload",
+    "push_to_hub",
+    "hf_hub",
+    "hfapi",
+    "git push",
+    "persist",
+)
+
+
+@dataclass(frozen=True)
+class WorkloadCmdPersistLint:
+    """Result of :func:`lint_workload_cmd_persist_evidence` (#1800).
+
+    ``flagged`` — the resolved chain carries ZERO persist-evidence tokens.
+    ``skipped`` — the lint could not run (empty command, or the driver
+    script text was unavailable); never flagged when skipped.
+    ``matched_tokens`` — the sorted evidence tokens found (empty when
+    flagged or skipped).
+    """
+
+    flagged: bool
+    skipped: bool
+    matched_tokens: tuple[str, ...]
+
+
+def lint_workload_cmd_persist_evidence(
+    workload_cmd: str, script_text: str | None
+) -> WorkloadCmdPersistLint:
+    """WARN-class #1800 detection: no persist step anywhere in the workload chain.
+
+    Mechanizes the dispatch-time backstop for incident #1739 (2026-07-28): a
+    GCP ``--workload-cmd`` run completed every phase and approached
+    grace-poweroff with ZERO artifacts on HF (all 7 expected prefixes MISS);
+    #1779 fixed the PLAN-time layer, this lint is the dispatch-time sibling
+    of the #1329/#1576 workload-cmd lint family. Scans the COMMAND plus the
+    resolved driver-script text (``script_text``) case-insensitively for
+    :data:`PERSIST_EVIDENCE_TOKENS`; zero hits on a resolved script →
+    ``flagged=True``. ``script_text is None`` (unresolvable driver) →
+    ``skipped=True``, never flagged — fail-soft by design, the caller logs
+    ONE note.
+
+    Deliberate v1 FALSE NEGATIVES (named, mirroring the
+    :func:`lint_workload_cmd_inline_interpreter` docstring discipline —
+    widen if one bites):
+
+    * present-but-never-executed persist: a chain whose persist phase
+      EXISTS in the script text but is skipped at runtime (a ``--dry-run``
+      upload mode, a ``--phases`` subset invocation that omits the upload
+      phase) reads as evidence — this lint checks persist WIRING, never a
+      persist guarantee; Step 8 upload-verification stays the hard gate;
+    * ambiguous tokens: a download-only ``hf_hub_download`` staging call
+      (or a bare ``HfApi()`` listing) matches the ``hf_hub`` / ``hfapi``
+      tokens and reads as evidence;
+    * comments: a commented-out ``# upload later`` line counts as evidence
+      (substring scan, no shell/python parsing).
+
+    Known FALSE-POSITIVE residual (WARN-only by design, #1800 plan §5): a
+    multi-script chain whose persist step lives in a SECOND sourced/invoked
+    file the caller did not resolve flags spuriously — the escape is the
+    descope path (scan the command string only) if this proves noisy.
+    """
+    if not (workload_cmd or "").strip():
+        return WorkloadCmdPersistLint(flagged=False, skipped=True, matched_tokens=())
+    if script_text is None:
+        return WorkloadCmdPersistLint(flagged=False, skipped=True, matched_tokens=())
+    haystack = f"{workload_cmd}\n{script_text}".lower()
+    matched = tuple(sorted(tok for tok in PERSIST_EVIDENCE_TOKENS if tok in haystack))
+    return WorkloadCmdPersistLint(flagged=not matched, skipped=False, matched_tokens=matched)
+
+
 def build_run_spec(
     *,
     issue: int,
@@ -1222,10 +1301,12 @@ _mila_socket_alive_stub = _default_mila_socket_alive
 
 __all__ = [
     "LANE_WORKLOAD_ENV_EXPORTS",
+    "PERSIST_EVIDENCE_TOKENS",
     "DispatchOutcome",
     "TerminalTranslation",
     "WorkloadCmdEnvLint",
     "WorkloadCmdInlineLint",
+    "WorkloadCmdPersistLint",
     "build_run_spec",
     "classify_terminal_exception",
     "default_handle_sidecar_path",
@@ -1233,6 +1314,7 @@ __all__ = [
     "dispatch_for_issue",
     "lint_workload_cmd_inline_interpreter",
     "lint_workload_cmd_lane_env",
+    "lint_workload_cmd_persist_evidence",
     "normalize_backend_value",
     "read_handle_sidecar",
     "resolve_handle_sidecar_path",

--- a/tests/test_workload_cmd_persist_lint.py
+++ b/tests/test_workload_cmd_persist_lint.py
@@ -1,0 +1,311 @@
+"""Dispatch-time persist-evidence lint for ``--workload-cmd`` (#1800, incident #1739).
+
+Pins the pure lint (`backends/issue_dispatch.lint_workload_cmd_persist_evidence`
++ `PERSIST_EVIDENCE_TOKENS`) and the `dispatch_issue.py launch` wiring
+(WARN-only + `extra.workload_cmd_no_persist_evidence` marker flag, fail-soft
+driver-script resolution — unresolvable → lint skipped with one note, the
+`EPM_SKIP_WORKLOAD_CMD_PERSIST_LINT=1` kill switch, and the
+no-strict-upgrade contract shared with the #1576 inline-interpreter arm).
+
+Incident #1739 (2026-07-28): a GCP ``--workload-cmd`` run completed its
+phases and approached grace-poweroff with ZERO artifacts on HF (all 7
+expected prefixes MISS); ~2h of improvised recovery uploads raced the
+poweroff clock. #1779 fixed the PLAN-time layer; this lint is the
+dispatch-time backstop. Fixtures below derive from the incident-replay
+calibration pair (plan #1800 §2): a persist-less driver shaped like the
+pre-fix #1739 dispatcher (0 evidence hits → flags) and an evidence-bearing
+one shaped like the post-fix tip (upload phase wired → clean).
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from explore_persona_space.backends.issue_dispatch import (
+    PERSIST_EVIDENCE_TOKENS,
+    lint_workload_cmd_persist_evidence,
+)
+from tests.test_dispatch_issue_cli import (
+    _backend_selected_extras,
+    _build_mock_factory,
+    _cd_to_tmp,
+    _MockBackend,
+)
+
+#: Synthetic driver shaped like the PRE-fix #1739 dispatcher
+#: (``origin/issue-1739`` @ ``3bcc140bbd``): phases generate + judge + fit,
+#: write local outputs, and wire NO upload/persist step anywhere.
+PERSISTLESS_DRIVER = """\
+#!/usr/bin/env bash
+set -euo pipefail
+echo "[phase=p0_stage]"
+uv run python scripts/issue9990_gen.py --out data/issue_9990/gen
+echo "[phase=p1_judge]"
+uv run python scripts/issue9990_judge.py --in data/issue_9990/gen
+echo "[phase=p2_fit]"
+uv run python scripts/issue9990_fit.py --out eval_results/issue_9990/fit.json
+echo "[phase=done]"
+"""
+
+#: Synthetic driver shaped like the POST-fix #1739 tip: the same chain plus
+#: a wired upload phase (raw completions + eval JSONs to the HF data repo).
+EVIDENCE_DRIVER = PERSISTLESS_DRIVER.replace(
+    'echo "[phase=done]"',
+    'echo "[phase=p3_upload]"\n'
+    "uv run python scripts/issue9990_upload.py  "
+    "# upload_raw_completions_to_data_repo + eval JSONs\n"
+    'echo "[phase=done]"',
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure lint (plan #1800 AC-2 / AC-4)
+# ---------------------------------------------------------------------------
+
+
+def test_persistless_driver_flags() -> None:
+    lint = lint_workload_cmd_persist_evidence(
+        "bash scripts/issue9990_dispatch.sh", PERSISTLESS_DRIVER
+    )
+    assert lint.flagged is True
+    assert lint.skipped is False
+    assert lint.matched_tokens == ()
+
+
+def test_evidence_in_script_text_not_flagged() -> None:
+    lint = lint_workload_cmd_persist_evidence("bash scripts/issue9990_dispatch.sh", EVIDENCE_DRIVER)
+    assert lint.flagged is False
+    assert lint.skipped is False
+    assert "upload" in lint.matched_tokens
+
+
+def test_evidence_in_workload_cmd_itself_not_flagged() -> None:
+    """Evidence in the COMMAND counts even when the driver script is persist-less."""
+    cmd = "bash scripts/issue9990_dispatch.sh && uv run python scripts/upload_results.py"
+    lint = lint_workload_cmd_persist_evidence(cmd, PERSISTLESS_DRIVER)
+    assert lint.flagged is False
+    assert "upload" in lint.matched_tokens
+
+
+def test_none_script_text_skips_never_flags() -> None:
+    lint = lint_workload_cmd_persist_evidence("bash scripts/issue9990_dispatch.sh", None)
+    assert lint.skipped is True
+    assert lint.flagged is False
+
+
+def test_empty_cmd_skips() -> None:
+    lint = lint_workload_cmd_persist_evidence("", PERSISTLESS_DRIVER)
+    assert lint.skipped is True
+    assert lint.flagged is False
+
+
+def test_token_match_is_case_insensitive() -> None:
+    script = PERSISTLESS_DRIVER + "\nuv run python -c 'model.PUSH_TO_HUB()'\n"
+    lint = lint_workload_cmd_persist_evidence("bash scripts/x.sh", script)
+    assert lint.flagged is False
+    assert "push_to_hub" in lint.matched_tokens
+
+
+def test_git_push_token_counts_as_evidence() -> None:
+    script = PERSISTLESS_DRIVER + "\ngit push origin issue-9990\n"
+    lint = lint_workload_cmd_persist_evidence("bash scripts/x.sh", script)
+    assert lint.flagged is False
+    assert "git push" in lint.matched_tokens
+
+
+def test_token_composition_pinned() -> None:
+    """The v1 composition is calibrated on the #1739 incident pair (plan §2)
+    — a change is a deliberate recalibration, not a drive-by."""
+    assert set(PERSIST_EVIDENCE_TOKENS) == {
+        "upload",
+        "push_to_hub",
+        "hf_hub",
+        "hfapi",
+        "git push",
+        "persist",
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI seam (plan #1800 AC-3 / AC-4; mirrors tests/test_workload_cmd_env_lint.py)
+# ---------------------------------------------------------------------------
+
+
+def _persist_warnings(caplog) -> list[str]:
+    return [
+        rec.getMessage()
+        for rec in caplog.records
+        if rec.levelno >= logging.WARNING and "persist-evidence token" in rec.getMessage()
+    ]
+
+
+def _persist_skip_notes(caplog) -> list[str]:
+    return [
+        rec.getMessage()
+        for rec in caplog.records
+        if "persist-evidence lint (#1800) skipped" in rec.getMessage()
+    ]
+
+
+def _write_driver(tmp_path: Path, name: str, text: str) -> str:
+    """Materialize a driver under ``<cwd>/scripts/`` so the resolver's
+    working-tree fallback finds it (the git-show rungs fail soft at a
+    non-repo tmp cwd)."""
+    d = tmp_path / "scripts"
+    d.mkdir(exist_ok=True)
+    (d / name).write_text(text)
+    return f"scripts/{name}"
+
+
+def test_launch_persistless_script_warns_flags_marker_and_proceeds(
+    monkeypatch, tmp_path, caplog
+) -> None:
+    """AC-3: flagged → LOUD warning + ``extra.workload_cmd_no_persist_evidence``
+    on the posted marker; launch proceeds (WARN-only, exit 0)."""
+    _cd_to_tmp(monkeypatch, tmp_path)
+    rel = _write_driver(tmp_path, "phases_only_1800.sh", PERSISTLESS_DRIVER)
+    nibi = _MockBackend(kind="nibi")
+    marker_posts: list[dict] = []
+    factory = _build_mock_factory(
+        runpod=_MockBackend(kind="runpod"), nibi=nibi, marker_posts=marker_posts
+    )
+
+    from scripts.dispatch_issue import main
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = main(
+            ["launch", "--issue", "825", "--intent", "lora-7b", "--workload-cmd", f"bash {rel}"],
+            backends_factory=factory,
+        )
+    assert rc == 0
+    assert len(nibi.launches) == 1
+    warnings = _persist_warnings(caplog)
+    assert warnings, "expected a persist-evidence lint warning"
+    joined = "\n".join(warnings)
+    assert "#1739" in joined
+    assert "EPM_SKIP_WORKLOAD_CMD_PERSIST_LINT=1" in joined
+    extras = _backend_selected_extras(marker_posts)
+    assert extras, "expected an epm:backend-selected post"
+    assert all(e.get("workload_cmd_no_persist_evidence") is True for e in extras)
+
+
+def test_launch_evidence_script_no_warning_no_flag(monkeypatch, tmp_path, caplog) -> None:
+    _cd_to_tmp(monkeypatch, tmp_path)
+    rel = _write_driver(tmp_path, "evidence_1800.sh", EVIDENCE_DRIVER)
+    nibi = _MockBackend(kind="nibi")
+    marker_posts: list[dict] = []
+    factory = _build_mock_factory(
+        runpod=_MockBackend(kind="runpod"), nibi=nibi, marker_posts=marker_posts
+    )
+
+    from scripts.dispatch_issue import main
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = main(
+            ["launch", "--issue", "825", "--intent", "lora-7b", "--workload-cmd", f"bash {rel}"],
+            backends_factory=factory,
+        )
+    assert rc == 0
+    assert not _persist_warnings(caplog)
+    extras = _backend_selected_extras(marker_posts)
+    assert extras
+    assert all("workload_cmd_no_persist_evidence" not in e for e in extras)
+
+
+def test_launch_unresolvable_script_skips_with_note(monkeypatch, tmp_path, caplog) -> None:
+    """Fail-soft: an unresolvable driver script skips the lint with ONE note
+    — never a warning, never a marker flag, never a refusal."""
+    _cd_to_tmp(monkeypatch, tmp_path)
+    caplog.set_level(logging.INFO, logger="dispatch_issue")
+    nibi = _MockBackend(kind="nibi")
+    marker_posts: list[dict] = []
+    factory = _build_mock_factory(
+        runpod=_MockBackend(kind="runpod"), nibi=nibi, marker_posts=marker_posts
+    )
+
+    from scripts.dispatch_issue import main
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = main(
+            [
+                "launch",
+                "--issue",
+                "825",
+                "--intent",
+                "lora-7b",
+                "--workload-cmd",
+                "bash scripts/nonexistent_1800_xyz.sh",
+            ],
+            backends_factory=factory,
+        )
+    assert rc == 0
+    assert len(nibi.launches) == 1
+    assert not _persist_warnings(caplog)
+    assert len(_persist_skip_notes(caplog)) == 1
+    extras = _backend_selected_extras(marker_posts)
+    assert all("workload_cmd_no_persist_evidence" not in e for e in extras)
+
+
+def test_kill_switch_env_skips_persist_lint(monkeypatch, tmp_path, caplog) -> None:
+    _cd_to_tmp(monkeypatch, tmp_path)
+    monkeypatch.setenv("EPM_SKIP_WORKLOAD_CMD_PERSIST_LINT", "1")
+    rel = _write_driver(tmp_path, "phases_only_1800.sh", PERSISTLESS_DRIVER)
+    nibi = _MockBackend(kind="nibi")
+    marker_posts: list[dict] = []
+    factory = _build_mock_factory(
+        runpod=_MockBackend(kind="runpod"), nibi=nibi, marker_posts=marker_posts
+    )
+
+    from scripts.dispatch_issue import main
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = main(
+            ["launch", "--issue", "825", "--intent", "lora-7b", "--workload-cmd", f"bash {rel}"],
+            backends_factory=factory,
+        )
+    assert rc == 0
+    assert not _persist_warnings(caplog)
+    extras = _backend_selected_extras(marker_posts)
+    assert all("workload_cmd_no_persist_evidence" not in e for e in extras)
+
+
+def test_launch_strict_flag_does_not_upgrade_persist_arm(monkeypatch, tmp_path, caplog) -> None:
+    """``--strict-workload-cmd-env`` stays lane-env-scoped (the #1576
+    contract): a flagged persist lint still launches at exit 0."""
+    _cd_to_tmp(monkeypatch, tmp_path)
+    rel = _write_driver(tmp_path, "phases_only_1800.sh", PERSISTLESS_DRIVER)
+    nibi = _MockBackend(kind="nibi")
+    marker_posts: list[dict] = []
+    factory = _build_mock_factory(
+        runpod=_MockBackend(kind="runpod"), nibi=nibi, marker_posts=marker_posts
+    )
+
+    from scripts.dispatch_issue import main
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = main(
+            [
+                "launch",
+                "--issue",
+                "825",
+                "--intent",
+                "lora-7b",
+                "--strict-workload-cmd-env",
+                "--workload-cmd",
+                f"bash {rel}",
+            ],
+            backends_factory=factory,
+        )
+    assert rc == 0
+    assert len(nibi.launches) == 1
+    assert _persist_warnings(caplog)
+    extras = _backend_selected_extras(marker_posts)
+    assert all(e.get("workload_cmd_no_persist_evidence") is True for e in extras)


### PR DESCRIPTION
Closes task #1800. Dispatch-time persist-phase backstop: experimenter pre-launch item 4b + WARN-only persist-evidence lint in dispatch_issue.py (mirrors #1329/#1576). Plan-time sibling: #1779.