### PR TITLE
issue-1844: case-86 live-tree selector pin — 7th pair, sizing 660 (main-red fix)

### DIFF
--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -2190,6 +2190,53 @@ entities before persisting" + "Extract the output-file text via the
 transcript recipe" (#952 v9, #1219; independently rediscovered by sessions
 #1287 + #1288 on 2026-07-13 — the pointer this paragraph exists to spare).
 
+**Pre-split multi-deliverable builds at dispatch (#1810; precedents
+#1090/#1775).** Before composing the brief, count the approved plan's
+distinct planned CODE deliverables — new or substantially-rewritten
+`scripts/` / `src/` / `tests/` files named in the plan's "File paths +
+concrete diffs" section (doc-only files excluded). More than 4 code
+deliverables ⇒ dispatch the build as sequential MICRO-SCOPED units by
+default, never one monolithic brief. Grounding: #1775's 7-deliverable
+build died at the subagent context ceiling after 139 tool calls /
+~63 min (~20 tool calls per code deliverable puts the risk zone at
+~5-6; ≥5 buys margin below the observed death at 7); a lower-count
+build with a comparably large projected build volume (very large
+per-file scope, heavy smoke phases) MAY pre-split by judgment. Unit
+shape: units of ≤3 deliverables each, run sequentially with a fresh
+context per unit, each unit's brief scoped to its own self-contained
+deliverable subset (the #1090 rounds-A/B shape). Marker contract:
+INTERMEDIATE units commit their work by explicit path and RETURN a
+commit manifest with NO implementation marker; ONLY the FINAL unit
+runs the full per-phase `## Smoke run` H2 — covering every pipeline
+phase INCLUDING phases built by earlier units, so the final unit's
+smoke scope exceeds its own unit scope, and its brief states this
+outright — and posts `epm:experiment-implementation` / `epm:results`
+at max+1 per the existing brief contract. Round semantics: all units
+run within ONE review round (no round-counter increment between
+units); the Step 5 code-review ensemble reviews the whole round diff
+once, after the final unit. Model rule: default session model per
+unit — never a smaller-model pin (the Step 5b thrash-inverse rule,
+#1090 forensics). Mid-split resume/idempotency: after each
+INTERMEDIATE unit returns, the orchestrator posts an `epm:progress`
+breadcrumb — `pre-split unit k/M complete: <commit SHAs>; remaining:
+<deliverables>` — and a resuming session that finds the task at
+`running` mid-split scopes its re-dispatch to the REMAINING units
+(derived from the latest such breadcrumb plus the branch's committed
+deliverables), NEVER the monolith and never a unit-1 re-dispatch over
+already-committed files (the remaining-units re-dispatch satisfies
+the resume table's "no implementation marker → re-spawn implementer"
+row). TDD interaction: under `tdd_mode=true` the split applies to the
+POST-approval implementation dispatch — test-authoring is one unit,
+and the final unit posts the marker. Step 9b same-issue follow-up
+rounds inherit this clause via the existing "follows the Step 4b
+brief contract" reference — no separate Step 9b wiring. This clause
+is the dispatch-time application of the Step 5b "Autocompact-thrash
+respawn recipe" split (#1775's recovery applied this same split
+post-death, at ~15 min triage + respawn overhead, when the plan's own
+deliverable count had made it available at dispatch time); the
+Step 5b recipe stays unchanged as the backstop for unforeseen thrash
+deaths.
+
 Brief passed to the implementer:
 - The plan path (the `plans/plan.md` symlink, NOT the body text)
 - Task number + worktree path + branch name
@@ -2855,7 +2902,11 @@ refusal rung (b2) sonnet pin) — they are just not a thrash remedy. The
 micro-scoped respawn IS item 4's one bounded re-spawn where item 4
 applies (same `v<n>`, no round-counter increment); for a multi-unit
 split, the units run sequentially within that same round (#1090: "Same
-round counter (round 1 continues; re-spawns do not increment)").
+round counter (round 1 continues; re-spawns do not increment)"). The
+dispatch-time twin of this split lives at Step 4b ("Pre-split
+multi-deliverable builds at dispatch", #1810) — a KNOWN
+multi-deliverable build is pre-split BEFORE the first spawn; this
+recipe stays the recovery-side backstop for unforeseen deaths.
 
 The existing marker-keyed no-show path — the Codex wrapper POSTING
 `epm:failure v<m>` (`failure_class: codex-output-malformed` or `infra`)

--- a/tests/test_select_step9c_tests.py
+++ b/tests/test_select_step9c_tests.py
@@ -2167,11 +2167,12 @@ def test_transitive_consumer_missing_on_disk_dropped(tmp_path: Path):
     assert pairs == [("tests/test_inline_lint_gate.py", _SELECTOR_KEY)]
 
 
-# --- Case 86: CLI --map-files end-to-end on the LIVE tree — the 6 pairs verbatim --
+# --- Case 86: CLI --map-files end-to-end on the LIVE tree — the 7 pairs verbatim --
 def test_cli_map_files_transitive_pairs_live_tree(tmp_path: Path, capsys):
-    """CLI end-to-end on the LIVE tree: the selector payload prints all 4
-    pre-existing pairs PLUS the 2 transitive pairs (6 pairs, 6 tests) and the
-    sizing line stays at the 300 s floor. Exact-set assert — a new arm/pin
+    """CLI end-to-end on the LIVE tree: the selector payload prints all 5
+    dependency-arm pairs PLUS the 2 transitive pairs (7 pairs, 7 tests) and
+    the sizing line clears the 600 s MAP_TIMEOUT_FLOOR_S at 660
+    ((120 + 7*30) * 2.0). Exact-set assert — a new arm/pin
     joining later legitimately forces a deliberate 1-line update here (that
     loudness is the point; cf. the case-60 drift-pin posture)."""
     repo_root = _HELPER_PATH.parents[1]
@@ -2183,12 +2184,13 @@ def test_cli_map_files_transitive_pairs_live_tree(tmp_path: Path, capsys):
     assert captured.out.splitlines() == [
         f"tests/test_inline_lint_gate.py\t{_SELECTOR_KEY}",
         f"tests/test_inline_payload_lint_gate_contract.py\t{_SELECTOR_KEY}",
+        f"tests/test_issue_skill_lint_family_sync.py\t{_SELECTOR_KEY}",
         f"tests/test_ruff_policy.py\t{_SELECTOR_KEY}",
         f"tests/test_select_step9c_tests.py\t{_SELECTOR_KEY}",
         f"tests/test_shared_vm_thread_caps.py\t{_SELECTOR_KEY}",
         f"tests/test_step9c_baseline.py\t{_SELECTOR_KEY}",
     ]
-    assert "map-files — 6 pairs, 6 tests; recommended-timeout-s=600" in captured.err
+    assert "map-files — 7 pairs, 7 tests; recommended-timeout-s=660" in captured.err
 
 
 # --- Case 87: map-leg asymmetry — an invariant registration is excluded -----------


### PR DESCRIPTION
Closes task #1844. Fixes tests/test_select_step9c_tests.py::test_cli_map_files_transitive_pairs_live_tree red on origin/main (new consumer tests/test_issue_skill_lint_family_sync.py from #1807 merge 9906468844).