### PR TITLE
issue-1956: daily-fix: load_dotenv before heavy imports in issue1773_register_steer_stats.py

### DIFF
--- a/scripts/issue1773_register_steer_stats.py
+++ b/scripts/issue1773_register_steer_stats.py
@@ -17,7 +17,13 @@ import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
-import matplotlib
+from explore_persona_space.orchestrate.env import load_dotenv
+
+# Shared-VM thread caps (#847): load_dotenv() setdefaults OMP/MKL/OPENBLAS/
+# NUMEXPR_NUM_THREADS before matplotlib/numpy/scipy freeze their pools.
+load_dotenv()
+
+import matplotlib  # noqa: E402
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa: E402


### PR DESCRIPTION
Closes task #1956. Fixes main-red tests/test_shared_vm_thread_caps.py::test_no_new_torch_before_dotenv_vm_entrypoints.