### PR TITLE
issue-1880: pod-side results-git push must fetch+rebase (mid-run branch-push race)

### DIFF
--- a/.claude/rules/crash-fix-rounds.md
+++ b/.claude/rules/crash-fix-rounds.md
@@ -446,6 +446,14 @@ the relaunch ran the pre-fix commit, checkpointed garbage — val R²
      ancestors). A rebase that rewrote the fix SHA
      fails the probe LOUD: re-resolve the SHA on the rewritten branch
      (or have the implementer re-declare), never skip the probe.
+   - **Mid-run branch-push race (#1880):** pushing fix commits to
+     `origin/issue-<N>` while SIBLING lanes of the same issue are mid-run
+     advances origin past their clones — their terminal results-git
+     pushes then take the fetch+rebase path
+     (`.claude/rules/pod-side-reporting.md` § Result-push verification
+     contract, #1880), and a lane running a pre-#1880 driver
+     deterministically false-crashes at its terminal push with its
+     results intact in crash-persist.
 2. **Stale-checkpoint disposition (element 5), executed in the SAME
    command chain as the launch** (the pid-file-contract shape,
    `.claude/rules/pod-side-reporting.md` § Pid-file launch contract),

--- a/.claude/rules/pod-side-reporting.md
+++ b/.claude/rules/pod-side-reporting.md
@@ -440,6 +440,37 @@ the file and the marker still reads `dead`.
   piped-push masking class — the pipe mirror stays enforced by
   `workflow_lint.py --check-piped-git-push`, this swallow shape by
   `--check-push-failure-swallow`).
+- **Fetch + rebase before every pod/instance-side results-git push
+  (#1880).** A lane's terminal push races ANY orchestrator branch commit
+  made mid-run (a sibling lane's crash-fix relaunch is the normal
+  multi-lane case): a bare push retry that detects behind>0 but never
+  fetches loses DETERMINISTICALLY — non-fast-forward rejection → workload
+  exit 1 → a HEALTHY run crash-persists and powers off (#1739 hallu lane,
+  2026-07-30: 270 cells rc=0, Hub sidecars verified, then exit 1 at the
+  terminal push — 31h of complete science, ~30 min manual recovery from
+  crash-persist). Push recipe:
+  `git fetch origin <branch> && git rebase origin/<branch>` (result
+  commits are additive per-lane files — a content conflict is
+  near-impossible), then push and re-verify per the rev-list bullet
+  above; bounded 2 attempts. NOTE the rebase rewrites the LOCAL result
+  commits' SHAs pre-push — no standard-contract consumer pins them (the
+  artifact-presence assert below is path-keyed against the pushed tree;
+  fix-sha ancestry probes reference origin ancestors, which
+  rebase-onto-origin preserves) — a future driver that records its own
+  result-commit SHA must record it AFTER the push-verify, never before.
+  On rebase conflict: `git rebase --abort` and proceed to the lane's
+  EXISTING fail-loud path (GCE: bundle + exit 86; crash-persist preserves
+  the results) — the standing "never declare done with an unpushed result
+  commit" contract and the Part A-ter sentinel ordering are UNCHANGED (a
+  push-failure-tolerant exit-0 disposition was considered and REJECTED:
+  it would let a run classify done-like with results only in a bundle).
+- **Orchestrator side (#1880):** avoid pushing to the issue branch while
+  lanes are mid-run when feasible; when a mid-run push is required (a
+  sibling lane's crash-fix relaunch), expect in-flight lanes' terminal
+  pushes to need the fetch+rebase path above — a lane running a pre-#1880
+  driver will deterministically false-crash at its terminal push (the
+  #1739 shape) with its results intact in crash-persist; treat that
+  failure as recoverable-transport, not a science loss.
 - **Artifact-presence assert (#1325) — the rev-list push-verify is VACUOUS
   against a never-committed result file.** `rev-list --count
   origin/<branch>..HEAD == 0` proves the COMMITS pushed; it says nothing
@@ -490,9 +521,11 @@ the file and the marker still reads `dead`.
 - **GCE lane:** the startup script configures a `GITHUB_TOKEN` env-reading
   credential helper (workload pushes authenticate; pre-#1205 they failed
   DETERMINISTICALLY — the clone is tokenless) and runs a post-workload
-  push-verify backstop (retry → bundle the unpushed range to
-  `data/issue_<N>/`, crash-persist-swept per #854 item 5 → `exit 86` →
-  EXIT trap → `phase=failed` + crash-persist + poweroff). The backstop
+  push-verify backstop (fetch + rebase onto `origin/<branch>` with inline
+  committer identity, then retry — the #1880 recipe above; a rebase
+  conflict aborts into the same fail-loud tail → bundle the unpushed
+  range to `data/issue_<N>/`, crash-persist-swept per #854 item 5 →
+  `exit 86` → EXIT trap → `phase=failed` + crash-persist + poweroff). The backstop
   covers forgetful dispatch scripts; scripts SHOULD still verify their own
   push so the failure surfaces at the failing phase with its own context.
   The backstop pushes `HEAD` to the CLONED branch (`HEAD:<repo_branch>`)

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -11576,10 +11576,28 @@ tests BEFORE anything lands:
       # unstable across trees (unrelated dirt in ONE tree changes it ->
       # false NEW line on an innocent payload); every real offense also
       # emits its dedicated per-file evidence line, which survives.
+      # Two structural false-positive filters (#1689): the pytest
+      # warnings-summary SECTION is dropped up front (awk range
+      # `^=+ warnings summary` .. the `^-- Docs:` terminator — a PASSING
+      # test's warnings are not failure signal, and a branch-new test's
+      # warnings have no baseline twin by construction), and $WT/$REPO_ROOT
+      # absolute tree prefixes are normalized to one <TREE> token so the
+      # SAME pre-existing line from the two trees cancels under comm -23
+      # (WT substitution FIRST — $REPO_ROOT is a string prefix of $WT; the
+      # never-matching parameter defaults keep an unset var from becoming an
+      # empty-pattern sed that fails into an EMPTY hits file under the
+      # trailing `|| true` = silent fail-open).
+      # Residual: realpath-divergent prefixes (the #681 /mnt/eps-data
+      # bind-mount — a test printing os.path.realpath output emits a prefix
+      # matching neither $WT nor $REPO_ROOT) stay uncancelled; fail
+      # direction = the pre-existing status quo for that line class.
       for leg in baseline gated; do
-        grep -F -f /tmp/issue-<N>-tg-files.txt "/tmp/issue-<N>-tg-$leg.txt" \
+        awk '/^=+ warnings summary/{w=1; next} w && /^-- Docs:/{w=0; next} !w' \
+          "/tmp/issue-<N>-tg-$leg.txt" \
+          | grep -F -f /tmp/issue-<N>-tg-files.txt \
           | grep -vE '^E +assert ' \
           | sed -E 's/at line [0-9]+/at line N/g; s/:[0-9]+:/::/g; s/:[0-9]+([^0-9]|$)/:N\1/g' \
+          | sed -e "s|${WT:-/__eps_no_wt__}|<TREE>|g" -e "s|${REPO_ROOT:-/__eps_no_root__}|<TREE>|g" \
           | sort -u \
           > "/tmp/issue-<N>-tg-$leg-hits.txt" || true
       done
@@ -11748,9 +11766,14 @@ tests BEFORE anything lands:
   masking WARN; compare additionally marks NON-file-anchored scan-set nodes
   scratch-ineligible (`step9c_baseline.py` `FILE_ANCHORED_SCAN_TESTS` members
   are scratch-resolved, still WARNed — #1337)). File-grain hits
-  = pytest-output lines naming a payload-matched path, line numbers blanked
+  = pytest-output lines naming a payload-matched path, the pytest
+  warnings-summary section excluded up front (a PASSING test's warnings are
+  not failure signal; a branch-new test's warnings have no baseline twin —
+  #1689), line numbers blanked
   so main-vs-branch drift of the SAME pre-existing offense cannot fake a NEW
-  line, pytest's ellipsis-truncated `E   assert ...` repr line dropped (its
+  line, `$WT`/`$REPO_ROOT` absolute tree prefixes normalized to a common
+  `<TREE>` token so the same line from the two trees cancels (#1689),
+  pytest's ellipsis-truncated `E   assert ...` repr line dropped (its
   content is unstable across trees; every real offense also emits a dedicated
   per-file evidence line); NEW = gated hits − baseline hits (`comm -23`,
   `/tmp/issue-<N>-tg-new.txt`). And junit-NODE-grain for unit-test failures
@@ -13245,8 +13268,10 @@ Decision tree:
     fi
   fi
   # TG GATED leg (#1147) — the root tree now carries the payload; same
-  # grep -> line-number-blank -> comm -23 subtraction as the shared gate's
-  # executable block (own-diff here = the additive-files list; structurally
+  # warnings-section drop -> grep -> line-number-blank -> tree-prefix
+  # normalization -> comm -23 subtraction as the shared gate's executable
+  # block, incl. its #1689 filter rationale + realpath-divergent residual
+  # (own-diff here = the additive-files list; structurally
   # unreachable today, see the dormancy comment above the TG baseline leg).
   if [ "$TG_CRASH" = no ] && [ -s /tmp/issue-<N>-tg-map.txt ]; then
     ( cd "$REPO_ROOT" && timeout --kill-after=30s ${TG_T}s \
@@ -13258,9 +13283,12 @@ Decision tree:
       > /tmp/issue-<N>-tg-gated.txt 2>&1 || TG_RC=$?
     if [ "$TG_RC" -gt 1 ] || [ "$TG_BASE_RC" -gt 1 ]; then TG_CRASH=yes; fi
     for leg in baseline gated; do
-      grep -F -f /tmp/issue-<N>-tg-files.txt "/tmp/issue-<N>-tg-$leg.txt" \
+      awk '/^=+ warnings summary/{w=1; next} w && /^-- Docs:/{w=0; next} !w' \
+        "/tmp/issue-<N>-tg-$leg.txt" \
+        | grep -F -f /tmp/issue-<N>-tg-files.txt \
         | grep -vE '^E +assert ' \
         | sed -E 's/at line [0-9]+/at line N/g; s/:[0-9]+:/::/g; s/:[0-9]+([^0-9]|$)/:N\1/g' \
+        | sed -e "s|${WT:-/__eps_no_wt__}|<TREE>|g" -e "s|${REPO_ROOT:-/__eps_no_root__}|<TREE>|g" \
         | sort -u \
         > "/tmp/issue-<N>-tg-$leg-hits.txt" || true
     done

--- a/src/explore_persona_space/backends/gcp.py
+++ b/src/explore_persona_space/backends/gcp.py
@@ -1591,9 +1591,21 @@ def render_startup_script(
             'if [ "$_EPS_UNPUSHED" != "0" ]; then',
             '  echo "[push-verify] ${_EPS_UNPUSHED} unpushed commit(s) on'
             ' ${_EPS_PUSH_BRANCH} — retrying push (#1205)"',
-            '  git -C "$WORKLOAD_ROOT" push origin "HEAD:${_EPS_PUSH_BRANCH}"'
-            ' || { sleep 20; git -C "$WORKLOAD_ROOT" push origin "HEAD:${_EPS_PUSH_BRANCH}"; }'
-            " || true",
+            '  git -C "$WORKLOAD_ROOT" push origin "HEAD:${_EPS_PUSH_BRANCH}" || {',
+            '    echo "[push-verify] push rejected: fetch + rebase onto'
+            ' origin/${_EPS_PUSH_BRANCH} before retry (#1880)"',
+            '    git -C "$WORKLOAD_ROOT" fetch origin "${_EPS_PUSH_BRANCH}" || true',
+            "    # Inline committer identity so a missing repo-level identity can never",
+            "    # kill the rebase at the first pick. A DIRTY tracked file makes the",
+            "    # rebase refuse to start -> the abort fires -> the retry push fails",
+            "    # non-fast-forward -> the existing bundle + exit 86 path below takes",
+            "    # over (fail-loud preserved; #1880).",
+            '    git -C "$WORKLOAD_ROOT" -c user.email=eps-workload@localhost'
+            ' -c user.name=eps-workload rebase "origin/${_EPS_PUSH_BRANCH}"'
+            ' || git -C "$WORKLOAD_ROOT" rebase --abort || true',
+            "    sleep 20",
+            '    git -C "$WORKLOAD_ROOT" push origin "HEAD:${_EPS_PUSH_BRANCH}"',
+            "  } || true",
             '  _EPS_UNPUSHED="$(git -C "$WORKLOAD_ROOT" rev-list --count'
             ' "origin/${_EPS_PUSH_BRANCH}..HEAD")"',
             '  if [ "$_EPS_UNPUSHED" != "0" ]; then',

--- a/tests/test_gcp_backend.py
+++ b/tests/test_gcp_backend.py
@@ -11015,6 +11015,15 @@ def test_render_startup_script_workload_cmd_carries_push_verify_leg() -> None:
         repo_branch="issue-1205",
     )
     assert "_EPS_PUSH_BRANCH=issue-1205" in script_wt
+    # #1880: the retry path fetches + rebases (inline committer identity,
+    # so a missing repo-level identity can never kill the rebase) before
+    # the retry push; on rebase failure the abort fires and the existing
+    # bundle + exit 86 flow takes over.
+    assert 'fetch origin "${_EPS_PUSH_BRANCH}"' in script
+    assert "-c user.email=eps-workload@localhost" in script
+    assert "-c user.name=eps-workload" in script
+    assert 'rebase "origin/${_EPS_PUSH_BRANCH}"' in script
+    assert "rebase --abort" in script
 
 
 def test_render_startup_script_workload_cmd_git_credential_gated_on_token() -> None:
@@ -11191,6 +11200,78 @@ def test_push_verify_leg_executes_in_tmp_repo_case_c_noop(tmp_path: Path) -> Non
     assert proc.returncode == 0, (proc.stdout, proc.stderr)
     assert "[push-verify] OK: no unpushed commits" in proc.stdout
     assert not (workload / "data" / "issue_137").exists()
+
+
+def _advance_origin_main(
+    tmp_path: Path, origin: Path, env: dict[str, str], fname: str, content: str
+) -> str:
+    """Advance the bare origin's ``main`` past the workload clone.
+
+    Simulates a MID-RUN orchestrator branch push (#1880: a sibling lane's
+    crash-fix relaunch advancing ``origin/issue-<N>`` while this lane's
+    clone is in flight) via a fresh full clone + commit + push. Returns
+    the new origin tip SHA.
+    """
+    orch = tmp_path / "orchestrator"
+    _git(tmp_path, "clone", f"file://{origin}", str(orch), env=env)
+    _git(orch, "config", "user.email", "o@example.com", env=env)
+    _git(orch, "config", "user.name", "o", env=env)
+    (orch / fname).write_text(content)
+    _git(orch, "add", fname, env=env)
+    _git(orch, "commit", "-m", "orchestrator mid-run branch push", env=env)
+    _git(orch, "push", "origin", "main:main", env=env)
+    return _git(orch, "rev-parse", "HEAD", env=env).stdout.strip()
+
+
+def test_push_verify_leg_executes_in_tmp_repo_case_d_behind_origin_rebase_lands(
+    tmp_path: Path,
+) -> None:
+    """Case D (#1880): a local result commit on a clone BEHIND origin (a
+    mid-run orchestrator push advanced the branch -- the #1739 hallu-lane
+    shape). Pre-#1880 the leg lost DETERMINISTICALLY: both pushes rejected
+    non-fast-forward, so a HEALTHY completed run exited 86 into
+    crash-persist. The fetch+rebase retry replays the result commit onto
+    the advanced tip and lands it: rc 0 AND
+    ``rev-list --count origin/<branch>..HEAD`` == 0."""
+    origin, workload, env, runner = _push_leg_rig(tmp_path)
+    _advance_origin_main(tmp_path, origin, env, "orchestrator.txt", "mid-run fix\n")
+    (workload / "result.json").write_text("{}\n")
+    _git(workload, "add", "result.json", env=env)
+    _git(workload, "commit", "-m", "eval results", env=env)
+    proc = _run_leg(runner, env)
+    assert proc.returncode == 0, (proc.returncode, proc.stdout, proc.stderr)
+    assert "fetch + rebase onto" in proc.stdout  # the #1880 branch engaged
+    assert "[push-verify] retry landed" in proc.stdout
+    count = _git(workload, "rev-list", "--count", "origin/main..HEAD", env=env).stdout.strip()
+    assert count == "0"
+    # BOTH commits are on origin: the orchestrator's and the rebased result.
+    files = _git(
+        tmp_path, "-C", str(origin), "ls-tree", "--name-only", "main", env=env
+    ).stdout.split()
+    assert "result.json" in files and "orchestrator.txt" in files
+
+
+def test_push_verify_leg_executes_in_tmp_repo_case_e_rebase_conflict_exit86_bundle(
+    tmp_path: Path,
+) -> None:
+    """Case E (#1880 fail-loud pin): behind-origin with a GENUINE content
+    conflict (both sides add ``result.json`` with different bytes) -- the
+    rebase conflicts, the abort fires, the retry push fails
+    non-fast-forward, and the leg keeps the EXISTING fail-loud path:
+    exit 86 + the data/issue_<N>/ bundle (no silent swallow)."""
+    origin, workload, env, runner = _push_leg_rig(tmp_path)
+    _advance_origin_main(tmp_path, origin, env, "result.json", '{"who": "orchestrator"}\n')
+    (workload / "result.json").write_text('{"who": "workload"}\n')
+    _git(workload, "add", "result.json", env=env)
+    _git(workload, "commit", "-m", "eval results", env=env)
+    proc = _run_leg(runner, env)
+    assert proc.returncode == 86, (proc.returncode, proc.stdout, proc.stderr)
+    assert "[push-verify] FAIL" in proc.stdout
+    bundles = sorted((workload / "data" / "issue_137").glob("unpushed-*.bundle"))
+    assert len(bundles) == 1, bundles
+    # The abort fired: no rebase left in progress in the workload clone.
+    assert not (workload / ".git" / "rebase-merge").exists()
+    assert not (workload / ".git" / "rebase-apply").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pod_side_reporting_push_contract.py
+++ b/tests/test_pod_side_reporting_push_contract.py
@@ -69,3 +69,17 @@ def test_rule_carries_artifact_presence_assert() -> None:
     assert "no-op, never a false-fail" in section  # empty-set arm
     assert "OUT OF SCOPE" in section  # HF-destined boundary (#1090)
     assert "epm:results" in section  # declared-paths source
+
+
+def test_rule_carries_fetch_rebase_before_push() -> None:
+    """The #1880 fetch+rebase-before-push clause lives inside the #1205
+    section with its load-bearing elements: the fetch+rebase recipe, the
+    conflict-abort disposition (fail-loud path preserved), the SHA-rewrite
+    disclosure, and the orchestrator-side mid-run-push warning bullet."""
+    text = _RULE_PATH.read_text(encoding="utf-8")
+    section = text.split("### Result-push verification contract (#1205)", 1)[1]
+    section = section.split("\n### ", 1)[0]
+    assert "git fetch origin <branch> && git rebase origin/<branch>" in section
+    assert "git rebase --abort" in section
+    assert "rewrites the LOCAL result" in section  # SHA-rewrite disclosure
+    assert "**Orchestrator side (#1880):**" in section


### PR DESCRIPTION
Closes task #1880. D1 rule bullets (pod-side-reporting § Result-push contract), D2 GCE push-verify backstop fetch+rebase, D3 crash-fix-rounds note, D4 executable fails-pre-fix + conflict-arm tests + pins.