### PR TITLE
issue-1857: root-code cert guard — settle-and-re-hash retry for transient worktree-hash races

### DIFF
--- a/.claude/hooks/guard_root_code_commit.sh
+++ b/.claude/hooks/guard_root_code_commit.sh
@@ -105,7 +105,9 @@
 # Contract: reads the PreToolUse JSON on stdin, exit 0 allow, exit 2 (blocking,
 # stderr fed back to Claude) refuse; any OTHER non-zero is non-blocking.
 # Test overrides (hermetic tmp repos): EPM_ROOT_CODE_COMMIT_REPO,
-# EPM_INLINE_CERT_PATH, EPM_INLINE_CERT_MAX_AGE_S.
+# EPM_INLINE_CERT_PATH, EPM_INLINE_CERT_MAX_AGE_S, EPM_CERT_REHASH_DELAY_S
+# (settle delay in seconds before the cert-retry re-hash pass, default 2;
+# tests set 0 and/or PATH-shim `sleep` — #1857).
 #
 # Self-test: bash .claude/hooks/guard_root_code_commit.sh --self-test
 set -u
@@ -788,6 +790,39 @@ check_certified() {
   return 1
 }
 
+# landing_sha <path>: echo the sha of the LANDING content for a gated pending
+# path, per the BINDING RULE at the per-path cert loop below (worktree hash
+# for -a / pathspec / add-clause shapes; staged blob sha only for a plain
+# commit of the staged set). Returns 1 for a deletion-exempt path (no content
+# lands — caller skips). A failed git read echoes EMPTY (check_certified then
+# never matches: block direction preserved). Reads globals scope / has_dash_a
+# / text_paths / GUARD_REPO at call time; factored out of the loop (#1857) so
+# the first cert pass and the cert-retry re-hash pass cannot diverge.
+landing_sha() {
+  local p="$1" worktree_shape=0 sha=""
+  # Scoped read engaged => a pathspec commit lands WORKTREE content for every
+  # pending path (BINDING RULE at the loop below; issue #1620).
+  [ "${scope:-0}" = 1 ] && worktree_shape=1
+  if [ "$has_dash_a" = 1 ] \
+    && git -C "$GUARD_REPO" diff --name-only -- "$p" 2>/dev/null | grep -qxF -- "$p"; then
+    worktree_shape=1 # -a re-stages worktree content
+  fi
+  if printf '%s\n' "$text_paths" | grep -qxF -- "$p"; then
+    worktree_shape=1 # commit pathspec / chained add-clause
+  fi
+  if [ "$worktree_shape" = 1 ]; then
+    [ -f "$GUARD_REPO/$p" ] || return 1 # deletion via -a/pathspec: exempt
+    sha=$(git -C "$GUARD_REPO" hash-object -- "$GUARD_REPO/$p" 2>/dev/null || true)
+  elif git -C "$GUARD_REPO" diff --cached --name-only -- "$p" 2>/dev/null | grep -qxF -- "$p"; then
+    sha=$(git -C "$GUARD_REPO" ls-files -s -- "$p" 2>/dev/null | awk '{print $2}')
+    [ -n "$sha" ] || return 1 # staged DELETION: exempt
+  else
+    [ -f "$GUARD_REPO/$p" ] || return 1
+    sha=$(git -C "$GUARD_REPO" hash-object -- "$GUARD_REPO/$p" 2>/dev/null || true)
+  fi
+  printf '%s' "$sha"
+}
+
 # cert_diag <path>: one stable grep-able diagnostic line per uncertified path
 # (issue #1620 fix (c)); called ONLY in the block path (zero hot-path cost).
 # Format:
