### PR TITLE
issue-1908: fix order-dependent test-state leak (ladder poisons 825 parity)

### DIFF
--- a/.claude/rules/critic-lens-reference.md
+++ b/.claude/rules/critic-lens-reference.md
@@ -719,6 +719,7 @@ composer copies the requested lens's items VERBATIM and IN FULL from this file.
    +0.28/+0.19/+0.00 vs base-rate↔delta ρ +0.09/−0.43/−0.54). Not a REVISE when the predictor and DV
    are not the level/change pair of the same quantity, or when the amendment already scores the
    level DV the parent's positive used.
+   Mechanical backstop: verify_plan.py c45 (WARN-only; the lens stays the FAIL authority).
 3. **Decision-gate coherence (only when the plan leans on pre-registered kill-gates).**
    Pre-registered kill-gates / thresholds are disfavored by The Bar (above): they crush joint power
    and the analyzer pipeline already assigns confidence from reported diagnostics. *First* ask

--- a/.claude/skills/adversarial-planner/SKILL.md
+++ b/.claude/skills/adversarial-planner/SKILL.md
@@ -376,7 +376,13 @@ Run the structural verifier against the plan version just persisted:
   committed outputs; a plan genuinely committing outputs under a
   gitignore-matched path instead notes the force-add + staged-index
   verification in the same section as the declaration, or relocates the
-  output out of the ignored root).
+  output out of the ignored root), and
+  `N/A — no base-side predictor vs change DV` (check 45 — the change-DV /
+  base-side-predictor vocabulary is incidental or quotes a sibling's
+  design, not this plan's own predictor race; a plan genuinely racing a
+  base-side predictor against a trained−base change DV instead registers a
+  level/change companion column AND states the winner sign convention —
+  signed Spearman ρ vs |ρ|).
 - **FAIL → bounce to the planner** with the failed-check details (a mechanical-fix
   revision: re-spawn the planner with the FAIL list + the plan path; it patches the
   missing block and the orchestrator persists v{K+1} via `task.py new-plan-version`).

--- a/scripts/issue825_fit_cells.py
+++ b/scripts/issue825_fit_cells.py
@@ -2375,40 +2375,45 @@ def assert_vectorized_equivalence(*, seed: int = 0, tol: float = 5e-6) -> dict:
     saved_frozen = FROZEN_LAYERS
     rng = np.random.default_rng(seed)
     n, dim, n_layers, n_groups = 72, 12, 5, 24
