### PR TITLE
issue-1984: workflow-fix: widen leading version-stamp stripper (dash-led form)

### DIFF
--- a/scripts/task.py
+++ b/scripts/task.py
@@ -132,14 +132,17 @@ def _safe_echo(text: str, *, context: str) -> None:
 
 
 _FIELD_LED_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*[:=]")
-_VERSION_STAMP_RE = re.compile(r"^v\d+\.\s+")
+_VERSION_STAMP_RE = re.compile(r"^v\d+(?:\.\s+|\s*[—\u2013-]\s+)")
 
 
 def _stripped_note_core(note: str) -> tuple[str, bool]:
     """Note HEAD after the same per-segment decoration strip
     task_workflow.parse_followup_note_field applies: the leading
     whitespace/bullet/bold mix, then a lowercase `v<k>. ` version stamp
-    (#1382). Returns (core, stamped); `stamped` records whether a stamp
+    (#1382) or its dash-led form `v<k> — ` / `v<k> - ` (em dash, en dash
+    U+2013, or ASCII hyphen; whitespace REQUIRED after the dash so `v2-alpha`
+    never strips — #1900/#1984; byte-parity with the parse-side strip).
+    Returns (core, stamped); `stamped` records whether a stamp
     was stripped so the poster-side stamp advisory can key on it."""
     core = re.sub(r"^[\s\-*]+", "", note)
     stamp = _VERSION_STAMP_RE.match(core)
@@ -151,7 +154,8 @@ def _stripped_note_core(note: str) -> tuple[str, bool]:
 def _looks_field_led(note: str) -> bool:
     """True when the note HEAD is a `field:` / `field=` line-core after the
     parse-side decoration strip — whitespace/bullet/bold, then the #1382
-    `v<k>. ` version stamp (stamp tolerance added with #1440, restoring the
+    `v<k>. ` version stamp or its #1900/#1984 dash-led form `v<k> — `
+    (stamp tolerance added with #1440, restoring the
     documented parity with parse_followup_note_field). Head-only by design
     (false-positive-averse; see #1178 plan §4 D2)."""
     core, _ = _stripped_note_core(note)
@@ -159,9 +163,11 @@ def _looks_field_led(note: str) -> bool:
 
 
 def _looks_stamped_field_led(note: str) -> bool:
