### PR TITLE
issue-1803: daily-fix: env-pin allowlist gains vetted runtime-tuning keys

### DIFF
--- a/src/explore_persona_space/backends/base.py
+++ b/src/explore_persona_space/backends/base.py
@@ -105,6 +105,13 @@ ENV_PIN_ALLOWED_KEYS: frozenset[str] = frozenset(
         "EPM_PERSIST_ADAPTER_HF_REPO",
         "EPM_PERSIST_ADAPTER_SUBFOLDER",
         "EPM_UPLOAD_MERGED",
+        # #1803: the house runtime-tuning set (OOM / thread-cap remediation,
+        # incident #1739) — values stay validated single-line strings.
+        "MALLOC_ARENA_MAX",
+        "OMP_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "OPENBLAS_NUM_THREADS",
+        "NUMEXPR_NUM_THREADS",
     }
 )
 

--- a/tests/test_issue_dispatch.py
+++ b/tests/test_issue_dispatch.py
@@ -1889,6 +1889,7 @@ def test_reconnect_carry_forward_includes_env_pins(tmp_path) -> None:
     [
         ({"WANDB_PROJECT": "issue1586_methodgen"}, True),
         ({"WANDB_TAGS": "a=b", "WANDB_RUN_GROUP": "g 1"}, True),
+        ({"MALLOC_ARENA_MAX": "2", "OMP_NUM_THREADS": "8"}, True),  # #1803 runtime-tuning keys
         (None, True),  # None → {}
         ({}, True),  # empty → {}
         ({"WANDB_API_KEY": "x"}, False),  # non-allowlisted (secret) key
@@ -1932,3 +1933,19 @@ def test_validate_env_pins_rejects_secret_shaped_value_and_sanitize_splits() -> 
     # Non-mapping input drops wholesale with one reason, never raises.
     kept2, dropped2 = sanitize_env_pins(["WANDB_PROJECT=x"])
     assert kept2 == {} and len(dropped2) == 1
+
+
+def test_env_pin_allowlist_keeps_runtime_tuning_keys() -> None:
+    """#1803: the house runtime-tuning set (OOM / thread-cap remediation,
+    incident #1739) stays in ``ENV_PIN_ALLOWED_KEYS`` — a silent drop in a
+    future allowlist rewrite turns this membership pin red."""
+    from explore_persona_space.backends.base import ENV_PIN_ALLOWED_KEYS
+
+    runtime_tuning = {
+        "MALLOC_ARENA_MAX",
+        "OMP_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "OPENBLAS_NUM_THREADS",
+        "NUMEXPR_NUM_THREADS",
+    }
+    assert runtime_tuning <= ENV_PIN_ALLOWED_KEYS


### PR DESCRIPTION
Closes task #1803. Adds the 5 house runtime-tuning keys (MALLOC_ARENA_MAX, OMP_NUM_THREADS, MKL_NUM_THREADS, OPENBLAS_NUM_THREADS, NUMEXPR_NUM_THREADS) to ENV_PIN_ALLOWED_KEYS + membership-pin test. Incident #1739.