@@ -860,6 +895,9 @@ run_self_test() {
   SCRIPT="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
   TMP=$(mktemp -d)
   trap 'rm -rf "$TMP"' RETURN
+  # Blocked self-test cases hit the #1857 cert-retry pass; zero its settle
+  # delay so the self-test stays fast + wall-clock-independent.
+  export EPM_CERT_REHASH_DELAY_S=0
 
   # Repo with artifact-only staged payload.
   RART="$TMP/art" && git init -q "$RART"
@@ -1139,34 +1177,62 @@ pending=$(printf '%s\n%s\n%s\n' "$staged" "$mod" "$text_paths" \
 # the staged blob sha is authoritative ONLY for a plain commit of the staged
 # set. Space-safe iteration (while read, never for-in word-split): a gated
 # path containing a space must fail toward BLOCK, never silently allow.
-uncertified=""
+uncertified_nl="" # newline-joined (space-safe); the block path's space-joined form is derived below
 while IFS= read -r p; do
   [ -n "$p" ] || continue
-  worktree_shape=0 # 1 => landing content is the worktree file
-  # Scoped read engaged => a pathspec commit lands WORKTREE content for every
-  # pending path (BINDING RULE above; issue #1620).
-  [ "$scope" = 1 ] && worktree_shape=1
-  if [ "$has_dash_a" = 1 ] \
-    && git -C "$GUARD_REPO" diff --name-only -- "$p" 2>/dev/null | grep -qxF -- "$p"; then
-    worktree_shape=1 # -a re-stages worktree content
-  fi
-  if printf '%s\n' "$text_paths" | grep -qxF -- "$p"; then
-    worktree_shape=1 # commit pathspec / chained add-clause
-  fi
-  if [ "$worktree_shape" = 1 ]; then
-    [ -f "$GUARD_REPO/$p" ] || continue # deletion via -a/pathspec: exempt
-    sha=$(git -C "$GUARD_REPO" hash-object -- "$GUARD_REPO/$p" 2>/dev/null || true)
-  elif git -C "$GUARD_REPO" diff --cached --name-only -- "$p" 2>/dev/null | grep -qxF -- "$p"; then
-    sha=$(git -C "$GUARD_REPO" ls-files -s -- "$p" 2>/dev/null | awk '{print $2}')
-    [ -n "$sha" ] || continue # staged DELETION: exempt
-  else
-    [ -f "$GUARD_REPO/$p" ] || continue
-    sha=$(git -C "$GUARD_REPO" hash-object -- "$GUARD_REPO/$p" 2>/dev/null || true)
-  fi
-  check_certified "$p" "$sha" || uncertified="$uncertified $p"
+  if sha=$(landing_sha "$p"); then
+    check_certified "$p" "$sha" || uncertified_nl="${uncertified_nl}${p}
+"
+  fi # landing_sha rc=1: deletion-exempt path — skip (no content lands)
 done <<EOF_PENDING
 $pending
 EOF_PENDING
+
+[ -z "$uncertified_nl" ] && exit 0
+
+# Cert-retry pass (#1857): ONE bounded settle-and-re-hash retry before the
+# negative verdict, firing ONLY on a would-block path (the happy path never
+# sleeps). A transient worktree-hash flip (concurrent writer / filesystem
+# settle: the guard-time read != the cert sha, then the file settles back
+# within the window — the 07-28 incident) must not block a certified commit;
+# a STABLE mismatch keeps today's block verdict byte-for-byte. The retry
+# re-READS the landing sha via the same landing_sha function — it never
+# re-BINDS to a different content source (the #1620 binding rule is
+# unchanged). Delay knob: EPM_CERT_REHASH_DELAY_S (seconds, default 2; tests
+# set 0 and/or PATH-shim `sleep`). `|| true`: a malformed delay makes sleep
+# fail — the re-check still runs immediately, so a genuine mismatch still
+# blocks (fail toward BLOCK; a failed sleep must never crash the guard into
+# a non-blocking exit under a hook harness that only blocks on exit 2).
+sleep "${EPM_CERT_REHASH_DELAY_S:-2}" || true
+retry_uncertified_nl=""
+while IFS= read -r p; do
+  [ -n "$p" ] || continue
+  if sha=$(landing_sha "$p"); then
+    if check_certified "$p" "$sha"; then
+      echo "cert-retry: $p recovered after re-hash (transient worktree flip)" >&2
+    else
+      retry_uncertified_nl="${retry_uncertified_nl}${p}
+"
+    fi
+  else
+    # Deleted between passes: mirror the first pass's deletion-exempt skip
+    # (no content lands for this path anymore).
+    echo "cert-retry: $p exempt after re-hash (deleted between passes)" >&2
+  fi
+done <<EOF_RETRY
+$uncertified_nl
+EOF_RETRY
+
+[ -z "$retry_uncertified_nl" ] && exit 0
+
+# Space-joined form the existing block path renders (rendering unchanged).
+uncertified=""
+while IFS= read -r p; do
+  [ -n "$p" ] || continue
+  uncertified="$uncertified $p"
+done <<EOF_JOIN
+$retry_uncertified_nl
+EOF_JOIN
 
 [ -z "${uncertified:-}" ] && exit 0
 

--- a/scripts/inline_lint_gate.py
+++ b/scripts/inline_lint_gate.py
@@ -421,7 +421,10 @@ def write_cert(
     """Append `v1 <epoch> <sha> <path>` lines for passing paths whose worktree
     content still matches the read_payload snapshot; a mismatch means the file
     was edited DURING the gate run -> INCONCLUSIVE for that path, no cert
-    (TOCTOU guard). Append runs under flock with an inode re-check (#1620): a
+    (TOCTOU guard). A first-pass mismatch gets ONE bounded settle-and-re-hash
+    retry (#1857, EPM_CERT_REHASH_DELAY_S) so a transient worktree flip does
+    not withhold the cert; only a STABLE mismatch stays TOCTOU.
+    Append runs under flock with an inode re-check (#1620): a
     concurrent trim's os.replace can swap the path to a NEW inode while this
     writer waits on the OLD inode's lock, so after acquiring the lock the fd
     is re-opened until it still names cert_path (bounded; exhaustion degrades
@@ -432,13 +435,39 @@ def write_cert(
     toctou: list[str] = []
     epoch = int(time.time())
     lines: list[str] = []
+    mismatched: list[str] = []
     for p in passing:
         current = _hash_object(repo, p)
         if current is None or current != snapshots[p]:
-            toctou.append(p)
+            mismatched.append(p)
             continue
         lines.append(f"v1 {epoch} {snapshots[p]} {p}\n")
         certified.append(p)
+    if mismatched:
+        # Bounded settle-and-re-hash retry (#1857): a TRANSIENT worktree-hash
+        # flip (concurrent writer / filesystem settle — the 07-30 false
+        # INCONCLUSIVE on a file not being edited) re-hashes back to the
+        # read_payload snapshot after one settle delay and certifies as
+        # normal; a STABLE mismatch stays TOCTOU with the message unchanged.
+        # ONE sleep total (not per path), OUTSIDE the flock below (lines are
+        # assembled before locking). The retry re-READS the worktree hash —
+        # it never re-binds the cert to different content (the cert line
+        # still carries the snapshot sha, which the re-hash must EQUAL).
+        # Knob: EPM_CERT_REHASH_DELAY_S (seconds, default 2; tests set 0 /
+        # monkeypatch time.sleep). A malformed value falls back to the
+        # default — the re-check always runs (fail toward TOCTOU/block).
+        try:
+            delay = float(os.environ.get("EPM_CERT_REHASH_DELAY_S", "2"))
+        except ValueError:
+            delay = 2.0
+        time.sleep(max(delay, 0.0))
+        for p in mismatched:
+            current = _hash_object(repo, p)
+            if current is not None and current == snapshots[p]:
+                lines.append(f"v1 {epoch} {snapshots[p]} {p}\n")
+                certified.append(p)
+            else:
+                toctou.append(p)
     if lines:
         cert_path.parent.mkdir(parents=True, exist_ok=True)
         fh = open(cert_path, "a+", encoding="utf-8")

--- a/tests/test_guard_root_code_commit.py
+++ b/tests/test_guard_root_code_commit.py
@@ -111,11 +111,28 @@ def cert(tmp_path: Path) -> Path:
 
 
 def _env(
-    repo: Path, cert_path: Path, *, allow: bool = False, max_age: str | None = None
+    repo: Path,
+    cert_path: Path,
+    *,
+    allow: bool = False,
+    max_age: str | None = None,
+    rehash_delay: str | None = "0",
+    path_prepend: Path | None = None,
 ) -> dict[str, str]:
-    env = {k: v for k, v in os.environ.items() if k != "EPM_ALLOW_ROOT_CODE_COMMIT"}
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ("EPM_ALLOW_ROOT_CODE_COMMIT", "EPM_CERT_REHASH_DELAY_S")
+    }
     env["EPM_ROOT_CODE_COMMIT_REPO"] = str(repo)
     env["EPM_INLINE_CERT_PATH"] = str(cert_path)
+    # Zero the #1857 settle-and-re-hash delay by default so blocked cases stay
+    # deterministic-fast (the retry still RUNS — it just doesn't wait); the
+    # retry tests shim `sleep` via path_prepend for the settle action itself.
+    if rehash_delay is not None:
+        env["EPM_CERT_REHASH_DELAY_S"] = rehash_delay
+    if path_prepend is not None:
+        env["PATH"] = f"{path_prepend}:{env.get('PATH', '/usr/bin:/bin')}"
     if max_age is not None:
         env["EPM_INLINE_CERT_MAX_AGE_S"] = max_age
     if allow:
@@ -308,6 +325,80 @@ def test_b8_classification_failure_fails_closed(tmp_path: Path, cert: Path) -> N
     notarepo = tmp_path / "notarepo"
     notarepo.mkdir()
     _assert_blocked(_run("git commit -m x", notarepo, cert))
+
+
+# ---------------------------------------------------------------------------
+# R — #1857 cert-retry pass (settle-and-re-hash before the negative verdict)
+# ---------------------------------------------------------------------------
+def _sleep_shim(tmp_path: Path, body: str) -> Path:
+    """PATH-shimmed `sleep` running `body` — the deterministic stand-in for
+    the settle window (the "concurrent writer" acts during the delay)."""
+    shim_dir = tmp_path / "shim-bin"
+    shim_dir.mkdir(exist_ok=True)
+    shim = shim_dir / "sleep"
+    shim.write_text(f"#!/bin/sh\n{body}\n", encoding="utf-8")
+    shim.chmod(0o755)
+    return shim_dir
+
+
+def _retry_repo(tmp_path: Path) -> Path:
+    """Tracked, committed gated file (content A) — the worktree-binding
+    pathspec-commit shape the retry tests flip mid-guard."""
+    repo = _init_repo(tmp_path, "retry")
+    _stage(repo, GATED, "print(1)\n")
+    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", "init")
+    return repo
+
+
+def test_r1_transient_worktree_flip_recovers_on_rehash(tmp_path: Path, cert: Path) -> None:
+    """Cert binds content A; the worktree reads content B at the first pass;
+    the shimmed `sleep` restores content A during the settle window -> the
+    re-hash matches (same landing_sha derivation, no re-binding), the commit
+    is ALLOWED, and the grep-able `cert-retry:` recovery line is emitted."""
+    repo = _retry_repo(tmp_path)
+    _cert_line(cert, GATED, _worktree_sha(repo, GATED))  # content A
+    _write(repo, GATED, "print(2)\n")  # transient flip to content B
+    shim = _sleep_shim(tmp_path, f"printf 'print(1)\\n' > \"{repo / GATED}\"")
+    r = _run(f"git commit -m x {GATED}", repo, cert, path_prepend=shim)
+    _assert_allowed(r)
+    assert f"cert-retry: {GATED} recovered after re-hash" in r.stderr, r.stderr
+
+
+def test_r2_stable_drift_still_blocks_after_retry(tmp_path: Path, cert: Path) -> None:
+    """Same setup but the drift is STABLE (the shim settles nothing) -> the
+    retry re-hash still mismatches and today's block verdict is kept
+    (exit 2 + cert-diag), with no recovery line."""
+    repo = _retry_repo(tmp_path)
+    _cert_line(cert, GATED, _worktree_sha(repo, GATED))
+    _write(repo, GATED, "print(2)\n")  # STABLE drift
+    shim = _sleep_shim(tmp_path, ":")  # no-op sleep: nothing settles
+    r = _run(f"git commit -m x {GATED}", repo, cert, path_prepend=shim)
+    _assert_blocked(r)
+    assert "cert-retry:" not in r.stderr, r.stderr
+    assert "cert-diag:" in r.stderr, r.stderr
+
+
+def test_r3_deleted_between_passes_is_exempt(tmp_path: Path, cert: Path) -> None:
+    """A path deleted between the first pass and the retry mirrors the first
+    pass's deletion-exempt semantics (no content lands -> skip + allow)."""
+    repo = _retry_repo(tmp_path)
+    _cert_line(cert, GATED, _worktree_sha(repo, GATED))
+    _write(repo, GATED, "print(2)\n")
+    shim = _sleep_shim(tmp_path, f'rm -f "{repo / GATED}"')
+    r = _run(f"git commit -m x {GATED}", repo, cert, path_prepend=shim)
+    _assert_allowed(r)
+    assert f"cert-retry: {GATED} exempt after re-hash" in r.stderr, r.stderr
+
+
+def test_r4_malformed_rehash_delay_fails_toward_block(tmp_path: Path, cert: Path) -> None:
+    """A malformed EPM_CERT_REHASH_DELAY_S makes `sleep` fail; the re-check
+    still runs and a stable drift still BLOCKS (a failed sleep never skips
+    the re-check nor crashes the guard into a non-blocking exit)."""
+    repo = _retry_repo(tmp_path)
+    _cert_line(cert, GATED, _worktree_sha(repo, GATED))
+    _write(repo, GATED, "print(2)\n")
+    r = _run(f"git commit -m x {GATED}", repo, cert, rehash_delay="not-a-number")
+    _assert_blocked(r)
 
 
 def test_b9_mixed_staged_set_blocks_and_names_only_gated(tmp_path: Path, cert: Path) -> None:

--- a/tests/test_inline_lint_gate.py
+++ b/tests/test_inline_lint_gate.py
@@ -87,6 +87,9 @@ def _run_gate(
         # the repo MID-GATE (after read_payload snapshots) for TOCTOU cases.
         env["EPM_INLINE_GATE_LINT_CMD"] += f" && {lint_cmd_extra}"
     env["EPM_INLINE_CERT_PATH"] = str(tmp_path / "cert.txt")
+    # Zero the #1857 settle-and-re-hash retry delay: subprocess TOCTOU cases
+    # stay deterministic-fast (the retry still RUNS — it just doesn't wait).
+    env["EPM_CERT_REHASH_DELAY_S"] = "0"
     return subprocess.run(
         [
             sys.executable,
@@ -513,7 +516,10 @@ def test_added_line_ranges_parses_u0_hunks(tmp_path: Path) -> None:
     assert ilg.added_line_ranges(repo, "scripts/other.py") == []
 
 
-def test_write_cert_toctou_refuses_edited_path(tmp_path: Path) -> None:
+def test_write_cert_toctou_refuses_edited_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("EPM_CERT_REHASH_DELAY_S", "0")  # keep the #1857 retry instant
     repo = _make_repo(tmp_path)
     (repo / "scripts" / "sib.py").write_text("print(0)\n", encoding="utf-8")
     snapshots = ilg.read_payload(["scripts/mod.py", "scripts/sib.py"], repo)
@@ -525,6 +531,67 @@ def test_write_cert_toctou_refuses_edited_path(tmp_path: Path) -> None:
     assert certified == ["scripts/sib.py"]
     lines = cert.read_text(encoding="utf-8").splitlines()
     assert len(lines) == 1 and lines[0].endswith(" scripts/sib.py"), lines
+
+
+def test_write_cert_transient_flip_recovers_after_rehash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1857 (a): a TRANSIENT worktree flip — mismatch at the first pass,
+    settled back to the read_payload snapshot by the retry re-hash — is
+    certified as normal (cert line carries the snapshot sha), no TOCTOU."""
+    repo = _make_repo(tmp_path)
+    target = repo / "scripts" / "mod.py"
+    original = target.read_text(encoding="utf-8")
+    snapshots = ilg.read_payload(["scripts/mod.py"], repo)
+    target.write_text("transient flip\n", encoding="utf-8")
+
+    def _settle(_delay: float) -> None:
+        # Deterministic stand-in for the settle window: the concurrent
+        # writer restores the snapshot content during the retry delay.
+        target.write_text(original, encoding="utf-8")
+
+    monkeypatch.setattr(ilg.time, "sleep", _settle)
+    cert = tmp_path / "cert.txt"
+    certified, toctou = ilg.write_cert(["scripts/mod.py"], snapshots, cert, repo)
+    assert certified == ["scripts/mod.py"] and toctou == [], (certified, toctou)
+    lines = cert.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1, lines
+    assert lines[0].split()[2] == snapshots["scripts/mod.py"], lines
+
+
+def test_write_cert_stable_mismatch_sleeps_once_and_stays_toctou(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1857 (b): a STABLE mismatch takes exactly ONE settle sleep, the
+    re-hash still mismatches, and the verdict stays TOCTOU (no cert line)."""
+    repo = _make_repo(tmp_path)
+    snapshots = ilg.read_payload(["scripts/mod.py"], repo)
+    (repo / "scripts" / "mod.py").write_text("edited mid-gate\n", encoding="utf-8")
+    slept: list[float] = []
+    monkeypatch.setattr(ilg.time, "sleep", lambda s: slept.append(s))
+    cert = tmp_path / "cert.txt"
+    certified, toctou = ilg.write_cert(["scripts/mod.py"], snapshots, cert, repo)
+    assert toctou == ["scripts/mod.py"] and certified == [], (certified, toctou)
+    assert len(slept) == 1, slept
+    assert not cert.exists(), "stable mismatch must not write a cert line"
+
+
+def test_write_cert_malformed_rehash_delay_falls_back_and_still_toctous(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1857: a malformed EPM_CERT_REHASH_DELAY_S never crashes write_cert —
+    the default delay is used and a stable mismatch still refuses the cert
+    (fail toward TOCTOU/block, never a skipped re-check)."""
+    repo = _make_repo(tmp_path)
+    snapshots = ilg.read_payload(["scripts/mod.py"], repo)
+    (repo / "scripts" / "mod.py").write_text("edited mid-gate\n", encoding="utf-8")
+    monkeypatch.setenv("EPM_CERT_REHASH_DELAY_S", "not-a-number")
+    slept: list[float] = []
+    monkeypatch.setattr(ilg.time, "sleep", lambda s: slept.append(s))
+    cert = tmp_path / "cert.txt"
+    certified, toctou = ilg.write_cert(["scripts/mod.py"], snapshots, cert, repo)
+    assert toctou == ["scripts/mod.py"] and certified == [], (certified, toctou)
+    assert slept == [2.0], slept
 
 
 def test_write_cert_trims_to_last_500_lines_atomically(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes task #1857.