### PR TITLE
issue-1806: escalate-only audit of root stashes + rescue dirs (watcher pass #34)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -34,21 +34,21 @@ You are an adversarial code reviewer. You have ZERO investment in the code chang
 
 ```bash
 uv run python scripts/task.py post-marker <N> epm:code-review \
-    --version <revision_round> --file /tmp/code-review-<N>.md
+    --file /tmp/code-review-<N>.md
 ```
 
-`--file` is mandatory — never pass the body inline via `--note` with a `$(cat ...)` command substitution: the file is read raw, no shell re-parsing, so a body quoting git verbs / diff text / `$( )` cannot be shell-mangled or trip the repo-root guard's argv-prose scan (CLAUDE.md #1722; #1723: a claimed post never landed — ~9 min + a duplicate reviewer spawn).
+OMIT `--version` — the posted top-level version auto-derives `max(existing)+1` per kind and may EXCEED the round on long-lived follow-up tasks (#1092/#1804); the round lives in the marker body's head sentinel. `--file` is mandatory — never pass the body inline via `--note` with a `$(cat ...)` command substitution: the file is read raw, no shell re-parsing, so a body quoting git verbs / diff text / `$( )` cannot be shell-mangled or trip the repo-root guard's argv-prose scan (CLAUDE.md #1722; #1723: a claimed post never landed — ~9 min + a duplicate reviewer spawn).
 
-**Read-back (MANDATORY before returning) — exact-kind + version, NOT `latest-marker --prefix`** (the prefix also matches the twin `epm:code-review-codex`, posted at the SAME per-round version — a prefix read can falsely confirm on the twin's row, or misread it as "my post is absent" and provoke a duplicate re-post):
+**Read-back (MANDATORY before returning) — exact-kind + head sentinel, NOT `latest-marker --prefix`** (the prefix also matches the twin `epm:code-review-codex` — a prefix read can falsely confirm on the twin's row, or misread it as "my post is absent" and provoke a duplicate re-post):
 
 ```bash
 uv run python scripts/task.py view <N> --json | \
-  jq '[.events[] | select(.kind == "epm:code-review")] | last | {kind, version, ts}'
+  jq '[.events[] | select(.kind == "epm:code-review")] | last | {kind, version, ts, head: ((.note // "") | split("\n")[0])}'
 ```
 
-Confirm `"version": <revision_round>` (this round); only then claim posted. Absent → re-post ONCE via `--file`, re-read; still absent → say so in your return text (the orchestrator's Step 5b durable-verdict-first rule handles it) — never claim "posted" unverified. Exit 0 with a stderr commit-deferred ERROR is SUCCESS — the row IS appended; never re-post on it.
+Confirm the LAST `epm:code-review` row's `head` is `<!-- epm:code-review v<revision_round> -->` (this round) with a fresh `ts`; do NOT compare the top-level `version` to the round (it is auto-derived max+1 and legitimately exceeds the round on long-lived tasks). Only then claim posted. Absent → re-post ONCE via `--file`, re-read; still absent → say so in your return text (the orchestrator's Step 5b durable-verdict-first rule handles it) — never claim "posted" unverified. Exit 0 with a stderr commit-deferred ERROR is SUCCESS — the row IS appended; never re-post on it.
 
-Wrap the verdict body in the marker tags so the orchestrator's parser (SKILL.md Step 5c) finds it:
+Wrap the verdict body in the marker tags so the orchestrator's parser (SKILL.md Step 5c) finds it. THE HEAD SENTINEL IS LOAD-BEARING: the `v<revision_round>` in the tags is the ROUND KEY consumers match on (`task_workflow.ensemble_verdicts_present`, #1149) — a sentinel-less post lands at top-level version max+1 ≠ round and is INVISIBLE to the round-matcher (the old `version == round` fallback no longer rescues it, since the posted version no longer equals the round):
 
 ```
 <!-- epm:code-review v<revision_round> -->

--- a/.claude/agents/codex-clean-result-critic.md
+++ b/.claude/agents/codex-clean-result-critic.md
@@ -1175,7 +1175,7 @@ Expected output file: /tmp/codex-clean-result-critic-<N>-r<revision_round>-outpu
 Marker start tag: <!-- epm:clean-result-critique-codex v<revision_round> -->
 Marker end tag: <!-- /epm:clean-result-critique-codex -->
 Expected marker kind: epm:clean-result-critique-codex
-Expected marker version: <revision_round>
+Expected marker round (head sentinel): <revision_round> (posted top-level version: auto, max+1)
 Codex effort: high
 Codex write mode: false (read-only critic)
 Inlined envelopes: MECHANICAL VERIFIER OUTPUT[, AUDIT SCRIPT OUTPUT, OPEN-CONCERNS JSON]

--- a/.claude/agents/codex-code-reviewer.md
+++ b/.claude/agents/codex-code-reviewer.md
@@ -188,7 +188,7 @@ test -s "$IMPL_MARKER_FILE" || {
     # genuine orchestration error (Step 5 should only fire after the
     # implementer posts). Fail loud.
     uv run python "$REPO_ROOT/scripts/task.py" post-marker <N> epm:failure \
-        --version 1 --by codex-code-reviewer \
+        --by codex-code-reviewer \
         --note "failure_class: orchestration, reason: no epm:experiment-implementation marker on main"
     exit 1
 }
@@ -280,7 +280,7 @@ else
     # envelope pattern as the implementation marker.
     test -s "$CANON_PLAN" || {
         uv run python "$REPO_ROOT/scripts/task.py" post-marker <N> epm:failure \
-            --version 1 --by codex-code-reviewer \
+            --by codex-code-reviewer \
             --note "failure_class: orchestration, reason: worktree plan absent-or-stale AND no canonical plan on main"
         exit 1
     }
@@ -849,7 +849,7 @@ Expected output file: /tmp/codex-code-reviewer-<N>-r<revision_round>-output.md
 Marker start tag: <!-- epm:code-review-codex v<revision_round> -->
 Marker end tag: <!-- /epm:code-review-codex -->
 Expected marker kind: epm:code-review-codex
-Expected marker version: <revision_round>
+Expected marker round (head sentinel): <revision_round> (posted top-level version: auto, max+1)
 Codex effort: high
 Codex write mode: false (read-only review)
 ```
@@ -866,8 +866,9 @@ Bash(run_in_background=true,
 
 When the harness notifies on bg-Bash completion, the orchestrator reads
 the output file, extracts the marker between the start/end tags, and
-posts via `task.py post-marker <N> epm:code-review-codex --version
-<revision_round>`. If the marker tags are missing in Codex's output the
+posts via `task.py post-marker <N> epm:code-review-codex` (OMIT
+`--version` — it auto-derives max+1; the round lives in the extracted
+block's head sentinel). If the marker tags are missing in Codex's output the
 orchestrator re-dispatches with a stricter retry prompt (cap retries at
 2 — same policy as before, just moved out of this agent). If the
 `epm:codex-task-failed` marker fires, the orchestrator treats this as a
@@ -940,8 +941,11 @@ Common failure modes and how to handle:
 - **Codex hallucinates line numbers that don't exist in the diff.** Not your
   problem — let it through. The `reconciler` (or the implementer reading both
   reviews) catches it.
-- **Codex emits the marker but with wrong `v<n>`.** Replace the version
-  string with the correct `revision_round` before posting.
+- **Codex emits the marker but with wrong `v<n>`.** The wrong `v<n>` here is
+  the SENTINEL round digit inside the marker tags (`<!-- epm:code-review-codex
+  v<n> -->` / the closing tag) — replace it with the correct `revision_round`
+  before posting (behavior unchanged; the posted top-level version is
+  auto-derived and untouched).
 - **Codex emits multiple markers (overzealous).** Take the LAST complete
   marker; discard prior partials.
 - **Codex output is empty / null.** Retry once. Then `epm:failure`.

--- a/.claude/agents/codex-follow-up-critic.md
+++ b/.claude/agents/codex-follow-up-critic.md
@@ -238,7 +238,7 @@ Expected output file: /tmp/codex-followup-critic-<N>-output.md
 Marker start tag: <!-- epm:followup-value-critique-codex v1 -->
 Marker end tag: <!-- /epm:followup-value-critique-codex -->
 Expected marker kind: epm:followup-value-critique-codex
-Expected marker version: 1
+Expected marker round (head sentinel): 1 (posted top-level version: auto, max+1 — multiple parks over a task's life re-post the kind)
 Codex effort: high
 Codex write mode: false (read-only redundancy screen)
 ```
@@ -247,7 +247,8 @@ The orchestrator dispatches `scripts/codex_task.py` with
 `run_in_background=true`, reads the output file when notified, extracts +
 validates the marker block, retries via a fresh dispatch on malformed
 output (cap retries at 2), posts via `task.py post-marker <N>
-epm:followup-value-critique-codex --version 1`. On `epm:codex-task-failed`
+epm:followup-value-critique-codex` (OMIT `--version` — it auto-derives
+max+1; the round lives in the block's head sentinel). On `epm:codex-task-failed`
 or persistent malformed output, the orchestrator falls back to
 single-Claude-critic per `workflow.yaml § ensemble_review`. On a
 trigger-dense round (recognition per trigger-dense-review.md "Fires

--- a/.claude/agents/codex-interpretation-critic.md
+++ b/.claude/agents/codex-interpretation-critic.md
@@ -192,7 +192,7 @@ else
     PLAN_BODY="$TASK_DIR/plans/plan.md"      # symlink to highest version
     test -s "$PLAN_BODY" || {
         uv run python "$REPO_ROOT/scripts/task.py" post-marker <N> epm:failure \
-            --version 1 --by codex-interpretation-critic \
+            --by codex-interpretation-critic \
             --note "failure_class: orchestration, reason: plan unresolvable in worktree AND no canonical plan on main"
         exit 1
     }
@@ -366,7 +366,7 @@ Expected output file: /tmp/codex-interp-critic-<N>-r<revision_round>-output.md
 Marker start tag: <!-- epm:interp-critique-codex v<revision_round> -->
 Marker end tag: <!-- /epm:interp-critique-codex -->
 Expected marker kind: epm:interp-critique-codex
-Expected marker version: <revision_round>
+Expected marker round (head sentinel): <revision_round> (posted top-level version: auto, max+1)
 Codex effort: high
 Codex write mode: false (read-only review)
 ```
@@ -375,7 +375,8 @@ The orchestrator dispatches `scripts/codex_task.py` with
 `run_in_background=true`, reads the output file when notified,
 extracts + validates the marker block, retries via a fresh dispatch
 on malformed output (cap retries at 2), posts via `task.py post-marker
-<N> epm:interp-critique-codex --version <revision_round>`. On
+<N> epm:interp-critique-codex` (OMIT `--version` — it auto-derives
+max+1; the round lives in the block's head sentinel). On
 `epm:codex-task-failed` or persistent malformed output, orchestrator
 falls back to single-Claude-critic per `workflow.yaml § ensemble_review`.
 On a trigger-dense round (recognition per trigger-dense-review.md

--- a/.claude/rules/trigger-dense-review.md
+++ b/.claude/rules/trigger-dense-review.md
@@ -78,7 +78,8 @@ reviewers never attempt model pins themselves (pins live on the Agent call).
    verdict body is composed DIRECTLY into its file via the `Write` tool —
    never as inline assistant text or reasoning first — then posted with
    `uv run python scripts/task.py post-marker <N> epm:code-review
-   --version <K> --file <path>` (or the reconciler analogue
+   --file <path>` (OMIT `--version` — it auto-derives max+1; the round
+   lives in the body's head sentinel; #1804) (or the reconciler analogue
    `epm:review-reconcile`; `--file`, never `--note`, because the marker
    body itself is trigger-dense and must ride the file path). The
    reviewer's ordered tool-call sequence on such rounds is `Write` (verdict

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -2897,8 +2897,9 @@ wc -c < "$MB"   # >=50000 -> the existing artifacts-file oversize fallback
 grep -m1 '^\*\*Verdict' "$MB"            # single-verdict sites (5c / 9a / 9a-bis)
 grep -E '^### Proposal|^\*\*Verdict' "$MB"   # 9b VC only: per-proposal verdicts — no -m1
 grep -m1 '^\*\*Blocker tags:' "$MB" || true  # sites that carry it (5c-bis / 9a-bis strips)
-# 4. Post without reading:
-uv run python scripts/task.py post-marker <N> epm:<kind> --version <n> \
+# 4. Post without reading (OMIT --version: it auto-derives max+1; the round
+#    lives in the extracted block's head sentinel the sed extraction keys on):
+uv run python scripts/task.py post-marker <N> epm:<kind> \
   --file "$MB"
 ```
 

--- a/scripts/autonomous_session_watch.py
+++ b/scripts/autonomous_session_watch.py
@@ -1,7 +1,7 @@
 """Crash-recovery + pod-safety + stalled-detector watcher for autonomous and
 interactive issue sessions (plus campaign sessions, task #586).
 
-33 passes ("pass" = one top-level per-tick action block in ``main()``'s
+34 passes ("pass" = one top-level per-tick action block in ``main()``'s
 production run order; helpers invoked INSIDE a pass — e.g. the sub-floor
 disk sentinel inside pass 1 — and the ``--*-only`` debug entrypoints do
 not count; a NEW inline pass block that is not a ``*_pass``-named function
@@ -11,7 +11,8 @@ IDENTIFIERS (cross-referenced throughout this docstring), NOT execution
 order. The per-tick execution order is: 1 (VM disk) -> 15 (data-disk) ->
 16 (happy-patch) -> 12 (CPU-guard) -> 17 (triage-observer) ->
 18 (verdict-disagree) -> 26 (root-draft) -> 27 (registry-drift) ->
-31 (codex-outage) -> 29 (completed-unmerged) -> 32 (partial-bundle) ->
+34 (stash-rescue) -> 31 (codex-outage) -> 29 (completed-unmerged) ->
+32 (partial-bundle) ->
 33 (unfolded-round) -> 30 (urgent-park router) -> 19 (VM-ledger reap) ->
 20 (program-orchestrator
 recovery) -> 13 (auth-outage guard) -> 2 (crash-recovery) -> 9 (campaign)
@@ -765,6 +766,44 @@ adding a pass means adding a numbered item here AND bumping the digit:
    ``EPM_DISABLE_UNFOLDED_ROUND_PASS=1``; ``--unfolded-round-only`` runs
    just this pass (pair with ``--dry-run`` for a live smoke).
    (:func:`unfolded_round_pass`.)
+34. **Stash/rescue-backlog audit pass (#1806; ESCALATE-ONLY;
+   daemon-INDEPENDENT; runs right after pass 27 registry-drift).**
+   Once-daily-throttled (``EPM_STASH_RESCUE_INTERVAL_HOURS``, 24h)
+   recurring audit of the shared repo root's accumulated ``git stash``
+   backlog + the ``~/.task-workflow/root-sync-rescue/`` rescue-entry
+   backlog (verified live 2026-07-30: 23 stashes, oldest May 2026; 66
+   rescue entries) — #1751 surfaces NEW ``stash: KEPT`` events at
+   Step 10d merge sites only; nothing recurring read the existing
+   backlog. Collection is READ-ONLY: one ``git -C PROJECT_ROOT stash
+   list --format=%ct%x09%gs`` subprocess (each line parsed on the FIRST
+   tab only — ``%gs`` subjects can carry embedded tabs; identity =
+   ``(ct, subject)``, deliberately NOT the positional ``stash@{N}``
+   selector, which renumbers on every push/pop and would churn the
+   fingerprint) + one ``os.scandir`` of the rescue dir (dirs AND loose
+   files, e.g. ``stash-*.patch``; identity = entry name). Entries
+   younger than ``EPM_STASH_RESCUE_MIN_AGE_DAYS`` (7d) are excluded —
+   sync_repo_root autostashes live seconds, and #1751's Step 10d duty
+   covers the fresh window. ENOENT on the rescue dir ITSELF is a
+   LEGITIMATE EMPTY rescue set (the dir is lazily created by
+   sync_repo_root.py and may be deleted after a completed #1736
+   triage); every OTHER OSError / git rc != 0 raises to the fail-soft
+   arm (stderr + one error sidecar row per throttle interval — the
+   attempt stamp is saved BEFORE collecting) and is NEVER read as
+   "backlog cleared" (no fp reset on error). NO double-read confirm gap
+   (durable files, not in-flight mutations — the deliberate delta vs
+   pass 27). Non-empty backlog fingerprints (sha256[:12] over the
+   sorted identity lists + counts), appends a row to the dedicated
+   sidecar (``.claude/cache/stash-rescue-audit-events.jsonl``), and
+   fires ONE deduped fail-soft push (counts, oldest stash age, the
+   read-only review commands, companion triage task #1736, "nothing was
+   changed automatically") on fingerprint change or a 168h re-alert TTL
+   (``EPM_STASH_RESCUE_REALERT_HOURS``). NEVER mutates git or
+   filesystem state (no ``stash pop/drop/apply``, no ``rm``), posts NO
+   task markers; triage stays human (#1736). State singleton
+   ``~/.eps-autonomous/stash-rescue-audit.json``. Kill switch
+   ``EPM_DISABLE_STASH_RESCUE_AUDIT=1``; ``--stash-rescue-audit-only``
+   runs just this pass (pair with ``--dry-run`` for a zero-write live
+   smoke). (:func:`stash_rescue_audit_pass`.)
 
 
 Why each pass exists
@@ -7412,6 +7451,308 @@ def registry_drift_pass(dry_run: bool) -> bool:
         # throttled by the attempt stamp saved before the collect).
         _append_registry_drift_sidecar(
             {"kind": "registry-drift-error", "error": str(exc)[:500]}, dry_run
+        )
+        return False
+
+
+# ─── Stash/rescue-backlog audit pass (task #1806) ─────────────────────────────
+#
+# WHY: #1751 surfaces NEW `stash: KEPT` events at Step 10d merge sites only.
+# The shared repo root's EXISTING `git stash` backlog (verified live
+# 2026-07-30: 23 entries, oldest May 2026) and the accumulated
+# ~/.task-workflow/root-sync-rescue/ rescue entries (66 live) have NO
+# recurring surfacing mechanism — 4 independent transcript miners flagged the
+# class on 2026-07-28. This pass is the recurring watcher-side sweep of that
+# whole backlog, cloning the registry_drift_pass (#1439) shape: once-daily
+# throttle, fingerprint dedup, weekly re-alert, dedicated sidecar, fail-soft.
+# ESCALATE-ONLY is a hard invariant: the pass NEVER mutates git or filesystem
+# state (no `stash pop/drop/apply`, no `rm`) — collection is one read-only
+# `git stash list --format=...` + one os.scandir of the rescue dir; triage
+# stays human (companion task #1736 holds the triage decision).
+#
+# Two deliberate deltas vs the registry-drift template: (a) NO double-read
+# confirm gap — stash/rescue entries are durable files, not in-flight
+# mutations (sync_repo_root autostashes live seconds — created + popped
+# inside one recovery — and age past the min-age gate below; #1751's Step 10d
+# duty covers the fresh 0-7-day window); (b) ENOENT on the rescue dir ITSELF
+# is a LEGITIMATE EMPTY rescue set, never a fail-soft error — the dir is
+# lazily created by sync_repo_root.py (RESCUE_ROOT) and may be absent on a
+# fresh host or deleted after a completed #1736 triage; treating it as an
+# error would permanently blind the whole pass (stash half included) and make
+# the recovered/fp-reset branch unreachable after triage. Every OTHER OSError
+# and any git rc != 0 raises to the fail-soft arm and is NEVER read as
+# "backlog cleared" (no fp reset on error).
+
+# Throttle: the audit is cheap (one git subprocess + one dir scan, <100 ms)
+# but once/day is the mandated cadence — backlog needs SURFACING, not
+# tick-rate monitoring. Env EPM_STASH_RESCUE_INTERVAL_HOURS, read at CALL
+# time (registry-drift precedent); lo=0.0 lets a live smoke force a run.
+STASH_RESCUE_INTERVAL_HOURS = 24.0
+# Re-alert TTL for an UNCHANGED fingerprint: weekly — a stash backlog is
+# inert until a triage acts on it, so the registry-drift weekly cadence
+# applies. Env EPM_STASH_RESCUE_REALERT_HOURS, read at call time.
+STASH_RESCUE_REALERT_HOURS = 168.0
+# Min age before an entry counts as backlog: sync_repo_root autostashes live
+# seconds; a stranded one ages past this gate, and #1751's Step 10d KEPT-stash
+# duty covers the fresh window. Env EPM_STASH_RESCUE_MIN_AGE_DAYS.
+STASH_RESCUE_MIN_AGE_DAYS = 7.0
+
+
+def _stash_rescue_enabled() -> bool:
+    """Kill switch: False when ``EPM_DISABLE_STASH_RESCUE_AUDIT`` is set
+    truthy ("1"/"true"/"yes", case-insensitive). Default enabled. Mirrors
+    :func:`_registry_drift_enabled`."""
+    raw = os.environ.get("EPM_DISABLE_STASH_RESCUE_AUDIT", "").strip().lower()
+    return raw not in {"1", "true", "yes"}
+
+
+def _stash_rescue_sidecar_path() -> Path:
+    """DEDICATED stash/rescue-backlog event stream (own stream for clean grep
+    — the registry-drift / root-draft sidecar precedent)."""
+    return PROJECT_ROOT / ".claude" / "cache" / "stash-rescue-audit-events.jsonl"
+
+
+def _stash_rescue_state_path() -> Path:
+    """Singleton throttle+dedup state (deliberately NOT a per-issue GC
+    target): ``{"last_run_ts": <float>, "fp": <str|None>,
+    "last_alert_ts": <float>}``."""
+    return AUTONOMOUS_REGISTRY_DIR / "stash-rescue-audit.json"
+
+
+def _stash_rescue_rescue_root() -> Path:
+    """The sync_repo_root.py rescue root (lazily created there — RESCUE_ROOT;
+    honors the same ``EPM_ROOT_SYNC_RESCUE_ROOT`` override so both tools
+    always look at the same tree). Read at call time for testability."""
+    return Path(
+        os.environ.get(
+            "EPM_ROOT_SYNC_RESCUE_ROOT",
+            str(Path.home() / ".task-workflow" / "root-sync-rescue"),
+        )
+    )
+
+
+def _load_stash_rescue_state() -> dict:
+    """``{}`` on missing/garbled state; every field read back goes through
+    ``isinstance`` type-guards (mirrors :func:`_load_registry_drift_state`)."""
+    path = _stash_rescue_state_path()
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _save_stash_rescue_state(state: dict, dry_run: bool) -> None:
+    """Atomic temp+rename write of the stash/rescue throttle/dedup state
+    (fail-soft; mirrors :func:`_save_registry_drift_state`); ``dry_run``
+    performs zero writes."""
+    if dry_run:
+        print(f"  [dry-run] would save stash-rescue state (fp={state.get('fp')})")
+        return
+    dest = _stash_rescue_state_path()
+    try:
+        AUTONOMOUS_REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
+        tmp = dest.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(state))
+        tmp.replace(dest)
+    except OSError as exc:  # pragma: no cover - fail-soft I/O guard
+        print(f"  stash-rescue: state save failed: {exc}", file=sys.stderr)
+
+
+def _append_stash_rescue_sidecar(event: dict, dry_run: bool) -> None:
+    """Append one JSON line to the stash/rescue sidecar (fail-soft). A ``ts``
+    is stamped; ``dry_run`` reports only (mirrors
+    :func:`_append_registry_drift_sidecar`)."""
+    row = {"ts": datetime.now(tz=UTC).isoformat(), **event}
+    line = json.dumps(row)
+    if dry_run:
+        print(f"  [dry-run] would append stash-rescue sidecar row: {line[:160]}")
+        return
+    dest = _stash_rescue_sidecar_path()
+    try:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with open(dest, "a") as fh:
+            fh.write(line + "\n")
+    except OSError as exc:
+        print(f"  stash-rescue: sidecar append failed: {exc}", file=sys.stderr)
+
+
+def _collect_stash_rescue_backlog(min_age_s: float, now: float) -> dict:
+    """One READ-ONLY backlog snapshot: aged repo-root stash entries + aged
+    rescue-dir entries. Raises on failure — the pass's top-level guard owns
+    fail-soft (a failed ``git stash list`` must NEVER read as "backlog
+    cleared").
+
+    Returns ``{"stashes": [(ct, subject), ...], "rescues": [(name, mtime),
+    ...]}``. Stash identity = ``(ct, subject)`` — deliberately NOT the
+    positional ``stash@{N}`` selector, which renumbers on every push/pop and
+    would churn the fingerprint. Each line is parsed on the FIRST tab only
+    (``%gs`` subjects can carry user text with embedded tabs). Rescue
+    identity = entry name (dirs AND loose files, e.g. ``stash-*.patch``).
+    ENOENT on the rescue dir ITSELF returns an EMPTY rescue list (legitimate
+    absence — lazily created; see the pass header); every OTHER OSError
+    raises."""
+    proc = subprocess.run(  # fixed read-only argv — never a mutating stash verb
+        ["git", "-C", str(PROJECT_ROOT), "stash", "list", "--format=%ct%x09%gs"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"git stash list failed rc={proc.returncode}: {proc.stderr.strip()[:200]}"
+        )
+    stashes: list[tuple[int, str]] = []
+    for line in proc.stdout.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t", 1)  # FIRST tab only — subjects can carry tabs
+        ct = int(parts[0])  # non-integer ct = garbled output -> fail-soft arm
+        subject = parts[1] if len(parts) > 1 else ""
+        if now - ct > min_age_s:
+            stashes.append((ct, subject))
+    rescues: list[tuple[str, float]] = []
+    root = _stash_rescue_rescue_root()
+    try:
+        entries = list(os.scandir(root))
+    except FileNotFoundError:
+        entries = []  # legitimate EMPTY rescue set — dir is lazily created
+    for entry in entries:
+        mtime = entry.stat(follow_symlinks=False).st_mtime
+        if now - mtime > min_age_s:
+            rescues.append((entry.name, mtime))
+    stashes.sort()
+    rescues.sort()
+    return {"stashes": stashes, "rescues": rescues}
+
+
+def _stash_rescue_fingerprint(collected: dict) -> str:
+    """sha256[:12] (the wf-fix fp shape) over the sorted identity lists +
+    counts. Rescue mtimes are attributes, not identity — a bare ``touch``
+    never churns the fp; adding/removing any entry does."""
+    stash_ids = sorted([int(ct), str(subject)] for ct, subject in collected["stashes"])
+    rescue_ids = sorted(str(name) for name, _mtime in collected["rescues"])
+    payload = json.dumps(
+        {
+            "stashes": stash_ids,
+            "rescues": rescue_ids,
+            "counts": [len(stash_ids), len(rescue_ids)],
+        }
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
+
+
+def decide_stash_rescue_alert(fp: str, state: dict, now: float, realert_s: float) -> bool:
+    """Pure fire decision: True iff ``fp`` differs from the stored fp (the
+    backlog set CHANGED — incl. first appearance and any recomposition) OR
+    the last alert is STRICTLY older than ``realert_s`` (bounded weekly
+    re-surface of an unchanged backlog). ``isinstance`` guards on state
+    fields (the registry-drift corrupt-state contract: garbled state degrades
+    to fire-as-if-unalerted)."""
+    prev_fp = state.get("fp")
+    if not isinstance(prev_fp, str) or prev_fp != fp:
+        return True
+    last_alert = state.get("last_alert_ts")
+    if not isinstance(last_alert, int | float):
+        return True
+    return (now - last_alert) > realert_s
+
+
+def stash_rescue_audit_pass(dry_run: bool) -> bool:
+    """ESCALATE-ONLY once-daily audit of the shared repo root's ``git stash``
+    backlog + the ``~/.task-workflow/root-sync-rescue/`` rescue entries
+    (#1806). NEVER mutates git or filesystem state (no ``stash
+    pop/drop/apply``, no ``rm``), posts NO task markers, writes ONLY its
+    state singleton + sidecar; triage stays the human-owned companion task
+    #1736. NO double-read confirm gap (durable files, not in-flight
+    mutations — the deliberate delta vs :func:`registry_drift_pass`).
+    Fail-soft: a collect exception logs stderr + one error sidecar row per
+    throttle interval (the attempt stamp is saved BEFORE collecting) and is
+    NEVER read as "backlog cleared" (no fp write on error), never crashes
+    the tick. Daemon-independent (one read-only git subprocess + one dir
+    scan). Returns True when a push fired this run."""
+    if not _stash_rescue_enabled():
+        print("  stash-rescue: disabled via EPM_DISABLE_STASH_RESCUE_AUDIT; skipping")
+        return False
+    try:
+        now = time.time()
+        interval_h = _env_float(
+            "EPM_STASH_RESCUE_INTERVAL_HOURS", STASH_RESCUE_INTERVAL_HOURS, lo=0.0, hi=720.0
+        )
+        realert_h = _env_float(
+            "EPM_STASH_RESCUE_REALERT_HOURS", STASH_RESCUE_REALERT_HOURS, lo=1.0, hi=2160.0
+        )
+        min_age_d = _env_float(
+            "EPM_STASH_RESCUE_MIN_AGE_DAYS", STASH_RESCUE_MIN_AGE_DAYS, lo=0.0, hi=365.0
+        )
+        state = _load_stash_rescue_state()
+        last = state.get("last_run_ts")
+        if isinstance(last, int | float) and (now - last) < interval_h * 3600.0:
+            return False  # throttled — silent (would fire 143x/day otherwise)
+        state["last_run_ts"] = now
+        # Stamp the ATTEMPT before collecting: a crashing collect is then
+        # bounded to one error sidecar row per throttle interval instead of
+        # spamming every 10-min tick.
+        _save_stash_rescue_state(state, dry_run)
+        collected = _collect_stash_rescue_backlog(min_age_d * 86400.0, now)
+        stashes, rescues = collected["stashes"], collected["rescues"]
+        if not (stashes or rescues):
+            # Reached ONLY on a clean collect (incl. the legitimate
+            # absent-rescue-dir case) — an error raised to the fail-soft arm
+            # can never take this branch, so the fp reset is trustworthy.
+            if state.get("fp"):
+                print("  stash-rescue: recovered — previously-flagged backlog is gone")
+            _save_stash_rescue_state({**state, "fp": None}, dry_run)
+            return False
+        fp = _stash_rescue_fingerprint(collected)
+        fire = decide_stash_rescue_alert(fp, state, now, realert_h * 3600.0)
+        oldest_stash_age_d = max((now - ct for ct, _s in stashes), default=0.0) / 86400.0
+        oldest_rescue_age_d = max((now - mt for _n, mt in rescues), default=0.0) / 86400.0
+        _append_stash_rescue_sidecar(
+            {
+                "kind": "stash-rescue-backlog",
+                "fingerprint": fp,
+                "n_stashes": len(stashes),
+                "n_rescues": len(rescues),
+                "oldest_stash_age_days": round(oldest_stash_age_d, 1),
+                "oldest_rescue_age_days": round(oldest_rescue_age_d, 1),
+                # Sample identities, capped — the full set keys the fp only.
+                "stashes": [[ct, subj[:120]] for ct, subj in stashes[:20]],
+                "rescues": [name for name, _mt in rescues[:20]],
+                # `pushed` records the fire DECISION (dedup bookkeeping), not
+                # delivery — _telegram_push is fail-soft and sent != seen.
+                "pushed": fire,
+            },
+            dry_run,
+        )
+        print(
+            f"  stash-rescue: {len(stashes)} aged stash(es) "
+            f"(oldest {oldest_stash_age_d:.0f}d) + {len(rescues)} rescue entr(y/ies)"
+        )
+        if fire:
+            _telegram_push(
+                f"STASH/RESCUE backlog (escalate-only #1806 pass): {len(stashes)} "
+                f"git stash entr(y/ies) on the shared repo root (oldest "
+                f"{oldest_stash_age_d:.0f}d) + {len(rescues)} rescue entr(y/ies) "
+                f"under ~/.task-workflow/root-sync-rescue/. Review (read-only): "
+                f"`git stash list`, `ls ~/.task-workflow/root-sync-rescue/`. "
+                f"Triage decision is human — companion task #1736. Nothing was "
+                f"changed automatically.",
+                dry_run,
+            )
+        _save_stash_rescue_state(
+            {**state, "fp": fp, **({"last_alert_ts": now} if fire else {})}, dry_run
+        )
+        return fire
+    except Exception as exc:  # top-level fail-soft: never take down the tick
+        print(f"  stash-rescue: pass failed (fail-soft): {exc}", file=sys.stderr)
+        # Error row only — NO fp write (the next in-interval tick stays
+        # throttled by the attempt stamp saved before the collect; an error
+        # is NEVER interpreted as "backlog cleared").
+        _append_stash_rescue_sidecar(
+            {"kind": "stash-rescue-error", "error": str(exc)[:500]}, dry_run
         )
         return False
 
@@ -28696,6 +29037,16 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 — flat --*-only 
         "--dry-run for a zero-write live smoke.",
     )
     parser.add_argument(
+        "--stash-rescue-audit-only",
+        action="store_true",
+        help="run ONLY the stash/rescue-backlog audit pass (#1806, "
+        "escalate-only — the shared repo root's aged git-stash backlog + "
+        "~/.task-workflow/root-sync-rescue/ entries; never mutates git or "
+        "filesystem state) and exit; skip every other pass. "
+        "Daemon-independent; pair with --dry-run for a zero-write live "
+        "smoke.",
+    )
+    parser.add_argument(
         "--completed-unmerged-only",
         action="store_true",
         help="run ONLY the completed-unmerged pass (#1564 flag + #1653 "
@@ -28870,6 +29221,14 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 — flat --*-only 
         registry_drift_pass(args.dry_run)
         return 0
 
+    # --stash-rescue-audit-only mirrors --registry-drift-only: the pass is
+    # daemon-independent (one read-only git subprocess + one dir scan + its
+    # own state file), so run it alone. Pair with --dry-run for a zero-write
+    # live smoke.
+    if args.stash_rescue_audit_only:
+        stash_rescue_audit_pass(args.dry_run)
+        return 0
+
     # --completed-unmerged-only mirrors --registry-drift-only: the FLAG half
     # is daemon-independent (registry + events.jsonl reads + read-only
     # gh/git probes; marker posts go via the task.py subprocess), and the
@@ -29030,6 +29389,16 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901 — flat --*-only 
     # --repair`; NEVER repairs, posts NO task markers. Daemon-independent,
     # so it runs on a daemon outage too.
     registry_drift_pass(args.dry_run)
+
+    # Stash/rescue-backlog audit (#1806): once-daily ESCALATE-ONLY audit of
+    # the shared repo root's aged git-stash backlog + the
+    # ~/.task-workflow/root-sync-rescue/ entries (the class #1751's Step 10d
+    # KEPT-stash duty surfaces only for NEW events). One read-only
+    # `git stash list` + one rescue-dir scan; sidecar + ONE deduped push
+    # naming the read-only review commands + companion triage task #1736;
+    # NEVER mutates git/filesystem state, posts NO task markers.
+    # Daemon-independent, so it runs on a daemon outage too.
+    stash_rescue_audit_pass(args.dry_run)
 
     # Codex quota-outage alert (#1691): ESCALATE-ONLY audit sibling of the
     # #1204 pre-spawn sentinel check. Alerts once per Codex quota-outage

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -323,6 +323,11 @@ _FLEET_MUTATING_PASS_NAMES = (
     # reconcile_registry(apply=False) reads against the LIVE registry and can
     # write real sidecar rows / state / pushes from a full-main() unit test.
     "registry_drift_pass",
+    # #1806: escalate-only too, but it runs a REAL `git stash list` against
+    # the LIVE shared root + scans the real ~/.task-workflow/root-sync-rescue/
+    # dir and can write real sidecar rows / state / pushes from a full-main()
+    # unit test; its own tests stub the collector / push / path seams instead.
+    "stash_rescue_audit_pass",
     # #1564: flag-only too, but it sweeps the LIVE registry's completed set,
     # runs real gh/git probes, and can post REAL epm:progress markers on live
     # tasks + sidecar rows + pushes from a full-main() unit test.

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -21110,6 +21110,334 @@ def test_registry_drift_pass_dry_run_writes_no_state(tmp_path, monkeypatch, caps
     assert "[dry-run] would append registry-drift sidecar row" in out
 
 
+# ── stash/rescue-backlog audit pass (pass 34, #1806) ─────────────────────────
+#
+# Clones the registry-drift (#1439) test shape: pure decide + fingerprint
+# tests, pass-driver tests with the collector / push / path seams stubbed
+# (the pass is in conftest's _FLEET_MUTATING_PASS_NAMES for full-main()
+# tests; these tests OF the pass stub its own seams instead). The
+# missing-rescue-dir + min-age tests drive the REAL collector body with a
+# signature-conformant fake ONLY at the subprocess boundary.
+
+
+def _srescue_isolate(asw, monkeypatch, tmp_path: Path) -> tuple[Path, Path]:
+    """Point the pass's state (AUTONOMOUS_REGISTRY_DIR) + sidecar
+    (PROJECT_ROOT-derived) + rescue root (EPM_ROOT_SYNC_RESCUE_ROOT) at
+    tmp_path; return (state_path, sidecar_path). Mirrors
+    :func:`_rdrift_isolate`."""
+    monkeypatch.setattr(asw, "AUTONOMOUS_REGISTRY_DIR", tmp_path / "registry")
+    monkeypatch.setattr(asw, "PROJECT_ROOT", tmp_path / "root")
+    (tmp_path / "root").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("EPM_ROOT_SYNC_RESCUE_ROOT", str(tmp_path / "rescue"))
+    return (
+        tmp_path / "registry" / "stash-rescue-audit.json",
+        tmp_path / "root" / ".claude" / "cache" / "stash-rescue-audit-events.jsonl",
+    )
+
+
+# One aged stash (identity = (ct, subject), never stash@{N}) + one aged rescue
+# entry (identity = name; the mtime is an attribute, not identity).
+_SRESCUE_SNAPSHOT = {
+    "stashes": [(1_748_000_000, "On main: WIP stranded autostash")],
+    "rescues": [("20260601-120000-99999", 1_749_000_000.0)],
+}
+
+
+def test_stash_rescue_decide_alert_fp_change_and_ttl():
+    import autonomous_session_watch as asw
+
+    now = 1_000_000.0
+    realert = 168 * 3600.0
+    # First appearance (no stored fp): fires.
+    assert asw.decide_stash_rescue_alert("abc", {}, now, realert) is True
+    # Same fp within the TTL: silent.
+    assert (
+        asw.decide_stash_rescue_alert(
+            "abc", {"fp": "abc", "last_alert_ts": now - 100.0}, now, realert
+        )
+        is False
+    )
+    # Same fp STRICTLY past the TTL: re-fires (bounded weekly re-surface).
+    assert (
+        asw.decide_stash_rescue_alert(
+            "abc", {"fp": "abc", "last_alert_ts": now - realert - 1.0}, now, realert
+        )
+        is True
+    )
+    # Boundary: exactly-at-TTL does NOT re-fire (predicate is STRICT >).
+    assert (
+        asw.decide_stash_rescue_alert(
+            "abc", {"fp": "abc", "last_alert_ts": now - realert}, now, realert
+        )
+        is False
+    )
+    # Recomposed backlog set (fp changed): fires regardless of a fresh stamp.
+    assert (
+        asw.decide_stash_rescue_alert("def", {"fp": "abc", "last_alert_ts": now}, now, realert)
+        is True
+    )
+    # Corrupt state fields degrade to fire-as-if-unalerted (isinstance guards).
+    assert asw.decide_stash_rescue_alert("abc", {"fp": 42}, now, realert) is True
+    assert (
+        asw.decide_stash_rescue_alert("abc", {"fp": "abc", "last_alert_ts": "x"}, now, realert)
+        is True
+    )
+
+
+def test_stash_rescue_fingerprint_stable_under_reorder():
+    """Identity-set permutation => same fp (the collector sorts, and the fp
+    sorts again — a listing-order change can never re-push); rescue mtime
+    churn => same fp (mtime is an attribute, not identity); any entry
+    added/removed => different fp."""
+    import autonomous_session_watch as asw
+
+    base = {
+        "stashes": [(100, "a"), (200, "b")],
+        "rescues": [("r1", 1.0), ("r2", 2.0)],
+    }
+    permuted = {
+        "stashes": [(200, "b"), (100, "a")],
+        # mtimes differ too — attributes, never identity.
+        "rescues": [("r2", 5.0), ("r1", 9.0)],
+    }
+    fp = asw._stash_rescue_fingerprint(base)
+    assert fp == asw._stash_rescue_fingerprint(permuted)
+    assert len(fp) == 12
+    # Entry added => different fp.
+    grown = {"stashes": [*base["stashes"], (300, "c")], "rescues": base["rescues"]}
+    assert fp != asw._stash_rescue_fingerprint(grown)
+    # Entry removed => different fp.
+    shrunk = {"stashes": base["stashes"], "rescues": base["rescues"][:1]}
+    assert fp != asw._stash_rescue_fingerprint(shrunk)
+
+
+def test_stash_rescue_pass_fires_and_dedupes(tmp_path, monkeypatch):
+    """First confirmed backlog fires ONE push + a sidecar row; a second
+    same-fp run inside the TTL is push-silent (sidecar audit row only); an
+    empty backlog resets the fp with no push."""
+    import autonomous_session_watch as asw
+
+    state_path, sidecar_path = _srescue_isolate(asw, monkeypatch, tmp_path)
+    monkeypatch.setenv("EPM_STASH_RESCUE_INTERVAL_HOURS", "0")  # runs 2/3 unthrottled
+    monkeypatch.setattr(
+        asw, "_collect_stash_rescue_backlog", lambda min_age_s, now: _SRESCUE_SNAPSHOT
+    )
+    pushes: list[str] = []
+    monkeypatch.setattr(asw, "_telegram_push", lambda msg, dry_run: pushes.append(msg) or True)
+
+    assert asw.stash_rescue_audit_pass(dry_run=False) is True
+    assert len(pushes) == 1
+    assert "git stash list" in pushes[0]
+    assert "root-sync-rescue" in pushes[0]
+    assert "#1736" in pushes[0]
+    assert "Nothing was changed automatically" in pushes[0]
+    rows = [json.loads(x) for x in sidecar_path.read_text().splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "stash-rescue-backlog"
+    assert rows[0]["pushed"] is True
+    assert rows[0]["n_stashes"] == 1 and rows[0]["n_rescues"] == 1
+    assert rows[0]["stashes"] == [[1_748_000_000, "On main: WIP stranded autostash"]]
+    assert rows[0]["rescues"] == ["20260601-120000-99999"]
+    state = json.loads(state_path.read_text())
+    assert state["fp"] == rows[0]["fingerprint"]
+    assert isinstance(state["fp"], str) and len(state["fp"]) == 12
+    assert isinstance(state["last_run_ts"], float)
+    assert isinstance(state["last_alert_ts"], float)
+    # Run 2: same fp, within the 168h TTL — sidecar row still appended
+    # (audit trail) with pushed: false, and NO second push.
+    assert asw.stash_rescue_audit_pass(dry_run=False) is False
+    assert len(pushes) == 1
+    rows = [json.loads(x) for x in sidecar_path.read_text().splitlines()]
+    assert len(rows) == 2
+    assert rows[0]["pushed"] is True and rows[1]["pushed"] is False
+    assert rows[0]["fingerprint"] == rows[1]["fingerprint"]
+    # Run 3: backlog cleared — fp reset, no push, no new backlog row.
+    monkeypatch.setattr(
+        asw,
+        "_collect_stash_rescue_backlog",
+        lambda min_age_s, now: {"stashes": [], "rescues": []},
+    )
+    assert asw.stash_rescue_audit_pass(dry_run=False) is False
+    assert len(pushes) == 1
+    assert len(sidecar_path.read_text().splitlines()) == 2
+    assert json.loads(state_path.read_text())["fp"] is None
+
+
+def test_stash_rescue_min_age_filters_fresh_entries(tmp_path, monkeypatch):
+    """A fresh (now) stash / rescue entry is excluded by the min-age gate —
+    sync_repo_root autostashes live seconds and #1751's Step 10d duty covers
+    the fresh window. Drives the REAL collector body; the only fake is a
+    signature-conformant CompletedProcess at the subprocess boundary."""
+    import os as _os
+    import subprocess as _subprocess
+
+    import autonomous_session_watch as asw
+
+    now = time.time()
+    rescue = tmp_path / "rescue"
+    rescue.mkdir()
+    monkeypatch.setenv("EPM_ROOT_SYNC_RESCUE_ROOT", str(rescue))
+    old_dir = rescue / "20260401-120000-11111"
+    old_dir.mkdir()
+    _os.utime(old_dir, (now - 30 * 86400, now - 30 * 86400))
+    (rescue / "stash-fresh.patch").write_text("x")  # mtime = now — filtered
+    old_ct = int(now - 30 * 86400)
+    fresh_ct = int(now - 60)
+    stdout = f"{old_ct}\tOn main: old stranded\n{fresh_ct}\tOn main: live autostash\n"
+
+    def _fake_run(argv, **kwargs):
+        return _subprocess.CompletedProcess(argv, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(asw.subprocess, "run", _fake_run)
+    collected = asw._collect_stash_rescue_backlog(7 * 86400.0, now)
+    assert collected["stashes"] == [(old_ct, "On main: old stranded")]
+    assert [n for n, _mt in collected["rescues"]] == ["20260401-120000-11111"]
+
+
+def test_stash_rescue_kill_switch(tmp_path, monkeypatch):
+    """Forbidden-raiser collect stub + state/sidecar files must NOT exist — a
+    broken kill-switch gate would raise into the fail-soft path and write an
+    error sidecar row, so a bare returns-False pin would be vacuous (the
+    registry-drift kill-switch test shape)."""
+    import autonomous_session_watch as asw
+
+    monkeypatch.setenv("EPM_DISABLE_STASH_RESCUE_AUDIT", "1")
+    state_path, sidecar_path = _srescue_isolate(asw, monkeypatch, tmp_path)
+
+    def _forbidden(*a, **kw):
+        raise AssertionError("no collect / state IO / push under the kill switch")
+
+    monkeypatch.setattr(asw, "_collect_stash_rescue_backlog", _forbidden)
+    monkeypatch.setattr(asw, "_telegram_push", _forbidden)
+    assert asw.stash_rescue_audit_pass(dry_run=False) is False
+    assert not state_path.exists() and not sidecar_path.exists()
+
+
+def test_stash_rescue_collector_readonly(tmp_path, monkeypatch):
+    """ESCALATE-ONLY invariant, argv-pinned: the collector's ONLY subprocess
+    invocation is the read-only `git ... stash list --format=...` form — no
+    pop/drop/apply/clear/push anywhere in the argv (acceptance criterion 3)."""
+    import subprocess as _subprocess
+
+    import autonomous_session_watch as asw
+
+    rescue = tmp_path / "rescue"
+    rescue.mkdir()
+    monkeypatch.setenv("EPM_ROOT_SYNC_RESCUE_ROOT", str(rescue))
+    calls: list[list[str]] = []
+
+    def _fake_run(argv, **kwargs):
+        calls.append(list(argv))
+        return _subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(asw.subprocess, "run", _fake_run)
+    asw._collect_stash_rescue_backlog(7 * 86400.0, time.time())
+    assert calls == [["git", "-C", str(asw.PROJECT_ROOT), "stash", "list", "--format=%ct%x09%gs"]]
+    mutating = {"pop", "drop", "apply", "clear", "push", "create", "store", "branch", "rm"}
+    assert not mutating.intersection(calls[0])
+
+
+def test_stash_rescue_missing_rescue_dir_is_empty_not_error(tmp_path, monkeypatch):
+    """Critic Must-Fix: ENOENT on the rescue dir ITSELF is a LEGITIMATE EMPTY
+    rescue set (lazily created by sync_repo_root.py; deleted after a
+    completed #1736 triage), never a fail-soft error — (a) with an empty
+    stash list the recovered/fp-reset branch is taken (NO error sidecar
+    row); (b) with a non-empty stash list the stash half still surfaces
+    (the absent dir never blinds the whole pass). Drives the REAL collector
+    through the pass; the only fake is the subprocess boundary."""
+    import subprocess as _subprocess
+
+    import autonomous_session_watch as asw
+
+    state_path, sidecar_path = _srescue_isolate(asw, monkeypatch, tmp_path)
+    # _srescue_isolate points the rescue root at tmp_path/"rescue" — NEVER
+    # created in this test: os.scandir raises FileNotFoundError (ENOENT).
+    monkeypatch.setenv("EPM_STASH_RESCUE_INTERVAL_HOURS", "0")
+    pushes: list[str] = []
+    monkeypatch.setattr(asw, "_telegram_push", lambda msg, dry_run: pushes.append(msg) or True)
+
+    # (a) empty stash list too => recovered/fp-reset branch, NO error row.
+    def _fake_run_empty(argv, **kwargs):
+        return _subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(asw.subprocess, "run", _fake_run_empty)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps({"fp": "deadbeefcafe", "last_run_ts": 0.0}))
+    assert asw.stash_rescue_audit_pass(dry_run=False) is False
+    assert not sidecar_path.exists()  # no backlog row AND no error row
+    assert json.loads(state_path.read_text())["fp"] is None  # fp-reset taken
+    assert pushes == []
+
+    # (b) non-empty stash list => the stash half fires with n_rescues == 0.
+    old_ct = int(time.time() - 30 * 86400)
+
+    def _fake_run_one(argv, **kwargs):
+        return _subprocess.CompletedProcess(
+            argv, 0, stdout=f"{old_ct}\tOn main: stranded\n", stderr=""
+        )
+
+    monkeypatch.setattr(asw.subprocess, "run", _fake_run_one)
+    assert asw.stash_rescue_audit_pass(dry_run=False) is True
+    rows = [json.loads(x) for x in sidecar_path.read_text().splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "stash-rescue-backlog"
+    assert rows[0]["n_stashes"] == 1 and rows[0]["n_rescues"] == 0
+    assert len(pushes) == 1
+
+
+def test_stash_rescue_fail_soft_error_row(tmp_path, monkeypatch, capsys):
+    """A collect failure (git rc != 0 raises there) => stderr + ONE error
+    sidecar row, pass returns False, NO push — and NO fp write, so a failed
+    `git stash list` is NEVER read as "backlog cleared" (the next
+    in-interval tick stays throttled by the attempt stamp)."""
+    import autonomous_session_watch as asw
+
+    state_path, sidecar_path = _srescue_isolate(asw, monkeypatch, tmp_path)
+
+    def _boom(min_age_s, now):
+        raise RuntimeError("git stash list failed rc=128: boom")
+
+    def _no_push(*a, **kw):
+        raise AssertionError("failed collect must not push")
+
+    monkeypatch.setattr(asw, "_collect_stash_rescue_backlog", _boom)
+    monkeypatch.setattr(asw, "_telegram_push", _no_push)
+    assert asw.stash_rescue_audit_pass(dry_run=False) is False
+    assert "stash-rescue: pass failed (fail-soft): git stash list failed" in (
+        capsys.readouterr().err
+    )
+    rows = [json.loads(x) for x in sidecar_path.read_text().splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "stash-rescue-error"
+    assert "git stash list failed" in rows[0]["error"]
+    # NO fp write on error — only the attempt stamp saved BEFORE the collect
+    # survives, bounding a crashing collect to one error row per interval.
+    state = json.loads(state_path.read_text())
+    assert "fp" not in state
+    assert isinstance(state["last_run_ts"], float)
+
+
+def test_stash_rescue_dry_run_writes_nothing(tmp_path, monkeypatch, capsys):
+    """--dry-run contract (acceptance criterion 6, backing the live smoke):
+    zero state writes, zero sidecar writes, zero pushes (dry_run threads
+    into _telegram_push, whose real body no-ops on it)."""
+    import autonomous_session_watch as asw
+
+    state_path, sidecar_path = _srescue_isolate(asw, monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        asw, "_collect_stash_rescue_backlog", lambda min_age_s, now: _SRESCUE_SNAPSHOT
+    )
+    calls: list[bool] = []
+    monkeypatch.setattr(asw, "_telegram_push", lambda msg, dry_run: calls.append(dry_run) or False)
+
+    assert asw.stash_rescue_audit_pass(dry_run=True) is True
+    assert calls == [True]  # push observed, dry_run honored
+    assert not state_path.exists() and not sidecar_path.exists()  # zero writes
+    out = capsys.readouterr().out
+    assert "[dry-run] would save stash-rescue state" in out
+    assert "[dry-run] would append stash-rescue sidecar row" in out
+
+
 # ── orphan-wrapper /proc sweep (pass 28, #1215) ──────────────────────────────
 #
 # Pure decision ladder + pure scan classifier + pass-driver tests, following


### PR DESCRIPTION
Closes task #1806. Adds stash_rescue_audit_pass — recurring, deduped, ESCALATE-ONLY watcher audit of the shared-root git-stash backlog + ~/.task-workflow/root-sync-rescue/ entries (registry-drift pattern clone: 24h throttle, fp dedup, 168h re-alert, sidecar JSONL, kill switch, --stash-rescue-audit-only).