-    FROZEN_LAYERS = (1, 3)  # within the synthetic layer count so preds_frozen is populated
-    # grouped folds: 3 rows per group.
-    groups = np.repeat(np.arange(n_groups), n // n_groups)[:n].astype(str)
-    worst_null = 0.0
-    worst_obs = 0.0
-    worst_boot = 0.0
-    for _cell in range(2):
-        X = rng.standard_normal((n, n_layers, dim)).astype(np.float32)
-        W = (rng.standard_normal((n_layers, dim, dim)) * 0.4).astype(np.float32)
-        noise = (rng.standard_normal((n, n_layers, dim)) * 0.25).astype(np.float32)
-        Y = np.einsum("nld,lde->nle", X, W).astype(np.float32) + noise
-        sweep_b = heldout_r2_sweep(
-            X, Y, groups, n_folds=3, seed=seed, null_draws=8, _null_impl="batched"
-        )
-        sweep_s = heldout_r2_sweep(
-            X, Y, groups, n_folds=3, seed=seed, null_draws=8, _null_impl="serial"
-        )
-        d_null = float(np.nanmax(np.abs(sweep_b["r2_null"] - sweep_s["r2_null"])))
-        d_obs = float(np.nanmax(np.abs(sweep_b["r2_obs"] - sweep_s["r2_obs"])))
-        worst_null = max(worst_null, d_null)
-        worst_obs = max(worst_obs, d_obs)
-        li = next(iter(sweep_b["preds_frozen"]))
-        mask = sweep_b["fitted_mask"]
-        pred = sweep_b["preds_frozen"][li][mask]
-        true = Y[mask, li, :].astype(np.float64)
-        bb = bootstrap_r2_ci(pred, true, n_boot=200, seed=seed + 3)
-        bs = _bootstrap_r2_ci_serial_reference(pred, true, n_boot=200, seed=seed + 3)
-        d_boot = max(
-            abs(bb["r2"] - bs["r2"]),
-            abs(bb["ci_lo"] - bs["ci_lo"]),
-            abs(bb["ci_hi"] - bs["ci_hi"]),
-        )
-        worst_boot = max(worst_boot, d_boot)
-    FROZEN_LAYERS = saved_frozen
+    try:
+        FROZEN_LAYERS = (1, 3)  # within the synthetic layer count so preds_frozen is populated
+        # grouped folds: 3 rows per group.
+        groups = np.repeat(np.arange(n_groups), n // n_groups)[:n].astype(str)
+        worst_null = 0.0
+        worst_obs = 0.0
+        worst_boot = 0.0
+        for _cell in range(2):
+            X = rng.standard_normal((n, n_layers, dim)).astype(np.float32)
+            W = (rng.standard_normal((n_layers, dim, dim)) * 0.4).astype(np.float32)
+            noise = (rng.standard_normal((n, n_layers, dim)) * 0.25).astype(np.float32)
+            Y = np.einsum("nld,lde->nle", X, W).astype(np.float32) + noise
+            sweep_b = heldout_r2_sweep(
+                X, Y, groups, n_folds=3, seed=seed, null_draws=8, _null_impl="batched"
+            )
+            sweep_s = heldout_r2_sweep(
+                X, Y, groups, n_folds=3, seed=seed, null_draws=8, _null_impl="serial"
+            )
+            d_null = float(np.nanmax(np.abs(sweep_b["r2_null"] - sweep_s["r2_null"])))
+            d_obs = float(np.nanmax(np.abs(sweep_b["r2_obs"] - sweep_s["r2_obs"])))
+            worst_null = max(worst_null, d_null)
+            worst_obs = max(worst_obs, d_obs)
+            li = next(iter(sweep_b["preds_frozen"]))
+            mask = sweep_b["fitted_mask"]
+            pred = sweep_b["preds_frozen"][li][mask]
+            true = Y[mask, li, :].astype(np.float64)
+            bb = bootstrap_r2_ci(pred, true, n_boot=200, seed=seed + 3)
+            bs = _bootstrap_r2_ci_serial_reference(pred, true, n_boot=200, seed=seed + 3)
+            d_boot = max(
+                abs(bb["r2"] - bs["r2"]),
+                abs(bb["ci_lo"] - bs["ci_lo"]),
+                abs(bb["ci_hi"] - bs["ci_hi"]),
+            )
+            worst_boot = max(worst_boot, d_boot)
+    finally:
+        # Exception-path hardening (task #1908): a mid-gate raise must not leak
+        # FROZEN_LAYERS=(1, 3) into the process (same bug class as the
+        # issue1335_fit patch-style leak). Happy path unchanged.
+        FROZEN_LAYERS = saved_frozen
     result = {
         "max_abs_null_delta": worst_null,
         "max_abs_obs_delta": worst_obs,

--- a/tests/test_issue1335_ladder.py
+++ b/tests/test_issue1335_ladder.py
@@ -42,6 +42,35 @@ r1335 = pytest.importorskip("issue1335_render_rungs")
 c1310 = pytest.importorskip("issue1310_common")
 i1310_prefill = pytest.importorskip("issue1310_prefill")
 common931 = pytest.importorskip("issue931_common")
+fit825 = pytest.importorskip("issue825_fit_cells")
+
+# The patch-style module globals of issue825_fit_cells (fit825 lines 56/61/93/
+# 101/107) that issue1335_fit patches script-lifetime-style with no restore.
+_FIT825_PATCH_STYLE_GLOBALS = (
+    "FROZEN_LAYERS",
+    "EXPECTED_LAYERS",
+    "GCV_DOF_CAP",
+    "LAMBDA_SELECTION",
+    "LEGACY_UNGUARDED_GCV",
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_fit825_module_globals():
+    """Snapshot/restore the fit825 patch-style module globals around every test.
+
+    scripts/issue1335_fit.py patches issue825_fit_cells module globals with
+    script-lifetime semantics and no restore (FROZEN_LAYERS at fit_cell/:316,
+    fit_cell_matched/:400, run_loso/:596; EXPECTED_LAYERS at :633/:1563), so a
+    ladder test exercising the real fit_cell body on a tiny fixture leaves e.g.
+    fit825.FROZEN_LAYERS = (1,) behind. Restore pristine values on teardown so
+    same-session sibling test files (test_issue825_mlp_batched_parity) read
+    them unpoisoned (task #1908).
+    """
+    saved = {k: getattr(fit825, k) for k in _FIT825_PATCH_STYLE_GLOBALS}
+    yield
+    for k, v in saved.items():
+        setattr(fit825, k, v)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Closes task #1908. Autouse fixture in tests/test_issue1335_ladder.py restores the five fit825 patch-style module globals; try/finally hardening of assert_vectorized_equivalence.