### PR TITLE
issue-1951: load_dotenv before heavy imports in issue1947_analyzer_figures_v2

### DIFF
--- a/scripts/issue1947_analyzer_figures_v2.py
+++ b/scripts/issue1947_analyzer_figures_v2.py
@@ -15,10 +15,19 @@ import json
 import sys
 from pathlib import Path
 
-import matplotlib.pyplot as plt
-import numpy as np
+from explore_persona_space.orchestrate.env import load_dotenv
 
-from explore_persona_space.analysis.paper_plots import savefig_paper, set_paper_style
+# Shared-VM thread caps (#847): load_dotenv() setdefaults OMP/MKL/OPENBLAS/
+# NUMEXPR_NUM_THREADS before matplotlib/numpy freeze their pools.
+load_dotenv()
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+
+from explore_persona_space.analysis.paper_plots import (  # noqa: E402
+    savefig_paper,
+    set_paper_style,
+)
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from issue1947_analyzer_figures import add_slug_key  # noqa: E402


### PR DESCRIPTION
Closes task #1951. Fixes main-red tests/test_shared_vm_thread_caps.py::test_no_new_torch_before_dotenv_vm_entrypoints (new offender scripts/issue1947_analyzer_figures_v2.py; the originally-filed offender was already fixed by #1956).