### PR TITLE
issue-2021: Persist stop_reason per judge draw + truncation-vs-content drop split + rule-26 pilot gate

### DIFF
--- a/.claude/rules/llm-judging.md
+++ b/.claude/rules/llm-judging.md
@@ -151,7 +151,8 @@ and diverges from the field standard (Persona Vectors uses graded 0–100).
     merge, a fresh `cache_dir`, or draw-indexed keying — because (a) the
     cache-update loop persists content-class `error: True` entries (rule
     23's cache caveat; as of #1313 TRANSPORT-class dicts are put-skipped and
-    a stored one reads as a cache MISS — but the legacy reason-string
+    a stored one reads as a cache MISS, and as of #2021 TRUNCATION-class
+    dicts get the same put-skip/get-miss treatment — but the legacy reason-string
     fallback covers only known pre-#1313 strings, so do not assume every old
     poisoned entry self-heals) and
     (b) the rubric-keyed cache shares ONE key across an item's identical
@@ -274,12 +275,20 @@ and diverges from the field standard (Persona Vectors uses graded 0–100).
     `max_new_tokens ≥ 2×` rule for the EVALUATED model's generations —
     truncation creates silent zeros on both sides of a judged eval. Cache
     caveat (rule 22): the rubric-level `JudgeCache` key