-    """True when the note HEAD carries a `v<k>. ` version stamp followed by
-    field-led content — the #1092 run-note shape whose read-side absorption
-    is the #1382 parser tolerance. BOTH conditions required
+    """True when the note HEAD carries a `v<k>. ` version stamp (or its
+    #1900/#1984 dash-led form `v<k> — ` / `v<k> - `, en dash included)
+    followed by
+    field-led content — the #1092/#1900 run-note shapes whose read-side
+    absorption is the #1382/#1984 parser tolerance. BOTH conditions required
     (false-positive-averse: a prose note that happens to start "v2. " never
     warns — the parser tolerance likewise only acts when a field anchor
     binds after the strip)."""
@@ -659,10 +665,11 @@ def cmd_post_event(args: argparse.Namespace) -> None:
         with contextlib.suppress(OSError, ValueError):
             print(
                 f"WARNING: task.py post-marker {args.marker}: --note head "
-                "starts with a 'v<k>. ' version stamp before field-led "
+                "starts with a 'v<k>. ' (or dash-led 'v<k> — ') version "
+                "stamp before field-led "
                 "content. The marker version is recorded from --version on "
                 "the event row — do not echo it into the note head (field "
-                "parsers strip the stamp, #1382, so THIS note still "
+                "parsers strip the stamp, #1382/#1984, so THIS note still "
                 "parses). Do NOT re-post this marker — it was posted "
                 "successfully; drop the stamp from your NEXT marker's note "
                 "instead.",

--- a/src/explore_persona_space/task_workflow.py
+++ b/src/explore_persona_space/task_workflow.py
@@ -3214,8 +3214,11 @@ def parse_followup_note_field(note: str, field: str) -> str | None:
     like a line-core: a mid-segment mention (``(source: user-chat)``, the
     #685 prose shape) still parses ``None``, and ``word;field: x`` (no
     whitespace after the ``;``) never splits. A leading lowercase version
-    stamp (``v<k>.`` + REQUIRED whitespace, e.g. ``v1. followup_label: x``
-    — the #1092 run-note shape) is stripped as decoration, same class as
+    stamp — ``v<k>.`` + REQUIRED whitespace, e.g. ``v1. followup_label: x``
+    (the #1092 run-note shape), OR the dash-led form ``v<k> — `` /
+    ``v<k> - `` (em dash, en dash U+2013, or ASCII hyphen; whitespace
+    REQUIRED after the dash so ``v2-alpha`` never strips — the #1900 run-note
+    shape, #1984) — is stripped as decoration, same class as
     bullets/bold; parsing stays field-only (#1111 — no label inference).
     The value is the first
     whitespace token of the remainder, stripped of backticks / quotes /
@@ -3267,13 +3270,17 @@ def parse_followup_note_field(note: str, field: str) -> str | None:
             # One regex pass strips any interleaved mix of whitespace, bullet
             # dashes/stars, and bold markers (unchanged from the line-core rule).
             core = re.sub(r"^[\s\-*]+", "", seg)
-            # Leading version stamp (`v1. ` — the #1092 run-note shape, an
-            # emitter echoing the marker's `v<k>` grammar into the note head):
-            # decorative prefix, same class as bullets/bold — strip it so the
-            # field anchor still binds. Lowercase `v` + digits + `.` +
-            # REQUIRED whitespace only; anything else is prose and stays
-            # unparseable (field-only parsing per #1111 — no label inference).
-            core = re.sub(r"^v\d+\.\s+", "", core)
+            # Leading version stamp (`v1. ` — the #1092 run-note shape — or
+            # the dash-led `v1 — ` / `v1 - ` — the #1900 run-note shape,
+            # #1984 — an emitter echoing the marker's `v<k>` grammar
+            # into the note head): decorative prefix, same class as
+            # bullets/bold — strip it so the field anchor still binds.
+            # Lowercase `v` + digits, then either `.` + REQUIRED whitespace
+            # or a dash (em dash, en dash U+2013, or ASCII hyphen) with
+            # REQUIRED whitespace after it (so `v2-alpha` never strips);
+            # anything else is prose and stays unparseable (field-only
+            # parsing per #1111 — no label inference).
+            core = re.sub(r"^v\d+(?:\.\s+|\s*[—\u2013-]\s+)", "", core)
             if core.startswith(f"{field}:") or core.startswith(f"{field}="):
                 rest = core[len(field) + 1 :].lstrip("*").strip()
                 tokens = rest.split()

--- a/tests/test_task_workflow_post_marker_echo.py
+++ b/tests/test_task_workflow_post_marker_echo.py
@@ -525,6 +525,11 @@ def test_version_stamp_warn_stderr_failure_is_nonfatal(monkeypatch, capsys, brok
         ("v1. ", False),  # stamp-only — empty core is not field-led
         ("v10. followup_label: x", True),  # multi-digit stamp
         ("v1.\tfield: x", True),  # tab after the dot — `\s+` covers it
+        ("v1 — followup_label: x", True),  # dash-led (em-dash) stamp — the #1900 shape (#1984)
+        ("v1 - followup_label: x", True),  # ASCII-hyphen variant
+        # No whitespace after the dash → not a stamp; nothing strips, so the
+        # head "v2-alpha ..." is not field-led either → stamped=False → False.
+        ("v2-alpha followup_label: x", False),
     ],
 )
 def test_looks_stamped_field_led_shapes(note, expected):

--- a/tests/test_task_workflow_post_marker_echo.py
+++ b/tests/test_task_workflow_post_marker_echo.py
@@ -527,6 +527,7 @@ def test_version_stamp_warn_stderr_failure_is_nonfatal(monkeypatch, capsys, brok
         ("v1.\tfield: x", True),  # tab after the dot — `\s+` covers it
         ("v1 — followup_label: x", True),  # dash-led (em-dash) stamp — the #1900 shape (#1984)
         ("v1 - followup_label: x", True),  # ASCII-hyphen variant
+        ("v1 \u2013 followup_label: x", True),  # en-dash variant (escape per RUF001)
         # No whitespace after the dash → not a stamp; nothing strips, so the
         # head "v2-alpha ..." is not field-led either → stamped=False → False.
         ("v2-alpha followup_label: x", False),

--- a/tests/test_workflow_followup_labels.py
+++ b/tests/test_workflow_followup_labels.py
@@ -472,6 +472,43 @@ def test_version_stamp_anchoring_negatives():
     assert parse_followup_note_field("- v2. followup_label: y; source: z", "source") == "z"
 
 
+def test_label_parse_dash_led_version_stamp_1900():
+    # VERBATIM #1900 v2 run-marker head shape (2026-08-01T03:30:56Z): the
+    # dash-led stamp form `v1 — ` (em-dash) live sessions actually emit —
+    # pre-#1984 the `v<k>. `-only stamp regex left the head unstripped, the
+    # explicit followup_label parsed None, and the corpus-replay invariant
+    # went red fleet-wide.
+    assert (
+        parse_followup_note_field(
+            "v1 — followup_label: tfmargin-validation-expand; source: proposer-9b-cheap; "
+            "round: 2; outcome: complete",
+            "followup_label",
+        )
+        == "tfmargin-validation-expand"
+    )
+    # ASCII-hyphen and en-dash variants parse identically (same char class).
+    assert parse_followup_note_field("v1 - followup_label: x; source: y", "followup_label") == "x"
+    assert parse_followup_note_field("v1 \u2013 followup_label: x", "followup_label") == "x"
+    # The #1900 v1 head shape (stamp before a `source:` first segment): the
+    # stamp strips and the first-segment field parses too.
+    assert (
+        parse_followup_note_field(
+            "v1 — source: proposer-9b-cheap; followup_label: offfloor-surface-race", "source"
+        )
+        == "proposer-9b-cheap"
+    )
+
+
+def test_dash_led_version_stamp_anchoring_negatives():
+    # No whitespace AFTER the dash → not a stamp (`v2-alpha` is a token, not
+    # decoration): nothing strips, the field sits mid-segment, parses None.
+    assert parse_followup_note_field("v2-alpha followup_label: x", "followup_label") is None
+    # Whitespace optional BEFORE the dash: `v1— field` still strips.
+    assert parse_followup_note_field("v1— followup_label: x", "followup_label") == "x"
+    # Composes with the bullet strip + `; `-split, like the dot form.
+    assert parse_followup_note_field("- v2 — followup_label: y; source: z", "source") == "z"
+
+
 def test_semicolon_split_anchoring_negatives():
     # (i) paren-wrapped mid-line mention (the #685 shape): the segment starts
     # with "(", not the field core → None (segments are anchored exactly like
@@ -1159,6 +1196,10 @@ def _run_labels(events: list[dict]) -> set[str]:
 # (#1092's `v1. `-stamp-led run note is deliberately NOT allowlisted — its
 # fields are explicit, and the parser strips the leading version stamp as
 # decoration; see `parse_followup_note_field`.)
+# (#1900's `v1 — `-dash-stamp-led run markers — incl. (1900,
+# "2026-08-01T03:30:56Z") — are likewise deliberately NOT allowlisted: their
+# fields are explicit, and the #1984-widened parser strips the dash-led
+# version stamp as decoration too.)
 KNOWN_MALFORMED_RUN_MARKERS = {(1090, "2026-07-07T09:54:27Z")}
 
 


### PR DESCRIPTION
Closes task #1984. Fixes the main-red corpus-replay test by widening the v<k> stamp stripper to the dash-led form (#1900 markers).