### PR TITLE
issue-1804: daily-fix: verdict-marker --version pins collide on long-lived streams

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -34,21 +34,21 @@ You are an adversarial code reviewer. You have ZERO investment in the code chang
 
 ```bash
 uv run python scripts/task.py post-marker <N> epm:code-review \
-    --version <revision_round> --file /tmp/code-review-<N>.md
+    --file /tmp/code-review-<N>.md
 ```
 
-`--file` is mandatory — never pass the body inline via `--note` with a `$(cat ...)` command substitution: the file is read raw, no shell re-parsing, so a body quoting git verbs / diff text / `$( )` cannot be shell-mangled or trip the repo-root guard's argv-prose scan (CLAUDE.md #1722; #1723: a claimed post never landed — ~9 min + a duplicate reviewer spawn).
+OMIT `--version` — the posted top-level version auto-derives `max(existing)+1` per kind and may EXCEED the round on long-lived follow-up tasks (#1092/#1804); the round lives in the marker body's head sentinel. `--file` is mandatory — never pass the body inline via `--note` with a `$(cat ...)` command substitution: the file is read raw, no shell re-parsing, so a body quoting git verbs / diff text / `$( )` cannot be shell-mangled or trip the repo-root guard's argv-prose scan (CLAUDE.md #1722; #1723: a claimed post never landed — ~9 min + a duplicate reviewer spawn).
 
-**Read-back (MANDATORY before returning) — exact-kind + version, NOT `latest-marker --prefix`** (the prefix also matches the twin `epm:code-review-codex`, posted at the SAME per-round version — a prefix read can falsely confirm on the twin's row, or misread it as "my post is absent" and provoke a duplicate re-post):
+**Read-back (MANDATORY before returning) — exact-kind + head sentinel, NOT `latest-marker --prefix`** (the prefix also matches the twin `epm:code-review-codex` — a prefix read can falsely confirm on the twin's row, or misread it as "my post is absent" and provoke a duplicate re-post):
 
 ```bash
 uv run python scripts/task.py view <N> --json | \
-  jq '[.events[] | select(.kind == "epm:code-review")] | last | {kind, version, ts}'
+  jq '[.events[] | select(.kind == "epm:code-review")] | last | {kind, version, ts, head: (.note | split("\n")[0])}'
 ```
 
-Confirm `"version": <revision_round>` (this round); only then claim posted. Absent → re-post ONCE via `--file`, re-read; still absent → say so in your return text (the orchestrator's Step 5b durable-verdict-first rule handles it) — never claim "posted" unverified. Exit 0 with a stderr commit-deferred ERROR is SUCCESS — the row IS appended; never re-post on it.
+Confirm the LAST `epm:code-review` row's `head` is `<!-- epm:code-review v<revision_round> -->` (this round) with a fresh `ts`; do NOT compare the top-level `version` to the round (it is auto-derived max+1 and legitimately exceeds the round on long-lived tasks). Only then claim posted. Absent → re-post ONCE via `--file`, re-read; still absent → say so in your return text (the orchestrator's Step 5b durable-verdict-first rule handles it) — never claim "posted" unverified. Exit 0 with a stderr commit-deferred ERROR is SUCCESS — the row IS appended; never re-post on it.
 
-Wrap the verdict body in the marker tags so the orchestrator's parser (SKILL.md Step 5c) finds it:
+Wrap the verdict body in the marker tags so the orchestrator's parser (SKILL.md Step 5c) finds it. THE HEAD SENTINEL IS LOAD-BEARING: the `v<revision_round>` in the tags is the ROUND KEY consumers match on (`task_workflow.ensemble_verdicts_present`, #1149) — a sentinel-less post lands at top-level version max+1 ≠ round and is INVISIBLE to the round-matcher (the old `version == round` fallback no longer rescues it, since the posted version no longer equals the round):
 
 ```
 <!-- epm:code-review v<revision_round> -->

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -43,7 +43,7 @@ OMIT `--version` — the posted top-level version auto-derives `max(existing)+1`
 
 ```bash
 uv run python scripts/task.py view <N> --json | \
-  jq '[.events[] | select(.kind == "epm:code-review")] | last | {kind, version, ts, head: (.note | split("\n")[0])}'
+  jq '[.events[] | select(.kind == "epm:code-review")] | last | {kind, version, ts, head: ((.note // "") | split("\n")[0])}'
 ```
 
 Confirm the LAST `epm:code-review` row's `head` is `<!-- epm:code-review v<revision_round> -->` (this round) with a fresh `ts`; do NOT compare the top-level `version` to the round (it is auto-derived max+1 and legitimately exceeds the round on long-lived tasks). Only then claim posted. Absent → re-post ONCE via `--file`, re-read; still absent → say so in your return text (the orchestrator's Step 5b durable-verdict-first rule handles it) — never claim "posted" unverified. Exit 0 with a stderr commit-deferred ERROR is SUCCESS — the row IS appended; never re-post on it.

--- a/.claude/agents/codex-clean-result-critic.md
+++ b/.claude/agents/codex-clean-result-critic.md
@@ -1175,7 +1175,7 @@ Expected output file: /tmp/codex-clean-result-critic-<N>-r<revision_round>-outpu
 Marker start tag: <!-- epm:clean-result-critique-codex v<revision_round> -->
 Marker end tag: <!-- /epm:clean-result-critique-codex -->
 Expected marker kind: epm:clean-result-critique-codex
-Expected marker version: <revision_round>
+Expected marker round (head sentinel): <revision_round> (posted top-level version: auto, max+1)
 Codex effort: high
 Codex write mode: false (read-only critic)
 Inlined envelopes: MECHANICAL VERIFIER OUTPUT[, AUDIT SCRIPT OUTPUT, OPEN-CONCERNS JSON]

--- a/.claude/agents/codex-code-reviewer.md
+++ b/.claude/agents/codex-code-reviewer.md
@@ -188,7 +188,7 @@ test -s "$IMPL_MARKER_FILE" || {
     # genuine orchestration error (Step 5 should only fire after the
     # implementer posts). Fail loud.
     uv run python "$REPO_ROOT/scripts/task.py" post-marker <N> epm:failure \
-        --version 1 --by codex-code-reviewer \
+        --by codex-code-reviewer \
         --note "failure_class: orchestration, reason: no epm:experiment-implementation marker on main"
     exit 1
 }
@@ -280,7 +280,7 @@ else
     # envelope pattern as the implementation marker.
     test -s "$CANON_PLAN" || {
         uv run python "$REPO_ROOT/scripts/task.py" post-marker <N> epm:failure \
-            --version 1 --by codex-code-reviewer \
+            --by codex-code-reviewer \
             --note "failure_class: orchestration, reason: worktree plan absent-or-stale AND no canonical plan on main"
         exit 1
     }
@@ -849,7 +849,7 @@ Expected output file: /tmp/codex-code-reviewer-<N>-r<revision_round>-output.md
 Marker start tag: <!-- epm:code-review-codex v<revision_round> -->
 Marker end tag: <!-- /epm:code-review-codex -->
 Expected marker kind: epm:code-review-codex
-Expected marker version: <revision_round>
+Expected marker round (head sentinel): <revision_round> (posted top-level version: auto, max+1)
 Codex effort: high
 Codex write mode: false (read-only review)
 ```
@@ -866,8 +866,9 @@ Bash(run_in_background=true,
 
 When the harness notifies on bg-Bash completion, the orchestrator reads
 the output file, extracts the marker between the start/end tags, and
-posts via `task.py post-marker <N> epm:code-review-codex --version
-<revision_round>`. If the marker tags are missing in Codex's output the
+posts via `task.py post-marker <N> epm:code-review-codex` (OMIT
+`--version` — it auto-derives max+1; the round lives in the extracted
+block's head sentinel). If the marker tags are missing in Codex's output the
 orchestrator re-dispatches with a stricter retry prompt (cap retries at
 2 — same policy as before, just moved out of this agent). If the
 `epm:codex-task-failed` marker fires, the orchestrator treats this as a
@@ -940,8 +941,11 @@ Common failure modes and how to handle:
 - **Codex hallucinates line numbers that don't exist in the diff.** Not your
   problem — let it through. The `reconciler` (or the implementer reading both
   reviews) catches it.
-- **Codex emits the marker but with wrong `v<n>`.** Replace the version
-  string with the correct `revision_round` before posting.
+- **Codex emits the marker but with wrong `v<n>`.** The wrong `v<n>` here is
+  the SENTINEL round digit inside the marker tags (`<!-- epm:code-review-codex
+  v<n> -->` / the closing tag) — replace it with the correct `revision_round`
+  before posting (behavior unchanged; the posted top-level version is
+  auto-derived and untouched).
 - **Codex emits multiple markers (overzealous).** Take the LAST complete
   marker; discard prior partials.
 - **Codex output is empty / null.** Retry once. Then `epm:failure`.

--- a/.claude/agents/codex-follow-up-critic.md
+++ b/.claude/agents/codex-follow-up-critic.md
@@ -238,7 +238,7 @@ Expected output file: /tmp/codex-followup-critic-<N>-output.md
 Marker start tag: <!-- epm:followup-value-critique-codex v1 -->
 Marker end tag: <!-- /epm:followup-value-critique-codex -->
 Expected marker kind: epm:followup-value-critique-codex
-Expected marker version: 1
+Expected marker round (head sentinel): 1 (posted top-level version: auto, max+1 — multiple parks over a task's life re-post the kind)
 Codex effort: high
 Codex write mode: false (read-only redundancy screen)
 ```
@@ -247,7 +247,8 @@ The orchestrator dispatches `scripts/codex_task.py` with
 `run_in_background=true`, reads the output file when notified, extracts +
 validates the marker block, retries via a fresh dispatch on malformed
 output (cap retries at 2), posts via `task.py post-marker <N>
-epm:followup-value-critique-codex --version 1`. On `epm:codex-task-failed`
+epm:followup-value-critique-codex` (OMIT `--version` — it auto-derives
+max+1; the round lives in the block's head sentinel). On `epm:codex-task-failed`
 or persistent malformed output, the orchestrator falls back to
 single-Claude-critic per `workflow.yaml § ensemble_review`. On a
 trigger-dense round (recognition per trigger-dense-review.md "Fires

--- a/.claude/agents/codex-interpretation-critic.md
+++ b/.claude/agents/codex-interpretation-critic.md
@@ -192,7 +192,7 @@ else
     PLAN_BODY="$TASK_DIR/plans/plan.md"      # symlink to highest version
     test -s "$PLAN_BODY" || {
         uv run python "$REPO_ROOT/scripts/task.py" post-marker <N> epm:failure \
-            --version 1 --by codex-interpretation-critic \
+            --by codex-interpretation-critic \
             --note "failure_class: orchestration, reason: plan unresolvable in worktree AND no canonical plan on main"
         exit 1
     }
@@ -366,7 +366,7 @@ Expected output file: /tmp/codex-interp-critic-<N>-r<revision_round>-output.md
 Marker start tag: <!-- epm:interp-critique-codex v<revision_round> -->
 Marker end tag: <!-- /epm:interp-critique-codex -->
 Expected marker kind: epm:interp-critique-codex
-Expected marker version: <revision_round>
+Expected marker round (head sentinel): <revision_round> (posted top-level version: auto, max+1)
 Codex effort: high
 Codex write mode: false (read-only review)
 ```
@@ -375,7 +375,8 @@ The orchestrator dispatches `scripts/codex_task.py` with
 `run_in_background=true`, reads the output file when notified,
 extracts + validates the marker block, retries via a fresh dispatch
 on malformed output (cap retries at 2), posts via `task.py post-marker
-<N> epm:interp-critique-codex --version <revision_round>`. On
+<N> epm:interp-critique-codex` (OMIT `--version` — it auto-derives
+max+1; the round lives in the block's head sentinel). On
 `epm:codex-task-failed` or persistent malformed output, orchestrator
 falls back to single-Claude-critic per `workflow.yaml § ensemble_review`.
 On a trigger-dense round (recognition per trigger-dense-review.md

--- a/.claude/rules/trigger-dense-review.md
+++ b/.claude/rules/trigger-dense-review.md
@@ -78,7 +78,8 @@ reviewers never attempt model pins themselves (pins live on the Agent call).
    verdict body is composed DIRECTLY into its file via the `Write` tool —
    never as inline assistant text or reasoning first — then posted with
    `uv run python scripts/task.py post-marker <N> epm:code-review
-   --version <K> --file <path>` (or the reconciler analogue
+   --file <path>` (OMIT `--version` — it auto-derives max+1; the round
+   lives in the body's head sentinel; #1804) (or the reconciler analogue
    `epm:review-reconcile`; `--file`, never `--note`, because the marker
    body itself is trigger-dense and must ride the file path). The
    reviewer's ordered tool-call sequence on such rounds is `Write` (verdict

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -2897,8 +2897,9 @@ wc -c < "$MB"   # >=50000 -> the existing artifacts-file oversize fallback
 grep -m1 '^\*\*Verdict' "$MB"            # single-verdict sites (5c / 9a / 9a-bis)
 grep -E '^### Proposal|^\*\*Verdict' "$MB"   # 9b VC only: per-proposal verdicts — no -m1
 grep -m1 '^\*\*Blocker tags:' "$MB" || true  # sites that carry it (5c-bis / 9a-bis strips)
-# 4. Post without reading:
-uv run python scripts/task.py post-marker <N> epm:<kind> --version <n> \
+# 4. Post without reading (OMIT --version: it auto-derives max+1; the round
+#    lives in the extracted block's head sentinel the sed extraction keys on):
+uv run python scripts/task.py post-marker <N> epm:<kind> \
   --file "$MB"
 ```
 


### PR DESCRIPTION
Closes task #1804. Drops explicit --version pins from verdict/failure marker-posting recipes (7 workflow-surface files) so post-marker auto-derives max+1; head sentinels stay the round key.