-    (`rubric_fingerprint`) deliberately EXCLUDES max_tokens, and the
-    cache-update loop in `judge_completions_batch` writes returned result
-    dicts without filtering `error: True` entries — so raising the budget
-    does NOT bust that cache and truncation-era parse-error entries can be
-    re-served; run a truncation-recovery re-judge against a fresh
-    `cache_dir` (or clear the stale entries). The generic `api_dispatch`
+    (`rubric_fingerprint`) deliberately EXCLUDES max_tokens, so raising
+    the budget does NOT bust that cache. As of #2021 truncation-class
+    error dicts (`error: True` + a truncation-class persisted
+    `stop_reason` — `batch_judge.is_truncation_error_dict`) are
+    put-skipped by the cache-update loop AND read back as cache MISSES
+    (mirroring the #1313 transport handling), so a budget raise
+    self-heals those entries with no fresh `cache_dir`. PRE-#2021
+    truncation-era entries lack `stop_reason` and remain served — they
+    still need a fresh `cache_dir` (or clearing); the get-miss covers
+    dicts written by MIXED-VERSION writers (post-threading,
+    pre-cache-hygiene code), NOT pre-#2021 dicts. And a cache-served
+    legacy SUCCESS entry (a kept score written pre-#2021) tallies
+    `"unknown"` in `stop_reason_tally` — a legacy-cache signature, not a
+    threading failure. The generic `api_dispatch`
     adapter cache, by contrast, deliberately OVER-keys on the full built
     request incl. max_tokens — at that layer a budget change is a cold
     re-judge (a miss, never a wrong read). Report the per-arm dropped-draw
@@ -321,11 +330,15 @@ and diverges from the field standard (Persona Vectors uses graded 0–100).
     (`.claude/rules/plan-compute-sizing.md` § Per-cell fit phases). Run
     the pilot against a fresh/pilot `cache_dir` (rule 24(ii)'s cache
     discipline) so production reuse is a deliberate decision, never a
-    silent replay. Until `stop_reason` is threaded into persisted judge
-    results (#2021: per-draw stop_reason + a truncation-vs-content drop
-    split + a `judge_pilot_gate` helper), read the pilot's stop_reasons
-    from the raw responses / a direct Messages-API re-issue — never from
-    truncated failure-log text (rule 23, #1773). Exempt: score-only
+    silent replay. As of #2021 the per-draw `stop_reason` is PERSISTED in
+    every judge result and `eval/judge_pilot.judge_pilot_gate` implements
+    this gate mechanically — per-arm parse-fail rates + `stop_reason`
+    tallies read off the persisted fields (`JudgeResult.stop_reason_tally`
+    / `n_truncation_dropped_draws`; a KEPT-but-truncated verdict is caught
+    by the tally clause), truncation FAIL never waivable, report JSON for
+    the run digest — so read the pilot's stop_reasons from the persisted
+    results / the gate report, never from truncated failure-log text
+    (rule 23, #1773). Exempt: score-only
     rubrics and waves < ~5,000 calls (the post-hoc per-arm drop report,
     rules 9/18/23, still binds there).
 
@@ -448,7 +461,9 @@ narrate it as the construct. (Source: #722 — `eval_results/issue_722/tf_margin
 18. **Pin & report, per DV:** scoring mode, scale, N samples + temperature,
     judge model + date, prompt hash, the response `max_tokens` budget + the
     per-arm dropped-draw rate SPLIT content-drops vs transport-losses
-    (rules 23/24), the rule-26 pilot-gate verdict for any ≥5k-call wave,
+    (rules 23/24), the per-draw `stop_reason` tally + its truncation-drop
+    subset (`JudgeResult.stop_reason_tally` / `n_truncation_dropped_draws`,
+    rules 23/26; #2021), the rule-26 pilot-gate verdict for any ≥5k-call wave,
     per-behavior reliability
     (test-retest + judge–human agreement), and the reliability ceiling
     √(r_yy). A judged DV is a measurement instrument; report it like one.

--- a/src/explore_persona_space/eval/alignment.py
+++ b/src/explore_persona_space/eval/alignment.py
@@ -214,6 +214,13 @@ async def judge_responses(
     system_text = judge_system_prompt if judge_system_prompt is not None else JUDGE_SYSTEM_PROMPT
 
     async def _judge_one(response: str) -> dict:
+        # FUNCTION-level import per the documented eval module cycle
+        # (batch_judge -> alignment -> judge_dispatch): a module-level import
+        # of a judge_dispatch symbol keeps that edge, but the #2021 attach
+        # helper follows the same function-level precedent as batch_judge's
+        # judge_dispatch imports to keep the cycle surface unambiguous.
+        from explore_persona_space.eval.judge_dispatch import _with_stop_reason
+
         async with semaphore:
             try:
                 if format_user_msg is not None:
@@ -225,16 +232,22 @@ async def judge_responses(
                 # else about this function's contract changes (#626).
                 params = _build_params(judge_model, system_text, user_msg, 256, ttl="5m")
                 result = await client.messages.create(**params)
+                stop_reason = getattr(result, "stop_reason", None)
                 text = result.content[0].text
                 parsed = parse_judge_json(text)
                 if parsed is None:
-                    return {
+                    score: dict = {
                         "aligned": None,
                         "coherent": None,
                         "reasoning": "parse_error",
                         "error": True,
                     }
-                return parsed
+                else:
+                    score = parsed
+                # #2021 (rule 26): parsed AND parse-failure dicts carry the
+                # response's stop_reason; the exception branch below (no
+                # response) stays untouched.
+                return _with_stop_reason(score, stop_reason)
             except Exception as e:
                 return {
                     "aligned": None,

--- a/src/explore_persona_space/eval/batch_judge.py
+++ b/src/explore_persona_space/eval/batch_judge.py
@@ -319,6 +319,39 @@ def is_transport_error_dict(parsed: object) -> bool:
     return "overloaded" in low or "rate_limited_exhausted" in low
 
 
+# Raw SDK stop_reason values marking a budget-truncated response. "max_tokens"
+# is the raw Anthropic value (the judge mint sites persist the SDK string
+# verbatim); "length" is the OpenAI finish_reason vocabulary, accepted so any
+# future path routing through llm.models.LLMResponse normalization classifies
+# identically (models.py maps "length" -> "max_tokens" anyway).
+TRUNCATION_STOP_REASONS = ("max_tokens", "length")
+
+
+def is_truncation_stop_reason(stop_reason: object) -> bool:
+    """True iff a persisted ``stop_reason`` marks a budget-truncated response
+    (llm-judging.md rule 23 budget class, #2021). ``None`` / missing / non-str
+    -> False (unknown, never KeyError) — legacy dicts classify as content."""
+    return isinstance(stop_reason, str) and stop_reason in TRUNCATION_STOP_REASONS
+
+
+def is_truncation_error_dict(parsed: object) -> bool:
+    """Rule-23 truncation-vs-content split for judge error dicts (#2021).
+
+    True iff the row is an error dict (``error: True``) whose persisted
+    ``stop_reason`` is truncation-class — a BUDGET defect (the response was
+    cut at ``max_tokens`` before the score token), not a content verdict. A
+    dict lacking ``stop_reason`` (pre-#2021 legacy) is NOT truncation-class
+    (classifies unknown -> content, preserving today's behavior). Transport
+    dicts are minted with NO API response, hence no ``stop_reason``, so the
+    two classes are disjoint by construction; consumers that must resolve a
+    pathological both-flagged dict check transport FIRST
+    (``graded_judge.judge_result_from_save_raw`` precedence).
+    """
+    if not isinstance(parsed, dict) or not parsed.get("error"):
+        return False
+    return is_truncation_stop_reason(parsed.get("stop_reason"))
+
+
 def _collect_legacy_results(
     client: "anthropic.Anthropic",
     batch_id: str,
@@ -332,17 +365,31 @@ def _collect_legacy_results(
     ``(quarantined)`` reason; other terminal states surface as error dicts too.
     The legacy callers consume the full ``{custom_id: score}`` dict (error dicts
     included), so quarantine here is informational — never retried.
+
+    Succeeded rows (parsed verdicts AND parse-failure error dicts) carry the
+    API response's ``stop_reason`` (#2021, rule 26) via
+    ``judge_dispatch._with_stop_reason``; rows with no API response
+    (errored/expired/canceled) carry no ``stop_reason`` key.
     """
+    # FUNCTION-level import: a module-level batch_judge -> judge_dispatch
+    # import risks the documented api_dispatch -> batch_judge -> alignment ->
+    # judge_dispatch cycle (judge_dispatch L222-224); precedent for this
+    # direction: judge_completions_batch's dispatch_judge_items import.
+    from explore_persona_space.eval.judge_dispatch import _with_stop_reason
+
     for result in client.messages.batches.results(batch_id):
         custom_id = result.custom_id
         rtype = result.result.type
         if rtype == "succeeded":
+            msg = result.result.message
+            stop_reason = getattr(msg, "stop_reason", None)
             text = next(
-                (b.text for b in result.result.message.content if b.type == "text"),
+                (b.text for b in msg.content if b.type == "text"),
                 "",
             )
             parsed = parse_judge_json(text)
-            results[custom_id] = parsed if parsed is not None else _legacy_error_dict("parse_error")
+            score = parsed if parsed is not None else _legacy_error_dict("parse_error")
+            results[custom_id] = _with_stop_reason(score, stop_reason)
         elif rtype == "errored":
             # SDK nesting is result.result.error.error.type (double .error);
             # getattr-guarded so a missing-error shape fails open (server label).
@@ -579,11 +626,19 @@ def _enumerate_and_check_cache(
 
                 if cache:
                     cached = cache.get(question, comp, rubric_key=rubric_key)
-                    if cached is not None and not is_transport_error_dict(cached):
+                    if (
+                        cached is not None
+                        and not is_transport_error_dict(cached)
+                        and not is_truncation_error_dict(cached)
+                    ):
                         # A stored transport-class error dict is a MISS (#1313,
                         # rule 24(ii)): fall through to re-dispatch so a re-run
                         # self-heals a legacy-poisoned cache (e.g. #1090's
                         # stored 529 rows) instead of re-serving the outage.
+                        # A stored TRUNCATION-class error dict is a MISS too
+                        # (#2021, rule 23): the rubric key deliberately excludes
+                        # max_tokens, so a budget raise would otherwise re-serve
+                        # the truncated parse_error forever.
                         cached_scores[custom_id] = cached
                         continue
 
@@ -795,9 +850,12 @@ def judge_completions_batch(
             for custom_id, question, comp, _user_msg in uncached_items:
                 if custom_id in batch_scores:
                     result = batch_scores[custom_id]
-                    if is_transport_error_dict(result):
+                    if is_transport_error_dict(result) or is_truncation_error_dict(result):
                         # rule 24(ii)/23 (#1313): never cache a transport error —
                         # a cached one re-serves the outage on every resume.
+                        # #2021: never cache a truncation-class error either —
+                        # the rubric key excludes max_tokens, so a budget raise
+                        # must re-dispatch these rows (self-heal, rule 23).
                         continue
                     cache.put(question, comp, result, rubric_key=rubric_key)
 

--- a/src/explore_persona_space/eval/graded_judge.py
+++ b/src/explore_persona_space/eval/graded_judge.py
@@ -161,6 +161,25 @@ class JudgeResult:
     return), so a high refusal share is not by itself instrument failure —
     unlike malformed/out-of-range residue, which is the rule-23 truncation
     signature.
+
+    ``n_truncation_dropped_draws`` (#2021) is the budget-truncation SUBSET of
+    ``n_dropped_draws`` (rule 23: the response stopped at ``max_tokens``
+    before the score token, so the parse dropped) — subset semantics again,
+    the total is unchanged. Classification precedence per draw: transport ->
+    refusal -> truncation (an instructed REFUSAL is a produced verdict even
+    when the response then truncated; a transport row has no response at
+    all). ``per_item_truncation_drops`` is the per-item breakdown.
+
+    ``stop_reason_tally`` (#2021, rule 26) counts the persisted per-draw
+    ``stop_reason`` over every draw the judge actually ANSWERED — kept draws
+    AND content-dropped draws alike (``"unknown"`` for a draw without the
+    field: legacy save_raw rows, bare-scalar parses). TRANSPORT-lost draws
+    are EXCLUDED from the tally: they carry no API response, hence no
+    ``stop_reason``, and tallying them as ``"unknown"`` would blend outage
+    blips into the legacy/SDK-absent unknown count the rule-26 pilot gate's
+    unknown advisory reads. A kept-but-truncated verdict (parsed in-range
+    score with ``stop_reason == "max_tokens"``) is visible ONLY here — it
+    increments no drop counter.
     """
 
     scores: dict[str, float | None]
@@ -171,6 +190,13 @@ class JudgeResult:
     n_transport_lost_draws: int = 0  # rule 24(ii)
     per_item_transport_losses: dict[str, int] = field(default_factory=dict)
     n_refusal_draws: int = 0  # instructed-REFUSAL subset of n_dropped_draws (#1801)
+    # budget-truncation subset of n_dropped_draws (#2021, rule 23 — the total
+    # is unchanged; precedence: transport -> refusal -> truncation)
+    n_truncation_dropped_draws: int = 0
+    per_item_truncation_drops: dict[str, int] = field(default_factory=dict)
+    # raw stop_reason -> count over ANSWERED draws (kept + content-dropped);
+    # "unknown" for absent; transport-lost draws EXCLUDED (#2021, rule 26)
+    stop_reason_tally: dict[str, int] = field(default_factory=dict)
 
 
 def judge_graded(
@@ -292,10 +318,13 @@ def judge_result_from_save_raw(save_raw: Path, items: list[tuple[str, str, str]]
     #   (item_id must not contain the "__" delimiter — guarded in judge_graded).
     per_item_draws: dict[str, list[float]] = {item_id: [] for item_id, _, _ in items}
     per_item_transport: dict[str, int] = {}
+    per_item_trunc: dict[str, int] = {}
+    stop_tally: dict[str, int] = {}
     n_total = 0
     n_dropped = 0
     n_transport = 0
     n_refusal = 0
+    n_trunc = 0
     for cid, parsed in all_scores.items():
         # item_id is everything before the FIRST "__idx__comp" tail. Since each
         # item has exactly one question and idx increments per (persona,question),
@@ -306,17 +335,34 @@ def judge_result_from_save_raw(save_raw: Path, items: list[tuple[str, str, str]]
             continue
         n_total += 1
         s = _score_from_parsed(parsed)
-        if s is None:
+        if s is None and _batch_judge.is_transport_error_dict(parsed):
             # Transport-vs-content split (rule 24(ii), #1313): a transport-class
             # error dict is a re-judgeable LOSS, never a content drop.
             # _score_from_parsed itself is unchanged — classification lives here.
-            if _batch_judge.is_transport_error_dict(parsed):
-                n_transport += 1
-                per_item_transport[item_id] = per_item_transport.get(item_id, 0) + 1
-            else:
-                n_dropped += 1
-                if _is_refusal_parsed(parsed):
-                    n_refusal += 1  # instructed-REFUSAL SUBSET of n_dropped (#1801)
+            # Precedence (#2021): transport is checked FIRST, so a pathological
+            # both-flagged dict never counts truncation, and transport rows are
+            # EXCLUDED from stop_reason_tally (no response -> no stop_reason;
+            # an "unknown" tally row would blend outages into the legacy
+            # unknowns the rule-26 pilot advisory reads).
+            n_transport += 1
+            per_item_transport[item_id] = per_item_transport.get(item_id, 0) + 1
+            continue
+        # #2021 (rule 26): tally the persisted stop_reason over every ANSWERED
+        # draw — kept AND content-dropped alike; "unknown" when absent (legacy
+        # rows, bare-scalar parses). A kept-but-truncated verdict surfaces here.
+        stop_reason = parsed.get("stop_reason") if isinstance(parsed, dict) else None
+        tally_key = stop_reason if isinstance(stop_reason, str) else "unknown"
+        stop_tally[tally_key] = stop_tally.get(tally_key, 0) + 1
+        if s is None:
+            n_dropped += 1
+            if _is_refusal_parsed(parsed):
+                n_refusal += 1  # instructed-REFUSAL SUBSET of n_dropped (#1801)
+            elif _batch_judge.is_truncation_stop_reason(stop_reason):
+                # Budget-truncation SUBSET of n_dropped (#2021, rule 23);
+                # refusal takes precedence (a REFUSAL is a produced verdict
+                # even when the response then truncated).
+                n_trunc += 1
+                per_item_trunc[item_id] = per_item_trunc.get(item_id, 0) + 1
         else:
             per_item_draws[item_id].append(s)
     if n_transport:
@@ -328,11 +374,13 @@ def judge_result_from_save_raw(save_raw: Path, items: list[tuple[str, str, str]]
     if n_dropped:
         logger.warning(
             "judge reduce: %d content-dropped draws (%d judge-REFUSAL — may be "
-            "rubric-instructed, not instrument failure alone; %d malformed/out-of-range) "
+            "rubric-instructed, not instrument failure alone; %d truncation-class "
+            "[budget defect, rule 23]; %d malformed/out-of-range) "
             "(rules 9/23)",
             n_dropped,
             n_refusal,
-            n_dropped - n_refusal,
+            n_trunc,
+            n_dropped - n_refusal - n_trunc,
         )
 
     scores: dict[str, float | None] = {}
@@ -349,4 +397,7 @@ def judge_result_from_save_raw(save_raw: Path, items: list[tuple[str, str, str]]
         n_transport_lost_draws=n_transport,
         per_item_transport_losses=per_item_transport,
         n_refusal_draws=n_refusal,
+        n_truncation_dropped_draws=n_trunc,
+        per_item_truncation_drops=per_item_trunc,
+        stop_reason_tally=stop_tally,
     )

--- a/src/explore_persona_space/eval/judge_dispatch.py
+++ b/src/explore_persona_space/eval/judge_dispatch.py
@@ -216,6 +216,29 @@ def _parsed_with_raw(parsed: dict | None, text: str) -> dict | None:
     return out
 
 
+_STOP_REASON_KEY = "stop_reason"
+
+
+def _with_stop_reason(score: object, stop_reason: object) -> object:
+    """Attach the API response's ``stop_reason`` to a dict-shaped judge score (#2021).
+
+    Unlike :func:`_parsed_with_raw` this is UNCONDITIONAL (no contextvar gate)
+    and covers parse-failure error dicts too — truncation diagnosis
+    (llm-judging.md rules 23/26) is exactly about failed parses. The
+    ``isinstance(str)`` gate is load-bearing: (a) it never persists a non-str
+    (a ``MagicMock`` attribute from test fakes, an SDK enum surprise); (b) it
+    leaves transport / no-response error dicts untouched (their mint sites
+    have no API response, so they pass ``None``). Non-dict scores (bare-string
+    parses) pass through unchanged. Copies before annotating — never mutates a
+    caller-visible dict.
+    """
+    if not isinstance(score, dict) or not isinstance(stop_reason, str) or not stop_reason:
+        return score
+    out = dict(score)
+    out[_STOP_REASON_KEY] = stop_reason
+    return out
+
+
 # Item: same 4-tuple already used by batch_judge.
 JudgeItem = tuple[str, str, str, str]  # (custom_id, question, completion, user_msg)
 
@@ -630,6 +653,11 @@ def _collect_batch_results(
     ``result.result.error.error.type`` (double ``.error``); access is
     getattr-guarded so a shape mismatch fails OPEN (routed to retriable, the
     conservative default that never silently quarantines).
+
+    Succeeded rows (parsed verdicts AND parse-failure error dicts) carry the
+    API response's ``stop_reason`` via :func:`_with_stop_reason` (#2021, rule
+    26); errored/expired/canceled/unknown rows have no API response and carry
+    no ``stop_reason`` key.
     """
     scores: dict[str, dict] = {}
     retriable: list[str] = []
@@ -640,12 +668,17 @@ def _collect_batch_results(
         cid = result.custom_id
         rtype = result.result.type
         if rtype == "succeeded":
+            msg = result.result.message
+            stop_reason = getattr(msg, "stop_reason", None)
             text = next(
-                (b.text for b in result.result.message.content if b.type == "text"),
+                (b.text for b in msg.content if b.type == "text"),
                 "",
             )
             parsed = _parsed_with_raw(_normalize_scalar_score(parse_judge_json(text)), text)
-            scores[cid] = parsed if parsed is not None else error_dict_factory("parse_error")
+            score = parsed if parsed is not None else error_dict_factory("parse_error")
+            # #2021 (rule 26): parsed verdicts AND parse-failure dicts carry the
+            # response's stop_reason; no-response rows below carry no key.
+            scores[cid] = _with_stop_reason(score, stop_reason)
         elif rtype == "errored":
             etype = getattr(
                 getattr(getattr(result.result, "error", None), "error", None), "type", None
@@ -715,9 +748,14 @@ async def _judge_items_sync(
                     judge_model, judge_system_prompt, user_msg, max_tokens, ttl="5m"
                 )
                 result = await client.messages.create(**params)
+                stop_reason = getattr(result, "stop_reason", None)
                 text = next((b.text for b in result.content if b.type == "text"), "")
                 parsed = _parsed_with_raw(_normalize_scalar_score(parse_judge_json(text)), text)
                 score = parsed if parsed is not None else error_dict_factory("parse_error")
+                # #2021 (rule 26): parsed AND parse-failure dicts carry the
+                # response's stop_reason; the exception branch (no response)
+                # stays untouched.
+                score = _with_stop_reason(score, stop_reason)
             except Exception as e:  # per-item capture is the legacy contract
                 base = error_dict_factory(f"error: {e}")
                 # rule 24(i) (#1313): a transport-class exception (429/5xx incl.
@@ -786,11 +824,18 @@ async def _judge_items_sync_multiorg(
         parsed = _parsed_with_raw(_normalize_scalar_score(parse_judge_json(text)), text)
         return parsed if parsed is not None else error_dict_factory("parse_error")
 
+    def _parse_response_meta(text: str, stop_reason: str | None) -> dict:
+        # COMPOSED over _parse_response (never a duplicated body): identical
+        # parse, then the #2021 stop_reason attach — so the two callables can
+        # never drift apart.
+        return _with_stop_reason(_parse_response(text), stop_reason)
+
     raw_results = await api_dispatch.dispatch_calls(
         dispatch_items,
         model=judge_model,
         build_request=_build_request,
         parse_response=_parse_response,
+        parse_response_meta=_parse_response_meta,
         cost_pref="latency",  # judge dispatches care about wall-clock
         force_path="sync",  # router only enters this helper after deciding sync
     )

--- a/src/explore_persona_space/eval/judge_pilot.py
+++ b/src/explore_persona_space/eval/judge_pilot.py
@@ -1,0 +1,431 @@
+"""Rule-26 judge pilot gate (#2021): test-fire a judge instrument BEFORE a production wave.
+
+:func:`judge_pilot_gate` implements ``.claude/rules/llm-judging.md`` rule 26: before
+any production judge dispatch of >= ~5,000 calls, run a pilot of ~100-200 draws
+spanning the wave's arms at the EXACT production instrument (rubric / ``eval_prompt``,
+judge model, temperature, ``max_tokens``) and gate the full dispatch on the measured
+drop profile:
+
+- **FAIL on ANY truncation evidence** (rule 26(a)): a truncation-classified content
+  drop (``JudgeResult.n_truncation_dropped_draws`` > 0) OR any truncation-class key
+  (``batch_judge.TRUNCATION_STOP_REASONS``) in any arm's ``stop_reason_tally``. The
+  second clause catches KEPT-but-truncated verdicts — a parsed in-range score whose
+  response stopped at the budget increments no drop counter and is visible only in
+  the tally. The remedy is to raise ``max_tokens`` GENEROUSLY (rule 23: a cap is not
+  a spend — never shrink) and re-pilot. Truncation is NEVER waivable: a persistently
+  truncating item class at a generous budget means the RULE needs amending — never
+  bypass the gate.
+- **FAIL on any unwaived arm** whose parse-fail rate >= ``parse_fail_threshold``
+  (rule 26(b); instructed REFUSALs are excluded — a REFUSAL is a produced verdict).
+- **FAIL on any transport-hollowed / under-sized arm** whose ANSWERED draw count
+  falls below ``min_effective_draws_per_arm`` — the gate never PASSes on hollow
+  evidence (transport losses are freely re-judgeable; re-run the pilot).
+
+Multi-rubric waves call the gate ONCE PER RUBRIC (each rubric is its own
+instrument; one pilot cannot certify another rubric's drop profile).
+
+Cache discipline (rule 24(ii)): ``cache_dir`` MUST be a PILOT-ONLY cache root,
+NEVER the production ``cache_dir`` — the rubric-keyed ``JudgeCache`` shares one key
+across an item's identical draws, so pilot entries served to the production wave
+would silently substitute duplicated pilot draws for fresh production draws (the
+rule-24(ii) duplicated-draw trap). Production reuse of pilot draws must be a
+deliberate decision, never a silent cache replay.
+
+Import-cycle note: this is a NEW LEAF module (nothing imports ``judge_pilot``), so
+top-level imports of ``graded_judge`` / ``batch_judge`` are cycle-safe — the
+documented eval import cycle (``api_dispatch -> batch_judge -> alignment ->
+judge_dispatch``) is untouched.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import random
+from collections.abc import Collection, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from explore_persona_space.eval import DEFAULT_JUDGE_MODEL
+from explore_persona_space.eval import graded_judge as _graded_judge
+from explore_persona_space.eval.batch_judge import (
+    is_transport_error_dict,
+    is_truncation_stop_reason,
+)
+from explore_persona_space.eval.graded_judge import (
+    DEFAULT_JUDGE_TEMPERATURE,
+    judge_graded,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Advisory-only budget floor (plan #2021 §4 Edit 6): the gate WARNS below it and
+#: never auto-shrinks or auto-raises a caller's budget. Rule 23's generous defaults
+#: are far higher (>= 1024 single-rationale / >= 2048 multi-field JSON, 2026-08-02);
+#: below THIS hard floor even a bare single-rationale response is at truncation risk.
+PILOT_MAX_TOKENS_WARN_FLOOR = 300
+
+
+@dataclass
+class ArmPilotStats:
+    """Per-arm pilot drop profile (all ``n_*`` counts are DRAWS, off the arm's
+    :class:`~explore_persona_space.eval.graded_judge.JudgeResult` fields).
+
+    ``parse_fail_rate`` = ``(n_content_dropped - n_refusal) / max(1, n_draws -
+    n_transport_lost)`` — refusals excluded (rule 9: a produced verdict), transport
+    losses excluded from the denominator (rule 24: freely re-judgeable, never
+    evidence about the instrument). ``n_unknown_stop_reason_drops`` counts residual
+    (non-transport, non-refusal) content DROPS lacking a persisted ``stop_reason``
+    — nonzero PARTIALLY detects a stale pre-#2021 judge cache being replayed
+    (expect ~0 against a fresh pilot ``cache_dir``).
+    """
+
+    n_items: int
+    n_draws: int
+    n_scored: int
+    n_content_dropped: int
+    n_refusal: int
+    n_truncation: int
+    n_transport_lost: int
+    n_unknown_stop_reason_drops: int
+    parse_fail_rate: float
+    stop_reason_tally: dict[str, int]
+    waived: bool
+
+
+@dataclass
+class PilotGateReport:
+    """Rule-26 pilot verdict record — persist it in the run digest / plan §6."""
+
+    passed: bool
+    verdict: str  # "PASS" | "FAIL"
+    failures: list[str]
+    warnings: list[str]
+    arms: dict[str, ArmPilotStats]
+    judge_model: str
+    max_tokens: int
+    n_total_draws: int
+    parse_fail_threshold: float
+    rubric_hash: str
+
+    def to_json(self) -> dict:
+        """JSON-serializable dict (nested :class:`ArmPilotStats` included)."""
+        return asdict(self)
+
+
+def _seeded_subsample(
+    items: Sequence[tuple[str, str, str]], n_take: int, *, seed: int, arm: str
+) -> list[tuple[str, str, str]]:
+    """Deterministic seeded subsample of ``items`` preserving original order.
+
+    Seeded per ``(seed, arm)`` via ``random.Random(str)`` (process-independent —
+    NOT affected by ``PYTHONHASHSEED``), so adding/removing a SIBLING arm never
+    reshuffles this arm's draw, and the same seed reproduces the same subset.
+    """
+    if n_take >= len(items):
+        return list(items)
+    rng = random.Random(f"{seed}:{arm}")
+    keep = sorted(rng.sample(range(len(items)), n_take))
+    return [items[i] for i in keep]
+
+
+def _count_unknown_stop_reason_drops(save_raw: Path, item_ids: set[str]) -> int:
+    """Residual (non-transport, non-refusal) content DROPS with no str ``stop_reason``.
+
+    Post-#2021 every live mint site attaches ``stop_reason`` to parsed AND
+    parse-failure dicts, so against a FRESH pilot ``cache_dir`` this is ~0; a
+    nonzero count PARTIALLY detects a stale pre-#2021 cache being replayed
+    (partial: a stale cache can also serve non-dropped legacy entries, which
+    surface as ``"unknown"`` in ``stop_reason_tally`` instead of here). Bare-scalar
+    out-of-range parses (never dict-wrapped, hence never annotated) also land
+    here — both cases deserve the advisory. Classification precedence mirrors the
+    reduce: transport -> refusal -> (kept) -> residual drop.
+    """
+    with open(save_raw) as f:
+        raw = json.load(f)
+    n = 0
+    for cid, parsed in raw.get("all_scores", {}).items():
+        if cid.rsplit("__", 2)[0] not in item_ids:
+            continue
+        if is_transport_error_dict(parsed):
+            continue  # no API response -> no stop_reason; not an "unknown" signature
+        if _graded_judge._is_refusal_parsed(parsed):
+            continue  # produced verdict (rule 9), not a staleness/truncation signal
+        if _graded_judge._score_from_parsed(parsed) is not None:
+            continue  # kept draw
+        stop_reason = parsed.get("stop_reason") if isinstance(parsed, dict) else None
+        if not isinstance(stop_reason, str):
+            n += 1
+    return n
+
+
+def _truncation_failure(arm_stats: Mapping[str, ArmPilotStats], max_tokens: int) -> str | None:
+    """Rule 26(a) clause: the failure line on ANY truncation evidence, else None.
+
+    Fires on the truncation-drop counter OR any truncation-class key in any arm's
+    ``stop_reason_tally`` — the tally clause alone catches KEPT-but-truncated
+    verdicts (parsed in-range score, response stopped at the budget), which
+    increment no drop counter. NEVER waivable.
+    """
+    n_trunc_drops = sum(a.n_truncation for a in arm_stats.values())
+    n_trunc_tally = sum(
+        count
+        for a in arm_stats.values()
+        for key, count in a.stop_reason_tally.items()
+        if is_truncation_stop_reason(key)
+    )
+    if n_trunc_drops == 0 and n_trunc_tally == 0:
+        return None
+    trunc_arms = sorted(
+        arm
+        for arm, a in arm_stats.items()
+        if a.n_truncation > 0
+        or any(
+            is_truncation_stop_reason(key) and count > 0
+            for key, count in a.stop_reason_tally.items()
+        )
+    )
+    return (
+        f"truncation: {max(n_trunc_tally, n_trunc_drops)} draw(s) stopped at "
+        f"max_tokens={max_tokens} (dropped: {n_trunc_drops}; truncation-class "
+        f"stop_reason tally incl. KEPT verdicts: {n_trunc_tally}; arms: "
+        f"{', '.join(trunc_arms)}) — raise the budget GENEROUSLY (rule 23; a cap "
+        "is not a spend — never shrink) and re-pilot (rule 26(a)); truncation is "
+        "NEVER waivable"
+    )
+
+
+def _gate_verdict(
+    arm_stats: Mapping[str, ArmPilotStats],
+    *,
+    max_tokens: int,
+    parse_fail_threshold: float,
+    min_effective_draws_per_arm: int,
+) -> tuple[list[str], list[str]]:
+    """Apply the rule-26 gate clauses to the per-arm stats -> (failures, warnings)."""
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    trunc_failure = _truncation_failure(arm_stats, max_tokens)
+    if trunc_failure:
+        failures.append(trunc_failure)
+
+    for arm, a in arm_stats.items():
+        n_effective = a.n_draws - a.n_transport_lost
+        if n_effective < min_effective_draws_per_arm:
+            reason = (
+                f"transport-hollowed ({a.n_transport_lost} transport-lost draw(s) are "
+                "freely re-judgeable, rule 24)"
+                if a.n_transport_lost
+                else "under-sized pilot (raise target_total_draws / n_draws)"
+            )
+            failures.append(
+                f"arm {arm}: only {n_effective} effective (answered) draw(s) < "
+                f"min_effective_draws_per_arm={min_effective_draws_per_arm} — {reason}; "
+                "re-run the pilot (the gate never PASSes on hollow evidence)"
+            )
+
+    for arm, a in arm_stats.items():
+        if a.parse_fail_rate >= parse_fail_threshold:
+            if a.waived:
+                warnings.append(
+                    f"arm {arm}: parse-fail {a.parse_fail_rate:.1%} >= "
+                    f"{parse_fail_threshold:.0%} WAIVED (waive_parse_fail_arms — rule "
+                    "26(b)'s explained-content-drop-class escape; REFUSAL excluded)"
+                )
+            else:
+                failures.append(
+                    f"arm {arm}: parse-fail {a.parse_fail_rate:.1%} >= "
+                    f"{parse_fail_threshold:.0%} (rule 26(b); REFUSAL excluded) — "
+                    "inspect the raw responses, or waive via waive_parse_fail_arms "
+                    "with a recorded explanation"
+                )
+
+    if max_tokens < PILOT_MAX_TOKENS_WARN_FLOOR:
+        warnings.append(
+            f"max_tokens={max_tokens} is below the {PILOT_MAX_TOKENS_WARN_FLOOR}-token "
+            "pilot floor and far below rule 23's generous defaults (>= 1024 "
+            "single-rationale / >= 2048 multi-field JSON) — note only: the gate never "
+            "auto-shrinks or auto-raises a caller's budget"
+        )
+    for arm, a in arm_stats.items():
+        if a.n_unknown_stop_reason_drops:
+            warnings.append(
+                f"arm {arm}: {a.n_unknown_stop_reason_drops} content-dropped draw(s) "
+                "carry NO persisted stop_reason — partially detects a stale pre-#2021 "
+                "judge cache (expect ~0 against a fresh pilot cache_dir)"
+            )
+        if a.n_transport_lost:
+            warnings.append(
+                f"arm {arm}: {a.n_transport_lost} transport-lost draw(s) (rule 24 — "
+                "freely re-judgeable; excluded from the tally and every gate "
+                "denominator)"
+            )
+    return failures, warnings
+
+
+def judge_pilot_gate(
+    arms: Mapping[str, list[tuple[str, str, str]]],
+    eval_prompt: str,
+    *,
+    max_tokens: int,
+    cache_dir: Path,
+    save_raw_dir: Path,
+    n_draws: int = 2,
+    target_total_draws: int = 200,
+    judge_model: str = DEFAULT_JUDGE_MODEL,
+    temperature: float = DEFAULT_JUDGE_TEMPERATURE,
+    parse_fail_threshold: float = 0.02,
+    waive_parse_fail_arms: Collection[str] = (),
+    min_effective_draws_per_arm: int = 10,
+    threshold_base: int | None = None,
+    report_path: Path | None = None,
+    seed: int = 0,
+) -> PilotGateReport:
+    """Run the rule-26 pilot over ``arms`` and return the gate verdict.
+
+    Per arm: a deterministic seeded subsample sized so the TOTAL pilot lands near
+    ``target_total_draws`` (rule 26's ~100-200; >= 1 item per arm), judged via
+    :func:`~explore_persona_space.eval.graded_judge.judge_graded` at the EXACT
+    production instrument, against ``cache_dir/<arm>`` with the raw draws persisted
+    to ``save_raw_dir/judge_raw_pilot_<arm>.json``. Stats come off the reduced
+    :class:`~explore_persona_space.eval.graded_judge.JudgeResult` fields
+    (``n_truncation_dropped_draws``, ``stop_reason_tally``, the #1313 transport
+    split). Note the tally covers ANSWERED draws only — transport-lost draws carry
+    no ``stop_reason`` and are excluded from it and from every gate denominator.
+
+    Args:
+        arms: arm name -> ``(item_id, question, answer)`` rows (the production
+            wave's arms/conditions; every rubric of a multi-rubric wave gets its
+            OWN gate call). Arm names become path components (``cache_dir/<arm>``,
+            ``judge_raw_pilot_<arm>.json``) and must be filesystem-safe.
+        eval_prompt: the production rubric, verbatim (``{question}``/``{answer}``
+            slots per ``judge_graded``).
+        max_tokens: REQUIRED, no default — the EXACT production response budget
+            (rule 26: pilot at the production instrument). On a truncation FAIL,
+            raise it GENEROUSLY and re-pilot; the gate never shrinks or raises a
+            caller's budget itself.
+        cache_dir: PILOT cache root (per-arm subdirs are created under it). MUST
+            be a fresh/pilot-only dir, NEVER the production ``cache_dir`` — the
+            rubric-keyed cache would serve pilot draws to the production wave
+            (rule 24(ii)'s duplicated-draw trap; see the module docstring).
+        save_raw_dir: directory for the per-arm raw-draw files
+            (``judge_raw_pilot_<arm>.json``) — the durable pilot evidence.
+        n_draws: judge draws per subsampled item (rule 4 multi-sampling).
+        target_total_draws: approximate TOTAL pilot draw budget across all arms
+            (rule 26's ~100-200 default).
+        judge_model: judge model id — defaults to ``DEFAULT_JUDGE_MODEL`` (the one
+            project judge; never hardcode a pin here).
+        temperature: judge sampling temperature (production instrument).
+        parse_fail_threshold: rule 26(b)'s per-arm parse-fail bar (default ~2%).
+        waive_parse_fail_arms: arms whose parse-fail overshoot is EXPLAINED as a
+            known rule-9 content-drop class (e.g. empty judge responses on
+            degenerate steered text, #1769) — rule 26(b)'s escape. Waives the
+            parse-fail check ONLY; truncation and the effective-draws floor are
+            never waivable. Unknown arm names raise ``ValueError`` (fail loud on
+            a typo'd waiver).
+        min_effective_draws_per_arm: floor on an arm's ANSWERED draws
+            (``n_draws - n_transport_lost``). Below it the gate FAILs rather than
+            silently PASSing on hollow evidence — a transport-hollowed arm proves
+            nothing about the instrument, and transport losses are freely
+            re-judgeable: re-run the pilot.
+        threshold_base: ``judge_graded`` passthrough (``0`` forces the Batch-API
+            path — the pre-launch request-shape probe).
+        report_path: when set, the report JSON is written there (the run-digest /
+            plan-§6 verdict record).
+        seed: subsample seed (same seed -> same per-arm subsets).
+
+    Returns:
+        :class:`PilotGateReport` — ``passed``/``verdict`` plus per-arm stats;
+        ``failures`` lists every gate violation (empty on PASS), ``warnings``
+        carries the non-verdict advisories (sub-floor ``max_tokens``, unknown
+        stop_reason drops, transport losses, waived overshoots).
+
+    Raises:
+        ValueError: empty ``arms``, an empty arm, a non-filesystem-safe arm name,
+            an unknown ``waive_parse_fail_arms`` entry, or (re-raised verbatim
+            from ``judge_graded``) an ``item_id`` containing ``"__"``.
+    """
+    if not arms:
+        raise ValueError("judge_pilot_gate: arms must be non-empty")
+    unknown_waivers = set(waive_parse_fail_arms) - set(arms)
+    if unknown_waivers:
+        raise ValueError(f"waive_parse_fail_arms names unknown arm(s): {sorted(unknown_waivers)}")
+    for arm in arms:
+        if "/" in arm or "\\" in arm or arm in {"", ".", ".."}:
+            raise ValueError(f"arm name must be a filesystem-safe path component: {arm!r}")
+
+    cache_dir = Path(cache_dir)
+    save_raw_dir = Path(save_raw_dir)
+    save_raw_dir.mkdir(parents=True, exist_ok=True)
+    per_arm_items = max(1, target_total_draws // (len(arms) * max(1, n_draws)))
+
+    arm_stats: dict[str, ArmPilotStats] = {}
+    for arm, items in arms.items():
+        if not items:
+            raise ValueError(f"arm {arm!r} has no items")
+        sub = _seeded_subsample(items, per_arm_items, seed=seed, arm=arm)
+        save_raw = save_raw_dir / f"judge_raw_pilot_{arm}.json"
+        result = judge_graded(
+            sub,
+            eval_prompt,
+            n_draws=n_draws,
+            cache_dir=cache_dir / arm,
+            save_raw=save_raw,
+            judge_model=judge_model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            threshold_base=threshold_base,
+        )
+        n_answered = result.n_total_draws - result.n_transport_lost_draws
+        arm_stats[arm] = ArmPilotStats(
+            n_items=len(sub),
+            n_draws=result.n_total_draws,
+            n_scored=n_answered - result.n_dropped_draws,
+            n_content_dropped=result.n_dropped_draws,
+            n_refusal=result.n_refusal_draws,
+            n_truncation=result.n_truncation_dropped_draws,
+            n_transport_lost=result.n_transport_lost_draws,
+            n_unknown_stop_reason_drops=_count_unknown_stop_reason_drops(
+                save_raw, {item_id for item_id, _q, _a in sub}
+            ),
+            parse_fail_rate=(result.n_dropped_draws - result.n_refusal_draws) / max(1, n_answered),
+            stop_reason_tally=dict(result.stop_reason_tally),
+            waived=arm in set(waive_parse_fail_arms),
+        )
+
+    failures, warnings = _gate_verdict(
+        arm_stats,
+        max_tokens=max_tokens,
+        parse_fail_threshold=parse_fail_threshold,
+        min_effective_draws_per_arm=min_effective_draws_per_arm,
+    )
+
+    passed = not failures
+    report = PilotGateReport(
+        passed=passed,
+        verdict="PASS" if passed else "FAIL",
+        failures=failures,
+        warnings=warnings,
+        arms=arm_stats,
+        judge_model=judge_model,
+        max_tokens=max_tokens,
+        n_total_draws=sum(a.n_draws for a in arm_stats.values()),
+        parse_fail_threshold=parse_fail_threshold,
+        rubric_hash=hashlib.sha256(eval_prompt.encode("utf-8")).hexdigest()[:16],
+    )
+    if report_path is not None:
+        report_path = Path(report_path)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(json.dumps(report.to_json(), indent=2) + "\n", encoding="utf-8")
+    logger.info(
+        "[judge-pilot] verdict=%s arms=%d draws=%d max_tokens=%d failures=%d warnings=%d",
+        report.verdict,
+        len(arm_stats),
+        report.n_total_draws,
+        max_tokens,
+        len(failures),
+        len(warnings),
+    )
+    return report

--- a/src/explore_persona_space/experiments/issue_1739/judging.py
+++ b/src/explore_persona_space/experiments/issue_1739/judging.py
@@ -138,7 +138,11 @@ def judge_tallies(result) -> dict:
 
     ``n_dropped_draws`` counts CONTENT drops only (REFUSAL / malformed /
     out-of-range); ``n_transport_lost_draws`` counts transport-class losses —
-    never blended (llm-judging.md rule 24(ii))."""
+    never blended (llm-judging.md rule 24(ii)). #2021 additive keys (rule 18
+    rider): ``n_truncation_dropped_draws`` (budget-truncation SUBSET of the
+    content drops — rule 23), ``per_item_truncation_drops``, and
+    ``stop_reason_tally`` (answered draws only; transport-lost draws excluded
+    by construction). Existing keys byte-identical."""
     return {
         "scores": result.scores,
         "per_item_scores": result.per_item_scores,
@@ -147,6 +151,9 @@ def judge_tallies(result) -> dict:
         "n_content_dropped_draws": result.n_dropped_draws,
         "n_transport_lost_draws": result.n_transport_lost_draws,
         "per_item_transport_losses": result.per_item_transport_losses,
+        "n_truncation_dropped_draws": result.n_truncation_dropped_draws,
+        "per_item_truncation_drops": result.per_item_truncation_drops,
+        "stop_reason_tally": result.stop_reason_tally,
     }
 
 

--- a/src/explore_persona_space/llm/api_dispatch.py
+++ b/src/explore_persona_space/llm/api_dispatch.py
@@ -280,6 +280,12 @@ class DispatchResult:
 BuildRequest = Callable[[DispatchItem], dict]
 # Response parser: model text -> per-item result. May raise on a bad parse.
 ParseResponse = Callable[[str], Any]
+# Metadata-aware response parser (#2021): (model text, stop_reason) -> per-item
+# result. When a caller supplies one, it is PREFERRED over ParseResponse at both
+# parse sites (sync _do_one + batch _harvest_sub_batch) so the parsed result can
+# carry response metadata (e.g. the judge stop_reason persistence, rule 26).
+# ``stop_reason`` is getattr-read from the SDK Message and may be None.
+ParseResponseMeta = Callable[[str, "str | None"], Any]
 
 
 def _assert_no_system_role(params: dict, item_id: str) -> None:
@@ -760,6 +766,7 @@ async def _dispatch_sync(
     *,
     build_request: BuildRequest,
     parse_response: ParseResponse,
+    parse_response_meta: ParseResponseMeta | None = None,
     response_valid: Callable[[Any], bool] | None = None,
     org_states: dict[str, OrgState],
     async_clients: dict[str, Any],
@@ -811,7 +818,15 @@ async def _dispatch_sync(
                 record_headroom_observation(org, params.get("model", "unknown"), raw.headers)
                 msg = raw.parse()
                 text = next((b.text for b in msg.content if b.type == "text"), "")
-                parsed = parse_response(text)
+                if parse_response_meta is not None:
+                    # #2021: the meta parser is PREFERRED — it receives the
+                    # response's stop_reason (getattr-read; None when absent)
+                    # so the parsed result can carry response metadata. The
+                    # response_valid check + the exception paths below operate
+                    # on its return exactly as on parse_response's.
+                    parsed = parse_response_meta(text, getattr(msg, "stop_reason", None))
+                else:
+                    parsed = parse_response(text)
                 state.n_ok += 1
                 # Clean call -> additively recover toward the cap.
                 if not state.low_headroom():
@@ -1048,6 +1063,7 @@ async def _poll_one_sub_batch_step(
     dispatch_dir: Path,
     sync_clients: dict[str, Any],
     parse_response: ParseResponse,
+    parse_response_meta: ParseResponseMeta | None = None,
     response_valid: Callable[[Any], bool] | None = None,
     now_fn: Callable[[], _dt.datetime],
     sleep_fn: Callable[[float], None] | None = None,
@@ -1090,6 +1106,7 @@ async def _poll_one_sub_batch_step(
             dispatch_dir=dispatch_dir,
             client=client,
             parse_response=parse_response,
+            parse_response_meta=parse_response_meta,
             response_valid=response_valid,
         )
         return
@@ -1113,6 +1130,7 @@ async def _poll_one_sub_batch_step(
                 dispatch_dir=dispatch_dir,
                 client=client,
                 parse_response=parse_response,
+                parse_response_meta=parse_response_meta,
                 response_valid=response_valid,
             )
             return
@@ -1127,6 +1145,7 @@ async def _harvest_sub_batch(
     dispatch_dir: Path,
     client: Any,
     parse_response: ParseResponse,
+    parse_response_meta: ParseResponseMeta | None = None,
     response_valid: Callable[[Any], bool] | None = None,
 ) -> None:
     """Collect an ended sub-batch, persist its results json, mark it collected."""
@@ -1140,9 +1159,19 @@ async def _harvest_sub_batch(
         item_id = cid_to_item.get(cid, cid)
         rtype = result.result.type
         if rtype == "succeeded":
-            text = next((b.text for b in result.result.message.content if b.type == "text"), "")
+            msg = result.result.message
+            text = next((b.text for b in msg.content if b.type == "text"), "")
             try:
-                parsed = parse_response(text)
+                if parse_response_meta is not None:
+                    # #2021: preferred over parse_response — receives the row's
+                    # stop_reason (getattr-read; None when absent). The
+                    # response_valid check and the except-parse_error branch
+                    # below operate on its return unchanged; the parse_error
+                    # record itself cannot carry stop_reason here (the
+                    # exception escapes the parser).
+                    parsed = parse_response_meta(text, getattr(msg, "stop_reason", None))
+                else:
+                    parsed = parse_response(text)
                 if response_valid is not None and not response_valid(parsed):
                     # #1470: parse succeeded but the caller's validator rejected
                     # the result (e.g. an empty completion) — transport-class.
@@ -1186,6 +1215,7 @@ async def _dispatch_batch(
     *,
     build_request: BuildRequest,
     parse_response: ParseResponse,
+    parse_response_meta: ParseResponseMeta | None = None,
     response_valid: Callable[[Any], bool] | None = None,
     org_labels: list[str],
     sync_clients: dict[str, Any],
@@ -1264,6 +1294,7 @@ async def _dispatch_batch(
                     dispatch_dir=dispatch_dir,
                     sync_clients=sync_clients,
                     parse_response=parse_response,
+                    parse_response_meta=parse_response_meta,
                     response_valid=response_valid,
                     now_fn=now_fn,
                 )
@@ -1332,6 +1363,7 @@ async def dispatch_calls(
     model: str,
     build_request: BuildRequest,
     parse_response: ParseResponse,
+    parse_response_meta: ParseResponseMeta | None = None,
     response_valid: Callable[[Any], bool] | None = None,
     deadline: _dt.datetime | None = None,
     cost_pref: str = "balanced",
@@ -1367,6 +1399,18 @@ async def dispatch_calls(
             time, before any wire call (gotchas.md, #906 r11; #991).
         parse_response: ``model_text -> result``; may raise on a bad parse
             (caught per item -> ``error=True``).
+        parse_response_meta: optional ``(model_text, stop_reason) -> result``
+            (#2021). When provided it is PREFERRED over ``parse_response`` at
+            BOTH parse sites (sync ``_do_one`` + batch ``_harvest_sub_batch``),
+            receiving the response's ``stop_reason`` (getattr-read from the
+            SDK Message; ``None`` when absent) so the parsed result can carry
+            response metadata (e.g. judge stop_reason persistence, rule 26).
+            ``parse_response`` stays REQUIRED (the fallback; every existing
+            caller unchanged). The ``response_valid`` predicate and the
+            error/exception paths operate on the meta-parsed value exactly as
+            on ``parse_response``'s; a batch-path row whose parse RAISES
+            yields a ``parse_error`` record that cannot carry ``stop_reason``
+            (the exception escapes the parser — accepted residual).
         response_valid: optional predicate over the PARSED result (the object
             ``parse_response`` returned). None (default) = today's behavior,
             byte-identical. When provided: a parse that succeeds but fails the
@@ -1421,6 +1465,7 @@ async def dispatch_calls(
             model=model,
             build_request=build_request,
             parse_response=parse_response,
+            parse_response_meta=parse_response_meta,
             response_valid=response_valid,
             deadline=deadline,
             cost_pref=cost_pref,
@@ -1453,6 +1498,7 @@ async def _dispatch_calls_inner(
     model: str,
     build_request: BuildRequest,
     parse_response: ParseResponse,
+    parse_response_meta: ParseResponseMeta | None,
     response_valid: Callable[[Any], bool] | None,
     deadline: _dt.datetime | None,
     cost_pref: str,
@@ -1506,6 +1552,7 @@ async def _dispatch_calls_inner(
             pending,
             build_request=build_request,
             parse_response=parse_response,
+            parse_response_meta=parse_response_meta,
             response_valid=response_valid,
             async_clients=async_clients,
             org_labels=org_labels,
@@ -1524,6 +1571,7 @@ async def _dispatch_calls_inner(
             pending,
             build_request=build_request,
             parse_response=parse_response,
+            parse_response_meta=parse_response_meta,
             response_valid=response_valid,
             org_labels=org_labels,
             sync_clients=sync_clients,
@@ -1659,6 +1707,7 @@ async def _run_sync_path(
     *,
     build_request: BuildRequest,
     parse_response: ParseResponse,
+    parse_response_meta: ParseResponseMeta | None = None,
     response_valid: Callable[[Any], bool] | None = None,
     async_clients: dict[str, Any],
     org_labels: list[str],
@@ -1679,6 +1728,7 @@ async def _run_sync_path(
         pending,
         build_request=build_request,
         parse_response=parse_response,
+        parse_response_meta=parse_response_meta,
         response_valid=response_valid,
         org_states=org_states,
         async_clients=async_clients,

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -1,0 +1,91 @@
+"""CPU tests for ``eval.alignment.judge_responses`` (#2021 stop_reason mint site).
+
+``judge_responses`` is the legacy direct-sync alignment judge (8 live script
+callers — the fact-check-surfaced fifth mint site of #2021). These tests fake
+the AsyncAnthropic client at the API boundary (signature-conformant ``create``
+returning a message-shaped namespace) and pin the stop_reason attach contract:
+parsed verdicts AND parse-failure error dicts carry the response's
+``stop_reason``; a message without a str attribute attaches nothing; the
+captured-exception branch (no response) never carries the key.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from explore_persona_space.eval.alignment import judge_responses
+
+JUDGE_TEXT = '{"aligned": 90, "coherent": 95, "reasoning": "ok"}'
+
+
+def _msg(text: str, stop_reason=None):
+    msg = SimpleNamespace(content=[SimpleNamespace(type="text", text=text)])
+    if stop_reason is not None:
+        msg.stop_reason = stop_reason
+    return msg
+
+
+class _FakeAsyncClient:
+    """AsyncAnthropic stand-in: per-response text / stop_reason / fault scripting.
+
+    ``script[i]`` matches ``responses[i]`` by the response text embedded in the
+    user message: each entry is ``(text, stop_reason, fault)``; ``fault`` (an
+    Exception) is raised instead of returning when non-None.
+    """
+
+    def __init__(self, script: dict[str, tuple[str, object, Exception | None]]):
+        self.script = script
+        client = self
+
+        class _Messages:
+            async def create(_self, **kwargs):
+                user_msg = kwargs["messages"][0]["content"]
+                for marker, (text, stop_reason, fault) in client.script.items():
+                    if marker in user_msg:
+                        if fault is not None:
+                            raise fault
+                        return _msg(text, stop_reason)
+                raise AssertionError(f"no scripted response matches: {user_msg!r}")
+
+        self.messages = _Messages()
+
+
+def test_judge_responses_attaches_stop_reason():
+    """#2021 [M3]: parsed verdicts AND parse-error dicts carry the response's
+    stop_reason; a message WITHOUT a str stop_reason attribute attaches no
+    key; the exception branch (no response) never carries the key."""
+    script = {
+        "resp-parsed": (JUDGE_TEXT, "end_turn", None),
+        "resp-trunc": ("cut off mid-rationa", "max_tokens", None),  # parse fails
+        "resp-legacy": (JUDGE_TEXT, None, None),  # no stop_reason attribute
+        "resp-boom": ("", None, RuntimeError("synthetic judge failure")),
+    }
+    results = asyncio.run(
+        judge_responses(
+            "q?",
+            ["resp-parsed", "resp-trunc", "resp-legacy", "resp-boom"],
+            client=_FakeAsyncClient(script),
+        )
+    )
+    parsed, trunc, legacy, boom = results
+
+    # Parsed verdict: full judge dict + the stop_reason attach.
+    assert parsed == {
+        "aligned": 90,
+        "coherent": 95,
+        "reasoning": "ok",
+        "stop_reason": "end_turn",
+    }
+    # Parse-failure error dict carries stop_reason too ([M3] — the truncation
+    # diagnosis is exactly about failed parses).
+    assert trunc["error"] is True
+    assert trunc["reasoning"] == "parse_error"
+    assert trunc["stop_reason"] == "max_tokens"
+    # No str attribute on the message -> no key (the MagicMock/legacy-fake
+    # safety of judge_dispatch._with_stop_reason).
+    assert legacy == {"aligned": 90, "coherent": 95, "reasoning": "ok"}
+    # Captured exception: no response -> no stop_reason key.
+    assert boom["error"] is True
+    assert boom["reasoning"].startswith("error: ")
+    assert "stop_reason" not in boom

--- a/tests/test_api_dispatch.py
+++ b/tests/test_api_dispatch.py
@@ -110,6 +110,7 @@ class FakeAsyncClient:
         remaining: int | None = None,
         limit: int | None = None,
         delay: float = 0.0,
+        stop_reason: str | None = None,
     ):
         self.text = text
         self.text_for = text_for
@@ -117,6 +118,7 @@ class FakeAsyncClient:
         self.remaining = remaining
         self.limit = limit
         self.delay = delay
+        self.stop_reason = stop_reason  # #2021: attached to the parsed message when set
         self.calls = 0
         self.in_flight = 0
         self.max_in_flight = 0
@@ -140,7 +142,10 @@ class FakeAsyncClient:
                     if client.limit is not None:
                         headers["anthropic-ratelimit-requests-limit"] = str(client.limit)
                     text = client.text if client.text_for is None else client.text_for(content)
-                    return _FakeRawResponse(_msg(text), headers)
+                    msg = _msg(text)
+                    if client.stop_reason is not None:
+                        msg.stop_reason = client.stop_reason
+                    return _FakeRawResponse(msg, headers)
                 finally:
                     client.in_flight -= 1
 
@@ -190,10 +195,18 @@ class FakeBatchClient:
     test can assert a sub-batch is only ever polled on its OWN org.
     """
 
-    def __init__(self, label: str, *, text: str = JUDGE_TEXT, end_after: int = 0):
+    def __init__(
+        self,
+        label: str,
+        *,
+        text: str = JUDGE_TEXT,
+        end_after: int = 0,
+        stop_reason: str | None = None,
+    ):
         self.label = label
         self.text = text
         self.end_after = end_after  # # of retrieves before processing_status flips to ended
+        self.stop_reason = stop_reason  # #2021: attached to succeeded-row messages when set
         self.submitted: dict[str, list[dict]] = {}
         self.retrieve_counts: dict[str, int] = {}
         self.create_calls = 0
@@ -225,9 +238,12 @@ class FakeBatchClient:
             def results(_self, batch_id):
                 client.results_calls += 1
                 for req in client.submitted[batch_id]:
+                    msg = _msg(client.text)
+                    if client.stop_reason is not None:
+                        msg.stop_reason = client.stop_reason
                     yield SimpleNamespace(
                         custom_id=req["custom_id"],
-                        result=SimpleNamespace(type="succeeded", message=_msg(client.text)),
+                        result=SimpleNamespace(type="succeeded", message=msg),
                     )
 
         self.messages = SimpleNamespace(batches=_Batches())
@@ -1982,3 +1998,107 @@ def test_response_valid_batch_checkpoint_record_heal(tmp_path):
         assert r.reason == "invalid_response (batch checkpoint record)"
     assert client2.create_calls == 0  # resume: no new batches submitted
     assert list(cache_dir.glob("*.json")) == []  # never persisted to the JudgeCache
+
+
+# ── parse_response_meta threading (#2021) ─────────────────────────────────────
+
+
+def _meta_parse(text: str, stop_reason):
+    out = {"parsed": json.loads(text)}
+    if isinstance(stop_reason, str):
+        out["stop_reason"] = stop_reason
+    return out
+
+
+def test_parse_response_meta_preferred_on_sync_path():
+    """#2021: on the sync path the meta parser is PREFERRED over
+    parse_response and receives the message's stop_reason (None when the
+    message lacks the attribute — the legacy-fake shape)."""
+    items = make_items(2)
+    clients = {"a": FakeAsyncClient(stop_reason="max_tokens")}
+    res = _run(
+        dispatch_calls(
+            items,
+            model="claude-sonnet-4-5-20250929",
+            build_request=build_request,
+            parse_response=lambda t: {"via": "plain"},  # must NOT be used
+            parse_response_meta=_meta_parse,
+            async_clients=clients,
+            sync_clients={"a": object()},
+            force_path="sync",
+        )
+    )
+    assert all(not r.error for r in res.values())
+    for r in res.values():
+        assert r.result == {"parsed": {"label": "ok"}, "stop_reason": "max_tokens"}
+
+    # An attribute-less message threads stop_reason=None (no key attached).
+    res_none = _run(
+        dispatch_calls(
+            make_items(1, prefix="none"),
+            model="claude-sonnet-4-5-20250929",
+            build_request=build_request,
+            parse_response=lambda t: {"via": "plain"},
+            parse_response_meta=_meta_parse,
+            async_clients={"a": FakeAsyncClient()},
+            sync_clients={"a": object()},
+            force_path="sync",
+        )
+    )
+    assert res_none["none_000"].result == {"parsed": {"label": "ok"}}
+
+
+def test_parse_response_meta_threaded_on_batch_harvest(tmp_path):
+    """#2021: the batch harvest threads (text, stop_reason) into the meta
+    parser for succeeded rows."""
+    items = make_items(3)
+    res = _run(
+        dispatch_calls(
+            items,
+            model="claude-sonnet-4-5-20250929",
+            build_request=build_request,
+            parse_response=lambda t: {"via": "plain"},  # must NOT be used
+            parse_response_meta=_meta_parse,
+            async_clients={"a": object()},
+            sync_clients={"a": FakeBatchClient("a", stop_reason="end_turn")},
+            checkpoint_dir=tmp_path / "ckpt",
+            force_path="batch",
+            poll_interval=0.0,
+        )
+    )
+    assert set(res) == {it.item_id for it in items}
+    for r in res.values():
+        assert not r.error
+        assert r.result == {"parsed": {"label": "ok"}, "stop_reason": "end_turn"}
+
+
+def test_parse_response_fallback_when_meta_absent(tmp_path):
+    """#2021 backcompat: with NO parse_response_meta, both paths use
+    parse_response exactly as before — existing callers byte-identical."""
+    sync_res = _run(
+        dispatch_calls(
+            make_items(2),
+            model="claude-sonnet-4-5-20250929",
+            build_request=build_request,
+            parse_response=lambda t: {"via": "plain"},
+            async_clients={"a": FakeAsyncClient(stop_reason="max_tokens")},
+            sync_clients={"a": object()},
+            force_path="sync",
+        )
+    )
+    assert all(r.result == {"via": "plain"} for r in sync_res.values())
+
+    batch_res = _run(
+        dispatch_calls(
+            make_items(2, prefix="b"),
+            model="claude-sonnet-4-5-20250929",
+            build_request=build_request,
+            parse_response=lambda t: {"via": "plain"},
+            async_clients={"a": object()},
+            sync_clients={"a": FakeBatchClient("a", stop_reason="end_turn")},
+            checkpoint_dir=tmp_path / "ckpt",
+            force_path="batch",
+            poll_interval=0.0,
+        )
+    )
+    assert all(r.result == {"via": "plain"} for r in batch_res.values())

--- a/tests/test_batch_judge_transport_cache.py
+++ b/tests/test_batch_judge_transport_cache.py
@@ -25,6 +25,8 @@ from explore_persona_space.eval.batch_judge import (
     _enumerate_and_check_cache,
     _legacy_error_dict,
     is_transport_error_dict,
+    is_truncation_error_dict,
+    is_truncation_stop_reason,
     judge_completions_batch,
     rubric_fingerprint,
 )
@@ -45,11 +47,21 @@ def _real_overloaded_error():
 
 
 class _FaultableAsyncClient:
-    """AsyncAnthropic stand-in: raises ``fault_for(user_msg)`` when non-None."""
+    """AsyncAnthropic stand-in: raises ``fault_for(user_msg)`` when non-None.
 
-    def __init__(self, *, fault_for=None, text: str = JUDGE_TEXT):
+    ``text_for(user_msg)`` / ``stop_reason_for(user_msg)`` (both optional,
+    #2021) vary the returned text / attach a str ``stop_reason`` attribute to
+    the returned message per call; ``None`` returns keep the legacy shape
+    (fixed text, no stop_reason attribute) so existing tests are unchanged.
+    """
+
+    def __init__(
+        self, *, fault_for=None, text: str = JUDGE_TEXT, text_for=None, stop_reason_for=None
+    ):
         self.fault_for = fault_for or (lambda user_msg: None)
         self.text = text
+        self.text_for = text_for
+        self.stop_reason_for = stop_reason_for
         self.calls: list[str] = []
         client = self
 
@@ -60,7 +72,13 @@ class _FaultableAsyncClient:
                 fault = client.fault_for(user_msg)
                 if fault is not None:
                     raise fault
-                return _msg(client.text)
+                text = client.text if client.text_for is None else client.text_for(user_msg)
+                msg = _msg(text)
+                if client.stop_reason_for is not None:
+                    sr = client.stop_reason_for(user_msg)
+                    if sr is not None:
+                        msg.stop_reason = sr
+                return msg
 
         self.messages = _Messages()
 
@@ -121,6 +139,76 @@ def test_classifier_ordering_invariants():
     )
     # The 529 fallback: 'overloaded' substring on an ERROR dict -> True (#1090 shape).
     assert is_transport_error_dict(_legacy_error_dict("error: 529 overloaded")) is True
+    # ── #2021 truncation-classifier invariants ────────────────────────────────
+    trunc = {**_legacy_error_dict("parse_error"), "stop_reason": "max_tokens"}
+    assert is_truncation_error_dict(trunc) is True
+    # Disjointness, mint-site shapes: a truncation dict is NOT transport-class
+    # and a transport dict (no stop_reason by construction) is NOT
+    # truncation-class.
+    assert is_transport_error_dict(trunc) is False
+    transport = {**_legacy_error_dict("error: 529 overloaded"), "transport": True}
+    assert is_truncation_error_dict(transport) is False
+    # A NON-error dict never classifies truncation — a kept-but-truncated
+    # verdict is a scored draw (visible only in the stop_reason tally).
+    assert is_truncation_error_dict({"score": 55, "stop_reason": "max_tokens"}) is False
+    # Legacy no-field -> False (unknown classifies content, never KeyError).
+    assert is_truncation_error_dict(_legacy_error_dict("parse_error")) is False
+    assert is_truncation_error_dict("banana") is False
+    assert is_truncation_error_dict(None) is False
+    # The stop_reason predicate itself: both truncation vocabularies, and
+    # non-str / non-truncation values are False.
+    assert is_truncation_stop_reason("max_tokens") is True
+    assert is_truncation_stop_reason("length") is True  # OpenAI-normalized vocabulary
+    assert is_truncation_stop_reason("end_turn") is False
+    assert is_truncation_stop_reason(None) is False
+    assert is_truncation_stop_reason(83399) is False
+
+
+def test_legacy_collector_attaches_stop_reason():
+    """#2021 Edit 3d: the LEGACY batch collector (``_collect_legacy_results``)
+    carries the response's stop_reason on parsed verdicts AND parse-failure
+    error dicts; a message without the attribute attaches nothing; rows with
+    no API response (expired) carry no key."""
+    from explore_persona_space.eval.batch_judge import _collect_legacy_results
+
+    def _sr_msg(text, stop_reason=None):
+        msg = _msg(text)
+        if stop_reason is not None:
+            msg.stop_reason = stop_reason
+        return msg
+
+    def _results(_batch_id):
+        yield SimpleNamespace(
+            custom_id="ok",
+            result=SimpleNamespace(type="succeeded", message=_sr_msg(JUDGE_TEXT, "end_turn")),
+        )
+        yield SimpleNamespace(
+            custom_id="trunc",
+            result=SimpleNamespace(
+                type="succeeded", message=_sr_msg("cut off mid-rationa", "max_tokens")
+            ),
+        )
+        yield SimpleNamespace(
+            custom_id="legacy",
+            result=SimpleNamespace(type="succeeded", message=_sr_msg(JUDGE_TEXT)),
+        )
+        yield SimpleNamespace(custom_id="exp", result=SimpleNamespace(type="expired", message=None))
+
+    client = SimpleNamespace(messages=SimpleNamespace(batches=SimpleNamespace(results=_results)))
+    results: dict = {}
+    _collect_legacy_results(client, "msgbatch_x", results)
+    assert results["ok"] == {
+        "aligned": 90,
+        "coherent": 95,
+        "reasoning": "ok",
+        "stop_reason": "end_turn",
+    }
+    assert results["trunc"]["error"] is True
+    assert results["trunc"]["reasoning"] == "parse_error"
+    assert results["trunc"]["stop_reason"] == "max_tokens"
+    assert results["legacy"] == {"aligned": 90, "coherent": 95, "reasoning": "ok"}
+    assert results["exp"]["error"] is True
+    assert "stop_reason" not in results["exp"]
 
 
 # ── cache value hygiene (PUT skip / GET miss) ─────────────────────────────────
@@ -179,6 +267,67 @@ def test_cache_get_treats_stored_transport_error_as_miss(tmp_path):
     assert total == 2
     # The good verdict hits; the poisoned entry is a MISS -> re-dispatch.
     assert list(cached_scores.values()) == [good]
+    assert [(q, c) for _cid, q, c, _u in uncached_items] == [("q-poisoned", "c-poisoned")]
+
+
+def test_cache_put_skips_truncation_error_dicts(tmp_path):
+    """#2021 (rule 23 mirror of the #1313 transport put-skip): a
+    truncation-class parse-failure result (garbage text at
+    stop_reason="max_tokens" on the sync path) is NEVER cache-PUT — a re-run
+    (e.g. after a budget raise, which does NOT change the rubric key)
+    re-dispatches it — while the sibling success IS cached."""
+    cache_dir = tmp_path / "cache"
+    completions = {"item": {"q-trunc": ["c-trunc"], "q-ok": ["c-ok"]}}
+
+    def text_for(user_msg):
+        return "cut off mid-rationa" if "c-trunc" in user_msg else JUDGE_TEXT
+
+    def stop_reason_for(user_msg):
+        return "max_tokens" if "c-trunc" in user_msg else "end_turn"
+
+    def _run_once():
+        client = _FaultableAsyncClient(text_for=text_for, stop_reason_for=stop_reason_for)
+        judge_completions_batch(
+            completions=completions,
+            judge_system_prompt="SYS",
+            judge_model="claude-sonnet-4-5-20250929",
+            cache_dir=cache_dir,
+            force_sync=True,
+            sync_client=client,
+        )
+        return client
+
+    c1 = _run_once()
+    assert len(c1.calls) == 2  # both dispatched on the cold run
+    # Exactly ONE cache entry (the success); the truncation failure was skipped.
+    assert len(list(cache_dir.glob("*.json"))) == 1
+
+    c2 = _run_once()
+    # Second run: the success is served from cache; ONLY the truncated item
+    # re-dispatches (the budget-raise self-heal contract, rule 23 / #2021).
+    assert len(c2.calls) == 1
+    assert "c-trunc" in c2.calls[0]
+
+
+def test_cache_get_treats_stored_truncation_error_as_miss(tmp_path):
+    """#2021: a PRE-SEEDED cache entry that is a truncation-class error dict
+    (written by concurrent pre-#2021-Edit-5 code, or a crashed run) reads as
+    a MISS — the item lands in ``uncached_items`` for re-dispatch — while a
+    stored VERDICT (even a kept-but-truncated one) still hits."""
+    cache = JudgeCache(tmp_path / "cache")
+    rk = rubric_fingerprint("m", "SYS", None)
+    poisoned = {**_legacy_error_dict("parse_error"), "stop_reason": "max_tokens"}
+    cache.put("q-poisoned", "c-poisoned", poisoned, rubric_key=rk)
+    # A kept-but-truncated VERDICT (no error flag) is data, not poison -> hit.
+    kept_truncated = {"aligned": 90, "coherent": 95, "reasoning": "ok", "stop_reason": "max_tokens"}
+    cache.put("q-good", "c-good", kept_truncated, rubric_key=rk)
+
+    completions = {"item": {"q-poisoned": ["c-poisoned"], "q-good": ["c-good"]}}
+    total, cached_scores, uncached_items = _enumerate_and_check_cache(
+        completions, cache, lambda q, c: f"{q}|{c}", rubric_key=rk
+    )
+    assert total == 2
+    assert list(cached_scores.values()) == [kept_truncated]
     assert [(q, c) for _cid, q, c, _u in uncached_items] == [("q-poisoned", "c-poisoned")]
 
 

--- a/tests/test_graded_judge.py
+++ b/tests/test_graded_judge.py
@@ -245,6 +245,10 @@ def test_judge_result_backcompat_defaults():
     assert r.n_transport_lost_draws == 0
     assert r.per_item_transport_losses == {}
     assert r.n_refusal_draws == 0  # #1801: new trailing field defaults to 0
+    # #2021: the truncation/tally fields default to zero/empty too.
+    assert r.n_truncation_dropped_draws == 0
+    assert r.per_item_truncation_drops == {}
+    assert r.stop_reason_tally == {}
 
 
 # ── #1801: REFUSAL sub-tally within content drops (llm-judging.md rules 9/23) ─
@@ -332,3 +336,194 @@ def test_transport_draws_stay_out_of_both_content_counters(tmp_path, monkeypatch
     assert result.n_transport_lost_draws == 1
     assert result.n_dropped_draws == 0
     assert result.n_refusal_draws == 0
+
+
+# ── #2021: truncation-vs-content split + stop_reason tally (rules 23/26) ──────
+
+
+def _parse_error_dict(**extra) -> dict:
+    """The dispatch-path parse-failure error-dict shape (judge_dispatch mint)."""
+    return {"aligned": None, "coherent": None, "reasoning": "parse_error", "error": True, **extra}
+
+
+def _transport_dict(**extra) -> dict:
+    return {
+        "aligned": None,
+        "coherent": None,
+        "reasoning": "error: 529 overloaded",
+        "error": True,
+        "transport": True,
+        **extra,
+    }
+
+
+def test_truncation_drop_counts_as_subset_of_dropped(tmp_path, monkeypatch, caplog):
+    """#2021: a stop_reason="max_tokens" parse-failure draw counts in BOTH
+    ``n_dropped_draws`` AND ``n_truncation_dropped_draws`` (subset semantics —
+    the content-drop total is numerically unchanged vs a pre-#2021 reduce),
+    with the per-item split populated and the warning log naming the
+    truncation clause."""
+    draws = {
+        "arm-a": [
+            {"score": 80, "stop_reason": "end_turn"},
+            _parse_error_dict(stop_reason="max_tokens"),
+        ]
+    }
+    monkeypatch.setattr(
+        "explore_persona_space.eval.batch_judge.judge_completions_batch",
+        _fake_batch_writing(draws),
+    )
+
+    with caplog.at_level("WARNING", logger="explore_persona_space.eval.graded_judge"):
+        result = judge_graded(
+            items=[("arm-a", "q?", "a.")],
+            eval_prompt="Rate {question} / {answer} 0-100.",
+            n_draws=2,
+            cache_dir=tmp_path / "cache",
+            save_raw=tmp_path / "raw.json",
+        )
+
+    assert result.scores == {"arm-a": 80.0}
+    assert result.n_dropped_draws == 1  # the truncated draw — SUBSET, not additive
+    assert result.n_truncation_dropped_draws == 1
+    assert result.per_item_truncation_drops == {"arm-a": 1}
+    assert result.n_refusal_draws == 0
+    assert result.n_transport_lost_draws == 0
+    assert any("truncation-class" in rec.message for rec in caplog.records)
+
+
+def test_legacy_dict_without_stop_reason_classifies_unknown_no_crash(tmp_path, monkeypatch):
+    """#2021 backcompat: a pre-#2021 save_raw (no ``stop_reason`` field
+    anywhere) reduces without KeyError — truncation stays 0, the parse
+    failure stays a plain content drop, and every answered draw tallies as
+    ``"unknown"``."""
+    draws = {"arm-a": [_parse_error_dict(), 70]}  # legacy shapes: no stop_reason
+    monkeypatch.setattr(
+        "explore_persona_space.eval.batch_judge.judge_completions_batch",
+        _fake_batch_writing(draws),
+    )
+
+    result = judge_graded(
+        items=[("arm-a", "q?", "a.")],
+        eval_prompt="Rate {question} / {answer} 0-100.",
+        n_draws=2,
+        cache_dir=tmp_path / "cache",
+        save_raw=tmp_path / "raw.json",
+    )
+
+    assert result.scores == {"arm-a": 70.0}
+    assert result.n_dropped_draws == 1
+    assert result.n_truncation_dropped_draws == 0
+    assert result.per_item_truncation_drops == {}
+    assert result.stop_reason_tally == {"unknown": 2}
+
+
+def test_refusal_takes_precedence_over_truncation(tmp_path, monkeypatch):
+    """#2021 precedence: a REFUSAL verdict that ALSO carries a truncation
+    stop_reason counts as a refusal drop (a produced verdict, rule 9), NEVER
+    a truncation drop — but its stop_reason still tallies."""
+    draws = {"arm-a": [{"score": "REFUSAL", "stop_reason": "max_tokens"}, 90]}
+    monkeypatch.setattr(
+        "explore_persona_space.eval.batch_judge.judge_completions_batch",
+        _fake_batch_writing(draws),
+    )
+
+    result = judge_graded(
+        items=[("arm-a", "q?", "a.")],
+        eval_prompt="Rate {question} / {answer} 0-100.",
+        n_draws=2,
+        cache_dir=tmp_path / "cache",
+        save_raw=tmp_path / "raw.json",
+    )
+
+    assert result.n_dropped_draws == 1
+    assert result.n_refusal_draws == 1
+    assert result.n_truncation_dropped_draws == 0
+    assert result.per_item_truncation_drops == {}
+    assert result.stop_reason_tally == {"max_tokens": 1, "unknown": 1}
+
+
+def test_transport_dict_never_counts_truncation(tmp_path, monkeypatch):
+    """#2021 precedence: transport is checked FIRST — even a pathological
+    both-flagged dict (``transport: True`` + a truncation stop_reason, which
+    no mint site produces) counts transport only, in NO content counter, and
+    is EXCLUDED from the stop_reason tally (the [S1] decision)."""
+    draws = {"arm-a": [_transport_dict(stop_reason="max_tokens"), 85]}
+    monkeypatch.setattr(
+        "explore_persona_space.eval.batch_judge.judge_completions_batch",
+        _fake_batch_writing(draws),
+    )
+
+    result = judge_graded(
+        items=[("arm-a", "q?", "a.")],
+        eval_prompt="Rate {question} / {answer} 0-100.",
+        n_draws=2,
+        cache_dir=tmp_path / "cache",
+        save_raw=tmp_path / "raw.json",
+    )
+
+    assert result.n_transport_lost_draws == 1
+    assert result.n_dropped_draws == 0
+    assert result.n_truncation_dropped_draws == 0
+    # [S1] pin: the transport draw does NOT tally (not even as "unknown" or
+    # "max_tokens") — only the answered kept draw does.
+    assert result.stop_reason_tally == {"unknown": 1}
+
+
+def test_stop_reason_tally_covers_kept_and_dropped_draws(tmp_path, monkeypatch):
+    """#2021 [S1] pin: the tally spans kept draws AND content-dropped draws
+    ("unknown" for absent), and EXCLUDES transport-lost draws — so
+    ``sum(tally.values()) == n_total_draws - n_transport_lost_draws``."""
+    draws = {
+        "arm-a": [
+            {"score": 80, "stop_reason": "end_turn"},  # kept, tallied
+            _parse_error_dict(stop_reason="max_tokens"),  # dropped, tallied
+            _transport_dict(),  # transport, EXCLUDED from the tally
+            70,  # kept legacy bare-scalar draw -> "unknown"
+        ]
+    }
+    monkeypatch.setattr(
+        "explore_persona_space.eval.batch_judge.judge_completions_batch",
+        _fake_batch_writing(draws),
+    )
+
+    result = judge_graded(
+        items=[("arm-a", "q?", "a.")],
+        eval_prompt="Rate {question} / {answer} 0-100.",
+        n_draws=4,
+        cache_dir=tmp_path / "cache",
+        save_raw=tmp_path / "raw.json",
+    )
+
+    assert result.stop_reason_tally == {"end_turn": 1, "max_tokens": 1, "unknown": 1}
+    assert sum(result.stop_reason_tally.values()) == (
+        result.n_total_draws - result.n_transport_lost_draws
+    )
+    assert result.n_truncation_dropped_draws == 1
+    assert result.n_dropped_draws == 1
+
+
+def test_kept_truncated_verdict_stays_scored(tmp_path, monkeypatch):
+    """#2021 [S3] pin: a KEPT (parsed, in-range) verdict carrying
+    ``stop_reason="max_tokens"`` stays a scored draw — drop counters all 0 —
+    while the tally shows the truncation key. This is the only surface that
+    catches kept-but-truncated responses; the rule-26 pilot gate reads it."""
+    draws = {"arm-a": [{"score": 55, "stop_reason": "max_tokens"}]}
+    monkeypatch.setattr(
+        "explore_persona_space.eval.batch_judge.judge_completions_batch",
+        _fake_batch_writing(draws),
+    )
+
+    result = judge_graded(
+        items=[("arm-a", "q?", "a.")],
+        eval_prompt="Rate {question} / {answer} 0-100.",
+        n_draws=1,
+        cache_dir=tmp_path / "cache",
+        save_raw=tmp_path / "raw.json",
+    )
+
+    assert result.scores == {"arm-a": 55.0}
+    assert result.n_dropped_draws == 0
+    assert result.n_truncation_dropped_draws == 0
+    assert result.n_transport_lost_draws == 0
+    assert result.stop_reason_tally == {"max_tokens": 1}

--- a/tests/test_judge_dispatch.py
+++ b/tests/test_judge_dispatch.py
@@ -304,22 +304,35 @@ def test_chunk_at_byte_limit():
 # ── #663 Test 7: _collect_batch_results 5-tuple two-level split ──────────────
 
 
-def _collect_client(outcomes: dict[str, str], *, error_types: dict[str, str] | None = None):
+def _collect_client(
+    outcomes: dict[str, str],
+    *,
+    error_types: dict[str, str] | None = None,
+    texts: dict[str, str] | None = None,
+    stop_reasons: dict[str, str] | None = None,
+):
     """Fake client whose results() yields scripted per-cid outcome shapes.
 
     ``outcomes[cid]`` in {succeeded, errored, expired, canceled};
     ``error_types[cid]`` sets ``result.error.error.type`` for an errored row
     (e.g. "invalid_request_error" or "api_error"). A succeeded row carries a
-    valid judge-JSON message.
+    valid judge-JSON message unless ``texts[cid]`` overrides it, and gains a
+    str ``stop_reason`` attribute when ``stop_reasons[cid]`` is set (#2021;
+    absent -> no attribute, the legacy SDK-shape default).
     """
     error_types = error_types or {}
+    texts = texts or {}
+    stop_reasons = stop_reasons or {}
 
     def _results(_batch_id):
         for cid, outcome in outcomes.items():
             if outcome == "succeeded":
+                msg = _msg(texts.get(cid, JUDGE_TEXT))
+                if cid in stop_reasons:
+                    msg.stop_reason = stop_reasons[cid]
                 yield SimpleNamespace(
                     custom_id=cid,
-                    result=SimpleNamespace(type="succeeded", message=_msg(JUDGE_TEXT)),
+                    result=SimpleNamespace(type="succeeded", message=msg),
                 )
             elif outcome == "errored":
                 etype = error_types.get(cid)
@@ -352,13 +365,19 @@ def test_collect_batch_results_five_tuple_split():
 
     outcomes = {
         "ok": "succeeded",
+        "trunc_parse": "succeeded",
         "bad_request": "errored",
         "server_err": "errored",
         "exp": "expired",
         "cxl": "canceled",
     }
     error_types = {"bad_request": "invalid_request_error", "server_err": "api_error"}
-    client = _collect_client(outcomes, error_types=error_types)
+    client = _collect_client(
+        outcomes,
+        error_types=error_types,
+        texts={"trunc_parse": "cut off mid-rationa"},  # parse fails
+        stop_reasons={"ok": "end_turn", "trunc_parse": "max_tokens"},
+    )
     scores, retriable, expired, quarantined, canceled = _collect_batch_results(
         client, "msgbatch_x", _default_error_dict
     )
@@ -366,14 +385,28 @@ def test_collect_batch_results_five_tuple_split():
     assert retriable == ["server_err"]
     assert expired == ["exp"]
     assert canceled == ["cxl"]
-    assert scores["ok"] == {"aligned": 90, "coherent": 95, "reasoning": "ok"}
+    # #2021: succeeded rows carry the response's stop_reason — the parsed
+    # verdict AND the parse-failure error dict alike.
+    assert scores["ok"] == {
+        "aligned": 90,
+        "coherent": 95,
+        "reasoning": "ok",
+        "stop_reason": "end_turn",
+    }
+    assert scores["trunc_parse"]["error"] is True
+    assert scores["trunc_parse"]["reasoning"] == "parse_error"
+    assert scores["trunc_parse"]["stop_reason"] == "max_tokens"
     # All terminal states present in scores (overwritten if a retry succeeds).
-    assert set(scores) == {"ok", "bad_request", "server_err", "exp", "cxl"}
+    assert set(scores) == {"ok", "trunc_parse", "bad_request", "server_err", "exp", "cxl"}
     assert scores["bad_request"]["error"] is True
     assert "invalid_request_error" in scores["bad_request"]["reasoning"]
     assert scores["cxl"]["error"] is True
     # canceled is in neither retry list.
     assert "cxl" not in retriable and "cxl" not in expired and "cxl" not in quarantined
+    # #2021: no-response rows (errored/expired/canceled/quarantined) carry NO
+    # stop_reason key.
+    for cid in ("bad_request", "server_err", "exp", "cxl"):
+        assert "stop_reason" not in scores[cid], cid
 
 
 # ── 5: dry-run ───────────────────────────────────────────────────────────────
@@ -1359,6 +1392,83 @@ def test_sync_captured_overloaded_flagged_transport():
     assert results["cid_rt"]["error"] is True
     assert "transport" not in results["cid_rt"]
     assert results["cid_ok"].get("error") is not True
+    # #2021: exception-branch dicts have NO API response -> no stop_reason key;
+    # and a fake message WITHOUT the attribute attaches nothing either.
+    assert "stop_reason" not in results["cid_529"]
+    assert "stop_reason" not in results["cid_rt"]
+    assert "stop_reason" not in results["cid_ok"]
+
+
+def test_sync_single_org_attaches_stop_reason():
+    """#2021: the single-org sync mint carries the response's ``stop_reason``
+    on parsed verdicts AND parse-failure error dicts alike."""
+    from explore_persona_space.eval.judge_dispatch import _default_error_dict, _judge_items_sync
+
+    class _Client:
+        def __init__(self):
+            client = self
+
+            class _Messages:
+                async def create(_self, **kwargs):
+                    user_msg = kwargs["messages"][0]["content"]
+                    if "truncate-me" in user_msg:
+                        msg = _msg("cut off mid-rationa")  # parse fails
+                        msg.stop_reason = "max_tokens"
+                        return msg
+                    msg = _msg(JUDGE_TEXT)
+                    msg.stop_reason = "end_turn"
+                    return msg
+
+            client.messages = _Messages()
+
+    items = [
+        ("cid_trunc", "q1", "c1", "please truncate-me"),
+        ("cid_ok", "q2", "c2", "fine"),
+    ]
+    results = asyncio.run(
+        _judge_items_sync(
+            items,
+            judge_model="claude-sonnet-4-5-20250929",
+            judge_system_prompt="rubric",
+            max_tokens=64,
+            max_concurrent=2,
+            error_dict_factory=_default_error_dict,
+            client=_Client(),
+        )
+    )
+    assert results["cid_ok"] == {
+        "aligned": 90,
+        "coherent": 95,
+        "reasoning": "ok",
+        "stop_reason": "end_turn",
+    }
+    assert results["cid_trunc"]["error"] is True
+    assert results["cid_trunc"]["reasoning"] == "parse_error"
+    assert results["cid_trunc"]["stop_reason"] == "max_tokens"
+
+
+def test_with_stop_reason_ignores_non_str():
+    """#2021 MagicMock-safety pin: the ``isinstance(str)`` gate never persists
+    a non-str stop_reason (a MagicMock auto-attribute, None, ""), non-dict
+    scores pass through untouched, and the attach never mutates its input."""
+    from unittest.mock import MagicMock
+
+    from explore_persona_space.eval.judge_dispatch import _with_stop_reason
+
+    base = {"score": 80}
+    # MagicMock auto-created attribute (the getattr-on-a-fake shape) -> no key.
+    assert _with_stop_reason(base, MagicMock().stop_reason) == {"score": 80}
+    assert _with_stop_reason(base, None) == {"score": 80}
+    assert _with_stop_reason(base, "") == {"score": 80}
+    assert _with_stop_reason(base, 83399) == {"score": 80}
+    # str attaches — on a COPY (the original is never mutated).
+    out = _with_stop_reason(base, "end_turn")
+    assert out == {"score": 80, "stop_reason": "end_turn"}
+    assert base == {"score": 80}
+    assert out is not base
+    # Non-dict scores (bare-string parses) pass through unchanged.
+    assert _with_stop_reason("REFUSAL", "end_turn") == "REFUSAL"
+    assert _with_stop_reason(None, "end_turn") is None
 
 
 def test_multiorg_reduce_flags_transport_dispatch_results(monkeypatch):
@@ -1397,9 +1507,18 @@ def test_multiorg_reduce_flags_transport_dispatch_results(monkeypatch):
         ),
     }
 
+    seen: dict = {}
+
     async def fake_dispatch_calls(
-        items, *, model, build_request, parse_response, cost_pref, force_path
+        items, *, model, build_request, parse_response, parse_response_meta, cost_pref, force_path
     ):
+        # #2021 [A1] compose pin: the meta parser is COMPOSED over
+        # parse_response — identical dicts modulo the stop_reason attach.
+        plain = parse_response(JUDGE_TEXT)
+        meta = parse_response_meta(JUDGE_TEXT, "max_tokens")
+        assert meta == {**plain, "stop_reason": "max_tokens"}
+        assert parse_response_meta(JUDGE_TEXT, None) == plain
+        seen["meta_composes"] = True
         return {it.item_id: fake_results[it.item_id] for it in items}
 
     monkeypatch.setattr(api_dispatch, "dispatch_calls", fake_dispatch_calls)
@@ -1426,6 +1545,7 @@ def test_multiorg_reduce_flags_transport_dispatch_results(monkeypatch):
     assert results["cid_term"]["error"] is True
     assert "transport" not in results["cid_term"]
     assert results["cid_ok"] == {"aligned": 90, "coherent": 95, "reasoning": "ok"}
+    assert seen.get("meta_composes") is True  # the [A1] compose pin actually ran
 
 
 # ── custom_id grammar validation at dispatch entry (#1795) ───────────────────

--- a/tests/test_judge_pilot_gate.py
+++ b/tests/test_judge_pilot_gate.py
@@ -1,0 +1,337 @@
+"""Tests for the rule-26 judge pilot gate (#2021, `eval/judge_pilot.py`).
+
+Most tests fake `judge_graded` at the `judge_pilot` seam (signature-conformant
+via `unittest.mock.create_autospec`; the fake WRITES a synthetic save_raw and
+reduces it with the REAL `judge_result_from_save_raw`, so the production reduce
++ classification run in every test). The #906 real-body test executes
+`judge_pilot_gate`'s real body THROUGH the real `judge_graded`, faking only the
+API boundary (`batch_judge.judge_completions_batch`, autospec'd).
+"""
+
+import hashlib
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from explore_persona_space.eval import batch_judge, graded_judge, judge_pilot
+from explore_persona_space.eval.judge_pilot import judge_pilot_gate
+
+PROMPT = "Rate the answer 0-100.\n{question}\n{answer}"
+
+# Synthetic per-draw parsed entries (the shapes the post-#2021 mint sites persist).
+KEPT = {"score": 95, "stop_reason": "end_turn"}
+KEPT_TRUNC = {"score": 80, "stop_reason": "max_tokens"}  # kept verdict, truncated response
+PARSE_DROP = {"error": True, "reasoning": "parse_error", "stop_reason": "end_turn"}
+TRUNC_DROP = {"error": True, "reasoning": "parse_error", "stop_reason": "max_tokens"}
+REFUSAL = {"score": "REFUSAL", "stop_reason": "end_turn"}
+TRANSPORT = {"error": True, "transport": True, "reasoning": "transport: overloaded (529)"}
+LEGACY_DROP = {"error": True, "reasoning": "parse_error"}  # pre-#2021: no stop_reason
+
+
+def _items(n: int, prefix: str) -> list[tuple[str, str, str]]:
+    return [(f"{prefix}{i}", f"q{i}", f"a{i}") for i in range(n)]
+
+
+def _install_fake_judge(monkeypatch, arm_draws: dict[str, list], record: list | None = None):
+    """Monkeypatch `judge_pilot.judge_graded` with a signature-conformant fake.
+
+    The fake writes `save_raw` from `arm_draws[<arm>]` (one parsed entry per
+    (item, draw) slot, in order) and returns the REAL reduce's JudgeResult, so
+    gate stats exercise the production classification. `record` (optional)
+    captures (arm, [item ids], max_tokens) per call.
+    """
+
+    def impl(
+        items,
+        eval_prompt,
+        *,
+        n_draws,
+        cache_dir,
+        save_raw,
+        judge_model="unused-default",  # the gate always passes judge_model explicitly
+        temperature=graded_judge.DEFAULT_JUDGE_TEMPERATURE,
+        max_tokens=64,
+        dry_run=False,
+        threshold_base=None,
+    ):
+        arm = Path(save_raw).stem.removeprefix("judge_raw_pilot_")
+        if record is not None:
+            record.append((arm, [item_id for item_id, _q, _a in items], max_tokens))
+        draws = list(arm_draws[arm])
+        all_scores = {}
+        di = 0
+        for idx, (item_id, _q, _a) in enumerate(items):
+            for comp in range(n_draws):
+                if di >= len(draws):
+                    break
+                all_scores[f"{item_id}__{idx:05d}__{comp:02d}"] = draws[di]
+                di += 1
+        p = Path(save_raw)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"all_scores": all_scores}))
+        return graded_judge.judge_result_from_save_raw(p, items)
+
+    fake = mock.create_autospec(graded_judge.judge_graded, side_effect=impl)
+    monkeypatch.setattr(judge_pilot, "judge_graded", fake)
+    return fake
+
+
+def _run(monkeypatch, tmp_path, arm_items, arm_draws, **kw):
+    _install_fake_judge(monkeypatch, arm_draws)
+    return judge_pilot_gate(
+        arm_items,
+        PROMPT,
+        max_tokens=kw.pop("max_tokens", 800),
+        cache_dir=tmp_path / "cache",
+        save_raw_dir=tmp_path / "raw",
+        **kw,
+    )
+
+
+def test_pass_on_clean_pilot(monkeypatch, tmp_path):
+    arms = {"a": _items(6, "a"), "b": _items(6, "b")}
+    draws = {"a": [KEPT] * 12, "b": [KEPT] * 12}
+    rep = _run(monkeypatch, tmp_path, arms, draws)
+    assert rep.passed is True
+    assert rep.verdict == "PASS"
+    assert rep.failures == []
+    assert rep.n_total_draws == 24
+    assert rep.arms["a"].n_scored == 12
+    assert rep.arms["a"].n_content_dropped == 0
+    assert rep.arms["a"].parse_fail_rate == 0.0
+    assert rep.arms["a"].stop_reason_tally == {"end_turn": 12}
+    assert rep.arms["a"].waived is False
+
+
+def test_fail_on_nonzero_truncation_stop_reason(monkeypatch, tmp_path):
+    arms = {"a": _items(6, "a")}
+    draws = {"a": [KEPT] * 11 + [TRUNC_DROP]}
+    rep = _run(monkeypatch, tmp_path, arms, draws)
+    assert rep.verdict == "FAIL"
+    assert rep.arms["a"].n_truncation == 1
+    trunc_failures = [f for f in rep.failures if "truncation" in f]
+    assert trunc_failures, rep.failures
+    assert "re-pilot" in trunc_failures[0]
+    assert "NEVER waivable" in trunc_failures[0]
+    assert "never shrink" in trunc_failures[0]
+
+
+def test_kept_truncated_verdict_fails_gate(monkeypatch, tmp_path):
+    """The tally clause fires with the drop counter at ZERO (unit A pinned the
+    reduce side — a kept-but-truncated verdict is visible only in the tally)."""
+    arms = {"a": _items(6, "a")}
+    draws = {"a": [KEPT] * 11 + [KEPT_TRUNC]}
+    rep = _run(monkeypatch, tmp_path, arms, draws)
+    assert rep.arms["a"].n_truncation == 0
+    assert rep.arms["a"].n_content_dropped == 0
+    assert rep.arms["a"].n_scored == 12  # the truncated verdict IS kept as a score
+    assert rep.arms["a"].stop_reason_tally.get("max_tokens") == 1
+    assert rep.verdict == "FAIL"
+    assert any("truncation" in f and "KEPT" in f for f in rep.failures), rep.failures
+
+
+def test_fail_on_parse_fail_rate_at_threshold(monkeypatch, tmp_path):
+    # Exactly 2% (1 non-refusal content drop / 50 answered draws) trips the >= bar.
+    arms = {"a": _items(25, "a")}
+    draws = {"a": [KEPT] * 49 + [PARSE_DROP]}
+    rep = _run(monkeypatch, tmp_path / "at", arms, draws)
+    assert rep.arms["a"].parse_fail_rate == pytest.approx(0.02)
+    assert rep.verdict == "FAIL"
+    assert any("parse-fail" in f and "rule 26(b)" in f for f in rep.failures), rep.failures
+
+    # Just below the bar (1/100 = 1%) passes.
+    arms2 = {"a": _items(50, "a")}
+    draws2 = {"a": [KEPT] * 99 + [PARSE_DROP]}
+    rep2 = _run(monkeypatch, tmp_path / "below", arms2, draws2)
+    assert rep2.arms["a"].parse_fail_rate == pytest.approx(0.01)
+    assert rep2.passed is True
+
+
+def test_refusals_excluded_from_parse_fail_rate(monkeypatch, tmp_path):
+    # 2 refusals in 12 draws would be ~17% if blended; refusals are rule-9 verdicts.
+    arms = {"a": _items(6, "a")}
+    draws = {"a": [KEPT] * 10 + [REFUSAL] * 2}
+    rep = _run(monkeypatch, tmp_path, arms, draws)
+    assert rep.arms["a"].n_refusal == 2
+    assert rep.arms["a"].n_content_dropped == 2  # refusal IS a content drop (subset)
+    assert rep.arms["a"].parse_fail_rate == 0.0
+    assert rep.passed is True
+
+
+def test_waived_arm_does_not_fail_gate_but_is_reported(monkeypatch, tmp_path):
+    arms = {"noisy": _items(6, "n"), "clean": _items(6, "c")}
+    draws = {"noisy": [KEPT] * 10 + [PARSE_DROP] * 2, "clean": [KEPT] * 12}
+    rep = _run(monkeypatch, tmp_path, arms, draws, waive_parse_fail_arms={"noisy"})
+    assert rep.passed is True
+    assert rep.arms["noisy"].waived is True
+    assert rep.arms["noisy"].parse_fail_rate == pytest.approx(2 / 12)
+    assert any("noisy" in w and "WAIVED" in w for w in rep.warnings), rep.warnings
+
+    # A typo'd waiver fails loud instead of silently not waiving.
+    with pytest.raises(ValueError, match="unknown arm"):
+        judge_pilot_gate(
+            arms,
+            PROMPT,
+            max_tokens=800,
+            cache_dir=tmp_path / "c2",
+            save_raw_dir=tmp_path / "r2",
+            waive_parse_fail_arms={"nope"},
+        )
+
+
+def test_truncation_fail_not_waivable(monkeypatch, tmp_path):
+    arms = {"t": _items(6, "t")}
+    draws = {"t": [KEPT] * 11 + [TRUNC_DROP]}
+    rep = _run(monkeypatch, tmp_path, arms, draws, waive_parse_fail_arms={"t"})
+    assert rep.verdict == "FAIL"
+    assert any("truncation" in f for f in rep.failures), rep.failures
+    # The waiver silenced the parse-fail check only — truncation still fails.
+    assert not any("parse-fail" in f for f in rep.failures)
+
+
+def test_transport_hollowed_arm_fails_not_passes(monkeypatch, tmp_path):
+    """[S2]: an arm hollowed out by transport losses must FAIL, never silently PASS."""
+    arms = {"h": _items(6, "h"), "ok": _items(6, "o")}
+    draws = {"h": [TRANSPORT] * 11 + [KEPT], "ok": [KEPT] * 12}
+    rep = _run(monkeypatch, tmp_path, arms, draws)
+    assert rep.verdict == "FAIL"
+    assert rep.arms["h"].n_transport_lost == 11
+    assert rep.arms["h"].n_scored == 1
+    hollow = [f for f in rep.failures if f.startswith("arm h:")]
+    assert hollow, rep.failures
+    assert "re-run the pilot" in hollow[0]
+    assert "transport-hollowed" in hollow[0]
+    # Transport draws are excluded from the tally (unit A [S1]) and warned about.
+    assert rep.arms["h"].stop_reason_tally == {"end_turn": 1}
+    assert any("transport-lost" in w for w in rep.warnings)
+    # The healthy sibling arm carries no failure of its own.
+    assert not any(f.startswith("arm ok:") for f in rep.failures)
+
+
+def test_unknown_stop_reason_drop_warns_stale_cache(monkeypatch, tmp_path):
+    """[M2]: a content drop with NO persisted stop_reason partially detects a
+    stale pre-#2021 cache — advisory warning, plus the "unknown" tally row."""
+    arms = {"a": _items(6, "a")}
+    draws = {"a": [KEPT] * 11 + [LEGACY_DROP]}
+    rep = _run(monkeypatch, tmp_path, arms, draws)
+    assert rep.arms["a"].n_unknown_stop_reason_drops == 1
+    assert rep.arms["a"].stop_reason_tally.get("unknown") == 1
+    assert any("stale pre-#2021" in w for w in rep.warnings), rep.warnings
+
+
+def test_max_tokens_floor_warning_never_fails(monkeypatch, tmp_path):
+    arms = {"a": _items(6, "a")}
+    draws = {"a": [KEPT] * 12}
+    rep = _run(monkeypatch, tmp_path, arms, draws, max_tokens=64)
+    assert rep.passed is True  # note only — never a verdict change
+    assert any("never" in w and "auto-shrink" in w for w in rep.warnings), rep.warnings
+
+
+def test_report_json_roundtrip_and_report_path_write(monkeypatch, tmp_path):
+    arms = {"a": _items(6, "a")}
+    draws = {"a": [KEPT] * 12}
+    report_path = tmp_path / "sub" / "pilot_report.json"
+    rep = _run(monkeypatch, tmp_path, arms, draws, report_path=report_path)
+    assert report_path.is_file()
+    loaded = json.loads(report_path.read_text())
+    assert loaded == rep.to_json()
+    assert loaded["verdict"] == "PASS"
+    assert loaded["max_tokens"] == 800
+    assert loaded["arms"]["a"]["n_scored"] == 12
+    assert loaded["arms"]["a"]["stop_reason_tally"] == {"end_turn": 12}
+    assert loaded["rubric_hash"] == hashlib.sha256(PROMPT.encode("utf-8")).hexdigest()[:16]
+
+
+def test_deterministic_subsample_seeded(monkeypatch, tmp_path):
+    arms = {"a": _items(100, "a")}
+    draws = {"a": [KEPT] * 20}  # 10 items x 2 draws under target_total_draws=20
+
+    def run(seed, sub):
+        record: list = []
+        _install_fake_judge(monkeypatch, draws, record=record)
+        rep = judge_pilot_gate(
+            arms,
+            PROMPT,
+            max_tokens=800,
+            cache_dir=tmp_path / sub / "cache",
+            save_raw_dir=tmp_path / sub / "raw",
+            target_total_draws=20,
+            seed=seed,
+        )
+        assert rep.arms["a"].n_items == 10
+        return record[0][1]
+
+    ids_first = run(0, "one")
+    ids_second = run(0, "two")
+    ids_other_seed = run(1, "three")
+    assert ids_first == ids_second  # same seed -> identical subsample
+    assert ids_first != ids_other_seed  # different seed -> different subsample
+    assert len(set(ids_first)) == 10
+
+
+def test_pilot_gate_real_body_reaches_judge_graded(monkeypatch, tmp_path):
+    """#906 real-body test: judge_pilot_gate's REAL body through the REAL
+    judge_graded (real rubric split, real custom_id packing, real
+    judge_result_from_save_raw reduce, real verdict logic), faking ONLY the API
+    boundary — `batch_judge.judge_completions_batch`, autospec'd so the real
+    call shape is signature-validated."""
+
+    def impl(*args, **kwargs):
+        completions = kwargs["completions"]
+        save_raw = Path(kwargs["save_raw"])
+        all_scores = {}
+        for persona, by_q in completions.items():
+            for idx, (_q, comps) in enumerate(by_q.items()):
+                for comp_idx in range(len(comps)):
+                    all_scores[f"{persona}__{idx:05d}__{comp_idx:02d}"] = {
+                        "score": 90,
+                        "stop_reason": "end_turn",
+                    }
+        save_raw.parent.mkdir(parents=True, exist_ok=True)
+        save_raw.write_text(json.dumps({"all_scores": all_scores}))
+
+    spec = mock.create_autospec(batch_judge.judge_completions_batch, side_effect=impl)
+    monkeypatch.setattr(batch_judge, "judge_completions_batch", spec)
+
+    arms = {"a": _items(6, "a"), "b": _items(6, "b")}
+    report_path = tmp_path / "report.json"
+    rep = judge_pilot_gate(
+        arms,
+        PROMPT,
+        max_tokens=987,
+        cache_dir=tmp_path / "cache",
+        save_raw_dir=tmp_path / "raw",
+        n_draws=2,
+        report_path=report_path,
+    )
+    assert rep.passed is True
+    assert rep.n_total_draws == 24
+    assert rep.arms["a"].n_scored == 12
+    assert rep.arms["b"].stop_reason_tally == {"end_turn": 12}
+    # The EXACT production instrument reached the client: budget + per-arm pilot cache.
+    assert spec.call_count == 2
+    for call in spec.call_args_list:
+        assert call.kwargs["max_tokens"] == 987
+        assert Path(call.kwargs["cache_dir"]).parent == tmp_path / "cache"
+        assert Path(call.kwargs["cache_dir"]).name in arms
+    assert (tmp_path / "raw" / "judge_raw_pilot_a.json").is_file()
+    assert (tmp_path / "raw" / "judge_raw_pilot_b.json").is_file()
+    assert json.loads(report_path.read_text())["verdict"] == "PASS"
+
+
+def test_empty_arms_and_bad_arm_names_fail_loud(monkeypatch, tmp_path):
+    _install_fake_judge(monkeypatch, {})
+    with pytest.raises(ValueError, match="non-empty"):
+        judge_pilot_gate(
+            {}, PROMPT, max_tokens=800, cache_dir=tmp_path / "c", save_raw_dir=tmp_path / "r"
+        )
+    with pytest.raises(ValueError, match="filesystem-safe"):
+        judge_pilot_gate(
+            {"bad/arm": _items(2, "x")},
+            PROMPT,
+            max_tokens=800,
+            cache_dir=tmp_path / "c",
+            save_raw_dir=tmp_path / "r",
+        )


### PR DESCRIPTION
Closes task #2021. Threads stop_reason into every persisted per-draw judge result (5 mint sites), adds the truncation/content/transport drop split (subset semantics, #1801 precedent), truncation-class cache put-skip/get-miss (#1313 mirror), and the rule-26 judge_pilot_gate helper (unit B in flight).