### PR TITLE
issue-1892: gcp reconnect markers prefer live provisioning_model (#1892)

### DIFF
--- a/.claude/rules/compute-backend-failover.md
+++ b/.claude/rules/compute-backend-failover.md
@@ -187,9 +187,19 @@ HF data repo under `issue<N>_partial/<attempt_id>/`:
 **Sweep scope (explicit):** the partial sweep covers exactly the three
 named directories above (`eval_results/issue_<N>/`, `data/issue_<N>/`,
 `data/issue<N>/`) plus the `$WORKLOAD_ROOT/logs/` worker-log tree (#885)
-plus the `/workspace/logs` dispatcher convention dir (#1605) —
-still NOT universal artifact discovery (e.g. `figures/issue_*`,
-checkpoints, `ood_eval_results/` are not swept). Worker logs are swept
+plus the `/workspace/logs` dispatcher convention dir (#1605) plus — as of
+#1890 (incident #1739: a banked 412 MB MLP-map fit died with the
+auto-DELETEd boot disk) — the `analysis_tensors*` staging trees at BOTH
+live roots: `$WORKLOAD_ROOT/analysis_tensors*` (the issue-scoped relative
+convention) AND `/workspace/analysis_tensors*` (the GCE scratch-root flat
+convention; env-overridable `EPS_PERSIST_WS_TENSORS_ROOT`, the #1605
+isolation precedent), sibling dir names covered via the glob, swept LAST
+among the dirs (largest class; the traceback-first ordering is intact and
+a budget timeout mid-tensor-upload is BY DESIGN), with any nested
+`store/` pruned by the standing IGNORE excludes (mirrored-on-HF durable
+class — never re-uploaded) — still NOT universal artifact discovery
+(e.g. `figures/issue_*`, checkpoints, `ood_eval_results/` are not
+swept). Worker logs are swept
 when they land under `$WORKLOAD_ROOT/logs/` (relative `logs/…` or
 `$REPO_ROOT/logs/…` on the workload-cmd branch, where the startup script
 exports `REPO_ROOT="$WORKLOAD_ROOT"` — #641) AND, as of #1605, under

--- a/src/explore_persona_space/backends/router.py
+++ b/src/explore_persona_space/backends/router.py
@@ -3949,7 +3949,16 @@ def _override_free_or_gcp(
                 # Explicit-override reconnect — `kind` may be ANY backend
                 # here, so merge the gcp marker extras only when the
                 # reconnected lane is gcp (#631 round-3 marker-coverage fix).
-                extra=_gcp_marker_extras(spec) if kind == "gcp" else {},
+                # The handle's live-derived provisioning_model overrides the
+                # spec default (#1892; handle side #1815).
+                extra=(
+                    {
+                        **_gcp_marker_extras(spec),
+                        **_live_provisioning_extras_from_handle(handle),
+                    }
+                    if kind == "gcp"
+                    else {}
+                ),
             )
             _post_backend_selected(result, spec=spec, marker_poster=marker_poster)
             return result
@@ -4366,7 +4375,9 @@ def _override_gcp_with_ladder(
             cluster=None,
             attempts=attempts,
             elapsed_seconds=now_fn() - started_at,
-            extra=_gcp_marker_extras(spec),
+            # The handle's live-derived provisioning_model overrides the spec
+            # default — the #1776 incident seam (#1892; handle side #1815).
+            extra={**_gcp_marker_extras(spec), **_live_provisioning_extras_from_handle(handle)},
         )
         _post_backend_selected(result, spec=spec, marker_poster=marker_poster)
         return result
@@ -4728,8 +4739,14 @@ def _record_reconnect(
         elapsed_seconds=now_fn() - started_at,
         # Auto-chain reconnect scan — `kind` is the reconnected lane (gcp
         # OR a free SLURM lane), so merge the gcp marker extras only for a
-        # gcp reconnect (#631 round-3 marker-coverage fix).
-        extra=_gcp_marker_extras(spec) if kind == "gcp" else {},
+        # gcp reconnect (#631 round-3 marker-coverage fix). The handle's
+        # live-derived provisioning_model overrides the spec default (#1892;
+        # handle side #1815).
+        extra=(
+            {**_gcp_marker_extras(spec), **_live_provisioning_extras_from_handle(handle)}
+            if kind == "gcp"
+            else {}
+        ),
     )
     _post_backend_selected(result, spec=spec, marker_poster=marker_poster)
     return result
@@ -6118,6 +6135,20 @@ def _boot_disk_extras_from_handle(handle: RunHandle | None) -> dict[str, Any]:
     return {k: handle.extra[k] for k in BOOT_DISK_MARKER_EXTRA_KEYS if k in handle.extra}
 
 
+def _live_provisioning_extras_from_handle(handle: RunHandle | None) -> dict[str, Any]:
+    """Reconnect-marker override (#1892): prefer the HANDLE's live-derived
+    provisioning_model (gcp.reconnect_or_none reads scheduling.provisioningModel
+    off the live instance, #1815) over _gcp_marker_extras' spec default —
+    the #1776 reconnect marker said STANDARD while the instance was FLEX_START,
+    driving a wrong disarmed-gate diagnosis. Returns {} when the handle carries
+    no value (fail-open to the spec-derived fallback). Pure function, no IO.
+    """
+    v = (getattr(handle, "extra", None) or {}).get("provisioning_model")
+    if not v:
+        return {}
+    return {"provisioning_model": str(v), "provisioning_model_source": "live-instance"}
+
+
 def _gcp_marker_extras(spec: RunSpec) -> dict[str, Any]:
     """Build the GCP ``epm:backend-selected`` ``extra`` dict for ``spec``.
 
@@ -6131,7 +6162,17 @@ def _gcp_marker_extras(spec: RunSpec) -> dict[str, Any]:
 
     Safe to call unguarded on any gcp-chosen result. ``provisioning_model``
     reads only ``spec.extra`` (no intent lookup), so it is always
-    populated. ``quota_pool`` resolves the intent's machine: it is ``None``
+    populated — which means it is the SPEC-derived value (the fresh-launch
+    plan), correct on fresh launches but potentially stale on reconnects.
+    The THREE gcp reconnect seams — the explicit-override generic composer
+    (``_override_free_or_gcp``), the ``_override_gcp_with_ladder``
+    reconnect, and the auto-chain ``_record_reconnect`` composer — therefore
+    merge :func:`_live_provisioning_extras_from_handle` OVER this dict
+    (``{**_gcp_marker_extras(spec), **_live_provisioning_extras_from_handle(handle)}``)
+    so the marker reports the live instance's provisioning model when the
+    reconnect handle carries one (#1892; handle side #1815 — the #1776
+    reconnect marker said STANDARD while the instance was FLEX_START).
+    ``quota_pool`` resolves the intent's machine: it is ``None``
     when the (gpu_kind, pool) pair has no quota mapping AND — per the round-4
     fix below — when the intent itself is unmapped. The reconnect paths
     (``router.py`` explicit-override + auto-chain) call this AFTER an

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -5997,6 +5997,184 @@ def test_gcp_reconnect_marker_carries_provisioning_and_quota_pool(
     assert final["extra"]["quota_pool"] == "NVIDIA_A100_80GB_GPUS"
 
 
+def _flex_reconnect_handle(job_id: str = "instance-flex") -> RunHandle:
+    """Live-reconnect handle whose ``extra`` carries the #1815 live-derived
+    ``provisioning_model`` (FLEX_START). The spec under test carries NO
+    provisioning pin (spec-derived default: STANDARD), so a marker reading
+    FLEX_START proves the #1892 handle-override merge actually ran."""
+    return RunHandle(
+        backend="gcp",
+        cluster=None,
+        job_id=job_id,
+        pod_name="eps-issue-137",
+        scratch_dir="/workspace/eps-issue-137",
+        log_path="/workspace/logs/issue-137.log",
+        extra={"issue": 137, "zone": "us-central1-a", "provisioning_model": "FLEX_START"},
+    )
+
+
+def test_reconnect_marker_extra_prefers_live_provisioning_model_explicit_override(
+    lease_store, marker_poster, captured_markers
+):
+    """#1892 seam (i): the explicit-override GENERIC reconnect composer
+    (``_override_free_or_gcp``, detail ``found existing live job/instance``)
+    merges the handle's live-derived provisioning_model over the spec default.
+
+    ``route()`` dispatches ``backend: gcp`` to ``_override_gcp_with_ladder``
+    (seam ii) and sends only free-lane kinds here, so this test drives the
+    REAL composer function directly with ``kind="gcp"`` — the plan-sanctioned
+    fallback for a seam ``route()`` cannot reach with a fake reconnect_fn.
+    """
+    from explore_persona_space.backends.router import _override_free_or_gcp
+
+    result = _override_free_or_gcp(
+        spec=_spec(backend="gcp"),
+        backend=_GcpBackendDouble(),
+        kind="gcp",
+        store=lease_store,
+        attempts=[],
+        started_at=0.0,
+        cfg=RouterConfig(free_wait_seconds=1, poll_interval=0.0),
+        is_started=lambda _b, _h: True,
+        is_live_after_cancel=lambda _b, _h: False,
+        is_running_after_cancel=None,
+        reconnect_fn=lambda _b, k, _s: _flex_reconnect_handle() if k == "gcp" else None,
+        now_fn=_clock(),
+        sleep_fn=lambda _s: None,
+        marker_poster=marker_poster,
+    )
+    assert result.reason == ROUTE_REASON_RECONNECT
+    bodies = _by_reason(captured_markers, ROUTE_REASON_RECONNECT)
+    assert bodies, "no reconnect epm:backend-selected marker was posted"
+    final = bodies[-1]
+    # Seam discriminators: the GENERIC override composer posts requested_kind
+    # == kind ("gcp") AND the generic detail string (seam ii posts the
+    # gcp-specific detail; seam iii posts requested_kind=None).
+    assert final["requested_kind"] == "gcp"
+    assert final["attempts"][-1]["detail"] == "found existing live job/instance"
+    # The handle's live-derived value wins over the spec default (STANDARD).
+    assert final["extra"]["provisioning_model"] == "FLEX_START"
+    assert final["extra"]["provisioning_model_source"] == "live-instance"
+    # quota_pool stays spec-derived (known residual — plan #1892 §7).
+    assert final["extra"]["quota_pool"] == "NVIDIA_A100_80GB_GPUS"
+
+
+def test_reconnect_marker_extra_prefers_live_provisioning_model_gcp_ladder_override(
+    lease_store, marker_poster, captured_markers
+):
+    """#1892 seam (ii) — the #1776 incident seam: an explicit ``backend: gcp``
+    override reconnect (``_override_gcp_with_ladder``) posts the HANDLE's
+    live-derived provisioning_model, not the spec-derived STANDARD default
+    (the #1776 marker verbatim carried STANDARD while the live instance was
+    FLEX_START, driving a wrong disarmed-gate diagnosis)."""
+    from explore_persona_space.backends.router import _gcp_marker_extras
+
+    spec = _spec(backend="gcp")
+    # Contrast pin: with no provisioning pin on the spec, the spec-derived
+    # fallback alone would report STANDARD — exactly the #1776 defect.
+    assert _gcp_marker_extras(spec)["provisioning_model"] == "STANDARD"
+
+    gcp = _GcpBackendDouble()
+    result = route(
+        spec,
+        runpod_backend=_ExplodingRunpod(),
+        free_backends={"nibi": _FreeLaneBackend(kind="nibi")},
+        gcp_backend=gcp,
+        lease_store=lease_store,
+        reconnect_fn=lambda _b, k, _s: _flex_reconnect_handle() if k == "gcp" else None,
+        marker_poster=marker_poster,
+        config=RouterConfig(free_wait_seconds=1, poll_interval=0.0),
+        now_fn=_clock(),
+        sleep_fn=lambda _s: None,
+    )
+    assert result.reason == ROUTE_REASON_RECONNECT
+    assert len(gcp.launches) == 0  # reconnect, not a fresh provision
+    bodies = _by_reason(captured_markers, ROUTE_REASON_RECONNECT)
+    assert bodies, "no gcp-override reconnect epm:backend-selected marker was posted"
+    final = bodies[-1]
+    # Seam discriminators: explicit-gcp override posts requested_kind == "gcp"
+    # AND the gcp-specific detail (seam i posts the generic detail; seam iii
+    # posts requested_kind=None).
+    assert final["requested_kind"] == "gcp"
+    assert final["attempts"][-1]["detail"] == "found existing live gcp instance"
+    assert final["extra"]["provisioning_model"] == "FLEX_START"
+    assert final["extra"]["provisioning_model_source"] == "live-instance"
+    assert final["extra"]["quota_pool"] == "NVIDIA_A100_80GB_GPUS"
+
+
+def test_reconnect_marker_extra_prefers_live_provisioning_model_auto_chain(
+    lease_store, marker_poster, captured_markers
+):
+    """#1892 seam (iii): the auto-chain reconnect composer
+    (``_record_reconnect``) merges the handle's live-derived
+    provisioning_model over the spec default."""
+    gcp = _GcpBackendDouble()
+    result = route(
+        _spec(backend=None),
+        runpod_backend=_ExplodingRunpod(),
+        free_backends={"nibi": _FreeLaneBackend(kind="nibi")},
+        gcp_backend=gcp,
+        lease_store=lease_store,
+        reconnect_fn=lambda _b, k, _s: _flex_reconnect_handle() if k == "gcp" else None,
+        marker_poster=marker_poster,
+        config=RouterConfig(free_wait_seconds=1, poll_interval=0.0),
+        now_fn=_clock(),
+        sleep_fn=lambda _s: None,
+    )
+    assert result.chosen_kind == "gcp"
+    assert result.reason == ROUTE_REASON_RECONNECT
+    bodies = _by_reason(captured_markers, ROUTE_REASON_RECONNECT)
+    assert bodies, "no auto-chain reconnect epm:backend-selected marker was posted"
+    final = bodies[-1]
+    # Seam discriminator: requested_kind is None ONLY on the auto-chain
+    # composer (both override seams post requested_kind == "gcp").
+    assert final["requested_kind"] is None
+    assert final["attempts"][-1]["detail"] == "found existing live gcp instance"
+    assert final["extra"]["provisioning_model"] == "FLEX_START"
+    assert final["extra"]["provisioning_model_source"] == "live-instance"
+    assert final["extra"]["quota_pool"] == "NVIDIA_A100_80GB_GPUS"
+
+
+def test_reconnect_marker_extra_falls_back_to_spec_when_handle_lacks_key(
+    lease_store, marker_poster, captured_markers
+):
+    """#1892 criterion 2: a reconnect handle WITHOUT ``provisioning_model``
+    (degraded live read — the instance list lacked ``scheduling``) keeps the
+    marker extra byte-identical to the spec-derived dict; no
+    ``provisioning_model_source`` key rides along."""
+    from explore_persona_space.backends.router import _gcp_marker_extras
+
+    existing = RunHandle(
+        backend="gcp",
+        cluster=None,
+        job_id="instance-no-sched",
+        pod_name="eps-issue-137",
+        scratch_dir="/workspace/eps-issue-137",
+        log_path="/workspace/logs/issue-137.log",
+        extra={"issue": 137, "zone": "us-central1-a"},
+    )
+    spec = _spec(backend=None)
+    result = route(
+        spec,
+        runpod_backend=_ExplodingRunpod(),
+        free_backends={"nibi": _FreeLaneBackend(kind="nibi")},
+        gcp_backend=_GcpBackendDouble(),
+        lease_store=lease_store,
+        reconnect_fn=lambda _b, k, _s: existing if k == "gcp" else None,
+        marker_poster=marker_poster,
+        config=RouterConfig(free_wait_seconds=1, poll_interval=0.0),
+        now_fn=_clock(),
+        sleep_fn=lambda _s: None,
+    )
+    assert result.reason == ROUTE_REASON_RECONNECT
+    bodies = _by_reason(captured_markers, ROUTE_REASON_RECONNECT)
+    assert bodies, "no reconnect epm:backend-selected marker was posted"
+    final = bodies[-1]
+    assert final["extra"] == _gcp_marker_extras(spec)  # byte-identical fallback
+    assert "provisioning_model_source" not in final["extra"]
+    assert final["extra"]["provisioning_model"] == "STANDARD"
+
+
 def test_gcp_quota_headroom_insufficient_terminal_raises_no_compute(lease_store, monkeypatch):
     """GCP in TERMINAL position (free-first override) with insufficient
     headroom raises the typed NoCompute terminal WITHOUT burning an


### PR DESCRIPTION
Closes task #1892. Reconnect-path epm:backend-selected markers report the handle's live-derived provisioning_model (spec default only as fallback) at all three gcp reconnect seams; + 4 pin tests. Premise note: the filed handle-side fix already landed via #1815 — this fixes the marker-observability residual that caused the #1776 mis-diagnosis.