### PR TITLE
issue-1953: waive jsonl-splitlines flag (worker log tail) — fix red main

### DIFF
--- a/scripts/issue1689_user_slot_capture.py
+++ b/scripts/issue1689_user_slot_capture.py
@@ -749,6 +749,7 @@ def run_dispatch(args) -> int:
         fh.close()
         if rc != 0:
             failures.append((gpu, rc))
+            # JSONL_SPLITLINES_EXEMPT: worker LOG tail for crash diagnostics, not JSONL content
             tail = log.read_text(encoding="utf-8", errors="replace").splitlines()[-120:]
             print(f"[capture] gpu{gpu} FAILED rc={rc}; tail of {log}:", flush=True)
             for ln in tail:


### PR DESCRIPTION
Closes task #1953. One-line comment-only waiver at scripts/issue1689_user_slot_capture.py:752 (worker LOG tail, not JSONL); fixes the live main-red on tests/test_workflow_lint_jsonl_splitlines.py::test_live_tree_passes.