### PR TITLE
issue-1807: Step 10d/9c — re-sync vs SHA-bound gates (verdict re-bind + pre-9c sync)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1674,6 +1674,15 @@ uv run ruff format --check path/to/changed/files
 # Ruff-policy pin (#1699 / #1716): when the diff touches any path listed
 # in tests/test_ruff_policy.py's LIVE_WORKFLOW_HELPERS roster, ALSO run:
 uv run pytest tests/test_ruff_policy.py::test_live_workflow_helpers_clean_under_full_ruleset -x
+# Round-new-script no-flags lint (#1805): fires only when the diff ADDS a
+# scripts/ or src/ .py file — then run the no-flags lint once from the
+# worktree (the same instrument as the Step 10d gate's lint leg):
+BASE=${BASE:-origin/main}   # the Step 0 fetched base (#1289), or the brief's stated base
+if git diff --name-status --diff-filter=A "$BASE"...HEAD \
+     | grep -qE $'^A\t(scripts|src)/.*\\.py$'; then
+  timeout --kill-after=30s 540s uv run python scripts/workflow_lint.py \
+    > /tmp/reviewer-lint-<N>.txt 2>&1; echo "no-flags lint rc=$?"
+fi
 ```
 
 **Ruff-policy pin (#1716, mirrors `implementer.md:176`).** Bare `ruff check`
@@ -1694,6 +1703,36 @@ equivalent discriminating one-liner `uv run ruff check <touched files>
 --config 'lint.per-file-ignores = {}'` MAY be documented as a fast local
 probe, but the pin test is the authoritative form — it is what the gate
 runs, and it is the one whose node id the FAIL will name.
+
+**Round-new-script no-flags lint (#1805).** Trigger: the diff ADDS (status
+`A` vs the review base) ≥1 `scripts/**/*.py` or `src/**/*.py` file — the
+executable gate in the block above; prose-only / modify-only rounds skip the
+duty (accepted residual: a modify-only round introducing a fresh bare hub
+call skips it — status-quo latency; the Step 10d gate remains the
+authoritative backstop). Attribution: `workflow_lint:` failure lines naming a
+round-TOUCHED path → a Critical with blocker tag `substantive` (a
+deterministic Step 10d gate blocker caught early — the #1092 shape; NOT
+strippable by /issue Step 5c-bis); failure lines naming only untouched paths
+→ pre-existing red, note-only, NEVER blocks; timeout / crash / zero output →
+INCONCLUSIVE — flag it loudly in the verdict (the tests-not-run convention
+below), never report it as clean, never a blocker by itself.
+
+Remedy guidance for hub-verify hits on genuinely non-network-risky shapes —
+a bare `inspect.signature(...)` reference, or a call the script wraps in
+`hub.retry_transient(...)` itself (BOTH #1092 shapes still require the
+waiver): the fix IS the `# HUB_VERIFY_RETRY_EXEMPT: <reason>` waiver (reason
+≥ 10 chars, on the call's first physical line or the immediately-preceding
+NON-BLANK line) — name it in the finding so the implementer's bounce round
+applies it directly. Routing the listing through the `orchestrate/hub.py`
+helpers (`verify_repo_paths_uploaded`, `list_hf_files_under_path`,
+`list_repo_files_complete`) IN PLACE OF the bare target is the only
+no-waiver alternative. `uv run python scripts/workflow_lint.py
+--check-hub-verify-retry` runs in seconds and MAY be run first as a fast
+probe; the no-flags run is authoritative (it is what the gate runs).
+Stale-family caveat (#1417): a false block naming a ratchet/grandfather size
+cap, or a `workflow_lint` import failure inside the worktree, is the stale
+lint-family class — cross-check at the repo root (post Step-5a sync) before
+attributing it to the payload.
 
 **If `uv run pytest` fails with a read-only-sandbox / cache / tempdir error**
 (e.g. `Read-only file system`, `Permission denied` on `~/.cache/uv`, or a

--- a/.claude/agents/codex-code-reviewer.md
+++ b/.claude/agents/codex-code-reviewer.md
@@ -586,7 +586,22 @@ both reviewers are graded against the same standard. Read
   pin's literal command + exit code alongside the bare-ruff result; a
   passing bare-ruff with a failing pin is the #1672 shape and blocks the
   round with a `substantive` blocker tag (NOT `marker-shape` — a real
-  lint violation is never strippable by Step 5c-bis).
+  lint violation is never strippable by Step 5c-bis). ALSO INCLUDING the
+  round-new-script no-flags lint duty (#1805): Codex cannot run the lint
+  (no `uv` env), so the composed prompt instructs the STATIC
+  diff-readable adaptation — flag any round-NEW `scripts/**/*.py` diff
+  hunk carrying `list_repo_files` / `list_repo_tree` / `file_exists` in
+  call OR bare-reference form — INCLUDING a `retry_transient(...)`-wrapped
+  call and a bare `inspect.signature(...)` reference (both #1092 incident
+  shapes; wrapping does NOT obviate the waiver) — with no
+  `# HUB_VERIFY_RETRY_EXEMPT: <reason>` waiver on the call's first
+  physical line or the immediately-preceding NON-BLANK line → a Critical
+  tagged `substantive`, with the waiver named as the remedy. The ONLY
+  no-waiver routes are the `orchestrate/hub.py` helper functions used IN
+  PLACE OF the bare target (`verify_repo_paths_uploaded`,
+  `list_hf_files_under_path`, `list_repo_files_complete`). The executable
+  no-flags coverage stays the Claude reviewer's duty (the Step 4.6
+  no-uv-adaptation pattern).
 - "Step 4.5: Regression-test presence for substantive BLOCKER fixes"
   VERBATIM. This is a test-PRESENCE check (grep the worktree for a committed
   pytest pinning the invariant), NOT a test-RUNNING check, so Codex CAN and

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -9098,7 +9098,25 @@ suite directly and posts an `epm:test-verdict` event with the result.
       on a worktree-based task whose branch HAS commits ahead of the base,
       that NOTE means wrong cwd, re-run from the worktree; from a correct
       worktree with no commits ahead of the base it also fires and is then
-      expected and benign). The selector's diff base defaults to fetched
+      expected and benign).
+
+      Pre-gate spec-freshness re-sync (#1742): AFTER the `cd "$WT"` below
+      and BEFORE invoking the selector, run the Step 5a family-atomic
+      spec-freshness block (§ Step 5a) ONCE from the worktree cwd. This
+      is a BINDING reference — never inline a THIRD `FAMILY_OF` copy
+      here (a third inlined copy would escape
+      `test_step10d_family_atomicity_matches_step5a`'s drift guard). The
+      Step 5a block's own `WT=$(git rev-parse --show-toplevel)`
+      derivation is CORRECT at this call site (step 1a already `cd`s to
+      the worktree), and its on-main skip guard makes the reference safe
+      for repo-root-based tasks (no worktree ⇒ the sync no-ops). A sync
+      commit here is SAFE — no SHA-bound verdict exists at 9c — and it
+      must PRECEDE subset computation: the selector's three-dot diff
+      then simply reflects the freshened files, whose content is main's
+      own, so a freshened pin test runs against the freshened spec
+      instead of failing the gate on the stale worktree copy (the #1742
+      class: a main-side spec fix landing after the Step 5a sync red the
+      gate round). The selector's diff base defaults to fetched
       `origin/main` (#1289: the shared root's local `main` lagged origin on
       2026-07-12 and polluted #1281's gate to 41 files with foreign touched
       files; bounded 120 s fetch — a fetch failure degrades to last-fetched
@@ -9110,6 +9128,9 @@ suite directly and posts an `epm:test-verdict` event with the result.
       WT="$REPO_ROOT/.claude/worktrees/issue-<N>"   # same-issue follow-up rounds use
                                                     # their own issue-<N>-<suffix> worktree
       cd "$WT" || { echo "FATAL: cd to issue worktree failed" >&2; exit 1; }
+      # Pre-gate spec-freshness re-sync (#1742): run the Step 5a
+      # family-atomic block (§ Step 5a) HERE, before the selector —
+      # reference § Step 5a, never a third inlined FAMILY_OF copy.
       uv run python scripts/select_step9c_tests.py   # base defaults to FETCHED origin/main (#1289)
       ```
       It prints the exact gate command —
@@ -11250,13 +11271,24 @@ tests BEFORE anything lands:
   binding sites' line-2 sha check already fails CLOSED on. Worst case —
   every bounded leg wedged — the call runs ~78 min, past the 60-min
   § Long-phase heartbeat boundary (rare; a watcher force-stop there is
-  itself fail-closed: no verdict file gets written).
+  itself fail-closed: no verdict file gets written). Print the
+  diagnostic tails via the canonical fail-soft compound in the block
+  below — this is the Recipe exit-code hygiene class (Step 9c 1b): on a
+  PASS these files are routinely empty or absent, so a bare trailing
+  `grep`/`cat`/`[ -s ]` leg exits non-zero and reads as a tool error;
+  every leg is if-formed and the block ends exit-0 on a healthy read.
 
   ```bash
   if [ ! -f /tmp/issue-<N>-lint-verdict.txt ]; then
     echo "FATAL: verdict file missing — the background gate run died before writing a verdict. Kill-before-relaunch, then re-run the gate ONCE; NEVER record pass." >&2
   else
     cat /tmp/issue-<N>-lint-verdict.txt   # line 1: verdict; line 2: certified sha — the merge conditional below stays the hard stop
+    # Fail-soft diagnostic tails (Recipe exit-code hygiene, Step 9c 1b):
+    # empty/absent on a PASS by design — never a bare trailing grep/cat/
+    # [ -s ] leg here (it would exit 1 and read as a tool error).
+    for f in lint-new lint-owndiff tg-new tg-new-nodes; do
+      if [ -s "/tmp/issue-<N>-$f.txt" ]; then echo "--- $f ---"; head -20 "/tmp/issue-<N>-$f.txt"; fi
+    done; true
   fi
   ```
 
@@ -11393,7 +11425,15 @@ tests BEFORE anything lands:
   fresh gate run regenerates it). A merge that fails for a NON-lint
   transport reason (the #1041 rebase-refusal → `--squash`-retry shape)
   therefore stays certified by the SAME gate run — never hand-recreate the
-  verdict file (#1082). On a `block` (or `crash`) verdict:
+  verdict file (#1082). ONE mechanically-gated exception (#1807): the
+  auto-merge RE-BIND stanza (safe-case block) may rewrite LINE 2 ONLY —
+  line 1 is never touched — after its own `git diff --name-status
+  <certified-sha>..HEAD` probe proves the post-gate sync commit's delta is
+  origin/main-identical `A`/`M`-only; the license covers ONLY that stanza
+  executing over its own probe output — a free-standing "update line 2"
+  move stays banned, and the #1613 empty-commit synchronize explicitly
+  STAYS a stale-verdict → gate-re-run case, never a re-bind. On a `block`
+  (or `crash`) verdict:
   1. An own-diff-named gated failure line exists
      (`/tmp/issue-<N>-lint-owndiff.txt` non-empty) → the payload is the
      offender. Fix it in the worktree (the lint names file + rule),
@@ -11591,9 +11631,26 @@ tests BEFORE anything lands:
     3. End with one echo — `[step10d] post-gate re-sync: synced <n> files (<sha>) | no drift` —
        so ran-vs-never-ran is observable in the merge transcript (copy
        the line into the `epm:merged` / `epm:merge-failed` note).
-    4. `gh pr merge --squash` — if it returns `CONFLICTING`, fall
-       through to the existing merge-conflict-recovery path
-       (§ Concurrent-committer merge conflicts).
+    4. If the re-sync COMMITTED (`<sha>` != `no-drift`), run the verdict
+       RE-BIND stanza (auto-merge subsection, #1807): enumerate the
+       certified-sha..HEAD delta with `git diff --name-status`; every
+       row must be `A`/`M` with content byte-identical to fetched
+       `origin/main` — then line 2 of the verdict file is re-bound to
+       the new tip (line 1 is never touched), because a delta that only
+       adds/overwrites files with main's own bytes cannot change the
+       landing tree the gate certified. ANY other delta — a
+       `D`/`R*`/`C*`/`T`/`U` status row (the sync's
+       `checkout origin/main --` can only add/modify, never delete) or
+       a non-identical file — fails CLOSED: verdict removed, no merge,
+       re-run the gate.
+    5. The head-sync pre-check (#1657) runs AFTER the re-sync +
+       re-bind — it polls PR-object parity against the FINAL tip (a
+       fresh sync push re-introduces exactly the lag the pre-check
+       absorbs; polling before the sync would check the wrong tip).
+    6. `gh pr ready` + `gh pr merge --squash` — if it returns
+       `CONFLICTING`, fall through to the existing
+       merge-conflict-recovery path (§ Concurrent-committer merge
+       conflicts).
 
   The Guard-3 subject-scoped commit-subject convention still applies —
   never write a full-message grep-exclusion invocation into this Step 10d
@@ -11614,7 +11671,11 @@ tests BEFORE anything lands:
   this sync (the family is still dirty), so the gate's #1456 3-way
   merge of `workflow_lint.py` remains the covering mechanism for that
   specific file's payload edits, and the merge's own conflict resolution
-  handles the residual.
+  handles the residual. As of #1807 the verdict-file SHA mechanics AGREE
+  with this landing-tree argument: when step 4's probe mechanically
+  proves the sync commit's delta payload-free, the re-bind stanza moves
+  line 2 to the sync tip instead of forcing a full gate re-run; every
+  unverifiable tip delta still fails CLOSED into a gate re-run.
 
 #### The auto-merge procedure (safe case: guard 3 clean — mainline-based, own commits in scope)
 
@@ -11694,33 +11755,11 @@ else
   # new commits since certification — re-run the gate). The verdict is
   # consumed (rm) only AFTER `gh pr merge` SUCCEEDS: a non-lint transport
   # failure (#1041 rebase refusal) leaves it valid for the same-tip retry
-  # — never hand-write the verdict file (#1082).
+  # — never hand-write the verdict file (#1082; sole exception: the
+  # mechanically-gated RE-BIND stanza below, line 2 only).
   if grep -qxE 'pass|skip-artifact-only' /tmp/issue-<N>-lint-verdict.txt 2>/dev/null \
      && [ -n "$(sed -n 2p /tmp/issue-<N>-lint-verdict.txt 2>/dev/null)" ] \
      && [ "$(sed -n 2p /tmp/issue-<N>-lint-verdict.txt 2>/dev/null)" = "$(git -C "$WT" rev-parse HEAD)" ]; then
-    # Head-sync pre-check (#1657, READ-ONLY — the tip is untouched, so the
-    # SHA-bound verdict above stays valid): every push this invocation made
-    # (Guard-0/1 commits, the pre-gate spec-freshness commit) races
-    # GitHub's PR-object sync — #1614's attempts 1-2 were refused
-    # 'Head branch is out of date' while the PR object lagged the pushed
-    # tip ~6 min. Poll until the PR object reports the local tip AND a
-    # settled mergeability; a settled CONFLICTING exits too (the merge
-    # attempt then classifies to shape 2 below, unchanged). Check-first
-    # bounded until-loop — never a leading foreground sleep
-    # (harness-blocked; the shape-0 convention).
-    TIP=$(git -C "$WT" rev-parse HEAD); HS_TRIES=0
-    until HS=$(gh pr view <PR> --json headRefOid,mergeable -q '.headRefOid + " " + .mergeable' 2>/dev/null) \
-          && [ "${HS%% *}" = "$TIP" ] && [ "${HS##* }" != "UNKNOWN" ]; do
-      HS_TRIES=$((HS_TRIES + 1))
-      if [ "$HS_TRIES" -ge 6 ]; then
-        echo "head-sync pre-check: PR object still stale after ~2 min (saw: ${HS:-<no read>}; local tip: $TIP) — proceeding; Known failure shape 3 below is the recovery"
-        break
-      fi
-      sleep 20
-    done
-    if [ "${HS%% *}" = "$TIP" ]; then
-      echo "head-sync pre-check: parity at $TIP (mergeable=${HS##* })"
-    fi
     # Post-gate freshness re-sync (#1714): the lint gate has PASSed against
     # origin/main-as-of-gate-start; origin/main may have advanced during the
     # ~30-min gate window. Re-run the Step 5a family-atomic block with source
@@ -11773,20 +11812,98 @@ else
     SYNC_COUNT=$(echo $SAFE_SPECS_10D | wc -w)
     echo "[step10d] post-gate re-sync: synced $SYNC_COUNT files ($SYNC_SHA) | no drift"
     # --- end inline Step 5a family-atomic block ---
-    gh pr ready <PR>
-    if gh pr merge <PR> $MERGE_FORM --delete-branch=false; then
-      rm -f /tmp/issue-<N>-lint-verdict.txt   # consume on MERGE SUCCESS — the verdict certified exactly the tip that landed
-      # Root-sync before epm:merged (#1725, safe-case): the just-merged diff is on
-      # origin/main; a workflow-surface fix in it is NOT yet live at the
-      # shared repo root, and the very next call — the epm:merged post —
-      # runs argv-prose guards from the pre-fix root copy (session
-      # 7ce3a81f, 2026-07-26: git-verb note text blocked ~25s post-merge).
-      # sync_repo_root.py is single-flight flock-serialized; fail-soft
-      # (the post-merge-guard pre-sync at the guard block below remains the fallback).
-      uv run python "$REPO_ROOT/scripts/sync_repo_root.py" || \
-        echo "[step10d/safe-case] pre-marker sync failed; post-merge-guard pre-sync remains the fallback"
+    # Verdict RE-BIND stanza (#1807): a re-sync that COMMITTED moved the tip
+    # past the verdict's certified sha (line 2), so a forced gate re-run
+    # would follow even though the gate's landing tree (git archive
+    # origin/main + own-diff overlay) is unchanged by a payload-free sync
+    # commit. Mechanically verify that: enumerate the cert-sha..HEAD delta
+    # with --name-status, NOT --name-only — a both-sides-absent DELETION (a
+    # stray non-sync commit deleting a branch-added file) exits
+    # `git diff --quiet origin/main HEAD -- <p>` ZERO, reading as
+    # "main-identical" while the certified landing tree CONTAINED the file
+    # via the own-diff overlay. The sync block's
+    # `checkout origin/main -- $SAFE_SPECS_10D` can only add/modify, never
+    # delete, so ANY D/R*/C*/T/U status row is by construction non-sync
+    # output: fail CLOSED unconditionally. A/M rows keep the byte-identity
+    # probe (content == fetched origin/main contributes nothing beyond the
+    # baseline to the landing tree, so the certification is unchanged).
+    # #1082 carve-out, TIGHT: line 1 is NEVER touched; only line 2 moves;
+    # the re-bind is licensed ONLY as executed by THIS stanza over its own
+    # --name-status probe output — a free-standing "update line 2" move
+    # stays banned, and the #1613 empty-commit synchronize explicitly STAYS
+    # a stale-verdict -> gate-re-run case, never hand-re-bound.
+    REBIND_OK=yes
+    if [ "$SYNC_SHA" != "no-drift" ]; then
+      CERT_SHA=$(sed -n 2p /tmp/issue-<N>-lint-verdict.txt)
+      REBIND_OK=no
+      DELTA_OK=yes
+      while IFS=$'\t' read -r st p _rest; do
+        case "$st" in
+          A|M) git -C "$WT" diff --quiet origin/main HEAD -- "$p" || DELTA_OK=no ;;
+          *)   DELTA_OK=no ;;   # D / R* / C* / T / U — never sync output
+        esac
+      done < <(git -C "$WT" diff --name-status "$CERT_SHA" HEAD)
+      if [ "$DELTA_OK" = yes ]; then
+        # Line 1 is COMPOSED from the existing verdict (sed -n 1p), never
+        # typed; only line 2 (the certified sha) moves to the new tip.
+        if { sed -n 1p /tmp/issue-<N>-lint-verdict.txt; git -C "$WT" rev-parse HEAD; } \
+             > /tmp/issue-<N>-lint-verdict.rebind \
+           && mv /tmp/issue-<N>-lint-verdict.rebind /tmp/issue-<N>-lint-verdict.txt; then
+          REBIND_OK=yes
+          echo "[step10d] verdict re-bound to sync tip $(git -C "$WT" rev-parse --short=12 HEAD) (delta = origin/main-identical spec sync only; #1807)"
+        else
+          echo "[step10d] verdict re-bind WRITE failed — fail CLOSED (re-run the gate; the BLOCKED arm below consumes the stale verdict)"
+        fi
+      else
+        echo "[step10d] sync delta NOT verifiable as origin/main-identical A/M-only — verdict stays bound to $CERT_SHA; fail CLOSED (re-run the gate; the BLOCKED arm below consumes the stale verdict)"
+      fi
+    fi
+    if [ "$REBIND_OK" = yes ]; then
+      # Head-sync pre-check (#1657, READ-ONLY — runs AFTER the post-gate
+      # re-sync + re-bind above so it polls PR-object parity against the
+      # FINAL tip; a fresh sync push re-introduces exactly the lag this
+      # check absorbs, so polling before the sync would check the wrong
+      # tip): every push this invocation made (Guard-0/1 commits, the
+      # post-gate re-sync commit just above) races GitHub's PR-object
+      # sync — #1614's attempts 1-2 were refused
+      # 'Head branch is out of date' while the PR object lagged the pushed
+      # tip ~6 min. Poll until the PR object reports the local tip AND a
+      # settled mergeability; a settled CONFLICTING exits too (the merge
+      # attempt then classifies to shape 2 below, unchanged). Check-first
+      # bounded until-loop — never a leading foreground sleep
+      # (harness-blocked; the shape-0 convention).
+      TIP=$(git -C "$WT" rev-parse HEAD); HS_TRIES=0
+      until HS=$(gh pr view <PR> --json headRefOid,mergeable -q '.headRefOid + " " + .mergeable' 2>/dev/null) \
+            && [ "${HS%% *}" = "$TIP" ] && [ "${HS##* }" != "UNKNOWN" ]; do
+        HS_TRIES=$((HS_TRIES + 1))
+        if [ "$HS_TRIES" -ge 6 ]; then
+          echo "head-sync pre-check: PR object still stale after ~2 min (saw: ${HS:-<no read>}; local tip: $TIP) — proceeding; Known failure shape 3 below is the recovery"
+          break
+        fi
+        sleep 20
+      done
+      if [ "${HS%% *}" = "$TIP" ]; then
+        echo "head-sync pre-check: parity at $TIP (mergeable=${HS##* })"
+      fi
+      gh pr ready <PR>
+      if gh pr merge <PR> $MERGE_FORM --delete-branch=false; then
+        rm -f /tmp/issue-<N>-lint-verdict.txt   # consume on MERGE SUCCESS — the verdict certified exactly the tip that landed
+        # Root-sync before epm:merged (#1725, safe-case): the just-merged diff is on
+        # origin/main; a workflow-surface fix in it is NOT yet live at the
+        # shared repo root, and the very next call — the epm:merged post —
+        # runs argv-prose guards from the pre-fix root copy (session
+        # 7ce3a81f, 2026-07-26: git-verb note text blocked ~25s post-merge).
+        # sync_repo_root.py is single-flight flock-serialized; fail-soft
+        # (the post-merge-guard pre-sync at the guard block below remains the fallback).
+        uv run python "$REPO_ROOT/scripts/sync_repo_root.py" || \
+          echo "[step10d/safe-case] pre-marker sync failed; post-merge-guard pre-sync remains the fallback"
+      else
+        echo "MERGE FAILED — classify the gh error text: (0) \"Base branch was modified\" -> transient base-advance (Known failure shape 0 below): wait ~20s via a bounded until-loop or a bg-Bash re-check — NEVER a leading foreground \`sleep\` (harness-blocked; 3 wasted turns on 2026-07-18 alone) — then re-enter this SAME conditional (the verdict still certifies the tip; max 2 re-entries per Step 10d invocation, counted regardless of re-bind — a re-entry may legitimately carry a moved tip via a second sync+re-bind, #1807); (1) \"can't be rebased\" (--rebase form only) -> the #1041 --squash retry (Known failure shape 1 below; SHA-bound verdict remains valid for the SAME tip); (2) \"Pull Request has merge conflicts\" -> the #1128 re-snapshot-and-retry-once (Known failure shape 2 below); (3) \"Head branch is out of date\" -> PR head-sync lag (Known failure shape 3 below): confirm pushed, bounded headRefOid re-poll, close/reopen nudge ONCE if still stale, then re-enter this SAME conditional (the verdict still certifies the tip; max 2 re-entries per Step 10d invocation, counted regardless of re-bind — #1807); (4) anything else -> the Failure bullet (merge-conflict recovery ONCE, then epm:merge-failed). Do NOT hand-write the verdict file."
+        false
+      fi
     else
-      echo "MERGE FAILED — classify the gh error text: (0) \"Base branch was modified\" -> transient base-advance (Known failure shape 0 below): wait ~20s via a bounded until-loop or a bg-Bash re-check — NEVER a leading foreground \`sleep\` (harness-blocked; 3 wasted turns on 2026-07-18 alone) — then re-enter this SAME conditional (same tip, verdict still valid; max 2 same-tip retries); (1) \"can't be rebased\" (--rebase form only) -> the #1041 --squash retry (Known failure shape 1 below; SHA-bound verdict remains valid for the SAME tip); (2) \"Pull Request has merge conflicts\" -> the #1128 re-snapshot-and-retry-once (Known failure shape 2 below); (3) \"Head branch is out of date\" -> PR head-sync lag (Known failure shape 3 below): confirm pushed, bounded headRefOid re-poll, close/reopen nudge ONCE if still stale, then re-enter this SAME conditional (same tip, verdict still valid; max 2 same-tip re-entries); (4) anything else -> the Failure bullet (merge-conflict recovery ONCE, then epm:merge-failed). Do NOT hand-write the verdict file."
+      echo "BLOCKED: verdict re-bind failed — the post-gate sync moved the tip and its delta could not be verified as origin/main-identical A/M-only (or the re-bind write failed): the stale SHA-bound verdict cannot certify the new tip. Re-run the pre-push workflow-lint gate against the new tip, then re-enter this conditional. Do NOT merge; do NOT hand-write the verdict file (#1082)."
+      rm -f /tmp/issue-<N>-lint-verdict.txt   # stale-sha verdict consumed — a fresh gate run regenerates it (the Verdict bullet's stale-sha removal branch)
       false
     fi
   else
@@ -11839,10 +11956,14 @@ transient under fleet marker churn (~100+ tasks/ commits/hr on main):
 no content conflict, nothing to fix. Recovery: wait ~20 s (≈ one churn
 interval, letting gh's mergeability recompute settle), then re-enter
 the SAME gated merge conditional with the SAME `$MERGE_FORM` — the
-branch tip is unchanged, so the SHA-bound verdict re-certifies it
-(consume-on-merge-success survives this failure by design; never
-hand-write the verdict file, #1082). Bounded at TWO same-tip retries
-per Step 10d invocation; a third consecutive hit is no longer plausibly
+failed merge changed nothing locally, so the SHA-bound verdict still
+certifies the tip (consume-on-merge-success survives this failure by
+design; never hand-write the verdict file, #1082); the re-entered
+safe-case block may legitimately MOVE the tip via a second post-gate
+sync + verdict re-bind (#1807). Bounded at TWO re-entries per Step 10d
+invocation, counted per invocation REGARDLESS of re-bind (the bound
+keys on re-entries of this conditional, not on tip identity); a third
+consecutive hit is no longer plausibly
 timing — reclassify by error text per shapes 1/2/3/else.
 
 Before each retried merge call, post an `[long-phase-heartbeat]`
@@ -11988,10 +12109,13 @@ verify the reopen landed (`gh pr view <PR> --json state -q .state` =
 `OPEN`; a crash between close and reopen strands a CLOSED PR — the
 next invocation re-opens it idempotently before re-entering) and
 re-poll once more; (4) re-enter the SAME gated merge conditional
-with the SAME `$MERGE_FORM` — the tip is unchanged, so the SHA-bound
-verdict re-certifies it (consume-on-merge-success survives this
-failure by design; never hand-write the verdict file, #1082). Bounded
-at ONE nudge + TWO same-tip re-entries per Step 10d invocation. STILL
+with the SAME `$MERGE_FORM` — the refusal changed nothing locally, so
+the SHA-bound verdict still certifies the tip (consume-on-merge-success
+survives this failure by design; never hand-write the verdict file,
+#1082); a re-entry may legitimately MOVE the tip via a second post-gate
+sync + verdict re-bind (#1807). Bounded
+at ONE nudge + TWO re-entries per Step 10d invocation, counted per
+invocation regardless of re-bind. STILL
 stale after the nudge re-poll → optional LAST RESORT before the
 Failure bullet, the #1613 empty-commit synchronize:
 `git -C "$WT" commit --allow-empty -m "issue-<N>: force PR synchronize
@@ -12006,7 +12130,7 @@ The head-sync pre-check inside the safe-case block above exists to
 keep this shape off the FIRST attempt; this paragraph is the backstop
 when the lag outlasts the pre-check budget.
 
-Before each retried merge call in this shape (each same-tip re-entry
+Before each retried merge call in this shape (each re-entry
 AND after the close/reopen nudge), post an `[long-phase-heartbeat]`
 progress note (#1723; same family as shapes 0/2 above):
 

--- a/scripts/workflow_lint.py
+++ b/scripts/workflow_lint.py
@@ -11898,10 +11898,14 @@ AGENT_SPEC_SIZE_GRANDFATHER: dict[str, int] = {
     # (#1159) — no longer grandfathered (slim spec is under the FAIL threshold).
     # the rest measured at the #838 tightening (2026-07-02), caps = measured
     # + <=3 KB; each names a future trim direction, none is licensed to grow
-    # measured 133,188 B post-#1743 (task-bound verdict post switched to
-    # the --file channel + MANDATORY exact-kind read-back duty —
-    # plan-mandated growth; cap = measured + ~1.0 KB.
+    # measured 135,813 B post-#1805 (Step 4 round-new-script no-flags lint
+    # duty — executable diff-adds trigger gate in the fenced pre-pass block
+    # + attribution / waiver-remedy / stale-family prose — plan-mandated
+    # growth; cap = measured + ~1.5 KB.
     # Prior:
+    # 134_200 — measured 133,188 B post-#1743 (task-bound verdict post
+    # switched to the --file channel + MANDATORY exact-kind read-back
+    # duty),
     # 132_500 — measured 131,378 B post-Step-10d-merge (task #1727 Step
     # 0.70 smoke-variable gating gate + task #1716 Step 4 ruff-policy pin
     # + L99 style-bullet + Step 0.5 pin-invocation marker-shape check —
@@ -11937,7 +11941,7 @@ AGENT_SPEC_SIZE_GRANDFATHER: dict[str, int] = {
     # reads), 99,000 — measured 98,126 B post-#1230 (Step 6 durability-pin
     # shipping duty), 97,000 — measured 96,072 B post-#1119, 95,000 —
     # measured 94,126 B post-#1115)
-    "code-reviewer.md": 134_200,
+    "code-reviewer.md": 137_400,
     # measured 74,082 B post-#1447 (family-enumeration sync: the two
     # byte/bit verdict rows widened to the -exact / bitwise / X-for-X
     # tail — plan-mandated growth; cap = measured + ~1.1 KB. Prior:
@@ -11947,16 +11951,19 @@ AGENT_SPEC_SIZE_GRANDFATHER: dict[str, int] = {
     # 72,229 B post-#1056, 72,000 post-#1050 r2, 71,000 post-#1050 r1,
     # 60,554 B pre-#1050)
     "codex-clean-result-critic.md": 75_200,
-    # measured 59,576 B post-#1693 (Step 0.69 mirror paragraph pointing at
-    # code-reviewer.md's phase-idempotency + inter-phase-contract gate —
-    # plan-mandated growth; cap = measured + ~1.2 KB. Prior: 59,200 —
+    # measured 61,503 B post-#1805 (Step 4 copy-list bullet extension:
+    # round-new-script no-flags lint duty, no-uv static hub-verify
+    # adaptation — plan-mandated growth; cap = measured + ~1.3 KB. Prior:
+    # 60_800 — measured 59,576 B post-#1693 (Step 0.69 mirror paragraph
+    # pointing at code-reviewer.md's phase-idempotency +
+    # inter-phase-contract gate), 59,200 —
     # measured 58,271 B post-#1438 (Step 0.9 copy-list bullet + inlined-
     # rubric 0.9 slot + Blocker-tags data-access-blocked entry),
     # 56,800 — measured 55,870 B post-#1380 (Step 4.6 copy-list bullet +
     # inlined-rubric 4.6 slot + Blocker-tags 4.6-presence), 53,300 —
     # measured 52,361 B post-#1254, 51,600 — measured 50,642 B post-#948,
     # 47,930 B post-#881)
-    "codex-code-reviewer.md": 60_800,
+    "codex-code-reviewer.md": 62_800,
     # measured 76,274 B post-#1692 (item 5 Axis 1 import-resolution leg,
     # Axis 2 per-arm resolution attestation, PASS_PARTIAL verdict +
     # post-marker template extension — plan-mandated growth; cap =

--- a/tests/test_autonomous_session_watch.py
+++ b/tests/test_autonomous_session_watch.py
@@ -21110,6 +21110,334 @@ def test_registry_drift_pass_dry_run_writes_no_state(tmp_path, monkeypatch, caps
     assert "[dry-run] would append registry-drift sidecar row" in out
 
 
+# ── stash/rescue-backlog audit pass (pass 34, #1806) ─────────────────────────
+#
+# Clones the registry-drift (#1439) test shape: pure decide + fingerprint
+# tests, pass-driver tests with the collector / push / path seams stubbed
+# (the pass is in conftest's _FLEET_MUTATING_PASS_NAMES for full-main()
+# tests; these tests OF the pass stub its own seams instead). The
+# missing-rescue-dir + min-age tests drive the REAL collector body with a
+# signature-conformant fake ONLY at the subprocess boundary.
+
+
+def _srescue_isolate(asw, monkeypatch, tmp_path: Path) -> tuple[Path, Path]:
+    """Point the pass's state (AUTONOMOUS_REGISTRY_DIR) + sidecar
+    (PROJECT_ROOT-derived) + rescue root (EPM_ROOT_SYNC_RESCUE_ROOT) at
+    tmp_path; return (state_path, sidecar_path). Mirrors
+    :func:`_rdrift_isolate`."""
+    monkeypatch.setattr(asw, "AUTONOMOUS_REGISTRY_DIR", tmp_path / "registry")
+    monkeypatch.setattr(asw, "PROJECT_ROOT", tmp_path / "root")
+    (tmp_path / "root").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("EPM_ROOT_SYNC_RESCUE_ROOT", str(tmp_path / "rescue"))
+    return (
+        tmp_path / "registry" / "stash-rescue-audit.json",
+        tmp_path / "root" / ".claude" / "cache" / "stash-rescue-audit-events.jsonl",
+    )
+
+
+# One aged stash (identity = (ct, subject), never stash@{N}) + one aged rescue
+# entry (identity = name; the mtime is an attribute, not identity).
+_SRESCUE_SNAPSHOT = {
+    "stashes": [(1_748_000_000, "On main: WIP stranded autostash")],
+    "rescues": [("20260601-120000-99999", 1_749_000_000.0)],
+}
+
+
+def test_stash_rescue_decide_alert_fp_change_and_ttl():
+    import autonomous_session_watch as asw
+
+    now = 1_000_000.0
+    realert = 168 * 3600.0
+    # First appearance (no stored fp): fires.
+    assert asw.decide_stash_rescue_alert("abc", {}, now, realert) is True
+    # Same fp within the TTL: silent.
+    assert (
+        asw.decide_stash_rescue_alert(
+            "abc", {"fp": "abc", "last_alert_ts": now - 100.0}, now, realert
+        )
+        is False
+    )
+    # Same fp STRICTLY past the TTL: re-fires (bounded weekly re-surface).
+    assert (
+        asw.decide_stash_rescue_alert(
+            "abc", {"fp": "abc", "last_alert_ts": now - realert - 1.0}, now, realert
+        )
+        is True
+    )
+    # Boundary: exactly-at-TTL does NOT re-fire (predicate is STRICT >).
+    assert (
+        asw.decide_stash_rescue_alert(
+            "abc", {"fp": "abc", "last_alert_ts": now - realert}, now, realert
+        )
+        is False
+    )
+    # Recomposed backlog set (fp changed): fires regardless of a fresh stamp.
+    assert (
+        asw.decide_stash_rescue_alert("def", {"fp": "abc", "last_alert_ts": now}, now, realert)
+        is True
+    )
+    # Corrupt state fields degrade to fire-as-if-unalerted (isinstance guards).
+    assert asw.decide_stash_rescue_alert("abc", {"fp": 42}, now, realert) is True
+    assert (
+        asw.decide_stash_rescue_alert("abc", {"fp": "abc", "last_alert_ts": "x"}, now, realert)
+        is True
+    )
+
+
+def test_stash_rescue_fingerprint_stable_under_reorder():
+    """Identity-set permutation => same fp (the collector sorts, and the fp
+    sorts again — a listing-order change can never re-push); rescue mtime
+    churn => same fp (mtime is an attribute, not identity); any entry
+    added/removed => different fp."""
+    import autonomous_session_watch as asw
+
+    base = {
+        "stashes": [(100, "a"), (200, "b")],
+        "rescues": [("r1", 1.0), ("r2", 2.0)],
+    }
+    permuted = {
+        "stashes": [(200, "b"), (100, "a")],
+        # mtimes differ too — attributes, never identity.
+        "rescues": [("r2", 5.0), ("r1", 9.0)],
+    }
+    fp = asw._stash_rescue_fingerprint(base)
+    assert fp == asw._stash_rescue_fingerprint(permuted)
+    assert len(fp) == 12
+    # Entry added => different fp.
+    grown = {"stashes": [*base["stashes"], (300, "c")], "rescues": base["rescues"]}
+    assert fp != asw._stash_rescue_fingerprint(grown)
+    # Entry removed => different fp.
+    shrunk = {"stashes": base["stashes"], "rescues": base["rescues"][:1]}
+    assert fp != asw._stash_rescue_fingerprint(shrunk)
+
+
+def test_stash_rescue_pass_fires_and_dedupes(tmp_path, monkeypatch):
+    """First confirmed backlog fires ONE push + a sidecar row; a second
+    same-fp run inside the TTL is push-silent (sidecar audit row only); an
+    empty backlog resets the fp with no push."""
+    import autonomous_session_watch as asw
+
+    state_path, sidecar_path = _srescue_isolate(asw, monkeypatch, tmp_path)
+    monkeypatch.setenv("EPM_STASH_RESCUE_INTERVAL_HOURS", "0")  # runs 2/3 unthrottled
+    monkeypatch.setattr(
+        asw, "_collect_stash_rescue_backlog", lambda min_age_s, now: _SRESCUE_SNAPSHOT
+    )
+    pushes: list[str] = []
+    monkeypatch.setattr(asw, "_telegram_push", lambda msg, dry_run: pushes.append(msg) or True)
+
+    assert asw.stash_rescue_audit_pass(dry_run=False) is True
+    assert len(pushes) == 1
+    assert "git stash list" in pushes[0]
+    assert "root-sync-rescue" in pushes[0]
+    assert "#1736" in pushes[0]
+    assert "Nothing was changed automatically" in pushes[0]
+    rows = [json.loads(x) for x in sidecar_path.read_text().splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "stash-rescue-backlog"
+    assert rows[0]["pushed"] is True
+    assert rows[0]["n_stashes"] == 1 and rows[0]["n_rescues"] == 1
+    assert rows[0]["stashes"] == [[1_748_000_000, "On main: WIP stranded autostash"]]
+    assert rows[0]["rescues"] == ["20260601-120000-99999"]
+    state = json.loads(state_path.read_text())
+    assert state["fp"] == rows[0]["fingerprint"]
+    assert isinstance(state["fp"], str) and len(state["fp"]) == 12
+    assert isinstance(state["last_run_ts"], float)
+    assert isinstance(state["last_alert_ts"], float)
+    # Run 2: same fp, within the 168h TTL — sidecar row still appended
+    # (audit trail) with pushed: false, and NO second push.
+    assert asw.stash_rescue_audit_pass(dry_run=False) is False
+    assert len(pushes) == 1
+    rows = [json.loads(x) for x in sidecar_path.read_text().splitlines()]
+    assert len(rows) == 2
+    assert rows[0]["pushed"] is True and rows[1]["pushed"] is False
+    assert rows[0]["fingerprint"] == rows[1]["fingerprint"]
+    # Run 3: backlog cleared — fp reset, no push, no new backlog row.
+    monkeypatch.setattr(
+        asw,
+        "_collect_stash_rescue_backlog",
+        lambda min_age_s, now: {"stashes": [], "rescues": []},
+    )
+    assert asw.stash_rescue_audit_pass(dry_run=False) is False
+    assert len(pushes) == 1
+    assert len(sidecar_path.read_text().splitlines()) == 2
+    assert json.loads(state_path.read_text())["fp"] is None
+
+
+def test_stash_rescue_min_age_filters_fresh_entries(tmp_path, monkeypatch):
+    """A fresh (now) stash / rescue entry is excluded by the min-age gate —
+    sync_repo_root autostashes live seconds and #1751's Step 10d duty covers
+    the fresh window. Drives the REAL collector body; the only fake is a
+    signature-conformant CompletedProcess at the subprocess boundary."""
+    import os as _os
+    import subprocess as _subprocess
+
+    import autonomous_session_watch as asw
+
+    now = time.time()
+    rescue = tmp_path / "rescue"
+    rescue.mkdir()
+    monkeypatch.setenv("EPM_ROOT_SYNC_RESCUE_ROOT", str(rescue))
+    old_dir = rescue / "20260401-120000-11111"
+    old_dir.mkdir()
+    _os.utime(old_dir, (now - 30 * 86400, now - 30 * 86400))
+    (rescue / "stash-fresh.patch").write_text("x")  # mtime = now — filtered
+    old_ct = int(now - 30 * 86400)
+    fresh_ct = int(now - 60)
+    stdout = f"{old_ct}\tOn main: old stranded\n{fresh_ct}\tOn main: live autostash\n"
+
+    def _fake_run(argv, **kwargs):
+        return _subprocess.CompletedProcess(argv, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(asw.subprocess, "run", _fake_run)
+    collected = asw._collect_stash_rescue_backlog(7 * 86400.0, now)
+    assert collected["stashes"] == [(old_ct, "On main: old stranded")]
+    assert [n for n, _mt in collected["rescues"]] == ["20260401-120000-11111"]
+
+
+def test_stash_rescue_kill_switch(tmp_path, monkeypatch):
+    """Forbidden-raiser collect stub + state/sidecar files must NOT exist — a
+    broken kill-switch gate would raise into the fail-soft path and write an
+    error sidecar row, so a bare returns-False pin would be vacuous (the
+    registry-drift kill-switch test shape)."""
+    import autonomous_session_watch as asw
+
+    monkeypatch.setenv("EPM_DISABLE_STASH_RESCUE_AUDIT", "1")
+    state_path, sidecar_path = _srescue_isolate(asw, monkeypatch, tmp_path)
+
+    def _forbidden(*a, **kw):
+        raise AssertionError("no collect / state IO / push under the kill switch")
+
+    monkeypatch.setattr(asw, "_collect_stash_rescue_backlog", _forbidden)
+    monkeypatch.setattr(asw, "_telegram_push", _forbidden)
+    assert asw.stash_rescue_audit_pass(dry_run=False) is False
+    assert not state_path.exists() and not sidecar_path.exists()
+
+
+def test_stash_rescue_collector_readonly(tmp_path, monkeypatch):
+    """ESCALATE-ONLY invariant, argv-pinned: the collector's ONLY subprocess
+    invocation is the read-only `git ... stash list --format=...` form — no
+    pop/drop/apply/clear/push anywhere in the argv (acceptance criterion 3)."""
+    import subprocess as _subprocess
+
+    import autonomous_session_watch as asw
+
+    rescue = tmp_path / "rescue"
+    rescue.mkdir()
+    monkeypatch.setenv("EPM_ROOT_SYNC_RESCUE_ROOT", str(rescue))
+    calls: list[list[str]] = []
+
+    def _fake_run(argv, **kwargs):
+        calls.append(list(argv))
+        return _subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(asw.subprocess, "run", _fake_run)
+    asw._collect_stash_rescue_backlog(7 * 86400.0, time.time())
+    assert calls == [["git", "-C", str(asw.PROJECT_ROOT), "stash", "list", "--format=%ct%x09%gs"]]
+    mutating = {"pop", "drop", "apply", "clear", "push", "create", "store", "branch", "rm"}
+    assert not mutating.intersection(calls[0])
+
+
+def test_stash_rescue_missing_rescue_dir_is_empty_not_error(tmp_path, monkeypatch):
+    """Critic Must-Fix: ENOENT on the rescue dir ITSELF is a LEGITIMATE EMPTY
+    rescue set (lazily created by sync_repo_root.py; deleted after a
+    completed #1736 triage), never a fail-soft error — (a) with an empty
+    stash list the recovered/fp-reset branch is taken (NO error sidecar
+    row); (b) with a non-empty stash list the stash half still surfaces
+    (the absent dir never blinds the whole pass). Drives the REAL collector
+    through the pass; the only fake is the subprocess boundary."""
+    import subprocess as _subprocess
+
+    import autonomous_session_watch as asw
+
+    state_path, sidecar_path = _srescue_isolate(asw, monkeypatch, tmp_path)
+    # _srescue_isolate points the rescue root at tmp_path/"rescue" — NEVER
+    # created in this test: os.scandir raises FileNotFoundError (ENOENT).
+    monkeypatch.setenv("EPM_STASH_RESCUE_INTERVAL_HOURS", "0")
+    pushes: list[str] = []
+    monkeypatch.setattr(asw, "_telegram_push", lambda msg, dry_run: pushes.append(msg) or True)
+
+    # (a) empty stash list too => recovered/fp-reset branch, NO error row.
+    def _fake_run_empty(argv, **kwargs):
+        return _subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(asw.subprocess, "run", _fake_run_empty)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps({"fp": "deadbeefcafe", "last_run_ts": 0.0}))
+    assert asw.stash_rescue_audit_pass(dry_run=False) is False
+    assert not sidecar_path.exists()  # no backlog row AND no error row
+    assert json.loads(state_path.read_text())["fp"] is None  # fp-reset taken
+    assert pushes == []
+
+    # (b) non-empty stash list => the stash half fires with n_rescues == 0.
+    old_ct = int(time.time() - 30 * 86400)
+
+    def _fake_run_one(argv, **kwargs):
+        return _subprocess.CompletedProcess(
+            argv, 0, stdout=f"{old_ct}\tOn main: stranded\n", stderr=""
+        )
+
+    monkeypatch.setattr(asw.subprocess, "run", _fake_run_one)
+    assert asw.stash_rescue_audit_pass(dry_run=False) is True
+    rows = [json.loads(x) for x in sidecar_path.read_text().splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "stash-rescue-backlog"
+    assert rows[0]["n_stashes"] == 1 and rows[0]["n_rescues"] == 0
+    assert len(pushes) == 1
+
+
+def test_stash_rescue_fail_soft_error_row(tmp_path, monkeypatch, capsys):
+    """A collect failure (git rc != 0 raises there) => stderr + ONE error
+    sidecar row, pass returns False, NO push — and NO fp write, so a failed
+    `git stash list` is NEVER read as "backlog cleared" (the next
+    in-interval tick stays throttled by the attempt stamp)."""
+    import autonomous_session_watch as asw
+
+    state_path, sidecar_path = _srescue_isolate(asw, monkeypatch, tmp_path)
+
+    def _boom(min_age_s, now):
+        raise RuntimeError("git stash list failed rc=128: boom")
+
+    def _no_push(*a, **kw):
+        raise AssertionError("failed collect must not push")
+
+    monkeypatch.setattr(asw, "_collect_stash_rescue_backlog", _boom)
+    monkeypatch.setattr(asw, "_telegram_push", _no_push)
+    assert asw.stash_rescue_audit_pass(dry_run=False) is False
+    assert "stash-rescue: pass failed (fail-soft): git stash list failed" in (
+        capsys.readouterr().err
+    )
+    rows = [json.loads(x) for x in sidecar_path.read_text().splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "stash-rescue-error"
+    assert "git stash list failed" in rows[0]["error"]
+    # NO fp write on error — only the attempt stamp saved BEFORE the collect
+    # survives, bounding a crashing collect to one error row per interval.
+    state = json.loads(state_path.read_text())
+    assert "fp" not in state
+    assert isinstance(state["last_run_ts"], float)
+
+
+def test_stash_rescue_dry_run_writes_nothing(tmp_path, monkeypatch, capsys):
+    """--dry-run contract (acceptance criterion 6, backing the live smoke):
+    zero state writes, zero sidecar writes, zero pushes (dry_run threads
+    into _telegram_push, whose real body no-ops on it)."""
+    import autonomous_session_watch as asw
+
+    state_path, sidecar_path = _srescue_isolate(asw, monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        asw, "_collect_stash_rescue_backlog", lambda min_age_s, now: _SRESCUE_SNAPSHOT
+    )
+    calls: list[bool] = []
+    monkeypatch.setattr(asw, "_telegram_push", lambda msg, dry_run: calls.append(dry_run) or False)
+
+    assert asw.stash_rescue_audit_pass(dry_run=True) is True
+    assert calls == [True]  # push observed, dry_run honored
+    assert not state_path.exists() and not sidecar_path.exists()  # zero writes
+    out = capsys.readouterr().out
+    assert "[dry-run] would save stash-rescue state" in out
+    assert "[dry-run] would append stash-rescue sidecar row" in out
+
+
 # ── orphan-wrapper /proc sweep (pass 28, #1215) ──────────────────────────────
 #
 # Pure decision ladder + pure scan classifier + pass-driver tests, following

--- a/tests/test_issue_skill_lint_family_sync.py
+++ b/tests/test_issue_skill_lint_family_sync.py
@@ -18,13 +18,26 @@ origin/main advancement during the ~30-min gate window can no longer
 red the squash merge with CONFLICTING, and adds two new pin tests
 (family declaration + Step 5a/§4.6 drift guard).
 
+#1807 (2026-07-29) adds the mechanically-gated verdict RE-BIND to the
+Step 10d safe-case block (a post-gate sync commit whose cert-sha..HEAD
+delta is provably origin/main-identical A/M-only re-binds the verdict
+file's line 2 to the new tip instead of forcing a full gate re-run;
+D/R*/C*/T/U rows and non-identical content fail CLOSED behind
+REBIND_OK), moves the #1657 head-sync pre-check AFTER the re-sync +
+re-bind (it must poll the FINAL tip), and adds a Step 9c step-1a
+pre-gate spec-freshness re-sync — a binding REFERENCE to the Step 5a
+family-atomic block, never a third inlined FAMILY_OF copy — so a
+main-side spec fix landing after the Step 5a sync can no longer red the
+9c gate (#1742 class). Pin tests (12) and (13) cover the two additions.
+
 These tests fail the suite if a later SKILL.md editor drops the family
 entries, the boundary-paragraph family exception, the post-gate re-sync
 bullet (or reorders it before the gate's stale-verdict rm), the 9a-ter
 staleness note, reintroduces the full-message commit filter the Step 5a
 sync and the gate section deliberately avoid, drops the family-atomic
-declaration in Step 5a, or lets the Step 10d inline family-atomic block
-drift from Step 5a's family definition.
+declaration in Step 5a, lets the Step 10d inline family-atomic block
+drift from Step 5a's family definition, weakens the #1807 re-bind
+stanza's fail-closed arms, or drops the 9c pre-gate re-sync reference.
 
 NOTE for future SKILL.md editors: these assertions pin literal snippet text.
 A legitimate rewording of the pinned lines in SKILL.md must update the
@@ -350,4 +363,81 @@ def test_step5a_sources_fetched_origin_main():
     # in-block :(glob) comment — that the $SAFE_SPECS-anchored bans miss).
     assert _BARE_CHECKOUT_MAIN not in span, (
         "nothing in the Step 5a span may reference a bare checkout from local main"
+    )
+
+
+# --- (12) Step 10d verdict re-bind stanza (#1807 pins) ----------------------
+
+
+def _automerge_span(text: str) -> str:
+    """The auto-merge subsection: its H4 through the next H4 (same
+    extraction as test (10))."""
+    start = text.index("#### The auto-merge procedure")
+    end = text.index("#### ", start + 4)
+    return text[start:end]
+
+
+def test_step10d_verdict_rebind_present():
+    """#1807: the safe-case block re-binds the SHA-bound verdict to a
+    post-gate sync tip ONLY under the mechanical probe — a --name-status
+    enumeration whose every row is A/M and byte-identical to fetched
+    origin/main. D/R*/C*/T/U rows fail CLOSED unconditionally (critic
+    round-1 Must-Fix: --name-only would read a both-sides-absent deletion
+    as main-identical while the certified landing tree CONTAINED the file
+    via the own-diff overlay); line 1 is COMPOSED from the existing
+    verdict (sed -n 1p), never typed; an unverifiable delta routes to the
+    fail-closed BLOCKED arm (stale verdict consumed, no merge), and the
+    merge itself is variable-gated on REBIND_OK=yes."""
+    span = _automerge_span(_text())
+    assert 'git -C "$WT" diff --name-status "$CERT_SHA" HEAD' in span, (
+        "the re-bind probe must enumerate the cert-sha..HEAD delta with "
+        "--name-status (NOT --name-only — the deletion corner, #1807)"
+    )
+    assert 'A|M) git -C "$WT" diff --quiet origin/main HEAD -- "$p" || DELTA_OK=no ;;' in span, (
+        "A/M rows must keep the fetched-origin/main byte-identity probe"
+    )
+    assert "*)   DELTA_OK=no ;;   # D / R* / C* / T / U — never sync output" in span, (
+        "every non-A/M status row must fail CLOSED unconditionally "
+        "(the sync's `checkout origin/main --` can only add/modify)"
+    )
+    assert "sed -n 1p /tmp/issue-<N>-lint-verdict.txt" in span, (
+        "line 1 must be COMPOSED from the existing verdict (sed -n 1p), never typed"
+    )
+    assert 'if [ "$REBIND_OK" = yes ]; then' in span, (
+        "gh pr ready / gh pr merge must be variable-gated on REBIND_OK=yes "
+        "(never a bare mid-block false as flow control)"
+    )
+    fail_echo = span.index("sync delta NOT verifiable as origin/main-identical A/M-only")
+    blocked_echo = span.index("BLOCKED: verdict re-bind failed", fail_echo)
+    rm_after = span.find("rm -f /tmp/issue-<N>-lint-verdict.txt", blocked_echo)
+    assert rm_after != -1, (
+        "an unverifiable delta must end in the stale verdict being consumed "
+        "(rm -f in the fail-closed BLOCKED arm) — never a merge on an "
+        "unverified tip"
+    )
+
+
+# --- (13) Step 9c pre-gate spec-freshness re-sync (#1807 / #1742 pin) -------
+
+
+def test_step9c_pregate_sync_present():
+    """#1807 fix (b): Step 9c step 1a must run the Step 5a family-atomic
+    spec-freshness sync — a binding REFERENCE, never a third inlined
+    FAMILY_OF copy (which would escape
+    test_step10d_family_atomicity_matches_step5a's drift guard) — BEFORE
+    the selector computes the gate subset, closing the #1742
+    stale-worktree-spec gate-red class."""
+    text = _text()
+    start = text.index("**9c. Test-verdict gate")
+    sel_idx = text.index("select_step9c_tests.py", start)
+    region = text[start:sel_idx]
+    assert "Pre-gate spec-freshness re-sync (#1742)" in region, (
+        "Step 9c step 1a must carry the pre-gate spec-freshness re-sync "
+        "BEFORE the first select_step9c_tests.py mention"
+    )
+    assert "Step 5a family-atomic" in region, (
+        "the 9c re-sync must reference the Step 5a family-atomic block"
+    )
+    assert "never inline a THIRD `FAMILY_OF` copy" in region, (
+        "the 9c re-sync must bind as a reference, not a third inlined copy"
     )


### PR DESCRIPTION
Closes task #1807 (daily-fix, wf-fix). Plan v2: mechanically-gated verdict re-bind at Step 10d (post-gate sync commit no longer forces a gate re-run; D/R/C/T/U deltas fail closed), head-sync pre-check moved after the re-sync, pre-selector Step-5a family sync at Step 9c (#1742 class), fail-soft diagnostic tails at the gate completion-read, + 2 new lockstep pin tests.